### PR TITLE
Drop min nozzle temperature to 5 degrees on MK3S

### DIFF
--- a/Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h
@@ -280,7 +280,7 @@
  *------------------------------------*/
 
 // Mintemps
-#define HEATER_0_MINTEMP 15
+#define HEATER_0_MINTEMP 5
 #define HEATER_1_MINTEMP 5
 #define HEATER_2_MINTEMP 5
 #define HEATER_MINTEMP_DELAY 15000                // [ms] ! if changed, check maximal allowed value @ ShortTimer

--- a/Firmware/variants/1_75mm_MK3S-EINSy10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK3S-EINSy10a-E3Dv6full.h
@@ -282,7 +282,7 @@
  *------------------------------------*/
 
 // Mintemps
-#define HEATER_0_MINTEMP 15
+#define HEATER_0_MINTEMP 5
 #define HEATER_1_MINTEMP 5
 #define HEATER_2_MINTEMP 5
 #define HEATER_MINTEMP_DELAY 15000                // [ms] ! if changed, check maximal allowed value @ ShortTimer


### PR DESCRIPTION
Follow up to #1775. My hot end thermistor generally reads ~5° below ambient. It is regularly 15° - 25° ambient temperature in my house (where I use the MK3), so this means I regularly get the MINTEMP error when the printer is perfectly fine. Normally this is just an annoyance and I have a small heater I use to preheat the machine, but with MMU prints I am now regularly failing prints while the printer waits for me to come sort out why the filament isn't loading.

I'm not sure if having a [plated copper heat block](https://e3d-online.com/v6-plated-copper-heater-block) is impacting it, but everything else seems to work fine to me. I have ~5k hours on the printer with the thermistor and it doesn't seem to otherwise have issues.

From a safety perspective, I tried shorting the sensor (read over 700° and set off an alarm), I tried opening the circuit and it showed 0°. I'm not sure why this value is higher than the others so I'm totally open to this being a conscious decision that I wasn't aware of.
