### PR TITLE
Fix warning: This is kind of important

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3262,10 +3262,10 @@ void process_commands()
             if( !(code_seen('X') || code_seen('Y') || code_seen('Z')) && code_seen('E')) {
               float echange=destination[E_AXIS]-current_position[E_AXIS];
 
-              if((echange<-MIN_RETRACT && !retracted) || (echange>MIN_RETRACT && retracted)) { //move appears to be an attempt to retract or recover
+              if((echange<-MIN_RETRACT && !retracted[active_extruder]) || (echange>MIN_RETRACT && retracted[active_extruder])) { //move appears to be an attempt to retract or recover
                   current_position[E_AXIS] = destination[E_AXIS]; //hide the slicer-generated retract/recover from calculations
                   plan_set_e_position(current_position[E_AXIS]); //AND from the planner
-                  retract(!retracted);
+                  retract(!retracted[active_extruder]);
                   return;
               }
 


### PR DESCRIPTION
Again another fix from https://github.com/prusa3d/Prusa-Firmware/pull/138 made by @Thess for the MK2 branch which i think is quite important.

Ardunio IDE 1.6.8 and 1.8.5 result with Compiler warnings set to "More" or "All"
```
sketch\Marlin_main.cpp:3265:44: warning: the address of 'retracted' will always evaluate as 'true' [-Waddress]

               if((echange<-MIN_RETRACT && !retracted) || (echange>MIN_RETRACT && retracted)) { //move appears to be an attempt to retract or recover

                                            ^

sketch\Marlin_main.cpp:3265:82: warning: the address of 'retracted' will always evaluate as 'true' [-Waddress]

               if((echange<-MIN_RETRACT && !retracted) || (echange>MIN_RETRACT && retracted)) { //move appears to be an attempt to retract or recover

                                                                                  ^

sketch\Marlin_main.cpp:3268:28: warning: the address of 'retracted' will always evaluate as 'true' [-Waddress]

                   retract(!retracted);

                            ^

sketch\Marlin_main.cpp:3870:15: warning: statement has no effect [-Wunused-value]
```

I don't know if that helps making small pull requests as they are easier to review or it would make sense to combine few more.

Prusa should really review this [pull request](https://github.com/prusa3d/Prusa-Firmware/pull/138) again for the MK3 branch, as it was one that made warnings disapear in the MK2 branch and made finding new flaws in the code much much easier.