### PR TITLE
PFW-1054: Fix the LCD pause function

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -9492,10 +9492,9 @@ void long_pause() //long pause print
 	current_position[Y_AXIS] = Y_PAUSE_POS;
 	plan_buffer_line_curposXYZE(50, active_extruder);
 
-	// Turn off the print fan
+	// Turn off the hotends and print fan
+    setAllTargetHotends(0);
 	fanSpeed = 0;
-
-	st_synchronize();
 }
 
 void serialecho_temperatures() {

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1059,12 +1059,8 @@ void lcd_commands()
 		if (!blocks_queued() && !homing_flag)
 		{
 			lcd_setstatuspgm(_i("Print paused"));////MSG_PRINT_PAUSED c=20 r=1
-			long_pause();
-               if (lcd_commands_type == LcdCommands::LongPause) // !!! because "lcd_commands_type" can be changed during/inside "long_pause()"
-               {
-                    lcd_commands_type = LcdCommands::Idle;
-                    lcd_commands_step = 0;
-               }
+            lcd_commands_type = LcdCommands::Idle;
+            lcd_commands_step = 0;
 		}
 	}
 
@@ -1644,7 +1640,7 @@ void lcd_pause_print()
 {
     lcd_return_to_status();
     stop_and_save_print_to_ram(0.0,0.0);
-    setAllTargetHotends(0);
+    long_pause();
     isPrintPaused = true;
     if (LcdCommands::Idle == lcd_commands_type)
     {


### PR DESCRIPTION
Do not call long_pause recursively!

long_pause() is called before resetting the lcd_command_type.  As long_pause uses st_synchronize() internally, there could be time to schedule another call to long_pause() within itself.

I'm actually wondering why this doesn't crash as often as it should!

We fix this by calling long_pause exactly after saving. Then we also remove an useless check and bogus comment (no: the command type cannot be changed during long_pause!).

We modify long_pause to schedule the moves so that the LCD is immediately usable, and also embed the heater control inside long_pause() itself, where it makes more sense. lcd_pause_print() is the only caller anyway.