### PR TITLE
Default to "Live Adjust Z" when longpressing during a print (closes #1604)

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -8252,8 +8252,22 @@ uint8_t get_message_level()
 
 void menu_lcd_longpress_func(void)
 {
-	move_menu_scale = 1.0;
-	menu_submenu(lcd_move_z);
+    if (homing_flag || mesh_bed_leveling_flag)
+    {
+        // disable longpress while homing or calibration
+        return;
+    }
+
+    if (moves_planned() || IS_SD_PRINTING || is_usb_printing)
+    {
+        lcd_clear();
+        menu_submenu(lcd_babystep_z);
+    }
+    else
+    {
+        move_menu_scale = 1.0;
+        menu_submenu(lcd_move_z);
+    }
 }
 
 void menu_lcd_charsetup_func(void)

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -8258,7 +8258,7 @@ void menu_lcd_longpress_func(void)
         return;
     }
 
-    if (moves_planned() || IS_SD_PRINTING || is_usb_printing)
+    if (current_position[Z_AXIS] < Z_HEIGHT_HIDE_LIVE_ADJUST_MENU && (moves_planned() || IS_SD_PRINTING || is_usb_printing ))
     {
         lcd_clear();
         menu_submenu(lcd_babystep_z);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -8252,9 +8252,10 @@ uint8_t get_message_level()
 
 void menu_lcd_longpress_func(void)
 {
-    if (homing_flag || mesh_bed_leveling_flag)
+    if (homing_flag || mesh_bed_leveling_flag || menu_menu == lcd_babystep_z || menu_menu == lcd_move_z)
     {
-        // disable longpress while homing or calibration
+        // disable longpress during re-entry, while homing or calibration
+        lcd_quick_feedback();
         return;
     }
 


### PR DESCRIPTION
Small but ergonomic change:

- Disable longpress action when homing or calibrating
- Default to Live Adjust Z during a print
- Retain "Move Z" otherwise