### PR TITLE
Improved M860 - now wait for cooling of PINDA, too

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -6389,10 +6389,10 @@ Sigma_Exit:
 #ifdef PINDA_THERMISTOR
 	case 860: // M860 - Wait for PINDA thermistor to reach target temperature.
 	{
-		int setTargetPinda = 0;
+		int set_target_pinda = 0;
 
 		if (code_seen('S')) {
-			setTargetPinda = code_value();
+			set_target_pinda = code_value();
 		}
 		else {
 			break;
@@ -6401,19 +6401,24 @@ Sigma_Exit:
 		LCD_MESSAGERPGM(_T(MSG_PLEASE_WAIT));
 
 		SERIAL_PROTOCOLPGM("Wait for PINDA target temperature:");
-		SERIAL_PROTOCOL(setTargetPinda);
+		SERIAL_PROTOCOL(set_target_pinda);
 		SERIAL_PROTOCOLLN("");
 
 		codenum = millis();
 		cancel_heatup = false;
 
-		while ((!cancel_heatup) && current_temperature_pinda < setTargetPinda) {
+    bool is_pinda_cooling = false;
+    if ((degTargetBed() == 0) && (degTargetHotend(0) == 0)) {
+      is_pinda_cooling = true;
+    }
+
+		while ( ((!is_pinda_cooling) && (!cancel_heatup) && (current_temperature_pinda < set_target_pinda)) || (is_pinda_cooling && (current_temperature_pinda > set_target_pinda)) ) {
 			if ((millis() - codenum) > 1000) //Print Temp Reading every 1 second while waiting.
 			{
 				SERIAL_PROTOCOLPGM("P:");
 				SERIAL_PROTOCOL_F(current_temperature_pinda, 1);
 				SERIAL_PROTOCOLPGM("/");
-				SERIAL_PROTOCOL(setTargetPinda);
+				SERIAL_PROTOCOL(set_target_pinda);
 				SERIAL_PROTOCOLLN("");
 				codenum = millis();
 			}
@@ -6425,6 +6430,7 @@ Sigma_Exit:
 
 		break;
 	}
+ 
 	case 861: // M861 - Set/Read PINDA temperature compensation offsets
 		if (code_seen('?')) { // ? - Print out current EEPROM offset values
 			uint8_t cal_status = calibration_status_pinda();

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -6407,10 +6407,10 @@ Sigma_Exit:
 		codenum = millis();
 		cancel_heatup = false;
 
-    bool is_pinda_cooling = false;
-    if ((degTargetBed() == 0) && (degTargetHotend(0) == 0)) {
-      is_pinda_cooling = true;
-    }
+		bool is_pinda_cooling = false;
+		if ((degTargetBed() == 0) && (degTargetHotend(0) == 0)) {
+		    is_pinda_cooling = true;
+		}
 
 		while ( ((!is_pinda_cooling) && (!cancel_heatup) && (current_temperature_pinda < set_target_pinda)) || (is_pinda_cooling && (current_temperature_pinda > set_target_pinda)) ) {
 			if ((millis() - codenum) > 1000) //Print Temp Reading every 1 second while waiting.


### PR DESCRIPTION
The M860 - wait for PINDA temperature - gcode has been improved. Until now it could only wait until the PINDA has been warmed up to a set temperature. Now it also can wait until the PINDA has cooled down to a set temperature. The calling syntax has not been changed at all. The logic now looks if the bed or hotend have a target temperature different from 0. If so, the code waits until PINDA has warmed up. Otherwise it waits until PINDA has cooled down.

Applications:
- Possibility to start a Print at exactly the right PINDA temperature. (Do not start the heater until PINDA is cooled down)
- Much easier manual temperature calibration (automating the wait for cool down in between calibration runs)
- Possibility for temp calibration verification on one heat bed by printing multiple objects with different PINDA temperatures one after the other