### PR TITLE
Change Prusa MK3 max_pos Z height to 350mm

### DIFF
--- a/Firmware/variants/1_75mm_MK3-EINY03-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK3-EINY03-E3Dv6full.h
@@ -50,7 +50,7 @@ const bool Z_MIN_ENDSTOP_INVERTING = false; // set to true to invert the logic o
 #define X_MIN_POS 0
 #define Y_MAX_POS 210
 #define Y_MIN_POS -12 //orig -4
-#define Z_MAX_POS 210
+#define Z_MAX_POS 350
 #define Z_MIN_POS 0.15
 
 // Canceled home position


### PR DESCRIPTION
I have made a taller Z axis for my printer and need to adjust the #define Z_MAX_POS 210 to 350 so that the X Y Z Calibration will work properly.
I'm completely new to this forum...  How do I create a .hex file from the adjusted source code?

Fairfarren