### PR TITLE
PFW-1057: SD Scroll workaround

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -305,7 +305,7 @@ const char STR_SEPARATOR[] PROGMEM = "------------";
 static void lcd_implementation_drawmenu_sdfile_selected(uint8_t row, char* longFilename)
 {
     char c;
-    int enc_dif = lcd_encoder_diff;
+    int enc_dif = lcd_encoder_diff / ENCODER_PULSES_PER_STEP;
     uint8_t n = LCD_WIDTH - 1;
     for(uint_least8_t g = 0; g<4;g++){
       lcd_set_cursor(0, g);
@@ -331,7 +331,7 @@ static void lcd_implementation_drawmenu_sdfile_selected(uint8_t row, char* longF
           n = LCD_WIDTH - 1;
           for(int g = 0; g<300 ;g++){
 			  manage_heater();
-            if(LCD_CLICKED || ( enc_dif != lcd_encoder_diff )){
+            if(LCD_CLICKED || ( enc_dif != (lcd_encoder_diff / ENCODER_PULSES_PER_STEP))){
 				longFilenameTMP = longFilename;
 				*(longFilenameTMP + LCD_WIDTH - 2) = '\0';
 				i = 1;


### PR DESCRIPTION
@DRracer This PR resolves #2125. It fixes the issue, but I don't really like the current SD filename scroll implementation. Might be worth looking into rewriting the feature.