### PR TITLE
PFW-1051: Introduce an editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+#-*-mode:conf-*-
+# editorconfig file (see EditorConfig.org)
+
+root                        = true
+
+[*]
+end_of_line                 = lf
+insert_final_newline        = true
+charset                     = utf-8
+trim_trailing_whitespace    = true
+indent_style                = space
+indent_size                 = 4
+tab_width                   = 4
+max_line_length             = 100


### PR DESCRIPTION
This is both a PR and RFC. The overall indentation status of the sources is ... messy :(
It think it could be improved a lot with minimal effort by at least providing some defaults for newly submitted code.

In this PR we add an "editorconfig" file, which just states the basic preferred values of:

- basic indentation width
- tab vs spaces
- tab width
- default charset

Nothing fancy, and it's zero effort.

The editorconfig is a simplified alternative to the vi/emacs modeline, and partially to vimrc or emacs's dirlocal files. I wasn't aware of this until a few weeks ago, when I noticed that editorconfig is supported by several popular windows editors.

It is fully advisory, so there's no harm in introducing this file. I've set the parameters to what the sources *seem* to use the most. I get more lines to line-up with tab set at 4 spaces, and the indentation is also mostly 4 as well. Trailing-whitespace-cleanup is turned on, which will result in cleaner files over time (although you'll see a lot of whitespace changes as files get saved).

emacs supports editorconfig through an elpa package, while newer vim versions should have this by default. But I could *also* supply an .exrc and .dirlocals file.

At least these will set the correct tab width, which will make the sources a bit more readable by default. The Arduino IDE doesn't seem to support those yet, but I'm going to create an issue for this too (so hopefully this will get even better).