### PR TITLE
Fix for Toshiba FlashAir (or other) SD card initialization

### DIFF
--- a/Firmware/Sd2Card.cpp
+++ b/Firmware/Sd2Card.cpp
@@ -321,17 +321,17 @@ bool Sd2Card::init(uint8_t sckRateID, uint8_t chipSelectPin) {
   }
 
    // send 0xFF until 0xFF received to give card some clock cycles
-  spiSend(0XFF);
-  while ((status_ = spiRec()) != 0xFF)
-  {
-    spiSend(0XFF);
-    if (((uint16_t)_millis() - t0) > SD_INIT_TIMEOUT)
-    {
-      error(SD_CARD_ERROR_FF_TIMEOUT);
-      SERIAL_ECHOLNRPGM(PSTR("No 0xFF received for 0xFF sent"));
-      goto fail;
-    }
-  }
+  // spiSend(0XFF);
+  // while ((status_ = spiRec()) != 0xFF)
+  // {
+  //   spiSend(0XFF);
+  //   if (((uint16_t)_millis() - t0) > SD_INIT_TIMEOUT)
+  //   {
+  //     error(SD_CARD_ERROR_FF_TIMEOUT);
+  //     SERIAL_ECHOLNRPGM(PSTR("No 0xFF received for 0xFF sent"));
+  //     goto fail;
+  //   }
+  // }
 
   // check SD version
   if ((cardCommand(CMD8, 0x1AA) & R1_ILLEGAL_COMMAND)) {

--- a/Firmware/Sd2Card.cpp
+++ b/Firmware/Sd2Card.cpp
@@ -319,6 +319,20 @@ bool Sd2Card::init(uint8_t sckRateID, uint8_t chipSelectPin) {
       goto fail;
     }
   }
+
+   // send 0xFF until 0xFF received to give card some clock cycles
+  spiSend(0XFF);
+  while ((status_ = spiRec()) != 0xFF)
+  {
+    spiSend(0XFF);
+    if (((uint16_t)_millis() - t0) > SD_INIT_TIMEOUT)
+    {
+      error(SD_CARD_ERROR_FF_TIMEOUT);
+      SERIAL_ECHOLNRPGM(PSTR("No 0xFF received for 0xFF sent"));
+      goto fail;
+    }
+  }
+
   // check SD version
   if ((cardCommand(CMD8, 0x1AA) & R1_ILLEGAL_COMMAND)) {
     type(SD_CARD_TYPE_SD1);

--- a/Firmware/Sd2Card.h
+++ b/Firmware/Sd2Card.h
@@ -105,6 +105,8 @@ uint8_t const SD_CARD_ERROR_SCK_RATE = 0X18;
 uint8_t const SD_CARD_ERROR_INIT_NOT_CALLED = 0X19;
 /** crc check error */
 uint8_t const SD_CARD_ERROR_CRC = 0X20;
+/** no response to sent 0xFF */
+uint8_t const SD_CARD_ERROR_FF_TIMEOUT = 0X21;
 
 /** Toshiba FlashAir: iSDIO */
 uint8_t const SD_CARD_ERROR_CMD48 = 0x80;

--- a/Firmware/Sd2Card.h
+++ b/Firmware/Sd2Card.h
@@ -108,6 +108,7 @@ uint8_t const SD_CARD_ERROR_CRC = 0X20;
 /** no response to sent 0xFF */
 uint8_t const SD_CARD_ERROR_FF_TIMEOUT = 0X21;
 
+
 /** Toshiba FlashAir: iSDIO */
 uint8_t const SD_CARD_ERROR_CMD48 = 0x80;
 /** Toshiba FlashAir: iSDIO */

--- a/Firmware/Sd2Card.h
+++ b/Firmware/Sd2Card.h
@@ -108,7 +108,6 @@ uint8_t const SD_CARD_ERROR_CRC = 0X20;
 /** no response to sent 0xFF */
 uint8_t const SD_CARD_ERROR_FF_TIMEOUT = 0X21;
 
-
 /** Toshiba FlashAir: iSDIO */
 uint8_t const SD_CARD_ERROR_CMD48 = 0x80;
 /** Toshiba FlashAir: iSDIO */


### PR DESCRIPTION
 Add clock cycles between sending CMD0 and CMD8.

I found that in Sd2Card.cpp::init, after CMD0 is sent to my Toshiba FlashAir W04 64Gb card and gets the proper response, the CMD8 that is sent next is receiving back R1_ILLEGAL_COMMAND instead of the R7 response. After much googling, I added code after the CMD0 is sent and before sending CMD8 to repeatedly send 0xFF until the card sends back 0xFF (or it times out). This is apparently sometimes needed to give extra clock cycles to the card to allow it to do work to get ready for the next command. Some (but not all) cards require this to function correctly.

According to google, it's suggested to send 0xFF before every command, but at least for my card it was necessary only between CMD0 and CMD8.

See related issue https://github.com/prusa3d/Prusa-Firmware/issues/1685