### PR TITLE
Fix (some) compiler warnings

### DIFF
--- a/Firmware/Dcodes.cpp
+++ b/Firmware/Dcodes.cpp
@@ -34,7 +34,6 @@ void print_eeprom(uint16_t address, uint16_t count, uint8_t countperline = 16)
 		uint8_t count_line = countperline;
 		while (count && count_line)
 		{
-			uint8_t data = 0;
 			putchar(' ');
 			print_hex_byte(eeprom_read_byte((uint8_t*)address++));
 			count_line--;

--- a/Firmware/Dcodes.cpp
+++ b/Firmware/Dcodes.cpp
@@ -114,7 +114,7 @@ void dcode_3()
 		count = parse_hex(strchr_pointer + 1, data, 16);
 		if (count > 0)
 		{
-			for (int i = 0; i < count; i++)
+			for (uint16_t i = 0; i < count; i++)
 				eeprom_write_byte((uint8_t*)(address + i), data[i]);
 			printf_P(_N("%d bytes written to EEPROM at address 0x%04x"), count, address);
 			putchar('\n');

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -6321,8 +6321,8 @@ if((eSoundMode==e_SOUND_MODE_LOUD)||(eSoundMode==e_SOUND_MODE_ONCE))
 		//firmware does not wait for "ok" from mmu
 		if (mmu_enabled)
 		{
-			uint8_t extruder;
-			uint8_t filament;
+			uint8_t extruder = 0;
+			uint8_t filament = 0;
 			if(code_seen('E')) extruder = code_value();
 			if(code_seen('F')) filament = code_value();
 			mmu_set_filament_type(extruder, filament);

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -2259,7 +2259,6 @@ void homeaxis(int axis, uint8_t cnt, uint8_t* pstep)
 ((LETTER##_MIN_PIN > -1 && LETTER##_HOME_DIR==-1) || (LETTER##_MAX_PIN > -1 && LETTER##_HOME_DIR==1))
     if ((axis==X_AXIS)?HOMEAXIS_DO(X):(axis==Y_AXIS)?HOMEAXIS_DO(Y):0)
 	{
-        int axis_home_dir = home_dir(axis);
         feedrate = homing_feedrate[axis];
 
 #ifdef TMC2130

--- a/Firmware/fsensor.cpp
+++ b/Firmware/fsensor.cpp
@@ -218,7 +218,7 @@ bool fsensor_check_autoload(void)
 		fsensor_autoload_check_start();
 		return false;
 	}
-	uint8_t fsensor_autoload_c_old = fsensor_autoload_c;
+//	uint8_t fsensor_autoload_c_old = fsensor_autoload_c;
 	if ((millis() - fsensor_autoload_last_millis) < 25) return false;
 	fsensor_autoload_last_millis = millis();
 	if (!pat9125_update_y()) //update sensor

--- a/Firmware/fsensor.cpp
+++ b/Firmware/fsensor.cpp
@@ -88,9 +88,9 @@ uint16_t fsensor_oq_er_sum;
 //max error counter value durring meassurement
 uint8_t  fsensor_oq_er_max;
 //minimum delta value
-uint16_t fsensor_oq_yd_min;
+int16_t fsensor_oq_yd_min;
 //maximum delta value
-uint16_t fsensor_oq_yd_max;
+int16_t fsensor_oq_yd_max;
 //sum of shutter value
 uint16_t fsensor_oq_sh_sum;
 

--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -506,7 +506,7 @@ uint8_t lcd_escape_write(uint8_t chr)
 		break;
 	}
 	escape_cnt = 0; // reset escape
-end:
+
 	return 1; // assume sucess
 }
 

--- a/Firmware/mmu.cpp
+++ b/Firmware/mmu.cpp
@@ -495,8 +495,6 @@ void mmu_M600_load_filament(bool automatic)
 { 
 	//load filament for mmu v2
 
-		  bool response = false;
-		  bool yes = false;
 		  tmp_extruder = mmu_extruder;
 		  if (!automatic) {
 #ifdef MMU_M600_SWITCH_EXTRUDER

--- a/Firmware/sm4.c
+++ b/Firmware/sm4.c
@@ -85,8 +85,8 @@ void sm4_set_dir(uint8_t axis, uint8_t dir)
 
 uint8_t sm4_get_dir_bits(void)
 {
-	uint8_t register dir_bits = 0;
-	uint8_t register portL = PORTL;
+	register uint8_t dir_bits = 0;
+	register uint8_t portL = PORTL;
 	//TODO -optimize in asm
 #if ((MOTHERBOARD == BOARD_RAMBO_MINI_1_0) || (MOTHERBOARD == BOARD_RAMBO_MINI_1_3))
 	if (portL & 2) dir_bits |= 1;
@@ -106,7 +106,7 @@ uint8_t sm4_get_dir_bits(void)
 
 void sm4_set_dir_bits(uint8_t dir_bits)
 {
-	uint8_t register portL = PORTL;
+	register uint8_t portL = PORTL;
 	portL &= 0xb8; //set direction bits to zero
 	//TODO -optimize in asm
 #if ((MOTHERBOARD == BOARD_RAMBO_MINI_1_0) || (MOTHERBOARD == BOARD_RAMBO_MINI_1_3))
@@ -129,7 +129,7 @@ void sm4_set_dir_bits(uint8_t dir_bits)
 void sm4_do_step(uint8_t axes_mask)
 {
 #if ((MOTHERBOARD == BOARD_RAMBO_MINI_1_0) || (MOTHERBOARD == BOARD_RAMBO_MINI_1_3) || (MOTHERBOARD == BOARD_EINSY_1_0a))
-	uint8_t register portC = PORTC & 0xf0;
+	register uint8_t portC = PORTC & 0xf0;
 	PORTC = portC | (axes_mask & 0x0f); //set step signals by mask
 	asm("nop");
 	PORTC = portC; //set step signals to zero

--- a/Firmware/stepper.cpp
+++ b/Firmware/stepper.cpp
@@ -1614,7 +1614,9 @@ void st_current_set(uint8_t driver, int current)
 
 void microstep_init()
 {
+  #if defined(X_MS1_PIN) && X_MS1_PIN > -1
   const uint8_t microstep_modes[] = MICROSTEP_MODES;
+  #endif
 
   #if defined(E1_MS1_PIN) && E1_MS1_PIN > -1
   pinMode(E1_MS1_PIN,OUTPUT);

--- a/Firmware/tmc2130.cpp
+++ b/Firmware/tmc2130.cpp
@@ -793,7 +793,7 @@ void tmc2130_do_steps(uint8_t axis, uint16_t steps, uint8_t dir, uint16_t delay_
 void tmc2130_goto_step(uint8_t axis, uint8_t step, uint8_t dir, uint16_t delay_us, uint16_t microstep_resolution)
 {
 	printf_P(PSTR("tmc2130_goto_step %d %d %d %d \n"), axis, step, dir, delay_us, microstep_resolution);
-	uint8_t shift; for (shift = 0; shift < 8; shift++) if (microstep_resolution == (256 >> shift)) break;
+	uint8_t shift; for (shift = 0; shift < 8; shift++) if (microstep_resolution == ((uint16_t)256 >> shift)) break;
 	uint16_t cnt = 4 * (1 << (8 - shift));
 	uint16_t mscnt = tmc2130_rd_MSCNT(axis);
 	if (dir == 2)
@@ -805,7 +805,7 @@ void tmc2130_goto_step(uint8_t axis, uint8_t step, uint8_t dir, uint16_t delay_u
 			dir ^= 1;
 			steps = -steps;
 		}
-		if (steps > (cnt / 2))
+		if (steps > (int)(cnt / 2))
 		{
 			dir ^= 1;
 			steps = cnt - steps;
@@ -829,7 +829,7 @@ void tmc2130_get_wave(uint8_t axis, uint8_t* data, FILE* stream)
 	tmc2130_setup_chopper(axis, tmc2130_usteps2mres(256), tmc2130_current_h[axis], tmc2130_current_r[axis]);
 	tmc2130_goto_step(axis, 0, 2, 100, 256);
 	tmc2130_set_dir(axis, tmc2130_get_inv(axis)?0:1);
-	for (int i = 0; i <= 255; i++)
+	for (uint8_t i = 0; i <= 255; i++)
 	{
 		uint32_t val = tmc2130_rd_MSCURACT(axis);
 		uint16_t mscnt = tmc2130_rd_MSCNT(axis);

--- a/Firmware/tmc2130.cpp
+++ b/Firmware/tmc2130.cpp
@@ -825,7 +825,6 @@ void tmc2130_goto_step(uint8_t axis, uint8_t step, uint8_t dir, uint16_t delay_u
 
 void tmc2130_get_wave(uint8_t axis, uint8_t* data, FILE* stream)
 {
-	uint8_t pwr = tmc2130_get_pwr(axis);
 	tmc2130_set_pwr(axis, 0);
 	tmc2130_setup_chopper(axis, tmc2130_usteps2mres(256), tmc2130_current_h[axis], tmc2130_current_r[axis]);
 	tmc2130_goto_step(axis, 0, 2, 100, 256);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3559,7 +3559,6 @@ static void menu_show_end_stops() {
 // Otherwise the Z calibration is not changed and false is returned.
 void lcd_diag_show_end_stops()
 {
-    int enc_dif = lcd_encoder_diff;
     lcd_clear();
     for (;;) {
         manage_heater();
@@ -6022,7 +6021,6 @@ void lcd_sdcard_stop()
 void lcd_sdcard_menu()
 {
   uint8_t sdSort = eeprom_read_byte((uint8_t*)EEPROM_SD_SORT);
-  int tempScrool = 0;
   if (presort_flag == true) {
 	  presort_flag = false;
 	  card.presort();
@@ -7191,7 +7189,6 @@ static void lcd_connect_printer() {
 	lcd_update_enable(false);
 	lcd_clear();
 	
-	bool pressed = false;
 	int i = 0;
 	int t = 0;
 	lcd_set_custom_characters_progress();

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -147,8 +147,8 @@ static void lcd_selftest_v();
 static bool lcd_selfcheck_endstops();
 
 #ifdef TMC2130
-static void reset_crash_det(char axis);
-static bool lcd_selfcheck_axis_sg(char axis);
+static void reset_crash_det(unsigned char axis);
+static bool lcd_selfcheck_axis_sg(unsigned char axis);
 static bool lcd_selfcheck_axis(int _axis, int _travel);
 #else
 static bool lcd_selfcheck_endstops();
@@ -6265,14 +6265,14 @@ bool lcd_selftest()
 
 #ifdef TMC2130
 
-static void reset_crash_det(char axis) {
+static void reset_crash_det(unsigned char axis) {
 	current_position[axis] += 10;
 	plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[3], manual_feedrate[0] / 60, active_extruder);
 	st_synchronize();
 	if (eeprom_read_byte((uint8_t*)EEPROM_CRASH_DET)) tmc2130_sg_stop_on_crash = true;
 }
 
-static bool lcd_selfcheck_axis_sg(char axis) {
+static bool lcd_selfcheck_axis_sg(unsigned char axis) {
 // each axis length is measured twice	
 	float axis_length, current_position_init, current_position_final;
 	float measured_axis_length[2];

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3457,7 +3457,7 @@ int8_t lcd_show_fullscreen_message_yes_no_and_wait_P(const char *msg, bool allow
 	}
 }
 
-void lcd_bed_calibration_show_result(uint8_t result, uint8_t point_too_far_mask)
+void lcd_bed_calibration_show_result(int8_t result, uint8_t point_too_far_mask)
 {
     const char *msg = NULL;
     if (result == BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND) {

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -59,7 +59,7 @@ extern bool lcd_calibrate_z_end_stop_manual(bool only_z);
 #endif
 
 // Show the result of the calibration process on the LCD screen.
-extern void lcd_bed_calibration_show_result(uint8_t result, uint8_t point_too_far_mask);
+extern void lcd_bed_calibration_show_result(int8_t result, uint8_t point_too_far_mask);
 
 extern void lcd_diag_show_end_stops();
 


### PR DESCRIPTION
I noticed a lot of compiler warnings when using -Wall on avr-gcc 5.4.0. I removed some unused variables, added initialization to others and adjusted signedness where comparisons between signed and unsigned was used. My Mk3 seems to work fine with these adjustments. I hope you can use some of this.
There are still a lot of unused functions and some unused variables left, but I guess those are used to create tiny delays while executing.