### PR TITLE
M600 in non-MMU mode now asks for confirmation before unloading

### DIFF
--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -509,7 +509,7 @@ void proc_commands();
 
 void M600_load_filament();
 void M600_load_filament_movements();
-void M600_wait_for_user(float HotendTempBckp);
+bool M600_wait_for_user(float HotendTempBckp);
 void M600_check_state(float nozzle_temp);
 void load_filament_final_feed();
 void marlin_wait_for_click();

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3804,43 +3804,41 @@ int8_t lcd_show_multiscreen_message_two_choices_and_wait_P(const char *msg, bool
 
 //! @brief Show single screen message with yes and no possible choices and wait with possible timeout
 //! @param msg Message to show
-//! @param allow_timeouting if true, allows time outing of the screen
-//! @param default_yes if true, yes choice is selected by default, otherwise no choice is preselected
+//! @param allow_timeouting if true, allows time outing of the screen with a default timeout. If any other
+//!        number != 0, then allows timeout with that number of milliseconds
+//! @param default_yes if true or -2, then yes choice is selected by default, otherwise no choice is preselected.
+//!        If return_immediately is true, then this should be the value of the previous call.
 //! @retval 1 yes choice selected by user
 //! @retval 0 no choice selected by user
-//! @retval -1 screen timed out
-int8_t lcd_show_fullscreen_message_yes_no_and_wait_P(const char *msg, bool allow_timeouting, bool default_yes)
+//! @retval -1 screen timed out and the cursor was on NO
+//! @retval -2 screen timed out and the cursor was on YES
+int8_t lcd_show_fullscreen_message_yes_no_and_wait_P(const char *msg, unsigned long allow_timeouting, int8_t default_yes)
 {
 
 	lcd_display_message_fullscreen_P(msg);
-	
-	if (default_yes) {
-		lcd_set_cursor(0, 2);
-		lcd_puts_P(PSTR(">"));
-		lcd_puts_P(_T(MSG_YES));
-		lcd_set_cursor(1, 3);
-		lcd_puts_P(_T(MSG_NO));
-	}
-	else {
-		lcd_set_cursor(1, 2);
-		lcd_puts_P(_T(MSG_YES));
-		lcd_set_cursor(0, 3);
-		lcd_puts_P(PSTR(">"));
-		lcd_puts_P(_T(MSG_NO));
-	}
-	int8_t retval = default_yes ? true : false;
+
+        bool yes = (default_yes == true) || (default_yes == -2);
+	int8_t retval = yes ? 1 : 0;
+
+        lcd_set_cursor(1, 2);
+        lcd_puts_P(_T(MSG_YES));
+        lcd_set_cursor(1, 3);
+        lcd_puts_P(_T(MSG_NO));
+
+        lcd_set_cursor(0, yes ? 2 : 3);
+        lcd_puts_P(PSTR(">"));
 
 	// Wait for user confirmation or a timeout.
 	unsigned long previous_millis_cmd = _millis();
+        unsigned long timeout = allow_timeouting == true ? LCD_TIMEOUT_TO_STATUS : allow_timeouting;
 	int8_t        enc_dif = lcd_encoder_diff;
 	lcd_consume_click();
 	KEEPALIVE_STATE(PAUSED_FOR_USER);
 	for (;;) {
-		if (allow_timeouting && _millis() - previous_millis_cmd > LCD_TIMEOUT_TO_STATUS)
-		{
-		    retval = -1;
-		    break;
-		}
+
+                if (allow_timeouting && _millis() - previous_millis_cmd > timeout)
+                    return yes ? -2 : -1;
+                
 		manage_heater();
 		manage_inactivity(true);
 		if (abs(enc_dif - lcd_encoder_diff) > 4) {

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -66,8 +66,8 @@ extern void lcd_return_to_status();
 extern void lcd_wait_for_click();
 extern bool lcd_wait_for_click_delay(uint16_t nDelay);
 extern void lcd_show_fullscreen_message_and_wait_P(const char *msg);
-// 0: no, 1: yes, -1: timeouted
-extern int8_t lcd_show_fullscreen_message_yes_no_and_wait_P(const char *msg, bool allow_timeouting = true, bool default_yes = false);
+// 0: no, 1: yes, -1: timeouted (cursor on NO), -2: timeouted (cursor on YES)
+extern int8_t lcd_show_fullscreen_message_yes_no_and_wait_P(const char *msg, unsigned long allow_timeouting = true, int8_t default_yes = false);
 extern int8_t lcd_show_multiscreen_message_two_choices_and_wait_P(const char *msg, bool allow_timeouting, bool default_yes,
         const char *first_choice, const char *second_choice);
 extern int8_t lcd_show_multiscreen_message_yes_no_and_wait_P(const char *msg, bool allow_timeouting = true, bool default_yes = false);


### PR DESCRIPTION
M600 now asks (yes/no) before unloading the filament.

All functionality of the command stays exactly the same - previously the user had to push the button. Now he can still just push the button and activate the default "yes". Then everything works as usual.

If the user instead selects "no", then no filament change is performed, and the print resumes immediately.

If MMU is installed, then nothing changes at all (the user was not prompted before, and is not prompted now).

While the yes/no question is up, the special logic for beeping, and for turning off the heater after a specific timeout, still work.

This gives the user a chance to opt-out of the filament change and be a bit more "dynamic" about this (for example, schedule the change ahead in a long print, and only do it if the old filament spool looks like it's not going to last).

A major secondary use of this change is that together with the filament-change feature of PrusaSlicer (which generates a M600 in user-selected layers) it is a very convenient and safe pause function: if the user does not actually want to change filament, but just to pause the print and move the nozzle head away at that layer for whatever reason (I do this frequently with creative manual support structures that I drop into a print physically; or for dropping in magnets and so on), he can now do this without the enforced filament unload/reload. The other choices (i.e., the "Pause" gcode) are much less powerful, and also would need manual manipulation of the gcode.
