### PR TITLE
Improve mmu load failed 2

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -6933,7 +6933,7 @@ if((eSoundMode==e_SOUND_MODE_LOUD)||(eSoundMode==e_SOUND_MODE_ONCE))
 				return; //dont execute the same T-code twice in a row
 			}
 			st_synchronize();
-			mmu_command(static_cast<MmuCmd>(MmuCmd::T0 + tmp_extruder));
+			mmu_command(MmuCmd::T0 + tmp_extruder);
 			manage_response(true, true, MMU_TCODE_MOVE);
 		}
 	  }
@@ -6974,7 +6974,7 @@ if((eSoundMode==e_SOUND_MODE_LOUD)||(eSoundMode==e_SOUND_MODE_ONCE))
                   printf_P(PSTR("Duplicit T-code ignored.\n"));
                   return; //dont execute the same T-code twice in a row
               }
-              mmu_command(static_cast<MmuCmd>(MmuCmd::T0 + tmp_extruder));
+              mmu_command(MmuCmd::T0 + tmp_extruder);
 
 			  manage_response(true, true, MMU_TCODE_MOVE);
 			  mmu_continue_loading();

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3037,7 +3037,7 @@ static void gcode_M600(bool automatic, float x_position, float y_position, float
                 lcd_set_cursor(0, 2);
                 lcd_puts_P(_T(MSG_PLEASE_WAIT));
 
-                mmu_command(MMU_CMD_R0);
+                mmu_command(MmuCmd::R0);
                 manage_response(false, false);
             }
         }
@@ -6933,7 +6933,7 @@ if((eSoundMode==e_SOUND_MODE_LOUD)||(eSoundMode==e_SOUND_MODE_ONCE))
 				return; //dont execute the same T-code twice in a row
 			}
 			st_synchronize();
-			mmu_command(MMU_CMD_T0 + tmp_extruder);
+			mmu_command(static_cast<MmuCmd>(MmuCmd::T0 + tmp_extruder));
 			manage_response(true, true, MMU_TCODE_MOVE);
 		}
 	  }
@@ -6974,7 +6974,7 @@ if((eSoundMode==e_SOUND_MODE_LOUD)||(eSoundMode==e_SOUND_MODE_ONCE))
                   printf_P(PSTR("Duplicit T-code ignored.\n"));
                   return; //dont execute the same T-code twice in a row
               }
-              mmu_command(MMU_CMD_T0 + tmp_extruder);
+              mmu_command(static_cast<MmuCmd>(MmuCmd::T0 + tmp_extruder));
 
 			  manage_response(true, true, MMU_TCODE_MOVE);
 			  mmu_continue_loading();

--- a/Firmware/mmu.cpp
+++ b/Firmware/mmu.cpp
@@ -379,7 +379,7 @@ void mmu_loop(void)
 		}
 		else if ((mmu_last_request + MMU_CMD_TIMEOUT) < _millis())
 		{ //resend request after timeout (5 min)
-			if (mmu_last_cmd != MmuCmd::None)
+			if (mmu_last_cmd >= MmuCmd::T0 && mmu_last_cmd <= MmuCmd::T4)
 			{
 				if (mmu_attempt_nr++ < MMU_MAX_RESEND_ATTEMPTS) {
 				    DEBUG_PRINTF_P(PSTR("MMU retry attempt nr. %d\n"), mmu_attempt_nr - 1);

--- a/Firmware/mmu.cpp
+++ b/Firmware/mmu.cpp
@@ -184,7 +184,6 @@ bool check_for_ir_sensor()
 void mmu_loop(void)
 {
 	static uint8_t mmu_attempt_nr = 0;
-	int filament = 0;
 //	printf_P(PSTR("MMU loop, state=%d\n"), mmu_state);
 	switch (mmu_state)
 	{
@@ -261,7 +260,7 @@ void mmu_loop(void)
 		{
 			if ((mmu_cmd >= MmuCmd::T0) && (mmu_cmd <= MmuCmd::T4))
 			{
-				filament = mmu_cmd - MmuCmd::T0;
+				const uint8_t filament = mmu_cmd - MmuCmd::T0;
 				DEBUG_PRINTF_P(PSTR("MMU <= 'T%d'\n"), filament);
 				mmu_printf_P(PSTR("T%d\n"), filament);
 				mmu_state = S::WaitCmd; // wait for response
@@ -270,7 +269,7 @@ void mmu_loop(void)
 			}
 			else if ((mmu_cmd >= MmuCmd::L0) && (mmu_cmd <= MmuCmd::L4))
 			{
-			    filament = mmu_cmd - MmuCmd::L0;
+			    const uint8_t filament = mmu_cmd - MmuCmd::L0;
 			    DEBUG_PRINTF_P(PSTR("MMU <= 'L%d'\n"), filament);
 			    mmu_printf_P(PSTR("L%d\n"), filament);
 			    mmu_state = S::WaitCmd; // wait for response
@@ -291,7 +290,7 @@ void mmu_loop(void)
 			}
 			else if ((mmu_cmd >= MmuCmd::E0) && (mmu_cmd <= MmuCmd::E4))
 			{
-				int filament = mmu_cmd - MmuCmd::E0;
+			    const uint8_t filament = mmu_cmd - MmuCmd::E0;
 				DEBUG_PRINTF_P(PSTR("MMU <= 'E%d'\n"), filament);
 				mmu_printf_P(PSTR("E%d\n"), filament); //send eject filament
 				mmu_fil_loaded = false;

--- a/Firmware/mmu.cpp
+++ b/Firmware/mmu.cpp
@@ -32,9 +32,9 @@
 
 namespace
 {
-    enum class S
+    enum class S : uint_least8_t
     {
-        WaitStealthMode = -5,
+        WaitStealthMode,
         GetFindaInit,
         GetBuildNr,
         GetVersion,

--- a/Firmware/mmu.cpp
+++ b/Firmware/mmu.cpp
@@ -1362,46 +1362,60 @@ void mmu_eject_filament(uint8_t filament, bool recover)
 	}
 }
 
+static void load_more()
+{
+    for (uint8_t i = 0; i < MMU_IDLER_SENSOR_ATTEMPTS_NR; i++)
+    {
+        if (PIN_GET(IR_SENSOR_PIN) == 0) return;
+#ifdef MMU_DEBUG
+        printf_P(PSTR("Additional load attempt nr. %d\n"), i);
+#endif // MMU_DEBUG
+        mmu_command(MMU_CMD_C0);
+        manage_response(true, true, MMU_LOAD_MOVE);
+    }
+}
+
 void mmu_continue_loading() 
 {
+	if (ir_sensor_detected)
+	{
+	    load_more();
 
-	if (ir_sensor_detected) {
-		for (uint8_t i = 0; i < MMU_IDLER_SENSOR_ATTEMPTS_NR; i++) {
-			if (PIN_GET(IR_SENSOR_PIN) == 0) return;
-#ifdef MMU_DEBUG
-			printf_P(PSTR("Additional load attempt nr. %d\n"), i);
-#endif // MMU_DEBUG
-			mmu_command(MMU_CMD_C0);
-			manage_response(true, true, MMU_LOAD_MOVE);
-		}
 		if (PIN_GET(IR_SENSOR_PIN) != 0) {
 			uint8_t mmu_load_fail = eeprom_read_byte((uint8_t*)EEPROM_MMU_LOAD_FAIL);
 			uint16_t mmu_load_fail_tot = eeprom_read_word((uint16_t*)EEPROM_MMU_LOAD_FAIL_TOT);
 			if(mmu_load_fail < 255) eeprom_update_byte((uint8_t*)EEPROM_MMU_LOAD_FAIL, mmu_load_fail + 1);
 			if(mmu_load_fail_tot < 65535) eeprom_update_word((uint16_t*)EEPROM_MMU_LOAD_FAIL_TOT, mmu_load_fail_tot + 1);
-			char cmd[3];
-			//pause print, show error message and then repeat last T-code
-			stop_and_save_print_to_ram(0, 0);
 
-			//lift z
-			current_position[Z_AXIS] += Z_PAUSE_LIFT;
-			if (current_position[Z_AXIS] > Z_MAX_POS) current_position[Z_AXIS] = Z_MAX_POS;
-			plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], 15, active_extruder);
-			st_synchronize();
+            mmu_command(MMU_CMD_T0 + tmp_extruder);
+            manage_response(true, true, MMU_TCODE_MOVE);
+            load_more();
 
-			//Move XY to side
-			current_position[X_AXIS] = X_PAUSE_POS;
-			current_position[Y_AXIS] = Y_PAUSE_POS;
-			plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], 50, active_extruder);
-			st_synchronize();
+            if (PIN_GET(IR_SENSOR_PIN) != 0)
+            {
+                //pause print, show error message and then repeat last T-code
+                stop_and_save_print_to_ram(0, 0);
 
-			mmu_command(MMU_CMD_U0);
-			manage_response(false, true, MMU_UNLOAD_MOVE);
+                //lift z
+                current_position[Z_AXIS] += Z_PAUSE_LIFT;
+                if (current_position[Z_AXIS] > Z_MAX_POS) current_position[Z_AXIS] = Z_MAX_POS;
+                plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], 15, active_extruder);
+                st_synchronize();
 
-			setAllTargetHotends(0);
-			lcd_setstatuspgm(_i("MMU load failed     "));////MSG_RECOVERING_PRINT c=20 r=1
-			mmu_fil_loaded = false; //so we can retry same T-code again
-			isPrintPaused = true;
+                //Move XY to side
+                current_position[X_AXIS] = X_PAUSE_POS;
+                current_position[Y_AXIS] = Y_PAUSE_POS;
+                plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], 50, active_extruder);
+                st_synchronize();
+
+                mmu_command(MMU_CMD_U0);
+                manage_response(false, true, MMU_UNLOAD_MOVE);
+
+                setAllTargetHotends(0);
+                lcd_setstatuspgm(_i("MMU load failed     "));////MSG_RECOVERING_PRINT c=20 r=1
+                mmu_fil_loaded = false; //so we can retry same T-code again
+                isPrintPaused = true;
+            }
 		}
 	}
 	else { //mmu_ir_sensor_detected == false

--- a/Firmware/mmu.cpp
+++ b/Firmware/mmu.cpp
@@ -1394,7 +1394,10 @@ void mmu_continue_loading()
 			current_position[Y_AXIS] = Y_PAUSE_POS;
 			plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], 50, active_extruder);
 			st_synchronize();
-			//set nozzle target temperature to 0
+
+			mmu_command(MMU_CMD_U0);
+			manage_response(false, true, MMU_UNLOAD_MOVE);
+
 			setAllTargetHotends(0);
 			lcd_setstatuspgm(_i("MMU load failed     "));////MSG_RECOVERING_PRINT c=20 r=1
 			mmu_fil_loaded = false; //so we can retry same T-code again

--- a/Firmware/mmu.h
+++ b/Firmware/mmu.h
@@ -54,6 +54,7 @@ enum class MmuCmd : uint_least8_t
     E4,
     R0,
     S3,
+    W0,
 };
 
 inline MmuCmd operator+ (MmuCmd cmd, uint8_t filament)

--- a/Firmware/mmu.h
+++ b/Firmware/mmu.h
@@ -32,26 +32,29 @@ extern uint16_t mmu_power_failures;
 #define MMU_LOAD_FEEDRATE 19.02f //mm/s
 #define MMU_LOAD_TIME_MS 2000 //should be fine tuned to load time for shortest allowed PTFE tubing and maximum loading speed
 
-#define MMU_CMD_NONE 0
-#define MMU_CMD_T0   0x10
-#define MMU_CMD_T1   0x11
-#define MMU_CMD_T2   0x12
-#define MMU_CMD_T3   0x13
-#define MMU_CMD_T4   0x14
-#define MMU_CMD_L0   0x20
-#define MMU_CMD_L1   0x21
-#define MMU_CMD_L2   0x22
-#define MMU_CMD_L3   0x23
-#define MMU_CMD_L4   0x24
-#define MMU_CMD_C0   0x30
-#define MMU_CMD_U0   0x40
-#define MMU_CMD_E0   0x50
-#define MMU_CMD_E1   0x51
-#define MMU_CMD_E2   0x52
-#define MMU_CMD_E3   0x53
-#define MMU_CMD_E4   0x54
-#define MMU_CMD_R0   0x60
-#define MMU_CMD_S3	 0x73
+enum MmuCmd : uint_least8_t
+{
+    None,
+    T0,
+    T1,
+    T2,
+    T3,
+    T4,
+    L0,
+    L1,
+    L2,
+    L3,
+    L4,
+    C0,
+    U0,
+    E0,
+    E1,
+    E2,
+    E3,
+    E4,
+    R0,
+    S3,
+};
 
 extern int mmu_puts_P(const char* str);
 
@@ -70,7 +73,7 @@ extern void mmu_reset(void);
 
 extern int8_t mmu_set_filament_type(uint8_t extruder, uint8_t filament);
 
-extern void mmu_command(uint8_t cmd);
+extern void mmu_command(MmuCmd cmd);
 
 extern bool mmu_get_response(uint8_t move = 0);
 

--- a/Firmware/mmu.h
+++ b/Firmware/mmu.h
@@ -32,7 +32,7 @@ extern uint16_t mmu_power_failures;
 #define MMU_LOAD_FEEDRATE 19.02f //mm/s
 #define MMU_LOAD_TIME_MS 2000 //should be fine tuned to load time for shortest allowed PTFE tubing and maximum loading speed
 
-enum MmuCmd : uint_least8_t
+enum class MmuCmd : uint_least8_t
 {
     None,
     T0,
@@ -55,6 +55,16 @@ enum MmuCmd : uint_least8_t
     R0,
     S3,
 };
+
+inline MmuCmd operator+ (MmuCmd cmd, uint8_t filament)
+{
+    return static_cast<MmuCmd>(static_cast<uint8_t>(cmd) + filament );
+}
+
+inline uint8_t operator- (MmuCmd cmda, MmuCmd cmdb)
+{
+    return (static_cast<uint8_t>(cmda) - static_cast<uint8_t>(cmdb));
+}
 
 extern int mmu_puts_P(const char* str);
 

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1986,7 +1986,7 @@ static void lcd_menu_fails_stats_mmu_total()
 // MMU load fails  000
 //
 //////////////////////
-	mmu_command(MMU_CMD_S3);
+	mmu_command(MmuCmd::S3);
 	lcd_timeoutToStatus.stop(); //infinite timeout
     uint8_t fails = eeprom_read_byte((uint8_t*)EEPROM_MMU_FAIL_TOT);
     uint16_t load_fails = eeprom_read_byte((uint8_t*)EEPROM_MMU_LOAD_FAIL_TOT);
@@ -7208,7 +7208,7 @@ static bool selftest_irsensor()
         mmu_filament_ramming();
     }
     progress = lcd_selftest_screen(testScreen::fsensor, progress, 1, true, 0);
-    mmu_command(MMU_CMD_U0);
+    mmu_command(MmuCmd::U0);
     manage_response(false, false);
 
     for(uint_least8_t i = 0; i < 200; ++i)


### PR DESCRIPTION
There is no need to update MMU firmware version dependence, as printer works also without MMU support. But of course print can not be resumed by MMU button.