### PR TITLE
Do not kill printer if External SPI flash W25X20CL is not responding.

### DIFF
--- a/Firmware/lcd.h
+++ b/Firmware/lcd.h
@@ -64,20 +64,14 @@ extern void lcd_print(long, int = 10);
 extern void lcd_print(unsigned long, int = 10);
 extern void lcd_print(double, int = 2);
 
+//! @brief Clear screen
 #define ESC_2J     "\x1b[2J"
 #define ESC_25h    "\x1b[?25h"
 #define ESC_25l    "\x1b[?25l"
+//! @brief Set cursor to
+//! @param c column
+//! @param r row
 #define ESC_H(c,r) "\x1b["#r";"#c"H"
-
-
-
-
-
-
-
-
-
-
 
 
 

--- a/Firmware/optiboot_w25x20cl.cpp
+++ b/Firmware/optiboot_w25x20cl.cpp
@@ -1,3 +1,4 @@
+//! @file
 // Based on the OptiBoot project
 // https://github.com/Optiboot/optiboot
 // Licence GLP 2 or later.
@@ -97,6 +98,7 @@ static const char entry_magic_cfm    [] PROGMEM = "w25x20cl_cfm\n";
 struct block_t;
 extern struct block_t *block_buffer;
 
+//! @brief Enter an STK500 compatible Optiboot boot loader waiting for flashing the languages to an external flash memory.
 void optiboot_w25x20cl_enter()
 {
   if (boot_app_flags & BOOT_APP_FLG_USER0) return;


### PR DESCRIPTION
Remove internationalization macro for this message. It has no sense to be translated as internationalization in most cases doesn't work if it is not responding.
Show this message instead of splash screen if the error is encountered.
There is no additional delay or wait for click, as such functions doesn't work in setup function.