### PR TITLE
Fix of a regression bug, caused by pre-calculating the extrudemultiply

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -91,6 +91,18 @@ union MenuData
         int    rear2;
     } adjustBed;
 
+    struct TuneMenu
+    {
+        // editMenuParentState is used when an edit menu is entered, so it knows
+        // the return menu and encoder state.
+        struct EditMenuParentState editMenuParentState;
+        // To recognize, whether the menu has been just initialized.
+        int8_t  status;
+        // Backup of extrudemultiply, to recognize, that the value has been changed and
+        // it needs to be applied.
+        int16_t extrudemultiply;
+    } tuneMenu;
+
     // editMenuParentState is used when an edit menu is entered, so it knows
     // the return menu and encoder state.
     struct EditMenuParentState editMenuParentState;
@@ -5326,7 +5338,17 @@ static void lcd_colorprint_change() {
 
 static void lcd_tune_menu()
 {
-	EEPROM_read(EEPROM_SILENT, (uint8_t*)&SilentModeMenu, sizeof(SilentModeMenu));
+  if (menuData.tuneMenu.status == 0) {
+    // Menu was entered. Mark the menu as entered and save the current extrudemultiply value.
+    menuData.tuneMenu.status = 1;
+    menuData.tuneMenu.extrudemultiply = extrudemultiply;
+  } else if (menuData.tuneMenu.extrudemultiply != extrudemultiply) {
+    // extrudemultiply has been changed from the child menu. Apply the new value.
+    menuData.tuneMenu.extrudemultiply = extrudemultiply;
+    calculate_extruder_multipliers();
+  }
+
+  EEPROM_read(EEPROM_SILENT, (uint8_t*)&SilentModeMenu, sizeof(SilentModeMenu));
 
 
 


### PR DESCRIPTION
for precission and performance: calculate_extruder_multipliers()
has to be called after extrudemultiply is changed from the printer panel.