### PR TITLE
Fix warning during language build

### DIFF
--- a/lang/lang_en_fr.txt
+++ b/lang/lang_en_fr.txt
@@ -676,7 +676,7 @@
 
 #
 "MMU2 connected"
-"MMU2 connectée"
+"MMU2 connecte"
 
 #MSG_SELFTEST_MOTOR c=0 r=0
 "Motor"

--- a/lang/po/Firmware_fr.po
+++ b/lang/po/Firmware_fr.po
@@ -863,7 +863,7 @@ msgstr "Mode[haute puiss]"
 # 
 #: ultralcd.cpp:2158
 msgid "MMU2 connected"
-msgstr "MMU2 connectée"
+msgstr "MMU2 connecte"
 
 # MSG_SELFTEST_MOTOR
 #: messages.c:79


### PR DESCRIPTION
Deleted an é as it generates a warning during lang-build.sh script.