### PR TITLE
Limit LCD refresh while printing to avoid planner stalls

### DIFF
--- a/Firmware/planner.cpp
+++ b/Firmware/planner.cpp
@@ -1369,3 +1369,23 @@ uint16_t planner_calc_sd_length()
 	}
 	return sdlen;
 }
+
+float planned_time()
+{
+    unsigned char _block_buffer_head = block_buffer_head;
+    unsigned char _block_buffer_tail = block_buffer_tail;
+
+    unsigned char n = 0;
+    float mm = 0;
+    float speed = 0;
+
+    while (_block_buffer_head != _block_buffer_tail)
+    {
+        mm += block_buffer[_block_buffer_tail].millimeters;
+        speed += block_buffer[_block_buffer_tail].nominal_speed;
+        ++n;
+
+        _block_buffer_tail = (_block_buffer_tail + 1) & (BLOCK_BUFFER_SIZE - 1);
+    }
+    return mm * ((float)n / speed);
+}

--- a/Firmware/planner.h
+++ b/Firmware/planner.h
@@ -237,7 +237,6 @@ void set_extrude_min_temp(float temp);
 #endif
 
 void reset_acceleration_rates();
-#endif
 
 void update_mode_profile();
 
@@ -254,3 +253,9 @@ extern void planner_queue_min_reset();
 extern void planner_add_sd_length(uint16_t sdlen);
 
 extern uint16_t planner_calc_sd_length();
+
+// Return a rough, optimistic estimate of the total time (s) for the planned moves
+// This function takes in the order of 50us
+float planned_time();
+
+#endif


### PR DESCRIPTION
Limit LCD reinitialization when the planner is busy

LCD operations, and to be precise the lcd_begin() call is extremely costly. When printing complex geometry or infill (such as gyroid) it can starve the planner and cause a stall.

This is also frequently visible during the 7x7 mesh leveling, where each move is individually planned and a single lcd refresh becomes noticeable as it prevents further moves to be scheduled.

We calculate a very rough estimate of the time taken by queued moves in ``planned_time``. This is just overall length at the average nominal speed. If we have less than 250ms available, we skip the current refresh and wait for the next cycle. If a full reset is pending though we keep on probing every second, as it's likely we're printing complex geometry and we should attempt more frequently in order to catch an available time slot.

planned_time() is usually quite optimistic as acceleration is completely ignored, but it's otherwise accurate while printing high-resolution curvy geometry such as gyroid. We only need a true lower-bound anyway, and the function should be fast to avoid overloading the planner. This means we will be refreshing the LCD mostly during slow moves, outer/straight perimeters or long travels.

See issue #1928 for more details. Using just the queue size and/or planned length is not sufficient to prevent stalls and ensure the LCD is still refreshed regularly. LCD functions can still be sped up, so the issue cannot be closed completely with this PR yet.