### PR TITLE
TMC2130 configuration axis separation

### DIFF
--- a/Firmware/tmc2130.cpp
+++ b/Firmware/tmc2130.cpp
@@ -11,7 +11,6 @@
 #include "spi.h"
 #endif //NEW_SPI
 
-
 extern LiquidCrystal_Prusa lcd;
 
 #define TMC2130_GCONF_NORMAL 0x00000000 // spreadCycle
@@ -25,46 +24,41 @@ extern long st_get_position(uint8_t axis);
 extern void crashdet_stop_and_save_print();
 extern void crashdet_stop_and_save_print2();
 
-//mode
-uint8_t tmc2130_mode = TMC2130_MODE_NORMAL;
-//holding currents
-uint8_t tmc2130_current_h[4] = TMC2130_CURRENTS_H;
-//running currents
-uint8_t tmc2130_current_r[4] = TMC2130_CURRENTS_R;
+//CHOPCONF REGISTER CONFIGURATION
+uint8_t tmc2130_toff[4] = TMC2130_TOFF;
+uint8_t tmc2130_hstrt[4] = TMC2130_HSTRT;
+uint8_t tmc2130_hend[4] = TMC2130_HEND;
+uint8_t tmc2130_fd3[4] = {0, 0, 0, 0};
+uint8_t tmc2130_disfdcc[4] = {0, 0, 0, 0};
+uint8_t tmc2130_rndtf[4] = {0, 0, 0, 0};
+uint8_t tmc2130_chm[4] = {0, 0, 0, 0};
+uint8_t tmc2130_tbl[4] = TMC2130_TBL;
+uint8_t tmc2130_vsense[4] = {0, 0, 0, 0};
+uint8_t tmc2130_vhighfs[4] = {0, 0, 0, 0};
+uint8_t tmc2130_vhighchm[4] = {0, 0, 0, 0};
+uint8_t tmc2130_sync[4] = {0, 0, 0, 0};
+uint8_t tmc2130_mres[4] = {0, 0, 0, 0}; //TMC2130_MRES;           // will be filed at begin of init 
+uint8_t tmc2130_intpol[4] = TMC2130_INTPOL;
+uint8_t tmc2130_dedge[4] = {0, 0, 0, 0};
+uint8_t tmc2130_diss2g[4] = {0, 0, 0, 0};
 
-//running currents for homing
-uint8_t tmc2130_current_r_home[4] = {8, 10, 20, 18};
-
-
-//pwm_ampl
-uint8_t tmc2130_pwm_ampl[4] = {TMC2130_PWM_AMPL_X, TMC2130_PWM_AMPL_Y, TMC2130_PWM_AMPL_Z, TMC2130_PWM_AMPL_E};
-//pwm_grad
-uint8_t tmc2130_pwm_grad[4] = {TMC2130_PWM_GRAD_X, TMC2130_PWM_GRAD_Y, TMC2130_PWM_GRAD_Z, TMC2130_PWM_GRAD_E};
-//pwm_auto
-uint8_t tmc2130_pwm_auto[4] = {TMC2130_PWM_AUTO_X, TMC2130_PWM_AUTO_Y, TMC2130_PWM_AUTO_Z, TMC2130_PWM_AUTO_E};
-//pwm_freq
-uint8_t tmc2130_pwm_freq[4] = {TMC2130_PWM_FREQ_X, TMC2130_PWM_FREQ_Y, TMC2130_PWM_FREQ_Z, TMC2130_PWM_FREQ_E};
-
-uint8_t tmc2130_mres[4] = {0, 0, 0, 0}; //will be filed at begin of init
-
-
-uint8_t tmc2130_sg_thr[4] = {TMC2130_SG_THRS_X, TMC2130_SG_THRS_Y, TMC2130_SG_THRS_Z, TMC2130_SG_THRS_E};
-uint8_t tmc2130_sg_thr_home[4] = {3, 3, TMC2130_SG_THRS_Z, TMC2130_SG_THRS_E};
-
-
-uint8_t tmc2130_sg_homing_axes_mask = 0x00;
-
-uint8_t tmc2130_sg_meassure = 0xff;
-uint32_t tmc2130_sg_meassure_cnt = 0;
-uint32_t tmc2130_sg_meassure_val = 0;
-
+//GENERAL CONFIGURATION 
+uint8_t tmc2130_current_h[4] = TMC2130_IHOLD;       //Holding currents for X, Y, Z & E axis
+uint8_t tmc2130_current_r[4] = TMC2130_IRUN;        //Running currents for X, Y, Z & E axis
+uint8_t tmc2130_current_r_home[4] = TMC2130_IHOME;  //Running currents during homing for X, Y, Z & E axis
+uint8_t tmc2130_mode = TMC2130_MODE_NORMAL;         //Sets default mode for normal operation
 uint8_t tmc2130_home_enabled = 0;
 uint8_t tmc2130_home_origin[2] = {0, 0};
-uint8_t tmc2130_home_bsteps[2] = {48, 48};
-uint8_t tmc2130_home_fsteps[2] = {48, 48};
+uint8_t tmc2130_home_bsteps[2] = {48, 48};          //Babysteps during homing procedure
+uint8_t tmc2130_home_fsteps[2] = {48, 48};          //Fullsteps during homing procedure
 
-uint8_t tmc2130_wave_fac[4] = {0, 0, 0, 0};
-
+//COOLSTEP REGISTER CONFIGURATION
+uint8_t tmc2130_sg_thr[4] = TMC2130_SG_THRS;        //Stallguard threshold for for X, Y, Z & E axis
+uint8_t tmc2130_sg_thr_home[4] = TMC2130_SG_HOMING; //Stallguard threshold during homing procedure for X, Y, Z & E axis
+uint8_t tmc2130_sg_homing_axes_mask = 0x00;
+uint8_t tmc2130_sg_measure = 0xff;
+uint32_t tmc2130_sg_measure_cnt = 0;
+uint32_t tmc2130_sg_measure_val = 0;
 bool tmc2130_sg_stop_on_crash = true;
 uint8_t tmc2130_sg_diag_mask = 0x00;
 uint8_t tmc2130_sg_crash = 0;
@@ -73,15 +67,19 @@ uint16_t tmc2130_sg_cnt[4] = {0, 0, 0, 0};
 bool tmc2130_sg_change = false;
 
 
+//STEALTHCHOP REGISTER CONFIGURATION
+uint8_t tmc2130_pwm_ampl[4] = TMC2130_PWM_AMPL;     //pwm_ampl  
+uint8_t tmc2130_pwm_grad[4] = TMC2130_PWM_GRAD;     //pwm_grad
+uint8_t tmc2130_pwm_auto[4] = TMC2130_PWM_AUTO;     //pwm_auto
+uint8_t tmc2130_pwm_freq[4] = TMC2130_PWM_FREQ;     //pwm_freq
+
+uint8_t tmc2130_wave_fac[4] = {0, 0, 0, 0};
+
 bool skip_debug_msg = false;
 
 #define DBG(args...) printf_P(args)
-#ifndef _n
 #define _n PSTR
-#endif //_n
-#ifndef _i
 #define _i PSTR
-#endif //_i
 
 //TMC2130 registers
 #define TMC2130_REG_GCONF      0x00 // 17 bits
@@ -116,12 +114,11 @@ bool skip_debug_msg = false;
 #define TMC2130_REG_ENCM_CTRL  0x72 // 2 bits
 #define TMC2130_REG_LOST_STEPS 0x73 // 20 bits
 
-
 uint16_t tmc2130_rd_TSTEP(uint8_t axis);
 uint16_t tmc2130_rd_MSCNT(uint8_t axis);
 uint32_t tmc2130_rd_MSCURACT(uint8_t axis);
 
-void tmc2130_wr_CHOPCONF(uint8_t axis, uint8_t toff = 3, uint8_t hstrt = 4, uint8_t hend = 1, uint8_t fd3 = 0, uint8_t disfdcc = 0, uint8_t rndtf = 0, uint8_t chm = 0, uint8_t tbl = 2, uint8_t vsense = 0, uint8_t vhighfs = 0, uint8_t vhighchm = 0, uint8_t sync = 0, uint8_t mres = 0b0100, uint8_t intpol = 1, uint8_t dedge = 0, uint8_t diss2g = 0);
+void tmc2130_wr_CHOPCONF(uint8_t axis, uint8_t toff, uint8_t hstrt, uint8_t hend, uint8_t fd3, uint8_t disfdcc, uint8_t rndtf, uint8_t chm, uint8_t tbl, uint8_t vsense, uint8_t vhighfs, uint8_t vhighchm, uint8_t sync, uint8_t mres, uint8_t intpol, uint8_t dedge, uint8_t diss2g);
 void tmc2130_wr_PWMCONF(uint8_t axis, uint8_t pwm_ampl, uint8_t pwm_grad, uint8_t pwm_freq, uint8_t pwm_auto, uint8_t pwm_symm, uint8_t freewheel);
 void tmc2130_wr_TPWMTHRS(uint8_t axis, uint32_t val32);
 void tmc2130_wr_THIGH(uint8_t axis, uint32_t val32);
@@ -135,13 +132,16 @@ uint8_t tmc2130_rx(uint8_t axis, uint8_t addr, uint32_t* rval);
 
 void tmc2130_setup_chopper(uint8_t axis, uint8_t mres, uint8_t current_h, uint8_t current_r);
 
+uint8_t tmc2130_tcoolthrs[4] = TMC2130_TCOOLTHRS;
+
 uint16_t __tcoolthrs(uint8_t axis)
 {
 	switch (axis)
 	{
-	case X_AXIS: return TMC2130_TCOOLTHRS_X;
-	case Y_AXIS: return TMC2130_TCOOLTHRS_Y;
-	case Z_AXIS: return TMC2130_TCOOLTHRS_Z;
+	case X_AXIS: return tmc2130_tcoolthrs[X_AXIS];
+	case Y_AXIS: return tmc2130_tcoolthrs[Y_AXIS];
+	case Z_AXIS: return tmc2130_tcoolthrs[Z_AXIS];
+  case E_AXIS: return tmc2130_tcoolthrs[E_AXIS];
 	}
 	return 0;
 }
@@ -164,17 +164,30 @@ void tmc2130_init()
 #ifndef NEW_SPI
 	SPI.begin();
 #endif //NEW_SPI
-	for (int axis = 0; axis < 2; axis++) // X Y axes
+	for (int axis = 0; axis < 1; axis++) // X Y axes
 	{
 		tmc2130_setup_chopper(axis, tmc2130_mres[axis], tmc2130_current_h[axis], tmc2130_current_r[axis]);
 		tmc2130_wr(axis, TMC2130_REG_TPOWERDOWN, 0x00000000);
 		tmc2130_wr(axis, TMC2130_REG_COOLCONF, (((uint32_t)tmc2130_sg_thr[axis]) << 16));
 		tmc2130_wr(axis, TMC2130_REG_TCOOLTHRS, (tmc2130_mode == TMC2130_MODE_SILENT)?0:__tcoolthrs(axis));
 		tmc2130_wr(axis, TMC2130_REG_GCONF, (tmc2130_mode == TMC2130_MODE_SILENT)?TMC2130_GCONF_SILENT:TMC2130_GCONF_SGSENS);
+    tmc2130_wr_CHOPCONF(axis, tmc2130_toff[axis], tmc2130_hstrt[axis], tmc2130_hend[axis], tmc2130_fd3[axis], tmc2130_disfdcc[axis], tmc2130_rndtf[axis], tmc2130_chm[axis], tmc2130_tbl[axis], tmc2130_vsense[axis], tmc2130_vhighfs[axis], tmc2130_vhighchm[axis], tmc2130_sync[axis], tmc2130_mres[axis], tmc2130_intpol[axis], tmc2130_dedge[axis], tmc2130_diss2g[axis]);
 		tmc2130_wr_PWMCONF(axis, tmc2130_pwm_ampl[axis], tmc2130_pwm_grad[axis], tmc2130_pwm_freq[axis], tmc2130_pwm_auto[axis], 0, 0);
 		tmc2130_wr_TPWMTHRS(axis, TMC2130_TPWMTHRS);
 		//tmc2130_wr_THIGH(axis, TMC2130_THIGH);
 	}
+  for (int axis = 1; axis < 2; axis++) // X Y axes
+  {
+    tmc2130_setup_chopper(axis, tmc2130_mres[axis], tmc2130_current_h[axis], tmc2130_current_r[axis]);
+    tmc2130_wr(axis, TMC2130_REG_TPOWERDOWN, 0x00000000);
+    tmc2130_wr(axis, TMC2130_REG_COOLCONF, (((uint32_t)tmc2130_sg_thr[axis]) << 16));
+    tmc2130_wr(axis, TMC2130_REG_TCOOLTHRS, (tmc2130_mode == TMC2130_MODE_SILENT)?0:__tcoolthrs(axis));
+    tmc2130_wr(axis, TMC2130_REG_GCONF, (tmc2130_mode == TMC2130_MODE_SILENT)?TMC2130_GCONF_SILENT:TMC2130_GCONF_SGSENS);
+    tmc2130_wr_CHOPCONF(axis, tmc2130_toff[axis], tmc2130_hstrt[axis], tmc2130_hend[axis], tmc2130_fd3[axis], tmc2130_disfdcc[axis], tmc2130_rndtf[axis], tmc2130_chm[axis], tmc2130_tbl[axis], tmc2130_vsense[axis], tmc2130_vhighfs[axis], tmc2130_vhighchm[axis], tmc2130_sync[axis], tmc2130_mres[axis], tmc2130_intpol[axis], tmc2130_dedge[axis], tmc2130_diss2g[axis]);
+    tmc2130_wr_PWMCONF(axis, tmc2130_pwm_ampl[axis], tmc2130_pwm_grad[axis], tmc2130_pwm_freq[axis], tmc2130_pwm_auto[axis], 0, 0);
+    tmc2130_wr_TPWMTHRS(axis, TMC2130_TPWMTHRS);
+    //tmc2130_wr_THIGH(axis, TMC2130_THIGH);
+  }
 	for (int axis = 2; axis < 3; axis++) // Z axis
 	{
 		tmc2130_setup_chopper(axis, tmc2130_mres[axis], tmc2130_current_h[axis], tmc2130_current_r[axis]);
@@ -185,6 +198,7 @@ void tmc2130_init()
 		tmc2130_wr(axis, TMC2130_REG_COOLCONF, (((uint32_t)tmc2130_sg_thr[axis]) << 16));
 		tmc2130_wr(axis, TMC2130_REG_TCOOLTHRS, (tmc2130_mode == TMC2130_MODE_SILENT)?0:__tcoolthrs(axis));
 		tmc2130_wr(axis, TMC2130_REG_GCONF, (tmc2130_mode == TMC2130_MODE_SILENT)?TMC2130_GCONF_SILENT:TMC2130_GCONF_SGSENS);
+    tmc2130_wr_CHOPCONF(axis, tmc2130_toff[axis], tmc2130_hstrt[axis], tmc2130_hend[axis], tmc2130_fd3[axis], tmc2130_disfdcc[axis], tmc2130_rndtf[axis], tmc2130_chm[axis], tmc2130_tbl[axis], tmc2130_vsense[axis], tmc2130_vhighfs[axis], tmc2130_vhighchm[axis], tmc2130_sync[axis], tmc2130_mres[axis], tmc2130_intpol[axis], tmc2130_dedge[axis], tmc2130_diss2g[axis]);
 		tmc2130_wr_PWMCONF(axis, tmc2130_pwm_ampl[axis], tmc2130_pwm_grad[axis], tmc2130_pwm_freq[axis], tmc2130_pwm_auto[axis], 0, 0);
 		tmc2130_wr_TPWMTHRS(axis, TMC2130_TPWMTHRS);
 #endif //TMC2130_STEALTH_Z
@@ -192,6 +206,7 @@ void tmc2130_init()
 	for (int axis = 3; axis < 4; axis++) // E axis
 	{
 		tmc2130_setup_chopper(axis, tmc2130_mres[axis], tmc2130_current_h[axis], tmc2130_current_r[axis]);
+    tmc2130_wr_CHOPCONF(axis, tmc2130_toff[axis], tmc2130_hstrt[axis], tmc2130_hend[axis], tmc2130_fd3[axis], tmc2130_disfdcc[axis], tmc2130_rndtf[axis], tmc2130_chm[axis], tmc2130_tbl[axis], tmc2130_vsense[axis], tmc2130_vhighfs[axis], tmc2130_vhighchm[axis], tmc2130_sync[axis], tmc2130_mres[axis], tmc2130_intpol[axis], tmc2130_dedge[axis], tmc2130_diss2g[axis]);
 		tmc2130_wr(axis, TMC2130_REG_TPOWERDOWN, 0x00000000);
 #ifndef TMC2130_STEALTH_E
 		tmc2130_wr(axis, TMC2130_REG_GCONF, TMC2130_GCONF_SGSENS);
@@ -213,12 +228,10 @@ void tmc2130_init()
 	tmc2130_sg_cnt[2] = 0;
 	tmc2130_sg_cnt[3] = 0;
 
-#ifdef TMC2130_LINEARITY_CORRECTION
-//	tmc2130_set_wave(X_AXIS, 247, tmc2130_wave_fac[X_AXIS]);
-//	tmc2130_set_wave(Y_AXIS, 247, tmc2130_wave_fac[Y_AXIS]);
-//	tmc2130_set_wave(Z_AXIS, 247, tmc2130_wave_fac[Z_AXIS]);
+	tmc2130_set_wave(X_AXIS, 247, tmc2130_wave_fac[X_AXIS]);
+	tmc2130_set_wave(Y_AXIS, 247, tmc2130_wave_fac[Y_AXIS]);
+	tmc2130_set_wave(Z_AXIS, 247, tmc2130_wave_fac[Z_AXIS]);
 	tmc2130_set_wave(E_AXIS, 247, tmc2130_wave_fac[E_AXIS]);
-#endif //TMC2130_LINEARITY_CORRECTION
 
 }
 
@@ -273,12 +286,12 @@ void tmc2130_st_isr(uint8_t last_step_mask)
 
 bool tmc2130_update_sg()
 {
-	if (tmc2130_sg_meassure <= E_AXIS)
+	if (tmc2130_sg_measure <= E_AXIS)
 	{
 		uint32_t val32 = 0;
-		tmc2130_rd(tmc2130_sg_meassure, TMC2130_REG_DRV_STATUS, &val32);
-		tmc2130_sg_meassure_val += (val32 & 0x3ff);
-		tmc2130_sg_meassure_cnt++;
+		tmc2130_rd(tmc2130_sg_measure, TMC2130_REG_DRV_STATUS, &val32);
+		tmc2130_sg_measure_val += (val32 & 0x3ff);
+		tmc2130_sg_measure_cnt++;
 		return true;
 	}
 	return false;
@@ -302,6 +315,7 @@ void tmc2130_home_enter(uint8_t axes_mask)
 //			tmc2130_wr(axis, TMC2130_REG_COOLCONF, (((uint32_t)tmc2130_sg_thr[axis]) << 16) | ((uint32_t)1 << 24));
 			tmc2130_wr(axis, TMC2130_REG_TCOOLTHRS, __tcoolthrs(axis));
 			tmc2130_setup_chopper(axis, tmc2130_mres[axis], tmc2130_current_h[axis], tmc2130_current_r_home[axis]);
+      tmc2130_wr_CHOPCONF(axis, tmc2130_toff[axis], tmc2130_hstrt[axis], tmc2130_hend[axis], tmc2130_fd3[axis], tmc2130_disfdcc[axis], tmc2130_rndtf[axis], tmc2130_chm[axis], tmc2130_tbl[axis], tmc2130_vsense[axis], tmc2130_vhighfs[axis], tmc2130_vhighchm[axis], tmc2130_sync[axis], tmc2130_mres[axis], tmc2130_intpol[axis], tmc2130_dedge[axis], tmc2130_diss2g[axis]);
 			if (mask & (X_AXIS_MASK | Y_AXIS_MASK | Z_AXIS_MASK))
 				tmc2130_wr(axis, TMC2130_REG_GCONF, TMC2130_GCONF_SGSENS); //stallguard output DIAG1, DIAG1 = pushpull
 		}
@@ -336,6 +350,7 @@ void tmc2130_home_exit()
 				{
 //					tmc2130_wr(axis, TMC2130_REG_GCONF, TMC2130_GCONF_NORMAL);
 					tmc2130_setup_chopper(axis, tmc2130_mres[axis], tmc2130_current_h[axis], tmc2130_current_r[axis]);
+          tmc2130_wr_CHOPCONF(axis, tmc2130_toff[axis], tmc2130_hstrt[axis], tmc2130_hend[axis], tmc2130_fd3[axis], tmc2130_disfdcc[axis], tmc2130_rndtf[axis], tmc2130_chm[axis], tmc2130_tbl[axis], tmc2130_vsense[axis], tmc2130_vhighfs[axis], tmc2130_vhighchm[axis], tmc2130_sync[axis], tmc2130_mres[axis], tmc2130_intpol[axis], tmc2130_dedge[axis], tmc2130_diss2g[axis]);
 //					tmc2130_wr(axis, TMC2130_REG_COOLCONF, (((uint32_t)tmc2130_sg_thr[axis]) << 16) | ((uint32_t)1 << 24));
 					tmc2130_wr(axis, TMC2130_REG_COOLCONF, (((uint32_t)tmc2130_sg_thr[axis]) << 16));
 					tmc2130_wr(axis, TMC2130_REG_TCOOLTHRS, __tcoolthrs(axis));
@@ -349,17 +364,17 @@ void tmc2130_home_exit()
 #endif
 }
 
-void tmc2130_sg_meassure_start(uint8_t axis)
+void tmc2130_sg_measure_start(uint8_t axis)
 {
-	tmc2130_sg_meassure = axis;
-	tmc2130_sg_meassure_cnt = 0;
-	tmc2130_sg_meassure_val = 0;
+	tmc2130_sg_measure = axis;
+	tmc2130_sg_measure_cnt = 0;
+	tmc2130_sg_measure_val = 0;
 }
 
-uint16_t tmc2130_sg_meassure_stop()
+uint16_t tmc2130_sg_measure_stop()
 {
-	tmc2130_sg_meassure = 0xff;
-	return tmc2130_sg_meassure_val / tmc2130_sg_meassure_cnt;
+	tmc2130_sg_measure = 0xff;
+	return tmc2130_sg_measure_val / tmc2130_sg_measure_cnt;
 }
 
 
@@ -422,10 +437,10 @@ void tmc2130_check_overtemp()
 
 void tmc2130_setup_chopper(uint8_t axis, uint8_t mres, uint8_t current_h, uint8_t current_r)
 {
-	uint8_t intpol = 1;
-	uint8_t toff = TMC2130_TOFF_XYZ; // toff = 3 (fchop = 27.778kHz)
-	uint8_t hstrt = 5; //initial 4, modified to 5
-	uint8_t hend = 1;
+	uint8_t intpol = intpol;
+	uint8_t toff = toff; // toff = 3 (fchop = 27.778kHz)
+	uint8_t hstrt = hstrt; //initial 4, modified to 5
+	uint8_t hend = hend;
 	uint8_t fd3 = 0;
 	uint8_t rndtf = 0; //random off time
 	uint8_t chm = 0; //spreadCycle
@@ -439,7 +454,7 @@ void tmc2130_setup_chopper(uint8_t axis, uint8_t mres, uint8_t current_h, uint8_
 		hend = 0; //sine wave offset
 		chm = 1; // constant off time mod
 #endif //TMC2130_CNSTOFF_E
-		toff = TMC2130_TOFF_E; // toff = 3-5
+		toff = toff; // toff = 3-5
 //		rndtf = 1;
 	}
 	if (current_r <= 31)

--- a/Firmware/tmc2130.cpp
+++ b/Firmware/tmc2130.cpp
@@ -37,7 +37,7 @@ uint8_t tmc2130_vsense[4] = {0, 0, 0, 0};
 uint8_t tmc2130_vhighfs[4] = {0, 0, 0, 0};
 uint8_t tmc2130_vhighchm[4] = {0, 0, 0, 0};
 uint8_t tmc2130_sync[4] = {0, 0, 0, 0};
-uint8_t tmc2130_mres[4] = {0, 0, 0, 0}; //TMC2130_MRES;           // will be filed at begin of init 
+uint8_t tmc2130_mres[4] = {0, 0, 0, 0};            // will be filed at begin of init 
 uint8_t tmc2130_intpol[4] = TMC2130_INTPOL;
 uint8_t tmc2130_dedge[4] = {0, 0, 0, 0};
 uint8_t tmc2130_diss2g[4] = {0, 0, 0, 0};
@@ -78,8 +78,12 @@ uint8_t tmc2130_wave_fac[4] = {0, 0, 0, 0};
 bool skip_debug_msg = false;
 
 #define DBG(args...) printf_P(args)
+#ifndef _n
 #define _n PSTR
+#endif //_n
+#ifndef _i
 #define _i PSTR
+#endif //_i
 
 //TMC2130 registers
 #define TMC2130_REG_GCONF      0x00 // 17 bits
@@ -364,17 +368,17 @@ void tmc2130_home_exit()
 #endif
 }
 
-void tmc2130_sg_measure_start(uint8_t axis)
+void tmc2130_sg_meassure_start(uint8_t axis)
 {
-	tmc2130_sg_measure = axis;
-	tmc2130_sg_measure_cnt = 0;
-	tmc2130_sg_measure_val = 0;
+	tmc2130_sg_meassure = axis;
+	tmc2130_sg_meassure_cnt = 0;
+	tmc2130_sg_meassure_val = 0;
 }
 
-uint16_t tmc2130_sg_measure_stop()
+uint16_t tmc2130_sg_meassure_stop()
 {
-	tmc2130_sg_measure = 0xff;
-	return tmc2130_sg_measure_val / tmc2130_sg_measure_cnt;
+	tmc2130_sg_meassure = 0xff;
+	return tmc2130_sg_meassure_val / tmc2130_sg_meassure_cnt;
 }
 
 
@@ -437,14 +441,14 @@ void tmc2130_check_overtemp()
 
 void tmc2130_setup_chopper(uint8_t axis, uint8_t mres, uint8_t current_h, uint8_t current_r)
 {
-	uint8_t intpol = intpol;
-	uint8_t toff = toff; // toff = 3 (fchop = 27.778kHz)
-	uint8_t hstrt = hstrt; //initial 4, modified to 5
-	uint8_t hend = hend;
+	uint8_t intpol = tmc2130_intpol[axis];
+	uint8_t toff = tmc2130_toff[axis]; 		// toff = 3 (fchop = 27.778kHz)
+	uint8_t hstrt = tmc2130_hstrt[axis]; 		//initial 4, modified to 5
+	uint8_t hend = tmc2130_hend[axis];
 	uint8_t fd3 = 0;
-	uint8_t rndtf = 0; //random off time
-	uint8_t chm = 0; //spreadCycle
-	uint8_t tbl = 2; //blanking time
+	uint8_t rndtf = 0; 				//random off time
+	uint8_t chm = 0; 				//spreadCycle
+	uint8_t tbl = tmc2130_tbl[axis]; 		//blanking time
 	if (axis == E_AXIS)
 	{
 #ifdef TMC2130_CNSTOFF_E
@@ -454,7 +458,7 @@ void tmc2130_setup_chopper(uint8_t axis, uint8_t mres, uint8_t current_h, uint8_
 		hend = 0; //sine wave offset
 		chm = 1; // constant off time mod
 #endif //TMC2130_CNSTOFF_E
-		toff = toff; // toff = 3-5
+		toff = tmc2130_toff[axis]; 		// toff = 3-5
 //		rndtf = 1;
 	}
 	if (current_r <= 31)

--- a/Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h
@@ -192,13 +192,11 @@ const bool Z_MIN_ENDSTOP_INVERTING = false; // set to true to invert the logic o
 //#define TMC2130_DEBUG_RD
 //#define TMC2130_VARIABLE_RESOLUTION
 
-//These definitions have been kept as reference for external functions
 #define TMC2130_USTEPS_XY   16        // microstep resolution for XY axes
 #define TMC2130_USTEPS_Z    16        // microstep resolution for Z axis
 #define TMC2130_USTEPS_E    32        // microstep resolution for E axis
 
 //                          {X, Y, Z, E}                           
-#define TMC2130_MRES        {4, 4, 4, 3}                // Default uStep steeting for each axis; X, Y, Z, E. ( 0 = 256 ... 3 = 32, 4 = 16 ... 8 = Fullstep) (ONLY IN TMC2130.cpp)
 #define TMC2130_INTPOL      {1, 1, 1, 1}                // Interpolate to driver native 256 uSteps for smooth movement
 //new settings is possible for vsense = 1, running current value > 31 set vsense to zero and shift both currents by 1 bit right (Z axis only) 
 #define TMC2130_IRUN        {16, 20, 35, 20}            // Default running currents for all axes 

--- a/Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h
@@ -183,85 +183,60 @@ const bool Z_MIN_ENDSTOP_INVERTING = false; // set to true to invert the logic o
 #define TMC2130_LINEARITY_CORRECTION
 //#define TMC2130_VARIABLE_RESOLUTION
 
-
-
 /*------------------------------------
  TMC2130 default settings
- *------------------------------------*/
-
-#define TMC2130_FCLK 12000000       // fclk = 12MHz
-
-#define TMC2130_USTEPS_XY   16        // microstep resolution for XY axes
-#define TMC2130_USTEPS_Z    16        // microstep resolution for Z axis
-#define TMC2130_USTEPS_E    32        // microstep resolution for E axis
-#define TMC2130_INTPOL_XY   1         // extrapolate 256 for XY axes
-#define TMC2130_INTPOL_Z    1         // extrapolate 256 for Z axis
-#define TMC2130_INTPOL_E    1         // extrapolate 256 for E axis
-
-#define TMC2130_PWM_GRAD_X  2         // PWMCONF
-#define TMC2130_PWM_AMPL_X  230       // PWMCONF
-#define TMC2130_PWM_AUTO_X  1         // PWMCONF
-#define TMC2130_PWM_FREQ_X  2         // PWMCONF
-
-#define TMC2130_PWM_GRAD_Y  2         // PWMCONF
-#define TMC2130_PWM_AMPL_Y  235       // PWMCONF
-#define TMC2130_PWM_AUTO_Y  1         // PWMCONF
-#define TMC2130_PWM_FREQ_Y  2         // PWMCONF
-
-#define TMC2130_PWM_GRAD_E  2         // PWMCONF
-#define TMC2130_PWM_AMPL_E  235       // PWMCONF
-#define TMC2130_PWM_AUTO_E  1         // PWMCONF
-#define TMC2130_PWM_FREQ_E  2         // PWMCONF
-
-#define TMC2130_PWM_GRAD_Z  4         // PWMCONF
-#define TMC2130_PWM_AMPL_Z  200       // PWMCONF
-#define TMC2130_PWM_AUTO_Z  1         // PWMCONF
-#define TMC2130_PWM_FREQ_Z  2         // PWMCONF
-
-#define TMC2130_PWM_GRAD_E  4         // PWMCONF
-#define TMC2130_PWM_AMPL_E  240       // PWMCONF
-#define TMC2130_PWM_AUTO_E  1         // PWMCONF
-#define TMC2130_PWM_FREQ_E  2         // PWMCONF
-
-#define TMC2130_TOFF_XYZ    3         // CHOPCONF // fchop = 27.778kHz
-#define TMC2130_TOFF_E      3         // CHOPCONF // fchop = 27.778kHz
-//#define TMC2130_TOFF_E      4         // CHOPCONF // fchop = 21.429kHz
-//#define TMC2130_TOFF_E      5         // CHOPCONF // fchop = 17.442kHz
-
-//#define TMC2130_STEALTH_E // Extruder stealthChop mode
-//#define TMC2130_CNSTOFF_E // Extruder constant-off-time mode (similar to MK2)
-
-//#define TMC2130_PWM_DIV   683         // PWM frequency divider (1024, 683, 512, 410)
-#define TMC2130_PWM_DIV   512         // PWM frequency divider (1024, 683, 512, 410)
-#define TMC2130_PWM_CLK   (2 * TMC2130_FCLK / TMC2130_PWM_DIV) // PWM frequency (23.4kHz, 35.1kHz, 46.9kHz, 58.5kHz for 12MHz fclk)
-
-#define TMC2130_TPWMTHRS  0         // TPWMTHRS - Sets the switching speed threshold based on TSTEP from stealthChop to spreadCycle mode
-#define TMC2130_THIGH     0         // THIGH - unused
-
-//#define TMC2130_TCOOLTHRS_X 450       // TCOOLTHRS - coolstep treshold
-//#define TMC2130_TCOOLTHRS_Y 450       // TCOOLTHRS - coolstep treshold
-#define TMC2130_TCOOLTHRS_X 430       // TCOOLTHRS - coolstep treshold
-#define TMC2130_TCOOLTHRS_Y 430       // TCOOLTHRS - coolstep treshold
-#define TMC2130_TCOOLTHRS_Z 500       // TCOOLTHRS - coolstep treshold
-#define TMC2130_TCOOLTHRS_E 500       // TCOOLTHRS - coolstep treshold
-
-#define TMC2130_SG_HOMING       1     // stallguard homing
-#define TMC2130_SG_THRS_X       3     // stallguard sensitivity for X axis
-#define TMC2130_SG_THRS_Y       3     // stallguard sensitivity for Y axis
-#define TMC2130_SG_THRS_Z       4     // stallguard sensitivity for Z axis
-#define TMC2130_SG_THRS_E       3     // stallguard sensitivity for E axis
-
-//new settings is possible for vsense = 1, running current value > 31 set vsense to zero and shift both currents by 1 bit right (Z axis only)
-#define TMC2130_CURRENTS_H {16, 20, 35, 30}  // default holding currents for all axes
-#define TMC2130_CURRENTS_R {16, 20, 35, 30}  // default running currents for all axes
-#define TMC2130_UNLOAD_CURRENT_R 12			 // lowe current for M600 to protect filament sensor 
-
-#define TMC2130_STEALTH_Z
+ *-----------------------------------*/
 
 //#define TMC2130_DEBUG
 //#define TMC2130_DEBUG_WR
 //#define TMC2130_DEBUG_RD
+//#define TMC2130_VARIABLE_RESOLUTION
 
+//These definitions have been kept as reference for external functions
+#define TMC2130_USTEPS_XY   16        // microstep resolution for XY axes
+#define TMC2130_USTEPS_Z    16        // microstep resolution for Z axis
+#define TMC2130_USTEPS_E    32        // microstep resolution for E axis
+
+//                          {X, Y, Z, E}                           
+#define TMC2130_MRES        {4, 4, 4, 3}                // Default uStep steeting for each axis; X, Y, Z, E. ( 0 = 256 ... 3 = 32, 4 = 16 ... 8 = Fullstep) (ONLY IN TMC2130.cpp)
+#define TMC2130_INTPOL      {1, 1, 1, 1}                // Interpolate to driver native 256 uSteps for smooth movement
+//new settings is possible for vsense = 1, running current value > 31 set vsense to zero and shift both currents by 1 bit right (Z axis only) 
+#define TMC2130_IRUN        {16, 20, 35, 20}            // Default running currents for all axes 
+#define TMC2130_IHOLD       {12, 14, 25, 14}            // Default holding currents for all axes 
+#define TMC2130_IHOME       {8, 10, 20, 10}             // Default homing currents for all axes to prevent belt slipping  
+#define TMC2130_UNLOAD_CURRENT_R 12                     // Lower extruder current for M600 moves to protect filament sensor 
+
+/*------------------------------------
+ CHOPPER CONFIGURATION
+ *-----------------------------------*/
+
+#define TMC2130_FCLK        12000000                    // CHOPCONF - Chopper clock frequency: fclk = 12MHz
+#define TMC2130_TBL         {1, 1, 1, 1}                // CHOPCONF - Blank time setting, for current desipation in sense resistor
+#define TMC2130_TOFF        {3, 3, 3, 3}                // CHOPCONF - Spreadcycle Chopper off time setting, regulating chopper frequency: 4 = 34.1kHz 
+#define TMC2130_HSTRT       {6, 6, 7, 6}                // CHOPCONF - Spreadcycle Waveform hysterisis start setting, based off motor resistance and inductance (MAX = 7)
+#define TMC2130_HEND        {1, 2, 5, 2}                // CHOPCONF - Spreadcycle Waveform hysterisis end setting, based off motor resistance and inductance (MAX = 15)
+#define TMC2130_TPWMTHRS    0                           // TPWMTHRS - Switching speed threshold based on TSTEP from stealthChop to spreadCycle mode
+#define TMC2130_THIGH       0                           // THIGH - unused
+
+/*------------------------------------
+ STALLGUARD AND COOLSTEP CONFIGURATION
+ *-----------------------------------*/
+           
+#define TMC2130_SG_THRS     {3, 3, 4, 3}                // SGTHRS - Stallguard running sensititvity
+#define TMC2130_SG_HOMING   {3, 3, 3, 3}                // SGTHRS - Stallguard homing sensitivity
+#define TMC2130_TCOOLTHRS   {430, 430, 500, 500}    // TCOOLTHRS - coolstep lower velocity treshold (430, 430, 500, 500)
+
+/*------------------------------------
+ STEALTHCHOP CONFIGURATION
+ *-----------------------------------*/
+
+#define TMC2130_PWM_GRAD    {2, 2, 4, 4}                // PWMCONF - Stealthchop maximum PWM amplitude per half wave 
+#define TMC2130_PWM_AMPL    {230, 235, 200, 240}        // PWMCONF - Stealthchop PWM amplitude
+#define TMC2130_PWM_AUTO    {1, 1, 1, 1}                // PWMCONF - Stealthchop enable automatic current control
+#define TMC2130_PWM_FREQ    {2, 2, 2, 2}                // PWMCONF - Stealthchop PWM frequency selection: 2 = 2/683*fclk = 35.2kHz
+#define TMC2130_STEALTH_Z                               // Enable Stealthchop for Z-axis
+//#define TMC2130_STEALTH_E                               // Extruder stealthChop mode
+//#define TMC2130_CNSTOFF_E                               // Extruder constant-off-time mode (similar to MK2)
 
 /*------------------------------------
  EXTRUDER SETTINGS


### PR DESCRIPTION
When debugging visible vertical lines on prints, I discovered that all axis' are configured equally in regard to the TMC2130 drivers as hardcoded values, which is sub-optimal. Ideally each TMC2130 driver has to be tuned to its specific motor and their individual resistances and inductances to ensure optimal performance. 
All motors cannot be expected to be equal, especially due to manufacturing differences. On my MK3 I have discovered one motors resistance to be 7.2 ohms, which is 11% deviated from the motors specified average of 6.5 ohms, hence the default configuration for that axis was not optimal and produced vertical lines corrosponding to the currents zero-crossing. This was fixed by tuning the HEND and HSTRT parameters.
Thus I attempted to separate the configuration of general parameters for each axis  so that these may be configured individually by advanced users seeking to improve their print quality. 
Parameters are now setup on the format of; TMC2130_PARAMETER {X-axis, Y-axis, Z-axis, E-axis}
More advanced options were left hard coded in tmc2130.cpp. 

Ideally a system should be devised so that anyone with access  to a multimeter should be able to set these parameters directly from the display of the printer: The user would measure the resistance of each motor and enter this into a dialogue on the display, then the printer would itself calculate the deviation from spec and adjust each axis' parameters accordingly. Thus users could fine tune their printers without having to flash the firmware.

Until then, I hope my contribution can be of assistance.

PS. Parameters have been tuned to my machine to the best of my ability, these would have to be fine tuned for general distribution and/or for each individual machine. 