### PR TITLE
Revert "menu data shared memory re-design"

### DIFF
--- a/Firmware/Timer.cpp
+++ b/Firmware/Timer.cpp
@@ -10,7 +10,7 @@
  * @brief construct Timer
  *
  * It is guaranteed, that construction is equivalent with zeroing all members.
- * This property can be exploited in menu_data.
+ * This property can be exploited in MenuData union.
  */
 template<typename T>
 Timer<T>::Timer() : m_isRunning(false), m_started()

--- a/Firmware/menu.cpp
+++ b/Firmware/menu.cpp
@@ -273,35 +273,25 @@ void menu_draw_float13(char chr, const char* str, float val)
 	lcd_printf_P(menu_fmt_float13, chr, str, spaces, val);
 }
 
-typedef struct
-{
-    //Variables used when editing values.
-    const char* editLabel;
-    void* editValue;
-    int32_t minEditValue;
-	int32_t maxEditValue;
-} menu_data_edit_t;
-
+#define _menu_data menuData.edit_menu
 void _menu_edit_int3(void)
 {
-	menu_data_edit_t* _md = (menu_data_edit_t*)&(menu_data[0]);
 	if (lcd_draw_update)
 	{
-		if (lcd_encoder < _md->minEditValue) lcd_encoder = _md->minEditValue;
-		if (lcd_encoder > _md->maxEditValue) lcd_encoder = _md->maxEditValue;
+		if (lcd_encoder < _menu_data.minEditValue) lcd_encoder = _menu_data.minEditValue;
+		if (lcd_encoder > _menu_data.maxEditValue) lcd_encoder = _menu_data.maxEditValue;
 		lcd_set_cursor(0, 1);
-		menu_draw_int3(' ', _md->editLabel, (int)lcd_encoder);
+		menu_draw_int3(' ', _menu_data.editLabel, (int)lcd_encoder);
 	}
 	if (LCD_CLICKED)
 	{
-		*((int*)(_md->editValue)) = (int)lcd_encoder;
+		*((int*)(_menu_data.editValue)) = (int)lcd_encoder;
 		menu_back();
 	}
 }
 
 uint8_t menu_item_edit_int3(const char* str, int16_t* pval, int16_t min_val, int16_t max_val)
 {
-	menu_data_edit_t* _md = (menu_data_edit_t*)&(menu_data[0]);
 	if (menu_item == menu_line)
 	{
 		if (lcd_draw_update) 
@@ -312,10 +302,10 @@ uint8_t menu_item_edit_int3(const char* str, int16_t* pval, int16_t min_val, int
 		if (menu_clicked && (lcd_encoder == menu_item))
 		{
 			menu_submenu(_menu_edit_int3);
-			_md->editLabel = str;
-			_md->editValue = pval;
-			_md->minEditValue = min_val;
-			_md->maxEditValue = max_val;
+			_menu_data.editLabel = str;
+			_menu_data.editValue = pval;
+			_menu_data.minEditValue = min_val;
+			_menu_data.maxEditValue = max_val;
 			lcd_encoder = *pval;
 			return menu_item_ret();
 		}

--- a/Firmware/menu.h
+++ b/Firmware/menu.h
@@ -16,6 +16,15 @@ typedef struct
     uint8_t position;
 } menu_record_t;
 
+typedef struct
+{
+    //Variables used when editing values.
+    const char* editLabel;
+    void* editValue;
+    int32_t minEditValue;
+	int32_t maxEditValue;
+} menu_data_edit_t;
+
 extern menu_record_t menu_stack[MENU_DEPTH_MAX];
 
 extern uint8_t menu_data[MENU_DATA_SIZE];

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -45,7 +45,9 @@ char longFilenameOLD[LONG_FILENAME_LENGTH];
 
 static void lcd_sd_updir();
 
-
+// State of the currently active menu.
+// C Union manages sharing of the static memory by all the menus.
+union MenuData menuData;
 
 int8_t ReInitLCD = 0;
 
@@ -2171,34 +2173,23 @@ static void lcd_preheat_menu()
 
 static void lcd_support_menu()
 {
-	typedef struct
-	{	// 22bytes total
-		int8_t status;                 // 1byte
-		bool is_flash_air;             // 1byte
-		uint8_t ip[4];                 // 4bytes
-		char ip_str[3*4+3+1];          // 16bytes
-	} _menu_data_t;
-#if (22 > MENU_DATA_SIZE)
-#error "check MENU_DATA_SIZE definition!"
-#endif
-	_menu_data_t* _md = (_menu_data_t*)&(menu_data[0]);
-    if (_md->status == 0 || lcd_draw_update == 2)
+    if (menuData.supportMenu.status == 0 || lcd_draw_update == 2)
 	{
         // Menu was entered or SD card status has changed (plugged in or removed).
         // Initialize its status.
-        _md->status = 1;
-        _md->is_flash_air = card.ToshibaFlashAir_isEnabled() && card.ToshibaFlashAir_GetIP(_md->ip);
-        if (_md->is_flash_air)
-            sprintf_P(_md->ip_str, PSTR("%d.%d.%d.%d"), 
-                _md->ip[0], _md->ip[1], 
-                _md->ip[2], _md->ip[3]);
-    } else if (_md->is_flash_air && 
-        _md->ip[0] == 0 && _md->ip[1] == 0 && 
-        _md->ip[2] == 0 && _md->ip[3] == 0 &&
-        ++ _md->status == 16)
+        menuData.supportMenu.status = 1;
+        menuData.supportMenu.is_flash_air = card.ToshibaFlashAir_isEnabled() && card.ToshibaFlashAir_GetIP(menuData.supportMenu.ip);
+        if (menuData.supportMenu.is_flash_air)
+            sprintf_P(menuData.supportMenu.ip_str, PSTR("%d.%d.%d.%d"), 
+                menuData.supportMenu.ip[0], menuData.supportMenu.ip[1], 
+                menuData.supportMenu.ip[2], menuData.supportMenu.ip[3]);
+    } else if (menuData.supportMenu.is_flash_air && 
+        menuData.supportMenu.ip[0] == 0 && menuData.supportMenu.ip[1] == 0 && 
+        menuData.supportMenu.ip[2] == 0 && menuData.supportMenu.ip[3] == 0 &&
+        ++ menuData.supportMenu.status == 16)
 	{
         // Waiting for the FlashAir card to get an IP address from a router. Force an update.
-        _md->status = 0;
+        menuData.supportMenu.status = 0;
     }
 
   MENU_BEGIN();
@@ -2248,10 +2239,10 @@ static void lcd_support_menu()
 
 
   // Show the FlashAir IP address, if the card is available.
-  if (_md->is_flash_air) {
+  if (menuData.supportMenu.is_flash_air) {
       MENU_ITEM_BACK_P(STR_SEPARATOR);
       MENU_ITEM_BACK_P(PSTR("FlashAir IP Addr:"));
-///!      MENU_ITEM(back_RAM, _md->ip_str, 0);
+///!      MENU_ITEM(back_RAM, menuData.supportMenu.ip_str, 0);
   }
 
   #ifndef MK1BP
@@ -2509,7 +2500,7 @@ static void lcd_menu_AutoLoadFilament()
     }
     else
     {
-		ShortTimer* ptimer = (ShortTimer*)&(menu_data[0]);
+		ShortTimer* ptimer = (ShortTimer*)&(menuData.autoLoadFilamentMenu.dummy);
         if (!ptimer->running()) ptimer->start();
         lcd_set_cursor(0, 0);
         lcd_puts_P(_T(MSG_ERROR));
@@ -2620,19 +2611,10 @@ void lcd_menu_statistics()
 
 static void _lcd_move(const char *name, int axis, int min, int max)
 {
-	typedef struct
-	{	// 2bytes total
-		bool initialized;              // 1byte
-		bool endstopsEnabledPrevious;  // 1byte
-	} _menu_data_t;
-#if (2 > MENU_DATA_SIZE)
-#error "check MENU_DATA_SIZE definition!"
-#endif
-	_menu_data_t* _md = (_menu_data_t*)&(menu_data[0]);
-	if (!_md->initialized)
+	if (!menuData._lcd_moveMenu.initialized)
 	{
-		_md->endstopsEnabledPrevious = enable_endstops(false);
-		_md->initialized = true;
+		menuData._lcd_moveMenu.endstopsEnabledPrevious = enable_endstops(false);
+		menuData._lcd_moveMenu.initialized = true;
 	}
 	if (lcd_encoder != 0)
 	{
@@ -2653,7 +2635,7 @@ static void _lcd_move(const char *name, int axis, int min, int max)
 	    lcd_set_cursor(0, 1);
 		menu_draw_float31(' ', name, current_position[axis]);
 	}
-	if (menuExiting || LCD_CLICKED) (void)enable_endstops(_md->endstopsEnabledPrevious);
+	if (menuExiting || LCD_CLICKED) (void)enable_endstops(menuData._lcd_moveMenu.endstopsEnabledPrevious);
 	if (LCD_CLICKED) menu_back();
 }
 
@@ -2825,37 +2807,27 @@ static void lcd_move_z() {
  */
 static void _lcd_babystep(int axis, const char *msg) 
 {
-	typedef struct
-	{	// 19bytes total
-		int8_t status;                 // 1byte
-		int babystepMem[3];            // 6bytes
-		float babystepMemMM[3];        // 12bytes
-	} _menu_data_t;
-#if (19 > MENU_DATA_SIZE)
-#error "check MENU_DATA_SIZE definition!"
-#endif
-	_menu_data_t* _md = (_menu_data_t*)&(menu_data[0]);
-	if (_md->status == 0)
+	if (menuData.babyStep.status == 0)
 	{
 		// Menu was entered.
 		// Initialize its status.
-		_md->status = 1;
+		menuData.babyStep.status = 1;
 		check_babystep();
 
-		EEPROM_read_B(EEPROM_BABYSTEP_X, &_md->babystepMem[0]);
-		EEPROM_read_B(EEPROM_BABYSTEP_Y, &_md->babystepMem[1]);
-		EEPROM_read_B(EEPROM_BABYSTEP_Z, &_md->babystepMem[2]);
+		EEPROM_read_B(EEPROM_BABYSTEP_X, &menuData.babyStep.babystepMem[0]);
+		EEPROM_read_B(EEPROM_BABYSTEP_Y, &menuData.babyStep.babystepMem[1]);
+		EEPROM_read_B(EEPROM_BABYSTEP_Z, &menuData.babyStep.babystepMem[2]);
 
 		// same logic as in babystep_load
 	    if (calibration_status() >= CALIBRATION_STATUS_LIVE_ADJUST)
-			_md->babystepMem[2] = 0;
+			menuData.babyStep.babystepMem[2] = 0;
 
-		_md->babystepMemMM[0] = _md->babystepMem[0]/axis_steps_per_unit[X_AXIS];
-		_md->babystepMemMM[1] = _md->babystepMem[1]/axis_steps_per_unit[Y_AXIS];
-		_md->babystepMemMM[2] = _md->babystepMem[2]/axis_steps_per_unit[Z_AXIS];
+		menuData.babyStep.babystepMemMM[0] = menuData.babyStep.babystepMem[0]/axis_steps_per_unit[X_AXIS];
+		menuData.babyStep.babystepMemMM[1] = menuData.babyStep.babystepMem[1]/axis_steps_per_unit[Y_AXIS];
+		menuData.babyStep.babystepMemMM[2] = menuData.babyStep.babystepMem[2]/axis_steps_per_unit[Z_AXIS];
 		lcd_draw_update = 1;
 		//SERIAL_ECHO("Z baby step: ");
-		//SERIAL_ECHO(_md->babystepMem[2]);
+		//SERIAL_ECHO(menuData.babyStep.babystepMem[2]);
 		// Wait 90 seconds before closing the live adjust dialog.
 		lcd_timeoutToStatus.start();
 	}
@@ -2863,11 +2835,11 @@ static void _lcd_babystep(int axis, const char *msg)
 	if (lcd_encoder != 0) 
 	{
 		if (homing_flag) lcd_encoder = 0;
-		_md->babystepMem[axis] += (int)lcd_encoder;
+		menuData.babyStep.babystepMem[axis] += (int)lcd_encoder;
 		if (axis == 2)
 		{
-			if (_md->babystepMem[axis] < Z_BABYSTEP_MIN) _md->babystepMem[axis] = Z_BABYSTEP_MIN; //-3999 -> -9.99 mm
-			else if (_md->babystepMem[axis] > Z_BABYSTEP_MAX) _md->babystepMem[axis] = Z_BABYSTEP_MAX; //0
+			if (menuData.babyStep.babystepMem[axis] < Z_BABYSTEP_MIN) menuData.babyStep.babystepMem[axis] = Z_BABYSTEP_MIN; //-3999 -> -9.99 mm
+			else if (menuData.babyStep.babystepMem[axis] > Z_BABYSTEP_MAX) menuData.babyStep.babystepMem[axis] = Z_BABYSTEP_MAX; //0
 			else
 			{
 				CRITICAL_SECTION_START
@@ -2875,7 +2847,7 @@ static void _lcd_babystep(int axis, const char *msg)
 				CRITICAL_SECTION_END		
 			}
 		}
-		_md->babystepMemMM[axis] = _md->babystepMem[axis]/axis_steps_per_unit[axis]; 
+		menuData.babyStep.babystepMemMM[axis] = menuData.babyStep.babystepMem[axis]/axis_steps_per_unit[axis]; 
 		delay(50);
 		lcd_encoder = 0;
 		lcd_draw_update = 1;
@@ -2883,14 +2855,14 @@ static void _lcd_babystep(int axis, const char *msg)
 	if (lcd_draw_update)
 	{
 	    lcd_set_cursor(0, 1);
-		menu_draw_float13(' ', msg, _md->babystepMemMM[axis]);
+		menu_draw_float13(' ', msg, menuData.babyStep.babystepMemMM[axis]);
 	}
 	if (LCD_CLICKED || menuExiting)
 	{
 		// Only update the EEPROM when leaving the menu.
 		EEPROM_save_B(
 		(axis == X_AXIS) ? EEPROM_BABYSTEP_X : ((axis == Y_AXIS) ? EEPROM_BABYSTEP_Y : EEPROM_BABYSTEP_Z),
-		&_md->babystepMem[axis]);
+		&menuData.babyStep.babystepMem[axis]);
 		if(Z_AXIS == axis) calibration_status_store(CALIBRATION_STATUS_CALIBRATED);
 	}
 	if (LCD_CLICKED) menu_back();
@@ -2908,94 +2880,72 @@ static void lcd_babystep_z() {
 
 static void lcd_adjust_bed();
 
-typedef struct
-{	// 13bytes total
-	int8_t status;                   // 1byte
-	int8_t left;                     // 1byte
-	int8_t right;                    // 1byte
-	int8_t front;                    // 1byte
-	int8_t rear;                     // 1byte
-	int    left2;                    // 2byte
-	int    right2;                   // 2byte
-	int    front2;                   // 2byte
-	int    rear2;                    // 2byte
-} _menu_data_adjust_bed_t;
-#if (13 > MENU_DATA_SIZE)
-#error "check MENU_DATA_SIZE definition!"
-#endif
-
 static void lcd_adjust_bed_reset()
 {
-	eeprom_update_byte((unsigned char*)EEPROM_BED_CORRECTION_VALID, 1);
-	eeprom_update_byte((unsigned char*)EEPROM_BED_CORRECTION_LEFT , 0);
-	eeprom_update_byte((unsigned char*)EEPROM_BED_CORRECTION_RIGHT, 0);
-	eeprom_update_byte((unsigned char*)EEPROM_BED_CORRECTION_FRONT, 0);
-	eeprom_update_byte((unsigned char*)EEPROM_BED_CORRECTION_REAR , 0);
-	_menu_data_adjust_bed_t* _md = (_menu_data_adjust_bed_t*)&(menu_data[0]);
-	_md->status = 0;
+    eeprom_update_byte((unsigned char*)EEPROM_BED_CORRECTION_VALID, 1);
+    eeprom_update_byte((unsigned char*)EEPROM_BED_CORRECTION_LEFT , 0);
+    eeprom_update_byte((unsigned char*)EEPROM_BED_CORRECTION_RIGHT, 0);
+    eeprom_update_byte((unsigned char*)EEPROM_BED_CORRECTION_FRONT, 0);
+    eeprom_update_byte((unsigned char*)EEPROM_BED_CORRECTION_REAR , 0);
+    menuData.adjustBed.status = 0;
 }
 
-void adjust_bed_reset()
-{
-	_menu_data_adjust_bed_t* _md = (_menu_data_adjust_bed_t*)&(menu_data[0]);
+void adjust_bed_reset() {
 	eeprom_update_byte((unsigned char*)EEPROM_BED_CORRECTION_VALID, 1);
 	eeprom_update_byte((unsigned char*)EEPROM_BED_CORRECTION_LEFT, 0);
 	eeprom_update_byte((unsigned char*)EEPROM_BED_CORRECTION_RIGHT, 0);
 	eeprom_update_byte((unsigned char*)EEPROM_BED_CORRECTION_FRONT, 0);
 	eeprom_update_byte((unsigned char*)EEPROM_BED_CORRECTION_REAR, 0);
-	_md->left = _md->left2 = 0;
-	_md->right = _md->right2 = 0;
-	_md->front = _md->front2 = 0;
-	_md->rear = _md->rear2 = 0;
+	menuData.adjustBed.left = menuData.adjustBed.left2 = 0;
+	menuData.adjustBed.right = menuData.adjustBed.right2 = 0;
+	menuData.adjustBed.front = menuData.adjustBed.front2 = 0;
+	menuData.adjustBed.rear = menuData.adjustBed.rear2 = 0;
 }
-
 #define BED_ADJUSTMENT_UM_MAX 50
 
 static void lcd_adjust_bed()
 {
-	_menu_data_adjust_bed_t* _md = (_menu_data_adjust_bed_t*)&(menu_data[0]);
-    if (_md->status == 0)
-	{
+    if (menuData.adjustBed.status == 0) {
         // Menu was entered.
         // Initialize its status.
-        _md->status = 1;
+        menuData.adjustBed.status = 1;
         bool valid = false;
-        _md->left  = _md->left2  = eeprom_read_int8((unsigned char*)EEPROM_BED_CORRECTION_LEFT);
-        _md->right = _md->right2 = eeprom_read_int8((unsigned char*)EEPROM_BED_CORRECTION_RIGHT);
-        _md->front = _md->front2 = eeprom_read_int8((unsigned char*)EEPROM_BED_CORRECTION_FRONT);
-        _md->rear  = _md->rear2  = eeprom_read_int8((unsigned char*)EEPROM_BED_CORRECTION_REAR);
+        menuData.adjustBed.left  = menuData.adjustBed.left2  = eeprom_read_int8((unsigned char*)EEPROM_BED_CORRECTION_LEFT);
+        menuData.adjustBed.right = menuData.adjustBed.right2 = eeprom_read_int8((unsigned char*)EEPROM_BED_CORRECTION_RIGHT);
+        menuData.adjustBed.front = menuData.adjustBed.front2 = eeprom_read_int8((unsigned char*)EEPROM_BED_CORRECTION_FRONT);
+        menuData.adjustBed.rear  = menuData.adjustBed.rear2  = eeprom_read_int8((unsigned char*)EEPROM_BED_CORRECTION_REAR);
         if (eeprom_read_byte((unsigned char*)EEPROM_BED_CORRECTION_VALID) == 1 && 
-            _md->left  >= -BED_ADJUSTMENT_UM_MAX && _md->left  <= BED_ADJUSTMENT_UM_MAX &&
-            _md->right >= -BED_ADJUSTMENT_UM_MAX && _md->right <= BED_ADJUSTMENT_UM_MAX &&
-            _md->front >= -BED_ADJUSTMENT_UM_MAX && _md->front <= BED_ADJUSTMENT_UM_MAX &&
-            _md->rear  >= -BED_ADJUSTMENT_UM_MAX && _md->rear  <= BED_ADJUSTMENT_UM_MAX)
+            menuData.adjustBed.left  >= -BED_ADJUSTMENT_UM_MAX && menuData.adjustBed.left  <= BED_ADJUSTMENT_UM_MAX &&
+            menuData.adjustBed.right >= -BED_ADJUSTMENT_UM_MAX && menuData.adjustBed.right <= BED_ADJUSTMENT_UM_MAX &&
+            menuData.adjustBed.front >= -BED_ADJUSTMENT_UM_MAX && menuData.adjustBed.front <= BED_ADJUSTMENT_UM_MAX &&
+            menuData.adjustBed.rear  >= -BED_ADJUSTMENT_UM_MAX && menuData.adjustBed.rear  <= BED_ADJUSTMENT_UM_MAX)
             valid = true;
         if (! valid) {
             // Reset the values: simulate an edit.
-            _md->left2  = 0;
-            _md->right2 = 0;
-            _md->front2 = 0;
-            _md->rear2  = 0;
+            menuData.adjustBed.left2  = 0;
+            menuData.adjustBed.right2 = 0;
+            menuData.adjustBed.front2 = 0;
+            menuData.adjustBed.rear2  = 0;
         }
         lcd_draw_update = 1;
         eeprom_update_byte((unsigned char*)EEPROM_BED_CORRECTION_VALID, 1);
     }
 
-    if (_md->left  != _md->left2)
-        eeprom_update_int8((unsigned char*)EEPROM_BED_CORRECTION_LEFT,  _md->left  = _md->left2);
-    if (_md->right != _md->right2)
-        eeprom_update_int8((unsigned char*)EEPROM_BED_CORRECTION_RIGHT, _md->right = _md->right2);
-    if (_md->front != _md->front2)
-        eeprom_update_int8((unsigned char*)EEPROM_BED_CORRECTION_FRONT, _md->front = _md->front2);
-    if (_md->rear  != _md->rear2)
-        eeprom_update_int8((unsigned char*)EEPROM_BED_CORRECTION_REAR,  _md->rear  = _md->rear2);
+    if (menuData.adjustBed.left  != menuData.adjustBed.left2)
+        eeprom_update_int8((unsigned char*)EEPROM_BED_CORRECTION_LEFT,  menuData.adjustBed.left  = menuData.adjustBed.left2);
+    if (menuData.adjustBed.right != menuData.adjustBed.right2)
+        eeprom_update_int8((unsigned char*)EEPROM_BED_CORRECTION_RIGHT, menuData.adjustBed.right = menuData.adjustBed.right2);
+    if (menuData.adjustBed.front != menuData.adjustBed.front2)
+        eeprom_update_int8((unsigned char*)EEPROM_BED_CORRECTION_FRONT, menuData.adjustBed.front = menuData.adjustBed.front2);
+    if (menuData.adjustBed.rear  != menuData.adjustBed.rear2)
+        eeprom_update_int8((unsigned char*)EEPROM_BED_CORRECTION_REAR,  menuData.adjustBed.rear  = menuData.adjustBed.rear2);
 
     MENU_BEGIN();
     MENU_ITEM_BACK_P(_T(MSG_SETTINGS));
-    MENU_ITEM_EDIT_int3_P(_i("Left side [um]"),  &_md->left2,  -BED_ADJUSTMENT_UM_MAX, BED_ADJUSTMENT_UM_MAX);////MSG_BED_CORRECTION_LEFT c=14 r=1
-    MENU_ITEM_EDIT_int3_P(_i("Right side[um]"), &_md->right2, -BED_ADJUSTMENT_UM_MAX, BED_ADJUSTMENT_UM_MAX);////MSG_BED_CORRECTION_RIGHT c=14 r=1
-    MENU_ITEM_EDIT_int3_P(_i("Front side[um]"), &_md->front2, -BED_ADJUSTMENT_UM_MAX, BED_ADJUSTMENT_UM_MAX);////MSG_BED_CORRECTION_FRONT c=14 r=1
-    MENU_ITEM_EDIT_int3_P(_i("Rear side [um]"),  &_md->rear2,  -BED_ADJUSTMENT_UM_MAX, BED_ADJUSTMENT_UM_MAX);////MSG_BED_CORRECTION_REAR c=14 r=1
+    MENU_ITEM_EDIT_int3_P(_i("Left side [um]"),  &menuData.adjustBed.left2,  -BED_ADJUSTMENT_UM_MAX, BED_ADJUSTMENT_UM_MAX);////MSG_BED_CORRECTION_LEFT c=14 r=1
+    MENU_ITEM_EDIT_int3_P(_i("Right side[um]"), &menuData.adjustBed.right2, -BED_ADJUSTMENT_UM_MAX, BED_ADJUSTMENT_UM_MAX);////MSG_BED_CORRECTION_RIGHT c=14 r=1
+    MENU_ITEM_EDIT_int3_P(_i("Front side[um]"), &menuData.adjustBed.front2, -BED_ADJUSTMENT_UM_MAX, BED_ADJUSTMENT_UM_MAX);////MSG_BED_CORRECTION_FRONT c=14 r=1
+    MENU_ITEM_EDIT_int3_P(_i("Rear side [um]"),  &menuData.adjustBed.rear2,  -BED_ADJUSTMENT_UM_MAX, BED_ADJUSTMENT_UM_MAX);////MSG_BED_CORRECTION_REAR c=14 r=1
     MENU_ITEM_FUNCTION_P(_i("Reset"), lcd_adjust_bed_reset);////MSG_BED_CORRECTION_RESET c=0 r=0
     MENU_END();
 }
@@ -5786,30 +5736,15 @@ static void lcd_colorprint_change() {
 
 static void lcd_tune_menu()
 {
-	typedef struct
-	{	// 3bytes total
-		// To recognize, whether the menu has been just initialized.
-		int8_t  status;                                 // 1byte
-		// Backup of extrudemultiply, to recognize, that the value has been changed and
-		// it needs to be applied.
-		int16_t extrudemultiply;                        // 2byte
-	} _menu_data_t;
-#if (3 > MENU_DATA_SIZE)
-#error "check MENU_DATA_SIZE definition!"
-#endif
-	_menu_data_t* _md = (_menu_data_t*)&(menu_data[0]);
-	if (_md->status == 0)
-	{
-		// Menu was entered. Mark the menu as entered and save the current extrudemultiply value.
-		_md->status = 1;
-		_md->extrudemultiply = extrudemultiply;
-	}
-	else if (_md->extrudemultiply != extrudemultiply)
-	{
-		// extrudemultiply has been changed from the child menu. Apply the new value.
-		_md->extrudemultiply = extrudemultiply;
-		calculate_extruder_multipliers();
-	}
+  if (menuData.tuneMenu.status == 0) {
+    // Menu was entered. Mark the menu as entered and save the current extrudemultiply value.
+    menuData.tuneMenu.status = 1;
+    menuData.tuneMenu.extrudemultiply = extrudemultiply;
+  } else if (menuData.tuneMenu.extrudemultiply != extrudemultiply) {
+    // extrudemultiply has been changed from the child menu. Apply the new value.
+    menuData.tuneMenu.extrudemultiply = extrudemultiply;
+    calculate_extruder_multipliers();
+  }
 
   EEPROM_read(EEPROM_SILENT, (uint8_t*)&SilentModeMenu, sizeof(SilentModeMenu));
 

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -13,6 +13,92 @@ extern void menu_lcd_longpress_func(void);
 extern void menu_lcd_charsetup_func(void);
 extern void menu_lcd_lcdupdate_func(void);
 
+struct EditMenuParentState
+{
+    //prevMenu and prevEncoderPosition are used to store the previous menu location when editing settings.
+    menu_func_t prevMenu;
+    uint16_t prevEncoderPosition;
+    //Variables used when editing values.
+    const char* editLabel;
+    void* editValue;
+    int32_t minEditValue, maxEditValue;
+    // menu_func_t callbackFunc;
+};
+
+union MenuData
+{
+    struct BabyStep
+    {
+        // 29B total
+        int8_t status;
+        int babystepMem[3];
+        float babystepMemMM[3];
+    } babyStep;
+
+    struct SupportMenu
+    {
+        // 6B+16B=22B total
+        int8_t status;
+        bool is_flash_air;
+        uint8_t ip[4];
+        char ip_str[3*4+3+1];
+    } supportMenu;
+
+    struct AdjustBed
+    {
+        // 6+13+16=35B
+        // editMenuParentState is used when an edit menu is entered, so it knows
+        // the return menu and encoder state.
+        struct EditMenuParentState editMenuParentState;
+        int8_t status;
+        int8_t left;
+        int8_t right;
+        int8_t front;
+        int8_t rear;
+        int    left2;
+        int    right2;
+        int    front2;
+        int    rear2;
+    } adjustBed;
+
+    struct TuneMenu
+    {
+        // editMenuParentState is used when an edit menu is entered, so it knows
+        // the return menu and encoder state.
+        struct EditMenuParentState editMenuParentState;
+        // To recognize, whether the menu has been just initialized.
+        int8_t  status;
+        // Backup of extrudemultiply, to recognize, that the value has been changed and
+        // it needs to be applied.
+        int16_t extrudemultiply;
+    } tuneMenu;
+
+    // editMenuParentState is used when an edit menu is entered, so it knows
+    // the return menu and encoder state.
+    struct EditMenuParentState editMenuParentState;
+
+    struct AutoLoadFilamentMenu
+    {
+        //ShortTimer timer;
+        char dummy;
+    } autoLoadFilamentMenu;
+    struct _Lcd_moveMenu
+    {
+        bool initialized;
+        bool endstopsEnabledPrevious;
+    } _lcd_moveMenu;
+    struct sdcard_menu_t
+    {
+        uint8_t viewState;
+    } sdcard_menu;
+    menu_data_edit_t edit_menu;
+};
+
+// State of the currently active menu.
+// C Union manages sharing of the static memory by all the menus.
+extern union MenuData menuData;
+
+
   // Call with a false parameter to suppress the LCD update from various places like the planner or the temp control.
   void ultralcd_init();
   void lcd_setstatus(const char* message);
@@ -138,6 +224,8 @@ void lcd_extr_cal_reset();
 void lcd_temp_cal_show_result(bool result);
 bool lcd_wait_for_pinda(float temp);
 
+
+union MenuData;
 
 void bowden_menu();
 char reset_menu();


### PR DESCRIPTION
This fixes: Unable to edit values in menu/calibration/Bed level correction.