### PR TITLE
Fix warnings and some bugs

### DIFF
--- a/Firmware/ConfigurationStore.h
+++ b/Firmware/ConfigurationStore.h
@@ -21,7 +21,7 @@ FORCE_INLINE void Config_RetrieveSettings() { Config_ResetDefault(); Config_Prin
 #endif
 
 inline uint8_t calibration_status() { return eeprom_read_byte((uint8_t*)EEPROM_CALIBRATION_STATUS); }
-inline uint8_t calibration_status_store(uint8_t status) { eeprom_update_byte((uint8_t*)EEPROM_CALIBRATION_STATUS, status); }
+inline void calibration_status_store(uint8_t status) { eeprom_update_byte((uint8_t*)EEPROM_CALIBRATION_STATUS, status); }
 inline bool calibration_status_pinda() { return eeprom_read_byte((uint8_t*)EEPROM_CALIBRATION_STATUS_PINDA); }
 
 #endif//CONFIG_STORE_H

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3258,8 +3258,8 @@ void process_commands()
 	  if(code_seen("CRASH_DETECTED"))
 	  {
 		  uint8_t mask = 0;
-		  if (code_seen("X")) mask |= X_AXIS_MASK;
-		  if (code_seen("Y")) mask |= Y_AXIS_MASK;
+		  if (code_seen('X')) mask |= X_AXIS_MASK;
+		  if (code_seen('Y')) mask |= Y_AXIS_MASK;
 		  crashdet_detected(mask);
 	  }
 	  else if(code_seen("CRASH_RECOVER"))
@@ -4177,10 +4177,10 @@ void process_commands()
 
 		if (code_seen('X')) dimension_x = code_value();
 		if (code_seen('Y')) dimension_y = code_value();
-		if (code_seen('XP')) points_x = code_value();
-		if (code_seen('YP')) points_y = code_value();
-		if (code_seen('XO')) offset_x = code_value();
-		if (code_seen('YO')) offset_y = code_value();
+		if (code_seen("XP")) { strchr_pointer+=1; points_x = code_value(); }
+		if (code_seen("YP")) { strchr_pointer+=1; points_y = code_value(); }
+		if (code_seen("XO")) { strchr_pointer+=1; offset_x = code_value(); }
+		if (code_seen("YO")) { strchr_pointer+=1; offset_y = code_value(); }
 		
 		bed_analysis(dimension_x,dimension_y,points_x,points_y,offset_x,offset_y);
 		

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -8082,7 +8082,7 @@ void bed_analysis(float x_dimension, float y_dimension, int x_points_num, int y_
 	int ix = 0;
 	int iy = 0;
 
-	char* filename_wldsd = "wldsd.txt";
+	const char* filename_wldsd = "wldsd.txt";
 	char data_wldsd[70];
 	char numb_wldsd[10];
 

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1873,6 +1873,7 @@ int serial_read_stream() {
         }
 
     }
+	return 0;
 }
 
 #ifdef HOST_KEEPALIVE_FEATURE

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -9069,7 +9069,7 @@ void print_world_coordinates()
 
 void print_physical_coordinates()
 {
-	printf_P(_N("physical coordinates: (%.3f, %.3f, %.3f)\n"), st_get_position_mm[X_AXIS], st_get_position_mm[Y_AXIS], st_get_position_mm[Z_AXIS]);
+	printf_P(_N("physical coordinates: (%.3f, %.3f, %.3f)\n"), st_get_position_mm(X_AXIS), st_get_position_mm(Y_AXIS), st_get_position_mm(Z_AXIS));
 }
 
 void print_mesh_bed_leveling_table()

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -2906,9 +2906,9 @@ bool gcode_M45(bool onlyZ, int8_t verbosity_level)
 	if (!onlyZ)
 	{
 		setTargetBed(0);
-		setTargetHotend(0, 0);
-		setTargetHotend(0, 1);
-		setTargetHotend(0, 2);
+		setTargetHotend0(0);
+		setTargetHotend1(0);
+		setTargetHotend2(0);
 		adjust_bed_reset(); //reset bed level correction
 	}
 
@@ -6353,9 +6353,9 @@ Sigma_Exit:
 				if (millis() > waiting_start_time + (unsigned long)M600_TIMEOUT * 1000) {
 					lcd_display_message_fullscreen_P(_i("Press knob to preheat nozzle and continue."));////MSG_PRESS_TO_PREHEAT c=20 r=4
 					wait_for_user_state = 1;
-					setTargetHotend(0, 0);
-					setTargetHotend(0, 1);
-					setTargetHotend(0, 2);
+					setTargetHotend0(0);
+					setTargetHotend1(0);
+					setTargetHotend2(0);
 					st_synchronize();
 					disable_e0();
 					disable_e1();
@@ -8407,9 +8407,9 @@ void long_pause() //long pause print
 	plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], 15, active_extruder);
 
 	//set nozzle target temperature to 0
-	setTargetHotend(0, 0);
-	setTargetHotend(0, 1);
-	setTargetHotend(0, 2);
+	setTargetHotend0(0);
+	setTargetHotend1(0);
+	setTargetHotend2(0);
 
 	//Move XY to side
 	current_position[X_AXIS] = X_PAUSE_POS;

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -4196,7 +4196,6 @@ void process_commands()
 				delay_keep_alive(100);
 
 			}
-			fan_speed[1];
 			printf_P(_N("%d: %d\n"), i, fan_speed[1]);
 		}
 	}break;

--- a/Firmware/adc.c
+++ b/Firmware/adc.c
@@ -2,7 +2,7 @@
 
 #include "adc.h"
 #include <avr/io.h>
-
+#include <stdio.h>
 
 uint8_t adc_state;
 uint8_t adc_count;

--- a/Firmware/adc.h
+++ b/Firmware/adc.h
@@ -10,6 +10,17 @@
 extern "C" {
 #endif //defined(__cplusplus)
 
+/*
+http://resnet.uoregon.edu/~gurney_j/jmpc/bitwise.html
+*/
+#define BITCOUNT(x) (((BX_(x)+(BX_(x)>>4)) & 0x0F0F0F0F) % 255)
+#define BX_(x) ((x) - (((x)>>1)&0x77777777) - (((x)>>2)&0x33333333) - (((x)>>3)&0x11111111))
+
+#define ADC_PIN_IDX(pin) BITCOUNT(ADC_CHAN_MSK & ((1 << (pin)) - 1))
+
+#if BITCOUNT(ADC_CHAN_MSK) != ADC_CHAN_CNT
+# error "ADC_CHAN_MSK oes not match ADC_CHAN_CNT"
+#endif
 
 extern uint8_t adc_state;
 extern uint8_t adc_count;

--- a/Firmware/cardreader.cpp
+++ b/Firmware/cardreader.cpp
@@ -258,7 +258,7 @@ void CardReader::pauseSDPrint()
 }
 
 
-void CardReader::openLogFile(char* name)
+void CardReader::openLogFile(const char* name)
 {
   logging = true;
   openFile(name, false);
@@ -289,7 +289,7 @@ void CardReader::getAbsFilename(char *t)
     t[0]=0;
 }
 
-void CardReader::openFile(char* name,bool read, bool replace_current/*=true*/)
+void CardReader::openFile(const char* name,bool read, bool replace_current/*=true*/)
 {
   if(!cardOK)
     return;
@@ -341,7 +341,7 @@ void CardReader::openFile(char* name,bool read, bool replace_current/*=true*/)
  
   SdFile myDir;
   curDir=&root;
-  char *fname=name;
+  const char *fname=name;
   
   char *dirname_start,*dirname_end;
   if(name[0]=='/')
@@ -429,7 +429,7 @@ void CardReader::openFile(char* name,bool read, bool replace_current/*=true*/)
   
 }
 
-void CardReader::removeFile(char* name)
+void CardReader::removeFile(const char* name)
 {
   if(!cardOK)
     return;
@@ -439,7 +439,7 @@ void CardReader::removeFile(char* name)
   
   SdFile myDir;
   curDir=&root;
-  char *fname=name;
+  const char *fname=name;
   
   char *dirname_start,*dirname_end;
   if(name[0]=='/')

--- a/Firmware/cardreader.h
+++ b/Firmware/cardreader.h
@@ -19,9 +19,9 @@ public:
   //this is to delay autostart and hence the initialisaiton of the sd card to some seconds after the normal init, so the device is available quick after a reset
 
   void checkautostart(bool x); 
-  void openFile(char* name,bool read,bool replace_current=true);
-  void openLogFile(char* name);
-  void removeFile(char* name);
+  void openFile(const char* name,bool read,bool replace_current=true);
+  void openLogFile(const char* name);
+  void removeFile(const char* name);
   void closefile(bool store_location=false);
   void release();
   void startFileprint();

--- a/Firmware/language.c
+++ b/Firmware/language.c
@@ -63,7 +63,7 @@ uint8_t lang_select(uint8_t lang)
 			if (lang_check(_SEC_LANG_TABLE))
 				if (pgm_read_dword(((uint32_t*)(_SEC_LANG_TABLE + 12))) == pgm_read_dword(((uint32_t*)(_PRI_LANG_SIGNATURE)))) //signature valid
 				{
-					lang_table = _SEC_LANG_TABLE; // set table pointer
+					lang_table = (lang_table_t*)_SEC_LANG_TABLE; // set table pointer
 					lang_selected = lang; // set language id
 				}
 		}
@@ -138,7 +138,7 @@ uint8_t lang_get_header(uint8_t lang, lang_table_header_t* header, uint32_t* off
 	if (lang == LANG_ID_SEC)
 	{
 		uint16_t ui = _SEC_LANG_TABLE; //table pointer
-		memcpy_P(header, ui, sizeof(lang_table_header_t)); //read table header from progmem
+		memcpy_P(header, (const void*)ui, sizeof(lang_table_header_t)); //read table header from progmem
 		if (offset) *offset = ui;
 		return (header->magic == LANG_MAGIC)?1:0; //return 1 if magic valid
 	}
@@ -147,7 +147,7 @@ uint8_t lang_get_header(uint8_t lang, lang_table_header_t* header, uint32_t* off
 	lang--;
 	while (1)
 	{
-		w25x20cl_rd_data(addr, header, sizeof(lang_table_header_t)); //read table header from xflash
+		w25x20cl_rd_data(addr, (uint8_t*)header, sizeof(lang_table_header_t)); //read table header from xflash
 		if (header->magic != LANG_MAGIC) break; //break if not valid
 		if (offset) *offset = addr;
 		if (--lang == 0) return 1;

--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -4,7 +4,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <avr/pgmspace.h>
-#include <avr/delay.h>
+#include <util/delay.h>
 #include "Timer.h"
 
 #include "Configuration.h"

--- a/Firmware/menu.cpp
+++ b/Firmware/menu.cpp
@@ -75,7 +75,10 @@ void menu_end(void)
 
 void menu_back(void)
 {
-	if (menu_depth > 0) menu_goto(menu_stack[--menu_depth].menu, menu_stack[menu_depth].position, true, true);
+	if (menu_depth > 0) {
+		menu_depth--;		
+		menu_goto(menu_stack[menu_depth].menu, menu_stack[menu_depth].position, true, true);
+	}
 }
 
 void menu_back_if_clicked(void)

--- a/Firmware/pat9125.c
+++ b/Firmware/pat9125.c
@@ -1,6 +1,6 @@
 //pat9125.c
 #include "pat9125.h"
-#include <avr/delay.h>
+#include <util/delay.h>
 #include <avr/pgmspace.h>
 #include "config.h"
 #include <stdio.h>

--- a/Firmware/sm4.c
+++ b/Firmware/sm4.c
@@ -1,6 +1,7 @@
 //sm4.c - simple 4-axis stepper control
 
 #include "sm4.h"
+#include <math.h>
 #include <avr/io.h>
 #include <avr/pgmspace.h>
 

--- a/Firmware/temperature.cpp
+++ b/Firmware/temperature.cpp
@@ -1473,7 +1473,7 @@ void bed_min_temp_error(void) {
     }
 #ifndef BOGUS_TEMPERATURE_FAILSAFE_OVERRIDE
     Stop();
-#endif*/
+#endif
 }
 
 #ifdef HEATER_0_USES_MAX6675

--- a/Firmware/temperature.cpp
+++ b/Firmware/temperature.cpp
@@ -1538,17 +1538,17 @@ extern "C" {
 
 void adc_ready(void) //callback from adc when sampling finished
 {
-	current_temperature_raw[0] = adc_values[TEMP_0_PIN]; //heater
-	current_temperature_raw_pinda = adc_values[TEMP_PINDA_PIN];
-	current_temperature_bed_raw = adc_values[TEMP_BED_PIN];
+	current_temperature_raw[0] = adc_values[ADC_PIN_IDX(TEMP_0_PIN)]; //heater
+	current_temperature_raw_pinda = adc_values[ADC_PIN_IDX(TEMP_PINDA_PIN)];
+	current_temperature_bed_raw = adc_values[ADC_PIN_IDX(TEMP_BED_PIN)];
 #ifdef VOLT_PWR_PIN
-	current_voltage_raw_pwr = adc_values[VOLT_PWR_PIN];
+	current_voltage_raw_pwr = adc_values[ADC_PIN_IDX(VOLT_PWR_PIN)];
 #endif
 #ifdef AMBIENT_THERMISTOR
-	current_temperature_raw_ambient = adc_values[TEMP_AMBIENT_PIN];
+	current_temperature_raw_ambient = adc_values[ADC_PIN_IDX(TEMP_AMBIENT_PIN)];
 #endif //AMBIENT_THERMISTOR
 #ifdef VOLT_BED_PIN
-	current_voltage_raw_bed = adc_values[VOLT_BED_PIN]; // 6->9
+	current_voltage_raw_bed = adc_values[ADC_PIN_IDX(VOLT_BED_PIN)]; // 6->9
 #endif
 	temp_meas_ready = true;
 }

--- a/Firmware/tmc2130.cpp
+++ b/Firmware/tmc2130.cpp
@@ -639,6 +639,7 @@ uint8_t tmc2130_tx(uint8_t axis, uint8_t addr, uint32_t wval)
 	TMC2130_SPI_TXRX(wval & 0xff); // LSB
 	tmc2130_cs_high(axis);
 	TMC2130_SPI_LEAVE();
+	return 0;
 }
 
 uint8_t tmc2130_rx(uint8_t axis, uint8_t addr, uint32_t* rval)

--- a/Firmware/tmc2130.cpp
+++ b/Firmware/tmc2130.cpp
@@ -129,7 +129,7 @@ void tmc2130_wr_TPWMTHRS(uint8_t axis, uint32_t val32);
 void tmc2130_wr_THIGH(uint8_t axis, uint32_t val32);
 
 #define tmc2130_rd(axis, addr, rval) tmc2130_rx(axis, addr, rval)
-#define tmc2130_wr(axis, addr, wval) tmc2130_tx(axis, addr | 0x80, wval)
+#define tmc2130_wr(axis, addr, wval) tmc2130_tx(axis, (addr) | 0x80, wval)
 
 uint8_t tmc2130_tx(uint8_t axis, uint8_t addr, uint32_t wval);
 uint8_t tmc2130_rx(uint8_t axis, uint8_t addr, uint32_t* rval);

--- a/Firmware/tmc2130.cpp
+++ b/Firmware/tmc2130.cpp
@@ -871,19 +871,19 @@ void tmc2130_set_wave(uint8_t axis, uint8_t amp, uint8_t fac1000)
 	printf_P(PSTR(" factor: %s\n"), ftostr43(fac));
 	uint8_t vA = 0;                //value of currentA
 	uint8_t va = 0;                //previous vA
-	uint8_t d0 = 0;                //delta0
-	uint8_t d1 = 1;                //delta1
+	int8_t d0 = 0;                //delta0
+	int8_t d1 = 1;                //delta1
 	uint8_t w[4] = {1,1,1,1};      //W bits (MSLUTSEL)
 	uint8_t x[3] = {255,255,255};  //X segment bounds (MSLUTSEL)
 	uint8_t s = 0;                 //current segment
 	int8_t b;                      //encoded bit value
-	uint8_t dA;                    //delta value
+	int8_t dA;                    //delta value
 	int i;                         //microstep index
 	uint32_t reg;                  //tmc2130 register
 	tmc2130_wr_MSLUTSTART(axis, 0, amp);
 	for (i = 0; i < 256; i++)
 	{
-		if ((i & 31) == 0)
+		if ((i & 0x1f) == 0)
 			reg = 0;
 		// calculate value
 		if (fac == 0) // default TMC wave

--- a/Firmware/uart2.c
+++ b/Firmware/uart2.c
@@ -45,6 +45,7 @@ uint8_t uart2_rx_clr(void)
 {
 	rbuf_w(uart2_ibuf) = 0;
 	rbuf_r(uart2_ibuf) = 0;
+	return 0;
 }
 
 uint8_t uart2_rx_ok(void)

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3495,7 +3495,7 @@ void lcd_bed_calibration_show_result(uint8_t result, uint8_t point_too_far_mask)
         else if (point_too_far_mask == 2 || point_too_far_mask == 7)
             // Only the center point or all the three front points.
             msg = _i("XYZ calibration failed. Front calibration points not reachable.");////MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=8
-        else if (point_too_far_mask & 1 == 0)
+        else if ((point_too_far_mask & 1) == 0)
             // The right and maybe the center point out of reach.
             msg = _i("XYZ calibration failed. Right front calibration point not reachable.");////MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=8
         else
@@ -3507,7 +3507,7 @@ void lcd_bed_calibration_show_result(uint8_t result, uint8_t point_too_far_mask)
             if (point_too_far_mask == 2 || point_too_far_mask == 7)
                 // Only the center point or all the three front points.
                 msg = _i("XYZ calibration compromised. Front calibration points not reachable.");////MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-            else if (point_too_far_mask & 1 == 0)
+            else if ((point_too_far_mask & 1) == 0)
                 // The right and maybe the center point out of reach.
                 msg = _i("XYZ calibration compromised. Right front calibration point not reachable.");////MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
             else

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -6441,13 +6441,12 @@ static bool lcd_selfcheck_axis_sg(char axis) {
 			enable_endstops(false);
 
 			const char *_error_1;
-			const char *_error_2;
 
 			if (axis == X_AXIS) _error_1 = "X";
 			if (axis == Y_AXIS) _error_1 = "Y";
 			if (axis == Z_AXIS) _error_1 = "Z";
 
-			lcd_selftest_error(9, _error_1, _error_2);
+			lcd_selftest_error(9, _error_1, NULL);
 			current_position[axis] = 0;
 			plan_set_position(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS]);
 			reset_crash_det(axis);
@@ -6460,13 +6459,12 @@ static bool lcd_selfcheck_axis_sg(char axis) {
 		if (abs(measured_axis_length[0] - measured_axis_length[1]) > 1) { //check if difference between first and second measurement is low
 			//loose pulleys
 			const char *_error_1;
-			const char *_error_2;
 
 			if (axis == X_AXIS) _error_1 = "X";
 			if (axis == Y_AXIS) _error_1 = "Y";
 			if (axis == Z_AXIS) _error_1 = "Z";
 
-			lcd_selftest_error(8, _error_1, _error_2);
+			lcd_selftest_error(8, _error_1, NULL);
 			current_position[axis] = 0;
 			plan_set_position(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS]);
 			reset_crash_det(axis);
@@ -6880,8 +6878,7 @@ static bool lcd_selftest_fsensor() {
 	fsensor_init();
 	if (fsensor_not_responding)
 	{
-		const char *_err;
-		lcd_selftest_error(11, _err, _err);
+		lcd_selftest_error(11, NULL, NULL);
 	}
 	return(!fsensor_not_responding);
 }
@@ -7036,8 +7033,7 @@ static bool lcd_selftest_fan_dialog(int _fan)
 	}
 	if (!_result)
 	{
-		const char *_err;
-		lcd_selftest_error(_errno, _err, _err);
+		lcd_selftest_error(_errno, NULL, NULL);
 	}
 	return _result;
 }

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -7041,7 +7041,7 @@ static bool lcd_selftest_fan_dialog(int _fan)
 static int lcd_selftest_screen(int _step, int _progress, int _progress_scale, bool _clear, int _delay)
 {
 
-	lcd_next_update_millis = millis() + (LCD_UPDATE_INTERVAL * 10000);
+	lcd_next_update_millis = millis() + (LCD_UPDATE_INTERVAL * 10000L);
 
 	int _step_block = 0;
 	const char *_indicator = (_progress > _progress_scale) ? "-" : "|";

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3570,11 +3570,11 @@ static void lcd_show_end_stops() {
 	lcd_set_cursor(0, 0);
 	lcd_puts_P((PSTR("End stops diag")));
 	lcd_set_cursor(0, 1);
-	lcd_puts_P((READ(X_MIN_PIN) ^ X_MIN_ENDSTOP_INVERTING == 1) ? (PSTR("X1")) : (PSTR("X0")));
+	lcd_puts_P((READ(X_MIN_PIN) ^ (bool)X_MIN_ENDSTOP_INVERTING) ? (PSTR("X1")) : (PSTR("X0")));
 	lcd_set_cursor(0, 2);
-	lcd_puts_P((READ(Y_MIN_PIN) ^ Y_MIN_ENDSTOP_INVERTING == 1) ? (PSTR("Y1")) : (PSTR("Y0")));
+	lcd_puts_P((READ(Y_MIN_PIN) ^ (bool)Y_MIN_ENDSTOP_INVERTING) ? (PSTR("Y1")) : (PSTR("Y0")));
 	lcd_set_cursor(0, 3);
-	lcd_puts_P((READ(Z_MIN_PIN) ^ Z_MIN_ENDSTOP_INVERTING == 1) ? (PSTR("Z1")) : (PSTR("Z0")));
+	lcd_puts_P((READ(Z_MIN_PIN) ^ (bool)Z_MIN_ENDSTOP_INVERTING) ? (PSTR("Z1")) : (PSTR("Z0")));
 }
 
 static void menu_show_end_stops() {
@@ -6504,11 +6504,11 @@ static bool lcd_selfcheck_axis(int _axis, int _travel)
 		plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[3], manual_feedrate[0] / 60, active_extruder);
 		st_synchronize();
 #ifdef TMC2130
-		if ((READ(Z_MIN_PIN) ^ Z_MIN_ENDSTOP_INVERTING == 1))
+		if ((READ(Z_MIN_PIN) ^ (bool)Z_MIN_ENDSTOP_INVERTING))
 #else //TMC2130
-		if (((READ(X_MIN_PIN) ^ X_MIN_ENDSTOP_INVERTING) == 1) ||
-			((READ(Y_MIN_PIN) ^ Y_MIN_ENDSTOP_INVERTING) == 1) ||
-			((READ(Z_MIN_PIN) ^ Z_MIN_ENDSTOP_INVERTING) == 1))
+		if ((READ(X_MIN_PIN) ^ (bool)X_MIN_ENDSTOP_INVERTING) ||
+			(READ(Y_MIN_PIN) ^ (bool)Y_MIN_ENDSTOP_INVERTING) ||
+			(READ(Z_MIN_PIN) ^ (bool)Z_MIN_ENDSTOP_INVERTING))
 #endif //TMC2130
 		{
 			if (_axis == 0)

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1747,9 +1747,9 @@ void lcd_commands()
 			cancel_heatup = true;
 			setTargetBed(0);
 			#ifndef SNMM
-			setTargetHotend(0, 0);	//heating when changing filament for multicolor
-			setTargetHotend(0, 1);
-			setTargetHotend(0, 2);
+			setTargetHotend0(0);  //heating when changing filament for multicolor
+			setTargetHotend1(0);
+			setTargetHotend2(0);
 			#endif
 			manage_heater();
 			custom_message = true;

--- a/Firmware/uni_avr_rpi.h
+++ b/Firmware/uni_avr_rpi.h
@@ -1,5 +1,7 @@
 // unification for AVR and RPI
-#define __AVR
+#ifndef __AVR
+# define __AVR
+#endif
 
 #ifdef __AVR
 	//#include "Arduino.h"

--- a/Firmware/xyzcal.cpp
+++ b/Firmware/xyzcal.cpp
@@ -210,16 +210,16 @@ bool xyzcal_spiral8(int16_t cx, int16_t cy, int16_t z0, int16_t dz, int16_t radi
 	if (pad) ad = *pad;
 	DBG(_n("xyzcal_spiral8 cx=%d cy=%d z0=%d dz=%d radius=%d ad=%d\n"), cx, cy, z0, dz, radius, ad);
 	if (!ret && (ad < 720))
-		if (ret = xyzcal_spiral2(cx, cy, z0 - 0*dz, dz, radius, 0, delay_us, check_pinda, &ad))
+		if ((ret = xyzcal_spiral2(cx, cy, z0 - 0*dz, dz, radius, 0, delay_us, check_pinda, &ad)) != 0)
 			ad += 0;
 	if (!ret && (ad < 1440))
-		if (ret = xyzcal_spiral2(cx, cy, z0 - 1*dz, dz, -radius, 0, delay_us, check_pinda, &ad))
+		if ((ret = xyzcal_spiral2(cx, cy, z0 - 1*dz, dz, -radius, 0, delay_us, check_pinda, &ad)) != 0)
 			ad += 720;
 	if (!ret && (ad < 2160))
-		if (ret = xyzcal_spiral2(cx, cy, z0 - 2*dz, dz, radius, 180, delay_us, check_pinda, &ad))
+		if ((ret = xyzcal_spiral2(cx, cy, z0 - 2*dz, dz, radius, 180, delay_us, check_pinda, &ad)) != 0)
 			ad += 1440;
 	if (!ret && (ad < 2880))
-		if (ret = xyzcal_spiral2(cx, cy, z0 - 3*dz, dz, -radius, 180, delay_us, check_pinda, &ad))
+		if ((ret = xyzcal_spiral2(cx, cy, z0 - 3*dz, dz, -radius, 180, delay_us, check_pinda, &ad)) != 0)
 			ad += 2160;
 	if (pad) *pad = ad;
 	return ret;


### PR DESCRIPTION
Fixed bugs:

- st_get_posiotion_mm is function, not array

- `code_seen` can't take multi byte character constant (not enabled in production code)

- `int` calculation is overflowing in some places (`long` or `L` suffix is needed)

- some `if` tests were always false due to operator precedence

- ADC indexing was wrong

- `setTargetHotend was called on non-existent extruder

- signed `switch` label was used with unsigned variable
