### PR TITLE
Fixed unused variable c as in pull request #138

### DIFF
--- a/Firmware/MarlinSerial.h
+++ b/Firmware/MarlinSerial.h
@@ -131,7 +131,7 @@ class MarlinSerial //: public Stream
                 if (M_UCSRxA & (1<<M_FEx)) {
                     // Characters received with the framing errors will be ignored.
                     // The temporary variable "c" was made volatile, so the compiler does not optimize this out.
-                    volatile unsigned char c = M_UDRx;
+                    (void)(*(char *)M_UDRx);
                 } else {
                     unsigned char c  =  M_UDRx;
                     int i = (unsigned int)(rx_buffer.head + 1) % RX_BUFFER_SIZE;
@@ -155,7 +155,7 @@ class MarlinSerial //: public Stream
                 if (UCSR1A & (1<<FE1)) {
                     // Characters received with the framing errors will be ignored.
                     // The temporary variable "c" was made volatile, so the compiler does not optimize this out.
-                    volatile unsigned char c = UDR1;
+                    (void)(*(char *)UDR1);
                 } else {
                     unsigned char c  =  UDR1;
                     int i = (unsigned int)(rx_buffer.head + 1) % RX_BUFFER_SIZE;


### PR DESCRIPTION
Compiling with Arduino IDE 1.6.8 and 'Compiler warnings' set to 'More' you get.
I try to get the firmware to zero warnings as it was in the MK2 branch, which makes it easier to find issues with new/changed code.

```
: warning: unused variable 'c' [-Wunused-variable]

                     volatile unsigned char c = M_UDRx;

                                            ^

sketch\MarlinSerial.h:158:44: warning: unused variable 'c' [-Wunused-variable]

                     volatile unsigned char c = UDR1;

                                            ^
```