### PR TITLE
Reflect NEW_XYZCAL dependency on HEATBED_V2

### DIFF
--- a/Firmware/variants/1_75mm_MK25-RAMBo13a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK25-RAMBo13a-E3Dv6full.h
@@ -462,7 +462,10 @@ const bool Z_MIN_ENDSTOP_INVERTING = false; // set to true to invert the logic o
 #define DEFAULT_RETRACTION 1 //used for PINDA temp calibration and pause print
 #endif
 
-#define HEATBED_V2
+// New XYZ calibration (HEATBED_V2 required!)
+#ifdef HEATBED_V2
+  #define NEW_XYZCAL
+#endif
 
 #define M600_TIMEOUT 600  //seconds
 


### PR DESCRIPTION
Context: I've got a MK2.5 with an old bed. Noticed that the firmware doesn't compile if you simply unset HEATBED_V2. Minor improvement.