### PR TITLE
M500 - M503 improvements, mmu v2 T code fix

### DIFF
--- a/Firmware/ConfigurationStore.cpp
+++ b/Firmware/ConfigurationStore.cpp
@@ -50,7 +50,7 @@ void _EEPROM_readData(int &pos, uint8_t* value, uint8_t size)
 #define EEPROM_VERSION "V2"
 
 #ifdef EEPROM_SETTINGS
-void Config_StoreSettings(uint16_t offset, uint8_t level) 
+void Config_StoreSettings(uint16_t offset) 
 {
   char ver[4]= "000";
   int i = offset;
@@ -119,12 +119,7 @@ void Config_StoreSettings(uint16_t offset, uint8_t level)
   #endif
   #endif
 
-#ifdef LIN_ADVANCE
-  if (level >= 10) {
-	  EEPROM_WRITE_VAR(i, extruder_advance_k);
-	  EEPROM_WRITE_VAR(i, advance_ed_ratio);
-  }
-#endif //LIN_ADVANCE
+
 
   EEPROM_WRITE_VAR(i,max_feedrate_silent);
   EEPROM_WRITE_VAR(i,max_acceleration_units_per_sq_second_silent);
@@ -225,7 +220,7 @@ void Config_PrintSettings(uint8_t level)
 
 
 #ifdef EEPROM_SETTINGS
-bool Config_RetrieveSettings(uint16_t offset, uint8_t level)
+bool Config_RetrieveSettings(uint16_t offset)
 {
     int i=offset;
 	bool previous_settings_retrieved = true;
@@ -302,12 +297,7 @@ bool Config_RetrieveSettings(uint16_t offset, uint8_t level)
 		EEPROM_READ_VAR(i, filament_size[2]);
 #endif
 #endif
-#ifdef LIN_ADVANCE
-		if (level >= 10) {
-			EEPROM_READ_VAR(i, extruder_advance_k);
-			EEPROM_READ_VAR(i, advance_ed_ratio);
-		}
-#endif //LIN_ADVANCE
+
     calculate_extruder_multipliers();
 
         EEPROM_READ_VAR(i,max_feedrate_silent);  

--- a/Firmware/ConfigurationStore.cpp
+++ b/Firmware/ConfigurationStore.cpp
@@ -189,11 +189,11 @@ void Config_PrintSettings(uint8_t level)
 	printf_P(PSTR(
 		"%SRetract: S=Length (mm) F:Speed (mm/m) Z: ZLift (mm)\n%S   M207 S%.2f F%.2f Z%.2f\n"
 		"%SRecover: S=Extra length (mm) F:Speed (mm/m)\n%S   M208 S%.2f F%.2f\n"
-		"%SAuto-Retract: S=0 to disable, 1 to interpret extrude-only moves as retracts or recoveries\n%S   M209 S%.2f\n"
+		"%SAuto-Retract: S=0 to disable, 1 to interpret extrude-only moves as retracts or recoveries\n%S   M209 S%d\n"
 		),
 		echomagic, echomagic, retract_length, retract_feedrate*60, retract_zlift,
 		echomagic, echomagic, retract_recover_length, retract_recover_feedrate*60,
-		echomagic, echomagic, (unsigned long)(autoretract_enabled ? 1 : 0)
+		echomagic, echomagic, (autoretract_enabled ? 1 : 0)
 	);
 #if EXTRUDERS > 1
 	printf_P(PSTR("%SMulti-extruder settings:\n%S   Swap retract length (mm):    %.2f\n%S   Swap rec. addl. length (mm): %.2f\n"),

--- a/Firmware/ConfigurationStore.h
+++ b/Firmware/ConfigurationStore.h
@@ -13,8 +13,8 @@ FORCE_INLINE void Config_PrintSettings() {}
 #endif
 
 #ifdef EEPROM_SETTINGS
-void Config_StoreSettings(uint16_t offset, uint8_t level = 0);
-bool Config_RetrieveSettings(uint16_t offset, uint8_t level = 0);
+void Config_StoreSettings(uint16_t offset);
+bool Config_RetrieveSettings(uint16_t offset);
 #else
 FORCE_INLINE void Config_StoreSettings() {}
 FORCE_INLINE void Config_RetrieveSettings() { Config_ResetDefault(); Config_PrintSettings(); }

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -6991,7 +6991,7 @@ Sigma_Exit:
 		  }
 		  snmm_filaments_used |= (1 << tmp_extruder); //for stop print
 
-#ifdef SNMM_V2
+#if defined (SNMM_V2)
 		  printf_P(PSTR("T code: %d \n"), tmp_extruder);
 		  fprintf_P(uart2io, PSTR("T%d\n"), tmp_extruder);
 
@@ -7004,9 +7004,8 @@ Sigma_Exit:
 			  mmu_load_to_nozzle();
 
 		  }
-#endif
+#elif defined(SNMM)
 
-#ifdef SNMM
           
     #ifdef LIN_ADVANCE
           if (snmm_extruder != tmp_extruder)
@@ -7053,7 +7052,7 @@ Sigma_Exit:
 		  }
 		  delay(100);
 
-#else
+#else //SNMM and SNMM_V2 undefined:
 		  if (tmp_extruder >= EXTRUDERS) {
 			  SERIAL_ECHO_START;
 			  SERIAL_ECHOPGM("T");
@@ -7061,19 +7060,19 @@ Sigma_Exit:
 			  SERIAL_ECHOLNRPGM(_n("Invalid extruder"));////MSG_INVALID_EXTRUDER c=0 r=0
 		  }
 		  else {
-#if EXTRUDERS > 1
+			#if EXTRUDERS > 1
 		      boolean make_move = false;
-#endif
+			#endif
 			  if (code_seen('F')) {
-#if EXTRUDERS > 1
+			#if EXTRUDERS > 1
 				  make_move = true;
-#endif
+			#endif
 				  next_feedrate = code_value();
 				  if (next_feedrate > 0.0) {
 					  feedrate = next_feedrate;
 				  }
 			  }
-#if EXTRUDERS > 1
+			#if EXTRUDERS > 1
 			  if (tmp_extruder != active_extruder) {
 				  // Save current position to return to after applying extruder offset
 				  memcpy(destination, current_position, sizeof(destination));
@@ -7092,7 +7091,7 @@ Sigma_Exit:
 					  prepare_move();
 				  }
 			  }
-#endif
+			#endif
 			  SERIAL_ECHO_START;
 			  SERIAL_ECHORPGM(_n("Active Extruder: "));////MSG_ACTIVE_EXTRUDER c=0 r=0
 			  SERIAL_PROTOCOLLN((int)active_extruder);


### PR DESCRIPTION
- M503 fix
- mmu v2 Tcode fix: dont print invalid extruder
- removed unused lin. advance variables from M500 - M503
