### PR TITLE
G76: fix Z homing after steel sheet removal

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3480,11 +3480,14 @@ void process_commands()
 				plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], 3000 / 60, active_extruder);
 				st_synchronize();
 				feedrate = homing_feedrate[Z_AXIS] / 10;
+				world2machine_revert_to_uncorrected();
 				enable_endstops(true);
 				endstops_hit_on_purpose();
 				homeaxis(Z_AXIS);
 				plan_set_position(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS]);
 				enable_endstops(false);
+				world2machine_initialize();
+				world2machine_update_current();
 			}
 			if ((current_temperature_pinda > 35) && (farm_mode == false)) {
 				//waiting for PIDNA probe to cool down in case that we are not in farm mode


### PR DESCRIPTION
When the steel sheet is in place, the user is asked to remove the
steel sheet before continuing the temperature calibration process.
After removal acknowledge from user, a Z homing is performed but world
coordinates are not properly updated and the extruder nozzle can crash
into the bed and then damage the bed and the nozzle.