### PR TITLE
Bug: M20 - List SD card

### DIFF
--- a/Firmware/cardreader.cpp
+++ b/Firmware/cardreader.cpp
@@ -81,7 +81,7 @@ void CardReader::lsDive(const char *prepend, SdFile parent, const char * const m
         if(lsAction==LS_SerialPrint)
         {
           SERIAL_ECHO_START;
-          SERIAL_ECHOLN(MSG_SD_CANT_OPEN_SUBDIR);
+          SERIAL_ECHORPGM(MSG_SD_CANT_ENTER_SUBDIR);
           SERIAL_ECHOLN(lfilename);
         }
       }


### PR DESCRIPTION
When the SD card is inserted in a Mac computer some special directory are written. The Prusa firmware is unable to navigate those directories and generates an error sent on the serial line.

The BUG is the instruction SERIAL_ECHOLN it does not work with string pointers and therefore garbage is sent on the serial line.

The proposed correction is to use the right instruction: SERIAL_ECHORPGM that works with string pointers.
I suggest to change also the original error message into MSG_SD_CANT_ENTER_SUBDIR with makes more sense and have semicolon and a space to his end.