### PR TITLE
Mk3 mk2.x fix default stepper power

### DIFF
--- a/Firmware/stepper.cpp
+++ b/Firmware/stepper.cpp
@@ -1563,7 +1563,7 @@ void EEPROM_read_st(int pos, uint8_t* value, uint8_t size)
 void st_current_init() //Initialize Digipot Motor Current
 {  
   uint8_t SilentMode = eeprom_read_byte((uint8_t*)EEPROM_SILENT);
-  if (SilentMode == 0xff) SilentMode = SILENT_MODE_POWER;
+  if (SilentMode == 0xff) SilentMode = 0; //set power to High Power (MK2.5) or Normal Power (MK3, unused)
   SilentModeMenu = SilentMode;
   #ifdef MOTOR_CURRENT_PWM_XY_PIN
     pinMode(MOTOR_CURRENT_PWM_XY_PIN, OUTPUT);

--- a/Firmware/stepper.cpp
+++ b/Firmware/stepper.cpp
@@ -1562,7 +1562,8 @@ void EEPROM_read_st(int pos, uint8_t* value, uint8_t size)
 
 void st_current_init() //Initialize Digipot Motor Current
 {  
-uint8_t SilentMode = eeprom_read_byte((uint8_t*)EEPROM_SILENT);
+  uint8_t SilentMode = eeprom_read_byte((uint8_t*)EEPROM_SILENT);
+  if (silentMode == 0xff) silentMode = SILENT_MODE_POWER;
   SilentModeMenu = SilentMode;
   #ifdef MOTOR_CURRENT_PWM_XY_PIN
     pinMode(MOTOR_CURRENT_PWM_XY_PIN, OUTPUT);

--- a/Firmware/stepper.cpp
+++ b/Firmware/stepper.cpp
@@ -1563,7 +1563,7 @@ void EEPROM_read_st(int pos, uint8_t* value, uint8_t size)
 void st_current_init() //Initialize Digipot Motor Current
 {  
   uint8_t SilentMode = eeprom_read_byte((uint8_t*)EEPROM_SILENT);
-  if (silentMode == 0xff) silentMode = SILENT_MODE_POWER;
+  if (SilentMode == 0xff) SilentMode = SILENT_MODE_POWER;
   SilentModeMenu = SilentMode;
   #ifdef MOTOR_CURRENT_PWM_XY_PIN
     pinMode(MOTOR_CURRENT_PWM_XY_PIN, OUTPUT);


### PR DESCRIPTION
This PR fixes desync between menu value and actual value for stepper power on MK2.5(S) after Factory reset. Without this change it would show you "high power", but motors are on "silent".