### PR TITLE
MK3 - PINDA2 Calibration Tuning

### DIFF
--- a/Firmware/Dcodes.cpp
+++ b/Firmware/Dcodes.cpp
@@ -353,18 +353,17 @@ void dcode_8()
 			if (i > 0) offs = eeprom_read_word(((uint16_t*)EEPROM_PROBE_TEMP_SHIFT) + (i - 1));
 			float foffs = ((float)offs) / axis_steps_per_unit[Z_AXIS];
 			offs = 1000 * foffs;
-			printf_P(PSTR("temp_pinda=%dC temp_shift=%dum\n"), 35 + i * 5, offs);
-		}
+      printf_P(PSTR("temp_pinda=%dC temp_shift=%dum\n"), 35 + i * 7, offs);
 	}
 	else if (strchr_pointer[1+1] == '!')
 	{
 		cal_status = 1;
 		eeprom_write_byte((uint8_t*)EEPROM_CALIBRATION_STATUS_PINDA, cal_status);
-		eeprom_write_word(((uint16_t*)EEPROM_PROBE_TEMP_SHIFT) + 0,   8); //40C -  20um -   8usteps
-		eeprom_write_word(((uint16_t*)EEPROM_PROBE_TEMP_SHIFT) + 1,  24); //45C -  60um -  24usteps
-		eeprom_write_word(((uint16_t*)EEPROM_PROBE_TEMP_SHIFT) + 2,  48); //50C - 120um -  48usteps
-		eeprom_write_word(((uint16_t*)EEPROM_PROBE_TEMP_SHIFT) + 3,  80); //55C - 200um -  80usteps
-		eeprom_write_word(((uint16_t*)EEPROM_PROBE_TEMP_SHIFT) + 4, 120); //60C - 300um - 120usteps
+		eeprom_write_word(((uint16_t*)EEPROM_PROBE_TEMP_SHIFT) + 0,   8); //42C -  20um -   8usteps
+		eeprom_write_word(((uint16_t*)EEPROM_PROBE_TEMP_SHIFT) + 1,  24); //49C -  60um -  24usteps
+		eeprom_write_word(((uint16_t*)EEPROM_PROBE_TEMP_SHIFT) + 2,  48); //56C - 120um -  48usteps
+		eeprom_write_word(((uint16_t*)EEPROM_PROBE_TEMP_SHIFT) + 3,  80); //63C - 200um -  80usteps
+		eeprom_write_word(((uint16_t*)EEPROM_PROBE_TEMP_SHIFT) + 4, 120); //70C - 300um - 120usteps
 	}
 	else
 	{

--- a/Firmware/Dcodes.cpp
+++ b/Firmware/Dcodes.cpp
@@ -353,7 +353,8 @@ void dcode_8()
 			if (i > 0) offs = eeprom_read_word(((uint16_t*)EEPROM_PROBE_TEMP_SHIFT) + (i - 1));
 			float foffs = ((float)offs) / axis_steps_per_unit[Z_AXIS];
 			offs = 1000 * foffs;
-      printf_P(PSTR("temp_pinda=%dC temp_shift=%dum\n"), 35 + i * 7, offs);
+      			printf_P(PSTR("temp_pinda=%dC temp_shift=%dum\n"), 35 + i * 7, offs);
+		}
 	}
 	else if (strchr_pointer[1+1] == '!')
 	{


### PR DESCRIPTION
Tuning of the PINDA2 Internal Thermistor table to better align with temperatures seen as they can get upward of 80C.
Also taken into account errors happening causing concern for machine safety and hard limits introduced for these cases. Issues raised under #421

Adjusted the echo temperatures function to show the PINDA2 temp when preforming this calibration.

This is tested and working on my MK3 with good results so far, hopefully a guide that some part or all can be incorporated to make the firmware more stable for all.

Rob "TZB"