### PR TITLE
Add fail statistics menu item for MK25.

### DIFF
--- a/Firmware/Configuration_prusa.h
+++ b/Firmware/Configuration_prusa.h
@@ -168,7 +168,7 @@ const bool Z_MIN_ENDSTOP_INVERTING = false; // set to true to invert the logic o
 #define EXTRUDER_AUTO_FAN_SPEED   255  // == full speed
 
 
-#define PAT9125
+#define PAT9125 //!< Filament sensor
 #define FANCHECK
 
 

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -681,6 +681,7 @@ void crashdet_cancel()
 	card.closefile();
 	tmc2130_sg_stop_on_crash = true;
 }
+#endif //TMC2130
 
 void failstats_reset_print()
 {
@@ -690,7 +691,6 @@ void failstats_reset_print()
 	eeprom_update_byte((uint8_t *)EEPROM_POWER_COUNT, 0);
 }
 
-#endif //TMC2130
 
 
 #ifdef MESH_BED_LEVELING
@@ -4081,10 +4081,8 @@ void process_commands()
       card.openFile(strchr_pointer + 4,true);
       break;
     case 24: //M24 - Start SD print
-#ifdef TMC2130
 	  if (!card.paused)
 		failstats_reset_print();
-#endif //TMC2130
       card.startFileprint();
       starttime=millis();
 	  break;


### PR DESCRIPTION
As there is only filament sensor and no crash and power interruption detection, squash everything into single screen.