### PR TITLE
PFW-1061: #2093 - Relocate sheet menu, show sheet on info screen

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -6580,6 +6580,15 @@ static void lcd_rename_sheet_menu()
         lcd_putc(menuData->name[i]);
     }
     lcd_set_cursor(menuData->selected, 1);
+    if (menuData->selected>0)
+    {
+	lcd_set_cursor(menuData->selected-1, 1);    
+	lcd_putc(' ');
+    }
+    else
+    {
+	lcd_set_cursor(menuData->selected, 1);
+    }
     lcd_putc('^');
     if (lcd_clicked())
     {

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -600,7 +600,7 @@ void lcdui_print_percent_done(void)
 	bool num = IS_SD_PRINTING || (PRINTER_ACTIVE && (print_percent_done_normal != PRINT_PERCENT_DONE_INIT));
 	if (!num || heating_status) // either not printing or heating
 	{
-		eeprom_read_block(sheet, EEPROM_Sheets_base->s[selected_sheet].name, 7);
+		eeprom_read_block(sheet, EEPROM_Sheets_base->s[eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet))].name, 7);
 		sheet[7] = '\0';
 		lcd_printf_P(PSTR("%s"),sheet);
 	}

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -598,11 +598,21 @@ void lcdui_print_feedrate(void)
 // Print percent done in form "USB---%", " SD---%", "   ---%" (7 chars total)
 void lcdui_print_percent_done(void)
 {
+	char sheet[8];
 	const char* src = is_usb_printing?_N("USB"):(IS_SD_PRINTING?_N(" SD"):_N("   "));
 	char per[4];
 	bool num = IS_SD_PRINTING || (PRINTER_ACTIVE && (print_percent_done_normal != PRINT_PERCENT_DONE_INIT));
-	sprintf_P(per, num?_N("%3hhd"):_N("---"), calc_percent_done());
-	lcd_printf_P(_N("%3S%3s%%"), src, per);
+	if (!num || heating_status) // either not printing or heating
+	{
+		eeprom_read_block(sheet, EEPROM_Sheets_base->s[selected_sheet].name, 7);
+		sheet[7] = '\0';
+		lcd_printf_P(PSTR("%s"),sheet);
+	}
+	else
+	{
+		sprintf_P(per, num?_N("%3hhd"):_N("---"), calc_percent_done());
+		lcd_printf_P(_N("%3S%3s%%"), src, per);
+	}
 }
 
 // Print extruder status (5 chars total)
@@ -6714,6 +6724,14 @@ static void lcd_main_menu()
   }
 #endif
 
+  if(!isPrintPaused && !IS_SD_PRINTING && !is_usb_printing && (lcd_commands_type != LcdCommands::Layer1Cal))
+  {
+    if (!farm_mode)
+    {
+	  MENU_ITEM_SUBMENU_SELECT_SHEET_E(EEPROM_Sheets_base->s[eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet))], change_sheet_from_menu);
+    }
+  }
+
 
   if (IS_SD_PRINTING || is_usb_printing || (lcd_commands_type == LcdCommands::Layer1Cal))
   {
@@ -6759,14 +6777,6 @@ static void lcd_main_menu()
 
   }
 
-  if(!isPrintPaused && !IS_SD_PRINTING && !is_usb_printing && (lcd_commands_type != LcdCommands::Layer1Cal))
-  {
-    if (!farm_mode)
-    {
-	  MENU_ITEM_SUBMENU_SELECT_SHEET_E(EEPROM_Sheets_base->s[eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet))], change_sheet_from_menu);
-    }
-  }
-  
   if (!is_usb_printing && (lcd_commands_type != LcdCommands::Layer1Cal))
   {
 	  MENU_ITEM_SUBMENU_P(_i("Statistics  "), lcd_menu_statistics);////MSG_STATISTICS

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -6552,15 +6552,6 @@ static void lcd_rename_sheet_menu()
         lcd_putc(menuData->name[i]);
     }
     lcd_set_cursor(menuData->selected, 1);
-    if (menuData->selected>0)
-    {
-	lcd_set_cursor(menuData->selected-1, 1);    
-	lcd_putc(' ');
-    }
-    else
-    {
-	lcd_set_cursor(menuData->selected, 1);
-    }
     lcd_putc('^');
     if (lcd_clicked())
     {


### PR DESCRIPTION
Implemented #2093 
-Sheet is shown instead of percentage done either if idle, or during
print preheat. (Both consume exactly 7 characters)
-Relocated sheet menu to below SD menu for additional visibility to
current sheet.