### PR TITLE
Put space between filename and size (fix M20 / lsDive)

### DIFF
--- a/Firmware/cardreader.cpp
+++ b/Firmware/cardreader.cpp
@@ -127,8 +127,12 @@ void CardReader::lsDive(const char *prepend, SdFile parent, const char * const m
 			case LS_SerialPrint:
 				createFilename(filename, p);
 				SERIAL_PROTOCOL(prepend);
-				SERIAL_PROTOCOL(filename);
-				//SERIAL_PROTOCOLCHAR(' ');
+				if (longFilename[0] != 0) {
+					SERIAL_PROTOCOL(longFilename);
+				} else {
+					SERIAL_PROTOCOL(filename);
+				}
+				MYSERIAL.write(' ');
 				SERIAL_PROTOCOLLN(p.fileSize);
 				break;
 


### PR DESCRIPTION
Recent revision broke M20 file lists.

