### PR TITLE
Fix length false positives in lang-check.py

### DIFF
--- a/lang/lang-check.py
+++ b/lang/lang-check.py
@@ -38,7 +38,7 @@ def parse_txt(lang, no_warning):
             if rows is None:
                 rows = 1
 
-            if len(translation) > cols*rows:
+            if len(translation)-2 > cols*rows:
                 stderr.write(
                     "[E]: Text %s is longer then definiton on line %d\n" %
                     (translation, lines))
@@ -56,7 +56,7 @@ def main():
         usage="$(prog)s lang")
     parser.add_argument(
         "lang", nargs='?', default="en", type=str,
-        help="Check lang file (en|cs|de|es|fr|it)")
+        help="Check lang file (en|cs|de|es|fr|it|pl)")
     parser.add_argument(
         "--no-warning", action="store_true",
         help="Disable warnings")


### PR DESCRIPTION
- Just reading the length of the translation line gives false positives as the " are included in the length BUT not displayed on the LCD.
- added missing argument 'pl'