### PR TITLE
LIN_ADVANCE: high e_steps value error fixed

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -5764,7 +5764,9 @@ case 404:  //M404 Enter the nominal filament width (3mm, 1.75mm ) N<3.0> or disp
 
   else if(code_seen('T'))
   {
+	#ifdef SNMM
 	  int index;
+	  st_synchronize();
 	  for (index = 1; *(strchr_pointer + index) == ' ' || *(strchr_pointer + index) == '\t'; index++);
 	   
 	  if ((*(strchr_pointer + index) < '0' || *(strchr_pointer + index) > '9') && *(strchr_pointer + index) != '?') {
@@ -5778,7 +5780,6 @@ case 404:  //M404 Enter the nominal filament width (3mm, 1.75mm ) N<3.0> or disp
 			  tmp_extruder = code_value();
 		  }
 		  snmm_filaments_used |= (1 << tmp_extruder); //for stop print
-#ifdef SNMM
       #ifdef LIN_ADVANCE
         if (snmm_extruder != tmp_extruder)
           clear_current_adv_vars(); //Check if the selected extruder is not the active one and reset LIN_ADVANCE variables if so.
@@ -5786,7 +5787,6 @@ case 404:  //M404 Enter the nominal filament width (3mm, 1.75mm ) N<3.0> or disp
       
       snmm_extruder = tmp_extruder;
 
-		  st_synchronize();
 		  delay(100);
 
 		  disable_e0();

--- a/Firmware/planner.cpp
+++ b/Firmware/planner.cpp
@@ -1288,6 +1288,9 @@ void plan_set_position(float x, float y, float z, const float &e)
 // Only useful in the bed leveling routine, when the mesh bed leveling is off.
 void plan_set_z_position(const float &z)
 {
+    #ifdef LIN_ADVANCE
+	position_float[Z_AXIS] = z;
+    #endif
     position[Z_AXIS] = lround(z*axis_steps_per_unit[Z_AXIS]);
     st_set_position(position[X_AXIS], position[Y_AXIS], position[Z_AXIS], position[E_AXIS]);
 }

--- a/Firmware/planner.cpp
+++ b/Firmware/planner.cpp
@@ -1294,6 +1294,9 @@ void plan_set_z_position(const float &z)
 
 void plan_set_e_position(const float &e)
 {
+  #ifdef LIN_ADVANCE
+  position_float[E_AXIS] = e;
+  #endif
   position[E_AXIS] = lround(e*axis_steps_per_unit[E_AXIS]);  
   st_set_e_position(position[E_AXIS]);
 }

--- a/Firmware/stepper.cpp
+++ b/Firmware/stepper.cpp
@@ -735,7 +735,7 @@ void isr() {
 
   void advance_isr() {
 
-    nextAdvanceISR = eISR_Rate;
+	nextAdvanceISR = eISR_Rate;
 
     if (e_steps) {
       bool dir =
@@ -752,7 +752,10 @@ void isr() {
         e_steps < 0 ? ++e_steps : --e_steps;
         WRITE(E0_STEP_PIN, INVERT_E_STEP_PIN);
       }
-    }
+	}
+	else if(eISR_Rate == 0) {
+	  nextAdvanceISR = ADV_NEVER;
+	}
   }
 
   void advance_isr_scheduler() {
@@ -782,7 +785,7 @@ void isr() {
     }
 
     // Don't run the ISR faster than possible
-    if (OCR1A < TCNT1 + 16) OCR1A = TCNT1 + 16;
+	if (OCR1A < TCNT1 + 16) OCR1A = TCNT1 + 16;
   }
   
   void clear_current_adv_vars() {

--- a/Firmware/stepper.cpp
+++ b/Firmware/stepper.cpp
@@ -735,8 +735,6 @@ void isr() {
 
   void advance_isr() {
 
-    nextAdvanceISR = eISR_Rate;
-
     if (e_steps) {
       bool dir =
       #ifdef SNMM
@@ -753,9 +751,10 @@ void isr() {
         WRITE(E0_STEP_PIN, INVERT_E_STEP_PIN);
       }
 	}
-	else if(eISR_Rate == 0) {
-	  nextAdvanceISR = ADV_NEVER;
+	else{
+		eISR_Rate = ADV_NEVER;
 	}
+	nextAdvanceISR = eISR_Rate;
   }
 
   void advance_isr_scheduler() {

--- a/Firmware/stepper.cpp
+++ b/Firmware/stepper.cpp
@@ -735,7 +735,7 @@ void isr() {
 
   void advance_isr() {
 
-	nextAdvanceISR = eISR_Rate;
+    nextAdvanceISR = eISR_Rate;
 
     if (e_steps) {
       bool dir =
@@ -785,7 +785,7 @@ void isr() {
     }
 
     // Don't run the ISR faster than possible
-	if (OCR1A < TCNT1 + 16) OCR1A = TCNT1 + 16;
+    if (OCR1A < TCNT1 + 16) OCR1A = TCNT1 + 16;
   }
   
   void clear_current_adv_vars() {


### PR DESCRIPTION
When using colorprint (M600) during multi material print it sometimes happened that right after M600 procedure, printer stopped working and also teperature regulation didn't work.
Reason was that in the end of M600 procedure, there is plan_set_e_position() function used, but inside this function, there was `position_float[E_AXIS] = e;` missing. This leaded to high e_steps value and thus eISR_Rate was set to zero value inside isr() function.
This leaded to extremly short TIMER1_COMPA_vect interrupt time where only advance_isr() (not isr()) was executed and eISR_Rate and nextAdvanceISR were never updated so it was stucked in loop.
TIMER0_COMPB_vect interrupt which serves for heater regulation (!) was blocked by this, because of lower priority.
There should be probably some low limit set for counting eISR_Rate/interrupt time.
I have updated advance_isr() function by setting nextAdvanceISR value to ADV_NEVER after all e_steps are executed.
Could you please look on this PR @Sebastianv650? It may also relate to: https://github.com/prusa3d/Prusa-Firmware/issues/234 .