### PR TITLE
Configure extruder height: useful for MK3S firmware and Bondtech or Bear extruders.

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -2118,12 +2118,16 @@ bool calibrate_z_auto()
 	plan_buffer_line(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS], destination[E_AXIS], feedrate / 60, active_extruder);
 	st_synchronize();
 	enable_endstops(endstops_enabled);
+#ifdef Z_MAX_POS_XYZ_CALIBRATION_CORRECTION
+    current_position[Z_AXIS] = Z_MAX_POS + Z_MAX_POS_XYZ_CALIBRATION_CORRECTION;
+#else   
 	if (PRINTER_TYPE == PRINTER_MK3) {
 		current_position[Z_AXIS] = Z_MAX_POS + 2.0;
 	}
 	else {
 		current_position[Z_AXIS] = Z_MAX_POS + 9.0;
 	}
+#endif //Z_MAX_POS_XYZ_CALIBRATION_CORRECTION
     plan_set_position(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS]);
 	return true;
 }

--- a/Firmware/config.h
+++ b/Firmware/config.h
@@ -44,7 +44,7 @@
 
 //LANG - Multi-language support
 //#define LANG_MODE              0 // primary language only
-#define LANG_MODE              1 // sec. language support
+#define LANG_MODE              0 // sec. language support
 #define LANG_SIZE_RESERVED     0x2f00 // reserved space for secondary language (12032 bytes)
 
 

--- a/Firmware/config.h
+++ b/Firmware/config.h
@@ -44,7 +44,7 @@
 
 //LANG - Multi-language support
 //#define LANG_MODE              0 // primary language only
-#define LANG_MODE              0 // sec. language support
+#define LANG_MODE              1 // sec. language support
 #define LANG_SIZE_RESERVED     0x2f00 // reserved space for secondary language (12032 bytes)
 
 

--- a/Firmware/variants/1_75mm_MK25S-RAMBo10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK25S-RAMBo10a-E3Dv6full.h
@@ -64,6 +64,11 @@
 #define Z_MAX_POS 210
 #define Z_MIN_POS 0.15
 
+// Uncomment Z_MAX_POS_XYZ_CALIBRATION_CORRECTION define for using the MK3S and MK2.5S firmware 
+//                                                in combination with an extruder different from Prusa.
+// This is only relevant for "S" firmware and an extruder like the Bondtech BMG or Bear extruders.
+// #define Z_MAX_POS_XYZ_CALIBRATION_CORRECTION 2.0 // This represents the correction as needed for MK2.5 and BMG (not MK2.5S) extruder 
+
 // Canceled home position
 #define X_CANCEL_POS 50
 #define Y_CANCEL_POS 190

--- a/Firmware/variants/1_75mm_MK25S-RAMBo13a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK25S-RAMBo13a-E3Dv6full.h
@@ -64,6 +64,11 @@
 #define Z_MAX_POS 210
 #define Z_MIN_POS 0.15
 
+// Uncomment Z_MAX_POS_XYZ_CALIBRATION_CORRECTION define for using the MK3S and MK2.5S firmware 
+//                                                in combination with an extruder different from Prusa.
+// This is only relevant for "S" firmware and an extruder like the Bondtech BMG or Bear extruders.
+// #define Z_MAX_POS_XYZ_CALIBRATION_CORRECTION 2.0 // This represents the correction as needed for MK2.5 and BMG (not MK2.5S) extruder 
+
 // Canceled home position
 #define X_CANCEL_POS 50
 #define Y_CANCEL_POS 190

--- a/Firmware/variants/1_75mm_MK3S-EINSy10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK3S-EINSy10a-E3Dv6full.h
@@ -65,6 +65,11 @@
 #define Z_MAX_POS 210
 #define Z_MIN_POS 0.15
 
+// Uncomment Z_MAX_POS_XYZ_CALIBRATION_CORRECTION define for using the MK3S and MK2.5S firmware 
+//                                                in combination with an extruder different from Prusa.
+// This is only relevant for "S" firmware and an extruder like the Bondtech BMG or Bear extruders.
+// #define Z_MAX_POS_XYZ_CALIBRATION_CORRECTION 2.0 // This represents the correction as needed for MK3 and BMG (not MK3S) extruder 
+
 // Canceled home position
 #define X_CANCEL_POS 50
 #define Y_CANCEL_POS 190


### PR DESCRIPTION
The MK3S and MK2.5S firmware is not fit for use with a Bondtech BMG extruder kit or a Bear extruder.

This is because during XYZ calibration, the lower MK3S extruder (compared to Bondtech and Bear) causes the Z calibration to fail prematurely: when the Pinda is triggered "earlier" then expected.

This fix configures a #define Z_MAX_POS_XYZ_CALIBRATION_CORRECTION, to be entered in Configuration_Prusa.h to easily compile and use extruders with a different height. In the example configurations, this define is NOT set, so the firmware is not affected in ANY way.

For Bondtech and Bear owners, compiling the firmware is just a matter of uncommenting the new Z_MAX_POS_XYZ_CALIBRATION_CORRECTION #define and compiling it.

FOR DISCUSSION

I feel it is best to instrument the M45 gcode with an option to specify the value for Z_MAX_POS and store this in EEPROM when specified (and initialized depending on MK3/MK3S printer type). This would allow users to use the standard compiled firmware and issue a XYZ calibaration by "just" entering a gcode like: 

M45 O2.0 
M500

to set the offset to 2.0mm (in EEPROM) Bondtech users need to store the eesteps anyhow to reflect the extruder reduction ratio.

Subsequent XYZ calibrations would then use the value stored in EEPROM. 

In my opinion this would be the preferred solution: no compilation needed, just some GCODE commands.

Before implementing this, please provide some feedback. Also, I feel that when EEPROM memory is used coordination with Prusa Dev is needed.
 