### PR TITLE
Layer1 cal flash

### DIFF
--- a/Firmware/first_lay_cal.cpp
+++ b/Firmware/first_lay_cal.cpp
@@ -173,7 +173,8 @@ static constexpr float count_e(float layer_heigth, float extrusion_width, float 
 
 static const float width = 0.4;
 static const float length = 20 - width;
-static const float extr = count_e(0.2, width, length);
+static const float heigth = 0.2; //!< TODO This is wrong, as current Z height is 0.15 mm
+static const float extr = count_e(heigth, width, length);
 
 void lay1cal_meander(char *cmd_buffer)
 {
@@ -193,7 +194,7 @@ void lay1cal_meander(char *cmd_buffer)
 //! @par i iteration
 void lay1cal_square(char *cmd_buffer, uint8_t i)
 {
-    const float extr_short_segment = count_e(0.2, width, width);
+    const float extr_short_segment = count_e(heigth, width, width);
 
     static const char fmt1[] PROGMEM = "G1 X%d Y%-.2f E%-.3f";
     static const char fmt2[] PROGMEM = "G1 Y%-.2f E%-.3f";

--- a/Firmware/first_lay_cal.cpp
+++ b/Firmware/first_lay_cal.cpp
@@ -8,27 +8,28 @@
 #include "Configuration_prusa.h"
 #include "language.h"
 #include "Marlin.h"
+#include "mmu.h"
 #include <avr/pgmspace.h>
 
 
-static const char cmd_0[] PROGMEM = "M107";
-static const char cmd_1[] PROGMEM = "M104 S" STRINGIFY(PLA_PREHEAT_HOTEND_TEMP);
-static const char cmd_2[] PROGMEM = "M140 S" STRINGIFY(PLA_PREHEAT_HPB_TEMP);
-static const char cmd_3[] PROGMEM = "M190 S" STRINGIFY(PLA_PREHEAT_HPB_TEMP);
-static const char cmd_4[] PROGMEM = "M109 S" STRINGIFY(PLA_PREHEAT_HOTEND_TEMP);
-static const char cmd_5[] PROGMEM = "G28";
-static const char cmd_6[] PROGMEM = "G92 E0.0";
+static const char cmd_preheat_0[] PROGMEM = "M107";
+static const char cmd_preheat_1[] PROGMEM = "M104 S" STRINGIFY(PLA_PREHEAT_HOTEND_TEMP);
+static const char cmd_preheat_2[] PROGMEM = "M140 S" STRINGIFY(PLA_PREHEAT_HPB_TEMP);
+static const char cmd_preheat_3[] PROGMEM = "M190 S" STRINGIFY(PLA_PREHEAT_HPB_TEMP);
+static const char cmd_preheat_4[] PROGMEM = "M109 S" STRINGIFY(PLA_PREHEAT_HOTEND_TEMP);
+static const char cmd_preheat_5[] PROGMEM = "G28";
+static const char cmd_preheat_6[] PROGMEM = "G92 E0.0";
 
 
 static const char * const preheat_cmd[] PROGMEM =
 {
-    cmd_0,
-    cmd_1,
-    cmd_2,
-    cmd_3,
-    cmd_4,
-    cmd_5, //call MSG_M117_V2_CALIBRATION before
-    cmd_6,
+    cmd_preheat_0,
+    cmd_preheat_1,
+    cmd_preheat_2,
+    cmd_preheat_3,
+    cmd_preheat_4,
+    cmd_preheat_5, //call MSG_M117_V2_CALIBRATION before
+    cmd_preheat_6,
 };
 
 void lay1cal_preheat()
@@ -39,4 +40,56 @@ void lay1cal_preheat()
         enquecommand_P(static_cast<char*>(pgm_read_ptr(&preheat_cmd[i])));
     }
 
+}
+
+static const char cmd_intro_mmu_0[] PROGMEM = "M83";
+static const char cmd_intro_mmu_1[] PROGMEM = "G1 Y-3.0 F1000.0";
+static const char cmd_intro_mmu_2[] PROGMEM = "G1 Z0.4 F1000.0";
+static const char cmd_intro_mmu_3[] PROGMEM = "G1 X55.0 E32.0 F1073.0"; // call T code before
+static const char cmd_intro_mmu_4[] PROGMEM = "G1 X5.0 E32.0 F1800.0";
+static const char cmd_intro_mmu_5[] PROGMEM = "G1 X55.0 E8.0 F2000.0";
+static const char cmd_intro_mmu_6[] PROGMEM = "G1 Z0.3 F1000.0";
+static const char cmd_intro_mmu_7[] PROGMEM = "G92 E0.0";
+static const char cmd_intro_mmu_8[] PROGMEM = "G1 X240.0 E25.0  F2200.0";
+static const char cmd_intro_mmu_9[] PROGMEM = "G1 Y-2.0 F1000.0";
+static const char cmd_intro_mmu_10[] PROGMEM = "G1 X55.0 E25 F1400.0";
+static const char cmd_intro_mmu_11[] PROGMEM = "G1 Z0.20 F1000.0";
+static const char cmd_intro_mmu_12[] PROGMEM = "G1 X5.0 E4.0 F1000.0";
+
+static const char * const intro_mmu_cmd[] PROGMEM =
+{
+    cmd_intro_mmu_0,
+    cmd_intro_mmu_1,
+    cmd_intro_mmu_2,
+    cmd_intro_mmu_3, // call T code before
+    cmd_intro_mmu_4,
+    cmd_intro_mmu_5,
+    cmd_intro_mmu_6,
+    cmd_intro_mmu_7,
+    cmd_intro_mmu_8,
+    cmd_intro_mmu_9,
+    cmd_intro_mmu_10,
+    cmd_intro_mmu_11,
+    cmd_intro_mmu_12,
+};
+
+void lay1cal_intro_line(char *cmd_buffer, uint8_t filament)
+{
+    if (mmu_enabled)
+    {
+        for (uint8_t i = 0; i < (sizeof(intro_mmu_cmd)/sizeof(intro_mmu_cmd[0])); ++i)
+        {
+            if (3 == i)
+                {
+                    sprintf_P(cmd_buffer, PSTR("T%d"), filament);
+                    enquecommand(cmd_buffer);
+                }
+            enquecommand_P(static_cast<char*>(pgm_read_ptr(&intro_mmu_cmd[i])));
+        }
+    }
+    else
+    {
+        enquecommand_P(PSTR("G1 X60.0 E9.0 F1000.0"));
+        enquecommand_P(PSTR("G1 X100.0 E12.5 F1000.0"));
+    }
 }

--- a/Firmware/first_lay_cal.cpp
+++ b/Firmware/first_lay_cal.cpp
@@ -10,30 +10,28 @@
 #include "mmu.h"
 #include <avr/pgmspace.h>
 
-
-static const char cmd_preheat_0[] PROGMEM = "M107";
-static const char cmd_preheat_1[] PROGMEM = "M104 S" STRINGIFY(PLA_PREHEAT_HOTEND_TEMP);
-static const char cmd_preheat_2[] PROGMEM = "M140 S" STRINGIFY(PLA_PREHEAT_HPB_TEMP);
-static const char cmd_preheat_3[] PROGMEM = "M190 S" STRINGIFY(PLA_PREHEAT_HPB_TEMP);
-static const char cmd_preheat_4[] PROGMEM = "M109 S" STRINGIFY(PLA_PREHEAT_HOTEND_TEMP);
-static const char cmd_preheat_5[] PROGMEM = "G28";
-static const char cmd_preheat_6[] PROGMEM = "G92 E0.0";
-
-
-static const char * const preheat_cmd[] PROGMEM =
-{
-    cmd_preheat_0,
-    cmd_preheat_1,
-    cmd_preheat_2,
-    cmd_preheat_3,
-    cmd_preheat_4,
-    cmd_preheat_5, //call MSG_M117_V2_CALIBRATION before
-    cmd_preheat_6,
-};
-
 //! @brief Preheat
 void lay1cal_preheat()
 {
+    static const char cmd_preheat_0[] PROGMEM = "M107";
+    static const char cmd_preheat_1[] PROGMEM = "M104 S" STRINGIFY(PLA_PREHEAT_HOTEND_TEMP);
+    static const char cmd_preheat_2[] PROGMEM = "M140 S" STRINGIFY(PLA_PREHEAT_HPB_TEMP);
+    static const char cmd_preheat_3[] PROGMEM = "M190 S" STRINGIFY(PLA_PREHEAT_HPB_TEMP);
+    static const char cmd_preheat_4[] PROGMEM = "M109 S" STRINGIFY(PLA_PREHEAT_HOTEND_TEMP);
+    static const char cmd_preheat_5[] PROGMEM = "G28";
+    static const char cmd_preheat_6[] PROGMEM = "G92 E0.0";
+
+    static const char * const preheat_cmd[] PROGMEM =
+    {
+        cmd_preheat_0,
+        cmd_preheat_1,
+        cmd_preheat_2,
+        cmd_preheat_3,
+        cmd_preheat_4,
+        cmd_preheat_5, //call MSG_M117_V2_CALIBRATION before
+        cmd_preheat_6,
+    };
+
     for (uint8_t i = 0; i < (sizeof(preheat_cmd)/sizeof(preheat_cmd[0])); ++i)
     {
         if (5 == i)  enquecommand_P(_T(MSG_M117_V2_CALIBRATION));
@@ -42,42 +40,42 @@ void lay1cal_preheat()
 
 }
 
-static const char cmd_intro_mmu_0[] PROGMEM = "M83";
-static const char cmd_intro_mmu_1[] PROGMEM = "G1 Y-3.0 F1000.0";
-static const char cmd_intro_mmu_2[] PROGMEM = "G1 Z0.4 F1000.0";
-static const char cmd_intro_mmu_3[] PROGMEM = "G1 X55.0 E32.0 F1073.0"; // call T code before
-static const char cmd_intro_mmu_4[] PROGMEM = "G1 X5.0 E32.0 F1800.0";
-static const char cmd_intro_mmu_5[] PROGMEM = "G1 X55.0 E8.0 F2000.0";
-static const char cmd_intro_mmu_6[] PROGMEM = "G1 Z0.3 F1000.0";
-static const char cmd_intro_mmu_7[] PROGMEM = "G92 E0.0";
-static const char cmd_intro_mmu_8[] PROGMEM = "G1 X240.0 E25.0  F2200.0";
-static const char cmd_intro_mmu_9[] PROGMEM = "G1 Y-2.0 F1000.0";
-static const char cmd_intro_mmu_10[] PROGMEM = "G1 X55.0 E25 F1400.0";
-static const char cmd_intro_mmu_11[] PROGMEM = "G1 Z0.20 F1000.0";
-static const char cmd_intro_mmu_12[] PROGMEM = "G1 X5.0 E4.0 F1000.0";
-
-static const char * const intro_mmu_cmd[] PROGMEM =
-{
-    cmd_intro_mmu_0,
-    cmd_intro_mmu_1,
-    cmd_intro_mmu_2,
-    cmd_intro_mmu_3, // call T code before
-    cmd_intro_mmu_4,
-    cmd_intro_mmu_5,
-    cmd_intro_mmu_6,
-    cmd_intro_mmu_7,
-    cmd_intro_mmu_8,
-    cmd_intro_mmu_9,
-    cmd_intro_mmu_10,
-    cmd_intro_mmu_11,
-    cmd_intro_mmu_12,
-};
-
 //! @brief Print intro line
 //! @param cmd_buffer character buffer needed to format gcodes
 //! @param filament filament to use (applies for MMU only)
 void lay1cal_intro_line(char *cmd_buffer, uint8_t filament)
 {
+    static const char cmd_intro_mmu_0[] PROGMEM = "M83";
+    static const char cmd_intro_mmu_1[] PROGMEM = "G1 Y-3.0 F1000.0";
+    static const char cmd_intro_mmu_2[] PROGMEM = "G1 Z0.4 F1000.0";
+    static const char cmd_intro_mmu_3[] PROGMEM = "G1 X55.0 E32.0 F1073.0"; // call T code before
+    static const char cmd_intro_mmu_4[] PROGMEM = "G1 X5.0 E32.0 F1800.0";
+    static const char cmd_intro_mmu_5[] PROGMEM = "G1 X55.0 E8.0 F2000.0";
+    static const char cmd_intro_mmu_6[] PROGMEM = "G1 Z0.3 F1000.0";
+    static const char cmd_intro_mmu_7[] PROGMEM = "G92 E0.0";
+    static const char cmd_intro_mmu_8[] PROGMEM = "G1 X240.0 E25.0  F2200.0";
+    static const char cmd_intro_mmu_9[] PROGMEM = "G1 Y-2.0 F1000.0";
+    static const char cmd_intro_mmu_10[] PROGMEM = "G1 X55.0 E25 F1400.0";
+    static const char cmd_intro_mmu_11[] PROGMEM = "G1 Z0.20 F1000.0";
+    static const char cmd_intro_mmu_12[] PROGMEM = "G1 X5.0 E4.0 F1000.0";
+
+    static const char * const intro_mmu_cmd[] PROGMEM =
+    {
+        cmd_intro_mmu_0,
+        cmd_intro_mmu_1,
+        cmd_intro_mmu_2,
+        cmd_intro_mmu_3, // call T code before
+        cmd_intro_mmu_4,
+        cmd_intro_mmu_5,
+        cmd_intro_mmu_6,
+        cmd_intro_mmu_7,
+        cmd_intro_mmu_8,
+        cmd_intro_mmu_9,
+        cmd_intro_mmu_10,
+        cmd_intro_mmu_11,
+        cmd_intro_mmu_12,
+    };
+
     if (mmu_enabled)
     {
         for (uint8_t i = 0; i < (sizeof(intro_mmu_cmd)/sizeof(intro_mmu_cmd[0])); ++i)
@@ -97,72 +95,36 @@ void lay1cal_intro_line(char *cmd_buffer, uint8_t filament)
     }
 }
 
-static const char cmd_pre_meander_0[] PROGMEM = "G92 E0.0";
-static const char cmd_pre_meander_1[] PROGMEM = "G21"; //set units to millimeters TODO unsupported command
-static const char cmd_pre_meander_2[] PROGMEM = "G90"; //use absolute coordinates
-static const char cmd_pre_meander_3[] PROGMEM = "M83"; //use relative distances for extrusion TODO: duplicate
-static const char cmd_pre_meander_4[] PROGMEM = "G1 E-1.50000 F2100.00000";
-static const char cmd_pre_meander_5[] PROGMEM = "G1 Z5 F7200.000";
-static const char cmd_pre_meander_6[] PROGMEM = "M204 S1000"; //set acceleration
-static const char cmd_pre_meander_7[] PROGMEM = "G1 F4000";
-
-static const char * const cmd_pre_meander[] PROGMEM =
-{
-        cmd_pre_meander_0,
-        cmd_pre_meander_1,
-        cmd_pre_meander_2,
-        cmd_pre_meander_3,
-        cmd_pre_meander_4,
-        cmd_pre_meander_5,
-        cmd_pre_meander_6,
-        cmd_pre_meander_7,
-};
-
 //! @brief Setup for printing meander
 void lay1cal_before_meander()
 {
+    static const char cmd_pre_meander_0[] PROGMEM = "G92 E0.0";
+    static const char cmd_pre_meander_1[] PROGMEM = "G21"; //set units to millimeters TODO unsupported command
+    static const char cmd_pre_meander_2[] PROGMEM = "G90"; //use absolute coordinates
+    static const char cmd_pre_meander_3[] PROGMEM = "M83"; //use relative distances for extrusion TODO: duplicate
+    static const char cmd_pre_meander_4[] PROGMEM = "G1 E-1.50000 F2100.00000";
+    static const char cmd_pre_meander_5[] PROGMEM = "G1 Z5 F7200.000";
+    static const char cmd_pre_meander_6[] PROGMEM = "M204 S1000"; //set acceleration
+    static const char cmd_pre_meander_7[] PROGMEM = "G1 F4000";
+
+    static const char * const cmd_pre_meander[] PROGMEM =
+    {
+            cmd_pre_meander_0,
+            cmd_pre_meander_1,
+            cmd_pre_meander_2,
+            cmd_pre_meander_3,
+            cmd_pre_meander_4,
+            cmd_pre_meander_5,
+            cmd_pre_meander_6,
+            cmd_pre_meander_7,
+    };
+
     for (uint8_t i = 0; i < (sizeof(cmd_pre_meander)/sizeof(cmd_pre_meander[0])); ++i)
     {
         enquecommand_P(static_cast<char*>(pgm_read_ptr(&cmd_pre_meander[i])));
     }
 }
 
-static const char cmd_meander_0[] PROGMEM = "G1 X50 Y155";
-static const char cmd_meander_1[] PROGMEM = "G1 Z0.150 F7200.000";
-static const char cmd_meander_2[] PROGMEM = "G1 F1080";
-static const char cmd_meander_3[] PROGMEM = "G1 X75 Y155 E2.5";
-static const char cmd_meander_4[] PROGMEM = "G1 X100 Y155 E2";
-static const char cmd_meander_5[] PROGMEM = "G1 X200 Y155 E2.62773";
-static const char cmd_meander_6[] PROGMEM = "G1 X200 Y135 E0.66174";
-static const char cmd_meander_7[] PROGMEM = "G1 X50 Y135 E3.62773";
-static const char cmd_meander_8[] PROGMEM = "G1 X50 Y115 E0.49386";
-static const char cmd_meander_9[] PROGMEM = "G1 X200 Y115 E3.62773";
-static const char cmd_meander_10[] PROGMEM = "G1 X200 Y95 E0.49386";
-static const char cmd_meander_11[] PROGMEM = "G1 X50 Y95 E3.62773";
-static const char cmd_meander_12[] PROGMEM = "G1 X50 Y75 E0.49386";
-static const char cmd_meander_13[] PROGMEM = "G1 X200 Y75 E3.62773";
-static const char cmd_meander_14[] PROGMEM = "G1 X200 Y55 E0.49386";
-static const char cmd_meander_15[] PROGMEM = "G1 X50 Y55 E3.62773";
-
-static const char * const cmd_meander[] PROGMEM =
-{
-    cmd_meander_0,
-    cmd_meander_1,
-    cmd_meander_2,
-    cmd_meander_3,
-    cmd_meander_4,
-    cmd_meander_5,
-    cmd_meander_6,
-    cmd_meander_7,
-    cmd_meander_8,
-    cmd_meander_9,
-    cmd_meander_10,
-    cmd_meander_11,
-    cmd_meander_12,
-    cmd_meander_13,
-    cmd_meander_14,
-    cmd_meander_15,
-};
 
 //! @brief Count extrude length
 //!
@@ -184,6 +146,43 @@ static const float extr = count_e(heigth, width, length); //!< E axis movement n
 //! @param cmd_buffer character buffer needed to format gcodes
 void lay1cal_meander(char *cmd_buffer)
 {
+    static const char cmd_meander_0[] PROGMEM = "G1 X50 Y155";
+    static const char cmd_meander_1[] PROGMEM = "G1 Z0.150 F7200.000";
+    static const char cmd_meander_2[] PROGMEM = "G1 F1080";
+    static const char cmd_meander_3[] PROGMEM = "G1 X75 Y155 E2.5";
+    static const char cmd_meander_4[] PROGMEM = "G1 X100 Y155 E2";
+    static const char cmd_meander_5[] PROGMEM = "G1 X200 Y155 E2.62773";
+    static const char cmd_meander_6[] PROGMEM = "G1 X200 Y135 E0.66174";
+    static const char cmd_meander_7[] PROGMEM = "G1 X50 Y135 E3.62773";
+    static const char cmd_meander_8[] PROGMEM = "G1 X50 Y115 E0.49386";
+    static const char cmd_meander_9[] PROGMEM = "G1 X200 Y115 E3.62773";
+    static const char cmd_meander_10[] PROGMEM = "G1 X200 Y95 E0.49386";
+    static const char cmd_meander_11[] PROGMEM = "G1 X50 Y95 E3.62773";
+    static const char cmd_meander_12[] PROGMEM = "G1 X50 Y75 E0.49386";
+    static const char cmd_meander_13[] PROGMEM = "G1 X200 Y75 E3.62773";
+    static const char cmd_meander_14[] PROGMEM = "G1 X200 Y55 E0.49386";
+    static const char cmd_meander_15[] PROGMEM = "G1 X50 Y55 E3.62773";
+
+    static const char * const cmd_meander[] PROGMEM =
+    {
+        cmd_meander_0,
+        cmd_meander_1,
+        cmd_meander_2,
+        cmd_meander_3,
+        cmd_meander_4,
+        cmd_meander_5,
+        cmd_meander_6,
+        cmd_meander_7,
+        cmd_meander_8,
+        cmd_meander_9,
+        cmd_meander_10,
+        cmd_meander_11,
+        cmd_meander_12,
+        cmd_meander_13,
+        cmd_meander_14,
+        cmd_meander_15,
+    };
+
     for (uint8_t i = 0; i < (sizeof(cmd_meander)/sizeof(cmd_meander[0])); ++i)
     {
         enquecommand_P(static_cast<char*>(pgm_read_ptr(&cmd_meander[i])));

--- a/Firmware/first_lay_cal.cpp
+++ b/Firmware/first_lay_cal.cpp
@@ -93,3 +93,32 @@ void lay1cal_intro_line(char *cmd_buffer, uint8_t filament)
         enquecommand_P(PSTR("G1 X100.0 E12.5 F1000.0"));
     }
 }
+
+static const char cmd_pre_meander_0[] PROGMEM = "G92 E0.0";
+static const char cmd_pre_meander_1[] PROGMEM = "G21"; //set units to millimeters TODO unsupported command
+static const char cmd_pre_meander_2[] PROGMEM = "G90"; //use absolute coordinates
+static const char cmd_pre_meander_3[] PROGMEM = "M83"; //use relative distances for extrusion TODO: duplicate
+static const char cmd_pre_meander_4[] PROGMEM = "G1 E-1.50000 F2100.00000";
+static const char cmd_pre_meander_5[] PROGMEM = "G1 Z5 F7200.000";
+static const char cmd_pre_meander_6[] PROGMEM = "M204 S1000"; //set acceleration
+static const char cmd_pre_meander_7[] PROGMEM = "G1 F4000";
+
+static const char * const cmd_pre_meander[] PROGMEM =
+{
+        cmd_pre_meander_0,
+        cmd_pre_meander_1,
+        cmd_pre_meander_2,
+        cmd_pre_meander_3,
+        cmd_pre_meander_4,
+        cmd_pre_meander_5,
+        cmd_pre_meander_6,
+        cmd_pre_meander_7,
+};
+
+void lay1cal_before_meander()
+{
+    for (uint8_t i = 0; i < (sizeof(cmd_pre_meander)/sizeof(cmd_pre_meander[0])); ++i)
+    {
+        enquecommand_P(static_cast<char*>(pgm_read_ptr(&cmd_pre_meander[i])));
+    }
+}

--- a/Firmware/first_lay_cal.cpp
+++ b/Firmware/first_lay_cal.cpp
@@ -1,0 +1,30 @@
+/*
+ * first_lay_cal.cpp
+ *
+ *  Created on: Jun 10, 2019
+ *      Author: marek
+ */
+#include "first_lay_cal.h"
+#include "Configuration_prusa.h"
+#include "language.h"
+
+static const char cmd_0[] PROGMEM = "M107";
+static const char cmd_1[] PROGMEM = "M104 S" STRINGIFY(PLA_PREHEAT_HOTEND_TEMP);
+static const char cmd_2[] PROGMEM = "M140 S" STRINGIFY(PLA_PREHEAT_HPB_TEMP);
+static const char cmd_3[] PROGMEM = "M190 S" STRINGIFY(PLA_PREHEAT_HPB_TEMP);
+static const char cmd_4[] PROGMEM = "M109 S" STRINGIFY(PLA_PREHEAT_HOTEND_TEMP);
+static const char cmd_6[] PROGMEM = "G28";
+static const char cmd_7[] PROGMEM = "G92 E0.0";
+
+
+const char * const layer1_cal[8] PROGMEM =
+{
+    cmd_0,
+    cmd_1,
+    cmd_2,
+    cmd_3,
+    cmd_4,
+    MSG_M117_V2_CALIBRATION, //TODO missing internationalization
+    cmd_6,
+    cmd_7,
+};

--- a/Firmware/first_lay_cal.cpp
+++ b/Firmware/first_lay_cal.cpp
@@ -122,3 +122,48 @@ void lay1cal_before_meander()
         enquecommand_P(static_cast<char*>(pgm_read_ptr(&cmd_pre_meander[i])));
     }
 }
+
+static const char cmd_meander_0[] PROGMEM = "G1 X50 Y155";
+static const char cmd_meander_1[] PROGMEM = "G1 Z0.150 F7200.000";
+static const char cmd_meander_2[] PROGMEM = "G1 F1080";
+static const char cmd_meander_3[] PROGMEM = "G1 X75 Y155 E2.5";
+static const char cmd_meander_4[] PROGMEM = "G1 X100 Y155 E2";
+static const char cmd_meander_5[] PROGMEM = "G1 X200 Y155 E2.62773";
+static const char cmd_meander_6[] PROGMEM = "G1 X200 Y135 E0.66174";
+static const char cmd_meander_7[] PROGMEM = "G1 X50 Y135 E3.62773";
+static const char cmd_meander_8[] PROGMEM = "G1 X50 Y115 E0.49386";
+static const char cmd_meander_9[] PROGMEM = "G1 X200 Y115 E3.62773";
+static const char cmd_meander_10[] PROGMEM = "G1 X200 Y95 E0.49386";
+static const char cmd_meander_11[] PROGMEM = "G1 X50 Y95 E3.62773";
+static const char cmd_meander_12[] PROGMEM = "G1 X50 Y75 E0.49386";
+static const char cmd_meander_13[] PROGMEM = "G1 X200 Y75 E3.62773";
+static const char cmd_meander_14[] PROGMEM = "G1 X200 Y55 E0.49386";
+static const char cmd_meander_15[] PROGMEM = "G1 X50 Y55 E3.62773";
+
+static const char * const cmd_meander[] PROGMEM =
+{
+    cmd_meander_0,
+    cmd_meander_1,
+    cmd_meander_2,
+    cmd_meander_3,
+    cmd_meander_4,
+    cmd_meander_5,
+    cmd_meander_6,
+    cmd_meander_7,
+    cmd_meander_8,
+    cmd_meander_9,
+    cmd_meander_10,
+    cmd_meander_11,
+    cmd_meander_12,
+    cmd_meander_13,
+    cmd_meander_14,
+    cmd_meander_15,
+};
+
+void lay1cal_meander()
+{
+    for (uint8_t i = 0; i < (sizeof(cmd_meander)/sizeof(cmd_meander[0])); ++i)
+    {
+        enquecommand_P(static_cast<char*>(pgm_read_ptr(&cmd_meander[i])));
+    }
+}

--- a/Firmware/first_lay_cal.cpp
+++ b/Firmware/first_lay_cal.cpp
@@ -7,24 +7,36 @@
 #include "first_lay_cal.h"
 #include "Configuration_prusa.h"
 #include "language.h"
+#include "Marlin.h"
+#include <avr/pgmspace.h>
+
 
 static const char cmd_0[] PROGMEM = "M107";
 static const char cmd_1[] PROGMEM = "M104 S" STRINGIFY(PLA_PREHEAT_HOTEND_TEMP);
 static const char cmd_2[] PROGMEM = "M140 S" STRINGIFY(PLA_PREHEAT_HPB_TEMP);
 static const char cmd_3[] PROGMEM = "M190 S" STRINGIFY(PLA_PREHEAT_HPB_TEMP);
 static const char cmd_4[] PROGMEM = "M109 S" STRINGIFY(PLA_PREHEAT_HOTEND_TEMP);
-static const char cmd_6[] PROGMEM = "G28";
-static const char cmd_7[] PROGMEM = "G92 E0.0";
+static const char cmd_5[] PROGMEM = "G28";
+static const char cmd_6[] PROGMEM = "G92 E0.0";
 
 
-const char * const layer1_cal[8] PROGMEM =
+static const char * const preheat_cmd[] PROGMEM =
 {
     cmd_0,
     cmd_1,
     cmd_2,
     cmd_3,
     cmd_4,
-    MSG_M117_V2_CALIBRATION, //TODO missing internationalization
+    cmd_5, //call MSG_M117_V2_CALIBRATION before
     cmd_6,
-    cmd_7,
 };
+
+void lay1cal_preheat()
+{
+    for (uint8_t i = 0; i < (sizeof(preheat_cmd)/sizeof(preheat_cmd[0])); ++i)
+    {
+        if (5 == i)  enquecommand_P(_T(MSG_M117_V2_CALIBRATION));
+        enquecommand_P(static_cast<char*>(pgm_read_ptr(&preheat_cmd[i])));
+    }
+
+}

--- a/Firmware/first_lay_cal.cpp
+++ b/Firmware/first_lay_cal.cpp
@@ -1,9 +1,8 @@
-/*
- * first_lay_cal.cpp
- *
- *  Created on: Jun 10, 2019
- *      Author: marek
- */
+//! @file
+//! @date Jun 10, 2019
+//! @author Marek Bel
+//! @brief First layer (Z offset) calibration
+
 #include "first_lay_cal.h"
 #include "Configuration_prusa.h"
 #include "language.h"
@@ -32,6 +31,7 @@ static const char * const preheat_cmd[] PROGMEM =
     cmd_preheat_6,
 };
 
+//! @brief Preheat
 void lay1cal_preheat()
 {
     for (uint8_t i = 0; i < (sizeof(preheat_cmd)/sizeof(preheat_cmd[0])); ++i)
@@ -73,6 +73,9 @@ static const char * const intro_mmu_cmd[] PROGMEM =
     cmd_intro_mmu_12,
 };
 
+//! @brief Print intro line
+//! @param cmd_buffer character buffer needed to format gcodes
+//! @param filament filament to use (applies for MMU only)
 void lay1cal_intro_line(char *cmd_buffer, uint8_t filament)
 {
     if (mmu_enabled)
@@ -115,6 +118,7 @@ static const char * const cmd_pre_meander[] PROGMEM =
         cmd_pre_meander_7,
 };
 
+//! @brief Setup for printing meander
 void lay1cal_before_meander()
 {
     for (uint8_t i = 0; i < (sizeof(cmd_pre_meander)/sizeof(cmd_pre_meander[0])); ++i)
@@ -171,11 +175,13 @@ static constexpr float count_e(float layer_heigth, float extrusion_width, float 
     return (extrusion_length * layer_heigth * extrusion_width / (M_PI * pow(1.75, 2) / 4));
 }
 
-static const float width = 0.4;
-static const float length = 20 - width;
-static const float heigth = 0.2; //!< TODO This is wrong, as current Z height is 0.15 mm
-static const float extr = count_e(heigth, width, length);
+static const float width = 0.4; //!< line width
+static const float length = 20 - width; //!< line length
+static const float heigth = 0.2; //!< layer height TODO This is wrong, as current Z height is 0.15 mm
+static const float extr = count_e(heigth, width, length); //!< E axis movement needed to print line
 
+//! @brief Print meander
+//! @param cmd_buffer character buffer needed to format gcodes
 void lay1cal_meander(char *cmd_buffer)
 {
     for (uint8_t i = 0; i < (sizeof(cmd_meander)/sizeof(cmd_meander[0])); ++i)
@@ -190,8 +196,8 @@ void lay1cal_meander(char *cmd_buffer)
 //!
 //! This function needs to be called 16 times for i from 0 to 15.
 //!
-//! @par cmd_buffer character buffer needed to format gcodes
-//! @par i iteration
+//! @param cmd_buffer character buffer needed to format gcodes
+//! @param i iteration
 void lay1cal_square(char *cmd_buffer, uint8_t i)
 {
     const float extr_short_segment = count_e(heigth, width, width);

--- a/Firmware/first_lay_cal.h
+++ b/Firmware/first_lay_cal.h
@@ -11,6 +11,7 @@
 
 void lay1cal_preheat();
 void lay1cal_intro_line(char *cmd_buffer, uint8_t filament);
+void lay1cal_before_meander();
 
 
 

--- a/Firmware/first_lay_cal.h
+++ b/Firmware/first_lay_cal.h
@@ -1,0 +1,16 @@
+/*
+ * first_lay_cal.h
+ *
+ *  Created on: Jun 10, 2019
+ *      Author: marek
+ */
+
+#ifndef FIRMWARE_FIRST_LAY_CAL_H_
+#define FIRMWARE_FIRST_LAY_CAL_H_
+#include <avr/pgmspace.h>
+
+
+extern const char * const layer1_cal[8] PROGMEM;
+
+
+#endif /* FIRMWARE_FIRST_LAY_CAL_H_ */

--- a/Firmware/first_lay_cal.h
+++ b/Firmware/first_lay_cal.h
@@ -12,8 +12,7 @@
 void lay1cal_preheat();
 void lay1cal_intro_line(char *cmd_buffer, uint8_t filament);
 void lay1cal_before_meander();
-void lay1cal_meander();
-
-
+void lay1cal_meander(char *cmd_buffer);
+void lay1cal_square(char *cmd_buffer, uint8_t i);
 
 #endif /* FIRMWARE_FIRST_LAY_CAL_H_ */

--- a/Firmware/first_lay_cal.h
+++ b/Firmware/first_lay_cal.h
@@ -1,9 +1,6 @@
-/*
- * first_lay_cal.h
- *
- *  Created on: Jun 10, 2019
- *      Author: marek
- */
+//! @file
+//! @date Jun 10, 2019
+//! @author Marek Bel
 
 #ifndef FIRMWARE_FIRST_LAY_CAL_H_
 #define FIRMWARE_FIRST_LAY_CAL_H_

--- a/Firmware/first_lay_cal.h
+++ b/Firmware/first_lay_cal.h
@@ -12,6 +12,7 @@
 void lay1cal_preheat();
 void lay1cal_intro_line(char *cmd_buffer, uint8_t filament);
 void lay1cal_before_meander();
+void lay1cal_meander();
 
 
 

--- a/Firmware/first_lay_cal.h
+++ b/Firmware/first_lay_cal.h
@@ -7,10 +7,9 @@
 
 #ifndef FIRMWARE_FIRST_LAY_CAL_H_
 #define FIRMWARE_FIRST_LAY_CAL_H_
-#include <avr/pgmspace.h>
 
+void lay1cal_preheat();
 
-extern const char * const layer1_cal[8] PROGMEM;
 
 
 #endif /* FIRMWARE_FIRST_LAY_CAL_H_ */

--- a/Firmware/first_lay_cal.h
+++ b/Firmware/first_lay_cal.h
@@ -7,8 +7,10 @@
 
 #ifndef FIRMWARE_FIRST_LAY_CAL_H_
 #define FIRMWARE_FIRST_LAY_CAL_H_
+#include <stdint.h>
 
 void lay1cal_preheat();
+void lay1cal_intro_line(char *cmd_buffer, uint8_t filament);
 
 
 

--- a/Firmware/temperature.cpp
+++ b/Firmware/temperature.cpp
@@ -434,7 +434,7 @@ static void temp_runaway_stop(bool isPreheat, bool isBed);
 void updatePID()
 {
 #ifdef PIDTEMP
-  for(uint8_t e = 0; e < EXTRUDERS; e++) { 
+  for(uint_least8_t e = 0; e < EXTRUDERS; e++) {
      iState_sum_max[e] = PID_INTEGRAL_DRIVE_MAX / cs.Ki;  
   }
 #endif

--- a/Firmware/temperature.cpp
+++ b/Firmware/temperature.cpp
@@ -434,7 +434,7 @@ static void temp_runaway_stop(bool isPreheat, bool isBed);
 void updatePID()
 {
 #ifdef PIDTEMP
-  for(int e = 0; e < EXTRUDERS; e++) { 
+  for(uint8_t e = 0; e < EXTRUDERS; e++) { 
      iState_sum_max[e] = PID_INTEGRAL_DRIVE_MAX / cs.Ki;  
   }
 #endif

--- a/Firmware/tmc2130.cpp
+++ b/Firmware/tmc2130.cpp
@@ -158,7 +158,7 @@ void tmc2130_init()
 	SET_INPUT(Y_TMC2130_DIAG);
 	SET_INPUT(Z_TMC2130_DIAG);
 	SET_INPUT(E0_TMC2130_DIAG);
-	for (uint8_t axis = 0; axis < 2; axis++) // X Y axes
+	for (uint_least8_t axis = 0; axis < 2; axis++) // X Y axes
 	{
 		tmc2130_setup_chopper(axis, tmc2130_mres[axis], tmc2130_current_h[axis], tmc2130_current_r[axis]);
 		tmc2130_wr(axis, TMC2130_REG_TPOWERDOWN, 0x00000000);
@@ -169,7 +169,7 @@ void tmc2130_init()
 		tmc2130_wr_TPWMTHRS(axis, TMC2130_TPWMTHRS);
 		//tmc2130_wr_THIGH(axis, TMC2130_THIGH);
 	}
-	for (uint8_t axis = 2; axis < 3; axis++) // Z axis
+	for (uint_least8_t axis = 2; axis < 3; axis++) // Z axis
 	{
 		tmc2130_setup_chopper(axis, tmc2130_mres[axis], tmc2130_current_h[axis], tmc2130_current_r[axis]);
 		tmc2130_wr(axis, TMC2130_REG_TPOWERDOWN, 0x00000000);
@@ -183,7 +183,7 @@ void tmc2130_init()
 		tmc2130_wr_TPWMTHRS(axis, TMC2130_TPWMTHRS);
 #endif //TMC2130_STEALTH_Z
 	}
-	for (uint8_t axis = 3; axis < 4; axis++) // E axis
+	for (uint_least8_t axis = 3; axis < 4; axis++) // E axis
 	{
 		tmc2130_setup_chopper(axis, tmc2130_mres[axis], tmc2130_current_h[axis], tmc2130_current_r[axis]);
 		tmc2130_wr(axis, TMC2130_REG_TPOWERDOWN, 0x00000000);
@@ -383,7 +383,7 @@ void tmc2130_check_overtemp()
 	static uint32_t checktime = 0;
 	if (_millis() - checktime > 1000 )
 	{
-		for (uint8_t i = 0; i < 4; i++)
+		for (uint_least8_t i = 0; i < 4; i++)
 		{
 			uint32_t drv_status = 0;
 			skip_debug_msg = true;
@@ -392,7 +392,7 @@ void tmc2130_check_overtemp()
 			{ // BIT 26 - over temp prewarning ~120C (+-20C)
 				SERIAL_ERRORRPGM(MSG_TMC_OVERTEMP);
 				SERIAL_ECHOLN(i);
-				for (uint8_t j = 0; j < 4; j++)
+				for (uint_least8_t j = 0; j < 4; j++)
 					tmc2130_wr(j, TMC2130_REG_CHOPCONF, 0x00010000);
 				kill(MSG_TMC_OVERTEMP);
 			}

--- a/Firmware/tmc2130.cpp
+++ b/Firmware/tmc2130.cpp
@@ -158,7 +158,7 @@ void tmc2130_init()
 	SET_INPUT(Y_TMC2130_DIAG);
 	SET_INPUT(Z_TMC2130_DIAG);
 	SET_INPUT(E0_TMC2130_DIAG);
-	for (int axis = 0; axis < 2; axis++) // X Y axes
+	for (uint8_t axis = 0; axis < 2; axis++) // X Y axes
 	{
 		tmc2130_setup_chopper(axis, tmc2130_mres[axis], tmc2130_current_h[axis], tmc2130_current_r[axis]);
 		tmc2130_wr(axis, TMC2130_REG_TPOWERDOWN, 0x00000000);
@@ -169,7 +169,7 @@ void tmc2130_init()
 		tmc2130_wr_TPWMTHRS(axis, TMC2130_TPWMTHRS);
 		//tmc2130_wr_THIGH(axis, TMC2130_THIGH);
 	}
-	for (int axis = 2; axis < 3; axis++) // Z axis
+	for (uint8_t axis = 2; axis < 3; axis++) // Z axis
 	{
 		tmc2130_setup_chopper(axis, tmc2130_mres[axis], tmc2130_current_h[axis], tmc2130_current_r[axis]);
 		tmc2130_wr(axis, TMC2130_REG_TPOWERDOWN, 0x00000000);
@@ -183,7 +183,7 @@ void tmc2130_init()
 		tmc2130_wr_TPWMTHRS(axis, TMC2130_TPWMTHRS);
 #endif //TMC2130_STEALTH_Z
 	}
-	for (int axis = 3; axis < 4; axis++) // E axis
+	for (uint8_t axis = 3; axis < 4; axis++) // E axis
 	{
 		tmc2130_setup_chopper(axis, tmc2130_mres[axis], tmc2130_current_h[axis], tmc2130_current_r[axis]);
 		tmc2130_wr(axis, TMC2130_REG_TPOWERDOWN, 0x00000000);
@@ -383,7 +383,7 @@ void tmc2130_check_overtemp()
 	static uint32_t checktime = 0;
 	if (_millis() - checktime > 1000 )
 	{
-		for (int i = 0; i < 4; i++)
+		for (uint8_t i = 0; i < 4; i++)
 		{
 			uint32_t drv_status = 0;
 			skip_debug_msg = true;
@@ -392,7 +392,7 @@ void tmc2130_check_overtemp()
 			{ // BIT 26 - over temp prewarning ~120C (+-20C)
 				SERIAL_ERRORRPGM(MSG_TMC_OVERTEMP);
 				SERIAL_ECHOLN(i);
-				for (int j = 0; j < 4; j++)
+				for (uint8_t j = 0; j < 4; j++)
 					tmc2130_wr(j, TMC2130_REG_CHOPCONF, 0x00010000);
 				kill(MSG_TMC_OVERTEMP);
 			}

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1363,10 +1363,10 @@ void lcd_commands()
 	{
 		char cmd1[30];
 		static uint8_t filament = 0;
-		float width = 0.4;
-		float length = 20 - width;
-		float extr = count_e(0.2, width, length);
-		float extr_short_segment = count_e(0.2, width, width);
+		const float width = 0.4;
+		const float length = 20 - width;
+		const float extr = count_e(0.2, width, length);
+		const float extr_short_segment = count_e(0.2, width, width);
 		if(lcd_commands_step>1) lcd_timeoutToStatus.start(); //if user dont confirm live adjust Z value by pressing the knob, we are saving last value by timeout to status screen
 
 		if (lcd_commands_step == 0 && !blocks_queued() && cmd_buffer_empty())

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -317,7 +317,7 @@ static void lcd_implementation_drawmenu_sdfile_selected(uint8_t row, char* longF
     char c;
     int enc_dif = lcd_encoder_diff;
     uint8_t n = LCD_WIDTH - 1;
-    for(int g = 0; g<4;g++){
+    for(uint8_t g = 0; g<4;g++){
       lcd_set_cursor(0, g);
     lcd_print(' ');
     }
@@ -2578,11 +2578,11 @@ void lcd_change_success() {
 
 static void lcd_loading_progress_bar(uint16_t loading_time_ms) { 
 	
-	for (int i = 0; i < 20; i++) {
+	for (uint8_t i = 0; i < 20; i++) {
 		lcd_set_cursor(i, 3);
 		lcd_print(".");
 		//loading_time_ms/20 delay
-		for (int j = 0; j < 5; j++) {
+		for (uint8_t j = 0; j < 5; j++) {
 			delay_keep_alive(loading_time_ms / 100);
 		}
 	}
@@ -3024,7 +3024,7 @@ static void lcd_menu_xyz_offset()
     float cntr[2];
     world2machine_read_valid(vec_x, vec_y, cntr);
 
-    for (int i = 0; i < 2; i++)
+    for (uint8_t i = 0; i < 2; i++)
     {
         lcd_puts_at_P(11, i + 2, PSTR(""));
         lcd_print(cntr[i]);
@@ -4692,7 +4692,7 @@ void lcd_v2_calibration()
 		else {
 			lcd_display_message_fullscreen_P(_i("Please load PLA filament first."));////MSG_PLEASE_LOAD_PLA c=20 r=4
 			lcd_consume_click();
-			for (int i = 0; i < 20; i++) { //wait max. 2s
+			for (uint8_t i = 0; i < 20; i++) { //wait max. 2s
 				delay_keep_alive(100);
 				if (lcd_clicked()) {
 					break;
@@ -5419,7 +5419,7 @@ void bowden_menu() {
 	lcd_clear();
 	lcd_set_cursor(0, 0);
 	lcd_print(">");
-	for (int i = 0; i < 4; i++) {
+	for (uint8_t i = 0; i < 4; i++) {
 		lcd_set_cursor(1, i);
 		lcd_print("Extruder ");
 		lcd_print(i);
@@ -5507,7 +5507,7 @@ void bowden_menu() {
 						enc_dif = lcd_encoder_diff;
 						lcd_set_cursor(0, cursor_pos);
 						lcd_print(">");
-						for (int i = 0; i < 4; i++) {
+						for (uint8_t i = 0; i < 4; i++) {
 							lcd_set_cursor(1, i);
 							lcd_print("Extruder ");
 							lcd_print(i);
@@ -5634,14 +5634,14 @@ uint8_t choose_menu_P(const char *header, const char *item, const char *last_ite
         if (header) lcd_puts_at_P(0,0,header);
 
         const bool last_visible = (first == items_no - 3);
-        const int8_t ordinary_items = (last_item&&last_visible)?2:3;
+        const uint8_t ordinary_items = (last_item&&last_visible)?2:3;
 
-        for (int i = 0; i < ordinary_items; i++)
+        for (uint8_t i = 0; i < ordinary_items; i++)
         {
             if (item) lcd_puts_at_P(1, i + 1, item);
         }
 
-        for (int i = 0; i < ordinary_items; i++)
+        for (uint8_t i = 0; i < ordinary_items; i++)
         {
             lcd_set_cursor(2 + item_len, i+1);
             lcd_print(first + i + 1);
@@ -5695,7 +5695,7 @@ char reset_menu() {
 	lcd_consume_click();
 	while (1) {		
 
-		for (int i = 0; i < 4; i++) {
+		for (uint8_t i = 0; i < 4; i++) {
 			lcd_set_cursor(1, i);
 			lcd_print(item[first + i]);
 		}
@@ -6021,7 +6021,7 @@ unsigned char lcd_choose_color() {
 	item[0] = "Orange";
 	item[1] = "Black";
 	//-----------------------------------------------------
-	unsigned char active_rows;
+	uint8_t active_rows;
 	static int first = 0;
 	int enc_dif = 0;
 	unsigned char cursor_pos = 1;
@@ -6034,7 +6034,7 @@ unsigned char lcd_choose_color() {
 	lcd_consume_click();
 	while (1) {
 		lcd_puts_at_P(0, 0, PSTR("Choose color:"));
-		for (int i = 0; i < active_rows; i++) {
+		for (uint8_t i = 0; i < active_rows; i++) {
 			lcd_set_cursor(1, i+1);
 			lcd_print(item[first + i]);
 		}
@@ -7071,7 +7071,7 @@ static bool lcd_selfcheck_axis_sg(unsigned char axis) {
 
 //end of second measurement, now check for possible errors:
 
-	for(int i = 0; i < 2; i++){ //check if measured axis length corresponds to expected length
+	for(uint8_t i = 0; i < 2; i++){ //check if measured axis length corresponds to expected length
 		printf_P(_N("Measured axis length:%.3f\n"), measured_axis_length[i]);
 		if (abs(measured_axis_length[i] - axis_length) > max_error_mm) {
 			enable_endstops(false);
@@ -7935,7 +7935,7 @@ static void menu_action_sdfile(const char* filename)
   const char end[5] = ".gco";
 
   //we are storing just first 8 characters of 8.3 filename assuming that extension is always ".gco"
-  for (int i = 0; i < 8; i++) {
+  for (uint8_t i = 0; i < 8; i++) {
 	  if (strcmp((cmd + i + 4), end) == 0) { 
 		  //filename is shorter then 8.3, store '\0' character on position where ".gco" string was found to terminate stored string properly
  		  eeprom_write_byte((uint8_t*)EEPROM_FILENAME + i, '\0');
@@ -7950,7 +7950,7 @@ static void menu_action_sdfile(const char* filename)
   eeprom_write_byte((uint8_t*)EEPROM_DIR_DEPTH, depth);
 
   for (uint8_t i = 0; i < depth; i++) {
-	  for (int j = 0; j < 8; j++) {
+	  for (uint8_t j = 0; j < 8; j++) {
 		  eeprom_write_byte((uint8_t*)EEPROM_DIRS + j + 8 * i, dir_names[i][j]);
 	  }
   }

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1413,22 +1413,7 @@ void lcd_commands()
                 lcd_commands_step = 7;
                 break;
             case 7:
-                enquecommand_P(PSTR("G1 X50 Y155"));
-                enquecommand_P(PSTR("G1 Z0.150 F7200.000"));
-                enquecommand_P(PSTR("G1 F1080"));
-                enquecommand_P(PSTR("G1 X75 Y155 E2.5"));
-                enquecommand_P(PSTR("G1 X100 Y155 E2"));
-                enquecommand_P(PSTR("G1 X200 Y155 E2.62773"));
-                enquecommand_P(PSTR("G1 X200 Y135 E0.66174"));
-                enquecommand_P(PSTR("G1 X50 Y135 E3.62773"));
-                enquecommand_P(PSTR("G1 X50 Y115 E0.49386"));
-                enquecommand_P(PSTR("G1 X200 Y115 E3.62773"));
-                enquecommand_P(PSTR("G1 X200 Y95 E0.49386"));
-                enquecommand_P(PSTR("G1 X50 Y95 E3.62773"));
-                enquecommand_P(PSTR("G1 X50 Y75 E0.49386"));
-                enquecommand_P(PSTR("G1 X200 Y75 E3.62773"));
-                enquecommand_P(PSTR("G1 X200 Y55 E0.49386"));
-                enquecommand_P(PSTR("G1 X50 Y55 E3.62773"));
+                lay1cal_meander();
 
                 strcpy(cmd1, "G1 X50 Y35 E");
                 strcat(cmd1, ftostr43(extr));

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -40,6 +40,7 @@
 
 #include "static_assert.h"
 #include "io_atmega2560.h"
+#include "first_lay_cal.h"
 
 
 int scrollstuff = 0;
@@ -1386,15 +1387,10 @@ void lcd_commands()
 
 		if (lcd_commands_step == 10)
 		{
-			enquecommand_P(PSTR("M107"));
-			enquecommand_P(PSTR("M104 S" STRINGIFY(PLA_PREHEAT_HOTEND_TEMP)));
-			enquecommand_P(PSTR("M140 S" STRINGIFY(PLA_PREHEAT_HPB_TEMP)));
-			enquecommand_P(PSTR("M190 S" STRINGIFY(PLA_PREHEAT_HPB_TEMP)));
-            enquecommand_P(PSTR("M109 S" STRINGIFY(PLA_PREHEAT_HOTEND_TEMP)));
-			enquecommand_P(_T(MSG_M117_V2_CALIBRATION));
-			enquecommand_P(PSTR("G28"));
-			enquecommand_P(PSTR("G92 E0.0"));
-
+		    for (uint8_t i = 0; i < (sizeof(layer1_cal)/sizeof(layer1_cal[0])); ++i)
+		    {
+		        enquecommand_P(static_cast<char*>(pgm_read_ptr(&layer1_cal[i])));
+		    }
             lcd_commands_step = 9;
 		}
         if (lcd_commands_step == 9 && !blocks_queued() && cmd_buffer_empty())

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -74,8 +74,8 @@ extern void crashdet_disable();
 bool presort_flag = false;
 #endif
 
-int lcd_commands_type = LCD_COMMAND_IDLE;
-int lcd_commands_step = 0;
+uint8_t lcd_commands_type = LCD_COMMAND_IDLE;
+uint8_t lcd_commands_step = 0;
 
 unsigned int custom_message_type = CUSTOM_MSG_TYPE_STATUS;
 unsigned int custom_message_state = 0;
@@ -1061,6 +1061,20 @@ static void lcd_status_screen()
 		feedmultiply = 999;
 }
 
+//! extracted common code from lcd_commands into a separate function
+//! along with the sprintf_P optimization this change gained more than 1.6KB
+static void lcd_commands_func1(char *cmd1, uint8_t i, float width, float extr, float extr_short_segment){
+	static const char fmt1[] PROGMEM = "G1 X%d Y%-.2f E%-.3f";
+	static const char fmt2[] PROGMEM = "G1 Y%-.2f E%-.3f";
+	sprintf_P(cmd1, fmt1, 70, (35 - i*width * 2), extr); 
+	enquecommand(cmd1);
+	sprintf_P(cmd1, fmt2, (35 - (2 * i + 1)*width), extr_short_segment);
+	enquecommand(cmd1);
+	sprintf_P(cmd1, fmt1, 50, (35 - (2 * i + 1)*width), extr);
+	enquecommand(cmd1);
+	sprintf_P(cmd1, fmt2, (35 - (i + 1)*width * 2), extr_short_segment); 
+	enquecommand(cmd1);
+}
 
 void lcd_commands()
 {	
@@ -1466,27 +1480,8 @@ void lcd_commands()
 
 			lcd_timeoutToStatus.start();
 
-			for (int i = 0; i < 4; i++) {
-				strcpy(cmd1, "G1 X70 Y");
-				strcat(cmd1, ftostr32(35 - i*width * 2));
-				strcat(cmd1, " E");
-				strcat(cmd1, ftostr43(extr));
-				enquecommand(cmd1);
-				strcpy(cmd1, "G1 Y");
-				strcat(cmd1, ftostr32(35 - (2 * i + 1)*width));
-				strcat(cmd1, " E");
-				strcat(cmd1, ftostr43(extr_short_segment));
-				enquecommand(cmd1);
-				strcpy(cmd1, "G1 X50 Y");
-				strcat(cmd1, ftostr32(35 - (2 * i + 1)*width));
-				strcat(cmd1, " E");
-				strcat(cmd1, ftostr43(extr));
-				enquecommand(cmd1);
-				strcpy(cmd1, "G1 Y");
-				strcat(cmd1, ftostr32(35 - (i + 1)*width * 2));
-				strcat(cmd1, " E");
-				strcat(cmd1, ftostr43(extr_short_segment));
-				enquecommand(cmd1);
+			for (uint8_t i = 0; i < 4; i++) {
+				lcd_commands_func1(cmd1, i, width, extr, extr_short_segment );
 			}
 
 			lcd_commands_step = 5;
@@ -1495,56 +1490,18 @@ void lcd_commands()
 		if (lcd_commands_step == 5 && !blocks_queued() && cmd_buffer_empty())
 		{
 			lcd_timeoutToStatus.start();
-			for (int i = 4; i < 8; i++) {
-				strcpy(cmd1, "G1 X70 Y");
-				strcat(cmd1, ftostr32(35 - i*width * 2));
-				strcat(cmd1, " E");
-				strcat(cmd1, ftostr43(extr));
-				enquecommand(cmd1);
-				strcpy(cmd1, "G1 Y");
-				strcat(cmd1, ftostr32(35 - (2 * i + 1)*width));
-				strcat(cmd1, " E");
-				strcat(cmd1, ftostr43(extr_short_segment));
-				enquecommand(cmd1);
-				strcpy(cmd1, "G1 X50 Y");
-				strcat(cmd1, ftostr32(35 - (2 * i + 1)*width));
-				strcat(cmd1, " E");
-				strcat(cmd1, ftostr43(extr));
-				enquecommand(cmd1);
-				strcpy(cmd1, "G1 Y");
-				strcat(cmd1, ftostr32(35 - (i + 1)*width * 2));
-				strcat(cmd1, " E");
-				strcat(cmd1, ftostr43(extr_short_segment));
-				enquecommand(cmd1);
+			for (uint8_t i = 4; i < 8; i++) {
+				lcd_commands_func1(cmd1, i, width, extr, extr_short_segment );
 			}
 
 			lcd_commands_step = 4;
 		}
-
+		
 		if (lcd_commands_step == 4 && !blocks_queued() && cmd_buffer_empty())
 		{
-			lcd_timeoutToStatus.start();
-			for (int i = 8; i < 12; i++) {
-				strcpy(cmd1, "G1 X70 Y");
-				strcat(cmd1, ftostr32(35 - i*width * 2));
-				strcat(cmd1, " E");
-				strcat(cmd1, ftostr43(extr));
-				enquecommand(cmd1);
-				strcpy(cmd1, "G1 Y");
-				strcat(cmd1, ftostr32(35 - (2 * i + 1)*width));
-				strcat(cmd1, " E");
-				strcat(cmd1, ftostr43(extr_short_segment));
-				enquecommand(cmd1);
-				strcpy(cmd1, "G1 X50 Y");
-				strcat(cmd1, ftostr32(35 - (2 * i + 1)*width));
-				strcat(cmd1, " E");
-				strcat(cmd1, ftostr43(extr));
-				enquecommand(cmd1);
-				strcpy(cmd1, "G1 Y");
-				strcat(cmd1, ftostr32(35 - (i + 1)*width * 2));
-				strcat(cmd1, " E");
-				strcat(cmd1, ftostr43(extr_short_segment));
-				enquecommand(cmd1);
+			lcd_timeoutToStatus.start();			
+			for (uint8_t i = 8; i < 12; i++) {
+				lcd_commands_func1(cmd1, i, width, extr, extr_short_segment );
 			}
 
 			lcd_commands_step = 3;
@@ -1553,27 +1510,8 @@ void lcd_commands()
 		if (lcd_commands_step == 3 && !blocks_queued() && cmd_buffer_empty())
 		{
 			lcd_timeoutToStatus.start();
-			for (int i = 12; i < 16; i++) {
-				strcpy(cmd1, "G1 X70 Y");
-				strcat(cmd1, ftostr32(35 - i*width * 2));
-				strcat(cmd1, " E");
-				strcat(cmd1, ftostr43(extr));
-				enquecommand(cmd1);
-				strcpy(cmd1, "G1 Y");
-				strcat(cmd1, ftostr32(35 - (2 * i + 1)*width));
-				strcat(cmd1, " E");
-				strcat(cmd1, ftostr43(extr_short_segment));
-				enquecommand(cmd1);
-				strcpy(cmd1, "G1 X50 Y");
-				strcat(cmd1, ftostr32(35 - (2 * i + 1)*width));
-				strcat(cmd1, " E");
-				strcat(cmd1, ftostr43(extr));
-				enquecommand(cmd1);
-				strcpy(cmd1, "G1 Y");
-				strcat(cmd1, ftostr32(35 - (i + 1)*width * 2));
-				strcat(cmd1, " E");
-				strcat(cmd1, ftostr43(extr_short_segment));
-				enquecommand(cmd1);
+			for (uint8_t i = 12; i < 16; i++) {
+				lcd_commands_func1(cmd1, i, width, extr, extr_short_segment );
 			}
 
 			lcd_commands_step = 2;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -317,7 +317,7 @@ static void lcd_implementation_drawmenu_sdfile_selected(uint8_t row, char* longF
     char c;
     int enc_dif = lcd_encoder_diff;
     uint8_t n = LCD_WIDTH - 1;
-    for(uint8_t g = 0; g<4;g++){
+    for(uint_least8_t g = 0; g<4;g++){
       lcd_set_cursor(0, g);
     lcd_print(' ');
     }
@@ -2578,11 +2578,11 @@ void lcd_change_success() {
 
 static void lcd_loading_progress_bar(uint16_t loading_time_ms) { 
 	
-	for (uint8_t i = 0; i < 20; i++) {
+	for (uint_least8_t i = 0; i < 20; i++) {
 		lcd_set_cursor(i, 3);
 		lcd_print(".");
 		//loading_time_ms/20 delay
-		for (uint8_t j = 0; j < 5; j++) {
+		for (uint_least8_t j = 0; j < 5; j++) {
 			delay_keep_alive(loading_time_ms / 100);
 		}
 	}
@@ -3024,7 +3024,7 @@ static void lcd_menu_xyz_offset()
     float cntr[2];
     world2machine_read_valid(vec_x, vec_y, cntr);
 
-    for (uint8_t i = 0; i < 2; i++)
+    for (uint_least8_t i = 0; i < 2; i++)
     {
         lcd_puts_at_P(11, i + 2, PSTR(""));
         lcd_print(cntr[i]);
@@ -4692,7 +4692,7 @@ void lcd_v2_calibration()
 		else {
 			lcd_display_message_fullscreen_P(_i("Please load PLA filament first."));////MSG_PLEASE_LOAD_PLA c=20 r=4
 			lcd_consume_click();
-			for (uint8_t i = 0; i < 20; i++) { //wait max. 2s
+			for (uint_least8_t i = 0; i < 20; i++) { //wait max. 2s
 				delay_keep_alive(100);
 				if (lcd_clicked()) {
 					break;
@@ -5419,7 +5419,7 @@ void bowden_menu() {
 	lcd_clear();
 	lcd_set_cursor(0, 0);
 	lcd_print(">");
-	for (uint8_t i = 0; i < 4; i++) {
+	for (uint_least8_t i = 0; i < 4; i++) {
 		lcd_set_cursor(1, i);
 		lcd_print("Extruder ");
 		lcd_print(i);
@@ -5507,7 +5507,7 @@ void bowden_menu() {
 						enc_dif = lcd_encoder_diff;
 						lcd_set_cursor(0, cursor_pos);
 						lcd_print(">");
-						for (uint8_t i = 0; i < 4; i++) {
+						for (uint_least8_t i = 0; i < 4; i++) {
 							lcd_set_cursor(1, i);
 							lcd_print("Extruder ");
 							lcd_print(i);
@@ -5634,14 +5634,14 @@ uint8_t choose_menu_P(const char *header, const char *item, const char *last_ite
         if (header) lcd_puts_at_P(0,0,header);
 
         const bool last_visible = (first == items_no - 3);
-        const uint8_t ordinary_items = (last_item&&last_visible)?2:3;
+        const uint_least8_t ordinary_items = (last_item&&last_visible)?2:3;
 
-        for (uint8_t i = 0; i < ordinary_items; i++)
+        for (uint_least8_t i = 0; i < ordinary_items; i++)
         {
             if (item) lcd_puts_at_P(1, i + 1, item);
         }
 
-        for (uint8_t i = 0; i < ordinary_items; i++)
+        for (uint_least8_t i = 0; i < ordinary_items; i++)
         {
             lcd_set_cursor(2 + item_len, i+1);
             lcd_print(first + i + 1);
@@ -5695,7 +5695,7 @@ char reset_menu() {
 	lcd_consume_click();
 	while (1) {		
 
-		for (uint8_t i = 0; i < 4; i++) {
+		for (uint_least8_t i = 0; i < 4; i++) {
 			lcd_set_cursor(1, i);
 			lcd_print(item[first + i]);
 		}
@@ -6021,7 +6021,7 @@ unsigned char lcd_choose_color() {
 	item[0] = "Orange";
 	item[1] = "Black";
 	//-----------------------------------------------------
-	uint8_t active_rows;
+	uint_least8_t active_rows;
 	static int first = 0;
 	int enc_dif = 0;
 	unsigned char cursor_pos = 1;
@@ -6034,7 +6034,7 @@ unsigned char lcd_choose_color() {
 	lcd_consume_click();
 	while (1) {
 		lcd_puts_at_P(0, 0, PSTR("Choose color:"));
-		for (uint8_t i = 0; i < active_rows; i++) {
+		for (uint_least8_t i = 0; i < active_rows; i++) {
 			lcd_set_cursor(1, i+1);
 			lcd_print(item[first + i]);
 		}
@@ -7071,7 +7071,7 @@ static bool lcd_selfcheck_axis_sg(unsigned char axis) {
 
 //end of second measurement, now check for possible errors:
 
-	for(uint8_t i = 0; i < 2; i++){ //check if measured axis length corresponds to expected length
+	for(uint_least8_t i = 0; i < 2; i++){ //check if measured axis length corresponds to expected length
 		printf_P(_N("Measured axis length:%.3f\n"), measured_axis_length[i]);
 		if (abs(measured_axis_length[i] - axis_length) > max_error_mm) {
 			enable_endstops(false);
@@ -7935,7 +7935,7 @@ static void menu_action_sdfile(const char* filename)
   const char end[5] = ".gco";
 
   //we are storing just first 8 characters of 8.3 filename assuming that extension is always ".gco"
-  for (uint8_t i = 0; i < 8; i++) {
+  for (uint_least8_t i = 0; i < 8; i++) {
 	  if (strcmp((cmd + i + 4), end) == 0) { 
 		  //filename is shorter then 8.3, store '\0' character on position where ".gco" string was found to terminate stored string properly
  		  eeprom_write_byte((uint8_t*)EEPROM_FILENAME + i, '\0');
@@ -7949,8 +7949,8 @@ static void menu_action_sdfile(const char* filename)
   uint8_t depth = (uint8_t)card.getWorkDirDepth();
   eeprom_write_byte((uint8_t*)EEPROM_DIR_DEPTH, depth);
 
-  for (uint8_t i = 0; i < depth; i++) {
-	  for (uint8_t j = 0; j < 8; j++) {
+  for (uint_least8_t i = 0; i < depth; i++) {
+	  for (uint_least8_t j = 0; j < 8; j++) {
 		  eeprom_write_byte((uint8_t*)EEPROM_DIRS + j + 8 * i, dir_names[i][j]);
 	  }
   }

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1409,14 +1409,7 @@ void lcd_commands()
                 lcd_commands_step = 8;
                 break;
             case 8:
-                enquecommand_P(PSTR("G92 E0.0"));
-                enquecommand_P(PSTR("G21")); //set units to millimeters
-                enquecommand_P(PSTR("G90")); //use absolute coordinates
-                enquecommand_P(PSTR("M83")); //use relative distances for extrusion
-                enquecommand_P(PSTR("G1 E-1.50000 F2100.00000"));
-                enquecommand_P(PSTR("G1 Z5 F7200.000"));
-                enquecommand_P(PSTR("M204 S1000")); //set acceleration
-                enquecommand_P(PSTR("G1 F4000"));
+                lay1cal_before_meander();
                 lcd_commands_step = 7;
                 break;
             case 7:

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -75,7 +75,7 @@ bool presort_flag = false;
 #endif
 
 uint8_t lcd_commands_type = LCD_COMMAND_IDLE;
-uint8_t lcd_commands_step = 0;
+static uint8_t lcd_commands_step = 0;
 
 unsigned int custom_message_type = CUSTOM_MSG_TYPE_STATUS;
 unsigned int custom_message_state = 0;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1414,9 +1414,7 @@ void lcd_commands()
                 break;
             case 7:
                 lay1cal_meander();
-
-                strcpy(cmd1, "G1 X50 Y35 E");
-                strcat(cmd1, ftostr43(extr));
+                sprintf_P(cmd1, PSTR("G1 X50 Y35 E%-.3f"), extr);
                 enquecommand(cmd1);
 
                 lcd_commands_step = 6;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1387,10 +1387,7 @@ void lcd_commands()
 
 		if (lcd_commands_step == 10)
 		{
-		    for (uint8_t i = 0; i < (sizeof(layer1_cal)/sizeof(layer1_cal[0])); ++i)
-		    {
-		        enquecommand_P(static_cast<char*>(pgm_read_ptr(&layer1_cal[i])));
-		    }
+            lay1cal_preheat();
             lcd_commands_step = 9;
 		}
         if (lcd_commands_step == 9 && !blocks_queued() && cmd_buffer_empty())

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -246,7 +246,7 @@ static char snmm_stop_print_menu();
 #ifdef SDCARD_SORT_ALPHA
  static void lcd_sort_type_set();
 #endif
-static float count_e(float layer_heigth, float extrusion_width, float extrusion_length);
+static constexpr float count_e(float layer_heigth, float extrusion_width, float extrusion_length);
 static void lcd_babystep_z();
 static void lcd_send_status();
 #ifdef FARM_CONNECT_MESSAGE
@@ -1680,10 +1680,9 @@ void lcd_commands()
 
 }
 
-static float count_e(float layer_heigth, float extrusion_width, float extrusion_length) {
+static constexpr float count_e(float layer_heigth, float extrusion_width, float extrusion_length) {
 	//returns filament length in mm which needs to be extrude to form line with extrusion_length * extrusion_width * layer heigth dimensions
-	float extr = extrusion_length * layer_heigth * extrusion_width / (M_PI * pow(1.75, 2) / 4);
-	return extr;
+	return (extrusion_length * layer_heigth * extrusion_width / (M_PI * pow(1.75, 2) / 4));
 }
 
 void lcd_return_to_status()

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1396,30 +1396,7 @@ void lcd_commands()
             menu_depth = 0;
             menu_submenu(lcd_babystep_z);
 
-            if (mmu_enabled)
-            {
-                enquecommand_P(PSTR("M83")); //intro line
-                enquecommand_P(PSTR("G1 Y-3.0 F1000.0")); //intro line
-                enquecommand_P(PSTR("G1 Z0.4 F1000.0")); //intro line
-                strcpy(cmd1, "T");
-                strcat(cmd1, itostr3left(filament));
-                enquecommand(cmd1);
-                enquecommand_P(PSTR("G1 X55.0 E32.0 F1073.0")); //intro line
-                enquecommand_P(PSTR("G1 X5.0 E32.0 F1800.0")); //intro line
-                enquecommand_P(PSTR("G1 X55.0 E8.0 F2000.0")); //intro line
-                enquecommand_P(PSTR("G1 Z0.3 F1000.0")); //intro line
-                enquecommand_P(PSTR("G92 E0.0")); //intro line
-                enquecommand_P(PSTR("G1 X240.0 E25.0  F2200.0")); //intro line
-                enquecommand_P(PSTR("G1 Y-2.0 F1000.0")); //intro line
-                enquecommand_P(PSTR("G1 X55.0 E25 F1400.0")); //intro line
-                enquecommand_P(PSTR("G1 Z0.20 F1000.0")); //intro line
-                enquecommand_P(PSTR("G1 X5.0 E4.0 F1000.0")); //intro line
-
-            } else
-            {
-                enquecommand_P(PSTR("G1 X60.0 E9.0 F1000.0")); //intro line
-                enquecommand_P(PSTR("G1 X100.0 E12.5 F1000.0")); //intro line
-            }
+            lay1cal_intro_line(cmd1, filament);
 
             lcd_commands_step = 8;
         }

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -97,7 +97,7 @@ extern void lcd_diag_show_end_stops();
 #define LCD_COMMAND_PID_EXTRUDER 7 
 #define LCD_COMMAND_V2_CAL 8
 
-extern int lcd_commands_type;
+extern uint8_t lcd_commands_type;
 extern int8_t FSensorStateMenu;
 
 #define CUSTOM_MSG_TYPE_STATUS 0 // status message from lcd_status_message variable


### PR DESCRIPTION
Save FLASH and RAM by refactoring first layer calibration and various for cycles control variables. For MK2.5S it saves 36B of RAM and 2888B of FLASH.