### PR TITLE
Fix warning #7

### DIFF
--- a/Firmware/mesh_bed_calibration.cpp
+++ b/Firmware/mesh_bed_calibration.cpp
@@ -2845,11 +2845,11 @@ bool sample_mesh_and_store_reference()
     {
         // Verify the span of the Z values.
         float zmin = mbl.z_values[0][0];
-        float zmax = zmax;
+        float zmax = zmin;
         for (int8_t j = 0; j < 3; ++ j)
            for (int8_t i = 0; i < 3; ++ i) {
                 zmin = min(zmin, mbl.z_values[j][i]);
-                zmax = min(zmax, mbl.z_values[j][i]);
+                zmax = max(zmax, mbl.z_values[j][i]);
            }
         if (zmax - zmin > 3.f) {
             // The span of the Z offsets is extreme. Give up.


### PR DESCRIPTION
Another fix from PR https://github.com/prusa3d/Prusa-Firmware/pull/138 and discussed in Issue https://github.com/prusa3d/Prusa-Firmware/issues/807

Ardunio IDE 1.6.8 and 1.8.5 result with Compiler warnings set to "More" or "All"

```
sketch\mesh_bed_calibration.cpp: In function 'sample_mesh_and_store_reference':

sketch\mesh_bed_calibration.cpp:2852:53: warning: 'zmax' may be used uninitialized in this function [-Wmaybe-uninitialized]

                 zmax = min(zmax, mbl.z_values[j][i]);

                                                     ^

sketch\mesh_bed_calibration.cpp:2848:15: note: 'zmax' was declared here

         float zmax = zmax;

               ^


```