### PR TITLE
Fix compiler warning arduino-1.6.9/hardware/tools/avr/avr/include/avr…

### DIFF
--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -4,7 +4,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <avr/pgmspace.h>
-#include <avr/delay.h>
+#include <util/delay.h>
 #include "Timer.h"
 
 #include "Configuration.h"

--- a/Firmware/swi2c.c
+++ b/Firmware/swi2c.c
@@ -1,7 +1,7 @@
 //swi2c.c
 #include "swi2c.h"
 #include <avr/io.h>
-#include <avr/delay.h>
+#include <util/delay.h>
 #include <avr/pgmspace.h>
 #include "Configuration_prusa.h"
 #include "pins.h"


### PR DESCRIPTION
…/delay.h:36:2: warning: #warning "This file has been moved to <util/delay.h>." [-Wcpp]