### PR TITLE
Fix wizard lay1 cal

### DIFF
--- a/Firmware/mmu.cpp
+++ b/Firmware/mmu.cpp
@@ -978,7 +978,7 @@ void extr_adj(uint8_t extruder) //loading filament for SNMM
 {
 #ifndef SNMM
     MmuCmd cmd = MmuCmd::L0 + extruder;
-    if (cmd > MmuCmd::L4)
+    if (extruder > (MmuCmd::L4 - MmuCmd::L0))
     {
         printf_P(PSTR("Filament out of range %d \n"),extruder);
         return;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -4798,6 +4798,7 @@ static void lcd_wizard_load()
 	if (mmu_enabled)
 	{
 		lcd_show_fullscreen_message_and_wait_P(_i("Please insert PLA filament to the first tube of MMU, then press the knob to load it."));////c=20 r=8
+		tmp_extruder = 0;
 	} 
 	else
 	{


### PR DESCRIPTION
Fix loading filament 255 instead of 0 in first layer calibration wizard. 
Fix unsigned char overflow cause invalid filament load.