### PR TITLE
Fix Load Filament 5 for MMU2

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5957,7 +5957,7 @@ static void fil_load_menu()
 
     if (mmu_enabled)
     {
-        MENU_ITEM_FUNCTION_NR_P(_T(MSG_LOAD_FILAMENT), '5', extr_adj, 3);
+        MENU_ITEM_FUNCTION_NR_P(_T(MSG_LOAD_FILAMENT), '5', extr_adj, 4);
     }
     MENU_END();
 }


### PR DESCRIPTION
As the itle suggests, this fixes a typo where loading filament 5 loads filament 4 with MMU2(S).

issue: #1883