### PR TITLE
Provide Platform.io project config & use it for CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ Firmware/Doc
 /build-env/
 /Firmware/Firmware.vcxproj
 /Firmware/Configuration_prusa_bckp.h
+/build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,15 @@
-dist: trusty
-before_install:
-  - sudo apt-get install -y ninja-build
+language: python
+python:
+    - "2.7"
+
+# Cache PlatformIO packages using Travis CI container-based infrastructure
+sudo: false
+cache:
+    directories:
+        - "build"
+
+install:
+    - pip install -U platformio
+
 script:
-  - bash -x test.sh
-  - cp Firmware/variants/1_75mm_MK3S-EINSy10a-E3Dv6full.h Firmware/Configuration_prusa.h
-  - bash -x build.sh || { echo "1_75mm_MK3S-EINSy10a-E3Dv6full variant failed" && false; }
-  - rm Firmware/Configuration_prusa.h
-  - cp Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h Firmware/Configuration_prusa.h
-  - bash -x build.sh || { echo "1_75mm_MK3-EINSy10a-E3Dv6full variant failed" && false; }
-  - rm Firmware/Configuration_prusa.h
-  - cp Firmware/variants/1_75mm_MK25S-RAMBo13a-E3Dv6full.h Firmware/Configuration_prusa.h
-  - bash -x build.sh || { echo "1_75mm_MK25S-RAMBo13a-E3Dv6full variant failed" && false; }
-  - rm Firmware/Configuration_prusa.h
-  - cp Firmware/variants/1_75mm_MK25S-RAMBo10a-E3Dv6full.h Firmware/Configuration_prusa.h
-  - bash -x build.sh || { echo "1_75mm_MK25S-RAMBo10a-E3Dv6full variant failed" && false; }
-  - rm Firmware/Configuration_prusa.h
-  - cp Firmware/variants/1_75mm_MK25-RAMBo13a-E3Dv6full.h Firmware/Configuration_prusa.h
-  - bash -x build.sh || { echo "1_75mm_MK25-RAMBo13a-E3Dv6full variant failed" && false; }
-  - rm Firmware/Configuration_prusa.h
-  - cp Firmware/variants/1_75mm_MK25-RAMBo10a-E3Dv6full.h Firmware/Configuration_prusa.h
-  - bash -x build.sh || { echo "1_75mm_MK25-RAMBo10a-E3Dv6full variant failed" && false; }
-  - rm Firmware/Configuration_prusa.h
-  - cp Firmware/variants/1_75mm_MK2-RAMBo13a-E3Dv6full.h Firmware/Configuration_prusa.h
-  - bash -x build.sh || { echo "1_75mm_MK2-RAMBo13a-E3Dv6full variant failed" && false; }
-  - rm Firmware/Configuration_prusa.h
-  - cp Firmware/variants/1_75mm_MK2-RAMBo10a-E3Dv6full.h Firmware/Configuration_prusa.h
-  - bash -x build.sh || { echo "1_75mm_MK2-RAMBo10a-E3Dv6full variant failed" && false; }
+    - platformio run -v

--- a/boards/prusa_rambo.json
+++ b/boards/prusa_rambo.json
@@ -1,0 +1,32 @@
+{
+  "build": {
+    "core": "arduino",
+    "extra_flags": "-DARDUINO_AVR_RAMBO",
+    "f_cpu": "16000000L",
+    "mcu": "atmega2560",
+    "variant": "rambo"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "fuses": {
+    "lfuse": "0xFF",
+    "hfuse": "0xD8",
+    "efuse": "0xFD",
+    "lock": "0x3F"
+  },
+  "hwids": [
+    "0x27b1",
+    "0x0001"
+  ],
+  "name": "Prusa (EINSy)RAMBo",
+  "upload": {
+    "maximum_ram_size": 8192,
+    "maximum_size": 258048,
+    "protocol": "stk500v2",
+    "require_upload_port": true,
+    "speed": 115200
+  },
+  "url": "http://reprap.org/wiki/EinsyRambo",
+  "vendor": "Prusa"
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,63 @@
+[platformio]
+src_dir = Firmware
+build_dir = build
+libdeps_dir = build/libs
+[common]
+build_flags =
+  -Wl,-u,vfprintf
+  -lprintf_flt
+
+[env:MK25_RAMBo10a]
+platform = atmelavr
+board = prusa_rambo
+framework = arduino
+lib_deps = U8glib@1.19.1
+build_flags =
+  ${common.build_flags}
+  !cp Firmware/variants/1_75mm_MK25-RAMBo10a-E3Dv6full.h Firmware/Configuration_prusa.h
+
+
+[env:MK25_RAMBo13a]
+platform = atmelavr
+board = prusa_rambo
+framework = arduino
+lib_deps = U8glib@1.19.1
+build_flags =
+  ${common.build_flags}
+  !cp Firmware/variants/1_75mm_MK25-RAMBo13a-E3Dv6full.h Firmware/Configuration_prusa.h
+
+[env:MK25S_RAMBo10a]
+platform = atmelavr
+board = prusa_rambo
+framework = arduino
+lib_deps = U8glib@1.19.1
+build_flags =
+  ${common.build_flags}
+  !cp Firmware/variants/1_75mm_MK25S-RAMBo10a-E3Dv6full.h Firmware/Configuration_prusa.h
+
+[env:MK25S_RAMBo13a]
+platform = atmelavr
+board = prusa_rambo
+framework = arduino
+lib_deps = U8glib@1.19.1
+build_flags =
+  ${common.build_flags}
+  !cp Firmware/variants/1_75mm_MK25S-RAMBo13a-E3Dv6full.h Firmware/Configuration_prusa.h
+
+[env:MK3]
+platform = atmelavr
+board = prusa_rambo
+framework = arduino
+lib_deps = U8glib@1.19.1
+build_flags =
+  ${common.build_flags}
+  !cp Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h Firmware/Configuration_prusa.h
+
+[env:MK3S]
+platform = atmelavr
+board = prusa_rambo
+framework = arduino
+lib_deps = U8glib@1.19.1
+build_flags =
+  ${common.build_flags}
+  !cp Firmware/variants/1_75mm_MK3S-EINSy10a-E3Dv6full.h Firmware/Configuration_prusa.h


### PR DESCRIPTION
Compared to the current solution, I find this a ridiculously trivial & transparent way to provide reproducible builds across host platforms.

It looks that the u8g library is not actually being linked to in which case it can be dropped. It is however included in the [original UltiMachine's Arduino Addon repository](https://github.com/ultimachine/ArduinoAddons/tree/master/rambo/libraries/U8glib), so I included it for parity.