### PR TITLE
SNMM: Dont use different verbosity levels in xyz/z cal. and mesh bed leveling

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3365,9 +3365,11 @@ void process_commands()
 		current_position[Y_AXIS] = pgm_read_float(bed_ref_points + 1);
 		bool clamped = world2machine_clamp(current_position[X_AXIS], current_position[Y_AXIS]);
 
+		#ifdef SUPPORT_VERBOSITY
 		if (verbosity_level >= 1) {
 			clamped ? SERIAL_PROTOCOLPGM("First calibration point clamped.\n") : SERIAL_PROTOCOLPGM("No clamping for first calibration point.\n");
 		}
+		#endif // SUPPORT_VERBOSITY
 		//            mbl.get_meas_xy(0, 0, current_position[X_AXIS], current_position[Y_AXIS], false);            
 		plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], homing_feedrate[X_AXIS] / 30, active_extruder);
 		// Wait until the move is finished.
@@ -3381,13 +3383,17 @@ void process_commands()
 		int XY_AXIS_FEEDRATE = homing_feedrate[X_AXIS] / 20;
 		int Z_LIFT_FEEDRATE = homing_feedrate[Z_AXIS] / 40;
 		bool has_z = is_bed_z_jitter_data_valid(); //checks if we have data from Z calibration (offsets of the Z heiths of the 8 calibration points from the first point)
+		#ifdef SUPPORT_VERBOSITY
 		if (verbosity_level >= 1) {
 			has_z ? SERIAL_PROTOCOLPGM("Z jitter data from Z cal. valid.\n") : SERIAL_PROTOCOLPGM("Z jitter data from Z cal. not valid.\n");
 		}
+		#endif // SUPPORT_VERBOSITY
 		setup_for_endstop_move(false); //save feedrate and feedmultiply, sets feedmultiply to 100
 		const char *kill_message = NULL;
 		while (mesh_point != MESH_MEAS_NUM_X_POINTS * MESH_MEAS_NUM_Y_POINTS) {
+			#ifdef SUPPORT_VERBOSITY
 			if (verbosity_level >= 1) SERIAL_ECHOLNPGM("");
+			#endif // SUPPORT_VERBOSITY
 			// Get coords of a measuring point.
 			ix = mesh_point % MESH_MEAS_NUM_X_POINTS; // from 0 to MESH_NUM_X_POINTS - 1
 			iy = mesh_point / MESH_MEAS_NUM_X_POINTS;
@@ -3396,7 +3402,7 @@ void process_commands()
 			if (has_z && mesh_point > 0) {
 				uint16_t z_offset_u = eeprom_read_word((uint16_t*)(EEPROM_BED_CALIBRATION_Z_JITTER + 2 * (ix + iy * 3 - 1)));
 				z0 = mbl.z_values[0][0] + *reinterpret_cast<int16_t*>(&z_offset_u) * 0.01;
-				//#if 0
+				#ifdef SUPPORT_VERBOSITY
 				if (verbosity_level >= 1) {
 					SERIAL_ECHOPGM("Bed leveling, point: ");
 					MYSERIAL.print(mesh_point);
@@ -3404,7 +3410,7 @@ void process_commands()
 					MYSERIAL.print(z0, 5);
 					SERIAL_ECHOLNPGM("");
 				}
-				//#endif
+				#endif // SUPPORT_VERBOSITY
 			}
 
 			// Move Z up to MESH_HOME_Z_SEARCH.
@@ -3419,11 +3425,13 @@ void process_commands()
 
 
 			world2machine_clamp(current_position[X_AXIS], current_position[Y_AXIS]);
+			#ifdef SUPPORT_VERBOSITY
 			if (verbosity_level >= 1) {
 
 				SERIAL_PROTOCOL(mesh_point);
 				clamped ? SERIAL_PROTOCOLPGM(": xy clamped.\n") : SERIAL_PROTOCOLPGM(": no xy clamping\n");
 			}
+			#endif // SUPPORT_VERBOSITY
 
 
 			plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], XY_AXIS_FEEDRATE, active_extruder);
@@ -3443,7 +3451,7 @@ void process_commands()
 				kill_message = MSG_BED_LEVELING_FAILED_POINT_HIGH;
 				break;
 			}
-
+			#ifdef SUPPORT_VERBOSITY
 			if (verbosity_level >= 10) {
 				SERIAL_ECHOPGM("X: ");
 				MYSERIAL.print(current_position[X_AXIS], 5);
@@ -3452,24 +3460,26 @@ void process_commands()
 				MYSERIAL.print(current_position[Y_AXIS], 5);
 				SERIAL_PROTOCOLPGM("\n");
 			}
-
 			if (verbosity_level >= 1) {
 				SERIAL_ECHOPGM("mesh bed leveling: ");
 				MYSERIAL.print(current_position[Z_AXIS], 5);
 				SERIAL_ECHOLNPGM("");
 			}
+			#endif // SUPPORT_VERBOSITY
 			mbl.set_z(ix, iy, current_position[Z_AXIS]); //store measured z values z_values[iy][ix] = z;
 
 			custom_message_state--;
 			mesh_point++;
 			lcd_update(1);
 		}
-		if (verbosity_level >= 20) SERIAL_ECHOLNPGM("Mesh bed leveling while loop finished.");
 		current_position[Z_AXIS] = MESH_HOME_Z_SEARCH;
+		#ifdef SUPPORT_VERBOSITY
 		if (verbosity_level >= 20) {
+			SERIAL_ECHOLNPGM("Mesh bed leveling while loop finished.");
 			SERIAL_ECHOLNPGM("MESH_HOME_Z_SEARCH: ");
 			MYSERIAL.print(current_position[Z_AXIS], 5);
 		}
+		#endif // SUPPORT_VERBOSITY
 		plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], Z_LIFT_FEEDRATE, active_extruder);
 		st_synchronize();
 		if (mesh_point != MESH_MEAS_NUM_X_POINTS * MESH_MEAS_NUM_Y_POINTS) {
@@ -3483,9 +3493,11 @@ void process_commands()
 		SERIAL_ECHOLNPGM("babystep applied");
 		bool eeprom_bed_correction_valid = eeprom_read_byte((unsigned char*)EEPROM_BED_CORRECTION_VALID) == 1;
 
+		#ifdef SUPPORT_VERBOSITY
 		if (verbosity_level >= 1) {
 			eeprom_bed_correction_valid ? SERIAL_PROTOCOLPGM("Bed correction data valid\n") : SERIAL_PROTOCOLPGM("Bed correction data not valid\n");
 		}
+		#endif // SUPPORT_VERBOSITY
 
 		for (uint8_t i = 0; i < 4; ++i) {
 			unsigned char codes[4] = { 'L', 'R', 'F', 'B' };

--- a/Firmware/mesh_bed_calibration.cpp
+++ b/Firmware/mesh_bed_calibration.cpp
@@ -144,6 +144,7 @@ BedSkewOffsetDetectionResultType calculate_machine_skew_and_offset_LS(
     )
 {
 	float angleDiff;
+	#ifdef SUPPORT_VERBOSITY
     if (verbosity_level >= 10) {
 		SERIAL_ECHOLNPGM("calculate machine skew and offset LS");
 
@@ -185,6 +186,7 @@ BedSkewOffsetDetectionResultType calculate_machine_skew_and_offset_LS(
         }
         delay_keep_alive(100);
     }
+	#endif // SUPPORT_VERBOSITY
 
     // Run some iterations of the Gauss-Newton method of non-linear least squares.
     // Initial set of parameters:
@@ -284,7 +286,7 @@ BedSkewOffsetDetectionResultType calculate_machine_skew_and_offset_LS(
         cntr[1] += h[1];
         a1 += h[2];
         a2 += h[3];
-
+		#ifdef SUPPORT_VERBOSITY
         if (verbosity_level >= 20) {
             SERIAL_ECHOPGM("iteration: ");
             MYSERIAL.print(int(iter));
@@ -308,6 +310,7 @@ BedSkewOffsetDetectionResultType calculate_machine_skew_and_offset_LS(
             MYSERIAL.print(180.f * a2 / M_PI, 5);
             SERIAL_ECHOLNPGM("");
         }
+		#endif // SUPPORT_VERBOSITY
     }
 
     vec_x[0] =  cos(a1) * MACHINE_AXIS_SCALE_X;
@@ -328,7 +331,7 @@ BedSkewOffsetDetectionResultType calculate_machine_skew_and_offset_LS(
             fabs(a2) > bed_skew_angle_extreme)
             result = BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME;
     }
-
+	#ifdef SUPPORT_VERBOSITY
     if (verbosity_level >= 1) {
         SERIAL_ECHOPGM("correction angles: ");
         MYSERIAL.print(180.f * a1 / M_PI, 5);
@@ -360,6 +363,7 @@ BedSkewOffsetDetectionResultType calculate_machine_skew_and_offset_LS(
 
         SERIAL_ECHOLNPGM("Error after correction: ");
     }
+	#endif // SUPPORT_VERBOSITY
 
     // Measure the error after correction.
     for (uint8_t i = 0; i < npts; ++i) {
@@ -368,33 +372,44 @@ BedSkewOffsetDetectionResultType calculate_machine_skew_and_offset_LS(
         float errX = sqr(pgm_read_float(true_pts + i * 2) - x);
         float errY = sqr(pgm_read_float(true_pts + i * 2 + 1) - y);
         float err = sqrt(errX + errY);
+		#ifdef SUPPORT_VERBOSITY
 		if (verbosity_level >= 10) {
 			SERIAL_ECHOPGM("point #");
 			MYSERIAL.print(int(i));
 			SERIAL_ECHOLNPGM(":");
 		}
+		#endif // SUPPORT_VERBOSITY
 
 		if (point_on_1st_row(i, npts)) {
-				if(verbosity_level >= 20) SERIAL_ECHOPGM("Point on first row");
+				#ifdef SUPPORT_VERBOSITY
+				if (verbosity_level >= 20) SERIAL_ECHOPGM("Point on first row");
+				#endif // SUPPORT_VERBOSITY
 				float w = point_weight_y(i, npts, measured_pts[2 * i + 1]);
 				if (sqrt(errX) > BED_CALIBRATION_POINT_OFFSET_MAX_1ST_ROW_X ||
 					(w != 0.f && sqrt(errY) > BED_CALIBRATION_POINT_OFFSET_MAX_1ST_ROW_Y)) {
 					result = BED_SKEW_OFFSET_DETECTION_FITTING_FAILED;
+					#ifdef SUPPORT_VERBOSITY
 					if (verbosity_level >= 20) {
 						SERIAL_ECHOPGM(", weigth Y: ");
 						MYSERIAL.print(w);
 						if (sqrt(errX) > BED_CALIBRATION_POINT_OFFSET_MAX_1ST_ROW_X) SERIAL_ECHOPGM(", error X > max. error X");
 						if (w != 0.f && sqrt(errY) > BED_CALIBRATION_POINT_OFFSET_MAX_1ST_ROW_Y) SERIAL_ECHOPGM(", error Y > max. error Y");
 					}
+					#endif // SUPPORT_VERBOSITY
 				}
 		}
 		else {
-			if(verbosity_level >=20 ) SERIAL_ECHOPGM("Point not on first row");
+			#ifdef SUPPORT_VERBOSITY
+			if (verbosity_level >=20 ) SERIAL_ECHOPGM("Point not on first row");
+			#endif // SUPPORT_VERBOSITY
 			if (err > BED_CALIBRATION_POINT_OFFSET_MAX_EUCLIDIAN) {
 				result = BED_SKEW_OFFSET_DETECTION_FITTING_FAILED;
-				if(verbosity_level >= 20) SERIAL_ECHOPGM(", error > max. error euclidian"); 
+				#ifdef SUPPORT_VERBOSITY
+				if (verbosity_level >= 20) SERIAL_ECHOPGM(", error > max. error euclidian");
+				#endif // SUPPORT_VERBOSITY
 			}
         }
+		#ifdef SUPPORT_VERBOSITY
         if (verbosity_level >= 10) {
 			SERIAL_ECHOLNPGM("");
             SERIAL_ECHOPGM("measured: (");
@@ -419,7 +434,9 @@ BedSkewOffsetDetectionResultType calculate_machine_skew_and_offset_LS(
 			SERIAL_ECHOLNPGM("");
 			SERIAL_ECHOLNPGM("");
         }
+		#endif // SUPPORT_VERBOSITY
     }
+	#ifdef SUPPORT_VERBOSITY
 	if (verbosity_level >= 20) {
 		SERIAL_ECHOLNPGM("Max. errors:");
 		SERIAL_ECHOPGM("Max. error X:");
@@ -430,6 +447,7 @@ BedSkewOffsetDetectionResultType calculate_machine_skew_and_offset_LS(
 		MYSERIAL.println(BED_CALIBRATION_POINT_OFFSET_MAX_EUCLIDIAN);
 		SERIAL_ECHOLNPGM("");
 	}
+	#endif // SUPPORT_VERBOSITY
 
     #if 0
     if (result == BED_SKEW_OFFSET_DETECTION_PERFECT && fabs(a1) < bed_skew_angle_mild && fabs(a2) < bed_skew_angle_mild) {
@@ -443,9 +461,11 @@ BedSkewOffsetDetectionResultType calculate_machine_skew_and_offset_LS(
     }
     #else
     if (result == BED_SKEW_OFFSET_DETECTION_PERFECT) {
+		#ifdef SUPPORT_VERBOSITY
         if (verbosity_level > 0)
             SERIAL_ECHOLNPGM("Very little skew detected. Orthogonalizing the axes.");
-        // Orthogonalize the axes.
+		#endif // SUPPORT_VERBOSITY
+		// Orthogonalize the axes.
         a1 = 0.5f * (a1 + a2);
         vec_x[0] =  cos(a1) * MACHINE_AXIS_SCALE_X;
         vec_x[1] =  sin(a1) * MACHINE_AXIS_SCALE_X;
@@ -462,6 +482,7 @@ BedSkewOffsetDetectionResultType calculate_machine_skew_and_offset_LS(
             float w = point_weight_x(i, npts, y);
 			cntr[0] += w * (pgm_read_float(true_pts + i * 2) - x);
 			wx += w;
+			#ifdef SUPPORT_VERBOSITY
 			if (verbosity_level >= 20) {
 				MYSERIAL.print(i);
 				SERIAL_ECHOLNPGM("");
@@ -474,10 +495,12 @@ BedSkewOffsetDetectionResultType calculate_machine_skew_and_offset_LS(
 				SERIAL_ECHOLNPGM("wx:");
 				MYSERIAL.print(wx);
 			}
+			#endif // SUPPORT_VERBOSITY
             w = point_weight_y(i, npts, y);
 			cntr[1] += w * (pgm_read_float(true_pts + i * 2 + 1) - y);
 			wy += w;
 
+			#ifdef SUPPORT_VERBOSITY
 			if (verbosity_level >= 20) {
 				SERIAL_ECHOLNPGM("");
 				SERIAL_ECHOLNPGM("Weight_y:");
@@ -491,9 +514,11 @@ BedSkewOffsetDetectionResultType calculate_machine_skew_and_offset_LS(
 				SERIAL_ECHOLNPGM("");
 				SERIAL_ECHOLNPGM("");
 			}
+			#endif // SUPPORT_VERBOSITY
 		}
         cntr[0] /= wx;
         cntr[1] /= wy;
+		#ifdef SUPPORT_VERBOSITY
 		if (verbosity_level >= 20) {
 			SERIAL_ECHOLNPGM("");
 			SERIAL_ECHOLNPGM("Final cntr values:");
@@ -504,6 +529,7 @@ BedSkewOffsetDetectionResultType calculate_machine_skew_and_offset_LS(
 			MYSERIAL.print(cntr[1]);
 			SERIAL_ECHOLNPGM("");
 		}
+		#endif // SUPPORT_VERBOSITY
 
     }
     #endif
@@ -527,7 +553,8 @@ BedSkewOffsetDetectionResultType calculate_machine_skew_and_offset_LS(
         cntr[1] = cntrInv[1];
     }
 
-    if (verbosity_level >= 1) {
+	#ifdef SUPPORT_VERBOSITY
+	if (verbosity_level >= 1) {
         // Show the adjusted state, before the fitting.
         SERIAL_ECHOPGM("X vector, adjusted: ");
         MYSERIAL.print(vec_x[0], 5);
@@ -581,6 +608,7 @@ BedSkewOffsetDetectionResultType calculate_machine_skew_and_offset_LS(
 		}
         delay_keep_alive(100);
     }
+	#endif // SUPPORT_VERBOSITY
 
     return result;
 }
@@ -793,8 +821,10 @@ static inline void update_current_position_z()
 // At the current position, find the Z stop.
 inline bool find_bed_induction_sensor_point_z(float minimum_z, uint8_t n_iter, int verbosity_level)
 {
+	#ifdef SUPPORT_VERBOSITY
     if(verbosity_level >= 10) SERIAL_ECHOLNPGM("find bed induction sensor point z");
-    bool endstops_enabled  = enable_endstops(true);
+	#endif // SUPPORT_VERBOSITY
+	bool endstops_enabled  = enable_endstops(true);
     bool endstop_z_enabled = enable_z_endstop(false);
     float z = 0.f;
     endstop_z_hit_on_purpose();
@@ -848,8 +878,10 @@ error:
 #define FIND_BED_INDUCTION_SENSOR_POINT_Z_STEP   (0.2f)
 inline bool find_bed_induction_sensor_point_xy(int verbosity_level)
 {
-	if(verbosity_level >= 10) MYSERIAL.println("find bed induction sensor point xy");
-    float feedrate = homing_feedrate[X_AXIS] / 60.f;
+	#ifdef SUPPORT_VERBOSITY
+	if (verbosity_level >= 10) MYSERIAL.println("find bed induction sensor point xy");
+	#endif // SUPPORT_VERBOSITY
+	float feedrate = homing_feedrate[X_AXIS] / 60.f;
     bool found = false;
 
     {
@@ -861,19 +893,27 @@ inline bool find_bed_induction_sensor_point_xy(int verbosity_level)
         uint8_t i;
 		if (x0 < X_MIN_POS) {
 			x0 = X_MIN_POS;
+			#ifdef SUPPORT_VERBOSITY
 			if (verbosity_level >= 20) SERIAL_ECHOLNPGM("X searching radius lower than X_MIN. Clamping was done.");
+			#endif // SUPPORT_VERBOSITY
 		}
 		if (x1 > X_MAX_POS) {
 			x1 = X_MAX_POS;
+			#ifdef SUPPORT_VERBOSITY
 			if (verbosity_level >= 20) SERIAL_ECHOLNPGM("X searching radius higher than X_MAX. Clamping was done.");
+			#endif // SUPPORT_VERBOSITY
 		}
 		if (y0 < Y_MIN_POS_FOR_BED_CALIBRATION) {
 			y0 = Y_MIN_POS_FOR_BED_CALIBRATION;
+			#ifdef SUPPORT_VERBOSITY
 			if (verbosity_level >= 20) SERIAL_ECHOLNPGM("Y searching radius lower than Y_MIN. Clamping was done.");
+			#endif // SUPPORT_VERBOSITY
 		}
 		if (y1 > Y_MAX_POS) {
 			y1 = Y_MAX_POS;
+			#ifdef SUPPORT_VERBOSITY
 			if (verbosity_level >= 20) SERIAL_ECHOLNPGM("Y searching radius higher than X_MAX. Clamping was done.");
+			#endif // SUPPORT_VERBOSITY
 		}
         nsteps_y = int(ceil((y1 - y0) / FIND_BED_INDUCTION_SENSOR_POINT_XY_STEP));
 
@@ -1178,11 +1218,13 @@ inline bool improve_bed_induction_sensor_point2(bool lift_z_on_min_y, int8_t ver
         }
         b = current_position[X_AXIS];
         if (b - a < MIN_BED_SENSOR_POINT_RESPONSE_DMR) {
-            if (verbosity_level >= 5) {
+			#ifdef SUPPORT_VERBOSITY
+			if (verbosity_level >= 5) {
                 SERIAL_ECHOPGM("Point width too small: ");
                 SERIAL_ECHO(b - a);
                 SERIAL_ECHOLNPGM("");
             }
+			#endif // SUPPORT_VERBOSITY
             // We force the calibration routine to move the Z axis slightly down to make the response more pronounced.
             if (b - a < 0.5f * MIN_BED_SENSOR_POINT_RESPONSE_DMR) {
                 // Don't use the new X value.
@@ -1193,10 +1235,12 @@ inline bool improve_bed_induction_sensor_point2(bool lift_z_on_min_y, int8_t ver
                 point_small = true;
             }
         }
+		#ifdef SUPPORT_VERBOSITY
         if (verbosity_level >= 5) {
             debug_output_point(PSTR("left" ), a, current_position[Y_AXIS], current_position[Z_AXIS]);
             debug_output_point(PSTR("right"), b, current_position[Y_AXIS], current_position[Z_AXIS]);
         }
+		#endif // SUPPORT_VERBOSITY
 
         // Go to the center.
         enable_z_endstop(false);
@@ -1249,11 +1293,13 @@ inline bool improve_bed_induction_sensor_point2(bool lift_z_on_min_y, int8_t ver
         b = current_position[Y_AXIS];
         if (b - a < MIN_BED_SENSOR_POINT_RESPONSE_DMR) {
             // We force the calibration routine to move the Z axis slightly down to make the response more pronounced.
-            if (verbosity_level >= 5) {
+			#ifdef SUPPORT_VERBOSITY
+			if (verbosity_level >= 5) {
                 SERIAL_ECHOPGM("Point height too small: ");
                 SERIAL_ECHO(b - a);
                 SERIAL_ECHOLNPGM("");
             }
+			#endif // SUPPORT_VERBOSITY
             if (b - a < 0.5f * MIN_BED_SENSOR_POINT_RESPONSE_DMR) {
                 // Don't use the new Y value.
                 current_position[Y_AXIS] = center_old_y;
@@ -1263,10 +1309,12 @@ inline bool improve_bed_induction_sensor_point2(bool lift_z_on_min_y, int8_t ver
                 point_small = true;
             }
         }
+		#ifdef SUPPORT_VERBOSITY
         if (verbosity_level >= 5) {
             debug_output_point(PSTR("top" ), current_position[X_AXIS], a, current_position[Z_AXIS]);
             debug_output_point(PSTR("bottom"), current_position[X_AXIS], b, current_position[Z_AXIS]);
         }
+		#endif // SUPPORT_VERBOSITY
 
         // Go to the center.
         enable_z_endstop(false);
@@ -1300,8 +1348,10 @@ inline bool improve_bed_induction_sensor_point3(int verbosity_level)
     float a, b;
     bool  result = true;
 
+	#ifdef SUPPORT_VERBOSITY
 	if (verbosity_level >= 20) MYSERIAL.println("Improve bed induction sensor point3");
-    // Was the sensor point detected too far in the minus Y axis?
+	#endif  // SUPPORT_VERBOSITY
+	// Was the sensor point detected too far in the minus Y axis?
     // If yes, the center of the induction point cannot be reached by the machine.
     {
         float x0 = center_old_x - IMPROVE_BED_INDUCTION_SENSOR_POINT3_SEARCH_RADIUS;
@@ -1319,6 +1369,7 @@ inline bool improve_bed_induction_sensor_point3(int verbosity_level)
         if (y1 > Y_MAX_POS)
             y1 = Y_MAX_POS;
 
+		#ifdef SUPPORT_VERBOSITY
         if (verbosity_level >= 20) {
             SERIAL_ECHOPGM("Initial position: ");
             SERIAL_ECHO(center_old_x);
@@ -1326,7 +1377,7 @@ inline bool improve_bed_induction_sensor_point3(int verbosity_level)
             SERIAL_ECHO(center_old_y);
             SERIAL_ECHOLNPGM("");
         }
-
+		#endif // SUPPORT_VERBOSITY
         // Search in the positive Y direction, until a maximum diameter is found.
         // (the next diameter is smaller than the current one.)
         float dmax = 0.f;
@@ -1357,10 +1408,12 @@ inline bool improve_bed_induction_sensor_point3(int verbosity_level)
                 // goto canceled;
             }
             b = current_position[X_AXIS];
+			#ifdef SUPPORT_VERBOSITY
             if (verbosity_level >= 5) {
                 debug_output_point(PSTR("left" ), a, current_position[Y_AXIS], current_position[Z_AXIS]);
                 debug_output_point(PSTR("right"), b, current_position[Y_AXIS], current_position[Z_AXIS]);
             }
+			#endif  // SUPPORT_VERBOSITY
             float d = b - a;
             if (d > dmax) {
                 xmax1 = 0.5f * (a + b);
@@ -1371,8 +1424,10 @@ inline bool improve_bed_induction_sensor_point3(int verbosity_level)
             }
         }
         if (dmax == 0.) {
+			#ifdef SUPPORT_VERBOSITY
             if (verbosity_level > 0)
                 SERIAL_PROTOCOLPGM("failed - not found\n");
+			#endif // SUPPORT_VERBOSITY
             current_position[X_AXIS] = center_old_x;
             current_position[Y_AXIS] = center_old_y;
             goto canceled;
@@ -1389,9 +1444,11 @@ inline bool improve_bed_induction_sensor_point3(int verbosity_level)
                 current_position[Y_AXIS] = center_old_y;
                 goto canceled;
             }
+			#ifdef SUPPORT_VERBOSITY
             if (verbosity_level >= 5)
                 debug_output_point(PSTR("top" ), current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS]);
-            y1 = current_position[Y_AXIS];
+			#endif // SUPPORT_VERBOSITY
+			y1 = current_position[Y_AXIS];
         }
 
         if (y1 <= y0) {
@@ -1433,10 +1490,12 @@ inline bool improve_bed_induction_sensor_point3(int verbosity_level)
                 */
             }
             b = current_position[X_AXIS];
+			#ifdef SUPPORT_VERBOSITY
             if (verbosity_level >= 5) {
                 debug_output_point(PSTR("left" ), a, current_position[Y_AXIS], current_position[Z_AXIS]);
                 debug_output_point(PSTR("right"), b, current_position[Y_AXIS], current_position[Z_AXIS]);
             }
+			#endif // SUPPORT_VERBOSITY
             float d = b - a;
             if (d > dmax) {
                 xmax2 = 0.5f * (a + b);
@@ -1484,10 +1543,12 @@ inline bool improve_bed_induction_sensor_point3(int verbosity_level)
                     */
                 }
                 b = current_position[X_AXIS];
+				#ifdef SUPPORT_VERBOSITY
                 if (verbosity_level >= 5) {
                     debug_output_point(PSTR("left" ), a, current_position[Y_AXIS], current_position[Z_AXIS]);
                     debug_output_point(PSTR("right"), b, current_position[Y_AXIS], current_position[Z_AXIS]);
                 }
+				#endif // SUPPORT_VERBOSITY
                 float d = b - a;
                 if (d > dmax) {
                     xmax = 0.5f * (a + b);
@@ -1509,24 +1570,29 @@ inline bool improve_bed_induction_sensor_point3(int verbosity_level)
                 current_position[Y_AXIS] = center_old_y;
                 goto canceled;
             }
+			#ifdef SUPPORT_VERBOSITY
             if (verbosity_level >= 5)
                 debug_output_point(PSTR("top" ), current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS]);
-            if (current_position[Y_AXIS] - Y_MIN_POS_FOR_BED_CALIBRATION < 0.5f * dmax) {
+			#endif // SUPPORT_VERBOSITY
+			if (current_position[Y_AXIS] - Y_MIN_POS_FOR_BED_CALIBRATION < 0.5f * dmax) {
                 // Probably not even a half circle was detected. The induction point is likely too far in the minus Y direction.
                 // First verify, if the measurement has been done at a sufficient height. If no, lower the Z axis a bit.
                 if (current_position[Y_AXIS] < ymax || dmax < 0.5f * MIN_BED_SENSOR_POINT_RESPONSE_DMR) {
-                    if (verbosity_level >= 5) {
+					#ifdef SUPPORT_VERBOSITY
+					if (verbosity_level >= 5) {
                         SERIAL_ECHOPGM("Partial point diameter too small: ");
                         SERIAL_ECHO(dmax);
                         SERIAL_ECHOLNPGM("");
                     }
+					#endif // SUPPORT_VERBOSITY
                     result = false;
                 } else {
                     // Estimate the circle radius from the maximum diameter and height:
                     float h = current_position[Y_AXIS] - ymax;
                     float r = dmax * dmax / (8.f * h) + 0.5f * h;
                     if (r < 0.8f * MIN_BED_SENSOR_POINT_RESPONSE_DMR) {
-                        if (verbosity_level >= 5) {
+						#ifdef SUPPORT_VERBOSITY
+						if (verbosity_level >= 5) {
                             SERIAL_ECHOPGM("Partial point estimated radius too small: ");
                             SERIAL_ECHO(r);
                             SERIAL_ECHOPGM(", dmax:");
@@ -1535,6 +1601,7 @@ inline bool improve_bed_induction_sensor_point3(int verbosity_level)
                             SERIAL_ECHO(h);
                             SERIAL_ECHOLNPGM("");
                         }
+						#endif // SUPPORT_VERBOSITY
                         result = false;
                     } else {
                         // The point may end up outside of the machine working space.
@@ -1561,13 +1628,15 @@ inline bool improve_bed_induction_sensor_point3(int verbosity_level)
         enable_z_endstop(false);
         current_position[X_AXIS] = xmax;
         current_position[Y_AXIS] = ymax;
-        if (verbosity_level >= 20) {
+		#ifdef SUPPORT_VERBOSITY
+		if (verbosity_level >= 20) {
             SERIAL_ECHOPGM("Adjusted position: ");
             SERIAL_ECHO(current_position[X_AXIS]);
             SERIAL_ECHOPGM(", ");
             SERIAL_ECHO(current_position[Y_AXIS]);
             SERIAL_ECHOLNPGM("");
         }
+		#endif // SUPPORT_VERBOSITY
 
         // Don't clamp current_position[Y_AXIS], because the out-of-reach Y coordinate may actually be true.
         // Only clamp the coordinate to go.
@@ -1657,6 +1726,7 @@ BedSkewOffsetDetectionResultType find_bed_offset_and_skew(int8_t verbosity_level
 
 		SERIAL_ECHOPGM("Iteration: ");
 		MYSERIAL.println(int(iteration + 1));
+		#ifdef SUPPORT_VERBOSITY
 		if (verbosity_level >= 20) {
 		SERIAL_ECHOLNPGM("Vectors: ");
 		
@@ -1679,6 +1749,7 @@ BedSkewOffsetDetectionResultType find_bed_offset_and_skew(int8_t verbosity_level
 			MYSERIAL.print(cntr[1], 5);
 			SERIAL_ECHOLNPGM("");
 		}
+		#endif // SUPPORT_VERBOSITY
 #ifdef MESH_BED_CALIBRATION_SHOW_LCD
     uint8_t next_line;
     lcd_display_message_fullscreen_P(MSG_FIND_BED_OFFSET_AND_SKEW_LINE1, next_line);
@@ -1704,6 +1775,7 @@ BedSkewOffsetDetectionResultType find_bed_offset_and_skew(int8_t verbosity_level
 		// Go up to z_initial.
 
 		go_to_current(homing_feedrate[Z_AXIS] / 60.f);
+		#ifdef SUPPORT_VERBOSITY
 		if (verbosity_level >= 20) {
 			// Go to Y0, wait, then go to Y-4.
 			current_position[Y_AXIS] = 0.f;
@@ -1715,6 +1787,7 @@ BedSkewOffsetDetectionResultType find_bed_offset_and_skew(int8_t verbosity_level
 			SERIAL_ECHOLNPGM("At Y-4");
 			delay_keep_alive(5000);
 		}
+		#endif // SUPPORT_VERBOSITY
 		// Go to the measurement point position.
 		//if (iteration == 0) {
 			current_position[X_AXIS] = pgm_read_float(bed_ref_points_4 + k * 2);
@@ -1732,6 +1805,7 @@ BedSkewOffsetDetectionResultType find_bed_offset_and_skew(int8_t verbosity_level
 				current_position[Y_AXIS] = Y_MIN_POS_FOR_BED_CALIBRATION;
 
 		}*/
+		#ifdef SUPPORT_VERBOSITY
 		if (verbosity_level >= 20) {
 			SERIAL_ECHOPGM("current_position[X_AXIS]:");
 			MYSERIAL.print(current_position[X_AXIS], 5);
@@ -1743,11 +1817,13 @@ BedSkewOffsetDetectionResultType find_bed_offset_and_skew(int8_t verbosity_level
 			MYSERIAL.print(current_position[Z_AXIS], 5);
 			SERIAL_ECHOLNPGM("");
 		}
-
+		#endif // SUPPORT_VERBOSITY
 
 		go_to_current(homing_feedrate[X_AXIS] / 60.f);
+		#ifdef SUPPORT_VERBOSITY
 		if (verbosity_level >= 10)
 			delay_keep_alive(3000);
+		#endif // SUPPORT_VERBOSITY
 		if (!find_bed_induction_sensor_point_xy(verbosity_level))
 			return BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND;
 #if 1
@@ -1772,6 +1848,7 @@ BedSkewOffsetDetectionResultType find_bed_offset_and_skew(int8_t verbosity_level
 					return BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND;
 			}
 #endif
+			#ifdef SUPPORT_VERBOSITY
 			if (verbosity_level >= 10)
 				delay_keep_alive(3000);
 			// Save the detected point position and then clamp the Y coordinate, which may have been estimated
@@ -1781,6 +1858,7 @@ BedSkewOffsetDetectionResultType find_bed_offset_and_skew(int8_t verbosity_level
 				MYSERIAL.println(current_position[X_AXIS]);
 				MYSERIAL.println(current_position[Y_AXIS]);
 			}
+			#endif // SUPPORT_VERBOSITY
 			pt[0] = (pt[0] * iteration) / (iteration + 1);
 			pt[0] += (current_position[X_AXIS]/(iteration + 1)); //count average
 			pt[1] = (pt[1] * iteration) / (iteration + 1);
@@ -1792,7 +1870,7 @@ BedSkewOffsetDetectionResultType find_bed_offset_and_skew(int8_t verbosity_level
 						
 			//pt[1] += current_position[Y_AXIS];
 			//if (iteration > 0) pt[1] = pt[1] / 2;
-
+			#ifdef SUPPORT_VERBOSITY
 			if (verbosity_level >= 20) {
 				SERIAL_ECHOLNPGM("");
 				SERIAL_ECHOPGM("pt[0]:");
@@ -1800,6 +1878,7 @@ BedSkewOffsetDetectionResultType find_bed_offset_and_skew(int8_t verbosity_level
 				SERIAL_ECHOPGM("pt[1]:");
 				MYSERIAL.println(pt[1]);
 			}
+			#endif // SUPPORT_VERBOSITY
 
 			if (current_position[Y_AXIS] < Y_MIN_POS)
 				current_position[Y_AXIS] = Y_MIN_POS;
@@ -1807,14 +1886,16 @@ BedSkewOffsetDetectionResultType find_bed_offset_and_skew(int8_t verbosity_level
 			current_position[Z_AXIS] += 3.f + FIND_BED_INDUCTION_SENSOR_POINT_Z_STEP * iteration * 0.3;
 			//cntr[0] += pt[0];
 			//cntr[1] += pt[1];
+			#ifdef SUPPORT_VERBOSITY
 			if (verbosity_level >= 10 && k == 0) {
 				// Show the zero. Test, whether the Y motor skipped steps.
 				current_position[Y_AXIS] = MANUAL_Y_HOME_POS;
 				go_to_current(homing_feedrate[X_AXIS] / 60.f);
 				delay_keep_alive(3000);
 			}
+			#endif // SUPPORT_VERBOSITY
 		}
-
+		#ifdef SUPPORT_VERBOSITY
 		if (verbosity_level >= 20) {
 			// Test the positions. Are the positions reproducible? Now the calibration is active in the planner.
 			delay_keep_alive(3000);
@@ -1829,6 +1910,7 @@ BedSkewOffsetDetectionResultType find_bed_offset_and_skew(int8_t verbosity_level
 				delay_keep_alive(3000);
 			}
 		}
+		#endif // SUPPORT_VERBOSITY
 
 		if (pts[1] < Y_MIN_POS_CALIBRATION_POINT_OUT_OF_REACH) {
 			too_far_mask |= 1 << 1; //front center point is out of reach
@@ -1851,6 +1933,7 @@ BedSkewOffsetDetectionResultType find_bed_offset_and_skew(int8_t verbosity_level
 			eeprom_update_float((float*)(EEPROM_BED_CALIBRATION_VEC_Y + 0), vec_y[0]);
 			eeprom_update_float((float*)(EEPROM_BED_CALIBRATION_VEC_Y + 4), vec_y[1]);
 #endif
+			#ifdef SUPPORT_VERBOSITY
 			if (verbosity_level >= 10) {
 				// Length of the vec_x
 				float l = sqrt(vec_x[0] * vec_x[0] + vec_x[1] * vec_x[1]);
@@ -1872,10 +1955,11 @@ BedSkewOffsetDetectionResultType find_bed_offset_and_skew(int8_t verbosity_level
 				MYSERIAL.println(fabs(l));
 				SERIAL_ECHOLNPGM("Saving bed calibration vectors to EEPROM");
 			}
+			#endif // SUPPORT_VERBOSITY
 			// Correct the current_position to match the transformed coordinate system after world2machine_rotation_and_skew and world2machine_shift were set.
 			world2machine_update_current();
 
-			
+			#ifdef SUPPORT_VERBOSITY
 			if (verbosity_level >= 20) {
 				// Test the positions. Are the positions reproducible? Now the calibration is active in the planner.
 				delay_keep_alive(3000);
@@ -1890,6 +1974,7 @@ BedSkewOffsetDetectionResultType find_bed_offset_and_skew(int8_t verbosity_level
 					delay_keep_alive(3000);
 				}
 			}
+			#endif // SUPPORT_VERBOSITY
 			return result;
 		}		
 		if (result == BED_SKEW_OFFSET_DETECTION_FITTING_FAILED && too_far_mask == 2) return result; //if fitting failed and front center point is out of reach, terminate calibration and inform user
@@ -1914,9 +1999,11 @@ BedSkewOffsetDetectionResultType improve_bed_offset_and_skew(int8_t method, int8
     float *cntr  = vec_y + 2;
     memset(pts, 0, sizeof(float) * 7 * 7);
 
+	#ifdef SUPPORT_VERBOSITY
 	if (verbosity_level >= 10) SERIAL_ECHOLNPGM("Improving bed offset and skew");
-
-    // Cache the current correction matrix.
+	#endif // SUPPORT_VERBOSITY
+    
+	// Cache the current correction matrix.
     world2machine_initialize();
     vec_x[0] = world2machine_rotation_and_skew[0][0];
     vec_x[1] = world2machine_rotation_and_skew[1][0];
@@ -1953,7 +2040,8 @@ BedSkewOffsetDetectionResultType improve_bed_offset_and_skew(int8_t method, int8
         enable_endstops(false);
         enable_z_endstop(false);
         go_to_current(homing_feedrate[Z_AXIS]/60);
-        if (verbosity_level >= 20) {
+		#ifdef SUPPORT_VERBOSITY
+		if (verbosity_level >= 20) {
             // Go to Y0, wait, then go to Y-4.
             current_position[Y_AXIS] = 0.f;
             go_to_current(homing_feedrate[X_AXIS] / 60.f);
@@ -1964,6 +2052,7 @@ BedSkewOffsetDetectionResultType improve_bed_offset_and_skew(int8_t method, int8
 			SERIAL_ECHOLNPGM("At Y_MIN_POS");
             delay_keep_alive(5000);
         }
+		#endif // SUPPORT_VERBOSITY
         // Go to the measurement point.
         // Use the coorrected coordinate, which is a result of find_bed_offset_and_skew().
         current_position[X_AXIS] = vec_x[0] * pgm_read_float(bed_ref_points+mesh_point*2) + vec_y[0] * pgm_read_float(bed_ref_points+mesh_point*2+1) + cntr[0];
@@ -1971,26 +2060,33 @@ BedSkewOffsetDetectionResultType improve_bed_offset_and_skew(int8_t method, int8
         // The calibration points are very close to the min Y.
         if (current_position[Y_AXIS] < Y_MIN_POS_FOR_BED_CALIBRATION){
             current_position[Y_AXIS] = Y_MIN_POS_FOR_BED_CALIBRATION;
+			#ifdef SUPPORT_VERBOSITY
 			if (verbosity_level >= 20) {
 				SERIAL_ECHOPGM("Calibration point ");
 				SERIAL_ECHO(mesh_point);
 				SERIAL_ECHOPGM("lower than Ymin. Y coordinate clamping was used.");
 				SERIAL_ECHOLNPGM("");
-			}			
+			}
+			#endif // SUPPORT_VERBOSITY
 		}
         go_to_current(homing_feedrate[X_AXIS]/60);
         // Find its Z position by running the normal vertical search.
-        if (verbosity_level >= 10)
+		#ifdef SUPPORT_VERBOSITY
+		if (verbosity_level >= 10)
             delay_keep_alive(3000);
-        find_bed_induction_sensor_point_z();
-        if (verbosity_level >= 10)
+		#endif // SUPPORT_VERBOSITY
+		find_bed_induction_sensor_point_z();
+		#ifdef SUPPORT_VERBOSITY
+		if (verbosity_level >= 10)
             delay_keep_alive(3000);
-        // Try to move the Z axis down a bit to increase a chance of the sensor to trigger.
+		#endif // SUPPORT_VERBOSITY
+		// Try to move the Z axis down a bit to increase a chance of the sensor to trigger.
         current_position[Z_AXIS] -= 0.025f;
         // Improve the point position by searching its center in a current plane.
         int8_t n_errors = 3;
         for (int8_t iter = 0; iter < 8; ) {
-            if (verbosity_level > 20) {
+			#ifdef SUPPORT_VERBOSITY
+			if (verbosity_level > 20) {
                 SERIAL_ECHOPGM("Improving bed point ");
                 SERIAL_ECHO(mesh_point);
                 SERIAL_ECHOPGM(", iteration ");
@@ -1999,6 +2095,7 @@ BedSkewOffsetDetectionResultType improve_bed_offset_and_skew(int8_t method, int8
                 MYSERIAL.print(current_position[Z_AXIS], 5);
                 SERIAL_ECHOLNPGM("");
             }
+			#endif // SUPPORT_VERBOSITY
             bool found = false;
             if (mesh_point < 3) {
                 // Because the sensor cannot move in front of the first row
@@ -2032,7 +2129,8 @@ BedSkewOffsetDetectionResultType improve_bed_offset_and_skew(int8_t method, int8
                 enable_endstops(false);
                 enable_z_endstop(false);
                 go_to_current(homing_feedrate[Z_AXIS]);
-                if (verbosity_level >= 5) {
+				#ifdef SUPPORT_VERBOSITY
+				if (verbosity_level >= 5) {
                     SERIAL_ECHOPGM("Improving bed point ");
                     SERIAL_ECHO(mesh_point);
                     SERIAL_ECHOPGM(", iteration ");
@@ -2041,10 +2139,13 @@ BedSkewOffsetDetectionResultType improve_bed_offset_and_skew(int8_t method, int8
                     MYSERIAL.print(current_position[Z_AXIS], 5);
                     SERIAL_ECHOLNPGM("");
                 }
+				#endif // SUPPORT_VERBOSITY
             }
         }
+		#ifdef SUPPORT_VERBOSITY
         if (verbosity_level >= 10)
             delay_keep_alive(3000);
+		#endif // SUPPORT_VERBOSITY
     }
     // Don't let the manage_inactivity() function remove power from the motors.
     refresh_cmd_timeout();
@@ -2056,6 +2157,7 @@ BedSkewOffsetDetectionResultType improve_bed_offset_and_skew(int8_t method, int8
     enable_endstops(false);
     enable_z_endstop(false);
 
+	#ifdef SUPPORT_VERBOSITY
     if (verbosity_level >= 5) {
         // Test the positions. Are the positions reproducible?
 		current_position[Z_AXIS] = MESH_HOME_Z_SEARCH;
@@ -2079,17 +2181,19 @@ BedSkewOffsetDetectionResultType improve_bed_offset_and_skew(int8_t method, int8
             SERIAL_ECHOLNPGM("");
         }
     }
+	#endif // SUPPORT_VERBOSITY
 
     {
         // First fill in the too_far_mask from the measured points.
         for (uint8_t mesh_point = 0; mesh_point < 3; ++ mesh_point)
             if (pts[mesh_point * 2 + 1] < Y_MIN_POS_CALIBRATION_POINT_OUT_OF_REACH)
                 too_far_mask |= 1 << mesh_point;
-		
+		#ifdef SUPPORT_VERBOSITY
 		if (verbosity_level >= 20) {
 			SERIAL_ECHOPGM("Distance from min before calculate_machine skew and offset LS:");
 			MYSERIAL.print(int(too_far_mask));
 		}
+		#endif // SUPPORT_VERBOSITY
 		
 		result = calculate_machine_skew_and_offset_LS(pts, 9, bed_ref_points, vec_x, vec_y, cntr, verbosity_level);
         if (result < 0) {
@@ -2098,11 +2202,13 @@ BedSkewOffsetDetectionResultType improve_bed_offset_and_skew(int8_t method, int8
         }
         // In case of success, update the too_far_mask from the calculated points.
 		too_far_mask = 0;
-		if(verbosity_level >= 20) SERIAL_ECHOPGM("Reseting too far mask.");
-
+		#ifdef SUPPORT_VERBOSITY
+		if (verbosity_level >= 20) SERIAL_ECHOPGM("Reseting too far mask.");
+		#endif // SUPPORT_VERBOSITY
         for (uint8_t mesh_point = 0; mesh_point < 3; ++ mesh_point) {
             float y = vec_x[1] * pgm_read_float(bed_ref_points+mesh_point*2) + vec_y[1] * pgm_read_float(bed_ref_points+mesh_point*2+1) + cntr[1];
 			distance_from_min[mesh_point] = (y - Y_MIN_POS_CALIBRATION_POINT_OUT_OF_REACH);
+			#ifdef SUPPORT_VERBOSITY
 			if (verbosity_level >= 20) {
 				SERIAL_ECHOLNPGM("");
 				SERIAL_ECHOPGM("Distance from min:");
@@ -2112,6 +2218,7 @@ BedSkewOffsetDetectionResultType improve_bed_offset_and_skew(int8_t method, int8
 				MYSERIAL.print(y);
 				SERIAL_ECHOLNPGM("");
 			}
+			#endif // SUPPORT_VERBOSITY
 			if (y < Y_MIN_POS_CALIBRATION_POINT_OUT_OF_REACH)
                 too_far_mask |= 1 << mesh_point;
         }
@@ -2133,7 +2240,7 @@ BedSkewOffsetDetectionResultType improve_bed_offset_and_skew(int8_t method, int8
 
     enable_endstops(false);
     enable_z_endstop(false);
-
+	#ifdef SUPPORT_VERBOSITY
     if (verbosity_level >= 5) {
         // Test the positions. Are the positions reproducible? Now the calibration is active in the planner.
         delay_keep_alive(3000);
@@ -2162,6 +2269,7 @@ BedSkewOffsetDetectionResultType improve_bed_offset_and_skew(int8_t method, int8
             }
         }
     }
+	#endif // SUPPORT_VERBOSITY
 
     // Sample Z heights for the mesh bed leveling.
     // In addition, store the results into an eeprom, to be used later for verification of the bed leveling process.

--- a/Firmware/variants/1_75mm_MK2-MultiMaterial-RAMBo10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK2-MultiMaterial-RAMBo10a-E3Dv6full.h
@@ -405,7 +405,7 @@ THERMISTORS SETTINGS
 
 #define END_FILE_SECTION 10000 //number of bytes from end of file used for checking if file is complete
 
-#ifdef SNMM
+#ifndef SNMM
 #define SUPPORT_VERBOSITY
 #endif
 

--- a/Firmware/variants/1_75mm_MK2-MultiMaterial-RAMBo10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK2-MultiMaterial-RAMBo10a-E3Dv6full.h
@@ -405,4 +405,8 @@ THERMISTORS SETTINGS
 
 #define END_FILE_SECTION 10000 //number of bytes from end of file used for checking if file is complete
 
+#ifdef SNMM
+#define SUPPORT_VERBOSITY
+#endif
+
 #endif //__CONFIGURATION_PRUSA_H

--- a/Firmware/variants/1_75mm_MK2-MultiMaterial-RAMBo13a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK2-MultiMaterial-RAMBo13a-E3Dv6full.h
@@ -407,7 +407,7 @@ THERMISTORS SETTINGS
 
 #define END_FILE_SECTION 10000 //number of bytes from end of file used for checking if file is complete
 
-#ifdef SNMM
+#ifndef SNMM
 #define SUPPORT_VERBOSITY
 #endif
 

--- a/Firmware/variants/1_75mm_MK2-MultiMaterial-RAMBo13a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK2-MultiMaterial-RAMBo13a-E3Dv6full.h
@@ -407,4 +407,8 @@ THERMISTORS SETTINGS
 
 #define END_FILE_SECTION 10000 //number of bytes from end of file used for checking if file is complete
 
+#ifdef SNMM
+#define SUPPORT_VERBOSITY
+#endif
+
 #endif //__CONFIGURATION_PRUSA_H

--- a/Firmware/variants/1_75mm_MK2-RAMBo10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK2-RAMBo10a-E3Dv6full.h
@@ -405,7 +405,7 @@ THERMISTORS SETTINGS
 
 #define END_FILE_SECTION 10000 //number of bytes from end of file used for checking if file is complete
 
-#ifdef SNMM
+#ifndef SNMM
 #define SUPPORT_VERBOSITY
 #endif
 

--- a/Firmware/variants/1_75mm_MK2-RAMBo10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK2-RAMBo10a-E3Dv6full.h
@@ -405,4 +405,8 @@ THERMISTORS SETTINGS
 
 #define END_FILE_SECTION 10000 //number of bytes from end of file used for checking if file is complete
 
+#ifdef SNMM
+#define SUPPORT_VERBOSITY
+#endif
+
 #endif //__CONFIGURATION_PRUSA_H

--- a/Firmware/variants/1_75mm_MK2-RAMBo13a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK2-RAMBo13a-E3Dv6full.h
@@ -407,7 +407,7 @@ THERMISTORS SETTINGS
 
 #define END_FILE_SECTION 10000 //number of bytes from end of file used for checking if file is complete
 
-#ifdef SNMM
+#ifndef SNMM
 #define SUPPORT_VERBOSITY
 #endif
 

--- a/Firmware/variants/1_75mm_MK2-RAMBo13a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK2-RAMBo13a-E3Dv6full.h
@@ -407,4 +407,8 @@ THERMISTORS SETTINGS
 
 #define END_FILE_SECTION 10000 //number of bytes from end of file used for checking if file is complete
 
+#ifdef SNMM
+#define SUPPORT_VERBOSITY
+#endif
+
 #endif //__CONFIGURATION_PRUSA_H


### PR DESCRIPTION
... to free some memory