### PR TITLE
Fix M0/M1/M117 commands when printing from SD.

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3430,6 +3430,7 @@ void process_commands()
 	  if (starpos != NULL)
 		  *(starpos) = '\0';
 	  lcd_setstatus(strchr_pointer + 5);
+	  custom_message_type = CUSTOM_MSG_TYPE_MSGUPD;
   }
 
   else if (code_seen("M0 ") || code_seen("M1 ")) { // M0 and M1 - (Un)conditional stop - Wait for user buttn press on LCD
@@ -3450,6 +3451,7 @@ void process_commands()
       starpos = strchr(src, '*');
       if (starpos != NULL) *(starpos) = '\0';
       while (*src == ' ') ++src;
+	  custom_message_type = CUSTOM_MSG_TYPE_M0WAIT;
       if (!hasP && !hasS && *src != '\0') {
         lcd_setstatus(src);
       } else {
@@ -3476,6 +3478,7 @@ void process_commands()
         LCD_MESSAGERPGM(_T(MSG_RESUMING_PRINT));
       else
         LCD_MESSAGERPGM(_T(WELCOME_MSG));
+	  custom_message_type = CUSTOM_MSG_TYPE_MSGUPD;
     }
 
 #ifdef TMC2130

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -794,7 +794,10 @@ void lcdui_print_status_line(void)
 	{ // Otherwise check for other special events
    		switch (custom_message_type)
 		{
+		case CUSTOM_MSG_TYPE_MSGUPD:
+			custom_message_type = CUSTOM_MSG_TYPE_STATUS;
 		case CUSTOM_MSG_TYPE_STATUS: // Nothing special, print status message normally
+		case CUSTOM_MSG_TYPE_M0WAIT:
 			lcd_print(lcd_status_message);
 			break;
 		case CUSTOM_MSG_TYPE_MESHBL: // If mesh bed leveling in progress, show the status

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -106,6 +106,8 @@ extern int8_t FSensorStateMenu;
 #define CUSTOM_MSG_TYPE_PIDCAL 3 // PID tuning in progress
 #define CUSTOM_MSG_TYPE_TEMCAL 4 // PINDA temp calibration
 #define CUSTOM_MSG_TYPE_TEMPRE 5 // Temp compensation preheat
+#define CUSTOM_MSG_TYPE_M0WAIT 6 // M0/M1 Wait command working even from SD
+#define CUSTOM_MSG_TYPE_MSGUPD 7 // Short message even while printing from SD
 
 extern unsigned int custom_message_type;
 extern unsigned int custom_message_state;


### PR DESCRIPTION
As reported in issue #1898 , M0/M1/M117 don't work under many scenarios. One is when an M0/M1 string contains a 'G' or any other substring decoded before M commands. This was already fixed fro M117 some time ago by moving it up to be decoded first. Another scenario is when printing from a SD card. Then the SD status takes priority over STATUS messages and the text from M0/M1/M117 is never shown. I've created two new CUSTOM_MSG_TYPEs, one that overrides the SD status for the M0/M1 message and another that overrides it temporarily for the M0/M1 resume message and the M117 message.