### PR TITLE
Fixed redefined warning

### DIFF
--- a/Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h
@@ -209,11 +209,6 @@
 #define TMC2130_PWM_AUTO_Y  1         // PWMCONF
 #define TMC2130_PWM_FREQ_Y  2         // PWMCONF
 
-#define TMC2130_PWM_GRAD_E  2         // PWMCONF
-#define TMC2130_PWM_AMPL_E  235       // PWMCONF
-#define TMC2130_PWM_AUTO_E  1         // PWMCONF
-#define TMC2130_PWM_FREQ_E  2         // PWMCONF
-
 #define TMC2130_PWM_GRAD_Z  4         // PWMCONF
 #define TMC2130_PWM_AMPL_Z  200       // PWMCONF
 #define TMC2130_PWM_AUTO_Z  1         // PWMCONF


### PR DESCRIPTION
Compiling with Arduino IDE 1.6.8 and 'Compiler warnings' set to 'More' you get.
I try to get the firmware to zero warnings as it was in the MK2 branch, which makes it easier to find issues with new/changed code.

As "TMC2130_PWM_xxxxx_E" are defined twice in the "Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h" which has to be copied to Firmware/Configuration_prusa.h" to compile the firmware, i deleted the 1st entries as i expect that these will be overwritten by the following. Guess it is a copy paste error.

```
In file included from sketch\messages.c:8:0:

sketch\Configuration_prusa.h:222:0: warning: "TMC2130_PWM_GRAD_E" redefined [enabled by default]

 #define TMC2130_PWM_GRAD_E  4         // PWMCONF

 ^

sketch\Configuration_prusa.h:212:0: note: this is the location of the previous definition

 #define TMC2130_PWM_GRAD_E  2         // PWMCONF

 ^

sketch\Configuration_prusa.h:223:0: warning: "TMC2130_PWM_AMPL_E" redefined [enabled by default]

 #define TMC2130_PWM_AMPL_E  240       // PWMCONF

 ^

sketch\Configuration_prusa.h:213:0: note: this is the location of the previous definition

 #define TMC2130_PWM_AMPL_E  235       // PWMCONF

 ^

In file included from sketch\sm4.c:11:0:

sketch\Configuration_prusa.h:222:0: warning: "TMC2130_PWM_GRAD_E" redefined [enabled by default]

 #define TMC2130_PWM_GRAD_E  4         // PWMCONF

 ^

sketch\Configuration_prusa.h:212:0: note: this is the location of the previous definition

 #define TMC2130_PWM_GRAD_E  2         // PWMCONF

 ^

sketch\Configuration_prusa.h:223:0: warning: "TMC2130_PWM_AMPL_E" redefined [enabled by default]

 #define TMC2130_PWM_AMPL_E  240       // PWMCONF

 ^

sketch\Configuration_prusa.h:213:0: note: this is the location of the previous definition

 #define TMC2130_PWM_AMPL_E  235       // PWMCONF

 ^
```