### PR TITLE
Remove function -Move filament back and forth to nozzle in order to detect jam

### DIFF
--- a/Firmware/mmu.cpp
+++ b/Firmware/mmu.cpp
@@ -1462,10 +1462,10 @@ static void load_more()
         mmu_command(MmuCmd::C0);
         manage_response(true, true, MMU_LOAD_MOVE);
     }
-    current_position[E_AXIS] += 60;
-    plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], MMU_LOAD_FEEDRATE, active_extruder);
-    current_position[E_AXIS] -= 58;
-    plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], MMU_LOAD_FEEDRATE, active_extruder);
+//    current_position[E_AXIS] += 60;
+//    plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], MMU_LOAD_FEEDRATE, active_extruder);
+//    current_position[E_AXIS] -= 58;
+//    plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], MMU_LOAD_FEEDRATE, active_extruder);
     st_synchronize();
 }
 


### PR DESCRIPTION
Removing the code that is doing the load/unload to check for jams in the extruder. This causes delays and it also makes the load procedure fail from time to time due to tips with a waist.

If a filament has a waist like OOOOOOoO> due to a badly formed tip the code will push the filament down and the up again and now it will not trigger the ir-sensor due to the waist and the filament will unload. 

The forum/fb-group has many ppl complaining about this load/unload behaviour. 

Jams are uncommon but having the load fail due to the tip is very common. Also, its hard to recover from a jam anyway 