### PR TITLE
lcd_clicked() fix (PFW-534 and PFW-546)

### DIFF
--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -687,7 +687,7 @@ LongTimer lcd_timeoutToStatus;
 uint8_t lcd_clicked(void)
 {
 	bool clicked = LCD_CLICKED;
-	if(clicked) lcd_button_pressed = 1;
+	if(clicked) lcd_button_pressed = 0;
     return clicked;
 }
 


### PR DESCRIPTION
Fixes strange priner behaviour when after returning to status screen printer enters main menu and/or clear screen.