### PR TITLE
Fix upper limit for x

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -9069,7 +9069,7 @@ void print_mesh_bed_leveling_table()
 {
   SERIAL_ECHOPGM("mesh bed leveling: ");
   for (int8_t y = 0; y < MESH_NUM_Y_POINTS; ++ y)
-    for (int8_t x = 0; x < MESH_NUM_Y_POINTS; ++ x) {
+    for (int8_t x = 0; x < MESH_NUM_X_POINTS; ++ x) {
       MYSERIAL.print(mbl.z_values[y][x], 3);
       SERIAL_ECHOPGM(" ");
     }


### PR DESCRIPTION
Use MESH_NUM_X_POINTS for x.
This only works, because MESH_NUM_X_POINTS and MESH_NUM_Y_POINTS have the same value.