### PR TITLE
M500 EEPROM version update and M500 EEPROM block size check

### DIFF
--- a/Firmware/ConfigurationStore.cpp
+++ b/Firmware/ConfigurationStore.cpp
@@ -360,7 +360,7 @@ bool Config_RetrieveSettings(uint16_t offset)
 			SERIAL_ECHOLNPGM("Stored settings retrieved");
 
 		}
-	    else { //size of eeprom M500 section probably changed by mistake and data are not valid; default values will be used
+		else { //size of eeprom M500 section probably changed by mistake and data are not valid; default values will be used
 			puts_P(PSTR("Data read from EEPROM not valid."));
 			Config_ResetDefault();
 			previous_settings_retrieved = false;

--- a/Firmware/ConfigurationStore.cpp
+++ b/Firmware/ConfigurationStore.cpp
@@ -354,8 +354,18 @@ bool Config_RetrieveSettings(uint16_t offset)
 
 		// Call updatePID (similar to when we have processed M301)
 		updatePID();
-        SERIAL_ECHO_START;
-        SERIAL_ECHOLNPGM("Stored settings retrieved");
+
+		if (EEPROM_M500_SIZE + EEPROM_OFFSET == i) {
+			SERIAL_ECHO_START;
+			SERIAL_ECHOLNPGM("Stored settings retrieved");
+
+		}
+	    else { //size of eeprom M500 section probably changed by mistake and data are not valid; default values will be used
+			puts_P(PSTR("Data read from EEPROM not valid."));
+			Config_ResetDefault();
+			previous_settings_retrieved = false;
+		}
+
     }
     else
     {

--- a/Firmware/ConfigurationStore.cpp
+++ b/Firmware/ConfigurationStore.cpp
@@ -57,13 +57,14 @@ void _EEPROM_readData(int &pos, uint8_t* value, uint8_t size, char* name)
 
 //======================================================================================
 #define EEPROM_OFFSET 20
+#define EEPROM_M500_SIZE 188 //bytes
 // IMPORTANT:  Whenever there are changes made to the variables stored in EEPROM
-// in the functions below, also increment the version number. This makes sure that
+// in the functions below, also increment the version number and update EEPROM_M500_SIZE. This makes sure that
 // the default values are used whenever there is a change to the data, to prevent
 // wrong data being written to the variables.
 // ALSO:  always make sure the variables in the Store and retrieve sections are in the same order.
 
-#define EEPROM_VERSION "V2"
+#define EEPROM_VERSION "V3"
 
 #ifdef EEPROM_SETTINGS
 void Config_StoreSettings(uint16_t offset) 
@@ -142,12 +143,17 @@ void Config_StoreSettings(uint16_t offset)
 
   EEPROM_WRITE_VAR(i,max_feedrate_silent);
   EEPROM_WRITE_VAR(i,max_acceleration_units_per_sq_second_silent);
-
-  char ver2[4]=EEPROM_VERSION;
-  i=offset;
-  EEPROM_WRITE_VAR(i,ver2); // validate data
-  SERIAL_ECHO_START;
-  SERIAL_ECHOLNPGM("Settings Stored");
+  if (EEPROM_M500_SIZE + EEPROM_OFFSET == i) {
+	  char ver2[4] = EEPROM_VERSION;
+	  i = offset;
+	  EEPROM_WRITE_VAR(i, ver2); // validate data
+	  SERIAL_ECHO_START;
+	  SERIAL_ECHOLNPGM("Settings Stored");
+  }
+  else { //size of eeprom M500 section probably changed by mistake and data are not valid; do not validate data by storing eeprom version
+	  //M500 EEPROM section will be erased on next printer reboot and default vaules will be used
+	  puts_P(PSTR("Data stored to EEPROM not valid."));
+  }
 }
 #endif //EEPROM_SETTINGS
 

--- a/Firmware/ConfigurationStore.cpp
+++ b/Firmware/ConfigurationStore.cpp
@@ -62,7 +62,7 @@ void _EEPROM_readData(int &pos, uint8_t* value, uint8_t size, char* name)
 // wrong data being written to the variables.
 // ALSO:  always make sure the variables in the Store and retrieve sections are in the same order.
 
-#define EEPROM_VERSION "V3"
+#define EEPROM_VERSION "V2"
 
 #ifdef EEPROM_SETTINGS
 void Config_StoreSettings(uint16_t offset) 
@@ -323,10 +323,18 @@ bool Config_RetrieveSettings(uint16_t offset)
 #endif
 #endif
 
-    calculate_extruder_multipliers();
-
+		calculate_extruder_multipliers();
+		int max_feedrate_silent_address = i;
         EEPROM_READ_VAR(i,max_feedrate_silent);  
         EEPROM_READ_VAR(i,max_acceleration_units_per_sq_second_silent);
+
+		//if max_feedrate_silent and max_acceleration_units_per_sq_second_silent were never stored to eeprom, use default values:
+	    float tmp_feedrate[]=DEFAULT_MAX_FEEDRATE_SILENT;
+		unsigned long tmp_acceleration[]=DEFAULT_MAX_ACCELERATION_SILENT;
+		for (uint8_t axis = X_AXIS; axis <= E_AXIS; axis++) {
+			if (eeprom_read_dword((uint32_t*)(max_feedrate_silent_address + axis * 4)) == 0xffffffff) max_feedrate_silent[axis] = tmp_feedrate[axis];
+			if (max_acceleration_units_per_sq_second_silent[axis] == 0xffffffff) max_acceleration_units_per_sq_second_silent[axis] = tmp_acceleration[axis];
+		}
 
 #ifdef TMC2130
 		for (uint8_t j = X_AXIS; j <= Y_AXIS; j++)

--- a/Firmware/ConfigurationStore.cpp
+++ b/Firmware/ConfigurationStore.cpp
@@ -56,8 +56,6 @@ void _EEPROM_readData(int &pos, uint8_t* value, uint8_t size, char* name)
 }
 
 //======================================================================================
-#define EEPROM_OFFSET 20
-#define EEPROM_M500_SIZE 188 //bytes
 // IMPORTANT:  Whenever there are changes made to the variables stored in EEPROM
 // in the functions below, also increment the version number and update EEPROM_M500_SIZE. This makes sure that
 // the default values are used whenever there is a change to the data, to prevent

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1642,7 +1642,7 @@ void setup()
 
   if (!previous_settings_retrieved) {
 	  lcd_show_fullscreen_message_and_wait_P(_i("Old settings found. Default PID, Esteps etc. will be set.")); //if EEPROM version or printer type was changed, inform user that default setting were loaded////MSG_DEFAULT_SETTINGS_LOADED c=20 r=4
-	  erase_eeprom_section(EEPROM_OFFSET, 156); 							   //erase M500 part of eeprom
+	  erase_eeprom_section(EEPROM_OFFSET, EEPROM_M500_SIZE); 							   //erase M500 part of eeprom
   }
   if (eeprom_read_byte((uint8_t*)EEPROM_WIZARD_ACTIVE) == 1) {
 	  lcd_wizard(0);

--- a/Firmware/eeprom.h
+++ b/Firmware/eeprom.h
@@ -183,6 +183,6 @@
 #define EEPROM_FIRMWARE_PRUSA_MAGIC 0
 
 #define EEPROM_OFFSET 20 //offset for storing settings using M500
-#define EEPROM_M500_SIZE 188 //size of M500 eeprom section in bytes
+#define EEPROM_M500_SIZE 188 //size of M500 eeprom section in bytes; if EEPROM_M500_SIZE increases it is necessary to update also EEPROM_VERSION
 
 #endif // EEPROM_H

--- a/Firmware/eeprom.h
+++ b/Firmware/eeprom.h
@@ -183,6 +183,6 @@
 #define EEPROM_FIRMWARE_PRUSA_MAGIC 0
 
 #define EEPROM_OFFSET 20 //offset for storing settings using M500
-//#define EEPROM_OFFSET 
+#define EEPROM_M500_SIZE 188 //size of M500 eeprom section in bytes
 
 #endif // EEPROM_H


### PR DESCRIPTION
- EEPROM version V2 -> V3: this will erase EEPROM M500 section and load default settings for all users who have stored data to EEPROM using M500 in the past;  max_feedrate_silent and max_acceleration_units_per_sq_second_silent have been added to M500 eeprom recently without updating eeprom version
- hardcoded EEPROM M500 size used for EEPROM erasing changed to #define EEPROM_M500_SIZE, this should prevent writing corrupted data to EEPROM in case that somebody changes size of M500 EEPROM section (variable type changed, removed variable etc.) by mistake (without changing eeprom version)  