### PR TITLE
Enhanced TMC2130-related config options, removed hard-coded values

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -6448,76 +6448,151 @@ Sigma_Exit:
     }
     break;
 
-	case 911: // M911 Set TMC2130 holding currents
+  case 911: // M911 Set TMC2130 holding currents
     {
-		if (code_seen('X')) tmc2130_set_current_h(0, code_value());
-		if (code_seen('Y')) tmc2130_set_current_h(1, code_value());
-        if (code_seen('Z')) tmc2130_set_current_h(2, code_value());
-        if (code_seen('E')) tmc2130_set_current_h(3, code_value());
+    if (code_seen('X')) tmc2130_set_current_h(0, code_value());
+    if (code_seen('Y')) tmc2130_set_current_h(1, code_value());
+    if (code_seen('Z')) tmc2130_set_current_h(2, code_value());
+    if (code_seen('E')) tmc2130_set_current_h(3, code_value());
+    MYSERIAL.println("Holding currents:");
+    MYSERIAL.print("X   ");
+    MYSERIAL.println(tmc2130_current_h[0]);
+    MYSERIAL.print("Y   ");
+    MYSERIAL.println(tmc2130_current_h[1]);
+    MYSERIAL.print("Z   ");
+    MYSERIAL.println(tmc2130_current_h[2]);
+    MYSERIAL.print("E   ");
+    MYSERIAL.println(tmc2130_current_h[3]);
     }
     break;
 
-	case 912: // M912 Set TMC2130 running currents
+  case 912: // M912 Set TMC2130 running currents
     {
-		if (code_seen('X')) tmc2130_set_current_r(0, code_value());
-		if (code_seen('Y')) tmc2130_set_current_r(1, code_value());
-        if (code_seen('Z')) tmc2130_set_current_r(2, code_value());
-        if (code_seen('E')) tmc2130_set_current_r(3, code_value());
+    if (code_seen('X')) tmc2130_set_current_r(0, code_value());
+    if (code_seen('Y')) tmc2130_set_current_r(1, code_value());
+    if (code_seen('Z')) tmc2130_set_current_r(2, code_value());
+    if (code_seen('E')) tmc2130_set_current_r(3, code_value());
+    MYSERIAL.println("Running currents:");
+    MYSERIAL.print("X   ");
+    MYSERIAL.println(tmc2130_current_r[0]);
+    MYSERIAL.print("Y   ");
+    MYSERIAL.println(tmc2130_current_r[1]);
+    MYSERIAL.print("Z   ");
+    MYSERIAL.println(tmc2130_current_r[2]);
+    MYSERIAL.print("E   ");
+    MYSERIAL.println(tmc2130_current_r[3]);
     }
     break;
 
-	case 913: // M913 Print TMC2130 currents
+  case 913: // M913 Print TMC2130 currents
     {
-		tmc2130_print_currents();
+    tmc2130_print_currents();
     }
     break;
 
-	case 914: // M914 Set normal mode
+  case 914: // M914 Set normal mode
     {
-		tmc2130_mode = TMC2130_MODE_NORMAL;
-		tmc2130_init();
+    tmc2130_mode = TMC2130_MODE_NORMAL;
+    tmc2130_init();
     }
     break;
 
-	case 915: // M915 Set silent mode
+  case 915: // M915 Set silent mode
     {
-		tmc2130_mode = TMC2130_MODE_SILENT;
-		tmc2130_init();
+    tmc2130_mode = TMC2130_MODE_SILENT;
+    tmc2130_init();
     }
     break;
 
-	case 916: // M916 Set sg_thrs
+  case 916: // M916 Set sg_thrs
     {
-		if (code_seen('X')) tmc2130_sg_thr[X_AXIS] = code_value();
-		if (code_seen('Y')) tmc2130_sg_thr[Y_AXIS] = code_value();
-		if (code_seen('Z')) tmc2130_sg_thr[Z_AXIS] = code_value();
-		if (code_seen('E')) tmc2130_sg_thr[E_AXIS] = code_value();
-		MYSERIAL.print("tmc2130_sg_thr[X]=");
-		MYSERIAL.println(tmc2130_sg_thr[X_AXIS], DEC);
-		MYSERIAL.print("tmc2130_sg_thr[Y]=");
-		MYSERIAL.println(tmc2130_sg_thr[Y_AXIS], DEC);
-		MYSERIAL.print("tmc2130_sg_thr[Z]=");
-		MYSERIAL.println(tmc2130_sg_thr[Z_AXIS], DEC);
-		MYSERIAL.print("tmc2130_sg_thr[E]=");
-		MYSERIAL.println(tmc2130_sg_thr[E_AXIS], DEC);
+    if (code_seen('X')) tmc2130_sg_thr[X_AXIS] = code_value();
+    if (code_seen('Y')) tmc2130_sg_thr[Y_AXIS] = code_value();
+    if (code_seen('Z')) tmc2130_sg_thr[Z_AXIS] = code_value();
+    if (code_seen('E')) tmc2130_sg_thr[E_AXIS] = code_value();
+    MYSERIAL.print("tmc2130_sg_thr[X]=");
+    MYSERIAL.println(tmc2130_sg_thr[X_AXIS], DEC);
+    MYSERIAL.print("tmc2130_sg_thr[Y]=");
+    MYSERIAL.println(tmc2130_sg_thr[Y_AXIS], DEC);
+    MYSERIAL.print("tmc2130_sg_thr[Z]=");
+    MYSERIAL.println(tmc2130_sg_thr[Z_AXIS], DEC);
+    MYSERIAL.print("tmc2130_sg_thr[E]=");
+    MYSERIAL.println(tmc2130_sg_thr[E_AXIS], DEC);
     }
     break;
 
-	case 917: // M917 Set TMC2130 pwm_ampl
+  case 917: // M917 Set TMC2130 pwm_ampl
     {
-		if (code_seen('X')) tmc2130_set_pwm_ampl(0, code_value());
-		if (code_seen('Y')) tmc2130_set_pwm_ampl(1, code_value());
-        if (code_seen('Z')) tmc2130_set_pwm_ampl(2, code_value());
-        if (code_seen('E')) tmc2130_set_pwm_ampl(3, code_value());
+    if (code_seen('X')) tmc2130_set_pwm_ampl(0, code_value());
+    if (code_seen('Y')) tmc2130_set_pwm_ampl(1, code_value());
+    if (code_seen('Z')) tmc2130_set_pwm_ampl(2, code_value());
+    if (code_seen('E')) tmc2130_set_pwm_ampl(3, code_value());
+    MYSERIAL.print("tmc2130_pwm_ampl[X]=");
+    MYSERIAL.println(tmc2130_pwm_ampl[X_AXIS], DEC);
+    MYSERIAL.print("tmc2130_pwm_ampl[Y]=");
+    MYSERIAL.println(tmc2130_pwm_ampl[Y_AXIS], DEC);
+    MYSERIAL.print("tmc2130_pwm_ampl[Z]=");
+    MYSERIAL.println(tmc2130_pwm_ampl[Z_AXIS], DEC);
+    MYSERIAL.print("tmc2130_pwm_ampl[E]=");
+    MYSERIAL.println(tmc2130_pwm_ampl[E_AXIS], DEC);
     }
     break;
 
-	case 918: // M918 Set TMC2130 pwm_grad
+  case 918: // M918 Set TMC2130 pwm_grad
     {
-		if (code_seen('X')) tmc2130_set_pwm_grad(0, code_value());
-		if (code_seen('Y')) tmc2130_set_pwm_grad(1, code_value());
-        if (code_seen('Z')) tmc2130_set_pwm_grad(2, code_value());
-        if (code_seen('E')) tmc2130_set_pwm_grad(3, code_value());
+    if (code_seen('X')) tmc2130_set_pwm_grad(0, code_value());
+    if (code_seen('Y')) tmc2130_set_pwm_grad(1, code_value());
+    if (code_seen('Z')) tmc2130_set_pwm_grad(2, code_value());
+    if (code_seen('E')) tmc2130_set_pwm_grad(3, code_value());
+    MYSERIAL.print("tmc2130_pwm_grad[X]=");
+    MYSERIAL.println(tmc2130_pwm_grad[X_AXIS], DEC);
+    MYSERIAL.print("tmc2130_pwm_grad[Y]=");
+    MYSERIAL.println(tmc2130_pwm_grad[Y_AXIS], DEC);
+    MYSERIAL.print("tmc2130_pwm_grad[Z]=");
+    MYSERIAL.println(tmc2130_pwm_grad[Z_AXIS], DEC);
+    MYSERIAL.print("tmc2130_pwm_grad[E]=");
+    MYSERIAL.println(tmc2130_pwm_grad[E_AXIS], DEC);
+    }
+    break;
+
+  case 919: // M919 Print sgt values
+    {
+    tmc2130_print_sgt();
+    }
+    break;
+
+  case 922: // M922 Set TMC2130 homing currents - compliment to M912
+    {
+    if (code_seen('X')) tmc2130_set_current_r_home(0, code_value());
+    if (code_seen('Y')) tmc2130_set_current_r_home(1, code_value());
+    if (code_seen('Z')) tmc2130_set_current_r_home(2, code_value());
+    if (code_seen('E')) tmc2130_set_current_r_home(3, code_value());
+    MYSERIAL.println("Homing currents:");
+    MYSERIAL.print("X   ");
+    MYSERIAL.println(tmc2130_current_r_home[0]);
+    MYSERIAL.print("Y   ");
+    MYSERIAL.println(tmc2130_current_r_home[1]);
+    MYSERIAL.print("Z   ");
+    MYSERIAL.println(tmc2130_current_r_home[2]);
+    MYSERIAL.print("E   ");
+    MYSERIAL.println(tmc2130_current_r_home[3]);
+    }
+    break;
+
+  case 926: // M926 Set tmc2130_sg_thr_home - compliment to M916
+    {
+    if (code_seen('X')) tmc2130_sg_thr_home[X_AXIS] = code_value();
+    if (code_seen('Y')) tmc2130_sg_thr_home[Y_AXIS] = code_value();
+    if (code_seen('Z')) tmc2130_sg_thr_home[Z_AXIS] = code_value();
+    if (code_seen('E')) tmc2130_sg_thr_home[E_AXIS] = code_value();
+    MYSERIAL.print("tmc2130_sg_thr_home[X]=");
+    MYSERIAL.println(tmc2130_sg_thr_home[X_AXIS], DEC);
+    MYSERIAL.print("tmc2130_sg_thr_home[Y]=");
+    MYSERIAL.println(tmc2130_sg_thr_home[Y_AXIS], DEC);
+    MYSERIAL.print("tmc2130_sg_thr_home[Z]=");
+    MYSERIAL.println(tmc2130_sg_thr_home[Z_AXIS], DEC);
+    MYSERIAL.print("tmc2130_sg_thr_home[E]=");
+    MYSERIAL.println(tmc2130_sg_thr_home[E_AXIS], DEC);
     }
     break;
 

--- a/Firmware/tmc2130.cpp
+++ b/Firmware/tmc2130.cpp
@@ -467,20 +467,57 @@ void tmc2130_setup_chopper(uint8_t axis, uint8_t mres, uint8_t current_h, uint8_
 void tmc2130_set_current_h(uint8_t axis, uint8_t current)
 {
 	DBG(_n("tmc2130_set_current_h(axis=%d, current=%d\n"), axis, current);
-	tmc2130_current_h[axis] = current;
-	tmc2130_setup_chopper(axis, tmc2130_mres[axis], tmc2130_current_h[axis], tmc2130_current_r[axis]);
+	if (current < 64)
+	{
+		tmc2130_current_h[axis] = current;
+		tmc2130_setup_chopper(axis, tmc2130_mres[axis], tmc2130_current_h[axis], tmc2130_current_r[axis]);
+	}
+	else
+	{
+		DBG(_n("ERROR: current > 63, tmc2130_current_h[%d] not set."), axis);
+	}
 }
 
 void tmc2130_set_current_r(uint8_t axis, uint8_t current)
 {
 	DBG(_n("tmc2130_set_current_r(axis=%d, current=%d\n"), axis, current);
-	tmc2130_current_r[axis] = current;
-	tmc2130_setup_chopper(axis, tmc2130_mres[axis], tmc2130_current_h[axis], tmc2130_current_r[axis]);
+	if (current < 64)
+	{
+		tmc2130_current_r[axis] = current;
+		tmc2130_setup_chopper(axis, tmc2130_mres[axis], tmc2130_current_h[axis], tmc2130_current_r[axis]);
+	}
+	else
+	{
+		DBG(_n("ERROR: current > 63, tmc2130_current_r[%d] not set."), axis);
+	}
+}
+
+void tmc2130_set_current_r_home(uint8_t axis, uint8_t current)
+{
+	DBG(_n("tmc2130_set_current_r_home(axis=%d, current=%d\n"), axis, current);
+	if (current < 64)
+	{
+		tmc2130_current_r_home[axis] = current;
+	}
+	else
+	{
+		DBG(_n("ERROR: current > 63, tmc2130_current_r_home[%d] not set."), axis);
+	}
 }
 
 void tmc2130_print_currents()
 {
-	DBG(_n("tmc2130_print_currents()\n\tH\tR\nX\t%d\t%d\nY\t%d\t%d\nZ\t%d\t%d\nE\t%d\t%d\n"),
+	DBG(_n("tmc2130_print_currents()\n\tHold\tRun\tHome\nX\t%d\t%d\t%d\nY\t%d\t%d\t%d\nZ\t%d\t%d\t%d\nE\t%d\t%d\t%d\n"),
+		tmc2130_current_h[0], tmc2130_current_r[0], tmc2130_current_r_home[0],
+		tmc2130_current_h[1], tmc2130_current_r[1], tmc2130_current_r_home[1],
+		tmc2130_current_h[2], tmc2130_current_r[2], tmc2130_current_r_home[2],
+		tmc2130_current_h[3], tmc2130_current_r[3], tmc2130_current_r_home[3]
+	);
+}
+
+void tmc2130_print_sgt()
+{
+	DBG(_n("tmc2130_print_sgt()\n\tPrinting:\tHoming:\nX\t%d\t%d\nY\t%d\t%d\nZ\t%d\t%d\nE\t%d\t%d\n"),
 		tmc2130_current_h[0], tmc2130_current_r[0],
 		tmc2130_current_h[1], tmc2130_current_r[1],
 		tmc2130_current_h[2], tmc2130_current_r[2],

--- a/Firmware/tmc2130.cpp
+++ b/Firmware/tmc2130.cpp
@@ -33,7 +33,7 @@ uint8_t tmc2130_current_h[4] = TMC2130_CURRENTS_H;
 uint8_t tmc2130_current_r[4] = TMC2130_CURRENTS_R;
 
 //running currents for homing
-uint8_t tmc2130_current_r_home[4] = {8, 10, 20, 18};
+uint8_t tmc2130_current_r_home[4] = TMC2130_CURRENTS_R_HOME;
 
 
 //pwm_ampl
@@ -48,8 +48,18 @@ uint8_t tmc2130_pwm_freq[4] = {TMC2130_PWM_FREQ_X, TMC2130_PWM_FREQ_Y, TMC2130_P
 uint8_t tmc2130_mres[4] = {0, 0, 0, 0}; //will be filed at begin of init
 
 
-uint8_t tmc2130_sg_thr[4] = {TMC2130_SG_THRS_X, TMC2130_SG_THRS_Y, TMC2130_SG_THRS_Z, TMC2130_SG_THRS_E};
-uint8_t tmc2130_sg_thr_home[4] = {3, 3, TMC2130_SG_THRS_Z, TMC2130_SG_THRS_E};
+uint8_t tmc2130_sg_thr[4] =      {TMC2130_SG_THRS_X,        TMC2130_SG_THRS_Y,        TMC2130_SG_THRS_Z,        TMC2130_SG_THRS_E};
+uint8_t tmc2130_sg_thr_home[4] = {TMC2130_HOMING_SG_THRS_X, TMC2130_HOMING_SG_THRS_Y, TMC2130_HOMING_SG_THRS_Z, TMC2130_HOMING_SG_THRS_E};
+
+
+uint8_t tmc2130_intpol[4] = TMC2130_STEP_INTERPOLATION;
+uint8_t tmc2130_toff = TMC2130_TOFF_XYZ;
+uint8_t tmc2130_hstrt = TMC2130_HSTART;
+uint8_t tmc2130_hend = TMC2130_HEND;
+uint8_t tmc2130_fd3 = TMC2130_FAST_DECAY3;
+uint8_t tmc2130_rndtf = TMC2130_RANDOM_OFF_TIME;
+uint8_t tmc2130_chm = TMC2130_CHOP_MODE;
+uint8_t tmc2130_tbl = TMC2130_BLANKING_TIME;
 
 
 uint8_t tmc2130_sg_homing_axes_mask = 0x00;
@@ -422,14 +432,14 @@ void tmc2130_check_overtemp()
 
 void tmc2130_setup_chopper(uint8_t axis, uint8_t mres, uint8_t current_h, uint8_t current_r)
 {
-	uint8_t intpol = 1;
-	uint8_t toff = TMC2130_TOFF_XYZ; // toff = 3 (fchop = 27.778kHz)
-	uint8_t hstrt = 5; //initial 4, modified to 5
-	uint8_t hend = 1;
-	uint8_t fd3 = 0;
-	uint8_t rndtf = 0; //random off time
-	uint8_t chm = 0; //spreadCycle
-	uint8_t tbl = 2; //blanking time
+	uint8_t intpol = tmc2130_intpol[axis];
+	uint8_t toff = tmc2130_toff; // toff = 3 (fchop = 27.778kHz)
+	uint8_t hstrt = tmc2130_hstrt; //initial 4, modified to 5
+	uint8_t hend = tmc2130_hend; // 1
+	uint8_t fd3 = tmc2130_fd3; // 0
+	uint8_t rndtf = tmc2130_rndtf; //random off time 0
+	uint8_t chm = tmc2130_chm; //spreadCycle 0
+	uint8_t tbl = tmc2130_tbl; //blanking time 2
 	if (axis == E_AXIS)
 	{
 #ifdef TMC2130_CNSTOFF_E

--- a/Firmware/tmc2130.cpp
+++ b/Firmware/tmc2130.cpp
@@ -518,10 +518,10 @@ void tmc2130_print_currents()
 void tmc2130_print_sgt()
 {
 	DBG(_n("tmc2130_print_sgt()\n\tPrinting:\tHoming:\nX\t%d\t%d\nY\t%d\t%d\nZ\t%d\t%d\nE\t%d\t%d\n"),
-		tmc2130_current_h[0], tmc2130_current_r[0],
-		tmc2130_current_h[1], tmc2130_current_r[1],
-		tmc2130_current_h[2], tmc2130_current_r[2],
-		tmc2130_current_h[3], tmc2130_current_r[3]
+		tmc2130_sg_thr[0], tmc2130_sg_thr_home[0],
+		tmc2130_sg_thr[1], tmc2130_sg_thr_home[1],
+		tmc2130_sg_thr[2], tmc2130_sg_thr_home[2],
+		tmc2130_sg_thr[3], tmc2130_sg_thr_home[3]
 	);
 }
 

--- a/Firmware/tmc2130.h
+++ b/Firmware/tmc2130.h
@@ -7,11 +7,15 @@ extern uint8_t tmc2130_mode;
 //holding and running currents
 extern uint8_t tmc2130_current_h[4];
 extern uint8_t tmc2130_current_r[4];
+extern uint8_t tmc2130_current_r_home[4];
 //microstep resolution (0 means 256usteps, 8 means 1ustep
 extern uint8_t tmc2130_mres[4];
 
 //flags for axis stall detection
 extern uint8_t tmc2130_sg_thr[4];
+extern uint8_t tmc2130_sg_thr_home[4];
+extern uint8_t tmc2130_pwm_ampl[4];
+extern uint8_t tmc2130_pwm_grad[4];
 
 extern bool tmc2130_sg_stop_on_crash;
 extern uint8_t tmc2130_sg_crash; //crash mask
@@ -67,7 +71,10 @@ extern void tmc2130_print_currents();
 extern void tmc2130_set_pwm_ampl(uint8_t axis, uint8_t pwm_ampl);
 //set PWM_GRAD for any axis (M918)
 extern void tmc2130_set_pwm_grad(uint8_t axis, uint8_t pwm_ampl);
-
+//set homing current for any axis (M922)
+extern void tmc2130_set_current_r_home(uint8_t axis, uint8_t current);
+//print sgt values (M919)
+extern void tmc2130_print_sgt();
 
 extern uint16_t tmc2130_rd_MSCNT(uint8_t axis);
 extern uint32_t tmc2130_rd_MSCURACT(uint8_t axis);

--- a/Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h
@@ -231,34 +231,45 @@ const bool Z_MIN_ENDSTOP_INVERTING = false; // set to true to invert the logic o
 #define TMC2130_TCOOLTHRS_Y 430       // TCOOLTHRS - coolstep treshold
 #define TMC2130_TCOOLTHRS_Z 500       // TCOOLTHRS - coolstep treshold
 
+#define TMC2130_SG_HOMING       	 1         // stallguard homing
 
-#define _sg(n) ((uint8_t)n & 127) //Convert 7-bit 2's complement to 8-bit unsigned
+#define _sg(n) (((uint8_t)n & 127)) //Convert 7-bit 2's complement to 8-bit unsigned
 
 //The SG_THRS stallGuard sensitivities have a range of -64 to 63.  -64 is the most sensitive, with 0 being half way, and 63 is the least sensitive.
+//Homing:
+#define TMC2130_HOMING_SG_THRS_X 	_sg(3)     // stallguard sensitivity for X axis when homing
+#define TMC2130_HOMING_SG_THRS_Y 	_sg(3)     // stallguard sensitivity for Y axis when homing
+#define TMC2130_HOMING_SG_THRS_Z 	_sg(4)     // stallguard sensitivity for Z axis when homing
+#define TMC2130_HOMING_SG_THRS_E 	_sg(3)     // stallguard sensitivity for E axis when homing
+//Running:
+#define TMC2130_SG_THRS_X        	_sg(3)     // stallguard sensitivity for X axis
+#define TMC2130_SG_THRS_Y        	_sg(3)     // stallguard sensitivity for Y axis
+#define TMC2130_SG_THRS_Z        	_sg(4)     // stallguard sensitivity for Z axis
+#define TMC2130_SG_THRS_E        	_sg(3)     // stallguard sensitivity for E axis
 
-//Used only when homing
-#define TMC2130_SG_HOMING       	 1      // stallguard homing
-#define TMC2130_HOMING_SG_THRS_X _sg(3)     // stallguard sensitivity for X axis when homing
-#define TMC2130_HOMING_SG_THRS_Y _sg(3)     // stallguard sensitivity for Y axis when homing
-#define TMC2130_HOMING_SG_THRS_Z _sg(4)     // stallguard sensitivity for Z axis when homing
-#define TMC2130_HOMING_SG_THRS_E _sg(3)     // stallguard sensitivity for E axis when homing
 
+// Values are scaling factors, not milliamps.
+// For a 0.22 Ohm Rsense resistor (Einsy RAMBO), actual RMS currents are:
+/*                                          value+1
+   For value < 31, current in milliamps =  –––––––– * 0.53
+										      32
 
-//Used only for crash detection, not homing
-#define TMC2130_SG_THRS_X        _sg(3)     // stallguard sensitivity for X axis
-#define TMC2130_SG_THRS_Y        _sg(3)     // stallguard sensitivity for Y axis
-#define TMC2130_SG_THRS_Z        _sg(4)     // stallguard sensitivity for Z axis
-#define TMC2130_SG_THRS_E        _sg(3)     // stallguard sensitivity for E axis
-
-//new settings is possible for vsense = 1, running current value > 31 set vsense to zero and shift both currents by 1 bit right (Z axis only)
+                                           value-31
+   For value > 31, current in milliamps = ––––––––– * 0.943
+                                              32
+*/
+									/* RANGE: 0-63 */
 #define TMC2130_CURRENTS_R_HOME 	{ 8, 10, 20, 18}  // default homing currents for all axes
 #define TMC2130_CURRENTS_H 			{16, 20, 35, 30}  // default holding currents for all axes
 #define TMC2130_CURRENTS_R 			{16, 20, 35, 30}  // default running currents for all axes
-#define TMC2130_UNLOAD_CURRENT_R 	12			 	  // low current for M600 to protect filament sensor 
 
+									/* 1=ON, 0=OFF */
+#define TMC2130_STEP_INTERPOLATION  { 1,  1,  1,  1}  // 256 microstep interpolation for X, Y, Z, and E axes
+
+#define TMC2130_UNLOAD_CURRENT_R 	12			 	  // low current for M600 to protect filament sensor
 #define TMC2130_STEALTH_Z
 
-#define TMC2130_STEP_INTERPOLATION {1, 1, 1, 1} // 256 microstep interpolation for X, Y, Z, and E axes
+// For descriptions of what these do, see https://www.trinamic.com/fileadmin/assets/Products/ICs_Documents/TMC2130_datasheet_Rev1.10.pdf 
 #define TMC2130_BLANKING_TIME 2 // current measurement blanking time, default 2
 #define TMC2130_CHOP_MODE 0 // 0 = spreadCycle
 #define TMC2130_RANDOM_OFF_TIME 0 // 0 = off

--- a/Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h
@@ -251,7 +251,7 @@ const bool Z_MIN_ENDSTOP_INVERTING = false; // set to true to invert the logic o
 #define TMC2130_SG_THRS_E        _sg(3)     // stallguard sensitivity for E axis
 
 //new settings is possible for vsense = 1, running current value > 31 set vsense to zero and shift both currents by 1 bit right (Z axis only)
-#define TMC2130_CURRENTS_R_HOME 	{ 8, 10, 30, 18}  // default homing currents for all axes
+#define TMC2130_CURRENTS_R_HOME 	{ 8, 10, 20, 18}  // default homing currents for all axes
 #define TMC2130_CURRENTS_H 			{16, 20, 35, 30}  // default holding currents for all axes
 #define TMC2130_CURRENTS_R 			{16, 20, 35, 30}  // default running currents for all axes
 #define TMC2130_UNLOAD_CURRENT_R 	12			 	  // low current for M600 to protect filament sensor 
@@ -259,7 +259,7 @@ const bool Z_MIN_ENDSTOP_INVERTING = false; // set to true to invert the logic o
 #define TMC2130_STEALTH_Z
 
 #define TMC2130_STEP_INTERPOLATION {1, 1, 1, 1} // 256 microstep interpolation for X, Y, Z, and E axes
-#define TMC2130_BLANKING_TIME 3 // current measurement blanking time
+#define TMC2130_BLANKING_TIME 2 // current measurement blanking time, default 2
 #define TMC2130_CHOP_MODE 0 // 0 = spreadCycle
 #define TMC2130_RANDOM_OFF_TIME 0 // 0 = off
 #define TMC2130_TOFF_XYZ 3 // toff = 3 (fchop = 27.778kHz)

--- a/Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h
@@ -194,9 +194,7 @@ const bool Z_MIN_ENDSTOP_INVERTING = false; // set to true to invert the logic o
 #define TMC2130_USTEPS_XY   16        // microstep resolution for XY axes
 #define TMC2130_USTEPS_Z    16        // microstep resolution for Z axis
 #define TMC2130_USTEPS_E    32        // microstep resolution for E axis
-#define TMC2130_INTPOL_XY   1         // extrapolate 256 for XY axes
-#define TMC2130_INTPOL_Z    1         // extrapolate 256 for Z axis
-#define TMC2130_INTPOL_E    1         // extrapolate 256 for E axis
+
 
 #define TMC2130_PWM_GRAD_X  2         // PWMCONF
 #define TMC2130_PWM_AMPL_X  230       // PWMCONF
@@ -207,11 +205,6 @@ const bool Z_MIN_ENDSTOP_INVERTING = false; // set to true to invert the logic o
 #define TMC2130_PWM_AMPL_Y  235       // PWMCONF
 #define TMC2130_PWM_AUTO_Y  1         // PWMCONF
 #define TMC2130_PWM_FREQ_Y  2         // PWMCONF
-
-#define TMC2130_PWM_GRAD_E  2         // PWMCONF
-#define TMC2130_PWM_AMPL_E  235       // PWMCONF
-#define TMC2130_PWM_AUTO_E  1         // PWMCONF
-#define TMC2130_PWM_FREQ_E  2         // PWMCONF
 
 #define TMC2130_PWM_GRAD_Z  4         // PWMCONF
 #define TMC2130_PWM_AMPL_Z  200       // PWMCONF
@@ -225,38 +218,54 @@ const bool Z_MIN_ENDSTOP_INVERTING = false; // set to true to invert the logic o
 
 #define TMC2130_TOFF_XYZ    3         // CHOPCONF // fchop = 27.778kHz
 #define TMC2130_TOFF_E      3         // CHOPCONF // fchop = 27.778kHz
-//#define TMC2130_TOFF_E      4         // CHOPCONF // fchop = 21.429kHz
-//#define TMC2130_TOFF_E      5         // CHOPCONF // fchop = 17.442kHz
 
 //#define TMC2130_STEALTH_E // Extruder stealthChop mode
 //#define TMC2130_CNSTOFF_E // Extruder constant-off-time mode (similar to MK2)
 
-//#define TMC2130_PWM_DIV   683         // PWM frequency divider (1024, 683, 512, 410)
 #define TMC2130_PWM_DIV   512         // PWM frequency divider (1024, 683, 512, 410)
 #define TMC2130_PWM_CLK   (2 * TMC2130_FCLK / TMC2130_PWM_DIV) // PWM frequency (23.4kHz, 35.1kHz, 46.9kHz, 58.5kHz for 12MHz fclk)
 
 #define TMC2130_TPWMTHRS  0         // TPWMTHRS - Sets the switching speed threshold based on TSTEP from stealthChop to spreadCycle mode
-#define TMC2130_THIGH     0         // THIGH - unused
 
-//#define TMC2130_TCOOLTHRS_X 450       // TCOOLTHRS - coolstep treshold
-//#define TMC2130_TCOOLTHRS_Y 450       // TCOOLTHRS - coolstep treshold
 #define TMC2130_TCOOLTHRS_X 430       // TCOOLTHRS - coolstep treshold
 #define TMC2130_TCOOLTHRS_Y 430       // TCOOLTHRS - coolstep treshold
 #define TMC2130_TCOOLTHRS_Z 500       // TCOOLTHRS - coolstep treshold
-#define TMC2130_TCOOLTHRS_E 500       // TCOOLTHRS - coolstep treshold
 
-#define TMC2130_SG_HOMING       1     // stallguard homing
-#define TMC2130_SG_THRS_X       3     // stallguard sensitivity for X axis
-#define TMC2130_SG_THRS_Y       3     // stallguard sensitivity for Y axis
-#define TMC2130_SG_THRS_Z       4     // stallguard sensitivity for Z axis
-#define TMC2130_SG_THRS_E       3     // stallguard sensitivity for E axis
+
+#define _sg(n) ((uint8_t)n & 127) //Convert 7-bit 2's complement to 8-bit unsigned
+
+//The SG_THRS stallGuard sensitivities have a range of -64 to 63.  -64 is the most sensitive, with 0 being half way, and 63 is the least sensitive.
+
+//Used only when homing
+#define TMC2130_SG_HOMING       	 1      // stallguard homing
+#define TMC2130_HOMING_SG_THRS_X _sg(3)     // stallguard sensitivity for X axis when homing
+#define TMC2130_HOMING_SG_THRS_Y _sg(3)     // stallguard sensitivity for Y axis when homing
+#define TMC2130_HOMING_SG_THRS_Z _sg(4)     // stallguard sensitivity for Z axis when homing
+#define TMC2130_HOMING_SG_THRS_E _sg(3)     // stallguard sensitivity for E axis when homing
+
+
+//Used only for crash detection, not homing
+#define TMC2130_SG_THRS_X        _sg(3)     // stallguard sensitivity for X axis
+#define TMC2130_SG_THRS_Y        _sg(3)     // stallguard sensitivity for Y axis
+#define TMC2130_SG_THRS_Z        _sg(4)     // stallguard sensitivity for Z axis
+#define TMC2130_SG_THRS_E        _sg(3)     // stallguard sensitivity for E axis
 
 //new settings is possible for vsense = 1, running current value > 31 set vsense to zero and shift both currents by 1 bit right (Z axis only)
-#define TMC2130_CURRENTS_H {16, 20, 35, 30}  // default holding currents for all axes
-#define TMC2130_CURRENTS_R {16, 20, 35, 30}  // default running currents for all axes
-#define TMC2130_UNLOAD_CURRENT_R 12			 // lowe current for M600 to protect filament sensor 
+#define TMC2130_CURRENTS_R_HOME 	{ 8, 10, 30, 18}  // default homing currents for all axes
+#define TMC2130_CURRENTS_H 			{16, 20, 35, 30}  // default holding currents for all axes
+#define TMC2130_CURRENTS_R 			{16, 20, 35, 30}  // default running currents for all axes
+#define TMC2130_UNLOAD_CURRENT_R 	12			 	  // low current for M600 to protect filament sensor 
 
 #define TMC2130_STEALTH_Z
+
+#define TMC2130_STEP_INTERPOLATION {1, 1, 1, 1} // 256 microstep interpolation for X, Y, Z, and E axes
+#define TMC2130_BLANKING_TIME 3 // current measurement blanking time
+#define TMC2130_CHOP_MODE 0 // 0 = spreadCycle
+#define TMC2130_RANDOM_OFF_TIME 0 // 0 = off
+#define TMC2130_TOFF_XYZ 3 // toff = 3 (fchop = 27.778kHz)
+#define TMC2130_HSTART 5 //initial 4, modified to 5
+#define TMC2130_HEND 1 // 1
+#define TMC2130_FAST_DECAY3 0 // Not used in spreadCycle mode
 
 //#define TMC2130_DEBUG
 //#define TMC2130_DEBUG_WR


### PR DESCRIPTION
Hi, I don't know if these are acceptable changes or not, but I figured I'd at least make a pull request in case you like them.  


I did a little 'spring cleaning' of some of the TMC2130 setup code to make it easier to play with the config registers.   This is in the context of figuring out the mysterious extrusion bug effecting print quality of the MK3, and I thought this might make it a little easier to track down (if it is even caused in part by something with the TMC2130 - which may or may not be the case).  But I digress.  

Changes:

1.  Removed hard homing values and gave them their own explicit #defines in the MK3 config variant header.  It's also just nice for people playing with custom firmware - I think most people would assume that changing the TMC2130_SG_THRS defines for the X and Y axes would apply to homing, but as the code stands now, its hard coded to '3'.  

2.  Added a small macro that allows 'native' signed values for sgt to be provided by converting it to the unsigned representation of a 7-bit 2's compliment number.  In other words, stallGuard threshold values can be given as -64 to 63, and as long as _sg(<value>) is used, it will turn negative values into their correct 7-bit 2's compliment.  

3.  There is a fair amount of TMC2130-related #defines in the MK3 variant header that don't do anything.  Not just that, but the define doesn't exist *anywhere* else in the entire codebase, except for that single define.  This too is problematic as one might expect if the #define is present, then it must actually do something.  And there were a few duplicate #defines.   Anyway, they've been removed.  

4. Step interpolation can now actually be turned on or off per axis (all the interpolation related defines the code as it is right now don't actually do anything or even appear anywhere else in the codebase), as well as a few other interesting options have been moved into the variant header and given their own #defines 

5.  Comments documenting some settings have been added or clarified. 

6.  The reason for declaring uint8_t variables for some of the new flags in tmc2130.cpp is to make it easy to add custom gcodes to read or set them instead of having no choice but to recompile.  


Anyway, I completely understand if this is not a direction you're interested in and this pull request gets rejected.  I'm just creating it in case any of you think it is useful.

S pozdravem