### PR TITLE
MK25: always show "normal mode" remaining time (PFW-553)

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -8857,8 +8857,12 @@ void print_mesh_bed_leveling_table()
 
 uint16_t print_time_remaining() {
 	uint16_t print_t = PRINT_TIME_REMAINING_INIT;
+#ifdef TMC2130 
 	if (SilentModeMenu == SILENT_MODE_OFF) print_t = print_time_remaining_normal;
 	else print_t = print_time_remaining_silent;
+#else
+	print_t = print_time_remaining_normal;
+#endif //TMC2130
 	if ((print_t != PRINT_TIME_REMAINING_INIT) && (feedmultiply != 0)) print_t = 100 * print_t / feedmultiply;
 	return print_t;
 }
@@ -8867,12 +8871,18 @@ uint8_t calc_percent_done()
 {
 	//in case that we have information from M73 gcode return percentage counted by slicer, else return percentage counted as byte_printed/filesize
 	uint8_t percent_done = 0;
+#ifdef TMC2130
 	if (SilentModeMenu == SILENT_MODE_OFF && print_percent_done_normal <= 100) {
 		percent_done = print_percent_done_normal;
 	}
 	else if (print_percent_done_silent <= 100) {
 		percent_done = print_percent_done_silent;
 	}
+#else
+	if (print_percent_done_normal <= 100) {
+		percent_done = print_percent_done_normal;
+	}
+#endif //TMC2130
 	else {
 		percent_done = card.percentDone();
 	}


### PR DESCRIPTION
Slicer provides just time for normal mode when MK2.5 profile is chosen as remaining time for all modes (normal, silent, auto power) are the same.