### PR TITLE
Mk3 fix lcd warning

### DIFF
--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -189,9 +189,10 @@ static void lcd_begin(uint8_t clear)
 	#endif
 }
 
-static void lcd_putchar(char c, FILE *)
+static int lcd_putchar(char c, FILE *)
 {
 	lcd_write(c);
+	return 0;
 }
 
 void lcd_init(void)

--- a/Firmware/lcd.h
+++ b/Firmware/lcd.h
@@ -11,7 +11,6 @@
 extern FILE _lcdout;
 
 #define lcdout (&_lcdout)
-extern void lcd_putchar(char c, FILE *stream);
 
 extern void lcd_init(void);
 


### PR DESCRIPTION
This PR fixes a warning introduced with #2008. It also fixes an issue where the status screen gets shifted on some build environments.