### PR TITLE
build.sh: update Configuration_prusa.h when needed

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,8 @@
 #!/bin/bash 
 BUILD_ENV="1.0.6"
 SCRIPT_PATH="$( cd "$(dirname "$0")" ; pwd -P )"
+DEFAULT_VARIANT="1_75mm_MK3-EINSy10a-E3Dv6full.h"
+VARIANT="${1:-$DEFAULT_VARIANT}"
 
 if [ ! -d "build-env" ]; then
     mkdir build-env || exit 1
@@ -27,8 +29,9 @@ fi
 cd Prusa-Firmware-build || exit 7
 BUILD_PATH="$( pwd -P )"
 
-if [ ! -f "$SCRIPT_PATH/Firmware/Configuration_prusa.h" ]; then
-    cp $SCRIPT_PATH/Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h $SCRIPT_PATH/Firmware/Configuration_prusa.h || exit 8
+if ! cmp -s "$SCRIPT_PATH/Firmware/variants/$VARIANT" "$SCRIPT_PATH/Firmware/Configuration_prusa.h"; then
+    cp "$SCRIPT_PATH/Firmware/variants/$VARIANT" $SCRIPT_PATH/Firmware/Configuration_prusa.h || exit 8
+    rm -rf includes.cache sketch preproc
 fi
 
 $BUILD_ENV_PATH/arduino $SCRIPT_PATH/Firmware/Firmware.ino --verify --board PrusaResearchRambo:avr:rambo --pref build.path=$BUILD_PATH --pref compiler.warning_level=all || exit 9


### PR DESCRIPTION
I know PF-build.sh is the new hot build script, but build.sh is more convenient for testing.

- build.sh now accepts a first optional parameter to specify the build variant
- Always update Configuration_prusa.h when the variant file has changed in order to trigger a correct rebuild

We use cmp and not simply a timestamp check in order to handle *also* a rebuild for a different variant with a pre-existing build tree.