### PR TITLE
Filament ramming and z improvements

### DIFF
--- a/Firmware/Configuration.h
+++ b/Firmware/Configuration.h
@@ -336,7 +336,7 @@ your extruder heater takes 2 minutes to hit the target on heating.
   #define Y_PROBE_OFFSET_FROM_EXTRUDER -29
   #define Z_PROBE_OFFSET_FROM_EXTRUDER -12.35
 
-  #define Z_RAISE_BEFORE_HOMING 4       // (in mm) Raise Z before homing (G28) for Probe Clearance.
+  #define Z_RAISE_BEFORE_HOMING 5       // (in mm) Raise Z before homing (G28) for Probe Clearance.
                                         // Be sure you have this distance over your Z_MAX_POS in case
 
   #define XY_TRAVEL_SPEED 8000         // X and Y axis travel speed between probes, in mm/min
@@ -536,6 +536,12 @@ enum CalibrationStatus
     // Currently the G86 sets the calibration status to 
     CALIBRATION_STATUS_UNKNOWN = 0,
 };
+
+// Try to maintain a minimum distance from the bed even when Z is
+// unknown when doing the following operations
+#define MIN_Z_FOR_LOAD    50
+#define MIN_Z_FOR_UNLOAD  20
+#define MIN_Z_FOR_PREHEAT 10
 
 #include "Configuration_adv.h"
 #include "thermistortables.h"

--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -124,7 +124,7 @@ FORCE_INLINE void serialprintPGM(const char *str)
 bool is_buffer_empty();
 void get_command();
 void process_commands();
-void ramming();
+void raise_z_above(float target);
 
 void manage_inactivity(bool ignore_stepper_queue=false);
 

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -2127,6 +2127,9 @@ void raise_z_above(float target)
     }
     else
     {
+        // ensure Z is powered in normal mode to overcome initial load
+        enable_z();
+
         // rely on crashguard to limit damage
         bool z_endstop_enabled = enable_z_endstop(true);
 #ifdef TMC2130

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -6066,17 +6066,7 @@ void unload_filament()
 	custom_message_type = CUSTOM_MSG_TYPE_F_LOAD;
 	lcd_setstatuspgm(_T(MSG_UNLOADING_FILAMENT));
 
-	//		extr_unload2();
-
-	current_position[E_AXIS] -= 45;
-	plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], 5200 / 60, active_extruder);
-	st_synchronize();
-	current_position[E_AXIS] -= 15;
-	plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], 1000 / 60, active_extruder);
-	st_synchronize();
-	current_position[E_AXIS] -= 20;
-	plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], 1000 / 60, active_extruder);
-	st_synchronize();
+    mmu_filament_ramming();
 
 	lcd_display_message_fullscreen_P(_T(MSG_PULL_OUT_FILAMENT));
 

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1853,6 +1853,7 @@ void lcd_preheat_farm_nozzle()
 
 void lcd_preheat_pla()
 {
+  raise_z_above(MIN_Z_FOR_PREHEAT);
   setTargetHotend0(PLA_PREHEAT_HOTEND_TEMP);
   if (!wizard_active) setTargetBed(PLA_PREHEAT_HPB_TEMP);
   fanSpeed = 0;
@@ -1863,6 +1864,7 @@ void lcd_preheat_pla()
 
 void lcd_preheat_abs()
 {
+  raise_z_above(MIN_Z_FOR_PREHEAT);
   setTargetHotend0(ABS_PREHEAT_HOTEND_TEMP);
   if (!wizard_active) setTargetBed(ABS_PREHEAT_HPB_TEMP);
   fanSpeed = 0;
@@ -1873,6 +1875,7 @@ void lcd_preheat_abs()
 
 void lcd_preheat_pp()
 {
+  raise_z_above(MIN_Z_FOR_PREHEAT);
   setTargetHotend0(PP_PREHEAT_HOTEND_TEMP);
   if (!wizard_active) setTargetBed(PP_PREHEAT_HPB_TEMP);
   fanSpeed = 0;
@@ -1883,6 +1886,7 @@ void lcd_preheat_pp()
 
 void lcd_preheat_pet()
 {
+  raise_z_above(MIN_Z_FOR_PREHEAT);
   setTargetHotend0(PET_PREHEAT_HOTEND_TEMP);
   if (!wizard_active) setTargetBed(PET_PREHEAT_HPB_TEMP);
   fanSpeed = 0;
@@ -1893,6 +1897,7 @@ void lcd_preheat_pet()
 
 void lcd_preheat_hips()
 {
+  raise_z_above(MIN_Z_FOR_PREHEAT);
   setTargetHotend0(HIPS_PREHEAT_HOTEND_TEMP);
   if (!wizard_active) setTargetBed(HIPS_PREHEAT_HPB_TEMP);
   fanSpeed = 0;
@@ -1903,6 +1908,7 @@ void lcd_preheat_hips()
 
 void lcd_preheat_flex()
 {
+  raise_z_above(MIN_Z_FOR_PREHEAT);
   setTargetHotend0(FLEX_PREHEAT_HOTEND_TEMP);
   if (!wizard_active) setTargetBed(FLEX_PREHEAT_HPB_TEMP);
   fanSpeed = 0;
@@ -6066,6 +6072,7 @@ void unload_filament()
 	custom_message_type = CUSTOM_MSG_TYPE_F_LOAD;
 	lcd_setstatuspgm(_T(MSG_UNLOADING_FILAMENT));
 
+    raise_z_above(MIN_Z_FOR_UNLOAD);
     mmu_filament_ramming();
 
 	lcd_display_message_fullscreen_P(_T(MSG_PULL_OUT_FILAMENT));

--- a/Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h
@@ -323,20 +323,6 @@
 #define EXTRUDER_AUTO_FAN_SPEED   255  // == full speed
 
 
-
-/*------------------------------------
- LOAD/UNLOAD FILAMENT SETTINGS
- *------------------------------------*/
-
-// Load filament commands
-#define LOAD_FILAMENT_0 "M83"
-#define LOAD_FILAMENT_1 "G1 E70 F400"
-#define LOAD_FILAMENT_2 "G1 E40 F100"
-
-// Unload filament commands
-#define UNLOAD_FILAMENT_0 "M83"
-#define UNLOAD_FILAMENT_1 "G1 E-80 F7000"
-
 /*------------------------------------
  CHANGE FILAMENT SETTINGS
  *------------------------------------*/

--- a/Firmware/variants/1_75mm_MK3S-EINSy10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK3S-EINSy10a-E3Dv6full.h
@@ -323,20 +323,6 @@
 #define EXTRUDER_AUTO_FAN_SPEED   255  // == full speed
 
 
-
-/*------------------------------------
- LOAD/UNLOAD FILAMENT SETTINGS
- *------------------------------------*/
-
-// Load filament commands
-#define LOAD_FILAMENT_0 "M83"
-#define LOAD_FILAMENT_1 "G1 E70 F400"
-#define LOAD_FILAMENT_2 "G1 E40 F100"
-
-// Unload filament commands
-#define UNLOAD_FILAMENT_0 "M83"
-#define UNLOAD_FILAMENT_1 "G1 E-80 F7000"
-
 /*------------------------------------
  CHANGE FILAMENT SETTINGS
  *------------------------------------*/


### PR DESCRIPTION
This PR combines a fix for #1095 and #1748 due to space requirements (FIY this PR will also make room for PR #1759 and #1758). Please let me know if you whish to split this further.

First, we replace the filament unloading procedure with the mmu_filament_ramming() code to fix #1095.
If ramming is good enough for the mmu2, well, it *must* be good enough for plain unloading ;).
I didn't touch the custom filament unload procedure which is triggered by the filament runout, because *that* sequence could be triggered also by a clogged extruder and ramming the clog might not be a good idea. Ramming will thus be done for the Menu -> unload filament, for M702 and M600. I tested all cases with PLA and PETG.

I introduce a new function, raise_z_above to move Z carefully when the current position is potentially unknown, using stallguard. The following conditions will now use raise_z_above:

* during filament loading/unloading, for blob clearance. This was already done during loading, but now it's also done while unloading, since the ramming will extrude a little bit.

* extruder spacing when preheating. This is done to avoid buildplate marks on the PEI sheet, which is something I have, as I often preheat from the menu and sometimes come back late.

* before homing to avoid scratching the build plate. Again, this was already done, but badly (see #1748).

In the original sequence, G28 will raise, home XY, then raise again unconditionally. If the printer was already at max height, then reset, then a G28 is issued, the carriage is essentially crashed twice against the Z tops.

We now use raise_z_above before homing XY, and during home Z. raise_z_above is a no-op if the position is already above the target, which means that no move is ever issued if current position is already beyond the target. This results in G28 in a single raising move, which is faster to booth. If Z was already raised by a preheat or filament loading sequence, then there won't be any Z movement.

As a plus, stallguard is used when the position is unknown, making raise_z_above useful in all cases when Z is unknown (basically, all the above). raise_z_above will move the axis carefully and set the current position to max_height if the endpoint is hit. This will effectively prevent/fix #1748.

Note that #1748 will happen during regular printing too: if a tall print is completed and leaves the extruder at maximum height, a G28 issued by a subsequent print will currently crash the axis. A simple check is not enough: if the printer is reset while the extruder is at maximum height, then both homing and filament unloading will crash the axis.