### PR TITLE
Re-use existing temp comp display code for M860

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -7228,8 +7228,10 @@ Sigma_Exit:
 		else {
 			break;
 		}
-
-		LCD_MESSAGERPGM(_T(MSG_PLEASE_WAIT));
+		CustomMsg custom_message_type_old = custom_message_type;
+		unsigned int custom_message_state_old = custom_message_state;
+		custom_message_type = CustomMsg::TempCompWait;
+		custom_message_state = set_target_pinda*10;
 
 		SERIAL_PROTOCOLPGM("Wait for PINDA target temperature:");
 		SERIAL_PROTOCOL(set_target_pinda);
@@ -7246,6 +7248,7 @@ Sigma_Exit:
 		while ( ((!is_pinda_cooling) && (!cancel_heatup) && (current_temperature_pinda < set_target_pinda)) || (is_pinda_cooling && (current_temperature_pinda > set_target_pinda)) ) {
 			if ((_millis() - codenum) > 1000) //Print Temp Reading every 1 second while waiting.
 			{
+				custom_message_state = (int)(current_temperature_pinda*10);
 				SERIAL_PROTOCOLPGM("P:");
 				SERIAL_PROTOCOL_F(current_temperature_pinda, 1);
 				SERIAL_PROTOCOLPGM("/");
@@ -7257,8 +7260,9 @@ Sigma_Exit:
 			manage_inactivity();
 			lcd_update(0);
 		}
-		LCD_MESSAGERPGM(MSG_OK);
-
+		// Restore LCD status state.
+		custom_message_state = custom_message_state_old;
+		custom_message_type = custom_message_type_old;
 		break;
 	}
  

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -839,9 +839,15 @@ void lcdui_print_status_line(void)
 			}
 			break;
 		case CustomMsg::TempCompPreheat: // temp compensation preheat
+		case CustomMsg::TempCompWait: // M860
 			lcd_set_cursor(0, 3);
 			lcd_puts_P(_i("PINDA Heating"));////MSG_PINDA_PREHEAT c=20 r=1
-			if (custom_message_state <= PINDA_HEAT_T)
+			if (custom_message_type == CustomMsg::TempCompWait)
+			{
+				lcd_puts_P(PSTR(": "));// Print temp C
+				lcd_printf_P(PSTR("%2.1f"),((float)custom_message_state)/10);
+			}
+			else if (custom_message_state <= PINDA_HEAT_T)
 			{
 				lcd_puts_P(PSTR(": "));
 				lcd_print(custom_message_state); //seconds

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -112,7 +112,8 @@ enum class CustomMsg : uint_least8_t
 	FilamentLoading, //!< Loading filament in progress
 	PidCal,          //!< PID tuning in progress
 	TempCal,         //!< PINDA temperature calibration
-	TempCompPreheat, //!< Temperature compensation preheat
+	TempCompPreheat, //!< Temperature compensation preheat (seconds)
+	TempCompWait,    //!< Temp wait, M860
 };
 
 extern CustomMsg custom_message_type;


### PR DESCRIPTION
Implementation for #2180 
There is already some temperature compensation status code in the firmware but it's unused because the PINDA #define disables temp_compensation_start.

This commit re-uses it to display the PINDA temperature on the status line when M860 is invoked, e.g. in print start gcode.