### PR TITLE
Fix/implement M110 command. Allow colons in command - don't treat as EOL

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1379,7 +1379,6 @@ void get_command()
         continue;
     if(serial_char == '\n' ||
        serial_char == '\r' ||
-       (serial_char == ':' && comment_mode == false) ||
        serial_count >= (MAX_CMD_SIZE - 1) )
     {
       if(!serial_count) { //if empty line
@@ -1388,7 +1387,6 @@ void get_command()
       }
       cmdbuffer[bufindw+serial_count+1] = 0; //terminate string
       if(!comment_mode){
-        comment_mode = false; //for new command
         if ((strchr_pointer = strstr(cmdbuffer+bufindw+1, "PRUSA")) == NULL && (strchr_pointer = strchr(cmdbuffer+bufindw+1, 'N')) != NULL) {
             if ((strchr_pointer = strchr(cmdbuffer+bufindw+1, 'N')) != NULL)
             {
@@ -4335,6 +4333,12 @@ Sigma_Exit:
           }
         }
       }
+      break;
+    case 110:   // M110 - reset line pos
+      if (code_seen('N'))
+        gcode_LastN = code_value_long();
+      else
+        gcode_LastN = 0;
       break;
     case 115: // M115
       if (code_seen('V')) {

--- a/Firmware/pins.h
+++ b/Firmware/pins.h
@@ -3,20 +3,6 @@
 
 #include "boards.h"
 
-#if !MB(5DPRINT)
-#define X_MS1_PIN -1
-#define X_MS2_PIN -1
-#define Y_MS1_PIN -1
-#define Y_MS2_PIN -1
-#define Z_MS1_PIN -1
-#define Z_MS2_PIN -1
-#define E0_MS1_PIN -1
-#define E0_MS2_PIN -1
-#define E1_MS1_PIN -1
-#define E1_MS2_PIN -1
-#define DIGIPOTSS_PIN -1
-#endif
-
 #define LARGE_FLASH true
 
 /*****************************************************************


### PR DESCRIPTION
Here's a couple of minor items affecting operation and building. The redundant definitions in **pins.h** are the cause of about 20% of the compiler warings.

- [Fixed] M110 commands return error: 'Invalid M code'
- [Fixed] Allow colon in commands. I believe them to be allowed and not to be treated as end-of-line. Try sending "M117 July 1,2017 14:30" and watch your print die. ref: Marlin FW.
- [Fixed] Multiple redundant pin definitions (removed unused rather than fixing conditionals) 