### PR TITLE
Fix "LANG_MODE 0" warnings

### DIFF
--- a/Firmware/language.c
+++ b/Firmware/language.c
@@ -17,10 +17,10 @@ uint8_t lang_selected = 0;
 
 #if (LANG_MODE == 0) //primary language only
 
-uint8_t lang_select(uint8_t lang) { return 0; }
+uint8_t lang_select(__attribute__((unused)) uint8_t lang) { return 0; }
 uint8_t lang_get_count() { return 1; }
-uint16_t lang_get_code(uint8_t lang) { return LANG_CODE_EN; }
-const char* lang_get_name_by_code(uint16_t code) { return _n("English"); }
+uint16_t lang_get_code(__attribute__((unused)) uint8_t lang) { return LANG_CODE_EN; }
+const char* lang_get_name_by_code(__attribute__((unused)) uint16_t code) { return _n("English"); }
 void lang_reset(void) { }
 uint8_t lang_is_selected(void) { return 1; }
 

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -114,7 +114,9 @@ static const char* lcd_display_message_fullscreen_nonBlocking_P(const char *msg,
 
 /* Different menus */
 static void lcd_status_screen();
+#if (LANG_MODE != 0)
 static void lcd_language_menu();
+#endif
 static void lcd_main_menu();
 static void lcd_tune_menu();
 //static void lcd_move_menu();
@@ -4733,6 +4735,7 @@ void lcd_wizard() {
 	}
 }
 
+#if (LANG_MODE != 0)
 void lcd_language()
 {
 	lcd_update_enable(true);
@@ -4752,6 +4755,7 @@ void lcd_language()
 	else
 		lang_select(LANG_ID_PRI);
 }
+#endif
 
 static void wait_preheat()
 {

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -6,6 +6,7 @@
 #include "conv2str.h"
 #include "menu.h"
 #include "mesh_bed_calibration.h"
+#include "config.h"
 
 extern void menu_lcd_longpress_func(void);
 extern void menu_lcd_charsetup_func(void);
@@ -208,7 +209,9 @@ void lcd_set_degree();
 void lcd_set_progress();
 #endif
 
+#if (LANG_MODE != 0)
 void lcd_language();
+#endif
 
 void lcd_wizard();
 bool lcd_autoDepleteEnabled();


### PR DESCRIPTION
@DRracer @mkbel This PR fixes warnings that are generated in single-language mode.
Also fixes some other warnings such as the farm number warning or the kill_message warning.

Remaining warnings are:
- lcd_check_gcode_set(). This is temporarily disabled though, so it should be fixed soon.
- two warnings that should be fixed by #2023 
- `'timer0_fract' defined but not used` in the new board definition. Maybe in 1.0.7 this gets fixed.