### PR TITLE
Fix missing first two characters from menu items in sheet menu

### DIFF
--- a/Firmware/messages.c
+++ b/Firmware/messages.c
@@ -101,6 +101,7 @@ const char MSG_WIZARD_DONE[] PROGMEM_I1 = ISTR("All is done. Happy printing!"); 
 const char MSG_WIZARD_HEATING[] PROGMEM_I1 = ISTR("Preheating nozzle. Please wait."); ////c=20 r=3
 const char MSG_WIZARD_QUIT[] PROGMEM_I1 = ISTR("You can always resume the Wizard from Calibration -> Wizard."); ////c=20 r=8
 const char MSG_YES[] PROGMEM_I1 = ISTR("Yes"); ////
+const char MSG_V2_CALIBRATION[] PROGMEM_I1 = ISTR("First layer cal."); ////c=17 r=1
 const char WELCOME_MSG[] PROGMEM_I1 = ISTR(CUSTOM_MENDEL_NAME " OK."); ////c=20
 //not internationalized messages
 const char MSG_SD_WORKDIR_FAIL[] PROGMEM_N1 = "workDir open failed"; ////
@@ -127,6 +128,3 @@ const char MSG_ENDSTOP_OPEN[] PROGMEM_N1 = "open"; ////
 const char MSG_POWERUP[] PROGMEM_N1 = "PowerUp"; ////
 const char MSG_ERR_STOPPED[] PROGMEM_N1 = "Printer stopped due to errors. Fix the error and use M999 to restart. (Temperature is reset. Set it after restarting)"; ////
 const char MSG_ENDSTOP_HIT[] PROGMEM_N1 = "TRIGGERED"; ////
-const char MSG_V2_CALIBRATION[] PROGMEM_N1 = "First layer cal."; ////c=17 r=1
-const char MSG_SELECT[] PROGMEM_N1 = "Select"; ////
-const char MSG_RENAME[] PROGMEM_N1 = "Rename"; ////

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -101,6 +101,7 @@ extern const char MSG_WIZARD_DONE[];
 extern const char MSG_WIZARD_HEATING[];
 extern const char MSG_WIZARD_QUIT[];
 extern const char MSG_YES[];
+extern const char MSG_V2_CALIBRATION[];
 extern const char WELCOME_MSG[];
 //not internationalized messages
 extern const char MSG_BROWNOUT_RESET[];
@@ -128,9 +129,6 @@ extern const char MSG_ERR_STOPPED[];
 extern const char MSG_ENDSTOP_HIT[];
 extern const char MSG_EJECT_FILAMENT[];
 extern const char MSG_CUT_FILAMENT[];
-extern const char MSG_V2_CALIBRATION[];
-extern const char MSG_SELECT[];
-extern const char MSG_RENAME[];
 
 #if defined(__cplusplus)
 }

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5482,7 +5482,7 @@ static void lcd_calibration_menu()
   if (!isPrintPaused)
   {
 	MENU_ITEM_FUNCTION_P(_i("Wizard"), lcd_wizard);////MSG_WIZARD c=17 r=1
-	MENU_ITEM_SUBMENU_P(_i("First layer cal."), lcd_v2_calibration);////MSG_V2_CALIBRATION c=17 r=1
+	MENU_ITEM_SUBMENU_P(_T(MSG_V2_CALIBRATION), lcd_v2_calibration);
 	MENU_ITEM_GCODE_P(_T(MSG_AUTO_HOME), PSTR("G28 W"));
 	MENU_ITEM_FUNCTION_P(_i("Selftest         "), lcd_selftest_v);////MSG_SELFTEST
 #ifdef MK1BP
@@ -6387,9 +6387,9 @@ static void lcd_sheet_menu()
 {
     MENU_BEGIN();
     MENU_ITEM_BACK_P(_T(MSG_MAIN));
-    MENU_ITEM_SUBMENU_P(_T(MSG_SELECT), lcd_select_sheet_menu); //// c=18
-    MENU_ITEM_SUBMENU_P(_T(MSG_RENAME), lcd_rename_sheet_menu); //// c=18
-    MENU_ITEM_SUBMENU_P(_T(MSG_V2_CALIBRATION), lcd_v2_calibration); ////MSG_V2_CALIBRATION c=17 r=1
+    MENU_ITEM_SUBMENU_P(_i("Select"), lcd_select_sheet_menu); //// c=18
+    MENU_ITEM_SUBMENU_P(_i("Rename"), lcd_rename_sheet_menu); //// c=18
+    MENU_ITEM_SUBMENU_P(_T(MSG_V2_CALIBRATION), lcd_v2_calibration);
 
     MENU_END();
 }


### PR DESCRIPTION
Move translated string MSG_V2_CALIBRATION from untranslated section to PROGMEM_I1, add missing ISTR macro. Revert _T(MSG_SELECT) and _T(MSG_RENAME) to _i("Select") and _i("Rename") as it is preferred macro for internationalized strings. Use MSG_V2_CALIBRATION in both occurrences.