### PR TITLE
[French translation] Wrong display during mesh bed calibration

### DIFF
--- a/lang/lang_en_fr.txt
+++ b/lang/lang_en_fr.txt
@@ -136,7 +136,7 @@
 
 #MSG_CALIBRATE_Z_AUTO c=20 r=2
 "Calibrating Z"
-"Calibration de Z"
+"Calibration Z"
 
 #MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end stoppers. Click when done."


### PR DESCRIPTION
Hello,

During mesh bed calibration, values superiors to 9 are wrongly displayed.
For example, for the point 36, the "6" of "36" is displayed instead of the first position in the first line (instead of the thermometer symbol).

See example below:
![20190917_213528](https://user-images.githubusercontent.com/42919109/65075892-0f82d680-d998-11e9-8898-740bbf45da03.jpg)

The display is a LCD 20x4, but "Calibration de Z : 36" counts 21 caracters.

Best regards,
Cyril