### PR TITLE
cmdqueue_reset fix

### DIFF
--- a/Firmware/cmdqueue.cpp
+++ b/Firmware/cmdqueue.cpp
@@ -94,7 +94,7 @@ void cmdqueue_reset()
     bufindr = 0;
     bufindw = 0;
     buflen = 0;
-    cmdbuffer_front_already_processed = false;
+    cmdbuffer_front_already_processed = true;
 }
 
 // How long a string could be pushed to the front of the command queue?


### PR DESCRIPTION
- fixes mmu stop print during T-code and probably other similar scenarios with stopping print during long running gcodes (for example M600)