### PR TITLE
Allow selection of extruder in MMU Single mode at M600

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3073,7 +3073,7 @@ static void gcode_M600(bool automatic, float x_position, float y_position, float
     {
         if (!automatic) {
             if (saved_printing) mmu_eject_filament(mmu_extruder, false); //if M600 was invoked by filament senzor (FINDA) eject filament so user can easily remove it
-            mmu_M600_wait_and_beep();
+            mmu_M600_wait_and_beep(saved_printing);
             if (saved_printing) {
 
                 lcd_clear();

--- a/Firmware/mmu.cpp
+++ b/Firmware/mmu.cpp
@@ -812,13 +812,17 @@ void mmu_load_to_nozzle()
 	if (!saved_e_relative_mode) axis_relative_modes[E_AXIS] = false;
 }
 
-void mmu_M600_wait_and_beep() {
+void mmu_M600_wait_and_beep(bool saved_printing) {
 		//Beep and wait for user to remove old filament and prepare new filament for load
 
 		KEEPALIVE_STATE(PAUSED_FOR_USER);
 
 		int counterBeep = 0;
-		lcd_display_message_fullscreen_P(_i("Remove old filament and press the knob to start loading new filament."));
+                if (saved_printing) {
+                    lcd_display_message_fullscreen_P(_i("Remove old filament and press the knob to start loading new filament."));
+                } else {
+                    lcd_display_message_fullscreen_P(_i("Press the knob to select next color."));
+                }
 		bool bFirst=true;
 
 		while (!lcd_clicked()){
@@ -856,10 +860,7 @@ void mmu_M600_load_filament(bool automatic, float nozzle_temp)
     tmp_extruder = mmu_extruder;
     if (!automatic)
     {
-    #ifdef MMU_M600_SWITCH_EXTRUDER
-        bool yes = lcd_show_fullscreen_message_yes_no_and_wait_P(_i("Do you want to switch extruder?"), false);
-        if(yes) tmp_extruder = choose_extruder_menu();
-    #endif //MMU_M600_SWITCH_EXTRUDER
+        tmp_extruder = choose_menu_P(_T(MSG_CHOOSE_FILAMENT), _T(MSG_FILAMENT));
     }
     else
     {

--- a/Firmware/mmu.h
+++ b/Firmware/mmu.h
@@ -97,7 +97,7 @@ extern void manage_response(bool move_axes, bool turn_off_nozzle, uint8_t move =
 extern void mmu_load_to_nozzle();
 
 extern void mmu_M600_load_filament(bool automatic, float nozzle_temp);
-extern void mmu_M600_wait_and_beep();
+extern void mmu_M600_wait_and_beep(bool saved_printing);
 
 extern void extr_mov(float shift, float feed_rate);
 extern void change_extr(int extr);


### PR DESCRIPTION
An attempt at providing the missing functionality reported in issue #1363.
Allows an MMU2 user to select a different extruder at each color change in 'ColorPrint' mode, rather than forcing the user to unload and reload the current extruder to change color.