### PR TITLE
Fix power panic

### DIFF
--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -166,17 +166,6 @@ void manage_inactivity(bool ignore_stepper_queue=false);
   #define disable_z() {}
 #endif
 
-#ifdef PSU_Delta
-void init_force_z();
-void check_force_z();
-#undef disable_z()
-#define disable_z() disable_force_z()
-void disable_force_z();
-#undef enable_disable_z()
-#define enable_z() enable_force_z()
-void enable_force_z();
-#endif // PSU_Delta
-
 
 
 

--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -167,14 +167,14 @@ void manage_inactivity(bool ignore_stepper_queue=false);
 #endif
 
 #ifdef PSU_Delta
-    void init_force_z();
-    void check_force_z();
-    #undef disable_z
-    #define disable_z() disable_force_z()
-    void disable_force_z();
-    #undef enable_z
-    #define enable_z() enable_force_z()
-    void enable_force_z();
+void init_force_z();
+void check_force_z();
+#undef disable_z()
+#define disable_z() disable_force_z()
+void disable_force_z();
+#undef enable_disable_z()
+#define enable_z() enable_force_z()
+void enable_force_z();
 #endif // PSU_Delta
 
 

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1312,9 +1312,6 @@ void setup()
 	update_mode_profile();
 	tmc2130_init();
 #endif //TMC2130
-#ifdef PSU_Delta
-     init_force_z();                              // ! important for correct Z-axis initialization
-#endif // PSU_Delta
     
 	setup_photpin();
 
@@ -1352,7 +1349,7 @@ void setup()
   }
 #endif //TMC2130
 
-#if defined(Z_AXIS_ALWAYS_ON) && !defined(PSU_Delta)
+#if defined(Z_AXIS_ALWAYS_ON)
 	enable_z();
 #endif
 	farm_mode = eeprom_read_byte((uint8_t*)EEPROM_FARM_MODE);
@@ -10463,69 +10460,3 @@ void marlin_wait_for_click()
 }
 
 #define FIL_LOAD_LENGTH 60
-
-#ifdef PSU_Delta
-bool bEnableForce_z;
-
-void init_force_z()
-{
-WRITE(Z_ENABLE_PIN,Z_ENABLE_ON);
-bEnableForce_z=true;                              // "true"-value enforce "disable_force_z()" executing
-disable_force_z();
-}
-
-void check_force_z()
-{
-if(!(bEnableForce_z||eeprom_read_byte((uint8_t*)EEPROM_SILENT)))
-     init_force_z();                              // causes enforced switching into disable-state
-}
-
-void disable_force_z()
-{
-uint16_t z_microsteps=0;
-
-if(!bEnableForce_z)
-     return;                                      // motor already disabled (may be ;-p )
-bEnableForce_z=false;
-
-// alignment to full-step
-#ifdef TMC2130
-z_microsteps=tmc2130_rd_MSCNT(Z_TMC2130_CS);
-#endif // TMC2130
-planner_abort_hard();
-sei();
-plan_buffer_line(
-     current_position[X_AXIS], 
-     current_position[Y_AXIS], 
-     current_position[Z_AXIS]+float((1024-z_microsteps+7)>>4)/cs.axis_steps_per_unit[Z_AXIS], 
-     current_position[E_AXIS],
-     40, active_extruder);
-st_synchronize();
-
-// switching to silent mode
-#ifdef TMC2130
-tmc2130_mode=TMC2130_MODE_SILENT;
-update_mode_profile();
-tmc2130_init(true);
-#endif // TMC2130
-
-axis_known_position[Z_AXIS]=false; 
-}
-
-
-void enable_force_z()
-{
-if(bEnableForce_z)
-     return;                                      // motor already enabled (may be ;-p )
-bEnableForce_z=true;
-
-// mode recovering
-#ifdef TMC2130
-tmc2130_mode=eeprom_read_byte((uint8_t*)EEPROM_SILENT)?TMC2130_MODE_SILENT:TMC2130_MODE_NORMAL;
-update_mode_profile();
-tmc2130_init(true);
-#endif // TMC2130
-
-WRITE(Z_ENABLE_PIN,Z_ENABLE_ON);                  // slightly redundant ;-p
-}
-#endif // PSU_Delta

--- a/Firmware/io_atmega2560.h
+++ b/Firmware/io_atmega2560.h
@@ -368,7 +368,6 @@
 #define PIN_SET(pin) PORT(pin) |= __MSK(pin)
 #define PIN_VAL(pin, val) if (val) PIN_SET(pin); else PIN_CLR(pin);
 #define PIN_GET(pin) (PIN(pin) & __MSK(pin))
-#define PIN_INQ(pin) (PORT(pin) & __MSK(pin))
 
 
 #endif //_IO_ATMEGA2560

--- a/Firmware/stepper.cpp
+++ b/Firmware/stepper.cpp
@@ -1122,7 +1122,7 @@ void clear_current_adv_vars() {
 }
 
 #endif // LIN_ADVANCE
-
+      
 void st_init()
 {
 #ifdef TMC2130
@@ -1306,9 +1306,6 @@ void st_init()
       SET_OUTPUT(Z2_STEP_PIN);
       WRITE(Z2_STEP_PIN,INVERT_Z_STEP_PIN);
     #endif
-    #ifdef PSU_Delta
-      init_force_z();
-    #endif // PSU_Delta
     disable_z();
   #endif
   #if defined(E0_STEP_PIN) && (E0_STEP_PIN > -1)

--- a/Firmware/tmc2130.cpp
+++ b/Firmware/tmc2130.cpp
@@ -143,7 +143,7 @@ uint16_t __tcoolthrs(uint8_t axis)
 	return 0;
 }
 
-void tmc2130_init(bool bSupressFlag=false)
+void tmc2130_init()
 {
 //	DBG(_n("tmc2130_init(), mode=%S\n"), tmc2130_mode?_n("STEALTH"):_n("NORMAL"));
 	WRITE(X_TMC2130_CS, HIGH);
@@ -215,11 +215,6 @@ void tmc2130_init(bool bSupressFlag=false)
 #endif //TMC2130_LINEARITY_CORRECTION_XYZ
 	tmc2130_set_wave(E_AXIS, 247, tmc2130_wave_fac[E_AXIS]);
 #endif //TMC2130_LINEARITY_CORRECTION
-
-#ifdef PSU_Delta
-     if(!bSupressFlag)
-          check_force_z();
-#endif // PSU_Delta
 
 }
 

--- a/Firmware/tmc2130.cpp
+++ b/Firmware/tmc2130.cpp
@@ -142,11 +142,8 @@ uint16_t __tcoolthrs(uint8_t axis)
 	}
 	return 0;
 }
-#ifdef PSU_Delta
-void tmc2130_init(bool bSupressFlag)
-#else
-void tmc2130_init()
-#endif
+
+void tmc2130_init(bool bSupressFlag=false)
 {
 //	DBG(_n("tmc2130_init(), mode=%S\n"), tmc2130_mode?_n("STEALTH"):_n("NORMAL"));
 	WRITE(X_TMC2130_CS, HIGH);

--- a/Firmware/tmc2130.h
+++ b/Firmware/tmc2130.h
@@ -51,11 +51,7 @@ typedef struct
 extern tmc2130_chopper_config_t tmc2130_chopper_config[4];
 
 //initialize tmc2130
-#ifdef PSU_Delta
 extern void tmc2130_init(bool bSupressFlag=false);
-#else
-extern void tmc2130_init();
-#endif
 //check diag pins (called from stepper isr)
 extern void tmc2130_st_isr();
 //update stall guard (called from st_synchronize inside the loop)

--- a/Firmware/tmc2130.h
+++ b/Firmware/tmc2130.h
@@ -51,7 +51,7 @@ typedef struct
 extern tmc2130_chopper_config_t tmc2130_chopper_config[4];
 
 //initialize tmc2130
-extern void tmc2130_init(bool bSupressFlag=false);
+extern void tmc2130_init();
 //check diag pins (called from stepper isr)
 extern void tmc2130_st_isr();
 //update stall guard (called from st_synchronize inside the loop)

--- a/Firmware/variants/1_75mm_MK3S-EINSy10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK3S-EINSy10a-E3Dv6full.h
@@ -26,9 +26,6 @@
 #define STEEL_SHEET
 #define HAS_SECOND_SERIAL_PORT
 
-// PSU
-#define PSU_Delta                                 // uncomment if DeltaElectronics PSU installed
-
 
 // Uncomment the below for the E3D PT100 temperature sensor (with or without PT100 Amplifier)
 //#define E3D_PT100_EXTRUDER_WITH_AMP


### PR DESCRIPTION
This fixes two problems with power panic. Power lost is sometimes not detected. Resumed Z level is sometimes lower.

This reverts "Merge pull request #1664 from MRprusa3d/PFW-811" and following compiler warning fixes. In original commit, there is suspicious sei() command in disable_force_z() without any cli() command.