### PR TITLE
Add missing include

### DIFF
--- a/Firmware/xyzcal.cpp
+++ b/Firmware/xyzcal.cpp
@@ -4,6 +4,7 @@
 #ifdef NEW_XYZCAL
 
 #include "xyzcal.h"
+#include <stdio.h>
 #include <avr/wdt.h>
 #include "stepper.h"
 #include "temperature.h"


### PR DESCRIPTION
printf_P requires stdio.h. As an alternative it would be possible to just include Marlin.h. I am not sure what the preferred option in this project is ().