### PR TITLE
Fix compile error if STEEL_SHEET is undefined.

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -2161,8 +2161,8 @@ bool gcode_M45(bool onlyZ, int8_t verbosity_level)
 			KEEPALIVE_STATE(PAUSED_FOR_USER);
 			#ifdef STEEL_SHEET
 			bool result = lcd_show_fullscreen_message_yes_no_and_wait_P(MSG_STEEL_SHEET_CHECK, false, false);
-			#endif //STEEL_SHEET
 			if(result) lcd_show_fullscreen_message_and_wait_P(MSG_REMOVE_STEEL_SHEET);
+			#endif //STEEL_SHEET
 			lcd_show_fullscreen_message_and_wait_P(MSG_CONFIRM_NOZZLE_CLEAN);
 		    lcd_show_fullscreen_message_and_wait_P(MSG_PAPER);
 			KEEPALIVE_STATE(IN_HANDLER);


### PR DESCRIPTION
result is declared inside of an #ifdef, but is used outside it. Moved the use inside the block.