### PR TITLE
Make M110 command compatible with Marlin, etc.

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -4633,8 +4633,6 @@ Sigma_Exit:
 	case 110:   // M110 - reset line pos
 		if (code_seen('N'))
 			gcode_LastN = code_value_long();
-		else
-			gcode_LastN = 0;
 		break;
 #ifdef HOST_KEEPALIVE_FEATURE
 	case 113: // M113 - Get or set Host Keepalive interval


### PR DESCRIPTION
Don't reset line number to 0 if no argument to M110 G-code.

Fixes #280 