### PR TITLE
Planner: Acceleration parity with 1.1.0 and some optimizations

### DIFF
--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -239,6 +239,17 @@ void setPwmFrequency(uint8_t pin, int val);
   #define CRITICAL_SECTION_END    SREG = _sreg;
 #endif //CRITICAL_SECTION_START
 
+// Array sizes
+#define ABC  3
+#define XYZ  3
+#define ABCE 4
+#define ABZE 4
+#define XYZE 4
+
+// Macros to contrain values
+#define NOLESS(v,n) do{ if (v < n) v = n; }while(0)
+#define NOMORE(v,n) do{ if (v > n) v = n; }while(0)
+
 extern float homing_feedrate[];
 extern bool axis_relative_modes[];
 extern int feedmultiply;

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3665,7 +3665,7 @@ Sigma_Exit:
               float factor = axis_steps_per_unit[i] / value; // increase e constants if M92 E14 is given for netfab.
               max_jerk[E_AXIS] *= factor;
               max_feedrate[i] *= factor;
-              axis_steps_per_sqr_second[i] *= factor;
+              max_acceleration_steps_per_s2[i] *= factor;
             }
             axis_steps_per_unit[i] = value;
           }

--- a/Firmware/planner.h
+++ b/Firmware/planner.h
@@ -46,8 +46,8 @@ enum BlockFlag {
 // the source g-code and may never actually be reached if acceleration management is active.
 typedef struct {
   // Fields used by the bresenham algorithm for tracing the line
-  // steps_x.y,z, step_event_count, acceleration_rate, direction_bits and active_extruder are set by plan_buffer_line().
-  long steps_x, steps_y, steps_z, steps_e;  // Step count along each axis
+  // steps, step_event_count, acceleration_rate, direction_bits and active_extruder are set by plan_buffer_line().
+  long steps[XYZE];                         // Step count along each axis
   unsigned long step_event_count;           // The number of step events required to complete this block
   long acceleration_rate;                   // The acceleration rate used for acceleration calculation
   unsigned char direction_bits;             // The direction bit set for this block (refers to *_DIRECTION_BIT in config.h)
@@ -80,7 +80,7 @@ typedef struct {
   unsigned long nominal_rate;                        // The nominal step rate for this block in step_events/sec 
   unsigned long initial_rate;                        // The jerk-adjusted step rate at start of block  
   unsigned long final_rate;                          // The minimal rate at exit
-  unsigned long acceleration_st;                     // acceleration steps/sec^2
+  unsigned long acceleration_steps_per_s2;           // acceleration steps/sec^2
   //FIXME does it have to be unsigned long? Probably uint8_t would be just fine.
   unsigned long fan_speed;
   volatile char busy;
@@ -135,7 +135,7 @@ extern float retract_acceleration; //  mm/s^2   filament pull-pack and push-forw
 // Jerk is a maximum immediate velocity change.
 extern float max_jerk[NUM_AXIS];
 extern float mintravelfeedrate;
-extern unsigned long axis_steps_per_sqr_second[NUM_AXIS];
+extern unsigned long max_acceleration_steps_per_s2[NUM_AXIS];
 
 #ifdef AUTOTEMP
     extern bool autotemp_enabled;

--- a/Firmware/stepper.cpp
+++ b/Firmware/stepper.cpp
@@ -341,7 +341,7 @@ ISR(TIMER1_COMPA_vect)
       step_events_completed = 0;
 
       #ifdef Z_LATE_ENABLE
-        if(current_block->steps_z > 0) {
+        if(current_block->steps[Z_AXIS] > 0) {
           enable_z();
           OCR1A = 2000; //1ms wait
           return;
@@ -397,7 +397,7 @@ ISR(TIMER1_COMPA_vect)
         {
           #if defined(X_MIN_PIN) && X_MIN_PIN > -1
             bool x_min_endstop=(READ(X_MIN_PIN) != X_MIN_ENDSTOP_INVERTING);
-            if(x_min_endstop && old_x_min_endstop && (current_block->steps_x > 0)) {
+            if(x_min_endstop && old_x_min_endstop && (current_block->steps[X_AXIS] > 0)) {
               endstops_trigsteps[X_AXIS] = count_position[X_AXIS];
               endstop_x_hit=true;
               step_events_completed = current_block->step_event_count;
@@ -413,7 +413,7 @@ ISR(TIMER1_COMPA_vect)
         {
           #if defined(X_MAX_PIN) && X_MAX_PIN > -1
             bool x_max_endstop=(READ(X_MAX_PIN) != X_MAX_ENDSTOP_INVERTING);
-            if(x_max_endstop && old_x_max_endstop && (current_block->steps_x > 0)){
+            if(x_max_endstop && old_x_max_endstop && (current_block->steps[X_AXIS] > 0)){
               endstops_trigsteps[X_AXIS] = count_position[X_AXIS];
               endstop_x_hit=true;
               step_events_completed = current_block->step_event_count;
@@ -433,7 +433,7 @@ ISR(TIMER1_COMPA_vect)
       {
         #if defined(Y_MIN_PIN) && Y_MIN_PIN > -1
           bool y_min_endstop=(READ(Y_MIN_PIN) != Y_MIN_ENDSTOP_INVERTING);
-          if(y_min_endstop && old_y_min_endstop && (current_block->steps_y > 0)) {
+          if(y_min_endstop && old_y_min_endstop && (current_block->steps[Y_AXIS] > 0)) {
             endstops_trigsteps[Y_AXIS] = count_position[Y_AXIS];
             endstop_y_hit=true;
             step_events_completed = current_block->step_event_count;
@@ -447,7 +447,7 @@ ISR(TIMER1_COMPA_vect)
       {
         #if defined(Y_MAX_PIN) && Y_MAX_PIN > -1
           bool y_max_endstop=(READ(Y_MAX_PIN) != Y_MAX_ENDSTOP_INVERTING);
-          if(y_max_endstop && old_y_max_endstop && (current_block->steps_y > 0)){
+          if(y_max_endstop && old_y_max_endstop && (current_block->steps[Y_AXIS] > 0)){
             endstops_trigsteps[Y_AXIS] = count_position[Y_AXIS];
             endstop_y_hit=true;
             step_events_completed = current_block->step_event_count;
@@ -469,7 +469,7 @@ ISR(TIMER1_COMPA_vect)
       {
         #if defined(Z_MIN_PIN) && Z_MIN_PIN > -1
           bool z_min_endstop=(READ(Z_MIN_PIN) != Z_MIN_ENDSTOP_INVERTING);
-          if(z_min_endstop && old_z_min_endstop && (current_block->steps_z > 0)) {
+          if(z_min_endstop && old_z_min_endstop && (current_block->steps[Z_AXIS] > 0)) {
             endstops_trigsteps[Z_AXIS] = count_position[Z_AXIS];
             endstop_z_hit=true;
             step_events_completed = current_block->step_event_count;
@@ -490,7 +490,7 @@ ISR(TIMER1_COMPA_vect)
       {
         #if defined(Z_MAX_PIN) && Z_MAX_PIN > -1
           bool z_max_endstop=(READ(Z_MAX_PIN) != Z_MAX_ENDSTOP_INVERTING);
-          if(z_max_endstop && old_z_max_endstop && (current_block->steps_z > 0)) {
+          if(z_max_endstop && old_z_max_endstop && (current_block->steps[Z_AXIS] > 0)) {
             endstops_trigsteps[Z_AXIS] = count_position[Z_AXIS];
             endstop_z_hit=true;
             step_events_completed = current_block->step_event_count;
@@ -529,7 +529,7 @@ ISR(TIMER1_COMPA_vect)
       MSerial.checkRx(); // Check for serial chars.
       #endif
 
-        counter_x += current_block->steps_x;
+        counter_x += current_block->steps[X_AXIS];
         if (counter_x > 0) {
           WRITE(X_STEP_PIN, !INVERT_X_STEP_PIN);
           counter_x -= current_block->step_event_count;
@@ -537,7 +537,7 @@ ISR(TIMER1_COMPA_vect)
           WRITE(X_STEP_PIN, INVERT_X_STEP_PIN);
         }
 
-        counter_y += current_block->steps_y;
+        counter_y += current_block->steps[Y_AXIS];
         if (counter_y > 0) {
           WRITE(Y_STEP_PIN, !INVERT_Y_STEP_PIN);
 		  
@@ -554,7 +554,7 @@ ISR(TIMER1_COMPA_vect)
 		  #endif
         }
 
-      counter_z += current_block->steps_z;
+      counter_z += current_block->steps[Z_AXIS];
       if (counter_z > 0) {
         WRITE(Z_STEP_PIN, !INVERT_Z_STEP_PIN);
         
@@ -571,7 +571,7 @@ ISR(TIMER1_COMPA_vect)
         #endif
       }
 
-        counter_e += current_block->steps_e;
+        counter_e += current_block->steps[E_AXIS];
         if (counter_e > 0) {
           WRITE_E_STEP(!INVERT_E_STEP_PIN);
           counter_e -= current_block->step_event_count;


### PR DESCRIPTION
As I'm working on integrating improvements to the planner Speed and Jerk code in the main Marlin project (See MarlinFirmware/Marlin#4997), I find it useful to cross-pollinate and bring some of the updates over to this branch, which is my reference.

So this PR's main change is: Apply the acceleration technique adopted into Marlin based on Ultimaker's fork… Optimize the maths to remove most division, using multiplication where possible.

``` cpp
// Compute and limit the acceleration rate for the trapezoid generator.  
// block->step_event_count ... event count of the fastest axis
// block->millimeters ... Euclidian length of the XYZ movement or the E length, if no XYZ movement.
float steps_per_mm = block->step_event_count / block->millimeters;
uint32_t accel = block->acceleration_steps_per_s2;
if (block->steps[X_AXIS] == 0 && block->steps[Y_AXIS] == 0 && block->steps[Z_AXIS] == 0) {
  accel = ceil(retract_acceleration * steps_per_mm); // convert to: acceleration steps/sec^2
}
else {
  // Limit acceleration per axis
  //FIXME Vojtech: One shall rather limit a projection of the acceleration vector instead of using the limit.
  #define LIMIT_ACCEL(AXIS) do{ \
    const uint32_t comp = max_acceleration_steps_per_s2[AXIS] * block->step_event_count; \
    if (accel * block->steps[AXIS] > comp) accel = comp / block->steps[AXIS]; \
  }while(0)
  accel = ceil(acceleration * steps_per_mm); // convert to: acceleration steps/sec^2
  LIMIT_ACCEL(X_AXIS);
  LIMIT_ACCEL(Y_AXIS);
  LIMIT_ACCEL(Z_AXIS);
  LIMIT_ACCEL(E_AXIS);
}
block->acceleration_steps_per_s2 = accel;
// Acceleration of the segment, in mm/sec^2
block->acceleration = accel / steps_per_mm;
```

Additionally:
- Make `steps_x`, `y`, `z`, `e` into an array
- `axis_steps_per_sqr_second` => `max_acceleration_steps_per_s2`
- Add some macros utilized in Marlin 1.1.x
- Adjust spacing and code style, esp. in `planner.cpp`
