### PR TITLE
Fix filament loading and autoloading issue #1392

### DIFF
--- a/Firmware/fsensor.cpp
+++ b/Firmware/fsensor.cpp
@@ -379,7 +379,7 @@ ISR(FSENSOR_INT_PIN_VECT)
 		fsensor_not_responding = true;
 		printf_P(ERRMSG_PAT9125_NOT_RESP, 1);
 	}
-	if (st_cnt != 0)
+	if (st_cnt != 0 && !loading_flag)
 	{ //movement
 		if (st_cnt > 0) //positive movement
 		{


### PR DESCRIPTION
Quick fix that disables filament runout checking during loading allowing normal operation

issue [https://github.com/prusa3d/Prusa-Firmware/issues/1392](#1392)