### PR TITLE
filecheck fix: check gcodes which remains in buffer after finding end of file

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1952,7 +1952,7 @@ static float probe_pt(float x, float y, float z_before) {
 bool check_commands() {
 	  bool end_command_found = false;
 
-	  if (buflen)
+	  while (buflen)
 	  {
 		  if ((code_seen("M84")) || (code_seen("M 84"))) end_command_found = true;
 		  if (!cmdbuffer_front_already_processed)

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5779,7 +5779,6 @@ static bool check_file(const char* filename) {
 		get_command();
 		result = check_commands();
 	}
-	cmdqueue_reset();
 	card.printingHasFinished();
 	strncpy_P(lcd_status_message, WELCOME_MSG, LCD_WIDTH);
 	return result;


### PR DESCRIPTION
When we found end of gcode file, there were some gcodes still in buffer and there were not checked for M84 (when M84 was in last few lines, it was not found). 