### PR TITLE
wizard hotfix

### DIFF
--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -363,6 +363,8 @@ extern uint16_t print_time_remaining_silent;
 extern uint16_t mcode_in_progress;
 extern uint16_t gcode_in_progress;
 
+extern bool wizard_active; //autoload temporarily disabled during wizard
+
 #define PRINT_TIME_REMAINING_INIT 0xffff
 #define PRINT_PERCENT_DONE_INIT   0xff
 #define PRINTER_ACTIVE (IS_SD_PRINTING || is_usb_printing || isPrintPaused || (custom_message_type == CUSTOM_MSG_TYPE_TEMCAL) || saved_printing || (lcd_commands_type == LCD_COMMAND_V2_CAL) || card.paused || mmu_print_saved)

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -480,6 +480,8 @@ uint16_t print_time_remaining_normal = PRINT_TIME_REMAINING_INIT; //estimated re
 uint8_t print_percent_done_silent = PRINT_PERCENT_DONE_INIT;
 uint16_t print_time_remaining_silent = PRINT_TIME_REMAINING_INIT; //estimated remaining print time in minutes
 
+bool wizard_active = false; //autoload temporarily disabled during wizard
+
 //===========================================================================
 //=============================Private Variables=============================
 //===========================================================================
@@ -7341,7 +7343,7 @@ void manage_inactivity(bool ignore_stepper_queue/*=false*/) //default argument s
 	{
 		if (mcode_in_progress != 600) //M600 not in progress
 		{
-			if (!moves_planned() && !IS_SD_PRINTING && !is_usb_printing && (lcd_commands_type != LCD_COMMAND_V2_CAL))
+			if (!moves_planned() && !IS_SD_PRINTING && !is_usb_printing && (lcd_commands_type != LCD_COMMAND_V2_CAL) && !wizard_active)
 			{
 				if (fsensor_check_autoload())
 				{

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -4361,8 +4361,10 @@ void lcd_wizard(int state) {
 	int wizard_event;
 	const char *msg = NULL;
 	while (!end) {
+		printf_P(PSTR("Wizard state: %d"), state);
 		switch (state) {
 		case 0: // run wizard?
+			wizard_active = true;
 			wizard_event = lcd_show_multiscreen_message_yes_no_and_wait_P(_i("Hi, I am your Original Prusa i3 printer. Would you like me to guide you through the setup process?"), false, true);////MSG_WIZARD_WELCOME c=20 r=7
 			if (wizard_event) {
 				state = 1;
@@ -4408,7 +4410,6 @@ void lcd_wizard(int state) {
 			break;
 		case 5: //is filament loaded?
 				//start to preheat nozzle and bed to save some time later
-               lcd_commands_type = LCD_COMMAND_V2_CAL;
 			setTargetHotend(PLA_PREHEAT_HOTEND_TEMP, 0);
 			setTargetBed(PLA_PREHEAT_HPB_TEMP);
 			wizard_event = lcd_show_fullscreen_message_yes_no_and_wait_P(_i("Is filament loaded?"), false);////MSG_WIZARD_FILAMENT_LOADED c=20 r=2
@@ -4446,7 +4447,7 @@ void lcd_wizard(int state) {
 #ifdef SNMM
 			change_extr(0);
 #endif
-               loading_flag = true;
+            loading_flag = true;
 			gcode_M701();
 			state = 9;
 			break;
@@ -4480,7 +4481,7 @@ void lcd_wizard(int state) {
 		}
 	}
 
-	printf_P(_N("State: %d\n"), state);
+	printf_P(_N("Wizard end state: %d\n"), state);
 	switch (state) { //final message
 	case 0: //user dont want to use wizard
 		msg = _T(MSG_WIZARD_QUIT);
@@ -4514,7 +4515,10 @@ void lcd_wizard(int state) {
 		break;
 
 	}
-	if (state != 9) lcd_show_fullscreen_message_and_wait_P(msg);
+	if (state != 9) {
+		lcd_show_fullscreen_message_and_wait_P(msg);
+		wizard_active = false;
+	}
 	lcd_update_enable(true);
 	lcd_return_to_status();
 	lcd_update(2);


### PR DESCRIPTION
Autoload during wizard is currently not working properly (load filament can be enqueued multiple times), thus autoload is now not active during wizard. This PR fixes bug made in PR https://github.com/prusa3d/Prusa-Firmware/pull/1089 which caused that first layer cal. started undesirably.