### PR TITLE
Disable menu on MINTEMP errors

### DIFF
--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -390,6 +390,14 @@ extern LongTimer safetyTimer;
 
 #define PRINT_PERCENT_DONE_INIT   0xff
 #define PRINTER_ACTIVE (IS_SD_PRINTING || is_usb_printing || isPrintPaused || (custom_message_type == CUSTOM_MSG_TYPE_TEMCAL) || saved_printing || (lcd_commands_type == LCD_COMMAND_V2_CAL) || card.paused || mmu_print_saved)
+
+//! Beware - mcode_in_progress is set as soon as the command gets really processed,
+//! which is not the same as posting the M600 command into the command queue
+//! There can be a considerable lag between posting M600 and its real processing which might result
+//! in posting multiple M600's into the command queue
+//! Instead, the fsensor uses another state variable :( , which is set to true, when the M600 command is enqued
+//! and is reset to false when the fsensor returns into its filament runout finished handler
+//! I'd normally change this macro, but who knows what would happen in the MMU :)
 #define CHECK_FSENSOR ((IS_SD_PRINTING || is_usb_printing) && (mcode_in_progress != 600) && !saved_printing && e_active())
 
 extern void calculate_extruder_multipliers();

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3091,7 +3091,7 @@ static void gcode_M600(bool automatic, float x_position, float y_position, float
         plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS],
                 current_position[E_AXIS], FILAMENTCHANGE_EXFEED, active_extruder);
     }
-
+	
     //Move XY back
     plan_buffer_line(lastpos[X_AXIS], lastpos[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS],
             FILAMENTCHANGE_XYFEED, active_extruder);
@@ -3526,9 +3526,13 @@ void process_commands()
                enquecommand_P(PSTR("M24")); 
 		}	
 #ifdef FILAMENT_SENSOR
+		else if (code_seen("fsensor_recover_IR")) //! PRUSA fsensor_recover_IR
+		{
+			fsensor_restore_print_and_continue_IR();
+		}
 		else if (code_seen("fsensor_recover")) //! PRUSA fsensor_recover
 		{
-               fsensor_restore_print_and_continue();
+			fsensor_restore_print_and_continue();
 		}	
 #endif //FILAMENT_SENSOR
 		else if (code_seen("MMURES")) //! PRUSA MMURES

--- a/Firmware/fsensor.cpp
+++ b/Firmware/fsensor.cpp
@@ -57,6 +57,11 @@ bool fsensor_not_responding = false;
 bool fsensor_printing_saved = false;
 //! enable/disable quality meassurement
 bool fsensor_oq_meassure_enabled = false;
+//! as explained in the CHECK_FSENSOR macro: this flag is set to true when fsensor posts
+//! the M600 into the command queue, which elliminates the hazard of having posted multiple M600's
+//! before the first one gets read and started processing.
+//! Btw., the IR fsensor could do up to 6 posts before the command queue managed to start processing the first M600 ;)
+static bool fsensor_m600_enqueued = false;
 
 //! number of errors, updated in ISR
 uint8_t fsensor_err_cnt = 0;
@@ -115,16 +120,22 @@ uint16_t fsensor_oq_sh_sum;
 void fsensor_stop_and_save_print(void)
 {
     printf_P(PSTR("fsensor_stop_and_save_print\n"));
-    stop_and_save_print_to_ram(0, 0); //XYZE - no change
+	stop_and_save_print_to_ram(0, 0); //XYZE - no change
 }
 
+void fsensor_restore_print_and_continue_IR(void)
+{
+	fsensor_watch_runout = true;
+	fsensor_err_cnt = 0;
+	fsensor_m600_enqueued = false;
+}
+	
 void fsensor_restore_print_and_continue(void)
 {
     printf_P(PSTR("fsensor_restore_print_and_continue\n"));
-	fsensor_watch_runout = true;
-	fsensor_err_cnt = 0;
-    restore_print_from_ram_and_continue(0); //XYZ = orig, E - no change
-}
+	fsensor_restore_print_and_continue_IR();
+	restore_print_from_ram_and_continue(0); //XYZ = orig, E - no change
+}	
 
 void fsensor_init(void)
 {
@@ -575,13 +586,14 @@ void fsensor_update(void)
 			fsensor_oq_meassure_enabled = oq_meassure_enabled_tmp;
 		}
 #else //PAT9125
-		if ((digitalRead(IR_SENSOR_PIN) == 1) && CHECK_FSENSOR && fsensor_enabled && ir_sensor_detected)
-		{
-			fsensor_stop_and_save_print();
-			printf_P(PSTR("fsensor_update - M600\n"));
+		if ((digitalRead(IR_SENSOR_PIN) == 1) && CHECK_FSENSOR && fsensor_enabled && ir_sensor_detected && ( ! fsensor_m600_enqueued) )
+		{	// just plan a simple M600 without any additional position save/restore, 
+			// which caused weird heating issues standing directly over the print
 			eeprom_update_byte((uint8_t*)EEPROM_FERROR_COUNT, eeprom_read_byte((uint8_t*)EEPROM_FERROR_COUNT) + 1);
 			eeprom_update_word((uint16_t*)EEPROM_FERROR_COUNT_TOT, eeprom_read_word((uint16_t*)EEPROM_FERROR_COUNT_TOT) + 1);
-			enquecommand_front_P(PSTR("PRUSA fsensor_recover"));
+			enquecommand_front_P(PSTR("PRUSA fsensor_recover_IR"));
+			// printf_P(PSTR("fsensor_update - enquecommand_front_P(M600)\n"));
+			fsensor_m600_enqueued = true;
 			enquecommand_front_P((PSTR("M600")));
 		}
 #endif //PAT9125

--- a/Firmware/fsensor.h
+++ b/Firmware/fsensor.h
@@ -18,6 +18,9 @@ extern bool fsensor_oq_meassure_enabled;
 //! @name save restore printing
 //! @{
 extern void fsensor_stop_and_save_print(void);
+//! special handling for the IR sensor (no restore position and heating, since this is already correctly handled in the M600 itself)
+extern void fsensor_restore_print_and_continue_IR(void);
+//! legacy restore print - restore position and heatup to original temperature - for the MMU and the optical fsensor
 extern void fsensor_restore_print_and_continue(void);
 //! @}
 

--- a/Firmware/menu.cpp
+++ b/Firmware/menu.cpp
@@ -26,7 +26,7 @@ uint8_t menu_data[MENU_DATA_SIZE];
 #endif
 
 uint8_t menu_depth = 0;
-
+uint8_t menu_block_entering_on_serious_errors = SERIOUS_ERR_NONE;
 uint8_t menu_line = 0;
 uint8_t menu_item = 0;
 uint8_t menu_row = 0;

--- a/Firmware/menu.h
+++ b/Firmware/menu.h
@@ -28,6 +28,28 @@ extern uint8_t menu_data[MENU_DATA_SIZE];
 
 extern uint8_t menu_depth;
 
+//! definition of serious errors possibly blocking the main menu
+//! Use them as bit mask, so that the code may set various errors at the same time
+enum ESeriousErrors { 
+	SERIOUS_ERR_NONE            = 0,
+	SERIOUS_ERR_MINTEMP_HEATER  = 0x01,
+	SERIOUS_ERR_MINTEMP_BED     = 0x02
+}; // and possibly others in the future.
+
+//! this is a flag for disabling entering the main menu. If this is set
+//! to anything != 0, the only the main status screen will be shown on the
+//! LCD and the user will be prevented from entering the menu.
+//! Now used only to block doing anything with the printer when there is
+//! the infamous MINTEMP error (SERIOUS_ERR_MINTEMP).
+extern uint8_t menu_block_entering_on_serious_errors;
+
+//! a pair of macros for manipulating the serious errors
+//! a c++ class would have been better
+#define menu_set_serious_error(x) menu_block_entering_on_serious_errors |= x;
+#define menu_unset_serious_error(x) menu_block_entering_on_serious_errors &= ~x;
+#define menu_is_serious_error(x) (menu_block_entering_on_serious_errors & x) != 0
+
+
 extern uint8_t menu_line;
 extern uint8_t menu_item;
 extern uint8_t menu_row;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -233,6 +233,7 @@ static void lcd_send_status();
 static void lcd_connect_printer();
 #endif //FARM_CONNECT_MESSAGE
 
+//! Beware: has side effects - forces lcd_draw_update to 2, which means clear the display
 void lcd_finishstatus();
 
 static void lcd_sdcard_menu();
@@ -999,10 +1000,13 @@ static void lcd_status_screen()
 		}
 	}
 
-	if (current_click && (lcd_commands_type != LCD_COMMAND_STOP_PRINT)) //click is aborted unless stop print finishes
+	if (current_click 
+		&& (lcd_commands_type != LCD_COMMAND_STOP_PRINT) //click is aborted unless stop print finishes
+		&& ( menu_block_entering_on_serious_errors == SERIOUS_ERR_NONE ) // or a serious error blocks entering the menu	
+	) 
 	{
 		menu_depth = 0; //redundant, as already done in lcd_return_to_status(), just to be sure
-		menu_submenu(lcd_main_menu);
+		menu_submenu(lcd_main_menu);		
 		lcd_refresh(); // to maybe revive the LCD if static electricity killed it.
 	}
 
@@ -8226,13 +8230,20 @@ void lcd_setstatus(const char* message)
   strncpy(lcd_status_message, message, LCD_WIDTH);
   lcd_finishstatus();
 }
+
+void lcd_updatestatuspgm(const char *message){
+	strncpy_P(lcd_status_message, message, LCD_WIDTH);
+	lcd_status_message[LCD_WIDTH] = 0;
+	lcd_finishstatus();
+	// hack lcd_draw_update to 1, i.e. without clear
+	lcd_draw_update = 1;
+}
+
 void lcd_setstatuspgm(const char* message)
 {
   if (lcd_status_message_level > 0)
     return;
-  strncpy_P(lcd_status_message, message, LCD_WIDTH);
-  lcd_status_message[LCD_WIDTH] = 0;
-  lcd_finishstatus();
+  lcd_updatestatuspgm(message);
 }
 void lcd_setalertstatuspgm(const char* message)
 {
@@ -8240,6 +8251,7 @@ void lcd_setalertstatuspgm(const char* message)
   lcd_status_message_level = 1;
   lcd_return_to_status();
 }
+
 void lcd_reset_alert_level()
 {
   lcd_status_message_level = 0;

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -18,7 +18,18 @@ extern void menu_lcd_lcdupdate_func(void);
 void ultralcd_init();
 void lcd_setstatus(const char* message);
 void lcd_setstatuspgm(const char* message);
+
+//! return to the main status screen and display the alert message
+//! Beware - it has sideeffects:
+//! - always returns the display to the main status screen
+//! - always makes lcd_reset (which is slow and causes flicker)
+//! - does not update the message if there is already one (i.e. lcd_status_message_level > 0) 
 void lcd_setalertstatuspgm(const char* message);
+
+//! only update the alert message on the main status screen
+//! has no sideeffects, may be called multiple times
+void lcd_updatestatuspgm(const char *message);
+
 void lcd_reset_alert_level();
 uint8_t get_message_level();
 void lcd_adjust_z();


### PR DESCRIPTION
Prevent the user from entering the main menu when there is a MINTEMP error. When the error fades out, the user must reset the printer to regain control.