### PR TITLE
snmm v2: send filament type to mmu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ Firmware/Doc
 /Firmware/Firmware.vcxproj.filters
 /Firmware/Firmware - Shortcut.lnk
 /Firmware/variants/1_75mm_MK3-MMU-EINSy10a-E3Dv6full.h.bak
+/Firmware/Marlin_main.cpp~RF12cfae7.TMP

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -6308,9 +6308,9 @@ if((eSoundMode==e_SOUND_MODE_LOUD)||(eSoundMode==e_SOUND_MODE_ONCE))
 
 		printf_P(PSTR("Extruder: %d; "), extruder);
 		switch (filament) {
-			case FILAMENT_FLEX: printf_P(PSTR("Flex")); break;
-			case FILAMENT_PVA: printf_P(PSTR("PVA")); break;
-			default: printf_P(PSTR("Default")); break;
+			case FILAMENT_FLEX: printf_P(PSTR("Flex\n")); break;
+			case FILAMENT_PVA: printf_P(PSTR("PVA\n")); break;
+			default: printf_P(PSTR("Default\n")); break;
 		}
 		printf_P(PSTR("F%d%d\n"), extruder, filament);
 		fprintf_P(uart2io, PSTR("F%d%d\n"), extruder, filament);

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -6297,7 +6297,9 @@ if((eSoundMode==e_SOUND_MODE_LOUD)||(eSoundMode==e_SOUND_MODE_ONCE))
 	case 403: //M403 set filament type (material) for particular extruder and send this information to mmu
 	{
 		//currently three different materials are needed (default, flex and PVA) 
-		//store this information for future use in different load/unload profiles etc.
+		//add storing this information for different load/unload profiles etc. in the future
+		//firmware does not wait for "ok" from mmu
+
 		uint8_t extruder;
 		uint8_t filament;
 

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -140,6 +140,11 @@
 #define PRINTING_TYPE_SD 0
 #define PRINTING_TYPE_USB 1
 
+//filament types 
+#define FILAMENT_DEFAULT 0
+#define FILAMENT_FLEX 1
+#define FILAMENT_PVA 2
+
 // look here for descriptions of G-codes: http://linuxcnc.org/handbook/gcode/g-code.html
 // http://objects.reprap.org/wiki/Mendel_User_Manual:_RepRapGCodes
 
@@ -6288,6 +6293,27 @@ if((eSoundMode==e_SOUND_MODE_LOUD)||(eSoundMode==e_SOUND_MODE_ONCE))
       st_synchronize();
     }
     break;
+
+	case 403: //M403 set filament type (material) for particular extruder and send this information to mmu
+	{
+		//currently three different materials are needed (default, flex and PVA) 
+		//store this information for future use in different load/unload profiles etc.
+		uint8_t extruder;
+		uint8_t filament;
+
+		if(code_seen('E')) extruder = code_value();
+		if(code_seen('F')) filament = code_value();
+
+		printf_P(PSTR("Extruder: %d; "), extruder);
+		switch (filament) {
+			case FILAMENT_FLEX: printf_P(PSTR("Flex")); break;
+			case FILAMENT_PVA: printf_P(PSTR("PVA")); break;
+			default: printf_P(PSTR("Default")); break;
+		}
+		printf_P(PSTR("F%d%d\n"), extruder, filament);
+		fprintf_P(uart2io, PSTR("F%d%d\n"), extruder, filament);
+	}
+	break;
 
     case 500: // M500 Store settings in EEPROM
     {


### PR DESCRIPTION
- intitial version which just resends extruder / filament type to mmu
- M403 Exxx Fyyy
- E stands for extruder number, Fstands for filament type (0: default; 1:flex; 2: PVA)