### PR TITLE
Linear Advance v1.5 implementation

### DIFF
--- a/Firmware/Configuration_adv.h
+++ b/Firmware/Configuration_adv.h
@@ -319,43 +319,25 @@
 #endif
 
 /**
- * Implementation of linear pressure control
+ * Linear Pressure Control v1.5
  *
- * Assumption: advance = k * (delta velocity)
+ * Assumption: advance [steps] = k * (delta velocity [steps/s])
  * K=0 means advance disabled.
- * See Marlin documentation for calibration instructions.
+ *
+ * NOTE: K values for LIN_ADVANCE 1.5 differ from earlier versions!
+ *
+ * Set K around 0.22 for 3mm PLA Direct Drive with ~6.5cm between the drive gear and heatbreak.
+ * Larger K values will be needed for flexible filament and greater distances.
+ * If this algorithm produces a higher speed offset than the extruder can handle (compared to E jerk)
+ * print acceleration will be reduced during the affected moves to keep within the limit.
+ *
+ * See http://marlinfw.org/docs/features/lin_advance.html for full instructions.
+ * Mention @Sebastianv650 on GitHub to alert the author of any issues.
  */
-#define LIN_ADVANCE
-
+//#define LIN_ADVANCE
 #ifdef LIN_ADVANCE
-  #define LIN_ADVANCE_K 0 //Try around 45 for PLA, around 25 for ABS.
-
-  /**
-   * Some Slicers produce Gcode with randomly jumping extrusion widths occasionally.
-   * For example within a 0.4mm perimeter it may produce a single segment of 0.05mm width.
-   * While this is harmless for normal printing (the fluid nature of the filament will
-   * close this very, very tiny gap), it throws off the LIN_ADVANCE pressure adaption.
-   *
-   * For this case LIN_ADVANCE_E_D_RATIO can be used to set the extrusion:distance ratio
-   * to a fixed value. Note that using a fixed ratio will lead to wrong nozzle pressures
-   * if the slicer is using variable widths or layer heights within one print!
-   *
-   * This option sets the default E:D ratio at startup. Use `M900` to override this value.
-   *
-   * Example: `M900 W0.4 H0.2 D1.75`, where:
-   *   - W is the extrusion width in mm
-   *   - H is the layer height in mm
-   *   - D is the filament diameter in mm
-   *
-   * Example: `M900 R0.0458` to set the ratio directly.
-   *
-   * Set to 0 to auto-detect the ratio based on given Gcode G1 print moves.
-   *
-   * Slic3r (including Prusa Slic3r) produces Gcode compatible with the automatic mode.
-   * Cura (as of this writing) may produce Gcode incompatible with the automatic mode.
-   */
-  #define LIN_ADVANCE_E_D_RATIO 0 // The calculated ratio (or 0) according to the formula W * H / ((D / 2) ^ 2 * PI)
-                                  // Example: 0.4 * 0.2 / ((1.75 / 2) ^ 2 * PI) = 0.033260135
+  #define LIN_ADVANCE_K 0 // Unit: mm compression per 1mm/s extruder speed
+  //#define LA_DEBUG      // If enabled, this will generate debug information output over USB.
 #endif
 
 // Arc interpretation settings:

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1918,34 +1918,22 @@ static float probe_pt(float x, float y, float z_before) {
 
 #ifdef LIN_ADVANCE
   /**
-   * M900: Set and/or Get advance K factor and WH/D ratio
+   * M900: Set and/or Get advance K factor
    *
    *  K<factor>                  Set advance K factor
-   *  R<ratio>                   Set ratio directly (overrides WH/D)
-   *  W<width> H<height> D<diam> Set ratio from WH/D
    */
   inline void gcode_M900() {
     st_synchronize();
 
     const float newK = code_seen('K') ? code_value_float() : -1;
-    if (newK >= 0) extruder_advance_k = newK;
-
-    float newR = code_seen('R') ? code_value_float() : -1;
-    if (newR < 0) {
-      const float newD = code_seen('D') ? code_value_float() : -1,
-                  newW = code_seen('W') ? code_value_float() : -1,
-                  newH = code_seen('H') ? code_value_float() : -1;
-      if (newD >= 0 && newW >= 0 && newH >= 0)
-        newR = newD ? (newW * newH) / (sq(newD * 0.5) * M_PI) : 0;
-    }
-    if (newR >= 0) advance_ed_ratio = newR;
+    if (newK >= 0 && newK < 10)
+      extruder_advance_K = newK;
+    else
+      SERIAL_ECHOLNPGM("K out of allowed range!");
 
     SERIAL_ECHO_START;
     SERIAL_ECHOPGM("Advance K=");
-    SERIAL_ECHOLN(extruder_advance_k);
-    SERIAL_ECHOPGM(" E/D=");
-    const float ratio = advance_ed_ratio;
-    if (ratio) SERIAL_ECHOLN(ratio); else SERIAL_ECHOLNPGM("Auto");
+    SERIAL_ECHOLN(extruder_advance_K);
   }
 #endif // LIN_ADVANCE
 

--- a/Firmware/planner.h
+++ b/Firmware/planner.h
@@ -91,12 +91,15 @@ typedef struct {
   
   #ifdef LIN_ADVANCE
     bool use_advance_lead;
-    unsigned long abs_adv_steps_multiplier8; // Factorised by 2^8 to avoid float
+    uint16_t advance_speed,                 // Timer value for extruder speed offset
+             max_adv_steps,                 // max. advance steps to get cruising speed pressure (not always nominal_speed!)
+             final_adv_steps;               // advance steps due to exit speed
+    float e_D_ratio;
   #endif
 } block_t;
 
 #ifdef LIN_ADVANCE
-  extern float extruder_advance_k, advance_ed_ratio;
+  extern float extruder_advance_K;
 #endif
 
 #ifdef ENABLE_AUTO_BED_LEVELING


### PR DESCRIPTION
This is my Linear Advance v1.5 code ported from Marlin. Seems to work just well, all test prints are fine after one test day.
~~I updated my "Community Mod" Branch with this PR, so testers can download precompiled .hex files: https://github.com/Sebastianv650/Prusa-Firmware~~ Community Mod is updated, but LA isn't enabled by default!

Notes:
- This is only usable for non-kinematic XYZ printers! As Prusa isn't offering delta or CORE machines up to now, I consider the related code section as broken and unmaintained anyway.
- Tested only on a MK2, as I only have this Prusa printer version. Please do extensive tests on MK2 MMU and MK3 before publishing it to avoid problems like described here #331.
- For the MK2, a K value of 0.08 for PLA seems to be fine. With default ejerk of 2.5mm/s (which I think is quite conservative) acceleration is limited to 985mm/s². I was therefore printing at ejerk = 5.5mm/s, without any problem.
- For MK2 MMU, I would expect a K value of around 0.47. This is clearly unusable with an ejerk of 2.5 as it would equal a max. acceleration of 167mm/s². Please test which ejerk values can be reached to give useable accelerations.

Feel free to comment!