### PR TITLE
Changing baud rate from 115200 to 250000

### DIFF
--- a/Firmware/Configuration.h
+++ b/Firmware/Configuration.h
@@ -80,7 +80,7 @@
 #define SERIAL_PORT 0
 
 // This determines the communication speed of the printer
-#define BAUDRATE 115200
+#define BAUDRATE 250000
 
 // This enables the serial port associated to the Bluetooth interface
 //#define BTENABLED              // Enable BT interface on AT90USB devices

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -2173,7 +2173,7 @@ void process_commands()
         return;
     } else if (code_seen("SERIAL HIGH")) {
         MYSERIAL.println("SERIAL HIGH");
-        MYSERIAL.begin(1152000);
+        MYSERIAL.begin(250000);
         return;
     } else if(code_seen("Beat")) {
         // Kick farm link timer


### PR DESCRIPTION
I use sometimes Octoprint to transfer files to the SD card and having baud rate set to 250000 helps bit...still slow but much better than 115200. Never had any issues with that baud rate and i am using it quite a long time.

Check for more info http://shop.prusa3d.com/forum/original-prusa-i3-mk2-f23/can-octoprint-connect-to-mk2-at-250k-baud-rate--t2026.html#p22216