### PR TITLE
Correct bug in util.cpp is_whitespace_or_nl function.

### DIFF
--- a/Firmware/util.cpp
+++ b/Firmware/util.cpp
@@ -27,7 +27,7 @@ const char STR_REVISION_RC   [] PROGMEM = "rc";
 
 inline bool is_whitespace_or_nl(char c)
 {
-    return c == ' ' || c == '\t' || c == '\n' || c == 'r';
+    return c == ' ' || c == '\t' || c == '\n' || c == '\r';
 }
 
 inline bool is_whitespace_or_nl_or_eol(char c)


### PR DESCRIPTION
Change 'r' to '\r'.