### PR TITLE
Fan check error fix

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3391,8 +3391,10 @@ void process_commands()
 {
   #ifdef FANCHECK
   if (fan_check_error){
-    fan_check_error = false;
-    lcd_pause_print();
+	if( fan_check_error == EFCE_DETECTED ){
+		fan_check_error = EFCE_REPORTED;
+		lcd_pause_print();
+	} // otherwise it has already been reported, so just ignore further processing
     return;
   }
   #endif

--- a/Firmware/pins_Einsy_1_0.h
+++ b/Firmware/pins_Einsy_1_0.h
@@ -99,8 +99,7 @@
 
 //#define KILL_PIN            32
 
-// LCD backlight pin may interfere with something, this is yet to be found out correctly
-#define LCD_BL_PIN          5   //backlight control pin
+//#define LCD_BL_PIN          5   //backlight control pin
 #define BEEPER              84  // Beeper on AUX-4
 #define LCD_PINS_RS         82
 #define LCD_PINS_ENABLE     61 // !!! changed from 18 (EINY03)

--- a/Firmware/pins_Einsy_1_0.h
+++ b/Firmware/pins_Einsy_1_0.h
@@ -99,7 +99,8 @@
 
 //#define KILL_PIN            32
 
-//#define LCD_BL_PIN          5   //backlight control pin
+// LCD backlight pin may interfere with something, this is yet to be found out correctly
+#define LCD_BL_PIN          5   //backlight control pin
 #define BEEPER              84  // Beeper on AUX-4
 #define LCD_PINS_RS         82
 #define LCD_PINS_ENABLE     61 // !!! changed from 18 (EINY03)

--- a/Firmware/temperature.cpp
+++ b/Firmware/temperature.cpp
@@ -528,7 +528,11 @@ void checkFanSpeed()
 	}
 }
 
-void fanSpeedErrorBeep(const char *serialMsg, const char *lcdMsg){
+//! Prints serialMsg to serial port, displays lcdMsg onto the LCD and beeps.
+//! Extracted from fanSpeedError to save some space.
+//! @param serialMsg pointer into PROGMEM, this text will be printed to the serial port
+//! @param lcdMsg pointer into PROGMEM, this text will be printed onto the LCD
+static void fanSpeedErrorBeep(const char *serialMsg, const char *lcdMsg){
 	SERIAL_ECHOLNRPGM(serialMsg);
 	if (get_message_level() == 0) {
 		if((eSoundMode==e_SOUND_MODE_LOUD)||(eSoundMode==e_SOUND_MODE_ONCE)||(eSoundMode==e_SOUND_MODE_SILENT)){

--- a/Firmware/temperature.h
+++ b/Firmware/temperature.h
@@ -238,7 +238,8 @@ void checkExtruderAutoFans();
 
 #if (defined(FANCHECK) && defined(TACH_0) && (TACH_0 > -1))
 
-extern volatile bool fan_check_error;
+enum { EFCE_OK = 0, EFCE_DETECTED, EFCE_REPORTED };
+extern volatile uint8_t fan_check_error;
 
 void countFanSpeed();
 void checkFanSpeed();

--- a/Firmware/temperature.h
+++ b/Firmware/temperature.h
@@ -238,7 +238,11 @@ void checkExtruderAutoFans();
 
 #if (defined(FANCHECK) && defined(TACH_0) && (TACH_0 > -1))
 
-enum { EFCE_OK = 0, EFCE_DETECTED, EFCE_REPORTED };
+enum { 
+	EFCE_OK = 0,   //!< normal operation, both fans are ok
+	EFCE_DETECTED, //!< fan error detected, but not reported yet
+	EFCE_REPORTED  //!< fan error detected and reported to LCD and serial
+};
 extern volatile uint8_t fan_check_error;
 
 void countFanSpeed();


### PR DESCRIPTION
When the user didn't resolve the fan error and tried to resume printing, the printer could get into an undefined state.