### PR TITLE
Resolved bug where live adjusting z height was not saving calibration status

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1266,6 +1266,10 @@ static void _lcd_babystep(int axis, const char *msg)
     EEPROM_save_B(
       (axis == 0) ? EEPROM_BABYSTEP_X : ((axis == 1) ? EEPROM_BABYSTEP_Y : EEPROM_BABYSTEP_Z), 
       &menuData.babyStep.babystepMem[axis]);
+
+    // We need to update our calibration status to calibrated
+    // Previously this was done at the end of lcd_pick_babystep()
+    calibration_status_store(CALIBRATION_STATUS_CALIBRATED);
   }
   if (LCD_CLICKED) lcd_goto_menu(lcd_main_menu);
 }


### PR DESCRIPTION
After spending some time testing diagnosing a problem with the current releases of firmware I noticed that once you exit the menu for live adjusting the z babystep the routine to save the calibration status is never saved. This routine was changed many times since June (IIRC) and migrated away from the function lcd_pick_babystep().

I had noticed that when i powered up my printer it would constantly suggest I ran the V2 calibration script. However I had done this. Due to this issue if you had previously had the status stored as any value other than CALIBRATION_STATUS_CALIBRATED it would ultimately disable babystep_z offset. This has been an on going issue for multiple firmware versions. If you had the value set correctly and updated the firmware your z-offset would continue to work until you had a calibration issue when running the calibration tool. This would change the calibration status in the EEPROM and stick indefinitely unless a user were to force a M87 command via serial.

I have tested this multiple times on my own printer and it has been working perfectly.

There are a number of forum posts with this problem such as:
http://shop.prusa3d.com/forum/prusa-i3-kit-building-calibrating-first-print-main-f6/live-z-adjust-constantly-decreasing-t2118.html