### PR TITLE
y-axis self-test hack cleanup

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -7132,7 +7132,7 @@ static bool lcd_selfcheck_axis_sg(unsigned char axis) {
 	float max_error_mm = 5;
 	switch (axis) {
 	case 0: axis_length = X_MAX_POS; break;
-	case 1: axis_length = Y_MAX_POS + 8; break;
+	case 1: axis_length = Y_MAX_POS - Y_MIN_POS + 4; break;
 	default: axis_length = 210; break;
 	}
 


### PR DESCRIPTION
y-axis could not pass self-test when printer build on custom frame with value Y_MIN_POS less then -8