### PR TITLE
Fix Home for MK2-MK2.5

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -2715,6 +2715,12 @@ void gcode_G28(bool home_x_axis, long home_x_value, bool home_y_axis, long home_
 		else
 			tmc2130_home_calibrate(Y_AXIS);
 	  }
+#else
+      if(home_x)
+        homeaxis(X_AXIS);
+
+      if(home_y)
+        homeaxis(Y_AXIS);
 #endif //TMC2130
 
 


### PR DESCRIPTION
Fix Home G28 X0
                G28 Y0 
for MK2, MK2.5, Octoprint, Pronterface.