### PR TITLE
Fix repeated power panic restarted print from beginning or jumped at …

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -5343,7 +5343,9 @@ if(eSoundMode!=e_SOUND_MODE_SILENT)
     // ----------------------------------
     case 26: 
       if(card.cardOK && code_seen('S')) {
-        card.setIndex(code_value_long());
+        long index = code_value_long();
+        card.setIndex(index);
+        sdpos_atomic = index;
       }
       break;
 
@@ -9497,7 +9499,7 @@ void serialecho_temperatures() {
 	SERIAL_PROTOCOL_F(degBed(), 1);
 	SERIAL_PROTOCOLLN("");
 }
-extern uint32_t sdpos_atomic;
+
 #ifdef UVLO_SUPPORT
 
 void uvlo_()

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -5339,12 +5339,17 @@ if(eSoundMode!=e_SOUND_MODE_SILENT)
       card.pauseSDPrint();
       break;
 
-    //! ### M26 - Set SD index
+    //! ### M26 S\<index\> - Set SD index
+    //! Set position in SD card file to index in bytes.
+    //! This command is expected to be called after M23 and before M24.
+    //! Otherwise effect of this command is undefined.
     // ----------------------------------
     case 26: 
       if(card.cardOK && code_seen('S')) {
         long index = code_value_long();
         card.setIndex(index);
+        // We don't disable interrupt during update of sdpos_atomic
+        // as we expect, that SD card print is not active in this moment
         sdpos_atomic = index;
       }
       break;

--- a/Firmware/cmdqueue.h
+++ b/Firmware/cmdqueue.h
@@ -45,6 +45,8 @@ extern bool cmdbuffer_front_already_processed;
 // Debugging information will be sent to serial line.
 //#define CMDBUFFER_DEBUG
 
+extern uint32_t sdpos_atomic;
+
 extern int serial_count;
 extern boolean comment_mode;
 extern char *strchr_pointer;


### PR DESCRIPTION
…most 65536 B back in file printed from SD card.

As sdpos_atomic was not updated after printer power up and first power panic recovery, it was equal 0. When the first command from SD card was queued its size on SD card was computed as current SD index position minus sdpos_atomic. This was equal to offset from beginning of the file limited to 16 bit storage type. When next power outage occurred earlier then this command was finished and wiped out of queue, this command size (extraordinarily big) was subtracted from sdpos_atomic and saved to EEPROM. This led to up to 65536 B jump back in file printed after next power panic recovery.