### PR TITLE
Renaming calculate_volumetric_multipliers() to...

### DIFF
--- a/Firmware/ConfigurationStore.cpp
+++ b/Firmware/ConfigurationStore.cpp
@@ -378,7 +378,7 @@ bool Config_RetrieveSettings(uint16_t offset, uint8_t level)
 			EEPROM_READ_VAR(i, extruder_advance_k);
 			EEPROM_READ_VAR(i, advance_ed_ratio);
 		}
-		calculate_volumetric_multipliers();
+		calculate_extruder_multipliers();
 #endif //LIN_ADVANCE
 
 		// Call updatePID (similar to when we have processed M301)


### PR DESCRIPTION
calculate_extruder_multipliers(). MK3 firmware will no longer compile when LIN_ADVANCE is enabled in Configuration_adv.h due to this function name change. I am betting nobody noticed it because LIN_ADVANCE is off by default now. Several of us are using it with sdcard only without issues. Thanks!