### PR TITLE
Make MMUv2 compatible with MK3 Einsy and MK2.5 miniRAMbo boards.

### DIFF
--- a/Firmware/mmu.cpp
+++ b/Firmware/mmu.cpp
@@ -21,7 +21,6 @@ extern char choose_extruder_menu();
 #define MMU_TIMEOUT 10
 
 #define MMU_HWRESET
-#define MMU_RST_PIN 76
 
 
 bool mmu_enabled = false;

--- a/Firmware/pins_Einsy_1_0.h
+++ b/Firmware/pins_Einsy_1_0.h
@@ -143,7 +143,7 @@
 #define WRITE_LOGIC_ANALYZER_CH4(value) if (value) PORTK |= (1 << 0); else PORTK &= ~(1 << 0) // PK0
 #define LOGIC_ANALYZER_CH5		16				// PH0 (RXD2)
 #define LOGIC_ANALYZER_CH6		17				// PH1 (TXD2)
-#ifndef SNMMP
+#ifndef SNMM
 	#define LOGIC_ANALYZER_CH7 		76				// PJ5
 #endif
 

--- a/Firmware/pins_Einsy_1_0.h
+++ b/Firmware/pins_Einsy_1_0.h
@@ -87,6 +87,14 @@
 #define E0_MS1_PIN          -1
 #define E0_MS2_PIN          -1
 
+// Used pins for MMUv1 and MMUv2
+#ifdef SNMM 
+  #define E_MUX0_PIN 14 //Controls the super switch on MMUv1
+  #define E_MUX1_PIN 15//Controls the super switch on MMUv1
+  #endif
+#define MMU_RST_PIN 76 //Hardware reset pin for MMUv2 controller
+// End MMU pins
+
 #define SDPOWER             -1
 #define SDSS                77
 #define LED_PIN             13
@@ -135,7 +143,9 @@
 #define WRITE_LOGIC_ANALYZER_CH4(value) if (value) PORTK |= (1 << 0); else PORTK &= ~(1 << 0) // PK0
 #define LOGIC_ANALYZER_CH5		16				// PH0 (RXD2)
 #define LOGIC_ANALYZER_CH6		17				// PH1 (TXD2)
-#define LOGIC_ANALYZER_CH7 		76				// PJ5
+#ifndef SNMMP
+	#define LOGIC_ANALYZER_CH7 		76				// PJ5
+#endif
 
 #define LOGIC_ANALYZER_CH0_ENABLE do { SET_OUTPUT(LOGIC_ANALYZER_CH0); WRITE(LOGIC_ANALYZER_CH0, false); } while (0)
 #define LOGIC_ANALYZER_CH1_ENABLE do { SET_OUTPUT(LOGIC_ANALYZER_CH1); WRITE(LOGIC_ANALYZER_CH1, false); } while (0)

--- a/Firmware/pins_Rambo_1_0.h
+++ b/Firmware/pins_Rambo_1_0.h
@@ -64,11 +64,13 @@
 #define E0_MS1_PIN             65
 #define E0_MS2_PIN             66
 
+// Used pins for MMUv1 and MMUv2
 #ifdef SNMM 
-  #define E_MUX0_PIN 17
-  #define E_MUX1_PIN 16
+  #define E_MUX0_PIN 17 //Controls the super switch on MMUv1
+  #define E_MUX1_PIN 16 //Controls the super switch on MMUv1
 #endif
-
+#define MMU_RST_PIN 30 //Hardware reset pin for MMUv2 controller z-max pin
+// End MMU pins
 
 #define MOTOR_CURRENT_PWM_XY_PIN 46
 #define MOTOR_CURRENT_PWM_Z_PIN  45

--- a/Firmware/pins_Rambo_1_3.h
+++ b/Firmware/pins_Rambo_1_3.h
@@ -64,11 +64,13 @@
 #define E0_MS1_PIN             65
 #define E0_MS2_PIN             66
 
+// Used pins for MMUv1 and MMUv2
 #ifdef SNMM 
-  #define E_MUX0_PIN 17
-  #define E_MUX1_PIN 16
+  #define E_MUX0_PIN 17 //Controls the super switch on MMUv1
+  #define E_MUX1_PIN 16 //Controls the super switch on MMUv1
 #endif
-
+#define MMU_RST_PIN 23 //Hardware reset pin for MMUv2 controller z-max pin
+//End MMU pins
 
 #define MOTOR_CURRENT_PWM_XY_PIN 46
 #define MOTOR_CURRENT_PWM_Z_PIN  45


### PR DESCRIPTION
The defined MMU_RST_PIN pin 76 is only available on the P3 connector on the Einsy board BUT not on the miniRAMbo.
As the MMUv2 should be supported on the MK3 and MK2.5, which has a miniRAMbo controller, you gonna need to use another pin on the miniRAMbo 1.0 and 1.3 for MMU_RST_PIN.
Like 'X-max' is used for Noctua tacho signal I propose to use 'z-max' for MMU_RST_PIN. Prusa also gonna need a split cable for the miniRAMBO MMUv2 as for the MK2.5 Noctuca and PINDAv2.
