### PR TITLE
Work around for M601 bug introduced in 3.5.0 firmware release

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -394,6 +394,8 @@ static bool saved_extruder_relative_mode = false;
 static int saved_fanSpeed = 0; //!< Print fan speed
 //! @}
 
+bool allow_M601 = true;
+
 //===========================================================================
 //=============================Routines======================================
 //===========================================================================
@@ -6493,12 +6495,15 @@ if((eSoundMode==e_SOUND_MODE_LOUD)||(eSoundMode==e_SOUND_MODE_ONCE))
     #endif //FILAMENTCHANGEENABLE
 	case 601: //! M601 - Pause print
 	{
-		lcd_pause_print();
+    if(allow_M601){
+      lcd_pause_print();
+      allow_M601 = false;
+    }
 	}
 	break;
 
 	case 602: { //! M602 - Resume print
-		lcd_resume_print();
+    allow_M601 = true;
 	}
 	break;
 


### PR DESCRIPTION
The M601(long pause) command will result in an infinite loop, because it resets the sd card location to before the M601 command.  This causes M601 to be executed again immediately after resuming.

This is more of a work around to skip any M601 commands until the corresponding M602(resume from long pause) has been triggered.  The proper fix would be to correct the behavior of M601 so that is doesn't execute itself again after a resume, but if that isn't something that will make it into the next release this could be a work around for anyone who relies on the M601 command.

See issue https://github.com/prusa3d/Prusa-Firmware/issues/1378