### PR TITLE
Use delay_keep_alive if sound is long

### DIFF
--- a/Firmware/sound.cpp
+++ b/Firmware/sound.cpp
@@ -62,34 +62,25 @@ Sound_SaveMode();
 }
 
 //if critical is true then silend and once mode is ignored
-void Sound_MakeCustom(uint16_t ms,uint16_t tone_,bool critical){
-     if (!critical){
-          if (eSoundMode != e_SOUND_MODE_SILENT){
-               if(!tone_){
-                    WRITE(BEEPER, HIGH);
-                    _delay(ms);
-                    WRITE(BEEPER, LOW);
-               }
-               else{
-                    _tone(BEEPER, tone_);
-                    _delay(ms);
-                    _noTone(BEEPER);
-               }
-          }
-     }
-     else{
-          if(!tone_){
-               WRITE(BEEPER, HIGH);
-               _delay(ms);
-               WRITE(BEEPER, LOW);
-               _delay(ms);
-          }
-          else{
-               _tone(BEEPER, tone_);
-               _delay(ms);
-               _noTone(BEEPER);
-          }
-     }
+void Sound_MakeCustom(uint16_t ms,uint16_t tone_,bool critical)
+{
+	if (critical || eSoundMode != e_SOUND_MODE_SILENT)
+	{
+		if (tone_ == 0)
+		{
+			WRITE(BEEPER,HIGH);
+			if (ms > 100) delay_keep_alive(ms); //use delay_keep_alive if the delay is long as to manage heaters and prevent WDT reset
+			else _delay(ms);
+			WRITE(BEEPER,LOW);
+		}
+		else
+		{
+			_tone(BEEPER, tone_);
+			if (ms > 100) delay_keep_alive(ms);
+			else _delay(ms);
+			_noTone(BEEPER);
+		}
+	}
 }
 
 void Sound_MakeSound(eSOUND_TYPE eSoundType)

--- a/Firmware/sound.cpp
+++ b/Firmware/sound.cpp
@@ -69,14 +69,22 @@ void Sound_MakeCustom(uint16_t ms,uint16_t tone_,bool critical)
 		if (tone_ == 0)
 		{
 			WRITE(BEEPER,HIGH);
-			if (ms > 100) delay_keep_alive(ms); //use delay_keep_alive if the delay is long as to manage heaters and prevent WDT reset
+			if (ms > 100)
+			{
+				LcdUpdateDisabler disableLcdUpdate;
+				delay_keep_alive(ms); //use delay_keep_alive if the delay is long as to manage heaters and prevent WDT reset. Don't update lcd.
+			}
 			else _delay(ms);
 			WRITE(BEEPER,LOW);
 		}
 		else
 		{
 			_tone(BEEPER, tone_);
-			if (ms > 100) delay_keep_alive(ms);
+			if (ms > 100)
+			{
+				LcdUpdateDisabler disableLcdUpdate;
+				delay_keep_alive(ms); //use delay_keep_alive if the delay is long as to manage heaters and prevent WDT reset. Don't update lcd.
+			}
 			else _delay(ms);
 			_noTone(BEEPER);
 		}


### PR DESCRIPTION
@DRracer This fixes issue #2045 as it prevents a M300 or any other sound that is long to trigger the WDT reset. Also manages heaters and updates screen if the sound is longer than 100ms. Also restructured Sound_MakeCustom().
I chose 100ms since it is the default refresh rate of the lcd. Can be made higher to avoid the use of this function on some of the error sounds. eg: fan error