### PR TITLE
Save 88B FLASH and fix compiler warnings:

### DIFF
--- a/Firmware/cmdqueue.h
+++ b/Firmware/cmdqueue.h
@@ -32,8 +32,7 @@
 #define CMDBUFFER_RESERVE_FRONT       (5*21)
 
 extern char cmdbuffer[BUFSIZE * (MAX_CMD_SIZE + 1) + CMDBUFFER_RESERVE_FRONT];
-extern int bufindr;
-extern int bufindw;
+extern size_t bufindr;
 extern int buflen;
 extern bool cmdbuffer_front_already_processed;
 
@@ -59,8 +58,6 @@ extern long Stopped_gcode_LastN;
 
 extern bool cmdqueue_pop_front();
 extern void cmdqueue_reset();
-extern bool cmdqueue_could_enqueue_front(int len_asked);
-extern bool cmdqueue_could_enqueue_back(int len_asked, bool atomic_update = false);
 #ifdef CMDBUFFER_DEBUG
 extern void cmdqueue_dump_to_serial_single_line(int nr, const char *p);
 extern void cmdqueue_dump_to_serial();


### PR DESCRIPTION
sketch/cmdqueue.cpp: In function 'bool cmdqueue_pop_front()':
sketch/cmdqueue.cpp:67:56: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
             for (++ bufindr; bufindr < sizeof(cmdbuffer) && cmdbuffer[bufindr] == 0; ++ bufindr) ;
                                                        ^
sketch/cmdqueue.cpp: In function 'bool cmdqueue_could_enqueue_back(int, bool)':
sketch/cmdqueue.cpp:170:63: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
             endw + CMDBUFFER_RESERVE_FRONT <= sizeof(cmdbuffer) ||
                                                               ^
sketch/cmdqueue.cpp:172:38: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
             (endw <= sizeof(cmdbuffer) && CMDBUFFER_RESERVE_FRONT <= bufindr))
                                      ^
sketch/cmdqueue.cpp:196:63: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
             endw + CMDBUFFER_RESERVE_FRONT <= sizeof(cmdbuffer) ||
                                                               ^
sketch/cmdqueue.cpp:198:38: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
             (endw <= sizeof(cmdbuffer) && CMDBUFFER_RESERVE_FRONT <= bufindr))
                                      ^
sketch/cmdqueue.cpp: In function 'void get_command()':
sketch/cmdqueue.cpp:380:10: warning: variable 'rx_buffer_full' set but not used [-Wunused-but-set-variable]
     bool rx_buffer_full = false; //flag that serial rx buffer is full
          ^
sketch/cmdqueue.cpp: In function 'uint16_t cmdqueue_calc_sd_length()':
sketch/cmdqueue.cpp:697:54: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
         for (++ _bufindr; _bufindr < sizeof(cmdbuffer) && cmdbuffer[_bufindr] == 0; ++ _bufindr) ;
                                                      ^