### PR TITLE
Fix compiler warning arduino-1.6.9/hardware/tools/avr/avr/include/avr…

### DIFF
--- a/Firmware/pat9125.c
+++ b/Firmware/pat9125.c
@@ -1,6 +1,6 @@
 //pat9125.c
 #include "pat9125.h"
-#include <avr/delay.h>
+#include <util/delay.h>
 #include <avr/pgmspace.h>
 #include "config.h"
 #include <stdio.h>


### PR DESCRIPTION
…/delay.h:36:2: warning: #warning "This file has been moved to <util/delay.h>." [-Wcpp]