### PR TITLE
Fix units reported in excessive bed leveling correction error

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -4565,7 +4565,7 @@ if((eSoundMode==e_SOUND_MODE_LOUD)||(eSoundMode==e_SOUND_MODE_ONCE))
 				SERIAL_ERROR_START;
 				SERIAL_ECHOPGM("Excessive bed leveling correction: ");
 				SERIAL_ECHO(offset);
-				SERIAL_ECHOLNPGM(" microns");
+				SERIAL_ECHOLNPGM(" mm");
 			}
 			else {
 				switch (i) {


### PR DESCRIPTION
This error was reporting an excessive bed leveling correction value as microns instead of millimeters.

The `correction` variable is in units of microns, before it's scaled down by a factor of `0.001f` to the variable `offset`, which then has units of millimeters. On a excessive correction error, `offset` is reported as having units of microns instead of millimeters.