### PR TITLE
Fix of wrong displaing minutes and seconds

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -913,7 +913,7 @@ static void lcd_menu_statistics()
 		int _t = (millis() - starttime) / 1000;
 
 		int _h = _t / 3600;
-		int _m = (_t - (_h * 60)) / 60;
+		int _m = (_t - (_h * 3600)) / 60;
 		int _s = _t - ((_h * 3600) + (_m * 60));
 		
 		lcd.setCursor(0, 0);


### PR DESCRIPTION
Status is displaing wrong minutes and seconds, when printing longer than 1h
