### PR TITLE
Fix mmu lay1cal

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -7768,7 +7768,7 @@ Sigma_Exit:
 	  	if (mmu_enabled) 
 		{
 			st_synchronize();
-			mmu_continue_loading(is_usb_printing);
+			mmu_continue_loading(is_usb_printing  || (lcd_commands_type == LcdCommands::Layer1Cal));
 			mmu_extruder = tmp_extruder; //filament change is finished
 			mmu_load_to_nozzle();
 		}
@@ -7812,7 +7812,7 @@ Sigma_Exit:
 #endif //defined(MMU_HAS_CUTTER) && defined(MMU_ALWAYS_CUT)
 				  mmu_command(MmuCmd::T0 + tmp_extruder);
 				  manage_response(true, true, MMU_TCODE_MOVE);
-		          mmu_continue_loading(is_usb_printing);
+		          mmu_continue_loading(is_usb_printing  || (lcd_commands_type == LcdCommands::Layer1Cal));
 
 				  mmu_extruder = tmp_extruder; //filament change is finished
 

--- a/Firmware/first_lay_cal.cpp
+++ b/Firmware/first_lay_cal.cpp
@@ -40,15 +40,26 @@ void lay1cal_preheat()
 
 }
 
-//! @brief Print intro line
+//! @brief Load filament
 //! @param cmd_buffer character buffer needed to format gcodes
 //! @param filament filament to use (applies for MMU only)
-void lay1cal_intro_line(char *cmd_buffer, uint8_t filament)
+void lay1cal_load_filament(char *cmd_buffer, uint8_t filament)
 {
-    static const char cmd_intro_mmu_0[] PROGMEM = "M83";
-    static const char cmd_intro_mmu_1[] PROGMEM = "G1 Y-3.0 F1000.0";
-    static const char cmd_intro_mmu_2[] PROGMEM = "G1 Z0.4 F1000.0";
-    static const char cmd_intro_mmu_3[] PROGMEM = "G1 X55.0 E32.0 F1073.0"; // call T code before
+    if (mmu_enabled)
+    {
+        enquecommand_P(PSTR("M83"));
+        enquecommand_P(PSTR("G1 Y-3.0 F1000.0"));
+        enquecommand_P(PSTR("G1 Z0.4 F1000.0"));
+        sprintf_P(cmd_buffer, PSTR("T%d"), filament);
+        enquecommand(cmd_buffer);
+    }
+
+}
+
+//! @brief Print intro line
+void lay1cal_intro_line()
+{
+    static const char cmd_intro_mmu_3[] PROGMEM = "G1 X55.0 E32.0 F1073.0";
     static const char cmd_intro_mmu_4[] PROGMEM = "G1 X5.0 E32.0 F1800.0";
     static const char cmd_intro_mmu_5[] PROGMEM = "G1 X55.0 E8.0 F2000.0";
     static const char cmd_intro_mmu_6[] PROGMEM = "G1 Z0.3 F1000.0";
@@ -61,10 +72,7 @@ void lay1cal_intro_line(char *cmd_buffer, uint8_t filament)
 
     static const char * const intro_mmu_cmd[] PROGMEM =
     {
-        cmd_intro_mmu_0,
-        cmd_intro_mmu_1,
-        cmd_intro_mmu_2,
-        cmd_intro_mmu_3, // call T code before
+        cmd_intro_mmu_3,
         cmd_intro_mmu_4,
         cmd_intro_mmu_5,
         cmd_intro_mmu_6,
@@ -80,11 +88,6 @@ void lay1cal_intro_line(char *cmd_buffer, uint8_t filament)
     {
         for (uint8_t i = 0; i < (sizeof(intro_mmu_cmd)/sizeof(intro_mmu_cmd[0])); ++i)
         {
-            if (3 == i)
-                {
-                    sprintf_P(cmd_buffer, PSTR("T%d"), filament);
-                    enquecommand(cmd_buffer);
-                }
             enquecommand_P(static_cast<char*>(pgm_read_ptr(&intro_mmu_cmd[i])));
         }
     }

--- a/Firmware/first_lay_cal.h
+++ b/Firmware/first_lay_cal.h
@@ -7,7 +7,8 @@
 #include <stdint.h>
 
 void lay1cal_preheat();
-void lay1cal_intro_line(char *cmd_buffer, uint8_t filament);
+void lay1cal_load_filament(char *cmd_buffer, uint8_t filament);
+void lay1cal_intro_line();
 void lay1cal_before_meander();
 void lay1cal_meander(char *cmd_buffer);
 void lay1cal_square(char *cmd_buffer, uint8_t i);

--- a/Firmware/mmu.cpp
+++ b/Firmware/mmu.cpp
@@ -889,7 +889,7 @@ void mmu_M600_load_filament(bool automatic, float nozzle_temp)
     mmu_command(MmuCmd::T0 + tmp_extruder);
 
     manage_response(false, true, MMU_LOAD_MOVE);
-    mmu_continue_loading(is_usb_printing);
+    mmu_continue_loading(is_usb_printing || (lcd_commands_type == LcdCommands::Layer1Cal));
     mmu_extruder = tmp_extruder; //filament change is finished
 
     mmu_load_to_nozzle();

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1354,7 +1354,7 @@ void lcd_commands()
 
 		if(lcd_commands_step>1) lcd_timeoutToStatus.start(); //if user dont confirm live adjust Z value by pressing the knob, we are saving last value by timeout to status screen
 
-        if (!blocks_queued() && cmd_buffer_empty())
+        if (!blocks_queued() && cmd_buffer_empty() && !saved_printing)
         {
             switch(lcd_commands_step)
             {

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1359,37 +1359,41 @@ void lcd_commands()
             switch(lcd_commands_step)
             {
             case 0:
-                lcd_commands_step = 10;
+                lcd_commands_step = 11;
                 break;
             case 20:
                 filament = 0;
-                lcd_commands_step = 10;
+                lcd_commands_step = 11;
                 break;
             case 21:
                 filament = 1;
-                lcd_commands_step = 10;
+                lcd_commands_step = 11;
                 break;
             case 22:
                 filament = 2;
-                lcd_commands_step = 10;
+                lcd_commands_step = 11;
                 break;
             case 23:
                 filament = 3;
-                lcd_commands_step = 10;
+                lcd_commands_step = 11;
                 break;
             case 24:
                 filament = 4;
+                lcd_commands_step = 11;
+                break;
+            case 11:
+                lay1cal_preheat();
                 lcd_commands_step = 10;
                 break;
             case 10:
-                lay1cal_preheat();
+                lay1cal_load_filament(cmd1, filament);
                 lcd_commands_step = 9;
                 break;
             case 9:
                 lcd_clear();
                 menu_depth = 0;
                 menu_submenu(lcd_babystep_z);
-                lay1cal_intro_line(cmd1, filament);
+                lay1cal_intro_line();
                 lcd_commands_step = 8;
                 break;
             case 8:


### PR DESCRIPTION
Fixes "viper" and fixes printing without filament in case MMU load failed occurred.