### PR TITLE
Allow to cut/eject filament on cold noozle when it is not loaded via MMU2

### DIFF
--- a/Firmware/mmu.cpp
+++ b/Firmware/mmu.cpp
@@ -1393,7 +1393,7 @@ void mmu_cut_filament(uint8_t filament_nr)
 {
     menu_back();
     bFilamentAction=false;                            // NOT in "mmu_load_to_nozzle_menu()"
-    if (degHotend0() > EXTRUDE_MINTEMP)
+    if (!mmu_fil_loaded || degHotend0() > EXTRUDE_MINTEMP)
     {
         LcdUpdateDisabler disableLcdUpdate;
         lcd_clear();
@@ -1418,7 +1418,7 @@ bFilamentAction=false;                            // NOT in "mmu_fil_eject_menu(
 	if (filament < 5) 
 	{
 
-		if (degHotend0() > EXTRUDE_MINTEMP)
+		if (!mmu_fil_loaded || degHotend0() > EXTRUDE_MINTEMP)
 		{
 			st_synchronize();
 


### PR DESCRIPTION
**The problem**: I made this small update for MMU2 users. Couple of Tims I wanted to cut or eject filament right after I started printer, but I wasn't able to do it, even if it wasn't loaded into noozle.

**The solution**: Allow to cut/eject filament when noozle is not preheated. None of these actions will push filament down to noozle, so temperature is not required when 

I did not test it manually yet, because I'm facing some issue with https://github.com/prusa3d/MM-control-01/issues/154 