### PR TITLE
Hot fix PFW-505 Speed change after tuning (on USB).

### DIFF
--- a/Firmware/menu.h
+++ b/Firmware/menu.h
@@ -14,7 +14,7 @@ typedef void (*menu_func_t)(void);
 typedef struct 
 {
     menu_func_t menu;
-    uint8_t position;
+    int8_t position;
 } menu_record_t;
 
 extern menu_record_t menu_stack[MENU_DEPTH_MAX];


### PR DESCRIPTION
When encoder is rotated left and pushed immediately on status screen, after returning to status screen print speed jumps to 345%.
This is caused by downcasting signed lcd_encoder to unsigned position and back to signed lcd_encoder.