### PR TITLE
PFW-1053: Use Configuration_Prusa.h Sensorless Homing Values (Fix issue  #1753)

### DIFF
--- a/Firmware/tmc2130.cpp
+++ b/Firmware/tmc2130.cpp
@@ -38,7 +38,7 @@ uint8_t tmc2130_mres[4] = {0, 0, 0, 0}; //will be filed at begin of init
 
 
 uint8_t tmc2130_sg_thr[4] = {TMC2130_SG_THRS_X, TMC2130_SG_THRS_Y, TMC2130_SG_THRS_Z, TMC2130_SG_THRS_E};
-uint8_t tmc2130_sg_thr_home[4] = {3, 3, TMC2130_SG_THRS_Z, TMC2130_SG_THRS_E};
+uint8_t tmc2130_sg_thr_home[4] = {TMC2130_SG_THRS_X, TMC2130_SG_THRS_Y, TMC2130_SG_THRS_Z, TMC2130_SG_THRS_E};
 
 
 uint8_t tmc2130_sg_homing_axes_mask = 0x00;


### PR DESCRIPTION
Use the value that have been defined in configuration_prusa.h file instead of the magic number?