### PR TITLE
Fix sound mode [assist]: encoder clicking indefinitely when MMU wants to

### DIFF
--- a/Firmware/sound.h
+++ b/Firmware/sound.h
@@ -3,10 +3,10 @@
 #define SOUND_H
 
 
-#define MSG_SOUND_MODE_LOUD "Sound      [loud]"
-#define MSG_SOUND_MODE_ONCE "Sound      [once]"
+#define MSG_SOUND_MODE_LOUD   "Sound      [loud]"
+#define MSG_SOUND_MODE_ONCE   "Sound      [once]"
 #define MSG_SOUND_MODE_SILENT "Sound    [silent]"
-#define MSG_SOUND_MODE_BLIND "Sound     [blind]" 
+#define MSG_SOUND_MODE_BLIND  "Sound    [assist]" 
 
 
 #define e_SOUND_MODE_NULL 0xFF

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5902,6 +5902,7 @@ uint8_t choose_menu_P(const char *header, const char *item, const char *last_ite
                 cursor_pos++;
             }
             enc_dif = lcd_encoder_diff;
+			Sound_MakeSound(e_SOUND_TYPE_EncoderMove);
 		}
 
 		if (cursor_pos > 3)
@@ -5952,7 +5953,6 @@ uint8_t choose_menu_P(const char *header, const char *item, const char *last_ite
         lcd_print(" ");
         lcd_set_cursor(0, cursor_pos);
         lcd_print(">");
-				Sound_MakeSound(e_SOUND_TYPE_EncoderMove);
         _delay(100);
 
 		if (lcd_clicked())

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5907,23 +5907,25 @@ uint8_t choose_menu_P(const char *header, const char *item, const char *last_ite
 
 		if (cursor_pos > 3)
 		{		
-			Sound_MakeSound(e_SOUND_TYPE_BlindAlert);
             cursor_pos = 3;
             if (first < items_no - 3)
             {
                 first++;
                 lcd_clear();
+            } else { // here we are at the very end of the list
+				Sound_MakeSound(e_SOUND_TYPE_BlindAlert);
             }
         }
 
         if (cursor_pos < 1)
         {
-					Sound_MakeSound(e_SOUND_TYPE_BlindAlert);
             cursor_pos = 1;
             if (first > 0)
             {
                 first--;
                 lcd_clear();
+            } else { // here we are at the very end of the list
+				Sound_MakeSound(e_SOUND_TYPE_BlindAlert);
             }
         }
 


### PR DESCRIPTION
Fix sound mode [assist]: encoder clicking indefinitely when MMU wants to select filament (and possibly other choose_menu_P() usage)