### PR TITLE
Fix few translation files inconsistencies 

### DIFF
--- a/lang/lang_en_cz.txt
+++ b/lang/lang_en_cz.txt
@@ -819,8 +819,8 @@
 "Predehrev k vyjmuti"
 
 #MSG_SELFTEST_PRINT_FAN_SPEED c=18
-"Print fan"
-"Tiskovy vent."
+"Print fan:"
+"Tiskovy vent.:"
 
 #MSG_CARD_MENU
 "Print from SD"

--- a/lang/lang_en_fr.txt
+++ b/lang/lang_en_fr.txt
@@ -62,7 +62,7 @@
 "Auto home"
 "Mise a 0 des axes"
 
-#MSG_AUTOLOAD_FILAMENT c=18
+#MSG_AUTOLOAD_FILAMENT c=17
 "AutoLoad filament"
 "Autocharge du fil."
 

--- a/lang/lang_en_pl.txt
+++ b/lang/lang_en_pl.txt
@@ -1413,6 +1413,7 @@
 #
 "Sheet"
 "Plyta"
+
 #
 "Sound    [assist]"
 "Dzwiek   [asyst.]"

--- a/lang/po/Firmware.pot
+++ b/lang/po/Firmware.pot
@@ -7,8 +7,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: en\n"
 "Project-Id-Version: Prusa-Firmware\n"
-"POT-Creation-Date: Wed Sep 4 16:13:32 CEST 2019\n"
-"PO-Revision-Date: Wed Sep 4 16:13:32 CEST 2019\n"
+"POT-Creation-Date: Sun, Sep 22, 2019 2:01:55 PM\n"
+"PO-Revision-Date: Sun, Sep 22, 2019 2:01:55 PM\n"
 "Language-Team: \n"
 "X-Generator: Poedit 2.0.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
@@ -26,7 +26,7 @@ msgid " of 9"
 msgstr ""
 
 # MSG_MEASURED_OFFSET
-#: ultralcd.cpp:3027
+#: ultralcd.cpp:3089
 msgid "[0;0] point offset"
 msgstr ""
 
@@ -41,17 +41,17 @@ msgid "WARNING:\x0aCrash detection\x0adisabled in\x0aStealth mode"
 msgstr ""
 
 # 
-#: ultralcd.cpp:2290
+#: ultralcd.cpp:2472
 msgid ">Cancel"
 msgstr ""
 
 # MSG_BABYSTEPPING_Z c=15
-#: ultralcd.cpp:3147
+#: ultralcd.cpp:3209
 msgid "Adjusting Z:"
 msgstr ""
 
 # MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ultralcd.cpp:8209
+#: ultralcd.cpp:8295
 msgid "All correct      "
 msgstr ""
 
@@ -61,32 +61,32 @@ msgid "All is done. Happy printing!"
 msgstr ""
 
 # 
-#: ultralcd.cpp:1974
+#: ultralcd.cpp:2009
 msgid "Ambient"
 msgstr ""
 
 # MSG_PRESS c=20
-#: ultralcd.cpp:2576
+#: ultralcd.cpp:2618
 msgid "and press the knob"
 msgstr ""
 
 # MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=2
-#: ultralcd.cpp:3445
+#: ultralcd.cpp:3529
 msgid "Are left and right Z~carriages all up?"
 msgstr ""
 
 # MSG_AUTO_DEPLETE_ON c=17 r=1
-#: ultralcd.cpp:5114
+#: ultralcd.cpp:5200
 msgid "SpoolJoin    [on]"
 msgstr ""
 
 # 
-#: ultralcd.cpp:5110
+#: ultralcd.cpp:5196
 msgid "SpoolJoin   [N/A]"
 msgstr ""
 
 # MSG_AUTO_DEPLETE_OFF c=17 r=1
-#: ultralcd.cpp:5118
+#: ultralcd.cpp:5204
 msgid "SpoolJoin   [off]"
 msgstr ""
 
@@ -96,32 +96,32 @@ msgid "Auto home"
 msgstr ""
 
 # MSG_AUTOLOAD_FILAMENT c=17
-#: ultralcd.cpp:6736
+#: ultralcd.cpp:6822
 msgid "AutoLoad filament"
 msgstr ""
 
 # MSG_AUTOLOADING_ONLY_IF_FSENS_ON c=20 r=4
-#: ultralcd.cpp:4378
+#: ultralcd.cpp:4462
 msgid "Autoloading filament available only when filament sensor is turned on..."
 msgstr ""
 
 # MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ultralcd.cpp:2771
+#: ultralcd.cpp:2813
 msgid "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
 
 # MSG_SELFTEST_AXIS_LENGTH
-#: ultralcd.cpp:7863
+#: ultralcd.cpp:7949
 msgid "Axis length"
 msgstr ""
 
 # MSG_SELFTEST_AXIS
-#: ultralcd.cpp:7865
+#: ultralcd.cpp:7951
 msgid "Axis"
 msgstr ""
 
 # MSG_SELFTEST_BEDHEATER
-#: ultralcd.cpp:7807
+#: ultralcd.cpp:7893
 msgid "Bed / Heater"
 msgstr ""
 
@@ -136,7 +136,7 @@ msgid "Bed Heating"
 msgstr ""
 
 # MSG_BED_CORRECTION_MENU
-#: ultralcd.cpp:5682
+#: ultralcd.cpp:5768
 msgid "Bed level correct"
 msgstr ""
 
@@ -151,7 +151,7 @@ msgid "Bed"
 msgstr ""
 
 # MSG_MENU_BELT_STATUS c=15 r=1
-#: ultralcd.cpp:2002
+#: ultralcd.cpp:2059
 msgid "Belt status"
 msgstr ""
 
@@ -161,12 +161,12 @@ msgid "Blackout occurred. Recover print?"
 msgstr ""
 
 # 
-#: ultralcd.cpp:8211
+#: ultralcd.cpp:8297
 msgid "Calibrating home"
 msgstr ""
 
 # MSG_CALIBRATE_BED
-#: ultralcd.cpp:5671
+#: ultralcd.cpp:5757
 msgid "Calibrate XYZ"
 msgstr ""
 
@@ -176,12 +176,12 @@ msgid "Calibrate Z"
 msgstr ""
 
 # MSG_CALIBRATE_PINDA c=17 r=1
-#: ultralcd.cpp:4570
+#: ultralcd.cpp:4654
 msgid "Calibrate"
 msgstr ""
 
 # MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ultralcd.cpp:3408
+#: ultralcd.cpp:3492
 msgid "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end stoppers. Click when done."
 msgstr ""
 
@@ -191,12 +191,12 @@ msgid "Calibrating Z"
 msgstr ""
 
 # MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ultralcd.cpp:3408
+#: ultralcd.cpp:3492
 msgid "Calibrating Z. Rotate the knob to move the Z carriage up to the end stoppers. Click when done."
 msgstr ""
 
 # MSG_HOMEYZ_DONE
-#: ultralcd.cpp:813
+#: ultralcd.cpp:816
 msgid "Calibration done"
 msgstr ""
 
@@ -206,17 +206,17 @@ msgid "Calibration"
 msgstr ""
 
 # 
-#: ultralcd.cpp:4695
+#: ultralcd.cpp:4781
 msgid "Cancel"
 msgstr ""
 
 # MSG_SD_REMOVED
-#: ultralcd.cpp:8578
+#: ultralcd.cpp:8679
 msgid "Card removed"
 msgstr ""
 
 # MSG_NOT_COLOR
-#: ultralcd.cpp:2676
+#: ultralcd.cpp:2718
 msgid "Color not correct"
 msgstr ""
 
@@ -226,7 +226,7 @@ msgid "Cooldown"
 msgstr ""
 
 # 
-#: ultralcd.cpp:4503
+#: ultralcd.cpp:4587
 msgid "Copy selected language?"
 msgstr ""
 
@@ -256,22 +256,22 @@ msgid "Crash detected. Resume print?"
 msgstr ""
 
 # 
-#: ultralcd.cpp:1876
+#: ultralcd.cpp:1853
 msgid "Crash"
 msgstr ""
 
 # MSG_CURRENT c=19 r=1
-#: ultralcd.cpp:5823
+#: ultralcd.cpp:5909
 msgid "Current"
 msgstr ""
 
 # MSG_DATE c=17 r=1
-#: ultralcd.cpp:2102
+#: ultralcd.cpp:2213
 msgid "Date:"
 msgstr ""
 
 # MSG_DISABLE_STEPPERS
-#: ultralcd.cpp:5568
+#: ultralcd.cpp:5654
 msgid "Disable steppers"
 msgstr ""
 
@@ -281,12 +281,12 @@ msgid "Distance between tip of the nozzle and the bed surface has not been set y
 msgstr ""
 
 # MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ultralcd.cpp:4984
+#: ultralcd.cpp:5070
 msgid "Do you want to repeat last step to readjust distance between nozzle and heatbed?"
 msgstr ""
 
 # MSG_EXTRUDER_CORRECTION c=10
-#: ultralcd.cpp:5048
+#: ultralcd.cpp:5134
 msgid "E-correct:"
 msgstr ""
 
@@ -296,7 +296,7 @@ msgid "Eject filament"
 msgstr ""
 
 # 
-#: ultralcd.cpp:4783
+#: ultralcd.cpp:4869
 msgid "Eject"
 msgstr ""
 
@@ -306,27 +306,27 @@ msgid "Ejecting filament"
 msgstr ""
 
 # MSG_SELFTEST_ENDSTOP_NOTHIT c=20 r=1
-#: ultralcd.cpp:7831
+#: ultralcd.cpp:7917
 msgid "Endstop not hit"
 msgstr ""
 
 # MSG_SELFTEST_ENDSTOP
-#: ultralcd.cpp:7825
+#: ultralcd.cpp:7911
 msgid "Endstop"
 msgstr ""
 
 # MSG_SELFTEST_ENDSTOPS
-#: ultralcd.cpp:7813
+#: ultralcd.cpp:7899
 msgid "Endstops"
 msgstr ""
 
 # MSG_STACK_ERROR c=20 r=4
-#: ultralcd.cpp:6773
+#: ultralcd.cpp:6859
 msgid "Error - static memory has been overwritten"
 msgstr ""
 
 # MSG_FSENS_NOT_RESPONDING c=20 r=4
-#: ultralcd.cpp:4391
+#: ultralcd.cpp:4475
 msgid "ERROR: Filament sensor is not responding, please check connection."
 msgstr ""
 
@@ -336,12 +336,12 @@ msgid "ERROR:"
 msgstr ""
 
 # MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
-#: ultralcd.cpp:8218
+#: ultralcd.cpp:8304
 msgid "Extruder fan:"
 msgstr ""
 
 # MSG_INFO_EXTRUDER c=15 r=1
-#: ultralcd.cpp:2133
+#: ultralcd.cpp:2244
 msgid "Extruder info"
 msgstr ""
 
@@ -351,12 +351,12 @@ msgid "Extruder"
 msgstr ""
 
 # 
-#: ultralcd.cpp:6760
+#: ultralcd.cpp:6846
 msgid "Fail stats MMU"
 msgstr ""
 
 # MSG_FSENS_AUTOLOAD_ON c=17 r=1
-#: ultralcd.cpp:5082
+#: ultralcd.cpp:5168
 msgid "F. autoload  [on]"
 msgstr ""
 
@@ -366,12 +366,12 @@ msgid "F. autoload [N/A]"
 msgstr ""
 
 # MSG_FSENS_AUTOLOAD_OFF c=17 r=1
-#: ultralcd.cpp:5084
+#: ultralcd.cpp:5170
 msgid "F. autoload [off]"
 msgstr ""
 
 # 
-#: ultralcd.cpp:6757
+#: ultralcd.cpp:6843
 msgid "Fail stats"
 msgstr ""
 
@@ -386,12 +386,12 @@ msgid "Fan test"
 msgstr ""
 
 # MSG_FANS_CHECK_ON c=17 r=1
-#: ultralcd.cpp:5577
+#: ultralcd.cpp:5663
 msgid "Fans check   [on]"
 msgstr ""
 
 # MSG_FANS_CHECK_OFF c=17 r=1
-#: ultralcd.cpp:5579
+#: ultralcd.cpp:5665
 msgid "Fans check  [off]"
 msgstr ""
 
@@ -401,7 +401,7 @@ msgid "Fil. sensor  [on]"
 msgstr ""
 
 # MSG_FSENSOR_NA
-#: ultralcd.cpp:5062
+#: ultralcd.cpp:5148
 msgid "Fil. sensor [N/A]"
 msgstr ""
 
@@ -411,7 +411,7 @@ msgid "Fil. sensor [off]"
 msgstr ""
 
 # 
-#: ultralcd.cpp:1876
+#: ultralcd.cpp:1852
 msgid "Filam. runouts"
 msgstr ""
 
@@ -421,7 +421,7 @@ msgid "Filament extruding & with correct color?"
 msgstr ""
 
 # MSG_NOT_LOADED c=19
-#: ultralcd.cpp:2672
+#: ultralcd.cpp:2714
 msgid "Filament not loaded"
 msgstr ""
 
@@ -431,17 +431,17 @@ msgid "Filament sensor"
 msgstr ""
 
 # MSG_FILAMENT_USED c=19 r=1
-#: ultralcd.cpp:2841
+#: ultralcd.cpp:2885
 msgid "Filament used"
 msgstr ""
 
 # MSG_PRINT_TIME c=19 r=1
-#: ultralcd.cpp:2841
+#: ultralcd.cpp:2886
 msgid "Print time"
 msgstr ""
 
 # MSG_FILE_INCOMPLETE c=20 r=2
-#: ultralcd.cpp:8346
+#: ultralcd.cpp:8432
 msgid "File incomplete. Continue anyway?"
 msgstr ""
 
@@ -456,7 +456,7 @@ msgid "First layer cal."
 msgstr ""
 
 # MSG_WIZARD_SELFTEST c=20 r=8
-#: ultralcd.cpp:4896
+#: ultralcd.cpp:4982
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 
@@ -466,12 +466,12 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr ""
 
 # MSG_FLOW
-#: ultralcd.cpp:6846
+#: ultralcd.cpp:6932
 msgid "Flow"
 msgstr ""
 
 # MSG_PRUSA3D_FORUM
-#: ultralcd.cpp:2095
+#: ultralcd.cpp:2206
 msgid "forum.prusa3d.com"
 msgstr ""
 
@@ -481,22 +481,22 @@ msgid "Front print fan?"
 msgstr ""
 
 # MSG_BED_CORRECTION_FRONT c=14 r=1
-#: ultralcd.cpp:3220
+#: ultralcd.cpp:3294
 msgid "Front side[um]"
 msgstr ""
 
 # MSG_SELFTEST_FANS
-#: ultralcd.cpp:7871
+#: ultralcd.cpp:7957
 msgid "Front/left fans"
 msgstr ""
 
 # MSG_SELFTEST_HEATERTHERMISTOR
-#: ultralcd.cpp:7801
+#: ultralcd.cpp:7887
 msgid "Heater/Thermistor"
 msgstr ""
 
 # MSG_BED_HEATING_SAFETY_DISABLED
-#: Marlin_main.cpp:8468
+#: Marlin_main.cpp:8467
 msgid "Heating disabled by safety timer."
 msgstr ""
 
@@ -511,12 +511,12 @@ msgid "Heating"
 msgstr ""
 
 # MSG_WIZARD_WELCOME c=20 r=7
-#: ultralcd.cpp:4875
+#: ultralcd.cpp:4961
 msgid "Hi, I am your Original Prusa i3 printer. Would you like me to guide you through the setup process?"
 msgstr ""
 
 # MSG_PRUSA3D_HOWTO
-#: ultralcd.cpp:2096
+#: ultralcd.cpp:2207
 msgid "howto.prusa3d.com"
 msgstr ""
 
@@ -526,12 +526,12 @@ msgid "Change filament"
 msgstr ""
 
 # MSG_CHANGE_SUCCESS
-#: ultralcd.cpp:2587
+#: ultralcd.cpp:2629
 msgid "Change success!"
 msgstr ""
 
 # MSG_CORRECTLY c=20
-#: ultralcd.cpp:2664
+#: ultralcd.cpp:2706
 msgid "Changed correctly?"
 msgstr ""
 
@@ -541,12 +541,12 @@ msgid "Checking bed     "
 msgstr ""
 
 # MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ultralcd.cpp:8200
+#: ultralcd.cpp:8286
 msgid "Checking endstops"
 msgstr ""
 
 # MSG_SELFTEST_CHECK_HOTEND c=20
-#: ultralcd.cpp:8206
+#: ultralcd.cpp:8292
 msgid "Checking hotend  "
 msgstr ""
 
@@ -556,17 +556,17 @@ msgid "Checking sensors "
 msgstr ""
 
 # MSG_SELFTEST_CHECK_X c=20
-#: ultralcd.cpp:8201
+#: ultralcd.cpp:8287
 msgid "Checking X axis  "
 msgstr ""
 
 # MSG_SELFTEST_CHECK_Y c=20
-#: ultralcd.cpp:8202
+#: ultralcd.cpp:8288
 msgid "Checking Y axis  "
 msgstr ""
 
 # MSG_SELFTEST_CHECK_Z c=20
-#: ultralcd.cpp:8203
+#: ultralcd.cpp:8289
 msgid "Checking Z axis  "
 msgstr ""
 
@@ -586,17 +586,17 @@ msgid "Filament"
 msgstr ""
 
 # MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ultralcd.cpp:4905
+#: ultralcd.cpp:4991
 msgid "I will run xyz calibration now. It will take approx. 12 mins."
 msgstr ""
 
 # MSG_WIZARD_Z_CAL c=20 r=8
-#: ultralcd.cpp:4913
+#: ultralcd.cpp:4999
 msgid "I will run z calibration now."
 msgstr ""
 
 # MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ultralcd.cpp:4978
+#: ultralcd.cpp:5064
 msgid "I will start to print line and you will gradually lower the nozzle by rotating the knob, until you reach optimal height. Check the pictures in our handbook in chapter Calibration."
 msgstr ""
 
@@ -606,27 +606,27 @@ msgid "Info screen"
 msgstr ""
 
 # 
-#: ultralcd.cpp:4938
+#: ultralcd.cpp:5024
 msgid "Is filament 1 loaded?"
 msgstr ""
 
 # MSG_INSERT_FILAMENT c=20
-#: ultralcd.cpp:2572
+#: ultralcd.cpp:2614
 msgid "Insert filament"
 msgstr ""
 
 # MSG_WIZARD_FILAMENT_LOADED c=20 r=2
-#: ultralcd.cpp:4941
+#: ultralcd.cpp:5027
 msgid "Is filament loaded?"
 msgstr ""
 
 # MSG_WIZARD_PLA_FILAMENT c=20 r=2
-#: ultralcd.cpp:4972
+#: ultralcd.cpp:5058
 msgid "Is it PLA filament?"
 msgstr ""
 
 # MSG_PLA_FILAMENT_LOADED c=20 r=2
-#: ultralcd.cpp:4704
+#: ultralcd.cpp:4790
 msgid "Is PLA filament loaded?"
 msgstr ""
 
@@ -636,12 +636,12 @@ msgid "Is steel sheet on heatbed?"
 msgstr ""
 
 # 
-#: ultralcd.cpp:1840
+#: ultralcd.cpp:1795
 msgid "Last print failures"
 msgstr ""
 
 # 
-#: ultralcd.cpp:1823
+#: ultralcd.cpp:1772
 msgid "Last print"
 msgstr ""
 
@@ -651,17 +651,17 @@ msgid "Left hotend fan?"
 msgstr ""
 
 # 
-#: ultralcd.cpp:2970
+#: ultralcd.cpp:3018
 msgid "Left"
 msgstr ""
 
 # MSG_BED_CORRECTION_LEFT c=14 r=1
-#: ultralcd.cpp:3218
+#: ultralcd.cpp:3292
 msgid "Left side [um]"
 msgstr ""
 
 # 
-#: ultralcd.cpp:5594
+#: ultralcd.cpp:5680
 msgid "Lin. correction"
 msgstr ""
 
@@ -676,7 +676,7 @@ msgid "Load filament"
 msgstr ""
 
 # MSG_LOADING_COLOR
-#: ultralcd.cpp:2612
+#: ultralcd.cpp:2654
 msgid "Loading color"
 msgstr ""
 
@@ -686,12 +686,12 @@ msgid "Loading filament"
 msgstr ""
 
 # MSG_LOOSE_PULLEY c=20 r=1
-#: ultralcd.cpp:7855
+#: ultralcd.cpp:7941
 msgid "Loose pulley"
 msgstr ""
 
 # 
-#: ultralcd.cpp:6719
+#: ultralcd.cpp:6805
 msgid "Load to nozzle"
 msgstr ""
 
@@ -711,7 +711,7 @@ msgid "Measuring reference height of calibration point"
 msgstr ""
 
 # MSG_MESH_BED_LEVELING
-#: ultralcd.cpp:5677
+#: ultralcd.cpp:5763
 msgid "Mesh Bed Leveling"
 msgstr ""
 
@@ -726,12 +726,12 @@ msgid "MMU OK. Resuming temperature..."
 msgstr ""
 
 # 
-#: ultralcd.cpp:3005
+#: ultralcd.cpp:3059
 msgid "Measured skew"
 msgstr ""
 
 # 
-#: ultralcd.cpp:1840
+#: ultralcd.cpp:1796
 msgid "MMU fails"
 msgstr ""
 
@@ -741,7 +741,7 @@ msgid "MMU load failed     "
 msgstr ""
 
 # 
-#: ultralcd.cpp:1840
+#: ultralcd.cpp:1797
 msgid "MMU load fails"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgid "MMU needs user attention."
 msgstr ""
 
 # 
-#: ultralcd.cpp:1857
+#: ultralcd.cpp:1823
 msgid "MMU power fails"
 msgstr ""
 
@@ -786,7 +786,7 @@ msgid "Mode [high power]"
 msgstr ""
 
 # 
-#: ultralcd.cpp:2108
+#: ultralcd.cpp:2219
 msgid "MMU2 connected"
 msgstr ""
 
@@ -796,37 +796,37 @@ msgid "Motor"
 msgstr ""
 
 # MSG_MOVE_AXIS
-#: ultralcd.cpp:5566
+#: ultralcd.cpp:5652
 msgid "Move axis"
 msgstr ""
 
 # MSG_MOVE_X
-#: ultralcd.cpp:4294
+#: ultralcd.cpp:4378
 msgid "Move X"
 msgstr ""
 
 # MSG_MOVE_Y
-#: ultralcd.cpp:4295
+#: ultralcd.cpp:4379
 msgid "Move Y"
 msgstr ""
 
 # MSG_MOVE_Z
-#: ultralcd.cpp:4296
+#: ultralcd.cpp:4380
 msgid "Move Z"
 msgstr ""
 
 # MSG_NO_MOVE
-#: Marlin_main.cpp:5291
+#: Marlin_main.cpp:5292
 msgid "No move."
 msgstr ""
 
 # MSG_NO_CARD
-#: ultralcd.cpp:6686
+#: ultralcd.cpp:6772
 msgid "No SD card"
 msgstr ""
 
 # 
-#: ultralcd.cpp:2976
+#: ultralcd.cpp:3024
 msgid "N/A"
 msgstr ""
 
@@ -836,7 +836,7 @@ msgid "No"
 msgstr ""
 
 # MSG_SELFTEST_NOTCONNECTED
-#: ultralcd.cpp:7803
+#: ultralcd.cpp:7889
 msgid "Not connected"
 msgstr ""
 
@@ -851,12 +851,12 @@ msgid "Not spinning"
 msgstr ""
 
 # MSG_WIZARD_V2_CAL c=20 r=8
-#: ultralcd.cpp:4977
+#: ultralcd.cpp:5063
 msgid "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr ""
 
 # MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ultralcd.cpp:4921
+#: ultralcd.cpp:5007
 msgid "Now I will preheat nozzle for PLA."
 msgstr ""
 
@@ -871,37 +871,37 @@ msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr ""
 
 # 
-#: ultralcd.cpp:4912
+#: ultralcd.cpp:4998
 msgid "Now remove the test print from steel sheet."
 msgstr ""
 
 # 
-#: ultralcd.cpp:1782
+#: ultralcd.cpp:1722
 msgid "Nozzle FAN"
 msgstr ""
 
 # MSG_PAUSE_PRINT
-#: ultralcd.cpp:6649
+#: ultralcd.cpp:6735
 msgid "Pause print"
 msgstr ""
 
 # MSG_PID_RUNNING c=20 r=1
-#: ultralcd.cpp:1598
+#: ultralcd.cpp:1606
 msgid "PID cal.           "
 msgstr ""
 
 # MSG_PID_FINISHED c=20 r=1
-#: ultralcd.cpp:1604
+#: ultralcd.cpp:1612
 msgid "PID cal. finished"
 msgstr ""
 
 # MSG_PID_EXTRUDER c=17 r=1
-#: ultralcd.cpp:5683
+#: ultralcd.cpp:5769
 msgid "PID calibration"
 msgstr ""
 
 # MSG_PINDA_PREHEAT c=20 r=1
-#: ultralcd.cpp:843
+#: ultralcd.cpp:846
 msgid "PINDA Heating"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgid "Place a sheet of paper under the nozzle during the calibration of first 4
 msgstr ""
 
 # MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ultralcd.cpp:4986
+#: ultralcd.cpp:5072
 msgid "Please clean heatbed and then press the knob."
 msgstr ""
 
@@ -921,7 +921,7 @@ msgid "Please clean the nozzle for calibration. Click when done."
 msgstr ""
 
 # MSG_SELFTEST_PLEASECHECK
-#: ultralcd.cpp:7795
+#: ultralcd.cpp:7881
 msgid "Please check :"
 msgstr ""
 
@@ -931,17 +931,17 @@ msgid "Please check our handbook and fix the problem. Then resume the Wizard by 
 msgstr ""
 
 # MSG_WIZARD_LOAD_FILAMENT c=20 r=8
-#: ultralcd.cpp:4808
+#: ultralcd.cpp:4894
 msgid "Please insert PLA filament to the extruder, then press knob to load it."
 msgstr ""
 
 # MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ultralcd.cpp:4709
+#: ultralcd.cpp:4795
 msgid "Please load PLA filament first."
 msgstr ""
 
 # MSG_CHECK_IDLER c=20 r=4
-#: Marlin_main.cpp:3063
+#: Marlin_main.cpp:3064
 msgid "Please open idler and remove filament manually."
 msgstr ""
 
@@ -956,7 +956,7 @@ msgid "Please press the knob to unload filament"
 msgstr ""
 
 # 
-#: ultralcd.cpp:4803
+#: ultralcd.cpp:4889
 msgid "Please insert PLA filament to the first tube of MMU, then press the knob to load it."
 msgstr ""
 
@@ -976,7 +976,7 @@ msgid "Please remove steel sheet from heatbed."
 msgstr ""
 
 # MSG_RUN_XYZ c=20 r=4
-#: Marlin_main.cpp:4354
+#: Marlin_main.cpp:4355
 msgid "Please run XYZ calibration first."
 msgstr ""
 
@@ -991,7 +991,7 @@ msgid "Please wait"
 msgstr ""
 
 # 
-#: ultralcd.cpp:4911
+#: ultralcd.cpp:4997
 msgid "Please remove shipping helpers first."
 msgstr ""
 
@@ -1001,7 +1001,7 @@ msgid "Preheat the nozzle!"
 msgstr ""
 
 # MSG_PREHEAT
-#: ultralcd.cpp:6636
+#: ultralcd.cpp:6722
 msgid "Preheat"
 msgstr ""
 
@@ -1016,12 +1016,12 @@ msgid "Please upgrade."
 msgstr ""
 
 # MSG_PRESS_TO_PREHEAT c=20 r=4
-#: Marlin_main.cpp:10365
+#: Marlin_main.cpp:10364
 msgid "Press knob to preheat nozzle and continue."
 msgstr ""
 
 # 
-#: ultralcd.cpp:1876
+#: ultralcd.cpp:1851
 msgid "Power failures"
 msgstr ""
 
@@ -1031,17 +1031,17 @@ msgid "Print aborted"
 msgstr ""
 
 # 
-#: ultralcd.cpp:2276
+#: ultralcd.cpp:2455
 msgid "Preheating to load"
 msgstr ""
 
 # 
-#: ultralcd.cpp:2280
+#: ultralcd.cpp:2459
 msgid "Preheating to unload"
 msgstr ""
 
 # MSG_SELFTEST_PRINT_FAN_SPEED c=18
-#: ultralcd.cpp:8221
+#: ultralcd.cpp:8307
 msgid "Print fan:"
 msgstr ""
 
@@ -1051,12 +1051,12 @@ msgid "Print from SD"
 msgstr ""
 
 # 
-#: ultralcd.cpp:2206
+#: ultralcd.cpp:2317
 msgid "Press the knob"
 msgstr ""
 
 # MSG_PRINT_PAUSED c=20 r=1
-#: ultralcd.cpp:1061
+#: ultralcd.cpp:1069
 msgid "Print paused"
 msgstr ""
 
@@ -1071,22 +1071,22 @@ msgid "Printer has not been calibrated yet. Please follow the manual, chapter Fi
 msgstr ""
 
 # 
-#: ultralcd.cpp:1784
+#: ultralcd.cpp:1723
 msgid "Print FAN"
 msgstr ""
 
 # MSG_PRUSA3D
-#: ultralcd.cpp:2094
+#: ultralcd.cpp:2205
 msgid "prusa3d.com"
 msgstr ""
 
 # MSG_BED_CORRECTION_REAR c=14 r=1
-#: ultralcd.cpp:3221
+#: ultralcd.cpp:3295
 msgid "Rear side [um]"
 msgstr ""
 
 # MSG_RECOVERING_PRINT c=20 r=1
-#: Marlin_main.cpp:9765
+#: Marlin_main.cpp:9764
 msgid "Recovering print    "
 msgstr ""
 
@@ -1101,17 +1101,17 @@ msgid "Prusa i3 MK3S OK."
 msgstr ""
 
 # MSG_CALIBRATE_BED_RESET
-#: ultralcd.cpp:5688
+#: ultralcd.cpp:5774
 msgid "Reset XYZ calibr."
 msgstr ""
 
 # MSG_BED_CORRECTION_RESET
-#: ultralcd.cpp:3222
+#: ultralcd.cpp:3296
 msgid "Reset"
 msgstr ""
 
 # MSG_RESUME_PRINT
-#: ultralcd.cpp:6656
+#: ultralcd.cpp:6742
 msgid "Resume print"
 msgstr ""
 
@@ -1121,37 +1121,37 @@ msgid "Resuming print"
 msgstr ""
 
 # MSG_BED_CORRECTION_RIGHT c=14 r=1
-#: ultralcd.cpp:3219
+#: ultralcd.cpp:3293
 msgid "Right side[um]"
 msgstr ""
 
 # MSG_SECOND_SERIAL_ON c=17 r=1
-#: ultralcd.cpp:5606
+#: ultralcd.cpp:5692
 msgid "RPi port     [on]"
 msgstr ""
 
 # MSG_SECOND_SERIAL_OFF c=17 r=1
-#: ultralcd.cpp:5604
+#: ultralcd.cpp:5690
 msgid "RPi port    [off]"
 msgstr ""
 
 # MSG_WIZARD_RERUN c=20 r=7
-#: ultralcd.cpp:4726
+#: ultralcd.cpp:4812
 msgid "Running Wizard will delete current calibration results and start from the beginning. Continue?"
 msgstr ""
 
 # MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_OFF c=19 r=1
-#: ultralcd.cpp:5236
+#: ultralcd.cpp:5322
 msgid "SD card  [normal]"
 msgstr ""
 
 # MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_ON c=19 r=1
-#: ultralcd.cpp:5234
+#: ultralcd.cpp:5320
 msgid "SD card [flshAir]"
 msgstr ""
 
 # 
-#: ultralcd.cpp:2971
+#: ultralcd.cpp:3019
 msgid "Right"
 msgstr ""
 
@@ -1161,27 +1161,27 @@ msgid "Searching bed calibration point"
 msgstr ""
 
 # MSG_LANGUAGE_SELECT
-#: ultralcd.cpp:5613
+#: ultralcd.cpp:5699
 msgid "Select language"
 msgstr ""
 
 # MSG_SELFTEST_OK
-#: ultralcd.cpp:7366
+#: ultralcd.cpp:7452
 msgid "Self test OK"
 msgstr ""
 
 # MSG_SELFTEST_START c=20
-#: ultralcd.cpp:7152
+#: ultralcd.cpp:7238
 msgid "Self test start  "
 msgstr ""
 
 # MSG_SELFTEST
-#: ultralcd.cpp:5664
+#: ultralcd.cpp:5750
 msgid "Selftest         "
 msgstr ""
 
 # MSG_SELFTEST_ERROR
-#: ultralcd.cpp:7793
+#: ultralcd.cpp:7879
 msgid "Selftest error !"
 msgstr ""
 
@@ -1196,17 +1196,17 @@ msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr ""
 
 # 
-#: ultralcd.cpp:4959
+#: ultralcd.cpp:5045
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr ""
 
 # 
-#: ultralcd.cpp:4695
+#: ultralcd.cpp:4780
 msgid "Select PLA filament:"
 msgstr ""
 
 # MSG_SET_TEMPERATURE c=19 r=1
-#: ultralcd.cpp:3230
+#: ultralcd.cpp:3314
 msgid "Set temperature:"
 msgstr ""
 
@@ -1216,12 +1216,12 @@ msgid "Settings"
 msgstr ""
 
 # MSG_SHOW_END_STOPS c=17 r=1
-#: ultralcd.cpp:5685
+#: ultralcd.cpp:5771
 msgid "Show end stops"
 msgstr ""
 
 # 
-#: ultralcd.cpp:3941
+#: ultralcd.cpp:4025
 msgid "Sensor state"
 msgstr ""
 
@@ -1231,22 +1231,22 @@ msgid "Some files will not be sorted. Max. No. of files in 1 folder for sorting 
 msgstr ""
 
 # MSG_SORT_NONE c=17 r=1
-#: ultralcd.cpp:5246
+#: ultralcd.cpp:5332
 msgid "Sort       [none]"
 msgstr ""
 
 # MSG_SORT_TIME c=17 r=1
-#: ultralcd.cpp:5244
+#: ultralcd.cpp:5330
 msgid "Sort       [time]"
 msgstr ""
 
 # 
-#: ultralcd.cpp:3008
-msgid "Severe skew"
+#: ultralcd.cpp:3062
+msgid "Severe skew:"
 msgstr ""
 
 # MSG_SORT_ALPHA c=17 r=1
-#: ultralcd.cpp:5245
+#: ultralcd.cpp:5331
 msgid "Sort   [alphabet]"
 msgstr ""
 
@@ -1261,8 +1261,8 @@ msgid "Sound      [loud]"
 msgstr ""
 
 # 
-#: ultralcd.cpp:3007
-msgid "Slight skew"
+#: ultralcd.cpp:3061
+msgid "Slight skew:"
 msgstr ""
 
 # MSG_SOUND_MUTE c=17 r=1
@@ -1271,7 +1271,7 @@ msgid "Sound      [mute]"
 msgstr ""
 
 # 
-#: Marlin_main.cpp:4870
+#: Marlin_main.cpp:4871
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr ""
 
@@ -1286,7 +1286,7 @@ msgid "Sound    [silent]"
 msgstr ""
 
 # MSG_SPEED
-#: ultralcd.cpp:6840
+#: ultralcd.cpp:6926
 msgid "Speed"
 msgstr ""
 
@@ -1296,12 +1296,12 @@ msgid "Spinning"
 msgstr ""
 
 # MSG_TEMP_CAL_WARNING c=20 r=4
-#: Marlin_main.cpp:4367
+#: Marlin_main.cpp:4368
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr ""
 
 # MSG_STATISTICS
-#: ultralcd.cpp:6753
+#: ultralcd.cpp:6839
 msgid "Statistics  "
 msgstr ""
 
@@ -1316,12 +1316,12 @@ msgid "STOPPED. "
 msgstr ""
 
 # MSG_SUPPORT
-#: ultralcd.cpp:6762
+#: ultralcd.cpp:6848
 msgid "Support"
 msgstr ""
 
 # MSG_SELFTEST_SWAPPED
-#: ultralcd.cpp:7873
+#: ultralcd.cpp:7959
 msgid "Swapped"
 msgstr ""
 
@@ -1331,22 +1331,22 @@ msgid "Temp. cal.          "
 msgstr ""
 
 # MSG_TEMP_CALIBRATION_ON c=20 r=1
-#: ultralcd.cpp:5600
+#: ultralcd.cpp:5686
 msgid "Temp. cal.   [on]"
 msgstr ""
 
 # MSG_TEMP_CALIBRATION_OFF c=20 r=1
-#: ultralcd.cpp:5598
+#: ultralcd.cpp:5684
 msgid "Temp. cal.  [off]"
 msgstr ""
 
 # MSG_CALIBRATION_PINDA_MENU c=17 r=1
-#: ultralcd.cpp:5694
+#: ultralcd.cpp:5780
 msgid "Temp. calibration"
 msgstr ""
 
 # MSG_TEMP_CAL_FAILED c=20 r=8
-#: ultralcd.cpp:3867
+#: ultralcd.cpp:3951
 msgid "Temperature calibration failed"
 msgstr ""
 
@@ -1356,12 +1356,12 @@ msgid "Temperature calibration is finished and active. Temp. calibration can be 
 msgstr ""
 
 # MSG_TEMPERATURE
-#: ultralcd.cpp:5564
+#: ultralcd.cpp:5650
 msgid "Temperature"
 msgstr ""
 
 # MSG_MENU_TEMPERATURES c=15 r=1
-#: ultralcd.cpp:2140
+#: ultralcd.cpp:2251
 msgid "Temperatures"
 msgstr ""
 
@@ -1371,37 +1371,37 @@ msgid "There is still a need to make Z calibration. Please follow the manual, ch
 msgstr ""
 
 # 
-#: ultralcd.cpp:2863
+#: ultralcd.cpp:2908
 msgid "Total filament"
 msgstr ""
 
 # 
-#: ultralcd.cpp:2863
+#: ultralcd.cpp:2908
 msgid "Total print time"
 msgstr ""
 
 # MSG_TUNE
-#: ultralcd.cpp:6633
+#: ultralcd.cpp:6719
 msgid "Tune"
 msgstr ""
 
 # 
-#: ultralcd.cpp:4783
+#: ultralcd.cpp:4869
 msgid "Unload"
 msgstr ""
 
 # 
-#: ultralcd.cpp:1857
+#: ultralcd.cpp:1820
 msgid "Total failures"
 msgstr ""
 
 # 
-#: ultralcd.cpp:2213
+#: ultralcd.cpp:2324
 msgid "to load filament"
 msgstr ""
 
 # 
-#: ultralcd.cpp:2217
+#: ultralcd.cpp:2328
 msgid "to unload filament"
 msgstr ""
 
@@ -1416,42 +1416,42 @@ msgid "Unloading filament"
 msgstr ""
 
 # 
-#: ultralcd.cpp:1824
+#: ultralcd.cpp:1773
 msgid "Total"
 msgstr ""
 
 # MSG_USED c=19 r=1
-#: ultralcd.cpp:5822
+#: ultralcd.cpp:5908
 msgid "Used during print"
 msgstr ""
 
 # MSG_MENU_VOLTAGES c=15 r=1
-#: ultralcd.cpp:2143
+#: ultralcd.cpp:2254
 msgid "Voltages"
 msgstr ""
 
 # 
-#: ultralcd.cpp:2116
+#: ultralcd.cpp:2227
 msgid "unknown"
 msgstr ""
 
 # MSG_USERWAIT
-#: Marlin_main.cpp:5262
+#: Marlin_main.cpp:5263
 msgid "Wait for user..."
 msgstr ""
 
 # MSG_WAITING_TEMP c=20 r=3
-#: ultralcd.cpp:3374
+#: ultralcd.cpp:3458
 msgid "Waiting for nozzle and bed cooling"
 msgstr ""
 
 # MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ultralcd.cpp:3338
+#: ultralcd.cpp:3422
 msgid "Waiting for PINDA probe cooling"
 msgstr ""
 
 # 
-#: ultralcd.cpp:4782
+#: ultralcd.cpp:4868
 msgid "Use unload to remove filament 1 if it protrudes outside of the rear MMU tube. Use eject if it is hidden in tube."
 msgstr ""
 
@@ -1471,7 +1471,7 @@ msgid "Warning: printer type changed."
 msgstr ""
 
 # MSG_UNLOAD_SUCCESSFUL c=20 r=2
-#: Marlin_main.cpp:3053
+#: Marlin_main.cpp:3054
 msgid "Was filament unload successful?"
 msgstr ""
 
@@ -1481,12 +1481,12 @@ msgid "Wiring error"
 msgstr ""
 
 # MSG_WIZARD c=17 r=1
-#: ultralcd.cpp:5661
+#: ultralcd.cpp:5747
 msgid "Wizard"
 msgstr ""
 
 # MSG_XYZ_DETAILS c=19 r=1
-#: ultralcd.cpp:2132
+#: ultralcd.cpp:2243
 msgid "XYZ cal. details"
 msgstr ""
 
@@ -1506,62 +1506,62 @@ msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr ""
 
 # MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ultralcd.cpp:3838
+#: ultralcd.cpp:3922
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr ""
 
 # MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ultralcd.cpp:3835
+#: ultralcd.cpp:3919
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr ""
 
 # 
-#: ultralcd.cpp:5044
+#: ultralcd.cpp:5130
 msgid "X-correct:"
 msgstr ""
 
 # MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ultralcd.cpp:3832
+#: ultralcd.cpp:3916
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr ""
 
 # MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ultralcd.cpp:3816
+#: ultralcd.cpp:3900
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr ""
 
 # MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ultralcd.cpp:3819
+#: ultralcd.cpp:3903
 msgid "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr ""
 
 # MSG_LOAD_ALL c=17
-#: ultralcd.cpp:6080
+#: ultralcd.cpp:6166
 msgid "Load all"
 msgstr ""
 
 # 
-#: ultralcd.cpp:3798
+#: ultralcd.cpp:3882
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr ""
 
 # 
-#: ultralcd.cpp:3804
+#: ultralcd.cpp:3888
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr ""
 
 # 
-#: ultralcd.cpp:3807
+#: ultralcd.cpp:3891
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr ""
 
 # 
-#: ultralcd.cpp:2968
+#: ultralcd.cpp:3016
 msgid "Y distance from min"
 msgstr ""
 
 # 
-#: ultralcd.cpp:5045
+#: ultralcd.cpp:5131
 msgid "Y-correct:"
 msgstr ""
 
@@ -1576,32 +1576,32 @@ msgid "Back"
 msgstr ""
 
 # 
-#: ultralcd.cpp:5553
+#: ultralcd.cpp:5639
 msgid "Checks"
 msgstr ""
 
 # 
-#: ultralcd.cpp:7887
+#: ultralcd.cpp:7973
 msgid "False triggering"
 msgstr ""
 
 # 
-#: ultralcd.cpp:3946
+#: ultralcd.cpp:4030
 msgid "FINDA:"
 msgstr ""
 
 # 
-#: ultralcd.cpp:5459
+#: ultralcd.cpp:5545
 msgid "Firmware   [none]"
 msgstr ""
 
 # 
-#: ultralcd.cpp:5465
+#: ultralcd.cpp:5551
 msgid "Firmware [strict]"
 msgstr ""
 
 # 
-#: ultralcd.cpp:5462
+#: ultralcd.cpp:5548
 msgid "Firmware   [warn]"
 msgstr ""
 
@@ -1611,37 +1611,37 @@ msgid "HW Setup"
 msgstr ""
 
 # 
-#: ultralcd.cpp:3950
+#: ultralcd.cpp:4034
 msgid "IR:"
 msgstr ""
 
 # 
-#: ultralcd.cpp:6960
+#: ultralcd.cpp:7046
 msgid "Magnets comp.[N/A]"
 msgstr ""
 
 # 
-#: ultralcd.cpp:6958
+#: ultralcd.cpp:7044
 msgid "Magnets comp.[Off]"
 msgstr ""
 
 # 
-#: ultralcd.cpp:6957
+#: ultralcd.cpp:7043
 msgid "Magnets comp. [On]"
 msgstr ""
 
 # 
-#: ultralcd.cpp:6949
+#: ultralcd.cpp:7035
 msgid "Mesh         [3x3]"
 msgstr ""
 
 # 
-#: ultralcd.cpp:6950
+#: ultralcd.cpp:7036
 msgid "Mesh         [7x7]"
 msgstr ""
 
 # 
-#: ultralcd.cpp:5591
+#: ultralcd.cpp:5677
 msgid "Mesh bed leveling"
 msgstr ""
 
@@ -1651,62 +1651,62 @@ msgid "MK3S firmware detected on MK3 printer"
 msgstr ""
 
 # 
-#: ultralcd.cpp:5220
+#: ultralcd.cpp:5306
 msgid "MMU Mode [Normal]"
 msgstr ""
 
 # 
-#: ultralcd.cpp:5221
+#: ultralcd.cpp:5307
 msgid "MMU Mode[Stealth]"
 msgstr ""
 
 # 
-#: ultralcd.cpp:4427
+#: ultralcd.cpp:4511
 msgid "Mode change in progress ..."
 msgstr ""
 
 # 
-#: ultralcd.cpp:5420
+#: ultralcd.cpp:5506
 msgid "Model      [none]"
 msgstr ""
 
 # 
-#: ultralcd.cpp:5426
+#: ultralcd.cpp:5512
 msgid "Model    [strict]"
 msgstr ""
 
 # 
-#: ultralcd.cpp:5423
+#: ultralcd.cpp:5509
 msgid "Model      [warn]"
 msgstr ""
 
 # 
-#: ultralcd.cpp:5381
+#: ultralcd.cpp:5467
 msgid "Nozzle d.  [0.25]"
 msgstr ""
 
 # 
-#: ultralcd.cpp:5384
+#: ultralcd.cpp:5470
 msgid "Nozzle d.  [0.40]"
 msgstr ""
 
 # 
-#: ultralcd.cpp:5387
+#: ultralcd.cpp:5473
 msgid "Nozzle d.  [0.60]"
 msgstr ""
 
 # 
-#: ultralcd.cpp:5335
+#: ultralcd.cpp:5421
 msgid "Nozzle     [none]"
 msgstr ""
 
 # 
-#: ultralcd.cpp:5341
+#: ultralcd.cpp:5427
 msgid "Nozzle   [strict]"
 msgstr ""
 
 # 
-#: ultralcd.cpp:5338
+#: ultralcd.cpp:5424
 msgid "Nozzle     [warn]"
 msgstr ""
 
@@ -1741,17 +1741,17 @@ msgid "G-code sliced for a newer firmware. Please update the firmware. Print can
 msgstr ""
 
 # 
-#: ultralcd.cpp:3942
+#: ultralcd.cpp:4026
 msgid "PINDA:"
 msgstr ""
 
 # 
-#: ultralcd.cpp:2286
+#: ultralcd.cpp:2465
 msgid "Preheating to cut"
 msgstr ""
 
 # 
-#: ultralcd.cpp:2283
+#: ultralcd.cpp:2462
 msgid "Preheating to eject"
 msgstr ""
 
@@ -1766,17 +1766,17 @@ msgid "Printer nozzle diameter differs from the G-code. Please check the value i
 msgstr ""
 
 # 
-#: ultralcd.cpp:6597
+#: ultralcd.cpp:6683
 msgid "Rename"
 msgstr ""
 
 # 
-#: ultralcd.cpp:6593
+#: ultralcd.cpp:6679
 msgid "Select"
 msgstr ""
 
 # 
-#: ultralcd.cpp:2134
+#: ultralcd.cpp:2245
 msgid "Sensor info"
 msgstr ""
 
@@ -1786,22 +1786,27 @@ msgid "Sheet"
 msgstr ""
 
 # 
-#: 
-msgid "Sound     [assist]"
+#: sound.h:9
+msgid "Sound    [assist]"
 msgstr ""
 
 # 
-#: ultralcd.cpp:5551
+#: ultralcd.cpp:5637
 msgid "Steel sheets"
 msgstr ""
 
 # 
-#: ultralcd.cpp:5046
+#: ultralcd.cpp:5132
 msgid "Z-correct:"
 msgstr ""
 
 # 
-#: ultralcd.cpp:6952
+#: ultralcd.cpp:7038
 msgid "Z-probe nr.    [1]"
+msgstr ""
+
+# 
+#: ultralcd.cpp:7040
+msgid "Z-probe nr.    [3]"
 msgstr ""
 

--- a/lang/po/Firmware_cs.po
+++ b/lang/po/Firmware_cs.po
@@ -7,8 +7,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: cs\n"
 "Project-Id-Version: Prusa-Firmware\n"
-"POT-Creation-Date: Wed Sep 4 16:13:39 CEST 2019\n"
-"PO-Revision-Date: Wed Sep 4 16:13:39 CEST 2019\n"
+"POT-Creation-Date: Sun, Sep 22, 2019 2:03:01 PM\n"
+"PO-Revision-Date: Sun, Sep 22, 2019 2:03:01 PM\n"
 "Language-Team: \n"
 "X-Generator: Poedit 2.0.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
@@ -26,7 +26,7 @@ msgid " of 9"
 msgstr " z 9"
 
 # MSG_MEASURED_OFFSET
-#: ultralcd.cpp:3027
+#: ultralcd.cpp:3089
 msgid "[0;0] point offset"
 msgstr "[0;0] odsazeni bodu"
 
@@ -41,17 +41,17 @@ msgid "WARNING:\x0aCrash detection\x0adisabled in\x0aStealth mode"
 msgstr "POZOR:\x0aCrash detekce\x0adeaktivovana ve\x0aStealth modu"
 
 # 
-#: ultralcd.cpp:2290
+#: ultralcd.cpp:2472
 msgid ">Cancel"
 msgstr ">Zrusit"
 
 # MSG_BABYSTEPPING_Z c=15
-#: ultralcd.cpp:3147
+#: ultralcd.cpp:3209
 msgid "Adjusting Z:"
-msgstr "Dostavovani Z:"
+msgstr "Doladeni Z:"
 
 # MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ultralcd.cpp:8209
+#: ultralcd.cpp:8295
 msgid "All correct      "
 msgstr "Vse OK "
 
@@ -61,32 +61,32 @@ msgid "All is done. Happy printing!"
 msgstr "Vse je hotovo."
 
 # 
-#: ultralcd.cpp:1974
+#: ultralcd.cpp:2009
 msgid "Ambient"
 msgstr "Okoli"
 
 # MSG_PRESS c=20
-#: ultralcd.cpp:2576
+#: ultralcd.cpp:2618
 msgid "and press the knob"
 msgstr "a stisknete tlacitko"
 
 # MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=2
-#: ultralcd.cpp:3445
+#: ultralcd.cpp:3529
 msgid "Are left and right Z~carriages all up?"
 msgstr "Dojely oba Z voziky k~hornimu dorazu?"
 
 # MSG_AUTO_DEPLETE_ON c=17 r=1
-#: ultralcd.cpp:5114
+#: ultralcd.cpp:5200
 msgid "SpoolJoin    [on]"
 msgstr "SpoolJoin   [zap]"
 
 # 
-#: ultralcd.cpp:5110
+#: ultralcd.cpp:5196
 msgid "SpoolJoin   [N/A]"
 msgstr ""
 
 # MSG_AUTO_DEPLETE_OFF c=17 r=1
-#: ultralcd.cpp:5118
+#: ultralcd.cpp:5204
 msgid "SpoolJoin   [off]"
 msgstr "SpoolJoin   [vyp]"
 
@@ -96,32 +96,32 @@ msgid "Auto home"
 msgstr ""
 
 # MSG_AUTOLOAD_FILAMENT c=17
-#: ultralcd.cpp:6736
+#: ultralcd.cpp:6822
 msgid "AutoLoad filament"
 msgstr "AutoZavedeni fil."
 
 # MSG_AUTOLOADING_ONLY_IF_FSENS_ON c=20 r=4
-#: ultralcd.cpp:4378
+#: ultralcd.cpp:4462
 msgid "Autoloading filament available only when filament sensor is turned on..."
 msgstr "Automaticke zavadeni filamentu je dostupne pouze pri zapnutem filament senzoru..."
 
 # MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ultralcd.cpp:2771
+#: ultralcd.cpp:2813
 msgid "Autoloading filament is active, just press the knob and insert filament..."
 msgstr "Automaticke zavadeni filamentu aktivni, stisknete tlacitko a vlozte filament..."
 
 # MSG_SELFTEST_AXIS_LENGTH
-#: ultralcd.cpp:7863
+#: ultralcd.cpp:7949
 msgid "Axis length"
 msgstr "Delka osy"
 
 # MSG_SELFTEST_AXIS
-#: ultralcd.cpp:7865
+#: ultralcd.cpp:7951
 msgid "Axis"
 msgstr "Osa"
 
 # MSG_SELFTEST_BEDHEATER
-#: ultralcd.cpp:7807
+#: ultralcd.cpp:7893
 msgid "Bed / Heater"
 msgstr "Podlozka / Topeni"
 
@@ -133,10 +133,10 @@ msgstr "Bed OK."
 # MSG_BED_HEATING
 #: messages.c:17
 msgid "Bed Heating"
-msgstr "Zahrivani bed"
+msgstr "Zahrivani bedu"
 
 # MSG_BED_CORRECTION_MENU
-#: ultralcd.cpp:5682
+#: ultralcd.cpp:5768
 msgid "Bed level correct"
 msgstr "Korekce podlozky"
 
@@ -151,7 +151,7 @@ msgid "Bed"
 msgstr "Podlozka"
 
 # MSG_MENU_BELT_STATUS c=15 r=1
-#: ultralcd.cpp:2002
+#: ultralcd.cpp:2059
 msgid "Belt status"
 msgstr "Stav remenu"
 
@@ -161,12 +161,12 @@ msgid "Blackout occurred. Recover print?"
 msgstr "Detekovan vypadek proudu.Obnovit tisk?"
 
 # 
-#: ultralcd.cpp:8211
+#: ultralcd.cpp:8297
 msgid "Calibrating home"
 msgstr "Kalibruji vychozi poz."
 
 # MSG_CALIBRATE_BED
-#: ultralcd.cpp:5671
+#: ultralcd.cpp:5757
 msgid "Calibrate XYZ"
 msgstr "Kalibrace XYZ"
 
@@ -176,12 +176,12 @@ msgid "Calibrate Z"
 msgstr "Kalibrovat Z"
 
 # MSG_CALIBRATE_PINDA c=17 r=1
-#: ultralcd.cpp:4570
+#: ultralcd.cpp:4654
 msgid "Calibrate"
 msgstr "Zkalibrovat"
 
 # MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ultralcd.cpp:3408
+#: ultralcd.cpp:3492
 msgid "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end stoppers. Click when done."
 msgstr "Kalibrace XYZ. Otacenim tlacitka posunte Z osu az k~hornimu dorazu. Potvrdte tlacitkem."
 
@@ -191,12 +191,12 @@ msgid "Calibrating Z"
 msgstr "Kalibruji Z"
 
 # MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ultralcd.cpp:3408
+#: ultralcd.cpp:3492
 msgid "Calibrating Z. Rotate the knob to move the Z carriage up to the end stoppers. Click when done."
 msgstr "Kalibrace Z. Otacenim tlacitka posunte Z osu az k~hornimu dorazu. Potvrdte tlacitkem."
 
 # MSG_HOMEYZ_DONE
-#: ultralcd.cpp:813
+#: ultralcd.cpp:816
 msgid "Calibration done"
 msgstr "Kalibrace OK"
 
@@ -206,17 +206,17 @@ msgid "Calibration"
 msgstr "Kalibrace"
 
 # 
-#: ultralcd.cpp:4695
+#: ultralcd.cpp:4781
 msgid "Cancel"
 msgstr "Zrusit"
 
 # MSG_SD_REMOVED
-#: ultralcd.cpp:8578
+#: ultralcd.cpp:8679
 msgid "Card removed"
 msgstr "Karta vyjmuta"
 
 # MSG_NOT_COLOR
-#: ultralcd.cpp:2676
+#: ultralcd.cpp:2718
 msgid "Color not correct"
 msgstr "Barva neni cista"
 
@@ -226,7 +226,7 @@ msgid "Cooldown"
 msgstr "Zchladit"
 
 # 
-#: ultralcd.cpp:4503
+#: ultralcd.cpp:4587
 msgid "Copy selected language?"
 msgstr "Kopirovat vybrany jazyk?"
 
@@ -256,22 +256,22 @@ msgid "Crash detected. Resume print?"
 msgstr "Detekovan naraz. Obnovit tisk?"
 
 # 
-#: ultralcd.cpp:1876
+#: ultralcd.cpp:1853
 msgid "Crash"
 msgstr "Naraz"
 
 # MSG_CURRENT c=19 r=1
-#: ultralcd.cpp:5823
+#: ultralcd.cpp:5909
 msgid "Current"
 msgstr "Pouze aktualni"
 
 # MSG_DATE c=17 r=1
-#: ultralcd.cpp:2102
+#: ultralcd.cpp:2213
 msgid "Date:"
 msgstr "Datum:"
 
 # MSG_DISABLE_STEPPERS
-#: ultralcd.cpp:5568
+#: ultralcd.cpp:5654
 msgid "Disable steppers"
 msgstr "Vypnout motory"
 
@@ -281,12 +281,12 @@ msgid "Distance between tip of the nozzle and the bed surface has not been set y
 msgstr "Neni zkalibrovana vzdalenost trysky od tiskove podlozky. Postupujte prosim podle manualu, kapitola Zaciname, odstavec Nastaveni prvni vrstvy."
 
 # MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ultralcd.cpp:4984
+#: ultralcd.cpp:5070
 msgid "Do you want to repeat last step to readjust distance between nozzle and heatbed?"
 msgstr "Chcete opakovat posledni krok a pozmenit vzdalenost mezi tryskou a podlozkou?"
 
 # MSG_EXTRUDER_CORRECTION c=10
-#: ultralcd.cpp:5048
+#: ultralcd.cpp:5134
 msgid "E-correct:"
 msgstr "Korekce E:"
 
@@ -296,7 +296,7 @@ msgid "Eject filament"
 msgstr "Vysunout filament"
 
 # 
-#: ultralcd.cpp:4783
+#: ultralcd.cpp:4869
 msgid "Eject"
 msgstr "Vysunout"
 
@@ -306,27 +306,27 @@ msgid "Ejecting filament"
 msgstr "Vysouvam filament"
 
 # MSG_SELFTEST_ENDSTOP_NOTHIT c=20 r=1
-#: ultralcd.cpp:7831
+#: ultralcd.cpp:7917
 msgid "Endstop not hit"
 msgstr "Kon. spinac nesepnut"
 
 # MSG_SELFTEST_ENDSTOP
-#: ultralcd.cpp:7825
+#: ultralcd.cpp:7911
 msgid "Endstop"
 msgstr "Koncovy spinac"
 
 # MSG_SELFTEST_ENDSTOPS
-#: ultralcd.cpp:7813
+#: ultralcd.cpp:7899
 msgid "Endstops"
 msgstr "Konc. spinace"
 
 # MSG_STACK_ERROR c=20 r=4
-#: ultralcd.cpp:6773
+#: ultralcd.cpp:6859
 msgid "Error - static memory has been overwritten"
 msgstr "Chyba - Doslo k prepisu staticke pameti!"
 
 # MSG_FSENS_NOT_RESPONDING c=20 r=4
-#: ultralcd.cpp:4391
+#: ultralcd.cpp:4475
 msgid "ERROR: Filament sensor is not responding, please check connection."
 msgstr "CHYBA: Filament senzor nereaguje, zkontrolujte zapojeni."
 
@@ -336,12 +336,12 @@ msgid "ERROR:"
 msgstr "CHYBA:"
 
 # MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
-#: ultralcd.cpp:8218
+#: ultralcd.cpp:8304
 msgid "Extruder fan:"
 msgstr "Levy vent.:"
 
 # MSG_INFO_EXTRUDER c=15 r=1
-#: ultralcd.cpp:2133
+#: ultralcd.cpp:2244
 msgid "Extruder info"
 msgstr ""
 
@@ -351,12 +351,12 @@ msgid "Extruder"
 msgstr ""
 
 # 
-#: ultralcd.cpp:6760
+#: ultralcd.cpp:6846
 msgid "Fail stats MMU"
 msgstr "Selhani MMU"
 
 # MSG_FSENS_AUTOLOAD_ON c=17 r=1
-#: ultralcd.cpp:5082
+#: ultralcd.cpp:5168
 msgid "F. autoload  [on]"
 msgstr "F. autozav. [zap]"
 
@@ -366,12 +366,12 @@ msgid "F. autoload [N/A]"
 msgstr "F. autozav. [N/A]"
 
 # MSG_FSENS_AUTOLOAD_OFF c=17 r=1
-#: ultralcd.cpp:5084
+#: ultralcd.cpp:5170
 msgid "F. autoload [off]"
 msgstr "F. autozav. [vyp]"
 
 # 
-#: ultralcd.cpp:6757
+#: ultralcd.cpp:6843
 msgid "Fail stats"
 msgstr "Selhani"
 
@@ -386,12 +386,12 @@ msgid "Fan test"
 msgstr "Test ventilatoru"
 
 # MSG_FANS_CHECK_ON c=17 r=1
-#: ultralcd.cpp:5577
+#: ultralcd.cpp:5663
 msgid "Fans check   [on]"
 msgstr "Kontr. vent.[zap]"
 
 # MSG_FANS_CHECK_OFF c=17 r=1
-#: ultralcd.cpp:5579
+#: ultralcd.cpp:5665
 msgid "Fans check  [off]"
 msgstr "Kontr. vent.[vyp]"
 
@@ -401,7 +401,7 @@ msgid "Fil. sensor  [on]"
 msgstr "Fil. senzor [zap]"
 
 # MSG_FSENSOR_NA
-#: ultralcd.cpp:5062
+#: ultralcd.cpp:5148
 msgid "Fil. sensor [N/A]"
 msgstr "Fil. senzor [N/A]"
 
@@ -411,9 +411,9 @@ msgid "Fil. sensor [off]"
 msgstr "Fil. senzor [vyp]"
 
 # 
-#: ultralcd.cpp:1876
+#: ultralcd.cpp:1852
 msgid "Filam. runouts"
-msgstr "Vypadky filamentu"
+msgstr "Vypadky filam."
 
 # MSG_FILAMENT_CLEAN c=20 r=2
 #: messages.c:32
@@ -421,7 +421,7 @@ msgid "Filament extruding & with correct color?"
 msgstr "Filament vytlacen a spravne barvy?"
 
 # MSG_NOT_LOADED c=19
-#: ultralcd.cpp:2672
+#: ultralcd.cpp:2714
 msgid "Filament not loaded"
 msgstr "Filament nezaveden"
 
@@ -431,17 +431,17 @@ msgid "Filament sensor"
 msgstr "Senzor filamentu"
 
 # MSG_FILAMENT_USED c=19 r=1
-#: ultralcd.cpp:2841
+#: ultralcd.cpp:2885
 msgid "Filament used"
 msgstr "Spotrebovano filamentu"
 
 # MSG_PRINT_TIME c=19 r=1
-#: ultralcd.cpp:2841
+#: ultralcd.cpp:2886
 msgid "Print time"
 msgstr "Cas tisku"
 
 # MSG_FILE_INCOMPLETE c=20 r=2
-#: ultralcd.cpp:8346
+#: ultralcd.cpp:8432
 msgid "File incomplete. Continue anyway?"
 msgstr "Soubor nekompletni. Pokracovat?"
 
@@ -456,7 +456,7 @@ msgid "First layer cal."
 msgstr "Kal. prvni vrstvy"
 
 # MSG_WIZARD_SELFTEST c=20 r=8
-#: ultralcd.cpp:4896
+#: ultralcd.cpp:4982
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr "Nejdriv pomoci selftestu zkontoluji nejcastejsi chyby vznikajici pri sestaveni tiskarny."
 
@@ -466,12 +466,12 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr "Opravte chybu a pote stisknete tlacitko na jednotce MMU."
 
 # MSG_FLOW
-#: ultralcd.cpp:6846
+#: ultralcd.cpp:6932
 msgid "Flow"
 msgstr "Prutok"
 
 # MSG_PRUSA3D_FORUM
-#: ultralcd.cpp:2095
+#: ultralcd.cpp:2206
 msgid "forum.prusa3d.com"
 msgstr ""
 
@@ -481,22 +481,22 @@ msgid "Front print fan?"
 msgstr "Predni tiskovy vent?"
 
 # MSG_BED_CORRECTION_FRONT c=14 r=1
-#: ultralcd.cpp:3220
+#: ultralcd.cpp:3294
 msgid "Front side[um]"
 msgstr "Vpredu [um]"
 
 # MSG_SELFTEST_FANS
-#: ultralcd.cpp:7871
+#: ultralcd.cpp:7957
 msgid "Front/left fans"
 msgstr "Predni/levy vent."
 
 # MSG_SELFTEST_HEATERTHERMISTOR
-#: ultralcd.cpp:7801
+#: ultralcd.cpp:7887
 msgid "Heater/Thermistor"
 msgstr "Topeni/Termistor"
 
 # MSG_BED_HEATING_SAFETY_DISABLED
-#: Marlin_main.cpp:8468
+#: Marlin_main.cpp:8467
 msgid "Heating disabled by safety timer."
 msgstr "Zahrivani preruseno bezpecnostnim casovacem."
 
@@ -511,12 +511,12 @@ msgid "Heating"
 msgstr "Zahrivani"
 
 # MSG_WIZARD_WELCOME c=20 r=7
-#: ultralcd.cpp:4875
+#: ultralcd.cpp:4961
 msgid "Hi, I am your Original Prusa i3 printer. Would you like me to guide you through the setup process?"
 msgstr "Dobry den, jsem vase tiskarna Original Prusa i3. Chcete abych Vas provedla kalibracnim procesem?"
 
 # MSG_PRUSA3D_HOWTO
-#: ultralcd.cpp:2096
+#: ultralcd.cpp:2207
 msgid "howto.prusa3d.com"
 msgstr ""
 
@@ -526,12 +526,12 @@ msgid "Change filament"
 msgstr "Vymenit filament"
 
 # MSG_CHANGE_SUCCESS
-#: ultralcd.cpp:2587
+#: ultralcd.cpp:2629
 msgid "Change success!"
 msgstr "Zmena uspesna!"
 
 # MSG_CORRECTLY c=20
-#: ultralcd.cpp:2664
+#: ultralcd.cpp:2706
 msgid "Changed correctly?"
 msgstr "Vymena ok?"
 
@@ -541,12 +541,12 @@ msgid "Checking bed     "
 msgstr "Kontrola podlozky"
 
 # MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ultralcd.cpp:8200
+#: ultralcd.cpp:8286
 msgid "Checking endstops"
 msgstr "Kontrola endstopu"
 
 # MSG_SELFTEST_CHECK_HOTEND c=20
-#: ultralcd.cpp:8206
+#: ultralcd.cpp:8292
 msgid "Checking hotend  "
 msgstr "Kontrola hotend "
 
@@ -556,17 +556,17 @@ msgid "Checking sensors "
 msgstr "Kontrola senzoru"
 
 # MSG_SELFTEST_CHECK_X c=20
-#: ultralcd.cpp:8201
+#: ultralcd.cpp:8287
 msgid "Checking X axis  "
 msgstr "Kontrola osy X"
 
 # MSG_SELFTEST_CHECK_Y c=20
-#: ultralcd.cpp:8202
+#: ultralcd.cpp:8288
 msgid "Checking Y axis  "
 msgstr "Kontrola osy Y"
 
 # MSG_SELFTEST_CHECK_Z c=20
-#: ultralcd.cpp:8203
+#: ultralcd.cpp:8289
 msgid "Checking Z axis  "
 msgstr "Kontrola osy Z"
 
@@ -586,17 +586,17 @@ msgid "Filament"
 msgstr ""
 
 # MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ultralcd.cpp:4905
+#: ultralcd.cpp:4991
 msgid "I will run xyz calibration now. It will take approx. 12 mins."
 msgstr "Nyni provedu xyz kalibraci. Zabere to priblizne 12 min."
 
 # MSG_WIZARD_Z_CAL c=20 r=8
-#: ultralcd.cpp:4913
+#: ultralcd.cpp:4999
 msgid "I will run z calibration now."
 msgstr "Nyni provedu z kalibraci."
 
 # MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ultralcd.cpp:4978
+#: ultralcd.cpp:5064
 msgid "I will start to print line and you will gradually lower the nozzle by rotating the knob, until you reach optimal height. Check the pictures in our handbook in chapter Calibration."
 msgstr "Zacnu tisknout linku a Vy budete postupne snizovat trysku otacenim tlacitka dokud nedosahnete optimalni vysky. Prohlednete si obrazky v nasi prirucce v kapitole Kalibrace."
 
@@ -606,27 +606,27 @@ msgid "Info screen"
 msgstr "Informace"
 
 # 
-#: ultralcd.cpp:4938
+#: ultralcd.cpp:5024
 msgid "Is filament 1 loaded?"
 msgstr "Je filament 1 zaveden?"
 
 # MSG_INSERT_FILAMENT c=20
-#: ultralcd.cpp:2572
+#: ultralcd.cpp:2614
 msgid "Insert filament"
 msgstr "Vlozte filament"
 
 # MSG_WIZARD_FILAMENT_LOADED c=20 r=2
-#: ultralcd.cpp:4941
+#: ultralcd.cpp:5027
 msgid "Is filament loaded?"
 msgstr "Je filament zaveden?"
 
 # MSG_WIZARD_PLA_FILAMENT c=20 r=2
-#: ultralcd.cpp:4972
+#: ultralcd.cpp:5058
 msgid "Is it PLA filament?"
 msgstr "Je to PLA filament?"
 
 # MSG_PLA_FILAMENT_LOADED c=20 r=2
-#: ultralcd.cpp:4704
+#: ultralcd.cpp:4790
 msgid "Is PLA filament loaded?"
 msgstr "Je PLA filament zaveden?"
 
@@ -636,12 +636,12 @@ msgid "Is steel sheet on heatbed?"
 msgstr "Je tiskovy plat na podlozce?"
 
 # 
-#: ultralcd.cpp:1840
+#: ultralcd.cpp:1795
 msgid "Last print failures"
 msgstr "Selhani posl. tisku"
 
 # 
-#: ultralcd.cpp:1823
+#: ultralcd.cpp:1772
 msgid "Last print"
 msgstr "Posledni tisk"
 
@@ -651,17 +651,17 @@ msgid "Left hotend fan?"
 msgstr "Levy vent na trysce?"
 
 # 
-#: ultralcd.cpp:2970
+#: ultralcd.cpp:3018
 msgid "Left"
-msgstr "Vlevo:"
+msgstr "Vlevo"
 
 # MSG_BED_CORRECTION_LEFT c=14 r=1
-#: ultralcd.cpp:3218
+#: ultralcd.cpp:3292
 msgid "Left side [um]"
 msgstr "Vlevo [um]"
 
 # 
-#: ultralcd.cpp:5594
+#: ultralcd.cpp:5680
 msgid "Lin. correction"
 msgstr "Korekce lin."
 
@@ -676,7 +676,7 @@ msgid "Load filament"
 msgstr "Zavest filament"
 
 # MSG_LOADING_COLOR
-#: ultralcd.cpp:2612
+#: ultralcd.cpp:2654
 msgid "Loading color"
 msgstr "Cisteni barvy"
 
@@ -686,12 +686,12 @@ msgid "Loading filament"
 msgstr "Zavadeni filamentu"
 
 # MSG_LOOSE_PULLEY c=20 r=1
-#: ultralcd.cpp:7855
+#: ultralcd.cpp:7941
 msgid "Loose pulley"
 msgstr "Uvolnena remenicka"
 
 # 
-#: ultralcd.cpp:6719
+#: ultralcd.cpp:6805
 msgid "Load to nozzle"
 msgstr "Zavest do trysky"
 
@@ -711,7 +711,7 @@ msgid "Measuring reference height of calibration point"
 msgstr "Merim referencni vysku kalibracniho bodu"
 
 # MSG_MESH_BED_LEVELING
-#: ultralcd.cpp:5677
+#: ultralcd.cpp:5763
 msgid "Mesh Bed Leveling"
 msgstr ""
 
@@ -726,12 +726,12 @@ msgid "MMU OK. Resuming temperature..."
 msgstr "MMU OK. Pokracuji v nahrivani..."
 
 # 
-#: ultralcd.cpp:3005
+#: ultralcd.cpp:3059
 msgid "Measured skew"
 msgstr "Merene zkoseni"
 
 # 
-#: ultralcd.cpp:1840
+#: ultralcd.cpp:1796
 msgid "MMU fails"
 msgstr "Selhani MMU"
 
@@ -741,7 +741,7 @@ msgid "MMU load failed     "
 msgstr "Zavedeni MMU selhalo"
 
 # 
-#: ultralcd.cpp:1840
+#: ultralcd.cpp:1797
 msgid "MMU load fails"
 msgstr "MMU selhani zavadeni"
 
@@ -766,7 +766,7 @@ msgid "MMU needs user attention."
 msgstr "MMU potrebuje zasah uzivatele."
 
 # 
-#: ultralcd.cpp:1857
+#: ultralcd.cpp:1823
 msgid "MMU power fails"
 msgstr "MMU vypadky proudu"
 
@@ -786,7 +786,7 @@ msgid "Mode [high power]"
 msgstr "Mod  [vys. vykon]"
 
 # 
-#: ultralcd.cpp:2108
+#: ultralcd.cpp:2219
 msgid "MMU2 connected"
 msgstr "MMU2 pripojeno"
 
@@ -796,37 +796,37 @@ msgid "Motor"
 msgstr ""
 
 # MSG_MOVE_AXIS
-#: ultralcd.cpp:5566
+#: ultralcd.cpp:5652
 msgid "Move axis"
 msgstr "Posunout osu"
 
 # MSG_MOVE_X
-#: ultralcd.cpp:4294
+#: ultralcd.cpp:4378
 msgid "Move X"
 msgstr "Posunout X"
 
 # MSG_MOVE_Y
-#: ultralcd.cpp:4295
+#: ultralcd.cpp:4379
 msgid "Move Y"
 msgstr "Posunout Y"
 
 # MSG_MOVE_Z
-#: ultralcd.cpp:4296
+#: ultralcd.cpp:4380
 msgid "Move Z"
 msgstr "Posunout Z"
 
 # MSG_NO_MOVE
-#: Marlin_main.cpp:5291
+#: Marlin_main.cpp:5292
 msgid "No move."
 msgstr "Bez pohybu."
 
 # MSG_NO_CARD
-#: ultralcd.cpp:6686
+#: ultralcd.cpp:6772
 msgid "No SD card"
 msgstr "Zadna SD karta"
 
 # 
-#: ultralcd.cpp:2976
+#: ultralcd.cpp:3024
 msgid "N/A"
 msgstr ""
 
@@ -836,7 +836,7 @@ msgid "No"
 msgstr "Ne"
 
 # MSG_SELFTEST_NOTCONNECTED
-#: ultralcd.cpp:7803
+#: ultralcd.cpp:7889
 msgid "Not connected"
 msgstr "Nezapojeno "
 
@@ -851,12 +851,12 @@ msgid "Not spinning"
 msgstr "Netoci se"
 
 # MSG_WIZARD_V2_CAL c=20 r=8
-#: ultralcd.cpp:4977
+#: ultralcd.cpp:5063
 msgid "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr "Nyni zkalibruji vzdalenost mezi koncem trysky a povrchem podlozky."
 
 # MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ultralcd.cpp:4921
+#: ultralcd.cpp:5007
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Nyni predehreji trysku pro PLA."
 
@@ -871,37 +871,37 @@ msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr "Neplatne hodnoty nastaveni. Bude pouzito vychozi PID, Esteps atd."
 
 # 
-#: ultralcd.cpp:4912
+#: ultralcd.cpp:4998
 msgid "Now remove the test print from steel sheet."
 msgstr "Nyni odstrante testovaci vytisk z tiskoveho platu."
 
 # 
-#: ultralcd.cpp:1782
+#: ultralcd.cpp:1722
 msgid "Nozzle FAN"
-msgstr "Trysk. vent."
+msgstr "Vent. trysky"
 
 # MSG_PAUSE_PRINT
-#: ultralcd.cpp:6649
+#: ultralcd.cpp:6735
 msgid "Pause print"
 msgstr "Pozastavit tisk"
 
 # MSG_PID_RUNNING c=20 r=1
-#: ultralcd.cpp:1598
+#: ultralcd.cpp:1606
 msgid "PID cal.           "
 msgstr "PID kal. "
 
 # MSG_PID_FINISHED c=20 r=1
-#: ultralcd.cpp:1604
+#: ultralcd.cpp:1612
 msgid "PID cal. finished"
 msgstr "PID kal. ukoncena"
 
 # MSG_PID_EXTRUDER c=17 r=1
-#: ultralcd.cpp:5683
+#: ultralcd.cpp:5769
 msgid "PID calibration"
 msgstr "PID kalibrace"
 
 # MSG_PINDA_PREHEAT c=20 r=1
-#: ultralcd.cpp:843
+#: ultralcd.cpp:846
 msgid "PINDA Heating"
 msgstr "Nahrivani PINDA"
 
@@ -911,7 +911,7 @@ msgid "Place a sheet of paper under the nozzle during the calibration of first 4
 msgstr "Umistete list papiru na podlozku a udrzujte jej pod tryskou behem mereni prvnich 4 bodu. Pokud tryska zachyti papir, okamzite vypnete tiskarnu."
 
 # MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ultralcd.cpp:4986
+#: ultralcd.cpp:5072
 msgid "Please clean heatbed and then press the knob."
 msgstr "Prosim ocistete podlozku a stisknete tlacitko."
 
@@ -921,7 +921,7 @@ msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Pro uspesnou kalibraci ocistete prosim tiskovou trysku. Potvrdte tlacitkem."
 
 # MSG_SELFTEST_PLEASECHECK
-#: ultralcd.cpp:7795
+#: ultralcd.cpp:7881
 msgid "Please check :"
 msgstr "Zkontrolujte :"
 
@@ -931,17 +931,17 @@ msgid "Please check our handbook and fix the problem. Then resume the Wizard by 
 msgstr "Prosim nahlednete do prirucky 3D tiskare a opravte problem. Pote obnovte Pruvodce restartovanim tiskarny."
 
 # MSG_WIZARD_LOAD_FILAMENT c=20 r=8
-#: ultralcd.cpp:4808
+#: ultralcd.cpp:4894
 msgid "Please insert PLA filament to the extruder, then press knob to load it."
 msgstr "Prosim vlozte PLA filament do extruderu, pote stisknete tlacitko pro zavedeni filamentu."
 
 # MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ultralcd.cpp:4709
+#: ultralcd.cpp:4795
 msgid "Please load PLA filament first."
 msgstr "Nejdrive prosim zavedte PLA filament."
 
 # MSG_CHECK_IDLER c=20 r=4
-#: Marlin_main.cpp:3063
+#: Marlin_main.cpp:3064
 msgid "Please open idler and remove filament manually."
 msgstr "Prosim otevrete idler a manualne odstrante filament."
 
@@ -956,7 +956,7 @@ msgid "Please press the knob to unload filament"
 msgstr "Pro vysunuti filamentu stisknete prosim tlacitko"
 
 # 
-#: ultralcd.cpp:4803
+#: ultralcd.cpp:4889
 msgid "Please insert PLA filament to the first tube of MMU, then press the knob to load it."
 msgstr "Prosim vlozte PLA filament do trubicky MMU, pote stisknete tlacitko pro zavedeni filamentu."
 
@@ -976,7 +976,7 @@ msgid "Please remove steel sheet from heatbed."
 msgstr "Odstrante prosim tiskovy plat z podlozky."
 
 # MSG_RUN_XYZ c=20 r=4
-#: Marlin_main.cpp:4354
+#: Marlin_main.cpp:4355
 msgid "Please run XYZ calibration first."
 msgstr "Nejprve spustte kalibraci XYZ."
 
@@ -991,7 +991,7 @@ msgid "Please wait"
 msgstr "Prosim cekejte"
 
 # 
-#: ultralcd.cpp:4911
+#: ultralcd.cpp:4997
 msgid "Please remove shipping helpers first."
 msgstr "Nejprve prosim sundejte transportni soucastky."
 
@@ -1001,14 +1001,14 @@ msgid "Preheat the nozzle!"
 msgstr "Predehrejte trysku!"
 
 # MSG_PREHEAT
-#: ultralcd.cpp:6636
+#: ultralcd.cpp:6722
 msgid "Preheat"
 msgstr "Predehrev"
 
 # MSG_WIZARD_HEATING c=20 r=3
 #: messages.c:102
 msgid "Preheating nozzle. Please wait."
-msgstr "Predehrivam trysku. Prosim cekejte."
+msgstr "Predehrev trysky. Prosim cekejte."
 
 # 
 #: util.cpp:297
@@ -1016,12 +1016,12 @@ msgid "Please upgrade."
 msgstr "Prosim aktualizujte."
 
 # MSG_PRESS_TO_PREHEAT c=20 r=4
-#: Marlin_main.cpp:10365
+#: Marlin_main.cpp:10364
 msgid "Press knob to preheat nozzle and continue."
 msgstr "Pro nahrati trysky a pokracovani stisknete tlacitko."
 
 # 
-#: ultralcd.cpp:1876
+#: ultralcd.cpp:1851
 msgid "Power failures"
 msgstr "Vypadky proudu"
 
@@ -1031,17 +1031,17 @@ msgid "Print aborted"
 msgstr "Tisk prerusen"
 
 # 
-#: ultralcd.cpp:2276
+#: ultralcd.cpp:2455
 msgid "Preheating to load"
-msgstr "Predehrivam k zavedeni"
+msgstr "Predehrev k zavedeni"
 
 # 
-#: ultralcd.cpp:2280
+#: ultralcd.cpp:2459
 msgid "Preheating to unload"
-msgstr "Predehrivam k vyjmuti"
+msgstr "Predehrev k vyjmuti"
 
 # MSG_SELFTEST_PRINT_FAN_SPEED c=18
-#: ultralcd.cpp:8221
+#: ultralcd.cpp:8307
 msgid "Print fan:"
 msgstr "Tiskovy vent.:"
 
@@ -1051,12 +1051,12 @@ msgid "Print from SD"
 msgstr "Tisk z SD"
 
 # 
-#: ultralcd.cpp:2206
+#: ultralcd.cpp:2317
 msgid "Press the knob"
 msgstr "Stisknete hl. tlacitko"
 
 # MSG_PRINT_PAUSED c=20 r=1
-#: ultralcd.cpp:1061
+#: ultralcd.cpp:1069
 msgid "Print paused"
 msgstr "Tisk pozastaven"
 
@@ -1071,22 +1071,22 @@ msgid "Printer has not been calibrated yet. Please follow the manual, chapter Fi
 msgstr "Tiskarna nebyla jeste zkalibrovana. Postupujte prosim podle manualu, kapitola Zaciname, odstavec Postup kalibrace."
 
 # 
-#: ultralcd.cpp:1784
+#: ultralcd.cpp:1723
 msgid "Print FAN"
 msgstr "Tiskovy vent."
 
 # MSG_PRUSA3D
-#: ultralcd.cpp:2094
+#: ultralcd.cpp:2205
 msgid "prusa3d.com"
 msgstr ""
 
 # MSG_BED_CORRECTION_REAR c=14 r=1
-#: ultralcd.cpp:3221
+#: ultralcd.cpp:3295
 msgid "Rear side [um]"
 msgstr "Vzadu [um]"
 
 # MSG_RECOVERING_PRINT c=20 r=1
-#: Marlin_main.cpp:9765
+#: Marlin_main.cpp:9764
 msgid "Recovering print    "
 msgstr "Obnovovani tisku "
 
@@ -1101,17 +1101,17 @@ msgid "Prusa i3 MK3S OK."
 msgstr ""
 
 # MSG_CALIBRATE_BED_RESET
-#: ultralcd.cpp:5688
+#: ultralcd.cpp:5774
 msgid "Reset XYZ calibr."
 msgstr "Reset XYZ kalibr."
 
 # MSG_BED_CORRECTION_RESET
-#: ultralcd.cpp:3222
+#: ultralcd.cpp:3296
 msgid "Reset"
 msgstr ""
 
 # MSG_RESUME_PRINT
-#: ultralcd.cpp:6656
+#: ultralcd.cpp:6742
 msgid "Resume print"
 msgstr "Pokracovat"
 
@@ -1121,37 +1121,37 @@ msgid "Resuming print"
 msgstr "Obnoveni tisku"
 
 # MSG_BED_CORRECTION_RIGHT c=14 r=1
-#: ultralcd.cpp:3219
+#: ultralcd.cpp:3293
 msgid "Right side[um]"
 msgstr "Vpravo [um]"
 
 # MSG_SECOND_SERIAL_ON c=17 r=1
-#: ultralcd.cpp:5606
+#: ultralcd.cpp:5692
 msgid "RPi port     [on]"
 msgstr "RPi port    [zap]"
 
 # MSG_SECOND_SERIAL_OFF c=17 r=1
-#: ultralcd.cpp:5604
+#: ultralcd.cpp:5690
 msgid "RPi port    [off]"
 msgstr "RPi port    [vyp]"
 
 # MSG_WIZARD_RERUN c=20 r=7
-#: ultralcd.cpp:4726
+#: ultralcd.cpp:4812
 msgid "Running Wizard will delete current calibration results and start from the beginning. Continue?"
 msgstr "Spusteni Pruvodce vymaze ulozene vysledky vsech kalibraci a spusti kalibracni proces od zacatku. Pokracovat?"
 
 # MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_OFF c=19 r=1
-#: ultralcd.cpp:5236
+#: ultralcd.cpp:5322
 msgid "SD card  [normal]"
 msgstr ""
 
 # MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_ON c=19 r=1
-#: ultralcd.cpp:5234
+#: ultralcd.cpp:5320
 msgid "SD card [flshAir]"
 msgstr "SD card [FlshAir]"
 
 # 
-#: ultralcd.cpp:2971
+#: ultralcd.cpp:3019
 msgid "Right"
 msgstr "Vpravo"
 
@@ -1161,27 +1161,27 @@ msgid "Searching bed calibration point"
 msgstr "Hledam kalibracni bod podlozky"
 
 # MSG_LANGUAGE_SELECT
-#: ultralcd.cpp:5613
+#: ultralcd.cpp:5699
 msgid "Select language"
 msgstr "Vyber jazyka"
 
 # MSG_SELFTEST_OK
-#: ultralcd.cpp:7366
+#: ultralcd.cpp:7452
 msgid "Self test OK"
 msgstr ""
 
 # MSG_SELFTEST_START c=20
-#: ultralcd.cpp:7152
+#: ultralcd.cpp:7238
 msgid "Self test start  "
 msgstr "Self test start "
 
 # MSG_SELFTEST
-#: ultralcd.cpp:5664
+#: ultralcd.cpp:5750
 msgid "Selftest         "
 msgstr "Selftest "
 
 # MSG_SELFTEST_ERROR
-#: ultralcd.cpp:7793
+#: ultralcd.cpp:7879
 msgid "Selftest error !"
 msgstr "Chyba Selftestu!"
 
@@ -1196,17 +1196,17 @@ msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr "Pro kalibraci presneho rehomovani bude nyni spusten selftest."
 
 # 
-#: ultralcd.cpp:4959
+#: ultralcd.cpp:5045
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr "Vyberte teplotu predehrati trysky ktera odpovida vasemu materialu."
 
 # 
-#: ultralcd.cpp:4695
+#: ultralcd.cpp:4780
 msgid "Select PLA filament:"
 msgstr "Vyberte PLA filament:"
 
 # MSG_SET_TEMPERATURE c=19 r=1
-#: ultralcd.cpp:3230
+#: ultralcd.cpp:3314
 msgid "Set temperature:"
 msgstr "Nastavte teplotu:"
 
@@ -1216,12 +1216,12 @@ msgid "Settings"
 msgstr "Nastaveni"
 
 # MSG_SHOW_END_STOPS c=17 r=1
-#: ultralcd.cpp:5685
+#: ultralcd.cpp:5771
 msgid "Show end stops"
 msgstr "Stav konc. spin."
 
 # 
-#: ultralcd.cpp:3941
+#: ultralcd.cpp:4025
 msgid "Sensor state"
 msgstr "Stav senzoru"
 
@@ -1231,22 +1231,22 @@ msgid "Some files will not be sorted. Max. No. of files in 1 folder for sorting 
 msgstr "Nektere soubory nebudou setrideny. Maximalni pocet souboru ve slozce pro setrideni je 100."
 
 # MSG_SORT_NONE c=17 r=1
-#: ultralcd.cpp:5246
+#: ultralcd.cpp:5332
 msgid "Sort       [none]"
 msgstr "Trideni   [Zadne]"
 
 # MSG_SORT_TIME c=17 r=1
-#: ultralcd.cpp:5244
+#: ultralcd.cpp:5330
 msgid "Sort       [time]"
 msgstr "Trideni     [cas]"
 
 # 
-#: ultralcd.cpp:3008
-msgid "Severe skew"
-msgstr "Tezke zkoseni"
+#: ultralcd.cpp:3062
+msgid "Severe skew:"
+msgstr "Tezke zkoseni:"
 
 # MSG_SORT_ALPHA c=17 r=1
-#: ultralcd.cpp:5245
+#: ultralcd.cpp:5331
 msgid "Sort   [alphabet]"
 msgstr "Trideni [Abeceda]"
 
@@ -1261,9 +1261,9 @@ msgid "Sound      [loud]"
 msgstr "Zvuk    [hlasity]"
 
 # 
-#: ultralcd.cpp:3007
-msgid "Slight skew"
-msgstr "Lehke zkoseni"
+#: ultralcd.cpp:3061
+msgid "Slight skew:"
+msgstr "Lehke zkoseni:"
 
 # MSG_SOUND_MUTE c=17 r=1
 #: 
@@ -1271,7 +1271,7 @@ msgid "Sound      [mute]"
 msgstr "Zvuk    [vypnuto]"
 
 # 
-#: Marlin_main.cpp:4870
+#: Marlin_main.cpp:4871
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Vyskytl se problem, srovnavam osu Z ..."
 
@@ -1286,7 +1286,7 @@ msgid "Sound    [silent]"
 msgstr "Zvuk      [tichy]"
 
 # MSG_SPEED
-#: ultralcd.cpp:6840
+#: ultralcd.cpp:6926
 msgid "Speed"
 msgstr "Rychlost"
 
@@ -1296,12 +1296,12 @@ msgid "Spinning"
 msgstr "Toci se"
 
 # MSG_TEMP_CAL_WARNING c=20 r=4
-#: Marlin_main.cpp:4367
+#: Marlin_main.cpp:4368
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr "Je vyzadovana stabilni pokojova teplota 21-26C a pevna podlozka."
 
 # MSG_STATISTICS
-#: ultralcd.cpp:6753
+#: ultralcd.cpp:6839
 msgid "Statistics  "
 msgstr "Statistika "
 
@@ -1316,12 +1316,12 @@ msgid "STOPPED. "
 msgstr "ZASTAVENO."
 
 # MSG_SUPPORT
-#: ultralcd.cpp:6762
+#: ultralcd.cpp:6848
 msgid "Support"
 msgstr "Podpora"
 
 # MSG_SELFTEST_SWAPPED
-#: ultralcd.cpp:7873
+#: ultralcd.cpp:7959
 msgid "Swapped"
 msgstr "Prohozene"
 
@@ -1331,22 +1331,22 @@ msgid "Temp. cal.          "
 msgstr "Tepl. kal. "
 
 # MSG_TEMP_CALIBRATION_ON c=20 r=1
-#: ultralcd.cpp:5600
+#: ultralcd.cpp:5686
 msgid "Temp. cal.   [on]"
 msgstr "Tepl. kal.  [zap]"
 
 # MSG_TEMP_CALIBRATION_OFF c=20 r=1
-#: ultralcd.cpp:5598
+#: ultralcd.cpp:5684
 msgid "Temp. cal.  [off]"
 msgstr "Tepl. kal.  [vyp]"
 
 # MSG_CALIBRATION_PINDA_MENU c=17 r=1
-#: ultralcd.cpp:5694
+#: ultralcd.cpp:5780
 msgid "Temp. calibration"
 msgstr "Teplot. kalibrace"
 
 # MSG_TEMP_CAL_FAILED c=20 r=8
-#: ultralcd.cpp:3867
+#: ultralcd.cpp:3951
 msgid "Temperature calibration failed"
 msgstr "Teplotni kalibrace selhala"
 
@@ -1356,12 +1356,12 @@ msgid "Temperature calibration is finished and active. Temp. calibration can be 
 msgstr "Teplotni kalibrace dokoncena a je nyni aktivni. Teplotni kalibraci je mozno deaktivovat v menu Nastaveni->Tepl. kal."
 
 # MSG_TEMPERATURE
-#: ultralcd.cpp:5564
+#: ultralcd.cpp:5650
 msgid "Temperature"
 msgstr "Teplota"
 
 # MSG_MENU_TEMPERATURES c=15 r=1
-#: ultralcd.cpp:2140
+#: ultralcd.cpp:2251
 msgid "Temperatures"
 msgstr "Teploty"
 
@@ -1371,37 +1371,37 @@ msgid "There is still a need to make Z calibration. Please follow the manual, ch
 msgstr "Je potreba kalibrovat osu Z. Prosim postupujte dle prirucky, kapitola Zaciname, sekce Postup kalibrace."
 
 # 
-#: ultralcd.cpp:2863
+#: ultralcd.cpp:2908
 msgid "Total filament"
 msgstr "Filament celkem"
 
 # 
-#: ultralcd.cpp:2863
+#: ultralcd.cpp:2908
 msgid "Total print time"
 msgstr "Celkovy cas tisku"
 
 # MSG_TUNE
-#: ultralcd.cpp:6633
+#: ultralcd.cpp:6719
 msgid "Tune"
 msgstr "Ladit"
 
 # 
-#: ultralcd.cpp:4783
+#: ultralcd.cpp:4869
 msgid "Unload"
 msgstr "Vysunout"
 
 # 
-#: ultralcd.cpp:1857
+#: ultralcd.cpp:1820
 msgid "Total failures"
 msgstr "Celkem selhani"
 
 # 
-#: ultralcd.cpp:2213
+#: ultralcd.cpp:2324
 msgid "to load filament"
 msgstr "k zavedeni filamentu"
 
 # 
-#: ultralcd.cpp:2217
+#: ultralcd.cpp:2328
 msgid "to unload filament"
 msgstr "k vyjmuti filamentu"
 
@@ -1416,42 +1416,42 @@ msgid "Unloading filament"
 msgstr "Vysouvam filament"
 
 # 
-#: ultralcd.cpp:1824
+#: ultralcd.cpp:1773
 msgid "Total"
 msgstr "Celkem"
 
 # MSG_USED c=19 r=1
-#: ultralcd.cpp:5822
+#: ultralcd.cpp:5908
 msgid "Used during print"
 msgstr "Pouzite behem tisku"
 
 # MSG_MENU_VOLTAGES c=15 r=1
-#: ultralcd.cpp:2143
+#: ultralcd.cpp:2254
 msgid "Voltages"
 msgstr "Napeti"
 
 # 
-#: ultralcd.cpp:2116
+#: ultralcd.cpp:2227
 msgid "unknown"
 msgstr "neznamy"
 
 # MSG_USERWAIT
-#: Marlin_main.cpp:5262
+#: Marlin_main.cpp:5263
 msgid "Wait for user..."
 msgstr "Ceka se na uzivatele..."
 
 # MSG_WAITING_TEMP c=20 r=3
-#: ultralcd.cpp:3374
+#: ultralcd.cpp:3458
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Cekani na zchladnuti trysky a podlozky."
 
 # MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ultralcd.cpp:3338
+#: ultralcd.cpp:3422
 msgid "Waiting for PINDA probe cooling"
 msgstr "Cekani na zchladnuti PINDA"
 
 # 
-#: ultralcd.cpp:4782
+#: ultralcd.cpp:4868
 msgid "Use unload to remove filament 1 if it protrudes outside of the rear MMU tube. Use eject if it is hidden in tube."
 msgstr "Pouzijte vyjmout pro odstraneni filamentu 1 pokud presahuje z PTFE trubicky za tiskarnou. Pouzijte vysunout, pokud neni videt."
 
@@ -1471,7 +1471,7 @@ msgid "Warning: printer type changed."
 msgstr "Varovani: doslo ke zmene typu tiskarny."
 
 # MSG_UNLOAD_SUCCESSFUL c=20 r=2
-#: Marlin_main.cpp:3053
+#: Marlin_main.cpp:3054
 msgid "Was filament unload successful?"
 msgstr "Bylo vysunuti filamentu uspesne?"
 
@@ -1481,12 +1481,12 @@ msgid "Wiring error"
 msgstr "Chyba zapojeni"
 
 # MSG_WIZARD c=17 r=1
-#: ultralcd.cpp:5661
+#: ultralcd.cpp:5747
 msgid "Wizard"
 msgstr "Pruvodce"
 
 # MSG_XYZ_DETAILS c=19 r=1
-#: ultralcd.cpp:2132
+#: ultralcd.cpp:2243
 msgid "XYZ cal. details"
 msgstr "Detaily XYZ kal."
 
@@ -1506,69 +1506,69 @@ msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr "Pruvodce muzete kdykoliv znovu spustit z menu Kalibrace -> Pruvodce"
 
 # MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ultralcd.cpp:3838
+#: ultralcd.cpp:3922
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr "Kalibrace XYZ v poradku. Zkoseni bude automaticky vyrovnano pri tisku."
 
 # MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ultralcd.cpp:3835
+#: ultralcd.cpp:3919
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr "Kalibrace XYZ v poradku. X/Y osy mirne zkosene. Dobra prace!"
 
 # 
-#: ultralcd.cpp:5044
+#: ultralcd.cpp:5130
 msgid "X-correct:"
 msgstr "Korekce X:"
 
 # MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ultralcd.cpp:3832
+#: ultralcd.cpp:3916
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "Kalibrace XYZ v poradku. X/Y osy jsou kolme. Gratuluji!"
 
 # MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ultralcd.cpp:3816
+#: ultralcd.cpp:3900
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr "Kalibrace XYZ nepresna. Predni kalibracni body moc vpredu."
 
 # MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ultralcd.cpp:3819
+#: ultralcd.cpp:3903
 msgid "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr "Kalibrace XYZ nepresna. Pravy predni bod moc vpredu."
 
 # MSG_LOAD_ALL c=17
-#: ultralcd.cpp:6080
+#: ultralcd.cpp:6166
 msgid "Load all"
 msgstr "Zavest vse"
 
 # 
-#: ultralcd.cpp:3798
+#: ultralcd.cpp:3882
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr "Kalibrace XYZ selhala. Kalibracni bod podlozky nenalezen."
 
 # 
-#: ultralcd.cpp:3804
+#: ultralcd.cpp:3888
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr "Kalibrace XYZ selhala. Predni kalibracni body moc vpredu. Srovnejte tiskarnu."
 
 # 
-#: ultralcd.cpp:3807
+#: ultralcd.cpp:3891
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr "Kalibrace XYZ selhala. Pravy predni bod moc vpredu. Srovnejte tiskarnu."
 
 # 
-#: ultralcd.cpp:2968
+#: ultralcd.cpp:3016
 msgid "Y distance from min"
 msgstr "Y vzdalenost od min"
 
 # 
-#: ultralcd.cpp:5045
+#: ultralcd.cpp:5131
 msgid "Y-correct:"
 msgstr "Korekce Y:"
 
 # MSG_OFF
 #: menu.cpp:426
 msgid " [off]"
-msgstr ""
+msgstr " [vyp]"
 
 # 
 #: messages.c:57
@@ -1576,32 +1576,32 @@ msgid "Back"
 msgstr "Zpet"
 
 # 
-#: ultralcd.cpp:5553
+#: ultralcd.cpp:5639
 msgid "Checks"
 msgstr "Kontrola"
 
 # 
-#: ultralcd.cpp:7887
+#: ultralcd.cpp:7973
 msgid "False triggering"
 msgstr "Falesne spusteni"
 
 # 
-#: ultralcd.cpp:3946
+#: ultralcd.cpp:4030
 msgid "FINDA:"
 msgstr ""
 
 # 
-#: ultralcd.cpp:5459
+#: ultralcd.cpp:5545
 msgid "Firmware   [none]"
 msgstr "Firmware  [Zadne]"
 
 # 
-#: ultralcd.cpp:5465
+#: ultralcd.cpp:5551
 msgid "Firmware [strict]"
 msgstr "Firmware [Prisne]"
 
 # 
-#: ultralcd.cpp:5462
+#: ultralcd.cpp:5548
 msgid "Firmware   [warn]"
 msgstr "Firmware[Varovat]"
 
@@ -1611,102 +1611,102 @@ msgid "HW Setup"
 msgstr "HW nastaveni"
 
 # 
-#: ultralcd.cpp:3950
+#: ultralcd.cpp:4034
 msgid "IR:"
 msgstr ""
 
 # 
-#: ultralcd.cpp:6960
+#: ultralcd.cpp:7046
 msgid "Magnets comp.[N/A]"
 msgstr "Komp. magnetu[N/A]"
 
 # 
-#: ultralcd.cpp:6958
+#: ultralcd.cpp:7044
 msgid "Magnets comp.[Off]"
 msgstr "Komp. magnetu[Vyp]"
 
 # 
-#: ultralcd.cpp:6957
+#: ultralcd.cpp:7043
 msgid "Magnets comp. [On]"
 msgstr "Komp. magnetu[Zap]"
 
 # 
-#: ultralcd.cpp:6949
+#: ultralcd.cpp:7035
 msgid "Mesh         [3x3]"
 msgstr "Mesh         [3x3]"
 
 # 
-#: ultralcd.cpp:6950
+#: ultralcd.cpp:7036
 msgid "Mesh         [7x7]"
 msgstr "Mesh         [7x7]"
 
 # 
-#: ultralcd.cpp:5591
+#: ultralcd.cpp:5677
 msgid "Mesh bed leveling"
 msgstr "Mesh Bed Leveling"
 
 # 
 #: Marlin_main.cpp:856
 msgid "MK3S firmware detected on MK3 printer"
-msgstr ""
+msgstr "MK3S firmware detekovan na tiskarne MK3"
 
 # 
-#: ultralcd.cpp:5220
+#: ultralcd.cpp:5306
 msgid "MMU Mode [Normal]"
 msgstr "MMU mod  [Normal]"
 
 # 
-#: ultralcd.cpp:5221
+#: ultralcd.cpp:5307
 msgid "MMU Mode[Stealth]"
 msgstr "MMU Mod   [Tichy]"
 
 # 
-#: ultralcd.cpp:4427
+#: ultralcd.cpp:4511
 msgid "Mode change in progress ..."
 msgstr "Probiha zmena modu..."
 
 # 
-#: ultralcd.cpp:5420
+#: ultralcd.cpp:5506
 msgid "Model      [none]"
 msgstr "Model     [Zadne]"
 
 # 
-#: ultralcd.cpp:5426
+#: ultralcd.cpp:5512
 msgid "Model    [strict]"
 msgstr "Model    [Prisne]"
 
 # 
-#: ultralcd.cpp:5423
+#: ultralcd.cpp:5509
 msgid "Model      [warn]"
 msgstr "Model   [Varovat]"
 
 # 
-#: ultralcd.cpp:5381
+#: ultralcd.cpp:5467
 msgid "Nozzle d.  [0.25]"
 msgstr "Tryska     [0.25]"
 
 # 
-#: ultralcd.cpp:5384
+#: ultralcd.cpp:5470
 msgid "Nozzle d.  [0.40]"
 msgstr "Tryska     [0.40]"
 
 # 
-#: ultralcd.cpp:5387
+#: ultralcd.cpp:5473
 msgid "Nozzle d.  [0.60]"
 msgstr "Tryska     [0.60]"
 
 # 
-#: ultralcd.cpp:5335
+#: ultralcd.cpp:5421
 msgid "Nozzle     [none]"
 msgstr "Tryska    [Zadne]"
 
 # 
-#: ultralcd.cpp:5341
+#: ultralcd.cpp:5427
 msgid "Nozzle   [strict]"
 msgstr "Tryska   [Prisne]"
 
 # 
-#: ultralcd.cpp:5338
+#: ultralcd.cpp:5424
 msgid "Nozzle     [warn]"
 msgstr "Tryska  [Varovat]"
 
@@ -1723,37 +1723,37 @@ msgstr ""
 # 
 #: util.cpp:427
 msgid "G-code sliced for a different printer type. Continue?"
-msgstr ""
+msgstr "G-code je pripraven pro jiny typ tiskarny. Pokracovat?"
 
 # 
 #: util.cpp:433
 msgid "G-code sliced for a different printer type. Please re-slice the model again. Print cancelled."
-msgstr ""
+msgstr "G-code je pripraven pro jiny typ tiskarny. Prosim preslicujte model znovu. Tisk zrusen."
 
 # 
 #: util.cpp:477
 msgid "G-code sliced for a newer firmware. Continue?"
-msgstr ""
+msgstr "G-code je pripraven pro novejsi firmware. Pokracovat?"
 
 # 
 #: util.cpp:483
 msgid "G-code sliced for a newer firmware. Please update the firmware. Print cancelled."
-msgstr ""
+msgstr "G-code je pripraven pro novejsi firmware. Prosim aktualizujte firmware. Tisk zrusen."
 
 # 
-#: ultralcd.cpp:3942
+#: ultralcd.cpp:4026
 msgid "PINDA:"
 msgstr ""
 
 # 
-#: ultralcd.cpp:2286
+#: ultralcd.cpp:2465
 msgid "Preheating to cut"
-msgstr "Predehrivam k ustrizeni"
+msgstr "Predehrev k ustrizeni"
 
 # 
-#: ultralcd.cpp:2283
+#: ultralcd.cpp:2462
 msgid "Preheating to eject"
-msgstr "Predehrivam k vysunuti"
+msgstr "Predehrev k vysunuti"
 
 # 
 #: util.cpp:390
@@ -1766,42 +1766,47 @@ msgid "Printer nozzle diameter differs from the G-code. Please check the value i
 msgstr "Prumer trysky tiskarny se lisi od G-code. Prosim zkontrolujte nastaveni. Tisk zrusen."
 
 # 
-#: ultralcd.cpp:6597
+#: ultralcd.cpp:6683
 msgid "Rename"
 msgstr "Prejmenovat"
 
 # 
-#: ultralcd.cpp:6593
+#: ultralcd.cpp:6679
 msgid "Select"
 msgstr "Vybrat"
 
 # 
-#: ultralcd.cpp:2134
+#: ultralcd.cpp:2245
 msgid "Sensor info"
 msgstr "Senzor info"
 
 # 
 #: messages.c:58
 msgid "Sheet"
-msgstr "Plech"
+msgstr "Plat"
 
 # 
-#: 
-msgid "Sound     [assist]"
-msgstr "Zvuk   [asistence]"
+#: sound.h:9
+msgid "Sound    [assist]"
+msgstr "Zvuk     [Asist.]"
 
 # 
-#: ultralcd.cpp:5551
+#: ultralcd.cpp:5637
 msgid "Steel sheets"
-msgstr "Tiskove plechy"
+msgstr "Tiskove platy"
 
 # 
-#: ultralcd.cpp:5046
+#: ultralcd.cpp:5132
 msgid "Z-correct:"
 msgstr "Korekce Z:"
 
 # 
-#: ultralcd.cpp:6952
+#: ultralcd.cpp:7038
 msgid "Z-probe nr.    [1]"
 msgstr "Pocet mereni Z [1]"
+
+# 
+#: ultralcd.cpp:7040
+msgid "Z-probe nr.    [3]"
+msgstr "Pocet mereni Z [3]"
 

--- a/lang/po/Firmware_de.po
+++ b/lang/po/Firmware_de.po
@@ -7,8 +7,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: de\n"
 "Project-Id-Version: Prusa-Firmware\n"
-"POT-Creation-Date: Wed Sep 4 16:13:46 CEST 2019\n"
-"PO-Revision-Date: Wed Sep 4 16:13:46 CEST 2019\n"
+"POT-Creation-Date: Sun, Sep 22, 2019 2:04:09 PM\n"
+"PO-Revision-Date: Sun, Sep 22, 2019 2:04:09 PM\n"
 "Language-Team: \n"
 "X-Generator: Poedit 2.0.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
@@ -26,7 +26,7 @@ msgid " of 9"
 msgstr " von 9"
 
 # MSG_MEASURED_OFFSET
-#: ultralcd.cpp:3027
+#: ultralcd.cpp:3089
 msgid "[0;0] point offset"
 msgstr "[0;0] Punktversatz"
 
@@ -41,19 +41,19 @@ msgid "WARNING:\x0aCrash detection\x0adisabled in\x0aStealth mode"
 msgstr "WARNUNG:\x0aCrash Erkennung\x0adeaktiviert im\x0aStealth Modus"
 
 # 
-#: ultralcd.cpp:2290
+#: ultralcd.cpp:2472
 msgid ">Cancel"
 msgstr ">Abbruch"
 
 # MSG_BABYSTEPPING_Z c=15
-#: ultralcd.cpp:3147
+#: ultralcd.cpp:3209
 msgid "Adjusting Z:"
 msgstr "Z Anpassen:"
 
 # MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ultralcd.cpp:8209
+#: ultralcd.cpp:8295
 msgid "All correct      "
-msgstr "Alles richtig "
+msgstr "Alles richtig    "
 
 # MSG_WIZARD_DONE c=20 r=8
 #: messages.c:101
@@ -61,32 +61,32 @@ msgid "All is done. Happy printing!"
 msgstr "Alles abgeschlossen. Viel Spass beim Drucken!"
 
 # 
-#: ultralcd.cpp:1974
+#: ultralcd.cpp:2009
 msgid "Ambient"
 msgstr "Raumtemp."
 
 # MSG_PRESS c=20
-#: ultralcd.cpp:2576
+#: ultralcd.cpp:2618
 msgid "and press the knob"
 msgstr "und Knopf druecken"
 
 # MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=2
-#: ultralcd.cpp:3445
+#: ultralcd.cpp:3529
 msgid "Are left and right Z~carriages all up?"
 msgstr "Sind linke+rechte Z- Schlitten ganz oben?"
 
 # MSG_AUTO_DEPLETE_ON c=17 r=1
-#: ultralcd.cpp:5114
+#: ultralcd.cpp:5200
 msgid "SpoolJoin    [on]"
 msgstr "SpoolJoin    [an]"
 
 # 
-#: ultralcd.cpp:5110
+#: ultralcd.cpp:5196
 msgid "SpoolJoin   [N/A]"
 msgstr "SpoolJoin   [N/V]"
 
 # MSG_AUTO_DEPLETE_OFF c=17 r=1
-#: ultralcd.cpp:5118
+#: ultralcd.cpp:5204
 msgid "SpoolJoin   [off]"
 msgstr "SpoolJoin   [aus]"
 
@@ -96,32 +96,32 @@ msgid "Auto home"
 msgstr "Startposition"
 
 # MSG_AUTOLOAD_FILAMENT c=17
-#: ultralcd.cpp:6736
+#: ultralcd.cpp:6822
 msgid "AutoLoad filament"
-msgstr "Auto-Laden Filament"
+msgstr "AutoLaden Filament"
 
 # MSG_AUTOLOADING_ONLY_IF_FSENS_ON c=20 r=4
-#: ultralcd.cpp:4378
+#: ultralcd.cpp:4462
 msgid "Autoloading filament available only when filament sensor is turned on..."
 msgstr "Automatisches Laden Filament nur bei einge schaltetem Filament- sensor verfuegbar..."
 
 # MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ultralcd.cpp:2771
+#: ultralcd.cpp:2813
 msgid "Autoloading filament is active, just press the knob and insert filament..."
 msgstr "Automatisches Laden Filament ist aktiv, Knopf druecken und Filament einlegen..."
 
 # MSG_SELFTEST_AXIS_LENGTH
-#: ultralcd.cpp:7863
+#: ultralcd.cpp:7949
 msgid "Axis length"
 msgstr "Achsenlaenge"
 
 # MSG_SELFTEST_AXIS
-#: ultralcd.cpp:7865
+#: ultralcd.cpp:7951
 msgid "Axis"
 msgstr "Achse"
 
 # MSG_SELFTEST_BEDHEATER
-#: ultralcd.cpp:7807
+#: ultralcd.cpp:7893
 msgid "Bed / Heater"
 msgstr "Bett / Heizung"
 
@@ -136,7 +136,7 @@ msgid "Bed Heating"
 msgstr "Bett aufwaermen"
 
 # MSG_BED_CORRECTION_MENU
-#: ultralcd.cpp:5682
+#: ultralcd.cpp:5768
 msgid "Bed level correct"
 msgstr "Ausgleich Bett ok"
 
@@ -151,7 +151,7 @@ msgid "Bed"
 msgstr "Bett"
 
 # MSG_MENU_BELT_STATUS c=15 r=1
-#: ultralcd.cpp:2002
+#: ultralcd.cpp:2059
 msgid "Belt status"
 msgstr "Gurtstatus"
 
@@ -161,12 +161,12 @@ msgid "Blackout occurred. Recover print?"
 msgstr "Stromausfall! Druck wiederherstellen?"
 
 # 
-#: ultralcd.cpp:8211
+#: ultralcd.cpp:8297
 msgid "Calibrating home"
 msgstr "Kalibriere Start"
 
 # MSG_CALIBRATE_BED
-#: ultralcd.cpp:5671
+#: ultralcd.cpp:5757
 msgid "Calibrate XYZ"
 msgstr "Kalibrierung XYZ"
 
@@ -176,12 +176,12 @@ msgid "Calibrate Z"
 msgstr "Kalibrierung Z"
 
 # MSG_CALIBRATE_PINDA c=17 r=1
-#: ultralcd.cpp:4570
+#: ultralcd.cpp:4654
 msgid "Calibrate"
 msgstr "Kalibrieren"
 
 # MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ultralcd.cpp:3408
+#: ultralcd.cpp:3492
 msgid "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end stoppers. Click when done."
 msgstr "XYZ Kalibrieren: Drehen Sie den Knopf bis der obere Anschlag erreicht wird. Anschliessend den Knopf druecken."
 
@@ -191,12 +191,12 @@ msgid "Calibrating Z"
 msgstr "Kalibrierung Z"
 
 # MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ultralcd.cpp:3408
+#: ultralcd.cpp:3492
 msgid "Calibrating Z. Rotate the knob to move the Z carriage up to the end stoppers. Click when done."
 msgstr "Z Kalibrieren: Drehen Sie den Knopf bis der obere Anschlag erreicht wird. Anschliessend den Knopf druecken."
 
 # MSG_HOMEYZ_DONE
-#: ultralcd.cpp:813
+#: ultralcd.cpp:816
 msgid "Calibration done"
 msgstr "Kalibrierung OK"
 
@@ -206,17 +206,17 @@ msgid "Calibration"
 msgstr "Kalibrierung"
 
 # 
-#: ultralcd.cpp:4695
+#: ultralcd.cpp:4781
 msgid "Cancel"
 msgstr "Abbruch"
 
 # MSG_SD_REMOVED
-#: ultralcd.cpp:8578
+#: ultralcd.cpp:8679
 msgid "Card removed"
 msgstr "SD Karte entfernt"
 
 # MSG_NOT_COLOR
-#: ultralcd.cpp:2676
+#: ultralcd.cpp:2718
 msgid "Color not correct"
 msgstr "Falsche Farbe"
 
@@ -226,7 +226,7 @@ msgid "Cooldown"
 msgstr "Abkuehlen"
 
 # 
-#: ultralcd.cpp:4503
+#: ultralcd.cpp:4587
 msgid "Copy selected language?"
 msgstr "Gewaehlte Sprache kopieren?"
 
@@ -256,22 +256,22 @@ msgid "Crash detected. Resume print?"
 msgstr "Crash erkannt. Druck fortfuehren?"
 
 # 
-#: ultralcd.cpp:1876
+#: ultralcd.cpp:1853
 msgid "Crash"
 msgstr ""
 
 # MSG_CURRENT c=19 r=1
-#: ultralcd.cpp:5823
+#: ultralcd.cpp:5909
 msgid "Current"
 msgstr "Aktuelles"
 
 # MSG_DATE c=17 r=1
-#: ultralcd.cpp:2102
+#: ultralcd.cpp:2213
 msgid "Date:"
 msgstr "Datum:"
 
 # MSG_DISABLE_STEPPERS
-#: ultralcd.cpp:5568
+#: ultralcd.cpp:5654
 msgid "Disable steppers"
 msgstr "Motoren aus"
 
@@ -281,12 +281,12 @@ msgid "Distance between tip of the nozzle and the bed surface has not been set y
 msgstr "Der Abstand zwischen der Spitze der Duese und dem Bett ist noch nicht eingestellt. Bitte folgen Sie dem Handbuch, Kapitel Erste Schritte, Abschnitt Erste Schicht Kalibrierung."
 
 # MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ultralcd.cpp:4984
+#: ultralcd.cpp:5070
 msgid "Do you want to repeat last step to readjust distance between nozzle and heatbed?"
 msgstr "Moechten Sie den letzten Schritt wiederholen, um den Abstand zwischen Duese und Druckbett neu einzustellen?"
 
 # MSG_EXTRUDER_CORRECTION c=10
-#: ultralcd.cpp:5048
+#: ultralcd.cpp:5134
 msgid "E-correct:"
 msgstr "E-Korrektur:"
 
@@ -296,7 +296,7 @@ msgid "Eject filament"
 msgstr "Filamentauswurf"
 
 # 
-#: ultralcd.cpp:4783
+#: ultralcd.cpp:4869
 msgid "Eject"
 msgstr "Auswurf"
 
@@ -306,27 +306,27 @@ msgid "Ejecting filament"
 msgstr "werfe Filament aus"
 
 # MSG_SELFTEST_ENDSTOP_NOTHIT c=20 r=1
-#: ultralcd.cpp:7831
+#: ultralcd.cpp:7917
 msgid "Endstop not hit"
 msgstr "Ende nicht getroffen"
 
 # MSG_SELFTEST_ENDSTOP
-#: ultralcd.cpp:7825
+#: ultralcd.cpp:7911
 msgid "Endstop"
 msgstr "Endanschlag"
 
 # MSG_SELFTEST_ENDSTOPS
-#: ultralcd.cpp:7813
+#: ultralcd.cpp:7899
 msgid "Endstops"
 msgstr "Endschalter"
 
 # MSG_STACK_ERROR c=20 r=4
-#: ultralcd.cpp:6773
+#: ultralcd.cpp:6859
 msgid "Error - static memory has been overwritten"
 msgstr "Fehler - statischer Speicher wurde ueberschrieben"
 
 # MSG_FSENS_NOT_RESPONDING c=20 r=4
-#: ultralcd.cpp:4391
+#: ultralcd.cpp:4475
 msgid "ERROR: Filament sensor is not responding, please check connection."
 msgstr "FEHLER: Filament- sensor reagiert nicht, bitte Verbindung pruefen."
 
@@ -336,12 +336,12 @@ msgid "ERROR:"
 msgstr "FEHLER:"
 
 # MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
-#: ultralcd.cpp:8218
+#: ultralcd.cpp:8304
 msgid "Extruder fan:"
 msgstr "Extruder Luefter:"
 
 # MSG_INFO_EXTRUDER c=15 r=1
-#: ultralcd.cpp:2133
+#: ultralcd.cpp:2244
 msgid "Extruder info"
 msgstr "Extruder Info"
 
@@ -351,12 +351,12 @@ msgid "Extruder"
 msgstr ""
 
 # 
-#: ultralcd.cpp:6760
+#: ultralcd.cpp:6846
 msgid "Fail stats MMU"
 msgstr "MMU-Fehler"
 
 # MSG_FSENS_AUTOLOAD_ON c=17 r=1
-#: ultralcd.cpp:5082
+#: ultralcd.cpp:5168
 msgid "F. autoload  [on]"
 msgstr "F.Autoladen  [an]"
 
@@ -366,12 +366,12 @@ msgid "F. autoload [N/A]"
 msgstr "F. Autoload  [nv]"
 
 # MSG_FSENS_AUTOLOAD_OFF c=17 r=1
-#: ultralcd.cpp:5084
+#: ultralcd.cpp:5170
 msgid "F. autoload [off]"
 msgstr "F. Autoload [aus]"
 
 # 
-#: ultralcd.cpp:6757
+#: ultralcd.cpp:6843
 msgid "Fail stats"
 msgstr "Fehlerstatistik"
 
@@ -386,12 +386,12 @@ msgid "Fan test"
 msgstr "Lueftertest"
 
 # MSG_FANS_CHECK_ON c=17 r=1
-#: ultralcd.cpp:5577
+#: ultralcd.cpp:5663
 msgid "Fans check   [on]"
 msgstr "Luefter Chk. [an]"
 
 # MSG_FANS_CHECK_OFF c=17 r=1
-#: ultralcd.cpp:5579
+#: ultralcd.cpp:5665
 msgid "Fans check  [off]"
 msgstr "Luefter Chk.[aus]"
 
@@ -401,7 +401,7 @@ msgid "Fil. sensor  [on]"
 msgstr "Fil. Sensor  [an]"
 
 # MSG_FSENSOR_NA
-#: ultralcd.cpp:5062
+#: ultralcd.cpp:5148
 msgid "Fil. sensor [N/A]"
 msgstr "Fil. Sensor  [nv]"
 
@@ -411,17 +411,17 @@ msgid "Fil. sensor [off]"
 msgstr "Fil. Sensor [aus]"
 
 # 
-#: ultralcd.cpp:1876
+#: ultralcd.cpp:1852
 msgid "Filam. runouts"
 msgstr "Filam. Maengel"
 
 # MSG_FILAMENT_CLEAN c=20 r=2
 #: messages.c:32
 msgid "Filament extruding & with correct color?"
-msgstr "Filament extrudiert + richtige Farbe?"
+msgstr "Filament extrudiert mit richtiger Farbe?"
 
 # MSG_NOT_LOADED c=19
-#: ultralcd.cpp:2672
+#: ultralcd.cpp:2714
 msgid "Filament not loaded"
 msgstr "Fil. nicht geladen"
 
@@ -431,17 +431,17 @@ msgid "Filament sensor"
 msgstr "Filamentsensor"
 
 # MSG_FILAMENT_USED c=19 r=1
-#: ultralcd.cpp:2841
+#: ultralcd.cpp:2885
 msgid "Filament used"
 msgstr "Filament benutzt"
 
 # MSG_PRINT_TIME c=19 r=1
-#: ultralcd.cpp:2841
+#: ultralcd.cpp:2886
 msgid "Print time"
 msgstr "Druckzeit"
 
 # MSG_FILE_INCOMPLETE c=20 r=2
-#: ultralcd.cpp:8346
+#: ultralcd.cpp:8432
 msgid "File incomplete. Continue anyway?"
 msgstr "Datei unvollstaendig Trotzdem fortfahren?"
 
@@ -456,7 +456,7 @@ msgid "First layer cal."
 msgstr "Erste-Schicht Kal."
 
 # MSG_WIZARD_SELFTEST c=20 r=8
-#: ultralcd.cpp:4896
+#: ultralcd.cpp:4982
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr "Zunaechst fuehre ich den Selbsttest durch, um die haeufigsten Probleme beim Zusammenbau zu ueberpruefen."
 
@@ -466,12 +466,12 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr "Beseitigen Sie das Problem und druecken Sie dann den Knopf am MMU."
 
 # MSG_FLOW
-#: ultralcd.cpp:6846
+#: ultralcd.cpp:6932
 msgid "Flow"
 msgstr "Durchfluss"
 
 # MSG_PRUSA3D_FORUM
-#: ultralcd.cpp:2095
+#: ultralcd.cpp:2206
 msgid "forum.prusa3d.com"
 msgstr ""
 
@@ -481,22 +481,22 @@ msgid "Front print fan?"
 msgstr "Vorderer Luefter?"
 
 # MSG_BED_CORRECTION_FRONT c=14 r=1
-#: ultralcd.cpp:3220
+#: ultralcd.cpp:3294
 msgid "Front side[um]"
 msgstr "Vorne [um]"
 
 # MSG_SELFTEST_FANS
-#: ultralcd.cpp:7871
+#: ultralcd.cpp:7957
 msgid "Front/left fans"
 msgstr "Vorderer/linke Luefter"
 
 # MSG_SELFTEST_HEATERTHERMISTOR
-#: ultralcd.cpp:7801
+#: ultralcd.cpp:7887
 msgid "Heater/Thermistor"
 msgstr "Heizung/Thermistor"
 
 # MSG_BED_HEATING_SAFETY_DISABLED
-#: Marlin_main.cpp:8468
+#: Marlin_main.cpp:8467
 msgid "Heating disabled by safety timer."
 msgstr "Heizung durch Sicherheitstimer deaktiviert."
 
@@ -511,12 +511,12 @@ msgid "Heating"
 msgstr "Aufwaermen"
 
 # MSG_WIZARD_WELCOME c=20 r=7
-#: ultralcd.cpp:4875
+#: ultralcd.cpp:4961
 msgid "Hi, I am your Original Prusa i3 printer. Would you like me to guide you through the setup process?"
 msgstr "Hallo, ich bin Ihr Original Prusa i3 Drucker. Moechten Sie, dass ich Sie durch den Einrich- tungsablauf fuehre?"
 
 # MSG_PRUSA3D_HOWTO
-#: ultralcd.cpp:2096
+#: ultralcd.cpp:2207
 msgid "howto.prusa3d.com"
 msgstr ""
 
@@ -526,12 +526,12 @@ msgid "Change filament"
 msgstr "Filament-Wechsel"
 
 # MSG_CHANGE_SUCCESS
-#: ultralcd.cpp:2587
+#: ultralcd.cpp:2629
 msgid "Change success!"
 msgstr "Wechsel erfolgr.!"
 
 # MSG_CORRECTLY c=20
-#: ultralcd.cpp:2664
+#: ultralcd.cpp:2706
 msgid "Changed correctly?"
 msgstr "Wechsel ok?"
 
@@ -541,12 +541,12 @@ msgid "Checking bed     "
 msgstr "Pruefe Bett "
 
 # MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ultralcd.cpp:8200
+#: ultralcd.cpp:8286
 msgid "Checking endstops"
 msgstr "Pruefe Endschalter"
 
 # MSG_SELFTEST_CHECK_HOTEND c=20
-#: ultralcd.cpp:8206
+#: ultralcd.cpp:8292
 msgid "Checking hotend  "
 msgstr "Pruefe Duese  "
 
@@ -556,17 +556,17 @@ msgid "Checking sensors "
 msgstr "Pruefe Sensoren "
 
 # MSG_SELFTEST_CHECK_X c=20
-#: ultralcd.cpp:8201
+#: ultralcd.cpp:8287
 msgid "Checking X axis  "
 msgstr "Pruefe X Achse "
 
 # MSG_SELFTEST_CHECK_Y c=20
-#: ultralcd.cpp:8202
+#: ultralcd.cpp:8288
 msgid "Checking Y axis  "
 msgstr "Pruefe Y Achse "
 
 # MSG_SELFTEST_CHECK_Z c=20
-#: ultralcd.cpp:8203
+#: ultralcd.cpp:8289
 msgid "Checking Z axis  "
 msgstr "Pruefe Z Achse "
 
@@ -586,17 +586,17 @@ msgid "Filament"
 msgstr ""
 
 # MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ultralcd.cpp:4905
+#: ultralcd.cpp:4991
 msgid "I will run xyz calibration now. It will take approx. 12 mins."
 msgstr "Ich werde jetzt die XYZ-Kalibrierung durchfuehren. Es wird ca. 12 Minuten dauern."
 
 # MSG_WIZARD_Z_CAL c=20 r=8
-#: ultralcd.cpp:4913
+#: ultralcd.cpp:4999
 msgid "I will run z calibration now."
 msgstr "Ich werde jetzt die Z Kalibrierung durchfuehren."
 
 # MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ultralcd.cpp:4978
+#: ultralcd.cpp:5064
 msgid "I will start to print line and you will gradually lower the nozzle by rotating the knob, until you reach optimal height. Check the pictures in our handbook in chapter Calibration."
 msgstr "Ich werde jetzt eine Linie drucken. Waehrend des Druckes koennen Sie die Duese allmaehlich senken, indem Sie den Knopf drehen, bis Sie die optimale Hoehe erreichen. Sehen Sie sich die Bilder in unserem Handbuch im Kapitel Kalibrierung an."
 
@@ -606,27 +606,27 @@ msgid "Info screen"
 msgstr "Infoanzeige"
 
 # 
-#: ultralcd.cpp:4938
+#: ultralcd.cpp:5024
 msgid "Is filament 1 loaded?"
 msgstr "Wurde Filament 1 geladen?"
 
 # MSG_INSERT_FILAMENT c=20
-#: ultralcd.cpp:2572
+#: ultralcd.cpp:2614
 msgid "Insert filament"
 msgstr "Filament einlegen"
 
 # MSG_WIZARD_FILAMENT_LOADED c=20 r=2
-#: ultralcd.cpp:4941
+#: ultralcd.cpp:5027
 msgid "Is filament loaded?"
 msgstr "Ist das Filament geladen?"
 
 # MSG_WIZARD_PLA_FILAMENT c=20 r=2
-#: ultralcd.cpp:4972
+#: ultralcd.cpp:5058
 msgid "Is it PLA filament?"
 msgstr "Ist es wirklich PLA Filament?"
 
 # MSG_PLA_FILAMENT_LOADED c=20 r=2
-#: ultralcd.cpp:4704
+#: ultralcd.cpp:4790
 msgid "Is PLA filament loaded?"
 msgstr "Ist PLA Filament geladen?"
 
@@ -636,12 +636,12 @@ msgid "Is steel sheet on heatbed?"
 msgstr "Liegt das Stahlblech auf dem Heizbett?"
 
 # 
-#: ultralcd.cpp:1840
+#: ultralcd.cpp:1795
 msgid "Last print failures"
 msgstr "Letzte Druckfehler"
 
 # 
-#: ultralcd.cpp:1823
+#: ultralcd.cpp:1772
 msgid "Last print"
 msgstr "Letzter Druck"
 
@@ -651,17 +651,17 @@ msgid "Left hotend fan?"
 msgstr "Linker Luefter?"
 
 # 
-#: ultralcd.cpp:2970
+#: ultralcd.cpp:3018
 msgid "Left"
 msgstr "Links"
 
 # MSG_BED_CORRECTION_LEFT c=14 r=1
-#: ultralcd.cpp:3218
+#: ultralcd.cpp:3292
 msgid "Left side [um]"
 msgstr "Links [um]"
 
 # 
-#: ultralcd.cpp:5594
+#: ultralcd.cpp:5680
 msgid "Lin. correction"
 msgstr "Lineare Korrektur"
 
@@ -676,7 +676,7 @@ msgid "Load filament"
 msgstr "Filament laden"
 
 # MSG_LOADING_COLOR
-#: ultralcd.cpp:2612
+#: ultralcd.cpp:2654
 msgid "Loading color"
 msgstr "Lade Farbe"
 
@@ -686,12 +686,12 @@ msgid "Loading filament"
 msgstr "Filament laedt"
 
 # MSG_LOOSE_PULLEY c=20 r=1
-#: ultralcd.cpp:7855
+#: ultralcd.cpp:7941
 msgid "Loose pulley"
 msgstr "Lose Riemenscheibe"
 
 # 
-#: ultralcd.cpp:6719
+#: ultralcd.cpp:6805
 msgid "Load to nozzle"
 msgstr "In Druckduese laden"
 
@@ -711,14 +711,14 @@ msgid "Measuring reference height of calibration point"
 msgstr "Messen der Referenzhoehe des Kalibrierpunktes"
 
 # MSG_MESH_BED_LEVELING
-#: ultralcd.cpp:5677
+#: ultralcd.cpp:5763
 msgid "Mesh Bed Leveling"
-msgstr "Mesh Bett Ausgleich"
+msgstr "MeshBett Ausgleich"
 
 # MSG_MMU_OK_RESUMING_POSITION c=20 r=4
 #: mmu.cpp:762
 msgid "MMU OK. Resuming position..."
-msgstr "MMU OK. Position    wiederherstellen... "
+msgstr "MMU OK. Position wiederherstellen..."
 
 # MSG_MMU_OK_RESUMING_TEMPERATURE c=20 r=4
 #: mmu.cpp:755
@@ -726,12 +726,12 @@ msgid "MMU OK. Resuming temperature..."
 msgstr "MMU OK. Temperatur wiederherstellen..."
 
 # 
-#: ultralcd.cpp:3005
+#: ultralcd.cpp:3059
 msgid "Measured skew"
 msgstr "Schraeglauf"
 
 # 
-#: ultralcd.cpp:1840
+#: ultralcd.cpp:1796
 msgid "MMU fails"
 msgstr "MMU Fehler"
 
@@ -741,7 +741,7 @@ msgid "MMU load failed     "
 msgstr "MMU Ladefehler"
 
 # 
-#: ultralcd.cpp:1840
+#: ultralcd.cpp:1797
 msgid "MMU load fails"
 msgstr "MMU Ladefehler"
 
@@ -766,7 +766,7 @@ msgid "MMU needs user attention."
 msgstr "MMU erfordert Benutzereingriff."
 
 # 
-#: ultralcd.cpp:1857
+#: ultralcd.cpp:1823
 msgid "MMU power fails"
 msgstr "MMU Netzfehler"
 
@@ -786,7 +786,7 @@ msgid "Mode [high power]"
 msgstr "Modus[Hohe Leist]"
 
 # 
-#: ultralcd.cpp:2108
+#: ultralcd.cpp:2219
 msgid "MMU2 connected"
 msgstr "MMU2 verbunden"
 
@@ -796,37 +796,37 @@ msgid "Motor"
 msgstr ""
 
 # MSG_MOVE_AXIS
-#: ultralcd.cpp:5566
+#: ultralcd.cpp:5652
 msgid "Move axis"
 msgstr "Achse bewegen"
 
 # MSG_MOVE_X
-#: ultralcd.cpp:4294
+#: ultralcd.cpp:4378
 msgid "Move X"
 msgstr "Bewege X"
 
 # MSG_MOVE_Y
-#: ultralcd.cpp:4295
+#: ultralcd.cpp:4379
 msgid "Move Y"
 msgstr "Bewege Y"
 
 # MSG_MOVE_Z
-#: ultralcd.cpp:4296
+#: ultralcd.cpp:4380
 msgid "Move Z"
 msgstr "Bewege Z"
 
 # MSG_NO_MOVE
-#: Marlin_main.cpp:5291
+#: Marlin_main.cpp:5292
 msgid "No move."
 msgstr "Keine Bewegung."
 
 # MSG_NO_CARD
-#: ultralcd.cpp:6686
+#: ultralcd.cpp:6772
 msgid "No SD card"
 msgstr "Keine SD Karte"
 
 # 
-#: ultralcd.cpp:2976
+#: ultralcd.cpp:3024
 msgid "N/A"
 msgstr "N.V."
 
@@ -836,7 +836,7 @@ msgid "No"
 msgstr "Nein"
 
 # MSG_SELFTEST_NOTCONNECTED
-#: ultralcd.cpp:7803
+#: ultralcd.cpp:7889
 msgid "Not connected"
 msgstr "Nicht angeschlossen"
 
@@ -851,12 +851,12 @@ msgid "Not spinning"
 msgstr "Dreht sich nicht"
 
 # MSG_WIZARD_V2_CAL c=20 r=8
-#: ultralcd.cpp:4977
+#: ultralcd.cpp:5063
 msgid "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr "Jetzt werde ich den Abstand zwischen Duesenspitze und Druckbett kalibrieren."
 
 # MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ultralcd.cpp:4921
+#: ultralcd.cpp:5007
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Jetzt werde ich die Duese fuer PLA vorheizen."
 
@@ -871,37 +871,37 @@ msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr "Alte Einstellungen gefunden. Standard PID, E-Steps u.s.w. werden gesetzt."
 
 # 
-#: ultralcd.cpp:4912
+#: ultralcd.cpp:4998
 msgid "Now remove the test print from steel sheet."
 msgstr "Testdruck jetzt von Stahlblech entfernen."
 
 # 
-#: ultralcd.cpp:1782
+#: ultralcd.cpp:1722
 msgid "Nozzle FAN"
-msgstr "Duesen Luefter"
+msgstr "Duesevent."
 
 # MSG_PAUSE_PRINT
-#: ultralcd.cpp:6649
+#: ultralcd.cpp:6735
 msgid "Pause print"
 msgstr "Druck pausieren"
 
 # MSG_PID_RUNNING c=20 r=1
-#: ultralcd.cpp:1598
+#: ultralcd.cpp:1606
 msgid "PID cal.           "
 msgstr "PID Kal.           "
 
 # MSG_PID_FINISHED c=20 r=1
-#: ultralcd.cpp:1604
+#: ultralcd.cpp:1612
 msgid "PID cal. finished"
 msgstr "PID Kalib. fertig"
 
 # MSG_PID_EXTRUDER c=17 r=1
-#: ultralcd.cpp:5683
+#: ultralcd.cpp:5769
 msgid "PID calibration"
 msgstr "PID Kalibrierung"
 
 # MSG_PINDA_PREHEAT c=20 r=1
-#: ultralcd.cpp:843
+#: ultralcd.cpp:846
 msgid "PINDA Heating"
 msgstr "PINDA erwaermen"
 
@@ -911,7 +911,7 @@ msgid "Place a sheet of paper under the nozzle during the calibration of first 4
 msgstr "Legen Sie ein Blatt Papier unter die Duese waehrend der Kalibrierung der ersten 4 Punkte. Wenn die Duese das Papier erfasst, den Drucker sofort ausschalten."
 
 # MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ultralcd.cpp:4986
+#: ultralcd.cpp:5072
 msgid "Please clean heatbed and then press the knob."
 msgstr "Bitte reinigen Sie das Heizbett und druecken Sie dann den Knopf."
 
@@ -921,7 +921,7 @@ msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Bitte entfernen Sie ueberstehendes Filament von der Duese. Klicken wenn sauber."
 
 # MSG_SELFTEST_PLEASECHECK
-#: ultralcd.cpp:7795
+#: ultralcd.cpp:7881
 msgid "Please check :"
 msgstr "Bitte pruefe:"
 
@@ -931,17 +931,17 @@ msgid "Please check our handbook and fix the problem. Then resume the Wizard by 
 msgstr "Bitte lesen Sie unser Handbuch und beheben Sie das Problem. Fahren Sie dann mit dem Assistenten fort, indem Sie den Drucker neu starten."
 
 # MSG_WIZARD_LOAD_FILAMENT c=20 r=8
-#: ultralcd.cpp:4808
+#: ultralcd.cpp:4894
 msgid "Please insert PLA filament to the extruder, then press knob to load it."
 msgstr "Legen Sie bitte PLA Filament in den Extruder und druecken Sie den Knopf,  um es zu laden."
 
 # MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ultralcd.cpp:4709
+#: ultralcd.cpp:4795
 msgid "Please load PLA filament first."
 msgstr "Bitte laden Sie zuerst PLA Filament."
 
 # MSG_CHECK_IDLER c=20 r=4
-#: Marlin_main.cpp:3063
+#: Marlin_main.cpp:3064
 msgid "Please open idler and remove filament manually."
 msgstr "Bitte Spannrolle oeffnen und Fila- ment von Hand entfernen"
 
@@ -956,7 +956,7 @@ msgid "Please press the knob to unload filament"
 msgstr "Bitte druecken Sie den Knopf um das Filament zu entladen."
 
 # 
-#: ultralcd.cpp:4803
+#: ultralcd.cpp:4889
 msgid "Please insert PLA filament to the first tube of MMU, then press the knob to load it."
 msgstr "Legen Sie bitte PLA Filament in den ersten Schlauch der MMU und druecken Sie den Knopf,  um es zu laden."
 
@@ -976,7 +976,7 @@ msgid "Please remove steel sheet from heatbed."
 msgstr "Bitte entfernen Sie das Stahlblech vom Heizbett."
 
 # MSG_RUN_XYZ c=20 r=4
-#: Marlin_main.cpp:4354
+#: Marlin_main.cpp:4355
 msgid "Please run XYZ calibration first."
 msgstr "Bitte zuerst XYZ Kalibrierung ausfuehren."
 
@@ -991,7 +991,7 @@ msgid "Please wait"
 msgstr "Bitte warten"
 
 # 
-#: ultralcd.cpp:4911
+#: ultralcd.cpp:4997
 msgid "Please remove shipping helpers first."
 msgstr "Bitte zuerst Transportsicherungen entfernen."
 
@@ -1001,7 +1001,7 @@ msgid "Preheat the nozzle!"
 msgstr "Duese vorheizen!"
 
 # MSG_PREHEAT
-#: ultralcd.cpp:6636
+#: ultralcd.cpp:6722
 msgid "Preheat"
 msgstr "Vorheizen"
 
@@ -1016,12 +1016,12 @@ msgid "Please upgrade."
 msgstr "Bitte aktualisieren."
 
 # MSG_PRESS_TO_PREHEAT c=20 r=4
-#: Marlin_main.cpp:10365
+#: Marlin_main.cpp:10364
 msgid "Press knob to preheat nozzle and continue."
 msgstr "Bitte druecken Sie den Knopf um die Duese vorzuheizen und fortzufahren."
 
 # 
-#: ultralcd.cpp:1876
+#: ultralcd.cpp:1851
 msgid "Power failures"
 msgstr "Netzfehler"
 
@@ -1031,17 +1031,17 @@ msgid "Print aborted"
 msgstr "Druck abgebrochen"
 
 # 
-#: ultralcd.cpp:2276
+#: ultralcd.cpp:2455
 msgid "Preheating to load"
 msgstr "Heizen zum Laden"
 
 # 
-#: ultralcd.cpp:2280
+#: ultralcd.cpp:2459
 msgid "Preheating to unload"
 msgstr "Heizen zum Entladen"
 
 # MSG_SELFTEST_PRINT_FAN_SPEED c=18
-#: ultralcd.cpp:8221
+#: ultralcd.cpp:8307
 msgid "Print fan:"
 msgstr "Druckvent.:"
 
@@ -1051,12 +1051,12 @@ msgid "Print from SD"
 msgstr "Drucken von SD"
 
 # 
-#: ultralcd.cpp:2206
+#: ultralcd.cpp:2317
 msgid "Press the knob"
-msgstr "Knopf druecken"
+msgstr "Knopf druecken zum"
 
 # MSG_PRINT_PAUSED c=20 r=1
-#: ultralcd.cpp:1061
+#: ultralcd.cpp:1069
 msgid "Print paused"
 msgstr "Druck pausiert"
 
@@ -1071,22 +1071,22 @@ msgid "Printer has not been calibrated yet. Please follow the manual, chapter Fi
 msgstr "Drucker wurde noch nicht kalibriert. Bitte folgen Sie dem Handbuch, Kapitel Erste Schritte, Abschnitt Kalibrie- rungsablauf."
 
 # 
-#: ultralcd.cpp:1784
+#: ultralcd.cpp:1723
 msgid "Print FAN"
-msgstr "Druckluefter"
+msgstr "Druckvent."
 
 # MSG_PRUSA3D
-#: ultralcd.cpp:2094
+#: ultralcd.cpp:2205
 msgid "prusa3d.com"
 msgstr ""
 
 # MSG_BED_CORRECTION_REAR c=14 r=1
-#: ultralcd.cpp:3221
+#: ultralcd.cpp:3295
 msgid "Rear side [um]"
 msgstr "Hinten [um]"
 
 # MSG_RECOVERING_PRINT c=20 r=1
-#: Marlin_main.cpp:9765
+#: Marlin_main.cpp:9764
 msgid "Recovering print    "
 msgstr "Druck wiederherst    "
 
@@ -1101,17 +1101,17 @@ msgid "Prusa i3 MK3S OK."
 msgstr ""
 
 # MSG_CALIBRATE_BED_RESET
-#: ultralcd.cpp:5688
+#: ultralcd.cpp:5774
 msgid "Reset XYZ calibr."
-msgstr "XYZ Kalibr. zuruecksetzen."
+msgstr "Reset XYZ Kalibr."
 
 # MSG_BED_CORRECTION_RESET
-#: ultralcd.cpp:3222
+#: ultralcd.cpp:3296
 msgid "Reset"
 msgstr "Ruecksetzen"
 
 # MSG_RESUME_PRINT
-#: ultralcd.cpp:6656
+#: ultralcd.cpp:6742
 msgid "Resume print"
 msgstr "Druck fortsetzen"
 
@@ -1121,37 +1121,37 @@ msgid "Resuming print"
 msgstr "Druck fortgesetzt"
 
 # MSG_BED_CORRECTION_RIGHT c=14 r=1
-#: ultralcd.cpp:3219
+#: ultralcd.cpp:3293
 msgid "Right side[um]"
 msgstr "Rechts    [um]"
 
 # MSG_SECOND_SERIAL_ON c=17 r=1
-#: ultralcd.cpp:5606
+#: ultralcd.cpp:5692
 msgid "RPi port     [on]"
 msgstr "RPi Port     [an]"
 
 # MSG_SECOND_SERIAL_OFF c=17 r=1
-#: ultralcd.cpp:5604
+#: ultralcd.cpp:5690
 msgid "RPi port    [off]"
 msgstr "RPi Port    [aus]"
 
 # MSG_WIZARD_RERUN c=20 r=7
-#: ultralcd.cpp:4726
+#: ultralcd.cpp:4812
 msgid "Running Wizard will delete current calibration results and start from the beginning. Continue?"
 msgstr "Der Assistent wird die aktuellen Kalibrierungsdaten loeschen und von vorne beginnen. Weiterfahren?"
 
 # MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_OFF c=19 r=1
-#: ultralcd.cpp:5236
+#: ultralcd.cpp:5322
 msgid "SD card  [normal]"
 msgstr "SD Karte [normal]"
 
 # MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_ON c=19 r=1
-#: ultralcd.cpp:5234
+#: ultralcd.cpp:5320
 msgid "SD card [flshAir]"
 msgstr "SD Karte[flshAir]"
 
 # 
-#: ultralcd.cpp:2971
+#: ultralcd.cpp:3019
 msgid "Right"
 msgstr "Rechts"
 
@@ -1161,34 +1161,34 @@ msgid "Searching bed calibration point"
 msgstr "Suche Bett Kalibrierpunkt"
 
 # MSG_LANGUAGE_SELECT
-#: ultralcd.cpp:5613
+#: ultralcd.cpp:5699
 msgid "Select language"
 msgstr "Waehle Sprache"
 
 # MSG_SELFTEST_OK
-#: ultralcd.cpp:7366
+#: ultralcd.cpp:7452
 msgid "Self test OK"
 msgstr "Selbsttest OK"
 
 # MSG_SELFTEST_START c=20
-#: ultralcd.cpp:7152
+#: ultralcd.cpp:7238
 msgid "Self test start  "
 msgstr "Selbsttest start "
 
 # MSG_SELFTEST
-#: ultralcd.cpp:5664
+#: ultralcd.cpp:5750
 msgid "Selftest         "
 msgstr "Selbsttest       "
 
 # MSG_SELFTEST_ERROR
-#: ultralcd.cpp:7793
+#: ultralcd.cpp:7879
 msgid "Selftest error !"
 msgstr "Selbsttest Fehler!"
 
 # MSG_SELFTEST_FAILED c=20
 #: messages.c:77
 msgid "Selftest failed  "
-msgstr "Selbsttest misslang"
+msgstr "Selbsttest Error "
 
 # MSG_FORCE_SELFTEST c=20 r=8
 #: Marlin_main.cpp:1551
@@ -1196,17 +1196,17 @@ msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr "Selbsttest im Gang, um die genaue Rueck- kehr zum Nullpunkt ohne Sensor zu kalibrieren"
 
 # 
-#: ultralcd.cpp:4959
+#: ultralcd.cpp:5045
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr "Bitte Vorheiztemperatur auswaehlen, die Ihrem Material entspricht."
 
 # 
-#: ultralcd.cpp:4695
+#: ultralcd.cpp:4780
 msgid "Select PLA filament:"
 msgstr "PLA Filament auswaehlen:"
 
 # MSG_SET_TEMPERATURE c=19 r=1
-#: ultralcd.cpp:3230
+#: ultralcd.cpp:3314
 msgid "Set temperature:"
 msgstr "Temp. einstellen:"
 
@@ -1216,12 +1216,12 @@ msgid "Settings"
 msgstr "Einstellungen"
 
 # MSG_SHOW_END_STOPS c=17 r=1
-#: ultralcd.cpp:5685
+#: ultralcd.cpp:5771
 msgid "Show end stops"
 msgstr "Endschalter Status"
 
 # 
-#: ultralcd.cpp:3941
+#: ultralcd.cpp:4025
 msgid "Sensor state"
 msgstr "Sensorstatus"
 
@@ -1231,22 +1231,22 @@ msgid "Some files will not be sorted. Max. No. of files in 1 folder for sorting 
 msgstr "Einige Dateien wur- den nicht sortiert. Max. Dateien pro Verzeichnis = 100."
 
 # MSG_SORT_NONE c=17 r=1
-#: ultralcd.cpp:5246
+#: ultralcd.cpp:5332
 msgid "Sort       [none]"
-msgstr "Sort.     [Keine]"
+msgstr "Sort.      [ohne]"
 
 # MSG_SORT_TIME c=17 r=1
-#: ultralcd.cpp:5244
+#: ultralcd.cpp:5330
 msgid "Sort       [time]"
 msgstr "Sort.      [Zeit]"
 
 # 
-#: ultralcd.cpp:3008
-msgid "Severe skew"
-msgstr "Schwerer Schraeglauf"
+#: ultralcd.cpp:3062
+msgid "Severe skew:"
+msgstr "Schwer.Schr:"
 
 # MSG_SORT_ALPHA c=17 r=1
-#: ultralcd.cpp:5245
+#: ultralcd.cpp:5331
 msgid "Sort   [alphabet]"
 msgstr "Sort.  [Alphabet]"
 
@@ -1261,9 +1261,9 @@ msgid "Sound      [loud]"
 msgstr "Sound      [laut]"
 
 # 
-#: ultralcd.cpp:3007
-msgid "Slight skew"
-msgstr "Leichter Schraeglauf"
+#: ultralcd.cpp:3061
+msgid "Slight skew:"
+msgstr "Leicht.Schr:"
 
 # MSG_SOUND_MUTE c=17 r=1
 #: 
@@ -1271,7 +1271,7 @@ msgid "Sound      [mute]"
 msgstr "Sound     [stumm]"
 
 # 
-#: Marlin_main.cpp:4870
+#: Marlin_main.cpp:4871
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Fehler aufgetreten, Z-Kalibrierung erforderlich..."
 
@@ -1286,7 +1286,7 @@ msgid "Sound    [silent]"
 msgstr "Sound     [leise]"
 
 # MSG_SPEED
-#: ultralcd.cpp:6840
+#: ultralcd.cpp:6926
 msgid "Speed"
 msgstr "Geschwindigkeit"
 
@@ -1296,12 +1296,12 @@ msgid "Spinning"
 msgstr "Dreht sich"
 
 # MSG_TEMP_CAL_WARNING c=20 r=4
-#: Marlin_main.cpp:4367
+#: Marlin_main.cpp:4368
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr "Stabile Umgebungs- temperatur 21-26C und feste Stand- flaeche erforderlich"
 
 # MSG_STATISTICS
-#: ultralcd.cpp:6753
+#: ultralcd.cpp:6839
 msgid "Statistics  "
 msgstr "Statistiken "
 
@@ -1316,12 +1316,12 @@ msgid "STOPPED. "
 msgstr "GESTOPPT."
 
 # MSG_SUPPORT
-#: ultralcd.cpp:6762
+#: ultralcd.cpp:6848
 msgid "Support"
 msgstr ""
 
 # MSG_SELFTEST_SWAPPED
-#: ultralcd.cpp:7873
+#: ultralcd.cpp:7959
 msgid "Swapped"
 msgstr "Ausgetauscht"
 
@@ -1331,22 +1331,22 @@ msgid "Temp. cal.          "
 msgstr "Temp Kalib.         "
 
 # MSG_TEMP_CALIBRATION_ON c=20 r=1
-#: ultralcd.cpp:5600
+#: ultralcd.cpp:5686
 msgid "Temp. cal.   [on]"
-msgstr "Temp. Kal.   [AN]"
+msgstr "Temp. Kal.   [an]"
 
 # MSG_TEMP_CALIBRATION_OFF c=20 r=1
-#: ultralcd.cpp:5598
+#: ultralcd.cpp:5684
 msgid "Temp. cal.  [off]"
-msgstr "Temp. Kal.  [AUS]"
+msgstr "Temp. Kal.  [aus]"
 
 # MSG_CALIBRATION_PINDA_MENU c=17 r=1
-#: ultralcd.cpp:5694
+#: ultralcd.cpp:5780
 msgid "Temp. calibration"
 msgstr "Temp. kalibrieren"
 
 # MSG_TEMP_CAL_FAILED c=20 r=8
-#: ultralcd.cpp:3867
+#: ultralcd.cpp:3951
 msgid "Temperature calibration failed"
 msgstr "Temperaturkalibrierung fehlgeschlagen"
 
@@ -1356,12 +1356,12 @@ msgid "Temperature calibration is finished and active. Temp. calibration can be 
 msgstr "Temp.kalibrierung ist fertig + aktiv. Temp.kalibrierung kann ausgeschaltet werden im Menu Einstellungen -> Temp.kal."
 
 # MSG_TEMPERATURE
-#: ultralcd.cpp:5564
+#: ultralcd.cpp:5650
 msgid "Temperature"
 msgstr "Temperatur"
 
 # MSG_MENU_TEMPERATURES c=15 r=1
-#: ultralcd.cpp:2140
+#: ultralcd.cpp:2251
 msgid "Temperatures"
 msgstr "Temperaturen"
 
@@ -1371,39 +1371,39 @@ msgid "There is still a need to make Z calibration. Please follow the manual, ch
 msgstr "Es ist noch notwendig die Z-Kalibrierung auszufuehren. Bitte befolgen Sie das Handbuch, Kapitel Erste Schritte, Abschnitt Kalibrierablauf."
 
 # 
-#: ultralcd.cpp:2863
+#: ultralcd.cpp:2908
 msgid "Total filament"
 msgstr "Gesamtes Filament"
 
 # 
-#: ultralcd.cpp:2863
+#: ultralcd.cpp:2908
 msgid "Total print time"
 msgstr "Gesamte Druckzeit"
 
 # MSG_TUNE
-#: ultralcd.cpp:6633
+#: ultralcd.cpp:6719
 msgid "Tune"
 msgstr "Feineinstellung"
 
 # 
-#: ultralcd.cpp:4783
+#: ultralcd.cpp:4869
 msgid "Unload"
 msgstr "Entladen"
 
 # 
-#: ultralcd.cpp:1857
+#: ultralcd.cpp:1820
 msgid "Total failures"
 msgstr "Gesamte Fehler"
 
 # 
-#: ultralcd.cpp:2213
+#: ultralcd.cpp:2324
 msgid "to load filament"
-msgstr "zum Filament laden"
+msgstr "Filament laden"
 
 # 
-#: ultralcd.cpp:2217
+#: ultralcd.cpp:2328
 msgid "to unload filament"
-msgstr "zum Filament entladen"
+msgstr "Filament entladen"
 
 # MSG_UNLOAD_FILAMENT c=17
 #: messages.c:97
@@ -1416,42 +1416,42 @@ msgid "Unloading filament"
 msgstr "Filament auswerfen"
 
 # 
-#: ultralcd.cpp:1824
+#: ultralcd.cpp:1773
 msgid "Total"
 msgstr "Gesamt"
 
 # MSG_USED c=19 r=1
-#: ultralcd.cpp:5822
+#: ultralcd.cpp:5908
 msgid "Used during print"
 msgstr "Beim Druck benutzt"
 
 # MSG_MENU_VOLTAGES c=15 r=1
-#: ultralcd.cpp:2143
+#: ultralcd.cpp:2254
 msgid "Voltages"
 msgstr "Spannungen"
 
 # 
-#: ultralcd.cpp:2116
+#: ultralcd.cpp:2227
 msgid "unknown"
 msgstr "unbekannt"
 
 # MSG_USERWAIT
-#: Marlin_main.cpp:5262
+#: Marlin_main.cpp:5263
 msgid "Wait for user..."
 msgstr "Warte auf Benutzer.."
 
 # MSG_WAITING_TEMP c=20 r=3
-#: ultralcd.cpp:3374
+#: ultralcd.cpp:3458
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Warten bis Heizung und Bett abgekuehlt sind"
 
 # MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ultralcd.cpp:3338
+#: ultralcd.cpp:3422
 msgid "Waiting for PINDA probe cooling"
 msgstr "Warten, bis PINDA- Sonde abgekuehlt ist"
 
 # 
-#: ultralcd.cpp:4782
+#: ultralcd.cpp:4868
 msgid "Use unload to remove filament 1 if it protrudes outside of the rear MMU tube. Use eject if it is hidden in tube."
 msgstr "Entladen Sie das Filament 1, wenn er aus dem hinteren MMU-Rohr herausragt. Verwenden Sie den Auswurf, wenn er im Rohr versteckt ist."
 
@@ -1471,7 +1471,7 @@ msgid "Warning: printer type changed."
 msgstr "Warnung: Druckertyp wurde geaendert."
 
 # MSG_UNLOAD_SUCCESSFUL c=20 r=2
-#: Marlin_main.cpp:3053
+#: Marlin_main.cpp:3054
 msgid "Was filament unload successful?"
 msgstr "Konnten Sie das Filament entnehmen?"
 
@@ -1481,12 +1481,12 @@ msgid "Wiring error"
 msgstr "Verdrahtungsfehler"
 
 # MSG_WIZARD c=17 r=1
-#: ultralcd.cpp:5661
+#: ultralcd.cpp:5747
 msgid "Wizard"
 msgstr "Assistent"
 
 # MSG_XYZ_DETAILS c=19 r=1
-#: ultralcd.cpp:2132
+#: ultralcd.cpp:2243
 msgid "XYZ cal. details"
 msgstr "XYZ Kal. Details"
 
@@ -1506,52 +1506,52 @@ msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr "Sie koennen den Assistenten immer im Menu neu starten: Kalibrierung -> Assistent"
 
 # MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ultralcd.cpp:3838
+#: ultralcd.cpp:3922
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr "XYZ Kalibrierung in Ordnung. Schraeglauf wird automatisch korrigiert."
 
 # MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ultralcd.cpp:3835
+#: ultralcd.cpp:3919
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr "XYZ Kalibrierung in Ordnung. X/Y Achsen sind etwas schraeg."
 
 # 
-#: ultralcd.cpp:5044
+#: ultralcd.cpp:5130
 msgid "X-correct:"
 msgstr "X-Korrektur:"
 
 # MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ultralcd.cpp:3832
+#: ultralcd.cpp:3916
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "XYZ-Kalibrierung ok. X/Y-Achsen sind senkrecht zueinander Glueckwunsch!"
 
 # MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ultralcd.cpp:3816
+#: ultralcd.cpp:3900
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr "XYZ-Kalibrierung beeintraechtigt. Vordere Kalibrierpunkte nicht erreichbar."
 
 # MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ultralcd.cpp:3819
+#: ultralcd.cpp:3903
 msgid "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr "XYZ-Kalibrierung beeintraechtigt. Rechter vorderer Kalibrierpunkt nicht erreichbar."
 
 # MSG_LOAD_ALL c=17
-#: ultralcd.cpp:6080
+#: ultralcd.cpp:6166
 msgid "Load all"
 msgstr "Alle laden"
 
 # 
-#: ultralcd.cpp:3798
+#: ultralcd.cpp:3882
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr "XYZ-Kalibrierung fehlgeschlagen. Bett-Kalibrierpunkt nicht gefunden."
 
 # 
-#: ultralcd.cpp:3804
+#: ultralcd.cpp:3888
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr "XYZ-Kalibrierung fehlgeschlagen. Vordere Kalibrierpunkte nicht erreichbar."
 
 # 
-#: ultralcd.cpp:3807
+#: ultralcd.cpp:3891
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr "XYZ-Kalibrierung fehlgeschlagen. Rechter vorderer Kalibrierpunkt ist nicht erreichbar."
 
@@ -1561,19 +1561,19 @@ msgid "XYZ-Kalibrierung fehlgeschlagen. Rechter vorderer Kalibrierpunkt ist nich
 msgstr 
 
 # 
-#: ultralcd.cpp:2968
+#: ultralcd.cpp:3016
 msgid "Y distance from min"
 msgstr "Y Entfernung vom Min"
 
 # 
-#: ultralcd.cpp:5045
+#: ultralcd.cpp:5131
 msgid "Y-correct:"
 msgstr "Y-Korrektur:"
 
 # MSG_OFF
 #: menu.cpp:426
 msgid " [off]"
-msgstr ""
+msgstr " [aus]"
 
 # 
 #: messages.c:57
@@ -1581,34 +1581,34 @@ msgid "Back"
 msgstr "Zurueck"
 
 # 
-#: ultralcd.cpp:5553
+#: ultralcd.cpp:5639
 msgid "Checks"
-msgstr ""
+msgstr "Kontrolle"
 
 # 
-#: ultralcd.cpp:7887
+#: ultralcd.cpp:7973
 msgid "False triggering"
 msgstr "Falschtriggerung"
 
 # 
-#: ultralcd.cpp:3946
+#: ultralcd.cpp:4030
 msgid "FINDA:"
 msgstr ""
 
 # 
-#: ultralcd.cpp:5459
+#: ultralcd.cpp:5545
 msgid "Firmware   [none]"
 msgstr "Firmware   [ohne]"
 
 # 
-#: ultralcd.cpp:5465
+#: ultralcd.cpp:5551
 msgid "Firmware [strict]"
-msgstr "Firmware [streng]"
+msgstr "Firmware [strikt]"
 
 # 
-#: ultralcd.cpp:5462
+#: ultralcd.cpp:5548
 msgid "Firmware   [warn]"
-msgstr ""
+msgstr "Firmware [warnen]"
 
 # 
 #: messages.c:87
@@ -1616,147 +1616,147 @@ msgid "HW Setup"
 msgstr "HW Einstellungen"
 
 # 
-#: ultralcd.cpp:3950
+#: ultralcd.cpp:4034
 msgid "IR:"
 msgstr ""
 
 # 
-#: ultralcd.cpp:6960
+#: ultralcd.cpp:7046
 msgid "Magnets comp.[N/A]"
 msgstr "Magnet Komp.  [nv]"
 
 # 
-#: ultralcd.cpp:6958
+#: ultralcd.cpp:7044
 msgid "Magnets comp.[Off]"
 msgstr "Magnet Komp. [Aus]"
 
 # 
-#: ultralcd.cpp:6957
+#: ultralcd.cpp:7043
 msgid "Magnets comp. [On]"
 msgstr "Magnet Komp.  [An]"
 
 # 
-#: ultralcd.cpp:6949
+#: ultralcd.cpp:7035
 msgid "Mesh         [3x3]"
-msgstr ""
+msgstr "Gitter       [3x3]"
 
 # 
-#: ultralcd.cpp:6950
+#: ultralcd.cpp:7036
 msgid "Mesh         [7x7]"
-msgstr ""
+msgstr "Gitter       [7x7]"
 
 # 
-#: ultralcd.cpp:5591
+#: ultralcd.cpp:5677
 msgid "Mesh bed leveling"
-msgstr "Mesh Bett Ausgleich"
+msgstr "MeshBett Ausgleich"
 
 # 
 #: Marlin_main.cpp:856
 msgid "MK3S firmware detected on MK3 printer"
-msgstr ""
+msgstr "MK3S-Firmware auf MK3-Drucker erkannt"
 
 # 
-#: ultralcd.cpp:5220
+#: ultralcd.cpp:5306
 msgid "MMU Mode [Normal]"
 msgstr "MMU Modus[Normal]"
 
 # 
-#: ultralcd.cpp:5221
+#: ultralcd.cpp:5307
 msgid "MMU Mode[Stealth]"
 msgstr "MMU Mod.[Stealth]"
 
 # 
-#: ultralcd.cpp:4427
+#: ultralcd.cpp:4511
 msgid "Mode change in progress ..."
 msgstr "Moduswechsel erfolgt..."
 
 # 
-#: ultralcd.cpp:5420
+#: ultralcd.cpp:5506
 msgid "Model      [none]"
 msgstr "Modell     [ohne]"
 
 # 
-#: ultralcd.cpp:5426
+#: ultralcd.cpp:5512
 msgid "Model    [strict]"
-msgstr "Modell   [streng]"
+msgstr "Modell   [strikt]"
 
 # 
-#: ultralcd.cpp:5423
+#: ultralcd.cpp:5509
 msgid "Model      [warn]"
-msgstr "Modell     [warn]"
+msgstr "Modell   [warnen]"
 
 # 
-#: ultralcd.cpp:5381
+#: ultralcd.cpp:5467
 msgid "Nozzle d.  [0.25]"
 msgstr "Duese D.   [0.25]"
 
 # 
-#: ultralcd.cpp:5384
+#: ultralcd.cpp:5470
 msgid "Nozzle d.  [0.40]"
 msgstr "Duese D.   [0.40]"
 
 # 
-#: ultralcd.cpp:5387
+#: ultralcd.cpp:5473
 msgid "Nozzle d.  [0.60]"
 msgstr "Duese D.   [0.60]"
 
 # 
-#: ultralcd.cpp:5335
+#: ultralcd.cpp:5421
 msgid "Nozzle     [none]"
 msgstr "Duese      [ohne]"
 
 # 
-#: ultralcd.cpp:5341
+#: ultralcd.cpp:5427
 msgid "Nozzle   [strict]"
-msgstr "Duese    [streng]"
+msgstr "Duese    [strikt]"
 
 # 
-#: ultralcd.cpp:5338
+#: ultralcd.cpp:5424
 msgid "Nozzle     [warn]"
-msgstr "Duese      [warn]"
+msgstr "Duese    [warnen]"
 
 # 
 #: util.cpp:510
 msgid "G-code sliced for a different level. Continue?"
-msgstr ""
+msgstr "G-Code ist fuer einen anderen Level geslict. Fortfahren?"
 
 # 
 #: util.cpp:516
 msgid "G-code sliced for a different level. Please re-slice the model again. Print cancelled."
-msgstr ""
+msgstr "G-Code ist fuer einen anderen Level geslict. Bitte slicen Sie das Modell erneut. Druck abgebrochen."
 
 # 
 #: util.cpp:427
 msgid "G-code sliced for a different printer type. Continue?"
-msgstr ""
+msgstr "G-Code ist fuer einen anderen Drucker geslict. Fortfahren?"
 
 # 
 #: util.cpp:433
 msgid "G-code sliced for a different printer type. Please re-slice the model again. Print cancelled."
-msgstr ""
+msgstr "G-Code ist fuer einen anderen Drucker geslict. Bitte slicen Sie das Modell erneut. Druck abgebrochen."
 
 # 
 #: util.cpp:477
 msgid "G-code sliced for a newer firmware. Continue?"
-msgstr ""
+msgstr "G-Code ist fuer eine neuere Firmware geslict. Fortfahren?"
 
 # 
 #: util.cpp:483
 msgid "G-code sliced for a newer firmware. Please update the firmware. Print cancelled."
-msgstr ""
+msgstr "G-Code ist fuer eine neuere Firmware geslict. Bitte die Firmware updaten. Druck abgebrochen."
 
 # 
-#: ultralcd.cpp:3942
+#: ultralcd.cpp:4026
 msgid "PINDA:"
 msgstr ""
 
 # 
-#: ultralcd.cpp:2286
+#: ultralcd.cpp:2465
 msgid "Preheating to cut"
 msgstr "Heizen zum Schnitt"
 
 # 
-#: ultralcd.cpp:2283
+#: ultralcd.cpp:2462
 msgid "Preheating to eject"
 msgstr "Heizen zum Auswurf"
 
@@ -1771,17 +1771,17 @@ msgid "Printer nozzle diameter differs from the G-code. Please check the value i
 msgstr "Der Durchmesser der Druckerduese weicht vom G-Code ab. Bitte ueberpruefen Sie den Wert in den Einstellungen. Druck abgebrochen."
 
 # 
-#: ultralcd.cpp:6597
+#: ultralcd.cpp:6683
 msgid "Rename"
 msgstr "Umbenennen"
 
 # 
-#: ultralcd.cpp:6593
+#: ultralcd.cpp:6679
 msgid "Select"
 msgstr "Auswahl"
 
 # 
-#: ultralcd.cpp:2134
+#: ultralcd.cpp:2245
 msgid "Sensor info"
 msgstr "Sensor Info"
 
@@ -1791,22 +1791,27 @@ msgid "Sheet"
 msgstr "Blech"
 
 # 
-#: 
-msgid "Sound     [assist]"
-msgstr ""
+#: sound.h:9
+msgid "Sound    [assist]"
+msgstr "Sound    [Assist]"
 
 # 
-#: ultralcd.cpp:5551
+#: ultralcd.cpp:5637
 msgid "Steel sheets"
-msgstr ""
+msgstr "Stahlbleche"
 
 # 
-#: ultralcd.cpp:5046
+#: ultralcd.cpp:5132
 msgid "Z-correct:"
 msgstr "Z-Korrektur:"
 
 # 
-#: ultralcd.cpp:6952
+#: ultralcd.cpp:7038
 msgid "Z-probe nr.    [1]"
 msgstr "Z-Probe Nr.    [1]"
+
+# 
+#: ultralcd.cpp:7040
+msgid "Z-probe nr.    [3]"
+msgstr "Z-Probe Nr.    [3]"
 

--- a/lang/po/Firmware_es.po
+++ b/lang/po/Firmware_es.po
@@ -7,8 +7,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: es\n"
 "Project-Id-Version: Prusa-Firmware\n"
-"POT-Creation-Date: Wed Sep 4 16:13:52 CEST 2019\n"
-"PO-Revision-Date: Wed Sep 4 16:13:52 CEST 2019\n"
+"POT-Creation-Date: Sun, Sep 22, 2019 2:05:16 PM\n"
+"PO-Revision-Date: Sun, Sep 22, 2019 2:05:16 PM\n"
 "Language-Team: \n"
 "X-Generator: Poedit 2.0.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
@@ -26,7 +26,7 @@ msgid " of 9"
 msgstr " de 9"
 
 # MSG_MEASURED_OFFSET
-#: ultralcd.cpp:3027
+#: ultralcd.cpp:3089
 msgid "[0;0] point offset"
 msgstr "[0;0] punto offset"
 
@@ -41,17 +41,17 @@ msgid "WARNING:\x0aCrash detection\x0adisabled in\x0aStealth mode"
 msgstr "ATENCION:\x0aDec. choque\x0adesactivada en\x0aModo silencio"
 
 # 
-#: ultralcd.cpp:2290
+#: ultralcd.cpp:2472
 msgid ">Cancel"
 msgstr ">Cancelar"
 
 # MSG_BABYSTEPPING_Z c=15
-#: ultralcd.cpp:3147
+#: ultralcd.cpp:3209
 msgid "Adjusting Z:"
-msgstr "Ajustar Z:"
+msgstr "Ajustar-Z:"
 
 # MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ultralcd.cpp:8209
+#: ultralcd.cpp:8295
 msgid "All correct      "
 msgstr "Todo bien"
 
@@ -61,32 +61,32 @@ msgid "All is done. Happy printing!"
 msgstr "Terminado! Feliz impresion!"
 
 # 
-#: ultralcd.cpp:1974
+#: ultralcd.cpp:2009
 msgid "Ambient"
 msgstr "Ambiente"
 
 # MSG_PRESS c=20
-#: ultralcd.cpp:2576
+#: ultralcd.cpp:2618
 msgid "and press the knob"
 msgstr "Haz clic"
 
 # MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=2
-#: ultralcd.cpp:3445
+#: ultralcd.cpp:3529
 msgid "Are left and right Z~carriages all up?"
 msgstr "Carros Z izq./der. estan arriba maximo?"
 
 # MSG_AUTO_DEPLETE_ON c=17 r=1
-#: ultralcd.cpp:5114
+#: ultralcd.cpp:5200
 msgid "SpoolJoin    [on]"
 msgstr ""
 
 # 
-#: ultralcd.cpp:5110
+#: ultralcd.cpp:5196
 msgid "SpoolJoin   [N/A]"
 msgstr ""
 
 # MSG_AUTO_DEPLETE_OFF c=17 r=1
-#: ultralcd.cpp:5118
+#: ultralcd.cpp:5204
 msgid "SpoolJoin   [off]"
 msgstr ""
 
@@ -96,32 +96,32 @@ msgid "Auto home"
 msgstr "Llevar al origen"
 
 # MSG_AUTOLOAD_FILAMENT c=17
-#: ultralcd.cpp:6736
+#: ultralcd.cpp:6822
 msgid "AutoLoad filament"
 msgstr "Carga automatica de filamento"
 
 # MSG_AUTOLOADING_ONLY_IF_FSENS_ON c=20 r=4
-#: ultralcd.cpp:4378
+#: ultralcd.cpp:4462
 msgid "Autoloading filament available only when filament sensor is turned on..."
 msgstr "La carga automatica de filamento solo funciona si el sensor de filamento esta activado..."
 
 # MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ultralcd.cpp:2771
+#: ultralcd.cpp:2813
 msgid "Autoloading filament is active, just press the knob and insert filament..."
 msgstr "La carga automatica de filamento esta activada, pulse el dial e inserte el filamento..."
 
 # MSG_SELFTEST_AXIS_LENGTH
-#: ultralcd.cpp:7863
+#: ultralcd.cpp:7949
 msgid "Axis length"
 msgstr "Longitud del eje"
 
 # MSG_SELFTEST_AXIS
-#: ultralcd.cpp:7865
+#: ultralcd.cpp:7951
 msgid "Axis"
 msgstr "Eje"
 
 # MSG_SELFTEST_BEDHEATER
-#: ultralcd.cpp:7807
+#: ultralcd.cpp:7893
 msgid "Bed / Heater"
 msgstr "Base / Calentador"
 
@@ -136,7 +136,7 @@ msgid "Bed Heating"
 msgstr "Calentando Base"
 
 # MSG_BED_CORRECTION_MENU
-#: ultralcd.cpp:5682
+#: ultralcd.cpp:5768
 msgid "Bed level correct"
 msgstr "Corr. de la cama"
 
@@ -148,10 +148,10 @@ msgstr "Nivelacion fallada. Sensor no funciona. Restos en boquilla? Esperando re
 # MSG_BED
 #: messages.c:15
 msgid "Bed"
-msgstr "Base calefactable "
+msgstr "Base"
 
 # MSG_MENU_BELT_STATUS c=15 r=1
-#: ultralcd.cpp:2002
+#: ultralcd.cpp:2059
 msgid "Belt status"
 msgstr "Estado de la correa"
 
@@ -161,12 +161,12 @@ msgid "Blackout occurred. Recover print?"
 msgstr "Se fue la luz. ?Reanudar la impresion?"
 
 # 
-#: ultralcd.cpp:8211
+#: ultralcd.cpp:8297
 msgid "Calibrating home"
 msgstr "Calibrando posicion inicial"
 
 # MSG_CALIBRATE_BED
-#: ultralcd.cpp:5671
+#: ultralcd.cpp:5757
 msgid "Calibrate XYZ"
 msgstr "Calibrar XYZ"
 
@@ -176,12 +176,12 @@ msgid "Calibrate Z"
 msgstr "Calibrar Z"
 
 # MSG_CALIBRATE_PINDA c=17 r=1
-#: ultralcd.cpp:4570
+#: ultralcd.cpp:4654
 msgid "Calibrate"
 msgstr "Calibrar"
 
 # MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ultralcd.cpp:3408
+#: ultralcd.cpp:3492
 msgid "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end stoppers. Click when done."
 msgstr "Calibrando XYZ. Gira el dial para subir el extrusor hasta tocar los topes superiores. Despues haz clic."
 
@@ -191,12 +191,12 @@ msgid "Calibrating Z"
 msgstr "Calibrando Z"
 
 # MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ultralcd.cpp:3408
+#: ultralcd.cpp:3492
 msgid "Calibrating Z. Rotate the knob to move the Z carriage up to the end stoppers. Click when done."
 msgstr "Calibrando Z. Gira el dial para subir el extrusor hasta tocar los topes superiores. Despues haz clic."
 
 # MSG_HOMEYZ_DONE
-#: ultralcd.cpp:813
+#: ultralcd.cpp:816
 msgid "Calibration done"
 msgstr "Calibracion OK"
 
@@ -206,17 +206,17 @@ msgid "Calibration"
 msgstr "Calibracion"
 
 # 
-#: ultralcd.cpp:4695
+#: ultralcd.cpp:4781
 msgid "Cancel"
 msgstr "Cancelar"
 
 # MSG_SD_REMOVED
-#: ultralcd.cpp:8578
+#: ultralcd.cpp:8679
 msgid "Card removed"
 msgstr "Tarjeta retirada"
 
 # MSG_NOT_COLOR
-#: ultralcd.cpp:2676
+#: ultralcd.cpp:2718
 msgid "Color not correct"
 msgstr "Color no homogeneo"
 
@@ -226,7 +226,7 @@ msgid "Cooldown"
 msgstr "Enfriar"
 
 # 
-#: ultralcd.cpp:4503
+#: ultralcd.cpp:4587
 msgid "Copy selected language?"
 msgstr "Copiar idioma seleccionado?"
 
@@ -256,22 +256,22 @@ msgid "Crash detected. Resume print?"
 msgstr "Choque detectado. Continuar impresion?"
 
 # 
-#: ultralcd.cpp:1876
+#: ultralcd.cpp:1853
 msgid "Crash"
 msgstr "Choque"
 
 # MSG_CURRENT c=19 r=1
-#: ultralcd.cpp:5823
+#: ultralcd.cpp:5909
 msgid "Current"
 msgstr "Actual"
 
 # MSG_DATE c=17 r=1
-#: ultralcd.cpp:2102
+#: ultralcd.cpp:2213
 msgid "Date:"
 msgstr "Fecha:"
 
 # MSG_DISABLE_STEPPERS
-#: ultralcd.cpp:5568
+#: ultralcd.cpp:5654
 msgid "Disable steppers"
 msgstr "Apagar motores"
 
@@ -281,14 +281,14 @@ msgid "Distance between tip of the nozzle and the bed surface has not been set y
 msgstr "Distancia entre la punta del boquilla y la superficie de la base aun no fijada. Por favor siga el manual, capitulo Primeros Pasos, Calibracion primera capa."
 
 # MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ultralcd.cpp:4984
+#: ultralcd.cpp:5070
 msgid "Do you want to repeat last step to readjust distance between nozzle and heatbed?"
 msgstr "Quieres repetir el ultimo paso para reajustar la distancia boquilla-base?"
 
 # MSG_EXTRUDER_CORRECTION c=10
-#: ultralcd.cpp:5048
+#: ultralcd.cpp:5134
 msgid "E-correct:"
-msgstr "E-correcion:"
+msgstr "Corregir-E:"
 
 # MSG_EJECT_FILAMENT c=17 r=1
 #: messages.c:53
@@ -296,7 +296,7 @@ msgid "Eject filament"
 msgstr "Expulsar filamento"
 
 # 
-#: ultralcd.cpp:4783
+#: ultralcd.cpp:4869
 msgid "Eject"
 msgstr "Expulsar"
 
@@ -306,27 +306,27 @@ msgid "Ejecting filament"
 msgstr "Expulsando filamento"
 
 # MSG_SELFTEST_ENDSTOP_NOTHIT c=20 r=1
-#: ultralcd.cpp:7831
+#: ultralcd.cpp:7917
 msgid "Endstop not hit"
 msgstr "Endstop no alcanzado"
 
 # MSG_SELFTEST_ENDSTOP
-#: ultralcd.cpp:7825
+#: ultralcd.cpp:7911
 msgid "Endstop"
 msgstr ""
 
 # MSG_SELFTEST_ENDSTOPS
-#: ultralcd.cpp:7813
+#: ultralcd.cpp:7899
 msgid "Endstops"
 msgstr ""
 
 # MSG_STACK_ERROR c=20 r=4
-#: ultralcd.cpp:6773
+#: ultralcd.cpp:6859
 msgid "Error - static memory has been overwritten"
 msgstr "Error - se ha sobre-escrito la memoria estatica"
 
 # MSG_FSENS_NOT_RESPONDING c=20 r=4
-#: ultralcd.cpp:4391
+#: ultralcd.cpp:4475
 msgid "ERROR: Filament sensor is not responding, please check connection."
 msgstr "ERROR: El sensor de filamento no responde, por favor comprueba la conexion."
 
@@ -336,12 +336,12 @@ msgid "ERROR:"
 msgstr ""
 
 # MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
-#: ultralcd.cpp:8218
+#: ultralcd.cpp:8304
 msgid "Extruder fan:"
-msgstr "Ventilador del extrusor:"
+msgstr "Vent.extrusor:"
 
 # MSG_INFO_EXTRUDER c=15 r=1
-#: ultralcd.cpp:2133
+#: ultralcd.cpp:2244
 msgid "Extruder info"
 msgstr "Informacion del extrusor"
 
@@ -351,12 +351,12 @@ msgid "Extruder"
 msgstr "Extruir"
 
 # 
-#: ultralcd.cpp:6760
+#: ultralcd.cpp:6846
 msgid "Fail stats MMU"
 msgstr "Estadistica de fallos MMU"
 
 # MSG_FSENS_AUTOLOAD_ON c=17 r=1
-#: ultralcd.cpp:5082
+#: ultralcd.cpp:5168
 msgid "F. autoload  [on]"
 msgstr "Autocarg.Fil[act]"
 
@@ -366,12 +366,12 @@ msgid "F. autoload [N/A]"
 msgstr "Autocarg.Fil[N/D]"
 
 # MSG_FSENS_AUTOLOAD_OFF c=17 r=1
-#: ultralcd.cpp:5084
+#: ultralcd.cpp:5170
 msgid "F. autoload [off]"
 msgstr "Autocarg.Fil[ina]"
 
 # 
-#: ultralcd.cpp:6757
+#: ultralcd.cpp:6843
 msgid "Fail stats"
 msgstr "Estadistica de fallos"
 
@@ -386,12 +386,12 @@ msgid "Fan test"
 msgstr "Test ventiladores"
 
 # MSG_FANS_CHECK_ON c=17 r=1
-#: ultralcd.cpp:5577
+#: ultralcd.cpp:5663
 msgid "Fans check   [on]"
 msgstr "Comprob.vent[act]"
 
 # MSG_FANS_CHECK_OFF c=17 r=1
-#: ultralcd.cpp:5579
+#: ultralcd.cpp:5665
 msgid "Fans check  [off]"
 msgstr "Comprob.vent[ina]"
 
@@ -401,7 +401,7 @@ msgid "Fil. sensor  [on]"
 msgstr "Sensor Fil. [act]"
 
 # MSG_FSENSOR_NA
-#: ultralcd.cpp:5062
+#: ultralcd.cpp:5148
 msgid "Fil. sensor [N/A]"
 msgstr "Sensor Fil. [N/D]"
 
@@ -411,7 +411,7 @@ msgid "Fil. sensor [off]"
 msgstr "Sensor Fil. [ina]"
 
 # 
-#: ultralcd.cpp:1876
+#: ultralcd.cpp:1852
 msgid "Filam. runouts"
 msgstr "Filam. acabado"
 
@@ -421,7 +421,7 @@ msgid "Filament extruding & with correct color?"
 msgstr "Es nitido el color nuevo?"
 
 # MSG_NOT_LOADED c=19
-#: ultralcd.cpp:2672
+#: ultralcd.cpp:2714
 msgid "Filament not loaded"
 msgstr "Fil. no introducido"
 
@@ -431,17 +431,17 @@ msgid "Filament sensor"
 msgstr "Sensor de filamento"
 
 # MSG_FILAMENT_USED c=19 r=1
-#: ultralcd.cpp:2841
+#: ultralcd.cpp:2885
 msgid "Filament used"
 msgstr "Filamento usado"
 
 # MSG_PRINT_TIME c=19 r=1
-#: ultralcd.cpp:2841
+#: ultralcd.cpp:2886
 msgid "Print time"
 msgstr "Tiempo de imp.:"
 
 # MSG_FILE_INCOMPLETE c=20 r=2
-#: ultralcd.cpp:8346
+#: ultralcd.cpp:8432
 msgid "File incomplete. Continue anyway?"
 msgstr "Archivo incompleto. ?Continuar de todos modos?"
 
@@ -456,7 +456,7 @@ msgid "First layer cal."
 msgstr "Cal. primera cap."
 
 # MSG_WIZARD_SELFTEST c=20 r=8
-#: ultralcd.cpp:4896
+#: ultralcd.cpp:4982
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr "Primero, hare el Selftest para comprobar los problemas de montaje mas comunes."
 
@@ -466,12 +466,12 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr "Corrige el problema y pulsa el boton en la unidad MMU."
 
 # MSG_FLOW
-#: ultralcd.cpp:6846
+#: ultralcd.cpp:6932
 msgid "Flow"
 msgstr "Flujo"
 
 # MSG_PRUSA3D_FORUM
-#: ultralcd.cpp:2095
+#: ultralcd.cpp:2206
 msgid "forum.prusa3d.com"
 msgstr ""
 
@@ -481,22 +481,22 @@ msgid "Front print fan?"
 msgstr "Vent. frontal?"
 
 # MSG_BED_CORRECTION_FRONT c=14 r=1
-#: ultralcd.cpp:3220
+#: ultralcd.cpp:3294
 msgid "Front side[um]"
 msgstr "Frontal [um]"
 
 # MSG_SELFTEST_FANS
-#: ultralcd.cpp:7871
+#: ultralcd.cpp:7957
 msgid "Front/left fans"
 msgstr "Ventiladores frontal/izquierdo"
 
 # MSG_SELFTEST_HEATERTHERMISTOR
-#: ultralcd.cpp:7801
+#: ultralcd.cpp:7887
 msgid "Heater/Thermistor"
 msgstr "Calentador/Termistor"
 
 # MSG_BED_HEATING_SAFETY_DISABLED
-#: Marlin_main.cpp:8468
+#: Marlin_main.cpp:8467
 msgid "Heating disabled by safety timer."
 msgstr "Calentadores desactivados por el temporizador de seguridad."
 
@@ -511,12 +511,12 @@ msgid "Heating"
 msgstr "Calentando..."
 
 # MSG_WIZARD_WELCOME c=20 r=7
-#: ultralcd.cpp:4875
+#: ultralcd.cpp:4961
 msgid "Hi, I am your Original Prusa i3 printer. Would you like me to guide you through the setup process?"
 msgstr "Hola, soy tu impresora Original Prusa i3. Quieres que te guie a traves de la configuracion?"
 
 # MSG_PRUSA3D_HOWTO
-#: ultralcd.cpp:2096
+#: ultralcd.cpp:2207
 msgid "howto.prusa3d.com"
 msgstr ""
 
@@ -526,12 +526,12 @@ msgid "Change filament"
 msgstr "Cambiar filamento"
 
 # MSG_CHANGE_SUCCESS
-#: ultralcd.cpp:2587
+#: ultralcd.cpp:2629
 msgid "Change success!"
 msgstr "Cambio correcto"
 
 # MSG_CORRECTLY c=20
-#: ultralcd.cpp:2664
+#: ultralcd.cpp:2706
 msgid "Changed correctly?"
 msgstr "Cambio correcto?"
 
@@ -541,12 +541,12 @@ msgid "Checking bed     "
 msgstr "Control base cal."
 
 # MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ultralcd.cpp:8200
+#: ultralcd.cpp:8286
 msgid "Checking endstops"
 msgstr "Control endstops"
 
 # MSG_SELFTEST_CHECK_HOTEND c=20
-#: ultralcd.cpp:8206
+#: ultralcd.cpp:8292
 msgid "Checking hotend  "
 msgstr "Control fusor"
 
@@ -556,17 +556,17 @@ msgid "Checking sensors "
 msgstr "Comprobando los sensores"
 
 # MSG_SELFTEST_CHECK_X c=20
-#: ultralcd.cpp:8201
+#: ultralcd.cpp:8287
 msgid "Checking X axis  "
 msgstr "Control sensor X"
 
 # MSG_SELFTEST_CHECK_Y c=20
-#: ultralcd.cpp:8202
+#: ultralcd.cpp:8288
 msgid "Checking Y axis  "
 msgstr "Control sensor Y"
 
 # MSG_SELFTEST_CHECK_Z c=20
-#: ultralcd.cpp:8203
+#: ultralcd.cpp:8289
 msgid "Checking Z axis  "
 msgstr "Control sensor Z"
 
@@ -586,17 +586,17 @@ msgid "Filament"
 msgstr "Filamento"
 
 # MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ultralcd.cpp:4905
+#: ultralcd.cpp:4991
 msgid "I will run xyz calibration now. It will take approx. 12 mins."
 msgstr "Hare la calibracion XYZ. Tardara 12 min. aproximadamente."
 
 # MSG_WIZARD_Z_CAL c=20 r=8
-#: ultralcd.cpp:4913
+#: ultralcd.cpp:4999
 msgid "I will run z calibration now."
 msgstr "Voy a hacer Calibracion Z ahora."
 
 # MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ultralcd.cpp:4978
+#: ultralcd.cpp:5064
 msgid "I will start to print line and you will gradually lower the nozzle by rotating the knob, until you reach optimal height. Check the pictures in our handbook in chapter Calibration."
 msgstr "Voy a comenzar a imprimir la linea y tu bajaras el nozzle gradualmente al rotar el dial, hasta que llegues a la altura optima. Mira las imagenes del capitulo Calibracion en el manual."
 
@@ -606,27 +606,27 @@ msgid "Info screen"
 msgstr "Monitorizar"
 
 # 
-#: ultralcd.cpp:4938
+#: ultralcd.cpp:5024
 msgid "Is filament 1 loaded?"
 msgstr "?Esta cargado el filamento 1?"
 
 # MSG_INSERT_FILAMENT c=20
-#: ultralcd.cpp:2572
+#: ultralcd.cpp:2614
 msgid "Insert filament"
 msgstr "Introducir filamento"
 
 # MSG_WIZARD_FILAMENT_LOADED c=20 r=2
-#: ultralcd.cpp:4941
+#: ultralcd.cpp:5027
 msgid "Is filament loaded?"
 msgstr "Esta el filamento cargado?"
 
 # MSG_WIZARD_PLA_FILAMENT c=20 r=2
-#: ultralcd.cpp:4972
+#: ultralcd.cpp:5058
 msgid "Is it PLA filament?"
 msgstr "Es el filamento PLA?"
 
 # MSG_PLA_FILAMENT_LOADED c=20 r=2
-#: ultralcd.cpp:4704
+#: ultralcd.cpp:4790
 msgid "Is PLA filament loaded?"
 msgstr "Esta el filamento PLA cargado?"
 
@@ -636,12 +636,12 @@ msgid "Is steel sheet on heatbed?"
 msgstr "?Esta colocada la lamina de acero sobre la base?"
 
 # 
-#: ultralcd.cpp:1840
+#: ultralcd.cpp:1795
 msgid "Last print failures"
 msgstr "Ultimas impresiones fallidas"
 
 # 
-#: ultralcd.cpp:1823
+#: ultralcd.cpp:1772
 msgid "Last print"
 msgstr "Ultima impresion"
 
@@ -651,17 +651,17 @@ msgid "Left hotend fan?"
 msgstr "Vent. izquierdo?"
 
 # 
-#: ultralcd.cpp:2970
+#: ultralcd.cpp:3018
 msgid "Left"
 msgstr "Izquierda"
 
 # MSG_BED_CORRECTION_LEFT c=14 r=1
-#: ultralcd.cpp:3218
+#: ultralcd.cpp:3292
 msgid "Left side [um]"
 msgstr "Izquierda [um]"
 
 # 
-#: ultralcd.cpp:5594
+#: ultralcd.cpp:5680
 msgid "Lin. correction"
 msgstr "Correccion de Linealidad"
 
@@ -676,7 +676,7 @@ msgid "Load filament"
 msgstr "Introducir filam."
 
 # MSG_LOADING_COLOR
-#: ultralcd.cpp:2612
+#: ultralcd.cpp:2654
 msgid "Loading color"
 msgstr "Cambiando color"
 
@@ -686,12 +686,12 @@ msgid "Loading filament"
 msgstr "Introduciendo filam."
 
 # MSG_LOOSE_PULLEY c=20 r=1
-#: ultralcd.cpp:7855
+#: ultralcd.cpp:7941
 msgid "Loose pulley"
 msgstr "Polea suelta"
 
 # 
-#: ultralcd.cpp:6719
+#: ultralcd.cpp:6805
 msgid "Load to nozzle"
 msgstr "Cargar a la boquilla"
 
@@ -711,7 +711,7 @@ msgid "Measuring reference height of calibration point"
 msgstr "Midiendo altura del punto de calibracion"
 
 # MSG_MESH_BED_LEVELING
-#: ultralcd.cpp:5677
+#: ultralcd.cpp:5763
 msgid "Mesh Bed Leveling"
 msgstr "Nivelacion Mesh Level"
 
@@ -726,12 +726,12 @@ msgid "MMU OK. Resuming temperature..."
 msgstr "MMU OK. Restaurando temperatura..."
 
 # 
-#: ultralcd.cpp:3005
+#: ultralcd.cpp:3059
 msgid "Measured skew"
-msgstr "Desviacion medida:"
+msgstr "Desviacion med:"
 
 # 
-#: ultralcd.cpp:1840
+#: ultralcd.cpp:1796
 msgid "MMU fails"
 msgstr "Fallos MMU"
 
@@ -741,7 +741,7 @@ msgid "MMU load failed     "
 msgstr "Carga MMU fallida"
 
 # 
-#: ultralcd.cpp:1840
+#: ultralcd.cpp:1797
 msgid "MMU load fails"
 msgstr "Carga MMU falla"
 
@@ -766,7 +766,7 @@ msgid "MMU needs user attention."
 msgstr "MMU necesita atencion del usuario."
 
 # 
-#: ultralcd.cpp:1857
+#: ultralcd.cpp:1823
 msgid "MMU power fails"
 msgstr "Fallo de energia en MMU"
 
@@ -786,7 +786,7 @@ msgid "Mode [high power]"
 msgstr "Modo [rend.pleno]"
 
 # 
-#: ultralcd.cpp:2108
+#: ultralcd.cpp:2219
 msgid "MMU2 connected"
 msgstr "MMU2 conectado"
 
@@ -796,39 +796,39 @@ msgid "Motor"
 msgstr ""
 
 # MSG_MOVE_AXIS
-#: ultralcd.cpp:5566
+#: ultralcd.cpp:5652
 msgid "Move axis"
 msgstr "Mover ejes"
 
 # MSG_MOVE_X
-#: ultralcd.cpp:4294
+#: ultralcd.cpp:4378
 msgid "Move X"
 msgstr "Mover X"
 
 # MSG_MOVE_Y
-#: ultralcd.cpp:4295
+#: ultralcd.cpp:4379
 msgid "Move Y"
 msgstr "Mover Y"
 
 # MSG_MOVE_Z
-#: ultralcd.cpp:4296
+#: ultralcd.cpp:4380
 msgid "Move Z"
 msgstr "Mover Z"
 
 # MSG_NO_MOVE
-#: Marlin_main.cpp:5291
+#: Marlin_main.cpp:5292
 msgid "No move."
 msgstr "Sin movimiento"
 
 # MSG_NO_CARD
-#: ultralcd.cpp:6686
+#: ultralcd.cpp:6772
 msgid "No SD card"
 msgstr "No hay tarjeta SD"
 
 # 
-#: ultralcd.cpp:2976
+#: ultralcd.cpp:3024
 msgid "N/A"
-msgstr "No disponible"
+msgstr "N/A"
 
 # MSG_NO
 #: messages.c:62
@@ -836,7 +836,7 @@ msgid "No"
 msgstr ""
 
 # MSG_SELFTEST_NOTCONNECTED
-#: ultralcd.cpp:7803
+#: ultralcd.cpp:7889
 msgid "Not connected"
 msgstr "No hay conexion "
 
@@ -851,14 +851,14 @@ msgid "Not spinning"
 msgstr "Ventilador no gira"
 
 # MSG_WIZARD_V2_CAL c=20 r=8
-#: ultralcd.cpp:4977
+#: ultralcd.cpp:5063
 msgid "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr "Voy a calibrar la distancia entre la punta de la boquilla y la superficie de la base."
 
 # MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ultralcd.cpp:4921
+#: ultralcd.cpp:5007
 msgid "Now I will preheat nozzle for PLA."
-msgstr "Voy a precalentar la boquilla para PLA ahora."
+msgstr "Ahora precalentare la boquilla para PLA."
 
 # MSG_NOZZLE
 #: messages.c:63
@@ -871,37 +871,37 @@ msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr "Se han encontrado ajustes anteriores. Se ajustara el PID, los pasos del extrusor, etc"
 
 # 
-#: ultralcd.cpp:4912
+#: ultralcd.cpp:4998
 msgid "Now remove the test print from steel sheet."
 msgstr "Ahora retira la prueba de la lamina de acero."
 
 # 
-#: ultralcd.cpp:1782
+#: ultralcd.cpp:1722
 msgid "Nozzle FAN"
-msgstr "Ventilador de capa"
+msgstr "Vent. capa"
 
 # MSG_PAUSE_PRINT
-#: ultralcd.cpp:6649
+#: ultralcd.cpp:6735
 msgid "Pause print"
 msgstr "Pausar impresion"
 
 # MSG_PID_RUNNING c=20 r=1
-#: ultralcd.cpp:1598
+#: ultralcd.cpp:1606
 msgid "PID cal.           "
 msgstr "Cal. PID "
 
 # MSG_PID_FINISHED c=20 r=1
-#: ultralcd.cpp:1604
+#: ultralcd.cpp:1612
 msgid "PID cal. finished"
 msgstr "Cal. PID terminada"
 
 # MSG_PID_EXTRUDER c=17 r=1
-#: ultralcd.cpp:5683
+#: ultralcd.cpp:5769
 msgid "PID calibration"
 msgstr "Calibracion PID"
 
 # MSG_PINDA_PREHEAT c=20 r=1
-#: ultralcd.cpp:843
+#: ultralcd.cpp:846
 msgid "PINDA Heating"
 msgstr "Calentando PINDA"
 
@@ -911,7 +911,7 @@ msgid "Place a sheet of paper under the nozzle during the calibration of first 4
 msgstr "Colocar una hoja de papel sobre la superficie de impresion durante la calibracion de los primeros 4 puntos. Si la boquilla mueve el papel, apagar impresora inmediatamente."
 
 # MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ultralcd.cpp:4986
+#: ultralcd.cpp:5072
 msgid "Please clean heatbed and then press the knob."
 msgstr "Limpia la superficie de la base, por favor, y haz clic"
 
@@ -921,7 +921,7 @@ msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Limpia boquilla para calibracion. Click cuando acabes."
 
 # MSG_SELFTEST_PLEASECHECK
-#: ultralcd.cpp:7795
+#: ultralcd.cpp:7881
 msgid "Please check :"
 msgstr "Controla :"
 
@@ -931,17 +931,17 @@ msgid "Please check our handbook and fix the problem. Then resume the Wizard by 
 msgstr "Lee el manual y resuelve el problema. Despues, reinicia la impresora y continua con el Wizard"
 
 # MSG_WIZARD_LOAD_FILAMENT c=20 r=8
-#: ultralcd.cpp:4808
+#: ultralcd.cpp:4894
 msgid "Please insert PLA filament to the extruder, then press knob to load it."
 msgstr "Inserta, por favor, filamento PLA en el extrusor. Despues haz clic para cargarlo."
 
 # MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ultralcd.cpp:4709
+#: ultralcd.cpp:4795
 msgid "Please load PLA filament first."
 msgstr "Carga el filamento PLA primero por favor."
 
 # MSG_CHECK_IDLER c=20 r=4
-#: Marlin_main.cpp:3063
+#: Marlin_main.cpp:3064
 msgid "Please open idler and remove filament manually."
 msgstr "Por favor abate el rodillo de empuje (idler) y retira el filamento manualmente."
 
@@ -956,7 +956,7 @@ msgid "Please press the knob to unload filament"
 msgstr "Por favor, pulsa el dial para descargar el filamento"
 
 # 
-#: ultralcd.cpp:4803
+#: ultralcd.cpp:4889
 msgid "Please insert PLA filament to the first tube of MMU, then press the knob to load it."
 msgstr "Por favor introduce el filamento al primer tubo MMU, despues presiona el dial para imprimirlo."
 
@@ -976,7 +976,7 @@ msgid "Please remove steel sheet from heatbed."
 msgstr "Por favor retire la chapa de acero de la base calefactable."
 
 # MSG_RUN_XYZ c=20 r=4
-#: Marlin_main.cpp:4354
+#: Marlin_main.cpp:4355
 msgid "Please run XYZ calibration first."
 msgstr "Por favor realiza la calibracion XYZ primero."
 
@@ -991,7 +991,7 @@ msgid "Please wait"
 msgstr "Por Favor Espere"
 
 # 
-#: ultralcd.cpp:4911
+#: ultralcd.cpp:4997
 msgid "Please remove shipping helpers first."
 msgstr "Por favor retira los soportes de envio primero."
 
@@ -1001,7 +1001,7 @@ msgid "Preheat the nozzle!"
 msgstr "Precalienta extrusor!"
 
 # MSG_PREHEAT
-#: ultralcd.cpp:6636
+#: ultralcd.cpp:6722
 msgid "Preheat"
 msgstr "Precalentar"
 
@@ -1016,12 +1016,12 @@ msgid "Please upgrade."
 msgstr "Actualize por favor"
 
 # MSG_PRESS_TO_PREHEAT c=20 r=4
-#: Marlin_main.cpp:10365
+#: Marlin_main.cpp:10364
 msgid "Press knob to preheat nozzle and continue."
 msgstr "Pulsa el dial para precalentar la boquilla y continue."
 
 # 
-#: ultralcd.cpp:1876
+#: ultralcd.cpp:1851
 msgid "Power failures"
 msgstr "Cortes de energia"
 
@@ -1031,19 +1031,19 @@ msgid "Print aborted"
 msgstr "Impresion cancelada"
 
 # 
-#: ultralcd.cpp:2276
+#: ultralcd.cpp:2455
 msgid "Preheating to load"
 msgstr "Precalentar para cargar"
 
 # 
-#: ultralcd.cpp:2280
+#: ultralcd.cpp:2459
 msgid "Preheating to unload"
 msgstr "Precalentar para descargar"
 
 # MSG_SELFTEST_PRINT_FAN_SPEED c=18
-#: ultralcd.cpp:8221
+#: ultralcd.cpp:8307
 msgid "Print fan:"
-msgstr "Ventilador del fusor:"
+msgstr "Vent.fusor:"
 
 # MSG_CARD_MENU
 #: messages.c:21
@@ -1051,12 +1051,12 @@ msgid "Print from SD"
 msgstr "Menu tarjeta SD"
 
 # 
-#: ultralcd.cpp:2206
+#: ultralcd.cpp:2317
 msgid "Press the knob"
 msgstr "Pulsa el dial"
 
 # MSG_PRINT_PAUSED c=20 r=1
-#: ultralcd.cpp:1061
+#: ultralcd.cpp:1069
 msgid "Print paused"
 msgstr "Impresion en pausa"
 
@@ -1071,22 +1071,22 @@ msgid "Printer has not been calibrated yet. Please follow the manual, chapter Fi
 msgstr "Impresora no esta calibrada todavia. Por favor usa el manual capitulo Primeros pasos Calibracion flujo."
 
 # 
-#: ultralcd.cpp:1784
+#: ultralcd.cpp:1723
 msgid "Print FAN"
-msgstr "Ventilador del extrusor"
+msgstr "Vent.extr"
 
 # MSG_PRUSA3D
-#: ultralcd.cpp:2094
+#: ultralcd.cpp:2205
 msgid "prusa3d.com"
 msgstr "prusa3d.es"
 
 # MSG_BED_CORRECTION_REAR c=14 r=1
-#: ultralcd.cpp:3221
+#: ultralcd.cpp:3295
 msgid "Rear side [um]"
 msgstr "Trasera [um]"
 
 # MSG_RECOVERING_PRINT c=20 r=1
-#: Marlin_main.cpp:9765
+#: Marlin_main.cpp:9764
 msgid "Recovering print    "
 msgstr "Recuperando impresion"
 
@@ -1101,57 +1101,57 @@ msgid "Prusa i3 MK3S OK."
 msgstr ""
 
 # MSG_CALIBRATE_BED_RESET
-#: ultralcd.cpp:5688
+#: ultralcd.cpp:5774
 msgid "Reset XYZ calibr."
 msgstr ""
 
 # MSG_BED_CORRECTION_RESET
-#: ultralcd.cpp:3222
+#: ultralcd.cpp:3296
 msgid "Reset"
 msgstr ""
 
 # MSG_RESUME_PRINT
-#: ultralcd.cpp:6656
+#: ultralcd.cpp:6742
 msgid "Resume print"
 msgstr "Reanudar impres."
 
 # MSG_RESUMING_PRINT c=20 r=1
 #: messages.c:73
 msgid "Resuming print"
-msgstr "Resumiendo impresion"
+msgstr "Continuando impresion"
 
 # MSG_BED_CORRECTION_RIGHT c=14 r=1
-#: ultralcd.cpp:3219
+#: ultralcd.cpp:3293
 msgid "Right side[um]"
 msgstr "Derecha [um]"
 
 # MSG_SECOND_SERIAL_ON c=17 r=1
-#: ultralcd.cpp:5606
+#: ultralcd.cpp:5692
 msgid "RPi port     [on]"
 msgstr "Puerto RPi  [act]"
 
 # MSG_SECOND_SERIAL_OFF c=17 r=1
-#: ultralcd.cpp:5604
+#: ultralcd.cpp:5690
 msgid "RPi port    [off]"
 msgstr "Puerto RPi  [ina]"
 
 # MSG_WIZARD_RERUN c=20 r=7
-#: ultralcd.cpp:4726
+#: ultralcd.cpp:4812
 msgid "Running Wizard will delete current calibration results and start from the beginning. Continue?"
 msgstr "Ejecutar el Wizard borrara los valores de calibracion actuales y comenzara de nuevo. Continuar?"
 
 # MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_OFF c=19 r=1
-#: ultralcd.cpp:5236
+#: ultralcd.cpp:5322
 msgid "SD card  [normal]"
 msgstr "Tarj. SD [normal]"
 
 # MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_ON c=19 r=1
-#: ultralcd.cpp:5234
+#: ultralcd.cpp:5320
 msgid "SD card [flshAir]"
 msgstr "Tarj. SD[FlshAir]"
 
 # 
-#: ultralcd.cpp:2971
+#: ultralcd.cpp:3019
 msgid "Right"
 msgstr "Derecha"
 
@@ -1161,27 +1161,27 @@ msgid "Searching bed calibration point"
 msgstr "Buscando punto de calibracion base"
 
 # MSG_LANGUAGE_SELECT
-#: ultralcd.cpp:5613
+#: ultralcd.cpp:5699
 msgid "Select language"
 msgstr "Cambiar el idioma"
 
 # MSG_SELFTEST_OK
-#: ultralcd.cpp:7366
+#: ultralcd.cpp:7452
 msgid "Self test OK"
 msgstr ""
 
 # MSG_SELFTEST_START c=20
-#: ultralcd.cpp:7152
+#: ultralcd.cpp:7238
 msgid "Self test start  "
 msgstr "Iniciar Selftest"
 
 # MSG_SELFTEST
-#: ultralcd.cpp:5664
+#: ultralcd.cpp:5750
 msgid "Selftest         "
 msgstr "Selftest"
 
 # MSG_SELFTEST_ERROR
-#: ultralcd.cpp:7793
+#: ultralcd.cpp:7879
 msgid "Selftest error !"
 msgstr "Error Selftest !"
 
@@ -1196,17 +1196,17 @@ msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr "Se realizara el auto-test para calibrar con precision la vuelta a la posicion inicial sin sensores."
 
 # 
-#: ultralcd.cpp:4959
+#: ultralcd.cpp:5045
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr "Selecciona la temperatura para precalentar la boquilla que se ajuste a tu material. "
 
 # 
-#: ultralcd.cpp:4695
+#: ultralcd.cpp:4780
 msgid "Select PLA filament:"
 msgstr "Seleccionar filamento PLA:"
 
 # MSG_SET_TEMPERATURE c=19 r=1
-#: ultralcd.cpp:3230
+#: ultralcd.cpp:3314
 msgid "Set temperature:"
 msgstr "Establecer temp.:"
 
@@ -1216,12 +1216,12 @@ msgid "Settings"
 msgstr "Configuracion"
 
 # MSG_SHOW_END_STOPS c=17 r=1
-#: ultralcd.cpp:5685
+#: ultralcd.cpp:5771
 msgid "Show end stops"
 msgstr "Mostrar endstops"
 
 # 
-#: ultralcd.cpp:3941
+#: ultralcd.cpp:4025
 msgid "Sensor state"
 msgstr "Estado del sensor"
 
@@ -1231,22 +1231,22 @@ msgid "Some files will not be sorted. Max. No. of files in 1 folder for sorting 
 msgstr "Algunos archivos no se ordenaran. Maximo 100 archivos por carpeta para ordenar. "
 
 # MSG_SORT_NONE c=17 r=1
-#: ultralcd.cpp:5246
+#: ultralcd.cpp:5332
 msgid "Sort       [none]"
-msgstr "Ordenar    [nada]"
+msgstr "Ordenar [ninguno]"
 
 # MSG_SORT_TIME c=17 r=1
-#: ultralcd.cpp:5244
+#: ultralcd.cpp:5330
 msgid "Sort       [time]"
-msgstr "Ordenar   [Fecha]"
+msgstr "Ordenar   [fecha]"
 
 # 
-#: ultralcd.cpp:3008
-msgid "Severe skew"
-msgstr "Inclinacion severa"
+#: ultralcd.cpp:3062
+msgid "Severe skew:"
+msgstr "Incl.severa:"
 
 # MSG_SORT_ALPHA c=17 r=1
-#: ultralcd.cpp:5245
+#: ultralcd.cpp:5331
 msgid "Sort   [alphabet]"
 msgstr "Ordenar [alfabet]"
 
@@ -1261,9 +1261,9 @@ msgid "Sound      [loud]"
 msgstr "Sonido     [alto]"
 
 # 
-#: ultralcd.cpp:3007
-msgid "Slight skew"
-msgstr "Ligeramente inclinado"
+#: ultralcd.cpp:3061
+msgid "Slight skew:"
+msgstr "Liger.incl.:"
 
 # MSG_SOUND_MUTE c=17 r=1
 #: 
@@ -1271,7 +1271,7 @@ msgid "Sound      [mute]"
 msgstr "Sonido[silenciad]"
 
 # 
-#: Marlin_main.cpp:4870
+#: Marlin_main.cpp:4871
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Problema encontrado, nivelacion Z forzosa ..."
 
@@ -1286,7 +1286,7 @@ msgid "Sound    [silent]"
 msgstr "Sonido[silencios]"
 
 # MSG_SPEED
-#: ultralcd.cpp:6840
+#: ultralcd.cpp:6926
 msgid "Speed"
 msgstr "Velocidad"
 
@@ -1296,12 +1296,12 @@ msgid "Spinning"
 msgstr "Ventilador girando"
 
 # MSG_TEMP_CAL_WARNING c=20 r=4
-#: Marlin_main.cpp:4367
+#: Marlin_main.cpp:4368
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr "Se necesita una temperatura ambiente ente 21 y 26C y un soporte rigido."
 
 # MSG_STATISTICS
-#: ultralcd.cpp:6753
+#: ultralcd.cpp:6839
 msgid "Statistics  "
 msgstr "Estadisticas "
 
@@ -1316,12 +1316,12 @@ msgid "STOPPED. "
 msgstr "PARADA"
 
 # MSG_SUPPORT
-#: ultralcd.cpp:6762
+#: ultralcd.cpp:6848
 msgid "Support"
 msgstr "Soporte"
 
 # MSG_SELFTEST_SWAPPED
-#: ultralcd.cpp:7873
+#: ultralcd.cpp:7959
 msgid "Swapped"
 msgstr "Intercambiado"
 
@@ -1331,22 +1331,22 @@ msgid "Temp. cal.          "
 msgstr "Cal. temp. "
 
 # MSG_TEMP_CALIBRATION_ON c=20 r=1
-#: ultralcd.cpp:5600
+#: ultralcd.cpp:5686
 msgid "Temp. cal.   [on]"
-msgstr "Cal. temp.   [ON]"
+msgstr "Cal. temp.   [on]"
 
 # MSG_TEMP_CALIBRATION_OFF c=20 r=1
-#: ultralcd.cpp:5598
+#: ultralcd.cpp:5684
 msgid "Temp. cal.  [off]"
-msgstr "Cal. temp.  [OFF]"
+msgstr "Cal. temp.  [off]"
 
 # MSG_CALIBRATION_PINDA_MENU c=17 r=1
-#: ultralcd.cpp:5694
+#: ultralcd.cpp:5780
 msgid "Temp. calibration"
 msgstr "Calibracion temp."
 
 # MSG_TEMP_CAL_FAILED c=20 r=8
-#: ultralcd.cpp:3867
+#: ultralcd.cpp:3951
 msgid "Temperature calibration failed"
 msgstr "Fallo de la calibracion de temperatura"
 
@@ -1356,12 +1356,12 @@ msgid "Temperature calibration is finished and active. Temp. calibration can be 
 msgstr "Calibracion temperatura terminada. Haz clic para continuar."
 
 # MSG_TEMPERATURE
-#: ultralcd.cpp:5564
+#: ultralcd.cpp:5650
 msgid "Temperature"
 msgstr "Temperatura"
 
 # MSG_MENU_TEMPERATURES c=15 r=1
-#: ultralcd.cpp:2140
+#: ultralcd.cpp:2251
 msgid "Temperatures"
 msgstr "Temperaturas"
 
@@ -1371,37 +1371,37 @@ msgid "There is still a need to make Z calibration. Please follow the manual, ch
 msgstr "Todavia es necesario hacer una calibracion Z. Por favor siga el manual, capitulo Primeros pasos, seccion Calibracion del flujo."
 
 # 
-#: ultralcd.cpp:2863
+#: ultralcd.cpp:2908
 msgid "Total filament"
 msgstr "Filamento total:"
 
 # 
-#: ultralcd.cpp:2863
+#: ultralcd.cpp:2908
 msgid "Total print time"
 msgstr "Tiempo total :"
 
 # MSG_TUNE
-#: ultralcd.cpp:6633
+#: ultralcd.cpp:6719
 msgid "Tune"
 msgstr "Ajustar"
 
 # 
-#: ultralcd.cpp:4783
+#: ultralcd.cpp:4869
 msgid "Unload"
 msgstr "Descargar"
 
 # 
-#: ultralcd.cpp:1857
+#: ultralcd.cpp:1820
 msgid "Total failures"
 msgstr "Fallos totales"
 
 # 
-#: ultralcd.cpp:2213
+#: ultralcd.cpp:2324
 msgid "to load filament"
 msgstr "para cargar el filamento"
 
 # 
-#: ultralcd.cpp:2217
+#: ultralcd.cpp:2328
 msgid "to unload filament"
 msgstr "para descargar el filamento"
 
@@ -1416,42 +1416,42 @@ msgid "Unloading filament"
 msgstr "Soltando filamento"
 
 # 
-#: ultralcd.cpp:1824
+#: ultralcd.cpp:1773
 msgid "Total"
 msgstr ""
 
 # MSG_USED c=19 r=1
-#: ultralcd.cpp:5822
+#: ultralcd.cpp:5908
 msgid "Used during print"
 msgstr "Usado en impresion"
 
 # MSG_MENU_VOLTAGES c=15 r=1
-#: ultralcd.cpp:2143
+#: ultralcd.cpp:2254
 msgid "Voltages"
 msgstr "Voltajes"
 
 # 
-#: ultralcd.cpp:2116
+#: ultralcd.cpp:2227
 msgid "unknown"
 msgstr "desconocido"
 
 # MSG_USERWAIT
-#: Marlin_main.cpp:5262
+#: Marlin_main.cpp:5263
 msgid "Wait for user..."
 msgstr "Esperando ordenes"
 
 # MSG_WAITING_TEMP c=20 r=3
-#: ultralcd.cpp:3374
+#: ultralcd.cpp:3458
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Esperando enfriamiento de la base y extrusor."
 
 # MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ultralcd.cpp:3338
+#: ultralcd.cpp:3422
 msgid "Waiting for PINDA probe cooling"
 msgstr "Esperando a que se enfrie la sonda PINDA"
 
 # 
-#: ultralcd.cpp:4782
+#: ultralcd.cpp:4868
 msgid "Use unload to remove filament 1 if it protrudes outside of the rear MMU tube. Use eject if it is hidden in tube."
 msgstr "Usa unload para retirar el filamento 1 si sobresale por fuera de la parte trasera del tubo MMU. Usa Expulsar si esta escondido dentro del tubo"
 
@@ -1471,7 +1471,7 @@ msgid "Warning: printer type changed."
 msgstr "Cuidado: Ha cambiado el tipo de impresora."
 
 # MSG_UNLOAD_SUCCESSFUL c=20 r=2
-#: Marlin_main.cpp:3053
+#: Marlin_main.cpp:3054
 msgid "Was filament unload successful?"
 msgstr "?Se cargocon exito el filamento?"
 
@@ -1481,12 +1481,12 @@ msgid "Wiring error"
 msgstr "Error de conexion"
 
 # MSG_WIZARD c=17 r=1
-#: ultralcd.cpp:5661
+#: ultralcd.cpp:5747
 msgid "Wizard"
 msgstr ""
 
 # MSG_XYZ_DETAILS c=19 r=1
-#: ultralcd.cpp:2132
+#: ultralcd.cpp:2243
 msgid "XYZ cal. details"
 msgstr "Detalles de calibracion XYZ"
 
@@ -1506,69 +1506,69 @@ msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr "Siempre puedes acceder al asistente desde Calibracion -> Wizard"
 
 # MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ultralcd.cpp:3838
+#: ultralcd.cpp:3922
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr "Calibracion XYZ correcta. La inclinacion se corregira automaticamente."
 
 # MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ultralcd.cpp:3835
+#: ultralcd.cpp:3919
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr "Calibracion XYZ correcta. Los ejes X / Y estan ligeramente inclinados. Buen trabajo!"
 
 # 
-#: ultralcd.cpp:5044
+#: ultralcd.cpp:5130
 msgid "X-correct:"
-msgstr "X-correcion:"
+msgstr "Corregir-X:"
 
 # MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ultralcd.cpp:3832
+#: ultralcd.cpp:3916
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "Calibracion XYZ ok. Ejes X/Y perpendiculares. Enhorabuena!"
 
 # MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ultralcd.cpp:3816
+#: ultralcd.cpp:3900
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr "Calibrazion XYZ comprometida. Puntos frontales no alcanzables."
 
 # MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ultralcd.cpp:3819
+#: ultralcd.cpp:3903
 msgid "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr "Calibrazion XYZ comprometida. Punto frontal derecho no alcanzable."
 
 # MSG_LOAD_ALL c=17
-#: ultralcd.cpp:6080
+#: ultralcd.cpp:6166
 msgid "Load all"
 msgstr "Intr. todos fil."
 
 # 
-#: ultralcd.cpp:3798
+#: ultralcd.cpp:3882
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr "Calibracion XYZ fallada. Puntos de calibracion en la base no encontrados."
 
 # 
-#: ultralcd.cpp:3804
+#: ultralcd.cpp:3888
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr "Calibracion XYZ fallada. Puntos frontales no alcanzables."
 
 # 
-#: ultralcd.cpp:3807
+#: ultralcd.cpp:3891
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr "Calibracion XYZ fallad. Punto frontal derecho no alcanzable."
 
 # 
-#: ultralcd.cpp:2968
+#: ultralcd.cpp:3016
 msgid "Y distance from min"
 msgstr "Distancia en Y desde el min"
 
 # 
-#: ultralcd.cpp:5045
+#: ultralcd.cpp:5131
 msgid "Y-correct:"
-msgstr "Y-correcion:"
+msgstr "Corregir-Y:"
 
 # MSG_OFF
 #: menu.cpp:426
 msgid " [off]"
-msgstr ""
+msgstr "[apag]"
 
 # 
 #: messages.c:57
@@ -1576,32 +1576,32 @@ msgid "Back"
 msgstr "atras"
 
 # 
-#: ultralcd.cpp:5553
+#: ultralcd.cpp:5639
 msgid "Checks"
 msgstr "Comprobaciones"
 
 # 
-#: ultralcd.cpp:7887
+#: ultralcd.cpp:7973
 msgid "False triggering"
 msgstr "Falsa activacion"
 
 # 
-#: ultralcd.cpp:3946
+#: ultralcd.cpp:4030
 msgid "FINDA:"
-msgstr ""
+msgstr "FINDA:"
 
 # 
-#: ultralcd.cpp:5459
+#: ultralcd.cpp:5545
 msgid "Firmware   [none]"
 msgstr "Firmware[ninguno]"
 
 # 
-#: ultralcd.cpp:5465
+#: ultralcd.cpp:5551
 msgid "Firmware [strict]"
 msgstr "Firmware[estrict]"
 
 # 
-#: ultralcd.cpp:5462
+#: ultralcd.cpp:5548
 msgid "Firmware   [warn]"
 msgstr "Firmware  [aviso]"
 
@@ -1611,147 +1611,147 @@ msgid "HW Setup"
 msgstr "Configuracion HW"
 
 # 
-#: ultralcd.cpp:3950
+#: ultralcd.cpp:4034
 msgid "IR:"
 msgstr ""
 
 # 
-#: ultralcd.cpp:6960
+#: ultralcd.cpp:7046
 msgid "Magnets comp.[N/A]"
 msgstr "Comp. imanes [N/A]"
 
 # 
-#: ultralcd.cpp:6958
+#: ultralcd.cpp:7044
 msgid "Magnets comp.[Off]"
 msgstr "Comp. imanes [Off]"
 
 # 
-#: ultralcd.cpp:6957
+#: ultralcd.cpp:7043
 msgid "Magnets comp. [On]"
 msgstr "Comp. imanes  [On]"
 
 # 
-#: ultralcd.cpp:6949
+#: ultralcd.cpp:7035
 msgid "Mesh         [3x3]"
 msgstr "Malla        [3x3]"
 
 # 
-#: ultralcd.cpp:6950
+#: ultralcd.cpp:7036
 msgid "Mesh         [7x7]"
 msgstr "Malla        [7x7]"
 
 # 
-#: ultralcd.cpp:5591
+#: ultralcd.cpp:5677
 msgid "Mesh bed leveling"
 msgstr "Nivelacion Malla Base"
 
 # 
 #: Marlin_main.cpp:856
 msgid "MK3S firmware detected on MK3 printer"
-msgstr ""
+msgstr "Firmware MK3S detectado en impresora MK3"
 
 # 
-#: ultralcd.cpp:5220
+#: ultralcd.cpp:5306
 msgid "MMU Mode [Normal]"
 msgstr "Modo MMU [Normal]"
 
 # 
-#: ultralcd.cpp:5221
+#: ultralcd.cpp:5307
 msgid "MMU Mode[Stealth]"
 msgstr "Modo MMU[Silenci]"
 
 # 
-#: ultralcd.cpp:4427
+#: ultralcd.cpp:4511
 msgid "Mode change in progress ..."
 msgstr "Cambio de modo progresando ..."
 
 # 
-#: ultralcd.cpp:5420
+#: ultralcd.cpp:5506
 msgid "Model      [none]"
 msgstr "Modelo  [ninguno]"
 
 # 
-#: ultralcd.cpp:5426
+#: ultralcd.cpp:5512
 msgid "Model    [strict]"
 msgstr "Modelo [estricto]"
 
 # 
-#: ultralcd.cpp:5423
+#: ultralcd.cpp:5509
 msgid "Model      [warn]"
 msgstr "Modelo    [aviso]"
 
 # 
-#: ultralcd.cpp:5381
+#: ultralcd.cpp:5467
 msgid "Nozzle d.  [0.25]"
 msgstr "Diam. nozzl[0.25]"
 
 # 
-#: ultralcd.cpp:5384
+#: ultralcd.cpp:5470
 msgid "Nozzle d.  [0.40]"
 msgstr "Diam. nozzl[0.40]"
 
 # 
-#: ultralcd.cpp:5387
+#: ultralcd.cpp:5473
 msgid "Nozzle d.  [0.60]"
 msgstr "Diam. nozzl[0.60]"
 
 # 
-#: ultralcd.cpp:5335
+#: ultralcd.cpp:5421
 msgid "Nozzle     [none]"
 msgstr "Nozzle  [ninguno]"
 
 # 
-#: ultralcd.cpp:5341
+#: ultralcd.cpp:5427
 msgid "Nozzle   [strict]"
 msgstr "Nozzle [estricto]"
 
 # 
-#: ultralcd.cpp:5338
+#: ultralcd.cpp:5424
 msgid "Nozzle     [warn]"
 msgstr "Nozzle    [aviso]"
 
 # 
 #: util.cpp:510
 msgid "G-code sliced for a different level. Continue?"
-msgstr ""
+msgstr "Codigo G laminado para un nivel diferente. ?Continuar?"
 
 # 
 #: util.cpp:516
 msgid "G-code sliced for a different level. Please re-slice the model again. Print cancelled."
-msgstr ""
+msgstr "Codigo G laminado para un nivel diferente. Por favor relamina el modelo de nuevo. Impresion cancelada."
 
 # 
 #: util.cpp:427
 msgid "G-code sliced for a different printer type. Continue?"
-msgstr ""
+msgstr "Codigo G laminado para un tipo de impresora diferente. ?Continuar?"
 
 # 
 #: util.cpp:433
 msgid "G-code sliced for a different printer type. Please re-slice the model again. Print cancelled."
-msgstr ""
+msgstr "Codigo G laminado para una impresora diferente. Por favor relamina el modelo de nuevo. Impresion cancelada."
 
 # 
 #: util.cpp:477
 msgid "G-code sliced for a newer firmware. Continue?"
-msgstr ""
+msgstr "Codigo G laminado para nuevo firmware. ?Continuar?"
 
 # 
 #: util.cpp:483
 msgid "G-code sliced for a newer firmware. Please update the firmware. Print cancelled."
-msgstr ""
+msgstr "Codigo G laminado para nuevo firmware. Por favor actualiza el firmware. Impresion cancelada."
 
 # 
-#: ultralcd.cpp:3942
+#: ultralcd.cpp:4026
 msgid "PINDA:"
-msgstr ""
+msgstr "PINDA:"
 
 # 
-#: ultralcd.cpp:2286
+#: ultralcd.cpp:2465
 msgid "Preheating to cut"
 msgstr "Precalentando para laminar"
 
 # 
-#: ultralcd.cpp:2283
+#: ultralcd.cpp:2462
 msgid "Preheating to eject"
 msgstr "Precalentar para expulsar"
 
@@ -1766,17 +1766,17 @@ msgid "Printer nozzle diameter differs from the G-code. Please check the value i
 msgstr "Diametro nozzle Impresora difiere de cod.G. Comprueba los valores en ajustes. Impresion cancelada."
 
 # 
-#: ultralcd.cpp:6597
+#: ultralcd.cpp:6683
 msgid "Rename"
 msgstr "Renombrar"
 
 # 
-#: ultralcd.cpp:6593
+#: ultralcd.cpp:6679
 msgid "Select"
 msgstr "Seleccionar"
 
 # 
-#: ultralcd.cpp:2134
+#: ultralcd.cpp:2245
 msgid "Sensor info"
 msgstr "Info sensor"
 
@@ -1786,22 +1786,27 @@ msgid "Sheet"
 msgstr "Lamina"
 
 # 
-#: 
-msgid "Sound     [assist]"
-msgstr ""
+#: sound.h:9
+msgid "Sound    [assist]"
+msgstr "Sonido [asistido]"
 
 # 
-#: ultralcd.cpp:5551
+#: ultralcd.cpp:5637
 msgid "Steel sheets"
-msgstr ""
+msgstr "Lamina de acero"
 
 # 
-#: ultralcd.cpp:5046
+#: ultralcd.cpp:5132
 msgid "Z-correct:"
-msgstr "Correccion-Z:"
+msgstr "Corregir-Z:"
 
 # 
-#: ultralcd.cpp:6952
+#: ultralcd.cpp:7038
 msgid "Z-probe nr.    [1]"
 msgstr "Z-sensor nr.   [1]"
+
+# 
+#: ultralcd.cpp:7040
+msgid "Z-probe nr.    [3]"
+msgstr "Z-sensor nr.   [3]"
 

--- a/lang/po/Firmware_fr.po
+++ b/lang/po/Firmware_fr.po
@@ -7,8 +7,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: fr\n"
 "Project-Id-Version: Prusa-Firmware\n"
-"POT-Creation-Date: Wed Sep 4 16:13:59 CEST 2019\n"
-"PO-Revision-Date: Wed Sep 4 16:13:59 CEST 2019\n"
+"POT-Creation-Date: Sun, Sep 22, 2019 2:06:22 PM\n"
+"PO-Revision-Date: Sun, Sep 22, 2019 2:06:22 PM\n"
 "Language-Team: \n"
 "X-Generator: Poedit 2.0.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
@@ -26,7 +26,7 @@ msgid " of 9"
 msgstr "de 9"
 
 # MSG_MEASURED_OFFSET
-#: ultralcd.cpp:3027
+#: ultralcd.cpp:3089
 msgid "[0;0] point offset"
 msgstr "Offset point [0;0]"
 
@@ -38,55 +38,55 @@ msgstr "La detection de\x0acrash peut etre\x0aactive seulement en\x0amode Normal
 # MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
 #: 
 msgid "WARNING:\x0aCrash detection\x0adisabled in\x0aStealth mode"
-msgstr "ATTENTION:\x0aDetection de crash\x0adesactivee en\x0amode Furtif"
+msgstr "ATTENTION:\x0aDetection de crash\x0adesactivee en\x0amode feutre"
 
 # 
-#: ultralcd.cpp:2290
+#: ultralcd.cpp:2472
 msgid ">Cancel"
 msgstr ">Annuler"
 
 # MSG_BABYSTEPPING_Z c=15
-#: ultralcd.cpp:3147
+#: ultralcd.cpp:3209
 msgid "Adjusting Z:"
-msgstr "Ajust. de Z:"
+msgstr "Ajuster Z:"
 
 # MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ultralcd.cpp:8209
+#: ultralcd.cpp:8295
 msgid "All correct      "
 msgstr "Tout est correct"
 
 # MSG_WIZARD_DONE c=20 r=8
 #: messages.c:101
 msgid "All is done. Happy printing!"
-msgstr "Tout est pret. Bonne impression !"
+msgstr "Tout est pret. Bonne impression!"
 
 # 
-#: ultralcd.cpp:1974
+#: ultralcd.cpp:2009
 msgid "Ambient"
 msgstr "Ambiant"
 
 # MSG_PRESS c=20
-#: ultralcd.cpp:2576
+#: ultralcd.cpp:2618
 msgid "and press the knob"
 msgstr "et pressez le bouton"
 
 # MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=2
-#: ultralcd.cpp:3445
+#: ultralcd.cpp:3529
 msgid "Are left and right Z~carriages all up?"
 msgstr "Z~carriages gauche + droite tout en haut?"
 
 # MSG_AUTO_DEPLETE_ON c=17 r=1
-#: ultralcd.cpp:5114
+#: ultralcd.cpp:5200
 msgid "SpoolJoin    [on]"
 msgstr ""
 
 # 
-#: ultralcd.cpp:5110
+#: ultralcd.cpp:5196
 msgid "SpoolJoin   [N/A]"
 msgstr ""
 
 # MSG_AUTO_DEPLETE_OFF c=17 r=1
-#: ultralcd.cpp:5118
+#: ultralcd.cpp:5204
 msgid "SpoolJoin   [off]"
 msgstr ""
 
@@ -96,32 +96,32 @@ msgid "Auto home"
 msgstr "Mise a 0 des axes"
 
 # MSG_AUTOLOAD_FILAMENT c=17
-#: ultralcd.cpp:6736
+#: ultralcd.cpp:6822
 msgid "AutoLoad filament"
-msgstr "AutoCharge du filament"
+msgstr "Autocharge du fil."
 
 # MSG_AUTOLOADING_ONLY_IF_FSENS_ON c=20 r=4
-#: ultralcd.cpp:4378
+#: ultralcd.cpp:4462
 msgid "Autoloading filament available only when filament sensor is turned on..."
 msgstr "Chargement auto du filament uniquement si le capteur de filament est active."
 
 # MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ultralcd.cpp:2771
+#: ultralcd.cpp:2813
 msgid "Autoloading filament is active, just press the knob and insert filament..."
-msgstr "Chargement auto du filament actif, appuyez sur le btn et inserez le fil."
+msgstr "Chargement auto. du fil. active, appuyez sur le bouton et inserez le fil."
 
 # MSG_SELFTEST_AXIS_LENGTH
-#: ultralcd.cpp:7863
+#: ultralcd.cpp:7949
 msgid "Axis length"
 msgstr "Longueur de l'axe"
 
 # MSG_SELFTEST_AXIS
-#: ultralcd.cpp:7865
+#: ultralcd.cpp:7951
 msgid "Axis"
 msgstr "Axe"
 
 # MSG_SELFTEST_BEDHEATER
-#: ultralcd.cpp:7807
+#: ultralcd.cpp:7893
 msgid "Bed / Heater"
 msgstr "Lit / Chauffage"
 
@@ -136,14 +136,14 @@ msgid "Bed Heating"
 msgstr "Chauffe du lit"
 
 # MSG_BED_CORRECTION_MENU
-#: ultralcd.cpp:5682
+#: ultralcd.cpp:5768
 msgid "Bed level correct"
 msgstr "Corr. niveau plateau"
 
 # MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=4
 #: messages.c:18
 msgid "Bed leveling failed. Sensor didnt trigger. Debris on nozzle? Waiting for reset."
-msgstr "Echec bed leveling. Capt. non declenche. Debris sur buse ? En attente d'un reset."
+msgstr "Echec bed leveling. Capt. non declenche. Debris sur buse? En attente d'un reset."
 
 # MSG_BED
 #: messages.c:15
@@ -151,22 +151,22 @@ msgid "Bed"
 msgstr "Lit"
 
 # MSG_MENU_BELT_STATUS c=15 r=1
-#: ultralcd.cpp:2002
+#: ultralcd.cpp:2059
 msgid "Belt status"
 msgstr "Statut courroie"
 
 # MSG_RECOVER_PRINT c=20 r=2
 #: messages.c:71
 msgid "Blackout occurred. Recover print?"
-msgstr "Coupure detectee. Recup. impression ?"
+msgstr "Coupure detectee. Reprendre impression?"
 
 # 
-#: ultralcd.cpp:8211
+#: ultralcd.cpp:8297
 msgid "Calibrating home"
 msgstr "Calib. mise a 0"
 
 # MSG_CALIBRATE_BED
-#: ultralcd.cpp:5671
+#: ultralcd.cpp:5757
 msgid "Calibrate XYZ"
 msgstr "Calibrer XYZ"
 
@@ -176,27 +176,27 @@ msgid "Calibrate Z"
 msgstr "Calibrer Z"
 
 # MSG_CALIBRATE_PINDA c=17 r=1
-#: ultralcd.cpp:4570
+#: ultralcd.cpp:4654
 msgid "Calibrate"
 msgstr "Calibrer"
 
 # MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ultralcd.cpp:3408
+#: ultralcd.cpp:3492
 msgid "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end stoppers. Click when done."
-msgstr "Calibration de XYZ. Tournez le bouton pour monter le chariot de l'axe Z jusqu'aux butees. Cliquez une fois fait."
+msgstr "Calibration de XYZ. Tournez le bouton pour faire monter l'extrudeur dans l'axe Z jusqu'aux butees. Cliquez une fois fait."
 
 # MSG_CALIBRATE_Z_AUTO c=20 r=2
 #: messages.c:20
 msgid "Calibrating Z"
-msgstr "Calibration de Z"
+msgstr "Calibration Z"
 
 # MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ultralcd.cpp:3408
+#: ultralcd.cpp:3492
 msgid "Calibrating Z. Rotate the knob to move the Z carriage up to the end stoppers. Click when done."
-msgstr "Calibration de Z. Tournez le bouton pour monter le chariot de l'axe Z jusqu'aux butees. Cliquez une fois fait."
+msgstr "Calibration de Z. Tournez le bouton pour faire monter l'extrudeur dans l'axe Z jusqu'aux butees. Cliquez une fois fait."
 
 # MSG_HOMEYZ_DONE
-#: ultralcd.cpp:813
+#: ultralcd.cpp:816
 msgid "Calibration done"
 msgstr "Calibration terminee"
 
@@ -206,17 +206,17 @@ msgid "Calibration"
 msgstr ""
 
 # 
-#: ultralcd.cpp:4695
+#: ultralcd.cpp:4781
 msgid "Cancel"
 msgstr "Annuler"
 
 # MSG_SD_REMOVED
-#: ultralcd.cpp:8578
+#: ultralcd.cpp:8679
 msgid "Card removed"
 msgstr "Carte retiree"
 
 # MSG_NOT_COLOR
-#: ultralcd.cpp:2676
+#: ultralcd.cpp:2718
 msgid "Color not correct"
 msgstr "Couleur incorrecte"
 
@@ -226,24 +226,24 @@ msgid "Cooldown"
 msgstr "Refroidissement"
 
 # 
-#: ultralcd.cpp:4503
+#: ultralcd.cpp:4587
 msgid "Copy selected language?"
-msgstr "Copier la langue selectionne ?"
+msgstr "Copier la langue selectionne?"
 
 # MSG_CRASHDETECT_ON
 #: messages.c:27
 msgid "Crash det.   [on]"
-msgstr "Detect. crash[on]"
+msgstr "Detect.crash [on]"
 
 # MSG_CRASHDETECT_NA
 #: messages.c:25
 msgid "Crash det.  [N/A]"
-msgstr "Detect. crash [N/A]"
+msgstr "Detect.crash[N/A]"
 
 # MSG_CRASHDETECT_OFF
 #: messages.c:26
 msgid "Crash det.  [off]"
-msgstr "Detect. crash[off]"
+msgstr "Detect.crash[off]"
 
 # MSG_CRASH_DETECTED c=20 r=1
 #: messages.c:24
@@ -253,25 +253,25 @@ msgstr "Crash detecte."
 # 
 #: Marlin_main.cpp:600
 msgid "Crash detected. Resume print?"
-msgstr "Crash detecte. Poursuivre l'impression ?"
+msgstr "Crash detecte. Poursuivre l'impression?"
 
 # 
-#: ultralcd.cpp:1876
+#: ultralcd.cpp:1853
 msgid "Crash"
 msgstr ""
 
 # MSG_CURRENT c=19 r=1
-#: ultralcd.cpp:5823
+#: ultralcd.cpp:5909
 msgid "Current"
 msgstr "Actuel"
 
 # MSG_DATE c=17 r=1
-#: ultralcd.cpp:2102
+#: ultralcd.cpp:2213
 msgid "Date:"
-msgstr "Date :"
+msgstr "Date:"
 
 # MSG_DISABLE_STEPPERS
-#: ultralcd.cpp:5568
+#: ultralcd.cpp:5654
 msgid "Disable steppers"
 msgstr "Desactiver moteurs"
 
@@ -281,67 +281,67 @@ msgid "Distance between tip of the nozzle and the bed surface has not been set y
 msgstr "La distance entre la pointe de la buse et la surface du plateau n'a pas encore ete reglee. Suivez le manuel, chapitre Premiers pas, section Calibration de la premiere couche."
 
 # MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ultralcd.cpp:4984
+#: ultralcd.cpp:5070
 msgid "Do you want to repeat last step to readjust distance between nozzle and heatbed?"
-msgstr "Voulez-vous repeter la derniere etape pour reajuster la distance entre la buse et le plateau chauffant ?"
+msgstr "Voulez-vous repeter la derniere etape pour reajuster la distance entre la buse et le plateau chauffant?"
 
 # MSG_EXTRUDER_CORRECTION c=10
-#: ultralcd.cpp:5048
+#: ultralcd.cpp:5134
 msgid "E-correct:"
 msgstr "Correct-E:"
 
 # MSG_EJECT_FILAMENT c=17 r=1
 #: messages.c:53
 msgid "Eject filament"
-msgstr "Ejecter le fil."
+msgstr "Remonter le fil."
 
 # 
-#: ultralcd.cpp:4783
+#: ultralcd.cpp:4869
 msgid "Eject"
-msgstr "Ejecter"
+msgstr "Remonter"
 
 # MSG_EJECTING_FILAMENT c=20 r=1
 #: mmu.cpp:1434
 msgid "Ejecting filament"
-msgstr "Ejection filament"
+msgstr "Le fil. remonte"
 
 # MSG_SELFTEST_ENDSTOP_NOTHIT c=20 r=1
-#: ultralcd.cpp:7831
+#: ultralcd.cpp:7917
 msgid "Endstop not hit"
 msgstr "Butee non atteinte"
 
 # MSG_SELFTEST_ENDSTOP
-#: ultralcd.cpp:7825
+#: ultralcd.cpp:7911
 msgid "Endstop"
 msgstr "Butee"
 
 # MSG_SELFTEST_ENDSTOPS
-#: ultralcd.cpp:7813
+#: ultralcd.cpp:7899
 msgid "Endstops"
 msgstr "Butees"
 
 # MSG_STACK_ERROR c=20 r=4
-#: ultralcd.cpp:6773
+#: ultralcd.cpp:6859
 msgid "Error - static memory has been overwritten"
 msgstr "Erreur - la memoire statique a ete ecrasee"
 
 # MSG_FSENS_NOT_RESPONDING c=20 r=4
-#: ultralcd.cpp:4391
+#: ultralcd.cpp:4475
 msgid "ERROR: Filament sensor is not responding, please check connection."
-msgstr "ERREUR : Le capteur de filament ne repond pas, verifiez le branchement."
+msgstr "ERREUR: Le capteur de filament ne repond pas, verifiez le branchement."
 
 # MSG_ERROR
 #: messages.c:28
 msgid "ERROR:"
-msgstr "ERREUR :"
+msgstr "ERREUR:"
 
 # MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
-#: ultralcd.cpp:8218
+#: ultralcd.cpp:8304
 msgid "Extruder fan:"
 msgstr "Ventilo extrudeur:"
 
 # MSG_INFO_EXTRUDER c=15 r=1
-#: ultralcd.cpp:2133
+#: ultralcd.cpp:2244
 msgid "Extruder info"
 msgstr "Infos extrudeur"
 
@@ -351,49 +351,49 @@ msgid "Extruder"
 msgstr "Extrudeur"
 
 # 
-#: ultralcd.cpp:6760
+#: ultralcd.cpp:6846
 msgid "Fail stats MMU"
-msgstr "Stat. echecs MMU"
+msgstr "Stat. d'echec MMU"
 
 # MSG_FSENS_AUTOLOAD_ON c=17 r=1
-#: ultralcd.cpp:5082
+#: ultralcd.cpp:5168
 msgid "F. autoload  [on]"
-msgstr "ChargAuto f. [on]"
+msgstr "Autochargeur [on]"
 
 # MSG_FSENS_AUTOLOAD_NA c=17 r=1
 #: messages.c:43
 msgid "F. autoload [N/A]"
-msgstr "AutoCharg F [N/A]"
+msgstr "Autochargeur[N/A]"
 
 # MSG_FSENS_AUTOLOAD_OFF c=17 r=1
-#: ultralcd.cpp:5084
+#: ultralcd.cpp:5170
 msgid "F. autoload [off]"
-msgstr "AutoCharg F [off]"
+msgstr "Autochargeur[off]"
 
 # 
-#: ultralcd.cpp:6757
+#: ultralcd.cpp:6843
 msgid "Fail stats"
-msgstr "Statist. d'echec"
+msgstr "Stat. d'echec"
 
 # MSG_FAN_SPEED c=14
 #: messages.c:31
 msgid "Fan speed"
-msgstr "Vitesse ventil"
+msgstr "Vitesse vent."
 
 # MSG_SELFTEST_FAN c=20
 #: messages.c:78
 msgid "Fan test"
-msgstr "Test ventilateur"
+msgstr "Test du ventilateur"
 
 # MSG_FANS_CHECK_ON c=17 r=1
-#: ultralcd.cpp:5577
+#: ultralcd.cpp:5663
 msgid "Fans check   [on]"
-msgstr "Verif ventilo[on]"
+msgstr "Verif vent.  [on]"
 
 # MSG_FANS_CHECK_OFF c=17 r=1
-#: ultralcd.cpp:5579
+#: ultralcd.cpp:5665
 msgid "Fans check  [off]"
-msgstr "Verif venti [off]"
+msgstr "Verif vent. [off]"
 
 # MSG_FSENSOR_ON
 #: messages.c:45
@@ -401,9 +401,9 @@ msgid "Fil. sensor  [on]"
 msgstr "Capteur Fil. [on]"
 
 # MSG_FSENSOR_NA
-#: ultralcd.cpp:5062
+#: ultralcd.cpp:5148
 msgid "Fil. sensor [N/A]"
-msgstr "Capteur Fil. [N/A]"
+msgstr "Capteur Fil.[N/A]"
 
 # MSG_FSENSOR_OFF
 #: messages.c:44
@@ -411,17 +411,17 @@ msgid "Fil. sensor [off]"
 msgstr "Capteur Fil.[off]"
 
 # 
-#: ultralcd.cpp:1876
+#: ultralcd.cpp:1852
 msgid "Filam. runouts"
 msgstr "Fins de filament"
 
 # MSG_FILAMENT_CLEAN c=20 r=2
 #: messages.c:32
 msgid "Filament extruding & with correct color?"
-msgstr "Filament extrude et avec bonne couleur ?"
+msgstr "Filament extrude et avec bonne couleur?"
 
 # MSG_NOT_LOADED c=19
-#: ultralcd.cpp:2672
+#: ultralcd.cpp:2714
 msgid "Filament not loaded"
 msgstr "Filament non charge"
 
@@ -431,24 +431,24 @@ msgid "Filament sensor"
 msgstr "Capteur de filament"
 
 # MSG_FILAMENT_USED c=19 r=1
-#: ultralcd.cpp:2841
+#: ultralcd.cpp:2885
 msgid "Filament used"
 msgstr "Filament utilise"
 
 # MSG_PRINT_TIME c=19 r=1
-#: ultralcd.cpp:2841
+#: ultralcd.cpp:2886
 msgid "Print time"
 msgstr "Temps d'impression"
 
 # MSG_FILE_INCOMPLETE c=20 r=2
-#: ultralcd.cpp:8346
+#: ultralcd.cpp:8432
 msgid "File incomplete. Continue anyway?"
-msgstr "Fichier incomplet. Continuer qd meme ?"
+msgstr "Fichier incomplet. Continuer qd meme?"
 
 # MSG_FINISHING_MOVEMENTS c=20 r=1
 #: messages.c:40
 msgid "Finishing movements"
-msgstr "Mouvements de fin"
+msgstr "Mouvement final"
 
 # MSG_V2_CALIBRATION c=17 r=1
 #: messages.c:105
@@ -456,49 +456,49 @@ msgid "First layer cal."
 msgstr "Cal. 1ere couche"
 
 # MSG_WIZARD_SELFTEST c=20 r=8
-#: ultralcd.cpp:4896
+#: ultralcd.cpp:4982
 msgid "First, I will run the selftest to check most common assembly problems."
-msgstr "D'abord, je vais lancer le Selftest pour verifier les problemes d'assemblage les plus communs."
+msgstr "D'abord, je vais lancer le Auto-test pour verifier les problemes d'assemblage les plus communs."
 
 # 
 #: mmu.cpp:724
 msgid "Fix the issue and then press button on MMU unit."
-msgstr "Corrigez le probleme et appuyez sur le bouton de l'unite MMU."
+msgstr "Corrigez le probleme et appuyez sur le bouton sur la MMU."
 
 # MSG_FLOW
-#: ultralcd.cpp:6846
+#: ultralcd.cpp:6932
 msgid "Flow"
 msgstr "Flux"
 
 # MSG_PRUSA3D_FORUM
-#: ultralcd.cpp:2095
+#: ultralcd.cpp:2206
 msgid "forum.prusa3d.com"
 msgstr ""
 
 # MSG_SELFTEST_COOLING_FAN c=20
 #: messages.c:75
 msgid "Front print fan?"
-msgstr "Ventilo impr avant ?"
+msgstr "Ventilo impr avant?"
 
 # MSG_BED_CORRECTION_FRONT c=14 r=1
-#: ultralcd.cpp:3220
+#: ultralcd.cpp:3294
 msgid "Front side[um]"
 msgstr "Avant [um]"
 
 # MSG_SELFTEST_FANS
-#: ultralcd.cpp:7871
+#: ultralcd.cpp:7957
 msgid "Front/left fans"
 msgstr "Ventilos avt/gauche"
 
 # MSG_SELFTEST_HEATERTHERMISTOR
-#: ultralcd.cpp:7801
+#: ultralcd.cpp:7887
 msgid "Heater/Thermistor"
 msgstr "Chauffage/Thermistor"
 
 # MSG_BED_HEATING_SAFETY_DISABLED
-#: Marlin_main.cpp:8468
+#: Marlin_main.cpp:8467
 msgid "Heating disabled by safety timer."
-msgstr "Chauffe desactivee par le compteur de securite."
+msgstr "Chauffage desactivee par le compteur de securite."
 
 # MSG_HEATING_COMPLETE c=20
 #: messages.c:47
@@ -511,12 +511,12 @@ msgid "Heating"
 msgstr "Chauffe"
 
 # MSG_WIZARD_WELCOME c=20 r=7
-#: ultralcd.cpp:4875
+#: ultralcd.cpp:4961
 msgid "Hi, I am your Original Prusa i3 printer. Would you like me to guide you through the setup process?"
-msgstr "Bonjour, je suis votre imprimante Original Prusa i3. Voulez-vous que je vous guide a travers le processus d'installation ?"
+msgstr "Bonjour, je suis votre imprimante Original Prusa i3. Voulez-vous que je vous guide a travers le processus d'installation?"
 
 # MSG_PRUSA3D_HOWTO
-#: ultralcd.cpp:2096
+#: ultralcd.cpp:2207
 msgid "howto.prusa3d.com"
 msgstr ""
 
@@ -526,12 +526,12 @@ msgid "Change filament"
 msgstr "Changer filament"
 
 # MSG_CHANGE_SUCCESS
-#: ultralcd.cpp:2587
+#: ultralcd.cpp:2629
 msgid "Change success!"
 msgstr "Changement reussi!"
 
 # MSG_CORRECTLY c=20
-#: ultralcd.cpp:2664
+#: ultralcd.cpp:2706
 msgid "Changed correctly?"
 msgstr "Change correctement?"
 
@@ -541,14 +541,14 @@ msgid "Checking bed     "
 msgstr "Verification du lit"
 
 # MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ultralcd.cpp:8200
+#: ultralcd.cpp:8286
 msgid "Checking endstops"
-msgstr "Verifications butees"
+msgstr "Verification butees"
 
 # MSG_SELFTEST_CHECK_HOTEND c=20
-#: ultralcd.cpp:8206
+#: ultralcd.cpp:8292
 msgid "Checking hotend  "
-msgstr "Verif. tete impr."
+msgstr "Verif. du hotend"
 
 # MSG_SELFTEST_CHECK_FSENSOR c=20
 #: messages.c:82
@@ -556,29 +556,29 @@ msgid "Checking sensors "
 msgstr "Verif. des capteurs"
 
 # MSG_SELFTEST_CHECK_X c=20
-#: ultralcd.cpp:8201
+#: ultralcd.cpp:8287
 msgid "Checking X axis  "
 msgstr "Verification axe X"
 
 # MSG_SELFTEST_CHECK_Y c=20
-#: ultralcd.cpp:8202
+#: ultralcd.cpp:8288
 msgid "Checking Y axis  "
 msgstr "Verification axe Y"
 
 # MSG_SELFTEST_CHECK_Z c=20
-#: ultralcd.cpp:8203
+#: ultralcd.cpp:8289
 msgid "Checking Z axis  "
 msgstr "Verification axe Z"
 
 # MSG_CHOOSE_EXTRUDER c=20 r=1
 #: messages.c:49
 msgid "Choose extruder:"
-msgstr "Choisir extrudeur :"
+msgstr "Choisir extrudeur:"
 
 # MSG_CHOOSE_FILAMENT c=20 r=1
 #: messages.c:50
 msgid "Choose filament:"
-msgstr "Choix du filament :"
+msgstr "Choix du filament:"
 
 # MSG_FILAMENT c=17 r=1
 #: messages.c:30
@@ -586,17 +586,17 @@ msgid "Filament"
 msgstr ""
 
 # MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ultralcd.cpp:4905
+#: ultralcd.cpp:4991
 msgid "I will run xyz calibration now. It will take approx. 12 mins."
-msgstr "Je vais maintenant lancer la calibration xyz. Cela prendra 12 min environ."
+msgstr "Je vais maintenant lancer la calibration XYZ. Cela prendra 12 min environ."
 
 # MSG_WIZARD_Z_CAL c=20 r=8
-#: ultralcd.cpp:4913
+#: ultralcd.cpp:4999
 msgid "I will run z calibration now."
-msgstr "Je vais maintenant lancer la calibration z."
+msgstr "Je vais maintenant lancer la calibration Z."
 
 # MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ultralcd.cpp:4978
+#: ultralcd.cpp:5064
 msgid "I will start to print line and you will gradually lower the nozzle by rotating the knob, until you reach optimal height. Check the pictures in our handbook in chapter Calibration."
 msgstr "Je vais commencer a imprimer une ligne et vous baisserez au fur et a mesure la buse en tournant le bouton jusqu'a atteindre la hauteur optimale. Regardez les photos dans notre manuel au chapitre Calibration"
 
@@ -606,44 +606,44 @@ msgid "Info screen"
 msgstr "Ecran d'info"
 
 # 
-#: ultralcd.cpp:4938
+#: ultralcd.cpp:5024
 msgid "Is filament 1 loaded?"
-msgstr "Le filament 1 est-il charge ?"
+msgstr "Fil.1 est-il charge?"
 
 # MSG_INSERT_FILAMENT c=20
-#: ultralcd.cpp:2572
+#: ultralcd.cpp:2614
 msgid "Insert filament"
 msgstr "Inserez le filament"
 
 # MSG_WIZARD_FILAMENT_LOADED c=20 r=2
-#: ultralcd.cpp:4941
+#: ultralcd.cpp:5027
 msgid "Is filament loaded?"
-msgstr "Le filament est-il charge ?"
+msgstr "Fil. est-il charge?"
 
 # MSG_WIZARD_PLA_FILAMENT c=20 r=2
-#: ultralcd.cpp:4972
+#: ultralcd.cpp:5058
 msgid "Is it PLA filament?"
-msgstr "Est-ce du filament PLA ?"
+msgstr "Est-ce du filament PLA?"
 
 # MSG_PLA_FILAMENT_LOADED c=20 r=2
-#: ultralcd.cpp:4704
+#: ultralcd.cpp:4790
 msgid "Is PLA filament loaded?"
-msgstr "Le filament PLA est-il charge ?"
+msgstr "Fil. PLA est-il charge?"
 
 # MSG_STEEL_SHEET_CHECK c=20 r=2
 #: messages.c:92
 msgid "Is steel sheet on heatbed?"
-msgstr "Feuille d'acier sur plateau chauffant ?"
+msgstr "Plaque d'impression sur le lit chauffant?"
 
 # 
-#: ultralcd.cpp:1840
+#: ultralcd.cpp:1795
 msgid "Last print failures"
-msgstr "Echecs derniere impr"
+msgstr "Echecs derniere imp."
 
 # 
-#: ultralcd.cpp:1823
+#: ultralcd.cpp:1772
 msgid "Last print"
-msgstr "Derniere impression"
+msgstr "Derniere impres."
 
 # MSG_SELFTEST_EXTRUDER_FAN c=20
 #: messages.c:76
@@ -651,24 +651,24 @@ msgid "Left hotend fan?"
 msgstr "Ventilo tete gauche?"
 
 # 
-#: ultralcd.cpp:2970
+#: ultralcd.cpp:3018
 msgid "Left"
 msgstr "Gauche"
 
 # MSG_BED_CORRECTION_LEFT c=14 r=1
-#: ultralcd.cpp:3218
+#: ultralcd.cpp:3292
 msgid "Left side [um]"
 msgstr "Gauche [um]"
 
 # 
-#: ultralcd.cpp:5594
+#: ultralcd.cpp:5680
 msgid "Lin. correction"
 msgstr "Correction lin."
 
 # MSG_BABYSTEP_Z
 #: messages.c:13
 msgid "Live adjust Z"
-msgstr "Ajuster Z en direct"
+msgstr "Ajuster Z en dir."
 
 # MSG_LOAD_FILAMENT c=17
 #: messages.c:51
@@ -676,24 +676,24 @@ msgid "Load filament"
 msgstr "Charger filament"
 
 # MSG_LOADING_COLOR
-#: ultralcd.cpp:2612
+#: ultralcd.cpp:2654
 msgid "Loading color"
-msgstr "Chargement couleur"
+msgstr "Charg. de la couleur"
 
 # MSG_LOADING_FILAMENT c=20
 #: messages.c:52
 msgid "Loading filament"
-msgstr "Chargement filament"
+msgstr "Chargement du fil."
 
 # MSG_LOOSE_PULLEY c=20 r=1
-#: ultralcd.cpp:7855
+#: ultralcd.cpp:7941
 msgid "Loose pulley"
 msgstr "Poulie lache"
 
 # 
-#: ultralcd.cpp:6719
+#: ultralcd.cpp:6805
 msgid "Load to nozzle"
-msgstr "Charger dans la buse"
+msgstr "Charger la buse"
 
 # MSG_M117_V2_CALIBRATION c=25 r=1
 #: messages.c:55
@@ -703,7 +703,7 @@ msgstr "M117 Cal. 1ere couche"
 # MSG_MAIN
 #: messages.c:56
 msgid "Main"
-msgstr "Principal"
+msgstr "Menu principal"
 
 # MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=60
 #: messages.c:59
@@ -711,7 +711,7 @@ msgid "Measuring reference height of calibration point"
 msgstr "Mesure de la hauteur de reference du point de calibration"
 
 # MSG_MESH_BED_LEVELING
-#: ultralcd.cpp:5677
+#: ultralcd.cpp:5763
 msgid "Mesh Bed Leveling"
 msgstr ""
 
@@ -723,17 +723,17 @@ msgstr "MMU OK. Reprise de la position ..."
 # MSG_MMU_OK_RESUMING_TEMPERATURE c=20 r=4
 #: mmu.cpp:755
 msgid "MMU OK. Resuming temperature..."
-msgstr "MMU OK. Remontee en temperature..."
+msgstr "MMU OK. Rechauffage de la buse..."
 
 # 
-#: ultralcd.cpp:3005
+#: ultralcd.cpp:3059
 msgid "Measured skew"
-msgstr "Deviation mesuree"
+msgstr "Deviat.mesuree"
 
 # 
-#: ultralcd.cpp:1840
+#: ultralcd.cpp:1796
 msgid "MMU fails"
-msgstr "Echec MMU"
+msgstr "Echecs MMU"
 
 # 
 #: mmu.cpp:1613
@@ -741,7 +741,7 @@ msgid "MMU load failed     "
 msgstr "Echec chargement MMU"
 
 # 
-#: ultralcd.cpp:1840
+#: ultralcd.cpp:1797
 msgid "MMU load fails"
 msgstr "Echecs charg. MMU"
 
@@ -758,7 +758,7 @@ msgstr ""
 # MSG_SILENT_MODE_ON
 #: messages.c:89
 msgid "Mode     [silent]"
-msgstr "Mode [silencieux]"
+msgstr "Mode     [feutre]"
 
 # 
 #: mmu.cpp:719
@@ -766,14 +766,14 @@ msgid "MMU needs user attention."
 msgstr "Le MMU necessite l'attention de l'utilisateur."
 
 # 
-#: ultralcd.cpp:1857
+#: ultralcd.cpp:1823
 msgid "MMU power fails"
 msgstr "Echecs alim. MMU"
 
 # MSG_STEALTH_MODE_ON
 #: messages.c:91
 msgid "Mode    [Stealth]"
-msgstr "Mode [Furtif]"
+msgstr "Mode     [furtif]"
 
 # MSG_AUTO_MODE_ON
 #: messages.c:12
@@ -783,10 +783,10 @@ msgstr "Mode [puiss.auto]"
 # MSG_SILENT_MODE_OFF
 #: messages.c:88
 msgid "Mode [high power]"
-msgstr "Mode [haute puiss]"
+msgstr "Mode[haute puiss]"
 
 # 
-#: ultralcd.cpp:2108
+#: ultralcd.cpp:2219
 msgid "MMU2 connected"
 msgstr "MMU2 connecte"
 
@@ -796,37 +796,37 @@ msgid "Motor"
 msgstr "Moteur"
 
 # MSG_MOVE_AXIS
-#: ultralcd.cpp:5566
+#: ultralcd.cpp:5652
 msgid "Move axis"
 msgstr "Deplacer l'axe"
 
 # MSG_MOVE_X
-#: ultralcd.cpp:4294
+#: ultralcd.cpp:4378
 msgid "Move X"
 msgstr "Deplacer X"
 
 # MSG_MOVE_Y
-#: ultralcd.cpp:4295
+#: ultralcd.cpp:4379
 msgid "Move Y"
 msgstr "Deplacer Y"
 
 # MSG_MOVE_Z
-#: ultralcd.cpp:4296
+#: ultralcd.cpp:4380
 msgid "Move Z"
 msgstr "Deplacer Z"
 
 # MSG_NO_MOVE
-#: Marlin_main.cpp:5291
+#: Marlin_main.cpp:5292
 msgid "No move."
 msgstr "Pas de mouvement."
 
 # MSG_NO_CARD
-#: ultralcd.cpp:6686
+#: ultralcd.cpp:6772
 msgid "No SD card"
 msgstr "Pas de carte SD"
 
 # 
-#: ultralcd.cpp:2976
+#: ultralcd.cpp:3024
 msgid "N/A"
 msgstr ""
 
@@ -836,7 +836,7 @@ msgid "No"
 msgstr "Non"
 
 # MSG_SELFTEST_NOTCONNECTED
-#: ultralcd.cpp:7803
+#: ultralcd.cpp:7889
 msgid "Not connected"
 msgstr "Non connecte"
 
@@ -851,12 +851,12 @@ msgid "Not spinning"
 msgstr "Ne tourne pas"
 
 # MSG_WIZARD_V2_CAL c=20 r=8
-#: ultralcd.cpp:4977
+#: ultralcd.cpp:5063
 msgid "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr "Maintenant je vais calibrer la distance entre la pointe de la buse et la surface du plateau chauffant."
 
 # MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ultralcd.cpp:4921
+#: ultralcd.cpp:5007
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Maintenant je vais prechauffer la buse pour du PLA."
 
@@ -871,37 +871,37 @@ msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr "Anciens reglages trouves. Le PID, les Esteps etc. par defaut seront regles"
 
 # 
-#: ultralcd.cpp:4912
+#: ultralcd.cpp:4998
 msgid "Now remove the test print from steel sheet."
-msgstr "Retirez maintenant l'impression de test de la feuille d'acier."
+msgstr "Retirez maintenant l'impression de test de la plaque en acier."
 
 # 
-#: ultralcd.cpp:1782
+#: ultralcd.cpp:1722
 msgid "Nozzle FAN"
-msgstr "Ventilateur buse"
+msgstr "Vent. buse"
 
 # MSG_PAUSE_PRINT
-#: ultralcd.cpp:6649
+#: ultralcd.cpp:6735
 msgid "Pause print"
 msgstr "Pause de l'impr."
 
 # MSG_PID_RUNNING c=20 r=1
-#: ultralcd.cpp:1598
+#: ultralcd.cpp:1606
 msgid "PID cal.           "
 msgstr "Calib. PID"
 
 # MSG_PID_FINISHED c=20 r=1
-#: ultralcd.cpp:1604
+#: ultralcd.cpp:1612
 msgid "PID cal. finished"
 msgstr "Calib. PID terminee"
 
 # MSG_PID_EXTRUDER c=17 r=1
-#: ultralcd.cpp:5683
+#: ultralcd.cpp:5769
 msgid "PID calibration"
 msgstr "Calibration PID"
 
 # MSG_PINDA_PREHEAT c=20 r=1
-#: ultralcd.cpp:843
+#: ultralcd.cpp:846
 msgid "PINDA Heating"
 msgstr "Chauffe de la PINDA"
 
@@ -911,9 +911,9 @@ msgid "Place a sheet of paper under the nozzle during the calibration of first 4
 msgstr "Placez une feuille de papier sous la buse pendant la calibration des 4 premiers points. Si la buse accroche le papier, eteignez vite l'imprimante."
 
 # MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ultralcd.cpp:4986
+#: ultralcd.cpp:5072
 msgid "Please clean heatbed and then press the knob."
-msgstr "Nettoyez le plateau chauffant et appuyez sur le bouton."
+msgstr "Nettoyez la plaque en acier et appuyez sur le bouton."
 
 # MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
 #: messages.c:22
@@ -921,34 +921,34 @@ msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Nettoyez la buse pour la calibration. Cliquez une fois fait."
 
 # MSG_SELFTEST_PLEASECHECK
-#: ultralcd.cpp:7795
+#: ultralcd.cpp:7881
 msgid "Please check :"
-msgstr "Verifiez :"
+msgstr "Verifiez:"
 
 # MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
 #: messages.c:100
 msgid "Please check our handbook and fix the problem. Then resume the Wizard by rebooting the printer."
-msgstr "Merci de verifier notre manuel et de corriger le probleme. Poursuivez alors l'assistant en redemarrant l'imprimante."
+msgstr "Merci de consulter notre manuel et de corriger le probleme. Poursuivez alors l'assistant en redemarrant l'imprimante."
 
 # MSG_WIZARD_LOAD_FILAMENT c=20 r=8
-#: ultralcd.cpp:4808
+#: ultralcd.cpp:4894
 msgid "Please insert PLA filament to the extruder, then press knob to load it."
 msgstr "Inserez du filament PLA dans l'extrudeur puis appuyez sur le bouton pour le charger."
 
 # MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ultralcd.cpp:4709
+#: ultralcd.cpp:4795
 msgid "Please load PLA filament first."
 msgstr "Chargez d'abord le filament PLA."
 
 # MSG_CHECK_IDLER c=20 r=4
-#: Marlin_main.cpp:3063
+#: Marlin_main.cpp:3064
 msgid "Please open idler and remove filament manually."
 msgstr "Ouvrez l'idler et retirez le filament manuellement."
 
 # MSG_PLACE_STEEL_SHEET c=20 r=4
 #: messages.c:65
 msgid "Please place steel sheet on heatbed."
-msgstr "Placez la feuille d'acier sur le plateau chauffant."
+msgstr "Placez la plaque en acier sur le plateau chauffant."
 
 # MSG_PRESS_TO_UNLOAD c=20 r=4
 #: messages.c:68
@@ -956,9 +956,9 @@ msgid "Please press the knob to unload filament"
 msgstr "Appuyez sur le bouton pour decharger le filament"
 
 # 
-#: ultralcd.cpp:4803
+#: ultralcd.cpp:4889
 msgid "Please insert PLA filament to the first tube of MMU, then press the knob to load it."
-msgstr "Veuillez inserer du filament PLA dans le premier tube du MMU, et pressez sur le bouton pour le charger."
+msgstr "Inserez du PLA dans le 1er tube du MMU, appuyez sur le bouton pour le charger."
 
 # MSG_PULL_OUT_FILAMENT c=20 r=4
 #: messages.c:70
@@ -973,10 +973,10 @@ msgstr "Veuillez retirer le filament puis appuyez sur le bouton."
 # MSG_REMOVE_STEEL_SHEET c=20 r=4
 #: messages.c:74
 msgid "Please remove steel sheet from heatbed."
-msgstr "Retirez la feuille d'acier du plateau chauffant."
+msgstr "Retirez la plaque en acier du plateau chauffant."
 
 # MSG_RUN_XYZ c=20 r=4
-#: Marlin_main.cpp:4354
+#: Marlin_main.cpp:4355
 msgid "Please run XYZ calibration first."
 msgstr "Veuillez d'abord lancer la calibration XYZ."
 
@@ -991,9 +991,9 @@ msgid "Please wait"
 msgstr "Merci de patienter"
 
 # 
-#: ultralcd.cpp:4911
+#: ultralcd.cpp:4997
 msgid "Please remove shipping helpers first."
-msgstr "Veuillez retirer d'abord les protections d'envoi."
+msgstr "Retirez d'abord les protections de transport."
 
 # MSG_PREHEAT_NOZZLE c=20
 #: messages.c:67
@@ -1001,7 +1001,7 @@ msgid "Preheat the nozzle!"
 msgstr "Prechauffez la buse!"
 
 # MSG_PREHEAT
-#: ultralcd.cpp:6636
+#: ultralcd.cpp:6722
 msgid "Preheat"
 msgstr "Prechauffage"
 
@@ -1016,54 +1016,54 @@ msgid "Please upgrade."
 msgstr "Mettez a jour le FW."
 
 # MSG_PRESS_TO_PREHEAT c=20 r=4
-#: Marlin_main.cpp:10365
+#: Marlin_main.cpp:10364
 msgid "Press knob to preheat nozzle and continue."
 msgstr "Appuyez sur le bouton pour prechauffer la buse et continuer."
 
 # 
-#: ultralcd.cpp:1876
+#: ultralcd.cpp:1851
 msgid "Power failures"
-msgstr "Coupures de courant"
+msgstr "Coup.de courant"
 
 # MSG_PRINT_ABORTED c=20
 #: messages.c:69
 msgid "Print aborted"
 msgstr "Impression annulee"
 
-# 
-#: ultralcd.cpp:2276
+#  c=20 r=1
+#: ultralcd.cpp:2455
 msgid "Preheating to load"
 msgstr "Chauffe pour charger"
 
-# 
-#: ultralcd.cpp:2280
+#  c=20 r=1
+#: ultralcd.cpp:2459
 msgid "Preheating to unload"
-msgstr "Chauffe pr decharger"
+msgstr "Chauf.pour decharger"
 
 # MSG_SELFTEST_PRINT_FAN_SPEED c=18
-#: ultralcd.cpp:8221
+#: ultralcd.cpp:8307
 msgid "Print fan:"
-msgstr "Ventilo impr. :"
+msgstr "Vent. impr:"
 
 # MSG_CARD_MENU
 #: messages.c:21
 msgid "Print from SD"
-msgstr "Impr depuis la SD"
+msgstr "Impr. depuis la SD"
 
 # 
-#: ultralcd.cpp:2206
+#: ultralcd.cpp:2317
 msgid "Press the knob"
 msgstr "App. sur sur bouton"
 
 # MSG_PRINT_PAUSED c=20 r=1
-#: ultralcd.cpp:1061
+#: ultralcd.cpp:1069
 msgid "Print paused"
 msgstr "Impression en pause"
 
 # 
 #: mmu.cpp:723
 msgid "Press the knob to resume nozzle temperature."
-msgstr "Appuyez sur le bouton pour poursuivre la mise en temperature de la buse."
+msgstr "Appuyez sur le bouton pour rechauffer la buse."
 
 # MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
 #: messages.c:41
@@ -1071,22 +1071,22 @@ msgid "Printer has not been calibrated yet. Please follow the manual, chapter Fi
 msgstr "L'imprimante n'a pas encore ete calibree. Suivez le manuel, chapitre Premiers pas, section Processus de calibration."
 
 # 
-#: ultralcd.cpp:1784
+#: ultralcd.cpp:1723
 msgid "Print FAN"
-msgstr "Ventilo impression"
+msgstr "Vent. impr"
 
 # MSG_PRUSA3D
-#: ultralcd.cpp:2094
+#: ultralcd.cpp:2205
 msgid "prusa3d.com"
 msgstr ""
 
 # MSG_BED_CORRECTION_REAR c=14 r=1
-#: ultralcd.cpp:3221
+#: ultralcd.cpp:3295
 msgid "Rear side [um]"
 msgstr "Arriere [um]"
 
 # MSG_RECOVERING_PRINT c=20 r=1
-#: Marlin_main.cpp:9765
+#: Marlin_main.cpp:9764
 msgid "Recovering print    "
 msgstr "Recup. impression"
 
@@ -1101,17 +1101,17 @@ msgid "Prusa i3 MK3S OK."
 msgstr ""
 
 # MSG_CALIBRATE_BED_RESET
-#: ultralcd.cpp:5688
+#: ultralcd.cpp:5774
 msgid "Reset XYZ calibr."
-msgstr "Reinit. calibr. XYZ"
+msgstr "Reinit. calib. XYZ"
 
 # MSG_BED_CORRECTION_RESET
-#: ultralcd.cpp:3222
+#: ultralcd.cpp:3296
 msgid "Reset"
 msgstr "Reinitialiser"
 
 # MSG_RESUME_PRINT
-#: ultralcd.cpp:6656
+#: ultralcd.cpp:6742
 msgid "Resume print"
 msgstr "Reprendre impression"
 
@@ -1121,37 +1121,37 @@ msgid "Resuming print"
 msgstr "Reprise de l'impr."
 
 # MSG_BED_CORRECTION_RIGHT c=14 r=1
-#: ultralcd.cpp:3219
+#: ultralcd.cpp:3293
 msgid "Right side[um]"
 msgstr "Droite [um]"
 
 # MSG_SECOND_SERIAL_ON c=17 r=1
-#: ultralcd.cpp:5606
+#: ultralcd.cpp:5692
 msgid "RPi port     [on]"
-msgstr "Port RPi [on]"
+msgstr "Port RPi     [on]"
 
 # MSG_SECOND_SERIAL_OFF c=17 r=1
-#: ultralcd.cpp:5604
+#: ultralcd.cpp:5690
 msgid "RPi port    [off]"
-msgstr "Port RPi [off]"
+msgstr "Port RPi    [off]"
 
 # MSG_WIZARD_RERUN c=20 r=7
-#: ultralcd.cpp:4726
+#: ultralcd.cpp:4812
 msgid "Running Wizard will delete current calibration results and start from the beginning. Continue?"
-msgstr "Lancer l'Assistant supprimera les resultats actuels de calibration et commencera du debut. Continuer ?"
+msgstr "Lancement de l'Assistant supprimera les resultats actuels de calibration et commencera du debut. Continuer?"
 
 # MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_OFF c=19 r=1
-#: ultralcd.cpp:5236
+#: ultralcd.cpp:5322
 msgid "SD card  [normal]"
 msgstr "Carte SD [normal]"
 
 # MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_ON c=19 r=1
-#: ultralcd.cpp:5234
+#: ultralcd.cpp:5320
 msgid "SD card [flshAir]"
-msgstr "Carte SD [flashAir]"
+msgstr "CarteSD [flshAir]"
 
 # 
-#: ultralcd.cpp:2971
+#: ultralcd.cpp:3019
 msgid "Right"
 msgstr "Droite"
 
@@ -1161,29 +1161,29 @@ msgid "Searching bed calibration point"
 msgstr "Recherche du point de calibration du lit"
 
 # MSG_LANGUAGE_SELECT
-#: ultralcd.cpp:5613
+#: ultralcd.cpp:5699
 msgid "Select language"
 msgstr "Choisir langue"
 
 # MSG_SELFTEST_OK
-#: ultralcd.cpp:7366
+#: ultralcd.cpp:7452
 msgid "Self test OK"
 msgstr "Auto-test OK"
 
 # MSG_SELFTEST_START c=20
-#: ultralcd.cpp:7152
+#: ultralcd.cpp:7238
 msgid "Self test start  "
 msgstr "Debut auto-test"
 
 # MSG_SELFTEST
-#: ultralcd.cpp:5664
+#: ultralcd.cpp:5750
 msgid "Selftest         "
 msgstr "Auto-test"
 
 # MSG_SELFTEST_ERROR
-#: ultralcd.cpp:7793
+#: ultralcd.cpp:7879
 msgid "Selftest error !"
-msgstr "Erreur auto-test !"
+msgstr "Erreur auto-test!"
 
 # MSG_SELFTEST_FAILED c=20
 #: messages.c:77
@@ -1196,19 +1196,19 @@ msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr "Le Selftest sera lance pour calibrer la remise a zero precise sans capteur"
 
 # 
-#: ultralcd.cpp:4959
+#: ultralcd.cpp:5045
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr "Selectionnez la temperature de prechauffage de la buse qui correspond a votre materiau."
 
 # 
-#: ultralcd.cpp:4695
+#: ultralcd.cpp:4780
 msgid "Select PLA filament:"
-msgstr "Selectionnez le filament PLA :"
+msgstr "Selectionnez le fil. PLA:"
 
 # MSG_SET_TEMPERATURE c=19 r=1
-#: ultralcd.cpp:3230
+#: ultralcd.cpp:3314
 msgid "Set temperature:"
-msgstr "Regler temp. :"
+msgstr "Regler temp.:"
 
 # MSG_SETTINGS
 #: messages.c:86
@@ -1216,12 +1216,12 @@ msgid "Settings"
 msgstr "Reglages"
 
 # MSG_SHOW_END_STOPS c=17 r=1
-#: ultralcd.cpp:5685
+#: ultralcd.cpp:5771
 msgid "Show end stops"
 msgstr "Afficher butees"
 
 # 
-#: ultralcd.cpp:3941
+#: ultralcd.cpp:4025
 msgid "Sensor state"
 msgstr "Etat capteur"
 
@@ -1231,22 +1231,22 @@ msgid "Some files will not be sorted. Max. No. of files in 1 folder for sorting 
 msgstr "Certains fichiers ne seront pas tries. Max 100 fichiers tries par dossier."
 
 # MSG_SORT_NONE c=17 r=1
-#: ultralcd.cpp:5246
+#: ultralcd.cpp:5332
 msgid "Sort       [none]"
-msgstr "Tri :     [aucun]"
+msgstr "Tri       [aucun]"
 
 # MSG_SORT_TIME c=17 r=1
-#: ultralcd.cpp:5244
+#: ultralcd.cpp:5330
 msgid "Sort       [time]"
 msgstr "Tri       [heure]"
 
 # 
-#: ultralcd.cpp:3008
-msgid "Severe skew"
-msgstr "Deviation severe"
+#: ultralcd.cpp:3062
+msgid "Severe skew:"
+msgstr "Deviat.sev.:"
 
 # MSG_SORT_ALPHA c=17 r=1
-#: ultralcd.cpp:5245
+#: ultralcd.cpp:5331
 msgid "Sort   [alphabet]"
 msgstr "Tri    [alphabet]"
 
@@ -1258,35 +1258,35 @@ msgstr "Tri des fichiers"
 # MSG_SOUND_LOUD c=17 r=1
 #: sound.h:6
 msgid "Sound      [loud]"
-msgstr "Son [fort]"
+msgstr "Son        [fort]"
 
 # 
-#: ultralcd.cpp:3007
-msgid "Slight skew"
-msgstr "Deviation legere"
+#: ultralcd.cpp:3061
+msgid "Slight skew:"
+msgstr "Deviat.leg.:"
 
 # MSG_SOUND_MUTE c=17 r=1
 #: 
 msgid "Sound      [mute]"
-msgstr "Son [muet]"
+msgstr "Son        [muet]"
 
 # 
-#: Marlin_main.cpp:4870
+#: Marlin_main.cpp:4871
 msgid "Some problem encountered, Z-leveling enforced ..."
-msgstr "Problemes rencontres, nivellement de l'axe Z applique..."
+msgstr "Probleme rencontre, cliquez sur le bouton pour niveller l'axe Z..."
 
 # MSG_SOUND_ONCE c=17 r=1
 #: sound.h:7
 msgid "Sound      [once]"
-msgstr "Son [une fois]"
+msgstr "Son    [une fois]"
 
 # MSG_SOUND_SILENT c=17 r=1
 #: sound.h:8
 msgid "Sound    [silent]"
-msgstr "Son [silencieux]"
+msgstr "Son      [feutre]"
 
 # MSG_SPEED
-#: ultralcd.cpp:6840
+#: ultralcd.cpp:6926
 msgid "Speed"
 msgstr "Vitesse"
 
@@ -1296,12 +1296,12 @@ msgid "Spinning"
 msgstr "Tourne"
 
 # MSG_TEMP_CAL_WARNING c=20 r=4
-#: Marlin_main.cpp:4367
+#: Marlin_main.cpp:4368
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr "Une temperature ambiante stable de 21-26C et un support stable sont requis."
 
 # MSG_STATISTICS
-#: ultralcd.cpp:6753
+#: ultralcd.cpp:6839
 msgid "Statistics  "
 msgstr "Statistiques"
 
@@ -1316,12 +1316,12 @@ msgid "STOPPED. "
 msgstr "ARRETE."
 
 # MSG_SUPPORT
-#: ultralcd.cpp:6762
+#: ultralcd.cpp:6848
 msgid "Support"
 msgstr ""
 
 # MSG_SELFTEST_SWAPPED
-#: ultralcd.cpp:7873
+#: ultralcd.cpp:7959
 msgid "Swapped"
 msgstr "Echange"
 
@@ -1331,22 +1331,22 @@ msgid "Temp. cal.          "
 msgstr "Calib. Temp."
 
 # MSG_TEMP_CALIBRATION_ON c=20 r=1
-#: ultralcd.cpp:5600
+#: ultralcd.cpp:5686
 msgid "Temp. cal.   [on]"
 msgstr "Calib. Temp. [on]"
 
 # MSG_TEMP_CALIBRATION_OFF c=20 r=1
-#: ultralcd.cpp:5598
+#: ultralcd.cpp:5684
 msgid "Temp. cal.  [off]"
 msgstr "Calib. Temp.[off]"
 
 # MSG_CALIBRATION_PINDA_MENU c=17 r=1
-#: ultralcd.cpp:5694
+#: ultralcd.cpp:5780
 msgid "Temp. calibration"
 msgstr "Calibration temp."
 
 # MSG_TEMP_CAL_FAILED c=20 r=8
-#: ultralcd.cpp:3867
+#: ultralcd.cpp:3951
 msgid "Temperature calibration failed"
 msgstr "Echec de la calibration en temperature"
 
@@ -1356,52 +1356,52 @@ msgid "Temperature calibration is finished and active. Temp. calibration can be 
 msgstr "La calibration en temperature est terminee et activee. La calibration en temperature peut etre desactivee dans le menu Reglages-> Cal. Temp."
 
 # MSG_TEMPERATURE
-#: ultralcd.cpp:5564
+#: ultralcd.cpp:5650
 msgid "Temperature"
 msgstr ""
 
 # MSG_MENU_TEMPERATURES c=15 r=1
-#: ultralcd.cpp:2140
+#: ultralcd.cpp:2251
 msgid "Temperatures"
 msgstr ""
 
 # MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=4
 #: messages.c:42
 msgid "There is still a need to make Z calibration. Please follow the manual, chapter First steps, section Calibration flow."
-msgstr "Il y a encore besoin d'effectuer la calibration Z. Veuillez suivre le manuel, chapitre Premiers pas, section Processus de calibration."
+msgstr "Il faut toujours effectuer la Calibration Z. Veuillez suivre le manuel, chapitre Premiers pas, section Processus de calibration."
 
 # 
-#: ultralcd.cpp:2863
+#: ultralcd.cpp:2908
 msgid "Total filament"
 msgstr "Filament total"
 
 # 
-#: ultralcd.cpp:2863
+#: ultralcd.cpp:2908
 msgid "Total print time"
 msgstr "Temps total impr."
 
 # MSG_TUNE
-#: ultralcd.cpp:6633
+#: ultralcd.cpp:6719
 msgid "Tune"
 msgstr "Regler"
 
 # 
-#: ultralcd.cpp:4783
+#: ultralcd.cpp:4869
 msgid "Unload"
 msgstr "Decharger"
 
 # 
-#: ultralcd.cpp:1857
+#: ultralcd.cpp:1820
 msgid "Total failures"
 msgstr "Total des echecs"
 
 # 
-#: ultralcd.cpp:2213
+#: ultralcd.cpp:2324
 msgid "to load filament"
 msgstr "pour charger le fil."
 
 # 
-#: ultralcd.cpp:2217
+#: ultralcd.cpp:2328
 msgid "to unload filament"
 msgstr "pour decharger fil."
 
@@ -1416,64 +1416,64 @@ msgid "Unloading filament"
 msgstr "Dechargement fil."
 
 # 
-#: ultralcd.cpp:1824
+#: ultralcd.cpp:1773
 msgid "Total"
 msgstr ""
 
 # MSG_USED c=19 r=1
-#: ultralcd.cpp:5822
+#: ultralcd.cpp:5908
 msgid "Used during print"
 msgstr "Utilise pdt impr."
 
 # MSG_MENU_VOLTAGES c=15 r=1
-#: ultralcd.cpp:2143
+#: ultralcd.cpp:2254
 msgid "Voltages"
 msgstr "Tensions"
 
 # 
-#: ultralcd.cpp:2116
+#: ultralcd.cpp:2227
 msgid "unknown"
 msgstr "inconnu"
 
 # MSG_USERWAIT
-#: Marlin_main.cpp:5262
+#: Marlin_main.cpp:5263
 msgid "Wait for user..."
 msgstr "Attente utilisateur..."
 
 # MSG_WAITING_TEMP c=20 r=3
-#: ultralcd.cpp:3374
+#: ultralcd.cpp:3458
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Attente du refroidissement des buse et plateau"
 
 # MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ultralcd.cpp:3338
+#: ultralcd.cpp:3422
 msgid "Waiting for PINDA probe cooling"
 msgstr "Attente du refroidissement de la sonde PINDA"
 
 # 
-#: ultralcd.cpp:4782
+#: ultralcd.cpp:4868
 msgid "Use unload to remove filament 1 if it protrudes outside of the rear MMU tube. Use eject if it is hidden in tube."
-msgstr "Utilisez decharger pour retirer le filament 1 s'il depasse du  tube arriere du MMU. Utilisez ejecter s'il est cache dans le tube."
+msgstr "Utilisez Remonter le fil. pour retirer le filament 1 s'il depasse du tube arriere du MMU. Utilisez ejecter s'il est cache dans le tube."
 
 # MSG_CHANGED_BOTH c=20 r=4
 #: Marlin_main.cpp:1511
 msgid "Warning: both printer type and motherboard type changed."
-msgstr "Attention : Types d'imprimante et de carte mere modifies"
+msgstr "Attention: Types d'imprimante et de carte mere modifies"
 
 # MSG_CHANGED_MOTHERBOARD c=20 r=4
 #: Marlin_main.cpp:1503
 msgid "Warning: motherboard type changed."
-msgstr "Attention : Type de carte mere modifie."
+msgstr "Attention: Type de carte mere modifie."
 
 # MSG_CHANGED_PRINTER c=20 r=4
 #: Marlin_main.cpp:1507
 msgid "Warning: printer type changed."
-msgstr "Attention : Type d'imprimante modifie"
+msgstr "Attention: Type d'imprimante modifie"
 
 # MSG_UNLOAD_SUCCESSFUL c=20 r=2
-#: Marlin_main.cpp:3053
+#: Marlin_main.cpp:3054
 msgid "Was filament unload successful?"
-msgstr "Dechargement du filament reussi ?"
+msgstr "Dechargement du filament reussi?"
 
 # MSG_SELFTEST_WIRINGERROR
 #: messages.c:85
@@ -1481,12 +1481,12 @@ msgid "Wiring error"
 msgstr "Erreur de cablage"
 
 # MSG_WIZARD c=17 r=1
-#: ultralcd.cpp:5661
+#: ultralcd.cpp:5747
 msgid "Wizard"
 msgstr "Assistant"
 
 # MSG_XYZ_DETAILS c=19 r=1
-#: ultralcd.cpp:2132
+#: ultralcd.cpp:2243
 msgid "XYZ cal. details"
 msgstr "Details calib. XYZ"
 
@@ -1503,212 +1503,212 @@ msgstr "Oui"
 # MSG_WIZARD_QUIT c=20 r=8
 #: messages.c:103
 msgid "You can always resume the Wizard from Calibration -> Wizard."
-msgstr "Vous pouvez toujours relancer l'assistant dans Calibration-> Assistant."
+msgstr "Vous pouvez toujours relancer l'Assistant dans Calibration > Assistant."
 
 # MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ultralcd.cpp:3838
+#: ultralcd.cpp:3922
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr "Calibration XYZ OK. L'ecart sera corrige automatiquement."
 
 # MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ultralcd.cpp:3835
+#: ultralcd.cpp:3919
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
-msgstr "Calibration XYZ OK. Les axes X/Y sont legerement non perpendiculaires. Bon boulot !"
+msgstr "Calibration XYZ OK. Les axes X/Y sont legerement non perpendiculaires. Bon boulot!"
 
 # 
-#: ultralcd.cpp:5044
+#: ultralcd.cpp:5130
 msgid "X-correct:"
 msgstr "Correct-X:"
 
 # MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ultralcd.cpp:3832
+#: ultralcd.cpp:3916
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
-msgstr "Calibration XYZ OK. Les axes X/Y sont perpendiculaires. Felicitations !"
+msgstr "Calibration XYZ OK. Les axes X/Y sont perpendiculaires. Felicitations!"
 
 # MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ultralcd.cpp:3816
+#: ultralcd.cpp:3900
 msgid "XYZ calibration compromised. Front calibration points not reachable."
-msgstr "Calibration XYZ compromise. Les points de calibration avant ne sont pas atteignables."
+msgstr "Calibration XYZ compromise. Les points de calibration en avant ne sont pas atteignables."
 
 # MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ultralcd.cpp:3819
+#: ultralcd.cpp:3903
 msgid "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr "Calibration XYZ compromise. Le point de calibration avant droit n'est pas atteignable."
 
 # MSG_LOAD_ALL c=17
-#: ultralcd.cpp:6080
+#: ultralcd.cpp:6166
 msgid "Load all"
-msgstr "Tout charger"
+msgstr "Charger un par un"
 
 # 
-#: ultralcd.cpp:3798
+#: ultralcd.cpp:3882
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr "Echec calibration XYZ. Le point de calibration du plateau n'a pas ete trouve."
 
 # 
-#: ultralcd.cpp:3804
+#: ultralcd.cpp:3888
 msgid "XYZ calibration failed. Front calibration points not reachable."
-msgstr "Echec calibration XYZ. Les points de calibration avant ne sont pas atteignables."
+msgstr "Echec calibration XYZ. Les points de calibration en avant ne sont pas atteignables."
 
 # 
-#: ultralcd.cpp:3807
+#: ultralcd.cpp:3891
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr "Echec calibration XYZ. Le point de calibration avant droit n'est pas atteignable."
 
 # 
-#: ultralcd.cpp:2968
+#: ultralcd.cpp:3016
 msgid "Y distance from min"
 msgstr "Distance Y du min"
 
 # 
-#: ultralcd.cpp:5045
+#: ultralcd.cpp:5131
 msgid "Y-correct:"
 msgstr "Correct-Y:"
 
 # MSG_OFF
 #: menu.cpp:426
 msgid " [off]"
-msgstr ""
+msgstr " [off]"
 
 # 
 #: messages.c:57
 msgid "Back"
-msgstr ""
+msgstr "Retour"
 
 # 
-#: ultralcd.cpp:5553
+#: ultralcd.cpp:5639
 msgid "Checks"
-msgstr ""
+msgstr "Verifications"
 
 # 
-#: ultralcd.cpp:7887
+#: ultralcd.cpp:7973
 msgid "False triggering"
-msgstr ""
+msgstr "Faux declenchement"
 
 # 
-#: ultralcd.cpp:3946
+#: ultralcd.cpp:4030
 msgid "FINDA:"
-msgstr ""
+msgstr "FINDA:"
 
 # 
-#: ultralcd.cpp:5459
+#: ultralcd.cpp:5545
 msgid "Firmware   [none]"
-msgstr ""
+msgstr "Firmware [aucune]"
 
 # 
-#: ultralcd.cpp:5465
+#: ultralcd.cpp:5551
 msgid "Firmware [strict]"
-msgstr ""
+msgstr "Firmware[stricte]"
 
 # 
-#: ultralcd.cpp:5462
+#: ultralcd.cpp:5548
 msgid "Firmware   [warn]"
-msgstr ""
+msgstr "Firmware  [avert]"
 
 # 
 #: messages.c:87
 msgid "HW Setup"
-msgstr ""
+msgstr "Config HW"
 
 # 
-#: ultralcd.cpp:3950
+#: ultralcd.cpp:4034
 msgid "IR:"
-msgstr ""
+msgstr "IR:"
 
 # 
-#: ultralcd.cpp:6960
+#: ultralcd.cpp:7046
 msgid "Magnets comp.[N/A]"
-msgstr ""
+msgstr "Compens. aim.[N/A]"
 
 # 
-#: ultralcd.cpp:6958
+#: ultralcd.cpp:7044
 msgid "Magnets comp.[Off]"
-msgstr ""
+msgstr "Compens. aim.[off]"
 
 # 
-#: ultralcd.cpp:6957
+#: ultralcd.cpp:7043
 msgid "Magnets comp. [On]"
-msgstr ""
+msgstr "Compens. aim. [on]"
 
 # 
-#: ultralcd.cpp:6949
+#: ultralcd.cpp:7035
 msgid "Mesh         [3x3]"
 msgstr ""
 
 # 
-#: ultralcd.cpp:6950
+#: ultralcd.cpp:7036
 msgid "Mesh         [7x7]"
 msgstr ""
 
 # 
-#: ultralcd.cpp:5591
+#: ultralcd.cpp:5677
 msgid "Mesh bed leveling"
 msgstr ""
 
 # 
 #: Marlin_main.cpp:856
 msgid "MK3S firmware detected on MK3 printer"
-msgstr ""
+msgstr "Firmware MK3S detecte sur imprimante MK3"
 
 # 
-#: ultralcd.cpp:5220
+#: ultralcd.cpp:5306
 msgid "MMU Mode [Normal]"
-msgstr ""
+msgstr "Mode MMU [normal]"
 
 # 
-#: ultralcd.cpp:5221
+#: ultralcd.cpp:5307
 msgid "MMU Mode[Stealth]"
-msgstr ""
+msgstr "Mode MMU [feutre]"
 
 # 
-#: ultralcd.cpp:4427
+#: ultralcd.cpp:4511
 msgid "Mode change in progress ..."
-msgstr ""
+msgstr "Changement de mode en cours..."
 
 # 
-#: ultralcd.cpp:5420
+#: ultralcd.cpp:5506
 msgid "Model      [none]"
-msgstr ""
+msgstr "Modele   [aucune]"
 
 # 
-#: ultralcd.cpp:5426
+#: ultralcd.cpp:5512
 msgid "Model    [strict]"
-msgstr ""
+msgstr "Modele  [stricte]"
 
 # 
-#: ultralcd.cpp:5423
+#: ultralcd.cpp:5509
 msgid "Model      [warn]"
-msgstr ""
+msgstr "Modele    [avert]"
 
 # 
-#: ultralcd.cpp:5381
+#: ultralcd.cpp:5467
 msgid "Nozzle d.  [0.25]"
-msgstr ""
+msgstr "Diam. buse [0.25]"
 
 # 
-#: ultralcd.cpp:5384
+#: ultralcd.cpp:5470
 msgid "Nozzle d.  [0.40]"
-msgstr ""
+msgstr "Diam. buse [0.40]"
 
 # 
-#: ultralcd.cpp:5387
+#: ultralcd.cpp:5473
 msgid "Nozzle d.  [0.60]"
-msgstr ""
+msgstr "Diam. buse [0.60]"
 
 # 
-#: ultralcd.cpp:5335
+#: ultralcd.cpp:5421
 msgid "Nozzle     [none]"
-msgstr ""
+msgstr "Buse     [aucune]"
 
 # 
-#: ultralcd.cpp:5341
+#: ultralcd.cpp:5427
 msgid "Nozzle   [strict]"
-msgstr ""
+msgstr "Buse    [stricte]"
 
 # 
-#: ultralcd.cpp:5338
+#: ultralcd.cpp:5424
 msgid "Nozzle     [warn]"
-msgstr ""
+msgstr "Buse      [avert]"
 
 # 
 #: util.cpp:510
@@ -1723,85 +1723,95 @@ msgstr ""
 # 
 #: util.cpp:427
 msgid "G-code sliced for a different printer type. Continue?"
-msgstr ""
+msgstr "Le G-code a ete prepare pour une autre version de l'imprimante. Continuer?"
 
 # 
 #: util.cpp:433
 msgid "G-code sliced for a different printer type. Please re-slice the model again. Print cancelled."
-msgstr ""
+msgstr "Le G-code a ete prepare pour une autre version de l'imprimante. Veuillez decouper le modele a nouveau. L'impression a ete annulee."
 
 # 
 #: util.cpp:477
 msgid "G-code sliced for a newer firmware. Continue?"
-msgstr ""
+msgstr "Le G-code a ete prepare pour une version plus recente du firmware. Continuer?"
 
 # 
 #: util.cpp:483
 msgid "G-code sliced for a newer firmware. Please update the firmware. Print cancelled."
-msgstr ""
+msgstr "Le G-code a ete prepare pour une version plus recente du firmware. Veuillez mettre a jour le firmware. L'impression annulee."
 
 # 
-#: ultralcd.cpp:3942
+#: ultralcd.cpp:4026
 msgid "PINDA:"
-msgstr ""
+msgstr "PINDA:"
 
-# 
-#: ultralcd.cpp:2286
+#  c=20 r=1
+#: ultralcd.cpp:2465
 msgid "Preheating to cut"
-msgstr ""
+msgstr "Chauffe pour couper"
 
-# 
-#: ultralcd.cpp:2283
+#  c=20 r=1
+#: ultralcd.cpp:2462
 msgid "Preheating to eject"
-msgstr ""
+msgstr "Chauf. pour remonter"
 
 # 
 #: util.cpp:390
 msgid "Printer nozzle diameter differs from the G-code. Continue?"
-msgstr ""
+msgstr "Diametre de la buse dans les reglages ne correspond pas a celui dans le G-Code. Continuer?"
 
 # 
 #: util.cpp:397
 msgid "Printer nozzle diameter differs from the G-code. Please check the value in settings. Print cancelled."
-msgstr ""
+msgstr "Diametre de la buse dans les reglages ne correspond pas a celui dans le G-Code. Merci de verifier le parametre dans les reglages. Impression annulee."
 
 # 
-#: ultralcd.cpp:6597
+#: ultralcd.cpp:6683
 msgid "Rename"
-msgstr ""
+msgstr "Renommer"
 
 # 
-#: ultralcd.cpp:6593
+#: ultralcd.cpp:6679
 msgid "Select"
-msgstr ""
+msgstr "Selectionner"
 
 # 
-#: ultralcd.cpp:2134
+#: ultralcd.cpp:2245
 msgid "Sensor info"
-msgstr ""
+msgstr "Info capteur"
 
 # 
 #: messages.c:58
 msgid "Sheet"
-msgstr ""
+msgstr "Plaque"
 
 # 
-#: 
-msgid "Sound     [assist]"
-msgstr ""
+#: sound.h:9
+msgid "Sound    [assist]"
+msgstr "Son      [assist]"
 
 # 
-#: ultralcd.cpp:5551
+#: ultralcd.cpp:5637
 msgid "Steel sheets"
-msgstr ""
+msgstr "Plaques en acier"
 
 # 
-#: ultralcd.cpp:5046
+#: ultralcd.cpp:5132
 msgid "Z-correct:"
-msgstr ""
+msgstr "Correct-Z:"
 
 # 
-#: ultralcd.cpp:6952
+#: ultralcd.cpp:7038
 msgid "Z-probe nr.    [1]"
-msgstr ""
+msgstr "Mesurer x-fois [1]"
+
+# 
+#: ultralcd.cpp:7040
+msgid "Z-probe nr.    [3]"
+msgstr "Mesurer x-fois [3]"
+
+# 
+#: ultralcd.cpp:7039
+msgid "Z-probe nr.    [5]"
+msgstr "Mesurer x-fois [5]"
 

--- a/lang/po/Firmware_it.po
+++ b/lang/po/Firmware_it.po
@@ -7,8 +7,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: it\n"
 "Project-Id-Version: Prusa-Firmware\n"
-"POT-Creation-Date: Wed Sep 4 16:14:05 CEST 2019\n"
-"PO-Revision-Date: Wed Sep 4 16:14:05 CEST 2019\n"
+"POT-Creation-Date: Sun, Sep 22, 2019 2:07:29 PM\n"
+"PO-Revision-Date: Sun, Sep 22, 2019 2:07:29 PM\n"
 "Language-Team: \n"
 "X-Generator: Poedit 2.0.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
@@ -26,7 +26,7 @@ msgid " of 9"
 msgstr "su 9"
 
 # MSG_MEASURED_OFFSET
-#: ultralcd.cpp:3027
+#: ultralcd.cpp:3089
 msgid "[0;0] point offset"
 msgstr "[0;0] punto offset"
 
@@ -37,21 +37,21 @@ msgstr "Rilev. impatto\x0aattivabile solo\x0ain Modalita normale"
 
 # MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
 #: 
-msgid "WARNING:\x0aCrash detection disabled in Stealth mode"
+msgid "WARNING:\x0aCrash detection\x0adisabled in\x0aStealth mode"
 msgstr "ATTENZIONE:\x0aRilev. impatto\x0adisattivato in\x0aModalita silenziosa"
 
 # 
-#: ultralcd.cpp:2290
+#: ultralcd.cpp:2472
 msgid ">Cancel"
 msgstr ">Annulla"
 
 # MSG_BABYSTEPPING_Z c=15
-#: ultralcd.cpp:3147
+#: ultralcd.cpp:3209
 msgid "Adjusting Z:"
 msgstr "Compensaz. Z:"
 
 # MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ultralcd.cpp:8209
+#: ultralcd.cpp:8295
 msgid "All correct      "
 msgstr "Nessun errore"
 
@@ -61,32 +61,32 @@ msgid "All is done. Happy printing!"
 msgstr "Tutto fatto. Buona stampa!"
 
 # 
-#: ultralcd.cpp:1974
+#: ultralcd.cpp:2009
 msgid "Ambient"
 msgstr "Ambiente"
 
 # MSG_PRESS c=20
-#: ultralcd.cpp:2576
+#: ultralcd.cpp:2618
 msgid "and press the knob"
 msgstr "e cliccare manopola"
 
 # MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=2
-#: ultralcd.cpp:3445
+#: ultralcd.cpp:3529
 msgid "Are left and right Z~carriages all up?"
 msgstr "I carrelli Z sin/des sono altezza max?"
 
 # MSG_AUTO_DEPLETE_ON c=17 r=1
-#: ultralcd.cpp:5114
+#: ultralcd.cpp:5200
 msgid "SpoolJoin    [on]"
 msgstr ""
 
 # 
-#: ultralcd.cpp:5110
+#: ultralcd.cpp:5196
 msgid "SpoolJoin   [N/A]"
 msgstr ""
 
 # MSG_AUTO_DEPLETE_OFF c=17 r=1
-#: ultralcd.cpp:5118
+#: ultralcd.cpp:5204
 msgid "SpoolJoin   [off]"
 msgstr ""
 
@@ -96,32 +96,32 @@ msgid "Auto home"
 msgstr "Trova origine"
 
 # MSG_AUTOLOAD_FILAMENT c=17
-#: ultralcd.cpp:6736
+#: ultralcd.cpp:6822
 msgid "AutoLoad filament"
 msgstr "Autocaric. filam."
 
 # MSG_AUTOLOADING_ONLY_IF_FSENS_ON c=20 r=4
-#: ultralcd.cpp:4378
+#: ultralcd.cpp:4462
 msgid "Autoloading filament available only when filament sensor is turned on..."
 msgstr "Caricamento auto. filam. disp. solo con il sensore attivo..."
 
 # MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ultralcd.cpp:2771
+#: ultralcd.cpp:2813
 msgid "Autoloading filament is active, just press the knob and insert filament..."
-msgstr "Il caricamento automatico e attivo, premete la manopola e inserite il filamento..."
+msgstr "Caricamento automatico attivo, premi la manopola e inserisci il filamento."
 
 # MSG_SELFTEST_AXIS_LENGTH
-#: ultralcd.cpp:7863
+#: ultralcd.cpp:7949
 msgid "Axis length"
 msgstr "Lunghezza dell'asse"
 
 # MSG_SELFTEST_AXIS
-#: ultralcd.cpp:7865
+#: ultralcd.cpp:7951
 msgid "Axis"
 msgstr "Assi"
 
 # MSG_SELFTEST_BEDHEATER
-#: ultralcd.cpp:7807
+#: ultralcd.cpp:7893
 msgid "Bed / Heater"
 msgstr "Letto/Riscald."
 
@@ -136,7 +136,7 @@ msgid "Bed Heating"
 msgstr "Riscald. letto"
 
 # MSG_BED_CORRECTION_MENU
-#: ultralcd.cpp:5682
+#: ultralcd.cpp:5768
 msgid "Bed level correct"
 msgstr "Correz. liv.letto"
 
@@ -151,9 +151,9 @@ msgid "Bed"
 msgstr "Letto"
 
 # MSG_MENU_BELT_STATUS c=15 r=1
-#: ultralcd.cpp:2002
+#: ultralcd.cpp:2059
 msgid "Belt status"
-msgstr "Stato delle cinghie"
+msgstr "Stato cinghie"
 
 # MSG_RECOVER_PRINT c=20 r=2
 #: messages.c:71
@@ -161,12 +161,12 @@ msgid "Blackout occurred. Recover print?"
 msgstr "C'e stato un Blackout. Recuperare la stampa?"
 
 # 
-#: ultralcd.cpp:8211
+#: ultralcd.cpp:8297
 msgid "Calibrating home"
 msgstr "Calibrazione Home"
 
 # MSG_CALIBRATE_BED
-#: ultralcd.cpp:5671
+#: ultralcd.cpp:5757
 msgid "Calibrate XYZ"
 msgstr "Calibra XYZ"
 
@@ -176,12 +176,12 @@ msgid "Calibrate Z"
 msgstr "Calibra Z"
 
 # MSG_CALIBRATE_PINDA c=17 r=1
-#: ultralcd.cpp:4570
+#: ultralcd.cpp:4654
 msgid "Calibrate"
 msgstr "Calibra"
 
 # MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ultralcd.cpp:3408
+#: ultralcd.cpp:3492
 msgid "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end stoppers. Click when done."
 msgstr "Calibrazione XYZ. Ruotare la manopola per alzare il carrello Z fino all'altezza massima. Click per terminare."
 
@@ -191,12 +191,12 @@ msgid "Calibrating Z"
 msgstr "Calibrando Z"
 
 # MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ultralcd.cpp:3408
+#: ultralcd.cpp:3492
 msgid "Calibrating Z. Rotate the knob to move the Z carriage up to the end stoppers. Click when done."
 msgstr "Calibrazione Z. Ruotare la manopola per alzare il carrello Z fino all'altezza massima. Click per terminare."
 
 # MSG_HOMEYZ_DONE
-#: ultralcd.cpp:813
+#: ultralcd.cpp:816
 msgid "Calibration done"
 msgstr "Calibrazione completa"
 
@@ -206,17 +206,17 @@ msgid "Calibration"
 msgstr "Calibrazione"
 
 # 
-#: ultralcd.cpp:4695
+#: ultralcd.cpp:4781
 msgid "Cancel"
 msgstr "Annulla"
 
 # MSG_SD_REMOVED
-#: ultralcd.cpp:8578
+#: ultralcd.cpp:8679
 msgid "Card removed"
 msgstr "SD rimossa"
 
 # MSG_NOT_COLOR
-#: ultralcd.cpp:2676
+#: ultralcd.cpp:2718
 msgid "Color not correct"
 msgstr "Colore non puro"
 
@@ -226,24 +226,24 @@ msgid "Cooldown"
 msgstr "Raffredda"
 
 # 
-#: ultralcd.cpp:4503
+#: ultralcd.cpp:4587
 msgid "Copy selected language?"
 msgstr "Copiare la lingua selezionata?"
 
 # MSG_CRASHDETECT_ON
 #: messages.c:27
 msgid "Crash det.   [on]"
-msgstr "Rilevam.imp. [on]"
+msgstr "Rileva.crash [on]"
 
 # MSG_CRASHDETECT_NA
 #: messages.c:25
 msgid "Crash det.  [N/A]"
-msgstr "Rilevam.imp.[N/A]"
+msgstr "Rileva.crash[N/A]"
 
 # MSG_CRASHDETECT_OFF
 #: messages.c:26
 msgid "Crash det.  [off]"
-msgstr "Rilevam.imp.[off]"
+msgstr "Rileva.crash[off]"
 
 # MSG_CRASH_DETECTED c=20 r=1
 #: messages.c:24
@@ -256,22 +256,22 @@ msgid "Crash detected. Resume print?"
 msgstr "Scontro rilevato. Riprendere la stampa?"
 
 # 
-#: ultralcd.cpp:1876
+#: ultralcd.cpp:1853
 msgid "Crash"
 msgstr "Impatto"
 
 # MSG_CURRENT c=19 r=1
-#: ultralcd.cpp:5823
+#: ultralcd.cpp:5909
 msgid "Current"
 msgstr "Attuale"
 
 # MSG_DATE c=17 r=1
-#: ultralcd.cpp:2102
+#: ultralcd.cpp:2213
 msgid "Date:"
 msgstr "Data:"
 
 # MSG_DISABLE_STEPPERS
-#: ultralcd.cpp:5568
+#: ultralcd.cpp:5654
 msgid "Disable steppers"
 msgstr "Disabilita motori"
 
@@ -281,12 +281,12 @@ msgid "Distance between tip of the nozzle and the bed surface has not been set y
 msgstr "Distanza tra la punta dell'ugello e la superficie del letto non ancora imposta. Si prega di seguire il manuale, capitolo Primi Passi, sezione Calibrazione primo layer."
 
 # MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ultralcd.cpp:4984
+#: ultralcd.cpp:5070
 msgid "Do you want to repeat last step to readjust distance between nozzle and heatbed?"
 msgstr "Desideri ripetere l'ultimo passaggio per migliorare la distanza fra ugello e piatto?"
 
 # MSG_EXTRUDER_CORRECTION c=10
-#: ultralcd.cpp:5048
+#: ultralcd.cpp:5134
 msgid "E-correct:"
 msgstr "Correzione-E:"
 
@@ -296,7 +296,7 @@ msgid "Eject filament"
 msgstr "Espelli filamento "
 
 # 
-#: ultralcd.cpp:4783
+#: ultralcd.cpp:4869
 msgid "Eject"
 msgstr "Espellere"
 
@@ -306,27 +306,27 @@ msgid "Ejecting filament"
 msgstr "Espellendo filamento "
 
 # MSG_SELFTEST_ENDSTOP_NOTHIT c=20 r=1
-#: ultralcd.cpp:7831
+#: ultralcd.cpp:7917
 msgid "Endstop not hit"
 msgstr "Finecorsa fuori portata"
 
 # MSG_SELFTEST_ENDSTOP
-#: ultralcd.cpp:7825
+#: ultralcd.cpp:7911
 msgid "Endstop"
 msgstr "Finecorsa"
 
 # MSG_SELFTEST_ENDSTOPS
-#: ultralcd.cpp:7813
+#: ultralcd.cpp:7899
 msgid "Endstops"
 msgstr "Finecorsa"
 
 # MSG_STACK_ERROR c=20 r=4
-#: ultralcd.cpp:6773
+#: ultralcd.cpp:6859
 msgid "Error - static memory has been overwritten"
 msgstr "Errore - la memoria statica e stata sovrascritta"
 
 # MSG_FSENS_NOT_RESPONDING c=20 r=4
-#: ultralcd.cpp:4391
+#: ultralcd.cpp:4475
 msgid "ERROR: Filament sensor is not responding, please check connection."
 msgstr "ERRORE: il sensore filam. non risponde,Controllare conness."
 
@@ -336,12 +336,12 @@ msgid "ERROR:"
 msgstr "ERRORE:"
 
 # MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
-#: ultralcd.cpp:8218
+#: ultralcd.cpp:8304
 msgid "Extruder fan:"
-msgstr "Ventola estrusore:"
+msgstr "Ventola estr:"
 
 # MSG_INFO_EXTRUDER c=15 r=1
-#: ultralcd.cpp:2133
+#: ultralcd.cpp:2244
 msgid "Extruder info"
 msgstr "Info estrusore"
 
@@ -351,14 +351,14 @@ msgid "Extruder"
 msgstr "Estrusore"
 
 # 
-#: ultralcd.cpp:6760
+#: ultralcd.cpp:6846
 msgid "Fail stats MMU"
-msgstr "Statistiche fallimenti MMU"
+msgstr "Stat.fall. MMU"
 
 # MSG_FSENS_AUTOLOAD_ON c=17 r=1
-#: ultralcd.cpp:5082
+#: ultralcd.cpp:5168
 msgid "F. autoload  [on]"
-msgstr "Autocar.filam[on]"
+msgstr "Autocar.fil. [on]"
 
 # MSG_FSENS_AUTOLOAD_NA c=17 r=1
 #: messages.c:43
@@ -366,19 +366,19 @@ msgid "F. autoload [N/A]"
 msgstr "Autocar.fil.[N/A]"
 
 # MSG_FSENS_AUTOLOAD_OFF c=17 r=1
-#: ultralcd.cpp:5084
+#: ultralcd.cpp:5170
 msgid "F. autoload [off]"
 msgstr "Autocar.fil.[off]"
 
 # 
-#: ultralcd.cpp:6757
+#: ultralcd.cpp:6843
 msgid "Fail stats"
-msgstr "Statistiche fallimenti"
+msgstr "Stat. fallimenti"
 
 # MSG_FAN_SPEED c=14
 #: messages.c:31
 msgid "Fan speed"
-msgstr "Velocita ventola"
+msgstr "Velocita vent."
 
 # MSG_SELFTEST_FAN c=20
 #: messages.c:78
@@ -386,32 +386,32 @@ msgid "Fan test"
 msgstr "Test ventola"
 
 # MSG_FANS_CHECK_ON c=17 r=1
-#: ultralcd.cpp:5577
+#: ultralcd.cpp:5663
 msgid "Fans check   [on]"
-msgstr "Controllo ventole [on]"
+msgstr "Control.vent [on]"
 
 # MSG_FANS_CHECK_OFF c=17 r=1
-#: ultralcd.cpp:5579
+#: ultralcd.cpp:5665
 msgid "Fans check  [off]"
 msgstr "Control.vent[off]"
 
 # MSG_FSENSOR_ON
 #: messages.c:45
 msgid "Fil. sensor  [on]"
-msgstr "Sensor filam.[On]"
+msgstr "Sensore fil. [on]"
 
 # MSG_FSENSOR_NA
-#: ultralcd.cpp:5062
+#: ultralcd.cpp:5148
 msgid "Fil. sensor [N/A]"
-msgstr "Sensor filam[N/A]"
+msgstr "Sensore fil.[N/A]"
 
 # MSG_FSENSOR_OFF
 #: messages.c:44
 msgid "Fil. sensor [off]"
-msgstr "Sensor filam[off]"
+msgstr "Sensore fil.[off]"
 
 # 
-#: ultralcd.cpp:1876
+#: ultralcd.cpp:1852
 msgid "Filam. runouts"
 msgstr "Filam. esauriti"
 
@@ -421,7 +421,7 @@ msgid "Filament extruding & with correct color?"
 msgstr "Filamento estruso & con il giusto colore?"
 
 # MSG_NOT_LOADED c=19
-#: ultralcd.cpp:2672
+#: ultralcd.cpp:2714
 msgid "Filament not loaded"
 msgstr "Fil. non caricato"
 
@@ -431,17 +431,17 @@ msgid "Filament sensor"
 msgstr "Sensore filam."
 
 # MSG_FILAMENT_USED c=19 r=1
-#: ultralcd.cpp:2841
+#: ultralcd.cpp:2885
 msgid "Filament used"
 msgstr "Filamento utilizzato"
 
 # MSG_PRINT_TIME c=19 r=1
-#: ultralcd.cpp:2841
+#: ultralcd.cpp:2886
 msgid "Print time"
 msgstr "Tempo di stampa"
 
 # MSG_FILE_INCOMPLETE c=20 r=2
-#: ultralcd.cpp:8346
+#: ultralcd.cpp:8432
 msgid "File incomplete. Continue anyway?"
 msgstr "File incompleto. Continuare comunque?"
 
@@ -453,10 +453,10 @@ msgstr "Finalizzando gli spostamenti"
 # MSG_V2_CALIBRATION c=17 r=1
 #: messages.c:105
 msgid "First layer cal."
-msgstr "Calibrazione primo layer."
+msgstr "Cal. primo strato"
 
 # MSG_WIZARD_SELFTEST c=20 r=8
-#: ultralcd.cpp:4896
+#: ultralcd.cpp:4982
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr "Per primo avviero l'autotest per controllare gli errori di assemblaggio piu comuni."
 
@@ -466,12 +466,12 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr "Risolvi il problema e quindi premi il bottone sull'unita MMU. "
 
 # MSG_FLOW
-#: ultralcd.cpp:6846
+#: ultralcd.cpp:6932
 msgid "Flow"
 msgstr "Flusso"
 
 # MSG_PRUSA3D_FORUM
-#: ultralcd.cpp:2095
+#: ultralcd.cpp:2206
 msgid "forum.prusa3d.com"
 msgstr ""
 
@@ -481,22 +481,22 @@ msgid "Front print fan?"
 msgstr "Ventola frontale?"
 
 # MSG_BED_CORRECTION_FRONT c=14 r=1
-#: ultralcd.cpp:3220
+#: ultralcd.cpp:3294
 msgid "Front side[um]"
 msgstr "Fronte [um]"
 
 # MSG_SELFTEST_FANS
-#: ultralcd.cpp:7871
+#: ultralcd.cpp:7957
 msgid "Front/left fans"
 msgstr "Ventola frontale/sinistra"
 
 # MSG_SELFTEST_HEATERTHERMISTOR
-#: ultralcd.cpp:7801
+#: ultralcd.cpp:7887
 msgid "Heater/Thermistor"
 msgstr "Riscald./Termist."
 
 # MSG_BED_HEATING_SAFETY_DISABLED
-#: Marlin_main.cpp:8468
+#: Marlin_main.cpp:8467
 msgid "Heating disabled by safety timer."
 msgstr "Riscaldamento fermato dal timer di sicurezza."
 
@@ -511,12 +511,12 @@ msgid "Heating"
 msgstr "Riscaldamento..."
 
 # MSG_WIZARD_WELCOME c=20 r=7
-#: ultralcd.cpp:4875
+#: ultralcd.cpp:4961
 msgid "Hi, I am your Original Prusa i3 printer. Would you like me to guide you through the setup process?"
 msgstr "Ciao, sono la tua stampante Original Prusa i3. Gradiresti un aiuto nel processo di configurazione?"
 
 # MSG_PRUSA3D_HOWTO
-#: ultralcd.cpp:2096
+#: ultralcd.cpp:2207
 msgid "howto.prusa3d.com"
 msgstr ""
 
@@ -526,12 +526,12 @@ msgid "Change filament"
 msgstr "Cambia filamento"
 
 # MSG_CHANGE_SUCCESS
-#: ultralcd.cpp:2587
+#: ultralcd.cpp:2629
 msgid "Change success!"
 msgstr "Cambio riuscito!"
 
 # MSG_CORRECTLY c=20
-#: ultralcd.cpp:2664
+#: ultralcd.cpp:2706
 msgid "Changed correctly?"
 msgstr "Cambiato correttamente?"
 
@@ -541,12 +541,12 @@ msgid "Checking bed     "
 msgstr "Verifica piano"
 
 # MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ultralcd.cpp:8200
+#: ultralcd.cpp:8286
 msgid "Checking endstops"
 msgstr "Verifica finecorsa"
 
 # MSG_SELFTEST_CHECK_HOTEND c=20
-#: ultralcd.cpp:8206
+#: ultralcd.cpp:8292
 msgid "Checking hotend  "
 msgstr "Verifica ugello"
 
@@ -556,17 +556,17 @@ msgid "Checking sensors "
 msgstr "Controllo sensori"
 
 # MSG_SELFTEST_CHECK_X c=20
-#: ultralcd.cpp:8201
+#: ultralcd.cpp:8287
 msgid "Checking X axis  "
 msgstr "Verifica asse X"
 
 # MSG_SELFTEST_CHECK_Y c=20
-#: ultralcd.cpp:8202
+#: ultralcd.cpp:8288
 msgid "Checking Y axis  "
 msgstr "Verifica asse Y"
 
 # MSG_SELFTEST_CHECK_Z c=20
-#: ultralcd.cpp:8203
+#: ultralcd.cpp:8289
 msgid "Checking Z axis  "
 msgstr "Verifica asse Z"
 
@@ -586,17 +586,17 @@ msgid "Filament"
 msgstr "Filamento"
 
 # MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ultralcd.cpp:4905
+#: ultralcd.cpp:4991
 msgid "I will run xyz calibration now. It will take approx. 12 mins."
 msgstr "Adesso avviero una Calibrazione XYZ. Puo durare circa 12 min."
 
 # MSG_WIZARD_Z_CAL c=20 r=8
-#: ultralcd.cpp:4913
+#: ultralcd.cpp:4999
 msgid "I will run z calibration now."
 msgstr "Adesso avviero la Calibrazione Z."
 
 # MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ultralcd.cpp:4978
+#: ultralcd.cpp:5064
 msgid "I will start to print line and you will gradually lower the nozzle by rotating the knob, until you reach optimal height. Check the pictures in our handbook in chapter Calibration."
 msgstr "Adesso iniziero a stampare una linea e tu dovrai abbassare l'ugello poco per volta ruotando la manopola sino a raggiungere una altezza ottimale. Per favore dai uno sguardo all'immagine del nostro manuale, cap.Calibrazione."
 
@@ -606,27 +606,27 @@ msgid "Info screen"
 msgstr "Schermata info"
 
 # 
-#: ultralcd.cpp:4938
+#: ultralcd.cpp:5024
 msgid "Is filament 1 loaded?"
 msgstr "Il filamento 1 e caricato?"
 
 # MSG_INSERT_FILAMENT c=20
-#: ultralcd.cpp:2572
+#: ultralcd.cpp:2614
 msgid "Insert filament"
 msgstr "Inserire filamento"
 
 # MSG_WIZARD_FILAMENT_LOADED c=20 r=2
-#: ultralcd.cpp:4941
+#: ultralcd.cpp:5027
 msgid "Is filament loaded?"
 msgstr "Il filamento e stato caricato?"
 
 # MSG_WIZARD_PLA_FILAMENT c=20 r=2
-#: ultralcd.cpp:4972
+#: ultralcd.cpp:5058
 msgid "Is it PLA filament?"
 msgstr "E' un filamento di PLA?"
 
 # MSG_PLA_FILAMENT_LOADED c=20 r=2
-#: ultralcd.cpp:4704
+#: ultralcd.cpp:4790
 msgid "Is PLA filament loaded?"
 msgstr "E' stato caricato il filamento di PLA?"
 
@@ -636,12 +636,12 @@ msgid "Is steel sheet on heatbed?"
 msgstr "La piastra d'acciaio e sul piano riscaldato?"
 
 # 
-#: ultralcd.cpp:1840
+#: ultralcd.cpp:1795
 msgid "Last print failures"
 msgstr "Fallimenti ultima stampa"
 
 # 
-#: ultralcd.cpp:1823
+#: ultralcd.cpp:1772
 msgid "Last print"
 msgstr "Ultima stampa"
 
@@ -651,19 +651,19 @@ msgid "Left hotend fan?"
 msgstr "Vent SX hotend?"
 
 # 
-#: ultralcd.cpp:2970
+#: ultralcd.cpp:3018
 msgid "Left"
 msgstr "Sinistra"
 
 # MSG_BED_CORRECTION_LEFT c=14 r=1
-#: ultralcd.cpp:3218
+#: ultralcd.cpp:3292
 msgid "Left side [um]"
-msgstr "Lato sinistro [um]"
+msgstr "Sinistra  [um]"
 
 # 
-#: ultralcd.cpp:5594
+#: ultralcd.cpp:5680
 msgid "Lin. correction"
-msgstr "Correzione lin."
+msgstr "Correzione lineare"
 
 # MSG_BABYSTEP_Z
 #: messages.c:13
@@ -676,7 +676,7 @@ msgid "Load filament"
 msgstr "Carica filamento"
 
 # MSG_LOADING_COLOR
-#: ultralcd.cpp:2612
+#: ultralcd.cpp:2654
 msgid "Loading color"
 msgstr "Caricando colore"
 
@@ -686,12 +686,12 @@ msgid "Loading filament"
 msgstr "Caricando filamento"
 
 # MSG_LOOSE_PULLEY c=20 r=1
-#: ultralcd.cpp:7855
+#: ultralcd.cpp:7941
 msgid "Loose pulley"
 msgstr "Puleggia lenta"
 
 # 
-#: ultralcd.cpp:6719
+#: ultralcd.cpp:6805
 msgid "Load to nozzle"
 msgstr "Carica ugello"
 
@@ -711,9 +711,9 @@ msgid "Measuring reference height of calibration point"
 msgstr "Misura altezza di rif. del punto di calib."
 
 # MSG_MESH_BED_LEVELING
-#: ultralcd.cpp:5677
+#: ultralcd.cpp:5763
 msgid "Mesh Bed Leveling"
-msgstr "Mesh livel. letto"
+msgstr "Livel. piatto"
 
 # MSG_MMU_OK_RESUMING_POSITION c=20 r=4
 #: mmu.cpp:762
@@ -726,12 +726,12 @@ msgid "MMU OK. Resuming temperature..."
 msgstr "MMU OK. Ripristino temperatura... "
 
 # 
-#: ultralcd.cpp:3005
+#: ultralcd.cpp:3059
 msgid "Measured skew"
-msgstr "Disassamento misurato"
+msgstr "Deviazione mis"
 
 # 
-#: ultralcd.cpp:1840
+#: ultralcd.cpp:1796
 msgid "MMU fails"
 msgstr "Fallimenti MMU"
 
@@ -741,7 +741,7 @@ msgid "MMU load failed     "
 msgstr "Caricamento MMU fallito"
 
 # 
-#: ultralcd.cpp:1840
+#: ultralcd.cpp:1797
 msgid "MMU load fails"
 msgstr "Caricamenti MMU falliti"
 
@@ -753,12 +753,12 @@ msgstr "MMU OK. Riprendendo... "
 # MSG_STEALTH_MODE_OFF
 #: messages.c:90
 msgid "Mode     [Normal]"
-msgstr "Modo    [normale]"
+msgstr "Mod.    [normale]"
 
 # MSG_SILENT_MODE_ON
 #: messages.c:89
 msgid "Mode     [silent]"
-msgstr "Modo [silenzioso]"
+msgstr "Mod. [silenziosa]"
 
 # 
 #: mmu.cpp:719
@@ -766,27 +766,27 @@ msgid "MMU needs user attention."
 msgstr "Il MMU richiede attenzione dall'utente."
 
 # 
-#: ultralcd.cpp:1857
+#: ultralcd.cpp:1823
 msgid "MMU power fails"
-msgstr "Mancanza corrente MMU"
+msgstr "Manc. corr. MMU"
 
 # MSG_STEALTH_MODE_ON
 #: messages.c:91
 msgid "Mode    [Stealth]"
-msgstr "Modo [Silenziosa]"
+msgstr "Mod. [silenziosa]"
 
 # MSG_AUTO_MODE_ON
 #: messages.c:12
 msgid "Mode [auto power]"
-msgstr "Modo       [auto]"
+msgstr "Mod.       [auto]"
 
 # MSG_SILENT_MODE_OFF
 #: messages.c:88
 msgid "Mode [high power]"
-msgstr "Mode      [forte]"
+msgstr "Mod.      [forte]"
 
 # 
-#: ultralcd.cpp:2108
+#: ultralcd.cpp:2219
 msgid "MMU2 connected"
 msgstr "MMU2 connessa"
 
@@ -796,37 +796,37 @@ msgid "Motor"
 msgstr "Motore"
 
 # MSG_MOVE_AXIS
-#: ultralcd.cpp:5566
+#: ultralcd.cpp:5652
 msgid "Move axis"
 msgstr "Muovi asse"
 
 # MSG_MOVE_X
-#: ultralcd.cpp:4294
+#: ultralcd.cpp:4378
 msgid "Move X"
-msgstr "Muovi X"
+msgstr "Sposta X"
 
 # MSG_MOVE_Y
-#: ultralcd.cpp:4295
+#: ultralcd.cpp:4379
 msgid "Move Y"
-msgstr "Muovi Y"
+msgstr "Sposta Y"
 
 # MSG_MOVE_Z
-#: ultralcd.cpp:4296
+#: ultralcd.cpp:4380
 msgid "Move Z"
-msgstr "Muovi Z"
+msgstr "Sposta Z"
 
 # MSG_NO_MOVE
-#: Marlin_main.cpp:5291
+#: Marlin_main.cpp:5292
 msgid "No move."
 msgstr "Nessun movimento."
 
 # MSG_NO_CARD
-#: ultralcd.cpp:6686
+#: ultralcd.cpp:6772
 msgid "No SD card"
 msgstr "Nessuna SD"
 
 # 
-#: ultralcd.cpp:2976
+#: ultralcd.cpp:3024
 msgid "N/A"
 msgstr ""
 
@@ -836,7 +836,7 @@ msgid "No"
 msgstr ""
 
 # MSG_SELFTEST_NOTCONNECTED
-#: ultralcd.cpp:7803
+#: ultralcd.cpp:7889
 msgid "Not connected"
 msgstr "Non connesso"
 
@@ -851,12 +851,12 @@ msgid "Not spinning"
 msgstr "Non gira"
 
 # MSG_WIZARD_V2_CAL c=20 r=8
-#: ultralcd.cpp:4977
+#: ultralcd.cpp:5063
 msgid "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr "Adesso calibro la distanza fra ugello e superfice del piatto."
 
 # MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ultralcd.cpp:4921
+#: ultralcd.cpp:5007
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Adesso preriscaldero l'ugello per PLA."
 
@@ -868,40 +868,40 @@ msgstr "Ugello"
 # MSG_DEFAULT_SETTINGS_LOADED c=20 r=4
 #: Marlin_main.cpp:1519
 msgid "Old settings found. Default PID, Esteps etc. will be set."
-msgstr "Sono state trovate impostazioni vecchie. I valori di default di PID, Esteps etc. saranno impostati"
+msgstr "Sono state trovate impostazioni vecchie. Verranno impostati i valori predefiniti di PID, Esteps etc."
 
 # 
-#: ultralcd.cpp:4912
+#: ultralcd.cpp:4998
 msgid "Now remove the test print from steel sheet."
 msgstr "Ora rimuovete la stampa di prova dalla piastra in acciaio."
 
 # 
-#: ultralcd.cpp:1782
+#: ultralcd.cpp:1722
 msgid "Nozzle FAN"
 msgstr "Ventola estrusore"
 
 # MSG_PAUSE_PRINT
-#: ultralcd.cpp:6649
+#: ultralcd.cpp:6735
 msgid "Pause print"
 msgstr "Metti in pausa"
 
 # MSG_PID_RUNNING c=20 r=1
-#: ultralcd.cpp:1598
+#: ultralcd.cpp:1606
 msgid "PID cal.           "
 msgstr "Calibrazione PID"
 
 # MSG_PID_FINISHED c=20 r=1
-#: ultralcd.cpp:1604
+#: ultralcd.cpp:1612
 msgid "PID cal. finished"
 msgstr "Calib. PID completa"
 
 # MSG_PID_EXTRUDER c=17 r=1
-#: ultralcd.cpp:5683
+#: ultralcd.cpp:5769
 msgid "PID calibration"
 msgstr "Calibrazione PID"
 
 # MSG_PINDA_PREHEAT c=20 r=1
-#: ultralcd.cpp:843
+#: ultralcd.cpp:846
 msgid "PINDA Heating"
 msgstr "Riscaldamento PINDA"
 
@@ -911,7 +911,7 @@ msgid "Place a sheet of paper under the nozzle during the calibration of first 4
 msgstr "Posizionare un foglio sotto l'ugello durante la calibrazione dei primi 4 punti. In caso l'ugello muova il foglio spegnere subito la stampante."
 
 # MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ultralcd.cpp:4986
+#: ultralcd.cpp:5072
 msgid "Please clean heatbed and then press the knob."
 msgstr "Per favore pulisci il piatto, poi premi la manopola."
 
@@ -921,7 +921,7 @@ msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Pulire l'ugello per la calibrazione, poi fare click."
 
 # MSG_SELFTEST_PLEASECHECK
-#: ultralcd.cpp:7795
+#: ultralcd.cpp:7881
 msgid "Please check :"
 msgstr "Verifica:"
 
@@ -931,17 +931,17 @@ msgid "Please check our handbook and fix the problem. Then resume the Wizard by 
 msgstr "Per favore consulta il nostro manuale per risolvere il problema. Poi riprendi il Wizard dopo aver riavviato la stampante."
 
 # MSG_WIZARD_LOAD_FILAMENT c=20 r=8
-#: ultralcd.cpp:4808
+#: ultralcd.cpp:4894
 msgid "Please insert PLA filament to the extruder, then press knob to load it."
 msgstr "Per favore inserisci il filamento di PLA nell'estrusore, poi premi la manopola per caricare."
 
 # MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ultralcd.cpp:4709
+#: ultralcd.cpp:4795
 msgid "Please load PLA filament first."
 msgstr "Per favore prima carica il filamento di PLA."
 
 # MSG_CHECK_IDLER c=20 r=4
-#: Marlin_main.cpp:3063
+#: Marlin_main.cpp:3064
 msgid "Please open idler and remove filament manually."
 msgstr "Aprire la guida filam. e rimuovere il filam. a mano"
 
@@ -956,7 +956,7 @@ msgid "Please press the knob to unload filament"
 msgstr "Premete la manopola per scaricare il filamento "
 
 # 
-#: ultralcd.cpp:4803
+#: ultralcd.cpp:4889
 msgid "Please insert PLA filament to the first tube of MMU, then press the knob to load it."
 msgstr "Per favore inserite del filamento PLA nel primo tubo del MMU, poi premete la manopola per caricarlo."
 
@@ -976,7 +976,7 @@ msgid "Please remove steel sheet from heatbed."
 msgstr "Rimuovete la piastra di acciaio dal piano riscaldato"
 
 # MSG_RUN_XYZ c=20 r=4
-#: Marlin_main.cpp:4354
+#: Marlin_main.cpp:4355
 msgid "Please run XYZ calibration first."
 msgstr "Esegui la calibrazione XYZ prima. "
 
@@ -991,7 +991,7 @@ msgid "Please wait"
 msgstr "Attendere"
 
 # 
-#: ultralcd.cpp:4911
+#: ultralcd.cpp:4997
 msgid "Please remove shipping helpers first."
 msgstr "Per favore rimuovete i materiali da spedizione"
 
@@ -1001,7 +1001,7 @@ msgid "Preheat the nozzle!"
 msgstr "Prerisc. ugello!"
 
 # MSG_PREHEAT
-#: ultralcd.cpp:6636
+#: ultralcd.cpp:6722
 msgid "Preheat"
 msgstr "Preriscalda"
 
@@ -1016,12 +1016,12 @@ msgid "Please upgrade."
 msgstr "Prego aggiornare."
 
 # MSG_PRESS_TO_PREHEAT c=20 r=4
-#: Marlin_main.cpp:10365
+#: Marlin_main.cpp:10364
 msgid "Press knob to preheat nozzle and continue."
 msgstr "Premete la manopola per preriscaldare l'ugello e continuare."
 
 # 
-#: ultralcd.cpp:1876
+#: ultralcd.cpp:1851
 msgid "Power failures"
 msgstr "Mancanza corrente"
 
@@ -1031,19 +1031,19 @@ msgid "Print aborted"
 msgstr "Stampa interrotta"
 
 # 
-#: ultralcd.cpp:2276
+#: ultralcd.cpp:2455
 msgid "Preheating to load"
 msgstr "Preriscaldamento per caricare"
 
 # 
-#: ultralcd.cpp:2280
+#: ultralcd.cpp:2459
 msgid "Preheating to unload"
 msgstr "Preriscaldamento per scaricare"
 
 # MSG_SELFTEST_PRINT_FAN_SPEED c=18
-#: ultralcd.cpp:8221
+#: ultralcd.cpp:8307
 msgid "Print fan:"
-msgstr "Ventola di stampa:"
+msgstr "Vent.stam:"
 
 # MSG_CARD_MENU
 #: messages.c:21
@@ -1051,12 +1051,12 @@ msgid "Print from SD"
 msgstr "Stampa da SD"
 
 # 
-#: ultralcd.cpp:2206
+#: ultralcd.cpp:2317
 msgid "Press the knob"
 msgstr "Premere la manopola"
 
 # MSG_PRINT_PAUSED c=20 r=1
-#: ultralcd.cpp:1061
+#: ultralcd.cpp:1069
 msgid "Print paused"
 msgstr "Stampa in pausa"
 
@@ -1071,22 +1071,22 @@ msgid "Printer has not been calibrated yet. Please follow the manual, chapter Fi
 msgstr "Stampante non ancora calibrata. Si prega di seguire il manuale, capitolo Primi Passi, sezione Sequenza di Calibrazione."
 
 # 
-#: ultralcd.cpp:1784
+#: ultralcd.cpp:1723
 msgid "Print FAN"
 msgstr "Ventola di stampa"
 
 # MSG_PRUSA3D
-#: ultralcd.cpp:2094
+#: ultralcd.cpp:2205
 msgid "prusa3d.com"
 msgstr ""
 
 # MSG_BED_CORRECTION_REAR c=14 r=1
-#: ultralcd.cpp:3221
+#: ultralcd.cpp:3295
 msgid "Rear side [um]"
 msgstr "Retro [um]"
 
 # MSG_RECOVERING_PRINT c=20 r=1
-#: Marlin_main.cpp:9765
+#: Marlin_main.cpp:9764
 msgid "Recovering print    "
 msgstr "Recupero stampa"
 
@@ -1101,17 +1101,17 @@ msgid "Prusa i3 MK3S OK."
 msgstr ""
 
 # MSG_CALIBRATE_BED_RESET
-#: ultralcd.cpp:5688
+#: ultralcd.cpp:5774
 msgid "Reset XYZ calibr."
 msgstr "Reset calibrazione XYZ."
 
 # MSG_BED_CORRECTION_RESET
-#: ultralcd.cpp:3222
+#: ultralcd.cpp:3296
 msgid "Reset"
 msgstr ""
 
 # MSG_RESUME_PRINT
-#: ultralcd.cpp:6656
+#: ultralcd.cpp:6742
 msgid "Resume print"
 msgstr "Riprendi stampa"
 
@@ -1121,37 +1121,37 @@ msgid "Resuming print"
 msgstr "Riprendi stampa"
 
 # MSG_BED_CORRECTION_RIGHT c=14 r=1
-#: ultralcd.cpp:3219
+#: ultralcd.cpp:3293
 msgid "Right side[um]"
 msgstr "Destra [um]"
 
 # MSG_SECOND_SERIAL_ON c=17 r=1
-#: ultralcd.cpp:5606
+#: ultralcd.cpp:5692
 msgid "RPi port     [on]"
 msgstr "Porta RPi    [on]"
 
 # MSG_SECOND_SERIAL_OFF c=17 r=1
-#: ultralcd.cpp:5604
+#: ultralcd.cpp:5690
 msgid "RPi port    [off]"
 msgstr "Porta RPi   [off]"
 
 # MSG_WIZARD_RERUN c=20 r=7
-#: ultralcd.cpp:4726
+#: ultralcd.cpp:4812
 msgid "Running Wizard will delete current calibration results and start from the beginning. Continue?"
 msgstr "Se avvi il Wizard perderai la calibrazione preesistente e dovrai ricominciare dall'inizio. Continuare?"
 
 # MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_OFF c=19 r=1
-#: ultralcd.cpp:5236
+#: ultralcd.cpp:5322
 msgid "SD card  [normal]"
 msgstr "Mem. SD [normale]"
 
 # MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_ON c=19 r=1
-#: ultralcd.cpp:5234
+#: ultralcd.cpp:5320
 msgid "SD card [flshAir]"
 msgstr "Mem. SD [flshAir]"
 
 # 
-#: ultralcd.cpp:2971
+#: ultralcd.cpp:3019
 msgid "Right"
 msgstr "Destra"
 
@@ -1161,27 +1161,27 @@ msgid "Searching bed calibration point"
 msgstr "Ricerca dei punti di calibrazione del piano"
 
 # MSG_LANGUAGE_SELECT
-#: ultralcd.cpp:5613
+#: ultralcd.cpp:5699
 msgid "Select language"
 msgstr "Seleziona lingua"
 
 # MSG_SELFTEST_OK
-#: ultralcd.cpp:7366
+#: ultralcd.cpp:7452
 msgid "Self test OK"
 msgstr "Autotest OK"
 
 # MSG_SELFTEST_START c=20
-#: ultralcd.cpp:7152
+#: ultralcd.cpp:7238
 msgid "Self test start  "
 msgstr "Avvia autotest"
 
 # MSG_SELFTEST
-#: ultralcd.cpp:5664
+#: ultralcd.cpp:5750
 msgid "Selftest         "
 msgstr "Autotest"
 
 # MSG_SELFTEST_ERROR
-#: ultralcd.cpp:7793
+#: ultralcd.cpp:7879
 msgid "Selftest error !"
 msgstr "Errore Autotest !"
 
@@ -1196,17 +1196,17 @@ msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr "Verra effettuato un self test per calibrare l'homing senza sensori"
 
 # 
-#: ultralcd.cpp:4959
+#: ultralcd.cpp:5045
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr "Selezionate la temperatura per il preriscaldamento dell'ugello adatta al vostro materiale."
 
 # 
-#: ultralcd.cpp:4695
+#: ultralcd.cpp:4780
 msgid "Select PLA filament:"
 msgstr "Selezionate filamento PLA:"
 
 # MSG_SET_TEMPERATURE c=19 r=1
-#: ultralcd.cpp:3230
+#: ultralcd.cpp:3314
 msgid "Set temperature:"
 msgstr "Imposta temperatura:"
 
@@ -1216,12 +1216,12 @@ msgid "Settings"
 msgstr "Impostazioni"
 
 # MSG_SHOW_END_STOPS c=17 r=1
-#: ultralcd.cpp:5685
+#: ultralcd.cpp:5771
 msgid "Show end stops"
 msgstr "Stato finecorsa"
 
 # 
-#: ultralcd.cpp:3941
+#: ultralcd.cpp:4025
 msgid "Sensor state"
 msgstr "Stato sensore"
 
@@ -1231,24 +1231,24 @@ msgid "Some files will not be sorted. Max. No. of files in 1 folder for sorting 
 msgstr "Alcuni file non saranno ordinati. Il numero massimo di file in una cartella e 100 perche siano ordinati."
 
 # MSG_SORT_NONE c=17 r=1
-#: ultralcd.cpp:5246
+#: ultralcd.cpp:5332
 msgid "Sort       [none]"
-msgstr "Ordina     [none]"
+msgstr "Ordina  [nessuno]"
 
 # MSG_SORT_TIME c=17 r=1
-#: ultralcd.cpp:5244
+#: ultralcd.cpp:5330
 msgid "Sort       [time]"
-msgstr "Ordina     [time]"
+msgstr "Ordina    [cron.]"
 
 # 
-#: ultralcd.cpp:3008
-msgid "Severe skew"
-msgstr "Disassamento grave"
+#: ultralcd.cpp:3062
+msgid "Severe skew:"
+msgstr "Devia.grave:"
 
 # MSG_SORT_ALPHA c=17 r=1
-#: ultralcd.cpp:5245
+#: ultralcd.cpp:5331
 msgid "Sort   [alphabet]"
-msgstr "Ordine  [alfabet]"
+msgstr "Ordine [alfabeti]"
 
 # MSG_SORTING c=20 r=1
 #: cardreader.cpp:746
@@ -1261,9 +1261,9 @@ msgid "Sound      [loud]"
 msgstr "Suono     [forte]"
 
 # 
-#: ultralcd.cpp:3007
-msgid "Slight skew"
-msgstr "Disassamento lieve"
+#: ultralcd.cpp:3061
+msgid "Slight skew:"
+msgstr "Devia.lieve:"
 
 # MSG_SOUND_MUTE c=17 r=1
 #: 
@@ -1271,7 +1271,7 @@ msgid "Sound      [mute]"
 msgstr "Suono      [mute]"
 
 # 
-#: Marlin_main.cpp:4870
+#: Marlin_main.cpp:4871
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Sono stati rilevati problemi, avviato livellamento Z ..."
 
@@ -1286,7 +1286,7 @@ msgid "Sound    [silent]"
 msgstr "Suono[silenzioso]"
 
 # MSG_SPEED
-#: ultralcd.cpp:6840
+#: ultralcd.cpp:6926
 msgid "Speed"
 msgstr "Velocita"
 
@@ -1296,12 +1296,12 @@ msgid "Spinning"
 msgstr "Gira"
 
 # MSG_TEMP_CAL_WARNING c=20 r=4
-#: Marlin_main.cpp:4367
+#: Marlin_main.cpp:4368
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr "Sono necessari una temperatura ambiente di 21-26C e una superficie rigida "
 
 # MSG_STATISTICS
-#: ultralcd.cpp:6753
+#: ultralcd.cpp:6839
 msgid "Statistics  "
 msgstr "Statistiche"
 
@@ -1316,12 +1316,12 @@ msgid "STOPPED. "
 msgstr "ARRESTATO."
 
 # MSG_SUPPORT
-#: ultralcd.cpp:6762
+#: ultralcd.cpp:6848
 msgid "Support"
 msgstr "Supporto"
 
 # MSG_SELFTEST_SWAPPED
-#: ultralcd.cpp:7873
+#: ultralcd.cpp:7959
 msgid "Swapped"
 msgstr "Scambiato"
 
@@ -1331,22 +1331,22 @@ msgid "Temp. cal.          "
 msgstr "Calib. temp. "
 
 # MSG_TEMP_CALIBRATION_ON c=20 r=1
-#: ultralcd.cpp:5600
+#: ultralcd.cpp:5686
 msgid "Temp. cal.   [on]"
-msgstr "Calib. temp. [ON]"
+msgstr "Calib. temp. [on]"
 
 # MSG_TEMP_CALIBRATION_OFF c=20 r=1
-#: ultralcd.cpp:5598
+#: ultralcd.cpp:5684
 msgid "Temp. cal.  [off]"
-msgstr "Calib. temp.[OFF]"
+msgstr "Calib. temp.[off]"
 
 # MSG_CALIBRATION_PINDA_MENU c=17 r=1
-#: ultralcd.cpp:5694
+#: ultralcd.cpp:5780
 msgid "Temp. calibration"
 msgstr "Calib. Temp."
 
 # MSG_TEMP_CAL_FAILED c=20 r=8
-#: ultralcd.cpp:3867
+#: ultralcd.cpp:3951
 msgid "Temperature calibration failed"
 msgstr "Calibrazione temperatura fallita"
 
@@ -1356,12 +1356,12 @@ msgid "Temperature calibration is finished and active. Temp. calibration can be 
 msgstr "Calibrazione temperatura completata e attiva. Puo essere disattivata dal menu Impostazioni ->Cal. Temp."
 
 # MSG_TEMPERATURE
-#: ultralcd.cpp:5564
+#: ultralcd.cpp:5650
 msgid "Temperature"
 msgstr ""
 
 # MSG_MENU_TEMPERATURES c=15 r=1
-#: ultralcd.cpp:2140
+#: ultralcd.cpp:2251
 msgid "Temperatures"
 msgstr "Temperature"
 
@@ -1371,44 +1371,44 @@ msgid "There is still a need to make Z calibration. Please follow the manual, ch
 msgstr "E ancora necessario effettuare la calibrazione Z. Segui il manuale, capitolo Primi Passi, sezione Sequenza di Calibrazione. "
 
 # 
-#: ultralcd.cpp:2863
+#: ultralcd.cpp:2908
 msgid "Total filament"
 msgstr "Filamento totale"
 
 # 
-#: ultralcd.cpp:2863
+#: ultralcd.cpp:2908
 msgid "Total print time"
-msgstr "Tempo di stampa totale"
+msgstr "Tempo stampa totale"
 
 # MSG_TUNE
-#: ultralcd.cpp:6633
+#: ultralcd.cpp:6719
 msgid "Tune"
 msgstr "Regola"
 
 # 
-#: ultralcd.cpp:4783
+#: ultralcd.cpp:4869
 msgid "Unload"
 msgstr "Scarica"
 
 # 
-#: ultralcd.cpp:1857
+#: ultralcd.cpp:1820
 msgid "Total failures"
 msgstr "Totale fallimenti"
 
 # 
-#: ultralcd.cpp:2213
+#: ultralcd.cpp:2324
 msgid "to load filament"
 msgstr "per caricare il filamento"
 
 # 
-#: ultralcd.cpp:2217
+#: ultralcd.cpp:2328
 msgid "to unload filament"
 msgstr "per scaricare il filamento"
 
 # MSG_UNLOAD_FILAMENT c=17
 #: messages.c:97
 msgid "Unload filament"
-msgstr "Scarica filam."
+msgstr "Scarica filamento"
 
 # MSG_UNLOADING_FILAMENT c=20 r=1
 #: messages.c:98
@@ -1416,42 +1416,42 @@ msgid "Unloading filament"
 msgstr "Scaricando filamento"
 
 # 
-#: ultralcd.cpp:1824
+#: ultralcd.cpp:1773
 msgid "Total"
 msgstr "Totale"
 
 # MSG_USED c=19 r=1
-#: ultralcd.cpp:5822
+#: ultralcd.cpp:5908
 msgid "Used during print"
 msgstr "Usati nella stampa"
 
 # MSG_MENU_VOLTAGES c=15 r=1
-#: ultralcd.cpp:2143
+#: ultralcd.cpp:2254
 msgid "Voltages"
 msgstr "Voltaggi"
 
 # 
-#: ultralcd.cpp:2116
+#: ultralcd.cpp:2227
 msgid "unknown"
 msgstr "sconosciuto"
 
 # MSG_USERWAIT
-#: Marlin_main.cpp:5262
+#: Marlin_main.cpp:5263
 msgid "Wait for user..."
 msgstr "Attendendo utente..."
 
 # MSG_WAITING_TEMP c=20 r=3
-#: ultralcd.cpp:3374
+#: ultralcd.cpp:3458
 msgid "Waiting for nozzle and bed cooling"
 msgstr "In attesa del raffreddamento dell'ugello e del piano"
 
 # MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ultralcd.cpp:3338
+#: ultralcd.cpp:3422
 msgid "Waiting for PINDA probe cooling"
 msgstr "In attesa del raffreddamento della sonda PINDA"
 
 # 
-#: ultralcd.cpp:4782
+#: ultralcd.cpp:4868
 msgid "Use unload to remove filament 1 if it protrudes outside of the rear MMU tube. Use eject if it is hidden in tube."
 msgstr "Usate lo scaricamento per rimuovere il filamento 1 se protrude dal retro del tubo posteriore del MMu. Utilizzate l'espulsione se e nascosto nel tubo."
 
@@ -1471,7 +1471,7 @@ msgid "Warning: printer type changed."
 msgstr "Avviso: tipo di stampante cambiato."
 
 # MSG_UNLOAD_SUCCESSFUL c=20 r=2
-#: Marlin_main.cpp:3053
+#: Marlin_main.cpp:3054
 msgid "Was filament unload successful?"
 msgstr "Filamento scaricato con successo?"
 
@@ -1481,12 +1481,12 @@ msgid "Wiring error"
 msgstr "Errore cablaggio"
 
 # MSG_WIZARD c=17 r=1
-#: ultralcd.cpp:5661
+#: ultralcd.cpp:5747
 msgid "Wizard"
 msgstr ""
 
 # MSG_XYZ_DETAILS c=19 r=1
-#: ultralcd.cpp:2132
+#: ultralcd.cpp:2243
 msgid "XYZ cal. details"
 msgstr "XYZ Cal. dettagli"
 
@@ -1506,62 +1506,62 @@ msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr "E possibile riprendere il Wizard in qualsiasi momento attraverso Calibrazione -> Wizard."
 
 # MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ultralcd.cpp:3838
+#: ultralcd.cpp:3922
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr "Calibrazione XYZ corretta. La distorsione verra compensata automaticamente."
 
 # MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ultralcd.cpp:3835
+#: ultralcd.cpp:3919
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr "Calibrazion XYZ corretta. Assi X/Y leggermente storti. Ben fatto!"
 
 # 
-#: ultralcd.cpp:5044
+#: ultralcd.cpp:5130
 msgid "X-correct:"
 msgstr "Correzione-X:"
 
 # MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ultralcd.cpp:3832
+#: ultralcd.cpp:3916
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "Calibrazione XYZ OK. Gli assi X/Y sono perpendicolari. Complimenti!"
 
 # MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ultralcd.cpp:3816
+#: ultralcd.cpp:3900
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr "Calibrazione XYZ compromessa. Punti anteriori non raggiungibili."
 
 # MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ultralcd.cpp:3819
+#: ultralcd.cpp:3903
 msgid "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr "Calibrazione XYZ compromessa. Punto anteriore destro non raggiungibile."
 
 # MSG_LOAD_ALL c=17
-#: ultralcd.cpp:6080
+#: ultralcd.cpp:6166
 msgid "Load all"
 msgstr "Caricare tutti"
 
 # 
-#: ultralcd.cpp:3798
+#: ultralcd.cpp:3882
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr "Calibrazione XYZ fallita. Il punto di calibrazione sul letto non e' stato trovato."
 
 # 
-#: ultralcd.cpp:3804
+#: ultralcd.cpp:3888
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr "Calibrazione XYZ fallita. Punti anteriori non raggiungibili."
 
 # 
-#: ultralcd.cpp:3807
+#: ultralcd.cpp:3891
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr "Calibrazione XYZ fallita. Punto anteriore destro non raggiungibile."
 
 # 
-#: ultralcd.cpp:2968
+#: ultralcd.cpp:3016
 msgid "Y distance from min"
 msgstr "Distanza Y dal min"
 
 # 
-#: ultralcd.cpp:5045
+#: ultralcd.cpp:5131
 msgid "Y-correct:"
 msgstr "Correzione-Y:"
 
@@ -1576,32 +1576,32 @@ msgid "Back"
 msgstr "Indietro"
 
 # 
-#: ultralcd.cpp:5553
+#: ultralcd.cpp:5639
 msgid "Checks"
 msgstr "Controlli"
 
 # 
-#: ultralcd.cpp:7887
+#: ultralcd.cpp:7973
 msgid "False triggering"
 msgstr "Falso innesco"
 
 # 
-#: ultralcd.cpp:3946
+#: ultralcd.cpp:4030
 msgid "FINDA:"
 msgstr ""
 
 # 
-#: ultralcd.cpp:5459
+#: ultralcd.cpp:5545
 msgid "Firmware   [none]"
 msgstr "Firmware[nessuno]"
 
 # 
-#: ultralcd.cpp:5465
+#: ultralcd.cpp:5551
 msgid "Firmware [strict]"
 msgstr "Firmware [esatto]"
 
 # 
-#: ultralcd.cpp:5462
+#: ultralcd.cpp:5548
 msgid "Firmware   [warn]"
 msgstr "Firmware [avviso]"
 
@@ -1611,147 +1611,147 @@ msgid "HW Setup"
 msgstr "Installazione HW"
 
 # 
-#: ultralcd.cpp:3950
+#: ultralcd.cpp:4034
 msgid "IR:"
 msgstr ""
 
 # 
-#: ultralcd.cpp:6960
+#: ultralcd.cpp:7046
 msgid "Magnets comp.[N/A]"
 msgstr "Comp. Magneti[N/A]"
 
 # 
-#: ultralcd.cpp:6958
+#: ultralcd.cpp:7044
 msgid "Magnets comp.[Off]"
 msgstr "Comp. Magneti[off]"
 
 # 
-#: ultralcd.cpp:6957
+#: ultralcd.cpp:7043
 msgid "Magnets comp. [On]"
 msgstr "Comp. Magneti [on]"
 
 # 
-#: ultralcd.cpp:6949
+#: ultralcd.cpp:7035
 msgid "Mesh         [3x3]"
 msgstr "Griglia      [3x3]"
 
 # 
-#: ultralcd.cpp:6950
+#: ultralcd.cpp:7036
 msgid "Mesh         [7x7]"
 msgstr "Griglia      [7x7]"
 
 # 
-#: ultralcd.cpp:5591
+#: ultralcd.cpp:5677
 msgid "Mesh bed leveling"
 msgstr "Mesh livel. letto"
 
 # 
 #: Marlin_main.cpp:856
 msgid "MK3S firmware detected on MK3 printer"
-msgstr ""
+msgstr "Firmware MK3S rilevato su stampante MK3"
 
 # 
-#: ultralcd.cpp:5220
+#: ultralcd.cpp:5306
 msgid "MMU Mode [Normal]"
 msgstr "Modalita MMU [Normale]"
 
 # 
-#: ultralcd.cpp:5221
+#: ultralcd.cpp:5307
 msgid "MMU Mode[Stealth]"
 msgstr "Modalita MMU [Silenziosa]"
 
 # 
-#: ultralcd.cpp:4427
+#: ultralcd.cpp:4511
 msgid "Mode change in progress ..."
 msgstr "Cambio modalita in corso ..."
 
 # 
-#: ultralcd.cpp:5420
+#: ultralcd.cpp:5506
 msgid "Model      [none]"
 msgstr "Modello [nessuno]"
 
 # 
-#: ultralcd.cpp:5426
+#: ultralcd.cpp:5512
 msgid "Model    [strict]"
 msgstr "Modello  [esatto]"
 
 # 
-#: ultralcd.cpp:5423
+#: ultralcd.cpp:5509
 msgid "Model      [warn]"
 msgstr "Modello  [avviso]"
 
 # 
-#: ultralcd.cpp:5381
+#: ultralcd.cpp:5467
 msgid "Nozzle d.  [0.25]"
-msgstr "Diam. Ugell[0.25]"
+msgstr "Diam.Ugello[0.25]"
 
 # 
-#: ultralcd.cpp:5384
+#: ultralcd.cpp:5470
 msgid "Nozzle d.  [0.40]"
-msgstr "Diam. Ugell[0.40]"
+msgstr "Diam.Ugello[0.40]"
 
 # 
-#: ultralcd.cpp:5387
+#: ultralcd.cpp:5473
 msgid "Nozzle d.  [0.60]"
-msgstr "Diam. Ugell[0.60]"
+msgstr "Diam.Ugello[0.60]"
 
 # 
-#: ultralcd.cpp:5335
+#: ultralcd.cpp:5421
 msgid "Nozzle     [none]"
 msgstr "Ugello  [nessuno]"
 
 # 
-#: ultralcd.cpp:5341
+#: ultralcd.cpp:5427
 msgid "Nozzle   [strict]"
 msgstr "Ugello   [esatto]"
 
 # 
-#: ultralcd.cpp:5338
+#: ultralcd.cpp:5424
 msgid "Nozzle     [warn]"
 msgstr "Ugello   [avviso]"
 
 # 
 #: util.cpp:510
 msgid "G-code sliced for a different level. Continue?"
-msgstr ""
+msgstr "G-code processato per un livello diverso. Continuare?"
 
 # 
 #: util.cpp:516
 msgid "G-code sliced for a different level. Please re-slice the model again. Print cancelled."
-msgstr ""
+msgstr "G-code processato per un livello diverso. Per favore esegui nuovamente lo slice del modello. Stampa annullata."
 
 # 
 #: util.cpp:427
 msgid "G-code sliced for a different printer type. Continue?"
-msgstr ""
+msgstr "G-code processato per una stampante diversa. Continuare?"
 
 # 
 #: util.cpp:433
 msgid "G-code sliced for a different printer type. Please re-slice the model again. Print cancelled."
-msgstr ""
+msgstr "G-code processato per una stampante diversa. Per favore esegui nuovamente lo slice del modello. Stampa annullata."
 
 # 
 #: util.cpp:477
 msgid "G-code sliced for a newer firmware. Continue?"
-msgstr ""
+msgstr "G-code processato per un firmware piu recente. Continuare?"
 
 # 
 #: util.cpp:483
 msgid "G-code sliced for a newer firmware. Please update the firmware. Print cancelled."
-msgstr ""
+msgstr "G-code processato per un firmware piu recente. Per favore aggiorna il firmware. Stampa annullata."
 
 # 
-#: ultralcd.cpp:3942
+#: ultralcd.cpp:4026
 msgid "PINDA:"
 msgstr ""
 
 # 
-#: ultralcd.cpp:2286
+#: ultralcd.cpp:2465
 msgid "Preheating to cut"
 msgstr "Preriscaldamento per taglio"
 
 # 
-#: ultralcd.cpp:2283
+#: ultralcd.cpp:2462
 msgid "Preheating to eject"
 msgstr "Preriscaldamento per espulsione"
 
@@ -1766,17 +1766,17 @@ msgid "Printer nozzle diameter differs from the G-code. Please check the value i
 msgstr "Diametro ugello diverso dal G-Code. Controlla il valore nelle impostazioni. Stampa annullata."
 
 # 
-#: ultralcd.cpp:6597
+#: ultralcd.cpp:6683
 msgid "Rename"
 msgstr "Rinomina"
 
 # 
-#: ultralcd.cpp:6593
+#: ultralcd.cpp:6679
 msgid "Select"
 msgstr "Seleziona"
 
 # 
-#: ultralcd.cpp:2134
+#: ultralcd.cpp:2245
 msgid "Sensor info"
 msgstr "Info Sensore"
 
@@ -1786,22 +1786,27 @@ msgid "Sheet"
 msgstr "Piano"
 
 # 
-#: 
-msgid "Sound     [assist]"
-msgstr ""
+#: sound.h:9
+msgid "Sound    [assist]"
+msgstr "Suono   [assist.]"
 
 # 
-#: ultralcd.cpp:5551
+#: ultralcd.cpp:5637
 msgid "Steel sheets"
-msgstr ""
+msgstr "Piani d'acciaio"
 
 # 
-#: ultralcd.cpp:5046
+#: ultralcd.cpp:5132
 msgid "Z-correct:"
 msgstr "Correzione-Z:"
 
 # 
-#: ultralcd.cpp:6952
+#: ultralcd.cpp:7038
 msgid "Z-probe nr.    [1]"
 msgstr "Z-probe nr.    [1]"
+
+# 
+#: ultralcd.cpp:7040
+msgid "Z-probe nr.    [3]"
+msgstr "Z-probe nr.    [3]"
 

--- a/lang/po/Firmware_pl.po
+++ b/lang/po/Firmware_pl.po
@@ -7,8 +7,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: pl\n"
 "Project-Id-Version: Prusa-Firmware\n"
-"POT-Creation-Date: Wed Sep 4 16:14:12 CEST 2019\n"
-"PO-Revision-Date: Wed Sep 4 16:14:12 CEST 2019\n"
+"POT-Creation-Date: Sun, Sep 22, 2019 2:08:35 PM\n"
+"PO-Revision-Date: Sun, Sep 22, 2019 2:08:35 PM\n"
 "Language-Team: \n"
 "X-Generator: Poedit 2.0.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
@@ -26,9 +26,9 @@ msgid " of 9"
 msgstr " z 9"
 
 # MSG_MEASURED_OFFSET
-#: ultralcd.cpp:3027
+#: ultralcd.cpp:3089
 msgid "[0;0] point offset"
-msgstr "[0;0] przesuniecie punktu"
+msgstr "[0;0] przesun.punktu"
 
 # MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
 #: 
@@ -41,17 +41,17 @@ msgid "WARNING:\x0aCrash detection\x0adisabled in\x0aStealth mode"
 msgstr "UWAGA:\x0aWykrywanie zderzen\x0awylaczone w\x0atrybie Stealth"
 
 # 
-#: ultralcd.cpp:2290
+#: ultralcd.cpp:2472
 msgid ">Cancel"
 msgstr ">Anuluj"
 
 # MSG_BABYSTEPPING_Z c=15
-#: ultralcd.cpp:3147
+#: ultralcd.cpp:3209
 msgid "Adjusting Z:"
-msgstr "Dostrajanie Z:"
+msgstr "Ustawianie Z:"
 
 # MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ultralcd.cpp:8209
+#: ultralcd.cpp:8295
 msgid "All correct      "
 msgstr "Wszystko OK "
 
@@ -61,32 +61,32 @@ msgid "All is done. Happy printing!"
 msgstr "Gotowe. Udanego drukowania!"
 
 # 
-#: ultralcd.cpp:1974
+#: ultralcd.cpp:2009
 msgid "Ambient"
 msgstr "Otoczenie"
 
 # MSG_PRESS c=20
-#: ultralcd.cpp:2576
+#: ultralcd.cpp:2618
 msgid "and press the knob"
 msgstr "i nacisnij pokretlo"
 
 # MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=2
-#: ultralcd.cpp:3445
+#: ultralcd.cpp:3529
 msgid "Are left and right Z~carriages all up?"
-msgstr "Obydwa konce osi dojechaly do gornych ogranicznikow?"
+msgstr "Obydwa konce osi sa na szczycie?"
 
 # MSG_AUTO_DEPLETE_ON c=17 r=1
-#: ultralcd.cpp:5114
+#: ultralcd.cpp:5200
 msgid "SpoolJoin    [on]"
 msgstr "SpoolJoin    [wl]"
 
 # 
-#: ultralcd.cpp:5110
+#: ultralcd.cpp:5196
 msgid "SpoolJoin   [N/A]"
-msgstr "SpoolJoin    [nd]"
+msgstr "SpoolJoin   [N/D]"
 
 # MSG_AUTO_DEPLETE_OFF c=17 r=1
-#: ultralcd.cpp:5118
+#: ultralcd.cpp:5204
 msgid "SpoolJoin   [off]"
 msgstr "SpoolJoin   [wyl]"
 
@@ -96,32 +96,32 @@ msgid "Auto home"
 msgstr "Auto zerowanie"
 
 # MSG_AUTOLOAD_FILAMENT c=17
-#: ultralcd.cpp:6736
+#: ultralcd.cpp:6822
 msgid "AutoLoad filament"
-msgstr "AutoLadowanie fil."
+msgstr "Autoladowanie fil."
 
 # MSG_AUTOLOADING_ONLY_IF_FSENS_ON c=20 r=4
-#: ultralcd.cpp:4378
+#: ultralcd.cpp:4462
 msgid "Autoloading filament available only when filament sensor is turned on..."
 msgstr "Autoladowanie filamentu dostepne tylko gdy czujnik filamentu jest wlaczony..."
 
 # MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ultralcd.cpp:2771
+#: ultralcd.cpp:2813
 msgid "Autoloading filament is active, just press the knob and insert filament..."
 msgstr "Autoladowanie filamentu wlaczone, nacisnij pokretlo i wsun filament..."
 
 # MSG_SELFTEST_AXIS_LENGTH
-#: ultralcd.cpp:7863
+#: ultralcd.cpp:7949
 msgid "Axis length"
 msgstr "Dlugosc osi"
 
 # MSG_SELFTEST_AXIS
-#: ultralcd.cpp:7865
+#: ultralcd.cpp:7951
 msgid "Axis"
 msgstr "Os"
 
 # MSG_SELFTEST_BEDHEATER
-#: ultralcd.cpp:7807
+#: ultralcd.cpp:7893
 msgid "Bed / Heater"
 msgstr "Stol / Grzanie"
 
@@ -136,9 +136,9 @@ msgid "Bed Heating"
 msgstr "Grzanie stolu.."
 
 # MSG_BED_CORRECTION_MENU
-#: ultralcd.cpp:5682
+#: ultralcd.cpp:5768
 msgid "Bed level correct"
-msgstr "Korekta poziomowania stolu"
+msgstr "Korekta stolu"
 
 # MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=4
 #: messages.c:18
@@ -151,7 +151,7 @@ msgid "Bed"
 msgstr "Stol"
 
 # MSG_MENU_BELT_STATUS c=15 r=1
-#: ultralcd.cpp:2002
+#: ultralcd.cpp:2059
 msgid "Belt status"
 msgstr "Stan paskow"
 
@@ -161,12 +161,12 @@ msgid "Blackout occurred. Recover print?"
 msgstr "Wykryto zanik napiecia. Kontynowac?"
 
 # 
-#: ultralcd.cpp:8211
+#: ultralcd.cpp:8297
 msgid "Calibrating home"
 msgstr "Zerowanie osi"
 
 # MSG_CALIBRATE_BED
-#: ultralcd.cpp:5671
+#: ultralcd.cpp:5757
 msgid "Calibrate XYZ"
 msgstr "Kalibracja XYZ"
 
@@ -176,12 +176,12 @@ msgid "Calibrate Z"
 msgstr "Kalibruj Z"
 
 # MSG_CALIBRATE_PINDA c=17 r=1
-#: ultralcd.cpp:4570
+#: ultralcd.cpp:4654
 msgid "Calibrate"
 msgstr "Kalibruj"
 
 # MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ultralcd.cpp:3408
+#: ultralcd.cpp:3492
 msgid "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end stoppers. Click when done."
 msgstr "Kalibracja XYZ. Przekrec pokretlo, aby przesunac os Z do gornych ogranicznikow. Nacisnij, by potwierdzic."
 
@@ -191,12 +191,12 @@ msgid "Calibrating Z"
 msgstr "Kalibruje Z"
 
 # MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ultralcd.cpp:3408
+#: ultralcd.cpp:3492
 msgid "Calibrating Z. Rotate the knob to move the Z carriage up to the end stoppers. Click when done."
 msgstr "Kalibracja XYZ. Przekrec pokretlo, aby przesunac os Z do gornych ogranicznikow. Nacisnij, by potwierdzic."
 
 # MSG_HOMEYZ_DONE
-#: ultralcd.cpp:813
+#: ultralcd.cpp:816
 msgid "Calibration done"
 msgstr "Kalibracja OK"
 
@@ -206,17 +206,17 @@ msgid "Calibration"
 msgstr "Kalibracja"
 
 # 
-#: ultralcd.cpp:4695
+#: ultralcd.cpp:4781
 msgid "Cancel"
 msgstr "Anuluj"
 
 # MSG_SD_REMOVED
-#: ultralcd.cpp:8578
+#: ultralcd.cpp:8679
 msgid "Card removed"
 msgstr "Karta wyjeta"
 
 # MSG_NOT_COLOR
-#: ultralcd.cpp:2676
+#: ultralcd.cpp:2718
 msgid "Color not correct"
 msgstr "Kolor zanieczysz."
 
@@ -226,7 +226,7 @@ msgid "Cooldown"
 msgstr "Chlodzenie"
 
 # 
-#: ultralcd.cpp:4503
+#: ultralcd.cpp:4587
 msgid "Copy selected language?"
 msgstr "Skopiowac wybrany jezyk?"
 
@@ -238,7 +238,7 @@ msgstr "Wykr.zderzen [wl]"
 # MSG_CRASHDETECT_NA
 #: messages.c:25
 msgid "Crash det.  [N/A]"
-msgstr "Wykr.zderzen[n/d]"
+msgstr "Wykr.zderzen[N/D]"
 
 # MSG_CRASHDETECT_OFF
 #: messages.c:26
@@ -256,24 +256,24 @@ msgid "Crash detected. Resume print?"
 msgstr "Wykryto zderzenie. Wznowic druk?"
 
 # 
-#: ultralcd.cpp:1876
+#: ultralcd.cpp:1853
 msgid "Crash"
 msgstr "Zderzenie"
 
 # MSG_CURRENT c=19 r=1
-#: ultralcd.cpp:5823
+#: ultralcd.cpp:5909
 msgid "Current"
 msgstr "Aktualne"
 
 # MSG_DATE c=17 r=1
-#: ultralcd.cpp:2102
+#: ultralcd.cpp:2213
 msgid "Date:"
 msgstr "Data:"
 
 # MSG_DISABLE_STEPPERS
-#: ultralcd.cpp:5568
+#: ultralcd.cpp:5654
 msgid "Disable steppers"
-msgstr "Wylaczenie silnikow"
+msgstr "Wylacz silniki"
 
 # MSG_BABYSTEP_Z_NOT_SET c=20 r=12
 #: messages.c:14
@@ -281,14 +281,14 @@ msgid "Distance between tip of the nozzle and the bed surface has not been set y
 msgstr "Odleglosc dyszy od powierzchni druku nie jest skalibrowana. Postepuj zgodnie z instrukcja: rozdzial Wprowadzenie - Kalibracja pierwszej warstwy."
 
 # MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ultralcd.cpp:4984
+#: ultralcd.cpp:5070
 msgid "Do you want to repeat last step to readjust distance between nozzle and heatbed?"
 msgstr "Chcesz powtorzyc ostatni krok i ponownie ustawic odleglosc miedzy dysza a stolikiem?"
 
 # MSG_EXTRUDER_CORRECTION c=10
-#: ultralcd.cpp:5048
+#: ultralcd.cpp:5134
 msgid "E-correct:"
-msgstr "Korekcja E:"
+msgstr "Korekcja-E:"
 
 # MSG_EJECT_FILAMENT c=17 r=1
 #: messages.c:53
@@ -296,7 +296,7 @@ msgid "Eject filament"
 msgstr "Wysun filament"
 
 # 
-#: ultralcd.cpp:4783
+#: ultralcd.cpp:4869
 msgid "Eject"
 msgstr "Wysun"
 
@@ -306,27 +306,27 @@ msgid "Ejecting filament"
 msgstr "Wysuwanie filamentu"
 
 # MSG_SELFTEST_ENDSTOP_NOTHIT c=20 r=1
-#: ultralcd.cpp:7831
+#: ultralcd.cpp:7917
 msgid "Endstop not hit"
 msgstr "Krancowka nie aktyw."
 
 # MSG_SELFTEST_ENDSTOP
-#: ultralcd.cpp:7825
+#: ultralcd.cpp:7911
 msgid "Endstop"
 msgstr "Krancowka"
 
 # MSG_SELFTEST_ENDSTOPS
-#: ultralcd.cpp:7813
+#: ultralcd.cpp:7899
 msgid "Endstops"
 msgstr "Krancowki"
 
 # MSG_STACK_ERROR c=20 r=4
-#: ultralcd.cpp:6773
+#: ultralcd.cpp:6859
 msgid "Error - static memory has been overwritten"
 msgstr "Blad - pamiec statyczna zostala nadpisana"
 
 # MSG_FSENS_NOT_RESPONDING c=20 r=4
-#: ultralcd.cpp:4391
+#: ultralcd.cpp:4475
 msgid "ERROR: Filament sensor is not responding, please check connection."
 msgstr "BLAD: Czujnik filamentu nie odpowiada, sprawdz polaczenie."
 
@@ -336,14 +336,14 @@ msgid "ERROR:"
 msgstr "BLAD:"
 
 # MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
-#: ultralcd.cpp:8218
+#: ultralcd.cpp:8304
 msgid "Extruder fan:"
-msgstr "Went. ekstrudera:"
+msgstr "WentHotend:"
 
 # MSG_INFO_EXTRUDER c=15 r=1
-#: ultralcd.cpp:2133
+#: ultralcd.cpp:2244
 msgid "Extruder info"
-msgstr "Informacje o ekstruderze"
+msgstr "Ekstruder - info"
 
 # MSG_MOVE_E
 #: messages.c:29
@@ -351,14 +351,14 @@ msgid "Extruder"
 msgstr "Ekstruder"
 
 # 
-#: ultralcd.cpp:6760
+#: ultralcd.cpp:6846
 msgid "Fail stats MMU"
 msgstr "Bledy MMU"
 
 # MSG_FSENS_AUTOLOAD_ON c=17 r=1
-#: ultralcd.cpp:5082
+#: ultralcd.cpp:5168
 msgid "F. autoload  [on]"
-msgstr "Autolad. fil [wl]"
+msgstr "Autolad.fil. [wl]"
 
 # MSG_FSENS_AUTOLOAD_NA c=17 r=1
 #: messages.c:43
@@ -366,12 +366,12 @@ msgid "F. autoload [N/A]"
 msgstr "Autolad.fil.[N/D]"
 
 # MSG_FSENS_AUTOLOAD_OFF c=17 r=1
-#: ultralcd.cpp:5084
+#: ultralcd.cpp:5170
 msgid "F. autoload [off]"
 msgstr "Autolad.fil.[wyl]"
 
 # 
-#: ultralcd.cpp:6757
+#: ultralcd.cpp:6843
 msgid "Fail stats"
 msgstr "Statystyki bledow"
 
@@ -386,12 +386,12 @@ msgid "Fan test"
 msgstr "Test wentylatora"
 
 # MSG_FANS_CHECK_ON c=17 r=1
-#: ultralcd.cpp:5577
+#: ultralcd.cpp:5663
 msgid "Fans check   [on]"
 msgstr "Sprawd.went. [wl]"
 
 # MSG_FANS_CHECK_OFF c=17 r=1
-#: ultralcd.cpp:5579
+#: ultralcd.cpp:5665
 msgid "Fans check  [off]"
 msgstr "Sprawd.went.[wyl]"
 
@@ -401,7 +401,7 @@ msgid "Fil. sensor  [on]"
 msgstr "Czuj. filam. [wl]"
 
 # MSG_FSENSOR_NA
-#: ultralcd.cpp:5062
+#: ultralcd.cpp:5148
 msgid "Fil. sensor [N/A]"
 msgstr "Czuj. filam.[N/D]"
 
@@ -411,17 +411,17 @@ msgid "Fil. sensor [off]"
 msgstr "Czuj. filam.[wyl]"
 
 # 
-#: ultralcd.cpp:1876
+#: ultralcd.cpp:1852
 msgid "Filam. runouts"
 msgstr "Konc. filamentu"
 
 # MSG_FILAMENT_CLEAN c=20 r=2
 #: messages.c:32
 msgid "Filament extruding & with correct color?"
-msgstr "Filament wychodzi z dyszy a kolor jest czysty?"
+msgstr "Filament wychodzi z dyszy, kolor jest ok?"
 
 # MSG_NOT_LOADED c=19
-#: ultralcd.cpp:2672
+#: ultralcd.cpp:2714
 msgid "Filament not loaded"
 msgstr "Fil. nie zaladowany"
 
@@ -431,17 +431,17 @@ msgid "Filament sensor"
 msgstr "Czujnik filamentu"
 
 # MSG_FILAMENT_USED c=19 r=1
-#: ultralcd.cpp:2841
+#: ultralcd.cpp:2885
 msgid "Filament used"
 msgstr "Uzyty filament"
 
 # MSG_PRINT_TIME c=19 r=1
-#: ultralcd.cpp:2841
+#: ultralcd.cpp:2886
 msgid "Print time"
 msgstr "Czas druku"
 
 # MSG_FILE_INCOMPLETE c=20 r=2
-#: ultralcd.cpp:8346
+#: ultralcd.cpp:8432
 msgid "File incomplete. Continue anyway?"
 msgstr "Plik niekompletny. Kontynowac?"
 
@@ -456,7 +456,7 @@ msgid "First layer cal."
 msgstr "Kal. 1. warstwy"
 
 # MSG_WIZARD_SELFTEST c=20 r=8
-#: ultralcd.cpp:4896
+#: ultralcd.cpp:4982
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr "Najpierw wlacze selftest w celu sprawdzenia najczestszych problemow podczas montazu."
 
@@ -466,12 +466,12 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr "Rozwiaz problem i wcisnij przycisk na MMU."
 
 # MSG_FLOW
-#: ultralcd.cpp:6846
+#: ultralcd.cpp:6932
 msgid "Flow"
 msgstr "Przeplyw"
 
 # MSG_PRUSA3D_FORUM
-#: ultralcd.cpp:2095
+#: ultralcd.cpp:2206
 msgid "forum.prusa3d.com"
 msgstr ""
 
@@ -481,22 +481,22 @@ msgid "Front print fan?"
 msgstr "Przedni went. druku?"
 
 # MSG_BED_CORRECTION_FRONT c=14 r=1
-#: ultralcd.cpp:3220
+#: ultralcd.cpp:3294
 msgid "Front side[um]"
 msgstr "Przod [um]"
 
 # MSG_SELFTEST_FANS
-#: ultralcd.cpp:7871
+#: ultralcd.cpp:7957
 msgid "Front/left fans"
 msgstr "Przedni/lewy wentylator"
 
 # MSG_SELFTEST_HEATERTHERMISTOR
-#: ultralcd.cpp:7801
+#: ultralcd.cpp:7887
 msgid "Heater/Thermistor"
 msgstr "Grzalka/Termistor"
 
 # MSG_BED_HEATING_SAFETY_DISABLED
-#: Marlin_main.cpp:8468
+#: Marlin_main.cpp:8467
 msgid "Heating disabled by safety timer."
 msgstr "Grzanie wylaczone przez wyl. czasowy"
 
@@ -511,12 +511,12 @@ msgid "Heating"
 msgstr "Grzanie..."
 
 # MSG_WIZARD_WELCOME c=20 r=7
-#: ultralcd.cpp:4875
+#: ultralcd.cpp:4961
 msgid "Hi, I am your Original Prusa i3 printer. Would you like me to guide you through the setup process?"
 msgstr "Czesc, jestem Twoja drukarka Original Prusa i3. Czy potrzebujesz pomocy z ustawieniem?"
 
 # MSG_PRUSA3D_HOWTO
-#: ultralcd.cpp:2096
+#: ultralcd.cpp:2207
 msgid "howto.prusa3d.com"
 msgstr ""
 
@@ -526,12 +526,12 @@ msgid "Change filament"
 msgstr "Wymiana filamentu"
 
 # MSG_CHANGE_SUCCESS
-#: ultralcd.cpp:2587
+#: ultralcd.cpp:2629
 msgid "Change success!"
 msgstr "Wymiana ok!"
 
 # MSG_CORRECTLY c=20
-#: ultralcd.cpp:2664
+#: ultralcd.cpp:2706
 msgid "Changed correctly?"
 msgstr "Wymiana ok?"
 
@@ -541,12 +541,12 @@ msgid "Checking bed     "
 msgstr "Kontrola stolu"
 
 # MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ultralcd.cpp:8200
+#: ultralcd.cpp:8286
 msgid "Checking endstops"
 msgstr "Kontrola krancowek"
 
 # MSG_SELFTEST_CHECK_HOTEND c=20
-#: ultralcd.cpp:8206
+#: ultralcd.cpp:8292
 msgid "Checking hotend  "
 msgstr "Kontrola hotendu"
 
@@ -556,17 +556,17 @@ msgid "Checking sensors "
 msgstr "Sprawdzanie czujnikow"
 
 # MSG_SELFTEST_CHECK_X c=20
-#: ultralcd.cpp:8201
+#: ultralcd.cpp:8287
 msgid "Checking X axis  "
 msgstr "Kontrola osi X"
 
 # MSG_SELFTEST_CHECK_Y c=20
-#: ultralcd.cpp:8202
+#: ultralcd.cpp:8288
 msgid "Checking Y axis  "
 msgstr "Kontrola osi Y"
 
 # MSG_SELFTEST_CHECK_Z c=20
-#: ultralcd.cpp:8203
+#: ultralcd.cpp:8289
 msgid "Checking Z axis  "
 msgstr "Kontrola osi Z"
 
@@ -586,17 +586,17 @@ msgid "Filament"
 msgstr ""
 
 # MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ultralcd.cpp:4905
+#: ultralcd.cpp:4991
 msgid "I will run xyz calibration now. It will take approx. 12 mins."
 msgstr "Przeprowadze teraz kalibracje XYZ. Zajmie ok. 12 min."
 
 # MSG_WIZARD_Z_CAL c=20 r=8
-#: ultralcd.cpp:4913
+#: ultralcd.cpp:4999
 msgid "I will run z calibration now."
 msgstr "Przeprowadze kalibracje Z."
 
 # MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ultralcd.cpp:4978
+#: ultralcd.cpp:5064
 msgid "I will start to print line and you will gradually lower the nozzle by rotating the knob, until you reach optimal height. Check the pictures in our handbook in chapter Calibration."
 msgstr "Zaczne drukowac linie. Stopniowo opuszczaj dysze przekrecajac pokretlo, poki nie uzyskasz optymalnej wysokosci. Sprawdz obrazki w naszym Podreczniku w rozdz. Kalibracja"
 
@@ -606,27 +606,27 @@ msgid "Info screen"
 msgstr "Ekran informacyjny"
 
 # 
-#: ultralcd.cpp:4938
+#: ultralcd.cpp:5024
 msgid "Is filament 1 loaded?"
 msgstr "Filament 1 zaladowany?"
 
 # MSG_INSERT_FILAMENT c=20
-#: ultralcd.cpp:2572
+#: ultralcd.cpp:2614
 msgid "Insert filament"
 msgstr "Wprowadz filament"
 
 # MSG_WIZARD_FILAMENT_LOADED c=20 r=2
-#: ultralcd.cpp:4941
+#: ultralcd.cpp:5027
 msgid "Is filament loaded?"
 msgstr "Filament jest zaladowany?"
 
 # MSG_WIZARD_PLA_FILAMENT c=20 r=2
-#: ultralcd.cpp:4972
+#: ultralcd.cpp:5058
 msgid "Is it PLA filament?"
 msgstr "Czy to filament PLA?"
 
 # MSG_PLA_FILAMENT_LOADED c=20 r=2
-#: ultralcd.cpp:4704
+#: ultralcd.cpp:4790
 msgid "Is PLA filament loaded?"
 msgstr "Fialment PLA jest zaladowany?"
 
@@ -636,12 +636,12 @@ msgid "Is steel sheet on heatbed?"
 msgstr "Czy plyta stal. jest na podgrzew. stole?"
 
 # 
-#: ultralcd.cpp:1840
+#: ultralcd.cpp:1795
 msgid "Last print failures"
 msgstr "Ostatnie bledy druku"
 
 # 
-#: ultralcd.cpp:1823
+#: ultralcd.cpp:1772
 msgid "Last print"
 msgstr "Ost. wydruk"
 
@@ -651,19 +651,19 @@ msgid "Left hotend fan?"
 msgstr "Lewy went hotendu?"
 
 # 
-#: ultralcd.cpp:2970
+#: ultralcd.cpp:3018
 msgid "Left"
 msgstr "Lewa"
 
 # MSG_BED_CORRECTION_LEFT c=14 r=1
-#: ultralcd.cpp:3218
+#: ultralcd.cpp:3292
 msgid "Left side [um]"
 msgstr "Lewo [um]"
 
 # 
-#: ultralcd.cpp:5594
+#: ultralcd.cpp:5680
 msgid "Lin. correction"
-msgstr "Korekcja lin."
+msgstr "Korekcja liniowa"
 
 # MSG_BABYSTEP_Z
 #: messages.c:13
@@ -676,7 +676,7 @@ msgid "Load filament"
 msgstr "Ladowanie fil."
 
 # MSG_LOADING_COLOR
-#: ultralcd.cpp:2612
+#: ultralcd.cpp:2654
 msgid "Loading color"
 msgstr "Czyszcz. koloru"
 
@@ -686,12 +686,12 @@ msgid "Loading filament"
 msgstr "Laduje filament"
 
 # MSG_LOOSE_PULLEY c=20 r=1
-#: ultralcd.cpp:7855
+#: ultralcd.cpp:7941
 msgid "Loose pulley"
 msgstr "Luzne kolo pasowe"
 
 # 
-#: ultralcd.cpp:6719
+#: ultralcd.cpp:6805
 msgid "Load to nozzle"
 msgstr "Zaladuj do dyszy"
 
@@ -711,7 +711,7 @@ msgid "Measuring reference height of calibration point"
 msgstr "Okreslam wysokosc odniesienia punktu kalibracyjnego"
 
 # MSG_MESH_BED_LEVELING
-#: ultralcd.cpp:5677
+#: ultralcd.cpp:5763
 msgid "Mesh Bed Leveling"
 msgstr "Poziomowanie stolu wg siatki"
 
@@ -726,12 +726,12 @@ msgid "MMU OK. Resuming temperature..."
 msgstr "MMU OK. Wznawiam nagrzewanie..."
 
 # 
-#: ultralcd.cpp:3005
+#: ultralcd.cpp:3059
 msgid "Measured skew"
 msgstr "Zmierzony skos"
 
 # 
-#: ultralcd.cpp:1840
+#: ultralcd.cpp:1796
 msgid "MMU fails"
 msgstr "Bledy MMU"
 
@@ -741,7 +741,7 @@ msgid "MMU load failed     "
 msgstr "Blad ladowania MMU"
 
 # 
-#: ultralcd.cpp:1840
+#: ultralcd.cpp:1797
 msgid "MMU load fails"
 msgstr "Bledy ladow. MMU"
 
@@ -766,14 +766,14 @@ msgid "MMU needs user attention."
 msgstr "MMU wymaga uwagi uzytkownika."
 
 # 
-#: ultralcd.cpp:1857
+#: ultralcd.cpp:1823
 msgid "MMU power fails"
 msgstr "Zaniki zasil. MMU"
 
 # MSG_STEALTH_MODE_ON
 #: messages.c:91
 msgid "Mode    [Stealth]"
-msgstr "Tryb    [Stealth]"
+msgstr "Tryb      [cichy]"
 
 # MSG_AUTO_MODE_ON
 #: messages.c:12
@@ -786,7 +786,7 @@ msgid "Mode [high power]"
 msgstr "Tryb[wysoka wyd.]"
 
 # 
-#: ultralcd.cpp:2108
+#: ultralcd.cpp:2219
 msgid "MMU2 connected"
 msgstr "MMU podlaczone"
 
@@ -796,37 +796,37 @@ msgid "Motor"
 msgstr "Silnik"
 
 # MSG_MOVE_AXIS
-#: ultralcd.cpp:5566
+#: ultralcd.cpp:5652
 msgid "Move axis"
 msgstr "Ruch osi"
 
 # MSG_MOVE_X
-#: ultralcd.cpp:4294
+#: ultralcd.cpp:4378
 msgid "Move X"
 msgstr "Ruch osi X"
 
 # MSG_MOVE_Y
-#: ultralcd.cpp:4295
+#: ultralcd.cpp:4379
 msgid "Move Y"
 msgstr "Ruch osi Y"
 
 # MSG_MOVE_Z
-#: ultralcd.cpp:4296
+#: ultralcd.cpp:4380
 msgid "Move Z"
 msgstr "Ruch osi Z"
 
 # MSG_NO_MOVE
-#: Marlin_main.cpp:5291
+#: Marlin_main.cpp:5292
 msgid "No move."
 msgstr "Brak ruchu."
 
 # MSG_NO_CARD
-#: ultralcd.cpp:6686
+#: ultralcd.cpp:6772
 msgid "No SD card"
 msgstr "Brak karty SD"
 
 # 
-#: ultralcd.cpp:2976
+#: ultralcd.cpp:3024
 msgid "N/A"
 msgstr "N/D"
 
@@ -836,7 +836,7 @@ msgid "No"
 msgstr "Nie"
 
 # MSG_SELFTEST_NOTCONNECTED
-#: ultralcd.cpp:7803
+#: ultralcd.cpp:7889
 msgid "Not connected"
 msgstr "Nie podlaczono "
 
@@ -851,12 +851,12 @@ msgid "Not spinning"
 msgstr "Nie kreci sie"
 
 # MSG_WIZARD_V2_CAL c=20 r=8
-#: ultralcd.cpp:4977
+#: ultralcd.cpp:5063
 msgid "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr "Kalibruje odleglosc miedzy koncowka dyszy a powierzchnia druku."
 
 # MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ultralcd.cpp:4921
+#: ultralcd.cpp:5007
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Nagrzewam dysze dla PLA."
 
@@ -871,37 +871,37 @@ msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr "Znaleziono stare ustawienia. Zostana przywrocone domyslne ust. PID, Esteps, itp."
 
 # 
-#: ultralcd.cpp:4912
+#: ultralcd.cpp:4998
 msgid "Now remove the test print from steel sheet."
 msgstr "Teraz zdejmij wydruk testowy ze stolu."
 
 # 
-#: ultralcd.cpp:1782
+#: ultralcd.cpp:1722
 msgid "Nozzle FAN"
-msgstr "Went. hotendu"
+msgstr "WentHotend"
 
 # MSG_PAUSE_PRINT
-#: ultralcd.cpp:6649
+#: ultralcd.cpp:6735
 msgid "Pause print"
 msgstr "Wstrzymanie wydruku"
 
 # MSG_PID_RUNNING c=20 r=1
-#: ultralcd.cpp:1598
+#: ultralcd.cpp:1606
 msgid "PID cal.           "
 msgstr "Kalibracja PID"
 
 # MSG_PID_FINISHED c=20 r=1
-#: ultralcd.cpp:1604
+#: ultralcd.cpp:1612
 msgid "PID cal. finished"
 msgstr "Kal. PID zakonczona"
 
 # MSG_PID_EXTRUDER c=17 r=1
-#: ultralcd.cpp:5683
+#: ultralcd.cpp:5769
 msgid "PID calibration"
 msgstr "Kalibracja PID"
 
 # MSG_PINDA_PREHEAT c=20 r=1
-#: ultralcd.cpp:843
+#: ultralcd.cpp:846
 msgid "PINDA Heating"
 msgstr "Grzanie sondy PINDA"
 
@@ -911,17 +911,17 @@ msgid "Place a sheet of paper under the nozzle during the calibration of first 4
 msgstr "Umiesc kartke papieru na stole roboczym i podczas pomiaru pierwszych 4 punktow. Jesli dysza zahaczy o papier, natychmiast wylacz drukarke."
 
 # MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ultralcd.cpp:4986
+#: ultralcd.cpp:5072
 msgid "Please clean heatbed and then press the knob."
 msgstr "Oczysc powierzchnie druku i nacisnij pokretlo."
 
 # MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
 #: messages.c:22
 msgid "Please clean the nozzle for calibration. Click when done."
-msgstr "Dla prawidl. kalibracji nalezy oczyscic dysze. Potw. guzikiem."
+msgstr "Dla prawidlowej kalibracji nalezy oczyscic dysze. Potwierdz guzikiem."
 
 # MSG_SELFTEST_PLEASECHECK
-#: ultralcd.cpp:7795
+#: ultralcd.cpp:7881
 msgid "Please check :"
 msgstr "Sprawdz :"
 
@@ -931,17 +931,17 @@ msgid "Please check our handbook and fix the problem. Then resume the Wizard by 
 msgstr "Przeczytaj nasz Podrecznik druku 3D aby naprawic problem. Potem wznow Asystenta przez restart drukarki."
 
 # MSG_WIZARD_LOAD_FILAMENT c=20 r=8
-#: ultralcd.cpp:4808
+#: ultralcd.cpp:4894
 msgid "Please insert PLA filament to the extruder, then press knob to load it."
 msgstr "Umiesc filament PLA w ekstruderze i nacisnij pokretlo, aby zaladowac."
 
 # MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ultralcd.cpp:4709
+#: ultralcd.cpp:4795
 msgid "Please load PLA filament first."
 msgstr "Najpierw zaladuj filament PLA."
 
 # MSG_CHECK_IDLER c=20 r=4
-#: Marlin_main.cpp:3063
+#: Marlin_main.cpp:3064
 msgid "Please open idler and remove filament manually."
 msgstr "Prosze odciagnac dzwignie dociskowa ekstrudera i recznie usunac filament."
 
@@ -956,7 +956,7 @@ msgid "Please press the knob to unload filament"
 msgstr "Nacisnij pokretlo aby rozladowac filament"
 
 # 
-#: ultralcd.cpp:4803
+#: ultralcd.cpp:4889
 msgid "Please insert PLA filament to the first tube of MMU, then press the knob to load it."
 msgstr "Wsun filament PLA do pierwszej rurki MMU i nacisnij pokretlo aby go zaladowac."
 
@@ -976,7 +976,7 @@ msgid "Please remove steel sheet from heatbed."
 msgstr "Prosze zdjac plyte stalowa z podgrzewanego stolu."
 
 # MSG_RUN_XYZ c=20 r=4
-#: Marlin_main.cpp:4354
+#: Marlin_main.cpp:4355
 msgid "Please run XYZ calibration first."
 msgstr "Prosze najpierw uruchomic kalibracje XYZ"
 
@@ -991,7 +991,7 @@ msgid "Please wait"
 msgstr "Prosze czekac"
 
 # 
-#: ultralcd.cpp:4911
+#: ultralcd.cpp:4997
 msgid "Please remove shipping helpers first."
 msgstr "Najpierw usun zabezpieczenia transportowe"
 
@@ -1001,7 +1001,7 @@ msgid "Preheat the nozzle!"
 msgstr "Nagrzej dysze!"
 
 # MSG_PREHEAT
-#: ultralcd.cpp:6636
+#: ultralcd.cpp:6722
 msgid "Preheat"
 msgstr "Grzanie"
 
@@ -1016,12 +1016,12 @@ msgid "Please upgrade."
 msgstr "Prosze zaktualizowac."
 
 # MSG_PRESS_TO_PREHEAT c=20 r=4
-#: Marlin_main.cpp:10365
+#: Marlin_main.cpp:10364
 msgid "Press knob to preheat nozzle and continue."
 msgstr "Wcisnij pokretlo aby rozgrzac dysze i kontynuowac."
 
 # 
-#: ultralcd.cpp:1876
+#: ultralcd.cpp:1851
 msgid "Power failures"
 msgstr "Zaniki zasilania"
 
@@ -1031,19 +1031,19 @@ msgid "Print aborted"
 msgstr "Druk przerwany"
 
 # 
-#: ultralcd.cpp:2276
+#: ultralcd.cpp:2455
 msgid "Preheating to load"
 msgstr "Nagrzew. do ladowania"
 
 # 
-#: ultralcd.cpp:2280
+#: ultralcd.cpp:2459
 msgid "Preheating to unload"
 msgstr "Nagrzew. do rozlad."
 
 # MSG_SELFTEST_PRINT_FAN_SPEED c=18
-#: ultralcd.cpp:8221
+#: ultralcd.cpp:8307
 msgid "Print fan:"
-msgstr "Went. wydruku:"
+msgstr "WentWydruk:"
 
 # MSG_CARD_MENU
 #: messages.c:21
@@ -1051,12 +1051,12 @@ msgid "Print from SD"
 msgstr "Druk z karty SD"
 
 # 
-#: ultralcd.cpp:2206
+#: ultralcd.cpp:2317
 msgid "Press the knob"
 msgstr "Wcisnij pokretlo"
 
 # MSG_PRINT_PAUSED c=20 r=1
-#: ultralcd.cpp:1061
+#: ultralcd.cpp:1069
 msgid "Print paused"
 msgstr "Druk wstrzymany"
 
@@ -1068,25 +1068,25 @@ msgstr "Wcisnij pokretlo aby wznowic podgrzewanie dyszy."
 # MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
 #: messages.c:41
 msgid "Printer has not been calibrated yet. Please follow the manual, chapter First steps, section Calibration flow."
-msgstr "Drukarka nie zostala jeszcze skalibrowana. Kieruj sie Samouczkiem: rozdzial Pierwsze Kroki, sekcja Konfiguracja przed drukowaniem."
+msgstr "Drukarka nie byla jeszcze kalibrowana. Kieruj sie Samouczkiem: rozdzial Pierwsze Kroki, sekcja Konfiguracja przed drukowaniem."
 
 # 
-#: ultralcd.cpp:1784
+#: ultralcd.cpp:1723
 msgid "Print FAN"
-msgstr "Went. wydruku"
+msgstr "WentWydruk"
 
 # MSG_PRUSA3D
-#: ultralcd.cpp:2094
+#: ultralcd.cpp:2205
 msgid "prusa3d.com"
 msgstr ""
 
 # MSG_BED_CORRECTION_REAR c=14 r=1
-#: ultralcd.cpp:3221
+#: ultralcd.cpp:3295
 msgid "Rear side [um]"
 msgstr "Tyl [um]"
 
 # MSG_RECOVERING_PRINT c=20 r=1
-#: Marlin_main.cpp:9765
+#: Marlin_main.cpp:9764
 msgid "Recovering print    "
 msgstr "Wznawianie wydruku"
 
@@ -1101,17 +1101,17 @@ msgid "Prusa i3 MK3S OK."
 msgstr "Prusa i3 MK3S OK"
 
 # MSG_CALIBRATE_BED_RESET
-#: ultralcd.cpp:5688
+#: ultralcd.cpp:5774
 msgid "Reset XYZ calibr."
 msgstr "Reset kalibr. XYZ"
 
 # MSG_BED_CORRECTION_RESET
-#: ultralcd.cpp:3222
+#: ultralcd.cpp:3296
 msgid "Reset"
 msgstr ""
 
 # MSG_RESUME_PRINT
-#: ultralcd.cpp:6656
+#: ultralcd.cpp:6742
 msgid "Resume print"
 msgstr "Wznowic wydruk"
 
@@ -1121,37 +1121,37 @@ msgid "Resuming print"
 msgstr "Wznawianie druku"
 
 # MSG_BED_CORRECTION_RIGHT c=14 r=1
-#: ultralcd.cpp:3219
+#: ultralcd.cpp:3293
 msgid "Right side[um]"
 msgstr "Prawo [um]"
 
 # MSG_SECOND_SERIAL_ON c=17 r=1
-#: ultralcd.cpp:5606
+#: ultralcd.cpp:5692
 msgid "RPi port     [on]"
 msgstr "Port RPi     [wl]"
 
 # MSG_SECOND_SERIAL_OFF c=17 r=1
-#: ultralcd.cpp:5604
+#: ultralcd.cpp:5690
 msgid "RPi port    [off]"
 msgstr "Port RPi    [wyl]"
 
 # MSG_WIZARD_RERUN c=20 r=7
-#: ultralcd.cpp:4726
+#: ultralcd.cpp:4812
 msgid "Running Wizard will delete current calibration results and start from the beginning. Continue?"
 msgstr "Wlaczenie Asystenta usunie obecne dane kalibracyjne i zacznie od poczatku. Kontynuowac?"
 
 # MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_OFF c=19 r=1
-#: ultralcd.cpp:5236
+#: ultralcd.cpp:5322
 msgid "SD card  [normal]"
 msgstr "Karta SD [normal]"
 
 # MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_ON c=19 r=1
-#: ultralcd.cpp:5234
+#: ultralcd.cpp:5320
 msgid "SD card [flshAir]"
 msgstr "Karta SD[FlshAir]"
 
 # 
-#: ultralcd.cpp:2971
+#: ultralcd.cpp:3019
 msgid "Right"
 msgstr "Prawa"
 
@@ -1161,29 +1161,29 @@ msgid "Searching bed calibration point"
 msgstr "Szukam punktu kalibracyjnego na stole"
 
 # MSG_LANGUAGE_SELECT
-#: ultralcd.cpp:5613
+#: ultralcd.cpp:5699
 msgid "Select language"
 msgstr "Wybor jezyka"
 
 # MSG_SELFTEST_OK
-#: ultralcd.cpp:7366
+#: ultralcd.cpp:7452
 msgid "Self test OK"
 msgstr "Selftest OK"
 
 # MSG_SELFTEST_START c=20
-#: ultralcd.cpp:7152
+#: ultralcd.cpp:7238
 msgid "Self test start  "
-msgstr "Rozpoczynanie Selftestu"
+msgstr "Selftest startuje"
 
 # MSG_SELFTEST
-#: ultralcd.cpp:5664
+#: ultralcd.cpp:5750
 msgid "Selftest         "
 msgstr "Selftest "
 
 # MSG_SELFTEST_ERROR
-#: ultralcd.cpp:7793
+#: ultralcd.cpp:7879
 msgid "Selftest error !"
-msgstr "Blad selftest !"
+msgstr "Blad selftest!"
 
 # MSG_SELFTEST_FAILED c=20
 #: messages.c:77
@@ -1196,19 +1196,19 @@ msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr "Zostanie uruchomiony Selftest aby dokladnie skalibrowac punkt bazowy bez krancowek"
 
 # 
-#: ultralcd.cpp:4959
+#: ultralcd.cpp:5045
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr "Wybierz temperature grzania dyszy odpowiednia dla materialu."
 
 # 
-#: ultralcd.cpp:4695
+#: ultralcd.cpp:4780
 msgid "Select PLA filament:"
 msgstr "Wybierz filament PLA:"
 
 # MSG_SET_TEMPERATURE c=19 r=1
-#: ultralcd.cpp:3230
+#: ultralcd.cpp:3314
 msgid "Set temperature:"
-msgstr "Ustaw. temperatury:"
+msgstr "Ustaw temperature:"
 
 # MSG_SETTINGS
 #: messages.c:86
@@ -1216,12 +1216,12 @@ msgid "Settings"
 msgstr "Ustawienia"
 
 # MSG_SHOW_END_STOPS c=17 r=1
-#: ultralcd.cpp:5685
+#: ultralcd.cpp:5771
 msgid "Show end stops"
 msgstr "Pokaz krancowki"
 
 # 
-#: ultralcd.cpp:3941
+#: ultralcd.cpp:4025
 msgid "Sensor state"
 msgstr "Stan czujnikow"
 
@@ -1231,24 +1231,24 @@ msgid "Some files will not be sorted. Max. No. of files in 1 folder for sorting 
 msgstr "Niektore pliki nie zostana posortowane. Max. liczba plikow w 1 folderze = 100."
 
 # MSG_SORT_NONE c=17 r=1
-#: ultralcd.cpp:5246
+#: ultralcd.cpp:5332
 msgid "Sort       [none]"
-msgstr "Sortuj     [brak]"
+msgstr "Sortowanie [brak]"
 
 # MSG_SORT_TIME c=17 r=1
-#: ultralcd.cpp:5244
+#: ultralcd.cpp:5330
 msgid "Sort       [time]"
-msgstr "Sortuj     [czas]"
+msgstr "Sortowanie [czas]"
 
 # 
-#: ultralcd.cpp:3008
-msgid "Severe skew"
-msgstr "Znaczny skos"
+#: ultralcd.cpp:3062
+msgid "Severe skew:"
+msgstr "Znaczny skos:"
 
 # MSG_SORT_ALPHA c=17 r=1
-#: ultralcd.cpp:5245
+#: ultralcd.cpp:5331
 msgid "Sort   [alphabet]"
-msgstr "Sortuj  [alfabet]"
+msgstr "Sortowanie[alfab]"
 
 # MSG_SORTING c=20 r=1
 #: cardreader.cpp:746
@@ -1258,22 +1258,22 @@ msgstr "Sortowanie plikow"
 # MSG_SOUND_LOUD c=17 r=1
 #: sound.h:6
 msgid "Sound      [loud]"
-msgstr "Dzwiek   [Glosny]"
+msgstr "Dzwiek   [glosny]"
 
 # 
-#: ultralcd.cpp:3007
-msgid "Slight skew"
-msgstr "Lekki skos"
+#: ultralcd.cpp:3061
+msgid "Slight skew:"
+msgstr "Lekki skos:"
 
 # MSG_SOUND_MUTE c=17 r=1
 #: 
 msgid "Sound      [mute]"
-msgstr "Dzwiek[Wylaczony]"
+msgstr "Dzwiek[wylaczony]"
 
 # 
-#: Marlin_main.cpp:4870
+#: Marlin_main.cpp:4871
 msgid "Some problem encountered, Z-leveling enforced ..."
-msgstr "Wykryto problem, wymuszono poziomowanie osi Z ..."
+msgstr "Wykryto problem, wymuszono poziomowanie osi Z."
 
 # MSG_SOUND_ONCE c=17 r=1
 #: sound.h:7
@@ -1283,10 +1283,10 @@ msgstr "Dzwiek    [1-raz]"
 # MSG_SOUND_SILENT c=17 r=1
 #: sound.h:8
 msgid "Sound    [silent]"
-msgstr "Dzwiek    [Cichy]"
+msgstr "Dzwiek    [cichy]"
 
 # MSG_SPEED
-#: ultralcd.cpp:6840
+#: ultralcd.cpp:6926
 msgid "Speed"
 msgstr "Predkosc"
 
@@ -1296,19 +1296,19 @@ msgid "Spinning"
 msgstr "Kreci sie"
 
 # MSG_TEMP_CAL_WARNING c=20 r=4
-#: Marlin_main.cpp:4367
+#: Marlin_main.cpp:4368
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr "Potrzebna jest stabilna temperatura otoczenia 21-26C i stabilne podloze."
 
 # MSG_STATISTICS
-#: ultralcd.cpp:6753
+#: ultralcd.cpp:6839
 msgid "Statistics  "
 msgstr "Statystyki"
 
 # MSG_STOP_PRINT
 #: messages.c:93
 msgid "Stop print"
-msgstr "Zatrzymac druk"
+msgstr "Przerwanie druku"
 
 # MSG_STOPPED
 #: messages.c:94
@@ -1316,12 +1316,12 @@ msgid "STOPPED. "
 msgstr "ZATRZYMANO."
 
 # MSG_SUPPORT
-#: ultralcd.cpp:6762
+#: ultralcd.cpp:6848
 msgid "Support"
 msgstr "Wsparcie"
 
 # MSG_SELFTEST_SWAPPED
-#: ultralcd.cpp:7873
+#: ultralcd.cpp:7959
 msgid "Swapped"
 msgstr "Zamieniono"
 
@@ -1331,22 +1331,22 @@ msgid "Temp. cal.          "
 msgstr "Kalibracja temp."
 
 # MSG_TEMP_CALIBRATION_ON c=20 r=1
-#: ultralcd.cpp:5600
+#: ultralcd.cpp:5686
 msgid "Temp. cal.   [on]"
-msgstr "Kalibr. temp.[wl]"
+msgstr "Kalibr.temp. [wl]"
 
 # MSG_TEMP_CALIBRATION_OFF c=20 r=1
-#: ultralcd.cpp:5598
+#: ultralcd.cpp:5684
 msgid "Temp. cal.  [off]"
 msgstr "Kalibr.temp.[wyl]"
 
 # MSG_CALIBRATION_PINDA_MENU c=17 r=1
-#: ultralcd.cpp:5694
+#: ultralcd.cpp:5780
 msgid "Temp. calibration"
 msgstr "Kalibracja temp."
 
 # MSG_TEMP_CAL_FAILED c=20 r=8
-#: ultralcd.cpp:3867
+#: ultralcd.cpp:3951
 msgid "Temperature calibration failed"
 msgstr "Kalibracja temperaturowa nieudana"
 
@@ -1356,12 +1356,12 @@ msgid "Temperature calibration is finished and active. Temp. calibration can be 
 msgstr "Kalibracja temperaturowa zakonczona i wlaczona. Moze byc wylaczona z menu Ustawienia -> Kalibracja temp."
 
 # MSG_TEMPERATURE
-#: ultralcd.cpp:5564
+#: ultralcd.cpp:5650
 msgid "Temperature"
 msgstr "Temperatura"
 
 # MSG_MENU_TEMPERATURES c=15 r=1
-#: ultralcd.cpp:2140
+#: ultralcd.cpp:2251
 msgid "Temperatures"
 msgstr "Temperatury"
 
@@ -1371,37 +1371,37 @@ msgid "There is still a need to make Z calibration. Please follow the manual, ch
 msgstr "Musimy przeprowadzic kalibracje Z. Kieruj sie Samouczkiem: rozdzial Pierwsze Kroki, sekcja Kalibracja."
 
 # 
-#: ultralcd.cpp:2863
+#: ultralcd.cpp:2908
 msgid "Total filament"
-msgstr "Calkowita dlugosc filamentu"
+msgstr "Zuzycie filamentu"
 
 # 
-#: ultralcd.cpp:2863
+#: ultralcd.cpp:2908
 msgid "Total print time"
-msgstr "Calkowity czas druku"
+msgstr "Laczny czas druku"
 
 # MSG_TUNE
-#: ultralcd.cpp:6633
+#: ultralcd.cpp:6719
 msgid "Tune"
 msgstr "Strojenie"
 
 # 
-#: ultralcd.cpp:4783
+#: ultralcd.cpp:4869
 msgid "Unload"
 msgstr "Rozladuj"
 
 # 
-#: ultralcd.cpp:1857
+#: ultralcd.cpp:1820
 msgid "Total failures"
 msgstr "Suma bledow"
 
 # 
-#: ultralcd.cpp:2213
+#: ultralcd.cpp:2324
 msgid "to load filament"
 msgstr "aby zaladow. fil."
 
 # 
-#: ultralcd.cpp:2217
+#: ultralcd.cpp:2328
 msgid "to unload filament"
 msgstr "aby rozlad. filament"
 
@@ -1416,42 +1416,42 @@ msgid "Unloading filament"
 msgstr "Rozladowuje filament"
 
 # 
-#: ultralcd.cpp:1824
+#: ultralcd.cpp:1773
 msgid "Total"
 msgstr "Suma"
 
 # MSG_USED c=19 r=1
-#: ultralcd.cpp:5822
+#: ultralcd.cpp:5908
 msgid "Used during print"
 msgstr "Uzyte podczas druku"
 
 # MSG_MENU_VOLTAGES c=15 r=1
-#: ultralcd.cpp:2143
+#: ultralcd.cpp:2254
 msgid "Voltages"
 msgstr "Napiecia"
 
 # 
-#: ultralcd.cpp:2116
+#: ultralcd.cpp:2227
 msgid "unknown"
 msgstr "nieznane"
 
 # MSG_USERWAIT
-#: Marlin_main.cpp:5262
+#: Marlin_main.cpp:5263
 msgid "Wait for user..."
 msgstr "Czekam na uzytkownika..."
 
 # MSG_WAITING_TEMP c=20 r=3
-#: ultralcd.cpp:3374
+#: ultralcd.cpp:3458
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Oczekiwanie na wychlodzenie dyszy i stolu"
 
 # MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ultralcd.cpp:3338
+#: ultralcd.cpp:3422
 msgid "Waiting for PINDA probe cooling"
 msgstr "Czekam az spadnie temp. sondy PINDA"
 
 # 
-#: ultralcd.cpp:4782
+#: ultralcd.cpp:4868
 msgid "Use unload to remove filament 1 if it protrudes outside of the rear MMU tube. Use eject if it is hidden in tube."
 msgstr "Uzyj opcji Rozladuj jesli filament wystaje z tylnej rurki MMU. Uzyj opcji Wysun jesli wciaz jest w srodku."
 
@@ -1471,7 +1471,7 @@ msgid "Warning: printer type changed."
 msgstr "Ostrzezenie: rodzaj drukarki ulegl zmianie"
 
 # MSG_UNLOAD_SUCCESSFUL c=20 r=2
-#: Marlin_main.cpp:3053
+#: Marlin_main.cpp:3054
 msgid "Was filament unload successful?"
 msgstr "Rozladowanie fil. ok?"
 
@@ -1481,12 +1481,12 @@ msgid "Wiring error"
 msgstr "Blad polaczenia"
 
 # MSG_WIZARD c=17 r=1
-#: ultralcd.cpp:5661
+#: ultralcd.cpp:5747
 msgid "Wizard"
 msgstr "Asystent"
 
 # MSG_XYZ_DETAILS c=19 r=1
-#: ultralcd.cpp:2132
+#: ultralcd.cpp:2243
 msgid "XYZ cal. details"
 msgstr "Szczegoly kal. XYZ"
 
@@ -1506,69 +1506,69 @@ msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr "Zawsze mozesz uruchomic Asystenta ponownie przez Kalibracja -> Asystent."
 
 # MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ultralcd.cpp:3838
+#: ultralcd.cpp:3922
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr "Kalibracja XYZ pomyslna. Skos bedzie automatycznie korygowany."
 
 # MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ultralcd.cpp:3835
+#: ultralcd.cpp:3919
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr "Kalibracja XYZ prawidlowa. Osie X/Y lekko skosne. Dobra robota!"
 
 # 
-#: ultralcd.cpp:5044
+#: ultralcd.cpp:5130
 msgid "X-correct:"
-msgstr "Korekcja X:"
+msgstr "Korekcja-X:"
 
 # MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ultralcd.cpp:3832
+#: ultralcd.cpp:3916
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "Kalibracja XYZ ok. Osie X/Y sa prostopadle. Gratulacje!"
 
 # MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ultralcd.cpp:3816
+#: ultralcd.cpp:3900
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr "Kalibr. XYZ niedokladna. Przednie punkty kalibr. nieosiagalne."
 
 # MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ultralcd.cpp:3819
+#: ultralcd.cpp:3903
 msgid "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr "Kalibracja XYZ niedokladna. Prawy przedni punkt nieosiagalny."
 
 # MSG_LOAD_ALL c=17
-#: ultralcd.cpp:6080
+#: ultralcd.cpp:6166
 msgid "Load all"
 msgstr "Zalad. wszystkie"
 
 # 
-#: ultralcd.cpp:3798
+#: ultralcd.cpp:3882
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr "Kalibracja XYZ nieudana. Nie znaleziono punktow kalibracyjnych."
 
 # 
-#: ultralcd.cpp:3804
+#: ultralcd.cpp:3888
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr "Kalibr. XYZ nieudana. Przednie punkty kalibr. nieosiagalne. Nalezy poprawic montaz drukarki."
 
 # 
-#: ultralcd.cpp:3807
+#: ultralcd.cpp:3891
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr "Kalibr. XYZ nieudana. Prawy przedni punkt nieosiagalny. Nalezy poprawic montaz drukarki."
 
 # 
-#: ultralcd.cpp:2968
+#: ultralcd.cpp:3016
 msgid "Y distance from min"
 msgstr "Dystans od 0 w osi Y"
 
 # 
-#: ultralcd.cpp:5045
+#: ultralcd.cpp:5131
 msgid "Y-correct:"
-msgstr "Korekcja Y:"
+msgstr "Korekcja-Y:"
 
 # MSG_OFF
 #: menu.cpp:426
 msgid " [off]"
-msgstr ""
+msgstr " [wyl]"
 
 # 
 #: messages.c:57
@@ -1576,32 +1576,32 @@ msgid "Back"
 msgstr "Wstecz"
 
 # 
-#: ultralcd.cpp:5553
+#: ultralcd.cpp:5639
 msgid "Checks"
 msgstr "Testy"
 
 # 
-#: ultralcd.cpp:7887
+#: ultralcd.cpp:7973
 msgid "False triggering"
 msgstr "Falszywy alarm"
 
 # 
-#: ultralcd.cpp:3946
+#: ultralcd.cpp:4030
 msgid "FINDA:"
 msgstr ""
 
 # 
-#: ultralcd.cpp:5459
+#: ultralcd.cpp:5545
 msgid "Firmware   [none]"
 msgstr "Firmware   [brak]"
 
 # 
-#: ultralcd.cpp:5465
+#: ultralcd.cpp:5551
 msgid "Firmware [strict]"
 msgstr "Firmware [restr.]"
 
 # 
-#: ultralcd.cpp:5462
+#: ultralcd.cpp:5548
 msgid "Firmware   [warn]"
 msgstr "Firmware[ostrzez]"
 
@@ -1611,102 +1611,102 @@ msgid "HW Setup"
 msgstr "Ustawienia HW"
 
 # 
-#: ultralcd.cpp:3950
+#: ultralcd.cpp:4034
 msgid "IR:"
 msgstr ""
 
 # 
-#: ultralcd.cpp:6960
+#: ultralcd.cpp:7046
 msgid "Magnets comp.[N/A]"
-msgstr "Kor. magnesow [nd]"
+msgstr "Kor. magnesow[N/D]"
 
 # 
-#: ultralcd.cpp:6958
+#: ultralcd.cpp:7044
 msgid "Magnets comp.[Off]"
 msgstr "Kor. magnesow[wyl]"
 
 # 
-#: ultralcd.cpp:6957
+#: ultralcd.cpp:7043
 msgid "Magnets comp. [On]"
 msgstr "Kor. magnesow [wl]"
 
 # 
-#: ultralcd.cpp:6949
+#: ultralcd.cpp:7035
 msgid "Mesh         [3x3]"
 msgstr "Siatka       [3x3]"
 
 # 
-#: ultralcd.cpp:6950
+#: ultralcd.cpp:7036
 msgid "Mesh         [7x7]"
 msgstr "Siatka       [7x7]"
 
 # 
-#: ultralcd.cpp:5591
+#: ultralcd.cpp:5677
 msgid "Mesh bed leveling"
-msgstr "Poziomowanie wg siatki"
+msgstr "Poziomowanie stolu"
 
 # 
 #: Marlin_main.cpp:856
 msgid "MK3S firmware detected on MK3 printer"
-msgstr ""
+msgstr "Wykryto firmware MK3S w drukarce MK3"
 
 # 
-#: ultralcd.cpp:5220
+#: ultralcd.cpp:5306
 msgid "MMU Mode [Normal]"
 msgstr "Tryb MMU[Normaln]"
 
 # 
-#: ultralcd.cpp:5221
+#: ultralcd.cpp:5307
 msgid "MMU Mode[Stealth]"
-msgstr "Tryb MMU [Stealth]"
+msgstr "Tryb MMU[Stealth]"
 
 # 
-#: ultralcd.cpp:4427
+#: ultralcd.cpp:4511
 msgid "Mode change in progress ..."
 msgstr "Trwa zmiana trybu..."
 
 # 
-#: ultralcd.cpp:5420
+#: ultralcd.cpp:5506
 msgid "Model      [none]"
 msgstr "Model      [brak]"
 
 # 
-#: ultralcd.cpp:5426
+#: ultralcd.cpp:5512
 msgid "Model    [strict]"
 msgstr "Model [restrykc.]"
 
 # 
-#: ultralcd.cpp:5423
+#: ultralcd.cpp:5509
 msgid "Model      [warn]"
 msgstr "Model  [ostrzez.]"
 
 # 
-#: ultralcd.cpp:5381
+#: ultralcd.cpp:5467
 msgid "Nozzle d.  [0.25]"
 msgstr "Sr. dyszy  [0,25]"
 
 # 
-#: ultralcd.cpp:5384
+#: ultralcd.cpp:5470
 msgid "Nozzle d.  [0.40]"
 msgstr "Sr. dyszy  [0,40]"
 
 # 
-#: ultralcd.cpp:5387
+#: ultralcd.cpp:5473
 msgid "Nozzle d.  [0.60]"
 msgstr "Sr. dyszy  [0,60]"
 
 # 
-#: ultralcd.cpp:5335
+#: ultralcd.cpp:5421
 msgid "Nozzle     [none]"
 msgstr "Dysza      [brak]"
 
 # 
-#: ultralcd.cpp:5341
+#: ultralcd.cpp:5427
 msgid "Nozzle   [strict]"
 msgstr "Dysza [restrykc.]"
 
 # 
-#: ultralcd.cpp:5338
+#: ultralcd.cpp:5424
 msgid "Nozzle     [warn]"
 msgstr "Dysza  [ostrzez.]"
 
@@ -1718,40 +1718,40 @@ msgstr ""
 # 
 #: util.cpp:516
 msgid "G-code sliced for a different level. Please re-slice the model again. Print cancelled."
-msgstr ""
+msgstr "G-code pociety na innym poziomie. Potnij model ponownie. Druk anulowany."
 
 # 
 #: util.cpp:427
 msgid "G-code sliced for a different printer type. Continue?"
-msgstr ""
+msgstr "G-code pociety dla innej drukarki. Kontynuowac?"
 
 # 
 #: util.cpp:433
 msgid "G-code sliced for a different printer type. Please re-slice the model again. Print cancelled."
-msgstr ""
+msgstr "G-code pociety dla drukarki innego typu. Potnij model ponownie. Druk anulowany."
 
 # 
 #: util.cpp:477
 msgid "G-code sliced for a newer firmware. Continue?"
-msgstr ""
+msgstr "G-code pociety dla nowszego firmware. Kontynuowac?"
 
 # 
 #: util.cpp:483
 msgid "G-code sliced for a newer firmware. Please update the firmware. Print cancelled."
-msgstr ""
+msgstr "G-code pociety dla nowszego firmware. Zaktualizuj firmware. Druk anulowany."
 
 # 
-#: ultralcd.cpp:3942
+#: ultralcd.cpp:4026
 msgid "PINDA:"
 msgstr ""
 
 # 
-#: ultralcd.cpp:2286
+#: ultralcd.cpp:2465
 msgid "Preheating to cut"
 msgstr "Nagrzewanie do obciecia"
 
 # 
-#: ultralcd.cpp:2283
+#: ultralcd.cpp:2462
 msgid "Preheating to eject"
 msgstr "Nagrzewanie do wysuniecia"
 
@@ -1766,17 +1766,17 @@ msgid "Printer nozzle diameter differs from the G-code. Please check the value i
 msgstr "Srednica dyszy rozni sie od tej w G-code. Sprawdz ustawienia. Druk anulowany."
 
 # 
-#: ultralcd.cpp:6597
+#: ultralcd.cpp:6683
 msgid "Rename"
 msgstr "Zmien nazwe"
 
 # 
-#: ultralcd.cpp:6593
+#: ultralcd.cpp:6679
 msgid "Select"
 msgstr "Wybierz"
 
 # 
-#: ultralcd.cpp:2134
+#: ultralcd.cpp:2245
 msgid "Sensor info"
 msgstr "Info o sensorach"
 
@@ -1786,22 +1786,27 @@ msgid "Sheet"
 msgstr "Plyta"
 
 # 
-#: 
-msgid "Sound     [assist]"
-msgstr ""
+#: sound.h:9
+msgid "Sound    [assist]"
+msgstr "Dzwiek   [asyst.]"
 
 # 
-#: ultralcd.cpp:5551
+#: ultralcd.cpp:5637
 msgid "Steel sheets"
-msgstr ""
+msgstr "Plyty stalowe"
 
 # 
-#: ultralcd.cpp:5046
+#: ultralcd.cpp:5132
 msgid "Z-correct:"
 msgstr "Korekcja-Z:"
 
 # 
-#: ultralcd.cpp:6952
+#: ultralcd.cpp:7038
 msgid "Z-probe nr.    [1]"
-msgstr "Pomiar-Z       [1]"
+msgstr "Ilosc Pomiarow [1]"
+
+# 
+#: ultralcd.cpp:7040
+msgid "Z-probe nr.    [3]"
+msgstr "Ilosc Pomiarow [3]"
 

--- a/lang/po/new/cs.po
+++ b/lang/po/new/cs.po
@@ -1,51 +1,19 @@
+# Translation of Prusa-Firmware into Czech.
+#
 msgid ""
 msgstr ""
-"Language: cs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: cs\n"
+"Project-Id-Version: Prusa-Firmware\n"
+"POT-Creation-Date: Sun, Sep 22, 2019 1:28:20 PM\n"
+"PO-Revision-Date: Sun, Sep 22, 2019 1:28:20 PM\n"
+"Language-Team: \n"
+"X-Generator: Poedit 2.0.7\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+"Last-Translator: \n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
-"X-Generator: PhraseApp (phraseapp.com)\n"
-
-# MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ultralcd.cpp:4219
-msgid "\e[2JCrash detection can\e[1;0Hbe turned on only in\e[2;0HNormal mode"
-msgstr "\e[2JCrash detekce muze\e[1;0Hbyt zapnuta pouze v\e[2;0HNormal modu"
-
-# MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ultralcd.cpp:4231
-msgid "\e[2JWARNING:\e[1;0HCrash detection\e[2;0Hdisabled in\e[3;0HStealth mode"
-msgstr "\e[2JPOZOR:\e[1;0HCrash detekce\e[2;0Hdeaktivovana ve\e[3;0Htichem modu"
-
-# 
-#: ultralcd.cpp:3913
-msgid "  1"
-msgstr "1"
-
-# MSG_PLANNER_BUFFER_BYTES
-#: Marlin_main.cpp:1184
-msgid "  PlannerBufferBytes: "
-msgstr " PlannerBufferBytes: "
-
-# MSG_EXTRUDER_CORRECTION_OFF c=6
-#: ultralcd.cpp:6312
-msgid "  [off"
-msgstr "[vyp"
-
-# MSG_ERR_COLD_EXTRUDE_STOP
-#: planner.cpp:761
-msgid " cold extrusion prevented"
-msgstr "zabraneno extruzi za studena"
-
-# MSG_FREE_MEMORY
-#: Marlin_main.cpp:1182
-msgid " Free Memory: "
-msgstr "Volna pamet: "
-
-# MSG_CONFIGURATION_VER
-#: Marlin_main.cpp:1172
-msgid " Last Updated: "
-msgstr "Naposledy aktualizovano:"
 
 # MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE2 c=14
 #: messages.c:39
@@ -57,48 +25,33 @@ msgstr " z 4"
 msgid " of 9"
 msgstr " z 9"
 
-# MSG_OFF
-#: menu.cpp:426
-msgid " [off]"
-msgstr "[vyp]"
+# MSG_MEASURED_OFFSET
+#: ultralcd.cpp:3089
+msgid "[0;0] point offset"
+msgstr "[0;0] odsazeni bodu"
 
-# MSG_FACTOR
-#: ultralcd.cpp:6008
-msgid " \002 Fact"
-msgstr " \002 Fact"
+# MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
+#: 
+msgid "Crash detection can\x0abe turned on only in\x0aNormal mode"
+msgstr "Crash detekce muze\x0abyt zapnuta pouze v\x0aNormal modu"
 
-# MSG_MAX
-#: ultralcd.cpp:6007
-msgid " \002 Max"
-msgstr " \002 Max"
-
-# MSG_MIN
-#: ultralcd.cpp:6006
-msgid " \002 Min"
-msgstr " \002 Min"
+# MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
+#: 
+msgid "WARNING:\x0aCrash detection\x0adisabled in\x0aStealth mode"
+msgstr "POZOR:\x0aCrash detekce\x0adeaktivovana ve\x0aStealth modu"
 
 # 
-#: ultralcd.cpp:2294
+#: ultralcd.cpp:2472
 msgid ">Cancel"
 msgstr ">Zrusit"
 
-# MSG_BABYSTEPPING_Z c=20
-#: ultralcd.cpp:3043
-msgid "Adjusting Z"
-msgstr "Doladeni Z"
-
 # MSG_BABYSTEPPING_Z c=15
-#: ultralcd.cpp:3144
+#: ultralcd.cpp:3209
 msgid "Adjusting Z:"
 msgstr "Doladeni Z:"
 
-# MSG_ALL c=19 r=1
-#: messages.c:11
-msgid "All"
-msgstr "Vse"
-
 # MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ultralcd.cpp:8209
+#: ultralcd.cpp:8295
 msgid "All correct      "
 msgstr "Vse OK "
 
@@ -108,92 +61,67 @@ msgid "All is done. Happy printing!"
 msgstr "Vse je hotovo."
 
 # 
-#: ultralcd.cpp:1979
+#: ultralcd.cpp:2009
 msgid "Ambient"
 msgstr "Okoli"
 
 # MSG_PRESS c=20
-#: ultralcd.cpp:2573
+#: ultralcd.cpp:2618
 msgid "and press the knob"
 msgstr "a stisknete tlacitko"
 
 # MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=2
-#: ultralcd.cpp:3442
+#: ultralcd.cpp:3529
 msgid "Are left and right Z~carriages all up?"
 msgstr "Dojely oba Z voziky k~hornimu dorazu?"
 
-# MSG_ADJUSTZ
-#: ultralcd.cpp:2600
-msgid "Auto adjust Z?"
-msgstr "Auto doladit Z ?"
-
 # MSG_AUTO_DEPLETE_ON c=17 r=1
-#: ultralcd.cpp:4706
-msgid "Auto deplete [on]"
-msgstr "Spoj Civky [zap]"
+#: ultralcd.cpp:5200
+msgid "SpoolJoin    [on]"
+msgstr "SpoolJoin   [zap]"
 
 # 
-#: ultralcd.cpp:4702
-msgid "Auto deplete[N/A]"
-msgstr "Spoj Civky [N/A]"
+#: ultralcd.cpp:5196
+msgid "SpoolJoin   [N/A]"
+msgstr ""
 
 # MSG_AUTO_DEPLETE_OFF c=17 r=1
-#: ultralcd.cpp:4710
-msgid "Auto deplete[off]"
-msgstr "Spoj Civky [vyp]"
+#: ultralcd.cpp:5204
+msgid "SpoolJoin   [off]"
+msgstr "SpoolJoin   [vyp]"
 
 # MSG_AUTO_HOME
 #: messages.c:11
 msgid "Auto home"
-msgstr "Auto home"
+msgstr ""
 
 # MSG_AUTOLOAD_FILAMENT c=17
-#: ultralcd.cpp:6731
+#: ultralcd.cpp:6822
 msgid "AutoLoad filament"
 msgstr "AutoZavedeni fil."
 
 # MSG_AUTOLOADING_ONLY_IF_FSENS_ON c=20 r=4
-#: ultralcd.cpp:4375
+#: ultralcd.cpp:4462
 msgid "Autoloading filament available only when filament sensor is turned on..."
 msgstr "Automaticke zavadeni filamentu je dostupne pouze pri zapnutem filament senzoru..."
 
 # MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ultralcd.cpp:2768
+#: ultralcd.cpp:2813
 msgid "Autoloading filament is active, just press the knob and insert filament..."
 msgstr "Automaticke zavadeni filamentu aktivni, stisknete tlacitko a vlozte filament..."
 
-# MSG_SELFTEST_AXIS
-#: ultralcd.cpp:7865
-msgid "Axis"
-msgstr "Osa"
-
 # MSG_SELFTEST_AXIS_LENGTH
-#: ultralcd.cpp:7863
+#: ultralcd.cpp:7949
 msgid "Axis length"
 msgstr "Delka osy"
 
-# MSG_BABYSTEPPING_X
-#: ultralcd.cpp:2481
-msgid "Babystepping X"
-msgstr "Babystepping X"
-
-# MSG_BABYSTEPPING_Y
-#: ultralcd.cpp:2484
-msgid "Babystepping Y"
-msgstr "Babystepping Y"
-
-# 
-#: messages.c:57
-msgid "Back"
-msgstr "Zpet"
-
-# MSG_BED
-#: messages.c:15
-msgid "Bed"
-msgstr "Podlozka"
+# MSG_SELFTEST_AXIS
+#: ultralcd.cpp:7951
+msgid "Axis"
+msgstr "Osa"
 
 # MSG_SELFTEST_BEDHEATER
-#: ultralcd.cpp:7807
+#: ultralcd.cpp:7893
 msgid "Bed / Heater"
 msgstr "Podlozka / Topeni"
 
@@ -205,10 +133,10 @@ msgstr "Bed OK."
 # MSG_BED_HEATING
 #: messages.c:17
 msgid "Bed Heating"
-msgstr "Zahrivani bed"
+msgstr "Zahrivani bedu"
 
 # MSG_BED_CORRECTION_MENU
-#: ultralcd.cpp:5663
+#: ultralcd.cpp:5768
 msgid "Bed level correct"
 msgstr "Korekce podlozky"
 
@@ -217,23 +145,13 @@ msgstr "Korekce podlozky"
 msgid "Bed leveling failed. Sensor didnt trigger. Debris on nozzle? Waiting for reset."
 msgstr "Kalibrace Z selhala. Sensor nesepnul. Znecistena tryska? Cekam na reset."
 
-# MSG_BED_LEVELING_FAILED_PROBE_DISCONNECTED c=20 r=4
-#: Marlin_main.cpp:4508
-msgid "Bed leveling failed. Sensor disconnected or cable broken. Waiting for reset."
-msgstr "Kalibrace Z selhala. Sensor je odpojeny nebo preruseny kabel. Cekam na reset."
-
-# MSG_BED_LEVELING_FAILED_POINT_HIGH c=20 r=4
-#: Marlin_main.cpp:4512
-msgid "Bed leveling failed. Sensor triggered too high. Waiting for reset."
-msgstr "Kalibrace Z selhala. Sensor sepnul prilis vysoko. Cekam na reset."
-
-# MSG_BEGIN_FILE_LIST
-#: Marlin_main.cpp:4405
-msgid "Begin file list"
-msgstr "Pocatek seznamu souboru"
+# MSG_BED
+#: messages.c:15
+msgid "Bed"
+msgstr "Podlozka"
 
 # MSG_MENU_BELT_STATUS c=15 r=1
-#: ultralcd.cpp:2007
+#: ultralcd.cpp:2059
 msgid "Belt status"
 msgstr "Stav remenu"
 
@@ -242,18 +160,13 @@ msgstr "Stav remenu"
 msgid "Blackout occurred. Recover print?"
 msgstr "Detekovan vypadek proudu.Obnovit tisk?"
 
-# MSG_CALIBRATE_PINDA c=17 r=1
-#: ultralcd.cpp:4566
-msgid "Calibrate"
-msgstr "Zkalibrovat"
-
-# MSG_CALIBRATE_E c=20 r=1
-#: ultralcd.cpp:4526
-msgid "Calibrate E"
-msgstr "Kalibrovat E"
+# 
+#: ultralcd.cpp:8297
+msgid "Calibrating home"
+msgstr "Kalibruji vychozi poz."
 
 # MSG_CALIBRATE_BED
-#: ultralcd.cpp:5652
+#: ultralcd.cpp:5757
 msgid "Calibrate XYZ"
 msgstr "Kalibrace XYZ"
 
@@ -262,13 +175,13 @@ msgstr "Kalibrace XYZ"
 msgid "Calibrate Z"
 msgstr "Kalibrovat Z"
 
-# 
-#: ultralcd.cpp:8211
-msgid "Calibrating home"
-msgstr "Kalibruji vychozi poz."
+# MSG_CALIBRATE_PINDA c=17 r=1
+#: ultralcd.cpp:4654
+msgid "Calibrate"
+msgstr "Zkalibrovat"
 
 # MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ultralcd.cpp:3405
+#: ultralcd.cpp:3492
 msgid "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end stoppers. Click when done."
 msgstr "Kalibrace XYZ. Otacenim tlacitka posunte Z osu az k~hornimu dorazu. Potvrdte tlacitkem."
 
@@ -278,132 +191,32 @@ msgid "Calibrating Z"
 msgstr "Kalibruji Z"
 
 # MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ultralcd.cpp:3405
+#: ultralcd.cpp:3492
 msgid "Calibrating Z. Rotate the knob to move the Z carriage up to the end stoppers. Click when done."
 msgstr "Kalibrace Z. Otacenim tlacitka posunte Z osu az k~hornimu dorazu. Potvrdte tlacitkem."
+
+# MSG_HOMEYZ_DONE
+#: ultralcd.cpp:816
+msgid "Calibration done"
+msgstr "Kalibrace OK"
 
 # MSG_MENU_CALIBRATION
 #: messages.c:61
 msgid "Calibration"
 msgstr "Kalibrace"
 
-# MSG_HOMEYZ_DONE
-#: ultralcd.cpp:832
-msgid "Calibration done"
-msgstr "Kalibrace OK"
-
 # 
-#: ultralcd.cpp:4692
+#: ultralcd.cpp:4781
 msgid "Cancel"
 msgstr "Zrusit"
 
-# MSG_SD_CANT_ENTER_SUBDIR
-#: cardreader.cpp:662
-msgid "Cannot enter subdir: "
-msgstr "Nelze otevrit slozku:"
-
-# MSG_SD_CANT_OPEN_SUBDIR
-#: cardreader.cpp:97
-msgid "Cannot open subdir"
-msgstr "Nelze otevrit slozku"
-
-# MSG_SD_INSERTED
-#:
-msgid "Card inserted"
-msgstr "Karta vlozena"
-
 # MSG_SD_REMOVED
-#: ultralcd.cpp:8578
+#: ultralcd.cpp:8679
 msgid "Card removed"
 msgstr "Karta vyjmuta"
 
-# 
-#: ultralcd.cpp:6087
-msgid "Change extruder"
-msgstr "Zmenit extruder"
-
-# MSG_FILAMENTCHANGE
-#: messages.c:37
-msgid "Change filament"
-msgstr "Vymenit filament"
-
-# MSG_CNG_SDCARD
-#: ultralcd.cpp:5777
-msgid "Change SD card"
-msgstr "Vymenit SD"
-
-# MSG_CHANGE_SUCCESS
-#: ultralcd.cpp:2584
-msgid "Change success!"
-msgstr "Zmena uspesna!"
-
-# MSG_CORRECTLY c=20
-#: ultralcd.cpp:2661
-msgid "Changed correctly?"
-msgstr "Vymena ok?"
-
-# MSG_CHANGING_FILAMENT c=20
-#: ultralcd.cpp:1899
-msgid "Changing filament!"
-msgstr "Vymena filamentu!"
-
-# MSG_SELFTEST_CHECK_BED c=20
-#: messages.c:81
-msgid "Checking bed     "
-msgstr "Kontrola podlozky"
-
-# MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ultralcd.cpp:8200
-msgid "Checking endstops"
-msgstr "Kontrola endstopu"
-
-# MSG_SELFTEST_CHECK_HOTEND c=20
-#: ultralcd.cpp:8206
-msgid "Checking hotend  "
-msgstr "Kontrola hotend "
-
-# MSG_SELFTEST_CHECK_FSENSOR c=20
-#: messages.c:82
-msgid "Checking sensors "
-msgstr "Kontrola senzoru"
-
-# MSG_SELFTEST_CHECK_X c=20
-#: ultralcd.cpp:8201
-msgid "Checking X axis  "
-msgstr "Kontrola osy X"
-
-# MSG_SELFTEST_CHECK_Y c=20
-#: ultralcd.cpp:8202
-msgid "Checking Y axis  "
-msgstr "Kontrola osy Y"
-
-# MSG_SELFTEST_CHECK_Z c=20
-#: ultralcd.cpp:8203
-msgid "Checking Z axis  "
-msgstr "Kontrola osy Z"
-
-# 
-#: ultralcd.cpp:5537
-msgid "Checks"
-msgstr "Kontrola"
-
-# MSG_ERR_CHECKSUM_MISMATCH
-#: cmdqueue.cpp:444
-msgid "checksum mismatch, Last Line: "
-msgstr "neplatny kontrolni soucet, posl. radek:\n"
-
-# MSG_CHOOSE_EXTRUDER c=20 r=1
-#: messages.c:49
-msgid "Choose extruder:"
-msgstr "Vyberte extruder:"
-
-# MSG_CHOOSE_FILAMENT c=20 r=1
-#: messages.c:50
-msgid "Choose filament:"
-msgstr "Vyber filament:"
-
 # MSG_NOT_COLOR
-#: ultralcd.cpp:2673
+#: ultralcd.cpp:2718
 msgid "Color not correct"
 msgstr "Barva neni cista"
 
@@ -413,19 +226,9 @@ msgid "Cooldown"
 msgstr "Zchladit"
 
 # 
-#: ultralcd.cpp:4108
-msgid "Copy selected language from XFLASH?"
-msgstr "Kopirovat vybrany jazyk do XFLASH?"
-
-# 
-#: ultralcd.cpp:4499
+#: ultralcd.cpp:4587
 msgid "Copy selected language?"
 msgstr "Kopirovat vybrany jazyk?"
-
-# 
-#: ultralcd.cpp:1881
-msgid "Crash"
-msgstr "Naraz"
 
 # MSG_CRASHDETECT_ON
 #: messages.c:27
@@ -435,7 +238,7 @@ msgstr "Crash det.  [zap]"
 # MSG_CRASHDETECT_NA
 #: messages.c:25
 msgid "Crash det.  [N/A]"
-msgstr "Crash det.  [N/A]"
+msgstr ""
 
 # MSG_CRASHDETECT_OFF
 #: messages.c:26
@@ -448,27 +251,27 @@ msgid "Crash detected."
 msgstr "Detekovan naraz."
 
 # 
-#: Marlin_main.cpp:618
+#: Marlin_main.cpp:600
 msgid "Crash detected. Resume print?"
 msgstr "Detekovan naraz. Obnovit tisk?"
 
-# MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#:
-msgid "Crash detection can\nbe turned on only in\nNormal mode"
-msgstr "Crash detekce muze byt zapnuta pouze v Normal modu"
+# 
+#: ultralcd.cpp:1853
+msgid "Crash"
+msgstr "Naraz"
 
 # MSG_CURRENT c=19 r=1
-#: ultralcd.cpp:5804
+#: ultralcd.cpp:5909
 msgid "Current"
 msgstr "Pouze aktualni"
 
 # MSG_DATE c=17 r=1
-#: ultralcd.cpp:2106
+#: ultralcd.cpp:2213
 msgid "Date:"
 msgstr "Datum:"
 
 # MSG_DISABLE_STEPPERS
-#: ultralcd.cpp:5552
+#: ultralcd.cpp:5654
 msgid "Disable steppers"
 msgstr "Vypnout motory"
 
@@ -478,162 +281,82 @@ msgid "Distance between tip of the nozzle and the bed surface has not been set y
 msgstr "Neni zkalibrovana vzdalenost trysky od tiskove podlozky. Postupujte prosim podle manualu, kapitola Zaciname, odstavec Nastaveni prvni vrstvy."
 
 # MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ultralcd.cpp:4968
+#: ultralcd.cpp:5070
 msgid "Do you want to repeat last step to readjust distance between nozzle and heatbed?"
 msgstr "Chcete opakovat posledni krok a pozmenit vzdalenost mezi tryskou a podlozkou?"
 
-# MSG_CLEAN_NOZZLE_E c=20 r=8
-#: ultralcd.cpp:3890
-msgid "E calibration finished. Please clean the nozzle. Click when done."
-msgstr "E kalibrace ukoncena. Prosim ocistete trysku. Pote potvrdte tlacitkem."
-
-# MSG_EXTRUDER_CORRECTION c=9
-#: ultralcd.cpp:4889
-msgid "E-correct"
-msgstr "Korekce E"
-
 # MSG_EXTRUDER_CORRECTION c=10
-#: ultralcd.cpp:5032
+#: ultralcd.cpp:5134
 msgid "E-correct:"
 msgstr "Korekce E:"
-
-# 
-#: ultralcd.cpp:4780
-msgid "Eject"
-msgstr "Vysunout"
 
 # MSG_EJECT_FILAMENT c=17 r=1
 #: messages.c:53
 msgid "Eject filament"
 msgstr "Vysunout filament"
 
-# MSG_EJECT_FILAMENT1 c=17 r=1
-#: ultralcd.cpp:5603
-msgid "Eject filament 1"
-msgstr "Vysunout filament 1"
-
-# MSG_EJECT_FILAMENT2 c=17 r=1
-#: ultralcd.cpp:5604
-msgid "Eject filament 2"
-msgstr "Vysunout filament 2"
-
-# MSG_EJECT_FILAMENT3 c=17 r=1
-#: ultralcd.cpp:5605
-msgid "Eject filament 3"
-msgstr "Vysunout filament 3"
-
-# MSG_EJECT_FILAMENT4 c=17 r=1
-#: ultralcd.cpp:5606
-msgid "Eject filament 4"
-msgstr "Vysunout filament 4"
-
-# MSG_EJECT_FILAMENT5 c=17 r=1
-#: ultralcd.cpp:5607
-msgid "Eject filament 5"
-msgstr "Vysunout filament 5"
+# 
+#: ultralcd.cpp:4869
+msgid "Eject"
+msgstr "Vysunout"
 
 # MSG_EJECTING_FILAMENT c=20 r=1
-#: mmu.cpp:1435
+#: mmu.cpp:1434
 msgid "Ejecting filament"
 msgstr "Vysouvam filament"
 
-# MSG_END_FILE_LIST
-#: Marlin_main.cpp:4407
-msgid "End file list"
-msgstr "Konec sezn. souboru"
-
-# MSG_SELFTEST_ENDSTOP
-#: ultralcd.cpp:7825
-msgid "Endstop"
-msgstr "Koncovy spinac"
-
 # MSG_SELFTEST_ENDSTOP_NOTHIT c=20 r=1
-#: ultralcd.cpp:7831
+#: ultralcd.cpp:7917
 msgid "Endstop not hit"
 msgstr "Kon. spinac nesepnut"
 
+# MSG_SELFTEST_ENDSTOP
+#: ultralcd.cpp:7911
+msgid "Endstop"
+msgstr "Koncovy spinac"
+
 # MSG_SELFTEST_ENDSTOPS
-#: ultralcd.cpp:7813
+#: ultralcd.cpp:7899
 msgid "Endstops"
 msgstr "Konc. spinace"
 
-# MSG_ENDSTOPS_HIT
-#: messages.c:30
-msgid "endstops hit: "
-msgstr "konc. spinace aktivovany: "
-
-# MSG_LANGUAGE_NAME
-#: language.c:153
-msgid "English"
-msgstr "Cestina"
-
-# MSG_Enqueing
-#:
-msgid "enqueing \""
-msgstr "zarazovani \""
-
 # MSG_STACK_ERROR c=20 r=4
-#: ultralcd.cpp:6773
+#: ultralcd.cpp:6859
 msgid "Error - static memory has been overwritten"
 msgstr "Chyba - Doslo k prepisu staticke pameti!"
 
-# MSG_SD_ERR_WRITE_TO_FILE
-#: messages.c:78
-msgid "error writing to file"
-msgstr "chyba zapisu do souboru"
+# MSG_FSENS_NOT_RESPONDING c=20 r=4
+#: ultralcd.cpp:4475
+msgid "ERROR: Filament sensor is not responding, please check connection."
+msgstr "CHYBA: Filament senzor nereaguje, zkontrolujte zapojeni."
 
 # MSG_ERROR
 #: messages.c:28
 msgid "ERROR:"
 msgstr "CHYBA:"
 
-# MSG_FSENS_NOT_RESPONDING c=20 r=4
-#: ultralcd.cpp:4388
-msgid "ERROR: Filament sensor is not responding, please check connection."
-msgstr "CHYBA: Filament senzor nereaguje, zkontrolujte zapojeni."
-
-# 
-#: Marlin_main.cpp:1006
-msgid "External SPI flash W25X20CL not responding."
-msgstr "Externi SPI flash W25X20CL neodpovida."
-
-# MSG_MOVE_E
-#: messages.c:29
-msgid "Extruder"
-msgstr "Extruder"
-
-# 
-#: ultralcd.cpp:5633
-msgid "Extruder 1"
-msgstr "Extruder 1"
-
-# 
-#: ultralcd.cpp:5634
-msgid "Extruder 2"
-msgstr "Extruder 2"
-
-# 
-#: ultralcd.cpp:5635
-msgid "Extruder 3"
-msgstr "Extruder 3"
-
-# 
-#: ultralcd.cpp:5636
-msgid "Extruder 4"
-msgstr "Extruder 4"
-
 # MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
-#: ultralcd.cpp:8218
+#: ultralcd.cpp:8304
 msgid "Extruder fan:"
 msgstr "Levy vent.:"
 
 # MSG_INFO_EXTRUDER c=15 r=1
-#: ultralcd.cpp:2137
+#: ultralcd.cpp:2244
 msgid "Extruder info"
-msgstr "Extruder info"
+msgstr ""
+
+# MSG_MOVE_E
+#: messages.c:29
+msgid "Extruder"
+msgstr ""
+
+# 
+#: ultralcd.cpp:6846
+msgid "Fail stats MMU"
+msgstr "Selhani MMU"
 
 # MSG_FSENS_AUTOLOAD_ON c=17 r=1
-#: ultralcd.cpp:5066
+#: ultralcd.cpp:5168
 msgid "F. autoload  [on]"
 msgstr "F. autozav. [zap]"
 
@@ -643,24 +366,14 @@ msgid "F. autoload [N/A]"
 msgstr "F. autozav. [N/A]"
 
 # MSG_FSENS_AUTOLOAD_OFF c=17 r=1
-#: ultralcd.cpp:5068
+#: ultralcd.cpp:5170
 msgid "F. autoload [off]"
 msgstr "F. autozav. [vyp]"
 
 # 
-#: ultralcd.cpp:6757
+#: ultralcd.cpp:6843
 msgid "Fail stats"
 msgstr "Selhani"
-
-# 
-#: ultralcd.cpp:6760
-msgid "Fail stats MMU"
-msgstr "Selhani MMU"
-
-# 
-#: ultralcd.cpp:7887
-msgid "False triggering"
-msgstr "Falesne spusteni"
 
 # MSG_FAN_SPEED c=14
 #: messages.c:31
@@ -673,12 +386,12 @@ msgid "Fan test"
 msgstr "Test ventilatoru"
 
 # MSG_FANS_CHECK_ON c=17 r=1
-#: ultralcd.cpp:5561
+#: ultralcd.cpp:5663
 msgid "Fans check   [on]"
 msgstr "Kontr. vent.[zap]"
 
 # MSG_FANS_CHECK_OFF c=17 r=1
-#: ultralcd.cpp:5563
+#: ultralcd.cpp:5665
 msgid "Fans check  [off]"
 msgstr "Kontr. vent.[vyp]"
 
@@ -687,13 +400,8 @@ msgstr "Kontr. vent.[vyp]"
 msgid "Fil. sensor  [on]"
 msgstr "Fil. senzor [zap]"
 
-# MSG_RESPONSE_POOR c=20 r=2
-#: Marlin_main.cpp:3146
-msgid "Fil. sensor response is poor, disable it?"
-msgstr "Senzor nerozpoznal filament, vypnout?"
-
 # MSG_FSENSOR_NA
-#: ultralcd.cpp:5046
+#: ultralcd.cpp:5148
 msgid "Fil. sensor [N/A]"
 msgstr "Fil. senzor [N/A]"
 
@@ -703,14 +411,9 @@ msgid "Fil. sensor [off]"
 msgstr "Fil. senzor [vyp]"
 
 # 
-#: ultralcd.cpp:1881
+#: ultralcd.cpp:1852
 msgid "Filam. runouts"
 msgstr "Vypadky filam."
-
-# MSG_FILAMENT c=17 r=1
-#: messages.c:30
-msgid "Filament"
-msgstr "Filament"
 
 # MSG_FILAMENT_CLEAN c=20 r=2
 #: messages.c:32
@@ -718,7 +421,7 @@ msgid "Filament extruding & with correct color?"
 msgstr "Filament vytlacen a spravne barvy?"
 
 # MSG_NOT_LOADED c=19
-#: ultralcd.cpp:2669
+#: ultralcd.cpp:2714
 msgid "Filament not loaded"
 msgstr "Filament nezaveden"
 
@@ -727,60 +430,25 @@ msgstr "Filament nezaveden"
 msgid "Filament sensor"
 msgstr "Senzor filamentu"
 
-# MSG_SELFTEST_FILAMENT_SENSOR c=18
-#: ultralcd.cpp:7477
-msgid "Filament sensor:"
-msgstr "Senzor filamentu:"
-
 # MSG_FILAMENT_USED c=19 r=1
-#: ultralcd.cpp:2838
+#: ultralcd.cpp:2885
 msgid "Filament used"
 msgstr "Spotrebovano filamentu"
 
-# MSG_STATS_FILAMENTUSED c=20
-#: ultralcd.cpp:2142
-msgid "Filament used:  "
-msgstr "Filament : "
+# MSG_PRINT_TIME c=19 r=1
+#: ultralcd.cpp:2886
+msgid "Print time"
+msgstr "Cas tisku"
 
 # MSG_FILE_INCOMPLETE c=20 r=2
-#: ultralcd.cpp:8346
+#: ultralcd.cpp:8432
 msgid "File incomplete. Continue anyway?"
 msgstr "Soubor nekompletni. Pokracovat?"
-
-# MSG_SD_FILE_OPENED
-#: cardreader.cpp:395
-msgid "File opened: "
-msgstr "Soubor otevren:"
-
-# MSG_SD_FILE_SELECTED
-#: cardreader.cpp:401
-msgid "File selected"
-msgstr "Soubor vybran"
-
-# 
-#: ultralcd.cpp:3943
-msgid "FINDA:"
-msgstr "FINDA:"
 
 # MSG_FINISHING_MOVEMENTS c=20 r=1
 #: messages.c:40
 msgid "Finishing movements"
 msgstr "Dokoncovani pohybu"
-
-# 
-#: ultralcd.cpp:5443
-msgid "Firmware   [none]"
-msgstr "Firmware [Zadne]"
-
-# 
-#: ultralcd.cpp:5446
-msgid "Firmware   [warn]"
-msgstr "Firmware [Varovat]"
-
-# 
-#: ultralcd.cpp:5449
-msgid "Firmware [strict]"
-msgstr "Firmware [Prisne]"
 
 # MSG_V2_CALIBRATION c=17 r=1
 #: messages.c:105
@@ -788,7 +456,7 @@ msgid "First layer cal."
 msgstr "Kal. prvni vrstvy"
 
 # MSG_WIZARD_SELFTEST c=20 r=8
-#: ultralcd.cpp:4880
+#: ultralcd.cpp:4982
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr "Nejdriv pomoci selftestu zkontoluji nejcastejsi chyby vznikajici pri sestaveni tiskarny."
 
@@ -798,14 +466,14 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr "Opravte chybu a pote stisknete tlacitko na jednotce MMU."
 
 # MSG_FLOW
-#: ultralcd.cpp:6846
+#: ultralcd.cpp:6932
 msgid "Flow"
 msgstr "Prutok"
 
 # MSG_PRUSA3D_FORUM
-#: ultralcd.cpp:2099
+#: ultralcd.cpp:2206
 msgid "forum.prusa3d.com"
-msgstr "forum.prusa3d.com"
+msgstr ""
 
 # MSG_SELFTEST_COOLING_FAN c=20
 #: messages.c:75
@@ -813,14 +481,1244 @@ msgid "Front print fan?"
 msgstr "Predni tiskovy vent?"
 
 # MSG_BED_CORRECTION_FRONT c=14 r=1
-#: ultralcd.cpp:3217
+#: ultralcd.cpp:3294
 msgid "Front side[um]"
 msgstr "Vpredu [um]"
 
 # MSG_SELFTEST_FANS
-#: ultralcd.cpp:7871
+#: ultralcd.cpp:7957
 msgid "Front/left fans"
 msgstr "Predni/levy vent."
+
+# MSG_SELFTEST_HEATERTHERMISTOR
+#: ultralcd.cpp:7887
+msgid "Heater/Thermistor"
+msgstr "Topeni/Termistor"
+
+# MSG_BED_HEATING_SAFETY_DISABLED
+#: Marlin_main.cpp:8467
+msgid "Heating disabled by safety timer."
+msgstr "Zahrivani preruseno bezpecnostnim casovacem."
+
+# MSG_HEATING_COMPLETE c=20
+#: messages.c:47
+msgid "Heating done."
+msgstr "Zahrivani OK."
+
+# MSG_HEATING
+#: messages.c:46
+msgid "Heating"
+msgstr "Zahrivani"
+
+# MSG_WIZARD_WELCOME c=20 r=7
+#: ultralcd.cpp:4961
+msgid "Hi, I am your Original Prusa i3 printer. Would you like me to guide you through the setup process?"
+msgstr "Dobry den, jsem vase tiskarna Original Prusa i3. Chcete abych Vas provedla kalibracnim procesem?"
+
+# MSG_PRUSA3D_HOWTO
+#: ultralcd.cpp:2207
+msgid "howto.prusa3d.com"
+msgstr ""
+
+# MSG_FILAMENTCHANGE
+#: messages.c:37
+msgid "Change filament"
+msgstr "Vymenit filament"
+
+# MSG_CHANGE_SUCCESS
+#: ultralcd.cpp:2629
+msgid "Change success!"
+msgstr "Zmena uspesna!"
+
+# MSG_CORRECTLY c=20
+#: ultralcd.cpp:2706
+msgid "Changed correctly?"
+msgstr "Vymena ok?"
+
+# MSG_SELFTEST_CHECK_BED c=20
+#: messages.c:81
+msgid "Checking bed     "
+msgstr "Kontrola podlozky"
+
+# MSG_SELFTEST_CHECK_ENDSTOPS c=20
+#: ultralcd.cpp:8286
+msgid "Checking endstops"
+msgstr "Kontrola endstopu"
+
+# MSG_SELFTEST_CHECK_HOTEND c=20
+#: ultralcd.cpp:8292
+msgid "Checking hotend  "
+msgstr "Kontrola hotend "
+
+# MSG_SELFTEST_CHECK_FSENSOR c=20
+#: messages.c:82
+msgid "Checking sensors "
+msgstr "Kontrola senzoru"
+
+# MSG_SELFTEST_CHECK_X c=20
+#: ultralcd.cpp:8287
+msgid "Checking X axis  "
+msgstr "Kontrola osy X"
+
+# MSG_SELFTEST_CHECK_Y c=20
+#: ultralcd.cpp:8288
+msgid "Checking Y axis  "
+msgstr "Kontrola osy Y"
+
+# MSG_SELFTEST_CHECK_Z c=20
+#: ultralcd.cpp:8289
+msgid "Checking Z axis  "
+msgstr "Kontrola osy Z"
+
+# MSG_CHOOSE_EXTRUDER c=20 r=1
+#: messages.c:49
+msgid "Choose extruder:"
+msgstr "Vyberte extruder:"
+
+# MSG_CHOOSE_FILAMENT c=20 r=1
+#: messages.c:50
+msgid "Choose filament:"
+msgstr "Vyber filament:"
+
+# MSG_FILAMENT c=17 r=1
+#: messages.c:30
+msgid "Filament"
+msgstr ""
+
+# MSG_WIZARD_XYZ_CAL c=20 r=8
+#: ultralcd.cpp:4991
+msgid "I will run xyz calibration now. It will take approx. 12 mins."
+msgstr "Nyni provedu xyz kalibraci. Zabere to priblizne 12 min."
+
+# MSG_WIZARD_Z_CAL c=20 r=8
+#: ultralcd.cpp:4999
+msgid "I will run z calibration now."
+msgstr "Nyni provedu z kalibraci."
+
+# MSG_WIZARD_V2_CAL_2 c=20 r=12
+#: ultralcd.cpp:5064
+msgid "I will start to print line and you will gradually lower the nozzle by rotating the knob, until you reach optimal height. Check the pictures in our handbook in chapter Calibration."
+msgstr "Zacnu tisknout linku a Vy budete postupne snizovat trysku otacenim tlacitka dokud nedosahnete optimalni vysky. Prohlednete si obrazky v nasi prirucce v kapitole Kalibrace."
+
+# MSG_WATCH
+#: messages.c:99
+msgid "Info screen"
+msgstr "Informace"
+
+# 
+#: ultralcd.cpp:5024
+msgid "Is filament 1 loaded?"
+msgstr "Je filament 1 zaveden?"
+
+# MSG_INSERT_FILAMENT c=20
+#: ultralcd.cpp:2614
+msgid "Insert filament"
+msgstr "Vlozte filament"
+
+# MSG_WIZARD_FILAMENT_LOADED c=20 r=2
+#: ultralcd.cpp:5027
+msgid "Is filament loaded?"
+msgstr "Je filament zaveden?"
+
+# MSG_WIZARD_PLA_FILAMENT c=20 r=2
+#: ultralcd.cpp:5058
+msgid "Is it PLA filament?"
+msgstr "Je to PLA filament?"
+
+# MSG_PLA_FILAMENT_LOADED c=20 r=2
+#: ultralcd.cpp:4790
+msgid "Is PLA filament loaded?"
+msgstr "Je PLA filament zaveden?"
+
+# MSG_STEEL_SHEET_CHECK c=20 r=2
+#: messages.c:92
+msgid "Is steel sheet on heatbed?"
+msgstr "Je tiskovy plat na podlozce?"
+
+# 
+#: ultralcd.cpp:1795
+msgid "Last print failures"
+msgstr "Selhani posl. tisku"
+
+# 
+#: ultralcd.cpp:1772
+msgid "Last print"
+msgstr "Posledni tisk"
+
+# MSG_SELFTEST_EXTRUDER_FAN c=20
+#: messages.c:76
+msgid "Left hotend fan?"
+msgstr "Levy vent na trysce?"
+
+# 
+#: ultralcd.cpp:3018
+msgid "Left"
+msgstr "Vlevo"
+
+# MSG_BED_CORRECTION_LEFT c=14 r=1
+#: ultralcd.cpp:3292
+msgid "Left side [um]"
+msgstr "Vlevo [um]"
+
+# 
+#: ultralcd.cpp:5680
+msgid "Lin. correction"
+msgstr "Korekce lin."
+
+# MSG_BABYSTEP_Z
+#: messages.c:13
+msgid "Live adjust Z"
+msgstr "Doladeni osy Z"
+
+# MSG_LOAD_FILAMENT c=17
+#: messages.c:51
+msgid "Load filament"
+msgstr "Zavest filament"
+
+# MSG_LOADING_COLOR
+#: ultralcd.cpp:2654
+msgid "Loading color"
+msgstr "Cisteni barvy"
+
+# MSG_LOADING_FILAMENT c=20
+#: messages.c:52
+msgid "Loading filament"
+msgstr "Zavadeni filamentu"
+
+# MSG_LOOSE_PULLEY c=20 r=1
+#: ultralcd.cpp:7941
+msgid "Loose pulley"
+msgstr "Uvolnena remenicka"
+
+# 
+#: ultralcd.cpp:6805
+msgid "Load to nozzle"
+msgstr "Zavest do trysky"
+
+# MSG_M117_V2_CALIBRATION c=25 r=1
+#: messages.c:55
+msgid "M117 First layer cal."
+msgstr "M117 Kal. prvni vrstvy"
+
+# MSG_MAIN
+#: messages.c:56
+msgid "Main"
+msgstr "Hlavni nabidka"
+
+# MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=60
+#: messages.c:59
+msgid "Measuring reference height of calibration point"
+msgstr "Merim referencni vysku kalibracniho bodu"
+
+# MSG_MESH_BED_LEVELING
+#: ultralcd.cpp:5763
+msgid "Mesh Bed Leveling"
+msgstr ""
+
+# MSG_MMU_OK_RESUMING_POSITION c=20 r=4
+#: mmu.cpp:762
+msgid "MMU OK. Resuming position..."
+msgstr "MMU OK. Pokracuji v tisku..."
+
+# MSG_MMU_OK_RESUMING_TEMPERATURE c=20 r=4
+#: mmu.cpp:755
+msgid "MMU OK. Resuming temperature..."
+msgstr "MMU OK. Pokracuji v nahrivani..."
+
+# 
+#: ultralcd.cpp:3059
+msgid "Measured skew"
+msgstr "Merene zkoseni"
+
+# 
+#: ultralcd.cpp:1796
+msgid "MMU fails"
+msgstr "Selhani MMU"
+
+# 
+#: mmu.cpp:1613
+msgid "MMU load failed     "
+msgstr "Zavedeni MMU selhalo"
+
+# 
+#: ultralcd.cpp:1797
+msgid "MMU load fails"
+msgstr "MMU selhani zavadeni"
+
+# MSG_MMU_OK_RESUMING c=20 r=4
+#: mmu.cpp:773
+msgid "MMU OK. Resuming..."
+msgstr "MMU OK. Pokracuji..."
+
+# MSG_STEALTH_MODE_OFF
+#: messages.c:90
+msgid "Mode     [Normal]"
+msgstr "Mod      [Normal]"
+
+# MSG_SILENT_MODE_ON
+#: messages.c:89
+msgid "Mode     [silent]"
+msgstr "Mod       [tichy]"
+
+# 
+#: mmu.cpp:719
+msgid "MMU needs user attention."
+msgstr "MMU potrebuje zasah uzivatele."
+
+# 
+#: ultralcd.cpp:1823
+msgid "MMU power fails"
+msgstr "MMU vypadky proudu"
+
+# MSG_STEALTH_MODE_ON
+#: messages.c:91
+msgid "Mode    [Stealth]"
+msgstr "Mod       [tichy]"
+
+# MSG_AUTO_MODE_ON
+#: messages.c:12
+msgid "Mode [auto power]"
+msgstr "Mod [automaticky]"
+
+# MSG_SILENT_MODE_OFF
+#: messages.c:88
+msgid "Mode [high power]"
+msgstr "Mod  [vys. vykon]"
+
+# 
+#: ultralcd.cpp:2219
+msgid "MMU2 connected"
+msgstr "MMU2 pripojeno"
+
+# MSG_SELFTEST_MOTOR
+#: messages.c:83
+msgid "Motor"
+msgstr ""
+
+# MSG_MOVE_AXIS
+#: ultralcd.cpp:5652
+msgid "Move axis"
+msgstr "Posunout osu"
+
+# MSG_MOVE_X
+#: ultralcd.cpp:4378
+msgid "Move X"
+msgstr "Posunout X"
+
+# MSG_MOVE_Y
+#: ultralcd.cpp:4379
+msgid "Move Y"
+msgstr "Posunout Y"
+
+# MSG_MOVE_Z
+#: ultralcd.cpp:4380
+msgid "Move Z"
+msgstr "Posunout Z"
+
+# MSG_NO_MOVE
+#: Marlin_main.cpp:5292
+msgid "No move."
+msgstr "Bez pohybu."
+
+# MSG_NO_CARD
+#: ultralcd.cpp:6772
+msgid "No SD card"
+msgstr "Zadna SD karta"
+
+# 
+#: ultralcd.cpp:3024
+msgid "N/A"
+msgstr ""
+
+# MSG_NO
+#: messages.c:62
+msgid "No"
+msgstr "Ne"
+
+# MSG_SELFTEST_NOTCONNECTED
+#: ultralcd.cpp:7889
+msgid "Not connected"
+msgstr "Nezapojeno "
+
+# 
+#: util.cpp:293
+msgid "New firmware version available:"
+msgstr "Vysla nova verze firmware:"
+
+# MSG_SELFTEST_FAN_NO c=19
+#: messages.c:79
+msgid "Not spinning"
+msgstr "Netoci se"
+
+# MSG_WIZARD_V2_CAL c=20 r=8
+#: ultralcd.cpp:5063
+msgid "Now I will calibrate distance between tip of the nozzle and heatbed surface."
+msgstr "Nyni zkalibruji vzdalenost mezi koncem trysky a povrchem podlozky."
+
+# MSG_WIZARD_WILL_PREHEAT c=20 r=4
+#: ultralcd.cpp:5007
+msgid "Now I will preheat nozzle for PLA."
+msgstr "Nyni predehreji trysku pro PLA."
+
+# MSG_NOZZLE
+#: messages.c:63
+msgid "Nozzle"
+msgstr "Tryska"
+
+# MSG_DEFAULT_SETTINGS_LOADED c=20 r=4
+#: Marlin_main.cpp:1519
+msgid "Old settings found. Default PID, Esteps etc. will be set."
+msgstr "Neplatne hodnoty nastaveni. Bude pouzito vychozi PID, Esteps atd."
+
+# 
+#: ultralcd.cpp:4998
+msgid "Now remove the test print from steel sheet."
+msgstr "Nyni odstrante testovaci vytisk z tiskoveho platu."
+
+# 
+#: ultralcd.cpp:1722
+msgid "Nozzle FAN"
+msgstr "Vent. trysky"
+
+# MSG_PAUSE_PRINT
+#: ultralcd.cpp:6735
+msgid "Pause print"
+msgstr "Pozastavit tisk"
+
+# MSG_PID_RUNNING c=20 r=1
+#: ultralcd.cpp:1606
+msgid "PID cal.           "
+msgstr "PID kal. "
+
+# MSG_PID_FINISHED c=20 r=1
+#: ultralcd.cpp:1612
+msgid "PID cal. finished"
+msgstr "PID kal. ukoncena"
+
+# MSG_PID_EXTRUDER c=17 r=1
+#: ultralcd.cpp:5769
+msgid "PID calibration"
+msgstr "PID kalibrace"
+
+# MSG_PINDA_PREHEAT c=20 r=1
+#: ultralcd.cpp:846
+msgid "PINDA Heating"
+msgstr "Nahrivani PINDA"
+
+# MSG_PAPER c=20 r=8
+#: messages.c:64
+msgid "Place a sheet of paper under the nozzle during the calibration of first 4 points. If the nozzle catches the paper, power off the printer immediately."
+msgstr "Umistete list papiru na podlozku a udrzujte jej pod tryskou behem mereni prvnich 4 bodu. Pokud tryska zachyti papir, okamzite vypnete tiskarnu."
+
+# MSG_WIZARD_CLEAN_HEATBED c=20 r=8
+#: ultralcd.cpp:5072
+msgid "Please clean heatbed and then press the knob."
+msgstr "Prosim ocistete podlozku a stisknete tlacitko."
+
+# MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
+#: messages.c:22
+msgid "Please clean the nozzle for calibration. Click when done."
+msgstr "Pro uspesnou kalibraci ocistete prosim tiskovou trysku. Potvrdte tlacitkem."
+
+# MSG_SELFTEST_PLEASECHECK
+#: ultralcd.cpp:7881
+msgid "Please check :"
+msgstr "Zkontrolujte :"
+
+# MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
+#: messages.c:100
+msgid "Please check our handbook and fix the problem. Then resume the Wizard by rebooting the printer."
+msgstr "Prosim nahlednete do prirucky 3D tiskare a opravte problem. Pote obnovte Pruvodce restartovanim tiskarny."
+
+# MSG_WIZARD_LOAD_FILAMENT c=20 r=8
+#: ultralcd.cpp:4894
+msgid "Please insert PLA filament to the extruder, then press knob to load it."
+msgstr "Prosim vlozte PLA filament do extruderu, pote stisknete tlacitko pro zavedeni filamentu."
+
+# MSG_PLEASE_LOAD_PLA c=20 r=4
+#: ultralcd.cpp:4795
+msgid "Please load PLA filament first."
+msgstr "Nejdrive prosim zavedte PLA filament."
+
+# MSG_CHECK_IDLER c=20 r=4
+#: Marlin_main.cpp:3064
+msgid "Please open idler and remove filament manually."
+msgstr "Prosim otevrete idler a manualne odstrante filament."
+
+# MSG_PLACE_STEEL_SHEET c=20 r=4
+#: messages.c:65
+msgid "Please place steel sheet on heatbed."
+msgstr "Umistete prosim tiskovy plat na podlozku"
+
+# MSG_PRESS_TO_UNLOAD c=20 r=4
+#: messages.c:68
+msgid "Please press the knob to unload filament"
+msgstr "Pro vysunuti filamentu stisknete prosim tlacitko"
+
+# 
+#: ultralcd.cpp:4889
+msgid "Please insert PLA filament to the first tube of MMU, then press the knob to load it."
+msgstr "Prosim vlozte PLA filament do trubicky MMU, pote stisknete tlacitko pro zavedeni filamentu."
+
+# MSG_PULL_OUT_FILAMENT c=20 r=4
+#: messages.c:70
+msgid "Please pull out filament immediately"
+msgstr "Prosim vyjmete urychlene filament"
+
+# MSG_EJECT_REMOVE c=20 r=4
+#: mmu.cpp:1440
+msgid "Please remove filament and then press the knob."
+msgstr "Prosim vyjmete filament a pote stisknete tlacitko."
+
+# MSG_REMOVE_STEEL_SHEET c=20 r=4
+#: messages.c:74
+msgid "Please remove steel sheet from heatbed."
+msgstr "Odstrante prosim tiskovy plat z podlozky."
+
+# MSG_RUN_XYZ c=20 r=4
+#: Marlin_main.cpp:4355
+msgid "Please run XYZ calibration first."
+msgstr "Nejprve spustte kalibraci XYZ."
+
+# MSG_UPDATE_MMU2_FW c=20 r=4
+#: mmu.cpp:1359
+msgid "Please update firmware in your MMU2. Waiting for reset."
+msgstr "Prosim aktualizujte firmware ve vasi MMU2 jednotce. Cekam na reset."
+
+# MSG_PLEASE_WAIT c=20
+#: messages.c:66
+msgid "Please wait"
+msgstr "Prosim cekejte"
+
+# 
+#: ultralcd.cpp:4997
+msgid "Please remove shipping helpers first."
+msgstr "Nejprve prosim sundejte transportni soucastky."
+
+# MSG_PREHEAT_NOZZLE c=20
+#: messages.c:67
+msgid "Preheat the nozzle!"
+msgstr "Predehrejte trysku!"
+
+# MSG_PREHEAT
+#: ultralcd.cpp:6722
+msgid "Preheat"
+msgstr "Predehrev"
+
+# MSG_WIZARD_HEATING c=20 r=3
+#: messages.c:102
+msgid "Preheating nozzle. Please wait."
+msgstr "Predehrev trysky. Prosim cekejte."
+
+# 
+#: util.cpp:297
+msgid "Please upgrade."
+msgstr "Prosim aktualizujte."
+
+# MSG_PRESS_TO_PREHEAT c=20 r=4
+#: Marlin_main.cpp:10364
+msgid "Press knob to preheat nozzle and continue."
+msgstr "Pro nahrati trysky a pokracovani stisknete tlacitko."
+
+# 
+#: ultralcd.cpp:1851
+msgid "Power failures"
+msgstr "Vypadky proudu"
+
+# MSG_PRINT_ABORTED c=20
+#: messages.c:69
+msgid "Print aborted"
+msgstr "Tisk prerusen"
+
+# 
+#: ultralcd.cpp:2455
+msgid "Preheating to load"
+msgstr "Predehrev k zavedeni"
+
+# 
+#: ultralcd.cpp:2459
+msgid "Preheating to unload"
+msgstr "Predehrev k vyjmuti"
+
+# MSG_SELFTEST_PRINT_FAN_SPEED c=18
+#: ultralcd.cpp:8307
+msgid "Print fan:"
+msgstr "Tiskovy vent.:"
+
+# MSG_CARD_MENU
+#: messages.c:21
+msgid "Print from SD"
+msgstr "Tisk z SD"
+
+# 
+#: ultralcd.cpp:2317
+msgid "Press the knob"
+msgstr "Stisknete hl. tlacitko"
+
+# MSG_PRINT_PAUSED c=20 r=1
+#: ultralcd.cpp:1069
+msgid "Print paused"
+msgstr "Tisk pozastaven"
+
+# 
+#: mmu.cpp:723
+msgid "Press the knob to resume nozzle temperature."
+msgstr "Pro pokracovani nahrivani trysky stisknete tlacitko."
+
+# MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
+#: messages.c:41
+msgid "Printer has not been calibrated yet. Please follow the manual, chapter First steps, section Calibration flow."
+msgstr "Tiskarna nebyla jeste zkalibrovana. Postupujte prosim podle manualu, kapitola Zaciname, odstavec Postup kalibrace."
+
+# 
+#: ultralcd.cpp:1723
+msgid "Print FAN"
+msgstr "Tiskovy vent."
+
+# MSG_PRUSA3D
+#: ultralcd.cpp:2205
+msgid "prusa3d.com"
+msgstr ""
+
+# MSG_BED_CORRECTION_REAR c=14 r=1
+#: ultralcd.cpp:3295
+msgid "Rear side [um]"
+msgstr "Vzadu [um]"
+
+# MSG_RECOVERING_PRINT c=20 r=1
+#: Marlin_main.cpp:9764
+msgid "Recovering print    "
+msgstr "Obnovovani tisku "
+
+# MSG_REMOVE_OLD_FILAMENT c=20 r=4
+#: mmu.cpp:830
+msgid "Remove old filament and press the knob to start loading new filament."
+msgstr "Vyjmete stary filament a stisknete tlacitko pro zavedeni noveho."
+
+# 
+#: 
+msgid "Prusa i3 MK3S OK."
+msgstr ""
+
+# MSG_CALIBRATE_BED_RESET
+#: ultralcd.cpp:5774
+msgid "Reset XYZ calibr."
+msgstr "Reset XYZ kalibr."
+
+# MSG_BED_CORRECTION_RESET
+#: ultralcd.cpp:3296
+msgid "Reset"
+msgstr ""
+
+# MSG_RESUME_PRINT
+#: ultralcd.cpp:6742
+msgid "Resume print"
+msgstr "Pokracovat"
+
+# MSG_RESUMING_PRINT c=20 r=1
+#: messages.c:73
+msgid "Resuming print"
+msgstr "Obnoveni tisku"
+
+# MSG_BED_CORRECTION_RIGHT c=14 r=1
+#: ultralcd.cpp:3293
+msgid "Right side[um]"
+msgstr "Vpravo [um]"
+
+# MSG_SECOND_SERIAL_ON c=17 r=1
+#: ultralcd.cpp:5692
+msgid "RPi port     [on]"
+msgstr "RPi port    [zap]"
+
+# MSG_SECOND_SERIAL_OFF c=17 r=1
+#: ultralcd.cpp:5690
+msgid "RPi port    [off]"
+msgstr "RPi port    [vyp]"
+
+# MSG_WIZARD_RERUN c=20 r=7
+#: ultralcd.cpp:4812
+msgid "Running Wizard will delete current calibration results and start from the beginning. Continue?"
+msgstr "Spusteni Pruvodce vymaze ulozene vysledky vsech kalibraci a spusti kalibracni proces od zacatku. Pokracovat?"
+
+# MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_OFF c=19 r=1
+#: ultralcd.cpp:5322
+msgid "SD card  [normal]"
+msgstr ""
+
+# MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_ON c=19 r=1
+#: ultralcd.cpp:5320
+msgid "SD card [flshAir]"
+msgstr "SD card [FlshAir]"
+
+# 
+#: ultralcd.cpp:3019
+msgid "Right"
+msgstr "Vpravo"
+
+# MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=60
+#: messages.c:38
+msgid "Searching bed calibration point"
+msgstr "Hledam kalibracni bod podlozky"
+
+# MSG_LANGUAGE_SELECT
+#: ultralcd.cpp:5699
+msgid "Select language"
+msgstr "Vyber jazyka"
+
+# MSG_SELFTEST_OK
+#: ultralcd.cpp:7452
+msgid "Self test OK"
+msgstr ""
+
+# MSG_SELFTEST_START c=20
+#: ultralcd.cpp:7238
+msgid "Self test start  "
+msgstr "Self test start "
+
+# MSG_SELFTEST
+#: ultralcd.cpp:5750
+msgid "Selftest         "
+msgstr "Selftest "
+
+# MSG_SELFTEST_ERROR
+#: ultralcd.cpp:7879
+msgid "Selftest error !"
+msgstr "Chyba Selftestu!"
+
+# MSG_SELFTEST_FAILED c=20
+#: messages.c:77
+msgid "Selftest failed  "
+msgstr "Selftest selhal "
+
+# MSG_FORCE_SELFTEST c=20 r=8
+#: Marlin_main.cpp:1551
+msgid "Selftest will be run to calibrate accurate sensorless rehoming."
+msgstr "Pro kalibraci presneho rehomovani bude nyni spusten selftest."
+
+# 
+#: ultralcd.cpp:5045
+msgid "Select nozzle preheat temperature which matches your material."
+msgstr "Vyberte teplotu predehrati trysky ktera odpovida vasemu materialu."
+
+# 
+#: ultralcd.cpp:4780
+msgid "Select PLA filament:"
+msgstr "Vyberte PLA filament:"
+
+# MSG_SET_TEMPERATURE c=19 r=1
+#: ultralcd.cpp:3314
+msgid "Set temperature:"
+msgstr "Nastavte teplotu:"
+
+# MSG_SETTINGS
+#: messages.c:86
+msgid "Settings"
+msgstr "Nastaveni"
+
+# MSG_SHOW_END_STOPS c=17 r=1
+#: ultralcd.cpp:5771
+msgid "Show end stops"
+msgstr "Stav konc. spin."
+
+# 
+#: ultralcd.cpp:4025
+msgid "Sensor state"
+msgstr "Stav senzoru"
+
+# MSG_FILE_CNT c=20 r=4
+#: cardreader.cpp:739
+msgid "Some files will not be sorted. Max. No. of files in 1 folder for sorting is 100."
+msgstr "Nektere soubory nebudou setrideny. Maximalni pocet souboru ve slozce pro setrideni je 100."
+
+# MSG_SORT_NONE c=17 r=1
+#: ultralcd.cpp:5332
+msgid "Sort       [none]"
+msgstr "Trideni   [Zadne]"
+
+# MSG_SORT_TIME c=17 r=1
+#: ultralcd.cpp:5330
+msgid "Sort       [time]"
+msgstr "Trideni     [cas]"
+
+# 
+#: ultralcd.cpp:3062
+msgid "Severe skew:"
+msgstr "Tezke zkoseni:"
+
+# MSG_SORT_ALPHA c=17 r=1
+#: ultralcd.cpp:5331
+msgid "Sort   [alphabet]"
+msgstr "Trideni [Abeceda]"
+
+# MSG_SORTING c=20 r=1
+#: cardreader.cpp:746
+msgid "Sorting files"
+msgstr "Trideni souboru"
+
+# MSG_SOUND_LOUD c=17 r=1
+#: sound.h:6
+msgid "Sound      [loud]"
+msgstr "Zvuk    [hlasity]"
+
+# 
+#: ultralcd.cpp:3061
+msgid "Slight skew:"
+msgstr "Lehke zkoseni:"
+
+# MSG_SOUND_MUTE c=17 r=1
+#: 
+msgid "Sound      [mute]"
+msgstr "Zvuk    [vypnuto]"
+
+# 
+#: Marlin_main.cpp:4871
+msgid "Some problem encountered, Z-leveling enforced ..."
+msgstr "Vyskytl se problem, srovnavam osu Z ..."
+
+# MSG_SOUND_ONCE c=17 r=1
+#: sound.h:7
+msgid "Sound      [once]"
+msgstr "Zvuk     [jednou]"
+
+# MSG_SOUND_SILENT c=17 r=1
+#: sound.h:8
+msgid "Sound    [silent]"
+msgstr "Zvuk      [tichy]"
+
+# MSG_SPEED
+#: ultralcd.cpp:6926
+msgid "Speed"
+msgstr "Rychlost"
+
+# MSG_SELFTEST_FAN_YES c=19
+#: messages.c:80
+msgid "Spinning"
+msgstr "Toci se"
+
+# MSG_TEMP_CAL_WARNING c=20 r=4
+#: Marlin_main.cpp:4368
+msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
+msgstr "Je vyzadovana stabilni pokojova teplota 21-26C a pevna podlozka."
+
+# MSG_STATISTICS
+#: ultralcd.cpp:6839
+msgid "Statistics  "
+msgstr "Statistika "
+
+# MSG_STOP_PRINT
+#: messages.c:93
+msgid "Stop print"
+msgstr "Zastavit tisk"
+
+# MSG_STOPPED
+#: messages.c:94
+msgid "STOPPED. "
+msgstr "ZASTAVENO."
+
+# MSG_SUPPORT
+#: ultralcd.cpp:6848
+msgid "Support"
+msgstr "Podpora"
+
+# MSG_SELFTEST_SWAPPED
+#: ultralcd.cpp:7959
+msgid "Swapped"
+msgstr "Prohozene"
+
+# MSG_TEMP_CALIBRATION c=20 r=1
+#: messages.c:95
+msgid "Temp. cal.          "
+msgstr "Tepl. kal. "
+
+# MSG_TEMP_CALIBRATION_ON c=20 r=1
+#: ultralcd.cpp:5686
+msgid "Temp. cal.   [on]"
+msgstr "Tepl. kal.  [zap]"
+
+# MSG_TEMP_CALIBRATION_OFF c=20 r=1
+#: ultralcd.cpp:5684
+msgid "Temp. cal.  [off]"
+msgstr "Tepl. kal.  [vyp]"
+
+# MSG_CALIBRATION_PINDA_MENU c=17 r=1
+#: ultralcd.cpp:5780
+msgid "Temp. calibration"
+msgstr "Teplot. kalibrace"
+
+# MSG_TEMP_CAL_FAILED c=20 r=8
+#: ultralcd.cpp:3951
+msgid "Temperature calibration failed"
+msgstr "Teplotni kalibrace selhala"
+
+# MSG_TEMP_CALIBRATION_DONE c=20 r=12
+#: messages.c:96
+msgid "Temperature calibration is finished and active. Temp. calibration can be disabled in menu Settings->Temp. cal."
+msgstr "Teplotni kalibrace dokoncena a je nyni aktivni. Teplotni kalibraci je mozno deaktivovat v menu Nastaveni->Tepl. kal."
+
+# MSG_TEMPERATURE
+#: ultralcd.cpp:5650
+msgid "Temperature"
+msgstr "Teplota"
+
+# MSG_MENU_TEMPERATURES c=15 r=1
+#: ultralcd.cpp:2251
+msgid "Temperatures"
+msgstr "Teploty"
+
+# MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=4
+#: messages.c:42
+msgid "There is still a need to make Z calibration. Please follow the manual, chapter First steps, section Calibration flow."
+msgstr "Je potreba kalibrovat osu Z. Prosim postupujte dle prirucky, kapitola Zaciname, sekce Postup kalibrace."
+
+# 
+#: ultralcd.cpp:2908
+msgid "Total filament"
+msgstr "Filament celkem"
+
+# 
+#: ultralcd.cpp:2908
+msgid "Total print time"
+msgstr "Celkovy cas tisku"
+
+# MSG_TUNE
+#: ultralcd.cpp:6719
+msgid "Tune"
+msgstr "Ladit"
+
+# 
+#: ultralcd.cpp:4869
+msgid "Unload"
+msgstr "Vysunout"
+
+# 
+#: ultralcd.cpp:1820
+msgid "Total failures"
+msgstr "Celkem selhani"
+
+# 
+#: ultralcd.cpp:2324
+msgid "to load filament"
+msgstr "k zavedeni filamentu"
+
+# 
+#: ultralcd.cpp:2328
+msgid "to unload filament"
+msgstr "k vyjmuti filamentu"
+
+# MSG_UNLOAD_FILAMENT c=17
+#: messages.c:97
+msgid "Unload filament"
+msgstr "Vyjmout filament"
+
+# MSG_UNLOADING_FILAMENT c=20 r=1
+#: messages.c:98
+msgid "Unloading filament"
+msgstr "Vysouvam filament"
+
+# 
+#: ultralcd.cpp:1773
+msgid "Total"
+msgstr "Celkem"
+
+# MSG_USED c=19 r=1
+#: ultralcd.cpp:5908
+msgid "Used during print"
+msgstr "Pouzite behem tisku"
+
+# MSG_MENU_VOLTAGES c=15 r=1
+#: ultralcd.cpp:2254
+msgid "Voltages"
+msgstr "Napeti"
+
+# 
+#: ultralcd.cpp:2227
+msgid "unknown"
+msgstr "neznamy"
+
+# MSG_USERWAIT
+#: Marlin_main.cpp:5263
+msgid "Wait for user..."
+msgstr "Ceka se na uzivatele..."
+
+# MSG_WAITING_TEMP c=20 r=3
+#: ultralcd.cpp:3458
+msgid "Waiting for nozzle and bed cooling"
+msgstr "Cekani na zchladnuti trysky a podlozky."
+
+# MSG_WAITING_TEMP_PINDA c=20 r=3
+#: ultralcd.cpp:3422
+msgid "Waiting for PINDA probe cooling"
+msgstr "Cekani na zchladnuti PINDA"
+
+# 
+#: ultralcd.cpp:4868
+msgid "Use unload to remove filament 1 if it protrudes outside of the rear MMU tube. Use eject if it is hidden in tube."
+msgstr "Pouzijte vyjmout pro odstraneni filamentu 1 pokud presahuje z PTFE trubicky za tiskarnou. Pouzijte vysunout, pokud neni videt."
+
+# MSG_CHANGED_BOTH c=20 r=4
+#: Marlin_main.cpp:1511
+msgid "Warning: both printer type and motherboard type changed."
+msgstr "Varovani: doslo ke zmene typu tiskarny a motherboardu."
+
+# MSG_CHANGED_MOTHERBOARD c=20 r=4
+#: Marlin_main.cpp:1503
+msgid "Warning: motherboard type changed."
+msgstr "Varovani: doslo ke zmene typu motherboardu."
+
+# MSG_CHANGED_PRINTER c=20 r=4
+#: Marlin_main.cpp:1507
+msgid "Warning: printer type changed."
+msgstr "Varovani: doslo ke zmene typu tiskarny."
+
+# MSG_UNLOAD_SUCCESSFUL c=20 r=2
+#: Marlin_main.cpp:3054
+msgid "Was filament unload successful?"
+msgstr "Bylo vysunuti filamentu uspesne?"
+
+# MSG_SELFTEST_WIRINGERROR
+#: messages.c:85
+msgid "Wiring error"
+msgstr "Chyba zapojeni"
+
+# MSG_WIZARD c=17 r=1
+#: ultralcd.cpp:5747
+msgid "Wizard"
+msgstr "Pruvodce"
+
+# MSG_XYZ_DETAILS c=19 r=1
+#: ultralcd.cpp:2243
+msgid "XYZ cal. details"
+msgstr "Detaily XYZ kal."
+
+# MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
+#: messages.c:19
+msgid "XYZ calibration failed. Please consult the manual."
+msgstr "Kalibrace XYZ selhala. Nahlednete do manualu."
+
+# MSG_YES
+#: messages.c:104
+msgid "Yes"
+msgstr "Ano"
+
+# MSG_WIZARD_QUIT c=20 r=8
+#: messages.c:103
+msgid "You can always resume the Wizard from Calibration -> Wizard."
+msgstr "Pruvodce muzete kdykoliv znovu spustit z menu Kalibrace -> Pruvodce"
+
+# MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
+#: ultralcd.cpp:3922
+msgid "XYZ calibration all right. Skew will be corrected automatically."
+msgstr "Kalibrace XYZ v poradku. Zkoseni bude automaticky vyrovnano pri tisku."
+
+# MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
+#: ultralcd.cpp:3919
+msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
+msgstr "Kalibrace XYZ v poradku. X/Y osy mirne zkosene. Dobra prace!"
+
+# 
+#: ultralcd.cpp:5130
+msgid "X-correct:"
+msgstr "Korekce X:"
+
+# MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
+#: ultralcd.cpp:3916
+msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
+msgstr "Kalibrace XYZ v poradku. X/Y osy jsou kolme. Gratuluji!"
+
+# MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
+#: ultralcd.cpp:3900
+msgid "XYZ calibration compromised. Front calibration points not reachable."
+msgstr "Kalibrace XYZ nepresna. Predni kalibracni body moc vpredu."
+
+# MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
+#: ultralcd.cpp:3903
+msgid "XYZ calibration compromised. Right front calibration point not reachable."
+msgstr "Kalibrace XYZ nepresna. Pravy predni bod moc vpredu."
+
+# MSG_LOAD_ALL c=17
+#: ultralcd.cpp:6166
+msgid "Load all"
+msgstr "Zavest vse"
+
+# 
+#: ultralcd.cpp:3882
+msgid "XYZ calibration failed. Bed calibration point was not found."
+msgstr "Kalibrace XYZ selhala. Kalibracni bod podlozky nenalezen."
+
+# 
+#: ultralcd.cpp:3888
+msgid "XYZ calibration failed. Front calibration points not reachable."
+msgstr "Kalibrace XYZ selhala. Predni kalibracni body moc vpredu. Srovnejte tiskarnu."
+
+# 
+#: ultralcd.cpp:3891
+msgid "XYZ calibration failed. Right front calibration point not reachable."
+msgstr "Kalibrace XYZ selhala. Pravy predni bod moc vpredu. Srovnejte tiskarnu."
+
+# 
+#: ultralcd.cpp:3016
+msgid "Y distance from min"
+msgstr "Y vzdalenost od min"
+
+# 
+#: ultralcd.cpp:5131
+msgid "Y-correct:"
+msgstr "Korekce Y:"
+
+# MSG_OFF
+#: menu.cpp:426
+msgid " [off]"
+msgstr " [vyp]"
+
+# 
+#: messages.c:57
+msgid "Back"
+msgstr "Zpet"
+
+# 
+#: ultralcd.cpp:5639
+msgid "Checks"
+msgstr "Kontrola"
+
+# 
+#: ultralcd.cpp:7973
+msgid "False triggering"
+msgstr "Falesne spusteni"
+
+# 
+#: ultralcd.cpp:4030
+msgid "FINDA:"
+msgstr ""
+
+# 
+#: ultralcd.cpp:5545
+msgid "Firmware   [none]"
+msgstr "Firmware  [Zadne]"
+
+# 
+#: ultralcd.cpp:5551
+msgid "Firmware [strict]"
+msgstr "Firmware [Prisne]"
+
+# 
+#: ultralcd.cpp:5548
+msgid "Firmware   [warn]"
+msgstr "Firmware[Varovat]"
+
+# 
+#: messages.c:87
+msgid "HW Setup"
+msgstr "HW nastaveni"
+
+# 
+#: ultralcd.cpp:4034
+msgid "IR:"
+msgstr ""
+
+# 
+#: ultralcd.cpp:7046
+msgid "Magnets comp.[N/A]"
+msgstr "Komp. magnetu[N/A]"
+
+# 
+#: ultralcd.cpp:7044
+msgid "Magnets comp.[Off]"
+msgstr "Komp. magnetu[Vyp]"
+
+# 
+#: ultralcd.cpp:7043
+msgid "Magnets comp. [On]"
+msgstr "Komp. magnetu[Zap]"
+
+# 
+#: ultralcd.cpp:7035
+msgid "Mesh         [3x3]"
+msgstr "Mesh         [3x3]"
+
+# 
+#: ultralcd.cpp:7036
+msgid "Mesh         [7x7]"
+msgstr "Mesh         [7x7]"
+
+# 
+#: ultralcd.cpp:5677
+msgid "Mesh bed leveling"
+msgstr "Mesh Bed Leveling"
+
+# 
+#: Marlin_main.cpp:856
+msgid "MK3S firmware detected on MK3 printer"
+msgstr "MK3S firmware detekovan na tiskarne MK3"
+
+# 
+#: ultralcd.cpp:5306
+msgid "MMU Mode [Normal]"
+msgstr "MMU mod  [Normal]"
+
+# 
+#: ultralcd.cpp:5307
+msgid "MMU Mode[Stealth]"
+msgstr "MMU Mod   [Tichy]"
+
+# 
+#: ultralcd.cpp:4511
+msgid "Mode change in progress ..."
+msgstr "Probiha zmena modu..."
+
+# 
+#: ultralcd.cpp:5506
+msgid "Model      [none]"
+msgstr "Model     [Zadne]"
+
+# 
+#: ultralcd.cpp:5512
+msgid "Model    [strict]"
+msgstr "Model    [Prisne]"
+
+# 
+#: ultralcd.cpp:5509
+msgid "Model      [warn]"
+msgstr "Model   [Varovat]"
+
+# 
+#: ultralcd.cpp:5467
+msgid "Nozzle d.  [0.25]"
+msgstr "Tryska     [0.25]"
+
+# 
+#: ultralcd.cpp:5470
+msgid "Nozzle d.  [0.40]"
+msgstr "Tryska     [0.40]"
+
+# 
+#: ultralcd.cpp:5473
+msgid "Nozzle d.  [0.60]"
+msgstr "Tryska     [0.60]"
+
+# 
+#: ultralcd.cpp:5421
+msgid "Nozzle     [none]"
+msgstr "Tryska    [Zadne]"
+
+# 
+#: ultralcd.cpp:5427
+msgid "Nozzle   [strict]"
+msgstr "Tryska   [Prisne]"
+
+# 
+#: ultralcd.cpp:5424
+msgid "Nozzle     [warn]"
+msgstr "Tryska  [Varovat]"
+
+# 
+#: util.cpp:510
+msgid "G-code sliced for a different level. Continue?"
+msgstr ""
+
+# 
+#: util.cpp:516
+msgid "G-code sliced for a different level. Please re-slice the model again. Print cancelled."
+msgstr ""
 
 # 
 #: util.cpp:427
@@ -842,885 +1740,20 @@ msgstr "G-code je pripraven pro novejsi firmware. Pokracovat?"
 msgid "G-code sliced for a newer firmware. Please update the firmware. Print cancelled."
 msgstr "G-code je pripraven pro novejsi firmware. Prosim aktualizujte firmware. Tisk zrusen."
 
-# MSG_SELFTEST_HEATERTHERMISTOR
-#: ultralcd.cpp:7801
-msgid "Heater/Thermistor"
-msgstr "Topeni/Termistor"
-
-# MSG_HEATING
-#: messages.c:46
-msgid "Heating"
-msgstr "Zahrivani"
-
-# MSG_BED_HEATING_SAFETY_DISABLED
-#: Marlin_main.cpp:8411
-msgid "Heating disabled by safety timer."
-msgstr "Zahrivani preruseno bezpecnostnim casovacem."
-
-# MSG_HEATING_COMPLETE c=20
-#: messages.c:47
-msgid "Heating done."
-msgstr "Zahrivani OK."
-
-# MSG_WIZARD_WELCOME c=20 r=7
-#: ultralcd.cpp:4859
-msgid "Hi, I am your Original Prusa i3 printer. Would you like me to guide you through the setup process?"
-msgstr "Dobry den, jsem vase tiskarna Original Prusa i3. Chcete abych Vas provedla kalibracnim procesem?"
-
-# MSG_PRUSA3D_HOWTO
-#: ultralcd.cpp:2100
-msgid "howto.prusa3d.com"
-msgstr "howto.prusa3d.com"
-
 # 
-#: messages.c:87
-msgid "HW Setup"
-msgstr "HW nastaveni"
-
-# MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ultralcd.cpp:4889
-msgid "I will run xyz calibration now. It will take approx. 12 mins."
-msgstr "Nyni provedu xyz kalibraci. Zabere to priblizne 12 min."
-
-# MSG_WIZARD_Z_CAL c=20 r=8
-#: ultralcd.cpp:4897
-msgid "I will run z calibration now."
-msgstr "Nyni provedu z kalibraci."
-
-# MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ultralcd.cpp:4962
-msgid "I will start to print line and you will gradually lower the nozzle by rotating the knob, until you reach optimal height. Check the pictures in our handbook in chapter Calibration."
-msgstr "Zacnu tisknout linku a Vy budete postupne snizovat trysku otacenim tlacitka dokud nedosahnete optimalni vysky. Prohlednete si obrazky v nasi prirucce v kapitole Kalibrace."
-
-# MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=60
-#: mesh_bed_calibration.cpp:2481
-msgid "Improving bed calibration point"
-msgstr "Zlepsuji presnost kalibracniho bodu"
-
-# MSG_WATCH
-#: messages.c:99
-msgid "Info screen"
-msgstr "Informace"
-
-# MSG_INIT_SDCARD
-#: ultralcd.cpp:5785
-msgid "Init. SD card"
-msgstr "Inic. SD"
-
-# MSG_INSERT_FILAMENT c=20
-#: ultralcd.cpp:2569
-msgid "Insert filament"
-msgstr "Vlozte filament"
-
-# MSG_FILAMENT_LOADING_T0 c=20 r=4
-#: messages.c:33
-msgid "Insert filament into extruder 1. Click when done."
-msgstr "Vlozte filament do extruderu 1. Potvrdte tlacitkem."
-
-# MSG_FILAMENT_LOADING_T1 c=20 r=4
-#: messages.c:34
-msgid "Insert filament into extruder 2. Click when done."
-msgstr "Vlozte filament do extruderu 2. Potvrdte tlacitkem."
-
-# MSG_FILAMENT_LOADING_T2 c=20 r=4
-#: messages.c:35
-msgid "Insert filament into extruder 3. Click when done."
-msgstr "Vlozte filament do extruderu 3. Potvrdte tlacitkem."
-
-# MSG_FILAMENT_LOADING_T3 c=20 r=4
-#: messages.c:36
-msgid "Insert filament into extruder 4. Click when done."
-msgstr "Vlozte filament do extruderu 4. Potvrdte tlacitkem."
-
-# 
-#: ultralcd.cpp:3947
-msgid "IR:"
-msgstr "IR:"
-
-# 
-#: ultralcd.cpp:4922
-msgid "Is filament 1 loaded?"
-msgstr "Je filament 1 zaveden?"
-
-# MSG_WIZARD_FILAMENT_LOADED c=20 r=2
-#: ultralcd.cpp:4925
-msgid "Is filament loaded?"
-msgstr "Je filament zaveden?"
-
-# MSG_WIZARD_PLA_FILAMENT c=20 r=2
-#: ultralcd.cpp:4956
-msgid "Is it PLA filament?"
-msgstr "Je to PLA filament?"
-
-# MSG_PLA_FILAMENT_LOADED c=20 r=2
-#: ultralcd.cpp:4701
-msgid "Is PLA filament loaded?"
-msgstr "Je PLA filament zaveden?"
-
-# MSG_STEEL_SHEET_CHECK c=20 r=2
-#: messages.c:92
-msgid "Is steel sheet on heatbed?"
-msgstr "Je tiskovy plat na podlozce?"
-
-# MSG_FIND_BED_OFFSET_AND_SKEW_ITERATION c=20
-#: mesh_bed_calibration.cpp:2223
-msgid "Iteration "
-msgstr "Iterace "
-
-# MSG_KILLED
-#: Marlin_main.cpp:7552
-msgid "KILLED. "
-msgstr "ZRUSENO."
-
-# 
-#: ultralcd.cpp:1828
-msgid "Last print"
-msgstr "Posledni tisk"
-
-# 
-#: ultralcd.cpp:1845
-msgid "Last print failures"
-msgstr "Selhani posl. tisku"
-
-# 
-#: ultralcd.cpp:2967
-msgid "Left"
-msgstr "Vlevo:"
-
-# MSG_SELFTEST_EXTRUDER_FAN c=20
-#: messages.c:76
-msgid "Left hotend fan?"
-msgstr "Levy vent na trysce?"
-
-# MSG_BED_CORRECTION_LEFT c=14 r=1
-#: ultralcd.cpp:3215
-msgid "Left side [um]"
-msgstr "Vlevo [um]"
-
-# MSG_LEFT c=12 r=1
-#: ultralcd.cpp:2308
-msgid "Left:"
-msgstr "Vlevo:"
-
-# 
-#: ultralcd.cpp:5575
-msgid "Lin. correction"
-msgstr "Korekce lin."
-
-# MSG_BABYSTEP_Z
-#: messages.c:13
-msgid "Live adjust Z"
-msgstr "Doladeni osy Z"
-
-# MSG_LOAD_ALL c=17
-#: ultralcd.cpp:6059
-msgid "Load all"
-msgstr "Zavest vse"
-
-# MSG_LOAD_FILAMENT c=17
-#: messages.c:51
-msgid "Load filament"
-msgstr "Zavest filament"
-
-# MSG_LOAD_FILAMENT_1 c=17
-#: ultralcd.cpp:5576
-msgid "Load filament 1"
-msgstr "Zavest filament 1"
-
-# MSG_LOAD_FILAMENT_2 c=17
-#: ultralcd.cpp:5577
-msgid "Load filament 2"
-msgstr "Zavest filament 2"
-
-# MSG_LOAD_FILAMENT_3 c=17
-#: ultralcd.cpp:5578
-msgid "Load filament 3"
-msgstr "Zavest filament 3"
-
-# MSG_LOAD_FILAMENT_4 c=17
-#: ultralcd.cpp:5579
-msgid "Load filament 4"
-msgstr "Zavest filament 4"
-
-# MSG_LOAD_FILAMENT_5 c=17
-#: ultralcd.cpp:5582
-msgid "Load filament 5"
-msgstr "Zavest filament 5"
-
-# 
-#: ultralcd.cpp:6714
-msgid "Load to nozzle"
-msgstr "Zavest do trysky"
-
-# MSG_LOADING_COLOR
-#: ultralcd.cpp:2609
-msgid "Loading color"
-msgstr "Cisteni barvy"
-
-# MSG_LOADING_FILAMENT c=20
-#: messages.c:52
-msgid "Loading filament"
-msgstr "Zavadeni filamentu"
-
-# MSG_LOOSE_PULLEY c=20 r=1
-#: ultralcd.cpp:7855
-msgid "Loose pulley"
-msgstr "Uvolnena remenicka"
-
-# MSG_M104_INVALID_EXTRUDER
-#: Marlin_main.cpp:7675
-msgid "M104 Invalid extruder "
-msgstr "M104 Neplatny extruder "
-
-# MSG_M105_INVALID_EXTRUDER
-#: Marlin_main.cpp:7678
-msgid "M105 Invalid extruder "
-msgstr "M105 Neplatny extruder "
-
-# MSG_M109_INVALID_EXTRUDER
-#: Marlin_main.cpp:7681
-msgid "M109 Invalid extruder "
-msgstr "M109 Neplatny extruder "
-
-# MSG_M117_V2_CALIBRATION c=25 r=1
-#: messages.c:55
-msgid "M117 First layer cal."
-msgstr "M117 Kal. prvni vrstvy"
-
-# MSG_M200_INVALID_EXTRUDER
-#: Marlin_main.cpp:5857
-msgid "M200 Invalid extruder "
-msgstr "M200 Neplatny extruder "
-
-# MSG_M218_INVALID_EXTRUDER
-#: Marlin_main.cpp:7684
-msgid "M218 Invalid extruder "
-msgstr "M218 Neplatny extruder "
-
-# MSG_M221_INVALID_EXTRUDER
-#: Marlin_main.cpp:7687
-msgid "M221 Invalid extruder "
-msgstr "M221 Neplatny extruder "
-
-# 
-#: ultralcd.cpp:6957
-msgid "Magnets comp. [On]"
-msgstr "Komp. magnetu[Zap]"
-
-# 
-#: ultralcd.cpp:6960
-msgid "Magnets comp.[N/A]"
-msgstr "Komp. magnetu[N/A]"
-
-# 
-#: ultralcd.cpp:6958
-msgid "Magnets comp.[Off]"
-msgstr "Komp. magnetu[Vyp]"
-
-# MSG_MAIN
-#: messages.c:56
-msgid "Main"
-msgstr "Hlavni nabidka"
-
-# MSG_MARK_FIL c=20 r=8
-#: ultralcd.cpp:3840
-msgid "Mark filament 100mm from extruder body. Click when done."
-msgstr "Oznacte filament 100 mm od tela extruderu a pote potvrdte tlacitkem."
-
-# 
-#: ultralcd.cpp:3002
-msgid "Measured skew"
-msgstr "Merene zkoseni"
-
-# MSG_MEASURED_SKEW c=15 r=1
-#: ultralcd.cpp:2335
-msgid "Measured skew:"
-msgstr "Merene zkos.:"
-
-# MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=60
-#: messages.c:59
-msgid "Measuring reference height of calibration point"
-msgstr "Merim referencni vysku kalibracniho bodu"
-
-# 
-#: ultralcd.cpp:6949
-msgid "Mesh         [3x3]"
-msgstr "Mesh [3x3]"
-
-# 
-#: ultralcd.cpp:6950
-msgid "Mesh         [7x7]"
-msgstr "Mesh [7x7]"
-
-# MSG_MESH_BED_LEVELING
-#: ultralcd.cpp:5658
-msgid "Mesh Bed Leveling"
-msgstr "Mesh Bed Leveling"
-
-# 
-#: ultralcd.cpp:5572
-msgid "Mesh bed leveling"
-msgstr "Mesh Bed Leveling"
-
-# 
-#: Marlin_main.cpp:881
-msgid "MK3 firmware detected on MK3S printer"
-msgstr "MK3 firmware detekovan na tiskarne MK3S"
-
-# 
-#: Marlin_main.cpp:856
-msgid "MK3S firmware detected on MK3 printer"
-msgstr "MK3S firmware detekovan na tiskarne MK3"
-
-# 
-#: ultralcd.cpp:1845
-msgid "MMU fails"
-msgstr "Selhani MMU"
-
-# 
-#: mmu.cpp:1617
-msgid "MMU load failed     "
-msgstr "Zavedeni MMU selhalo"
-
-# 
-#: ultralcd.cpp:1845
-msgid "MMU load fails"
-msgstr "MMU selhani zavadeni"
-
-# 
-#: ultralcd.cpp:5204
-msgid "MMU Mode [Normal]"
-msgstr "MMU mod [Normal]"
-
-# 
-#: ultralcd.cpp:5205
-msgid "MMU Mode[Stealth]"
-msgstr "MMU Mod [Tichy]"
-
-# 
-#: mmu.cpp:719
-msgid "MMU needs user attention."
-msgstr "MMU potrebuje zasah uzivatele."
-
-# MSG_MMU_NEEDS_ATTENTION c=20 r=4
-#: mmu.cpp:359
-msgid "MMU needs user attention. Fix the issue and then press button on MMU unit."
-msgstr "MMU potrebuje zasah uzivatele. Opravte chybu a pote stisknete tlacitko na jednotce MMU."
-
-# MSG_MMU_OK_RESUMING_POSITION c=20 r=4
-#: mmu.cpp:762
-msgid "MMU OK. Resuming position..."
-msgstr "MMU OK. Pokracuji v tisku..."
-
-# MSG_MMU_OK_RESUMING_TEMPERATURE c=20 r=4
-#: mmu.cpp:755
-msgid "MMU OK. Resuming temperature..."
-msgstr "MMU OK. Pokracuji v nahrivani..."
-
-# MSG_MMU_OK_RESUMING c=20 r=4
-#: mmu.cpp:773
-msgid "MMU OK. Resuming..."
-msgstr "MMU OK. Pokracuji..."
-
-# 
-#: ultralcd.cpp:1862
-msgid "MMU power fails"
-msgstr "MMU vypadky proudu"
-
-# 
-#: ultralcd.cpp:2112
-msgid "MMU2 connected"
-msgstr "MMU2 pripojeno"
-
-# MSG_STEALTH_MODE_OFF
-#: messages.c:90
-msgid "Mode     [Normal]"
-msgstr "Mod      [Normal]"
-
-# MSG_SILENT_MODE_ON
-#: messages.c:89
-msgid "Mode     [silent]"
-msgstr "Mod       [tichy]"
-
-# MSG_STEALTH_MODE_ON
-#: messages.c:91
-msgid "Mode    [Stealth]"
-msgstr "Mod [Tichy]"
-
-# 
-#: ultralcd.cpp:4424
-msgid "Mode change in progress ..."
-msgstr "Probiha zmena modu..."
-
-# MSG_AUTO_MODE_ON
-#: messages.c:12
-msgid "Mode [auto power]"
-msgstr "Mod [automaticky]"
-
-# MSG_SILENT_MODE_OFF
-#: messages.c:88
-msgid "Mode [high power]"
-msgstr "Mod  [vys. vykon]"
-
-# 
-#: ultralcd.cpp:5404
-msgid "Model      [none]"
-msgstr "Trideni [Zadne]"
-
-# 
-#: ultralcd.cpp:5407
-msgid "Model      [warn]"
-msgstr "Model [Varovat]"
-
-# 
-#: ultralcd.cpp:5410
-msgid "Model    [strict]"
-msgstr "Model [Prisne]"
-
-# MSG_SELFTEST_MOTOR
-#: messages.c:83
-msgid "Motor"
-msgstr "Motor"
-
-# MSG_MOVE_AXIS
-#: ultralcd.cpp:5550
-msgid "Move axis"
-msgstr "Posunout osu"
-
-# MSG_MOVE_X
-#: ultralcd.cpp:4291
-msgid "Move X"
-msgstr "Posunout X"
-
-# MSG_MOVE_Y
-#: ultralcd.cpp:4292
-msgid "Move Y"
-msgstr "Posunout Y"
-
-# MSG_MOVE_Z
-#: ultralcd.cpp:4293
-msgid "Move Z"
-msgstr "Posunout Z"
-
-# 
-#: ultralcd.cpp:2973
-msgid "N/A"
-msgstr "N/A"
-
-# 
-#: util.cpp:293
-msgid "New firmware version available:"
-msgstr "Vysla nova verze firmware:"
-
-# MSG_NO
-#: messages.c:62
-msgid "No"
-msgstr "Ne"
-
-# 
-#:
-msgid "No "
-msgstr "Ne"
-
-# MSG_ERR_NO_CHECKSUM
-#: cmdqueue.cpp:456
-msgid "No Checksum with line number, Last Line: "
-msgstr "Zadny kontrolni soucet s cislem radku, Posl. radek:"
-
-# MSG_NO_MOVE
-#: Marlin_main.cpp:5254
-msgid "No move."
-msgstr "Bez pohybu."
-
-# MSG_NO_CARD
-#: ultralcd.cpp:6694
-msgid "No SD card"
-msgstr "Zadna SD karta"
-
-# MSG_ERR_NO_THERMISTORS
-#: Marlin_main.cpp:4946
-msgid "No thermistors - no temperature"
-msgstr "Bez termistoru - bez odectu teploty"
-
-# MSG_SELFTEST_NOTCONNECTED
-#: ultralcd.cpp:7803
-msgid "Not connected"
-msgstr "Nezapojeno "
-
-# MSG_SELFTEST_FAN_NO c=19
-#: messages.c:79
-msgid "Not spinning"
-msgstr "Netoci se"
-
-# MSG_WIZARD_V2_CAL c=20 r=8
-#: ultralcd.cpp:4961
-msgid "Now I will calibrate distance between tip of the nozzle and heatbed surface."
-msgstr "Nyni zkalibruji vzdalenost mezi koncem trysky a povrchem podlozky."
-
-# MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ultralcd.cpp:4905
-msgid "Now I will preheat nozzle for PLA."
-msgstr "Nyni predehreji trysku pro PLA."
-
-# 
-#: ultralcd.cpp:4896
-msgid "Now remove the test print from steel sheet."
-msgstr "Nyni odstrante testovaci vytisk z tiskoveho platu."
-
-# MSG_NOZZLE
-#: messages.c:63
-msgid "Nozzle"
-msgstr "Tryska"
-
-# 
-#: ultralcd.cpp:5319
-msgid "Nozzle     [none]"
-msgstr "Tryska [Zadne]"
-
-# 
-#: ultralcd.cpp:5322
-msgid "Nozzle     [warn]"
-msgstr "Tryska [Varovat]"
-
-# 
-#: ultralcd.cpp:5325
-msgid "Nozzle   [strict]"
-msgstr "Tryska [Prisne]"
-
-# 
-#: ultralcd.cpp:5365
-msgid "Nozzle d.  [0.25]"
-msgstr "Tryska [0.25]"
-
-# 
-#: ultralcd.cpp:5368
-msgid "Nozzle d.  [0.40]"
-msgstr "Tryska [0.40]"
-
-# 
-#: ultralcd.cpp:5371
-msgid "Nozzle d.  [0.60]"
-msgstr "Tryska [0.60]"
-
-# 
-#: ultralcd.cpp:1787
-msgid "Nozzle FAN"
-msgstr "Trysk. vent."
-
-# MSG_INFO_NOZZLE_FAN c=11 r=1
-#: ultralcd.cpp:1537
-msgid "Nozzle FAN:"
-msgstr "Trysk. vent:"
-
-# MSG_NOZZLE1
-#: ultralcd.cpp:5995
-msgid "Nozzle2"
-msgstr "Tryska2"
-
-# MSG_NOZZLE2
-#: ultralcd.cpp:5998
-msgid "Nozzle3"
-msgstr "Tryska3"
-
-# MSG_OK
-#: Marlin_main.cpp:6333
-msgid "ok"
-msgstr "ok"
-
-# MSG_DEFAULT_SETTINGS_LOADED c=20 r=4
-#: Marlin_main.cpp:1535
-msgid "Old settings found. Default PID, Esteps etc. will be set."
-msgstr "Neplatne hodnoty nastaveni. Bude pouzito vychozi PID, Esteps atd."
-
-# MSG_ENDSTOP_OPEN
-#: messages.c:29
-msgid "open"
-msgstr "otevrit"
-
-# MSG_SD_OPEN_FILE_FAIL
-#: messages.c:79
-msgid "open failed, File: "
-msgstr "nelze otevrit, Soubor: "
-
-# MSG_SD_OPENROOT_FAIL
-#: cardreader.cpp:196
-msgid "openRoot failed"
-msgstr "openRoot selhal"
-
-# MSG_PAUSE_PRINT
-#: ultralcd.cpp:6657
-msgid "Pause print"
-msgstr "Pozastavit tisk"
-
-# MSG_PICK_Z
-#: ultralcd.cpp:3463
-msgid "Pick print"
-msgstr "Vyberte vytisk"
-
-# MSG_PID_RUNNING c=20 r=1
-#: ultralcd.cpp:1613
-msgid "PID cal.           "
-msgstr "PID kal. "
-
-# MSG_PID_FINISHED c=20 r=1
-#: ultralcd.cpp:1619
-msgid "PID cal. finished"
-msgstr "PID kal. ukoncena"
-
-# MSG_PID_EXTRUDER c=17 r=1
-#: ultralcd.cpp:5664
-msgid "PID calibration"
-msgstr "PID kalibrace"
-
-# MSG_PINDA_PREHEAT c=20 r=1
-#: ultralcd.cpp:862
-msgid "PINDA Heating"
-msgstr "Nahrivani PINDA"
-
-# 
-#: ultralcd.cpp:3939
+#: ultralcd.cpp:4026
 msgid "PINDA:"
-msgstr "PINDA:"
-
-# MSG_PAPER c=20 r=8
-#: messages.c:64
-msgid "Place a sheet of paper under the nozzle during the calibration of first 4 points. If the nozzle catches the paper, power off the printer immediately."
-msgstr "Umistete list papiru na podlozku a udrzujte jej pod tryskou behem mereni prvnich 4 bodu. Pokud tryska zachyti papir, okamzite vypnete tiskarnu."
-
-# MSG_SELFTEST_PLEASECHECK
-#: ultralcd.cpp:7795
-msgid "Please check :"
-msgstr "Zkontrolujte :"
-
-# MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: messages.c:100
-msgid "Please check our handbook and fix the problem. Then resume the Wizard by rebooting the printer."
-msgstr "Prosim nahlednete do prirucky 3D tiskare a opravte problem. Pote obnovte Pruvodce restartovanim tiskarny."
-
-# MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ultralcd.cpp:4970
-msgid "Please clean heatbed and then press the knob."
-msgstr "Prosim ocistete podlozku a stisknete tlacitko."
-
-# MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: messages.c:22
-msgid "Please clean the nozzle for calibration. Click when done."
-msgstr "Pro uspesnou kalibraci ocistete prosim tiskovou trysku. Potvrdte tlacitkem."
-
-# MSG_WIZARD_LOAD_FILAMENT c=20 r=8
-#: ultralcd.cpp:4804
-msgid "Please insert PLA filament to the extruder, then press knob to load it."
-msgstr "Prosim vlozte PLA filament do extruderu, pote stisknete tlacitko pro zavedeni filamentu."
+msgstr ""
 
 # 
-#: ultralcd.cpp:4800
-msgid "Please insert PLA filament to the first tube of MMU, then press the knob to load it."
-msgstr "Prosim vlozte PLA filament do trubicky MMU, pote stisknete tlacitko pro zavedeni filamentu."
-
-# MSG_WIZARD_INSERT_CORRECT_FILAMENT c=20 r=8
-#: ultralcd.cpp:4109
-msgid "Please load PLA filament and then resume Wizard by rebooting the printer."
-msgstr "Prosim zavedte PLA filament a po te obnovte Pruvodce stisknutim reset tlacitka."
-
-# MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ultralcd.cpp:4706
-msgid "Please load PLA filament first."
-msgstr "Nejdrive prosim zavedte PLA filament."
-
-# MSG_CHECK_IDLER c=20 r=4
-#: Marlin_main.cpp:3083
-msgid "Please open idler and remove filament manually."
-msgstr "Prosim otevrete idler a manualne odstrante filament."
-
-# MSG_PLACE_STEEL_SHEET c=20 r=4
-#: messages.c:65
-msgid "Please place steel sheet on heatbed."
-msgstr "Umistete prosim tiskovy plat na podlozku"
-
-# MSG_PRESS_TO_UNLOAD c=20 r=4
-#: messages.c:68
-msgid "Please press the knob to unload filament"
-msgstr "Pro vysunuti filamentu stisknete prosim tlacitko"
-
-# MSG_PULL_OUT_FILAMENT c=20 r=4
-#: messages.c:70
-msgid "Please pull out filament immediately"
-msgstr "Prosim vyjmete urychlene filament"
-
-# MSG_EJECT_REMOVE c=20 r=4
-#: mmu.cpp:1441
-msgid "Please remove filament and then press the knob."
-msgstr "Prosim vyjmete filament a pote stisknete tlacitko."
-
-# 
-#: ultralcd.cpp:4895
-msgid "Please remove shipping helpers first."
-msgstr "Nejprve prosim sundejte transportni soucastky."
-
-# MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: messages.c:74
-msgid "Please remove steel sheet from heatbed."
-msgstr "Odstrante prosim tiskovy plat z podlozky."
-
-# MSG_RUN_XYZ c=20 r=4
-#: Marlin_main.cpp:4317
-msgid "Please run XYZ calibration first."
-msgstr "Nejprve spustte kalibraci XYZ."
-
-# MSG_UPDATE_MMU2_FW c=20 r=4
-#: mmu.cpp:1360
-msgid "Please update firmware in your MMU2. Waiting for reset."
-msgstr "Prosim aktualizujte firmware ve vasi MMU2 jednotce. Cekam na reset."
-
-# 
-#: util.cpp:297
-msgid "Please upgrade."
-msgstr "Prosim aktualizujte."
-
-# MSG_PLEASE_WAIT c=20
-#: messages.c:66
-msgid "Please wait"
-msgstr "Prosim cekejte"
-
-# 
-#: ultralcd.cpp:1881
-msgid "Power failures"
-msgstr "Vypadky proudu"
-
-# MSG_POWERUP
-#: messages.c:69
-msgid "PowerUp"
-msgstr "Zapnuti"
-
-# MSG_PREHEAT
-#: ultralcd.cpp:6644
-msgid "Preheat"
-msgstr "Predehrev"
-
-# MSG_PREHEAT_NOZZLE c=20
-#: messages.c:67
-msgid "Preheat the nozzle!"
-msgstr "Predehrejte trysku!"
-
-# MSG_WIZARD_HEATING c=20 r=3
-#: messages.c:102
-msgid "Preheating nozzle. Please wait."
-msgstr "Predehrev trysky. Prosim cekejte."
-
-# 
-#: ultralcd.cpp:2290
+#: ultralcd.cpp:2465
 msgid "Preheating to cut"
 msgstr "Predehrev k ustrizeni"
 
 # 
-#: ultralcd.cpp:2287
+#: ultralcd.cpp:2462
 msgid "Preheating to eject"
 msgstr "Predehrev k vysunuti"
-
-# 
-#: ultralcd.cpp:2280
-msgid "Preheating to load"
-msgstr "Predehrev k zavedeni"
-
-# 
-#: ultralcd.cpp:2284
-msgid "Preheating to unload"
-msgstr "Predehrev k vyjmuti"
-
-# MSG_PREPARE_FILAMENT c=20 r=1
-#: ultralcd.cpp:1911
-msgid "Prepare new filament"
-msgstr "Pripravte filament"
-
-# MSG_PRESS_TO_PREHEAT c=20 r=4
-#: Marlin_main.cpp:10312
-msgid "Press knob to preheat nozzle and continue."
-msgstr "Pro nahrati trysky a pokracovani stisknete tlacitko."
-
-# 
-#: ultralcd.cpp:2210
-msgid "Press the knob"
-msgstr "Stisknete hl. tlacitko"
-
-# 
-#: mmu.cpp:723
-msgid "Press the knob to resume nozzle temperature."
-msgstr "Pro pokracovani nahrivani trysky stisknete tlacitko."
-
-# MSG_PRINT_ABORTED c=20
-#: messages.c:69
-msgid "Print aborted"
-msgstr "Tisk prerusen"
-
-# 
-#: ultralcd.cpp:1789
-msgid "Print FAN"
-msgstr "Tiskovy vent."
-
-# MSG_INFO_PRINT_FAN c=11 r=1
-#: ultralcd.cpp:1549
-msgid "Print FAN: "
-msgstr "Tisk. vent:"
-
-# MSG_SELFTEST_PRINT_FAN_SPEED c=18
-#: ultralcd.cpp:8221
-msgid "Print fan:"
-msgstr "Tiskovy vent.:"
-
-# MSG_CARD_MENU
-#: messages.c:21
-msgid "Print from SD"
-msgstr "Tisk z SD"
-
-# MSG_PRINT_PAUSED c=20 r=1
-#: ultralcd.cpp:1080
-msgid "Print paused"
-msgstr "Tisk pozastaven"
-
-# MSG_PRINT_TIME c=19 r=1
-#: ultralcd.cpp:2838
-msgid "Print time"
-msgstr "Cas tisku"
-
-# MSG_STATS_PRINTTIME c=20
-#: ultralcd.cpp:2151
-msgid "Print time:  "
-msgstr "Cas tisku: "
-
-# MSG_PRINTER_DISCONNECTED c=20 r=1
-#: ultralcd.cpp:607
-msgid "Printer disconnected"
-msgstr "Tiskarna odpojena"
-
-# 
-#: util.cpp:473
-msgid "Printer FW version differs from the G-code. Continue?"
-msgstr "Firmware tiskarny se lisi od G-code. Pokracovat?"
-
-# 
-#: util.cpp:480
-msgid "Printer FW version differs from the G-code. Please check the value in settings. Print cancelled."
-msgstr "Firmware tiskarny se lisi od G-code. Prosim zkontrolujte nastaveni. Tisk zrusen."
-
-# MSG_ERR_KILLED
-#: Marlin_main.cpp:7547
-msgid "Printer halted. kill() called!"
-msgstr "Tiskarna zastavena. Volano kill()!"
-
-# MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: messages.c:41
-msgid "Printer has not been calibrated yet. Please follow the manual, chapter First steps, section Calibration flow."
-msgstr "Tiskarna nebyla jeste zkalibrovana. Postupujte prosim podle manualu, kapitola Zaciname, odstavec Postup kalibrace."
-
-# 
-#: util.cpp:423
-msgid "Printer model differs from the G-code. Continue?"
-msgstr "Model tiskarny se lisi od G-code. Pokracovat?"
-
-# 
-#: util.cpp:430
-msgid "Printer model differs from the G-code. Please check the value in settings. Print cancelled."
-msgstr "Model tiskarny se lisi od G-code. Prosim zkontrolujte nastaveni. Tisk zrusen."
 
 # 
 #: util.cpp:390
@@ -1732,802 +1765,48 @@ msgstr "Prumer trysky tiskarny se lisi od G-code. Pokracovat?"
 msgid "Printer nozzle diameter differs from the G-code. Please check the value in settings. Print cancelled."
 msgstr "Prumer trysky tiskarny se lisi od G-code. Prosim zkontrolujte nastaveni. Tisk zrusen."
 
-# MSG_ERR_STOPPED
-#: messages.c:32
-msgid "Printer stopped due to errors. Fix the error and use M999 to restart. (Temperature is reset. Set it after restarting)"
-msgstr "Tisk zastaven kvuli chybam. Opravte chybu a pouzijte M999 pro restart. (Teplota resetovana, nastavte ji po restartu)"
-
 # 
-#:
-msgid "Prusa i3 MK2 ready."
-msgstr "Prusa i3 MK2 ok."
-
-# WELCOME_MSG c=20
-#:
-msgid "Prusa i3 MK2.5 ready."
-msgstr "Prusa i3 MK2.5 ok."
-
-# 
-#:
-msgid "Prusa i3 MK3 OK."
-msgstr "Prusa i3 MK3 OK."
-
-# WELCOME_MSG c=20
-#:
-msgid "Prusa i3 MK3 ready."
-msgstr "Prusa i3 MK3 ok."
-
-# 
-#:
-msgid "Prusa i3 MK3S OK."
-msgstr "Prusa i3 MK3S OK."
-
-# MSG_PRUSA3D
-#: ultralcd.cpp:2098
-msgid "prusa3d.com"
-msgstr "prusa3d.com"
-
-# MSG_BED_CORRECTION_REAR c=14 r=1
-#: ultralcd.cpp:3218
-msgid "Rear side [um]"
-msgstr "Vzadu [um]"
-
-# MSG_RECOVERING_PRINT c=20 r=1
-#: Marlin_main.cpp:9712
-msgid "Recovering print    "
-msgstr "Obnovovani tisku "
-
-# MSG_REFRESH
-#:
-msgid "Refresh"
-msgstr "Obnovit"
-
-# MSG_REMOVE_OLD_FILAMENT c=20 r=4
-#: mmu.cpp:830
-msgid "Remove old filament and press the knob to start loading new filament."
-msgstr "Vyjmete stary filament a stisknete tlacitko pro zavedeni noveho."
-
-# 
-#: ultralcd.cpp:6605
+#: ultralcd.cpp:6683
 msgid "Rename"
 msgstr "Prejmenovat"
 
-# MSG_M119_REPORT
-#: Marlin_main.cpp:5297
-msgid "Reporting endstop status"
-msgstr "Report stavu konc. spinacu"
-
 # 
-#: Marlin_main.cpp:7076
-msgid "Resend"
-msgstr "Poslat znovu"
-
-# MSG_RESEND
-#: Marlin_main.cpp:6911
-msgid "Resend: "
-msgstr "Poslat znovu: "
-
-# MSG_BED_CORRECTION_RESET
-#: ultralcd.cpp:3219
-msgid "Reset"
-msgstr "Reset"
-
-# MSG_CALIBRATE_BED_RESET
-#: ultralcd.cpp:5669
-msgid "Reset XYZ calibr."
-msgstr "Reset XYZ kalibr."
-
-# MSG_RESUME_PRINT
-#: ultralcd.cpp:6664
-msgid "Resume print"
-msgstr "Pokracovat"
-
-# MSG_RESUMING_PRINT c=20 r=1
-#: messages.c:73
-msgid "Resuming print"
-msgstr "Obnoveni tisku"
-
-# 
-#: ultralcd.cpp:2968
-msgid "Right"
-msgstr "Vpravo"
-
-# MSG_BED_CORRECTION_RIGHT c=14 r=1
-#: ultralcd.cpp:3216
-msgid "Right side[um]"
-msgstr "Vpravo [um]"
-
-# MSG_RIGHT c=12 r=1
-#: ultralcd.cpp:2309
-msgid "Right:"
-msgstr "Pravy:"
-
-# MSG_E_CAL_KNOB c=20 r=8
-#: ultralcd.cpp:3835
-msgid "Rotate knob until mark reaches extruder body. Click when done."
-msgstr "Otacejte tlacitkem dokud znacka nedosahne tela extruderu. Potvrdte tlacitkem."
-
-# MSG_SECOND_SERIAL_ON c=17 r=1
-#: ultralcd.cpp:5587
-msgid "RPi port     [on]"
-msgstr "RPi port    [zap]"
-
-# MSG_SECOND_SERIAL_OFF c=17 r=1
-#: ultralcd.cpp:5585
-msgid "RPi port    [off]"
-msgstr "RPi port    [vyp]"
-
-# MSG_WIZARD_RERUN c=20 r=7
-#: ultralcd.cpp:4723
-msgid "Running Wizard will delete current calibration results and start from the beginning. Continue?"
-msgstr "Spusteni Pruvodce vymaze ulozene vysledky vsech kalibraci a spusti kalibracni proces od zacatku. Pokracovat?"
-
-# MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_OFF c=19 r=1
-#: ultralcd.cpp:5220
-msgid "SD card  [normal]"
-msgstr "SD card  [normal]"
-
-# MSG_SD_CARD_OK
-#: cardreader.cpp:202
-msgid "SD card ok"
-msgstr "SD karta ok"
-
-# MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_ON c=19 r=1
-#: ultralcd.cpp:4238
-msgid "SD card [FlshAir]"
-msgstr "SD card [FlshAir]"
-
-# MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_ON c=19 r=1
-#: ultralcd.cpp:5218
-msgid "SD card [flshAir]"
-msgstr "SD card [FlshAir]"
-
-# MSG_SD_INIT_FAIL
-#: cardreader.cpp:186
-msgid "SD init fail"
-msgstr "Selhala inicializace SD"
-
-# MSG_SD_PRINTING_BYTE
-#: cardreader.cpp:516
-msgid "SD printing byte "
-msgstr "SD printing byte "
-
-# MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=60
-#: messages.c:38
-msgid "Searching bed calibration point"
-msgstr "Hledam kalibracni bod podlozky"
-
-# 
-#: ultralcd.cpp:6601
+#: ultralcd.cpp:6679
 msgid "Select"
 msgstr "Vybrat"
 
-# MSG_LANGUAGE_SELECT
-#: ultralcd.cpp:5594
-msgid "Select language"
-msgstr "Vyber jazyka"
-
 # 
-#: ultralcd.cpp:4943
-msgid "Select nozzle preheat temperature which matches your material."
-msgstr "Vyberte teplotu predehrati trysky ktera odpovida vasemu materialu."
-
-# 
-#: ultralcd.cpp:4692
-msgid "Select PLA filament:"
-msgstr "Vyberte PLA filament:"
-
-# MSG_SELFTEST_OK
-#: ultralcd.cpp:7366
-msgid "Self test OK"
-msgstr "Self test OK"
-
-# MSG_SELFTEST_START c=20
-#: ultralcd.cpp:7152
-msgid "Self test start  "
-msgstr "Self test start "
-
-# MSG_SELFTEST
-#: ultralcd.cpp:5645
-msgid "Selftest         "
-msgstr "Selftest "
-
-# MSG_SELFTEST_ERROR
-#: ultralcd.cpp:7793
-msgid "Selftest error !"
-msgstr "Chyba Selftestu!"
-
-# MSG_SELFTEST_FAILED c=20
-#: messages.c:77
-msgid "Selftest failed  "
-msgstr "Selftest selhal "
-
-# MSG_FORCE_SELFTEST c=20 r=8
-#: Marlin_main.cpp:1567
-msgid "Selftest will be run to calibrate accurate sensorless rehoming."
-msgstr "Pro kalibraci presneho rehomovani bude nyni spusten selftest."
-
-# 
-#: ultralcd.cpp:2138
+#: ultralcd.cpp:2245
 msgid "Sensor info"
 msgstr "Senzor info"
 
 # 
-#: ultralcd.cpp:3938
-msgid "Sensor state"
-msgstr "Stav senzoru"
-
-# 
-#:
-msgid "Sensors info"
-msgstr "Senzor info"
-
-# MSG_SET_TEMPERATURE c=19 r=1
-#: ultralcd.cpp:3227
-msgid "Set temperature:"
-msgstr "Nastavte teplotu:"
-
-# MSG_SETTINGS
-#: messages.c:86
-msgid "Settings"
-msgstr "Nastaveni"
-
-# 
-#: ultralcd.cpp:3005
-msgid "Severe skew"
-msgstr "Tezke zkoseni"
-
-# MSG_SEVERE_SKEW c=15 r=1
-#: ultralcd.cpp:2346
-msgid "Severe skew:"
-msgstr "Tezke zkoseni:"
-
-# 
 #: messages.c:58
 msgid "Sheet"
-msgstr "Plech"
-
-# MSG_SHOW_END_STOPS c=17 r=1
-#: ultralcd.cpp:5666
-msgid "Show end stops"
-msgstr "Stav konc. spin."
+msgstr "Plat"
 
 # 
-#:
-msgid "Show pinda state"
-msgstr "Zobrazit stav PINDA"
-
-# MSG_DWELL
-#: Marlin_main.cpp:3752
-msgid "Sleep..."
-msgstr "Spankovy rezim..."
+#: sound.h:9
+msgid "Sound    [assist]"
+msgstr "Zvuk     [Asist.]"
 
 # 
-#: ultralcd.cpp:3004
-msgid "Slight skew"
-msgstr "Lehke zkoseni"
-
-# MSG_SLIGHT_SKEW c=15 r=1
-#: ultralcd.cpp:2342
-msgid "Slight skew:"
-msgstr "Lehke zkoseni:"
-
-# MSG_FILE_CNT c=20 r=4
-#: cardreader.cpp:739
-msgid "Some files will not be sorted. Max. No. of files in 1 folder for sorting is 100."
-msgstr "Nektere soubory nebudou setrideny. Maximalni pocet souboru ve slozce pro setrideni je 100."
-
-# 
-#: Marlin_main.cpp:4833
-msgid "Some problem encountered, Z-leveling enforced ..."
-msgstr "Vyskytl se problem, srovnavam osu Z ..."
-
-# MSG_SORT_NONE c=17 r=1
-#: ultralcd.cpp:5230
-msgid "Sort       [none]"
-msgstr "Trideni [Zadne]"
-
-# MSG_SORT_TIME c=17 r=1
-#: ultralcd.cpp:5228
-msgid "Sort       [time]"
-msgstr "Trideni [cas]"
-
-# MSG_SORT_ALPHA c=17 r=1
-#: ultralcd.cpp:5229
-msgid "Sort   [alphabet]"
-msgstr "Trideni [Abeceda]"
-
-# MSG_SORT_NONE c=17 r=1
-#: ultralcd.cpp:4250
-msgid "Sort:      [None]"
-msgstr "Trideni [Zadne]"
-
-# MSG_SORT_NONE c=17 r=1
-#: ultralcd.cpp:5043
-msgid "Sort:      [none]"
-msgstr "Trideni   [Zadne]"
-
-# MSG_SORT_TIME c=17 r=1
-#: ultralcd.cpp:4248
-msgid "Sort:      [Time]"
-msgstr "Trideni [Cas]\n"
-
-# MSG_SORT_TIME c=17 r=1
-#: ultralcd.cpp:5041
-msgid "Sort:      [time]"
-msgstr "Trideni:    [cas]"
-
-# MSG_SORT_ALPHA c=17 r=1
-#: ultralcd.cpp:4249
-msgid "Sort:  [Alphabet]"
-msgstr "Trideni [Abeceda]"
-
-# MSG_SORT_ALPHA c=17 r=1
-#: ultralcd.cpp:5042
-msgid "Sort:  [alphabet]"
-msgstr "Trideni [Abeceda]"
-
-# MSG_SORT_NONE c=17 r=1
-#:
-msgid "Sort:  [none]"
-msgstr "Trideni [Zadne]"
-
-# MSG_SORT_TIME c=17 r=1
-#:
-msgid "Sort:  [time]"
-msgstr "Trideni [Cas]\n"
-
-# MSG_SORTING c=20 r=1
-#: cardreader.cpp:746
-msgid "Sorting files"
-msgstr "Trideni souboru"
-
-# MSG_SOUND_LOUD c=17 r=1
-#: sound.h:6
-msgid "Sound      [loud]"
-msgstr "Zvuk    [hlasity]"
-
-# MSG_SOUND_MUTE c=17 r=1
-#:
-msgid "Sound      [mute]"
-msgstr "Zvuk    [vypnuto]"
-
-# MSG_SOUND_ONCE c=17 r=1
-#: sound.h:7
-msgid "Sound      [once]"
-msgstr "Zvuk     [jednou]"
-
-# 
-#:
-msgid "Sound     [assist]"
-msgstr "Zvuk [Asist.]"
-
-# MSG_SOUND_SILENT c=17 r=1
-#: sound.h:8
-msgid "Sound    [silent]"
-msgstr "Zvuk      [tichy]"
-
-# MSG_SPEED
-#: ultralcd.cpp:6840
-msgid "Speed"
-msgstr "Rychlost"
-
-# MSG_SELFTEST_FAN_YES c=19
-#: messages.c:80
-msgid "Spinning"
-msgstr "Toci se"
-
-# MSG_AUTO_DEPLETE_ON c=17 r=1
-#: ultralcd.cpp:5098
-msgid "SpoolJoin    [on]"
-msgstr "SpoolJoin   [zap]"
-
-# 
-#: ultralcd.cpp:5094
-msgid "SpoolJoin   [N/A]"
-msgstr "SpoolJoin   [N/A]"
-
-# MSG_AUTO_DEPLETE_OFF c=17 r=1
-#: ultralcd.cpp:5102
-msgid "SpoolJoin   [off]"
-msgstr "SpoolJoin   [vyp]"
-
-# MSG_TEMP_CAL_WARNING c=20 r=4
-#: Marlin_main.cpp:4330
-msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
-msgstr "Je vyzadovana stabilni pokojova teplota 21-26C a pevna podlozka."
-
-# MSG_STATISTICS
-#: ultralcd.cpp:6753
-msgid "Statistics  "
-msgstr "Statistika "
-
-# 
-#: ultralcd.cpp:5551
+#: ultralcd.cpp:5637
 msgid "Steel sheets"
 msgstr "Tiskove platy"
 
-# MSG_STEPPER_TOO_HIGH
-#: stepper.cpp:345
-msgid "Steprate too high: "
-msgstr "Krokovani prilis vysoko:"
-
-# MSG_STOP_PRINT
-#: messages.c:93
-msgid "Stop print"
-msgstr "Zastavit tisk"
-
-# MSG_STOPPED
-#: messages.c:94
-msgid "STOPPED. "
-msgstr "ZASTAVENO."
-
-# MSG_SUPPORT
-#: ultralcd.cpp:6762
-msgid "Support"
-msgstr "Podpora"
-
-# MSG_SELFTEST_SWAPPED
-#: ultralcd.cpp:7873
-msgid "Swapped"
-msgstr "Prohozene"
-
-# MSG_TEMP_CALIBRATION c=20 r=1
-#: messages.c:95
-msgid "Temp. cal.          "
-msgstr "Tepl. kal. "
-
-# MSG_TEMP_CALIBRATION_ON c=20 r=1
-#: ultralcd.cpp:5581
-msgid "Temp. cal.   [on]"
-msgstr "Tepl. kal.  [zap]"
-
-# MSG_TEMP_CALIBRATION_OFF c=20 r=1
-#: ultralcd.cpp:5579
-msgid "Temp. cal.  [off]"
-msgstr "Tepl. kal.  [vyp]"
-
-# MSG_CALIBRATION_PINDA_MENU c=17 r=1
-#: ultralcd.cpp:5675
-msgid "Temp. calibration"
-msgstr "Teplot. kalibrace"
-
-# MSG_TEMPERATURE
-#: ultralcd.cpp:5548
-msgid "Temperature"
-msgstr "Teplota"
-
-# MSG_TEMP_CAL_FAILED c=20 r=8
-#: ultralcd.cpp:3864
-msgid "Temperature calibration failed"
-msgstr "Teplotni kalibrace selhala"
-
-# MSG_PINDA_NOT_CALIBRATED c=20 r=4
-#: Marlin_main.cpp:1403
-msgid "Temperature calibration has not been run yet"
-msgstr "Tiskarna nebyla teplotne zkalibrovana"
-
-# MSG_TEMP_CALIBRATION_DONE c=20 r=12
-#: messages.c:96
-msgid "Temperature calibration is finished and active. Temp. calibration can be disabled in menu Settings->Temp. cal."
-msgstr "Teplotni kalibrace dokoncena a je nyni aktivni. Teplotni kalibraci je mozno deaktivovat v menu Nastaveni->Tepl. kal."
-
-# MSG_MENU_TEMPERATURES c=15 r=1
-#: ultralcd.cpp:2144
-msgid "Temperatures"
-msgstr "Teploty"
-
-# MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=4
-#: messages.c:42
-msgid "There is still a need to make Z calibration. Please follow the manual, chapter First steps, section Calibration flow."
-msgstr "Je potreba kalibrovat osu Z. Prosim postupujte dle prirucky, kapitola Zaciname, sekce Postup kalibrace."
-
 # 
-#: ultralcd.cpp:2217
-msgid "to load filament"
-msgstr "k zavedeni filamentu"
-
-# 
-#: ultralcd.cpp:2221
-msgid "to unload filament"
-msgstr "k vyjmuti filamentu"
-
-# 
-#: ultralcd.cpp:1829
-msgid "Total"
-msgstr "Celkem"
-
-# 
-#: ultralcd.cpp:1862
-msgid "Total failures"
-msgstr "Celkem selhani"
-
-# 
-#: ultralcd.cpp:2860
-msgid "Total filament"
-msgstr "Filament celkem"
-
-# MSG_STATS_TOTALFILAMENT c=20
-#: ultralcd.cpp:2186
-msgid "Total filament :"
-msgstr "Filament celkem :"
-
-# 
-#: ultralcd.cpp:2860
-msgid "Total print time"
-msgstr "Celkovy cas tisku"
-
-# MSG_STATS_TOTALPRINTTIME c=20
-#: ultralcd.cpp:2203
-msgid "Total print time :"
-msgstr "Celkovy cas :"
-
-# MSG_ENDSTOP_HIT
-#: messages.c:28
-msgid "TRIGGERED"
-msgstr "AKTIVNI"
-
-# MSG_TUNE
-#: ultralcd.cpp:6641
-msgid "Tune"
-msgstr "Ladit"
-
-# 
-#: ultralcd.cpp:2120
-msgid "unknown"
-msgstr "neznamy"
-
-# 
-#: ultralcd.cpp:4780
-msgid "Unload"
-msgstr "Vysunout"
-
-# 
-#: ultralcd.cpp:5617
-msgid "Unload all"
-msgstr "Vyjmout vse"
-
-# MSG_UNLOAD_FILAMENT c=17
-#: messages.c:97
-msgid "Unload filament"
-msgstr "Vyjmout filament"
-
-# MSG_UNLOAD_FILAMENT_1 c=17
-#: ultralcd.cpp:5406
-msgid "Unload filament 1"
-msgstr "Vyjmout filam. 1"
-
-# MSG_UNLOAD_FILAMENT_2 c=17
-#: ultralcd.cpp:5407
-msgid "Unload filament 2"
-msgstr "Vyjmout filam. 2"
-
-# MSG_UNLOAD_FILAMENT_3 c=17
-#: ultralcd.cpp:5408
-msgid "Unload filament 3"
-msgstr "Vyjmout filam. 3"
-
-# MSG_UNLOAD_FILAMENT_4 c=17
-#: ultralcd.cpp:5409
-msgid "Unload filament 4"
-msgstr "Vyjmout filam. 4"
-
-# MSG_UNLOADING_FILAMENT c=20 r=1
-#: messages.c:98
-msgid "Unloading filament"
-msgstr "Vysouvam filament"
-
-# 
-#: ultralcd.cpp:4779
-msgid "Use unload to remove filament 1 if it protrudes outside of the rear MMU tube. Use eject if it is hidden in tube."
-msgstr "Pouzijte vyjmout pro odstraneni filamentu 1 pokud presahuje z PTFE trubicky za tiskarnou. Pouzijte vysunout, pokud neni videt."
-
-# MSG_USED c=19 r=1
-#: ultralcd.cpp:5803
-msgid "Used during print"
-msgstr "Pouzite behem tisku"
-
-# MSG_MENU_VOLTAGES c=15 r=1
-#: ultralcd.cpp:2147
-msgid "Voltages"
-msgstr "Napeti"
-
-# MSG_SD_VOL_INIT_FAIL
-#: cardreader.cpp:191
-msgid "volume.init failed"
-msgstr "volume.init selhalo"
-
-# MSG_USERWAIT
-#: Marlin_main.cpp:5225
-msgid "Wait for user..."
-msgstr "Ceka se na uzivatele..."
-
-# MSG_WAITING_TEMP c=20 r=3
-#: ultralcd.cpp:3371
-msgid "Waiting for nozzle and bed cooling"
-msgstr "Cekani na zchladnuti trysky a podlozky."
-
-# MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ultralcd.cpp:3335
-msgid "Waiting for PINDA probe cooling"
-msgstr "Cekani na zchladnuti PINDA"
-
-# MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#:
-msgid "WARNING:\nCrash detection\ndisabled in\nStealth mode"
-msgstr "VAROVANI: Crash detekce je zakazana v Tichem rezimu"
-
-# MSG_CHANGED_BOTH c=20 r=4
-#: Marlin_main.cpp:1527
-msgid "Warning: both printer type and motherboard type changed."
-msgstr "Varovani: doslo ke zmene typu tiskarny a motherboardu."
-
-# MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: Marlin_main.cpp:1519
-msgid "Warning: motherboard type changed."
-msgstr "Varovani: doslo ke zmene typu motherboardu."
-
-# MSG_CHANGED_PRINTER c=20 r=4
-#: Marlin_main.cpp:1523
-msgid "Warning: printer type changed."
-msgstr "Varovani: doslo ke zmene typu tiskarny."
-
-# MSG_FW_VERSION_UNKNOWN c=20 r=8
-#: Marlin_main.cpp:946
-msgid "WARNING: This is an unofficial, unsupported build. Use at your own risk!"
-msgstr "VAROVANI: Neznama, nepodporovana verze firmware. Pouziti na vlastni nebezpeci!"
-
-# MSG_UNLOAD_SUCCESSFUL c=20 r=2
-#: Marlin_main.cpp:3072
-msgid "Was filament unload successful?"
-msgstr "Bylo vysunuti filamentu uspesne?"
-
-# MSG_SELFTEST_WIRINGERROR
-#: messages.c:85
-msgid "Wiring error"
-msgstr "Chyba zapojeni"
-
-# MSG_WIZARD c=17 r=1
-#: ultralcd.cpp:5642
-msgid "Wizard"
-msgstr "Pruvodce"
-
-# MSG_SD_WORKDIR_FAIL
-#: messages.c:78
-msgid "workDir open failed"
-msgstr "Nelze otevrit workDir"
-
-# MSG_SD_WRITE_TO_FILE
-#: cardreader.cpp:424
-msgid "Writing to file: "
-msgstr "Zapis do souboru:"
-
-# 
-#: ultralcd.cpp:4885
-msgid "X-correct"
-msgstr "Korekce X"
-
-# 
-#: ultralcd.cpp:5028
-msgid "X-correct:"
-msgstr "Korekce X"
-
-# MSG_XYZ_DETAILS c=19 r=1
-#: ultralcd.cpp:2136
-msgid "XYZ cal. details"
-msgstr "Detaily XYZ kal."
-
-# MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ultralcd.cpp:3835
-msgid "XYZ calibration all right. Skew will be corrected automatically."
-msgstr "Kalibrace XYZ v poradku. Zkoseni bude automaticky vyrovnano pri tisku."
-
-# MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ultralcd.cpp:3832
-msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
-msgstr "Kalibrace XYZ v poradku. X/Y osy mirne zkosene. Dobra prace!"
-
-# MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ultralcd.cpp:3813
-msgid "XYZ calibration compromised. Front calibration points not reachable."
-msgstr "Kalibrace XYZ nepresna. Predni kalibracni body moc vpredu."
-
-# MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_LEFT_FAR c=20 r=8
-#: ultralcd.cpp:3699
-msgid "XYZ calibration compromised. Left front calibration point not reachable."
-msgstr "Kalibrace XYZ nepresna. Levy predni bod moc vpredu."
-
-# MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ultralcd.cpp:3816
-msgid "XYZ calibration compromised. Right front calibration point not reachable."
-msgstr "Kalibrace XYZ nepresna. Pravy predni bod moc vpredu."
-
-# 
-#: ultralcd.cpp:3795
-msgid "XYZ calibration failed. Bed calibration point was not found."
-msgstr "Kalibrace XYZ selhala. Kalibracni bod podlozky nenalezen."
-
-# 
-#: ultralcd.cpp:3801
-msgid "XYZ calibration failed. Front calibration points not reachable."
-msgstr "Kalibrace XYZ selhala. Predni kalibracni body moc vpredu. Srovnejte tiskarnu."
-
-# 
-#: ultralcd.cpp:3687
-msgid "XYZ calibration failed. Left front calibration point not reachable."
-msgstr "Kalibrace XYZ selhala. Levy predni bod moc vpredu. Srovnejte tiskarnu."
-
-# MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: messages.c:19
-msgid "XYZ calibration failed. Please consult the manual."
-msgstr "Kalibrace XYZ selhala. Nahlednete do manualu."
-
-# 
-#: ultralcd.cpp:3804
-msgid "XYZ calibration failed. Right front calibration point not reachable."
-msgstr "Kalibrace XYZ selhala. Pravy predni bod moc vpredu. Srovnejte tiskarnu."
-
-# MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ultralcd.cpp:3829
-msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
-msgstr "Kalibrace XYZ v poradku. X/Y osy jsou kolme. Gratuluji!"
-
-# 
-#: ultralcd.cpp:2965
-msgid "Y distance from min"
-msgstr "Y vzdalenost od min"
-
-# MSG_Y_DISTANCE_FROM_MIN c=20 r=1
-#: ultralcd.cpp:2306
-msgid "Y distance from min:"
-msgstr "Y vzdalenost od min:"
-
-# 
-#: ultralcd.cpp:4886
-msgid "Y-correct"
-msgstr "Korekce Y"
-
-# 
-#: ultralcd.cpp:5029
-msgid "Y-correct:"
-msgstr "Korekce Y:"
-
-# MSG_YES
-#: messages.c:104
-msgid "Yes"
-msgstr "Ano"
-
-# MSG_FW_VERSION_ALPHA c=20 r=8
-#: Marlin_main.cpp:930
-msgid "You are using firmware alpha version. This is development version. Using this version is not recommended and may cause printer damage."
-msgstr "Pouzivate alpha verzi firmwaru. Jedna se o vyvojovou verzi. Pouzivani teto verze firmware neni doporuceno a muze zpusobit poskozeni tiskarny."
-
-# MSG_FW_VERSION_BETA c=20 r=8
-#: Marlin_main.cpp:931
-msgid "You are using firmware beta version. This is development version. Using this version is not recommended and may cause printer damage."
-msgstr "Pouzivate beta verzi firmwaru. Jedna se o vyvojovou verzi. Pouzivani teto verze firmware neni doporuceno a muze zpusobit poskozeni tiskarny."
-
-# MSG_WIZARD_QUIT c=20 r=8
-#: messages.c:103
-msgid "You can always resume the Wizard from Calibration -> Wizard."
-msgstr "Pruvodce muzete kdykoliv znovu spustit z menu Kalibrace -> Pruvodce"
-
-# 
-#: ultralcd.cpp:5030
+#: ultralcd.cpp:5132
 msgid "Z-correct:"
 msgstr "Korekce Z:"
 
 # 
-#: ultralcd.cpp:6952
+#: ultralcd.cpp:7038
 msgid "Z-probe nr.    [1]"
 msgstr "Pocet mereni Z [1]"
 
 # 
-#: ultralcd.cpp:6954
+#: ultralcd.cpp:7040
 msgid "Z-probe nr.    [3]"
 msgstr "Pocet mereni Z [3]"
 
-# MSG_MEASURED_OFFSET
-#: ultralcd.cpp:3024
-msgid "[0;0] point offset"
-msgstr "[0;0] odsazeni bodu"

--- a/lang/po/new/de.po
+++ b/lang/po/new/de.po
@@ -1,51 +1,19 @@
+# Translation of Prusa-Firmware into German.
+#
 msgid ""
 msgstr ""
-"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: PhraseApp (phraseapp.com)\n"
-
-# MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ultralcd.cpp:4219
-msgid "\e[2JCrash detection can\e[1;0Hbe turned on only in\e[2;0HNormal mode"
-msgstr "\e[2JCrash Erkennung kann\e[1;0Hnur im Modus Normal\e[2;0Hgenutzt werden"
-
-# MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ultralcd.cpp:4231
-msgid "\e[2JWARNING:\e[1;0HCrash detection\e[2;0Hdisabled in\e[3;0HStealth mode"
-msgstr "\e[2JWARNUNG:\e[1;0HCrash Erkennung\e[2;0Hdeaktiviert im\e[3;0HStealth Modus"
-
-# 
-#: ultralcd.cpp:3913
-msgid "  1"
-msgstr "  1"
-
-# MSG_PLANNER_BUFFER_BYTES
-#: Marlin_main.cpp:1184
-msgid "  PlannerBufferBytes: "
-msgstr " PlannerPufferBytes: "
-
-# MSG_EXTRUDER_CORRECTION_OFF c=6
-#: ultralcd.cpp:6312
-msgid "  [off"
-msgstr "  [aus"
-
-# MSG_ERR_COLD_EXTRUDE_STOP
-#: planner.cpp:761
-msgid " cold extrusion prevented"
-msgstr " stopp, Extruder kalt!"
-
-# MSG_FREE_MEMORY
-#: Marlin_main.cpp:1182
-msgid " Free Memory: "
-msgstr " Freier Speicher: "
-
-# MSG_CONFIGURATION_VER
-#: Marlin_main.cpp:1172
-msgid " Last Updated: "
-msgstr " Letztes Update: "
+"Language: de\n"
+"Project-Id-Version: Prusa-Firmware\n"
+"POT-Creation-Date: Sun, Sep 22, 2019 1:29:42 PM\n"
+"PO-Revision-Date: Sun, Sep 22, 2019 1:29:42 PM\n"
+"Language-Team: \n"
+"X-Generator: Poedit 2.0.7\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+"Last-Translator: \n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
 # MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE2 c=14
 #: messages.c:39
@@ -57,50 +25,35 @@ msgstr " von 4"
 msgid " of 9"
 msgstr " von 9"
 
-# MSG_OFF
-#: menu.cpp:426
-msgid " [off]"
-msgstr "[aus]"
+# MSG_MEASURED_OFFSET
+#: ultralcd.cpp:3089
+msgid "[0;0] point offset"
+msgstr "[0;0] Punktversatz"
 
-# MSG_FACTOR
-#: ultralcd.cpp:6008
-msgid " \002 Fact"
-msgstr " \002 Faktor"
+# MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
+#: 
+msgid "Crash detection can\x0abe turned on only in\x0aNormal mode"
+msgstr "Crash Erkennung kann\x0anur im Modus Normal\x0agenutzt werden"
 
-# MSG_MAX
-#: ultralcd.cpp:6007
-msgid " \002 Max"
-msgstr " \002 Max"
-
-# MSG_MIN
-#: ultralcd.cpp:6006
-msgid " \002 Min"
-msgstr " \002 Min"
+# MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
+#: 
+msgid "WARNING:\x0aCrash detection\x0adisabled in\x0aStealth mode"
+msgstr "WARNUNG:\x0aCrash Erkennung\x0adeaktiviert im\x0aStealth Modus"
 
 # 
-#: ultralcd.cpp:2294
+#: ultralcd.cpp:2472
 msgid ">Cancel"
 msgstr ">Abbruch"
 
-# MSG_BABYSTEPPING_Z c=20
-#: ultralcd.cpp:3043
-msgid "Adjusting Z"
-msgstr "Z wurde eingestellt"
-
 # MSG_BABYSTEPPING_Z c=15
-#: ultralcd.cpp:3144
+#: ultralcd.cpp:3209
 msgid "Adjusting Z:"
 msgstr "Z Anpassen:"
 
-# MSG_ALL c=19 r=1
-#: messages.c:11
-msgid "All"
-msgstr "Alle"
-
 # MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ultralcd.cpp:8209
+#: ultralcd.cpp:8295
 msgid "All correct      "
-msgstr "Alles richtig "
+msgstr "Alles richtig    "
 
 # MSG_WIZARD_DONE c=20 r=8
 #: messages.c:101
@@ -108,39 +61,34 @@ msgid "All is done. Happy printing!"
 msgstr "Alles abgeschlossen. Viel Spass beim Drucken!"
 
 # 
-#: ultralcd.cpp:1979
+#: ultralcd.cpp:2009
 msgid "Ambient"
 msgstr "Raumtemp."
 
 # MSG_PRESS c=20
-#: ultralcd.cpp:2573
+#: ultralcd.cpp:2618
 msgid "and press the knob"
 msgstr "und Knopf druecken"
 
 # MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=2
-#: ultralcd.cpp:3442
+#: ultralcd.cpp:3529
 msgid "Are left and right Z~carriages all up?"
 msgstr "Sind linke+rechte Z- Schlitten ganz oben?"
 
-# MSG_ADJUSTZ
-#: ultralcd.cpp:2600
-msgid "Auto adjust Z?"
-msgstr "Auto Z einstellen?"
-
 # MSG_AUTO_DEPLETE_ON c=17 r=1
-#: ultralcd.cpp:4706
-msgid "Auto deplete [on]"
-msgstr "Restemodus   [an]"
+#: ultralcd.cpp:5200
+msgid "SpoolJoin    [on]"
+msgstr "SpoolJoin    [an]"
 
 # 
-#: ultralcd.cpp:4702
-msgid "Auto deplete[N/A]"
-msgstr "Restemodus[N/V]"
+#: ultralcd.cpp:5196
+msgid "SpoolJoin   [N/A]"
+msgstr "SpoolJoin   [N/V]"
 
 # MSG_AUTO_DEPLETE_OFF c=17 r=1
-#: ultralcd.cpp:4710
-msgid "Auto deplete[off]"
-msgstr "Restemodus  [aus]"
+#: ultralcd.cpp:5204
+msgid "SpoolJoin   [off]"
+msgstr "SpoolJoin   [aus]"
 
 # MSG_AUTO_HOME
 #: messages.c:11
@@ -148,52 +96,32 @@ msgid "Auto home"
 msgstr "Startposition"
 
 # MSG_AUTOLOAD_FILAMENT c=17
-#: ultralcd.cpp:6731
+#: ultralcd.cpp:6822
 msgid "AutoLoad filament"
-msgstr "Auto-Laden Filament"
+msgstr "AutoLaden Filament"
 
 # MSG_AUTOLOADING_ONLY_IF_FSENS_ON c=20 r=4
-#: ultralcd.cpp:4375
+#: ultralcd.cpp:4462
 msgid "Autoloading filament available only when filament sensor is turned on..."
 msgstr "Automatisches Laden Filament nur bei einge schaltetem Filament- sensor verfuegbar..."
 
 # MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ultralcd.cpp:2768
+#: ultralcd.cpp:2813
 msgid "Autoloading filament is active, just press the knob and insert filament..."
 msgstr "Automatisches Laden Filament ist aktiv, Knopf druecken und Filament einlegen..."
 
-# MSG_SELFTEST_AXIS
-#: ultralcd.cpp:7865
-msgid "Axis"
-msgstr "Achse"
-
 # MSG_SELFTEST_AXIS_LENGTH
-#: ultralcd.cpp:7863
+#: ultralcd.cpp:7949
 msgid "Axis length"
 msgstr "Achsenlaenge"
 
-# MSG_BABYSTEPPING_X
-#: ultralcd.cpp:2481
-msgid "Babystepping X"
-msgstr "Babystepping X"
-
-# MSG_BABYSTEPPING_Y
-#: ultralcd.cpp:2484
-msgid "Babystepping Y"
-msgstr "Babystepping Y"
-
-# 
-#: messages.c:57
-msgid "Back"
-msgstr "Zurueck"
-
-# MSG_BED
-#: messages.c:15
-msgid "Bed"
-msgstr "Bett"
+# MSG_SELFTEST_AXIS
+#: ultralcd.cpp:7951
+msgid "Axis"
+msgstr "Achse"
 
 # MSG_SELFTEST_BEDHEATER
-#: ultralcd.cpp:7807
+#: ultralcd.cpp:7893
 msgid "Bed / Heater"
 msgstr "Bett / Heizung"
 
@@ -208,7 +136,7 @@ msgid "Bed Heating"
 msgstr "Bett aufwaermen"
 
 # MSG_BED_CORRECTION_MENU
-#: ultralcd.cpp:5663
+#: ultralcd.cpp:5768
 msgid "Bed level correct"
 msgstr "Ausgleich Bett ok"
 
@@ -217,23 +145,13 @@ msgstr "Ausgleich Bett ok"
 msgid "Bed leveling failed. Sensor didnt trigger. Debris on nozzle? Waiting for reset."
 msgstr "Z-Kal. fehlgeschlg. Sensor nicht ausgeloest. Schmutzige Duese? Warte auf Reset."
 
-# MSG_BED_LEVELING_FAILED_PROBE_DISCONNECTED c=20 r=4
-#: Marlin_main.cpp:4508
-msgid "Bed leveling failed. Sensor disconnected or cable broken. Waiting for reset."
-msgstr "Z-Kalibrierung fehl- geschlagen. Sensor getrennt/Kabelbruch? Warte auf Reset."
-
-# MSG_BED_LEVELING_FAILED_POINT_HIGH c=20 r=4
-#: Marlin_main.cpp:4512
-msgid "Bed leveling failed. Sensor triggered too high. Waiting for reset."
-msgstr "Z-Kalibrierung fehl- geschlagen. Sensor zu hoch ausgeloest. Warte auf Reset."
-
-# MSG_BEGIN_FILE_LIST
-#: Marlin_main.cpp:4405
-msgid "Begin file list"
-msgstr "Beginn Dateiliste"
+# MSG_BED
+#: messages.c:15
+msgid "Bed"
+msgstr "Bett"
 
 # MSG_MENU_BELT_STATUS c=15 r=1
-#: ultralcd.cpp:2007
+#: ultralcd.cpp:2059
 msgid "Belt status"
 msgstr "Gurtstatus"
 
@@ -242,18 +160,13 @@ msgstr "Gurtstatus"
 msgid "Blackout occurred. Recover print?"
 msgstr "Stromausfall! Druck wiederherstellen?"
 
-# MSG_CALIBRATE_PINDA c=17 r=1
-#: ultralcd.cpp:4566
-msgid "Calibrate"
-msgstr "Kalibrieren"
-
-# MSG_CALIBRATE_E c=20 r=1
-#: ultralcd.cpp:4526
-msgid "Calibrate E"
-msgstr "Kalibrierung E"
+# 
+#: ultralcd.cpp:8297
+msgid "Calibrating home"
+msgstr "Kalibriere Start"
 
 # MSG_CALIBRATE_BED
-#: ultralcd.cpp:5652
+#: ultralcd.cpp:5757
 msgid "Calibrate XYZ"
 msgstr "Kalibrierung XYZ"
 
@@ -262,13 +175,13 @@ msgstr "Kalibrierung XYZ"
 msgid "Calibrate Z"
 msgstr "Kalibrierung Z"
 
-# 
-#: ultralcd.cpp:8211
-msgid "Calibrating home"
-msgstr "Kalibriere Start"
+# MSG_CALIBRATE_PINDA c=17 r=1
+#: ultralcd.cpp:4654
+msgid "Calibrate"
+msgstr "Kalibrieren"
 
 # MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ultralcd.cpp:3405
+#: ultralcd.cpp:3492
 msgid "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end stoppers. Click when done."
 msgstr "XYZ Kalibrieren: Drehen Sie den Knopf bis der obere Anschlag erreicht wird. Anschliessend den Knopf druecken."
 
@@ -278,132 +191,32 @@ msgid "Calibrating Z"
 msgstr "Kalibrierung Z"
 
 # MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ultralcd.cpp:3405
+#: ultralcd.cpp:3492
 msgid "Calibrating Z. Rotate the knob to move the Z carriage up to the end stoppers. Click when done."
 msgstr "Z Kalibrieren: Drehen Sie den Knopf bis der obere Anschlag erreicht wird. Anschliessend den Knopf druecken."
+
+# MSG_HOMEYZ_DONE
+#: ultralcd.cpp:816
+msgid "Calibration done"
+msgstr "Kalibrierung OK"
 
 # MSG_MENU_CALIBRATION
 #: messages.c:61
 msgid "Calibration"
 msgstr "Kalibrierung"
 
-# MSG_HOMEYZ_DONE
-#: ultralcd.cpp:832
-msgid "Calibration done"
-msgstr "Kalibrierung OK"
-
 # 
-#: ultralcd.cpp:4692
+#: ultralcd.cpp:4781
 msgid "Cancel"
 msgstr "Abbruch"
 
-# MSG_SD_CANT_ENTER_SUBDIR
-#: cardreader.cpp:662
-msgid "Cannot enter subdir: "
-msgstr "Kann Unterverzeichnis nicht oeffnen: "
-
-# MSG_SD_CANT_OPEN_SUBDIR
-#: cardreader.cpp:97
-msgid "Cannot open subdir"
-msgstr "Kann Unterverz. nicht oeffnen"
-
-# MSG_SD_INSERTED
-#:
-msgid "Card inserted"
-msgstr "SD Karte eingesetzt"
-
 # MSG_SD_REMOVED
-#: ultralcd.cpp:8578
+#: ultralcd.cpp:8679
 msgid "Card removed"
 msgstr "SD Karte entfernt"
 
-# 
-#: ultralcd.cpp:6087
-msgid "Change extruder"
-msgstr "Wechsel Extruder"
-
-# MSG_FILAMENTCHANGE
-#: messages.c:37
-msgid "Change filament"
-msgstr "Filament-Wechsel"
-
-# MSG_CNG_SDCARD
-#: ultralcd.cpp:5777
-msgid "Change SD card"
-msgstr "Wechsel SD Karte"
-
-# MSG_CHANGE_SUCCESS
-#: ultralcd.cpp:2584
-msgid "Change success!"
-msgstr "Wechsel erfolgr.!"
-
-# MSG_CORRECTLY c=20
-#: ultralcd.cpp:2661
-msgid "Changed correctly?"
-msgstr "Wechsel ok?"
-
-# MSG_CHANGING_FILAMENT c=20
-#: ultralcd.cpp:1899
-msgid "Changing filament!"
-msgstr "Filament-Wechsel!"
-
-# MSG_SELFTEST_CHECK_BED c=20
-#: messages.c:81
-msgid "Checking bed     "
-msgstr "Pruefe Bett "
-
-# MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ultralcd.cpp:8200
-msgid "Checking endstops"
-msgstr "Pruefe Endschalter"
-
-# MSG_SELFTEST_CHECK_HOTEND c=20
-#: ultralcd.cpp:8206
-msgid "Checking hotend  "
-msgstr "Pruefe Duese  "
-
-# MSG_SELFTEST_CHECK_FSENSOR c=20
-#: messages.c:82
-msgid "Checking sensors "
-msgstr "Pruefe Sensoren "
-
-# MSG_SELFTEST_CHECK_X c=20
-#: ultralcd.cpp:8201
-msgid "Checking X axis  "
-msgstr "Pruefe X Achse "
-
-# MSG_SELFTEST_CHECK_Y c=20
-#: ultralcd.cpp:8202
-msgid "Checking Y axis  "
-msgstr "Pruefe Y Achse "
-
-# MSG_SELFTEST_CHECK_Z c=20
-#: ultralcd.cpp:8203
-msgid "Checking Z axis  "
-msgstr "Pruefe Z Achse "
-
-# 
-#: ultralcd.cpp:5537
-msgid "Checks"
-msgstr "Checks"
-
-# MSG_ERR_CHECKSUM_MISMATCH
-#: cmdqueue.cpp:444
-msgid "checksum mismatch, Last Line: "
-msgstr "Pruefsummenfehler, Letzte Zeile: "
-
-# MSG_CHOOSE_EXTRUDER c=20 r=1
-#: messages.c:49
-msgid "Choose extruder:"
-msgstr "Extruder waehlen:"
-
-# MSG_CHOOSE_FILAMENT c=20 r=1
-#: messages.c:50
-msgid "Choose filament:"
-msgstr "Waehle Filament:"
-
 # MSG_NOT_COLOR
-#: ultralcd.cpp:2673
+#: ultralcd.cpp:2718
 msgid "Color not correct"
 msgstr "Falsche Farbe"
 
@@ -413,19 +226,9 @@ msgid "Cooldown"
 msgstr "Abkuehlen"
 
 # 
-#: ultralcd.cpp:4108
-msgid "Copy selected language from XFLASH?"
-msgstr "Gewaehlte Sprache vom Xflash kopieren?"
-
-# 
-#: ultralcd.cpp:4499
+#: ultralcd.cpp:4587
 msgid "Copy selected language?"
 msgstr "Gewaehlte Sprache kopieren?"
-
-# 
-#: ultralcd.cpp:1881
-msgid "Crash"
-msgstr "Crash"
 
 # MSG_CRASHDETECT_ON
 #: messages.c:27
@@ -448,27 +251,27 @@ msgid "Crash detected."
 msgstr "Crash erkannt."
 
 # 
-#: Marlin_main.cpp:618
+#: Marlin_main.cpp:600
 msgid "Crash detected. Resume print?"
 msgstr "Crash erkannt. Druck fortfuehren?"
 
-# MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#:
-msgid "Crash detection can\nbe turned on only in\nNormal mode"
-msgstr "Crash-Erkennung\nkann nur im Normal\nModus erfolgen"
+# 
+#: ultralcd.cpp:1853
+msgid "Crash"
+msgstr ""
 
 # MSG_CURRENT c=19 r=1
-#: ultralcd.cpp:5804
+#: ultralcd.cpp:5909
 msgid "Current"
 msgstr "Aktuelles"
 
 # MSG_DATE c=17 r=1
-#: ultralcd.cpp:2106
+#: ultralcd.cpp:2213
 msgid "Date:"
 msgstr "Datum:"
 
 # MSG_DISABLE_STEPPERS
-#: ultralcd.cpp:5552
+#: ultralcd.cpp:5654
 msgid "Disable steppers"
 msgstr "Motoren aus"
 
@@ -478,162 +281,82 @@ msgid "Distance between tip of the nozzle and the bed surface has not been set y
 msgstr "Der Abstand zwischen der Spitze der Duese und dem Bett ist noch nicht eingestellt. Bitte folgen Sie dem Handbuch, Kapitel Erste Schritte, Abschnitt Erste Schicht Kalibrierung."
 
 # MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ultralcd.cpp:4968
+#: ultralcd.cpp:5070
 msgid "Do you want to repeat last step to readjust distance between nozzle and heatbed?"
 msgstr "Moechten Sie den letzten Schritt wiederholen, um den Abstand zwischen Duese und Druckbett neu einzustellen?"
 
-# MSG_CLEAN_NOZZLE_E c=20 r=8
-#: ultralcd.cpp:3890
-msgid "E calibration finished. Please clean the nozzle. Click when done."
-msgstr "E-Kalibrierung beendet. Bitte reinigen Sie die Duese. Klicken wenn fertig."
-
-# MSG_EXTRUDER_CORRECTION c=9
-#: ultralcd.cpp:4889
-msgid "E-correct"
-msgstr "E-Korrektur"
-
 # MSG_EXTRUDER_CORRECTION c=10
-#: ultralcd.cpp:5032
+#: ultralcd.cpp:5134
 msgid "E-correct:"
 msgstr "E-Korrektur:"
-
-# 
-#: ultralcd.cpp:4780
-msgid "Eject"
-msgstr "Auswurf"
 
 # MSG_EJECT_FILAMENT c=17 r=1
 #: messages.c:53
 msgid "Eject filament"
 msgstr "Filamentauswurf"
 
-# MSG_EJECT_FILAMENT1 c=17 r=1
-#: ultralcd.cpp:5603
-msgid "Eject filament 1"
-msgstr "Filamentauswurf 1"
-
-# MSG_EJECT_FILAMENT2 c=17 r=1
-#: ultralcd.cpp:5604
-msgid "Eject filament 2"
-msgstr "Fil.2 auswerfen"
-
-# MSG_EJECT_FILAMENT3 c=17 r=1
-#: ultralcd.cpp:5605
-msgid "Eject filament 3"
-msgstr "Fil.3 auswerfen"
-
-# MSG_EJECT_FILAMENT4 c=17 r=1
-#: ultralcd.cpp:5606
-msgid "Eject filament 4"
-msgstr "Fil.4 auswerfen"
-
-# MSG_EJECT_FILAMENT5 c=17 r=1
-#: ultralcd.cpp:5607
-msgid "Eject filament 5"
-msgstr "Fil.5 auswerfen"
+# 
+#: ultralcd.cpp:4869
+msgid "Eject"
+msgstr "Auswurf"
 
 # MSG_EJECTING_FILAMENT c=20 r=1
-#: mmu.cpp:1435
+#: mmu.cpp:1434
 msgid "Ejecting filament"
 msgstr "werfe Filament aus"
 
-# MSG_END_FILE_LIST
-#: Marlin_main.cpp:4407
-msgid "End file list"
-msgstr "Ende Dateiliste"
-
-# MSG_SELFTEST_ENDSTOP
-#: ultralcd.cpp:7825
-msgid "Endstop"
-msgstr "Endanschlag"
-
 # MSG_SELFTEST_ENDSTOP_NOTHIT c=20 r=1
-#: ultralcd.cpp:7831
+#: ultralcd.cpp:7917
 msgid "Endstop not hit"
 msgstr "Ende nicht getroffen"
 
+# MSG_SELFTEST_ENDSTOP
+#: ultralcd.cpp:7911
+msgid "Endstop"
+msgstr "Endanschlag"
+
 # MSG_SELFTEST_ENDSTOPS
-#: ultralcd.cpp:7813
+#: ultralcd.cpp:7899
 msgid "Endstops"
 msgstr "Endschalter"
 
-# MSG_ENDSTOPS_HIT
-#: messages.c:30
-msgid "endstops hit: "
-msgstr "Endanschlag erreicht: "
-
-# MSG_LANGUAGE_NAME
-#: language.c:153
-msgid "English"
-msgstr "Deutsch"
-
-# MSG_Enqueing
-#:
-msgid "enqueing \""
-msgstr "In Warteschlange \""
-
 # MSG_STACK_ERROR c=20 r=4
-#: ultralcd.cpp:6773
+#: ultralcd.cpp:6859
 msgid "Error - static memory has been overwritten"
 msgstr "Fehler - statischer Speicher wurde ueberschrieben"
 
-# MSG_SD_ERR_WRITE_TO_FILE
-#: messages.c:78
-msgid "error writing to file"
-msgstr "Fehler beim Schreiben in Datei"
+# MSG_FSENS_NOT_RESPONDING c=20 r=4
+#: ultralcd.cpp:4475
+msgid "ERROR: Filament sensor is not responding, please check connection."
+msgstr "FEHLER: Filament- sensor reagiert nicht, bitte Verbindung pruefen."
 
 # MSG_ERROR
 #: messages.c:28
 msgid "ERROR:"
 msgstr "FEHLER:"
 
-# MSG_FSENS_NOT_RESPONDING c=20 r=4
-#: ultralcd.cpp:4388
-msgid "ERROR: Filament sensor is not responding, please check connection."
-msgstr "FEHLER: Filament- sensor reagiert nicht, bitte Verbindung pruefen."
-
-# 
-#: Marlin_main.cpp:1006
-msgid "External SPI flash W25X20CL not responding."
-msgstr "Der externe SPI Flash W25X20CL antwortet nicht."
-
-# MSG_MOVE_E
-#: messages.c:29
-msgid "Extruder"
-msgstr "Extruder"
-
-# 
-#: ultralcd.cpp:5633
-msgid "Extruder 1"
-msgstr "Extruder 1"
-
-# 
-#: ultralcd.cpp:5634
-msgid "Extruder 2"
-msgstr "Extruder 2"
-
-# 
-#: ultralcd.cpp:5635
-msgid "Extruder 3"
-msgstr "Extruder 3"
-
-# 
-#: ultralcd.cpp:5636
-msgid "Extruder 4"
-msgstr "Extruder 4"
-
 # MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
-#: ultralcd.cpp:8218
+#: ultralcd.cpp:8304
 msgid "Extruder fan:"
 msgstr "Extruder Luefter:"
 
 # MSG_INFO_EXTRUDER c=15 r=1
-#: ultralcd.cpp:2137
+#: ultralcd.cpp:2244
 msgid "Extruder info"
 msgstr "Extruder Info"
 
+# MSG_MOVE_E
+#: messages.c:29
+msgid "Extruder"
+msgstr ""
+
+# 
+#: ultralcd.cpp:6846
+msgid "Fail stats MMU"
+msgstr "MMU-Fehler"
+
 # MSG_FSENS_AUTOLOAD_ON c=17 r=1
-#: ultralcd.cpp:5066
+#: ultralcd.cpp:5168
 msgid "F. autoload  [on]"
 msgstr "F.Autoladen  [an]"
 
@@ -643,24 +366,14 @@ msgid "F. autoload [N/A]"
 msgstr "F. Autoload  [nv]"
 
 # MSG_FSENS_AUTOLOAD_OFF c=17 r=1
-#: ultralcd.cpp:5068
+#: ultralcd.cpp:5170
 msgid "F. autoload [off]"
 msgstr "F. Autoload [aus]"
 
 # 
-#: ultralcd.cpp:6757
+#: ultralcd.cpp:6843
 msgid "Fail stats"
 msgstr "Fehlerstatistik"
-
-# 
-#: ultralcd.cpp:6760
-msgid "Fail stats MMU"
-msgstr "MMU-Fehler"
-
-# 
-#: ultralcd.cpp:7887
-msgid "False triggering"
-msgstr "Falschtriggerung"
 
 # MSG_FAN_SPEED c=14
 #: messages.c:31
@@ -673,12 +386,12 @@ msgid "Fan test"
 msgstr "Lueftertest"
 
 # MSG_FANS_CHECK_ON c=17 r=1
-#: ultralcd.cpp:5561
+#: ultralcd.cpp:5663
 msgid "Fans check   [on]"
 msgstr "Luefter Chk. [an]"
 
 # MSG_FANS_CHECK_OFF c=17 r=1
-#: ultralcd.cpp:5563
+#: ultralcd.cpp:5665
 msgid "Fans check  [off]"
 msgstr "Luefter Chk.[aus]"
 
@@ -687,13 +400,8 @@ msgstr "Luefter Chk.[aus]"
 msgid "Fil. sensor  [on]"
 msgstr "Fil. Sensor  [an]"
 
-# MSG_RESPONSE_POOR c=20 r=2
-#: Marlin_main.cpp:3146
-msgid "Fil. sensor response is poor, disable it?"
-msgstr "Fil. Sensorsignal ist schlecht, ausschalten?"
-
 # MSG_FSENSOR_NA
-#: ultralcd.cpp:5046
+#: ultralcd.cpp:5148
 msgid "Fil. sensor [N/A]"
 msgstr "Fil. Sensor  [nv]"
 
@@ -703,22 +411,17 @@ msgid "Fil. sensor [off]"
 msgstr "Fil. Sensor [aus]"
 
 # 
-#: ultralcd.cpp:1881
+#: ultralcd.cpp:1852
 msgid "Filam. runouts"
 msgstr "Filam. Maengel"
-
-# MSG_FILAMENT c=17 r=1
-#: messages.c:30
-msgid "Filament"
-msgstr "Filament"
 
 # MSG_FILAMENT_CLEAN c=20 r=2
 #: messages.c:32
 msgid "Filament extruding & with correct color?"
-msgstr "Filament extrudiert + richtige Farbe?"
+msgstr "Filament extrudiert mit richtiger Farbe?"
 
 # MSG_NOT_LOADED c=19
-#: ultralcd.cpp:2669
+#: ultralcd.cpp:2714
 msgid "Filament not loaded"
 msgstr "Fil. nicht geladen"
 
@@ -727,60 +430,25 @@ msgstr "Fil. nicht geladen"
 msgid "Filament sensor"
 msgstr "Filamentsensor"
 
-# MSG_SELFTEST_FILAMENT_SENSOR c=18
-#: ultralcd.cpp:7477
-msgid "Filament sensor:"
-msgstr "Filamentsensor:"
-
 # MSG_FILAMENT_USED c=19 r=1
-#: ultralcd.cpp:2838
+#: ultralcd.cpp:2885
 msgid "Filament used"
 msgstr "Filament benutzt"
 
-# MSG_STATS_FILAMENTUSED c=20
-#: ultralcd.cpp:2142
-msgid "Filament used:  "
-msgstr "Filamentverbrauch:  "
+# MSG_PRINT_TIME c=19 r=1
+#: ultralcd.cpp:2886
+msgid "Print time"
+msgstr "Druckzeit"
 
 # MSG_FILE_INCOMPLETE c=20 r=2
-#: ultralcd.cpp:8346
+#: ultralcd.cpp:8432
 msgid "File incomplete. Continue anyway?"
 msgstr "Datei unvollstaendig Trotzdem fortfahren?"
-
-# MSG_SD_FILE_OPENED
-#: cardreader.cpp:395
-msgid "File opened: "
-msgstr "Datei geoeffnet: "
-
-# MSG_SD_FILE_SELECTED
-#: cardreader.cpp:401
-msgid "File selected"
-msgstr "Datei ausgewaehlt"
-
-# 
-#: ultralcd.cpp:3943
-msgid "FINDA:"
-msgstr "FINDA:"
 
 # MSG_FINISHING_MOVEMENTS c=20 r=1
 #: messages.c:40
 msgid "Finishing movements"
 msgstr "Bewegung beenden"
-
-# 
-#: ultralcd.cpp:5443
-msgid "Firmware   [none]"
-msgstr "Firmware   [ohne]"
-
-# 
-#: ultralcd.cpp:5446
-msgid "Firmware   [warn]"
-msgstr "Firmware   [warn]"
-
-# 
-#: ultralcd.cpp:5449
-msgid "Firmware [strict]"
-msgstr "Firmware [streng]"
 
 # MSG_V2_CALIBRATION c=17 r=1
 #: messages.c:105
@@ -788,7 +456,7 @@ msgid "First layer cal."
 msgstr "Erste-Schicht Kal."
 
 # MSG_WIZARD_SELFTEST c=20 r=8
-#: ultralcd.cpp:4880
+#: ultralcd.cpp:4982
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr "Zunaechst fuehre ich den Selbsttest durch, um die haeufigsten Probleme beim Zusammenbau zu ueberpruefen."
 
@@ -798,14 +466,14 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr "Beseitigen Sie das Problem und druecken Sie dann den Knopf am MMU."
 
 # MSG_FLOW
-#: ultralcd.cpp:6846
+#: ultralcd.cpp:6932
 msgid "Flow"
 msgstr "Durchfluss"
 
 # MSG_PRUSA3D_FORUM
-#: ultralcd.cpp:2099
+#: ultralcd.cpp:2206
 msgid "forum.prusa3d.com"
-msgstr "forum.prusa3d.com"
+msgstr ""
 
 # MSG_SELFTEST_COOLING_FAN c=20
 #: messages.c:75
@@ -813,57 +481,22 @@ msgid "Front print fan?"
 msgstr "Vorderer Luefter?"
 
 # MSG_BED_CORRECTION_FRONT c=14 r=1
-#: ultralcd.cpp:3217
+#: ultralcd.cpp:3294
 msgid "Front side[um]"
 msgstr "Vorne [um]"
 
 # MSG_SELFTEST_FANS
-#: ultralcd.cpp:7871
+#: ultralcd.cpp:7957
 msgid "Front/left fans"
 msgstr "Vorderer/linke Luefter"
 
-# 
-#: util.cpp:510
-msgid "G-code sliced for a different level. Continue?"
-msgstr "G-Code ist für einen anderen Level geslict. Fortfahren?"
-
-# 
-#: util.cpp:516
-msgid "G-code sliced for a different level. Please re-slice the model again. Print cancelled."
-msgstr "G-Code ist für einen anderen Level geslict. Bitte slicen Sie das Modell erneut. Druck abgebrochen."
-
-# 
-#: util.cpp:427
-msgid "G-code sliced for a different printer type. Continue?"
-msgstr "G-Code ist für einen anderen Drucker geslict. Fortfahren?"
-
-# 
-#: util.cpp:433
-msgid "G-code sliced for a different printer type. Please re-slice the model again. Print cancelled."
-msgstr "G-Code ist für einen anderen Drucker geslict. Bitte slicen Sie das Modell erneut. Druck abgebrochen."
-
-# 
-#: util.cpp:477
-msgid "G-code sliced for a newer firmware. Continue?"
-msgstr "G-Code ist für eine neuere Firmware geslict. Fortfahren?"
-
-# 
-#: util.cpp:483
-msgid "G-code sliced for a newer firmware. Please update the firmware. Print cancelled."
-msgstr "G-Code ist für eine neuere Firmware geslict. Bitte die Firmware updaten. Druck abgebrochen."
-
 # MSG_SELFTEST_HEATERTHERMISTOR
-#: ultralcd.cpp:7801
+#: ultralcd.cpp:7887
 msgid "Heater/Thermistor"
 msgstr "Heizung/Thermistor"
 
-# MSG_HEATING
-#: messages.c:46
-msgid "Heating"
-msgstr "Aufwaermen"
-
 # MSG_BED_HEATING_SAFETY_DISABLED
-#: Marlin_main.cpp:8411
+#: Marlin_main.cpp:8467
 msgid "Heating disabled by safety timer."
 msgstr "Heizung durch Sicherheitstimer deaktiviert."
 
@@ -872,98 +505,128 @@ msgstr "Heizung durch Sicherheitstimer deaktiviert."
 msgid "Heating done."
 msgstr "Aufwaermen OK."
 
+# MSG_HEATING
+#: messages.c:46
+msgid "Heating"
+msgstr "Aufwaermen"
+
 # MSG_WIZARD_WELCOME c=20 r=7
-#: ultralcd.cpp:4859
+#: ultralcd.cpp:4961
 msgid "Hi, I am your Original Prusa i3 printer. Would you like me to guide you through the setup process?"
 msgstr "Hallo, ich bin Ihr Original Prusa i3 Drucker. Moechten Sie, dass ich Sie durch den Einrich- tungsablauf fuehre?"
 
 # MSG_PRUSA3D_HOWTO
-#: ultralcd.cpp:2100
+#: ultralcd.cpp:2207
 msgid "howto.prusa3d.com"
-msgstr "howto.prusa3d.com"
+msgstr ""
 
-# 
-#: messages.c:87
-msgid "HW Setup"
-msgstr "HW Einstellungen"
+# MSG_FILAMENTCHANGE
+#: messages.c:37
+msgid "Change filament"
+msgstr "Filament-Wechsel"
+
+# MSG_CHANGE_SUCCESS
+#: ultralcd.cpp:2629
+msgid "Change success!"
+msgstr "Wechsel erfolgr.!"
+
+# MSG_CORRECTLY c=20
+#: ultralcd.cpp:2706
+msgid "Changed correctly?"
+msgstr "Wechsel ok?"
+
+# MSG_SELFTEST_CHECK_BED c=20
+#: messages.c:81
+msgid "Checking bed     "
+msgstr "Pruefe Bett "
+
+# MSG_SELFTEST_CHECK_ENDSTOPS c=20
+#: ultralcd.cpp:8286
+msgid "Checking endstops"
+msgstr "Pruefe Endschalter"
+
+# MSG_SELFTEST_CHECK_HOTEND c=20
+#: ultralcd.cpp:8292
+msgid "Checking hotend  "
+msgstr "Pruefe Duese  "
+
+# MSG_SELFTEST_CHECK_FSENSOR c=20
+#: messages.c:82
+msgid "Checking sensors "
+msgstr "Pruefe Sensoren "
+
+# MSG_SELFTEST_CHECK_X c=20
+#: ultralcd.cpp:8287
+msgid "Checking X axis  "
+msgstr "Pruefe X Achse "
+
+# MSG_SELFTEST_CHECK_Y c=20
+#: ultralcd.cpp:8288
+msgid "Checking Y axis  "
+msgstr "Pruefe Y Achse "
+
+# MSG_SELFTEST_CHECK_Z c=20
+#: ultralcd.cpp:8289
+msgid "Checking Z axis  "
+msgstr "Pruefe Z Achse "
+
+# MSG_CHOOSE_EXTRUDER c=20 r=1
+#: messages.c:49
+msgid "Choose extruder:"
+msgstr "Extruder waehlen:"
+
+# MSG_CHOOSE_FILAMENT c=20 r=1
+#: messages.c:50
+msgid "Choose filament:"
+msgstr "Waehle Filament:"
+
+# MSG_FILAMENT c=17 r=1
+#: messages.c:30
+msgid "Filament"
+msgstr ""
 
 # MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ultralcd.cpp:4889
+#: ultralcd.cpp:4991
 msgid "I will run xyz calibration now. It will take approx. 12 mins."
 msgstr "Ich werde jetzt die XYZ-Kalibrierung durchfuehren. Es wird ca. 12 Minuten dauern."
 
 # MSG_WIZARD_Z_CAL c=20 r=8
-#: ultralcd.cpp:4897
+#: ultralcd.cpp:4999
 msgid "I will run z calibration now."
 msgstr "Ich werde jetzt die Z Kalibrierung durchfuehren."
 
 # MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ultralcd.cpp:4962
+#: ultralcd.cpp:5064
 msgid "I will start to print line and you will gradually lower the nozzle by rotating the knob, until you reach optimal height. Check the pictures in our handbook in chapter Calibration."
 msgstr "Ich werde jetzt eine Linie drucken. Waehrend des Druckes koennen Sie die Duese allmaehlich senken, indem Sie den Knopf drehen, bis Sie die optimale Hoehe erreichen. Sehen Sie sich die Bilder in unserem Handbuch im Kapitel Kalibrierung an."
-
-# MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=60
-#: mesh_bed_calibration.cpp:2481
-msgid "Improving bed calibration point"
-msgstr "Verbessere Bett Kalibrierpunkt"
 
 # MSG_WATCH
 #: messages.c:99
 msgid "Info screen"
 msgstr "Infoanzeige"
 
-# MSG_INIT_SDCARD
-#: ultralcd.cpp:5785
-msgid "Init. SD card"
-msgstr "Init. SD Karte"
-
-# MSG_INSERT_FILAMENT c=20
-#: ultralcd.cpp:2569
-msgid "Insert filament"
-msgstr "Filament einlegen"
-
-# MSG_FILAMENT_LOADING_T0 c=20 r=4
-#: messages.c:33
-msgid "Insert filament into extruder 1. Click when done."
-msgstr "Filament in Extruder 1 einlegen. Klicken wenn fertig."
-
-# MSG_FILAMENT_LOADING_T1 c=20 r=4
-#: messages.c:34
-msgid "Insert filament into extruder 2. Click when done."
-msgstr "Filament in Extruder 2 einlegen. Klicken wenn fertig."
-
-# MSG_FILAMENT_LOADING_T2 c=20 r=4
-#: messages.c:35
-msgid "Insert filament into extruder 3. Click when done."
-msgstr "Filament in Extruder 3 einlegen. Klicken wenn fertig."
-
-# MSG_FILAMENT_LOADING_T3 c=20 r=4
-#: messages.c:36
-msgid "Insert filament into extruder 4. Click when done."
-msgstr "Filament in Extruder 4 einlegen. Klicken wenn fertig."
-
 # 
-#: ultralcd.cpp:3947
-msgid "IR:"
-msgstr "IR:"
-
-# 
-#: ultralcd.cpp:4922
+#: ultralcd.cpp:5024
 msgid "Is filament 1 loaded?"
 msgstr "Wurde Filament 1 geladen?"
 
+# MSG_INSERT_FILAMENT c=20
+#: ultralcd.cpp:2614
+msgid "Insert filament"
+msgstr "Filament einlegen"
+
 # MSG_WIZARD_FILAMENT_LOADED c=20 r=2
-#: ultralcd.cpp:4925
+#: ultralcd.cpp:5027
 msgid "Is filament loaded?"
 msgstr "Ist das Filament geladen?"
 
 # MSG_WIZARD_PLA_FILAMENT c=20 r=2
-#: ultralcd.cpp:4956
+#: ultralcd.cpp:5058
 msgid "Is it PLA filament?"
 msgstr "Ist es wirklich PLA Filament?"
 
 # MSG_PLA_FILAMENT_LOADED c=20 r=2
-#: ultralcd.cpp:4701
+#: ultralcd.cpp:4790
 msgid "Is PLA filament loaded?"
 msgstr "Ist PLA Filament geladen?"
 
@@ -972,48 +635,33 @@ msgstr "Ist PLA Filament geladen?"
 msgid "Is steel sheet on heatbed?"
 msgstr "Liegt das Stahlblech auf dem Heizbett?"
 
-# MSG_FIND_BED_OFFSET_AND_SKEW_ITERATION c=20
-#: mesh_bed_calibration.cpp:2223
-msgid "Iteration "
-msgstr "Iteration "
-
-# MSG_KILLED
-#: Marlin_main.cpp:7552
-msgid "KILLED. "
-msgstr "ABGEBROCHEN. "
-
 # 
-#: ultralcd.cpp:1828
-msgid "Last print"
-msgstr "Letzter Druck"
-
-# 
-#: ultralcd.cpp:1845
+#: ultralcd.cpp:1795
 msgid "Last print failures"
 msgstr "Letzte Druckfehler"
 
 # 
-#: ultralcd.cpp:2967
-msgid "Left"
-msgstr "Links"
+#: ultralcd.cpp:1772
+msgid "Last print"
+msgstr "Letzter Druck"
 
 # MSG_SELFTEST_EXTRUDER_FAN c=20
 #: messages.c:76
 msgid "Left hotend fan?"
 msgstr "Linker Luefter?"
 
+# 
+#: ultralcd.cpp:3018
+msgid "Left"
+msgstr "Links"
+
 # MSG_BED_CORRECTION_LEFT c=14 r=1
-#: ultralcd.cpp:3215
+#: ultralcd.cpp:3292
 msgid "Left side [um]"
 msgstr "Links [um]"
 
-# MSG_LEFT c=12 r=1
-#: ultralcd.cpp:2308
-msgid "Left:"
-msgstr "Links:"
-
 # 
-#: ultralcd.cpp:5575
+#: ultralcd.cpp:5680
 msgid "Lin. correction"
 msgstr "Lineare Korrektur"
 
@@ -1022,48 +670,13 @@ msgstr "Lineare Korrektur"
 msgid "Live adjust Z"
 msgstr "Z einstellen"
 
-# MSG_LOAD_ALL c=17
-#: ultralcd.cpp:6059
-msgid "Load all"
-msgstr "Alle laden"
-
 # MSG_LOAD_FILAMENT c=17
 #: messages.c:51
 msgid "Load filament"
 msgstr "Filament laden"
 
-# MSG_LOAD_FILAMENT_1 c=17
-#: ultralcd.cpp:5576
-msgid "Load filament 1"
-msgstr "Filament 1 laden"
-
-# MSG_LOAD_FILAMENT_2 c=17
-#: ultralcd.cpp:5577
-msgid "Load filament 2"
-msgstr "Filament 2 laden"
-
-# MSG_LOAD_FILAMENT_3 c=17
-#: ultralcd.cpp:5578
-msgid "Load filament 3"
-msgstr "Filament 3 laden"
-
-# MSG_LOAD_FILAMENT_4 c=17
-#: ultralcd.cpp:5579
-msgid "Load filament 4"
-msgstr "Filament 4 laden"
-
-# MSG_LOAD_FILAMENT_5 c=17
-#: ultralcd.cpp:5582
-msgid "Load filament 5"
-msgstr "Filament 5 laden"
-
-# 
-#: ultralcd.cpp:6714
-msgid "Load to nozzle"
-msgstr "In Druckduese laden"
-
 # MSG_LOADING_COLOR
-#: ultralcd.cpp:2609
+#: ultralcd.cpp:2654
 msgid "Loading color"
 msgstr "Lade Farbe"
 
@@ -1073,174 +686,69 @@ msgid "Loading filament"
 msgstr "Filament laedt"
 
 # MSG_LOOSE_PULLEY c=20 r=1
-#: ultralcd.cpp:7855
+#: ultralcd.cpp:7941
 msgid "Loose pulley"
 msgstr "Lose Riemenscheibe"
 
-# MSG_M104_INVALID_EXTRUDER
-#: Marlin_main.cpp:7675
-msgid "M104 Invalid extruder "
-msgstr "M104 Falscher Extruder "
-
-# MSG_M105_INVALID_EXTRUDER
-#: Marlin_main.cpp:7678
-msgid "M105 Invalid extruder "
-msgstr "M105 Falscher Extruder "
-
-# MSG_M109_INVALID_EXTRUDER
-#: Marlin_main.cpp:7681
-msgid "M109 Invalid extruder "
-msgstr "M109 Falscher Extruder "
+# 
+#: ultralcd.cpp:6805
+msgid "Load to nozzle"
+msgstr "In Druckduese laden"
 
 # MSG_M117_V2_CALIBRATION c=25 r=1
 #: messages.c:55
 msgid "M117 First layer cal."
 msgstr "M117 Erste-Schicht Kal."
 
-# MSG_M200_INVALID_EXTRUDER
-#: Marlin_main.cpp:5857
-msgid "M200 Invalid extruder "
-msgstr "M200 Falscher Extruder "
-
-# MSG_M218_INVALID_EXTRUDER
-#: Marlin_main.cpp:7684
-msgid "M218 Invalid extruder "
-msgstr "M218 Falscher Extruder "
-
-# MSG_M221_INVALID_EXTRUDER
-#: Marlin_main.cpp:7687
-msgid "M221 Invalid extruder "
-msgstr "M221 Falscher Extruder "
-
-# 
-#: ultralcd.cpp:6957
-msgid "Magnets comp. [On]"
-msgstr "Magnet Komp. [An]"
-
-# 
-#: ultralcd.cpp:6960
-msgid "Magnets comp.[N/A]"
-msgstr "Magnet Komp. [nv]"
-
-# 
-#: ultralcd.cpp:6958
-msgid "Magnets comp.[Off]"
-msgstr "Magnet Komp.[Aus]"
-
 # MSG_MAIN
 #: messages.c:56
 msgid "Main"
 msgstr "Hauptmenue"
-
-# MSG_MARK_FIL c=20 r=8
-#: ultralcd.cpp:3840
-msgid "Mark filament 100mm from extruder body. Click when done."
-msgstr "Filament 100mm vom Extrudergehaeuse markieren. Klicken wenn Fertig."
-
-# 
-#: ultralcd.cpp:3002
-msgid "Measured skew"
-msgstr "Schraeglauf"
-
-# MSG_MEASURED_SKEW c=15 r=1
-#: ultralcd.cpp:2335
-msgid "Measured skew:"
-msgstr "Schraeglauf:"
 
 # MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=60
 #: messages.c:59
 msgid "Measuring reference height of calibration point"
 msgstr "Messen der Referenzhoehe des Kalibrierpunktes"
 
-# 
-#: ultralcd.cpp:6949
-msgid "Mesh         [3x3]"
-msgstr "Mesh         [3x3]"
-
-# 
-#: ultralcd.cpp:6950
-msgid "Mesh         [7x7]"
-msgstr "Mesh         [7x7]"
-
 # MSG_MESH_BED_LEVELING
-#: ultralcd.cpp:5658
+#: ultralcd.cpp:5763
 msgid "Mesh Bed Leveling"
-msgstr "Mesh Bett Ausgleich"
-
-# 
-#: ultralcd.cpp:5572
-msgid "Mesh bed leveling"
-msgstr "Mesh Bett Ausgleich"
-
-# 
-#: Marlin_main.cpp:881
-msgid "MK3 firmware detected on MK3S printer"
-msgstr "MK3-Firmware auf MK3S-Drucker erkannt"
-
-# 
-#: Marlin_main.cpp:856
-msgid "MK3S firmware detected on MK3 printer"
-msgstr "MK3S-Firmware auf MK3-Drucker erkannt"
-
-# 
-#: ultralcd.cpp:1845
-msgid "MMU fails"
-msgstr "MMU Fehler"
-
-# 
-#: mmu.cpp:1617
-msgid "MMU load failed     "
-msgstr "MMU Ladefehler"
-
-# 
-#: ultralcd.cpp:1845
-msgid "MMU load fails"
-msgstr "MMU Ladefehler"
-
-# 
-#: ultralcd.cpp:5204
-msgid "MMU Mode [Normal]"
-msgstr "MMU Modus[Normal]"
-
-# 
-#: ultralcd.cpp:5205
-msgid "MMU Mode[Stealth]"
-msgstr "MMU Modus[Stealth]"
-
-# 
-#: mmu.cpp:719
-msgid "MMU needs user attention."
-msgstr "MMU erfordert Benutzereingriff."
-
-# MSG_MMU_NEEDS_ATTENTION c=20 r=4
-#: mmu.cpp:359
-msgid "MMU needs user attention. Fix the issue and then press button on MMU unit."
-msgstr "MMU hat eine Stoerung. Beseitigen Sie das Problem und druecken Sie den Knopf an der MMU."
+msgstr "MeshBett Ausgleich"
 
 # MSG_MMU_OK_RESUMING_POSITION c=20 r=4
 #: mmu.cpp:762
 msgid "MMU OK. Resuming position..."
-msgstr "MMU OK. Position    wiederherstellen... "
+msgstr "MMU OK. Position wiederherstellen..."
 
 # MSG_MMU_OK_RESUMING_TEMPERATURE c=20 r=4
 #: mmu.cpp:755
 msgid "MMU OK. Resuming temperature..."
 msgstr "MMU OK. Temperatur wiederherstellen..."
 
+# 
+#: ultralcd.cpp:3059
+msgid "Measured skew"
+msgstr "Schraeglauf"
+
+# 
+#: ultralcd.cpp:1796
+msgid "MMU fails"
+msgstr "MMU Fehler"
+
+# 
+#: mmu.cpp:1613
+msgid "MMU load failed     "
+msgstr "MMU Ladefehler"
+
+# 
+#: ultralcd.cpp:1797
+msgid "MMU load fails"
+msgstr "MMU Ladefehler"
+
 # MSG_MMU_OK_RESUMING c=20 r=4
 #: mmu.cpp:773
 msgid "MMU OK. Resuming..."
 msgstr "MMU OK.  Weiterdrucken..."
-
-# 
-#: ultralcd.cpp:1862
-msgid "MMU power fails"
-msgstr "MMU Netzfehler"
-
-# 
-#: ultralcd.cpp:2112
-msgid "MMU2 connected"
-msgstr "MMU2 verbunden"
 
 # MSG_STEALTH_MODE_OFF
 #: messages.c:90
@@ -1252,15 +760,20 @@ msgstr "Modus    [Normal]"
 msgid "Mode     [silent]"
 msgstr "Modus     [leise]"
 
+# 
+#: mmu.cpp:719
+msgid "MMU needs user attention."
+msgstr "MMU erfordert Benutzereingriff."
+
+# 
+#: ultralcd.cpp:1823
+msgid "MMU power fails"
+msgstr "MMU Netzfehler"
+
 # MSG_STEALTH_MODE_ON
 #: messages.c:91
 msgid "Mode    [Stealth]"
 msgstr "Modus   [Stealth]"
-
-# 
-#: ultralcd.cpp:4424
-msgid "Mode change in progress ..."
-msgstr "Moduswechsel erfolgt..."
 
 # MSG_AUTO_MODE_ON
 #: messages.c:12
@@ -1273,89 +786,64 @@ msgid "Mode [high power]"
 msgstr "Modus[Hohe Leist]"
 
 # 
-#: ultralcd.cpp:5404
-msgid "Model      [none]"
-msgstr "Modell      [ohne]"
-
-# 
-#: ultralcd.cpp:5407
-msgid "Model      [warn]"
-msgstr "Modell     [warn]"
-
-# 
-#: ultralcd.cpp:5410
-msgid "Model    [strict]"
-msgstr "Modell   [streng]"
+#: ultralcd.cpp:2219
+msgid "MMU2 connected"
+msgstr "MMU2 verbunden"
 
 # MSG_SELFTEST_MOTOR
 #: messages.c:83
 msgid "Motor"
-msgstr "Motor"
+msgstr ""
 
 # MSG_MOVE_AXIS
-#: ultralcd.cpp:5550
+#: ultralcd.cpp:5652
 msgid "Move axis"
 msgstr "Achse bewegen"
 
 # MSG_MOVE_X
-#: ultralcd.cpp:4291
+#: ultralcd.cpp:4378
 msgid "Move X"
 msgstr "Bewege X"
 
 # MSG_MOVE_Y
-#: ultralcd.cpp:4292
+#: ultralcd.cpp:4379
 msgid "Move Y"
 msgstr "Bewege Y"
 
 # MSG_MOVE_Z
-#: ultralcd.cpp:4293
+#: ultralcd.cpp:4380
 msgid "Move Z"
 msgstr "Bewege Z"
 
-# 
-#: ultralcd.cpp:2973
-msgid "N/A"
-msgstr "N.V."
+# MSG_NO_MOVE
+#: Marlin_main.cpp:5292
+msgid "No move."
+msgstr "Keine Bewegung."
+
+# MSG_NO_CARD
+#: ultralcd.cpp:6772
+msgid "No SD card"
+msgstr "Keine SD Karte"
 
 # 
-#: util.cpp:293
-msgid "New firmware version available:"
-msgstr "Neue Firmware- Version verfuegbar:"
+#: ultralcd.cpp:3024
+msgid "N/A"
+msgstr "N.V."
 
 # MSG_NO
 #: messages.c:62
 msgid "No"
 msgstr "Nein"
 
-# 
-#:
-msgid "No "
-msgstr "Nein"
-
-# MSG_ERR_NO_CHECKSUM
-#: cmdqueue.cpp:456
-msgid "No Checksum with line number, Last Line: "
-msgstr "Keine Pruefsumme mit Zeilennummer, Letzte Zeile: "
-
-# MSG_NO_MOVE
-#: Marlin_main.cpp:5254
-msgid "No move."
-msgstr "Keine Bewegung."
-
-# MSG_NO_CARD
-#: ultralcd.cpp:6694
-msgid "No SD card"
-msgstr "Keine SD Karte"
-
-# MSG_ERR_NO_THERMISTORS
-#: Marlin_main.cpp:4946
-msgid "No thermistors - no temperature"
-msgstr "Keine Thermistoren - keine Temperatur"
-
 # MSG_SELFTEST_NOTCONNECTED
-#: ultralcd.cpp:7803
+#: ultralcd.cpp:7889
 msgid "Not connected"
 msgstr "Nicht angeschlossen"
+
+# 
+#: util.cpp:293
+msgid "New firmware version available:"
+msgstr "Neue Firmware- Version verfuegbar:"
 
 # MSG_SELFTEST_FAN_NO c=19
 #: messages.c:79
@@ -1363,152 +851,67 @@ msgid "Not spinning"
 msgstr "Dreht sich nicht"
 
 # MSG_WIZARD_V2_CAL c=20 r=8
-#: ultralcd.cpp:4961
+#: ultralcd.cpp:5063
 msgid "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr "Jetzt werde ich den Abstand zwischen Duesenspitze und Druckbett kalibrieren."
 
 # MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ultralcd.cpp:4905
+#: ultralcd.cpp:5007
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Jetzt werde ich die Duese fuer PLA vorheizen."
-
-# 
-#: ultralcd.cpp:4896
-msgid "Now remove the test print from steel sheet."
-msgstr "Testdruck jetzt von Stahlblech entfernen."
 
 # MSG_NOZZLE
 #: messages.c:63
 msgid "Nozzle"
 msgstr "Duese"
 
-# 
-#: ultralcd.cpp:5319
-msgid "Nozzle     [none]"
-msgstr "Duese      [ohne]"
-
-# 
-#: ultralcd.cpp:5322
-msgid "Nozzle     [warn]"
-msgstr "Duese      [warn]"
-
-# 
-#: ultralcd.cpp:5325
-msgid "Nozzle   [strict]"
-msgstr "Duese    [streng]"
-
-# 
-#: ultralcd.cpp:5365
-msgid "Nozzle d.  [0.25]"
-msgstr "Duese D.   [0.25]"
-
-# 
-#: ultralcd.cpp:5368
-msgid "Nozzle d.  [0.40]"
-msgstr "Duese D.   [0.40]"
-
-# 
-#: ultralcd.cpp:5371
-msgid "Nozzle d.  [0.60]"
-msgstr "Duese D.   [0.60]"
-
-# 
-#: ultralcd.cpp:1787
-msgid "Nozzle FAN"
-msgstr "Duesen Luefter"
-
-# MSG_INFO_NOZZLE_FAN c=11 r=1
-#: ultralcd.cpp:1537
-msgid "Nozzle FAN:"
-msgstr "Duesen Luefter:"
-
-# MSG_NOZZLE1
-#: ultralcd.cpp:5995
-msgid "Nozzle2"
-msgstr "Duese2"
-
-# MSG_NOZZLE2
-#: ultralcd.cpp:5998
-msgid "Nozzle3"
-msgstr "Duese3"
-
-# MSG_OK
-#: Marlin_main.cpp:6333
-msgid "ok"
-msgstr "ok"
-
 # MSG_DEFAULT_SETTINGS_LOADED c=20 r=4
-#: Marlin_main.cpp:1535
+#: Marlin_main.cpp:1519
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr "Alte Einstellungen gefunden. Standard PID, E-Steps u.s.w. werden gesetzt."
 
-# MSG_ENDSTOP_OPEN
-#: messages.c:29
-msgid "open"
-msgstr "offen"
+# 
+#: ultralcd.cpp:4998
+msgid "Now remove the test print from steel sheet."
+msgstr "Testdruck jetzt von Stahlblech entfernen."
 
-# MSG_SD_OPEN_FILE_FAIL
-#: messages.c:79
-msgid "open failed, File: "
-msgstr "Fehler beim Oeffnen der Datei: "
-
-# MSG_SD_OPENROOT_FAIL
-#: cardreader.cpp:196
-msgid "openRoot failed"
-msgstr "Zugriff auf Hauptverzeichnis misslungen"
+# 
+#: ultralcd.cpp:1722
+msgid "Nozzle FAN"
+msgstr "Duesevent."
 
 # MSG_PAUSE_PRINT
-#: ultralcd.cpp:6657
+#: ultralcd.cpp:6735
 msgid "Pause print"
 msgstr "Druck pausieren"
 
-# MSG_PICK_Z
-#: ultralcd.cpp:3463
-msgid "Pick print"
-msgstr "Druck auswaehlen"
-
 # MSG_PID_RUNNING c=20 r=1
-#: ultralcd.cpp:1613
+#: ultralcd.cpp:1606
 msgid "PID cal.           "
 msgstr "PID Kal.           "
 
 # MSG_PID_FINISHED c=20 r=1
-#: ultralcd.cpp:1619
+#: ultralcd.cpp:1612
 msgid "PID cal. finished"
 msgstr "PID Kalib. fertig"
 
 # MSG_PID_EXTRUDER c=17 r=1
-#: ultralcd.cpp:5664
+#: ultralcd.cpp:5769
 msgid "PID calibration"
 msgstr "PID Kalibrierung"
 
 # MSG_PINDA_PREHEAT c=20 r=1
-#: ultralcd.cpp:862
+#: ultralcd.cpp:846
 msgid "PINDA Heating"
 msgstr "PINDA erwaermen"
-
-# 
-#: ultralcd.cpp:3939
-msgid "PINDA:"
-msgstr "PINDA:"
 
 # MSG_PAPER c=20 r=8
 #: messages.c:64
 msgid "Place a sheet of paper under the nozzle during the calibration of first 4 points. If the nozzle catches the paper, power off the printer immediately."
 msgstr "Legen Sie ein Blatt Papier unter die Duese waehrend der Kalibrierung der ersten 4 Punkte. Wenn die Duese das Papier erfasst, den Drucker sofort ausschalten."
 
-# MSG_SELFTEST_PLEASECHECK
-#: ultralcd.cpp:7795
-msgid "Please check :"
-msgstr "Bitte pruefe:"
-
-# MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: messages.c:100
-msgid "Please check our handbook and fix the problem. Then resume the Wizard by rebooting the printer."
-msgstr "Bitte lesen Sie unser Handbuch und beheben Sie das Problem. Fahren Sie dann mit dem Assistenten fort, indem Sie den Drucker neu starten."
-
 # MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ultralcd.cpp:4970
+#: ultralcd.cpp:5072
 msgid "Please clean heatbed and then press the knob."
 msgstr "Bitte reinigen Sie das Heizbett und druecken Sie dann den Knopf."
 
@@ -1517,28 +920,28 @@ msgstr "Bitte reinigen Sie das Heizbett und druecken Sie dann den Knopf."
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Bitte entfernen Sie ueberstehendes Filament von der Duese. Klicken wenn sauber."
 
+# MSG_SELFTEST_PLEASECHECK
+#: ultralcd.cpp:7881
+msgid "Please check :"
+msgstr "Bitte pruefe:"
+
+# MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
+#: messages.c:100
+msgid "Please check our handbook and fix the problem. Then resume the Wizard by rebooting the printer."
+msgstr "Bitte lesen Sie unser Handbuch und beheben Sie das Problem. Fahren Sie dann mit dem Assistenten fort, indem Sie den Drucker neu starten."
+
 # MSG_WIZARD_LOAD_FILAMENT c=20 r=8
-#: ultralcd.cpp:4804
+#: ultralcd.cpp:4894
 msgid "Please insert PLA filament to the extruder, then press knob to load it."
 msgstr "Legen Sie bitte PLA Filament in den Extruder und druecken Sie den Knopf,  um es zu laden."
 
-# 
-#: ultralcd.cpp:4800
-msgid "Please insert PLA filament to the first tube of MMU, then press the knob to load it."
-msgstr "Legen Sie bitte PLA Filament in den ersten Schlauch der MMU und druecken Sie den Knopf,  um es zu laden."
-
-# MSG_WIZARD_INSERT_CORRECT_FILAMENT c=20 r=8
-#: ultralcd.cpp:4109
-msgid "Please load PLA filament and then resume Wizard by rebooting the printer."
-msgstr "Bitte PLA-Filament\nladen und Assistent\nfortsetzen, indem\nSie den Drucker neu\nstarten."
-
 # MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ultralcd.cpp:4706
+#: ultralcd.cpp:4795
 msgid "Please load PLA filament first."
 msgstr "Bitte laden Sie zuerst PLA Filament."
 
 # MSG_CHECK_IDLER c=20 r=4
-#: Marlin_main.cpp:3083
+#: Marlin_main.cpp:3064
 msgid "Please open idler and remove filament manually."
 msgstr "Bitte Spannrolle oeffnen und Fila- ment von Hand entfernen"
 
@@ -1552,20 +955,20 @@ msgstr "Bitte legen Sie das Stahlblech auf das Heizbett."
 msgid "Please press the knob to unload filament"
 msgstr "Bitte druecken Sie den Knopf um das Filament zu entladen."
 
+# 
+#: ultralcd.cpp:4889
+msgid "Please insert PLA filament to the first tube of MMU, then press the knob to load it."
+msgstr "Legen Sie bitte PLA Filament in den ersten Schlauch der MMU und druecken Sie den Knopf,  um es zu laden."
+
 # MSG_PULL_OUT_FILAMENT c=20 r=4
 #: messages.c:70
 msgid "Please pull out filament immediately"
 msgstr "Bitte ziehen Sie das Filament sofort heraus"
 
 # MSG_EJECT_REMOVE c=20 r=4
-#: mmu.cpp:1441
+#: mmu.cpp:1440
 msgid "Please remove filament and then press the knob."
 msgstr "Bitte Filament entfernen und dann den Knopf druecken"
-
-# 
-#: ultralcd.cpp:4895
-msgid "Please remove shipping helpers first."
-msgstr "Bitte zuerst Transportsicherungen entfernen."
 
 # MSG_REMOVE_STEEL_SHEET c=20 r=4
 #: messages.c:74
@@ -1573,19 +976,14 @@ msgid "Please remove steel sheet from heatbed."
 msgstr "Bitte entfernen Sie das Stahlblech vom Heizbett."
 
 # MSG_RUN_XYZ c=20 r=4
-#: Marlin_main.cpp:4317
+#: Marlin_main.cpp:4355
 msgid "Please run XYZ calibration first."
 msgstr "Bitte zuerst XYZ Kalibrierung ausfuehren."
 
 # MSG_UPDATE_MMU2_FW c=20 r=4
-#: mmu.cpp:1360
+#: mmu.cpp:1359
 msgid "Please update firmware in your MMU2. Waiting for reset."
 msgstr "Bitte aktualisieren Sie die Firmware in der MMU2. Warte auf Reset."
-
-# 
-#: util.cpp:297
-msgid "Please upgrade."
-msgstr "Bitte aktualisieren."
 
 # MSG_PLEASE_WAIT c=20
 #: messages.c:66
@@ -1593,24 +991,19 @@ msgid "Please wait"
 msgstr "Bitte warten"
 
 # 
-#: ultralcd.cpp:1881
-msgid "Power failures"
-msgstr "Netzfehler"
-
-# MSG_POWERUP
-#: messages.c:69
-msgid "PowerUp"
-msgstr "Einschalten"
-
-# MSG_PREHEAT
-#: ultralcd.cpp:6644
-msgid "Preheat"
-msgstr "Vorheizen"
+#: ultralcd.cpp:4997
+msgid "Please remove shipping helpers first."
+msgstr "Bitte zuerst Transportsicherungen entfernen."
 
 # MSG_PREHEAT_NOZZLE c=20
 #: messages.c:67
 msgid "Preheat the nozzle!"
 msgstr "Duese vorheizen!"
+
+# MSG_PREHEAT
+#: ultralcd.cpp:6722
+msgid "Preheat"
+msgstr "Vorheizen"
 
 # MSG_WIZARD_HEATING c=20 r=3
 #: messages.c:102
@@ -1618,44 +1011,19 @@ msgid "Preheating nozzle. Please wait."
 msgstr "Vorheizen der Duese. Bitte warten."
 
 # 
-#: ultralcd.cpp:2290
-msgid "Preheating to cut"
-msgstr "Heizen zum Schnitt"
-
-# 
-#: ultralcd.cpp:2287
-msgid "Preheating to eject"
-msgstr "Heizen zum Auswurf"
-
-# 
-#: ultralcd.cpp:2280
-msgid "Preheating to load"
-msgstr "Heizen zum Laden"
-
-# 
-#: ultralcd.cpp:2284
-msgid "Preheating to unload"
-msgstr "Heizen zum Entladen"
-
-# MSG_PREPARE_FILAMENT c=20 r=1
-#: ultralcd.cpp:1911
-msgid "Prepare new filament"
-msgstr "Filam. bereithalten"
+#: util.cpp:297
+msgid "Please upgrade."
+msgstr "Bitte aktualisieren."
 
 # MSG_PRESS_TO_PREHEAT c=20 r=4
-#: Marlin_main.cpp:10312
+#: Marlin_main.cpp:10364
 msgid "Press knob to preheat nozzle and continue."
 msgstr "Bitte druecken Sie den Knopf um die Duese vorzuheizen und fortzufahren."
 
 # 
-#: ultralcd.cpp:2210
-msgid "Press the knob"
-msgstr "Knopf druecken"
-
-# 
-#: mmu.cpp:723
-msgid "Press the knob to resume nozzle temperature."
-msgstr "Druecken Sie den Knopf um die Duesentemperatur wiederherzustellen"
+#: ultralcd.cpp:1851
+msgid "Power failures"
+msgstr "Netzfehler"
 
 # MSG_PRINT_ABORTED c=20
 #: messages.c:69
@@ -1663,17 +1031,17 @@ msgid "Print aborted"
 msgstr "Druck abgebrochen"
 
 # 
-#: ultralcd.cpp:1789
-msgid "Print FAN"
-msgstr "Druckluefter"
+#: ultralcd.cpp:2455
+msgid "Preheating to load"
+msgstr "Heizen zum Laden"
 
-# MSG_INFO_PRINT_FAN c=11 r=1
-#: ultralcd.cpp:1549
-msgid "Print FAN: "
-msgstr "Druckvent.: "
+# 
+#: ultralcd.cpp:2459
+msgid "Preheating to unload"
+msgstr "Heizen zum Entladen"
 
 # MSG_SELFTEST_PRINT_FAN_SPEED c=18
-#: ultralcd.cpp:8221
+#: ultralcd.cpp:8307
 msgid "Print fan:"
 msgstr "Druckvent.:"
 
@@ -1682,50 +1050,20 @@ msgstr "Druckvent.:"
 msgid "Print from SD"
 msgstr "Drucken von SD"
 
+# 
+#: ultralcd.cpp:2317
+msgid "Press the knob"
+msgstr "Knopf druecken zum"
+
 # MSG_PRINT_PAUSED c=20 r=1
-#: ultralcd.cpp:1080
+#: ultralcd.cpp:1069
 msgid "Print paused"
 msgstr "Druck pausiert"
 
-# MSG_PRINT_TIME c=19 r=1
-#: ultralcd.cpp:2838
-msgid "Print time"
-msgstr "Druckzeit"
-
-# MSG_STATS_PRINTTIME c=20
-#: ultralcd.cpp:2151
-msgid "Print time:  "
-msgstr "Druckzeit: "
-
-# MSG_PRINTER_DISCONNECTED c=20 r=1
-#: ultralcd.cpp:607
-msgid "Printer disconnected"
-msgstr "Drucker getrennt"
-
 # 
-#: util.cpp:473
-msgid "Printer FW version differs from the G-code. Continue?"
-msgstr "Drucker FW-Version weicht vom G-Code ab. Fortfahren?"
-
-# 
-#: util.cpp:480
-msgid "Printer FW version differs from the G-code. Please check the value in settings. Print cancelled."
-msgstr "Drucker FW-Version weicht vom G-Code ab. Bitte ueberpruefen Sie den Wert in den Einstellungen. Druck abgebrochen."
-
-# 
-#: util.cpp:506
-msgid "Printer G-code level differs from the G-code. Continue?"
-msgstr "Drucker G-Code Level unterscheidet sich vom G-Code. Fortfahren?"
-
-# 
-#: util.cpp:513
-msgid "Printer G-code level differs from the G-code. Please check the value in settings. Print cancelled."
-msgstr "Der Drucker-G-Code Level unterscheidet sich vom G-Code. Bitte ueberpruefen Sie den Wert in den Einstellungen. Druck abgebrochen."
-
-# MSG_ERR_KILLED
-#: Marlin_main.cpp:7547
-msgid "Printer halted. kill() called!"
-msgstr "Printer gestoppt. kill() aufgerufen!"
+#: mmu.cpp:723
+msgid "Press the knob to resume nozzle temperature."
+msgstr "Druecken Sie den Knopf um die Duesentemperatur wiederherzustellen"
 
 # MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
 #: messages.c:41
@@ -1733,74 +1071,24 @@ msgid "Printer has not been calibrated yet. Please follow the manual, chapter Fi
 msgstr "Drucker wurde noch nicht kalibriert. Bitte folgen Sie dem Handbuch, Kapitel Erste Schritte, Abschnitt Kalibrie- rungsablauf."
 
 # 
-#: util.cpp:423
-msgid "Printer model differs from the G-code. Continue?"
-msgstr "Druckermodell unterscheidet sich vom G-Code. Fortfahren?"
-
-# 
-#: util.cpp:430
-msgid "Printer model differs from the G-code. Please check the value in settings. Print cancelled."
-msgstr "Das Druckermodell unterscheidet sich vom G-Code. Bitte ueberpruefen Sie den Wert in den Einstellungen. Druck abgebrochen."
-
-# 
-#: util.cpp:390
-msgid "Printer nozzle diameter differs from the G-code. Continue?"
-msgstr "Der Durchmesser der Druckerduese weicht vom G-Code ab. Fortfahren?"
-
-# 
-#: util.cpp:397
-msgid "Printer nozzle diameter differs from the G-code. Please check the value in settings. Print cancelled."
-msgstr "Der Durchmesser der Druckerduese weicht vom G-Code ab. Bitte ueberpruefen Sie den Wert in den Einstellungen. Druck abgebrochen."
-
-# MSG_ERR_STOPPED
-#: messages.c:32
-msgid "Printer stopped due to errors. Fix the error and use M999 to restart. (Temperature is reset. Set it after restarting)"
-msgstr "Drucker aufgrund von Fehlern gestoppt. Fehler beheben und mit M999 neu starten. (Temperatur wird zurueckgesetzt. Nach dem Neustart neu einstellen!)"
-
-# 
-#:
-msgid "Prusa i3 MK2 ready."
-msgstr "Prusa i3 MK2 bereit."
-
-# WELCOME_MSG c=20
-#:
-msgid "Prusa i3 MK2.5 ready."
-msgstr "Prusa i3 MK2.5 bereit."
-
-# 
-#:
-msgid "Prusa i3 MK3 OK."
-msgstr "Prusa i3 MK3 OK."
-
-# WELCOME_MSG c=20
-#:
-msgid "Prusa i3 MK3 ready."
-msgstr "Prusa i3 MK3 bereit."
-
-# 
-#:
-msgid "Prusa i3 MK3S OK."
-msgstr "Prusa i3 MK3S OK."
+#: ultralcd.cpp:1723
+msgid "Print FAN"
+msgstr "Druckvent."
 
 # MSG_PRUSA3D
-#: ultralcd.cpp:2098
+#: ultralcd.cpp:2205
 msgid "prusa3d.com"
-msgstr "prusa3d.com"
+msgstr ""
 
 # MSG_BED_CORRECTION_REAR c=14 r=1
-#: ultralcd.cpp:3218
+#: ultralcd.cpp:3295
 msgid "Rear side [um]"
 msgstr "Hinten [um]"
 
 # MSG_RECOVERING_PRINT c=20 r=1
-#: Marlin_main.cpp:9712
+#: Marlin_main.cpp:9764
 msgid "Recovering print    "
 msgstr "Druck wiederherst    "
-
-# MSG_REFRESH
-#:
-msgid "Refresh"
-msgstr "Erneuern"
 
 # MSG_REMOVE_OLD_FILAMENT c=20 r=4
 #: mmu.cpp:830
@@ -1808,37 +1096,22 @@ msgid "Remove old filament and press the knob to start loading new filament."
 msgstr "Entfernen Sie das alte Filament und druecken Sie den Knopf, um das neue zu laden."
 
 # 
-#: ultralcd.cpp:6605
-msgid "Rename"
-msgstr "Umbenennen"
+#: 
+msgid "Prusa i3 MK3S OK."
+msgstr ""
 
-# MSG_M119_REPORT
-#: Marlin_main.cpp:5297
-msgid "Reporting endstop status"
-msgstr "Statusbericht Endanschlag"
-
-# 
-#: Marlin_main.cpp:7076
-msgid "Resend"
-msgstr "Wiederholen"
-
-# MSG_RESEND
-#: Marlin_main.cpp:6911
-msgid "Resend: "
-msgstr "Wiederholen: "
+# MSG_CALIBRATE_BED_RESET
+#: ultralcd.cpp:5774
+msgid "Reset XYZ calibr."
+msgstr "Reset XYZ Kalibr."
 
 # MSG_BED_CORRECTION_RESET
-#: ultralcd.cpp:3219
+#: ultralcd.cpp:3296
 msgid "Reset"
 msgstr "Ruecksetzen"
 
-# MSG_CALIBRATE_BED_RESET
-#: ultralcd.cpp:5669
-msgid "Reset XYZ calibr."
-msgstr "XYZ Kalibr. zuruecksetzen."
-
 # MSG_RESUME_PRINT
-#: ultralcd.cpp:6664
+#: ultralcd.cpp:6742
 msgid "Resume print"
 msgstr "Druck fortsetzen"
 
@@ -1847,143 +1120,93 @@ msgstr "Druck fortsetzen"
 msgid "Resuming print"
 msgstr "Druck fortgesetzt"
 
-# 
-#: ultralcd.cpp:2968
-msgid "Right"
-msgstr "Rechts"
-
 # MSG_BED_CORRECTION_RIGHT c=14 r=1
-#: ultralcd.cpp:3216
+#: ultralcd.cpp:3293
 msgid "Right side[um]"
-msgstr "Rechts [um]"
-
-# MSG_RIGHT c=12 r=1
-#: ultralcd.cpp:2309
-msgid "Right:"
-msgstr "Rechts:"
-
-# MSG_E_CAL_KNOB c=20 r=8
-#: ultralcd.cpp:3835
-msgid "Rotate knob until mark reaches extruder body. Click when done."
-msgstr "Knopf drehen bis die Markierung das Extrudergehaeuse erreicht. Klicken wenn fertig."
+msgstr "Rechts    [um]"
 
 # MSG_SECOND_SERIAL_ON c=17 r=1
-#: ultralcd.cpp:5587
+#: ultralcd.cpp:5692
 msgid "RPi port     [on]"
 msgstr "RPi Port     [an]"
 
 # MSG_SECOND_SERIAL_OFF c=17 r=1
-#: ultralcd.cpp:5585
+#: ultralcd.cpp:5690
 msgid "RPi port    [off]"
 msgstr "RPi Port    [aus]"
 
 # MSG_WIZARD_RERUN c=20 r=7
-#: ultralcd.cpp:4723
+#: ultralcd.cpp:4812
 msgid "Running Wizard will delete current calibration results and start from the beginning. Continue?"
 msgstr "Der Assistent wird die aktuellen Kalibrierungsdaten loeschen und von vorne beginnen. Weiterfahren?"
 
 # MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_OFF c=19 r=1
-#: ultralcd.cpp:5220
+#: ultralcd.cpp:5322
 msgid "SD card  [normal]"
 msgstr "SD Karte [normal]"
 
-# MSG_SD_CARD_OK
-#: cardreader.cpp:202
-msgid "SD card ok"
-msgstr "SD Karte ok"
-
 # MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_ON c=19 r=1
-#: ultralcd.cpp:4238
-msgid "SD card [FlshAir]"
-msgstr "SD Karte [FlashAir]"
-
-# MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_ON c=19 r=1
-#: ultralcd.cpp:5218
+#: ultralcd.cpp:5320
 msgid "SD card [flshAir]"
 msgstr "SD Karte[flshAir]"
 
-# MSG_SD_INIT_FAIL
-#: cardreader.cpp:186
-msgid "SD init fail"
-msgstr "SD Init fehlerhaft"
-
-# MSG_SD_PRINTING_BYTE
-#: cardreader.cpp:516
-msgid "SD printing byte "
-msgstr "SD drucke Byte "
+# 
+#: ultralcd.cpp:3019
+msgid "Right"
+msgstr "Rechts"
 
 # MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=60
 #: messages.c:38
 msgid "Searching bed calibration point"
 msgstr "Suche Bett Kalibrierpunkt"
 
-# 
-#: ultralcd.cpp:6601
-msgid "Select"
-msgstr "Auswahl"
-
 # MSG_LANGUAGE_SELECT
-#: ultralcd.cpp:5594
+#: ultralcd.cpp:5699
 msgid "Select language"
 msgstr "Waehle Sprache"
 
-# 
-#: ultralcd.cpp:4943
-msgid "Select nozzle preheat temperature which matches your material."
-msgstr "Bitte Vorheiztemperatur auswaehlen, die Ihrem Material entspricht."
-
-# 
-#: ultralcd.cpp:4692
-msgid "Select PLA filament:"
-msgstr "PLA Filament auswaehlen:"
-
 # MSG_SELFTEST_OK
-#: ultralcd.cpp:7366
+#: ultralcd.cpp:7452
 msgid "Self test OK"
 msgstr "Selbsttest OK"
 
 # MSG_SELFTEST_START c=20
-#: ultralcd.cpp:7152
+#: ultralcd.cpp:7238
 msgid "Self test start  "
 msgstr "Selbsttest start "
 
 # MSG_SELFTEST
-#: ultralcd.cpp:5645
+#: ultralcd.cpp:5750
 msgid "Selftest         "
-msgstr "Selbsttest "
+msgstr "Selbsttest       "
 
 # MSG_SELFTEST_ERROR
-#: ultralcd.cpp:7793
+#: ultralcd.cpp:7879
 msgid "Selftest error !"
 msgstr "Selbsttest Fehler!"
 
 # MSG_SELFTEST_FAILED c=20
 #: messages.c:77
 msgid "Selftest failed  "
-msgstr "Selbsttest misslung  "
+msgstr "Selbsttest Error "
 
 # MSG_FORCE_SELFTEST c=20 r=8
-#: Marlin_main.cpp:1567
+#: Marlin_main.cpp:1551
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr "Selbsttest im Gang, um die genaue Rueck- kehr zum Nullpunkt ohne Sensor zu kalibrieren"
 
 # 
-#: ultralcd.cpp:2138
-msgid "Sensor info"
-msgstr "Sensor Info"
+#: ultralcd.cpp:5045
+msgid "Select nozzle preheat temperature which matches your material."
+msgstr "Bitte Vorheiztemperatur auswaehlen, die Ihrem Material entspricht."
 
 # 
-#: ultralcd.cpp:3938
-msgid "Sensor state"
-msgstr "Sensorstatus"
-
-# 
-#:
-msgid "Sensors info"
-msgstr "Sensoren Info"
+#: ultralcd.cpp:4780
+msgid "Select PLA filament:"
+msgstr "PLA Filament auswaehlen:"
 
 # MSG_SET_TEMPERATURE c=19 r=1
-#: ultralcd.cpp:3227
+#: ultralcd.cpp:3314
 msgid "Set temperature:"
 msgstr "Temp. einstellen:"
 
@@ -1992,110 +1215,40 @@ msgstr "Temp. einstellen:"
 msgid "Settings"
 msgstr "Einstellungen"
 
-# 
-#: ultralcd.cpp:3005
-msgid "Severe skew"
-msgstr "Schwerer Schraeglauf"
-
-# MSG_SEVERE_SKEW c=15 r=1
-#: ultralcd.cpp:2346
-msgid "Severe skew:"
-msgstr "Schwerer Verzug:"
-
-# 
-#: messages.c:58
-msgid "Sheet"
-msgstr "Blech"
-
 # MSG_SHOW_END_STOPS c=17 r=1
-#: ultralcd.cpp:5666
+#: ultralcd.cpp:5771
 msgid "Show end stops"
 msgstr "Endschalter Status"
 
 # 
-#:
-msgid "Show pinda state"
-msgstr "Pinda-Status anzeigen"
-
-# MSG_DWELL
-#: Marlin_main.cpp:3752
-msgid "Sleep..."
-msgstr "Schlafzustand..."
-
-# 
-#: ultralcd.cpp:3004
-msgid "Slight skew"
-msgstr "Leichter Schraeglauf"
-
-# MSG_SLIGHT_SKEW c=15 r=1
-#: ultralcd.cpp:2342
-msgid "Slight skew:"
-msgstr "Etwas verzogen:"
+#: ultralcd.cpp:4025
+msgid "Sensor state"
+msgstr "Sensorstatus"
 
 # MSG_FILE_CNT c=20 r=4
 #: cardreader.cpp:739
 msgid "Some files will not be sorted. Max. No. of files in 1 folder for sorting is 100."
 msgstr "Einige Dateien wur- den nicht sortiert. Max. Dateien pro Verzeichnis = 100."
 
-# 
-#: Marlin_main.cpp:4833
-msgid "Some problem encountered, Z-leveling enforced ..."
-msgstr "Fehler aufgetreten, Z-Kalibrierung erforderlich..."
-
 # MSG_SORT_NONE c=17 r=1
-#: ultralcd.cpp:5230
+#: ultralcd.cpp:5332
 msgid "Sort       [none]"
-msgstr "Sort. [ohne]"
+msgstr "Sort.      [ohne]"
 
 # MSG_SORT_TIME c=17 r=1
-#: ultralcd.cpp:5228
+#: ultralcd.cpp:5330
 msgid "Sort       [time]"
-msgstr "Sort. [Zeit]"
+msgstr "Sort.      [Zeit]"
+
+# 
+#: ultralcd.cpp:3062
+msgid "Severe skew:"
+msgstr "Schwer.Schr:"
 
 # MSG_SORT_ALPHA c=17 r=1
-#: ultralcd.cpp:5229
+#: ultralcd.cpp:5331
 msgid "Sort   [alphabet]"
-msgstr "Sort. [Alphabetisch]"
-
-# MSG_SORT_NONE c=17 r=1
-#: ultralcd.cpp:4250
-msgid "Sort:      [None]"
-msgstr "Sort.:    [Keine]"
-
-# MSG_SORT_NONE c=17 r=1
-#: ultralcd.cpp:5043
-msgid "Sort:      [none]"
-msgstr "Sort.:    [Keine]"
-
-# MSG_SORT_TIME c=17 r=1
-#: ultralcd.cpp:4248
-msgid "Sort:      [Time]"
-msgstr "Sort.: [Zeit]"
-
-# MSG_SORT_TIME c=17 r=1
-#: ultralcd.cpp:5041
-msgid "Sort:      [time]"
-msgstr "Sort.:     [Zeit]"
-
-# MSG_SORT_ALPHA c=17 r=1
-#: ultralcd.cpp:4249
-msgid "Sort:  [Alphabet]"
-msgstr "Sort.: [Alphab.]"
-
-# MSG_SORT_ALPHA c=17 r=1
-#: ultralcd.cpp:5042
-msgid "Sort:  [alphabet]"
-msgstr "Sort.: [Alphabet]"
-
-# MSG_SORT_NONE c=17 r=1
-#:
-msgid "Sort:  [none]"
-msgstr "Sort.: [ohne]"
-
-# MSG_SORT_TIME c=17 r=1
-#:
-msgid "Sort:  [time]"
-msgstr "Sort.: [Zeit]"
+msgstr "Sort.  [Alphabet]"
 
 # MSG_SORTING c=20 r=1
 #: cardreader.cpp:746
@@ -2107,25 +1260,25 @@ msgstr "Sortiere Dateien"
 msgid "Sound      [loud]"
 msgstr "Sound      [laut]"
 
+# 
+#: ultralcd.cpp:3061
+msgid "Slight skew:"
+msgstr "Leicht.Schr:"
+
 # MSG_SOUND_MUTE c=17 r=1
-#:
+#: 
 msgid "Sound      [mute]"
 msgstr "Sound     [stumm]"
+
+# 
+#: Marlin_main.cpp:4871
+msgid "Some problem encountered, Z-leveling enforced ..."
+msgstr "Fehler aufgetreten, Z-Kalibrierung erforderlich..."
 
 # MSG_SOUND_ONCE c=17 r=1
 #: sound.h:7
 msgid "Sound      [once]"
 msgstr "Sound    [einmal]"
-
-# 
-#:
-msgid "Sound     [assist]"
-msgstr "Sound     [assist]"
-
-# 
-#: sound.h:9
-msgid "Sound     [blind]"
-msgstr "Sound     [blind]"
 
 # MSG_SOUND_SILENT c=17 r=1
 #: sound.h:8
@@ -2133,7 +1286,7 @@ msgid "Sound    [silent]"
 msgstr "Sound     [leise]"
 
 # MSG_SPEED
-#: ultralcd.cpp:6840
+#: ultralcd.cpp:6926
 msgid "Speed"
 msgstr "Geschwindigkeit"
 
@@ -2142,40 +1295,15 @@ msgstr "Geschwindigkeit"
 msgid "Spinning"
 msgstr "Dreht sich"
 
-# MSG_AUTO_DEPLETE_ON c=17 r=1
-#: ultralcd.cpp:5098
-msgid "SpoolJoin    [on]"
-msgstr "SpoolJoin    [an]"
-
-# 
-#: ultralcd.cpp:5094
-msgid "SpoolJoin   [N/A]"
-msgstr "SpoolJoin   [N/V]"
-
-# MSG_AUTO_DEPLETE_OFF c=17 r=1
-#: ultralcd.cpp:5102
-msgid "SpoolJoin   [off]"
-msgstr "SpoolJoin   [aus]"
-
 # MSG_TEMP_CAL_WARNING c=20 r=4
-#: Marlin_main.cpp:4330
+#: Marlin_main.cpp:4368
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr "Stabile Umgebungs- temperatur 21-26C und feste Stand- flaeche erforderlich"
 
 # MSG_STATISTICS
-#: ultralcd.cpp:6753
+#: ultralcd.cpp:6839
 msgid "Statistics  "
 msgstr "Statistiken "
-
-# 
-#: ultralcd.cpp:5551
-msgid "Steel sheets"
-msgstr "Stahlbleche"
-
-# MSG_STEPPER_TOO_HIGH
-#: stepper.cpp:345
-msgid "Steprate too high: "
-msgstr "Schrittrate zu hoch: "
 
 # MSG_STOP_PRINT
 #: messages.c:93
@@ -2185,60 +1313,55 @@ msgstr "Druck abbrechen"
 # MSG_STOPPED
 #: messages.c:94
 msgid "STOPPED. "
-msgstr "GESTOPPT. "
+msgstr "GESTOPPT."
 
 # MSG_SUPPORT
-#: ultralcd.cpp:6762
+#: ultralcd.cpp:6848
 msgid "Support"
-msgstr "Support"
+msgstr ""
 
 # MSG_SELFTEST_SWAPPED
-#: ultralcd.cpp:7873
+#: ultralcd.cpp:7959
 msgid "Swapped"
 msgstr "Ausgetauscht"
 
 # MSG_TEMP_CALIBRATION c=20 r=1
 #: messages.c:95
 msgid "Temp. cal.          "
-msgstr "Temp Kalib. "
+msgstr "Temp Kalib.         "
 
 # MSG_TEMP_CALIBRATION_ON c=20 r=1
-#: ultralcd.cpp:5581
+#: ultralcd.cpp:5686
 msgid "Temp. cal.   [on]"
-msgstr "Temp. Kal.   [AN]"
+msgstr "Temp. Kal.   [an]"
 
 # MSG_TEMP_CALIBRATION_OFF c=20 r=1
-#: ultralcd.cpp:5579
+#: ultralcd.cpp:5684
 msgid "Temp. cal.  [off]"
-msgstr "Temp. Kal.  [AUS]"
+msgstr "Temp. Kal.  [aus]"
 
 # MSG_CALIBRATION_PINDA_MENU c=17 r=1
-#: ultralcd.cpp:5675
+#: ultralcd.cpp:5780
 msgid "Temp. calibration"
 msgstr "Temp. kalibrieren"
 
-# MSG_TEMPERATURE
-#: ultralcd.cpp:5548
-msgid "Temperature"
-msgstr "Temperatur"
-
 # MSG_TEMP_CAL_FAILED c=20 r=8
-#: ultralcd.cpp:3864
+#: ultralcd.cpp:3951
 msgid "Temperature calibration failed"
 msgstr "Temperaturkalibrierung fehlgeschlagen"
-
-# MSG_PINDA_NOT_CALIBRATED c=20 r=4
-#: Marlin_main.cpp:1403
-msgid "Temperature calibration has not been run yet"
-msgstr "Temperatur wurde\nnoch nicht\nkalibriert"
 
 # MSG_TEMP_CALIBRATION_DONE c=20 r=12
 #: messages.c:96
 msgid "Temperature calibration is finished and active. Temp. calibration can be disabled in menu Settings->Temp. cal."
 msgstr "Temp.kalibrierung ist fertig + aktiv. Temp.kalibrierung kann ausgeschaltet werden im Menu Einstellungen -> Temp.kal."
 
+# MSG_TEMPERATURE
+#: ultralcd.cpp:5650
+msgid "Temperature"
+msgstr "Temperatur"
+
 # MSG_MENU_TEMPERATURES c=15 r=1
-#: ultralcd.cpp:2144
+#: ultralcd.cpp:2251
 msgid "Temperatures"
 msgstr "Temperaturen"
 
@@ -2248,94 +1371,44 @@ msgid "There is still a need to make Z calibration. Please follow the manual, ch
 msgstr "Es ist noch notwendig die Z-Kalibrierung auszufuehren. Bitte befolgen Sie das Handbuch, Kapitel Erste Schritte, Abschnitt Kalibrierablauf."
 
 # 
-#: ultralcd.cpp:2217
-msgid "to load filament"
-msgstr "zum Filament laden"
-
-# 
-#: ultralcd.cpp:2221
-msgid "to unload filament"
-msgstr "zum Filament entladen"
-
-# 
-#: ultralcd.cpp:1829
-msgid "Total"
-msgstr "Gesamt"
-
-# 
-#: ultralcd.cpp:1862
-msgid "Total failures"
-msgstr "Gesamte Fehler"
-
-# 
-#: ultralcd.cpp:2860
+#: ultralcd.cpp:2908
 msgid "Total filament"
 msgstr "Gesamtes Filament"
 
-# MSG_STATS_TOTALFILAMENT c=20
-#: ultralcd.cpp:2186
-msgid "Total filament :"
-msgstr "Gesamtes Filament:"
-
 # 
-#: ultralcd.cpp:2860
+#: ultralcd.cpp:2908
 msgid "Total print time"
 msgstr "Gesamte Druckzeit"
 
-# MSG_STATS_TOTALPRINTTIME c=20
-#: ultralcd.cpp:2203
-msgid "Total print time :"
-msgstr "Gesamte Druckzeit:"
-
-# MSG_ENDSTOP_HIT
-#: messages.c:28
-msgid "TRIGGERED"
-msgstr "AUSGELOEST"
-
 # MSG_TUNE
-#: ultralcd.cpp:6641
+#: ultralcd.cpp:6719
 msgid "Tune"
 msgstr "Feineinstellung"
 
 # 
-#: ultralcd.cpp:2120
-msgid "unknown"
-msgstr "unbekannt"
-
-# 
-#: ultralcd.cpp:4780
+#: ultralcd.cpp:4869
 msgid "Unload"
 msgstr "Entladen"
 
 # 
-#: ultralcd.cpp:5617
-msgid "Unload all"
-msgstr "Alles entladen"
+#: ultralcd.cpp:1820
+msgid "Total failures"
+msgstr "Gesamte Fehler"
+
+# 
+#: ultralcd.cpp:2324
+msgid "to load filament"
+msgstr "Filament laden"
+
+# 
+#: ultralcd.cpp:2328
+msgid "to unload filament"
+msgstr "Filament entladen"
 
 # MSG_UNLOAD_FILAMENT c=17
 #: messages.c:97
 msgid "Unload filament"
 msgstr "Filament entladen"
-
-# MSG_UNLOAD_FILAMENT_1 c=17
-#: ultralcd.cpp:5406
-msgid "Unload filament 1"
-msgstr "Filam. 1 entladen"
-
-# MSG_UNLOAD_FILAMENT_2 c=17
-#: ultralcd.cpp:5407
-msgid "Unload filament 2"
-msgstr "Filam. 2 entladen"
-
-# MSG_UNLOAD_FILAMENT_3 c=17
-#: ultralcd.cpp:5408
-msgid "Unload filament 3"
-msgstr "Filam. 3 entladen"
-
-# MSG_UNLOAD_FILAMENT_4 c=17
-#: ultralcd.cpp:5409
-msgid "Unload filament 4"
-msgstr "Filam. 4 entladen"
 
 # MSG_UNLOADING_FILAMENT c=20 r=1
 #: messages.c:98
@@ -2343,67 +1416,62 @@ msgid "Unloading filament"
 msgstr "Filament auswerfen"
 
 # 
-#: ultralcd.cpp:4779
-msgid "Use unload to remove filament 1 if it protrudes outside of the rear MMU tube. Use eject if it is hidden in tube."
-msgstr "Entladen Sie das Filament 1, wenn er aus dem hinteren MMU-Rohr herausragt. Verwenden Sie den Auswurf, wenn er im Rohr versteckt ist."
+#: ultralcd.cpp:1773
+msgid "Total"
+msgstr "Gesamt"
 
 # MSG_USED c=19 r=1
-#: ultralcd.cpp:5803
+#: ultralcd.cpp:5908
 msgid "Used during print"
 msgstr "Beim Druck benutzt"
 
 # MSG_MENU_VOLTAGES c=15 r=1
-#: ultralcd.cpp:2147
+#: ultralcd.cpp:2254
 msgid "Voltages"
 msgstr "Spannungen"
 
-# MSG_SD_VOL_INIT_FAIL
-#: cardreader.cpp:191
-msgid "volume.init failed"
-msgstr "Dateisystem Init fehlerhaft"
+# 
+#: ultralcd.cpp:2227
+msgid "unknown"
+msgstr "unbekannt"
 
 # MSG_USERWAIT
-#: Marlin_main.cpp:5225
+#: Marlin_main.cpp:5263
 msgid "Wait for user..."
 msgstr "Warte auf Benutzer.."
 
 # MSG_WAITING_TEMP c=20 r=3
-#: ultralcd.cpp:3371
+#: ultralcd.cpp:3458
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Warten bis Heizung und Bett abgekuehlt sind"
 
 # MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ultralcd.cpp:3335
+#: ultralcd.cpp:3422
 msgid "Waiting for PINDA probe cooling"
 msgstr "Warten, bis PINDA- Sonde abgekuehlt ist"
 
-# MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#:
-msgid "WARNING:\nCrash detection\ndisabled in\nStealth mode"
-msgstr "WARNUNG:\nCrash-Erkennung\nim Stealth Modus\nausgeschaltet"
+# 
+#: ultralcd.cpp:4868
+msgid "Use unload to remove filament 1 if it protrudes outside of the rear MMU tube. Use eject if it is hidden in tube."
+msgstr "Entladen Sie das Filament 1, wenn er aus dem hinteren MMU-Rohr herausragt. Verwenden Sie den Auswurf, wenn er im Rohr versteckt ist."
 
 # MSG_CHANGED_BOTH c=20 r=4
-#: Marlin_main.cpp:1527
+#: Marlin_main.cpp:1511
 msgid "Warning: both printer type and motherboard type changed."
 msgstr "Warnung: Druckertyp und Platinentyp wurden beide geaendert."
 
 # MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: Marlin_main.cpp:1519
+#: Marlin_main.cpp:1503
 msgid "Warning: motherboard type changed."
 msgstr "Warnung: Platinentyp wurde geaendert."
 
 # MSG_CHANGED_PRINTER c=20 r=4
-#: Marlin_main.cpp:1523
+#: Marlin_main.cpp:1507
 msgid "Warning: printer type changed."
 msgstr "Warnung: Druckertyp wurde geaendert."
 
-# MSG_FW_VERSION_UNKNOWN c=20 r=8
-#: Marlin_main.cpp:946
-msgid "WARNING: This is an unofficial, unsupported build. Use at your own risk!"
-msgstr "WARNUNG: Dies ist\neine inoffizielle,\nnicht unterstuetzte\nVersion. Benutzung\nauf eigene Gefahr!"
-
 # MSG_UNLOAD_SUCCESSFUL c=20 r=2
-#: Marlin_main.cpp:3072
+#: Marlin_main.cpp:3054
 msgid "Was filament unload successful?"
 msgstr "Konnten Sie das Filament entnehmen?"
 
@@ -2413,146 +1481,337 @@ msgid "Wiring error"
 msgstr "Verdrahtungsfehler"
 
 # MSG_WIZARD c=17 r=1
-#: ultralcd.cpp:5642
+#: ultralcd.cpp:5747
 msgid "Wizard"
 msgstr "Assistent"
 
-# MSG_SD_WORKDIR_FAIL
-#: messages.c:78
-msgid "workDir open failed"
-msgstr "Arbeitsverzeichnis oeffnen misslungen"
-
-# MSG_SD_WRITE_TO_FILE
-#: cardreader.cpp:424
-msgid "Writing to file: "
-msgstr "Schreibe in Datei: "
-
-# 
-#: ultralcd.cpp:4885
-msgid "X-correct"
-msgstr "X-Korrektur"
-
-# 
-#: ultralcd.cpp:5028
-msgid "X-correct:"
-msgstr "X-Korrektur:"
-
 # MSG_XYZ_DETAILS c=19 r=1
-#: ultralcd.cpp:2136
+#: ultralcd.cpp:2243
 msgid "XYZ cal. details"
 msgstr "XYZ Kal. Details"
-
-# MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ultralcd.cpp:3835
-msgid "XYZ calibration all right. Skew will be corrected automatically."
-msgstr "XYZ Kalibrierung in Ordnung. Schraeglauf wird automatisch korrigiert."
-
-# MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ultralcd.cpp:3832
-msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
-msgstr "XYZ Kalibrierung in Ordnung. X/Y Achsen sind etwas schraeg."
-
-# MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ultralcd.cpp:3813
-msgid "XYZ calibration compromised. Front calibration points not reachable."
-msgstr "XYZ-Kalibrierung beeintraechtigt. Vordere Kalibrierpunkte nicht erreichbar."
-
-# MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_LEFT_FAR c=20 r=8
-#: ultralcd.cpp:3699
-msgid "XYZ calibration compromised. Left front calibration point not reachable."
-msgstr "XYZ-Kalibrierung beeintraechtigt. Linker vorderer Kalibrierpunkt nicht erreichbar."
-
-# MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ultralcd.cpp:3816
-msgid "XYZ calibration compromised. Right front calibration point not reachable."
-msgstr "XYZ-Kalibrierung beeintraechtigt. Rechter vorderer Kalibrierpunkt nicht erreichbar."
-
-# 
-#: ultralcd.cpp:3795
-msgid "XYZ calibration failed. Bed calibration point was not found."
-msgstr "XYZ-Kalibrierung fehlgeschlagen. Bett-Kalibrierpunkt nicht gefunden."
-
-# 
-#: ultralcd.cpp:3801
-msgid "XYZ calibration failed. Front calibration points not reachable."
-msgstr "XYZ-Kalibrierung fehlgeschlagen. Vordere Kalibrierpunkte nicht erreichbar."
-
-# 
-#: ultralcd.cpp:3687
-msgid "XYZ calibration failed. Left front calibration point not reachable."
-msgstr "XYZ-Kalibrierung fehlgeschlagen. Linker vorderer Kalibrierpunkt nicht erreichbar."
 
 # MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
 #: messages.c:19
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "XYZ-Kalibrierung fehlgeschlagen. Bitte schauen Sie in das Handbuch."
 
-# 
-#: ultralcd.cpp:3804
-msgid "XYZ calibration failed. Right front calibration point not reachable."
-msgstr "XYZ-Kalibrierung fehlgeschlagen. Rechter vorderer Kalibrierpunkt ist nicht erreichbar."
-
-# MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ultralcd.cpp:3829
-msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
-msgstr "XYZ-Kalibrierung ok. X/Y-Achsen sind senkrecht zueinander Glueckwunsch!"
-
-# 
-#: ultralcd.cpp:2965
-msgid "Y distance from min"
-msgstr "Y Entfernung vom Min"
-
-# MSG_Y_DISTANCE_FROM_MIN c=20 r=1
-#: ultralcd.cpp:2306
-msgid "Y distance from min:"
-msgstr "Y Entfernung vom Min:"
-
-# 
-#: ultralcd.cpp:4886
-msgid "Y-correct"
-msgstr "Y-Korrektur"
-
-# 
-#: ultralcd.cpp:5029
-msgid "Y-correct:"
-msgstr "Y-Korrektur:"
-
 # MSG_YES
 #: messages.c:104
 msgid "Yes"
 msgstr "Ja"
-
-# MSG_FW_VERSION_ALPHA c=20 r=8
-#: Marlin_main.cpp:930
-msgid "You are using firmware alpha version. This is development version. Using this version is not recommended and may cause printer damage."
-msgstr "Sie benutzen eine\nAlpha Firmware\nVersion. Dies ist\neine Entwicklungs-\nversion. Die Ver-\nwendung ist nicht\nempfohlen und kann\nzu Schaeden fuehren."
-
-# MSG_FW_VERSION_BETA c=20 r=8
-#: Marlin_main.cpp:931
-msgid "You are using firmware beta version. This is development version. Using this version is not recommended and may cause printer damage."
-msgstr "Sie benutzen eine\nBeta Firmware\nVersion. Dies ist\neine Entwicklungs-\nversion. Die Ver-\nwendung ist nicht\nempfohlen und kann\nzu Schaeden fuehren."
 
 # MSG_WIZARD_QUIT c=20 r=8
 #: messages.c:103
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr "Sie koennen den Assistenten immer im Menu neu starten: Kalibrierung -> Assistent"
 
+# MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
+#: ultralcd.cpp:3922
+msgid "XYZ calibration all right. Skew will be corrected automatically."
+msgstr "XYZ Kalibrierung in Ordnung. Schraeglauf wird automatisch korrigiert."
+
+# MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
+#: ultralcd.cpp:3919
+msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
+msgstr "XYZ Kalibrierung in Ordnung. X/Y Achsen sind etwas schraeg."
+
 # 
-#: ultralcd.cpp:5030
+#: ultralcd.cpp:5130
+msgid "X-correct:"
+msgstr "X-Korrektur:"
+
+# MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
+#: ultralcd.cpp:3916
+msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
+msgstr "XYZ-Kalibrierung ok. X/Y-Achsen sind senkrecht zueinander Glueckwunsch!"
+
+# MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
+#: ultralcd.cpp:3900
+msgid "XYZ calibration compromised. Front calibration points not reachable."
+msgstr "XYZ-Kalibrierung beeintraechtigt. Vordere Kalibrierpunkte nicht erreichbar."
+
+# MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
+#: ultralcd.cpp:3903
+msgid "XYZ calibration compromised. Right front calibration point not reachable."
+msgstr "XYZ-Kalibrierung beeintraechtigt. Rechter vorderer Kalibrierpunkt nicht erreichbar."
+
+# MSG_LOAD_ALL c=17
+#: ultralcd.cpp:6166
+msgid "Load all"
+msgstr "Alle laden"
+
+# 
+#: ultralcd.cpp:3882
+msgid "XYZ calibration failed. Bed calibration point was not found."
+msgstr "XYZ-Kalibrierung fehlgeschlagen. Bett-Kalibrierpunkt nicht gefunden."
+
+# 
+#: ultralcd.cpp:3888
+msgid "XYZ calibration failed. Front calibration points not reachable."
+msgstr "XYZ-Kalibrierung fehlgeschlagen. Vordere Kalibrierpunkte nicht erreichbar."
+
+# 
+#: ultralcd.cpp:3891
+msgid "XYZ calibration failed. Right front calibration point not reachable."
+msgstr "XYZ-Kalibrierung fehlgeschlagen. Rechter vorderer Kalibrierpunkt ist nicht erreichbar."
+
+"XYZ calibration failed. Right front calibration point not reachable."
+#: 
+msgid "XYZ-Kalibrierung fehlgeschlagen. Rechter vorderer Kalibrierpunkt ist nicht erreichbar."
+msgstr 
+
+# 
+#: ultralcd.cpp:3016
+msgid "Y distance from min"
+msgstr "Y Entfernung vom Min"
+
+# 
+#: ultralcd.cpp:5131
+msgid "Y-correct:"
+msgstr "Y-Korrektur:"
+
+# MSG_OFF
+#: menu.cpp:426
+msgid " [off]"
+msgstr " [aus]"
+
+# 
+#: messages.c:57
+msgid "Back"
+msgstr "Zurueck"
+
+# 
+#: ultralcd.cpp:5639
+msgid "Checks"
+msgstr "Kontrolle"
+
+# 
+#: ultralcd.cpp:7973
+msgid "False triggering"
+msgstr "Falschtriggerung"
+
+# 
+#: ultralcd.cpp:4030
+msgid "FINDA:"
+msgstr ""
+
+# 
+#: ultralcd.cpp:5545
+msgid "Firmware   [none]"
+msgstr "Firmware   [ohne]"
+
+# 
+#: ultralcd.cpp:5551
+msgid "Firmware [strict]"
+msgstr "Firmware [strikt]"
+
+# 
+#: ultralcd.cpp:5548
+msgid "Firmware   [warn]"
+msgstr "Firmware [warnen]"
+
+# 
+#: messages.c:87
+msgid "HW Setup"
+msgstr "HW Einstellungen"
+
+# 
+#: ultralcd.cpp:4034
+msgid "IR:"
+msgstr ""
+
+# 
+#: ultralcd.cpp:7046
+msgid "Magnets comp.[N/A]"
+msgstr "Magnet Komp.  [nv]"
+
+# 
+#: ultralcd.cpp:7044
+msgid "Magnets comp.[Off]"
+msgstr "Magnet Komp. [Aus]"
+
+# 
+#: ultralcd.cpp:7043
+msgid "Magnets comp. [On]"
+msgstr "Magnet Komp.  [An]"
+
+# 
+#: ultralcd.cpp:7035
+msgid "Mesh         [3x3]"
+msgstr "Gitter       [3x3]"
+
+# 
+#: ultralcd.cpp:7036
+msgid "Mesh         [7x7]"
+msgstr "Gitter       [7x7]"
+
+# 
+#: ultralcd.cpp:5677
+msgid "Mesh bed leveling"
+msgstr "MeshBett Ausgleich"
+
+# 
+#: Marlin_main.cpp:856
+msgid "MK3S firmware detected on MK3 printer"
+msgstr "MK3S-Firmware auf MK3-Drucker erkannt"
+
+# 
+#: ultralcd.cpp:5306
+msgid "MMU Mode [Normal]"
+msgstr "MMU Modus[Normal]"
+
+# 
+#: ultralcd.cpp:5307
+msgid "MMU Mode[Stealth]"
+msgstr "MMU Mod.[Stealth]"
+
+# 
+#: ultralcd.cpp:4511
+msgid "Mode change in progress ..."
+msgstr "Moduswechsel erfolgt..."
+
+# 
+#: ultralcd.cpp:5506
+msgid "Model      [none]"
+msgstr "Modell     [ohne]"
+
+# 
+#: ultralcd.cpp:5512
+msgid "Model    [strict]"
+msgstr "Modell   [strikt]"
+
+# 
+#: ultralcd.cpp:5509
+msgid "Model      [warn]"
+msgstr "Modell   [warnen]"
+
+# 
+#: ultralcd.cpp:5467
+msgid "Nozzle d.  [0.25]"
+msgstr "Duese D.   [0.25]"
+
+# 
+#: ultralcd.cpp:5470
+msgid "Nozzle d.  [0.40]"
+msgstr "Duese D.   [0.40]"
+
+# 
+#: ultralcd.cpp:5473
+msgid "Nozzle d.  [0.60]"
+msgstr "Duese D.   [0.60]"
+
+# 
+#: ultralcd.cpp:5421
+msgid "Nozzle     [none]"
+msgstr "Duese      [ohne]"
+
+# 
+#: ultralcd.cpp:5427
+msgid "Nozzle   [strict]"
+msgstr "Duese    [strikt]"
+
+# 
+#: ultralcd.cpp:5424
+msgid "Nozzle     [warn]"
+msgstr "Duese    [warnen]"
+
+# 
+#: util.cpp:510
+msgid "G-code sliced for a different level. Continue?"
+msgstr "G-Code ist fuer einen anderen Level geslict. Fortfahren?"
+
+# 
+#: util.cpp:516
+msgid "G-code sliced for a different level. Please re-slice the model again. Print cancelled."
+msgstr "G-Code ist fuer einen anderen Level geslict. Bitte slicen Sie das Modell erneut. Druck abgebrochen."
+
+# 
+#: util.cpp:427
+msgid "G-code sliced for a different printer type. Continue?"
+msgstr "G-Code ist fuer einen anderen Drucker geslict. Fortfahren?"
+
+# 
+#: util.cpp:433
+msgid "G-code sliced for a different printer type. Please re-slice the model again. Print cancelled."
+msgstr "G-Code ist fuer einen anderen Drucker geslict. Bitte slicen Sie das Modell erneut. Druck abgebrochen."
+
+# 
+#: util.cpp:477
+msgid "G-code sliced for a newer firmware. Continue?"
+msgstr "G-Code ist fuer eine neuere Firmware geslict. Fortfahren?"
+
+# 
+#: util.cpp:483
+msgid "G-code sliced for a newer firmware. Please update the firmware. Print cancelled."
+msgstr "G-Code ist fuer eine neuere Firmware geslict. Bitte die Firmware updaten. Druck abgebrochen."
+
+# 
+#: ultralcd.cpp:4026
+msgid "PINDA:"
+msgstr ""
+
+# 
+#: ultralcd.cpp:2465
+msgid "Preheating to cut"
+msgstr "Heizen zum Schnitt"
+
+# 
+#: ultralcd.cpp:2462
+msgid "Preheating to eject"
+msgstr "Heizen zum Auswurf"
+
+# 
+#: util.cpp:390
+msgid "Printer nozzle diameter differs from the G-code. Continue?"
+msgstr "Der Durchmesser der Druckerduese weicht vom G-Code ab. Fortfahren?"
+
+# 
+#: util.cpp:397
+msgid "Printer nozzle diameter differs from the G-code. Please check the value in settings. Print cancelled."
+msgstr "Der Durchmesser der Druckerduese weicht vom G-Code ab. Bitte ueberpruefen Sie den Wert in den Einstellungen. Druck abgebrochen."
+
+# 
+#: ultralcd.cpp:6683
+msgid "Rename"
+msgstr "Umbenennen"
+
+# 
+#: ultralcd.cpp:6679
+msgid "Select"
+msgstr "Auswahl"
+
+# 
+#: ultralcd.cpp:2245
+msgid "Sensor info"
+msgstr "Sensor Info"
+
+# 
+#: messages.c:58
+msgid "Sheet"
+msgstr "Blech"
+
+# 
+#: sound.h:9
+msgid "Sound    [assist]"
+msgstr "Sound    [Assist]"
+
+# 
+#: ultralcd.cpp:5637
+msgid "Steel sheets"
+msgstr "Stahlbleche"
+
+# 
+#: ultralcd.cpp:5132
 msgid "Z-correct:"
 msgstr "Z-Korrektur:"
 
 # 
-#: ultralcd.cpp:6952
+#: ultralcd.cpp:7038
 msgid "Z-probe nr.    [1]"
 msgstr "Z-Probe Nr.    [1]"
 
 # 
-#: ultralcd.cpp:6954
+#: ultralcd.cpp:7040
 msgid "Z-probe nr.    [3]"
 msgstr "Z-Probe Nr.    [3]"
 
-# MSG_MEASURED_OFFSET
-#: ultralcd.cpp:3024
-msgid "[0;0] point offset"
-msgstr "[0;0] Punktversatz"

--- a/lang/po/new/es.po
+++ b/lang/po/new/es.po
@@ -1,51 +1,19 @@
+# Translation of Prusa-Firmware into Spanish.
+#
 msgid ""
 msgstr ""
-"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: PhraseApp (phraseapp.com)\n"
-
-# MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ultralcd.cpp:4219
-msgid "\e[2JCrash detection can\e[1;0Hbe turned on only in\e[2;0HNormal mode"
-msgstr "\e[2JDec. choque\e[1;0Hpuede ser activada solo en\e[2;0HModo normal"
-
-# MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ultralcd.cpp:4231
-msgid "\e[2JWARNING:\e[1;0HCrash detection\e[2;0Hdisabled in\e[3;0HStealth mode"
-msgstr "\e[2JATENCION:\e[1;0HDec. choque\e[2;0Hdesactivada en\e[3;0HModo silencio"
-
-# 
-#: ultralcd.cpp:3913
-msgid "  1"
-msgstr "  1"
-
-# MSG_PLANNER_BUFFER_BYTES
-#: Marlin_main.cpp:1184
-msgid "  PlannerBufferBytes: "
-msgstr " PlannerBufferBytes: "
-
-# MSG_EXTRUDER_CORRECTION_OFF c=6
-#: ultralcd.cpp:6312
-msgid "  [off"
-msgstr "[inactivo"
-
-# MSG_ERR_COLD_EXTRUDE_STOP
-#: planner.cpp:761
-msgid " cold extrusion prevented"
-msgstr "extrusion en frio prevenida"
-
-# MSG_FREE_MEMORY
-#: Marlin_main.cpp:1182
-msgid " Free Memory: "
-msgstr "Memoria Libre: "
-
-# MSG_CONFIGURATION_VER
-#: Marlin_main.cpp:1172
-msgid " Last Updated: "
-msgstr "Ultima actualizacion: "
+"Language: es\n"
+"Project-Id-Version: Prusa-Firmware\n"
+"POT-Creation-Date: Sun, Sep 22, 2019 1:30:59 PM\n"
+"PO-Revision-Date: Sun, Sep 22, 2019 1:30:59 PM\n"
+"Language-Team: \n"
+"X-Generator: Poedit 2.0.7\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+"Last-Translator: \n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
 # MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE2 c=14
 #: messages.c:39
@@ -57,48 +25,33 @@ msgstr " de 4"
 msgid " of 9"
 msgstr " de 9"
 
-# MSG_OFF
-#: menu.cpp:426
-msgid " [off]"
-msgstr " [apagado]"
+# MSG_MEASURED_OFFSET
+#: ultralcd.cpp:3089
+msgid "[0;0] point offset"
+msgstr "[0;0] punto offset"
 
-# MSG_FACTOR
-#: ultralcd.cpp:6008
-msgid " \002 Fact"
-msgstr " \002 Fact"
+# MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
+#: 
+msgid "Crash detection can\x0abe turned on only in\x0aNormal mode"
+msgstr "Dec. choque puede\x0aser activada solo en\x0aModo normal"
 
-# MSG_MAX
-#: ultralcd.cpp:6007
-msgid " \002 Max"
-msgstr " \002 Max"
-
-# MSG_MIN
-#: ultralcd.cpp:6006
-msgid " \002 Min"
-msgstr " \002 Min"
+# MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
+#: 
+msgid "WARNING:\x0aCrash detection\x0adisabled in\x0aStealth mode"
+msgstr "ATENCION:\x0aDec. choque\x0adesactivada en\x0aModo silencio"
 
 # 
-#: ultralcd.cpp:2294
+#: ultralcd.cpp:2472
 msgid ">Cancel"
 msgstr ">Cancelar"
 
-# MSG_BABYSTEPPING_Z c=20
-#: ultralcd.cpp:3043
-msgid "Adjusting Z"
-msgstr "Ajustar Z"
-
 # MSG_BABYSTEPPING_Z c=15
-#: ultralcd.cpp:3144
+#: ultralcd.cpp:3209
 msgid "Adjusting Z:"
-msgstr "Ajustando Z:"
-
-# MSG_ALL c=19 r=1
-#: messages.c:11
-msgid "All"
-msgstr "Todos"
+msgstr "Ajustar-Z:"
 
 # MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ultralcd.cpp:8209
+#: ultralcd.cpp:8295
 msgid "All correct      "
 msgstr "Todo bien"
 
@@ -108,39 +61,34 @@ msgid "All is done. Happy printing!"
 msgstr "Terminado! Feliz impresion!"
 
 # 
-#: ultralcd.cpp:1979
+#: ultralcd.cpp:2009
 msgid "Ambient"
 msgstr "Ambiente"
 
 # MSG_PRESS c=20
-#: ultralcd.cpp:2573
+#: ultralcd.cpp:2618
 msgid "and press the knob"
 msgstr "Haz clic"
 
 # MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=2
-#: ultralcd.cpp:3442
+#: ultralcd.cpp:3529
 msgid "Are left and right Z~carriages all up?"
 msgstr "Carros Z izq./der. estan arriba maximo?"
 
-# MSG_ADJUSTZ
-#: ultralcd.cpp:2600
-msgid "Auto adjust Z?"
-msgstr "Ajustar Eje Z"
-
 # MSG_AUTO_DEPLETE_ON c=17 r=1
-#: ultralcd.cpp:4706
-msgid "Auto deplete [on]"
-msgstr "Auto agotar[on]"
+#: ultralcd.cpp:5200
+msgid "SpoolJoin    [on]"
+msgstr ""
 
 # 
-#: ultralcd.cpp:4702
-msgid "Auto deplete[N/A]"
-msgstr "Auto agotar[N/A]"
+#: ultralcd.cpp:5196
+msgid "SpoolJoin   [N/A]"
+msgstr ""
 
 # MSG_AUTO_DEPLETE_OFF c=17 r=1
-#: ultralcd.cpp:4710
-msgid "Auto deplete[off]"
-msgstr "Auto agotar[off]"
+#: ultralcd.cpp:5204
+msgid "SpoolJoin   [off]"
+msgstr ""
 
 # MSG_AUTO_HOME
 #: messages.c:11
@@ -148,52 +96,32 @@ msgid "Auto home"
 msgstr "Llevar al origen"
 
 # MSG_AUTOLOAD_FILAMENT c=17
-#: ultralcd.cpp:6731
+#: ultralcd.cpp:6822
 msgid "AutoLoad filament"
 msgstr "Carga automatica de filamento"
 
 # MSG_AUTOLOADING_ONLY_IF_FSENS_ON c=20 r=4
-#: ultralcd.cpp:4375
+#: ultralcd.cpp:4462
 msgid "Autoloading filament available only when filament sensor is turned on..."
 msgstr "La carga automatica de filamento solo funciona si el sensor de filamento esta activado..."
 
 # MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ultralcd.cpp:2768
+#: ultralcd.cpp:2813
 msgid "Autoloading filament is active, just press the knob and insert filament..."
 msgstr "La carga automatica de filamento esta activada, pulse el dial e inserte el filamento..."
 
-# MSG_SELFTEST_AXIS
-#: ultralcd.cpp:7865
-msgid "Axis"
-msgstr "Eje"
-
 # MSG_SELFTEST_AXIS_LENGTH
-#: ultralcd.cpp:7863
+#: ultralcd.cpp:7949
 msgid "Axis length"
 msgstr "Longitud del eje"
 
-# MSG_BABYSTEPPING_X
-#: ultralcd.cpp:2481
-msgid "Babystepping X"
-msgstr "Micropasos X"
-
-# MSG_BABYSTEPPING_Y
-#: ultralcd.cpp:2484
-msgid "Babystepping Y"
-msgstr "Micropasos Y"
-
-# 
-#: messages.c:57
-msgid "Back"
-msgstr "atras"
-
-# MSG_BED
-#: messages.c:15
-msgid "Bed"
-msgstr "Base calefactable "
+# MSG_SELFTEST_AXIS
+#: ultralcd.cpp:7951
+msgid "Axis"
+msgstr "Eje"
 
 # MSG_SELFTEST_BEDHEATER
-#: ultralcd.cpp:7807
+#: ultralcd.cpp:7893
 msgid "Bed / Heater"
 msgstr "Base / Calentador"
 
@@ -208,7 +136,7 @@ msgid "Bed Heating"
 msgstr "Calentando Base"
 
 # MSG_BED_CORRECTION_MENU
-#: ultralcd.cpp:5663
+#: ultralcd.cpp:5768
 msgid "Bed level correct"
 msgstr "Corr. de la cama"
 
@@ -217,23 +145,13 @@ msgstr "Corr. de la cama"
 msgid "Bed leveling failed. Sensor didnt trigger. Debris on nozzle? Waiting for reset."
 msgstr "Nivelacion fallada. Sensor no funciona. Restos en boquilla? Esperando reset."
 
-# MSG_BED_LEVELING_FAILED_PROBE_DISCONNECTED c=20 r=4
-#: Marlin_main.cpp:4508
-msgid "Bed leveling failed. Sensor disconnected or cable broken. Waiting for reset."
-msgstr "Nivelacion fallada. Sensor desconectado o cables danados. Esperando reset."
-
-# MSG_BED_LEVELING_FAILED_POINT_HIGH c=20 r=4
-#: Marlin_main.cpp:4512
-msgid "Bed leveling failed. Sensor triggered too high. Waiting for reset."
-msgstr "Nivelacion fallada. Sensor funciona demasiado pronto. Esperando reset."
-
-# MSG_BEGIN_FILE_LIST
-#: Marlin_main.cpp:4405
-msgid "Begin file list"
-msgstr "Comienzo lista arch. "
+# MSG_BED
+#: messages.c:15
+msgid "Bed"
+msgstr "Base"
 
 # MSG_MENU_BELT_STATUS c=15 r=1
-#: ultralcd.cpp:2007
+#: ultralcd.cpp:2059
 msgid "Belt status"
 msgstr "Estado de la correa"
 
@@ -242,18 +160,13 @@ msgstr "Estado de la correa"
 msgid "Blackout occurred. Recover print?"
 msgstr "Se fue la luz. ?Reanudar la impresion?"
 
-# MSG_CALIBRATE_PINDA c=17 r=1
-#: ultralcd.cpp:4566
-msgid "Calibrate"
-msgstr "Calibrar"
-
-# MSG_CALIBRATE_E c=20 r=1
-#: ultralcd.cpp:4526
-msgid "Calibrate E"
-msgstr "Calibrar E"
+# 
+#: ultralcd.cpp:8297
+msgid "Calibrating home"
+msgstr "Calibrando posicion inicial"
 
 # MSG_CALIBRATE_BED
-#: ultralcd.cpp:5652
+#: ultralcd.cpp:5757
 msgid "Calibrate XYZ"
 msgstr "Calibrar XYZ"
 
@@ -262,13 +175,13 @@ msgstr "Calibrar XYZ"
 msgid "Calibrate Z"
 msgstr "Calibrar Z"
 
-# 
-#: ultralcd.cpp:8211
-msgid "Calibrating home"
-msgstr "Calibrando posicion inicial"
+# MSG_CALIBRATE_PINDA c=17 r=1
+#: ultralcd.cpp:4654
+msgid "Calibrate"
+msgstr "Calibrar"
 
 # MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ultralcd.cpp:3405
+#: ultralcd.cpp:3492
 msgid "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end stoppers. Click when done."
 msgstr "Calibrando XYZ. Gira el dial para subir el extrusor hasta tocar los topes superiores. Despues haz clic."
 
@@ -278,132 +191,32 @@ msgid "Calibrating Z"
 msgstr "Calibrando Z"
 
 # MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ultralcd.cpp:3405
+#: ultralcd.cpp:3492
 msgid "Calibrating Z. Rotate the knob to move the Z carriage up to the end stoppers. Click when done."
 msgstr "Calibrando Z. Gira el dial para subir el extrusor hasta tocar los topes superiores. Despues haz clic."
+
+# MSG_HOMEYZ_DONE
+#: ultralcd.cpp:816
+msgid "Calibration done"
+msgstr "Calibracion OK"
 
 # MSG_MENU_CALIBRATION
 #: messages.c:61
 msgid "Calibration"
 msgstr "Calibracion"
 
-# MSG_HOMEYZ_DONE
-#: ultralcd.cpp:832
-msgid "Calibration done"
-msgstr "Calibracion OK"
-
 # 
-#: ultralcd.cpp:4692
+#: ultralcd.cpp:4781
 msgid "Cancel"
 msgstr "Cancelar"
 
-# MSG_SD_CANT_ENTER_SUBDIR
-#: cardreader.cpp:662
-msgid "Cannot enter subdir: "
-msgstr "Sin acceso subdir: "
-
-# MSG_SD_CANT_OPEN_SUBDIR
-#: cardreader.cpp:97
-msgid "Cannot open subdir"
-msgstr "No se puede abrir subdir"
-
-# MSG_SD_INSERTED
-#:
-msgid "Card inserted"
-msgstr "Tarjeta insertada"
-
 # MSG_SD_REMOVED
-#: ultralcd.cpp:8578
+#: ultralcd.cpp:8679
 msgid "Card removed"
 msgstr "Tarjeta retirada"
 
-# 
-#: ultralcd.cpp:6087
-msgid "Change extruder"
-msgstr "Cambiar extrusor."
-
-# MSG_FILAMENTCHANGE
-#: messages.c:37
-msgid "Change filament"
-msgstr "Cambiar filamento"
-
-# MSG_CNG_SDCARD
-#: ultralcd.cpp:5777
-msgid "Change SD card"
-msgstr "Cambiar tarjeta SD"
-
-# MSG_CHANGE_SUCCESS
-#: ultralcd.cpp:2584
-msgid "Change success!"
-msgstr "Cambio correcto"
-
-# MSG_CORRECTLY c=20
-#: ultralcd.cpp:2661
-msgid "Changed correctly?"
-msgstr "Cambio correcto?"
-
-# MSG_CHANGING_FILAMENT c=20
-#: ultralcd.cpp:1899
-msgid "Changing filament!"
-msgstr "Cambiando filamento"
-
-# MSG_SELFTEST_CHECK_BED c=20
-#: messages.c:81
-msgid "Checking bed     "
-msgstr "Control base cal."
-
-# MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ultralcd.cpp:8200
-msgid "Checking endstops"
-msgstr "Control endstops"
-
-# MSG_SELFTEST_CHECK_HOTEND c=20
-#: ultralcd.cpp:8206
-msgid "Checking hotend  "
-msgstr "Control fusor"
-
-# MSG_SELFTEST_CHECK_FSENSOR c=20
-#: messages.c:82
-msgid "Checking sensors "
-msgstr "Comprobando los sensores"
-
-# MSG_SELFTEST_CHECK_X c=20
-#: ultralcd.cpp:8201
-msgid "Checking X axis  "
-msgstr "Control sensor X"
-
-# MSG_SELFTEST_CHECK_Y c=20
-#: ultralcd.cpp:8202
-msgid "Checking Y axis  "
-msgstr "Control sensor Y"
-
-# MSG_SELFTEST_CHECK_Z c=20
-#: ultralcd.cpp:8203
-msgid "Checking Z axis  "
-msgstr "Control sensor Z"
-
-# 
-#: ultralcd.cpp:5537
-msgid "Checks"
-msgstr "Comprobaciones"
-
-# MSG_ERR_CHECKSUM_MISMATCH
-#: cmdqueue.cpp:444
-msgid "checksum mismatch, Last Line: "
-msgstr "error de checksum, Ult. Linea: "
-
-# MSG_CHOOSE_EXTRUDER c=20 r=1
-#: messages.c:49
-msgid "Choose extruder:"
-msgstr "Elegir extrusor:"
-
-# MSG_CHOOSE_FILAMENT c=20 r=1
-#: messages.c:50
-msgid "Choose filament:"
-msgstr "Elije filamento:"
-
 # MSG_NOT_COLOR
-#: ultralcd.cpp:2673
+#: ultralcd.cpp:2718
 msgid "Color not correct"
 msgstr "Color no homogeneo"
 
@@ -413,19 +226,9 @@ msgid "Cooldown"
 msgstr "Enfriar"
 
 # 
-#: ultralcd.cpp:4108
-msgid "Copy selected language from XFLASH?"
-msgstr "Copiar idioma seleccionado desde XFLASH?"
-
-# 
-#: ultralcd.cpp:4499
+#: ultralcd.cpp:4587
 msgid "Copy selected language?"
 msgstr "Copiar idioma seleccionado?"
-
-# 
-#: ultralcd.cpp:1881
-msgid "Crash"
-msgstr "Choque"
 
 # MSG_CRASHDETECT_ON
 #: messages.c:27
@@ -448,27 +251,27 @@ msgid "Crash detected."
 msgstr "Choque detectado."
 
 # 
-#: Marlin_main.cpp:618
+#: Marlin_main.cpp:600
 msgid "Crash detected. Resume print?"
 msgstr "Choque detectado. Continuar impresion?"
 
-# MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#:
-msgid "Crash detection can\nbe turned on only in\nNormal mode"
-msgstr "Detect. choque solo\npuede activarse en\nmodo Normal"
+# 
+#: ultralcd.cpp:1853
+msgid "Crash"
+msgstr "Choque"
 
 # MSG_CURRENT c=19 r=1
-#: ultralcd.cpp:5804
+#: ultralcd.cpp:5909
 msgid "Current"
 msgstr "Actual"
 
 # MSG_DATE c=17 r=1
-#: ultralcd.cpp:2106
+#: ultralcd.cpp:2213
 msgid "Date:"
 msgstr "Fecha:"
 
 # MSG_DISABLE_STEPPERS
-#: ultralcd.cpp:5552
+#: ultralcd.cpp:5654
 msgid "Disable steppers"
 msgstr "Apagar motores"
 
@@ -478,124 +281,69 @@ msgid "Distance between tip of the nozzle and the bed surface has not been set y
 msgstr "Distancia entre la punta del boquilla y la superficie de la base aun no fijada. Por favor siga el manual, capitulo Primeros Pasos, Calibracion primera capa."
 
 # MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ultralcd.cpp:4968
+#: ultralcd.cpp:5070
 msgid "Do you want to repeat last step to readjust distance between nozzle and heatbed?"
 msgstr "Quieres repetir el ultimo paso para reajustar la distancia boquilla-base?"
 
-# MSG_CLEAN_NOZZLE_E c=20 r=8
-#: ultralcd.cpp:3890
-msgid "E calibration finished. Please clean the nozzle. Click when done."
-msgstr "E calibrado. Limpia nozzle. Haz clic una vez terminado."
-
-# MSG_EXTRUDER_CORRECTION c=9
-#: ultralcd.cpp:4889
-msgid "E-correct"
-msgstr "E-correcion"
-
 # MSG_EXTRUDER_CORRECTION c=10
-#: ultralcd.cpp:5032
+#: ultralcd.cpp:5134
 msgid "E-correct:"
-msgstr "Correccion-E:"
-
-# 
-#: ultralcd.cpp:4780
-msgid "Eject"
-msgstr "Expulsar"
+msgstr "Corregir-E:"
 
 # MSG_EJECT_FILAMENT c=17 r=1
 #: messages.c:53
 msgid "Eject filament"
 msgstr "Expulsar filamento"
 
-# MSG_EJECT_FILAMENT1 c=17 r=1
-#: ultralcd.cpp:5603
-msgid "Eject filament 1"
-msgstr "Expulsar filamento 1"
-
-# MSG_EJECT_FILAMENT2 c=17 r=1
-#: ultralcd.cpp:5604
-msgid "Eject filament 2"
-msgstr "Expulsar filamento 2"
-
-# MSG_EJECT_FILAMENT3 c=17 r=1
-#: ultralcd.cpp:5605
-msgid "Eject filament 3"
-msgstr "Expulsar filamento 3"
-
-# MSG_EJECT_FILAMENT4 c=17 r=1
-#: ultralcd.cpp:5606
-msgid "Eject filament 4"
-msgstr "Expulsar filamento 4"
-
-# MSG_EJECT_FILAMENT5 c=17 r=1
-#: ultralcd.cpp:5607
-msgid "Eject filament 5"
-msgstr "Expulsar filamento 5"
+# 
+#: ultralcd.cpp:4869
+msgid "Eject"
+msgstr "Expulsar"
 
 # MSG_EJECTING_FILAMENT c=20 r=1
-#: mmu.cpp:1435
+#: mmu.cpp:1434
 msgid "Ejecting filament"
 msgstr "Expulsando filamento"
 
-# MSG_END_FILE_LIST
-#: Marlin_main.cpp:4407
-msgid "End file list"
-msgstr "Fin lista arch. "
-
-# MSG_SELFTEST_ENDSTOP
-#: ultralcd.cpp:7825
-msgid "Endstop"
-msgstr "Endstop"
-
 # MSG_SELFTEST_ENDSTOP_NOTHIT c=20 r=1
-#: ultralcd.cpp:7831
+#: ultralcd.cpp:7917
 msgid "Endstop not hit"
 msgstr "Endstop no alcanzado"
 
+# MSG_SELFTEST_ENDSTOP
+#: ultralcd.cpp:7911
+msgid "Endstop"
+msgstr ""
+
 # MSG_SELFTEST_ENDSTOPS
-#: ultralcd.cpp:7813
+#: ultralcd.cpp:7899
 msgid "Endstops"
-msgstr "Endstops"
-
-# MSG_ENDSTOPS_HIT
-#: messages.c:30
-msgid "endstops hit: "
-msgstr "endstops golpean: "
-
-# MSG_LANGUAGE_NAME
-#: language.c:153
-msgid "English"
-msgstr "Espanol"
-
-# MSG_Enqueing
-#:
-msgid "enqueing \""
-msgstr "en cola \""
+msgstr ""
 
 # MSG_STACK_ERROR c=20 r=4
-#: ultralcd.cpp:6773
+#: ultralcd.cpp:6859
 msgid "Error - static memory has been overwritten"
 msgstr "Error - se ha sobre-escrito la memoria estatica"
 
-# MSG_SD_ERR_WRITE_TO_FILE
-#: messages.c:78
-msgid "error writing to file"
-msgstr "error al escribir arch."
+# MSG_FSENS_NOT_RESPONDING c=20 r=4
+#: ultralcd.cpp:4475
+msgid "ERROR: Filament sensor is not responding, please check connection."
+msgstr "ERROR: El sensor de filamento no responde, por favor comprueba la conexion."
 
 # MSG_ERROR
 #: messages.c:28
 msgid "ERROR:"
-msgstr "ERROR:"
+msgstr ""
 
-# MSG_FSENS_NOT_RESPONDING c=20 r=4
-#: ultralcd.cpp:4388
-msgid "ERROR: Filament sensor is not responding, please check connection."
-msgstr "ERROR: El sensor de filamento no responde, por favor comprueba la conexion."
+# MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
+#: ultralcd.cpp:8304
+msgid "Extruder fan:"
+msgstr "Vent.extrusor:"
 
-# 
-#: Marlin_main.cpp:1006
-msgid "External SPI flash W25X20CL not responding."
-msgstr "No responde el flasheo externo SPI W25X20CL"
+# MSG_INFO_EXTRUDER c=15 r=1
+#: ultralcd.cpp:2244
+msgid "Extruder info"
+msgstr "Informacion del extrusor"
 
 # MSG_MOVE_E
 #: messages.c:29
@@ -603,37 +351,12 @@ msgid "Extruder"
 msgstr "Extruir"
 
 # 
-#: ultralcd.cpp:5633
-msgid "Extruder 1"
-msgstr "Extrusor 1"
-
-# 
-#: ultralcd.cpp:5634
-msgid "Extruder 2"
-msgstr "Extrusor 2"
-
-# 
-#: ultralcd.cpp:5635
-msgid "Extruder 3"
-msgstr "Extrusor 3"
-
-# 
-#: ultralcd.cpp:5636
-msgid "Extruder 4"
-msgstr "Extrusor 4"
-
-# MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
-#: ultralcd.cpp:8218
-msgid "Extruder fan:"
-msgstr "Ventilador del extrusor:"
-
-# MSG_INFO_EXTRUDER c=15 r=1
-#: ultralcd.cpp:2137
-msgid "Extruder info"
-msgstr "Informacion del extrusor"
+#: ultralcd.cpp:6846
+msgid "Fail stats MMU"
+msgstr "Estadistica de fallos MMU"
 
 # MSG_FSENS_AUTOLOAD_ON c=17 r=1
-#: ultralcd.cpp:5066
+#: ultralcd.cpp:5168
 msgid "F. autoload  [on]"
 msgstr "Autocarg.Fil[act]"
 
@@ -643,24 +366,14 @@ msgid "F. autoload [N/A]"
 msgstr "Autocarg.Fil[N/D]"
 
 # MSG_FSENS_AUTOLOAD_OFF c=17 r=1
-#: ultralcd.cpp:5068
+#: ultralcd.cpp:5170
 msgid "F. autoload [off]"
 msgstr "Autocarg.Fil[ina]"
 
 # 
-#: ultralcd.cpp:6757
+#: ultralcd.cpp:6843
 msgid "Fail stats"
 msgstr "Estadistica de fallos"
-
-# 
-#: ultralcd.cpp:6760
-msgid "Fail stats MMU"
-msgstr "Estadistica de fallos MMU"
-
-# 
-#: ultralcd.cpp:7887
-msgid "False triggering"
-msgstr "Falsa activación"
 
 # MSG_FAN_SPEED c=14
 #: messages.c:31
@@ -673,12 +386,12 @@ msgid "Fan test"
 msgstr "Test ventiladores"
 
 # MSG_FANS_CHECK_ON c=17 r=1
-#: ultralcd.cpp:5561
+#: ultralcd.cpp:5663
 msgid "Fans check   [on]"
 msgstr "Comprob.vent[act]"
 
 # MSG_FANS_CHECK_OFF c=17 r=1
-#: ultralcd.cpp:5563
+#: ultralcd.cpp:5665
 msgid "Fans check  [off]"
 msgstr "Comprob.vent[ina]"
 
@@ -687,13 +400,8 @@ msgstr "Comprob.vent[ina]"
 msgid "Fil. sensor  [on]"
 msgstr "Sensor Fil. [act]"
 
-# MSG_RESPONSE_POOR c=20 r=2
-#: Marlin_main.cpp:3146
-msgid "Fil. sensor response is poor, disable it?"
-msgstr "La respuesta del sensor de fil es deficiente, ?desactivarlo?"
-
 # MSG_FSENSOR_NA
-#: ultralcd.cpp:5046
+#: ultralcd.cpp:5148
 msgid "Fil. sensor [N/A]"
 msgstr "Sensor Fil. [N/D]"
 
@@ -703,14 +411,9 @@ msgid "Fil. sensor [off]"
 msgstr "Sensor Fil. [ina]"
 
 # 
-#: ultralcd.cpp:1881
+#: ultralcd.cpp:1852
 msgid "Filam. runouts"
 msgstr "Filam. acabado"
-
-# MSG_FILAMENT c=17 r=1
-#: messages.c:30
-msgid "Filament"
-msgstr "Filamento"
 
 # MSG_FILAMENT_CLEAN c=20 r=2
 #: messages.c:32
@@ -718,7 +421,7 @@ msgid "Filament extruding & with correct color?"
 msgstr "Es nitido el color nuevo?"
 
 # MSG_NOT_LOADED c=19
-#: ultralcd.cpp:2669
+#: ultralcd.cpp:2714
 msgid "Filament not loaded"
 msgstr "Fil. no introducido"
 
@@ -727,60 +430,25 @@ msgstr "Fil. no introducido"
 msgid "Filament sensor"
 msgstr "Sensor de filamento"
 
-# MSG_SELFTEST_FILAMENT_SENSOR c=18
-#: ultralcd.cpp:7477
-msgid "Filament sensor:"
-msgstr "Sensor de filamento:"
-
 # MSG_FILAMENT_USED c=19 r=1
-#: ultralcd.cpp:2838
+#: ultralcd.cpp:2885
 msgid "Filament used"
 msgstr "Filamento usado"
 
-# MSG_STATS_FILAMENTUSED c=20
-#: ultralcd.cpp:2142
-msgid "Filament used:  "
-msgstr "Filamento usado: "
+# MSG_PRINT_TIME c=19 r=1
+#: ultralcd.cpp:2886
+msgid "Print time"
+msgstr "Tiempo de imp.:"
 
 # MSG_FILE_INCOMPLETE c=20 r=2
-#: ultralcd.cpp:8346
+#: ultralcd.cpp:8432
 msgid "File incomplete. Continue anyway?"
 msgstr "Archivo incompleto. ?Continuar de todos modos?"
-
-# MSG_SD_FILE_OPENED
-#: cardreader.cpp:395
-msgid "File opened: "
-msgstr "Arch. abierto: "
-
-# MSG_SD_FILE_SELECTED
-#: cardreader.cpp:401
-msgid "File selected"
-msgstr "Arch. elegido"
-
-# 
-#: ultralcd.cpp:3943
-msgid "FINDA:"
-msgstr "FINDA:"
 
 # MSG_FINISHING_MOVEMENTS c=20 r=1
 #: messages.c:40
 msgid "Finishing movements"
 msgstr "Term. movimientos"
-
-# 
-#: ultralcd.cpp:5443
-msgid "Firmware   [none]"
-msgstr "Firmware   [ninguno]"
-
-# 
-#: ultralcd.cpp:5446
-msgid "Firmware   [warn]"
-msgstr "Firmware   [aviso]"
-
-# 
-#: ultralcd.cpp:5449
-msgid "Firmware [strict]"
-msgstr "Firmware [estricto]"
 
 # MSG_V2_CALIBRATION c=17 r=1
 #: messages.c:105
@@ -788,7 +456,7 @@ msgid "First layer cal."
 msgstr "Cal. primera cap."
 
 # MSG_WIZARD_SELFTEST c=20 r=8
-#: ultralcd.cpp:4880
+#: ultralcd.cpp:4982
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr "Primero, hare el Selftest para comprobar los problemas de montaje mas comunes."
 
@@ -798,14 +466,14 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr "Corrige el problema y pulsa el boton en la unidad MMU."
 
 # MSG_FLOW
-#: ultralcd.cpp:6846
+#: ultralcd.cpp:6932
 msgid "Flow"
 msgstr "Flujo"
 
 # MSG_PRUSA3D_FORUM
-#: ultralcd.cpp:2099
+#: ultralcd.cpp:2206
 msgid "forum.prusa3d.com"
-msgstr "forum.prusa3d.com"
+msgstr ""
 
 # MSG_SELFTEST_COOLING_FAN c=20
 #: messages.c:75
@@ -813,57 +481,22 @@ msgid "Front print fan?"
 msgstr "Vent. frontal?"
 
 # MSG_BED_CORRECTION_FRONT c=14 r=1
-#: ultralcd.cpp:3217
+#: ultralcd.cpp:3294
 msgid "Front side[um]"
 msgstr "Frontal [um]"
 
 # MSG_SELFTEST_FANS
-#: ultralcd.cpp:7871
+#: ultralcd.cpp:7957
 msgid "Front/left fans"
 msgstr "Ventiladores frontal/izquierdo"
 
-# 
-#: util.cpp:510
-msgid "G-code sliced for a different level. Continue?"
-msgstr "Código G laminado para un nivel diferente. ¿Continuar?"
-
-# 
-#: util.cpp:516
-msgid "G-code sliced for a different level. Please re-slice the model again. Print cancelled."
-msgstr "Código G laminado para un nivel diferente. Por favor relamina el modelo de nuevo. Impresión cancelada."
-
-# 
-#: util.cpp:427
-msgid "G-code sliced for a different printer type. Continue?"
-msgstr "Código G laminado para un tipo de impresora diferente. ¿Continuar?"
-
-# 
-#: util.cpp:433
-msgid "G-code sliced for a different printer type. Please re-slice the model again. Print cancelled."
-msgstr "Código G laminado para una impresora diferente. Por favor relamina el modelo de nuevo. Impresión cancelada."
-
-# 
-#: util.cpp:477
-msgid "G-code sliced for a newer firmware. Continue?"
-msgstr "Código G laminado para nuevo firmware. ¿Continuar?"
-
-# 
-#: util.cpp:483
-msgid "G-code sliced for a newer firmware. Please update the firmware. Print cancelled."
-msgstr "Código G laminado para nuevo firmware. Por favor actualiza el firmware. Impresión cancelada."
-
 # MSG_SELFTEST_HEATERTHERMISTOR
-#: ultralcd.cpp:7801
+#: ultralcd.cpp:7887
 msgid "Heater/Thermistor"
 msgstr "Calentador/Termistor"
 
-# MSG_HEATING
-#: messages.c:46
-msgid "Heating"
-msgstr "Calentando..."
-
 # MSG_BED_HEATING_SAFETY_DISABLED
-#: Marlin_main.cpp:8411
+#: Marlin_main.cpp:8467
 msgid "Heating disabled by safety timer."
 msgstr "Calentadores desactivados por el temporizador de seguridad."
 
@@ -872,148 +505,163 @@ msgstr "Calentadores desactivados por el temporizador de seguridad."
 msgid "Heating done."
 msgstr "Calentamiento acabado."
 
+# MSG_HEATING
+#: messages.c:46
+msgid "Heating"
+msgstr "Calentando..."
+
 # MSG_WIZARD_WELCOME c=20 r=7
-#: ultralcd.cpp:4859
+#: ultralcd.cpp:4961
 msgid "Hi, I am your Original Prusa i3 printer. Would you like me to guide you through the setup process?"
 msgstr "Hola, soy tu impresora Original Prusa i3. Quieres que te guie a traves de la configuracion?"
 
 # MSG_PRUSA3D_HOWTO
-#: ultralcd.cpp:2100
+#: ultralcd.cpp:2207
 msgid "howto.prusa3d.com"
-msgstr "howto.prusa3d.com"
+msgstr ""
 
-# 
-#: messages.c:87
-msgid "HW Setup"
-msgstr "Configuracion HW"
+# MSG_FILAMENTCHANGE
+#: messages.c:37
+msgid "Change filament"
+msgstr "Cambiar filamento"
+
+# MSG_CHANGE_SUCCESS
+#: ultralcd.cpp:2629
+msgid "Change success!"
+msgstr "Cambio correcto"
+
+# MSG_CORRECTLY c=20
+#: ultralcd.cpp:2706
+msgid "Changed correctly?"
+msgstr "Cambio correcto?"
+
+# MSG_SELFTEST_CHECK_BED c=20
+#: messages.c:81
+msgid "Checking bed     "
+msgstr "Control base cal."
+
+# MSG_SELFTEST_CHECK_ENDSTOPS c=20
+#: ultralcd.cpp:8286
+msgid "Checking endstops"
+msgstr "Control endstops"
+
+# MSG_SELFTEST_CHECK_HOTEND c=20
+#: ultralcd.cpp:8292
+msgid "Checking hotend  "
+msgstr "Control fusor"
+
+# MSG_SELFTEST_CHECK_FSENSOR c=20
+#: messages.c:82
+msgid "Checking sensors "
+msgstr "Comprobando los sensores"
+
+# MSG_SELFTEST_CHECK_X c=20
+#: ultralcd.cpp:8287
+msgid "Checking X axis  "
+msgstr "Control sensor X"
+
+# MSG_SELFTEST_CHECK_Y c=20
+#: ultralcd.cpp:8288
+msgid "Checking Y axis  "
+msgstr "Control sensor Y"
+
+# MSG_SELFTEST_CHECK_Z c=20
+#: ultralcd.cpp:8289
+msgid "Checking Z axis  "
+msgstr "Control sensor Z"
+
+# MSG_CHOOSE_EXTRUDER c=20 r=1
+#: messages.c:49
+msgid "Choose extruder:"
+msgstr "Elegir extrusor:"
+
+# MSG_CHOOSE_FILAMENT c=20 r=1
+#: messages.c:50
+msgid "Choose filament:"
+msgstr "Elije filamento:"
+
+# MSG_FILAMENT c=17 r=1
+#: messages.c:30
+msgid "Filament"
+msgstr "Filamento"
 
 # MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ultralcd.cpp:4889
+#: ultralcd.cpp:4991
 msgid "I will run xyz calibration now. It will take approx. 12 mins."
 msgstr "Hare la calibracion XYZ. Tardara 12 min. aproximadamente."
 
 # MSG_WIZARD_Z_CAL c=20 r=8
-#: ultralcd.cpp:4897
+#: ultralcd.cpp:4999
 msgid "I will run z calibration now."
 msgstr "Voy a hacer Calibracion Z ahora."
 
 # MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ultralcd.cpp:4962
+#: ultralcd.cpp:5064
 msgid "I will start to print line and you will gradually lower the nozzle by rotating the knob, until you reach optimal height. Check the pictures in our handbook in chapter Calibration."
 msgstr "Voy a comenzar a imprimir la linea y tu bajaras el nozzle gradualmente al rotar el dial, hasta que llegues a la altura optima. Mira las imagenes del capitulo Calibracion en el manual."
-
-# MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=60
-#: mesh_bed_calibration.cpp:2481
-msgid "Improving bed calibration point"
-msgstr "Mejorando punto de calibracion base"
 
 # MSG_WATCH
 #: messages.c:99
 msgid "Info screen"
 msgstr "Monitorizar"
 
-# MSG_INIT_SDCARD
-#: ultralcd.cpp:5785
-msgid "Init. SD card"
-msgstr "Iniciar tarj. SD"
-
-# MSG_INSERT_FILAMENT c=20
-#: ultralcd.cpp:2569
-msgid "Insert filament"
-msgstr "Introducir filamento"
-
-# MSG_FILAMENT_LOADING_T0 c=20 r=4
-#: messages.c:33
-msgid "Insert filament into extruder 1. Click when done."
-msgstr "Insertar filamento en el extrusor 1. Haz clic una vez terminado."
-
-# MSG_FILAMENT_LOADING_T1 c=20 r=4
-#: messages.c:34
-msgid "Insert filament into extruder 2. Click when done."
-msgstr "Insertar filamento en el extrusor 2. Haz clic una vez terminado."
-
-# MSG_FILAMENT_LOADING_T2 c=20 r=4
-#: messages.c:35
-msgid "Insert filament into extruder 3. Click when done."
-msgstr "Insertar filamento en el extrusor 3. Haz clic una vez terminado."
-
-# MSG_FILAMENT_LOADING_T3 c=20 r=4
-#: messages.c:36
-msgid "Insert filament into extruder 4. Click when done."
-msgstr "Insertar filamento en el extrusor 4. Haz clic una vez terminado."
-
 # 
-#: ultralcd.cpp:3947
-msgid "IR:"
-msgstr "IR:"
-
-# 
-#: ultralcd.cpp:4922
+#: ultralcd.cpp:5024
 msgid "Is filament 1 loaded?"
 msgstr "?Esta cargado el filamento 1?"
 
+# MSG_INSERT_FILAMENT c=20
+#: ultralcd.cpp:2614
+msgid "Insert filament"
+msgstr "Introducir filamento"
+
 # MSG_WIZARD_FILAMENT_LOADED c=20 r=2
-#: ultralcd.cpp:4925
+#: ultralcd.cpp:5027
 msgid "Is filament loaded?"
 msgstr "Esta el filamento cargado?"
 
 # MSG_WIZARD_PLA_FILAMENT c=20 r=2
-#: ultralcd.cpp:4956
+#: ultralcd.cpp:5058
 msgid "Is it PLA filament?"
 msgstr "Es el filamento PLA?"
 
 # MSG_PLA_FILAMENT_LOADED c=20 r=2
-#: ultralcd.cpp:4701
+#: ultralcd.cpp:4790
 msgid "Is PLA filament loaded?"
 msgstr "Esta el filamento PLA cargado?"
 
 # MSG_STEEL_SHEET_CHECK c=20 r=2
 #: messages.c:92
 msgid "Is steel sheet on heatbed?"
-msgstr "¿Esta colocada la lamina de acero sobre la base?"
-
-# MSG_FIND_BED_OFFSET_AND_SKEW_ITERATION c=20
-#: mesh_bed_calibration.cpp:2223
-msgid "Iteration "
-msgstr "Reiteracion "
-
-# MSG_KILLED
-#: Marlin_main.cpp:7552
-msgid "KILLED. "
-msgstr "PARADA DE EMERGENCIA"
+msgstr "?Esta colocada la lamina de acero sobre la base?"
 
 # 
-#: ultralcd.cpp:1828
-msgid "Last print"
-msgstr "Ultima impresion"
-
-# 
-#: ultralcd.cpp:1845
+#: ultralcd.cpp:1795
 msgid "Last print failures"
 msgstr "Ultimas impresiones fallidas"
 
 # 
-#: ultralcd.cpp:2967
-msgid "Left"
-msgstr "Izquierda"
+#: ultralcd.cpp:1772
+msgid "Last print"
+msgstr "Ultima impresion"
 
 # MSG_SELFTEST_EXTRUDER_FAN c=20
 #: messages.c:76
 msgid "Left hotend fan?"
 msgstr "Vent. izquierdo?"
 
+# 
+#: ultralcd.cpp:3018
+msgid "Left"
+msgstr "Izquierda"
+
 # MSG_BED_CORRECTION_LEFT c=14 r=1
-#: ultralcd.cpp:3215
+#: ultralcd.cpp:3292
 msgid "Left side [um]"
 msgstr "Izquierda [um]"
 
-# MSG_LEFT c=12 r=1
-#: ultralcd.cpp:2308
-msgid "Left:"
-msgstr "Izda:"
-
 # 
-#: ultralcd.cpp:5575
+#: ultralcd.cpp:5680
 msgid "Lin. correction"
 msgstr "Correccion de Linealidad"
 
@@ -1022,48 +670,13 @@ msgstr "Correccion de Linealidad"
 msgid "Live adjust Z"
 msgstr "Micropaso Eje Z"
 
-# MSG_LOAD_ALL c=17
-#: ultralcd.cpp:6059
-msgid "Load all"
-msgstr "Intr. todos fil."
-
 # MSG_LOAD_FILAMENT c=17
 #: messages.c:51
 msgid "Load filament"
 msgstr "Introducir filam."
 
-# MSG_LOAD_FILAMENT_1 c=17
-#: ultralcd.cpp:5576
-msgid "Load filament 1"
-msgstr "Introducir fil. 1"
-
-# MSG_LOAD_FILAMENT_2 c=17
-#: ultralcd.cpp:5577
-msgid "Load filament 2"
-msgstr "Introducir fil. 2"
-
-# MSG_LOAD_FILAMENT_3 c=17
-#: ultralcd.cpp:5578
-msgid "Load filament 3"
-msgstr "Introducir fil. 3"
-
-# MSG_LOAD_FILAMENT_4 c=17
-#: ultralcd.cpp:5579
-msgid "Load filament 4"
-msgstr "Introducir fil. 4"
-
-# MSG_LOAD_FILAMENT_5 c=17
-#: ultralcd.cpp:5582
-msgid "Load filament 5"
-msgstr "Introducir fil. 5"
-
-# 
-#: ultralcd.cpp:6714
-msgid "Load to nozzle"
-msgstr "Cargar a la boquilla"
-
 # MSG_LOADING_COLOR
-#: ultralcd.cpp:2609
+#: ultralcd.cpp:2654
 msgid "Loading color"
 msgstr "Cambiando color"
 
@@ -1073,149 +686,34 @@ msgid "Loading filament"
 msgstr "Introduciendo filam."
 
 # MSG_LOOSE_PULLEY c=20 r=1
-#: ultralcd.cpp:7855
+#: ultralcd.cpp:7941
 msgid "Loose pulley"
 msgstr "Polea suelta"
 
-# MSG_M104_INVALID_EXTRUDER
-#: Marlin_main.cpp:7675
-msgid "M104 Invalid extruder "
-msgstr "M104 Extrusor invalido"
-
-# MSG_M105_INVALID_EXTRUDER
-#: Marlin_main.cpp:7678
-msgid "M105 Invalid extruder "
-msgstr "M105 Extrusor invalido"
-
-# MSG_M109_INVALID_EXTRUDER
-#: Marlin_main.cpp:7681
-msgid "M109 Invalid extruder "
-msgstr "M109 Extrusor invalido"
+# 
+#: ultralcd.cpp:6805
+msgid "Load to nozzle"
+msgstr "Cargar a la boquilla"
 
 # MSG_M117_V2_CALIBRATION c=25 r=1
 #: messages.c:55
 msgid "M117 First layer cal."
 msgstr "M117 Cal. primera cap."
 
-# MSG_M200_INVALID_EXTRUDER
-#: Marlin_main.cpp:5857
-msgid "M200 Invalid extruder "
-msgstr "M200 Extrusor invalido"
-
-# MSG_M218_INVALID_EXTRUDER
-#: Marlin_main.cpp:7684
-msgid "M218 Invalid extruder "
-msgstr "M218 Extrusor invalido"
-
-# MSG_M221_INVALID_EXTRUDER
-#: Marlin_main.cpp:7687
-msgid "M221 Invalid extruder "
-msgstr "M221 Extrusor invalido"
-
-# 
-#: ultralcd.cpp:6957
-msgid "Magnets comp. [On]"
-msgstr "Comp. imanes [On]"
-
-# 
-#: ultralcd.cpp:6960
-msgid "Magnets comp.[N/A]"
-msgstr "Comp. imanes [N/A]"
-
-# 
-#: ultralcd.cpp:6958
-msgid "Magnets comp.[Off]"
-msgstr "Comp. imanes [Off]"
-
 # MSG_MAIN
 #: messages.c:56
 msgid "Main"
 msgstr "Menu principal"
-
-# MSG_MARK_FIL c=20 r=8
-#: ultralcd.cpp:3840
-msgid "Mark filament 100mm from extruder body. Click when done."
-msgstr "Marque el filamento 100 mm por encima del final del extrusor. Haz clic una vez terminado."
-
-# 
-#: ultralcd.cpp:3002
-msgid "Measured skew"
-msgstr "Desviacion medida:"
-
-# MSG_MEASURED_SKEW c=15 r=1
-#: ultralcd.cpp:2335
-msgid "Measured skew:"
-msgstr "Desviación medida:"
 
 # MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=60
 #: messages.c:59
 msgid "Measuring reference height of calibration point"
 msgstr "Midiendo altura del punto de calibracion"
 
-# 
-#: ultralcd.cpp:6949
-msgid "Mesh         [3x3]"
-msgstr "Malla [3x3]"
-
-# 
-#: ultralcd.cpp:6950
-msgid "Mesh         [7x7]"
-msgstr "Malla [7x7]"
-
 # MSG_MESH_BED_LEVELING
-#: ultralcd.cpp:5658
+#: ultralcd.cpp:5763
 msgid "Mesh Bed Leveling"
 msgstr "Nivelacion Mesh Level"
-
-# 
-#: ultralcd.cpp:5572
-msgid "Mesh bed leveling"
-msgstr "Nivelacion Malla Base"
-
-# 
-#: Marlin_main.cpp:881
-msgid "MK3 firmware detected on MK3S printer"
-msgstr "Firmware MK3 detectado en impresora MK3S"
-
-# 
-#: Marlin_main.cpp:856
-msgid "MK3S firmware detected on MK3 printer"
-msgstr "Firmware MK3S detectado en impresora MK3"
-
-# 
-#: ultralcd.cpp:1845
-msgid "MMU fails"
-msgstr "Fallos MMU"
-
-# 
-#: mmu.cpp:1617
-msgid "MMU load failed     "
-msgstr "Carga MMU fallida"
-
-# 
-#: ultralcd.cpp:1845
-msgid "MMU load fails"
-msgstr "Carga MMU falla"
-
-# 
-#: ultralcd.cpp:5204
-msgid "MMU Mode [Normal]"
-msgstr "Modo MMU [Normal]"
-
-# 
-#: ultralcd.cpp:5205
-msgid "MMU Mode[Stealth]"
-msgstr "Modo MMU [Silencioso]"
-
-# 
-#: mmu.cpp:719
-msgid "MMU needs user attention."
-msgstr "MMU necesita atencion del usuario."
-
-# MSG_MMU_NEEDS_ATTENTION c=20 r=4
-#: mmu.cpp:359
-msgid "MMU needs user attention. Fix the issue and then press button on MMU unit."
-msgstr "MMU necesita atencion del usuario. Corrija el problema y luego presione el boton en la unidad MMU."
 
 # MSG_MMU_OK_RESUMING_POSITION c=20 r=4
 #: mmu.cpp:762
@@ -1227,20 +725,30 @@ msgstr "MMU OK. Restaurando posicion..."
 msgid "MMU OK. Resuming temperature..."
 msgstr "MMU OK. Restaurando temperatura..."
 
+# 
+#: ultralcd.cpp:3059
+msgid "Measured skew"
+msgstr "Desviacion med:"
+
+# 
+#: ultralcd.cpp:1796
+msgid "MMU fails"
+msgstr "Fallos MMU"
+
+# 
+#: mmu.cpp:1613
+msgid "MMU load failed     "
+msgstr "Carga MMU fallida"
+
+# 
+#: ultralcd.cpp:1797
+msgid "MMU load fails"
+msgstr "Carga MMU falla"
+
 # MSG_MMU_OK_RESUMING c=20 r=4
 #: mmu.cpp:773
 msgid "MMU OK. Resuming..."
 msgstr "MMU OK. Resumiendo..."
-
-# 
-#: ultralcd.cpp:1862
-msgid "MMU power fails"
-msgstr "Fallo de energia en MMU"
-
-# 
-#: ultralcd.cpp:2112
-msgid "MMU2 connected"
-msgstr "MMU2 conectado"
 
 # MSG_STEALTH_MODE_OFF
 #: messages.c:90
@@ -1252,15 +760,20 @@ msgstr "Modo     [Normal]"
 msgid "Mode     [silent]"
 msgstr "Modo   [silencio]"
 
+# 
+#: mmu.cpp:719
+msgid "MMU needs user attention."
+msgstr "MMU necesita atencion del usuario."
+
+# 
+#: ultralcd.cpp:1823
+msgid "MMU power fails"
+msgstr "Fallo de energia en MMU"
+
 # MSG_STEALTH_MODE_ON
 #: messages.c:91
 msgid "Mode    [Stealth]"
 msgstr "Modo   [Silencio]"
-
-# 
-#: ultralcd.cpp:4424
-msgid "Mode change in progress ..."
-msgstr "Cambio de modo progresando ..."
 
 # MSG_AUTO_MODE_ON
 #: messages.c:12
@@ -1273,89 +786,64 @@ msgid "Mode [high power]"
 msgstr "Modo [rend.pleno]"
 
 # 
-#: ultralcd.cpp:5404
-msgid "Model      [none]"
-msgstr "Modelo      [ninguno]"
-
-# 
-#: ultralcd.cpp:5407
-msgid "Model      [warn]"
-msgstr "Modelo [aviso]"
-
-# 
-#: ultralcd.cpp:5410
-msgid "Model    [strict]"
-msgstr "Modelo [estricto]"
+#: ultralcd.cpp:2219
+msgid "MMU2 connected"
+msgstr "MMU2 conectado"
 
 # MSG_SELFTEST_MOTOR
 #: messages.c:83
 msgid "Motor"
-msgstr "Motor"
+msgstr ""
 
 # MSG_MOVE_AXIS
-#: ultralcd.cpp:5550
+#: ultralcd.cpp:5652
 msgid "Move axis"
 msgstr "Mover ejes"
 
 # MSG_MOVE_X
-#: ultralcd.cpp:4291
+#: ultralcd.cpp:4378
 msgid "Move X"
 msgstr "Mover X"
 
 # MSG_MOVE_Y
-#: ultralcd.cpp:4292
+#: ultralcd.cpp:4379
 msgid "Move Y"
 msgstr "Mover Y"
 
 # MSG_MOVE_Z
-#: ultralcd.cpp:4293
+#: ultralcd.cpp:4380
 msgid "Move Z"
 msgstr "Mover Z"
 
+# MSG_NO_MOVE
+#: Marlin_main.cpp:5292
+msgid "No move."
+msgstr "Sin movimiento"
+
+# MSG_NO_CARD
+#: ultralcd.cpp:6772
+msgid "No SD card"
+msgstr "No hay tarjeta SD"
+
 # 
-#: ultralcd.cpp:2973
+#: ultralcd.cpp:3024
 msgid "N/A"
-msgstr "No disponible"
+msgstr "N/A"
+
+# MSG_NO
+#: messages.c:62
+msgid "No"
+msgstr ""
+
+# MSG_SELFTEST_NOTCONNECTED
+#: ultralcd.cpp:7889
+msgid "Not connected"
+msgstr "No hay conexion "
 
 # 
 #: util.cpp:293
 msgid "New firmware version available:"
 msgstr "Nuevo firmware disponible:"
-
-# MSG_NO
-#: messages.c:62
-msgid "No"
-msgstr "No"
-
-# 
-#:
-msgid "No "
-msgstr "No"
-
-# MSG_ERR_NO_CHECKSUM
-#: cmdqueue.cpp:456
-msgid "No Checksum with line number, Last Line: "
-msgstr "Sin Checksum con linea numero, Ult. Linea: "
-
-# MSG_NO_MOVE
-#: Marlin_main.cpp:5254
-msgid "No move."
-msgstr "Sin movimiento"
-
-# MSG_NO_CARD
-#: ultralcd.cpp:6694
-msgid "No SD card"
-msgstr "No hay tarjeta SD"
-
-# MSG_ERR_NO_THERMISTORS
-#: Marlin_main.cpp:4946
-msgid "No thermistors - no temperature"
-msgstr "Sin termistores - sin temperatura"
-
-# MSG_SELFTEST_NOTCONNECTED
-#: ultralcd.cpp:7803
-msgid "Not connected"
-msgstr "No hay conexion "
 
 # MSG_SELFTEST_FAN_NO c=19
 #: messages.c:79
@@ -1363,152 +851,67 @@ msgid "Not spinning"
 msgstr "Ventilador no gira"
 
 # MSG_WIZARD_V2_CAL c=20 r=8
-#: ultralcd.cpp:4961
+#: ultralcd.cpp:5063
 msgid "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr "Voy a calibrar la distancia entre la punta de la boquilla y la superficie de la base."
 
 # MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ultralcd.cpp:4905
+#: ultralcd.cpp:5007
 msgid "Now I will preheat nozzle for PLA."
-msgstr "Ahora precalentare la boquilla para PLA ."
-
-# 
-#: ultralcd.cpp:4896
-msgid "Now remove the test print from steel sheet."
-msgstr "Ahora retira la prueba de la lamina de acero."
+msgstr "Ahora precalentare la boquilla para PLA."
 
 # MSG_NOZZLE
 #: messages.c:63
 msgid "Nozzle"
 msgstr "Boquilla"
 
-# 
-#: ultralcd.cpp:5319
-msgid "Nozzle     [none]"
-msgstr "Nozzle     [ninguno]"
-
-# 
-#: ultralcd.cpp:5322
-msgid "Nozzle     [warn]"
-msgstr "Nozzle     [aviso]"
-
-# 
-#: ultralcd.cpp:5325
-msgid "Nozzle   [strict]"
-msgstr "Nozzle   [estricto]"
-
-# 
-#: ultralcd.cpp:5365
-msgid "Nozzle d.  [0.25]"
-msgstr "Diam. nozzle [0.25]"
-
-# 
-#: ultralcd.cpp:5368
-msgid "Nozzle d.  [0.40]"
-msgstr "Diam. nozzle  [0.40]"
-
-# 
-#: ultralcd.cpp:5371
-msgid "Nozzle d.  [0.60]"
-msgstr "Diam. nozzle  [0.60]"
-
-# 
-#: ultralcd.cpp:1787
-msgid "Nozzle FAN"
-msgstr "Ventilador de capa"
-
-# MSG_INFO_NOZZLE_FAN c=11 r=1
-#: ultralcd.cpp:1537
-msgid "Nozzle FAN:"
-msgstr "Ventilador de capa:"
-
-# MSG_NOZZLE1
-#: ultralcd.cpp:5995
-msgid "Nozzle2"
-msgstr "Boquilla2"
-
-# MSG_NOZZLE2
-#: ultralcd.cpp:5998
-msgid "Nozzle3"
-msgstr "Boquilla3"
-
-# MSG_OK
-#: Marlin_main.cpp:6333
-msgid "ok"
-msgstr "ok"
-
 # MSG_DEFAULT_SETTINGS_LOADED c=20 r=4
-#: Marlin_main.cpp:1535
+#: Marlin_main.cpp:1519
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr "Se han encontrado ajustes anteriores. Se ajustara el PID, los pasos del extrusor, etc"
 
-# MSG_ENDSTOP_OPEN
-#: messages.c:29
-msgid "open"
-msgstr "abrir"
+# 
+#: ultralcd.cpp:4998
+msgid "Now remove the test print from steel sheet."
+msgstr "Ahora retira la prueba de la lamina de acero."
 
-# MSG_SD_OPEN_FILE_FAIL
-#: messages.c:79
-msgid "open failed, File: "
-msgstr "error apertura, Arch.: "
-
-# MSG_SD_OPENROOT_FAIL
-#: cardreader.cpp:196
-msgid "openRoot failed"
-msgstr "fallo openRoot "
+# 
+#: ultralcd.cpp:1722
+msgid "Nozzle FAN"
+msgstr "Vent. capa"
 
 # MSG_PAUSE_PRINT
-#: ultralcd.cpp:6657
+#: ultralcd.cpp:6735
 msgid "Pause print"
 msgstr "Pausar impresion"
 
-# MSG_PICK_Z
-#: ultralcd.cpp:3463
-msgid "Pick print"
-msgstr "Esc. Modelo Adecuado"
-
 # MSG_PID_RUNNING c=20 r=1
-#: ultralcd.cpp:1613
+#: ultralcd.cpp:1606
 msgid "PID cal.           "
 msgstr "Cal. PID "
 
 # MSG_PID_FINISHED c=20 r=1
-#: ultralcd.cpp:1619
+#: ultralcd.cpp:1612
 msgid "PID cal. finished"
 msgstr "Cal. PID terminada"
 
 # MSG_PID_EXTRUDER c=17 r=1
-#: ultralcd.cpp:5664
+#: ultralcd.cpp:5769
 msgid "PID calibration"
 msgstr "Calibracion PID"
 
 # MSG_PINDA_PREHEAT c=20 r=1
-#: ultralcd.cpp:862
+#: ultralcd.cpp:846
 msgid "PINDA Heating"
 msgstr "Calentando PINDA"
-
-# 
-#: ultralcd.cpp:3939
-msgid "PINDA:"
-msgstr "PINDA:"
 
 # MSG_PAPER c=20 r=8
 #: messages.c:64
 msgid "Place a sheet of paper under the nozzle during the calibration of first 4 points. If the nozzle catches the paper, power off the printer immediately."
 msgstr "Colocar una hoja de papel sobre la superficie de impresion durante la calibracion de los primeros 4 puntos. Si la boquilla mueve el papel, apagar impresora inmediatamente."
 
-# MSG_SELFTEST_PLEASECHECK
-#: ultralcd.cpp:7795
-msgid "Please check :"
-msgstr "Controla :"
-
-# MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: messages.c:100
-msgid "Please check our handbook and fix the problem. Then resume the Wizard by rebooting the printer."
-msgstr "Lee el manual y resuelve el problema. Despues, reinicia la impresora y continua con el Wizard"
-
 # MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ultralcd.cpp:4970
+#: ultralcd.cpp:5072
 msgid "Please clean heatbed and then press the knob."
 msgstr "Limpia la superficie de la base, por favor, y haz clic"
 
@@ -1517,28 +920,28 @@ msgstr "Limpia la superficie de la base, por favor, y haz clic"
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Limpia boquilla para calibracion. Click cuando acabes."
 
+# MSG_SELFTEST_PLEASECHECK
+#: ultralcd.cpp:7881
+msgid "Please check :"
+msgstr "Controla :"
+
+# MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
+#: messages.c:100
+msgid "Please check our handbook and fix the problem. Then resume the Wizard by rebooting the printer."
+msgstr "Lee el manual y resuelve el problema. Despues, reinicia la impresora y continua con el Wizard"
+
 # MSG_WIZARD_LOAD_FILAMENT c=20 r=8
-#: ultralcd.cpp:4804
+#: ultralcd.cpp:4894
 msgid "Please insert PLA filament to the extruder, then press knob to load it."
 msgstr "Inserta, por favor, filamento PLA en el extrusor. Despues haz clic para cargarlo."
 
-# 
-#: ultralcd.cpp:4800
-msgid "Please insert PLA filament to the first tube of MMU, then press the knob to load it."
-msgstr "Por favor introduce el filamento al primer tubo MMU, despues presiona el dial para imprimirlo."
-
-# MSG_WIZARD_INSERT_CORRECT_FILAMENT c=20 r=8
-#: ultralcd.cpp:4109
-msgid "Please load PLA filament and then resume Wizard by rebooting the printer."
-msgstr "Carga filamento PLA y reinicia la impresora para continuar con el asistente"
-
 # MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ultralcd.cpp:4706
+#: ultralcd.cpp:4795
 msgid "Please load PLA filament first."
 msgstr "Carga el filamento PLA primero por favor."
 
 # MSG_CHECK_IDLER c=20 r=4
-#: Marlin_main.cpp:3083
+#: Marlin_main.cpp:3064
 msgid "Please open idler and remove filament manually."
 msgstr "Por favor abate el rodillo de empuje (idler) y retira el filamento manualmente."
 
@@ -1552,20 +955,20 @@ msgstr "Por favor coloca la chapa de acero en la base calefactable."
 msgid "Please press the knob to unload filament"
 msgstr "Por favor, pulsa el dial para descargar el filamento"
 
+# 
+#: ultralcd.cpp:4889
+msgid "Please insert PLA filament to the first tube of MMU, then press the knob to load it."
+msgstr "Por favor introduce el filamento al primer tubo MMU, despues presiona el dial para imprimirlo."
+
 # MSG_PULL_OUT_FILAMENT c=20 r=4
 #: messages.c:70
 msgid "Please pull out filament immediately"
 msgstr "Por favor retire el filamento de inmediato"
 
 # MSG_EJECT_REMOVE c=20 r=4
-#: mmu.cpp:1441
+#: mmu.cpp:1440
 msgid "Please remove filament and then press the knob."
 msgstr "Por favor quite el filamento y luego presione el dial."
-
-# 
-#: ultralcd.cpp:4895
-msgid "Please remove shipping helpers first."
-msgstr "Por favor retira los soportes de envio primero."
 
 # MSG_REMOVE_STEEL_SHEET c=20 r=4
 #: messages.c:74
@@ -1573,19 +976,14 @@ msgid "Please remove steel sheet from heatbed."
 msgstr "Por favor retire la chapa de acero de la base calefactable."
 
 # MSG_RUN_XYZ c=20 r=4
-#: Marlin_main.cpp:4317
+#: Marlin_main.cpp:4355
 msgid "Please run XYZ calibration first."
 msgstr "Por favor realiza la calibracion XYZ primero."
 
 # MSG_UPDATE_MMU2_FW c=20 r=4
-#: mmu.cpp:1360
+#: mmu.cpp:1359
 msgid "Please update firmware in your MMU2. Waiting for reset."
 msgstr "Por favor actualice el firmware en tu MMU2. Esperando el reseteo."
-
-# 
-#: util.cpp:297
-msgid "Please upgrade."
-msgstr "Actualize por favor"
 
 # MSG_PLEASE_WAIT c=20
 #: messages.c:66
@@ -1593,24 +991,19 @@ msgid "Please wait"
 msgstr "Por Favor Espere"
 
 # 
-#: ultralcd.cpp:1881
-msgid "Power failures"
-msgstr "Cortes de energia"
-
-# MSG_POWERUP
-#: messages.c:69
-msgid "PowerUp"
-msgstr "Encendido"
-
-# MSG_PREHEAT
-#: ultralcd.cpp:6644
-msgid "Preheat"
-msgstr "Precalentar"
+#: ultralcd.cpp:4997
+msgid "Please remove shipping helpers first."
+msgstr "Por favor retira los soportes de envio primero."
 
 # MSG_PREHEAT_NOZZLE c=20
 #: messages.c:67
 msgid "Preheat the nozzle!"
 msgstr "Precalienta extrusor!"
+
+# MSG_PREHEAT
+#: ultralcd.cpp:6722
+msgid "Preheat"
+msgstr "Precalentar"
 
 # MSG_WIZARD_HEATING c=20 r=3
 #: messages.c:102
@@ -1618,44 +1011,19 @@ msgid "Preheating nozzle. Please wait."
 msgstr "Precalentando nozzle. Espera por favor."
 
 # 
-#: ultralcd.cpp:2290
-msgid "Preheating to cut"
-msgstr "Precalentando para laminar"
-
-# 
-#: ultralcd.cpp:2287
-msgid "Preheating to eject"
-msgstr "Precalentar para expulsar"
-
-# 
-#: ultralcd.cpp:2280
-msgid "Preheating to load"
-msgstr "Precalentar para cargar"
-
-# 
-#: ultralcd.cpp:2284
-msgid "Preheating to unload"
-msgstr "Precalentar para descargar"
-
-# MSG_PREPARE_FILAMENT c=20 r=1
-#: ultralcd.cpp:1911
-msgid "Prepare new filament"
-msgstr "Preparar filamento"
+#: util.cpp:297
+msgid "Please upgrade."
+msgstr "Actualize por favor"
 
 # MSG_PRESS_TO_PREHEAT c=20 r=4
-#: Marlin_main.cpp:10312
+#: Marlin_main.cpp:10364
 msgid "Press knob to preheat nozzle and continue."
 msgstr "Pulsa el dial para precalentar la boquilla y continue."
 
 # 
-#: ultralcd.cpp:2210
-msgid "Press the knob"
-msgstr "Pulsa el dial"
-
-# 
-#: mmu.cpp:723
-msgid "Press the knob to resume nozzle temperature."
-msgstr "Presiona el dial para continuar con la temperatura de la boquilla."
+#: ultralcd.cpp:1851
+msgid "Power failures"
+msgstr "Cortes de energia"
 
 # MSG_PRINT_ABORTED c=20
 #: messages.c:69
@@ -1663,69 +1031,39 @@ msgid "Print aborted"
 msgstr "Impresion cancelada"
 
 # 
-#: ultralcd.cpp:1789
-msgid "Print FAN"
-msgstr "Ventilador del extrusor"
+#: ultralcd.cpp:2455
+msgid "Preheating to load"
+msgstr "Precalentar para cargar"
 
-# MSG_INFO_PRINT_FAN c=11 r=1
-#: ultralcd.cpp:1549
-msgid "Print FAN: "
-msgstr "Ventilador del fusor:"
+# 
+#: ultralcd.cpp:2459
+msgid "Preheating to unload"
+msgstr "Precalentar para descargar"
 
 # MSG_SELFTEST_PRINT_FAN_SPEED c=18
-#: ultralcd.cpp:8221
+#: ultralcd.cpp:8307
 msgid "Print fan:"
-msgstr "Ventilador del fusor:"
+msgstr "Vent.fusor:"
 
 # MSG_CARD_MENU
 #: messages.c:21
 msgid "Print from SD"
 msgstr "Menu tarjeta SD"
 
+# 
+#: ultralcd.cpp:2317
+msgid "Press the knob"
+msgstr "Pulsa el dial"
+
 # MSG_PRINT_PAUSED c=20 r=1
-#: ultralcd.cpp:1080
+#: ultralcd.cpp:1069
 msgid "Print paused"
 msgstr "Impresion en pausa"
 
-# MSG_PRINT_TIME c=19 r=1
-#: ultralcd.cpp:2838
-msgid "Print time"
-msgstr "Tiempo de imp.:"
-
-# MSG_STATS_PRINTTIME c=20
-#: ultralcd.cpp:2151
-msgid "Print time:  "
-msgstr "Tiempo de imp.:"
-
-# MSG_PRINTER_DISCONNECTED c=20 r=1
-#: ultralcd.cpp:607
-msgid "Printer disconnected"
-msgstr "Impresora desconectada"
-
 # 
-#: util.cpp:473
-msgid "Printer FW version differs from the G-code. Continue?"
-msgstr "FW Impresora difiere de cod.G. ¿Continuar?"
-
-# 
-#: util.cpp:480
-msgid "Printer FW version differs from the G-code. Please check the value in settings. Print cancelled."
-msgstr "FW Impresora difiere de cod. G. Comprueba los valores en ajustes. Impresion cancelada."
-
-# 
-#: util.cpp:506
-msgid "Printer G-code level differs from the G-code. Continue?"
-msgstr "Nivel cod.G Impresora difiere de cod.G. ¿Continuar?"
-
-# 
-#: util.cpp:513
-msgid "Printer G-code level differs from the G-code. Please check the value in settings. Print cancelled."
-msgstr "Nivel cod.G Impresora difiere de cod.G. Comprueba los valores en ajustes. Impresión cancelada."
-
-# MSG_ERR_KILLED
-#: Marlin_main.cpp:7547
-msgid "Printer halted. kill() called!"
-msgstr "Impresora detenida. kill() activado!"
+#: mmu.cpp:723
+msgid "Press the knob to resume nozzle temperature."
+msgstr "Presiona el dial para continuar con la temperatura de la boquilla."
 
 # MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
 #: messages.c:41
@@ -1733,74 +1071,24 @@ msgid "Printer has not been calibrated yet. Please follow the manual, chapter Fi
 msgstr "Impresora no esta calibrada todavia. Por favor usa el manual capitulo Primeros pasos Calibracion flujo."
 
 # 
-#: util.cpp:423
-msgid "Printer model differs from the G-code. Continue?"
-msgstr "Modelo Impresora difiere de cod.G. ¿Continuar?"
-
-# 
-#: util.cpp:430
-msgid "Printer model differs from the G-code. Please check the value in settings. Print cancelled."
-msgstr "Modelo Impresora difiere de cod. G. Comprueba los valores en ajustes. Impresión cancelada."
-
-# 
-#: util.cpp:390
-msgid "Printer nozzle diameter differs from the G-code. Continue?"
-msgstr "Diametro nozzle impresora difiere de cod.G. ¿Continuar?"
-
-# 
-#: util.cpp:397
-msgid "Printer nozzle diameter differs from the G-code. Please check the value in settings. Print cancelled."
-msgstr "Diametro nozzle Impresora difiere de cod.G. Comprueba los valores en ajustes. Impresion cancelada."
-
-# MSG_ERR_STOPPED
-#: messages.c:32
-msgid "Printer stopped due to errors. Fix the error and use M999 to restart. (Temperature is reset. Set it after restarting)"
-msgstr "Impresora parada debido a errores. Arregle el error y use M999 para reinicio. (Temperatura se resetea. Ajustar despues de reinicio)"
-
-# 
-#:
-msgid "Prusa i3 MK2 ready."
-msgstr "Preparado para i3 MK2."
-
-# WELCOME_MSG c=20
-#:
-msgid "Prusa i3 MK2.5 ready."
-msgstr "Preparado para Prusa i3 MK2.5."
-
-# 
-#:
-msgid "Prusa i3 MK3 OK."
-msgstr "Prusa i3 MK3 OK."
-
-# WELCOME_MSG c=20
-#:
-msgid "Prusa i3 MK3 ready."
-msgstr "Prusa i3 MK3 prep."
-
-# 
-#:
-msgid "Prusa i3 MK3S OK."
-msgstr "Prusa i3 MK3S OK."
+#: ultralcd.cpp:1723
+msgid "Print FAN"
+msgstr "Vent.extr"
 
 # MSG_PRUSA3D
-#: ultralcd.cpp:2098
+#: ultralcd.cpp:2205
 msgid "prusa3d.com"
 msgstr "prusa3d.es"
 
 # MSG_BED_CORRECTION_REAR c=14 r=1
-#: ultralcd.cpp:3218
+#: ultralcd.cpp:3295
 msgid "Rear side [um]"
 msgstr "Trasera [um]"
 
 # MSG_RECOVERING_PRINT c=20 r=1
-#: Marlin_main.cpp:9712
+#: Marlin_main.cpp:9764
 msgid "Recovering print    "
 msgstr "Recuperando impresion"
-
-# MSG_REFRESH
-#:
-msgid "Refresh"
-msgstr "Refrescar"
 
 # MSG_REMOVE_OLD_FILAMENT c=20 r=4
 #: mmu.cpp:830
@@ -1808,37 +1096,22 @@ msgid "Remove old filament and press the knob to start loading new filament."
 msgstr "Retire el filamento viejo y presione el dial para comenzar a cargar el nuevo filamento."
 
 # 
-#: ultralcd.cpp:6605
-msgid "Rename"
-msgstr "Renombrar"
-
-# MSG_M119_REPORT
-#: Marlin_main.cpp:5297
-msgid "Reporting endstop status"
-msgstr "Estado endstop"
-
-# 
-#: Marlin_main.cpp:7076
-msgid "Resend"
-msgstr "Reenviar: "
-
-# MSG_RESEND
-#: Marlin_main.cpp:6911
-msgid "Resend: "
-msgstr "Reenviar: "
-
-# MSG_BED_CORRECTION_RESET
-#: ultralcd.cpp:3219
-msgid "Reset"
-msgstr "Reset"
+#: 
+msgid "Prusa i3 MK3S OK."
+msgstr ""
 
 # MSG_CALIBRATE_BED_RESET
-#: ultralcd.cpp:5669
+#: ultralcd.cpp:5774
 msgid "Reset XYZ calibr."
-msgstr "Reset XYZ calibr."
+msgstr ""
+
+# MSG_BED_CORRECTION_RESET
+#: ultralcd.cpp:3296
+msgid "Reset"
+msgstr ""
 
 # MSG_RESUME_PRINT
-#: ultralcd.cpp:6664
+#: ultralcd.cpp:6742
 msgid "Resume print"
 msgstr "Reanudar impres."
 
@@ -1847,113 +1120,68 @@ msgstr "Reanudar impres."
 msgid "Resuming print"
 msgstr "Continuando impresion"
 
-# 
-#: ultralcd.cpp:2968
-msgid "Right"
-msgstr "Derecha"
-
 # MSG_BED_CORRECTION_RIGHT c=14 r=1
-#: ultralcd.cpp:3216
+#: ultralcd.cpp:3293
 msgid "Right side[um]"
 msgstr "Derecha [um]"
 
-# MSG_RIGHT c=12 r=1
-#: ultralcd.cpp:2309
-msgid "Right:"
-msgstr "Der:"
-
-# MSG_E_CAL_KNOB c=20 r=8
-#: ultralcd.cpp:3835
-msgid "Rotate knob until mark reaches extruder body. Click when done."
-msgstr "Rotar el dial hasta que la marca llegue al cuerpo del extrusor. Haz clic una vez terminado."
-
 # MSG_SECOND_SERIAL_ON c=17 r=1
-#: ultralcd.cpp:5587
+#: ultralcd.cpp:5692
 msgid "RPi port     [on]"
 msgstr "Puerto RPi  [act]"
 
 # MSG_SECOND_SERIAL_OFF c=17 r=1
-#: ultralcd.cpp:5585
+#: ultralcd.cpp:5690
 msgid "RPi port    [off]"
 msgstr "Puerto RPi  [ina]"
 
 # MSG_WIZARD_RERUN c=20 r=7
-#: ultralcd.cpp:4723
+#: ultralcd.cpp:4812
 msgid "Running Wizard will delete current calibration results and start from the beginning. Continue?"
 msgstr "Ejecutar el Wizard borrara los valores de calibracion actuales y comenzara de nuevo. Continuar?"
 
 # MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_OFF c=19 r=1
-#: ultralcd.cpp:5220
+#: ultralcd.cpp:5322
 msgid "SD card  [normal]"
 msgstr "Tarj. SD [normal]"
 
-# MSG_SD_CARD_OK
-#: cardreader.cpp:202
-msgid "SD card ok"
-msgstr "Tarj. SD ok"
-
 # MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_ON c=19 r=1
-#: ultralcd.cpp:4238
-msgid "SD card [FlshAir]"
-msgstr "Tarj. SD [FlshAir]"
-
-# MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_ON c=19 r=1
-#: ultralcd.cpp:5218
+#: ultralcd.cpp:5320
 msgid "SD card [flshAir]"
 msgstr "Tarj. SD[FlshAir]"
 
-# MSG_SD_INIT_FAIL
-#: cardreader.cpp:186
-msgid "SD init fail"
-msgstr "Error init SD"
-
-# MSG_SD_PRINTING_BYTE
-#: cardreader.cpp:516
-msgid "SD printing byte "
-msgstr "SD byte impresion"
+# 
+#: ultralcd.cpp:3019
+msgid "Right"
+msgstr "Derecha"
 
 # MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=60
 #: messages.c:38
 msgid "Searching bed calibration point"
 msgstr "Buscando punto de calibracion base"
 
-# 
-#: ultralcd.cpp:6601
-msgid "Select"
-msgstr "Seleccionar"
-
 # MSG_LANGUAGE_SELECT
-#: ultralcd.cpp:5594
+#: ultralcd.cpp:5699
 msgid "Select language"
 msgstr "Cambiar el idioma"
 
-# 
-#: ultralcd.cpp:4943
-msgid "Select nozzle preheat temperature which matches your material."
-msgstr "Selecciona la temperatura para precalentar la boquilla que se ajuste a tu material. "
-
-# 
-#: ultralcd.cpp:4692
-msgid "Select PLA filament:"
-msgstr "Seleccionar filamento PLA:"
-
 # MSG_SELFTEST_OK
-#: ultralcd.cpp:7366
+#: ultralcd.cpp:7452
 msgid "Self test OK"
-msgstr "Self test OK"
+msgstr ""
 
 # MSG_SELFTEST_START c=20
-#: ultralcd.cpp:7152
+#: ultralcd.cpp:7238
 msgid "Self test start  "
 msgstr "Iniciar Selftest"
 
 # MSG_SELFTEST
-#: ultralcd.cpp:5645
+#: ultralcd.cpp:5750
 msgid "Selftest         "
 msgstr "Selftest"
 
 # MSG_SELFTEST_ERROR
-#: ultralcd.cpp:7793
+#: ultralcd.cpp:7879
 msgid "Selftest error !"
 msgstr "Error Selftest !"
 
@@ -1963,27 +1191,22 @@ msgid "Selftest failed  "
 msgstr "Fallo Selftest"
 
 # MSG_FORCE_SELFTEST c=20 r=8
-#: Marlin_main.cpp:1567
+#: Marlin_main.cpp:1551
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr "Se realizara el auto-test para calibrar con precision la vuelta a la posicion inicial sin sensores."
 
 # 
-#: ultralcd.cpp:2138
-msgid "Sensor info"
-msgstr "Info sensor"
+#: ultralcd.cpp:5045
+msgid "Select nozzle preheat temperature which matches your material."
+msgstr "Selecciona la temperatura para precalentar la boquilla que se ajuste a tu material. "
 
 # 
-#: ultralcd.cpp:3938
-msgid "Sensor state"
-msgstr "Estado del sensor"
-
-# 
-#:
-msgid "Sensors info"
-msgstr "Informacion sensores"
+#: ultralcd.cpp:4780
+msgid "Select PLA filament:"
+msgstr "Seleccionar filamento PLA:"
 
 # MSG_SET_TEMPERATURE c=19 r=1
-#: ultralcd.cpp:3227
+#: ultralcd.cpp:3314
 msgid "Set temperature:"
 msgstr "Establecer temp.:"
 
@@ -1992,110 +1215,40 @@ msgstr "Establecer temp.:"
 msgid "Settings"
 msgstr "Configuracion"
 
-# 
-#: ultralcd.cpp:3005
-msgid "Severe skew"
-msgstr "Inclinacion severa"
-
-# MSG_SEVERE_SKEW c=15 r=1
-#: ultralcd.cpp:2346
-msgid "Severe skew:"
-msgstr "Inclinación severa:"
-
-# 
-#: messages.c:58
-msgid "Sheet"
-msgstr "Lamina"
-
 # MSG_SHOW_END_STOPS c=17 r=1
-#: ultralcd.cpp:5666
+#: ultralcd.cpp:5771
 msgid "Show end stops"
 msgstr "Mostrar endstops"
 
 # 
-#:
-msgid "Show pinda state"
-msgstr "Mostrar estado pinda"
-
-# MSG_DWELL
-#: Marlin_main.cpp:3752
-msgid "Sleep..."
-msgstr "En reposo..."
-
-# 
-#: ultralcd.cpp:3004
-msgid "Slight skew"
-msgstr "Ligeramente inclinado"
-
-# MSG_SLIGHT_SKEW c=15 r=1
-#: ultralcd.cpp:2342
-msgid "Slight skew:"
-msgstr "Ligeramente inclinado:"
+#: ultralcd.cpp:4025
+msgid "Sensor state"
+msgstr "Estado del sensor"
 
 # MSG_FILE_CNT c=20 r=4
 #: cardreader.cpp:739
 msgid "Some files will not be sorted. Max. No. of files in 1 folder for sorting is 100."
 msgstr "Algunos archivos no se ordenaran. Maximo 100 archivos por carpeta para ordenar. "
 
-# 
-#: Marlin_main.cpp:4833
-msgid "Some problem encountered, Z-leveling enforced ..."
-msgstr "Problema encontrado, nivelacion Z forzosa ..."
-
 # MSG_SORT_NONE c=17 r=1
-#: ultralcd.cpp:5230
+#: ultralcd.cpp:5332
 msgid "Sort       [none]"
-msgstr "Ordenar       [ninguno]"
+msgstr "Ordenar [ninguno]"
 
 # MSG_SORT_TIME c=17 r=1
-#: ultralcd.cpp:5228
+#: ultralcd.cpp:5330
 msgid "Sort       [time]"
-msgstr "Ordenar       [tiempo]"
+msgstr "Ordenar   [fecha]"
+
+# 
+#: ultralcd.cpp:3062
+msgid "Severe skew:"
+msgstr "Incl.severa:"
 
 # MSG_SORT_ALPHA c=17 r=1
-#: ultralcd.cpp:5229
+#: ultralcd.cpp:5331
 msgid "Sort   [alphabet]"
-msgstr "Ordenar   [Alfabetico]"
-
-# MSG_SORT_NONE c=17 r=1
-#: ultralcd.cpp:4250
-msgid "Sort:      [None]"
-msgstr "Ordena: [Ninguno]"
-
-# MSG_SORT_NONE c=17 r=1
-#: ultralcd.cpp:5043
-msgid "Sort:      [none]"
-msgstr "Ordenar:   [nada]"
-
-# MSG_SORT_TIME c=17 r=1
-#: ultralcd.cpp:4248
-msgid "Sort:      [Time]"
-msgstr "Orden: [Fecha]"
-
-# MSG_SORT_TIME c=17 r=1
-#: ultralcd.cpp:5041
-msgid "Sort:      [time]"
-msgstr "Orden:    [Fecha]"
-
-# MSG_SORT_ALPHA c=17 r=1
-#: ultralcd.cpp:4249
-msgid "Sort:  [Alphabet]"
-msgstr "Orden: [Alfabético]"
-
-# MSG_SORT_ALPHA c=17 r=1
-#: ultralcd.cpp:5042
-msgid "Sort:  [alphabet]"
-msgstr "Ordenar:[alfabet]"
-
-# MSG_SORT_NONE c=17 r=1
-#:
-msgid "Sort:  [none]"
-msgstr "Ordenar: [nada]"
-
-# MSG_SORT_TIME c=17 r=1
-#:
-msgid "Sort:  [time]"
-msgstr "Ordenar: [tiempo]"
+msgstr "Ordenar [alfabet]"
 
 # MSG_SORTING c=20 r=1
 #: cardreader.cpp:746
@@ -2107,25 +1260,25 @@ msgstr "Ordenando archivos"
 msgid "Sound      [loud]"
 msgstr "Sonido     [alto]"
 
+# 
+#: ultralcd.cpp:3061
+msgid "Slight skew:"
+msgstr "Liger.incl.:"
+
 # MSG_SOUND_MUTE c=17 r=1
-#:
+#: 
 msgid "Sound      [mute]"
 msgstr "Sonido[silenciad]"
+
+# 
+#: Marlin_main.cpp:4871
+msgid "Some problem encountered, Z-leveling enforced ..."
+msgstr "Problema encontrado, nivelacion Z forzosa ..."
 
 # MSG_SOUND_ONCE c=17 r=1
 #: sound.h:7
 msgid "Sound      [once]"
 msgstr "Sonido  [una vez]"
-
-# 
-#:
-msgid "Sound     [assist]"
-msgstr "Sonido [asistido]"
-
-# 
-#: sound.h:9
-msgid "Sound     [blind]"
-msgstr "Sonido     [ciego]"
 
 # MSG_SOUND_SILENT c=17 r=1
 #: sound.h:8
@@ -2133,7 +1286,7 @@ msgid "Sound    [silent]"
 msgstr "Sonido[silencios]"
 
 # MSG_SPEED
-#: ultralcd.cpp:6840
+#: ultralcd.cpp:6926
 msgid "Speed"
 msgstr "Velocidad"
 
@@ -2142,40 +1295,15 @@ msgstr "Velocidad"
 msgid "Spinning"
 msgstr "Ventilador girando"
 
-# MSG_AUTO_DEPLETE_ON c=17 r=1
-#: ultralcd.cpp:5098
-msgid "SpoolJoin    [on]"
-msgstr "SpoolJoin    [on]"
-
-# 
-#: ultralcd.cpp:5094
-msgid "SpoolJoin   [N/A]"
-msgstr "SpoolJoin   [N/A]"
-
-# MSG_AUTO_DEPLETE_OFF c=17 r=1
-#: ultralcd.cpp:5102
-msgid "SpoolJoin   [off]"
-msgstr "SpoolJoin   [off]"
-
 # MSG_TEMP_CAL_WARNING c=20 r=4
-#: Marlin_main.cpp:4330
+#: Marlin_main.cpp:4368
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr "Se necesita una temperatura ambiente ente 21 y 26C y un soporte rigido."
 
 # MSG_STATISTICS
-#: ultralcd.cpp:6753
+#: ultralcd.cpp:6839
 msgid "Statistics  "
 msgstr "Estadisticas "
-
-# 
-#: ultralcd.cpp:5551
-msgid "Steel sheets"
-msgstr "Lámina de acero"
-
-# MSG_STEPPER_TOO_HIGH
-#: stepper.cpp:345
-msgid "Steprate too high: "
-msgstr "Pasos muy altos: "
 
 # MSG_STOP_PRINT
 #: messages.c:93
@@ -2188,12 +1316,12 @@ msgid "STOPPED. "
 msgstr "PARADA"
 
 # MSG_SUPPORT
-#: ultralcd.cpp:6762
+#: ultralcd.cpp:6848
 msgid "Support"
 msgstr "Soporte"
 
 # MSG_SELFTEST_SWAPPED
-#: ultralcd.cpp:7873
+#: ultralcd.cpp:7959
 msgid "Swapped"
 msgstr "Intercambiado"
 
@@ -2203,42 +1331,37 @@ msgid "Temp. cal.          "
 msgstr "Cal. temp. "
 
 # MSG_TEMP_CALIBRATION_ON c=20 r=1
-#: ultralcd.cpp:5581
+#: ultralcd.cpp:5686
 msgid "Temp. cal.   [on]"
-msgstr "Cal. temp.   [ON]"
+msgstr "Cal. temp.   [on]"
 
 # MSG_TEMP_CALIBRATION_OFF c=20 r=1
-#: ultralcd.cpp:5579
+#: ultralcd.cpp:5684
 msgid "Temp. cal.  [off]"
-msgstr "Cal. temp.  [OFF]"
+msgstr "Cal. temp.  [off]"
 
 # MSG_CALIBRATION_PINDA_MENU c=17 r=1
-#: ultralcd.cpp:5675
+#: ultralcd.cpp:5780
 msgid "Temp. calibration"
 msgstr "Calibracion temp."
 
-# MSG_TEMPERATURE
-#: ultralcd.cpp:5548
-msgid "Temperature"
-msgstr "Temperatura"
-
 # MSG_TEMP_CAL_FAILED c=20 r=8
-#: ultralcd.cpp:3864
+#: ultralcd.cpp:3951
 msgid "Temperature calibration failed"
 msgstr "Fallo de la calibracion de temperatura"
-
-# MSG_PINDA_NOT_CALIBRATED c=20 r=4
-#: Marlin_main.cpp:1403
-msgid "Temperature calibration has not been run yet"
-msgstr "La temperatura de calibracion no ha sido ajustada"
 
 # MSG_TEMP_CALIBRATION_DONE c=20 r=12
 #: messages.c:96
 msgid "Temperature calibration is finished and active. Temp. calibration can be disabled in menu Settings->Temp. cal."
 msgstr "Calibracion temperatura terminada. Haz clic para continuar."
 
+# MSG_TEMPERATURE
+#: ultralcd.cpp:5650
+msgid "Temperature"
+msgstr "Temperatura"
+
 # MSG_MENU_TEMPERATURES c=15 r=1
-#: ultralcd.cpp:2144
+#: ultralcd.cpp:2251
 msgid "Temperatures"
 msgstr "Temperaturas"
 
@@ -2248,94 +1371,44 @@ msgid "There is still a need to make Z calibration. Please follow the manual, ch
 msgstr "Todavia es necesario hacer una calibracion Z. Por favor siga el manual, capitulo Primeros pasos, seccion Calibracion del flujo."
 
 # 
-#: ultralcd.cpp:2217
-msgid "to load filament"
-msgstr "para cargar el filamento"
-
-# 
-#: ultralcd.cpp:2221
-msgid "to unload filament"
-msgstr "para descargar el filamento"
-
-# 
-#: ultralcd.cpp:1829
-msgid "Total"
-msgstr "Total"
-
-# 
-#: ultralcd.cpp:1862
-msgid "Total failures"
-msgstr "Fallos totales"
-
-# 
-#: ultralcd.cpp:2860
+#: ultralcd.cpp:2908
 msgid "Total filament"
 msgstr "Filamento total:"
 
-# MSG_STATS_TOTALFILAMENT c=20
-#: ultralcd.cpp:2186
-msgid "Total filament :"
-msgstr "Filamento total:"
-
 # 
-#: ultralcd.cpp:2860
+#: ultralcd.cpp:2908
 msgid "Total print time"
 msgstr "Tiempo total :"
 
-# MSG_STATS_TOTALPRINTTIME c=20
-#: ultralcd.cpp:2203
-msgid "Total print time :"
-msgstr "Tiempo total :"
-
-# MSG_ENDSTOP_HIT
-#: messages.c:28
-msgid "TRIGGERED"
-msgstr "ACTIVADO"
-
 # MSG_TUNE
-#: ultralcd.cpp:6641
+#: ultralcd.cpp:6719
 msgid "Tune"
 msgstr "Ajustar"
 
 # 
-#: ultralcd.cpp:2120
-msgid "unknown"
-msgstr "desconocido"
-
-# 
-#: ultralcd.cpp:4780
+#: ultralcd.cpp:4869
 msgid "Unload"
 msgstr "Descargar"
 
 # 
-#: ultralcd.cpp:5617
-msgid "Unload all"
-msgstr "Soltar todos fil."
+#: ultralcd.cpp:1820
+msgid "Total failures"
+msgstr "Fallos totales"
+
+# 
+#: ultralcd.cpp:2324
+msgid "to load filament"
+msgstr "para cargar el filamento"
+
+# 
+#: ultralcd.cpp:2328
+msgid "to unload filament"
+msgstr "para descargar el filamento"
 
 # MSG_UNLOAD_FILAMENT c=17
 #: messages.c:97
 msgid "Unload filament"
 msgstr "Soltar filamento"
-
-# MSG_UNLOAD_FILAMENT_1 c=17
-#: ultralcd.cpp:5406
-msgid "Unload filament 1"
-msgstr "Soltar fil. 1"
-
-# MSG_UNLOAD_FILAMENT_2 c=17
-#: ultralcd.cpp:5407
-msgid "Unload filament 2"
-msgstr "Soltar fil. 2"
-
-# MSG_UNLOAD_FILAMENT_3 c=17
-#: ultralcd.cpp:5408
-msgid "Unload filament 3"
-msgstr "Soltar fil. 3"
-
-# MSG_UNLOAD_FILAMENT_4 c=17
-#: ultralcd.cpp:5409
-msgid "Unload filament 4"
-msgstr "Soltar fil. 4"
 
 # MSG_UNLOADING_FILAMENT c=20 r=1
 #: messages.c:98
@@ -2343,69 +1416,64 @@ msgid "Unloading filament"
 msgstr "Soltando filamento"
 
 # 
-#: ultralcd.cpp:4779
-msgid "Use unload to remove filament 1 if it protrudes outside of the rear MMU tube. Use eject if it is hidden in tube."
-msgstr "Usa unload para retirar el filamento 1 si sobresale por fuera de la parte trasera del tubo MMU. Usa Expulsar si esta escondido dentro del tubo"
+#: ultralcd.cpp:1773
+msgid "Total"
+msgstr ""
 
 # MSG_USED c=19 r=1
-#: ultralcd.cpp:5803
+#: ultralcd.cpp:5908
 msgid "Used during print"
 msgstr "Usado en impresion"
 
 # MSG_MENU_VOLTAGES c=15 r=1
-#: ultralcd.cpp:2147
+#: ultralcd.cpp:2254
 msgid "Voltages"
 msgstr "Voltajes"
 
-# MSG_SD_VOL_INIT_FAIL
-#: cardreader.cpp:191
-msgid "volume.init failed"
-msgstr "fallo volume.init \n"
+# 
+#: ultralcd.cpp:2227
+msgid "unknown"
+msgstr "desconocido"
 
 # MSG_USERWAIT
-#: Marlin_main.cpp:5225
+#: Marlin_main.cpp:5263
 msgid "Wait for user..."
 msgstr "Esperando ordenes"
 
 # MSG_WAITING_TEMP c=20 r=3
-#: ultralcd.cpp:3371
+#: ultralcd.cpp:3458
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Esperando enfriamiento de la base y extrusor."
 
 # MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ultralcd.cpp:3335
+#: ultralcd.cpp:3422
 msgid "Waiting for PINDA probe cooling"
 msgstr "Esperando a que se enfrie la sonda PINDA"
 
-# MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#:
-msgid "WARNING:\nCrash detection\ndisabled in\nStealth mode"
-msgstr "ATENCION:\nDetect. choque \ndesactivada en\nmodo Silencioso"
+# 
+#: ultralcd.cpp:4868
+msgid "Use unload to remove filament 1 if it protrudes outside of the rear MMU tube. Use eject if it is hidden in tube."
+msgstr "Usa unload para retirar el filamento 1 si sobresale por fuera de la parte trasera del tubo MMU. Usa Expulsar si esta escondido dentro del tubo"
 
 # MSG_CHANGED_BOTH c=20 r=4
-#: Marlin_main.cpp:1527
+#: Marlin_main.cpp:1511
 msgid "Warning: both printer type and motherboard type changed."
 msgstr "Aviso: tanto el tipo de impresora como el tipo de la placa han cambiado."
 
 # MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: Marlin_main.cpp:1519
+#: Marlin_main.cpp:1503
 msgid "Warning: motherboard type changed."
 msgstr "Cuidado: el tipo de placa ha cambiado."
 
 # MSG_CHANGED_PRINTER c=20 r=4
-#: Marlin_main.cpp:1523
+#: Marlin_main.cpp:1507
 msgid "Warning: printer type changed."
 msgstr "Cuidado: Ha cambiado el tipo de impresora."
 
-# MSG_FW_VERSION_UNKNOWN c=20 r=8
-#: Marlin_main.cpp:946
-msgid "WARNING: This is an unofficial, unsupported build. Use at your own risk!"
-msgstr "CUIDADO: Esta es una version no-oficial y sin soporte. ¡Usala bajo tu responsabilidad!"
-
 # MSG_UNLOAD_SUCCESSFUL c=20 r=2
-#: Marlin_main.cpp:3072
+#: Marlin_main.cpp:3054
 msgid "Was filament unload successful?"
-msgstr "?Se cargo con exito el filamento?"
+msgstr "?Se cargocon exito el filamento?"
 
 # MSG_SELFTEST_WIRINGERROR
 #: messages.c:85
@@ -2413,146 +1481,332 @@ msgid "Wiring error"
 msgstr "Error de conexion"
 
 # MSG_WIZARD c=17 r=1
-#: ultralcd.cpp:5642
+#: ultralcd.cpp:5747
 msgid "Wizard"
-msgstr "Wizard"
-
-# MSG_SD_WORKDIR_FAIL
-#: messages.c:78
-msgid "workDir open failed"
-msgstr "error al abrir workDir"
-
-# MSG_SD_WRITE_TO_FILE
-#: cardreader.cpp:424
-msgid "Writing to file: "
-msgstr "Escribiendo al arch.: "
-
-# 
-#: ultralcd.cpp:4885
-msgid "X-correct"
-msgstr "X-correcion"
-
-# 
-#: ultralcd.cpp:5028
-msgid "X-correct:"
-msgstr "Correccion-X:"
+msgstr ""
 
 # MSG_XYZ_DETAILS c=19 r=1
-#: ultralcd.cpp:2136
+#: ultralcd.cpp:2243
 msgid "XYZ cal. details"
 msgstr "Detalles de calibracion XYZ"
-
-# MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ultralcd.cpp:3835
-msgid "XYZ calibration all right. Skew will be corrected automatically."
-msgstr "Calibracion XYZ correcta. La inclinacion se corregira automaticamente."
-
-# MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ultralcd.cpp:3832
-msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
-msgstr "Calibracion XYZ correcta. Los ejes X / Y estan ligeramente inclinados. Buen trabajo!"
-
-# MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ultralcd.cpp:3813
-msgid "XYZ calibration compromised. Front calibration points not reachable."
-msgstr "Calibrazion XYZ comprometida. Puntos frontales no alcanzables."
-
-# MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_LEFT_FAR c=20 r=8
-#: ultralcd.cpp:3699
-msgid "XYZ calibration compromised. Left front calibration point not reachable."
-msgstr "Calibrazion XYZ comprometida. Punto frontal izquierdo no alcanzable."
-
-# MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ultralcd.cpp:3816
-msgid "XYZ calibration compromised. Right front calibration point not reachable."
-msgstr "Calibrazion XYZ comprometida. Punto frontal derecho no alcanzable."
-
-# 
-#: ultralcd.cpp:3795
-msgid "XYZ calibration failed. Bed calibration point was not found."
-msgstr "Calibracion XYZ fallada. Puntos de calibracion en la base no encontrados."
-
-# 
-#: ultralcd.cpp:3801
-msgid "XYZ calibration failed. Front calibration points not reachable."
-msgstr "Calibracion XYZ fallada. Puntos frontales no alcanzables."
-
-# 
-#: ultralcd.cpp:3687
-msgid "XYZ calibration failed. Left front calibration point not reachable."
-msgstr "Calibracion XYZ fallada. Punto frontal izquierdo no alcanzable."
 
 # MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
 #: messages.c:19
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "Calibracion XYZ fallada. Consulta el manual por favor."
 
-# 
-#: ultralcd.cpp:3804
-msgid "XYZ calibration failed. Right front calibration point not reachable."
-msgstr "Calibracion XYZ fallad. Punto frontal derecho no alcanzable."
-
-# MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ultralcd.cpp:3829
-msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
-msgstr "Calibracion XYZ ok. Ejes X/Y perpendiculares. Enhorabuena!"
-
-# 
-#: ultralcd.cpp:2965
-msgid "Y distance from min"
-msgstr "Distancia en Y desde el min"
-
-# MSG_Y_DISTANCE_FROM_MIN c=20 r=1
-#: ultralcd.cpp:2306
-msgid "Y distance from min:"
-msgstr "Distancia en Y desde el min:"
-
-# 
-#: ultralcd.cpp:4886
-msgid "Y-correct"
-msgstr "Y-correccion"
-
-# 
-#: ultralcd.cpp:5029
-msgid "Y-correct:"
-msgstr "Correccion-Y:"
-
 # MSG_YES
 #: messages.c:104
 msgid "Yes"
 msgstr "Si"
-
-# MSG_FW_VERSION_ALPHA c=20 r=8
-#: Marlin_main.cpp:930
-msgid "You are using firmware alpha version. This is development version. Using this version is not recommended and may cause printer damage."
-msgstr "Estas usando una version alpha de firmware. Esta es una version de desarrollo. No recomendamos usar esta version y podria causar daños a la impresora."
-
-# MSG_FW_VERSION_BETA c=20 r=8
-#: Marlin_main.cpp:931
-msgid "You are using firmware beta version. This is development version. Using this version is not recommended and may cause printer damage."
-msgstr "Estas usando una version beta de firmware. Es una version en desarrollo. No recomendamos que la uses y podria causar daños a la impresora."
 
 # MSG_WIZARD_QUIT c=20 r=8
 #: messages.c:103
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr "Siempre puedes acceder al asistente desde Calibracion -> Wizard"
 
+# MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
+#: ultralcd.cpp:3922
+msgid "XYZ calibration all right. Skew will be corrected automatically."
+msgstr "Calibracion XYZ correcta. La inclinacion se corregira automaticamente."
+
+# MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
+#: ultralcd.cpp:3919
+msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
+msgstr "Calibracion XYZ correcta. Los ejes X / Y estan ligeramente inclinados. Buen trabajo!"
+
 # 
-#: ultralcd.cpp:5030
+#: ultralcd.cpp:5130
+msgid "X-correct:"
+msgstr "Corregir-X:"
+
+# MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
+#: ultralcd.cpp:3916
+msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
+msgstr "Calibracion XYZ ok. Ejes X/Y perpendiculares. Enhorabuena!"
+
+# MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
+#: ultralcd.cpp:3900
+msgid "XYZ calibration compromised. Front calibration points not reachable."
+msgstr "Calibrazion XYZ comprometida. Puntos frontales no alcanzables."
+
+# MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
+#: ultralcd.cpp:3903
+msgid "XYZ calibration compromised. Right front calibration point not reachable."
+msgstr "Calibrazion XYZ comprometida. Punto frontal derecho no alcanzable."
+
+# MSG_LOAD_ALL c=17
+#: ultralcd.cpp:6166
+msgid "Load all"
+msgstr "Intr. todos fil."
+
+# 
+#: ultralcd.cpp:3882
+msgid "XYZ calibration failed. Bed calibration point was not found."
+msgstr "Calibracion XYZ fallada. Puntos de calibracion en la base no encontrados."
+
+# 
+#: ultralcd.cpp:3888
+msgid "XYZ calibration failed. Front calibration points not reachable."
+msgstr "Calibracion XYZ fallada. Puntos frontales no alcanzables."
+
+# 
+#: ultralcd.cpp:3891
+msgid "XYZ calibration failed. Right front calibration point not reachable."
+msgstr "Calibracion XYZ fallad. Punto frontal derecho no alcanzable."
+
+# 
+#: ultralcd.cpp:3016
+msgid "Y distance from min"
+msgstr "Distancia en Y desde el min"
+
+# 
+#: ultralcd.cpp:5131
+msgid "Y-correct:"
+msgstr "Corregir-Y:"
+
+# MSG_OFF
+#: menu.cpp:426
+msgid " [off]"
+msgstr "[apag]"
+
+# 
+#: messages.c:57
+msgid "Back"
+msgstr "atras"
+
+# 
+#: ultralcd.cpp:5639
+msgid "Checks"
+msgstr "Comprobaciones"
+
+# 
+#: ultralcd.cpp:7973
+msgid "False triggering"
+msgstr "Falsa activacion"
+
+# 
+#: ultralcd.cpp:4030
+msgid "FINDA:"
+msgstr "FINDA:"
+
+# 
+#: ultralcd.cpp:5545
+msgid "Firmware   [none]"
+msgstr "Firmware[ninguno]"
+
+# 
+#: ultralcd.cpp:5551
+msgid "Firmware [strict]"
+msgstr "Firmware[estrict]"
+
+# 
+#: ultralcd.cpp:5548
+msgid "Firmware   [warn]"
+msgstr "Firmware  [aviso]"
+
+# 
+#: messages.c:87
+msgid "HW Setup"
+msgstr "Configuracion HW"
+
+# 
+#: ultralcd.cpp:4034
+msgid "IR:"
+msgstr ""
+
+# 
+#: ultralcd.cpp:7046
+msgid "Magnets comp.[N/A]"
+msgstr "Comp. imanes [N/A]"
+
+# 
+#: ultralcd.cpp:7044
+msgid "Magnets comp.[Off]"
+msgstr "Comp. imanes [Off]"
+
+# 
+#: ultralcd.cpp:7043
+msgid "Magnets comp. [On]"
+msgstr "Comp. imanes  [On]"
+
+# 
+#: ultralcd.cpp:7035
+msgid "Mesh         [3x3]"
+msgstr "Malla        [3x3]"
+
+# 
+#: ultralcd.cpp:7036
+msgid "Mesh         [7x7]"
+msgstr "Malla        [7x7]"
+
+# 
+#: ultralcd.cpp:5677
+msgid "Mesh bed leveling"
+msgstr "Nivelacion Malla Base"
+
+# 
+#: Marlin_main.cpp:856
+msgid "MK3S firmware detected on MK3 printer"
+msgstr "Firmware MK3S detectado en impresora MK3"
+
+# 
+#: ultralcd.cpp:5306
+msgid "MMU Mode [Normal]"
+msgstr "Modo MMU [Normal]"
+
+# 
+#: ultralcd.cpp:5307
+msgid "MMU Mode[Stealth]"
+msgstr "Modo MMU[Silenci]"
+
+# 
+#: ultralcd.cpp:4511
+msgid "Mode change in progress ..."
+msgstr "Cambio de modo progresando ..."
+
+# 
+#: ultralcd.cpp:5506
+msgid "Model      [none]"
+msgstr "Modelo  [ninguno]"
+
+# 
+#: ultralcd.cpp:5512
+msgid "Model    [strict]"
+msgstr "Modelo [estricto]"
+
+# 
+#: ultralcd.cpp:5509
+msgid "Model      [warn]"
+msgstr "Modelo    [aviso]"
+
+# 
+#: ultralcd.cpp:5467
+msgid "Nozzle d.  [0.25]"
+msgstr "Diam. nozzl[0.25]"
+
+# 
+#: ultralcd.cpp:5470
+msgid "Nozzle d.  [0.40]"
+msgstr "Diam. nozzl[0.40]"
+
+# 
+#: ultralcd.cpp:5473
+msgid "Nozzle d.  [0.60]"
+msgstr "Diam. nozzl[0.60]"
+
+# 
+#: ultralcd.cpp:5421
+msgid "Nozzle     [none]"
+msgstr "Nozzle  [ninguno]"
+
+# 
+#: ultralcd.cpp:5427
+msgid "Nozzle   [strict]"
+msgstr "Nozzle [estricto]"
+
+# 
+#: ultralcd.cpp:5424
+msgid "Nozzle     [warn]"
+msgstr "Nozzle    [aviso]"
+
+# 
+#: util.cpp:510
+msgid "G-code sliced for a different level. Continue?"
+msgstr "Codigo G laminado para un nivel diferente. ?Continuar?"
+
+# 
+#: util.cpp:516
+msgid "G-code sliced for a different level. Please re-slice the model again. Print cancelled."
+msgstr "Codigo G laminado para un nivel diferente. Por favor relamina el modelo de nuevo. Impresion cancelada."
+
+# 
+#: util.cpp:427
+msgid "G-code sliced for a different printer type. Continue?"
+msgstr "Codigo G laminado para un tipo de impresora diferente. ?Continuar?"
+
+# 
+#: util.cpp:433
+msgid "G-code sliced for a different printer type. Please re-slice the model again. Print cancelled."
+msgstr "Codigo G laminado para una impresora diferente. Por favor relamina el modelo de nuevo. Impresion cancelada."
+
+# 
+#: util.cpp:477
+msgid "G-code sliced for a newer firmware. Continue?"
+msgstr "Codigo G laminado para nuevo firmware. ?Continuar?"
+
+# 
+#: util.cpp:483
+msgid "G-code sliced for a newer firmware. Please update the firmware. Print cancelled."
+msgstr "Codigo G laminado para nuevo firmware. Por favor actualiza el firmware. Impresion cancelada."
+
+# 
+#: ultralcd.cpp:4026
+msgid "PINDA:"
+msgstr "PINDA:"
+
+# 
+#: ultralcd.cpp:2465
+msgid "Preheating to cut"
+msgstr "Precalentando para laminar"
+
+# 
+#: ultralcd.cpp:2462
+msgid "Preheating to eject"
+msgstr "Precalentar para expulsar"
+
+# 
+#: util.cpp:390
+msgid "Printer nozzle diameter differs from the G-code. Continue?"
+msgstr "Diametro nozzle impresora difiere de cod.G. ?Continuar?"
+
+# 
+#: util.cpp:397
+msgid "Printer nozzle diameter differs from the G-code. Please check the value in settings. Print cancelled."
+msgstr "Diametro nozzle Impresora difiere de cod.G. Comprueba los valores en ajustes. Impresion cancelada."
+
+# 
+#: ultralcd.cpp:6683
+msgid "Rename"
+msgstr "Renombrar"
+
+# 
+#: ultralcd.cpp:6679
+msgid "Select"
+msgstr "Seleccionar"
+
+# 
+#: ultralcd.cpp:2245
+msgid "Sensor info"
+msgstr "Info sensor"
+
+# 
+#: messages.c:58
+msgid "Sheet"
+msgstr "Lamina"
+
+# 
+#: sound.h:9
+msgid "Sound    [assist]"
+msgstr "Sonido [asistido]"
+
+# 
+#: ultralcd.cpp:5637
+msgid "Steel sheets"
+msgstr "Lamina de acero"
+
+# 
+#: ultralcd.cpp:5132
 msgid "Z-correct:"
-msgstr "Correccion-Z:"
+msgstr "Corregir-Z:"
 
 # 
-#: ultralcd.cpp:6952
+#: ultralcd.cpp:7038
 msgid "Z-probe nr.    [1]"
-msgstr "Z-sensor nr.    [1]"
+msgstr "Z-sensor nr.   [1]"
 
 # 
-#: ultralcd.cpp:6954
+#: ultralcd.cpp:7040
 msgid "Z-probe nr.    [3]"
-msgstr "Z-sensor nr.    [3]"
+msgstr "Z-sensor nr.   [3]"
 
-# MSG_MEASURED_OFFSET
-#: ultralcd.cpp:3024
-msgid "[0;0] point offset"
-msgstr "[0;0] punto offset"

--- a/lang/po/new/fr.po
+++ b/lang/po/new/fr.po
@@ -1,51 +1,19 @@
+# Translation of Prusa-Firmware into French.
+#
 msgid ""
 msgstr ""
-"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
-"X-Generator: PhraseApp (phraseapp.com)\n"
-
-# MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ultralcd.cpp:4219
-msgid "\e[2JCrash detection can\e[1;0Hbe turned on only in\e[2;0HNormal mode"
-msgstr "\e[2JLa detection de crash peut etre\e[1;0Hactive seulement\e[2;0Hen mode Normal"
-
-# MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ultralcd.cpp:4231
-msgid "\e[2JWARNING:\e[1;0HCrash detection\e[2;0Hdisabled in\e[3;0HStealth mode"
-msgstr "\e[2JATTENTION :\e[1;0HDetection de crash\e[2;0H desactivee en\e[3;0Hmode Furtif"
-
-# 
-#: ultralcd.cpp:3913
-msgid "  1"
-msgstr "  1"
-
-# MSG_PLANNER_BUFFER_BYTES
-#: Marlin_main.cpp:1184
-msgid "  PlannerBufferBytes: "
-msgstr "  PlannerBufferBytes : "
-
-# MSG_EXTRUDER_CORRECTION_OFF c=6
-#: ultralcd.cpp:6312
-msgid "  [off"
-msgstr "  [off"
-
-# MSG_ERR_COLD_EXTRUDE_STOP
-#: planner.cpp:761
-msgid " cold extrusion prevented"
-msgstr "extrusion a froid \nevitee"
-
-# MSG_FREE_MEMORY
-#: Marlin_main.cpp:1182
-msgid " Free Memory: "
-msgstr "Memoire libre :"
-
-# MSG_CONFIGURATION_VER
-#: Marlin_main.cpp:1172
-msgid " Last Updated: "
-msgstr "Derniere MAJ :"
+"Language: fr\n"
+"Project-Id-Version: Prusa-Firmware\n"
+"POT-Creation-Date: Sun, Sep 22, 2019 1:32:08 PM\n"
+"PO-Revision-Date: Sun, Sep 22, 2019 1:32:08 PM\n"
+"Language-Team: \n"
+"X-Generator: Poedit 2.0.7\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+"Last-Translator: \n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
 # MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE2 c=14
 #: messages.c:39
@@ -57,90 +25,70 @@ msgstr "de 4"
 msgid " of 9"
 msgstr "de 9"
 
-# MSG_OFF
-#: menu.cpp:426
-msgid " [off]"
-msgstr "[off]"
+# MSG_MEASURED_OFFSET
+#: ultralcd.cpp:3089
+msgid "[0;0] point offset"
+msgstr "Offset point [0;0]"
 
-# MSG_FACTOR
-#: ultralcd.cpp:6008
-msgid " \002 Fact"
-msgstr " \002 Facteur"
+# MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
+#: 
+msgid "Crash detection can\x0abe turned on only in\x0aNormal mode"
+msgstr "La detection de\x0acrash peut etre\x0aactive seulement en\x0amode Normal"
 
-# MSG_MAX
-#: ultralcd.cpp:6007
-msgid " \002 Max"
-msgstr " \002 Max"
-
-# MSG_MIN
-#: ultralcd.cpp:6006
-msgid " \002 Min"
-msgstr " \002 Min"
+# MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
+#: 
+msgid "WARNING:\x0aCrash detection\x0adisabled in\x0aStealth mode"
+msgstr "ATTENTION:\x0aDetection de crash\x0adesactivee en\x0amode feutre"
 
 # 
-#: ultralcd.cpp:2294
+#: ultralcd.cpp:2472
 msgid ">Cancel"
 msgstr ">Annuler"
 
-# MSG_BABYSTEPPING_Z c=20
-#: ultralcd.cpp:3043
-msgid "Adjusting Z"
-msgstr "Ajustement de Z"
-
 # MSG_BABYSTEPPING_Z c=15
-#: ultralcd.cpp:3144
+#: ultralcd.cpp:3209
 msgid "Adjusting Z:"
-msgstr "Ajuster Z :"
-
-# MSG_ALL c=19 r=1
-#: messages.c:11
-msgid "All"
-msgstr "Tous"
+msgstr "Ajuster Z:"
 
 # MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ultralcd.cpp:8209
+#: ultralcd.cpp:8295
 msgid "All correct      "
 msgstr "Tout est correct"
 
 # MSG_WIZARD_DONE c=20 r=8
 #: messages.c:101
 msgid "All is done. Happy printing!"
-msgstr "Tout est pret. Bonne\nimpression !"
+msgstr "Tout est pret. Bonne impression!"
 
 # 
-#: ultralcd.cpp:1979
+#: ultralcd.cpp:2009
 msgid "Ambient"
 msgstr "Ambiant"
 
 # MSG_PRESS c=20
-#: ultralcd.cpp:2573
+#: ultralcd.cpp:2618
 msgid "and press the knob"
 msgstr "et pressez le bouton"
 
 # MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=2
-#: ultralcd.cpp:3442
+#: ultralcd.cpp:3529
 msgid "Are left and right Z~carriages all up?"
-msgstr "Z~carriages gauche +\ndroite tout en haut?"
-
-# MSG_ADJUSTZ
-#: ultralcd.cpp:2600
-msgid "Auto adjust Z?"
-msgstr "Ajustement Z auto ?"
+msgstr "Z~carriages gauche + droite tout en haut?"
 
 # MSG_AUTO_DEPLETE_ON c=17 r=1
-#: ultralcd.cpp:4706
-msgid "Auto deplete [on]"
-msgstr "Purge auto [on]"
+#: ultralcd.cpp:5200
+msgid "SpoolJoin    [on]"
+msgstr ""
 
 # 
-#: ultralcd.cpp:4702
-msgid "Auto deplete[N/A]"
-msgstr "Vidage auto[N/A]"
+#: ultralcd.cpp:5196
+msgid "SpoolJoin   [N/A]"
+msgstr ""
 
 # MSG_AUTO_DEPLETE_OFF c=17 r=1
-#: ultralcd.cpp:4710
-msgid "Auto deplete[off]"
-msgstr "Purge auto [off]"
+#: ultralcd.cpp:5204
+msgid "SpoolJoin   [off]"
+msgstr ""
 
 # MSG_AUTO_HOME
 #: messages.c:11
@@ -148,52 +96,32 @@ msgid "Auto home"
 msgstr "Mise a 0 des axes"
 
 # MSG_AUTOLOAD_FILAMENT c=17
-#: ultralcd.cpp:6731
+#: ultralcd.cpp:6822
 msgid "AutoLoad filament"
-msgstr "AutoCharge du filament"
+msgstr "Autocharge du fil."
 
 # MSG_AUTOLOADING_ONLY_IF_FSENS_ON c=20 r=4
-#: ultralcd.cpp:4375
+#: ultralcd.cpp:4462
 msgid "Autoloading filament available only when filament sensor is turned on..."
-msgstr "Chargement auto du\nfilament uniquement\nsi le capteur de\nfilament est active."
+msgstr "Chargement auto du filament uniquement si le capteur de filament est active."
 
 # MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ultralcd.cpp:2768
+#: ultralcd.cpp:2813
 msgid "Autoloading filament is active, just press the knob and insert filament..."
-msgstr "Chargement auto du\nfilament actif,\nappuyez sur le btn\net inserez le fil."
-
-# MSG_SELFTEST_AXIS
-#: ultralcd.cpp:7865
-msgid "Axis"
-msgstr "Axe"
+msgstr "Chargement auto. du fil. active, appuyez sur le bouton et inserez le fil."
 
 # MSG_SELFTEST_AXIS_LENGTH
-#: ultralcd.cpp:7863
+#: ultralcd.cpp:7949
 msgid "Axis length"
 msgstr "Longueur de l'axe"
 
-# MSG_BABYSTEPPING_X
-#: ultralcd.cpp:2481
-msgid "Babystepping X"
-msgstr "Babystepping X"
-
-# MSG_BABYSTEPPING_Y
-#: ultralcd.cpp:2484
-msgid "Babystepping Y"
-msgstr "Babystepping Y"
-
-# 
-#: messages.c:57
-msgid "Back"
-msgstr "Retour"
-
-# MSG_BED
-#: messages.c:15
-msgid "Bed"
-msgstr "Lit"
+# MSG_SELFTEST_AXIS
+#: ultralcd.cpp:7951
+msgid "Axis"
+msgstr "Axe"
 
 # MSG_SELFTEST_BEDHEATER
-#: ultralcd.cpp:7807
+#: ultralcd.cpp:7893
 msgid "Bed / Heater"
 msgstr "Lit / Chauffage"
 
@@ -208,52 +136,37 @@ msgid "Bed Heating"
 msgstr "Chauffe du lit"
 
 # MSG_BED_CORRECTION_MENU
-#: ultralcd.cpp:5663
+#: ultralcd.cpp:5768
 msgid "Bed level correct"
 msgstr "Corr. niveau plateau"
 
 # MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=4
 #: messages.c:18
 msgid "Bed leveling failed. Sensor didnt trigger. Debris on nozzle? Waiting for reset."
-msgstr "Echec bed leveling.\nCapt. non declenche.\nDebris sur buse ? En\nattente d'un reset."
+msgstr "Echec bed leveling. Capt. non declenche. Debris sur buse? En attente d'un reset."
 
-# MSG_BED_LEVELING_FAILED_PROBE_DISCONNECTED c=20 r=4
-#: Marlin_main.cpp:4508
-msgid "Bed leveling failed. Sensor disconnected or cable broken. Waiting for reset."
-msgstr "Echec du nivellement\nCapteur deconnecte\nou cable casse. En\nattente d'un reset."
-
-# MSG_BED_LEVELING_FAILED_POINT_HIGH c=20 r=4
-#: Marlin_main.cpp:4512
-msgid "Bed leveling failed. Sensor triggered too high. Waiting for reset."
-msgstr "Echec bed leveling.\nCapt. declenche\ntrop trop haut. En\nattente d'un reset."
-
-# MSG_BEGIN_FILE_LIST
-#: Marlin_main.cpp:4405
-msgid "Begin file list"
-msgstr "Debut liste fichiers"
+# MSG_BED
+#: messages.c:15
+msgid "Bed"
+msgstr "Lit"
 
 # MSG_MENU_BELT_STATUS c=15 r=1
-#: ultralcd.cpp:2007
+#: ultralcd.cpp:2059
 msgid "Belt status"
 msgstr "Statut courroie"
 
 # MSG_RECOVER_PRINT c=20 r=2
 #: messages.c:71
 msgid "Blackout occurred. Recover print?"
-msgstr "Coupure detectee.\nRecup. impression ?"
+msgstr "Coupure detectee. Reprendre impression?"
 
-# MSG_CALIBRATE_PINDA c=17 r=1
-#: ultralcd.cpp:4566
-msgid "Calibrate"
-msgstr "Calibrer"
-
-# MSG_CALIBRATE_E c=20 r=1
-#: ultralcd.cpp:4526
-msgid "Calibrate E"
-msgstr "Calibrer E"
+# 
+#: ultralcd.cpp:8297
+msgid "Calibrating home"
+msgstr "Calib. mise a 0"
 
 # MSG_CALIBRATE_BED
-#: ultralcd.cpp:5652
+#: ultralcd.cpp:5757
 msgid "Calibrate XYZ"
 msgstr "Calibrer XYZ"
 
@@ -262,148 +175,48 @@ msgstr "Calibrer XYZ"
 msgid "Calibrate Z"
 msgstr "Calibrer Z"
 
-# 
-#: ultralcd.cpp:8211
-msgid "Calibrating home"
-msgstr "Calib. mise a 0"
+# MSG_CALIBRATE_PINDA c=17 r=1
+#: ultralcd.cpp:4654
+msgid "Calibrate"
+msgstr "Calibrer"
 
 # MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ultralcd.cpp:3405
+#: ultralcd.cpp:3492
 msgid "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end stoppers. Click when done."
-msgstr "Calibration de XYZ.\nTournez le bouton\npour monter le\nchariot de l'axe Z\njusqu'aux butees.\nCliquez une fois\nfait."
+msgstr "Calibration de XYZ. Tournez le bouton pour faire monter l'extrudeur dans l'axe Z jusqu'aux butees. Cliquez une fois fait."
 
 # MSG_CALIBRATE_Z_AUTO c=20 r=2
 #: messages.c:20
 msgid "Calibrating Z"
-msgstr "Calibration de Z"
+msgstr "Calibration Z"
 
 # MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ultralcd.cpp:3405
+#: ultralcd.cpp:3492
 msgid "Calibrating Z. Rotate the knob to move the Z carriage up to the end stoppers. Click when done."
-msgstr "Calibration de Z.\nTournez le bouton\npour monter le\nchariot de l'axe Z\njusqu'aux butees.\nCliquez une fois\nfait."
+msgstr "Calibration de Z. Tournez le bouton pour faire monter l'extrudeur dans l'axe Z jusqu'aux butees. Cliquez une fois fait."
+
+# MSG_HOMEYZ_DONE
+#: ultralcd.cpp:816
+msgid "Calibration done"
+msgstr "Calibration terminee"
 
 # MSG_MENU_CALIBRATION
 #: messages.c:61
 msgid "Calibration"
-msgstr "Calibration"
-
-# MSG_HOMEYZ_DONE
-#: ultralcd.cpp:832
-msgid "Calibration done"
-msgstr "Calibration terminee"
+msgstr ""
 
 # 
-#: ultralcd.cpp:4692
+#: ultralcd.cpp:4781
 msgid "Cancel"
 msgstr "Annuler"
 
-# MSG_SD_CANT_ENTER_SUBDIR
-#: cardreader.cpp:662
-msgid "Cannot enter subdir: "
-msgstr "Impossible d'entrer\ndans le repertoire :"
-
-# MSG_SD_CANT_OPEN_SUBDIR
-#: cardreader.cpp:97
-msgid "Cannot open subdir"
-msgstr "Impossible d'ouvrir\nle repertoire"
-
-# MSG_SD_INSERTED
-#:
-msgid "Card inserted"
-msgstr "Carte  inseree"
-
 # MSG_SD_REMOVED
-#: ultralcd.cpp:8578
+#: ultralcd.cpp:8679
 msgid "Card removed"
 msgstr "Carte retiree"
 
-# 
-#: ultralcd.cpp:6087
-msgid "Change extruder"
-msgstr "Changer extrudeur"
-
-# MSG_FILAMENTCHANGE
-#: messages.c:37
-msgid "Change filament"
-msgstr "Changer filament"
-
-# MSG_CNG_SDCARD
-#: ultralcd.cpp:5777
-msgid "Change SD card"
-msgstr "Changer carte SD"
-
-# MSG_CHANGE_SUCCESS
-#: ultralcd.cpp:2584
-msgid "Change success!"
-msgstr "Changement reussi!"
-
-# MSG_CORRECTLY c=20
-#: ultralcd.cpp:2661
-msgid "Changed correctly?"
-msgstr "Change correctement?"
-
-# MSG_CHANGING_FILAMENT c=20
-#: ultralcd.cpp:1899
-msgid "Changing filament!"
-msgstr "Changement filament!"
-
-# MSG_SELFTEST_CHECK_BED c=20
-#: messages.c:81
-msgid "Checking bed     "
-msgstr "Verification du lit"
-
-# MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ultralcd.cpp:8200
-msgid "Checking endstops"
-msgstr "Verifications butees"
-
-# MSG_SELFTEST_CHECK_HOTEND c=20
-#: ultralcd.cpp:8206
-msgid "Checking hotend  "
-msgstr "Verif. tete impr."
-
-# MSG_SELFTEST_CHECK_FSENSOR c=20
-#: messages.c:82
-msgid "Checking sensors "
-msgstr "Verif. des capteurs"
-
-# MSG_SELFTEST_CHECK_X c=20
-#: ultralcd.cpp:8201
-msgid "Checking X axis  "
-msgstr "Verification axe X"
-
-# MSG_SELFTEST_CHECK_Y c=20
-#: ultralcd.cpp:8202
-msgid "Checking Y axis  "
-msgstr "Verification axe Y"
-
-# MSG_SELFTEST_CHECK_Z c=20
-#: ultralcd.cpp:8203
-msgid "Checking Z axis  "
-msgstr "Verification axe Z"
-
-# 
-#: ultralcd.cpp:5537
-msgid "Checks"
-msgstr "Verifications"
-
-# MSG_ERR_CHECKSUM_MISMATCH
-#: cmdqueue.cpp:444
-msgid "checksum mismatch, Last Line: "
-msgstr "dissemblance du checksum, Derniere Ligne :"
-
-# MSG_CHOOSE_EXTRUDER c=20 r=1
-#: messages.c:49
-msgid "Choose extruder:"
-msgstr "Choisir extrudeur :"
-
-# MSG_CHOOSE_FILAMENT c=20 r=1
-#: messages.c:50
-msgid "Choose filament:"
-msgstr "Choix du filament :"
-
 # MSG_NOT_COLOR
-#: ultralcd.cpp:2673
+#: ultralcd.cpp:2718
 msgid "Color not correct"
 msgstr "Couleur incorrecte"
 
@@ -413,34 +226,24 @@ msgid "Cooldown"
 msgstr "Refroidissement"
 
 # 
-#: ultralcd.cpp:4108
-msgid "Copy selected language from XFLASH?"
-msgstr "Copier la langue selectionne depuis la XFLASH ?"
-
-# 
-#: ultralcd.cpp:4499
+#: ultralcd.cpp:4587
 msgid "Copy selected language?"
-msgstr "Copier la langue\nselectionne ?"
-
-# 
-#: ultralcd.cpp:1881
-msgid "Crash"
-msgstr "Crash"
+msgstr "Copier la langue selectionne?"
 
 # MSG_CRASHDETECT_ON
 #: messages.c:27
 msgid "Crash det.   [on]"
-msgstr "Detect. crash[on]"
+msgstr "Detect.crash [on]"
 
 # MSG_CRASHDETECT_NA
 #: messages.c:25
 msgid "Crash det.  [N/A]"
-msgstr "Detect. crash [N/A]"
+msgstr "Detect.crash[N/A]"
 
 # MSG_CRASHDETECT_OFF
 #: messages.c:26
 msgid "Crash det.  [off]"
-msgstr "Detect. crash[off]"
+msgstr "Detect.crash[off]"
 
 # MSG_CRASH_DETECTED c=20 r=1
 #: messages.c:24
@@ -448,154 +251,99 @@ msgid "Crash detected."
 msgstr "Crash detecte."
 
 # 
-#: Marlin_main.cpp:618
+#: Marlin_main.cpp:600
 msgid "Crash detected. Resume print?"
-msgstr "Crash detecte. Poursuivre l'impression ?"
+msgstr "Crash detecte. Poursuivre l'impression?"
 
-# MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#:
-msgid "Crash detection can\nbe turned on only in\nNormal mode"
-msgstr "La detection de\ncrash ne peut etre\nactive en mode\nNormal"
+# 
+#: ultralcd.cpp:1853
+msgid "Crash"
+msgstr ""
 
 # MSG_CURRENT c=19 r=1
-#: ultralcd.cpp:5804
+#: ultralcd.cpp:5909
 msgid "Current"
 msgstr "Actuel"
 
 # MSG_DATE c=17 r=1
-#: ultralcd.cpp:2106
+#: ultralcd.cpp:2213
 msgid "Date:"
-msgstr "Date :"
+msgstr "Date:"
 
 # MSG_DISABLE_STEPPERS
-#: ultralcd.cpp:5552
+#: ultralcd.cpp:5654
 msgid "Disable steppers"
 msgstr "Desactiver moteurs"
 
 # MSG_BABYSTEP_Z_NOT_SET c=20 r=12
 #: messages.c:14
 msgid "Distance between tip of the nozzle and the bed surface has not been set yet. Please follow the manual, chapter First steps, section First layer calibration."
-msgstr "La distance entre la\npointe de la buse et\nla surface du\nplateau n'a pas\nencore ete reglee.\nSuivez le manuel,\nchapitre Premiers\npas, section\nCalibration de la\npremiere couche."
+msgstr "La distance entre la pointe de la buse et la surface du plateau n'a pas encore ete reglee. Suivez le manuel, chapitre Premiers pas, section Calibration de la premiere couche."
 
 # MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ultralcd.cpp:4968
+#: ultralcd.cpp:5070
 msgid "Do you want to repeat last step to readjust distance between nozzle and heatbed?"
-msgstr "Voulez-vous repeter\nla derniere etape\npour reajuster la\ndistance entre la\nbuse et le plateau\nchauffant ?"
-
-# MSG_CLEAN_NOZZLE_E c=20 r=8
-#: ultralcd.cpp:3890
-msgid "E calibration finished. Please clean the nozzle. Click when done."
-msgstr "Calibration de E\nterminee. Nettoyez\nla buse. Cliquez une\nfois fait."
-
-# MSG_EXTRUDER_CORRECTION c=9
-#: ultralcd.cpp:4889
-msgid "E-correct"
-msgstr "Correct-E"
+msgstr "Voulez-vous repeter la derniere etape pour reajuster la distance entre la buse et le plateau chauffant?"
 
 # MSG_EXTRUDER_CORRECTION c=10
-#: ultralcd.cpp:5032
+#: ultralcd.cpp:5134
 msgid "E-correct:"
 msgstr "Correct-E:"
-
-# 
-#: ultralcd.cpp:4780
-msgid "Eject"
-msgstr "Ejecter"
 
 # MSG_EJECT_FILAMENT c=17 r=1
 #: messages.c:53
 msgid "Eject filament"
-msgstr "Ejecter le fil."
+msgstr "Remonter le fil."
 
-# MSG_EJECT_FILAMENT1 c=17 r=1
-#: ultralcd.cpp:5603
-msgid "Eject filament 1"
-msgstr "Ejecter fil. 1"
-
-# MSG_EJECT_FILAMENT2 c=17 r=1
-#: ultralcd.cpp:5604
-msgid "Eject filament 2"
-msgstr "Ejecter fil. 2"
-
-# MSG_EJECT_FILAMENT3 c=17 r=1
-#: ultralcd.cpp:5605
-msgid "Eject filament 3"
-msgstr "Ejecter fil. 3"
-
-# MSG_EJECT_FILAMENT4 c=17 r=1
-#: ultralcd.cpp:5606
-msgid "Eject filament 4"
-msgstr "Ejecter fil. 4"
-
-# MSG_EJECT_FILAMENT5 c=17 r=1
-#: ultralcd.cpp:5607
-msgid "Eject filament 5"
-msgstr "Ejecter fil. 5"
+# 
+#: ultralcd.cpp:4869
+msgid "Eject"
+msgstr "Remonter"
 
 # MSG_EJECTING_FILAMENT c=20 r=1
-#: mmu.cpp:1435
+#: mmu.cpp:1434
 msgid "Ejecting filament"
-msgstr "Ejection filament"
-
-# MSG_END_FILE_LIST
-#: Marlin_main.cpp:4407
-msgid "End file list"
-msgstr "Fin liste fichiers"
-
-# MSG_SELFTEST_ENDSTOP
-#: ultralcd.cpp:7825
-msgid "Endstop"
-msgstr "Butee"
+msgstr "Le fil. remonte"
 
 # MSG_SELFTEST_ENDSTOP_NOTHIT c=20 r=1
-#: ultralcd.cpp:7831
+#: ultralcd.cpp:7917
 msgid "Endstop not hit"
 msgstr "Butee non atteinte"
 
+# MSG_SELFTEST_ENDSTOP
+#: ultralcd.cpp:7911
+msgid "Endstop"
+msgstr "Butee"
+
 # MSG_SELFTEST_ENDSTOPS
-#: ultralcd.cpp:7813
+#: ultralcd.cpp:7899
 msgid "Endstops"
 msgstr "Butees"
 
-# MSG_ENDSTOPS_HIT
-#: messages.c:30
-msgid "endstops hit: "
-msgstr "butees atteintes :"
-
-# MSG_LANGUAGE_NAME
-#: language.c:153
-msgid "English"
-msgstr "Francais"
-
-# MSG_Enqueing
-#:
-msgid "enqueing \""
-msgstr "mise en file \""
-
 # MSG_STACK_ERROR c=20 r=4
-#: ultralcd.cpp:6773
+#: ultralcd.cpp:6859
 msgid "Error - static memory has been overwritten"
-msgstr "Erreur - la memoire\nstatique a ete\necrasee"
+msgstr "Erreur - la memoire statique a ete ecrasee"
 
-# MSG_SD_ERR_WRITE_TO_FILE
-#: messages.c:78
-msgid "error writing to file"
-msgstr "erreur d'ecriture du fichier"
+# MSG_FSENS_NOT_RESPONDING c=20 r=4
+#: ultralcd.cpp:4475
+msgid "ERROR: Filament sensor is not responding, please check connection."
+msgstr "ERREUR: Le capteur de filament ne repond pas, verifiez le branchement."
 
 # MSG_ERROR
 #: messages.c:28
 msgid "ERROR:"
-msgstr "ERREUR :"
+msgstr "ERREUR:"
 
-# MSG_FSENS_NOT_RESPONDING c=20 r=4
-#: ultralcd.cpp:4388
-msgid "ERROR: Filament sensor is not responding, please check connection."
-msgstr "ERREUR : Le capteur\nde filament ne\nrepond pas, verifiez\nle branchement."
+# MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
+#: ultralcd.cpp:8304
+msgid "Extruder fan:"
+msgstr "Ventilo extrudeur:"
 
-# 
-#: Marlin_main.cpp:1006
-msgid "External SPI flash W25X20CL not responding."
-msgstr "La Flash SPI externe W25X20CL ne repond pas."
+# MSG_INFO_EXTRUDER c=15 r=1
+#: ultralcd.cpp:2244
+msgid "Extruder info"
+msgstr "Infos extrudeur"
 
 # MSG_MOVE_E
 #: messages.c:29
@@ -603,99 +351,59 @@ msgid "Extruder"
 msgstr "Extrudeur"
 
 # 
-#: ultralcd.cpp:5633
-msgid "Extruder 1"
-msgstr "Extrudeur 1"
-
-# 
-#: ultralcd.cpp:5634
-msgid "Extruder 2"
-msgstr "Extrudeur 2"
-
-# 
-#: ultralcd.cpp:5635
-msgid "Extruder 3"
-msgstr "Extrudeur 3"
-
-# 
-#: ultralcd.cpp:5636
-msgid "Extruder 4"
-msgstr "Extrudeur 4"
-
-# MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
-#: ultralcd.cpp:8218
-msgid "Extruder fan:"
-msgstr "Ventilo extrudeur:"
-
-# MSG_INFO_EXTRUDER c=15 r=1
-#: ultralcd.cpp:2137
-msgid "Extruder info"
-msgstr "Infos extrudeur"
+#: ultralcd.cpp:6846
+msgid "Fail stats MMU"
+msgstr "Stat. d'echec MMU"
 
 # MSG_FSENS_AUTOLOAD_ON c=17 r=1
-#: ultralcd.cpp:5066
+#: ultralcd.cpp:5168
 msgid "F. autoload  [on]"
-msgstr "ChargAuto f. [on]"
+msgstr "Autochargeur [on]"
 
 # MSG_FSENS_AUTOLOAD_NA c=17 r=1
 #: messages.c:43
 msgid "F. autoload [N/A]"
-msgstr "AutoCharg F [N/A]"
+msgstr "Autochargeur[N/A]"
 
 # MSG_FSENS_AUTOLOAD_OFF c=17 r=1
-#: ultralcd.cpp:5068
+#: ultralcd.cpp:5170
 msgid "F. autoload [off]"
-msgstr "AutoCharg F [off]"
+msgstr "Autochargeur[off]"
 
 # 
-#: ultralcd.cpp:6757
+#: ultralcd.cpp:6843
 msgid "Fail stats"
-msgstr "Statist. d'echec"
-
-# 
-#: ultralcd.cpp:6760
-msgid "Fail stats MMU"
-msgstr "Stat. echecs MMU"
-
-# 
-#: ultralcd.cpp:7887
-msgid "False triggering"
-msgstr "Faux declenchement"
+msgstr "Stat. d'echec"
 
 # MSG_FAN_SPEED c=14
 #: messages.c:31
 msgid "Fan speed"
-msgstr "Vitesse ventil"
+msgstr "Vitesse vent."
 
 # MSG_SELFTEST_FAN c=20
 #: messages.c:78
 msgid "Fan test"
-msgstr "Test ventilateur"
+msgstr "Test du ventilateur"
 
 # MSG_FANS_CHECK_ON c=17 r=1
-#: ultralcd.cpp:5561
+#: ultralcd.cpp:5663
 msgid "Fans check   [on]"
-msgstr "Verif ventilo[on]"
+msgstr "Verif vent.  [on]"
 
 # MSG_FANS_CHECK_OFF c=17 r=1
-#: ultralcd.cpp:5563
+#: ultralcd.cpp:5665
 msgid "Fans check  [off]"
-msgstr "Verif venti [off]"
+msgstr "Verif vent. [off]"
 
 # MSG_FSENSOR_ON
 #: messages.c:45
 msgid "Fil. sensor  [on]"
 msgstr "Capteur Fil. [on]"
 
-# MSG_RESPONSE_POOR c=20 r=2
-#: Marlin_main.cpp:3146
-msgid "Fil. sensor response is poor, disable it?"
-msgstr "Capteur de fil. non\nprecis, desactiver ?"
-
 # MSG_FSENSOR_NA
-#: ultralcd.cpp:5046
+#: ultralcd.cpp:5148
 msgid "Fil. sensor [N/A]"
-msgstr "Capteur Fil. [N/A]"
+msgstr "Capteur Fil.[N/A]"
 
 # MSG_FSENSOR_OFF
 #: messages.c:44
@@ -703,22 +411,17 @@ msgid "Fil. sensor [off]"
 msgstr "Capteur Fil.[off]"
 
 # 
-#: ultralcd.cpp:1881
+#: ultralcd.cpp:1852
 msgid "Filam. runouts"
 msgstr "Fins de filament"
-
-# MSG_FILAMENT c=17 r=1
-#: messages.c:30
-msgid "Filament"
-msgstr "Filament"
 
 # MSG_FILAMENT_CLEAN c=20 r=2
 #: messages.c:32
 msgid "Filament extruding & with correct color?"
-msgstr "Filament extrude et\navec bonne couleur ?"
+msgstr "Filament extrude et avec bonne couleur?"
 
 # MSG_NOT_LOADED c=19
-#: ultralcd.cpp:2669
+#: ultralcd.cpp:2714
 msgid "Filament not loaded"
 msgstr "Filament non charge"
 
@@ -727,60 +430,25 @@ msgstr "Filament non charge"
 msgid "Filament sensor"
 msgstr "Capteur de filament"
 
-# MSG_SELFTEST_FILAMENT_SENSOR c=18
-#: ultralcd.cpp:7477
-msgid "Filament sensor:"
-msgstr "Capteur filament :"
-
 # MSG_FILAMENT_USED c=19 r=1
-#: ultralcd.cpp:2838
+#: ultralcd.cpp:2885
 msgid "Filament used"
 msgstr "Filament utilise"
 
-# MSG_STATS_FILAMENTUSED c=20
-#: ultralcd.cpp:2142
-msgid "Filament used:  "
-msgstr "Filament utilise :"
+# MSG_PRINT_TIME c=19 r=1
+#: ultralcd.cpp:2886
+msgid "Print time"
+msgstr "Temps d'impression"
 
 # MSG_FILE_INCOMPLETE c=20 r=2
-#: ultralcd.cpp:8346
+#: ultralcd.cpp:8432
 msgid "File incomplete. Continue anyway?"
-msgstr "Fichier incomplet.\nContinuer qd meme ?"
-
-# MSG_SD_FILE_OPENED
-#: cardreader.cpp:395
-msgid "File opened: "
-msgstr "Fichier ouvert :"
-
-# MSG_SD_FILE_SELECTED
-#: cardreader.cpp:401
-msgid "File selected"
-msgstr "Fichier selectionne"
-
-# 
-#: ultralcd.cpp:3943
-msgid "FINDA:"
-msgstr "FINDA :"
+msgstr "Fichier incomplet. Continuer qd meme?"
 
 # MSG_FINISHING_MOVEMENTS c=20 r=1
 #: messages.c:40
 msgid "Finishing movements"
-msgstr "Mouvements de fin"
-
-# 
-#: ultralcd.cpp:5443
-msgid "Firmware   [none]"
-msgstr "Firmware [aucune]"
-
-# 
-#: ultralcd.cpp:5446
-msgid "Firmware   [warn]"
-msgstr "Firmware  [avert]"
-
-# 
-#: ultralcd.cpp:5449
-msgid "Firmware [strict]"
-msgstr "Firmware[stricte]"
+msgstr "Mouvement final"
 
 # MSG_V2_CALIBRATION c=17 r=1
 #: messages.c:105
@@ -788,424 +456,264 @@ msgid "First layer cal."
 msgstr "Cal. 1ere couche"
 
 # MSG_WIZARD_SELFTEST c=20 r=8
-#: ultralcd.cpp:4880
+#: ultralcd.cpp:4982
 msgid "First, I will run the selftest to check most common assembly problems."
-msgstr "D'abord, je vais\nlancer le Selftest\npour verifier les\nproblemes\nd'assemblage les\nplus communs."
+msgstr "D'abord, je vais lancer le Auto-test pour verifier les problemes d'assemblage les plus communs."
 
 # 
 #: mmu.cpp:724
 msgid "Fix the issue and then press button on MMU unit."
-msgstr "Corrigez le probleme et appuyez sur le bouton de l'unite MMU."
+msgstr "Corrigez le probleme et appuyez sur le bouton sur la MMU."
 
 # MSG_FLOW
-#: ultralcd.cpp:6846
+#: ultralcd.cpp:6932
 msgid "Flow"
 msgstr "Flux"
 
 # MSG_PRUSA3D_FORUM
-#: ultralcd.cpp:2099
+#: ultralcd.cpp:2206
 msgid "forum.prusa3d.com"
-msgstr "forum.prusa3d.com"
+msgstr ""
 
 # MSG_SELFTEST_COOLING_FAN c=20
 #: messages.c:75
 msgid "Front print fan?"
-msgstr "Ventilo impr avant ?"
+msgstr "Ventilo impr avant?"
 
 # MSG_BED_CORRECTION_FRONT c=14 r=1
-#: ultralcd.cpp:3217
+#: ultralcd.cpp:3294
 msgid "Front side[um]"
 msgstr "Avant [um]"
 
 # MSG_SELFTEST_FANS
-#: ultralcd.cpp:7871
+#: ultralcd.cpp:7957
 msgid "Front/left fans"
 msgstr "Ventilos avt/gauche"
 
-# 
-#: util.cpp:427
-msgid "G-code sliced for a different printer type. Continue?"
-msgstr "Le G-code a ete prepare pour une autre version de l'imprimante. Continuer?"
-
-# 
-#: util.cpp:433
-msgid "G-code sliced for a different printer type. Please re-slice the model again. Print cancelled."
-msgstr "Le G-code a ete prepare pour une autre version de l'imprimante. Veuillez decouper le modele a nouveau. L'impression a ete annulee. "
-
-# 
-#: util.cpp:477
-msgid "G-code sliced for a newer firmware. Continue?"
-msgstr "Le G-code a ete prepare pour une version plus recente du firmware. Continuer?"
-
-# 
-#: util.cpp:483
-msgid "G-code sliced for a newer firmware. Please update the firmware. Print cancelled."
-msgstr "Le G-code a ete prepare pour une version plus recente du firmware. Veuillez mettre a jour le firmware. L'impression  annulee."
-
 # MSG_SELFTEST_HEATERTHERMISTOR
-#: ultralcd.cpp:7801
+#: ultralcd.cpp:7887
 msgid "Heater/Thermistor"
 msgstr "Chauffage/Thermistor"
 
-# MSG_HEATING
-#: messages.c:46
-msgid "Heating"
-msgstr "Chauffe"
-
 # MSG_BED_HEATING_SAFETY_DISABLED
-#: Marlin_main.cpp:8411
+#: Marlin_main.cpp:8467
 msgid "Heating disabled by safety timer."
-msgstr "Chauffe desactivee\npar le compteur de\nsecurite."
+msgstr "Chauffage desactivee par le compteur de securite."
 
 # MSG_HEATING_COMPLETE c=20
 #: messages.c:47
 msgid "Heating done."
 msgstr "Chauffe terminee."
 
+# MSG_HEATING
+#: messages.c:46
+msgid "Heating"
+msgstr "Chauffe"
+
 # MSG_WIZARD_WELCOME c=20 r=7
-#: ultralcd.cpp:4859
+#: ultralcd.cpp:4961
 msgid "Hi, I am your Original Prusa i3 printer. Would you like me to guide you through the setup process?"
-msgstr "Bonjour, je suis\nvotre imprimante\nOriginal Prusa i3.\nVoulez-vous que je\nvous guide a travers\nle processus\nd'installation ?"
+msgstr "Bonjour, je suis votre imprimante Original Prusa i3. Voulez-vous que je vous guide a travers le processus d'installation?"
 
 # MSG_PRUSA3D_HOWTO
-#: ultralcd.cpp:2100
+#: ultralcd.cpp:2207
 msgid "howto.prusa3d.com"
-msgstr "howto.prusa3d.com"
+msgstr ""
 
-# 
-#: messages.c:87
-msgid "HW Setup"
-msgstr "Config HW"
+# MSG_FILAMENTCHANGE
+#: messages.c:37
+msgid "Change filament"
+msgstr "Changer filament"
+
+# MSG_CHANGE_SUCCESS
+#: ultralcd.cpp:2629
+msgid "Change success!"
+msgstr "Changement reussi!"
+
+# MSG_CORRECTLY c=20
+#: ultralcd.cpp:2706
+msgid "Changed correctly?"
+msgstr "Change correctement?"
+
+# MSG_SELFTEST_CHECK_BED c=20
+#: messages.c:81
+msgid "Checking bed     "
+msgstr "Verification du lit"
+
+# MSG_SELFTEST_CHECK_ENDSTOPS c=20
+#: ultralcd.cpp:8286
+msgid "Checking endstops"
+msgstr "Verification butees"
+
+# MSG_SELFTEST_CHECK_HOTEND c=20
+#: ultralcd.cpp:8292
+msgid "Checking hotend  "
+msgstr "Verif. du hotend"
+
+# MSG_SELFTEST_CHECK_FSENSOR c=20
+#: messages.c:82
+msgid "Checking sensors "
+msgstr "Verif. des capteurs"
+
+# MSG_SELFTEST_CHECK_X c=20
+#: ultralcd.cpp:8287
+msgid "Checking X axis  "
+msgstr "Verification axe X"
+
+# MSG_SELFTEST_CHECK_Y c=20
+#: ultralcd.cpp:8288
+msgid "Checking Y axis  "
+msgstr "Verification axe Y"
+
+# MSG_SELFTEST_CHECK_Z c=20
+#: ultralcd.cpp:8289
+msgid "Checking Z axis  "
+msgstr "Verification axe Z"
+
+# MSG_CHOOSE_EXTRUDER c=20 r=1
+#: messages.c:49
+msgid "Choose extruder:"
+msgstr "Choisir extrudeur:"
+
+# MSG_CHOOSE_FILAMENT c=20 r=1
+#: messages.c:50
+msgid "Choose filament:"
+msgstr "Choix du filament:"
+
+# MSG_FILAMENT c=17 r=1
+#: messages.c:30
+msgid "Filament"
+msgstr ""
 
 # MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ultralcd.cpp:4889
+#: ultralcd.cpp:4991
 msgid "I will run xyz calibration now. It will take approx. 12 mins."
-msgstr "Je vais maintenant\nlancer la\ncalibration xyz.\nCela prendra 12 min\nenviron."
+msgstr "Je vais maintenant lancer la calibration XYZ. Cela prendra 12 min environ."
 
 # MSG_WIZARD_Z_CAL c=20 r=8
-#: ultralcd.cpp:4897
+#: ultralcd.cpp:4999
 msgid "I will run z calibration now."
-msgstr "Je vais maintenant\nlancer la\ncalibration z."
+msgstr "Je vais maintenant lancer la calibration Z."
 
 # MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ultralcd.cpp:4962
+#: ultralcd.cpp:5064
 msgid "I will start to print line and you will gradually lower the nozzle by rotating the knob, until you reach optimal height. Check the pictures in our handbook in chapter Calibration."
-msgstr "Je vais commencer a \nimprimer une ligne\net vous baisserez au\nfur et a mesure la\nbuse en tournant le\nbouton jusqu'a\natteindre la hauteur\noptimale. Regardez\nles photos dans\nnotre manuel au\nchapitre Calibration"
-
-# MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=60
-#: mesh_bed_calibration.cpp:2481
-msgid "Improving bed calibration point"
-msgstr "Amelioration du point de calibration du lit"
+msgstr "Je vais commencer a imprimer une ligne et vous baisserez au fur et a mesure la buse en tournant le bouton jusqu'a atteindre la hauteur optimale. Regardez les photos dans notre manuel au chapitre Calibration"
 
 # MSG_WATCH
 #: messages.c:99
 msgid "Info screen"
 msgstr "Ecran d'info"
 
-# MSG_INIT_SDCARD
-#: ultralcd.cpp:5785
-msgid "Init. SD card"
-msgstr "Init. carte SD"
+# 
+#: ultralcd.cpp:5024
+msgid "Is filament 1 loaded?"
+msgstr "Fil.1 est-il charge?"
 
 # MSG_INSERT_FILAMENT c=20
-#: ultralcd.cpp:2569
+#: ultralcd.cpp:2614
 msgid "Insert filament"
 msgstr "Inserez le filament"
 
-# MSG_FILAMENT_LOADING_T0 c=20 r=4
-#: messages.c:33
-msgid "Insert filament into extruder 1. Click when done."
-msgstr "Inserez le filament\ndans l'extrudeur 1.\nCliquez une fois\npret."
-
-# MSG_FILAMENT_LOADING_T1 c=20 r=4
-#: messages.c:34
-msgid "Insert filament into extruder 2. Click when done."
-msgstr "Inserez le filament\ndans l'extrudeur 2.\nCliquez une fois\npret."
-
-# MSG_FILAMENT_LOADING_T2 c=20 r=4
-#: messages.c:35
-msgid "Insert filament into extruder 3. Click when done."
-msgstr "Inserez le filament\ndans l'extrudeur 3.\nCliquez une fois\npret."
-
-# MSG_FILAMENT_LOADING_T3 c=20 r=4
-#: messages.c:36
-msgid "Insert filament into extruder 4. Click when done."
-msgstr "Inserez le filament\ndans l'extrudeur 4.\nCliquez une fois\npret."
-
-# 
-#: ultralcd.cpp:3947
-msgid "IR:"
-msgstr "IR :"
-
-# 
-#: ultralcd.cpp:4922
-msgid "Is filament 1 loaded?"
-msgstr "Le filament 1 est-il charge ?"
-
 # MSG_WIZARD_FILAMENT_LOADED c=20 r=2
-#: ultralcd.cpp:4925
+#: ultralcd.cpp:5027
 msgid "Is filament loaded?"
-msgstr "Le filament est-il\ncharge ?"
+msgstr "Fil. est-il charge?"
 
 # MSG_WIZARD_PLA_FILAMENT c=20 r=2
-#: ultralcd.cpp:4956
+#: ultralcd.cpp:5058
 msgid "Is it PLA filament?"
-msgstr "Est-ce du filament\nPLA ?"
+msgstr "Est-ce du filament PLA?"
 
 # MSG_PLA_FILAMENT_LOADED c=20 r=2
-#: ultralcd.cpp:4701
+#: ultralcd.cpp:4790
 msgid "Is PLA filament loaded?"
-msgstr "Le filament PLA\nest-il charge ?"
+msgstr "Fil. PLA est-il charge?"
 
 # MSG_STEEL_SHEET_CHECK c=20 r=2
 #: messages.c:92
 msgid "Is steel sheet on heatbed?"
-msgstr "Feuille d'acier sur\nplateau chauffant ?"
-
-# MSG_FIND_BED_OFFSET_AND_SKEW_ITERATION c=20
-#: mesh_bed_calibration.cpp:2223
-msgid "Iteration "
-msgstr "Iteration "
-
-# MSG_KILLED
-#: Marlin_main.cpp:7552
-msgid "KILLED. "
-msgstr "TUE."
+msgstr "Plaque d'impression sur le lit chauffant?"
 
 # 
-#: ultralcd.cpp:1828
-msgid "Last print"
-msgstr "Derniere impression"
-
-# 
-#: ultralcd.cpp:1845
+#: ultralcd.cpp:1795
 msgid "Last print failures"
-msgstr "Echecs derniere impr"
+msgstr "Echecs derniere imp."
 
 # 
-#: ultralcd.cpp:2967
-msgid "Left"
-msgstr "Gauche"
+#: ultralcd.cpp:1772
+msgid "Last print"
+msgstr "Derniere impres."
 
 # MSG_SELFTEST_EXTRUDER_FAN c=20
 #: messages.c:76
 msgid "Left hotend fan?"
 msgstr "Ventilo tete gauche?"
 
+# 
+#: ultralcd.cpp:3018
+msgid "Left"
+msgstr "Gauche"
+
 # MSG_BED_CORRECTION_LEFT c=14 r=1
-#: ultralcd.cpp:3215
+#: ultralcd.cpp:3292
 msgid "Left side [um]"
 msgstr "Gauche [um]"
 
-# MSG_LEFT c=12 r=1
-#: ultralcd.cpp:2308
-msgid "Left:"
-msgstr "Gauche :"
-
 # 
-#: ultralcd.cpp:5575
+#: ultralcd.cpp:5680
 msgid "Lin. correction"
 msgstr "Correction lin."
 
 # MSG_BABYSTEP_Z
 #: messages.c:13
 msgid "Live adjust Z"
-msgstr "Ajuster Z en direct"
-
-# MSG_LOAD_ALL c=17
-#: ultralcd.cpp:6059
-msgid "Load all"
-msgstr "Tout charger"
+msgstr "Ajuster Z en dir."
 
 # MSG_LOAD_FILAMENT c=17
 #: messages.c:51
 msgid "Load filament"
 msgstr "Charger filament"
 
-# MSG_LOAD_FILAMENT_1 c=17
-#: ultralcd.cpp:5576
-msgid "Load filament 1"
-msgstr "Charger fil. 1"
-
-# MSG_LOAD_FILAMENT_2 c=17
-#: ultralcd.cpp:5577
-msgid "Load filament 2"
-msgstr "Charger fil. 2"
-
-# MSG_LOAD_FILAMENT_3 c=17
-#: ultralcd.cpp:5578
-msgid "Load filament 3"
-msgstr "Charger fil. 3"
-
-# MSG_LOAD_FILAMENT_4 c=17
-#: ultralcd.cpp:5579
-msgid "Load filament 4"
-msgstr "Charger fil. 4"
-
-# MSG_LOAD_FILAMENT_5 c=17
-#: ultralcd.cpp:5582
-msgid "Load filament 5"
-msgstr "Charger fil. 5"
-
-# 
-#: ultralcd.cpp:6714
-msgid "Load to nozzle"
-msgstr "Charger dans la buse"
-
 # MSG_LOADING_COLOR
-#: ultralcd.cpp:2609
+#: ultralcd.cpp:2654
 msgid "Loading color"
-msgstr "Chargement couleur"
+msgstr "Charg. de la couleur"
 
 # MSG_LOADING_FILAMENT c=20
 #: messages.c:52
 msgid "Loading filament"
-msgstr "Chargement filament"
+msgstr "Chargement du fil."
 
 # MSG_LOOSE_PULLEY c=20 r=1
-#: ultralcd.cpp:7855
+#: ultralcd.cpp:7941
 msgid "Loose pulley"
 msgstr "Poulie lache"
 
-# MSG_M104_INVALID_EXTRUDER
-#: Marlin_main.cpp:7675
-msgid "M104 Invalid extruder "
-msgstr "M104 extrudeur invalide"
-
-# MSG_M105_INVALID_EXTRUDER
-#: Marlin_main.cpp:7678
-msgid "M105 Invalid extruder "
-msgstr "M105 extrudeur invalide"
-
-# MSG_M109_INVALID_EXTRUDER
-#: Marlin_main.cpp:7681
-msgid "M109 Invalid extruder "
-msgstr "M109 extrudeur invalide"
+# 
+#: ultralcd.cpp:6805
+msgid "Load to nozzle"
+msgstr "Charger la buse"
 
 # MSG_M117_V2_CALIBRATION c=25 r=1
 #: messages.c:55
 msgid "M117 First layer cal."
 msgstr "M117 Cal. 1ere couche"
 
-# MSG_M200_INVALID_EXTRUDER
-#: Marlin_main.cpp:5857
-msgid "M200 Invalid extruder "
-msgstr "M200 extrudeur invalide"
-
-# MSG_M218_INVALID_EXTRUDER
-#: Marlin_main.cpp:7684
-msgid "M218 Invalid extruder "
-msgstr "M218 extrudeur invalide"
-
-# MSG_M221_INVALID_EXTRUDER
-#: Marlin_main.cpp:7687
-msgid "M221 Invalid extruder "
-msgstr "M221 extrudeur invalide"
-
-# 
-#: ultralcd.cpp:6957
-msgid "Magnets comp. [On]"
-msgstr "Comp. aimants [On]"
-
-# 
-#: ultralcd.cpp:6960
-msgid "Magnets comp.[N/A]"
-msgstr "Comp. aimants[N/A]"
-
-# 
-#: ultralcd.cpp:6958
-msgid "Magnets comp.[Off]"
-msgstr "Comp. aimants[Off]"
-
 # MSG_MAIN
 #: messages.c:56
 msgid "Main"
-msgstr "Principal"
-
-# MSG_MARK_FIL c=20 r=8
-#: ultralcd.cpp:3840
-msgid "Mark filament 100mm from extruder body. Click when done."
-msgstr "Marquez le filament\na 100 mm du corps de\nl'extrudeur. Cliquez\nune fois fait."
-
-# 
-#: ultralcd.cpp:3002
-msgid "Measured skew"
-msgstr "Deviation mesuree"
-
-# MSG_MEASURED_SKEW c=15 r=1
-#: ultralcd.cpp:2335
-msgid "Measured skew:"
-msgstr "Ecart mesure :"
+msgstr "Menu principal"
 
 # MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=60
 #: messages.c:59
 msgid "Measuring reference height of calibration point"
 msgstr "Mesure de la hauteur de reference du point de calibration"
 
-# 
-#: ultralcd.cpp:6949
-msgid "Mesh         [3x3]"
-msgstr "Mesh         [3x3]"
-
-# 
-#: ultralcd.cpp:6950
-msgid "Mesh         [7x7]"
-msgstr "Mesh         [7x7]"
-
 # MSG_MESH_BED_LEVELING
-#: ultralcd.cpp:5658
+#: ultralcd.cpp:5763
 msgid "Mesh Bed Leveling"
-msgstr "Mesh Bed Leveling"
-
-# 
-#: ultralcd.cpp:5572
-msgid "Mesh bed leveling"
-msgstr "Mesh bed leveling"
-
-# 
-#: Marlin_main.cpp:881
-msgid "MK3 firmware detected on MK3S printer"
-msgstr "Firmware MK3 detecte sur imprimante MK3S"
-
-# 
-#: Marlin_main.cpp:856
-msgid "MK3S firmware detected on MK3 printer"
-msgstr "Firmware MK3S detecte sur imprimante MK3"
-
-# 
-#: ultralcd.cpp:1845
-msgid "MMU fails"
-msgstr "Echec MMU"
-
-# 
-#: mmu.cpp:1617
-msgid "MMU load failed     "
-msgstr "Echec chargement MMU"
-
-# 
-#: ultralcd.cpp:1845
-msgid "MMU load fails"
-msgstr "Echecs charg. MMU"
-
-# 
-#: ultralcd.cpp:5204
-msgid "MMU Mode [Normal]"
-msgstr "Mode MMU [Normal]"
-
-# 
-#: ultralcd.cpp:5205
-msgid "MMU Mode[Stealth]"
-msgstr "Mode MMU [Furtif]"
-
-# 
-#: mmu.cpp:719
-msgid "MMU needs user attention."
-msgstr "Le MMU necessite l'attention de l'utilisateur."
-
-# MSG_MMU_NEEDS_ATTENTION c=20 r=4
-#: mmu.cpp:359
-msgid "MMU needs user attention. Fix the issue and then press button on MMU unit."
-msgstr "La MMU requiert votre attention. Réglez le problème puis appuyez sur le bouton on sur l'unité MMU."
+msgstr ""
 
 # MSG_MMU_OK_RESUMING_POSITION c=20 r=4
 #: mmu.cpp:762
@@ -1215,42 +723,57 @@ msgstr "MMU OK. Reprise de la position ..."
 # MSG_MMU_OK_RESUMING_TEMPERATURE c=20 r=4
 #: mmu.cpp:755
 msgid "MMU OK. Resuming temperature..."
-msgstr "MMU OK. Remontee en\ntemperature..."
+msgstr "MMU OK. Rechauffage de la buse..."
+
+# 
+#: ultralcd.cpp:3059
+msgid "Measured skew"
+msgstr "Deviat.mesuree"
+
+# 
+#: ultralcd.cpp:1796
+msgid "MMU fails"
+msgstr "Echecs MMU"
+
+# 
+#: mmu.cpp:1613
+msgid "MMU load failed     "
+msgstr "Echec chargement MMU"
+
+# 
+#: ultralcd.cpp:1797
+msgid "MMU load fails"
+msgstr "Echecs charg. MMU"
 
 # MSG_MMU_OK_RESUMING c=20 r=4
 #: mmu.cpp:773
 msgid "MMU OK. Resuming..."
 msgstr "MMU OK. Reprise ..."
 
-# 
-#: ultralcd.cpp:1862
-msgid "MMU power fails"
-msgstr "Echecs alim. MMU"
-
-# 
-#: ultralcd.cpp:2112
-msgid "MMU2 connected"
-msgstr "MMU2 connecte"
-
 # MSG_STEALTH_MODE_OFF
 #: messages.c:90
 msgid "Mode     [Normal]"
-msgstr "Mode     [Normal]"
+msgstr ""
 
 # MSG_SILENT_MODE_ON
 #: messages.c:89
 msgid "Mode     [silent]"
-msgstr "Mode [silencieux]"
+msgstr "Mode     [feutre]"
+
+# 
+#: mmu.cpp:719
+msgid "MMU needs user attention."
+msgstr "Le MMU necessite l'attention de l'utilisateur."
+
+# 
+#: ultralcd.cpp:1823
+msgid "MMU power fails"
+msgstr "Echecs alim. MMU"
 
 # MSG_STEALTH_MODE_ON
 #: messages.c:91
 msgid "Mode    [Stealth]"
-msgstr "Mode [Furtif]"
-
-# 
-#: ultralcd.cpp:4424
-msgid "Mode change in progress ..."
-msgstr "Changement de mode en cours..."
+msgstr "Mode     [furtif]"
 
 # MSG_AUTO_MODE_ON
 #: messages.c:12
@@ -1260,22 +783,12 @@ msgstr "Mode [puiss.auto]"
 # MSG_SILENT_MODE_OFF
 #: messages.c:88
 msgid "Mode [high power]"
-msgstr "Mode [haute puiss]"
+msgstr "Mode[haute puiss]"
 
 # 
-#: ultralcd.cpp:5404
-msgid "Model      [none]"
-msgstr "Modele   [aucune]"
-
-# 
-#: ultralcd.cpp:5407
-msgid "Model      [warn]"
-msgstr "Modele    [avert]"
-
-# 
-#: ultralcd.cpp:5410
-msgid "Model    [strict]"
-msgstr "Modele  [stricte]"
+#: ultralcd.cpp:2219
+msgid "MMU2 connected"
+msgstr "MMU2 connecte"
 
 # MSG_SELFTEST_MOTOR
 #: messages.c:83
@@ -1283,69 +796,54 @@ msgid "Motor"
 msgstr "Moteur"
 
 # MSG_MOVE_AXIS
-#: ultralcd.cpp:5550
+#: ultralcd.cpp:5652
 msgid "Move axis"
 msgstr "Deplacer l'axe"
 
 # MSG_MOVE_X
-#: ultralcd.cpp:4291
+#: ultralcd.cpp:4378
 msgid "Move X"
 msgstr "Deplacer X"
 
 # MSG_MOVE_Y
-#: ultralcd.cpp:4292
+#: ultralcd.cpp:4379
 msgid "Move Y"
 msgstr "Deplacer Y"
 
 # MSG_MOVE_Z
-#: ultralcd.cpp:4293
+#: ultralcd.cpp:4380
 msgid "Move Z"
 msgstr "Deplacer Z"
 
-# 
-#: ultralcd.cpp:2973
-msgid "N/A"
-msgstr "N/A"
+# MSG_NO_MOVE
+#: Marlin_main.cpp:5292
+msgid "No move."
+msgstr "Pas de mouvement."
+
+# MSG_NO_CARD
+#: ultralcd.cpp:6772
+msgid "No SD card"
+msgstr "Pas de carte SD"
 
 # 
-#: util.cpp:293
-msgid "New firmware version available:"
-msgstr "Nouvelle version de\nfirmware disponible:"
+#: ultralcd.cpp:3024
+msgid "N/A"
+msgstr ""
 
 # MSG_NO
 #: messages.c:62
 msgid "No"
 msgstr "Non"
 
-# 
-#:
-msgid "No "
-msgstr "Non"
-
-# MSG_ERR_NO_CHECKSUM
-#: cmdqueue.cpp:456
-msgid "No Checksum with line number, Last Line: "
-msgstr "Pas de checksum avec\nnumero de ligne, \nDerniere ligne :"
-
-# MSG_NO_MOVE
-#: Marlin_main.cpp:5254
-msgid "No move."
-msgstr "Pas de mouvement."
-
-# MSG_NO_CARD
-#: ultralcd.cpp:6694
-msgid "No SD card"
-msgstr "Pas de carte SD"
-
-# MSG_ERR_NO_THERMISTORS
-#: Marlin_main.cpp:4946
-msgid "No thermistors - no temperature"
-msgstr "Pas de thermistors\n- pas de temperature"
-
 # MSG_SELFTEST_NOTCONNECTED
-#: ultralcd.cpp:7803
+#: ultralcd.cpp:7889
 msgid "Not connected"
 msgstr "Non connecte"
+
+# 
+#: util.cpp:293
+msgid "New firmware version available:"
+msgstr "Nouvelle version de firmware disponible:"
 
 # MSG_SELFTEST_FAN_NO c=19
 #: messages.c:79
@@ -1353,229 +851,139 @@ msgid "Not spinning"
 msgstr "Ne tourne pas"
 
 # MSG_WIZARD_V2_CAL c=20 r=8
-#: ultralcd.cpp:4961
+#: ultralcd.cpp:5063
 msgid "Now I will calibrate distance between tip of the nozzle and heatbed surface."
-msgstr "Maintenant je vais\ncalibrer la distance \nentre la pointe de\nla buse et la\nsurface du plateau\nchauffant."
+msgstr "Maintenant je vais calibrer la distance entre la pointe de la buse et la surface du plateau chauffant."
 
 # MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ultralcd.cpp:4905
+#: ultralcd.cpp:5007
 msgid "Now I will preheat nozzle for PLA."
-msgstr "Maintenant je vais\nprechauffer la buse\npour du PLA."
-
-# 
-#: ultralcd.cpp:4896
-msgid "Now remove the test print from steel sheet."
-msgstr "Retirez maintenant l'impression de test de la feuille d'acier."
+msgstr "Maintenant je vais prechauffer la buse pour du PLA."
 
 # MSG_NOZZLE
 #: messages.c:63
 msgid "Nozzle"
 msgstr "Buse"
 
-# 
-#: ultralcd.cpp:5319
-msgid "Nozzle     [none]"
-msgstr "Buse     [aucune]"
-
-# 
-#: ultralcd.cpp:5322
-msgid "Nozzle     [warn]"
-msgstr "Buse      [avert]"
-
-# 
-#: ultralcd.cpp:5325
-msgid "Nozzle   [strict]"
-msgstr "Buse    [stricte]"
-
-# 
-#: ultralcd.cpp:5365
-msgid "Nozzle d.  [0.25]"
-msgstr "Diam. buse [0.25]"
-
-# 
-#: ultralcd.cpp:5368
-msgid "Nozzle d.  [0.40]"
-msgstr "Diam. buse [0.40]"
-
-# 
-#: ultralcd.cpp:5371
-msgid "Nozzle d.  [0.60]"
-msgstr "Diam. buse [0.60]"
-
-# 
-#: ultralcd.cpp:1787
-msgid "Nozzle FAN"
-msgstr "Ventilateur buse"
-
-# MSG_INFO_NOZZLE_FAN c=11 r=1
-#: ultralcd.cpp:1537
-msgid "Nozzle FAN:"
-msgstr "Vent. buse:"
-
-# MSG_NOZZLE1
-#: ultralcd.cpp:5995
-msgid "Nozzle2"
-msgstr "Buse2"
-
-# MSG_NOZZLE2
-#: ultralcd.cpp:5998
-msgid "Nozzle3"
-msgstr "Buse3"
-
-# MSG_OK
-#: Marlin_main.cpp:6333
-msgid "ok"
-msgstr "ok"
-
 # MSG_DEFAULT_SETTINGS_LOADED c=20 r=4
-#: Marlin_main.cpp:1535
+#: Marlin_main.cpp:1519
 msgid "Old settings found. Default PID, Esteps etc. will be set."
-msgstr "Anciens reglages\ntrouves. Le PID, les\nEsteps etc. par\ndefaut seront regles"
+msgstr "Anciens reglages trouves. Le PID, les Esteps etc. par defaut seront regles"
 
-# MSG_ENDSTOP_OPEN
-#: messages.c:29
-msgid "open"
-msgstr "ouvrir"
+# 
+#: ultralcd.cpp:4998
+msgid "Now remove the test print from steel sheet."
+msgstr "Retirez maintenant l'impression de test de la plaque en acier."
 
-# MSG_SD_OPEN_FILE_FAIL
-#: messages.c:79
-msgid "open failed, File: "
-msgstr "Echec ouverture, Fichier :"
-
-# MSG_SD_OPENROOT_FAIL
-#: cardreader.cpp:196
-msgid "openRoot failed"
-msgstr "Echec openRoot"
+# 
+#: ultralcd.cpp:1722
+msgid "Nozzle FAN"
+msgstr "Vent. buse"
 
 # MSG_PAUSE_PRINT
-#: ultralcd.cpp:6657
+#: ultralcd.cpp:6735
 msgid "Pause print"
 msgstr "Pause de l'impr."
 
-# MSG_PICK_Z
-#: ultralcd.cpp:3463
-msgid "Pick print"
-msgstr "Choisir impression"
-
 # MSG_PID_RUNNING c=20 r=1
-#: ultralcd.cpp:1613
+#: ultralcd.cpp:1606
 msgid "PID cal.           "
 msgstr "Calib. PID"
 
 # MSG_PID_FINISHED c=20 r=1
-#: ultralcd.cpp:1619
+#: ultralcd.cpp:1612
 msgid "PID cal. finished"
 msgstr "Calib. PID terminee"
 
 # MSG_PID_EXTRUDER c=17 r=1
-#: ultralcd.cpp:5664
+#: ultralcd.cpp:5769
 msgid "PID calibration"
 msgstr "Calibration PID"
 
 # MSG_PINDA_PREHEAT c=20 r=1
-#: ultralcd.cpp:862
+#: ultralcd.cpp:846
 msgid "PINDA Heating"
 msgstr "Chauffe de la PINDA"
-
-# 
-#: ultralcd.cpp:3939
-msgid "PINDA:"
-msgstr "PINDA :"
 
 # MSG_PAPER c=20 r=8
 #: messages.c:64
 msgid "Place a sheet of paper under the nozzle during the calibration of first 4 points. If the nozzle catches the paper, power off the printer immediately."
-msgstr "Placez une feuille\nde papier sous la\nbuse pendant la\ncalibration des 4\npremiers points.\nSi la buse accroche\nle papier, eteignez\nvite l'imprimante."
-
-# MSG_SELFTEST_PLEASECHECK
-#: ultralcd.cpp:7795
-msgid "Please check :"
-msgstr "Verifiez :"
-
-# MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: messages.c:100
-msgid "Please check our handbook and fix the problem. Then resume the Wizard by rebooting the printer."
-msgstr "Merci de verifier\nnotre manuel et de\ncorriger le\nprobleme. Poursuivez\nalors l'assistant en\nredemarrant\nl'imprimante."
+msgstr "Placez une feuille de papier sous la buse pendant la calibration des 4 premiers points. Si la buse accroche le papier, eteignez vite l'imprimante."
 
 # MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ultralcd.cpp:4970
+#: ultralcd.cpp:5072
 msgid "Please clean heatbed and then press the knob."
-msgstr "Nettoyez le plateau\nchauffant et appuyez\nsur le bouton."
+msgstr "Nettoyez la plaque en acier et appuyez sur le bouton."
 
 # MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
 #: messages.c:22
 msgid "Please clean the nozzle for calibration. Click when done."
-msgstr "Nettoyez la buse\npour la calibration.\nCliquez une fois\nfait."
+msgstr "Nettoyez la buse pour la calibration. Cliquez une fois fait."
+
+# MSG_SELFTEST_PLEASECHECK
+#: ultralcd.cpp:7881
+msgid "Please check :"
+msgstr "Verifiez:"
+
+# MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
+#: messages.c:100
+msgid "Please check our handbook and fix the problem. Then resume the Wizard by rebooting the printer."
+msgstr "Merci de consulter notre manuel et de corriger le probleme. Poursuivez alors l'assistant en redemarrant l'imprimante."
 
 # MSG_WIZARD_LOAD_FILAMENT c=20 r=8
-#: ultralcd.cpp:4804
+#: ultralcd.cpp:4894
 msgid "Please insert PLA filament to the extruder, then press knob to load it."
-msgstr "Inserez du filament\nPLA dans l'extrudeur\npuis appuyez sur le\nbouton pour le\ncharger."
-
-# 
-#: ultralcd.cpp:4800
-msgid "Please insert PLA filament to the first tube of MMU, then press the knob to load it."
-msgstr "Veuillez inserer du filament PLA dans le premier tube du MMU, et pressez sur le bouton pour le charger."
-
-# MSG_WIZARD_INSERT_CORRECT_FILAMENT c=20 r=8
-#: ultralcd.cpp:4109
-msgid "Please load PLA filament and then resume Wizard by rebooting the printer."
-msgstr "Chargez le filament\nPLA et poursuivez\nl'assistant en\nredemarrant\nl'imprimante."
+msgstr "Inserez du filament PLA dans l'extrudeur puis appuyez sur le bouton pour le charger."
 
 # MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ultralcd.cpp:4706
+#: ultralcd.cpp:4795
 msgid "Please load PLA filament first."
-msgstr "Chargez d'abord le\nfilament PLA."
+msgstr "Chargez d'abord le filament PLA."
 
 # MSG_CHECK_IDLER c=20 r=4
-#: Marlin_main.cpp:3083
+#: Marlin_main.cpp:3064
 msgid "Please open idler and remove filament manually."
-msgstr "Ouvrez l'idler et\nretirez le filament\nmanuellement."
+msgstr "Ouvrez l'idler et retirez le filament manuellement."
 
 # MSG_PLACE_STEEL_SHEET c=20 r=4
 #: messages.c:65
 msgid "Please place steel sheet on heatbed."
-msgstr "Placez la feuille\nd'acier sur le\nplateau chauffant."
+msgstr "Placez la plaque en acier sur le plateau chauffant."
 
 # MSG_PRESS_TO_UNLOAD c=20 r=4
 #: messages.c:68
 msgid "Please press the knob to unload filament"
-msgstr "Appuyez sur le\nbouton pour \ndecharger le \nfilament"
+msgstr "Appuyez sur le bouton pour decharger le filament"
+
+# 
+#: ultralcd.cpp:4889
+msgid "Please insert PLA filament to the first tube of MMU, then press the knob to load it."
+msgstr "Inserez du PLA dans le 1er tube du MMU, appuyez sur le bouton pour le charger."
 
 # MSG_PULL_OUT_FILAMENT c=20 r=4
 #: messages.c:70
 msgid "Please pull out filament immediately"
-msgstr "Retirez\nimmediatement le\nfilament"
+msgstr "Retirez immediatement le filament"
 
 # MSG_EJECT_REMOVE c=20 r=4
-#: mmu.cpp:1441
+#: mmu.cpp:1440
 msgid "Please remove filament and then press the knob."
 msgstr "Veuillez retirer le filament puis appuyez sur le bouton."
-
-# 
-#: ultralcd.cpp:4895
-msgid "Please remove shipping helpers first."
-msgstr "Veuillez retirer d'abord les protections d'envoi."
 
 # MSG_REMOVE_STEEL_SHEET c=20 r=4
 #: messages.c:74
 msgid "Please remove steel sheet from heatbed."
-msgstr "Retirez la feuille\nd'acier du plateau\nchauffant."
+msgstr "Retirez la plaque en acier du plateau chauffant."
 
 # MSG_RUN_XYZ c=20 r=4
-#: Marlin_main.cpp:4317
+#: Marlin_main.cpp:4355
 msgid "Please run XYZ calibration first."
 msgstr "Veuillez d'abord lancer la calibration XYZ."
 
 # MSG_UPDATE_MMU2_FW c=20 r=4
-#: mmu.cpp:1360
+#: mmu.cpp:1359
 msgid "Please update firmware in your MMU2. Waiting for reset."
-msgstr "Veuillez mettre a\njour le firmware de\nvotre MMU2. En\nattente d'un reset."
-
-# 
-#: util.cpp:297
-msgid "Please upgrade."
-msgstr "Mettez a jour le FW."
+msgstr "Veuillez mettre a jour le firmware de votre MMU2. En attente d'un reset."
 
 # MSG_PLEASE_WAIT c=20
 #: messages.c:66
@@ -1583,214 +991,104 @@ msgid "Please wait"
 msgstr "Merci de patienter"
 
 # 
-#: ultralcd.cpp:1881
-msgid "Power failures"
-msgstr "Coupures de courant"
-
-# MSG_POWERUP
-#: messages.c:69
-msgid "PowerUp"
-msgstr "Demarrage"
-
-# MSG_PREHEAT
-#: ultralcd.cpp:6644
-msgid "Preheat"
-msgstr "Prechauffage"
+#: ultralcd.cpp:4997
+msgid "Please remove shipping helpers first."
+msgstr "Retirez d'abord les protections de transport."
 
 # MSG_PREHEAT_NOZZLE c=20
 #: messages.c:67
 msgid "Preheat the nozzle!"
 msgstr "Prechauffez la buse!"
 
+# MSG_PREHEAT
+#: ultralcd.cpp:6722
+msgid "Preheat"
+msgstr "Prechauffage"
+
 # MSG_WIZARD_HEATING c=20 r=3
 #: messages.c:102
 msgid "Preheating nozzle. Please wait."
-msgstr "Prechauffage de la\nbuse. Merci de\npatienter."
+msgstr "Prechauffage de la buse. Merci de patienter."
 
 # 
-#: ultralcd.cpp:2290
-msgid "Preheating to cut"
-msgstr "Prechauffage pour couper"
-
-# 
-#: ultralcd.cpp:2287
-msgid "Preheating to eject"
-msgstr "Prechauffage pour ejecter"
-
-# 
-#: ultralcd.cpp:2280
-msgid "Preheating to load"
-msgstr "Chauffe pour charger"
-
-# 
-#: ultralcd.cpp:2284
-msgid "Preheating to unload"
-msgstr "Chauffe pr decharger"
-
-# MSG_PREPARE_FILAMENT c=20 r=1
-#: ultralcd.cpp:1911
-msgid "Prepare new filament"
-msgstr "Preparez le filament"
+#: util.cpp:297
+msgid "Please upgrade."
+msgstr "Mettez a jour le FW."
 
 # MSG_PRESS_TO_PREHEAT c=20 r=4
-#: Marlin_main.cpp:10312
+#: Marlin_main.cpp:10364
 msgid "Press knob to preheat nozzle and continue."
-msgstr "Appuyez sur le\nbouton pour\nprechauffer la buse\net continuer."
+msgstr "Appuyez sur le bouton pour prechauffer la buse et continuer."
 
 # 
-#: ultralcd.cpp:2210
-msgid "Press the knob"
-msgstr "App. sur sur bouton"
-
-# 
-#: mmu.cpp:723
-msgid "Press the knob to resume nozzle temperature."
-msgstr "Appuyez sur le bouton pour poursuivre la mise en temperature de la buse."
+#: ultralcd.cpp:1851
+msgid "Power failures"
+msgstr "Coup.de courant"
 
 # MSG_PRINT_ABORTED c=20
 #: messages.c:69
 msgid "Print aborted"
 msgstr "Impression annulee"
 
-# 
-#: ultralcd.cpp:1789
-msgid "Print FAN"
-msgstr "Ventilo impression"
+#  c=20 r=1
+#: ultralcd.cpp:2455
+msgid "Preheating to load"
+msgstr "Chauffe pour charger"
 
-# MSG_INFO_PRINT_FAN c=11 r=1
-#: ultralcd.cpp:1549
-msgid "Print FAN: "
-msgstr "Vent impr :"
+#  c=20 r=1
+#: ultralcd.cpp:2459
+msgid "Preheating to unload"
+msgstr "Chauf.pour decharger"
 
 # MSG_SELFTEST_PRINT_FAN_SPEED c=18
-#: ultralcd.cpp:8221
+#: ultralcd.cpp:8307
 msgid "Print fan:"
-msgstr "Ventilo impr. :"
+msgstr "Vent. impr:"
 
 # MSG_CARD_MENU
 #: messages.c:21
 msgid "Print from SD"
-msgstr "Impr depuis la SD"
+msgstr "Impr. depuis la SD"
+
+# 
+#: ultralcd.cpp:2317
+msgid "Press the knob"
+msgstr "App. sur sur bouton"
 
 # MSG_PRINT_PAUSED c=20 r=1
-#: ultralcd.cpp:1080
+#: ultralcd.cpp:1069
 msgid "Print paused"
 msgstr "Impression en pause"
 
-# MSG_PRINT_TIME c=19 r=1
-#: ultralcd.cpp:2838
-msgid "Print time"
-msgstr "Temps d'impression"
-
-# MSG_STATS_PRINTTIME c=20
-#: ultralcd.cpp:2151
-msgid "Print time:  "
-msgstr "Temps d'impression :"
-
-# MSG_PRINTER_DISCONNECTED c=20 r=1
-#: ultralcd.cpp:607
-msgid "Printer disconnected"
-msgstr "Impri. deconnectee"
-
 # 
-#: util.cpp:473
-msgid "Printer FW version differs from the G-code. Continue?"
-msgstr "Version FW de l'imprimante differente du G-Code. Continuer ?"
-
-# 
-#: util.cpp:480
-msgid "Printer FW version differs from the G-code. Please check the value in settings. Print cancelled."
-msgstr "Version FW de l'imprimante differente du G-Code. Merci de verifier le parametre dans les reglages. Impression annulee."
-
-# 
-#: util.cpp:506
-msgid "Printer G-code level differs from the G-code. Continue?"
-msgstr "Niveau de G-Code de l'imprimante different du G-Code. Continuer ?"
-
-# 
-#: util.cpp:513
-msgid "Printer G-code level differs from the G-code. Please check the value in settings. Print cancelled."
-msgstr "Merci de verifier le parametre dans les reglages. Impression annulee."
-
-# MSG_ERR_KILLED
-#: Marlin_main.cpp:7547
-msgid "Printer halted. kill() called!"
-msgstr "Imprimante stoppee.\nkill() appelee !"
+#: mmu.cpp:723
+msgid "Press the knob to resume nozzle temperature."
+msgstr "Appuyez sur le bouton pour rechauffer la buse."
 
 # MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
 #: messages.c:41
 msgid "Printer has not been calibrated yet. Please follow the manual, chapter First steps, section Calibration flow."
-msgstr "L'imprimante n'a pas\nencore ete calibree.\nSuivez le manuel,\nchapitre Premiers\npas, section\nProcessus de\ncalibration."
+msgstr "L'imprimante n'a pas encore ete calibree. Suivez le manuel, chapitre Premiers pas, section Processus de calibration."
 
 # 
-#: util.cpp:423
-msgid "Printer model differs from the G-code. Continue?"
-msgstr "Modele d'imprimante different du G-Code. Continuer ?"
-
-# 
-#: util.cpp:430
-msgid "Printer model differs from the G-code. Please check the value in settings. Print cancelled."
-msgstr "Modele d'imprimante diffent du G-Code. Merci de verifier le parametre dans les reglages. Impression annulee."
-
-# 
-#: util.cpp:390
-msgid "Printer nozzle diameter differs from the G-code. Continue?"
-msgstr "Diametre de la  buse de l'imprimante different du G-Code. Continuer ?"
-
-# 
-#: util.cpp:397
-msgid "Printer nozzle diameter differs from the G-code. Please check the value in settings. Print cancelled."
-msgstr "Diametre de la  buse de l'imprimante different du G-Code. Merci de verifier le parametre dans les reglages. Impression annulee."
-
-# MSG_ERR_STOPPED
-#: messages.c:32
-msgid "Printer stopped due to errors. Fix the error and use M999 to restart. (Temperature is reset. Set it after restarting)"
-msgstr "Imprimante arretee a\ncause d'erreurs.\nCorrigez l'erreur et\nutilisez M999 pour\nredemarrer. (La\ntemperature est\nreinitilisee.\nParametrez la apres\nle redemarrage)"
-
-# 
-#:
-msgid "Prusa i3 MK2 ready."
-msgstr "Prusa i3 MK2 prete."
-
-# WELCOME_MSG c=20
-#:
-msgid "Prusa i3 MK2.5 ready."
-msgstr "Prusa i3 MK2.5 prete."
-
-# 
-#:
-msgid "Prusa i3 MK3 OK."
-msgstr "Prusa i3 MK3 OK."
-
-# WELCOME_MSG c=20
-#:
-msgid "Prusa i3 MK3 ready."
-msgstr "Prusa i3 MK3 prete."
-
-# 
-#:
-msgid "Prusa i3 MK3S OK."
-msgstr "Prusa i3 MK3S OK."
+#: ultralcd.cpp:1723
+msgid "Print FAN"
+msgstr "Vent. impr"
 
 # MSG_PRUSA3D
-#: ultralcd.cpp:2098
+#: ultralcd.cpp:2205
 msgid "prusa3d.com"
-msgstr "prusa3d.com"
+msgstr ""
 
 # MSG_BED_CORRECTION_REAR c=14 r=1
-#: ultralcd.cpp:3218
+#: ultralcd.cpp:3295
 msgid "Rear side [um]"
 msgstr "Arriere [um]"
 
 # MSG_RECOVERING_PRINT c=20 r=1
-#: Marlin_main.cpp:9712
+#: Marlin_main.cpp:9764
 msgid "Recovering print    "
 msgstr "Recup. impression"
-
-# MSG_REFRESH
-#:
-msgid "Refresh"
-msgstr "Rafraichir"
 
 # MSG_REMOVE_OLD_FILAMENT c=20 r=4
 #: mmu.cpp:830
@@ -1798,37 +1096,22 @@ msgid "Remove old filament and press the knob to start loading new filament."
 msgstr "Retirez l'ancien filament puis appuyez sur le bouton pour charger le nouveau."
 
 # 
-#: ultralcd.cpp:6605
-msgid "Rename"
-msgstr "Renommer"
+#: 
+msgid "Prusa i3 MK3S OK."
+msgstr ""
 
-# MSG_M119_REPORT
-#: Marlin_main.cpp:5297
-msgid "Reporting endstop status"
-msgstr "Retour du statut des\nbutees"
-
-# 
-#: Marlin_main.cpp:7076
-msgid "Resend"
-msgstr "Renvoyer"
-
-# MSG_RESEND
-#: Marlin_main.cpp:6911
-msgid "Resend: "
-msgstr "Renvoi :"
+# MSG_CALIBRATE_BED_RESET
+#: ultralcd.cpp:5774
+msgid "Reset XYZ calibr."
+msgstr "Reinit. calib. XYZ"
 
 # MSG_BED_CORRECTION_RESET
-#: ultralcd.cpp:3219
+#: ultralcd.cpp:3296
 msgid "Reset"
 msgstr "Reinitialiser"
 
-# MSG_CALIBRATE_BED_RESET
-#: ultralcd.cpp:5669
-msgid "Reset XYZ calibr."
-msgstr "Reinit. calibr. XYZ"
-
 # MSG_RESUME_PRINT
-#: ultralcd.cpp:6664
+#: ultralcd.cpp:6742
 msgid "Resume print"
 msgstr "Reprendre impression"
 
@@ -1837,115 +1120,70 @@ msgstr "Reprendre impression"
 msgid "Resuming print"
 msgstr "Reprise de l'impr."
 
-# 
-#: ultralcd.cpp:2968
-msgid "Right"
-msgstr "Droite"
-
 # MSG_BED_CORRECTION_RIGHT c=14 r=1
-#: ultralcd.cpp:3216
+#: ultralcd.cpp:3293
 msgid "Right side[um]"
 msgstr "Droite [um]"
 
-# MSG_RIGHT c=12 r=1
-#: ultralcd.cpp:2309
-msgid "Right:"
-msgstr "Droite :"
-
-# MSG_E_CAL_KNOB c=20 r=8
-#: ultralcd.cpp:3835
-msgid "Rotate knob until mark reaches extruder body. Click when done."
-msgstr "Tournez le bouton\njusqu'a ce que la\nmarque atteigne le\ncorps de\nl'extrudeur. Cliquez\nune fois fait."
-
 # MSG_SECOND_SERIAL_ON c=17 r=1
-#: ultralcd.cpp:5587
+#: ultralcd.cpp:5692
 msgid "RPi port     [on]"
-msgstr "Port RPi [on]"
+msgstr "Port RPi     [on]"
 
 # MSG_SECOND_SERIAL_OFF c=17 r=1
-#: ultralcd.cpp:5585
+#: ultralcd.cpp:5690
 msgid "RPi port    [off]"
-msgstr "Port RPi [off]"
+msgstr "Port RPi    [off]"
 
 # MSG_WIZARD_RERUN c=20 r=7
-#: ultralcd.cpp:4723
+#: ultralcd.cpp:4812
 msgid "Running Wizard will delete current calibration results and start from the beginning. Continue?"
-msgstr "Lancer l'Assistant\nsupprimera les\nresultats actuels de\ncalibration et\ncommencera du debut.\nContinuer ?"
+msgstr "Lancement de l'Assistant supprimera les resultats actuels de calibration et commencera du debut. Continuer?"
 
 # MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_OFF c=19 r=1
-#: ultralcd.cpp:5220
+#: ultralcd.cpp:5322
 msgid "SD card  [normal]"
 msgstr "Carte SD [normal]"
 
-# MSG_SD_CARD_OK
-#: cardreader.cpp:202
-msgid "SD card ok"
-msgstr "Carte SD ok"
-
 # MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_ON c=19 r=1
-#: ultralcd.cpp:4238
-msgid "SD card [FlshAir]"
-msgstr "Carte SD [FlashAir]"
-
-# MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_ON c=19 r=1
-#: ultralcd.cpp:5218
+#: ultralcd.cpp:5320
 msgid "SD card [flshAir]"
-msgstr "Carte SD [flashAir]"
+msgstr "CarteSD [flshAir]"
 
-# MSG_SD_INIT_FAIL
-#: cardreader.cpp:186
-msgid "SD init fail"
-msgstr "Echec init SD"
-
-# MSG_SD_PRINTING_BYTE
-#: cardreader.cpp:516
-msgid "SD printing byte "
-msgstr "Octet d'impression de la SD"
+# 
+#: ultralcd.cpp:3019
+msgid "Right"
+msgstr "Droite"
 
 # MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=60
 #: messages.c:38
 msgid "Searching bed calibration point"
 msgstr "Recherche du point de calibration du lit"
 
-# 
-#: ultralcd.cpp:6601
-msgid "Select"
-msgstr "Selectionner"
-
 # MSG_LANGUAGE_SELECT
-#: ultralcd.cpp:5594
+#: ultralcd.cpp:5699
 msgid "Select language"
 msgstr "Choisir langue"
 
-# 
-#: ultralcd.cpp:4943
-msgid "Select nozzle preheat temperature which matches your material."
-msgstr "Selectionnez la temperature de prechauffage de la buse qui correspond a votre materiau."
-
-# 
-#: ultralcd.cpp:4692
-msgid "Select PLA filament:"
-msgstr "Selectionnez le filament PLA :"
-
 # MSG_SELFTEST_OK
-#: ultralcd.cpp:7366
+#: ultralcd.cpp:7452
 msgid "Self test OK"
 msgstr "Auto-test OK"
 
 # MSG_SELFTEST_START c=20
-#: ultralcd.cpp:7152
+#: ultralcd.cpp:7238
 msgid "Self test start  "
 msgstr "Debut auto-test"
 
 # MSG_SELFTEST
-#: ultralcd.cpp:5645
+#: ultralcd.cpp:5750
 msgid "Selftest         "
 msgstr "Auto-test"
 
 # MSG_SELFTEST_ERROR
-#: ultralcd.cpp:7793
+#: ultralcd.cpp:7879
 msgid "Selftest error !"
-msgstr "Erreur auto-test !"
+msgstr "Erreur auto-test!"
 
 # MSG_SELFTEST_FAILED c=20
 #: messages.c:77
@@ -1953,139 +1191,64 @@ msgid "Selftest failed  "
 msgstr "Echec de l'auto-test"
 
 # MSG_FORCE_SELFTEST c=20 r=8
-#: Marlin_main.cpp:1567
+#: Marlin_main.cpp:1551
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
-msgstr "Le Selftest sera\nlance pour calibrer\nla remise a zero\nprecise sans capteur"
+msgstr "Le Selftest sera lance pour calibrer la remise a zero precise sans capteur"
 
 # 
-#: ultralcd.cpp:2138
-msgid "Sensor info"
-msgstr "Info capteur"
+#: ultralcd.cpp:5045
+msgid "Select nozzle preheat temperature which matches your material."
+msgstr "Selectionnez la temperature de prechauffage de la buse qui correspond a votre materiau."
 
 # 
-#: ultralcd.cpp:3938
-msgid "Sensor state"
-msgstr "Etat capteur"
-
-# 
-#:
-msgid "Sensors info"
-msgstr "Infos capteurs"
+#: ultralcd.cpp:4780
+msgid "Select PLA filament:"
+msgstr "Selectionnez le fil. PLA:"
 
 # MSG_SET_TEMPERATURE c=19 r=1
-#: ultralcd.cpp:3227
+#: ultralcd.cpp:3314
 msgid "Set temperature:"
-msgstr "Regler temp. :"
+msgstr "Regler temp.:"
 
 # MSG_SETTINGS
 #: messages.c:86
 msgid "Settings"
 msgstr "Reglages"
 
-# 
-#: ultralcd.cpp:3005
-msgid "Severe skew"
-msgstr "Deviation severe"
-
-# MSG_SEVERE_SKEW c=15 r=1
-#: ultralcd.cpp:2346
-msgid "Severe skew:"
-msgstr "Ecart severe :"
-
-# 
-#: messages.c:58
-msgid "Sheet"
-msgstr "Feuille"
-
 # MSG_SHOW_END_STOPS c=17 r=1
-#: ultralcd.cpp:5666
+#: ultralcd.cpp:5771
 msgid "Show end stops"
 msgstr "Afficher butees"
 
 # 
-#:
-msgid "Show pinda state"
-msgstr "Etat de la PINDA"
-
-# MSG_DWELL
-#: Marlin_main.cpp:3752
-msgid "Sleep..."
-msgstr "Repos..."
-
-# 
-#: ultralcd.cpp:3004
-msgid "Slight skew"
-msgstr "Deviation legere"
-
-# MSG_SLIGHT_SKEW c=15 r=1
-#: ultralcd.cpp:2342
-msgid "Slight skew:"
-msgstr "Leger ecart :"
+#: ultralcd.cpp:4025
+msgid "Sensor state"
+msgstr "Etat capteur"
 
 # MSG_FILE_CNT c=20 r=4
 #: cardreader.cpp:739
 msgid "Some files will not be sorted. Max. No. of files in 1 folder for sorting is 100."
-msgstr "Certains fichiers ne\nseront pas tries.\nMax 100 fichiers\ntries par dossier."
-
-# 
-#: Marlin_main.cpp:4833
-msgid "Some problem encountered, Z-leveling enforced ..."
-msgstr "Problemes rencontres, nivellement de l'axe Z applique..."
+msgstr "Certains fichiers ne seront pas tries. Max 100 fichiers tries par dossier."
 
 # MSG_SORT_NONE c=17 r=1
-#: ultralcd.cpp:5230
+#: ultralcd.cpp:5332
 msgid "Sort       [none]"
 msgstr "Tri       [aucun]"
 
 # MSG_SORT_TIME c=17 r=1
-#: ultralcd.cpp:5228
+#: ultralcd.cpp:5330
 msgid "Sort       [time]"
-msgstr "Tri        [date]"
+msgstr "Tri       [heure]"
+
+# 
+#: ultralcd.cpp:3062
+msgid "Severe skew:"
+msgstr "Deviat.sev.:"
 
 # MSG_SORT_ALPHA c=17 r=1
-#: ultralcd.cpp:5229
+#: ultralcd.cpp:5331
 msgid "Sort   [alphabet]"
 msgstr "Tri    [alphabet]"
-
-# MSG_SORT_NONE c=17 r=1
-#: ultralcd.cpp:4250
-msgid "Sort:      [None]"
-msgstr "Tri : [Aucun]"
-
-# MSG_SORT_NONE c=17 r=1
-#: ultralcd.cpp:5043
-msgid "Sort:      [none]"
-msgstr "Tri :     [aucun]"
-
-# MSG_SORT_TIME c=17 r=1
-#: ultralcd.cpp:4248
-msgid "Sort:      [Time]"
-msgstr "Tri : [Heure]"
-
-# MSG_SORT_TIME c=17 r=1
-#: ultralcd.cpp:5041
-msgid "Sort:      [time]"
-msgstr "Tri :     [heure]"
-
-# MSG_SORT_ALPHA c=17 r=1
-#: ultralcd.cpp:4249
-msgid "Sort:  [Alphabet]"
-msgstr "Tri : [Alphabet]"
-
-# MSG_SORT_ALPHA c=17 r=1
-#: ultralcd.cpp:5042
-msgid "Sort:  [alphabet]"
-msgstr "Tri : [alphabet]"
-
-# MSG_SORT_NONE c=17 r=1
-#:
-msgid "Sort:  [none]"
-msgstr "Tri : [aucun]"
-
-# MSG_SORT_TIME c=17 r=1
-#:
-msgid "Sort:  [time]"
-msgstr "Tri : [heure]"
 
 # MSG_SORTING c=20 r=1
 #: cardreader.cpp:746
@@ -2095,35 +1258,35 @@ msgstr "Tri des fichiers"
 # MSG_SOUND_LOUD c=17 r=1
 #: sound.h:6
 msgid "Sound      [loud]"
-msgstr "Son [fort]"
+msgstr "Son        [fort]"
+
+# 
+#: ultralcd.cpp:3061
+msgid "Slight skew:"
+msgstr "Deviat.leg.:"
 
 # MSG_SOUND_MUTE c=17 r=1
-#:
+#: 
 msgid "Sound      [mute]"
-msgstr "Son [muet]"
+msgstr "Son        [muet]"
+
+# 
+#: Marlin_main.cpp:4871
+msgid "Some problem encountered, Z-leveling enforced ..."
+msgstr "Probleme rencontre, cliquez sur le bouton pour niveller l'axe Z..."
 
 # MSG_SOUND_ONCE c=17 r=1
 #: sound.h:7
 msgid "Sound      [once]"
-msgstr "Son [une fois]"
-
-# 
-#:
-msgid "Sound     [assist]"
-msgstr "Son [Assist]"
-
-# 
-#: sound.h:9
-msgid "Sound     [blind]"
-msgstr "Son     [aveugle]"
+msgstr "Son    [une fois]"
 
 # MSG_SOUND_SILENT c=17 r=1
 #: sound.h:8
 msgid "Sound    [silent]"
-msgstr "Son [silencieux]"
+msgstr "Son      [feutre]"
 
 # MSG_SPEED
-#: ultralcd.cpp:6840
+#: ultralcd.cpp:6926
 msgid "Speed"
 msgstr "Vitesse"
 
@@ -2132,40 +1295,15 @@ msgstr "Vitesse"
 msgid "Spinning"
 msgstr "Tourne"
 
-# MSG_AUTO_DEPLETE_ON c=17 r=1
-#: ultralcd.cpp:5098
-msgid "SpoolJoin    [on]"
-msgstr "SpoolJoin    [on]"
-
-# 
-#: ultralcd.cpp:5094
-msgid "SpoolJoin   [N/A]"
-msgstr "SpoolJoin   [N/A]"
-
-# MSG_AUTO_DEPLETE_OFF c=17 r=1
-#: ultralcd.cpp:5102
-msgid "SpoolJoin   [off]"
-msgstr "SpoolJoin   [off]"
-
 # MSG_TEMP_CAL_WARNING c=20 r=4
-#: Marlin_main.cpp:4330
+#: Marlin_main.cpp:4368
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
-msgstr "Une temperature\nambiante stable de\n21-26C et un support\nstable sont requis."
+msgstr "Une temperature ambiante stable de 21-26C et un support stable sont requis."
 
 # MSG_STATISTICS
-#: ultralcd.cpp:6753
+#: ultralcd.cpp:6839
 msgid "Statistics  "
 msgstr "Statistiques"
-
-# 
-#: ultralcd.cpp:5551
-msgid "Steel sheets"
-msgstr "Plaques en acier"
-
-# MSG_STEPPER_TOO_HIGH
-#: stepper.cpp:345
-msgid "Steprate too high: "
-msgstr "Nombre de pas trop eleve :"
 
 # MSG_STOP_PRINT
 #: messages.c:93
@@ -2178,12 +1316,12 @@ msgid "STOPPED. "
 msgstr "ARRETE."
 
 # MSG_SUPPORT
-#: ultralcd.cpp:6762
+#: ultralcd.cpp:6848
 msgid "Support"
-msgstr "Support"
+msgstr ""
 
 # MSG_SELFTEST_SWAPPED
-#: ultralcd.cpp:7873
+#: ultralcd.cpp:7959
 msgid "Swapped"
 msgstr "Echange"
 
@@ -2193,139 +1331,84 @@ msgid "Temp. cal.          "
 msgstr "Calib. Temp."
 
 # MSG_TEMP_CALIBRATION_ON c=20 r=1
-#: ultralcd.cpp:5581
+#: ultralcd.cpp:5686
 msgid "Temp. cal.   [on]"
 msgstr "Calib. Temp. [on]"
 
 # MSG_TEMP_CALIBRATION_OFF c=20 r=1
-#: ultralcd.cpp:5579
+#: ultralcd.cpp:5684
 msgid "Temp. cal.  [off]"
 msgstr "Calib. Temp.[off]"
 
 # MSG_CALIBRATION_PINDA_MENU c=17 r=1
-#: ultralcd.cpp:5675
+#: ultralcd.cpp:5780
 msgid "Temp. calibration"
 msgstr "Calibration temp."
 
-# MSG_TEMPERATURE
-#: ultralcd.cpp:5548
-msgid "Temperature"
-msgstr "Temperature"
-
 # MSG_TEMP_CAL_FAILED c=20 r=8
-#: ultralcd.cpp:3864
+#: ultralcd.cpp:3951
 msgid "Temperature calibration failed"
-msgstr "Echec de la\ncalibration en\ntemperature"
-
-# MSG_PINDA_NOT_CALIBRATED c=20 r=4
-#: Marlin_main.cpp:1403
-msgid "Temperature calibration has not been run yet"
-msgstr "La calibration en\ntemperature n'a pas\nencore ete lancee"
+msgstr "Echec de la calibration en temperature"
 
 # MSG_TEMP_CALIBRATION_DONE c=20 r=12
 #: messages.c:96
 msgid "Temperature calibration is finished and active. Temp. calibration can be disabled in menu Settings->Temp. cal."
-msgstr "La calibration en\ntemperature est\nterminee et activee.\nLa calibration en\ntemperature peut\netre desactivee dans\nle menu Reglages->\nCal. Temp."
+msgstr "La calibration en temperature est terminee et activee. La calibration en temperature peut etre desactivee dans le menu Reglages-> Cal. Temp."
+
+# MSG_TEMPERATURE
+#: ultralcd.cpp:5650
+msgid "Temperature"
+msgstr ""
 
 # MSG_MENU_TEMPERATURES c=15 r=1
-#: ultralcd.cpp:2144
+#: ultralcd.cpp:2251
 msgid "Temperatures"
-msgstr "Temperatures"
+msgstr ""
 
 # MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=4
 #: messages.c:42
 msgid "There is still a need to make Z calibration. Please follow the manual, chapter First steps, section Calibration flow."
-msgstr "Il y a encore besoin d'effectuer la calibration Z. Veuillez suivre le manuel, chapitre Premiers pas, section Processus de calibration."
+msgstr "Il faut toujours effectuer la Calibration Z. Veuillez suivre le manuel, chapitre Premiers pas, section Processus de calibration."
 
 # 
-#: ultralcd.cpp:2217
-msgid "to load filament"
-msgstr "pour charger le fil."
-
-# 
-#: ultralcd.cpp:2221
-msgid "to unload filament"
-msgstr "pour decharger fil."
-
-# 
-#: ultralcd.cpp:1829
-msgid "Total"
-msgstr "Total"
-
-# 
-#: ultralcd.cpp:1862
-msgid "Total failures"
-msgstr "Total des echecs"
-
-# 
-#: ultralcd.cpp:2860
+#: ultralcd.cpp:2908
 msgid "Total filament"
 msgstr "Filament total"
 
-# MSG_STATS_TOTALFILAMENT c=20
-#: ultralcd.cpp:2186
-msgid "Total filament :"
-msgstr "Total filament :"
-
 # 
-#: ultralcd.cpp:2860
+#: ultralcd.cpp:2908
 msgid "Total print time"
 msgstr "Temps total impr."
 
-# MSG_STATS_TOTALPRINTTIME c=20
-#: ultralcd.cpp:2203
-msgid "Total print time :"
-msgstr "Temps total impr. :"
-
-# MSG_ENDSTOP_HIT
-#: messages.c:28
-msgid "TRIGGERED"
-msgstr "ACTIVE"
-
 # MSG_TUNE
-#: ultralcd.cpp:6641
+#: ultralcd.cpp:6719
 msgid "Tune"
 msgstr "Regler"
 
 # 
-#: ultralcd.cpp:2120
-msgid "unknown"
-msgstr "inconnu"
-
-# 
-#: ultralcd.cpp:4780
+#: ultralcd.cpp:4869
 msgid "Unload"
 msgstr "Decharger"
 
 # 
-#: ultralcd.cpp:5617
-msgid "Unload all"
-msgstr "Decharger tout"
+#: ultralcd.cpp:1820
+msgid "Total failures"
+msgstr "Total des echecs"
+
+# 
+#: ultralcd.cpp:2324
+msgid "to load filament"
+msgstr "pour charger le fil."
+
+# 
+#: ultralcd.cpp:2328
+msgid "to unload filament"
+msgstr "pour decharger fil."
 
 # MSG_UNLOAD_FILAMENT c=17
 #: messages.c:97
 msgid "Unload filament"
 msgstr "Decharger fil."
-
-# MSG_UNLOAD_FILAMENT_1 c=17
-#: ultralcd.cpp:5406
-msgid "Unload filament 1"
-msgstr "Decharger fil. 1"
-
-# MSG_UNLOAD_FILAMENT_2 c=17
-#: ultralcd.cpp:5407
-msgid "Unload filament 2"
-msgstr "Decharger fil. 2"
-
-# MSG_UNLOAD_FILAMENT_3 c=17
-#: ultralcd.cpp:5408
-msgid "Unload filament 3"
-msgstr "Decharger fil. 3"
-
-# MSG_UNLOAD_FILAMENT_4 c=17
-#: ultralcd.cpp:5409
-msgid "Unload filament 4"
-msgstr "Decharger fil. 4"
 
 # MSG_UNLOADING_FILAMENT c=20 r=1
 #: messages.c:98
@@ -2333,69 +1416,64 @@ msgid "Unloading filament"
 msgstr "Dechargement fil."
 
 # 
-#: ultralcd.cpp:4779
-msgid "Use unload to remove filament 1 if it protrudes outside of the rear MMU tube. Use eject if it is hidden in tube."
-msgstr "Utilisez decharger pour retirer le filament 1 s'il depasse du  tube arriere du MMU. Utilisez ejecter s'il est cache dans le tube."
+#: ultralcd.cpp:1773
+msgid "Total"
+msgstr ""
 
 # MSG_USED c=19 r=1
-#: ultralcd.cpp:5803
+#: ultralcd.cpp:5908
 msgid "Used during print"
 msgstr "Utilise pdt impr."
 
 # MSG_MENU_VOLTAGES c=15 r=1
-#: ultralcd.cpp:2147
+#: ultralcd.cpp:2254
 msgid "Voltages"
 msgstr "Tensions"
 
-# MSG_SD_VOL_INIT_FAIL
-#: cardreader.cpp:191
-msgid "volume.init failed"
-msgstr "Echec volume.init"
+# 
+#: ultralcd.cpp:2227
+msgid "unknown"
+msgstr "inconnu"
 
 # MSG_USERWAIT
-#: Marlin_main.cpp:5225
+#: Marlin_main.cpp:5263
 msgid "Wait for user..."
 msgstr "Attente utilisateur..."
 
 # MSG_WAITING_TEMP c=20 r=3
-#: ultralcd.cpp:3371
+#: ultralcd.cpp:3458
 msgid "Waiting for nozzle and bed cooling"
-msgstr "Attente du\nrefroidissement des\nbuse et plateau"
+msgstr "Attente du refroidissement des buse et plateau"
 
 # MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ultralcd.cpp:3335
+#: ultralcd.cpp:3422
 msgid "Waiting for PINDA probe cooling"
-msgstr "Attente du\nrefroidissement de\nla sonde PINDA"
+msgstr "Attente du refroidissement de la sonde PINDA"
 
-# MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#:
-msgid "WARNING:\nCrash detection\ndisabled in\nStealth mode"
-msgstr "ATTENTION :\nDetection de crash\ndesactivee en mode\nFurtif"
+# 
+#: ultralcd.cpp:4868
+msgid "Use unload to remove filament 1 if it protrudes outside of the rear MMU tube. Use eject if it is hidden in tube."
+msgstr "Utilisez Remonter le fil. pour retirer le filament 1 s'il depasse du tube arriere du MMU. Utilisez ejecter s'il est cache dans le tube."
 
 # MSG_CHANGED_BOTH c=20 r=4
-#: Marlin_main.cpp:1527
+#: Marlin_main.cpp:1511
 msgid "Warning: both printer type and motherboard type changed."
-msgstr "Attention : Types\nd'imprimante et de\ncarte mere modifies"
+msgstr "Attention: Types d'imprimante et de carte mere modifies"
 
 # MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: Marlin_main.cpp:1519
+#: Marlin_main.cpp:1503
 msgid "Warning: motherboard type changed."
-msgstr "Attention : Type de\ncarte mere modifie."
+msgstr "Attention: Type de carte mere modifie."
 
 # MSG_CHANGED_PRINTER c=20 r=4
-#: Marlin_main.cpp:1523
+#: Marlin_main.cpp:1507
 msgid "Warning: printer type changed."
-msgstr "Attention : Type\nd'imprimante modifie"
-
-# MSG_FW_VERSION_UNKNOWN c=20 r=8
-#: Marlin_main.cpp:946
-msgid "WARNING: This is an unofficial, unsupported build. Use at your own risk!"
-msgstr "ATTENTION : ceci est\nune build non\nofficielle et non\nsupportee. Utilisez\nla a votre propre\nrisque !"
+msgstr "Attention: Type d'imprimante modifie"
 
 # MSG_UNLOAD_SUCCESSFUL c=20 r=2
-#: Marlin_main.cpp:3072
+#: Marlin_main.cpp:3054
 msgid "Was filament unload successful?"
-msgstr "Dechargement du\nfilament reussi ?"
+msgstr "Dechargement du filament reussi?"
 
 # MSG_SELFTEST_WIRINGERROR
 #: messages.c:85
@@ -2403,146 +1481,337 @@ msgid "Wiring error"
 msgstr "Erreur de cablage"
 
 # MSG_WIZARD c=17 r=1
-#: ultralcd.cpp:5642
+#: ultralcd.cpp:5747
 msgid "Wizard"
 msgstr "Assistant"
 
-# MSG_SD_WORKDIR_FAIL
-#: messages.c:78
-msgid "workDir open failed"
-msgstr "Echec ouverture workDir"
-
-# MSG_SD_WRITE_TO_FILE
-#: cardreader.cpp:424
-msgid "Writing to file: "
-msgstr "Ecriture dans le fichier :"
-
-# 
-#: ultralcd.cpp:4885
-msgid "X-correct"
-msgstr "Correction-X"
-
-# 
-#: ultralcd.cpp:5028
-msgid "X-correct:"
-msgstr "Correct-X:"
-
 # MSG_XYZ_DETAILS c=19 r=1
-#: ultralcd.cpp:2136
+#: ultralcd.cpp:2243
 msgid "XYZ cal. details"
 msgstr "Details calib. XYZ"
-
-# MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ultralcd.cpp:3835
-msgid "XYZ calibration all right. Skew will be corrected automatically."
-msgstr "Calibration XYZ OK.\nL'ecart sera corrige\nautomatiquement."
-
-# MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ultralcd.cpp:3832
-msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
-msgstr "Calibration XYZ OK.\nLes axes X/Y sont\nlegerement non\nperpendiculaires.\nBon boulot !"
-
-# MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ultralcd.cpp:3813
-msgid "XYZ calibration compromised. Front calibration points not reachable."
-msgstr "Calibration XYZ\ncompromise. Les\npoints de\ncalibration avant ne\nsont pas\natteignables."
-
-# MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_LEFT_FAR c=20 r=8
-#: ultralcd.cpp:3699
-msgid "XYZ calibration compromised. Left front calibration point not reachable."
-msgstr "Calibration XYZ\ncompromise. Le point\n de calibration\n avant gauche n'est\n pas atteignable."
-
-# MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ultralcd.cpp:3816
-msgid "XYZ calibration compromised. Right front calibration point not reachable."
-msgstr "Calibration XYZ\ncompromise. Le point\nde calibration avant\ndroit n'est pas\natteignable."
-
-# 
-#: ultralcd.cpp:3795
-msgid "XYZ calibration failed. Bed calibration point was not found."
-msgstr "Echec calibration\nXYZ. Le point de\ncalibration du\nplateau n'a pas ete\ntrouve."
-
-# 
-#: ultralcd.cpp:3801
-msgid "XYZ calibration failed. Front calibration points not reachable."
-msgstr "Echec calibration\nXYZ. Les points de\ncalibration avant ne\nsont pas\natteignables."
-
-# 
-#: ultralcd.cpp:3687
-msgid "XYZ calibration failed. Left front calibration point not reachable."
-msgstr "Echec calibration\nXYZ. Le point de\ncalibration avant\ngauche n'est pas\natteignable."
 
 # MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
 #: messages.c:19
 msgid "XYZ calibration failed. Please consult the manual."
-msgstr "Echec calibration\nXYZ. Consultez le\nmanuel."
-
-# 
-#: ultralcd.cpp:3804
-msgid "XYZ calibration failed. Right front calibration point not reachable."
-msgstr "Echec calibration\nXYZ. Le point de\ncalibration avant\ndroit n'est pas\natteignable."
-
-# MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ultralcd.cpp:3829
-msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
-msgstr "Calibration XYZ OK.\nLes axes X/Y sont\nperpendiculaires.\nFelicitations !"
-
-# 
-#: ultralcd.cpp:2965
-msgid "Y distance from min"
-msgstr "Distance Y du min"
-
-# MSG_Y_DISTANCE_FROM_MIN c=20 r=1
-#: ultralcd.cpp:2306
-msgid "Y distance from min:"
-msgstr "Distance Y du mini :"
-
-# 
-#: ultralcd.cpp:4886
-msgid "Y-correct"
-msgstr "Correction-Y"
-
-# 
-#: ultralcd.cpp:5029
-msgid "Y-correct:"
-msgstr "Correct-Y:"
+msgstr "Echec calibration XYZ. Consultez le manuel."
 
 # MSG_YES
 #: messages.c:104
 msgid "Yes"
 msgstr "Oui"
 
-# MSG_FW_VERSION_ALPHA c=20 r=8
-#: Marlin_main.cpp:930
-msgid "You are using firmware alpha version. This is development version. Using this version is not recommended and may cause printer damage."
-msgstr "Vous utilisez un\nfirmware en version\nalpha. C'est une\nversion de dev.\nCeci n'est pas\nrecommande et peut\nendommager\nl'imprimante."
-
-# MSG_FW_VERSION_BETA c=20 r=8
-#: Marlin_main.cpp:931
-msgid "You are using firmware beta version. This is development version. Using this version is not recommended and may cause printer damage."
-msgstr "Vous utilisez un\nfirmware en version\nbeta. C'est une\nversion de dev.\nCeci n'est pas\nrecommande et peut\nendommager\nl'imprimante."
-
 # MSG_WIZARD_QUIT c=20 r=8
 #: messages.c:103
 msgid "You can always resume the Wizard from Calibration -> Wizard."
-msgstr "Vous pouvez toujours\nrelancer l'assistant\ndans Calibration->\nAssistant."
+msgstr "Vous pouvez toujours relancer l'Assistant dans Calibration > Assistant."
+
+# MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
+#: ultralcd.cpp:3922
+msgid "XYZ calibration all right. Skew will be corrected automatically."
+msgstr "Calibration XYZ OK. L'ecart sera corrige automatiquement."
+
+# MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
+#: ultralcd.cpp:3919
+msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
+msgstr "Calibration XYZ OK. Les axes X/Y sont legerement non perpendiculaires. Bon boulot!"
 
 # 
-#: ultralcd.cpp:5030
+#: ultralcd.cpp:5130
+msgid "X-correct:"
+msgstr "Correct-X:"
+
+# MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
+#: ultralcd.cpp:3916
+msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
+msgstr "Calibration XYZ OK. Les axes X/Y sont perpendiculaires. Felicitations!"
+
+# MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
+#: ultralcd.cpp:3900
+msgid "XYZ calibration compromised. Front calibration points not reachable."
+msgstr "Calibration XYZ compromise. Les points de calibration en avant ne sont pas atteignables."
+
+# MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
+#: ultralcd.cpp:3903
+msgid "XYZ calibration compromised. Right front calibration point not reachable."
+msgstr "Calibration XYZ compromise. Le point de calibration avant droit n'est pas atteignable."
+
+# MSG_LOAD_ALL c=17
+#: ultralcd.cpp:6166
+msgid "Load all"
+msgstr "Charger un par un"
+
+# 
+#: ultralcd.cpp:3882
+msgid "XYZ calibration failed. Bed calibration point was not found."
+msgstr "Echec calibration XYZ. Le point de calibration du plateau n'a pas ete trouve."
+
+# 
+#: ultralcd.cpp:3888
+msgid "XYZ calibration failed. Front calibration points not reachable."
+msgstr "Echec calibration XYZ. Les points de calibration en avant ne sont pas atteignables."
+
+# 
+#: ultralcd.cpp:3891
+msgid "XYZ calibration failed. Right front calibration point not reachable."
+msgstr "Echec calibration XYZ. Le point de calibration avant droit n'est pas atteignable."
+
+# 
+#: ultralcd.cpp:3016
+msgid "Y distance from min"
+msgstr "Distance Y du min"
+
+# 
+#: ultralcd.cpp:5131
+msgid "Y-correct:"
+msgstr "Correct-Y:"
+
+# MSG_OFF
+#: menu.cpp:426
+msgid " [off]"
+msgstr " [off]"
+
+# 
+#: messages.c:57
+msgid "Back"
+msgstr "Retour"
+
+# 
+#: ultralcd.cpp:5639
+msgid "Checks"
+msgstr "Verifications"
+
+# 
+#: ultralcd.cpp:7973
+msgid "False triggering"
+msgstr "Faux declenchement"
+
+# 
+#: ultralcd.cpp:4030
+msgid "FINDA:"
+msgstr "FINDA:"
+
+# 
+#: ultralcd.cpp:5545
+msgid "Firmware   [none]"
+msgstr "Firmware [aucune]"
+
+# 
+#: ultralcd.cpp:5551
+msgid "Firmware [strict]"
+msgstr "Firmware[stricte]"
+
+# 
+#: ultralcd.cpp:5548
+msgid "Firmware   [warn]"
+msgstr "Firmware  [avert]"
+
+# 
+#: messages.c:87
+msgid "HW Setup"
+msgstr "Config HW"
+
+# 
+#: ultralcd.cpp:4034
+msgid "IR:"
+msgstr "IR:"
+
+# 
+#: ultralcd.cpp:7046
+msgid "Magnets comp.[N/A]"
+msgstr "Compens. aim.[N/A]"
+
+# 
+#: ultralcd.cpp:7044
+msgid "Magnets comp.[Off]"
+msgstr "Compens. aim.[off]"
+
+# 
+#: ultralcd.cpp:7043
+msgid "Magnets comp. [On]"
+msgstr "Compens. aim. [on]"
+
+# 
+#: ultralcd.cpp:7035
+msgid "Mesh         [3x3]"
+msgstr ""
+
+# 
+#: ultralcd.cpp:7036
+msgid "Mesh         [7x7]"
+msgstr ""
+
+# 
+#: ultralcd.cpp:5677
+msgid "Mesh bed leveling"
+msgstr ""
+
+# 
+#: Marlin_main.cpp:856
+msgid "MK3S firmware detected on MK3 printer"
+msgstr "Firmware MK3S detecte sur imprimante MK3"
+
+# 
+#: ultralcd.cpp:5306
+msgid "MMU Mode [Normal]"
+msgstr "Mode MMU [normal]"
+
+# 
+#: ultralcd.cpp:5307
+msgid "MMU Mode[Stealth]"
+msgstr "Mode MMU [feutre]"
+
+# 
+#: ultralcd.cpp:4511
+msgid "Mode change in progress ..."
+msgstr "Changement de mode en cours..."
+
+# 
+#: ultralcd.cpp:5506
+msgid "Model      [none]"
+msgstr "Modele   [aucune]"
+
+# 
+#: ultralcd.cpp:5512
+msgid "Model    [strict]"
+msgstr "Modele  [stricte]"
+
+# 
+#: ultralcd.cpp:5509
+msgid "Model      [warn]"
+msgstr "Modele    [avert]"
+
+# 
+#: ultralcd.cpp:5467
+msgid "Nozzle d.  [0.25]"
+msgstr "Diam. buse [0.25]"
+
+# 
+#: ultralcd.cpp:5470
+msgid "Nozzle d.  [0.40]"
+msgstr "Diam. buse [0.40]"
+
+# 
+#: ultralcd.cpp:5473
+msgid "Nozzle d.  [0.60]"
+msgstr "Diam. buse [0.60]"
+
+# 
+#: ultralcd.cpp:5421
+msgid "Nozzle     [none]"
+msgstr "Buse     [aucune]"
+
+# 
+#: ultralcd.cpp:5427
+msgid "Nozzle   [strict]"
+msgstr "Buse    [stricte]"
+
+# 
+#: ultralcd.cpp:5424
+msgid "Nozzle     [warn]"
+msgstr "Buse      [avert]"
+
+# 
+#: util.cpp:510
+msgid "G-code sliced for a different level. Continue?"
+msgstr ""
+
+# 
+#: util.cpp:516
+msgid "G-code sliced for a different level. Please re-slice the model again. Print cancelled."
+msgstr ""
+
+# 
+#: util.cpp:427
+msgid "G-code sliced for a different printer type. Continue?"
+msgstr "Le G-code a ete prepare pour une autre version de l'imprimante. Continuer?"
+
+# 
+#: util.cpp:433
+msgid "G-code sliced for a different printer type. Please re-slice the model again. Print cancelled."
+msgstr "Le G-code a ete prepare pour une autre version de l'imprimante. Veuillez decouper le modele a nouveau. L'impression a ete annulee."
+
+# 
+#: util.cpp:477
+msgid "G-code sliced for a newer firmware. Continue?"
+msgstr "Le G-code a ete prepare pour une version plus recente du firmware. Continuer?"
+
+# 
+#: util.cpp:483
+msgid "G-code sliced for a newer firmware. Please update the firmware. Print cancelled."
+msgstr "Le G-code a ete prepare pour une version plus recente du firmware. Veuillez mettre a jour le firmware. L'impression annulee."
+
+# 
+#: ultralcd.cpp:4026
+msgid "PINDA:"
+msgstr "PINDA:"
+
+#  c=20 r=1
+#: ultralcd.cpp:2465
+msgid "Preheating to cut"
+msgstr "Chauffe pour couper"
+
+#  c=20 r=1
+#: ultralcd.cpp:2462
+msgid "Preheating to eject"
+msgstr "Chauf. pour remonter"
+
+# 
+#: util.cpp:390
+msgid "Printer nozzle diameter differs from the G-code. Continue?"
+msgstr "Diametre de la buse dans les reglages ne correspond pas a celui dans le G-Code. Continuer?"
+
+# 
+#: util.cpp:397
+msgid "Printer nozzle diameter differs from the G-code. Please check the value in settings. Print cancelled."
+msgstr "Diametre de la buse dans les reglages ne correspond pas a celui dans le G-Code. Merci de verifier le parametre dans les reglages. Impression annulee."
+
+# 
+#: ultralcd.cpp:6683
+msgid "Rename"
+msgstr "Renommer"
+
+# 
+#: ultralcd.cpp:6679
+msgid "Select"
+msgstr "Selectionner"
+
+# 
+#: ultralcd.cpp:2245
+msgid "Sensor info"
+msgstr "Info capteur"
+
+# 
+#: messages.c:58
+msgid "Sheet"
+msgstr "Plaque"
+
+# 
+#: sound.h:9
+msgid "Sound    [assist]"
+msgstr "Son      [assist]"
+
+# 
+#: ultralcd.cpp:5637
+msgid "Steel sheets"
+msgstr "Plaques en acier"
+
+# 
+#: ultralcd.cpp:5132
 msgid "Z-correct:"
 msgstr "Correct-Z:"
 
 # 
-#: ultralcd.cpp:6952
+#: ultralcd.cpp:7038
 msgid "Z-probe nr.    [1]"
-msgstr "Sonde-Z num.   [1]"
+msgstr "Mesurer x-fois [1]"
 
 # 
-#: ultralcd.cpp:6954
+#: ultralcd.cpp:7040
 msgid "Z-probe nr.    [3]"
-msgstr "Sonde-Z num.   [3]"
+msgstr "Mesurer x-fois [3]"
 
-# MSG_MEASURED_OFFSET
-#: ultralcd.cpp:3024
-msgid "[0;0] point offset"
-msgstr "Offset point [0;0]"
+# 
+#: ultralcd.cpp:7039
+msgid "Z-probe nr.    [5]"
+msgstr "Mesurer x-fois [5]"
+

--- a/lang/po/new/it.po
+++ b/lang/po/new/it.po
@@ -1,51 +1,19 @@
+# Translation of Prusa-Firmware into Italian.
+#
 msgid ""
 msgstr ""
-"Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: PhraseApp (phraseapp.com)\n"
-
-# MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ultralcd.cpp:4219
-msgid "\e[2JCrash detection can\e[1;0Hbe turned on only in\e[2;0HNormal mode"
-msgstr "\e[2JRilev. impatto\e[1;0Hattivabile solo\e[2;0Hin Modalita normale"
-
-# MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ultralcd.cpp:4231
-msgid "\e[2JWARNING:\e[1;0HCrash detection\e[2;0Hdisabled in\e[3;0HStealth mode"
-msgstr "\e[2JATTENZIONE:\e[1;0HRilev. impatto\e[2;0Hdisattivato in\e[3;0HModalita silenziosa"
-
-# 
-#: ultralcd.cpp:3913
-msgid "  1"
-msgstr "  1"
-
-# MSG_PLANNER_BUFFER_BYTES
-#: Marlin_main.cpp:1184
-msgid "  PlannerBufferBytes: "
-msgstr " PlannerBufferBytes: "
-
-# MSG_EXTRUDER_CORRECTION_OFF c=6
-#: ultralcd.cpp:6312
-msgid "  [off"
-msgstr "  [off"
-
-# MSG_ERR_COLD_EXTRUDE_STOP
-#: planner.cpp:761
-msgid " cold extrusion prevented"
-msgstr "evitata estrusione fredda"
-
-# MSG_FREE_MEMORY
-#: Marlin_main.cpp:1182
-msgid " Free Memory: "
-msgstr "Memoria Libera: "
-
-# MSG_CONFIGURATION_VER
-#: Marlin_main.cpp:1172
-msgid " Last Updated: "
-msgstr "Ultimo aggiornamento: "
+"Language: it\n"
+"Project-Id-Version: Prusa-Firmware\n"
+"POT-Creation-Date: Sun, Sep 22, 2019 1:33:15 PM\n"
+"PO-Revision-Date: Sun, Sep 22, 2019 1:33:15 PM\n"
+"Language-Team: \n"
+"X-Generator: Poedit 2.0.7\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+"Last-Translator: \n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
 # MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE2 c=14
 #: messages.c:39
@@ -57,48 +25,33 @@ msgstr " su 4"
 msgid " of 9"
 msgstr "su 9"
 
-# MSG_OFF
-#: menu.cpp:426
-msgid " [off]"
-msgstr " [off]"
+# MSG_MEASURED_OFFSET
+#: ultralcd.cpp:3089
+msgid "[0;0] point offset"
+msgstr "[0;0] punto offset"
 
-# MSG_FACTOR
-#: ultralcd.cpp:6008
-msgid " \002 Fact"
-msgstr " \002 Fattore"
+# MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
+#: 
+msgid "Crash detection can\x0abe turned on only in\x0aNormal mode"
+msgstr "Rilev. impatto\x0aattivabile solo\x0ain Modalita normale"
 
-# MSG_MAX
-#: ultralcd.cpp:6007
-msgid " \002 Max"
-msgstr " \002 Max"
-
-# MSG_MIN
-#: ultralcd.cpp:6006
-msgid " \002 Min"
-msgstr " \002 Min"
+# MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
+#: 
+msgid "WARNING:\x0aCrash detection\x0adisabled in\x0aStealth mode"
+msgstr "ATTENZIONE:\x0aRilev. impatto\x0adisattivato in\x0aModalita silenziosa"
 
 # 
-#: ultralcd.cpp:2294
+#: ultralcd.cpp:2472
 msgid ">Cancel"
 msgstr ">Annulla"
 
-# MSG_BABYSTEPPING_Z c=20
-#: ultralcd.cpp:3043
-msgid "Adjusting Z"
-msgstr "Compensazione Z"
-
 # MSG_BABYSTEPPING_Z c=15
-#: ultralcd.cpp:3144
+#: ultralcd.cpp:3209
 msgid "Adjusting Z:"
-msgstr "Compensazione Z:"
-
-# MSG_ALL c=19 r=1
-#: messages.c:11
-msgid "All"
-msgstr "Tutti"
+msgstr "Compensaz. Z:"
 
 # MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ultralcd.cpp:8209
+#: ultralcd.cpp:8295
 msgid "All correct      "
 msgstr "Nessun errore"
 
@@ -108,39 +61,34 @@ msgid "All is done. Happy printing!"
 msgstr "Tutto fatto. Buona stampa!"
 
 # 
-#: ultralcd.cpp:1979
+#: ultralcd.cpp:2009
 msgid "Ambient"
 msgstr "Ambiente"
 
 # MSG_PRESS c=20
-#: ultralcd.cpp:2573
+#: ultralcd.cpp:2618
 msgid "and press the knob"
 msgstr "e cliccare manopola"
 
 # MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=2
-#: ultralcd.cpp:3442
+#: ultralcd.cpp:3529
 msgid "Are left and right Z~carriages all up?"
 msgstr "I carrelli Z sin/des sono altezza max?"
 
-# MSG_ADJUSTZ
-#: ultralcd.cpp:2600
-msgid "Auto adjust Z?"
-msgstr "Autoregolare Z?"
-
 # MSG_AUTO_DEPLETE_ON c=17 r=1
-#: ultralcd.cpp:4706
-msgid "Auto deplete [on]"
-msgstr "Esaurimento automatico [on]"
+#: ultralcd.cpp:5200
+msgid "SpoolJoin    [on]"
+msgstr ""
 
 # 
-#: ultralcd.cpp:4702
-msgid "Auto deplete[N/A]"
-msgstr "Auto svuotamento[N/A]"
+#: ultralcd.cpp:5196
+msgid "SpoolJoin   [N/A]"
+msgstr ""
 
 # MSG_AUTO_DEPLETE_OFF c=17 r=1
-#: ultralcd.cpp:4710
-msgid "Auto deplete[off]"
-msgstr "Esaurimento automatico [off]"
+#: ultralcd.cpp:5204
+msgid "SpoolJoin   [off]"
+msgstr ""
 
 # MSG_AUTO_HOME
 #: messages.c:11
@@ -148,52 +96,32 @@ msgid "Auto home"
 msgstr "Trova origine"
 
 # MSG_AUTOLOAD_FILAMENT c=17
-#: ultralcd.cpp:6731
+#: ultralcd.cpp:6822
 msgid "AutoLoad filament"
 msgstr "Autocaric. filam."
 
 # MSG_AUTOLOADING_ONLY_IF_FSENS_ON c=20 r=4
-#: ultralcd.cpp:4375
+#: ultralcd.cpp:4462
 msgid "Autoloading filament available only when filament sensor is turned on..."
 msgstr "Caricamento auto. filam. disp. solo con il sensore attivo..."
 
 # MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ultralcd.cpp:2768
+#: ultralcd.cpp:2813
 msgid "Autoloading filament is active, just press the knob and insert filament..."
-msgstr "Il caricamento automatico e attivo, premete la manopola e inserite il filamento..."
-
-# MSG_SELFTEST_AXIS
-#: ultralcd.cpp:7865
-msgid "Axis"
-msgstr "Assi"
+msgstr "Caricamento automatico attivo, premi la manopola e inserisci il filamento."
 
 # MSG_SELFTEST_AXIS_LENGTH
-#: ultralcd.cpp:7863
+#: ultralcd.cpp:7949
 msgid "Axis length"
 msgstr "Lunghezza dell'asse"
 
-# MSG_BABYSTEPPING_X
-#: ultralcd.cpp:2481
-msgid "Babystepping X"
-msgstr "Babystepping X"
-
-# MSG_BABYSTEPPING_Y
-#: ultralcd.cpp:2484
-msgid "Babystepping Y"
-msgstr "Babystepping Y"
-
-# 
-#: messages.c:57
-msgid "Back"
-msgstr "Indietro"
-
-# MSG_BED
-#: messages.c:15
-msgid "Bed"
-msgstr "Letto"
+# MSG_SELFTEST_AXIS
+#: ultralcd.cpp:7951
+msgid "Axis"
+msgstr "Assi"
 
 # MSG_SELFTEST_BEDHEATER
-#: ultralcd.cpp:7807
+#: ultralcd.cpp:7893
 msgid "Bed / Heater"
 msgstr "Letto/Riscald."
 
@@ -208,7 +136,7 @@ msgid "Bed Heating"
 msgstr "Riscald. letto"
 
 # MSG_BED_CORRECTION_MENU
-#: ultralcd.cpp:5663
+#: ultralcd.cpp:5768
 msgid "Bed level correct"
 msgstr "Correz. liv.letto"
 
@@ -217,43 +145,28 @@ msgstr "Correz. liv.letto"
 msgid "Bed leveling failed. Sensor didnt trigger. Debris on nozzle? Waiting for reset."
 msgstr "Livellamento letto fallito.NoRispSensore.Residui su ugello? In attesa di reset."
 
-# MSG_BED_LEVELING_FAILED_PROBE_DISCONNECTED c=20 r=4
-#: Marlin_main.cpp:4508
-msgid "Bed leveling failed. Sensor disconnected or cable broken. Waiting for reset."
-msgstr "Livellamento piano fallito. Sensore disconnesso o Cavo Danneggiato. In attesa di reset."
-
-# MSG_BED_LEVELING_FAILED_POINT_HIGH c=20 r=4
-#: Marlin_main.cpp:4512
-msgid "Bed leveling failed. Sensor triggered too high. Waiting for reset."
-msgstr "Livellamento piano fallito. Risposta sensore troppo presto. In attesa di reset."
-
-# MSG_BEGIN_FILE_LIST
-#: Marlin_main.cpp:4405
-msgid "Begin file list"
-msgstr "Inizio lista file"
+# MSG_BED
+#: messages.c:15
+msgid "Bed"
+msgstr "Letto"
 
 # MSG_MENU_BELT_STATUS c=15 r=1
-#: ultralcd.cpp:2007
+#: ultralcd.cpp:2059
 msgid "Belt status"
-msgstr "Stato delle cinghie"
+msgstr "Stato cinghie"
 
 # MSG_RECOVER_PRINT c=20 r=2
 #: messages.c:71
 msgid "Blackout occurred. Recover print?"
 msgstr "C'e stato un Blackout. Recuperare la stampa?"
 
-# MSG_CALIBRATE_PINDA c=17 r=1
-#: ultralcd.cpp:4566
-msgid "Calibrate"
-msgstr "Calibra"
-
-# MSG_CALIBRATE_E c=20 r=1
-#: ultralcd.cpp:4526
-msgid "Calibrate E"
-msgstr "Calibra E"
+# 
+#: ultralcd.cpp:8297
+msgid "Calibrating home"
+msgstr "Calibrazione Home"
 
 # MSG_CALIBRATE_BED
-#: ultralcd.cpp:5652
+#: ultralcd.cpp:5757
 msgid "Calibrate XYZ"
 msgstr "Calibra XYZ"
 
@@ -262,13 +175,13 @@ msgstr "Calibra XYZ"
 msgid "Calibrate Z"
 msgstr "Calibra Z"
 
-# 
-#: ultralcd.cpp:8211
-msgid "Calibrating home"
-msgstr "Calibrazione Home"
+# MSG_CALIBRATE_PINDA c=17 r=1
+#: ultralcd.cpp:4654
+msgid "Calibrate"
+msgstr "Calibra"
 
 # MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ultralcd.cpp:3405
+#: ultralcd.cpp:3492
 msgid "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end stoppers. Click when done."
 msgstr "Calibrazione XYZ. Ruotare la manopola per alzare il carrello Z fino all'altezza massima. Click per terminare."
 
@@ -278,74 +191,349 @@ msgid "Calibrating Z"
 msgstr "Calibrando Z"
 
 # MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ultralcd.cpp:3405
+#: ultralcd.cpp:3492
 msgid "Calibrating Z. Rotate the knob to move the Z carriage up to the end stoppers. Click when done."
 msgstr "Calibrazione Z. Ruotare la manopola per alzare il carrello Z fino all'altezza massima. Click per terminare."
+
+# MSG_HOMEYZ_DONE
+#: ultralcd.cpp:816
+msgid "Calibration done"
+msgstr "Calibrazione completa"
 
 # MSG_MENU_CALIBRATION
 #: messages.c:61
 msgid "Calibration"
 msgstr "Calibrazione"
 
-# MSG_HOMEYZ_DONE
-#: ultralcd.cpp:832
-msgid "Calibration done"
-msgstr "Calibrazione completa"
-
 # 
-#: ultralcd.cpp:4692
+#: ultralcd.cpp:4781
 msgid "Cancel"
 msgstr "Annulla"
 
-# MSG_SD_CANT_ENTER_SUBDIR
-#: cardreader.cpp:662
-msgid "Cannot enter subdir: "
-msgstr "Impossibile accedere alla sottocartella: "
-
-# MSG_SD_CANT_OPEN_SUBDIR
-#: cardreader.cpp:97
-msgid "Cannot open subdir"
-msgstr "Impossibile aprire la subdir"
-
-# MSG_SD_INSERTED
-#:
-msgid "Card inserted"
-msgstr "SD inserita"
-
 # MSG_SD_REMOVED
-#: ultralcd.cpp:8578
+#: ultralcd.cpp:8679
 msgid "Card removed"
 msgstr "SD rimossa"
 
+# MSG_NOT_COLOR
+#: ultralcd.cpp:2718
+msgid "Color not correct"
+msgstr "Colore non puro"
+
+# MSG_COOLDOWN
+#: messages.c:23
+msgid "Cooldown"
+msgstr "Raffredda"
+
 # 
-#: ultralcd.cpp:6087
-msgid "Change extruder"
-msgstr "Cambio estrusore"
+#: ultralcd.cpp:4587
+msgid "Copy selected language?"
+msgstr "Copiare la lingua selezionata?"
+
+# MSG_CRASHDETECT_ON
+#: messages.c:27
+msgid "Crash det.   [on]"
+msgstr "Rileva.crash [on]"
+
+# MSG_CRASHDETECT_NA
+#: messages.c:25
+msgid "Crash det.  [N/A]"
+msgstr "Rileva.crash[N/A]"
+
+# MSG_CRASHDETECT_OFF
+#: messages.c:26
+msgid "Crash det.  [off]"
+msgstr "Rileva.crash[off]"
+
+# MSG_CRASH_DETECTED c=20 r=1
+#: messages.c:24
+msgid "Crash detected."
+msgstr "Rilevato impatto."
+
+# 
+#: Marlin_main.cpp:600
+msgid "Crash detected. Resume print?"
+msgstr "Scontro rilevato. Riprendere la stampa?"
+
+# 
+#: ultralcd.cpp:1853
+msgid "Crash"
+msgstr "Impatto"
+
+# MSG_CURRENT c=19 r=1
+#: ultralcd.cpp:5909
+msgid "Current"
+msgstr "Attuale"
+
+# MSG_DATE c=17 r=1
+#: ultralcd.cpp:2213
+msgid "Date:"
+msgstr "Data:"
+
+# MSG_DISABLE_STEPPERS
+#: ultralcd.cpp:5654
+msgid "Disable steppers"
+msgstr "Disabilita motori"
+
+# MSG_BABYSTEP_Z_NOT_SET c=20 r=12
+#: messages.c:14
+msgid "Distance between tip of the nozzle and the bed surface has not been set yet. Please follow the manual, chapter First steps, section First layer calibration."
+msgstr "Distanza tra la punta dell'ugello e la superficie del letto non ancora imposta. Si prega di seguire il manuale, capitolo Primi Passi, sezione Calibrazione primo layer."
+
+# MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
+#: ultralcd.cpp:5070
+msgid "Do you want to repeat last step to readjust distance between nozzle and heatbed?"
+msgstr "Desideri ripetere l'ultimo passaggio per migliorare la distanza fra ugello e piatto?"
+
+# MSG_EXTRUDER_CORRECTION c=10
+#: ultralcd.cpp:5134
+msgid "E-correct:"
+msgstr "Correzione-E:"
+
+# MSG_EJECT_FILAMENT c=17 r=1
+#: messages.c:53
+msgid "Eject filament"
+msgstr "Espelli filamento "
+
+# 
+#: ultralcd.cpp:4869
+msgid "Eject"
+msgstr "Espellere"
+
+# MSG_EJECTING_FILAMENT c=20 r=1
+#: mmu.cpp:1434
+msgid "Ejecting filament"
+msgstr "Espellendo filamento "
+
+# MSG_SELFTEST_ENDSTOP_NOTHIT c=20 r=1
+#: ultralcd.cpp:7917
+msgid "Endstop not hit"
+msgstr "Finecorsa fuori portata"
+
+# MSG_SELFTEST_ENDSTOP
+#: ultralcd.cpp:7911
+msgid "Endstop"
+msgstr "Finecorsa"
+
+# MSG_SELFTEST_ENDSTOPS
+#: ultralcd.cpp:7899
+msgid "Endstops"
+msgstr "Finecorsa"
+
+# MSG_STACK_ERROR c=20 r=4
+#: ultralcd.cpp:6859
+msgid "Error - static memory has been overwritten"
+msgstr "Errore - la memoria statica e stata sovrascritta"
+
+# MSG_FSENS_NOT_RESPONDING c=20 r=4
+#: ultralcd.cpp:4475
+msgid "ERROR: Filament sensor is not responding, please check connection."
+msgstr "ERRORE: il sensore filam. non risponde,Controllare conness."
+
+# MSG_ERROR
+#: messages.c:28
+msgid "ERROR:"
+msgstr "ERRORE:"
+
+# MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
+#: ultralcd.cpp:8304
+msgid "Extruder fan:"
+msgstr "Ventola estr:"
+
+# MSG_INFO_EXTRUDER c=15 r=1
+#: ultralcd.cpp:2244
+msgid "Extruder info"
+msgstr "Info estrusore"
+
+# MSG_MOVE_E
+#: messages.c:29
+msgid "Extruder"
+msgstr "Estrusore"
+
+# 
+#: ultralcd.cpp:6846
+msgid "Fail stats MMU"
+msgstr "Stat.fall. MMU"
+
+# MSG_FSENS_AUTOLOAD_ON c=17 r=1
+#: ultralcd.cpp:5168
+msgid "F. autoload  [on]"
+msgstr "Autocar.fil. [on]"
+
+# MSG_FSENS_AUTOLOAD_NA c=17 r=1
+#: messages.c:43
+msgid "F. autoload [N/A]"
+msgstr "Autocar.fil.[N/A]"
+
+# MSG_FSENS_AUTOLOAD_OFF c=17 r=1
+#: ultralcd.cpp:5170
+msgid "F. autoload [off]"
+msgstr "Autocar.fil.[off]"
+
+# 
+#: ultralcd.cpp:6843
+msgid "Fail stats"
+msgstr "Stat. fallimenti"
+
+# MSG_FAN_SPEED c=14
+#: messages.c:31
+msgid "Fan speed"
+msgstr "Velocita vent."
+
+# MSG_SELFTEST_FAN c=20
+#: messages.c:78
+msgid "Fan test"
+msgstr "Test ventola"
+
+# MSG_FANS_CHECK_ON c=17 r=1
+#: ultralcd.cpp:5663
+msgid "Fans check   [on]"
+msgstr "Control.vent [on]"
+
+# MSG_FANS_CHECK_OFF c=17 r=1
+#: ultralcd.cpp:5665
+msgid "Fans check  [off]"
+msgstr "Control.vent[off]"
+
+# MSG_FSENSOR_ON
+#: messages.c:45
+msgid "Fil. sensor  [on]"
+msgstr "Sensore fil. [on]"
+
+# MSG_FSENSOR_NA
+#: ultralcd.cpp:5148
+msgid "Fil. sensor [N/A]"
+msgstr "Sensore fil.[N/A]"
+
+# MSG_FSENSOR_OFF
+#: messages.c:44
+msgid "Fil. sensor [off]"
+msgstr "Sensore fil.[off]"
+
+# 
+#: ultralcd.cpp:1852
+msgid "Filam. runouts"
+msgstr "Filam. esauriti"
+
+# MSG_FILAMENT_CLEAN c=20 r=2
+#: messages.c:32
+msgid "Filament extruding & with correct color?"
+msgstr "Filamento estruso & con il giusto colore?"
+
+# MSG_NOT_LOADED c=19
+#: ultralcd.cpp:2714
+msgid "Filament not loaded"
+msgstr "Fil. non caricato"
+
+# MSG_FILAMENT_SENSOR c=20
+#: messages.c:84
+msgid "Filament sensor"
+msgstr "Sensore filam."
+
+# MSG_FILAMENT_USED c=19 r=1
+#: ultralcd.cpp:2885
+msgid "Filament used"
+msgstr "Filamento utilizzato"
+
+# MSG_PRINT_TIME c=19 r=1
+#: ultralcd.cpp:2886
+msgid "Print time"
+msgstr "Tempo di stampa"
+
+# MSG_FILE_INCOMPLETE c=20 r=2
+#: ultralcd.cpp:8432
+msgid "File incomplete. Continue anyway?"
+msgstr "File incompleto. Continuare comunque?"
+
+# MSG_FINISHING_MOVEMENTS c=20 r=1
+#: messages.c:40
+msgid "Finishing movements"
+msgstr "Finalizzando gli spostamenti"
+
+# MSG_V2_CALIBRATION c=17 r=1
+#: messages.c:105
+msgid "First layer cal."
+msgstr "Cal. primo strato"
+
+# MSG_WIZARD_SELFTEST c=20 r=8
+#: ultralcd.cpp:4982
+msgid "First, I will run the selftest to check most common assembly problems."
+msgstr "Per primo avviero l'autotest per controllare gli errori di assemblaggio piu comuni."
+
+# 
+#: mmu.cpp:724
+msgid "Fix the issue and then press button on MMU unit."
+msgstr "Risolvi il problema e quindi premi il bottone sull'unita MMU. "
+
+# MSG_FLOW
+#: ultralcd.cpp:6932
+msgid "Flow"
+msgstr "Flusso"
+
+# MSG_PRUSA3D_FORUM
+#: ultralcd.cpp:2206
+msgid "forum.prusa3d.com"
+msgstr ""
+
+# MSG_SELFTEST_COOLING_FAN c=20
+#: messages.c:75
+msgid "Front print fan?"
+msgstr "Ventola frontale?"
+
+# MSG_BED_CORRECTION_FRONT c=14 r=1
+#: ultralcd.cpp:3294
+msgid "Front side[um]"
+msgstr "Fronte [um]"
+
+# MSG_SELFTEST_FANS
+#: ultralcd.cpp:7957
+msgid "Front/left fans"
+msgstr "Ventola frontale/sinistra"
+
+# MSG_SELFTEST_HEATERTHERMISTOR
+#: ultralcd.cpp:7887
+msgid "Heater/Thermistor"
+msgstr "Riscald./Termist."
+
+# MSG_BED_HEATING_SAFETY_DISABLED
+#: Marlin_main.cpp:8467
+msgid "Heating disabled by safety timer."
+msgstr "Riscaldamento fermato dal timer di sicurezza."
+
+# MSG_HEATING_COMPLETE c=20
+#: messages.c:47
+msgid "Heating done."
+msgstr "Riscald. completo"
+
+# MSG_HEATING
+#: messages.c:46
+msgid "Heating"
+msgstr "Riscaldamento..."
+
+# MSG_WIZARD_WELCOME c=20 r=7
+#: ultralcd.cpp:4961
+msgid "Hi, I am your Original Prusa i3 printer. Would you like me to guide you through the setup process?"
+msgstr "Ciao, sono la tua stampante Original Prusa i3. Gradiresti un aiuto nel processo di configurazione?"
+
+# MSG_PRUSA3D_HOWTO
+#: ultralcd.cpp:2207
+msgid "howto.prusa3d.com"
+msgstr ""
 
 # MSG_FILAMENTCHANGE
 #: messages.c:37
 msgid "Change filament"
 msgstr "Cambia filamento"
 
-# MSG_CNG_SDCARD
-#: ultralcd.cpp:5777
-msgid "Change SD card"
-msgstr "Cambia memoria SD"
-
 # MSG_CHANGE_SUCCESS
-#: ultralcd.cpp:2584
+#: ultralcd.cpp:2629
 msgid "Change success!"
 msgstr "Cambio riuscito!"
 
 # MSG_CORRECTLY c=20
-#: ultralcd.cpp:2661
+#: ultralcd.cpp:2706
 msgid "Changed correctly?"
 msgstr "Cambiato correttamente?"
-
-# MSG_CHANGING_FILAMENT c=20
-#: ultralcd.cpp:1899
-msgid "Changing filament!"
-msgstr "Cambiando filam."
 
 # MSG_SELFTEST_CHECK_BED c=20
 #: messages.c:81
@@ -353,12 +541,12 @@ msgid "Checking bed     "
 msgstr "Verifica piano"
 
 # MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ultralcd.cpp:8200
+#: ultralcd.cpp:8286
 msgid "Checking endstops"
 msgstr "Verifica finecorsa"
 
 # MSG_SELFTEST_CHECK_HOTEND c=20
-#: ultralcd.cpp:8206
+#: ultralcd.cpp:8292
 msgid "Checking hotend  "
 msgstr "Verifica ugello"
 
@@ -368,29 +556,19 @@ msgid "Checking sensors "
 msgstr "Controllo sensori"
 
 # MSG_SELFTEST_CHECK_X c=20
-#: ultralcd.cpp:8201
+#: ultralcd.cpp:8287
 msgid "Checking X axis  "
 msgstr "Verifica asse X"
 
 # MSG_SELFTEST_CHECK_Y c=20
-#: ultralcd.cpp:8202
+#: ultralcd.cpp:8288
 msgid "Checking Y axis  "
 msgstr "Verifica asse Y"
 
 # MSG_SELFTEST_CHECK_Z c=20
-#: ultralcd.cpp:8203
+#: ultralcd.cpp:8289
 msgid "Checking Z axis  "
 msgstr "Verifica asse Z"
-
-# 
-#: ultralcd.cpp:5537
-msgid "Checks"
-msgstr "Controlli"
-
-# MSG_ERR_CHECKSUM_MISMATCH
-#: cmdqueue.cpp:444
-msgid "checksum mismatch, Last Line: "
-msgstr "mancata corrispondenza di checksum, ultima riga:"
 
 # MSG_CHOOSE_EXTRUDER c=20 r=1
 #: messages.c:49
@@ -402,425 +580,1135 @@ msgstr "Seleziona estrusore:"
 msgid "Choose filament:"
 msgstr "Scegliere filamento:"
 
-# MSG_NOT_COLOR
-#: ultralcd.cpp:2673
-msgid "Color not correct"
-msgstr "Colore non puro"
-
-# MSG_COOLDOWN
-#: messages.c:23
-msgid "Cooldown"
-msgstr "Raffredda"
-
-# 
-#: ultralcd.cpp:4108
-msgid "Copy selected language from XFLASH?"
-msgstr "Copiare la lingua selezionata da XFLASH?"
-
-# 
-#: ultralcd.cpp:4499
-msgid "Copy selected language?"
-msgstr "Copiare la lingua selezionata?"
-
-# 
-#: ultralcd.cpp:1881
-msgid "Crash"
-msgstr "Impatto"
-
-# MSG_CRASHDETECT_ON
-#: messages.c:27
-msgid "Crash det.   [on]"
-msgstr "Rilevam.imp. [on]"
-
-# MSG_CRASHDETECT_NA
-#: messages.c:25
-msgid "Crash det.  [N/A]"
-msgstr "Rilevam.imp.[N/A]"
-
-# MSG_CRASHDETECT_OFF
-#: messages.c:26
-msgid "Crash det.  [off]"
-msgstr "Rilevam.imp.[off]"
-
-# MSG_CRASH_DETECTED c=20 r=1
-#: messages.c:24
-msgid "Crash detected."
-msgstr "Rilevato impatto."
-
-# 
-#: Marlin_main.cpp:618
-msgid "Crash detected. Resume print?"
-msgstr "Scontro rilevato. Riprendere la stampa?"
-
-# MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#:
-msgid "Crash detection can\nbe turned on only in\nNormal mode"
-msgstr "Rilevamento impatto può\nessere attivato in\nModalità Normale"
-
-# MSG_CURRENT c=19 r=1
-#: ultralcd.cpp:5804
-msgid "Current"
-msgstr "Attuale"
-
-# MSG_DATE c=17 r=1
-#: ultralcd.cpp:2106
-msgid "Date:"
-msgstr "Data:"
-
-# MSG_DISABLE_STEPPERS
-#: ultralcd.cpp:5552
-msgid "Disable steppers"
-msgstr "Disabilita motori"
-
-# MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: messages.c:14
-msgid "Distance between tip of the nozzle and the bed surface has not been set yet. Please follow the manual, chapter First steps, section First layer calibration."
-msgstr "Distanza tra la punta dell'ugello e la superficie del letto non ancora imposta. Si prega di seguire il manuale, capitolo Primi Passi, sezione Calibrazione primo layer."
-
-# MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ultralcd.cpp:4968
-msgid "Do you want to repeat last step to readjust distance between nozzle and heatbed?"
-msgstr "Desideri ripetere l'ultimo passaggio per migliorare la distanza fra ugello e piatto?"
-
-# MSG_CLEAN_NOZZLE_E c=20 r=8
-#: ultralcd.cpp:3890
-msgid "E calibration finished. Please clean the nozzle. Click when done."
-msgstr "Calibrazione E terminata. Si prega di pulire l'ugello. Click per continuare."
-
-# MSG_EXTRUDER_CORRECTION c=9
-#: ultralcd.cpp:4889
-msgid "E-correct"
-msgstr "Correzione-E"
-
-# MSG_EXTRUDER_CORRECTION c=10
-#: ultralcd.cpp:5032
-msgid "E-correct:"
-msgstr "Correzione-E:"
-
-# 
-#: ultralcd.cpp:4780
-msgid "Eject"
-msgstr "Espellere"
-
-# MSG_EJECT_FILAMENT c=17 r=1
-#: messages.c:53
-msgid "Eject filament"
-msgstr "Espelli filamento "
-
-# MSG_EJECT_FILAMENT1 c=17 r=1
-#: ultralcd.cpp:5603
-msgid "Eject filament 1"
-msgstr "Espelli filamento 1"
-
-# MSG_EJECT_FILAMENT2 c=17 r=1
-#: ultralcd.cpp:5604
-msgid "Eject filament 2"
-msgstr "Espellere filamento 2"
-
-# MSG_EJECT_FILAMENT3 c=17 r=1
-#: ultralcd.cpp:5605
-msgid "Eject filament 3"
-msgstr "Espelli filamento 3"
-
-# MSG_EJECT_FILAMENT4 c=17 r=1
-#: ultralcd.cpp:5606
-msgid "Eject filament 4"
-msgstr "Espellere filamento 4"
-
-# MSG_EJECT_FILAMENT5 c=17 r=1
-#: ultralcd.cpp:5607
-msgid "Eject filament 5"
-msgstr "Espelli filamento 5"
-
-# MSG_EJECTING_FILAMENT c=20 r=1
-#: mmu.cpp:1435
-msgid "Ejecting filament"
-msgstr "Espellendo filamento "
-
-# MSG_END_FILE_LIST
-#: Marlin_main.cpp:4407
-msgid "End file list"
-msgstr "Fine lista file"
-
-# MSG_SELFTEST_ENDSTOP
-#: ultralcd.cpp:7825
-msgid "Endstop"
-msgstr "Finecorsa"
-
-# MSG_SELFTEST_ENDSTOP_NOTHIT c=20 r=1
-#: ultralcd.cpp:7831
-msgid "Endstop not hit"
-msgstr "Finecorsa fuori portata"
-
-# MSG_SELFTEST_ENDSTOPS
-#: ultralcd.cpp:7813
-msgid "Endstops"
-msgstr "Finecorsa"
-
-# MSG_ENDSTOPS_HIT
-#: messages.c:30
-msgid "endstops hit: "
-msgstr "finecorsa colpito: "
-
-# MSG_LANGUAGE_NAME
-#: language.c:153
-msgid "English"
-msgstr "Italiano"
-
-# MSG_Enqueing
-#:
-msgid "enqueing \""
-msgstr "accodamento\""
-
-# MSG_STACK_ERROR c=20 r=4
-#: ultralcd.cpp:6773
-msgid "Error - static memory has been overwritten"
-msgstr "Errore - la memoria statica e stata sovrascritta"
-
-# MSG_SD_ERR_WRITE_TO_FILE
-#: messages.c:78
-msgid "error writing to file"
-msgstr "errore scrittura sul file"
-
-# MSG_ERROR
-#: messages.c:28
-msgid "ERROR:"
-msgstr "ERRORE:"
-
-# MSG_FSENS_NOT_RESPONDING c=20 r=4
-#: ultralcd.cpp:4388
-msgid "ERROR: Filament sensor is not responding, please check connection."
-msgstr "ERRORE: il sensore filam. non risponde,Controllare conness."
-
-# 
-#: Marlin_main.cpp:1006
-msgid "External SPI flash W25X20CL not responding."
-msgstr "Flash SPI W25X20CL esterno non risponde."
-
-# MSG_MOVE_E
-#: messages.c:29
-msgid "Extruder"
-msgstr "Estrusore"
-
-# 
-#: ultralcd.cpp:5633
-msgid "Extruder 1"
-msgstr "Estrusore 1"
-
-# 
-#: ultralcd.cpp:5634
-msgid "Extruder 2"
-msgstr "Estrusore 2"
-
-# 
-#: ultralcd.cpp:5635
-msgid "Extruder 3"
-msgstr "Estrusore 3"
-
-# 
-#: ultralcd.cpp:5636
-msgid "Extruder 4"
-msgstr "Estrusore 4"
-
-# MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
-#: ultralcd.cpp:8218
-msgid "Extruder fan:"
-msgstr "Ventola estrusore:"
-
-# MSG_INFO_EXTRUDER c=15 r=1
-#: ultralcd.cpp:2137
-msgid "Extruder info"
-msgstr "Info estrusore"
-
-# MSG_FSENS_AUTOLOAD_ON c=17 r=1
-#: ultralcd.cpp:5066
-msgid "F. autoload  [on]"
-msgstr "Autocar.filam[on]"
-
-# MSG_FSENS_AUTOLOAD_NA c=17 r=1
-#: messages.c:43
-msgid "F. autoload [N/A]"
-msgstr "Autocar.fil.[N/A]"
-
-# MSG_FSENS_AUTOLOAD_OFF c=17 r=1
-#: ultralcd.cpp:5068
-msgid "F. autoload [off]"
-msgstr "Autocar.fil.[off]"
-
-# 
-#: ultralcd.cpp:6757
-msgid "Fail stats"
-msgstr "Statistiche fallimenti"
-
-# 
-#: ultralcd.cpp:6760
-msgid "Fail stats MMU"
-msgstr "Statistiche fallimenti MMU"
-
-# 
-#: ultralcd.cpp:7887
-msgid "False triggering"
-msgstr "Falso innesco"
-
-# MSG_FAN_SPEED c=14
-#: messages.c:31
-msgid "Fan speed"
-msgstr "Velocita ventola"
-
-# MSG_SELFTEST_FAN c=20
-#: messages.c:78
-msgid "Fan test"
-msgstr "Test ventola"
-
-# MSG_FANS_CHECK_ON c=17 r=1
-#: ultralcd.cpp:5561
-msgid "Fans check   [on]"
-msgstr "Control.vent[on]"
-
-# MSG_FANS_CHECK_OFF c=17 r=1
-#: ultralcd.cpp:5563
-msgid "Fans check  [off]"
-msgstr "Control.vent[off]"
-
-# MSG_FSENSOR_ON
-#: messages.c:45
-msgid "Fil. sensor  [on]"
-msgstr "Sensor filam.[On]"
-
-# MSG_RESPONSE_POOR c=20 r=2
-#: Marlin_main.cpp:3146
-msgid "Fil. sensor response is poor, disable it?"
-msgstr "Risposta Sens. Fil. debole, disattivare? "
-
-# MSG_FSENSOR_NA
-#: ultralcd.cpp:5046
-msgid "Fil. sensor [N/A]"
-msgstr "Sensor filam[N/A]"
-
-# MSG_FSENSOR_OFF
-#: messages.c:44
-msgid "Fil. sensor [off]"
-msgstr "Sensor filam[off]"
-
-# 
-#: ultralcd.cpp:1881
-msgid "Filam. runouts"
-msgstr "Filam. esauriti"
-
 # MSG_FILAMENT c=17 r=1
 #: messages.c:30
 msgid "Filament"
 msgstr "Filamento"
 
-# MSG_FILAMENT_CLEAN c=20 r=2
-#: messages.c:32
-msgid "Filament extruding & with correct color?"
-msgstr "Filamento estruso & con il giusto colore?"
+# MSG_WIZARD_XYZ_CAL c=20 r=8
+#: ultralcd.cpp:4991
+msgid "I will run xyz calibration now. It will take approx. 12 mins."
+msgstr "Adesso avviero una Calibrazione XYZ. Puo durare circa 12 min."
 
-# MSG_NOT_LOADED c=19
-#: ultralcd.cpp:2669
-msgid "Filament not loaded"
-msgstr "Fil. non caricato"
+# MSG_WIZARD_Z_CAL c=20 r=8
+#: ultralcd.cpp:4999
+msgid "I will run z calibration now."
+msgstr "Adesso avviero la Calibrazione Z."
 
-# MSG_FILAMENT_SENSOR c=20
-#: messages.c:84
-msgid "Filament sensor"
-msgstr "Sensore filam."
+# MSG_WIZARD_V2_CAL_2 c=20 r=12
+#: ultralcd.cpp:5064
+msgid "I will start to print line and you will gradually lower the nozzle by rotating the knob, until you reach optimal height. Check the pictures in our handbook in chapter Calibration."
+msgstr "Adesso iniziero a stampare una linea e tu dovrai abbassare l'ugello poco per volta ruotando la manopola sino a raggiungere una altezza ottimale. Per favore dai uno sguardo all'immagine del nostro manuale, cap.Calibrazione."
 
-# MSG_SELFTEST_FILAMENT_SENSOR c=18
-#: ultralcd.cpp:7477
-msgid "Filament sensor:"
-msgstr "Sensore filam.:"
-
-# MSG_FILAMENT_USED c=19 r=1
-#: ultralcd.cpp:2838
-msgid "Filament used"
-msgstr "Filamento utilizzato"
-
-# MSG_STATS_FILAMENTUSED c=20
-#: ultralcd.cpp:2142
-msgid "Filament used:  "
-msgstr "Filamento usato:"
-
-# MSG_FILE_INCOMPLETE c=20 r=2
-#: ultralcd.cpp:8346
-msgid "File incomplete. Continue anyway?"
-msgstr "File incompleto. Continuare comunque?"
-
-# MSG_SD_FILE_OPENED
-#: cardreader.cpp:395
-msgid "File opened: "
-msgstr "File aperto: "
-
-# MSG_SD_FILE_SELECTED
-#: cardreader.cpp:401
-msgid "File selected"
-msgstr "File selezionato"
+# MSG_WATCH
+#: messages.c:99
+msgid "Info screen"
+msgstr "Schermata info"
 
 # 
-#: ultralcd.cpp:3943
+#: ultralcd.cpp:5024
+msgid "Is filament 1 loaded?"
+msgstr "Il filamento 1 e caricato?"
+
+# MSG_INSERT_FILAMENT c=20
+#: ultralcd.cpp:2614
+msgid "Insert filament"
+msgstr "Inserire filamento"
+
+# MSG_WIZARD_FILAMENT_LOADED c=20 r=2
+#: ultralcd.cpp:5027
+msgid "Is filament loaded?"
+msgstr "Il filamento e stato caricato?"
+
+# MSG_WIZARD_PLA_FILAMENT c=20 r=2
+#: ultralcd.cpp:5058
+msgid "Is it PLA filament?"
+msgstr "E' un filamento di PLA?"
+
+# MSG_PLA_FILAMENT_LOADED c=20 r=2
+#: ultralcd.cpp:4790
+msgid "Is PLA filament loaded?"
+msgstr "E' stato caricato il filamento di PLA?"
+
+# MSG_STEEL_SHEET_CHECK c=20 r=2
+#: messages.c:92
+msgid "Is steel sheet on heatbed?"
+msgstr "La piastra d'acciaio e sul piano riscaldato?"
+
+# 
+#: ultralcd.cpp:1795
+msgid "Last print failures"
+msgstr "Fallimenti ultima stampa"
+
+# 
+#: ultralcd.cpp:1772
+msgid "Last print"
+msgstr "Ultima stampa"
+
+# MSG_SELFTEST_EXTRUDER_FAN c=20
+#: messages.c:76
+msgid "Left hotend fan?"
+msgstr "Vent SX hotend?"
+
+# 
+#: ultralcd.cpp:3018
+msgid "Left"
+msgstr "Sinistra"
+
+# MSG_BED_CORRECTION_LEFT c=14 r=1
+#: ultralcd.cpp:3292
+msgid "Left side [um]"
+msgstr "Sinistra  [um]"
+
+# 
+#: ultralcd.cpp:5680
+msgid "Lin. correction"
+msgstr "Correzione lineare"
+
+# MSG_BABYSTEP_Z
+#: messages.c:13
+msgid "Live adjust Z"
+msgstr "Compensazione Z"
+
+# MSG_LOAD_FILAMENT c=17
+#: messages.c:51
+msgid "Load filament"
+msgstr "Carica filamento"
+
+# MSG_LOADING_COLOR
+#: ultralcd.cpp:2654
+msgid "Loading color"
+msgstr "Caricando colore"
+
+# MSG_LOADING_FILAMENT c=20
+#: messages.c:52
+msgid "Loading filament"
+msgstr "Caricando filamento"
+
+# MSG_LOOSE_PULLEY c=20 r=1
+#: ultralcd.cpp:7941
+msgid "Loose pulley"
+msgstr "Puleggia lenta"
+
+# 
+#: ultralcd.cpp:6805
+msgid "Load to nozzle"
+msgstr "Carica ugello"
+
+# MSG_M117_V2_CALIBRATION c=25 r=1
+#: messages.c:55
+msgid "M117 First layer cal."
+msgstr "M117 Calibrazione primo layer."
+
+# MSG_MAIN
+#: messages.c:56
+msgid "Main"
+msgstr "Menu principale"
+
+# MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=60
+#: messages.c:59
+msgid "Measuring reference height of calibration point"
+msgstr "Misura altezza di rif. del punto di calib."
+
+# MSG_MESH_BED_LEVELING
+#: ultralcd.cpp:5763
+msgid "Mesh Bed Leveling"
+msgstr "Livel. piatto"
+
+# MSG_MMU_OK_RESUMING_POSITION c=20 r=4
+#: mmu.cpp:762
+msgid "MMU OK. Resuming position..."
+msgstr "MMU OK. riprendendo la posizione... "
+
+# MSG_MMU_OK_RESUMING_TEMPERATURE c=20 r=4
+#: mmu.cpp:755
+msgid "MMU OK. Resuming temperature..."
+msgstr "MMU OK. Ripristino temperatura... "
+
+# 
+#: ultralcd.cpp:3059
+msgid "Measured skew"
+msgstr "Deviazione mis"
+
+# 
+#: ultralcd.cpp:1796
+msgid "MMU fails"
+msgstr "Fallimenti MMU"
+
+# 
+#: mmu.cpp:1613
+msgid "MMU load failed     "
+msgstr "Caricamento MMU fallito"
+
+# 
+#: ultralcd.cpp:1797
+msgid "MMU load fails"
+msgstr "Caricamenti MMU falliti"
+
+# MSG_MMU_OK_RESUMING c=20 r=4
+#: mmu.cpp:773
+msgid "MMU OK. Resuming..."
+msgstr "MMU OK. Riprendendo... "
+
+# MSG_STEALTH_MODE_OFF
+#: messages.c:90
+msgid "Mode     [Normal]"
+msgstr "Mod.    [normale]"
+
+# MSG_SILENT_MODE_ON
+#: messages.c:89
+msgid "Mode     [silent]"
+msgstr "Mod. [silenziosa]"
+
+# 
+#: mmu.cpp:719
+msgid "MMU needs user attention."
+msgstr "Il MMU richiede attenzione dall'utente."
+
+# 
+#: ultralcd.cpp:1823
+msgid "MMU power fails"
+msgstr "Manc. corr. MMU"
+
+# MSG_STEALTH_MODE_ON
+#: messages.c:91
+msgid "Mode    [Stealth]"
+msgstr "Mod. [silenziosa]"
+
+# MSG_AUTO_MODE_ON
+#: messages.c:12
+msgid "Mode [auto power]"
+msgstr "Mod.       [auto]"
+
+# MSG_SILENT_MODE_OFF
+#: messages.c:88
+msgid "Mode [high power]"
+msgstr "Mod.      [forte]"
+
+# 
+#: ultralcd.cpp:2219
+msgid "MMU2 connected"
+msgstr "MMU2 connessa"
+
+# MSG_SELFTEST_MOTOR
+#: messages.c:83
+msgid "Motor"
+msgstr "Motore"
+
+# MSG_MOVE_AXIS
+#: ultralcd.cpp:5652
+msgid "Move axis"
+msgstr "Muovi asse"
+
+# MSG_MOVE_X
+#: ultralcd.cpp:4378
+msgid "Move X"
+msgstr "Sposta X"
+
+# MSG_MOVE_Y
+#: ultralcd.cpp:4379
+msgid "Move Y"
+msgstr "Sposta Y"
+
+# MSG_MOVE_Z
+#: ultralcd.cpp:4380
+msgid "Move Z"
+msgstr "Sposta Z"
+
+# MSG_NO_MOVE
+#: Marlin_main.cpp:5292
+msgid "No move."
+msgstr "Nessun movimento."
+
+# MSG_NO_CARD
+#: ultralcd.cpp:6772
+msgid "No SD card"
+msgstr "Nessuna SD"
+
+# 
+#: ultralcd.cpp:3024
+msgid "N/A"
+msgstr ""
+
+# MSG_NO
+#: messages.c:62
+msgid "No"
+msgstr ""
+
+# MSG_SELFTEST_NOTCONNECTED
+#: ultralcd.cpp:7889
+msgid "Not connected"
+msgstr "Non connesso"
+
+# 
+#: util.cpp:293
+msgid "New firmware version available:"
+msgstr "Nuova versione firmware disponibile:"
+
+# MSG_SELFTEST_FAN_NO c=19
+#: messages.c:79
+msgid "Not spinning"
+msgstr "Non gira"
+
+# MSG_WIZARD_V2_CAL c=20 r=8
+#: ultralcd.cpp:5063
+msgid "Now I will calibrate distance between tip of the nozzle and heatbed surface."
+msgstr "Adesso calibro la distanza fra ugello e superfice del piatto."
+
+# MSG_WIZARD_WILL_PREHEAT c=20 r=4
+#: ultralcd.cpp:5007
+msgid "Now I will preheat nozzle for PLA."
+msgstr "Adesso preriscaldero l'ugello per PLA."
+
+# MSG_NOZZLE
+#: messages.c:63
+msgid "Nozzle"
+msgstr "Ugello"
+
+# MSG_DEFAULT_SETTINGS_LOADED c=20 r=4
+#: Marlin_main.cpp:1519
+msgid "Old settings found. Default PID, Esteps etc. will be set."
+msgstr "Sono state trovate impostazioni vecchie. Verranno impostati i valori predefiniti di PID, Esteps etc."
+
+# 
+#: ultralcd.cpp:4998
+msgid "Now remove the test print from steel sheet."
+msgstr "Ora rimuovete la stampa di prova dalla piastra in acciaio."
+
+# 
+#: ultralcd.cpp:1722
+msgid "Nozzle FAN"
+msgstr "Ventola estrusore"
+
+# MSG_PAUSE_PRINT
+#: ultralcd.cpp:6735
+msgid "Pause print"
+msgstr "Metti in pausa"
+
+# MSG_PID_RUNNING c=20 r=1
+#: ultralcd.cpp:1606
+msgid "PID cal.           "
+msgstr "Calibrazione PID"
+
+# MSG_PID_FINISHED c=20 r=1
+#: ultralcd.cpp:1612
+msgid "PID cal. finished"
+msgstr "Calib. PID completa"
+
+# MSG_PID_EXTRUDER c=17 r=1
+#: ultralcd.cpp:5769
+msgid "PID calibration"
+msgstr "Calibrazione PID"
+
+# MSG_PINDA_PREHEAT c=20 r=1
+#: ultralcd.cpp:846
+msgid "PINDA Heating"
+msgstr "Riscaldamento PINDA"
+
+# MSG_PAPER c=20 r=8
+#: messages.c:64
+msgid "Place a sheet of paper under the nozzle during the calibration of first 4 points. If the nozzle catches the paper, power off the printer immediately."
+msgstr "Posizionare un foglio sotto l'ugello durante la calibrazione dei primi 4 punti. In caso l'ugello muova il foglio spegnere subito la stampante."
+
+# MSG_WIZARD_CLEAN_HEATBED c=20 r=8
+#: ultralcd.cpp:5072
+msgid "Please clean heatbed and then press the knob."
+msgstr "Per favore pulisci il piatto, poi premi la manopola."
+
+# MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
+#: messages.c:22
+msgid "Please clean the nozzle for calibration. Click when done."
+msgstr "Pulire l'ugello per la calibrazione, poi fare click."
+
+# MSG_SELFTEST_PLEASECHECK
+#: ultralcd.cpp:7881
+msgid "Please check :"
+msgstr "Verifica:"
+
+# MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
+#: messages.c:100
+msgid "Please check our handbook and fix the problem. Then resume the Wizard by rebooting the printer."
+msgstr "Per favore consulta il nostro manuale per risolvere il problema. Poi riprendi il Wizard dopo aver riavviato la stampante."
+
+# MSG_WIZARD_LOAD_FILAMENT c=20 r=8
+#: ultralcd.cpp:4894
+msgid "Please insert PLA filament to the extruder, then press knob to load it."
+msgstr "Per favore inserisci il filamento di PLA nell'estrusore, poi premi la manopola per caricare."
+
+# MSG_PLEASE_LOAD_PLA c=20 r=4
+#: ultralcd.cpp:4795
+msgid "Please load PLA filament first."
+msgstr "Per favore prima carica il filamento di PLA."
+
+# MSG_CHECK_IDLER c=20 r=4
+#: Marlin_main.cpp:3064
+msgid "Please open idler and remove filament manually."
+msgstr "Aprire la guida filam. e rimuovere il filam. a mano"
+
+# MSG_PLACE_STEEL_SHEET c=20 r=4
+#: messages.c:65
+msgid "Please place steel sheet on heatbed."
+msgstr "Per favore posizionate la piastra d'acciaio sul piano riscaldato."
+
+# MSG_PRESS_TO_UNLOAD c=20 r=4
+#: messages.c:68
+msgid "Please press the knob to unload filament"
+msgstr "Premete la manopola per scaricare il filamento "
+
+# 
+#: ultralcd.cpp:4889
+msgid "Please insert PLA filament to the first tube of MMU, then press the knob to load it."
+msgstr "Per favore inserite del filamento PLA nel primo tubo del MMU, poi premete la manopola per caricarlo."
+
+# MSG_PULL_OUT_FILAMENT c=20 r=4
+#: messages.c:70
+msgid "Please pull out filament immediately"
+msgstr "Estrarre il filamento immediatamente"
+
+# MSG_EJECT_REMOVE c=20 r=4
+#: mmu.cpp:1440
+msgid "Please remove filament and then press the knob."
+msgstr "Rimuovi il filamento e quindi premi la manopola. "
+
+# MSG_REMOVE_STEEL_SHEET c=20 r=4
+#: messages.c:74
+msgid "Please remove steel sheet from heatbed."
+msgstr "Rimuovete la piastra di acciaio dal piano riscaldato"
+
+# MSG_RUN_XYZ c=20 r=4
+#: Marlin_main.cpp:4355
+msgid "Please run XYZ calibration first."
+msgstr "Esegui la calibrazione XYZ prima. "
+
+# MSG_UPDATE_MMU2_FW c=20 r=4
+#: mmu.cpp:1359
+msgid "Please update firmware in your MMU2. Waiting for reset."
+msgstr "Aggiorna il firmware sul tuo MMU2. In attesa di reset. "
+
+# MSG_PLEASE_WAIT c=20
+#: messages.c:66
+msgid "Please wait"
+msgstr "Attendere"
+
+# 
+#: ultralcd.cpp:4997
+msgid "Please remove shipping helpers first."
+msgstr "Per favore rimuovete i materiali da spedizione"
+
+# MSG_PREHEAT_NOZZLE c=20
+#: messages.c:67
+msgid "Preheat the nozzle!"
+msgstr "Prerisc. ugello!"
+
+# MSG_PREHEAT
+#: ultralcd.cpp:6722
+msgid "Preheat"
+msgstr "Preriscalda"
+
+# MSG_WIZARD_HEATING c=20 r=3
+#: messages.c:102
+msgid "Preheating nozzle. Please wait."
+msgstr "Preriscaldando l'ugello. Attendere prego."
+
+# 
+#: util.cpp:297
+msgid "Please upgrade."
+msgstr "Prego aggiornare."
+
+# MSG_PRESS_TO_PREHEAT c=20 r=4
+#: Marlin_main.cpp:10364
+msgid "Press knob to preheat nozzle and continue."
+msgstr "Premete la manopola per preriscaldare l'ugello e continuare."
+
+# 
+#: ultralcd.cpp:1851
+msgid "Power failures"
+msgstr "Mancanza corrente"
+
+# MSG_PRINT_ABORTED c=20
+#: messages.c:69
+msgid "Print aborted"
+msgstr "Stampa interrotta"
+
+# 
+#: ultralcd.cpp:2455
+msgid "Preheating to load"
+msgstr "Preriscaldamento per caricare"
+
+# 
+#: ultralcd.cpp:2459
+msgid "Preheating to unload"
+msgstr "Preriscaldamento per scaricare"
+
+# MSG_SELFTEST_PRINT_FAN_SPEED c=18
+#: ultralcd.cpp:8307
+msgid "Print fan:"
+msgstr "Vent.stam:"
+
+# MSG_CARD_MENU
+#: messages.c:21
+msgid "Print from SD"
+msgstr "Stampa da SD"
+
+# 
+#: ultralcd.cpp:2317
+msgid "Press the knob"
+msgstr "Premere la manopola"
+
+# MSG_PRINT_PAUSED c=20 r=1
+#: ultralcd.cpp:1069
+msgid "Print paused"
+msgstr "Stampa in pausa"
+
+# 
+#: mmu.cpp:723
+msgid "Press the knob to resume nozzle temperature."
+msgstr "Premete la manopola per recuperare la temperatura dell'ugello."
+
+# MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
+#: messages.c:41
+msgid "Printer has not been calibrated yet. Please follow the manual, chapter First steps, section Calibration flow."
+msgstr "Stampante non ancora calibrata. Si prega di seguire il manuale, capitolo Primi Passi, sezione Sequenza di Calibrazione."
+
+# 
+#: ultralcd.cpp:1723
+msgid "Print FAN"
+msgstr "Ventola di stampa"
+
+# MSG_PRUSA3D
+#: ultralcd.cpp:2205
+msgid "prusa3d.com"
+msgstr ""
+
+# MSG_BED_CORRECTION_REAR c=14 r=1
+#: ultralcd.cpp:3295
+msgid "Rear side [um]"
+msgstr "Retro [um]"
+
+# MSG_RECOVERING_PRINT c=20 r=1
+#: Marlin_main.cpp:9764
+msgid "Recovering print    "
+msgstr "Recupero stampa"
+
+# MSG_REMOVE_OLD_FILAMENT c=20 r=4
+#: mmu.cpp:830
+msgid "Remove old filament and press the knob to start loading new filament."
+msgstr "Rimuovi il filamento precedente e premi la manopola per caricare il nuovo filamento. "
+
+# 
+#: 
+msgid "Prusa i3 MK3S OK."
+msgstr ""
+
+# MSG_CALIBRATE_BED_RESET
+#: ultralcd.cpp:5774
+msgid "Reset XYZ calibr."
+msgstr "Reset calibrazione XYZ."
+
+# MSG_BED_CORRECTION_RESET
+#: ultralcd.cpp:3296
+msgid "Reset"
+msgstr ""
+
+# MSG_RESUME_PRINT
+#: ultralcd.cpp:6742
+msgid "Resume print"
+msgstr "Riprendi stampa"
+
+# MSG_RESUMING_PRINT c=20 r=1
+#: messages.c:73
+msgid "Resuming print"
+msgstr "Riprendi stampa"
+
+# MSG_BED_CORRECTION_RIGHT c=14 r=1
+#: ultralcd.cpp:3293
+msgid "Right side[um]"
+msgstr "Destra [um]"
+
+# MSG_SECOND_SERIAL_ON c=17 r=1
+#: ultralcd.cpp:5692
+msgid "RPi port     [on]"
+msgstr "Porta RPi    [on]"
+
+# MSG_SECOND_SERIAL_OFF c=17 r=1
+#: ultralcd.cpp:5690
+msgid "RPi port    [off]"
+msgstr "Porta RPi   [off]"
+
+# MSG_WIZARD_RERUN c=20 r=7
+#: ultralcd.cpp:4812
+msgid "Running Wizard will delete current calibration results and start from the beginning. Continue?"
+msgstr "Se avvi il Wizard perderai la calibrazione preesistente e dovrai ricominciare dall'inizio. Continuare?"
+
+# MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_OFF c=19 r=1
+#: ultralcd.cpp:5322
+msgid "SD card  [normal]"
+msgstr "Mem. SD [normale]"
+
+# MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_ON c=19 r=1
+#: ultralcd.cpp:5320
+msgid "SD card [flshAir]"
+msgstr "Mem. SD [flshAir]"
+
+# 
+#: ultralcd.cpp:3019
+msgid "Right"
+msgstr "Destra"
+
+# MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=60
+#: messages.c:38
+msgid "Searching bed calibration point"
+msgstr "Ricerca dei punti di calibrazione del piano"
+
+# MSG_LANGUAGE_SELECT
+#: ultralcd.cpp:5699
+msgid "Select language"
+msgstr "Seleziona lingua"
+
+# MSG_SELFTEST_OK
+#: ultralcd.cpp:7452
+msgid "Self test OK"
+msgstr "Autotest OK"
+
+# MSG_SELFTEST_START c=20
+#: ultralcd.cpp:7238
+msgid "Self test start  "
+msgstr "Avvia autotest"
+
+# MSG_SELFTEST
+#: ultralcd.cpp:5750
+msgid "Selftest         "
+msgstr "Autotest"
+
+# MSG_SELFTEST_ERROR
+#: ultralcd.cpp:7879
+msgid "Selftest error !"
+msgstr "Errore Autotest !"
+
+# MSG_SELFTEST_FAILED c=20
+#: messages.c:77
+msgid "Selftest failed  "
+msgstr "Autotest fallito"
+
+# MSG_FORCE_SELFTEST c=20 r=8
+#: Marlin_main.cpp:1551
+msgid "Selftest will be run to calibrate accurate sensorless rehoming."
+msgstr "Verra effettuato un self test per calibrare l'homing senza sensori"
+
+# 
+#: ultralcd.cpp:5045
+msgid "Select nozzle preheat temperature which matches your material."
+msgstr "Selezionate la temperatura per il preriscaldamento dell'ugello adatta al vostro materiale."
+
+# 
+#: ultralcd.cpp:4780
+msgid "Select PLA filament:"
+msgstr "Selezionate filamento PLA:"
+
+# MSG_SET_TEMPERATURE c=19 r=1
+#: ultralcd.cpp:3314
+msgid "Set temperature:"
+msgstr "Imposta temperatura:"
+
+# MSG_SETTINGS
+#: messages.c:86
+msgid "Settings"
+msgstr "Impostazioni"
+
+# MSG_SHOW_END_STOPS c=17 r=1
+#: ultralcd.cpp:5771
+msgid "Show end stops"
+msgstr "Stato finecorsa"
+
+# 
+#: ultralcd.cpp:4025
+msgid "Sensor state"
+msgstr "Stato sensore"
+
+# MSG_FILE_CNT c=20 r=4
+#: cardreader.cpp:739
+msgid "Some files will not be sorted. Max. No. of files in 1 folder for sorting is 100."
+msgstr "Alcuni file non saranno ordinati. Il numero massimo di file in una cartella e 100 perche siano ordinati."
+
+# MSG_SORT_NONE c=17 r=1
+#: ultralcd.cpp:5332
+msgid "Sort       [none]"
+msgstr "Ordina  [nessuno]"
+
+# MSG_SORT_TIME c=17 r=1
+#: ultralcd.cpp:5330
+msgid "Sort       [time]"
+msgstr "Ordina    [cron.]"
+
+# 
+#: ultralcd.cpp:3062
+msgid "Severe skew:"
+msgstr "Devia.grave:"
+
+# MSG_SORT_ALPHA c=17 r=1
+#: ultralcd.cpp:5331
+msgid "Sort   [alphabet]"
+msgstr "Ordine [alfabeti]"
+
+# MSG_SORTING c=20 r=1
+#: cardreader.cpp:746
+msgid "Sorting files"
+msgstr "Ordinando i file"
+
+# MSG_SOUND_LOUD c=17 r=1
+#: sound.h:6
+msgid "Sound      [loud]"
+msgstr "Suono     [forte]"
+
+# 
+#: ultralcd.cpp:3061
+msgid "Slight skew:"
+msgstr "Devia.lieve:"
+
+# MSG_SOUND_MUTE c=17 r=1
+#: 
+msgid "Sound      [mute]"
+msgstr "Suono      [mute]"
+
+# 
+#: Marlin_main.cpp:4871
+msgid "Some problem encountered, Z-leveling enforced ..."
+msgstr "Sono stati rilevati problemi, avviato livellamento Z ..."
+
+# MSG_SOUND_ONCE c=17 r=1
+#: sound.h:7
+msgid "Sound      [once]"
+msgstr "Suono   [singolo]"
+
+# MSG_SOUND_SILENT c=17 r=1
+#: sound.h:8
+msgid "Sound    [silent]"
+msgstr "Suono[silenzioso]"
+
+# MSG_SPEED
+#: ultralcd.cpp:6926
+msgid "Speed"
+msgstr "Velocita"
+
+# MSG_SELFTEST_FAN_YES c=19
+#: messages.c:80
+msgid "Spinning"
+msgstr "Gira"
+
+# MSG_TEMP_CAL_WARNING c=20 r=4
+#: Marlin_main.cpp:4368
+msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
+msgstr "Sono necessari una temperatura ambiente di 21-26C e una superficie rigida "
+
+# MSG_STATISTICS
+#: ultralcd.cpp:6839
+msgid "Statistics  "
+msgstr "Statistiche"
+
+# MSG_STOP_PRINT
+#: messages.c:93
+msgid "Stop print"
+msgstr "Arresta stampa"
+
+# MSG_STOPPED
+#: messages.c:94
+msgid "STOPPED. "
+msgstr "ARRESTATO."
+
+# MSG_SUPPORT
+#: ultralcd.cpp:6848
+msgid "Support"
+msgstr "Supporto"
+
+# MSG_SELFTEST_SWAPPED
+#: ultralcd.cpp:7959
+msgid "Swapped"
+msgstr "Scambiato"
+
+# MSG_TEMP_CALIBRATION c=20 r=1
+#: messages.c:95
+msgid "Temp. cal.          "
+msgstr "Calib. temp. "
+
+# MSG_TEMP_CALIBRATION_ON c=20 r=1
+#: ultralcd.cpp:5686
+msgid "Temp. cal.   [on]"
+msgstr "Calib. temp. [on]"
+
+# MSG_TEMP_CALIBRATION_OFF c=20 r=1
+#: ultralcd.cpp:5684
+msgid "Temp. cal.  [off]"
+msgstr "Calib. temp.[off]"
+
+# MSG_CALIBRATION_PINDA_MENU c=17 r=1
+#: ultralcd.cpp:5780
+msgid "Temp. calibration"
+msgstr "Calib. Temp."
+
+# MSG_TEMP_CAL_FAILED c=20 r=8
+#: ultralcd.cpp:3951
+msgid "Temperature calibration failed"
+msgstr "Calibrazione temperatura fallita"
+
+# MSG_TEMP_CALIBRATION_DONE c=20 r=12
+#: messages.c:96
+msgid "Temperature calibration is finished and active. Temp. calibration can be disabled in menu Settings->Temp. cal."
+msgstr "Calibrazione temperatura completata e attiva. Puo essere disattivata dal menu Impostazioni ->Cal. Temp."
+
+# MSG_TEMPERATURE
+#: ultralcd.cpp:5650
+msgid "Temperature"
+msgstr ""
+
+# MSG_MENU_TEMPERATURES c=15 r=1
+#: ultralcd.cpp:2251
+msgid "Temperatures"
+msgstr "Temperature"
+
+# MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=4
+#: messages.c:42
+msgid "There is still a need to make Z calibration. Please follow the manual, chapter First steps, section Calibration flow."
+msgstr "E ancora necessario effettuare la calibrazione Z. Segui il manuale, capitolo Primi Passi, sezione Sequenza di Calibrazione. "
+
+# 
+#: ultralcd.cpp:2908
+msgid "Total filament"
+msgstr "Filamento totale"
+
+# 
+#: ultralcd.cpp:2908
+msgid "Total print time"
+msgstr "Tempo stampa totale"
+
+# MSG_TUNE
+#: ultralcd.cpp:6719
+msgid "Tune"
+msgstr "Regola"
+
+# 
+#: ultralcd.cpp:4869
+msgid "Unload"
+msgstr "Scarica"
+
+# 
+#: ultralcd.cpp:1820
+msgid "Total failures"
+msgstr "Totale fallimenti"
+
+# 
+#: ultralcd.cpp:2324
+msgid "to load filament"
+msgstr "per caricare il filamento"
+
+# 
+#: ultralcd.cpp:2328
+msgid "to unload filament"
+msgstr "per scaricare il filamento"
+
+# MSG_UNLOAD_FILAMENT c=17
+#: messages.c:97
+msgid "Unload filament"
+msgstr "Scarica filamento"
+
+# MSG_UNLOADING_FILAMENT c=20 r=1
+#: messages.c:98
+msgid "Unloading filament"
+msgstr "Scaricando filamento"
+
+# 
+#: ultralcd.cpp:1773
+msgid "Total"
+msgstr "Totale"
+
+# MSG_USED c=19 r=1
+#: ultralcd.cpp:5908
+msgid "Used during print"
+msgstr "Usati nella stampa"
+
+# MSG_MENU_VOLTAGES c=15 r=1
+#: ultralcd.cpp:2254
+msgid "Voltages"
+msgstr "Voltaggi"
+
+# 
+#: ultralcd.cpp:2227
+msgid "unknown"
+msgstr "sconosciuto"
+
+# MSG_USERWAIT
+#: Marlin_main.cpp:5263
+msgid "Wait for user..."
+msgstr "Attendendo utente..."
+
+# MSG_WAITING_TEMP c=20 r=3
+#: ultralcd.cpp:3458
+msgid "Waiting for nozzle and bed cooling"
+msgstr "In attesa del raffreddamento dell'ugello e del piano"
+
+# MSG_WAITING_TEMP_PINDA c=20 r=3
+#: ultralcd.cpp:3422
+msgid "Waiting for PINDA probe cooling"
+msgstr "In attesa del raffreddamento della sonda PINDA"
+
+# 
+#: ultralcd.cpp:4868
+msgid "Use unload to remove filament 1 if it protrudes outside of the rear MMU tube. Use eject if it is hidden in tube."
+msgstr "Usate lo scaricamento per rimuovere il filamento 1 se protrude dal retro del tubo posteriore del MMu. Utilizzate l'espulsione se e nascosto nel tubo."
+
+# MSG_CHANGED_BOTH c=20 r=4
+#: Marlin_main.cpp:1511
+msgid "Warning: both printer type and motherboard type changed."
+msgstr "Attenzione: tipo di stampante e di scheda madre cambiati."
+
+# MSG_CHANGED_MOTHERBOARD c=20 r=4
+#: Marlin_main.cpp:1503
+msgid "Warning: motherboard type changed."
+msgstr "Avviso: tipo di scheda madre cambiato"
+
+# MSG_CHANGED_PRINTER c=20 r=4
+#: Marlin_main.cpp:1507
+msgid "Warning: printer type changed."
+msgstr "Avviso: tipo di stampante cambiato."
+
+# MSG_UNLOAD_SUCCESSFUL c=20 r=2
+#: Marlin_main.cpp:3054
+msgid "Was filament unload successful?"
+msgstr "Filamento scaricato con successo?"
+
+# MSG_SELFTEST_WIRINGERROR
+#: messages.c:85
+msgid "Wiring error"
+msgstr "Errore cablaggio"
+
+# MSG_WIZARD c=17 r=1
+#: ultralcd.cpp:5747
+msgid "Wizard"
+msgstr ""
+
+# MSG_XYZ_DETAILS c=19 r=1
+#: ultralcd.cpp:2243
+msgid "XYZ cal. details"
+msgstr "XYZ Cal. dettagli"
+
+# MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
+#: messages.c:19
+msgid "XYZ calibration failed. Please consult the manual."
+msgstr "Calibrazione XYZ fallita. Si prega di consultare il manuale."
+
+# MSG_YES
+#: messages.c:104
+msgid "Yes"
+msgstr "Si"
+
+# MSG_WIZARD_QUIT c=20 r=8
+#: messages.c:103
+msgid "You can always resume the Wizard from Calibration -> Wizard."
+msgstr "E possibile riprendere il Wizard in qualsiasi momento attraverso Calibrazione -> Wizard."
+
+# MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
+#: ultralcd.cpp:3922
+msgid "XYZ calibration all right. Skew will be corrected automatically."
+msgstr "Calibrazione XYZ corretta. La distorsione verra compensata automaticamente."
+
+# MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
+#: ultralcd.cpp:3919
+msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
+msgstr "Calibrazion XYZ corretta. Assi X/Y leggermente storti. Ben fatto!"
+
+# 
+#: ultralcd.cpp:5130
+msgid "X-correct:"
+msgstr "Correzione-X:"
+
+# MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
+#: ultralcd.cpp:3916
+msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
+msgstr "Calibrazione XYZ OK. Gli assi X/Y sono perpendicolari. Complimenti!"
+
+# MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
+#: ultralcd.cpp:3900
+msgid "XYZ calibration compromised. Front calibration points not reachable."
+msgstr "Calibrazione XYZ compromessa. Punti anteriori non raggiungibili."
+
+# MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
+#: ultralcd.cpp:3903
+msgid "XYZ calibration compromised. Right front calibration point not reachable."
+msgstr "Calibrazione XYZ compromessa. Punto anteriore destro non raggiungibile."
+
+# MSG_LOAD_ALL c=17
+#: ultralcd.cpp:6166
+msgid "Load all"
+msgstr "Caricare tutti"
+
+# 
+#: ultralcd.cpp:3882
+msgid "XYZ calibration failed. Bed calibration point was not found."
+msgstr "Calibrazione XYZ fallita. Il punto di calibrazione sul letto non e' stato trovato."
+
+# 
+#: ultralcd.cpp:3888
+msgid "XYZ calibration failed. Front calibration points not reachable."
+msgstr "Calibrazione XYZ fallita. Punti anteriori non raggiungibili."
+
+# 
+#: ultralcd.cpp:3891
+msgid "XYZ calibration failed. Right front calibration point not reachable."
+msgstr "Calibrazione XYZ fallita. Punto anteriore destro non raggiungibile."
+
+# 
+#: ultralcd.cpp:3016
+msgid "Y distance from min"
+msgstr "Distanza Y dal min"
+
+# 
+#: ultralcd.cpp:5131
+msgid "Y-correct:"
+msgstr "Correzione-Y:"
+
+# MSG_OFF
+#: menu.cpp:426
+msgid " [off]"
+msgstr ""
+
+# 
+#: messages.c:57
+msgid "Back"
+msgstr "Indietro"
+
+# 
+#: ultralcd.cpp:5639
+msgid "Checks"
+msgstr "Controlli"
+
+# 
+#: ultralcd.cpp:7973
+msgid "False triggering"
+msgstr "Falso innesco"
+
+# 
+#: ultralcd.cpp:4030
 msgid "FINDA:"
-msgstr "FINDA:"
-
-# MSG_FINISHING_MOVEMENTS c=20 r=1
-#: messages.c:40
-msgid "Finishing movements"
-msgstr "Finalizzando gli spostamenti"
+msgstr ""
 
 # 
-#: ultralcd.cpp:5443
+#: ultralcd.cpp:5545
 msgid "Firmware   [none]"
-msgstr "Firmware [nessuno]"
+msgstr "Firmware[nessuno]"
 
 # 
-#: ultralcd.cpp:5446
+#: ultralcd.cpp:5551
+msgid "Firmware [strict]"
+msgstr "Firmware [esatto]"
+
+# 
+#: ultralcd.cpp:5548
 msgid "Firmware   [warn]"
 msgstr "Firmware [avviso]"
 
 # 
-#: ultralcd.cpp:5449
-msgid "Firmware [strict]"
-msgstr "Firmware [esatto]"
-
-# MSG_V2_CALIBRATION c=17 r=1
-#: messages.c:105
-msgid "First layer cal."
-msgstr "Calibrazione primo layer."
-
-# MSG_WIZARD_SELFTEST c=20 r=8
-#: ultralcd.cpp:4880
-msgid "First, I will run the selftest to check most common assembly problems."
-msgstr "Per primo avviero l'autotest per controllare gli errori di assemblaggio piu comuni."
+#: messages.c:87
+msgid "HW Setup"
+msgstr "Installazione HW"
 
 # 
-#: mmu.cpp:724
-msgid "Fix the issue and then press button on MMU unit."
-msgstr "Risolvi il problema e quindi premi il bottone sull'unita MMU. "
+#: ultralcd.cpp:4034
+msgid "IR:"
+msgstr ""
 
-# MSG_FLOW
-#: ultralcd.cpp:6846
-msgid "Flow"
-msgstr "Flusso"
+# 
+#: ultralcd.cpp:7046
+msgid "Magnets comp.[N/A]"
+msgstr "Comp. Magneti[N/A]"
 
-# MSG_PRUSA3D_FORUM
-#: ultralcd.cpp:2099
-msgid "forum.prusa3d.com"
-msgstr "forum.prusa3d.com"
+# 
+#: ultralcd.cpp:7044
+msgid "Magnets comp.[Off]"
+msgstr "Comp. Magneti[off]"
 
-# MSG_SELFTEST_COOLING_FAN c=20
-#: messages.c:75
-msgid "Front print fan?"
-msgstr "Ventola frontale?"
+# 
+#: ultralcd.cpp:7043
+msgid "Magnets comp. [On]"
+msgstr "Comp. Magneti [on]"
 
-# MSG_BED_CORRECTION_FRONT c=14 r=1
-#: ultralcd.cpp:3217
-msgid "Front side[um]"
-msgstr "Fronte [um]"
+# 
+#: ultralcd.cpp:7035
+msgid "Mesh         [3x3]"
+msgstr "Griglia      [3x3]"
 
-# MSG_SELFTEST_FANS
-#: ultralcd.cpp:7871
-msgid "Front/left fans"
-msgstr "Ventola frontale/sinistra"
+# 
+#: ultralcd.cpp:7036
+msgid "Mesh         [7x7]"
+msgstr "Griglia      [7x7]"
+
+# 
+#: ultralcd.cpp:5677
+msgid "Mesh bed leveling"
+msgstr "Mesh livel. letto"
+
+# 
+#: Marlin_main.cpp:856
+msgid "MK3S firmware detected on MK3 printer"
+msgstr "Firmware MK3S rilevato su stampante MK3"
+
+# 
+#: ultralcd.cpp:5306
+msgid "MMU Mode [Normal]"
+msgstr "Modalita MMU [Normale]"
+
+# 
+#: ultralcd.cpp:5307
+msgid "MMU Mode[Stealth]"
+msgstr "Modalita MMU [Silenziosa]"
+
+# 
+#: ultralcd.cpp:4511
+msgid "Mode change in progress ..."
+msgstr "Cambio modalita in corso ..."
+
+# 
+#: ultralcd.cpp:5506
+msgid "Model      [none]"
+msgstr "Modello [nessuno]"
+
+# 
+#: ultralcd.cpp:5512
+msgid "Model    [strict]"
+msgstr "Modello  [esatto]"
+
+# 
+#: ultralcd.cpp:5509
+msgid "Model      [warn]"
+msgstr "Modello  [avviso]"
+
+# 
+#: ultralcd.cpp:5467
+msgid "Nozzle d.  [0.25]"
+msgstr "Diam.Ugello[0.25]"
+
+# 
+#: ultralcd.cpp:5470
+msgid "Nozzle d.  [0.40]"
+msgstr "Diam.Ugello[0.40]"
+
+# 
+#: ultralcd.cpp:5473
+msgid "Nozzle d.  [0.60]"
+msgstr "Diam.Ugello[0.60]"
+
+# 
+#: ultralcd.cpp:5421
+msgid "Nozzle     [none]"
+msgstr "Ugello  [nessuno]"
+
+# 
+#: ultralcd.cpp:5427
+msgid "Nozzle   [strict]"
+msgstr "Ugello   [esatto]"
+
+# 
+#: ultralcd.cpp:5424
+msgid "Nozzle     [warn]"
+msgstr "Ugello   [avviso]"
 
 # 
 #: util.cpp:510
@@ -845,902 +1733,27 @@ msgstr "G-code processato per una stampante diversa. Per favore esegui nuovament
 # 
 #: util.cpp:477
 msgid "G-code sliced for a newer firmware. Continue?"
-msgstr "G-code processato per un firmware più recente. Continuare?"
+msgstr "G-code processato per un firmware piu recente. Continuare?"
 
 # 
 #: util.cpp:483
 msgid "G-code sliced for a newer firmware. Please update the firmware. Print cancelled."
-msgstr "G-code processato per un firmware più recente. Per favore aggiorna il firmware. Stampa annullata."
-
-# MSG_SELFTEST_HEATERTHERMISTOR
-#: ultralcd.cpp:7801
-msgid "Heater/Thermistor"
-msgstr "Riscald./Termist."
-
-# MSG_HEATING
-#: messages.c:46
-msgid "Heating"
-msgstr "Riscaldamento..."
-
-# MSG_BED_HEATING_SAFETY_DISABLED
-#: Marlin_main.cpp:8411
-msgid "Heating disabled by safety timer."
-msgstr "Riscaldamento fermato dal timer di sicurezza."
-
-# MSG_HEATING_COMPLETE c=20
-#: messages.c:47
-msgid "Heating done."
-msgstr "Riscald. completo"
-
-# MSG_WIZARD_WELCOME c=20 r=7
-#: ultralcd.cpp:4859
-msgid "Hi, I am your Original Prusa i3 printer. Would you like me to guide you through the setup process?"
-msgstr "Ciao, sono la tua stampante Original Prusa i3. Gradiresti un aiuto nel processo di configurazione?"
-
-# MSG_PRUSA3D_HOWTO
-#: ultralcd.cpp:2100
-msgid "howto.prusa3d.com"
-msgstr "howto.prusa3d.com"
+msgstr "G-code processato per un firmware piu recente. Per favore aggiorna il firmware. Stampa annullata."
 
 # 
-#: messages.c:87
-msgid "HW Setup"
-msgstr "Installazione HW"
-
-# MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ultralcd.cpp:4889
-msgid "I will run xyz calibration now. It will take approx. 12 mins."
-msgstr "Adesso avviero una Calibrazione XYZ. Puo durare circa 12 min."
-
-# MSG_WIZARD_Z_CAL c=20 r=8
-#: ultralcd.cpp:4897
-msgid "I will run z calibration now."
-msgstr "Adesso avviero la Calibrazione Z."
-
-# MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ultralcd.cpp:4962
-msgid "I will start to print line and you will gradually lower the nozzle by rotating the knob, until you reach optimal height. Check the pictures in our handbook in chapter Calibration."
-msgstr "Adesso iniziero a stampare una linea e tu dovrai abbassare l'ugello poco per volta ruotando la manopola sino a raggiungere una altezza ottimale. Per favore dai uno sguardo all'immagine del nostro manuale, cap.Calibrazione."
-
-# MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=60
-#: mesh_bed_calibration.cpp:2481
-msgid "Improving bed calibration point"
-msgstr "Perfezion. punto di calibraz. letto"
-
-# MSG_WATCH
-#: messages.c:99
-msgid "Info screen"
-msgstr "Schermata info"
-
-# MSG_INIT_SDCARD
-#: ultralcd.cpp:5785
-msgid "Init. SD card"
-msgstr "Inizializza scheda SD"
-
-# MSG_INSERT_FILAMENT c=20
-#: ultralcd.cpp:2569
-msgid "Insert filament"
-msgstr "Inserire filamento"
-
-# MSG_FILAMENT_LOADING_T0 c=20 r=4
-#: messages.c:33
-msgid "Insert filament into extruder 1. Click when done."
-msgstr "Inserire filamento nell'estrusore 1. Click per continuare"
-
-# MSG_FILAMENT_LOADING_T1 c=20 r=4
-#: messages.c:34
-msgid "Insert filament into extruder 2. Click when done."
-msgstr "Inserire filamento nell'estrusore 2. Click per continuare"
-
-# MSG_FILAMENT_LOADING_T2 c=20 r=4
-#: messages.c:35
-msgid "Insert filament into extruder 3. Click when done."
-msgstr "Inserire filamento nell'estrusore 3. Click per continuare"
-
-# MSG_FILAMENT_LOADING_T3 c=20 r=4
-#: messages.c:36
-msgid "Insert filament into extruder 4. Click when done."
-msgstr "Inserire filamento nell'estrusore 4. Click per continuare"
-
-# 
-#: ultralcd.cpp:3947
-msgid "IR:"
-msgstr "IR:"
-
-# 
-#: ultralcd.cpp:4922
-msgid "Is filament 1 loaded?"
-msgstr "Il filamento 1 e caricato?"
-
-# MSG_WIZARD_FILAMENT_LOADED c=20 r=2
-#: ultralcd.cpp:4925
-msgid "Is filament loaded?"
-msgstr "Il filamento e stato caricato?"
-
-# MSG_WIZARD_PLA_FILAMENT c=20 r=2
-#: ultralcd.cpp:4956
-msgid "Is it PLA filament?"
-msgstr "E' un filamento di PLA?"
-
-# MSG_PLA_FILAMENT_LOADED c=20 r=2
-#: ultralcd.cpp:4701
-msgid "Is PLA filament loaded?"
-msgstr "E' stato caricato il filamento di PLA?"
-
-# MSG_STEEL_SHEET_CHECK c=20 r=2
-#: messages.c:92
-msgid "Is steel sheet on heatbed?"
-msgstr "La piastra d'acciaio e sul piano riscaldato?"
-
-# MSG_FIND_BED_OFFSET_AND_SKEW_ITERATION c=20
-#: mesh_bed_calibration.cpp:2223
-msgid "Iteration "
-msgstr "Iterazione"
-
-# MSG_KILLED
-#: Marlin_main.cpp:7552
-msgid "KILLED. "
-msgstr "IN TILT."
-
-# 
-#: ultralcd.cpp:1828
-msgid "Last print"
-msgstr "Ultima stampa"
-
-# 
-#: ultralcd.cpp:1845
-msgid "Last print failures"
-msgstr "Fallimenti ultima stampa"
-
-# 
-#: ultralcd.cpp:2967
-msgid "Left"
-msgstr "Sinistra"
-
-# MSG_SELFTEST_EXTRUDER_FAN c=20
-#: messages.c:76
-msgid "Left hotend fan?"
-msgstr "Vent SX hotend?"
-
-# MSG_BED_CORRECTION_LEFT c=14 r=1
-#: ultralcd.cpp:3215
-msgid "Left side [um]"
-msgstr "Sinistra [um]"
-
-# MSG_LEFT c=12 r=1
-#: ultralcd.cpp:2308
-msgid "Left:"
-msgstr "Sinistra:"
-
-# 
-#: ultralcd.cpp:5575
-msgid "Lin. correction"
-msgstr "Correzione lin."
-
-# MSG_BABYSTEP_Z
-#: messages.c:13
-msgid "Live adjust Z"
-msgstr "Compensazione Z"
-
-# MSG_LOAD_ALL c=17
-#: ultralcd.cpp:6059
-msgid "Load all"
-msgstr "Caricare tutti"
-
-# MSG_LOAD_FILAMENT c=17
-#: messages.c:51
-msgid "Load filament"
-msgstr "Carica filamento"
-
-# MSG_LOAD_FILAMENT_1 c=17
-#: ultralcd.cpp:5576
-msgid "Load filament 1"
-msgstr "Caricare fil. 1"
-
-# MSG_LOAD_FILAMENT_2 c=17
-#: ultralcd.cpp:5577
-msgid "Load filament 2"
-msgstr "Caricare fil. 2"
-
-# MSG_LOAD_FILAMENT_3 c=17
-#: ultralcd.cpp:5578
-msgid "Load filament 3"
-msgstr "Carica fil. 3"
-
-# MSG_LOAD_FILAMENT_4 c=17
-#: ultralcd.cpp:5579
-msgid "Load filament 4"
-msgstr "Caricare fil. 4"
-
-# MSG_LOAD_FILAMENT_5 c=17
-#: ultralcd.cpp:5582
-msgid "Load filament 5"
-msgstr "Caricare fil. 5"
-
-# 
-#: ultralcd.cpp:6714
-msgid "Load to nozzle"
-msgstr "Carica ugello"
-
-# MSG_LOADING_COLOR
-#: ultralcd.cpp:2609
-msgid "Loading color"
-msgstr "Caricando colore"
-
-# MSG_LOADING_FILAMENT c=20
-#: messages.c:52
-msgid "Loading filament"
-msgstr "Caricando filamento"
-
-# MSG_LOOSE_PULLEY c=20 r=1
-#: ultralcd.cpp:7855
-msgid "Loose pulley"
-msgstr "Puleggia lenta"
-
-# MSG_M104_INVALID_EXTRUDER
-#: Marlin_main.cpp:7675
-msgid "M104 Invalid extruder "
-msgstr "M104 Estrusore non valido"
-
-# MSG_M105_INVALID_EXTRUDER
-#: Marlin_main.cpp:7678
-msgid "M105 Invalid extruder "
-msgstr "M105 Estrusore non valido"
-
-# MSG_M109_INVALID_EXTRUDER
-#: Marlin_main.cpp:7681
-msgid "M109 Invalid extruder "
-msgstr "M109 Estrusore non valido"
-
-# MSG_M117_V2_CALIBRATION c=25 r=1
-#: messages.c:55
-msgid "M117 First layer cal."
-msgstr "M117 Calibrazione primo layer."
-
-# MSG_M200_INVALID_EXTRUDER
-#: Marlin_main.cpp:5857
-msgid "M200 Invalid extruder "
-msgstr "M200 Estrusore non valido"
-
-# MSG_M218_INVALID_EXTRUDER
-#: Marlin_main.cpp:7684
-msgid "M218 Invalid extruder "
-msgstr "M218 Estrusore non valido"
-
-# MSG_M221_INVALID_EXTRUDER
-#: Marlin_main.cpp:7687
-msgid "M221 Invalid extruder "
-msgstr "M221 Estrusore non valido"
-
-# 
-#: ultralcd.cpp:6957
-msgid "Magnets comp. [On]"
-msgstr "Comp. Magneti [on]"
-
-# 
-#: ultralcd.cpp:6960
-msgid "Magnets comp.[N/A]"
-msgstr "Comp. Magneti [N/A]"
-
-# 
-#: ultralcd.cpp:6958
-msgid "Magnets comp.[Off]"
-msgstr "Comp. Magneti [off]"
-
-# MSG_MAIN
-#: messages.c:56
-msgid "Main"
-msgstr "Menu principale"
-
-# MSG_MARK_FIL c=20 r=8
-#: ultralcd.cpp:3840
-msgid "Mark filament 100mm from extruder body. Click when done."
-msgstr "Segnare il filamento a 100 mm di distanza dal corpo dell'estrusore. Click per continuare."
-
-# 
-#: ultralcd.cpp:3002
-msgid "Measured skew"
-msgstr "Deviazione misurata"
-
-# MSG_MEASURED_SKEW c=15 r=1
-#: ultralcd.cpp:2335
-msgid "Measured skew:"
-msgstr "Distorsione misurata:"
-
-# MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=60
-#: messages.c:59
-msgid "Measuring reference height of calibration point"
-msgstr "Misura altezza di rif. del punto di calib."
-
-# 
-#: ultralcd.cpp:6949
-msgid "Mesh         [3x3]"
-msgstr "Griglia [3x3]"
-
-# 
-#: ultralcd.cpp:6950
-msgid "Mesh         [7x7]"
-msgstr "Griglia [7x7]"
-
-# MSG_MESH_BED_LEVELING
-#: ultralcd.cpp:5658
-msgid "Mesh Bed Leveling"
-msgstr "Mesh livel. letto"
-
-# 
-#: ultralcd.cpp:5572
-msgid "Mesh bed leveling"
-msgstr "Mesh livel. letto"
-
-# 
-#: Marlin_main.cpp:881
-msgid "MK3 firmware detected on MK3S printer"
-msgstr "Rilevato firmware MK3 su stampante MK3S"
-
-# 
-#: Marlin_main.cpp:856
-msgid "MK3S firmware detected on MK3 printer"
-msgstr "Firmware MK3S rilevato su stampante MK3"
-
-# 
-#: ultralcd.cpp:1845
-msgid "MMU fails"
-msgstr "Fallimenti MMU"
-
-# 
-#: mmu.cpp:1617
-msgid "MMU load failed     "
-msgstr "Caricamento MMU fallito"
-
-# 
-#: ultralcd.cpp:1845
-msgid "MMU load fails"
-msgstr "Caricamenti MMU falliti"
-
-# 
-#: ultralcd.cpp:5204
-msgid "MMU Mode [Normal]"
-msgstr "Modalità MMU [Normale]"
-
-# 
-#: ultralcd.cpp:5205
-msgid "MMU Mode[Stealth]"
-msgstr "Modalità MMU [Silenziosa]"
-
-# 
-#: mmu.cpp:719
-msgid "MMU needs user attention."
-msgstr "Il MMU richiede attenzione dall'utente."
-
-# MSG_MMU_NEEDS_ATTENTION c=20 r=4
-#: mmu.cpp:359
-msgid "MMU needs user attention. Fix the issue and then press button on MMU unit."
-msgstr "MMU richiede l'attenzione dell'utente. Risolvi il problema e quindi premi il bottone sull'unità MMU. "
-
-# MSG_MMU_OK_RESUMING_POSITION c=20 r=4
-#: mmu.cpp:762
-msgid "MMU OK. Resuming position..."
-msgstr "MMU OK. riprendendo la posizione... "
-
-# MSG_MMU_OK_RESUMING_TEMPERATURE c=20 r=4
-#: mmu.cpp:755
-msgid "MMU OK. Resuming temperature..."
-msgstr "MMU OK. Ripristino temperatura... "
-
-# MSG_MMU_OK_RESUMING c=20 r=4
-#: mmu.cpp:773
-msgid "MMU OK. Resuming..."
-msgstr "MMU OK. Riprendendo... "
-
-# 
-#: ultralcd.cpp:1862
-msgid "MMU power fails"
-msgstr "Mancanza corrente MMU"
-
-# 
-#: ultralcd.cpp:2112
-msgid "MMU2 connected"
-msgstr "MMU2 connessa"
-
-# MSG_STEALTH_MODE_OFF
-#: messages.c:90
-msgid "Mode     [Normal]"
-msgstr "Modo    [normale]"
-
-# MSG_SILENT_MODE_ON
-#: messages.c:89
-msgid "Mode     [silent]"
-msgstr "Modo [silenzioso]"
-
-# MSG_STEALTH_MODE_ON
-#: messages.c:91
-msgid "Mode    [Stealth]"
-msgstr "Modo [Silenziosa]"
-
-# 
-#: ultralcd.cpp:4424
-msgid "Mode change in progress ..."
-msgstr "Cambio modalità in corso ..."
-
-# MSG_AUTO_MODE_ON
-#: messages.c:12
-msgid "Mode [auto power]"
-msgstr "Modo       [auto]"
-
-# MSG_SILENT_MODE_OFF
-#: messages.c:88
-msgid "Mode [high power]"
-msgstr "Mode      [forte]"
-
-# 
-#: ultralcd.cpp:5404
-msgid "Model      [none]"
-msgstr "Modello [nessuno]"
-
-# 
-#: ultralcd.cpp:5407
-msgid "Model      [warn]"
-msgstr "Modello [avviso]"
-
-# 
-#: ultralcd.cpp:5410
-msgid "Model    [strict]"
-msgstr "Modello [esatto]"
-
-# MSG_SELFTEST_MOTOR
-#: messages.c:83
-msgid "Motor"
-msgstr "Motore"
-
-# MSG_MOVE_AXIS
-#: ultralcd.cpp:5550
-msgid "Move axis"
-msgstr "Muovi asse"
-
-# MSG_MOVE_X
-#: ultralcd.cpp:4291
-msgid "Move X"
-msgstr "Sposta X"
-
-# MSG_MOVE_Y
-#: ultralcd.cpp:4292
-msgid "Move Y"
-msgstr "Sposta Y"
-
-# MSG_MOVE_Z
-#: ultralcd.cpp:4293
-msgid "Move Z"
-msgstr "Sposta Z"
-
-# 
-#: ultralcd.cpp:2973
-msgid "N/A"
-msgstr "N/A"
-
-# 
-#: util.cpp:293
-msgid "New firmware version available:"
-msgstr "Nuova versione firmware disponibile:"
-
-# MSG_NO
-#: messages.c:62
-msgid "No"
-msgstr "No"
-
-# 
-#:
-msgid "No "
-msgstr "No"
-
-# MSG_ERR_NO_CHECKSUM
-#: cmdqueue.cpp:456
-msgid "No Checksum with line number, Last Line: "
-msgstr "Nessun checksum con numero di riga, ultima riga:"
-
-# MSG_NO_MOVE
-#: Marlin_main.cpp:5254
-msgid "No move."
-msgstr "Nessun movimento."
-
-# MSG_NO_CARD
-#: ultralcd.cpp:6694
-msgid "No SD card"
-msgstr "Nessuna SD"
-
-# MSG_ERR_NO_THERMISTORS
-#: Marlin_main.cpp:4946
-msgid "No thermistors - no temperature"
-msgstr "No termistore - no temperatura"
-
-# MSG_SELFTEST_NOTCONNECTED
-#: ultralcd.cpp:7803
-msgid "Not connected"
-msgstr "Non connesso"
-
-# MSG_SELFTEST_FAN_NO c=19
-#: messages.c:79
-msgid "Not spinning"
-msgstr "Non gira"
-
-# MSG_WIZARD_V2_CAL c=20 r=8
-#: ultralcd.cpp:4961
-msgid "Now I will calibrate distance between tip of the nozzle and heatbed surface."
-msgstr "Adesso calibro la distanza fra ugello e superfice del piatto."
-
-# MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ultralcd.cpp:4905
-msgid "Now I will preheat nozzle for PLA."
-msgstr "Adesso preriscaldero l'ugello per PLA."
-
-# 
-#: ultralcd.cpp:4896
-msgid "Now remove the test print from steel sheet."
-msgstr "Ora rimuovete la stampa di prova dalla piastra in acciaio."
-
-# MSG_NOZZLE
-#: messages.c:63
-msgid "Nozzle"
-msgstr "Ugello"
-
-# 
-#: ultralcd.cpp:5319
-msgid "Nozzle     [none]"
-msgstr "Ugello [nessuno]"
-
-# 
-#: ultralcd.cpp:5322
-msgid "Nozzle     [warn]"
-msgstr "Ugello [avviso]"
-
-# 
-#: ultralcd.cpp:5325
-msgid "Nozzle   [strict]"
-msgstr "Ugello [esatto]"
-
-# 
-#: ultralcd.cpp:5365
-msgid "Nozzle d.  [0.25]"
-msgstr "Diam. Ugello [0.25]"
-
-# 
-#: ultralcd.cpp:5368
-msgid "Nozzle d.  [0.40]"
-msgstr "Diam. Ugello [0.40]"
-
-# 
-#: ultralcd.cpp:5371
-msgid "Nozzle d.  [0.60]"
-msgstr "Diam. Ugello [0.60]"
-
-# 
-#: ultralcd.cpp:1787
-msgid "Nozzle FAN"
-msgstr "Ventola estrusore"
-
-# MSG_INFO_NOZZLE_FAN c=11 r=1
-#: ultralcd.cpp:1537
-msgid "Nozzle FAN:"
-msgstr "Ventola dell'ugello:"
-
-# MSG_NOZZLE1
-#: ultralcd.cpp:5995
-msgid "Nozzle2"
-msgstr "Ugello2"
-
-# MSG_NOZZLE2
-#: ultralcd.cpp:5998
-msgid "Nozzle3"
-msgstr "Nozzle3"
-
-# MSG_OK
-#: Marlin_main.cpp:6333
-msgid "ok"
-msgstr "ok"
-
-# MSG_DEFAULT_SETTINGS_LOADED c=20 r=4
-#: Marlin_main.cpp:1535
-msgid "Old settings found. Default PID, Esteps etc. will be set."
-msgstr "Sono state trovate impostazioni vecchie. Verranno impostati i valori predefiniti di PID, Esteps etc."
-
-# MSG_ENDSTOP_OPEN
-#: messages.c:29
-msgid "open"
-msgstr "apri"
-
-# MSG_SD_OPEN_FILE_FAIL
-#: messages.c:79
-msgid "open failed, File: "
-msgstr "apertura fallita, File: "
-
-# MSG_SD_OPENROOT_FAIL
-#: cardreader.cpp:196
-msgid "openRoot failed"
-msgstr "openRoot fallito"
-
-# MSG_PAUSE_PRINT
-#: ultralcd.cpp:6657
-msgid "Pause print"
-msgstr "Metti in pausa"
-
-# MSG_PICK_Z
-#: ultralcd.cpp:3463
-msgid "Pick print"
-msgstr "Scegli stampa"
-
-# MSG_PID_RUNNING c=20 r=1
-#: ultralcd.cpp:1613
-msgid "PID cal.           "
-msgstr "Calibrazione PID"
-
-# MSG_PID_FINISHED c=20 r=1
-#: ultralcd.cpp:1619
-msgid "PID cal. finished"
-msgstr "Calib. PID completa"
-
-# MSG_PID_EXTRUDER c=17 r=1
-#: ultralcd.cpp:5664
-msgid "PID calibration"
-msgstr "Calibrazione PID"
-
-# MSG_PINDA_PREHEAT c=20 r=1
-#: ultralcd.cpp:862
-msgid "PINDA Heating"
-msgstr "Riscaldamento PINDA"
-
-# 
-#: ultralcd.cpp:3939
+#: ultralcd.cpp:4026
 msgid "PINDA:"
-msgstr "PINDA:"
-
-# MSG_PAPER c=20 r=8
-#: messages.c:64
-msgid "Place a sheet of paper under the nozzle during the calibration of first 4 points. If the nozzle catches the paper, power off the printer immediately."
-msgstr "Posizionare un foglio sotto l'ugello durante la calibrazione dei primi 4 punti. In caso l'ugello muova il foglio spegnere subito la stampante."
-
-# MSG_SELFTEST_PLEASECHECK
-#: ultralcd.cpp:7795
-msgid "Please check :"
-msgstr "Verifica:"
-
-# MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: messages.c:100
-msgid "Please check our handbook and fix the problem. Then resume the Wizard by rebooting the printer."
-msgstr "Per favore consulta il nostro manuale per risolvere il problema. Poi riprendi il Wizard dopo aver riavviato la stampante."
-
-# MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ultralcd.cpp:4970
-msgid "Please clean heatbed and then press the knob."
-msgstr "Per favore pulisci il piatto, poi premi la manopola."
-
-# MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: messages.c:22
-msgid "Please clean the nozzle for calibration. Click when done."
-msgstr "Pulire l'ugello per la calibrazione, poi fare click."
-
-# MSG_WIZARD_LOAD_FILAMENT c=20 r=8
-#: ultralcd.cpp:4804
-msgid "Please insert PLA filament to the extruder, then press knob to load it."
-msgstr "Per favore inserisci il filamento di PLA nell'estrusore, poi premi la manopola per caricare."
+msgstr ""
 
 # 
-#: ultralcd.cpp:4800
-msgid "Please insert PLA filament to the first tube of MMU, then press the knob to load it."
-msgstr "Per favore inserite del filamento PLA nel primo tubo del MMU, poi premete la manopola per caricarlo."
-
-# MSG_WIZARD_INSERT_CORRECT_FILAMENT c=20 r=8
-#: ultralcd.cpp:4109
-msgid "Please load PLA filament and then resume Wizard by rebooting the printer."
-msgstr "Per favore carica filamento di PLA e riprendi il Wizard dopo aver riavviato la stampante."
-
-# MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ultralcd.cpp:4706
-msgid "Please load PLA filament first."
-msgstr "Per favore prima carica il filamento di PLA."
-
-# MSG_CHECK_IDLER c=20 r=4
-#: Marlin_main.cpp:3083
-msgid "Please open idler and remove filament manually."
-msgstr "Aprire la guida filam. e rimuovere il filam. a mano"
-
-# MSG_PLACE_STEEL_SHEET c=20 r=4
-#: messages.c:65
-msgid "Please place steel sheet on heatbed."
-msgstr "Per favore posizionate la piastra d'acciaio sul piano riscaldato."
-
-# MSG_PRESS_TO_UNLOAD c=20 r=4
-#: messages.c:68
-msgid "Please press the knob to unload filament"
-msgstr "Premete la manopola per scaricare il filamento "
-
-# MSG_PULL_OUT_FILAMENT c=20 r=4
-#: messages.c:70
-msgid "Please pull out filament immediately"
-msgstr "Estrarre il filamento immediatamente"
-
-# MSG_EJECT_REMOVE c=20 r=4
-#: mmu.cpp:1441
-msgid "Please remove filament and then press the knob."
-msgstr "Rimuovi il filamento e quindi premi la manopola. "
-
-# 
-#: ultralcd.cpp:4895
-msgid "Please remove shipping helpers first."
-msgstr "Per favore rimuovete i materiali da spedizione"
-
-# MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: messages.c:74
-msgid "Please remove steel sheet from heatbed."
-msgstr "Rimuovete la piastra di acciaio dal piano riscaldato"
-
-# MSG_RUN_XYZ c=20 r=4
-#: Marlin_main.cpp:4317
-msgid "Please run XYZ calibration first."
-msgstr "Esegui la calibrazione XYZ prima. "
-
-# MSG_UPDATE_MMU2_FW c=20 r=4
-#: mmu.cpp:1360
-msgid "Please update firmware in your MMU2. Waiting for reset."
-msgstr "Aggiorna il firmware sul tuo MMU2. In attesa di reset. "
-
-# 
-#: util.cpp:297
-msgid "Please upgrade."
-msgstr "Prego aggiornare."
-
-# MSG_PLEASE_WAIT c=20
-#: messages.c:66
-msgid "Please wait"
-msgstr "Attendere"
-
-# 
-#: ultralcd.cpp:1881
-msgid "Power failures"
-msgstr "Mancanza corrente"
-
-# MSG_POWERUP
-#: messages.c:69
-msgid "PowerUp"
-msgstr "Accendi"
-
-# MSG_PREHEAT
-#: ultralcd.cpp:6644
-msgid "Preheat"
-msgstr "Preriscalda"
-
-# MSG_PREHEAT_NOZZLE c=20
-#: messages.c:67
-msgid "Preheat the nozzle!"
-msgstr "Prerisc. ugello!"
-
-# MSG_WIZARD_HEATING c=20 r=3
-#: messages.c:102
-msgid "Preheating nozzle. Please wait."
-msgstr "Preriscaldando l'ugello. Attendere prego."
-
-# 
-#: ultralcd.cpp:2290
+#: ultralcd.cpp:2465
 msgid "Preheating to cut"
 msgstr "Preriscaldamento per taglio"
 
 # 
-#: ultralcd.cpp:2287
+#: ultralcd.cpp:2462
 msgid "Preheating to eject"
 msgstr "Preriscaldamento per espulsione"
-
-# 
-#: ultralcd.cpp:2280
-msgid "Preheating to load"
-msgstr "Preriscaldamento per caricare"
-
-# 
-#: ultralcd.cpp:2284
-msgid "Preheating to unload"
-msgstr "Preriscaldamento per scaricare"
-
-# MSG_PREPARE_FILAMENT c=20 r=1
-#: ultralcd.cpp:1911
-msgid "Prepare new filament"
-msgstr "Preparare il nuovo filamento"
-
-# MSG_PRESS_TO_PREHEAT c=20 r=4
-#: Marlin_main.cpp:10312
-msgid "Press knob to preheat nozzle and continue."
-msgstr "Premete la manopola per preriscaldare l'ugello e continuare."
-
-# 
-#: ultralcd.cpp:2210
-msgid "Press the knob"
-msgstr "Premere la manopola"
-
-# 
-#: mmu.cpp:723
-msgid "Press the knob to resume nozzle temperature."
-msgstr "Premete la manopola per recuperare la temperatura dell'ugello."
-
-# MSG_PRINT_ABORTED c=20
-#: messages.c:69
-msgid "Print aborted"
-msgstr "Stampa interrotta"
-
-# 
-#: ultralcd.cpp:1789
-msgid "Print FAN"
-msgstr "Ventola di stampa"
-
-# MSG_INFO_PRINT_FAN c=11 r=1
-#: ultralcd.cpp:1549
-msgid "Print FAN: "
-msgstr "Ventola di stampa:"
-
-# MSG_SELFTEST_PRINT_FAN_SPEED c=18
-#: ultralcd.cpp:8221
-msgid "Print fan:"
-msgstr "Ventola di stampa:"
-
-# MSG_CARD_MENU
-#: messages.c:21
-msgid "Print from SD"
-msgstr "Stampa da SD"
-
-# MSG_PRINT_PAUSED c=20 r=1
-#: ultralcd.cpp:1080
-msgid "Print paused"
-msgstr "Stampa in pausa"
-
-# MSG_PRINT_TIME c=19 r=1
-#: ultralcd.cpp:2838
-msgid "Print time"
-msgstr "Tempo di stampa"
-
-# MSG_STATS_PRINTTIME c=20
-#: ultralcd.cpp:2151
-msgid "Print time:  "
-msgstr "Tempo di stampa:"
-
-# MSG_PRINTER_DISCONNECTED c=20 r=1
-#: ultralcd.cpp:607
-msgid "Printer disconnected"
-msgstr "Stampante sconnessa"
-
-# 
-#: util.cpp:473
-msgid "Printer FW version differs from the G-code. Continue?"
-msgstr "Versione FW stampante diversa dal G-Code. Continuare?"
-
-# 
-#: util.cpp:480
-msgid "Printer FW version differs from the G-code. Please check the value in settings. Print cancelled."
-msgstr "Versione FW stampante diversa dal G-Code. Controlla il valore nelle impostazioni. Stampa annullata."
-
-# 
-#: util.cpp:506
-msgid "Printer G-code level differs from the G-code. Continue?"
-msgstr "Il livello G-code della stampante è diverso dal G-Code. Continuare?"
-
-# 
-#: util.cpp:513
-msgid "Printer G-code level differs from the G-code. Please check the value in settings. Print cancelled."
-msgstr "Il livello G-code della stampante è diverso dal G-Code. Controlla il valore nelle impostazioni. Stampa annullata."
-
-# MSG_ERR_KILLED
-#: Marlin_main.cpp:7547
-msgid "Printer halted. kill() called!"
-msgstr "Stampante ferma. kill () chiamato!"
-
-# MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: messages.c:41
-msgid "Printer has not been calibrated yet. Please follow the manual, chapter First steps, section Calibration flow."
-msgstr "Stampante non ancora calibrata. Si prega di seguire il manuale, capitolo Primi Passi, sezione Sequenza di Calibrazione."
-
-# 
-#: util.cpp:423
-msgid "Printer model differs from the G-code. Continue?"
-msgstr "Modello stampante diversa dal G-Code. Continuare?"
-
-# 
-#: util.cpp:430
-msgid "Printer model differs from the G-code. Please check the value in settings. Print cancelled."
-msgstr "Il modello stampante è diverso dal G-Code. Controlla il valore nelle impostazioni. Stampa annullata."
 
 # 
 #: util.cpp:390
@@ -1752,807 +1765,48 @@ msgstr "Diametro ugello diverso da G-Code. Continuare?"
 msgid "Printer nozzle diameter differs from the G-code. Please check the value in settings. Print cancelled."
 msgstr "Diametro ugello diverso dal G-Code. Controlla il valore nelle impostazioni. Stampa annullata."
 
-# MSG_ERR_STOPPED
-#: messages.c:32
-msgid "Printer stopped due to errors. Fix the error and use M999 to restart. (Temperature is reset. Set it after restarting)"
-msgstr "La stampante si è fermata a causa di errori. Correggete l'errore e usate M999 per riavviare. (La temperatura viene resettate. Impostatela dopo il riavvio)"
-
 # 
-#:
-msgid "Prusa i3 MK2 ready."
-msgstr "Prusa i3 MK2 pronta."
-
-# WELCOME_MSG c=20
-#:
-msgid "Prusa i3 MK2.5 ready."
-msgstr "Prusa i3 MK2.5 ready."
-
-# 
-#:
-msgid "Prusa i3 MK3 OK."
-msgstr "Prusa i3 MK3 OK."
-
-# WELCOME_MSG c=20
-#:
-msgid "Prusa i3 MK3 ready."
-msgstr "Prusa i3 MK3 pronta."
-
-# 
-#:
-msgid "Prusa i3 MK3S OK."
-msgstr "Prusa i3 MK3S OK."
-
-# MSG_PRUSA3D
-#: ultralcd.cpp:2098
-msgid "prusa3d.com"
-msgstr "prusa3d.com"
-
-# MSG_BED_CORRECTION_REAR c=14 r=1
-#: ultralcd.cpp:3218
-msgid "Rear side [um]"
-msgstr "Retro [um]"
-
-# MSG_RECOVERING_PRINT c=20 r=1
-#: Marlin_main.cpp:9712
-msgid "Recovering print    "
-msgstr "Recupero stampa"
-
-# MSG_REFRESH
-#:
-msgid "Refresh"
-msgstr "Refresh"
-
-# MSG_REMOVE_OLD_FILAMENT c=20 r=4
-#: mmu.cpp:830
-msgid "Remove old filament and press the knob to start loading new filament."
-msgstr "Rimuovi il filamento precedente e premi la manopola per caricare il nuovo filamento. "
-
-# 
-#: ultralcd.cpp:6605
+#: ultralcd.cpp:6683
 msgid "Rename"
 msgstr "Rinomina"
 
-# MSG_M119_REPORT
-#: Marlin_main.cpp:5297
-msgid "Reporting endstop status"
-msgstr "Segnalazione dello stato finecorsa"
-
 # 
-#: Marlin_main.cpp:7076
-msgid "Resend"
-msgstr "Ripeti"
-
-# MSG_RESEND
-#: Marlin_main.cpp:6911
-msgid "Resend: "
-msgstr "Invia di nuovo: "
-
-# MSG_BED_CORRECTION_RESET
-#: ultralcd.cpp:3219
-msgid "Reset"
-msgstr "Reset"
-
-# MSG_CALIBRATE_BED_RESET
-#: ultralcd.cpp:5669
-msgid "Reset XYZ calibr."
-msgstr "Reset calibrazione XYZ."
-
-# MSG_RESUME_PRINT
-#: ultralcd.cpp:6664
-msgid "Resume print"
-msgstr "Riprendi stampa"
-
-# MSG_RESUMING_PRINT c=20 r=1
-#: messages.c:73
-msgid "Resuming print"
-msgstr "Riprendi stampa"
-
-# 
-#: ultralcd.cpp:2968
-msgid "Right"
-msgstr "Destra"
-
-# MSG_BED_CORRECTION_RIGHT c=14 r=1
-#: ultralcd.cpp:3216
-msgid "Right side[um]"
-msgstr "Destra [um]"
-
-# MSG_RIGHT c=12 r=1
-#: ultralcd.cpp:2309
-msgid "Right:"
-msgstr "Destra:"
-
-# MSG_E_CAL_KNOB c=20 r=8
-#: ultralcd.cpp:3835
-msgid "Rotate knob until mark reaches extruder body. Click when done."
-msgstr "Ruota la manopola finchè il segno raggiunga il corpo dell'estrusore. Clicca per continuare."
-
-# MSG_SECOND_SERIAL_ON c=17 r=1
-#: ultralcd.cpp:5587
-msgid "RPi port     [on]"
-msgstr "Porta RPi    [on]"
-
-# MSG_SECOND_SERIAL_OFF c=17 r=1
-#: ultralcd.cpp:5585
-msgid "RPi port    [off]"
-msgstr "Porta RPi   [off]"
-
-# MSG_WIZARD_RERUN c=20 r=7
-#: ultralcd.cpp:4723
-msgid "Running Wizard will delete current calibration results and start from the beginning. Continue?"
-msgstr "Se avvi il Wizard perderai la calibrazione preesistente e dovrai ricominciare dall'inizio. Continuare?"
-
-# MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_OFF c=19 r=1
-#: ultralcd.cpp:5220
-msgid "SD card  [normal]"
-msgstr "Mem. SD [normale]"
-
-# MSG_SD_CARD_OK
-#: cardreader.cpp:202
-msgid "SD card ok"
-msgstr "Memoria SD ok"
-
-# MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_ON c=19 r=1
-#: ultralcd.cpp:4238
-msgid "SD card [FlshAir]"
-msgstr "Mem. SD [FlashAir]"
-
-# MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_ON c=19 r=1
-#: ultralcd.cpp:5218
-msgid "SD card [flshAir]"
-msgstr "Mem. SD [flshAir]"
-
-# MSG_SD_INIT_FAIL
-#: cardreader.cpp:186
-msgid "SD init fail"
-msgstr "Inizializzazione Memoria SD Fallita"
-
-# MSG_SD_PRINTING_BYTE
-#: cardreader.cpp:516
-msgid "SD printing byte "
-msgstr "SD stampa byte "
-
-# MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=60
-#: messages.c:38
-msgid "Searching bed calibration point"
-msgstr "Ricerca dei punti di calibrazione del piano"
-
-# 
-#: ultralcd.cpp:6601
+#: ultralcd.cpp:6679
 msgid "Select"
 msgstr "Seleziona"
 
-# MSG_LANGUAGE_SELECT
-#: ultralcd.cpp:5594
-msgid "Select language"
-msgstr "Seleziona lingua"
-
 # 
-#: ultralcd.cpp:4943
-msgid "Select nozzle preheat temperature which matches your material."
-msgstr "Selezionate la temperatura per il preriscaldamento dell'ugello adatta al vostro materiale."
-
-# 
-#: ultralcd.cpp:4692
-msgid "Select PLA filament:"
-msgstr "Selezionate filamento PLA:"
-
-# MSG_SELFTEST_OK
-#: ultralcd.cpp:7366
-msgid "Self test OK"
-msgstr "Autotest OK"
-
-# MSG_SELFTEST_START c=20
-#: ultralcd.cpp:7152
-msgid "Self test start  "
-msgstr "Avvia autotest"
-
-# MSG_SELFTEST
-#: ultralcd.cpp:5645
-msgid "Selftest         "
-msgstr "Autotest"
-
-# MSG_SELFTEST_ERROR
-#: ultralcd.cpp:7793
-msgid "Selftest error !"
-msgstr "Errore Autotest !"
-
-# MSG_SELFTEST_FAILED c=20
-#: messages.c:77
-msgid "Selftest failed  "
-msgstr "Autotest fallito"
-
-# MSG_FORCE_SELFTEST c=20 r=8
-#: Marlin_main.cpp:1567
-msgid "Selftest will be run to calibrate accurate sensorless rehoming."
-msgstr "Verra effettuato un self test per calibrare l'homing senza sensori"
-
-# 
-#: ultralcd.cpp:2138
+#: ultralcd.cpp:2245
 msgid "Sensor info"
 msgstr "Info Sensore"
-
-# 
-#: ultralcd.cpp:3938
-msgid "Sensor state"
-msgstr "Stato sensore"
-
-# 
-#:
-msgid "Sensors info"
-msgstr "Info Sensori"
-
-# MSG_SET_TEMPERATURE c=19 r=1
-#: ultralcd.cpp:3227
-msgid "Set temperature:"
-msgstr "Imposta temperatura:"
-
-# MSG_SETTINGS
-#: messages.c:86
-msgid "Settings"
-msgstr "Impostazioni"
-
-# 
-#: ultralcd.cpp:3005
-msgid "Severe skew"
-msgstr "Deviazione grave"
-
-# MSG_SEVERE_SKEW c=15 r=1
-#: ultralcd.cpp:2346
-msgid "Severe skew:"
-msgstr "Distorsione grave:"
 
 # 
 #: messages.c:58
 msgid "Sheet"
 msgstr "Piano"
 
-# MSG_SHOW_END_STOPS c=17 r=1
-#: ultralcd.cpp:5666
-msgid "Show end stops"
-msgstr "Stato finecorsa"
-
-# 
-#:
-msgid "Show pinda state"
-msgstr "Mostra stato pinda"
-
-# MSG_DWELL
-#: Marlin_main.cpp:3752
-msgid "Sleep..."
-msgstr "Sospensione..."
-
-# 
-#: ultralcd.cpp:3004
-msgid "Slight skew"
-msgstr "Deviazione lieve"
-
-# MSG_SLIGHT_SKEW c=15 r=1
-#: ultralcd.cpp:2342
-msgid "Slight skew:"
-msgstr "Distorsione leggera:"
-
-# MSG_FILE_CNT c=20 r=4
-#: cardreader.cpp:739
-msgid "Some files will not be sorted. Max. No. of files in 1 folder for sorting is 100."
-msgstr "Alcuni file non saranno ordinati. Il numero massimo di file in una cartella e 100 perche siano ordinati."
-
-# 
-#: Marlin_main.cpp:4833
-msgid "Some problem encountered, Z-leveling enforced ..."
-msgstr "Sono stati rilevati problemi, avviato livellamento Z ..."
-
-# MSG_SORT_NONE c=17 r=1
-#: ultralcd.cpp:5230
-msgid "Sort       [none]"
-msgstr "Ordina [nessuno]"
-
-# MSG_SORT_TIME c=17 r=1
-#: ultralcd.cpp:5228
-msgid "Sort       [time]"
-msgstr "Ordina [tempo]"
-
-# MSG_SORT_ALPHA c=17 r=1
-#: ultralcd.cpp:5229
-msgid "Sort   [alphabet]"
-msgstr "Ordine [alfabetico]"
-
-# MSG_SORT_NONE c=17 r=1
-#: ultralcd.cpp:4250
-msgid "Sort:      [None]"
-msgstr "Ordine: [Nessuno]"
-
-# MSG_SORT_NONE c=17 r=1
-#: ultralcd.cpp:5043
-msgid "Sort:      [none]"
-msgstr "Ordina:    [none]"
-
-# MSG_SORT_TIME c=17 r=1
-#: ultralcd.cpp:4248
-msgid "Sort:      [Time]"
-msgstr "Ordine: [Tempo]"
-
-# MSG_SORT_TIME c=17 r=1
-#: ultralcd.cpp:5041
-msgid "Sort:      [time]"
-msgstr "Ordina:    [time]"
-
-# MSG_SORT_ALPHA c=17 r=1
-#: ultralcd.cpp:4249
-msgid "Sort:  [Alphabet]"
-msgstr "Ordine: [Alfabetico]"
-
-# MSG_SORT_ALPHA c=17 r=1
-#: ultralcd.cpp:5042
-msgid "Sort:  [alphabet]"
-msgstr "Ordine: [alfabet]"
-
-# MSG_SORT_NONE c=17 r=1
-#:
-msgid "Sort:  [none]"
-msgstr "Ordine: [nessuno]"
-
-# MSG_SORT_TIME c=17 r=1
-#:
-msgid "Sort:  [time]"
-msgstr "Ordina: [time]"
-
-# MSG_SORTING c=20 r=1
-#: cardreader.cpp:746
-msgid "Sorting files"
-msgstr "Ordinando i file"
-
-# MSG_SOUND_LOUD c=17 r=1
-#: sound.h:6
-msgid "Sound      [loud]"
-msgstr "Suono     [forte]"
-
-# MSG_SOUND_MUTE c=17 r=1
-#:
-msgid "Sound      [mute]"
-msgstr "Suono      [mute]"
-
-# MSG_SOUND_ONCE c=17 r=1
-#: sound.h:7
-msgid "Sound      [once]"
-msgstr "Suono   [singolo]"
-
-# 
-#:
-msgid "Sound     [assist]"
-msgstr "Suono [assistito]"
-
 # 
 #: sound.h:9
-msgid "Sound     [blind]"
-msgstr "Suono [cieco]"
-
-# MSG_SOUND_SILENT c=17 r=1
-#: sound.h:8
-msgid "Sound    [silent]"
-msgstr "Suono[silenzioso]"
-
-# MSG_SPEED
-#: ultralcd.cpp:6840
-msgid "Speed"
-msgstr "Velocita"
-
-# MSG_SELFTEST_FAN_YES c=19
-#: messages.c:80
-msgid "Spinning"
-msgstr "Gira"
-
-# MSG_AUTO_DEPLETE_ON c=17 r=1
-#: ultralcd.cpp:5098
-msgid "SpoolJoin    [on]"
-msgstr "SpoolJoin    [on]"
+msgid "Sound    [assist]"
+msgstr "Suono   [assist.]"
 
 # 
-#: ultralcd.cpp:5094
-msgid "SpoolJoin   [N/A]"
-msgstr "SpoolJoin   [N/A]"
-
-# MSG_AUTO_DEPLETE_OFF c=17 r=1
-#: ultralcd.cpp:5102
-msgid "SpoolJoin   [off]"
-msgstr "SpoolJoin   [off]"
-
-# MSG_TEMP_CAL_WARNING c=20 r=4
-#: Marlin_main.cpp:4330
-msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
-msgstr "Sono necessari una temperatura ambiente di 21-26C e una superficie rigida "
-
-# MSG_STATISTICS
-#: ultralcd.cpp:6753
-msgid "Statistics  "
-msgstr "Statistiche"
-
-# 
-#: ultralcd.cpp:5551
+#: ultralcd.cpp:5637
 msgid "Steel sheets"
 msgstr "Piani d'acciaio"
 
-# MSG_STEPPER_TOO_HIGH
-#: stepper.cpp:345
-msgid "Steprate too high: "
-msgstr "Velocità passo troppo alta: "
-
-# MSG_STOP_PRINT
-#: messages.c:93
-msgid "Stop print"
-msgstr "Arresta stampa"
-
-# MSG_STOPPED
-#: messages.c:94
-msgid "STOPPED. "
-msgstr "ARRESTATO."
-
-# MSG_SUPPORT
-#: ultralcd.cpp:6762
-msgid "Support"
-msgstr "Supporto"
-
-# MSG_SELFTEST_SWAPPED
-#: ultralcd.cpp:7873
-msgid "Swapped"
-msgstr "Scambiato"
-
-# MSG_TEMP_CALIBRATION c=20 r=1
-#: messages.c:95
-msgid "Temp. cal.          "
-msgstr "Calib. temp. "
-
-# MSG_TEMP_CALIBRATION_ON c=20 r=1
-#: ultralcd.cpp:5581
-msgid "Temp. cal.   [on]"
-msgstr "Calib. temp. [ON]"
-
-# MSG_TEMP_CALIBRATION_OFF c=20 r=1
-#: ultralcd.cpp:5579
-msgid "Temp. cal.  [off]"
-msgstr "Calib. temp.[OFF]"
-
-# MSG_CALIBRATION_PINDA_MENU c=17 r=1
-#: ultralcd.cpp:5675
-msgid "Temp. calibration"
-msgstr "Calib. Temp."
-
-# MSG_TEMPERATURE
-#: ultralcd.cpp:5548
-msgid "Temperature"
-msgstr "Temperatura"
-
-# MSG_TEMP_CAL_FAILED c=20 r=8
-#: ultralcd.cpp:3864
-msgid "Temperature calibration failed"
-msgstr "Calibrazione temperatura fallita"
-
-# MSG_PINDA_NOT_CALIBRATED c=20 r=4
-#: Marlin_main.cpp:1403
-msgid "Temperature calibration has not been run yet"
-msgstr "Calibrazione della temperatura non ancora eseguita"
-
-# MSG_TEMP_CALIBRATION_DONE c=20 r=12
-#: messages.c:96
-msgid "Temperature calibration is finished and active. Temp. calibration can be disabled in menu Settings->Temp. cal."
-msgstr "Calibrazione temperatura completata e attiva. Puo essere disattivata dal menu Impostazioni ->Cal. Temp."
-
-# MSG_MENU_TEMPERATURES c=15 r=1
-#: ultralcd.cpp:2144
-msgid "Temperatures"
-msgstr "Temperature"
-
-# MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=4
-#: messages.c:42
-msgid "There is still a need to make Z calibration. Please follow the manual, chapter First steps, section Calibration flow."
-msgstr "E ancora necessario effettuare la calibrazione Z. Segui il manuale, capitolo Primi Passi, sezione Sequenza di Calibrazione. "
-
 # 
-#: ultralcd.cpp:2217
-msgid "to load filament"
-msgstr "per caricare il filamento"
-
-# 
-#: ultralcd.cpp:2221
-msgid "to unload filament"
-msgstr "per scaricare il filamento"
-
-# 
-#: ultralcd.cpp:1829
-msgid "Total"
-msgstr "Totale"
-
-# 
-#: ultralcd.cpp:1862
-msgid "Total failures"
-msgstr "Totale fallimenti"
-
-# 
-#: ultralcd.cpp:2860
-msgid "Total filament"
-msgstr "Filamento totale"
-
-# MSG_STATS_TOTALFILAMENT c=20
-#: ultralcd.cpp:2186
-msgid "Total filament :"
-msgstr "Filamento tot:"
-
-# 
-#: ultralcd.cpp:2860
-msgid "Total print time"
-msgstr "Tempo di stampa totale"
-
-# MSG_STATS_TOTALPRINTTIME c=20
-#: ultralcd.cpp:2203
-msgid "Total print time :"
-msgstr "Tempo stampa tot:"
-
-# MSG_ENDSTOP_HIT
-#: messages.c:28
-msgid "TRIGGERED"
-msgstr "ATTIVATO"
-
-# MSG_TUNE
-#: ultralcd.cpp:6641
-msgid "Tune"
-msgstr "Regola"
-
-# 
-#: ultralcd.cpp:2120
-msgid "unknown"
-msgstr "sconosciuto"
-
-# 
-#: ultralcd.cpp:4780
-msgid "Unload"
-msgstr "Scarica"
-
-# 
-#: ultralcd.cpp:5617
-msgid "Unload all"
-msgstr "Rilasciare tutti"
-
-# MSG_UNLOAD_FILAMENT c=17
-#: messages.c:97
-msgid "Unload filament"
-msgstr "Scarica filamento"
-
-# MSG_UNLOAD_FILAMENT_1 c=17
-#: ultralcd.cpp:5406
-msgid "Unload filament 1"
-msgstr "Rilasciare fil. 1"
-
-# MSG_UNLOAD_FILAMENT_2 c=17
-#: ultralcd.cpp:5407
-msgid "Unload filament 2"
-msgstr "Scarica filam. 2"
-
-# MSG_UNLOAD_FILAMENT_3 c=17
-#: ultralcd.cpp:5408
-msgid "Unload filament 3"
-msgstr "Scarica filam. 3"
-
-# MSG_UNLOAD_FILAMENT_4 c=17
-#: ultralcd.cpp:5409
-msgid "Unload filament 4"
-msgstr "Scarica filam. 4"
-
-# MSG_UNLOADING_FILAMENT c=20 r=1
-#: messages.c:98
-msgid "Unloading filament"
-msgstr "Scaricando filamento"
-
-# 
-#: ultralcd.cpp:4779
-msgid "Use unload to remove filament 1 if it protrudes outside of the rear MMU tube. Use eject if it is hidden in tube."
-msgstr "Usate lo scaricamento per rimuovere il filamento 1 se protrude dal retro del tubo posteriore del MMu. Utilizzate l'espulsione se e nascosto nel tubo."
-
-# MSG_USED c=19 r=1
-#: ultralcd.cpp:5803
-msgid "Used during print"
-msgstr "Usati nella stampa"
-
-# MSG_MENU_VOLTAGES c=15 r=1
-#: ultralcd.cpp:2147
-msgid "Voltages"
-msgstr "Voltaggi"
-
-# MSG_SD_VOL_INIT_FAIL
-#: cardreader.cpp:191
-msgid "volume.init failed"
-msgstr "volume.init fallito"
-
-# MSG_USERWAIT
-#: Marlin_main.cpp:5225
-msgid "Wait for user..."
-msgstr "Attendendo utente..."
-
-# MSG_WAITING_TEMP c=20 r=3
-#: ultralcd.cpp:3371
-msgid "Waiting for nozzle and bed cooling"
-msgstr "In attesa del raffreddamento dell'ugello e del piano"
-
-# MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ultralcd.cpp:3335
-msgid "Waiting for PINDA probe cooling"
-msgstr "In attesa del raffreddamento della sonda PINDA"
-
-# MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#:
-msgid "WARNING:\nCrash detection\ndisabled in\nStealth mode"
-msgstr "ATTENZIONE:\nRilevamento impatto\ndisattivato in\nModalità Silenziosa"
-
-# MSG_CHANGED_BOTH c=20 r=4
-#: Marlin_main.cpp:1527
-msgid "Warning: both printer type and motherboard type changed."
-msgstr "Attenzione: tipo di stampante e di scheda madre cambiati."
-
-# MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: Marlin_main.cpp:1519
-msgid "Warning: motherboard type changed."
-msgstr "Avviso: tipo di scheda madre cambiato"
-
-# MSG_CHANGED_PRINTER c=20 r=4
-#: Marlin_main.cpp:1523
-msgid "Warning: printer type changed."
-msgstr "Avviso: tipo di stampante cambiato."
-
-# MSG_FW_VERSION_UNKNOWN c=20 r=8
-#: Marlin_main.cpp:946
-msgid "WARNING: This is an unofficial, unsupported build. Use at your own risk!"
-msgstr "ATTENZIONE: Questo è un build non ufficiale, non supportato. Utilizzatelo a vostro rischio!"
-
-# MSG_UNLOAD_SUCCESSFUL c=20 r=2
-#: Marlin_main.cpp:3072
-msgid "Was filament unload successful?"
-msgstr "Filamento scaricato con successo?"
-
-# MSG_SELFTEST_WIRINGERROR
-#: messages.c:85
-msgid "Wiring error"
-msgstr "Errore cablaggio"
-
-# MSG_WIZARD c=17 r=1
-#: ultralcd.cpp:5642
-msgid "Wizard"
-msgstr "Wizard"
-
-# MSG_SD_WORKDIR_FAIL
-#: messages.c:78
-msgid "workDir open failed"
-msgstr "workDir open fallito"
-
-# MSG_SD_WRITE_TO_FILE
-#: cardreader.cpp:424
-msgid "Writing to file: "
-msgstr "Scrittura su file: "
-
-# 
-#: ultralcd.cpp:4885
-msgid "X-correct"
-msgstr "Correzione-X"
-
-# 
-#: ultralcd.cpp:5028
-msgid "X-correct:"
-msgstr "Correzione-X:"
-
-# MSG_XYZ_DETAILS c=19 r=1
-#: ultralcd.cpp:2136
-msgid "XYZ cal. details"
-msgstr "XYZ Cal. dettagli"
-
-# MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ultralcd.cpp:3835
-msgid "XYZ calibration all right. Skew will be corrected automatically."
-msgstr "Calibrazione XYZ corretta. La distorsione verra compensata automaticamente."
-
-# MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ultralcd.cpp:3832
-msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
-msgstr "Calibrazion XYZ corretta. Assi X/Y leggermente storti. Ben fatto!"
-
-# MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ultralcd.cpp:3813
-msgid "XYZ calibration compromised. Front calibration points not reachable."
-msgstr "Calibrazione XYZ compromessa. Punti anteriori non raggiungibili."
-
-# MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_LEFT_FAR c=20 r=8
-#: ultralcd.cpp:3699
-msgid "XYZ calibration compromised. Left front calibration point not reachable."
-msgstr "Calibrazione XYZ compromessa. Punto anteriore sinistro non raggiungibile."
-
-# MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ultralcd.cpp:3816
-msgid "XYZ calibration compromised. Right front calibration point not reachable."
-msgstr "Calibrazione XYZ compromessa. Punto anteriore destro non raggiungibile."
-
-# 
-#: ultralcd.cpp:3795
-msgid "XYZ calibration failed. Bed calibration point was not found."
-msgstr "Calibrazione XYZ fallita. Il punto di calibrazione sul letto non e' stato trovato."
-
-# 
-#: ultralcd.cpp:3801
-msgid "XYZ calibration failed. Front calibration points not reachable."
-msgstr "Calibrazione XYZ fallita. Punti anteriori non raggiungibili."
-
-# 
-#: ultralcd.cpp:3687
-msgid "XYZ calibration failed. Left front calibration point not reachable."
-msgstr "Calibrazione XYZ fallita. Punto anteriore sinistro non raggiungibile."
-
-# MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: messages.c:19
-msgid "XYZ calibration failed. Please consult the manual."
-msgstr "Calibrazione XYZ fallita. Si prega di consultare il manuale."
-
-# 
-#: ultralcd.cpp:3804
-msgid "XYZ calibration failed. Right front calibration point not reachable."
-msgstr "Calibrazione XYZ fallita. Punto anteriore destro non raggiungibile."
-
-# MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ultralcd.cpp:3829
-msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
-msgstr "Calibrazione XYZ OK. Gli assi X/Y sono perpendicolari. Complimenti!"
-
-# 
-#: ultralcd.cpp:2965
-msgid "Y distance from min"
-msgstr "Distanza Y dal min"
-
-# MSG_Y_DISTANCE_FROM_MIN c=20 r=1
-#: ultralcd.cpp:2306
-msgid "Y distance from min:"
-msgstr "Distanza Y da min:"
-
-# 
-#: ultralcd.cpp:4886
-msgid "Y-correct"
-msgstr "Correzione-Y"
-
-# 
-#: ultralcd.cpp:5029
-msgid "Y-correct:"
-msgstr "Correzione-Y:"
-
-# MSG_YES
-#: messages.c:104
-msgid "Yes"
-msgstr "Si"
-
-# MSG_FW_VERSION_ALPHA c=20 r=8
-#: Marlin_main.cpp:930
-msgid "You are using firmware alpha version. This is development version. Using this version is not recommended and may cause printer damage."
-msgstr "State utilizzando una versione alpha del firmware. Questa versione è in via di sviluppo. L'utilizzo non è raccomandato e potrebbe causare danni alla stampante."
-
-# MSG_FW_VERSION_BETA c=20 r=8
-#: Marlin_main.cpp:931
-msgid "You are using firmware beta version. This is development version. Using this version is not recommended and may cause printer damage."
-msgstr "State utilizzando una versione beta del firmware. Questa versione è in via di sviluppo. L'utilizzo non è raccomandato e potrebbe causare danni alla stampante."
-
-# MSG_WIZARD_QUIT c=20 r=8
-#: messages.c:103
-msgid "You can always resume the Wizard from Calibration -> Wizard."
-msgstr "E possibile riprendere il Wizard in qualsiasi momento attraverso Calibrazione -> Wizard."
-
-# 
-#: ultralcd.cpp:5030
+#: ultralcd.cpp:5132
 msgid "Z-correct:"
 msgstr "Correzione-Z:"
 
 # 
-#: ultralcd.cpp:6952
+#: ultralcd.cpp:7038
 msgid "Z-probe nr.    [1]"
-msgstr "Z-probe nr. [1]"
+msgstr "Z-probe nr.    [1]"
 
 # 
-#: ultralcd.cpp:6954
+#: ultralcd.cpp:7040
 msgid "Z-probe nr.    [3]"
-msgstr "Z-probe nr. [3]"
+msgstr "Z-probe nr.    [3]"
 
-# MSG_MEASURED_OFFSET
-#: ultralcd.cpp:3024
-msgid "[0;0] point offset"
-msgstr "[0;0] punto offset"

--- a/lang/po/new/pl.po
+++ b/lang/po/new/pl.po
@@ -1,51 +1,19 @@
+# Translation of Prusa-Firmware into Polish.
+#
 msgid ""
 msgstr ""
-"Language: pl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=(n == 1) ? 0 : ((n%10 >= 2 && n%10 <=4 && (n%100 < 12 || n%100 > 14)) ? 1 : ((n%10 == 0 || n%10 == 1 || (n%10 >= 5 && n%10 <=9)) || (n%100 >= 12 && n%100 <= 14)) ? 2 : 3);\n"
-"X-Generator: PhraseApp (phraseapp.com)\n"
-
-# MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ultralcd.cpp:4219
-msgid "\e[2JCrash detection can\e[1;0Hbe turned on only in\e[2;0HNormal mode"
-msgstr "\e[2JWykrywanie zderzen moze\e[1;0Hbyc wlaczone tylko w\e[2;0Htrybie Normalnym"
-
-# MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ultralcd.cpp:4231
-msgid "\e[2JWARNING:\e[1;0HCrash detection\e[2;0Hdisabled in\e[3;0HStealth mode"
-msgstr "\e[2JUWAGA:\e[1;0HWykrywanie zderzen\e[2;0Hwylaczone w\e[3;0Htrybie Stealth"
-
-# 
-#: ultralcd.cpp:3913
-msgid "  1"
-msgstr "1"
-
-# MSG_PLANNER_BUFFER_BYTES
-#: Marlin_main.cpp:1184
-msgid "  PlannerBufferBytes: "
-msgstr " PlannerBufferBytes: "
-
-# MSG_EXTRUDER_CORRECTION_OFF c=6
-#: ultralcd.cpp:6312
-msgid "  [off"
-msgstr "[wyl"
-
-# MSG_ERR_COLD_EXTRUDE_STOP
-#: planner.cpp:761
-msgid " cold extrusion prevented"
-msgstr " nie dopuszczono do zimnej ekstruzji"
-
-# MSG_FREE_MEMORY
-#: Marlin_main.cpp:1182
-msgid " Free Memory: "
-msgstr " Wolna pamiec:"
-
-# MSG_CONFIGURATION_VER
-#: Marlin_main.cpp:1172
-msgid " Last Updated: "
-msgstr "Ostatnia aktualizacja: "
+"Language: pl\n"
+"Project-Id-Version: Prusa-Firmware\n"
+"POT-Creation-Date: Sun, Sep 22, 2019 1:34:25 PM\n"
+"PO-Revision-Date: Sun, Sep 22, 2019 1:34:25 PM\n"
+"Language-Team: \n"
+"X-Generator: Poedit 2.0.7\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+"Last-Translator: \n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
 # MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE2 c=14
 #: messages.c:39
@@ -57,48 +25,33 @@ msgstr " z 4"
 msgid " of 9"
 msgstr " z 9"
 
-# MSG_OFF
-#: menu.cpp:426
-msgid " [off]"
-msgstr "[wyl]"
+# MSG_MEASURED_OFFSET
+#: ultralcd.cpp:3089
+msgid "[0;0] point offset"
+msgstr "[0;0] przesun.punktu"
 
-# MSG_FACTOR
-#: ultralcd.cpp:6008
-msgid " \002 Fact"
-msgstr " \002 Fact"
+# MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
+#: 
+msgid "Crash detection can\x0abe turned on only in\x0aNormal mode"
+msgstr "Wykrywanie zderzen\x0amoze byc wlaczone\x0atylko w\x0atrybie Normalnym"
 
-# MSG_MAX
-#: ultralcd.cpp:6007
-msgid " \002 Max"
-msgstr " \002 Max"
-
-# MSG_MIN
-#: ultralcd.cpp:6006
-msgid " \002 Min"
-msgstr " \002 Min"
+# MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
+#: 
+msgid "WARNING:\x0aCrash detection\x0adisabled in\x0aStealth mode"
+msgstr "UWAGA:\x0aWykrywanie zderzen\x0awylaczone w\x0atrybie Stealth"
 
 # 
-#: ultralcd.cpp:2294
+#: ultralcd.cpp:2472
 msgid ">Cancel"
 msgstr ">Anuluj"
 
-# MSG_BABYSTEPPING_Z c=20
-#: ultralcd.cpp:3043
-msgid "Adjusting Z"
-msgstr "Dostrajanie Z"
-
 # MSG_BABYSTEPPING_Z c=15
-#: ultralcd.cpp:3144
+#: ultralcd.cpp:3209
 msgid "Adjusting Z:"
 msgstr "Ustawianie Z:"
 
-# MSG_ALL c=19 r=1
-#: messages.c:11
-msgid "All"
-msgstr "Wszystko"
-
 # MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ultralcd.cpp:8209
+#: ultralcd.cpp:8295
 msgid "All correct      "
 msgstr "Wszystko OK "
 
@@ -108,39 +61,34 @@ msgid "All is done. Happy printing!"
 msgstr "Gotowe. Udanego drukowania!"
 
 # 
-#: ultralcd.cpp:1979
+#: ultralcd.cpp:2009
 msgid "Ambient"
 msgstr "Otoczenie"
 
 # MSG_PRESS c=20
-#: ultralcd.cpp:2573
+#: ultralcd.cpp:2618
 msgid "and press the knob"
 msgstr "i nacisnij pokretlo"
 
 # MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=2
-#: ultralcd.cpp:3442
+#: ultralcd.cpp:3529
 msgid "Are left and right Z~carriages all up?"
 msgstr "Obydwa konce osi sa na szczycie?"
 
-# MSG_ADJUSTZ
-#: ultralcd.cpp:2600
-msgid "Auto adjust Z?"
-msgstr "Autodostroic Z?"
-
 # MSG_AUTO_DEPLETE_ON c=17 r=1
-#: ultralcd.cpp:4706
-msgid "Auto deplete [on]"
-msgstr "SpoolJoin [wl]"
+#: ultralcd.cpp:5200
+msgid "SpoolJoin    [on]"
+msgstr "SpoolJoin    [wl]"
 
 # 
-#: ultralcd.cpp:4702
-msgid "Auto deplete[N/A]"
-msgstr "SpoolJoin [nd]"
+#: ultralcd.cpp:5196
+msgid "SpoolJoin   [N/A]"
+msgstr "SpoolJoin   [N/D]"
 
 # MSG_AUTO_DEPLETE_OFF c=17 r=1
-#: ultralcd.cpp:4710
-msgid "Auto deplete[off]"
-msgstr "SpoolJoin [wyl]"
+#: ultralcd.cpp:5204
+msgid "SpoolJoin   [off]"
+msgstr "SpoolJoin   [wyl]"
 
 # MSG_AUTO_HOME
 #: messages.c:11
@@ -148,52 +96,32 @@ msgid "Auto home"
 msgstr "Auto zerowanie"
 
 # MSG_AUTOLOAD_FILAMENT c=17
-#: ultralcd.cpp:6731
+#: ultralcd.cpp:6822
 msgid "AutoLoad filament"
-msgstr "AutoLadowanie fil."
+msgstr "Autoladowanie fil."
 
 # MSG_AUTOLOADING_ONLY_IF_FSENS_ON c=20 r=4
-#: ultralcd.cpp:4375
+#: ultralcd.cpp:4462
 msgid "Autoloading filament available only when filament sensor is turned on..."
 msgstr "Autoladowanie filamentu dostepne tylko gdy czujnik filamentu jest wlaczony..."
 
 # MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ultralcd.cpp:2768
+#: ultralcd.cpp:2813
 msgid "Autoloading filament is active, just press the knob and insert filament..."
 msgstr "Autoladowanie filamentu wlaczone, nacisnij pokretlo i wsun filament..."
 
-# MSG_SELFTEST_AXIS
-#: ultralcd.cpp:7865
-msgid "Axis"
-msgstr "Os"
-
 # MSG_SELFTEST_AXIS_LENGTH
-#: ultralcd.cpp:7863
+#: ultralcd.cpp:7949
 msgid "Axis length"
 msgstr "Dlugosc osi"
 
-# MSG_BABYSTEPPING_X
-#: ultralcd.cpp:2481
-msgid "Babystepping X"
-msgstr "Babystepping X"
-
-# MSG_BABYSTEPPING_Y
-#: ultralcd.cpp:2484
-msgid "Babystepping Y"
-msgstr "Babystepping Y"
-
-# 
-#: messages.c:57
-msgid "Back"
-msgstr "Wstecz"
-
-# MSG_BED
-#: messages.c:15
-msgid "Bed"
-msgstr "Stol"
+# MSG_SELFTEST_AXIS
+#: ultralcd.cpp:7951
+msgid "Axis"
+msgstr "Os"
 
 # MSG_SELFTEST_BEDHEATER
-#: ultralcd.cpp:7807
+#: ultralcd.cpp:7893
 msgid "Bed / Heater"
 msgstr "Stol / Grzanie"
 
@@ -208,32 +136,22 @@ msgid "Bed Heating"
 msgstr "Grzanie stolu.."
 
 # MSG_BED_CORRECTION_MENU
-#: ultralcd.cpp:5663
+#: ultralcd.cpp:5768
 msgid "Bed level correct"
-msgstr "Korekta poziomowania stolu"
+msgstr "Korekta stolu"
 
 # MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=4
 #: messages.c:18
 msgid "Bed leveling failed. Sensor didnt trigger. Debris on nozzle? Waiting for reset."
 msgstr "Kalibracja nieudana. Sensor nie aktywowal sie. Zanieczysz. dysza? Czekam na reset."
 
-# MSG_BED_LEVELING_FAILED_PROBE_DISCONNECTED c=20 r=4
-#: Marlin_main.cpp:4508
-msgid "Bed leveling failed. Sensor disconnected or cable broken. Waiting for reset."
-msgstr "Poziomowanie stolu nieudane. Sensor odlacz. lub uszkodz. przewod. Czekam na reset."
-
-# MSG_BED_LEVELING_FAILED_POINT_HIGH c=20 r=4
-#: Marlin_main.cpp:4512
-msgid "Bed leveling failed. Sensor triggered too high. Waiting for reset."
-msgstr "Kalibracja Z nieudana. Sensor aktywowal za wysoko. Czekam na reset."
-
-# MSG_BEGIN_FILE_LIST
-#: Marlin_main.cpp:4405
-msgid "Begin file list"
-msgstr "Poczatek listy plikowogranicznikow"
+# MSG_BED
+#: messages.c:15
+msgid "Bed"
+msgstr "Stol"
 
 # MSG_MENU_BELT_STATUS c=15 r=1
-#: ultralcd.cpp:2007
+#: ultralcd.cpp:2059
 msgid "Belt status"
 msgstr "Stan paskow"
 
@@ -242,18 +160,13 @@ msgstr "Stan paskow"
 msgid "Blackout occurred. Recover print?"
 msgstr "Wykryto zanik napiecia. Kontynowac?"
 
-# MSG_CALIBRATE_PINDA c=17 r=1
-#: ultralcd.cpp:4566
-msgid "Calibrate"
-msgstr "Kalibruj"
-
-# MSG_CALIBRATE_E c=20 r=1
-#: ultralcd.cpp:4526
-msgid "Calibrate E"
-msgstr "Kalibruj E"
+# 
+#: ultralcd.cpp:8297
+msgid "Calibrating home"
+msgstr "Zerowanie osi"
 
 # MSG_CALIBRATE_BED
-#: ultralcd.cpp:5652
+#: ultralcd.cpp:5757
 msgid "Calibrate XYZ"
 msgstr "Kalibracja XYZ"
 
@@ -262,13 +175,13 @@ msgstr "Kalibracja XYZ"
 msgid "Calibrate Z"
 msgstr "Kalibruj Z"
 
-# 
-#: ultralcd.cpp:8211
-msgid "Calibrating home"
-msgstr "Zerowanie osi"
+# MSG_CALIBRATE_PINDA c=17 r=1
+#: ultralcd.cpp:4654
+msgid "Calibrate"
+msgstr "Kalibruj"
 
 # MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ultralcd.cpp:3405
+#: ultralcd.cpp:3492
 msgid "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end stoppers. Click when done."
 msgstr "Kalibracja XYZ. Przekrec pokretlo, aby przesunac os Z do gornych ogranicznikow. Nacisnij, by potwierdzic."
 
@@ -278,132 +191,32 @@ msgid "Calibrating Z"
 msgstr "Kalibruje Z"
 
 # MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ultralcd.cpp:3405
+#: ultralcd.cpp:3492
 msgid "Calibrating Z. Rotate the knob to move the Z carriage up to the end stoppers. Click when done."
 msgstr "Kalibracja XYZ. Przekrec pokretlo, aby przesunac os Z do gornych ogranicznikow. Nacisnij, by potwierdzic."
+
+# MSG_HOMEYZ_DONE
+#: ultralcd.cpp:816
+msgid "Calibration done"
+msgstr "Kalibracja OK"
 
 # MSG_MENU_CALIBRATION
 #: messages.c:61
 msgid "Calibration"
 msgstr "Kalibracja"
 
-# MSG_HOMEYZ_DONE
-#: ultralcd.cpp:832
-msgid "Calibration done"
-msgstr "Kalibracja OK"
-
 # 
-#: ultralcd.cpp:4692
+#: ultralcd.cpp:4781
 msgid "Cancel"
 msgstr "Anuluj"
 
-# MSG_SD_CANT_ENTER_SUBDIR
-#: cardreader.cpp:662
-msgid "Cannot enter subdir: "
-msgstr "Brak dostepu do subdir: "
-
-# MSG_SD_CANT_OPEN_SUBDIR
-#: cardreader.cpp:97
-msgid "Cannot open subdir"
-msgstr "Nie moge otworzyc subdir"
-
-# MSG_SD_INSERTED
-#:
-msgid "Card inserted"
-msgstr "Karta wlozona"
-
 # MSG_SD_REMOVED
-#: ultralcd.cpp:8578
+#: ultralcd.cpp:8679
 msgid "Card removed"
 msgstr "Karta wyjeta"
 
-# 
-#: ultralcd.cpp:6087
-msgid "Change extruder"
-msgstr "Zmiana ekstrudera"
-
-# MSG_FILAMENTCHANGE
-#: messages.c:37
-msgid "Change filament"
-msgstr "Wymiana filamentu"
-
-# MSG_CNG_SDCARD
-#: ultralcd.cpp:5777
-msgid "Change SD card"
-msgstr "Wymien karte SD"
-
-# MSG_CHANGE_SUCCESS
-#: ultralcd.cpp:2584
-msgid "Change success!"
-msgstr "Wymiana ok!"
-
-# MSG_CORRECTLY c=20
-#: ultralcd.cpp:2661
-msgid "Changed correctly?"
-msgstr "Wymiana ok?"
-
-# MSG_CHANGING_FILAMENT c=20
-#: ultralcd.cpp:1899
-msgid "Changing filament!"
-msgstr "Wymiana filamentu!"
-
-# MSG_SELFTEST_CHECK_BED c=20
-#: messages.c:81
-msgid "Checking bed     "
-msgstr "Kontrola stolu"
-
-# MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ultralcd.cpp:8200
-msgid "Checking endstops"
-msgstr "Kontrola krancowek"
-
-# MSG_SELFTEST_CHECK_HOTEND c=20
-#: ultralcd.cpp:8206
-msgid "Checking hotend  "
-msgstr "Kontrola hotendu"
-
-# MSG_SELFTEST_CHECK_FSENSOR c=20
-#: messages.c:82
-msgid "Checking sensors "
-msgstr "Sprawdzanie czujnikow"
-
-# MSG_SELFTEST_CHECK_X c=20
-#: ultralcd.cpp:8201
-msgid "Checking X axis  "
-msgstr "Kontrola osi X"
-
-# MSG_SELFTEST_CHECK_Y c=20
-#: ultralcd.cpp:8202
-msgid "Checking Y axis  "
-msgstr "Kontrola osi Y"
-
-# MSG_SELFTEST_CHECK_Z c=20
-#: ultralcd.cpp:8203
-msgid "Checking Z axis  "
-msgstr "Kontrola osi Z"
-
-# 
-#: ultralcd.cpp:5537
-msgid "Checks"
-msgstr "Testy"
-
-# MSG_ERR_CHECKSUM_MISMATCH
-#: cmdqueue.cpp:444
-msgid "checksum mismatch, Last Line: "
-msgstr "suma kontrolna niezgodna, ostatnia linia:"
-
-# MSG_CHOOSE_EXTRUDER c=20 r=1
-#: messages.c:49
-msgid "Choose extruder:"
-msgstr "Wybierz ekstruder:"
-
-# MSG_CHOOSE_FILAMENT c=20 r=1
-#: messages.c:50
-msgid "Choose filament:"
-msgstr "Wybierz filament:"
-
 # MSG_NOT_COLOR
-#: ultralcd.cpp:2673
+#: ultralcd.cpp:2718
 msgid "Color not correct"
 msgstr "Kolor zanieczysz."
 
@@ -413,19 +226,9 @@ msgid "Cooldown"
 msgstr "Chlodzenie"
 
 # 
-#: ultralcd.cpp:4108
-msgid "Copy selected language from XFLASH?"
-msgstr "Skopiowac wybrany jezyk z XFLASH?"
-
-# 
-#: ultralcd.cpp:4499
+#: ultralcd.cpp:4587
 msgid "Copy selected language?"
 msgstr "Skopiowac wybrany jezyk?"
-
-# 
-#: ultralcd.cpp:1881
-msgid "Crash"
-msgstr "Zderzenie"
 
 # MSG_CRASHDETECT_ON
 #: messages.c:27
@@ -435,7 +238,7 @@ msgstr "Wykr.zderzen [wl]"
 # MSG_CRASHDETECT_NA
 #: messages.c:25
 msgid "Crash det.  [N/A]"
-msgstr "Wykr.zderzen[n/d]"
+msgstr "Wykr.zderzen[N/D]"
 
 # MSG_CRASHDETECT_OFF
 #: messages.c:26
@@ -448,29 +251,29 @@ msgid "Crash detected."
 msgstr "Zderzenie wykryte"
 
 # 
-#: Marlin_main.cpp:618
+#: Marlin_main.cpp:600
 msgid "Crash detected. Resume print?"
 msgstr "Wykryto zderzenie. Wznowic druk?"
 
-# MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#:
-msgid "Crash detection can\nbe turned on only in\nNormal mode"
-msgstr "Wykrywanie zderzen\nmoze byc wlaczone tylko\nw trybie Normalnym"
+# 
+#: ultralcd.cpp:1853
+msgid "Crash"
+msgstr "Zderzenie"
 
 # MSG_CURRENT c=19 r=1
-#: ultralcd.cpp:5804
+#: ultralcd.cpp:5909
 msgid "Current"
 msgstr "Aktualne"
 
 # MSG_DATE c=17 r=1
-#: ultralcd.cpp:2106
+#: ultralcd.cpp:2213
 msgid "Date:"
 msgstr "Data:"
 
 # MSG_DISABLE_STEPPERS
-#: ultralcd.cpp:5552
+#: ultralcd.cpp:5654
 msgid "Disable steppers"
-msgstr "Wylaczenie silnikow"
+msgstr "Wylacz silniki"
 
 # MSG_BABYSTEP_Z_NOT_SET c=20 r=12
 #: messages.c:14
@@ -478,124 +281,69 @@ msgid "Distance between tip of the nozzle and the bed surface has not been set y
 msgstr "Odleglosc dyszy od powierzchni druku nie jest skalibrowana. Postepuj zgodnie z instrukcja: rozdzial Wprowadzenie - Kalibracja pierwszej warstwy."
 
 # MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ultralcd.cpp:4968
+#: ultralcd.cpp:5070
 msgid "Do you want to repeat last step to readjust distance between nozzle and heatbed?"
 msgstr "Chcesz powtorzyc ostatni krok i ponownie ustawic odleglosc miedzy dysza a stolikiem?"
 
-# MSG_CLEAN_NOZZLE_E c=20 r=8
-#: ultralcd.cpp:3890
-msgid "E calibration finished. Please clean the nozzle. Click when done."
-msgstr "Kalibracja E zakonczona. Oczysc dysze i potwierdz naciskajac pokretlo. "
-
-# MSG_EXTRUDER_CORRECTION c=9
-#: ultralcd.cpp:4889
-msgid "E-correct"
-msgstr "Korekcja E"
-
 # MSG_EXTRUDER_CORRECTION c=10
-#: ultralcd.cpp:5032
+#: ultralcd.cpp:5134
 msgid "E-correct:"
 msgstr "Korekcja-E:"
-
-# 
-#: ultralcd.cpp:4780
-msgid "Eject"
-msgstr "Wysun"
 
 # MSG_EJECT_FILAMENT c=17 r=1
 #: messages.c:53
 msgid "Eject filament"
 msgstr "Wysun filament"
 
-# MSG_EJECT_FILAMENT1 c=17 r=1
-#: ultralcd.cpp:5603
-msgid "Eject filament 1"
-msgstr "Wysun filament 1"
-
-# MSG_EJECT_FILAMENT2 c=17 r=1
-#: ultralcd.cpp:5604
-msgid "Eject filament 2"
-msgstr "Wysun filament 2"
-
-# MSG_EJECT_FILAMENT3 c=17 r=1
-#: ultralcd.cpp:5605
-msgid "Eject filament 3"
-msgstr "Wysun filament 3"
-
-# MSG_EJECT_FILAMENT4 c=17 r=1
-#: ultralcd.cpp:5606
-msgid "Eject filament 4"
-msgstr "Wysun filament 4"
-
-# MSG_EJECT_FILAMENT5 c=17 r=1
-#: ultralcd.cpp:5607
-msgid "Eject filament 5"
-msgstr "Wysun filament 5"
+# 
+#: ultralcd.cpp:4869
+msgid "Eject"
+msgstr "Wysun"
 
 # MSG_EJECTING_FILAMENT c=20 r=1
-#: mmu.cpp:1435
+#: mmu.cpp:1434
 msgid "Ejecting filament"
 msgstr "Wysuwanie filamentu"
 
-# MSG_END_FILE_LIST
-#: Marlin_main.cpp:4407
-msgid "End file list"
-msgstr "Koniec listy plikow"
-
-# MSG_SELFTEST_ENDSTOP
-#: ultralcd.cpp:7825
-msgid "Endstop"
-msgstr "Krancowka"
-
 # MSG_SELFTEST_ENDSTOP_NOTHIT c=20 r=1
-#: ultralcd.cpp:7831
+#: ultralcd.cpp:7917
 msgid "Endstop not hit"
 msgstr "Krancowka nie aktyw."
 
+# MSG_SELFTEST_ENDSTOP
+#: ultralcd.cpp:7911
+msgid "Endstop"
+msgstr "Krancowka"
+
 # MSG_SELFTEST_ENDSTOPS
-#: ultralcd.cpp:7813
+#: ultralcd.cpp:7899
 msgid "Endstops"
 msgstr "Krancowki"
 
-# MSG_ENDSTOPS_HIT
-#: messages.c:30
-msgid "endstops hit: "
-msgstr "krancowki aktywowane:"
-
-# MSG_LANGUAGE_NAME
-#: language.c:153
-msgid "English"
-msgstr "Angielski"
-
-# MSG_Enqueing
-#:
-msgid "enqueing \""
-msgstr "kolejkowanie \""
-
 # MSG_STACK_ERROR c=20 r=4
-#: ultralcd.cpp:6773
+#: ultralcd.cpp:6859
 msgid "Error - static memory has been overwritten"
 msgstr "Blad - pamiec statyczna zostala nadpisana"
 
-# MSG_SD_ERR_WRITE_TO_FILE
-#: messages.c:78
-msgid "error writing to file"
-msgstr "blad zapisywania pliku"
+# MSG_FSENS_NOT_RESPONDING c=20 r=4
+#: ultralcd.cpp:4475
+msgid "ERROR: Filament sensor is not responding, please check connection."
+msgstr "BLAD: Czujnik filamentu nie odpowiada, sprawdz polaczenie."
 
 # MSG_ERROR
 #: messages.c:28
 msgid "ERROR:"
 msgstr "BLAD:"
 
-# MSG_FSENS_NOT_RESPONDING c=20 r=4
-#: ultralcd.cpp:4388
-msgid "ERROR: Filament sensor is not responding, please check connection."
-msgstr "BLAD: Czujnik filamentu nie odpowiada, sprawdz polaczenie."
+# MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
+#: ultralcd.cpp:8304
+msgid "Extruder fan:"
+msgstr "WentHotend:"
 
-# 
-#: Marlin_main.cpp:1006
-msgid "External SPI flash W25X20CL not responding."
-msgstr "Zewnetrzna pamiec flash SPI W25X20CL nie odpowiada."
+# MSG_INFO_EXTRUDER c=15 r=1
+#: ultralcd.cpp:2244
+msgid "Extruder info"
+msgstr "Ekstruder - info"
 
 # MSG_MOVE_E
 #: messages.c:29
@@ -603,39 +351,14 @@ msgid "Extruder"
 msgstr "Ekstruder"
 
 # 
-#: ultralcd.cpp:5633
-msgid "Extruder 1"
-msgstr "Ekstruder 1"
-
-# 
-#: ultralcd.cpp:5634
-msgid "Extruder 2"
-msgstr "Ekstruder 2"
-
-# 
-#: ultralcd.cpp:5635
-msgid "Extruder 3"
-msgstr "Ekstruder 3"
-
-# 
-#: ultralcd.cpp:5636
-msgid "Extruder 4"
-msgstr "Ekstruder 4"
-
-# MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
-#: ultralcd.cpp:8218
-msgid "Extruder fan:"
-msgstr "Went. ekstrudera:"
-
-# MSG_INFO_EXTRUDER c=15 r=1
-#: ultralcd.cpp:2137
-msgid "Extruder info"
-msgstr "Informacje o ekstruderze"
+#: ultralcd.cpp:6846
+msgid "Fail stats MMU"
+msgstr "Bledy MMU"
 
 # MSG_FSENS_AUTOLOAD_ON c=17 r=1
-#: ultralcd.cpp:5066
+#: ultralcd.cpp:5168
 msgid "F. autoload  [on]"
-msgstr "Autolad. fil [wl]"
+msgstr "Autolad.fil. [wl]"
 
 # MSG_FSENS_AUTOLOAD_NA c=17 r=1
 #: messages.c:43
@@ -643,24 +366,14 @@ msgid "F. autoload [N/A]"
 msgstr "Autolad.fil.[N/D]"
 
 # MSG_FSENS_AUTOLOAD_OFF c=17 r=1
-#: ultralcd.cpp:5068
+#: ultralcd.cpp:5170
 msgid "F. autoload [off]"
 msgstr "Autolad.fil.[wyl]"
 
 # 
-#: ultralcd.cpp:6757
+#: ultralcd.cpp:6843
 msgid "Fail stats"
 msgstr "Statystyki bledow"
-
-# 
-#: ultralcd.cpp:6760
-msgid "Fail stats MMU"
-msgstr "Bledy MMU"
-
-# 
-#: ultralcd.cpp:7887
-msgid "False triggering"
-msgstr "Falszywy alarm"
 
 # MSG_FAN_SPEED c=14
 #: messages.c:31
@@ -673,12 +386,12 @@ msgid "Fan test"
 msgstr "Test wentylatora"
 
 # MSG_FANS_CHECK_ON c=17 r=1
-#: ultralcd.cpp:5561
+#: ultralcd.cpp:5663
 msgid "Fans check   [on]"
 msgstr "Sprawd.went. [wl]"
 
 # MSG_FANS_CHECK_OFF c=17 r=1
-#: ultralcd.cpp:5563
+#: ultralcd.cpp:5665
 msgid "Fans check  [off]"
 msgstr "Sprawd.went.[wyl]"
 
@@ -687,13 +400,8 @@ msgstr "Sprawd.went.[wyl]"
 msgid "Fil. sensor  [on]"
 msgstr "Czuj. filam. [wl]"
 
-# MSG_RESPONSE_POOR c=20 r=2
-#: Marlin_main.cpp:3146
-msgid "Fil. sensor response is poor, disable it?"
-msgstr "Reakcja czujnika slaba, wylaczyc?"
-
 # MSG_FSENSOR_NA
-#: ultralcd.cpp:5046
+#: ultralcd.cpp:5148
 msgid "Fil. sensor [N/A]"
 msgstr "Czuj. filam.[N/D]"
 
@@ -703,22 +411,17 @@ msgid "Fil. sensor [off]"
 msgstr "Czuj. filam.[wyl]"
 
 # 
-#: ultralcd.cpp:1881
+#: ultralcd.cpp:1852
 msgid "Filam. runouts"
 msgstr "Konc. filamentu"
-
-# MSG_FILAMENT c=17 r=1
-#: messages.c:30
-msgid "Filament"
-msgstr "Filament"
 
 # MSG_FILAMENT_CLEAN c=20 r=2
 #: messages.c:32
 msgid "Filament extruding & with correct color?"
-msgstr "Filament wychodzi z dyszy a kolor jest czysty?"
+msgstr "Filament wychodzi z dyszy, kolor jest ok?"
 
 # MSG_NOT_LOADED c=19
-#: ultralcd.cpp:2669
+#: ultralcd.cpp:2714
 msgid "Filament not loaded"
 msgstr "Fil. nie zaladowany"
 
@@ -727,60 +430,25 @@ msgstr "Fil. nie zaladowany"
 msgid "Filament sensor"
 msgstr "Czujnik filamentu"
 
-# MSG_SELFTEST_FILAMENT_SENSOR c=18
-#: ultralcd.cpp:7477
-msgid "Filament sensor:"
-msgstr "Czujnik filamentu:"
-
 # MSG_FILAMENT_USED c=19 r=1
-#: ultralcd.cpp:2838
+#: ultralcd.cpp:2885
 msgid "Filament used"
 msgstr "Uzyty filament"
 
-# MSG_STATS_FILAMENTUSED c=20
-#: ultralcd.cpp:2142
-msgid "Filament used:  "
-msgstr "Uzywany filament:"
+# MSG_PRINT_TIME c=19 r=1
+#: ultralcd.cpp:2886
+msgid "Print time"
+msgstr "Czas druku"
 
 # MSG_FILE_INCOMPLETE c=20 r=2
-#: ultralcd.cpp:8346
+#: ultralcd.cpp:8432
 msgid "File incomplete. Continue anyway?"
 msgstr "Plik niekompletny. Kontynowac?"
-
-# MSG_SD_FILE_OPENED
-#: cardreader.cpp:395
-msgid "File opened: "
-msgstr "Otwarty plik:"
-
-# MSG_SD_FILE_SELECTED
-#: cardreader.cpp:401
-msgid "File selected"
-msgstr "Wybrano plik"
-
-# 
-#: ultralcd.cpp:3943
-msgid "FINDA:"
-msgstr "FINDA:"
 
 # MSG_FINISHING_MOVEMENTS c=20 r=1
 #: messages.c:40
 msgid "Finishing movements"
 msgstr "Konczenie druku"
-
-# 
-#: ultralcd.cpp:5443
-msgid "Firmware   [none]"
-msgstr "Firmware [brak]"
-
-# 
-#: ultralcd.cpp:5446
-msgid "Firmware   [warn]"
-msgstr "Firmware [ostrzez.]"
-
-# 
-#: ultralcd.cpp:5449
-msgid "Firmware [strict]"
-msgstr "Firmware [restr.]"
 
 # MSG_V2_CALIBRATION c=17 r=1
 #: messages.c:105
@@ -788,7 +456,7 @@ msgid "First layer cal."
 msgstr "Kal. 1. warstwy"
 
 # MSG_WIZARD_SELFTEST c=20 r=8
-#: ultralcd.cpp:4880
+#: ultralcd.cpp:4982
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr "Najpierw wlacze selftest w celu sprawdzenia najczestszych problemow podczas montazu."
 
@@ -798,14 +466,14 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr "Rozwiaz problem i wcisnij przycisk na MMU."
 
 # MSG_FLOW
-#: ultralcd.cpp:6846
+#: ultralcd.cpp:6932
 msgid "Flow"
 msgstr "Przeplyw"
 
 # MSG_PRUSA3D_FORUM
-#: ultralcd.cpp:2099
+#: ultralcd.cpp:2206
 msgid "forum.prusa3d.com"
-msgstr "forum.prusa3d.com"
+msgstr ""
 
 # MSG_SELFTEST_COOLING_FAN c=20
 #: messages.c:75
@@ -813,19 +481,1239 @@ msgid "Front print fan?"
 msgstr "Przedni went. druku?"
 
 # MSG_BED_CORRECTION_FRONT c=14 r=1
-#: ultralcd.cpp:3217
+#: ultralcd.cpp:3294
 msgid "Front side[um]"
 msgstr "Przod [um]"
 
 # MSG_SELFTEST_FANS
-#: ultralcd.cpp:7871
+#: ultralcd.cpp:7957
 msgid "Front/left fans"
 msgstr "Przedni/lewy wentylator"
+
+# MSG_SELFTEST_HEATERTHERMISTOR
+#: ultralcd.cpp:7887
+msgid "Heater/Thermistor"
+msgstr "Grzalka/Termistor"
+
+# MSG_BED_HEATING_SAFETY_DISABLED
+#: Marlin_main.cpp:8467
+msgid "Heating disabled by safety timer."
+msgstr "Grzanie wylaczone przez wyl. czasowy"
+
+# MSG_HEATING_COMPLETE c=20
+#: messages.c:47
+msgid "Heating done."
+msgstr "Grzanie zakonczone"
+
+# MSG_HEATING
+#: messages.c:46
+msgid "Heating"
+msgstr "Grzanie..."
+
+# MSG_WIZARD_WELCOME c=20 r=7
+#: ultralcd.cpp:4961
+msgid "Hi, I am your Original Prusa i3 printer. Would you like me to guide you through the setup process?"
+msgstr "Czesc, jestem Twoja drukarka Original Prusa i3. Czy potrzebujesz pomocy z ustawieniem?"
+
+# MSG_PRUSA3D_HOWTO
+#: ultralcd.cpp:2207
+msgid "howto.prusa3d.com"
+msgstr ""
+
+# MSG_FILAMENTCHANGE
+#: messages.c:37
+msgid "Change filament"
+msgstr "Wymiana filamentu"
+
+# MSG_CHANGE_SUCCESS
+#: ultralcd.cpp:2629
+msgid "Change success!"
+msgstr "Wymiana ok!"
+
+# MSG_CORRECTLY c=20
+#: ultralcd.cpp:2706
+msgid "Changed correctly?"
+msgstr "Wymiana ok?"
+
+# MSG_SELFTEST_CHECK_BED c=20
+#: messages.c:81
+msgid "Checking bed     "
+msgstr "Kontrola stolu"
+
+# MSG_SELFTEST_CHECK_ENDSTOPS c=20
+#: ultralcd.cpp:8286
+msgid "Checking endstops"
+msgstr "Kontrola krancowek"
+
+# MSG_SELFTEST_CHECK_HOTEND c=20
+#: ultralcd.cpp:8292
+msgid "Checking hotend  "
+msgstr "Kontrola hotendu"
+
+# MSG_SELFTEST_CHECK_FSENSOR c=20
+#: messages.c:82
+msgid "Checking sensors "
+msgstr "Sprawdzanie czujnikow"
+
+# MSG_SELFTEST_CHECK_X c=20
+#: ultralcd.cpp:8287
+msgid "Checking X axis  "
+msgstr "Kontrola osi X"
+
+# MSG_SELFTEST_CHECK_Y c=20
+#: ultralcd.cpp:8288
+msgid "Checking Y axis  "
+msgstr "Kontrola osi Y"
+
+# MSG_SELFTEST_CHECK_Z c=20
+#: ultralcd.cpp:8289
+msgid "Checking Z axis  "
+msgstr "Kontrola osi Z"
+
+# MSG_CHOOSE_EXTRUDER c=20 r=1
+#: messages.c:49
+msgid "Choose extruder:"
+msgstr "Wybierz ekstruder:"
+
+# MSG_CHOOSE_FILAMENT c=20 r=1
+#: messages.c:50
+msgid "Choose filament:"
+msgstr "Wybierz filament:"
+
+# MSG_FILAMENT c=17 r=1
+#: messages.c:30
+msgid "Filament"
+msgstr ""
+
+# MSG_WIZARD_XYZ_CAL c=20 r=8
+#: ultralcd.cpp:4991
+msgid "I will run xyz calibration now. It will take approx. 12 mins."
+msgstr "Przeprowadze teraz kalibracje XYZ. Zajmie ok. 12 min."
+
+# MSG_WIZARD_Z_CAL c=20 r=8
+#: ultralcd.cpp:4999
+msgid "I will run z calibration now."
+msgstr "Przeprowadze kalibracje Z."
+
+# MSG_WIZARD_V2_CAL_2 c=20 r=12
+#: ultralcd.cpp:5064
+msgid "I will start to print line and you will gradually lower the nozzle by rotating the knob, until you reach optimal height. Check the pictures in our handbook in chapter Calibration."
+msgstr "Zaczne drukowac linie. Stopniowo opuszczaj dysze przekrecajac pokretlo, poki nie uzyskasz optymalnej wysokosci. Sprawdz obrazki w naszym Podreczniku w rozdz. Kalibracja"
+
+# MSG_WATCH
+#: messages.c:99
+msgid "Info screen"
+msgstr "Ekran informacyjny"
+
+# 
+#: ultralcd.cpp:5024
+msgid "Is filament 1 loaded?"
+msgstr "Filament 1 zaladowany?"
+
+# MSG_INSERT_FILAMENT c=20
+#: ultralcd.cpp:2614
+msgid "Insert filament"
+msgstr "Wprowadz filament"
+
+# MSG_WIZARD_FILAMENT_LOADED c=20 r=2
+#: ultralcd.cpp:5027
+msgid "Is filament loaded?"
+msgstr "Filament jest zaladowany?"
+
+# MSG_WIZARD_PLA_FILAMENT c=20 r=2
+#: ultralcd.cpp:5058
+msgid "Is it PLA filament?"
+msgstr "Czy to filament PLA?"
+
+# MSG_PLA_FILAMENT_LOADED c=20 r=2
+#: ultralcd.cpp:4790
+msgid "Is PLA filament loaded?"
+msgstr "Fialment PLA jest zaladowany?"
+
+# MSG_STEEL_SHEET_CHECK c=20 r=2
+#: messages.c:92
+msgid "Is steel sheet on heatbed?"
+msgstr "Czy plyta stal. jest na podgrzew. stole?"
+
+# 
+#: ultralcd.cpp:1795
+msgid "Last print failures"
+msgstr "Ostatnie bledy druku"
+
+# 
+#: ultralcd.cpp:1772
+msgid "Last print"
+msgstr "Ost. wydruk"
+
+# MSG_SELFTEST_EXTRUDER_FAN c=20
+#: messages.c:76
+msgid "Left hotend fan?"
+msgstr "Lewy went hotendu?"
+
+# 
+#: ultralcd.cpp:3018
+msgid "Left"
+msgstr "Lewa"
+
+# MSG_BED_CORRECTION_LEFT c=14 r=1
+#: ultralcd.cpp:3292
+msgid "Left side [um]"
+msgstr "Lewo [um]"
+
+# 
+#: ultralcd.cpp:5680
+msgid "Lin. correction"
+msgstr "Korekcja liniowa"
+
+# MSG_BABYSTEP_Z
+#: messages.c:13
+msgid "Live adjust Z"
+msgstr "Ustaw. Live Z"
+
+# MSG_LOAD_FILAMENT c=17
+#: messages.c:51
+msgid "Load filament"
+msgstr "Ladowanie fil."
+
+# MSG_LOADING_COLOR
+#: ultralcd.cpp:2654
+msgid "Loading color"
+msgstr "Czyszcz. koloru"
+
+# MSG_LOADING_FILAMENT c=20
+#: messages.c:52
+msgid "Loading filament"
+msgstr "Laduje filament"
+
+# MSG_LOOSE_PULLEY c=20 r=1
+#: ultralcd.cpp:7941
+msgid "Loose pulley"
+msgstr "Luzne kolo pasowe"
+
+# 
+#: ultralcd.cpp:6805
+msgid "Load to nozzle"
+msgstr "Zaladuj do dyszy"
+
+# MSG_M117_V2_CALIBRATION c=25 r=1
+#: messages.c:55
+msgid "M117 First layer cal."
+msgstr "M117 Kal. 1. warstwy"
+
+# MSG_MAIN
+#: messages.c:56
+msgid "Main"
+msgstr "Menu glowne"
+
+# MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=60
+#: messages.c:59
+msgid "Measuring reference height of calibration point"
+msgstr "Okreslam wysokosc odniesienia punktu kalibracyjnego"
+
+# MSG_MESH_BED_LEVELING
+#: ultralcd.cpp:5763
+msgid "Mesh Bed Leveling"
+msgstr "Poziomowanie stolu wg siatki"
+
+# MSG_MMU_OK_RESUMING_POSITION c=20 r=4
+#: mmu.cpp:762
+msgid "MMU OK. Resuming position..."
+msgstr "MMU OK. Wznawianie pozycji."
+
+# MSG_MMU_OK_RESUMING_TEMPERATURE c=20 r=4
+#: mmu.cpp:755
+msgid "MMU OK. Resuming temperature..."
+msgstr "MMU OK. Wznawiam nagrzewanie..."
+
+# 
+#: ultralcd.cpp:3059
+msgid "Measured skew"
+msgstr "Zmierzony skos"
+
+# 
+#: ultralcd.cpp:1796
+msgid "MMU fails"
+msgstr "Bledy MMU"
+
+# 
+#: mmu.cpp:1613
+msgid "MMU load failed     "
+msgstr "Blad ladowania MMU"
+
+# 
+#: ultralcd.cpp:1797
+msgid "MMU load fails"
+msgstr "Bledy ladow. MMU"
+
+# MSG_MMU_OK_RESUMING c=20 r=4
+#: mmu.cpp:773
+msgid "MMU OK. Resuming..."
+msgstr "MMU OK. Wznawianie..."
+
+# MSG_STEALTH_MODE_OFF
+#: messages.c:90
+msgid "Mode     [Normal]"
+msgstr "Tryb   [normalny]"
+
+# MSG_SILENT_MODE_ON
+#: messages.c:89
+msgid "Mode     [silent]"
+msgstr "Tryb      [cichy]"
+
+# 
+#: mmu.cpp:719
+msgid "MMU needs user attention."
+msgstr "MMU wymaga uwagi uzytkownika."
+
+# 
+#: ultralcd.cpp:1823
+msgid "MMU power fails"
+msgstr "Zaniki zasil. MMU"
+
+# MSG_STEALTH_MODE_ON
+#: messages.c:91
+msgid "Mode    [Stealth]"
+msgstr "Tryb      [cichy]"
+
+# MSG_AUTO_MODE_ON
+#: messages.c:12
+msgid "Mode [auto power]"
+msgstr "Tryb [automatycz]"
+
+# MSG_SILENT_MODE_OFF
+#: messages.c:88
+msgid "Mode [high power]"
+msgstr "Tryb[wysoka wyd.]"
+
+# 
+#: ultralcd.cpp:2219
+msgid "MMU2 connected"
+msgstr "MMU podlaczone"
+
+# MSG_SELFTEST_MOTOR
+#: messages.c:83
+msgid "Motor"
+msgstr "Silnik"
+
+# MSG_MOVE_AXIS
+#: ultralcd.cpp:5652
+msgid "Move axis"
+msgstr "Ruch osi"
+
+# MSG_MOVE_X
+#: ultralcd.cpp:4378
+msgid "Move X"
+msgstr "Ruch osi X"
+
+# MSG_MOVE_Y
+#: ultralcd.cpp:4379
+msgid "Move Y"
+msgstr "Ruch osi Y"
+
+# MSG_MOVE_Z
+#: ultralcd.cpp:4380
+msgid "Move Z"
+msgstr "Ruch osi Z"
+
+# MSG_NO_MOVE
+#: Marlin_main.cpp:5292
+msgid "No move."
+msgstr "Brak ruchu."
+
+# MSG_NO_CARD
+#: ultralcd.cpp:6772
+msgid "No SD card"
+msgstr "Brak karty SD"
+
+# 
+#: ultralcd.cpp:3024
+msgid "N/A"
+msgstr "N/D"
+
+# MSG_NO
+#: messages.c:62
+msgid "No"
+msgstr "Nie"
+
+# MSG_SELFTEST_NOTCONNECTED
+#: ultralcd.cpp:7889
+msgid "Not connected"
+msgstr "Nie podlaczono "
+
+# 
+#: util.cpp:293
+msgid "New firmware version available:"
+msgstr "Dostepna nowa wersja firmware:"
+
+# MSG_SELFTEST_FAN_NO c=19
+#: messages.c:79
+msgid "Not spinning"
+msgstr "Nie kreci sie"
+
+# MSG_WIZARD_V2_CAL c=20 r=8
+#: ultralcd.cpp:5063
+msgid "Now I will calibrate distance between tip of the nozzle and heatbed surface."
+msgstr "Kalibruje odleglosc miedzy koncowka dyszy a powierzchnia druku."
+
+# MSG_WIZARD_WILL_PREHEAT c=20 r=4
+#: ultralcd.cpp:5007
+msgid "Now I will preheat nozzle for PLA."
+msgstr "Nagrzewam dysze dla PLA."
+
+# MSG_NOZZLE
+#: messages.c:63
+msgid "Nozzle"
+msgstr "Dysza"
+
+# MSG_DEFAULT_SETTINGS_LOADED c=20 r=4
+#: Marlin_main.cpp:1519
+msgid "Old settings found. Default PID, Esteps etc. will be set."
+msgstr "Znaleziono stare ustawienia. Zostana przywrocone domyslne ust. PID, Esteps, itp."
+
+# 
+#: ultralcd.cpp:4998
+msgid "Now remove the test print from steel sheet."
+msgstr "Teraz zdejmij wydruk testowy ze stolu."
+
+# 
+#: ultralcd.cpp:1722
+msgid "Nozzle FAN"
+msgstr "WentHotend"
+
+# MSG_PAUSE_PRINT
+#: ultralcd.cpp:6735
+msgid "Pause print"
+msgstr "Wstrzymanie wydruku"
+
+# MSG_PID_RUNNING c=20 r=1
+#: ultralcd.cpp:1606
+msgid "PID cal.           "
+msgstr "Kalibracja PID"
+
+# MSG_PID_FINISHED c=20 r=1
+#: ultralcd.cpp:1612
+msgid "PID cal. finished"
+msgstr "Kal. PID zakonczona"
+
+# MSG_PID_EXTRUDER c=17 r=1
+#: ultralcd.cpp:5769
+msgid "PID calibration"
+msgstr "Kalibracja PID"
+
+# MSG_PINDA_PREHEAT c=20 r=1
+#: ultralcd.cpp:846
+msgid "PINDA Heating"
+msgstr "Grzanie sondy PINDA"
+
+# MSG_PAPER c=20 r=8
+#: messages.c:64
+msgid "Place a sheet of paper under the nozzle during the calibration of first 4 points. If the nozzle catches the paper, power off the printer immediately."
+msgstr "Umiesc kartke papieru na stole roboczym i podczas pomiaru pierwszych 4 punktow. Jesli dysza zahaczy o papier, natychmiast wylacz drukarke."
+
+# MSG_WIZARD_CLEAN_HEATBED c=20 r=8
+#: ultralcd.cpp:5072
+msgid "Please clean heatbed and then press the knob."
+msgstr "Oczysc powierzchnie druku i nacisnij pokretlo."
+
+# MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
+#: messages.c:22
+msgid "Please clean the nozzle for calibration. Click when done."
+msgstr "Dla prawidlowej kalibracji nalezy oczyscic dysze. Potwierdz guzikiem."
+
+# MSG_SELFTEST_PLEASECHECK
+#: ultralcd.cpp:7881
+msgid "Please check :"
+msgstr "Sprawdz :"
+
+# MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
+#: messages.c:100
+msgid "Please check our handbook and fix the problem. Then resume the Wizard by rebooting the printer."
+msgstr "Przeczytaj nasz Podrecznik druku 3D aby naprawic problem. Potem wznow Asystenta przez restart drukarki."
+
+# MSG_WIZARD_LOAD_FILAMENT c=20 r=8
+#: ultralcd.cpp:4894
+msgid "Please insert PLA filament to the extruder, then press knob to load it."
+msgstr "Umiesc filament PLA w ekstruderze i nacisnij pokretlo, aby zaladowac."
+
+# MSG_PLEASE_LOAD_PLA c=20 r=4
+#: ultralcd.cpp:4795
+msgid "Please load PLA filament first."
+msgstr "Najpierw zaladuj filament PLA."
+
+# MSG_CHECK_IDLER c=20 r=4
+#: Marlin_main.cpp:3064
+msgid "Please open idler and remove filament manually."
+msgstr "Prosze odciagnac dzwignie dociskowa ekstrudera i recznie usunac filament."
+
+# MSG_PLACE_STEEL_SHEET c=20 r=4
+#: messages.c:65
+msgid "Please place steel sheet on heatbed."
+msgstr "Prosze umiescic plyte stalowa na stole podgrzewanym."
+
+# MSG_PRESS_TO_UNLOAD c=20 r=4
+#: messages.c:68
+msgid "Please press the knob to unload filament"
+msgstr "Nacisnij pokretlo aby rozladowac filament"
+
+# 
+#: ultralcd.cpp:4889
+msgid "Please insert PLA filament to the first tube of MMU, then press the knob to load it."
+msgstr "Wsun filament PLA do pierwszej rurki MMU i nacisnij pokretlo aby go zaladowac."
+
+# MSG_PULL_OUT_FILAMENT c=20 r=4
+#: messages.c:70
+msgid "Please pull out filament immediately"
+msgstr "Wyciagnij filament teraz"
+
+# MSG_EJECT_REMOVE c=20 r=4
+#: mmu.cpp:1440
+msgid "Please remove filament and then press the knob."
+msgstr "Wyciagnij filament i wcisnij pokretlo."
+
+# MSG_REMOVE_STEEL_SHEET c=20 r=4
+#: messages.c:74
+msgid "Please remove steel sheet from heatbed."
+msgstr "Prosze zdjac plyte stalowa z podgrzewanego stolu."
+
+# MSG_RUN_XYZ c=20 r=4
+#: Marlin_main.cpp:4355
+msgid "Please run XYZ calibration first."
+msgstr "Prosze najpierw uruchomic kalibracje XYZ"
+
+# MSG_UPDATE_MMU2_FW c=20 r=4
+#: mmu.cpp:1359
+msgid "Please update firmware in your MMU2. Waiting for reset."
+msgstr "Prosze zaktualizowac Firmware MMU2. Czekam na reset."
+
+# MSG_PLEASE_WAIT c=20
+#: messages.c:66
+msgid "Please wait"
+msgstr "Prosze czekac"
+
+# 
+#: ultralcd.cpp:4997
+msgid "Please remove shipping helpers first."
+msgstr "Najpierw usun zabezpieczenia transportowe"
+
+# MSG_PREHEAT_NOZZLE c=20
+#: messages.c:67
+msgid "Preheat the nozzle!"
+msgstr "Nagrzej dysze!"
+
+# MSG_PREHEAT
+#: ultralcd.cpp:6722
+msgid "Preheat"
+msgstr "Grzanie"
+
+# MSG_WIZARD_HEATING c=20 r=3
+#: messages.c:102
+msgid "Preheating nozzle. Please wait."
+msgstr "Nagrzewanie dyszy. Prosze czekac."
+
+# 
+#: util.cpp:297
+msgid "Please upgrade."
+msgstr "Prosze zaktualizowac."
+
+# MSG_PRESS_TO_PREHEAT c=20 r=4
+#: Marlin_main.cpp:10364
+msgid "Press knob to preheat nozzle and continue."
+msgstr "Wcisnij pokretlo aby rozgrzac dysze i kontynuowac."
+
+# 
+#: ultralcd.cpp:1851
+msgid "Power failures"
+msgstr "Zaniki zasilania"
+
+# MSG_PRINT_ABORTED c=20
+#: messages.c:69
+msgid "Print aborted"
+msgstr "Druk przerwany"
+
+# 
+#: ultralcd.cpp:2455
+msgid "Preheating to load"
+msgstr "Nagrzew. do ladowania"
+
+# 
+#: ultralcd.cpp:2459
+msgid "Preheating to unload"
+msgstr "Nagrzew. do rozlad."
+
+# MSG_SELFTEST_PRINT_FAN_SPEED c=18
+#: ultralcd.cpp:8307
+msgid "Print fan:"
+msgstr "WentWydruk:"
+
+# MSG_CARD_MENU
+#: messages.c:21
+msgid "Print from SD"
+msgstr "Druk z karty SD"
+
+# 
+#: ultralcd.cpp:2317
+msgid "Press the knob"
+msgstr "Wcisnij pokretlo"
+
+# MSG_PRINT_PAUSED c=20 r=1
+#: ultralcd.cpp:1069
+msgid "Print paused"
+msgstr "Druk wstrzymany"
+
+# 
+#: mmu.cpp:723
+msgid "Press the knob to resume nozzle temperature."
+msgstr "Wcisnij pokretlo aby wznowic podgrzewanie dyszy."
+
+# MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
+#: messages.c:41
+msgid "Printer has not been calibrated yet. Please follow the manual, chapter First steps, section Calibration flow."
+msgstr "Drukarka nie byla jeszcze kalibrowana. Kieruj sie Samouczkiem: rozdzial Pierwsze Kroki, sekcja Konfiguracja przed drukowaniem."
+
+# 
+#: ultralcd.cpp:1723
+msgid "Print FAN"
+msgstr "WentWydruk"
+
+# MSG_PRUSA3D
+#: ultralcd.cpp:2205
+msgid "prusa3d.com"
+msgstr ""
+
+# MSG_BED_CORRECTION_REAR c=14 r=1
+#: ultralcd.cpp:3295
+msgid "Rear side [um]"
+msgstr "Tyl [um]"
+
+# MSG_RECOVERING_PRINT c=20 r=1
+#: Marlin_main.cpp:9764
+msgid "Recovering print    "
+msgstr "Wznawianie wydruku"
+
+# MSG_REMOVE_OLD_FILAMENT c=20 r=4
+#: mmu.cpp:830
+msgid "Remove old filament and press the knob to start loading new filament."
+msgstr "Wyciagnij poprzedni filament i nacisnij pokretlo aby zaladowac nowy."
+
+# 
+#: 
+msgid "Prusa i3 MK3S OK."
+msgstr "Prusa i3 MK3S OK"
+
+# MSG_CALIBRATE_BED_RESET
+#: ultralcd.cpp:5774
+msgid "Reset XYZ calibr."
+msgstr "Reset kalibr. XYZ"
+
+# MSG_BED_CORRECTION_RESET
+#: ultralcd.cpp:3296
+msgid "Reset"
+msgstr ""
+
+# MSG_RESUME_PRINT
+#: ultralcd.cpp:6742
+msgid "Resume print"
+msgstr "Wznowic wydruk"
+
+# MSG_RESUMING_PRINT c=20 r=1
+#: messages.c:73
+msgid "Resuming print"
+msgstr "Wznawianie druku"
+
+# MSG_BED_CORRECTION_RIGHT c=14 r=1
+#: ultralcd.cpp:3293
+msgid "Right side[um]"
+msgstr "Prawo [um]"
+
+# MSG_SECOND_SERIAL_ON c=17 r=1
+#: ultralcd.cpp:5692
+msgid "RPi port     [on]"
+msgstr "Port RPi     [wl]"
+
+# MSG_SECOND_SERIAL_OFF c=17 r=1
+#: ultralcd.cpp:5690
+msgid "RPi port    [off]"
+msgstr "Port RPi    [wyl]"
+
+# MSG_WIZARD_RERUN c=20 r=7
+#: ultralcd.cpp:4812
+msgid "Running Wizard will delete current calibration results and start from the beginning. Continue?"
+msgstr "Wlaczenie Asystenta usunie obecne dane kalibracyjne i zacznie od poczatku. Kontynuowac?"
+
+# MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_OFF c=19 r=1
+#: ultralcd.cpp:5322
+msgid "SD card  [normal]"
+msgstr "Karta SD [normal]"
+
+# MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_ON c=19 r=1
+#: ultralcd.cpp:5320
+msgid "SD card [flshAir]"
+msgstr "Karta SD[FlshAir]"
+
+# 
+#: ultralcd.cpp:3019
+msgid "Right"
+msgstr "Prawa"
+
+# MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=60
+#: messages.c:38
+msgid "Searching bed calibration point"
+msgstr "Szukam punktu kalibracyjnego na stole"
+
+# MSG_LANGUAGE_SELECT
+#: ultralcd.cpp:5699
+msgid "Select language"
+msgstr "Wybor jezyka"
+
+# MSG_SELFTEST_OK
+#: ultralcd.cpp:7452
+msgid "Self test OK"
+msgstr "Selftest OK"
+
+# MSG_SELFTEST_START c=20
+#: ultralcd.cpp:7238
+msgid "Self test start  "
+msgstr "Selftest startuje"
+
+# MSG_SELFTEST
+#: ultralcd.cpp:5750
+msgid "Selftest         "
+msgstr "Selftest "
+
+# MSG_SELFTEST_ERROR
+#: ultralcd.cpp:7879
+msgid "Selftest error !"
+msgstr "Blad selftest!"
+
+# MSG_SELFTEST_FAILED c=20
+#: messages.c:77
+msgid "Selftest failed  "
+msgstr "Selftest nieudany"
+
+# MSG_FORCE_SELFTEST c=20 r=8
+#: Marlin_main.cpp:1551
+msgid "Selftest will be run to calibrate accurate sensorless rehoming."
+msgstr "Zostanie uruchomiony Selftest aby dokladnie skalibrowac punkt bazowy bez krancowek"
+
+# 
+#: ultralcd.cpp:5045
+msgid "Select nozzle preheat temperature which matches your material."
+msgstr "Wybierz temperature grzania dyszy odpowiednia dla materialu."
+
+# 
+#: ultralcd.cpp:4780
+msgid "Select PLA filament:"
+msgstr "Wybierz filament PLA:"
+
+# MSG_SET_TEMPERATURE c=19 r=1
+#: ultralcd.cpp:3314
+msgid "Set temperature:"
+msgstr "Ustaw temperature:"
+
+# MSG_SETTINGS
+#: messages.c:86
+msgid "Settings"
+msgstr "Ustawienia"
+
+# MSG_SHOW_END_STOPS c=17 r=1
+#: ultralcd.cpp:5771
+msgid "Show end stops"
+msgstr "Pokaz krancowki"
+
+# 
+#: ultralcd.cpp:4025
+msgid "Sensor state"
+msgstr "Stan czujnikow"
+
+# MSG_FILE_CNT c=20 r=4
+#: cardreader.cpp:739
+msgid "Some files will not be sorted. Max. No. of files in 1 folder for sorting is 100."
+msgstr "Niektore pliki nie zostana posortowane. Max. liczba plikow w 1 folderze = 100."
+
+# MSG_SORT_NONE c=17 r=1
+#: ultralcd.cpp:5332
+msgid "Sort       [none]"
+msgstr "Sortowanie [brak]"
+
+# MSG_SORT_TIME c=17 r=1
+#: ultralcd.cpp:5330
+msgid "Sort       [time]"
+msgstr "Sortowanie [czas]"
+
+# 
+#: ultralcd.cpp:3062
+msgid "Severe skew:"
+msgstr "Znaczny skos:"
+
+# MSG_SORT_ALPHA c=17 r=1
+#: ultralcd.cpp:5331
+msgid "Sort   [alphabet]"
+msgstr "Sortowanie[alfab]"
+
+# MSG_SORTING c=20 r=1
+#: cardreader.cpp:746
+msgid "Sorting files"
+msgstr "Sortowanie plikow"
+
+# MSG_SOUND_LOUD c=17 r=1
+#: sound.h:6
+msgid "Sound      [loud]"
+msgstr "Dzwiek   [glosny]"
+
+# 
+#: ultralcd.cpp:3061
+msgid "Slight skew:"
+msgstr "Lekki skos:"
+
+# MSG_SOUND_MUTE c=17 r=1
+#: 
+msgid "Sound      [mute]"
+msgstr "Dzwiek[wylaczony]"
+
+# 
+#: Marlin_main.cpp:4871
+msgid "Some problem encountered, Z-leveling enforced ..."
+msgstr "Wykryto problem, wymuszono poziomowanie osi Z."
+
+# MSG_SOUND_ONCE c=17 r=1
+#: sound.h:7
+msgid "Sound      [once]"
+msgstr "Dzwiek    [1-raz]"
+
+# MSG_SOUND_SILENT c=17 r=1
+#: sound.h:8
+msgid "Sound    [silent]"
+msgstr "Dzwiek    [cichy]"
+
+# MSG_SPEED
+#: ultralcd.cpp:6926
+msgid "Speed"
+msgstr "Predkosc"
+
+# MSG_SELFTEST_FAN_YES c=19
+#: messages.c:80
+msgid "Spinning"
+msgstr "Kreci sie"
+
+# MSG_TEMP_CAL_WARNING c=20 r=4
+#: Marlin_main.cpp:4368
+msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
+msgstr "Potrzebna jest stabilna temperatura otoczenia 21-26C i stabilne podloze."
+
+# MSG_STATISTICS
+#: ultralcd.cpp:6839
+msgid "Statistics  "
+msgstr "Statystyki"
+
+# MSG_STOP_PRINT
+#: messages.c:93
+msgid "Stop print"
+msgstr "Przerwanie druku"
+
+# MSG_STOPPED
+#: messages.c:94
+msgid "STOPPED. "
+msgstr "ZATRZYMANO."
+
+# MSG_SUPPORT
+#: ultralcd.cpp:6848
+msgid "Support"
+msgstr "Wsparcie"
+
+# MSG_SELFTEST_SWAPPED
+#: ultralcd.cpp:7959
+msgid "Swapped"
+msgstr "Zamieniono"
+
+# MSG_TEMP_CALIBRATION c=20 r=1
+#: messages.c:95
+msgid "Temp. cal.          "
+msgstr "Kalibracja temp."
+
+# MSG_TEMP_CALIBRATION_ON c=20 r=1
+#: ultralcd.cpp:5686
+msgid "Temp. cal.   [on]"
+msgstr "Kalibr.temp. [wl]"
+
+# MSG_TEMP_CALIBRATION_OFF c=20 r=1
+#: ultralcd.cpp:5684
+msgid "Temp. cal.  [off]"
+msgstr "Kalibr.temp.[wyl]"
+
+# MSG_CALIBRATION_PINDA_MENU c=17 r=1
+#: ultralcd.cpp:5780
+msgid "Temp. calibration"
+msgstr "Kalibracja temp."
+
+# MSG_TEMP_CAL_FAILED c=20 r=8
+#: ultralcd.cpp:3951
+msgid "Temperature calibration failed"
+msgstr "Kalibracja temperaturowa nieudana"
+
+# MSG_TEMP_CALIBRATION_DONE c=20 r=12
+#: messages.c:96
+msgid "Temperature calibration is finished and active. Temp. calibration can be disabled in menu Settings->Temp. cal."
+msgstr "Kalibracja temperaturowa zakonczona i wlaczona. Moze byc wylaczona z menu Ustawienia -> Kalibracja temp."
+
+# MSG_TEMPERATURE
+#: ultralcd.cpp:5650
+msgid "Temperature"
+msgstr "Temperatura"
+
+# MSG_MENU_TEMPERATURES c=15 r=1
+#: ultralcd.cpp:2251
+msgid "Temperatures"
+msgstr "Temperatury"
+
+# MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=4
+#: messages.c:42
+msgid "There is still a need to make Z calibration. Please follow the manual, chapter First steps, section Calibration flow."
+msgstr "Musimy przeprowadzic kalibracje Z. Kieruj sie Samouczkiem: rozdzial Pierwsze Kroki, sekcja Kalibracja."
+
+# 
+#: ultralcd.cpp:2908
+msgid "Total filament"
+msgstr "Zuzycie filamentu"
+
+# 
+#: ultralcd.cpp:2908
+msgid "Total print time"
+msgstr "Laczny czas druku"
+
+# MSG_TUNE
+#: ultralcd.cpp:6719
+msgid "Tune"
+msgstr "Strojenie"
+
+# 
+#: ultralcd.cpp:4869
+msgid "Unload"
+msgstr "Rozladuj"
+
+# 
+#: ultralcd.cpp:1820
+msgid "Total failures"
+msgstr "Suma bledow"
+
+# 
+#: ultralcd.cpp:2324
+msgid "to load filament"
+msgstr "aby zaladow. fil."
+
+# 
+#: ultralcd.cpp:2328
+msgid "to unload filament"
+msgstr "aby rozlad. filament"
+
+# MSG_UNLOAD_FILAMENT c=17
+#: messages.c:97
+msgid "Unload filament"
+msgstr "Rozladowanie fil."
+
+# MSG_UNLOADING_FILAMENT c=20 r=1
+#: messages.c:98
+msgid "Unloading filament"
+msgstr "Rozladowuje filament"
+
+# 
+#: ultralcd.cpp:1773
+msgid "Total"
+msgstr "Suma"
+
+# MSG_USED c=19 r=1
+#: ultralcd.cpp:5908
+msgid "Used during print"
+msgstr "Uzyte podczas druku"
+
+# MSG_MENU_VOLTAGES c=15 r=1
+#: ultralcd.cpp:2254
+msgid "Voltages"
+msgstr "Napiecia"
+
+# 
+#: ultralcd.cpp:2227
+msgid "unknown"
+msgstr "nieznane"
+
+# MSG_USERWAIT
+#: Marlin_main.cpp:5263
+msgid "Wait for user..."
+msgstr "Czekam na uzytkownika..."
+
+# MSG_WAITING_TEMP c=20 r=3
+#: ultralcd.cpp:3458
+msgid "Waiting for nozzle and bed cooling"
+msgstr "Oczekiwanie na wychlodzenie dyszy i stolu"
+
+# MSG_WAITING_TEMP_PINDA c=20 r=3
+#: ultralcd.cpp:3422
+msgid "Waiting for PINDA probe cooling"
+msgstr "Czekam az spadnie temp. sondy PINDA"
+
+# 
+#: ultralcd.cpp:4868
+msgid "Use unload to remove filament 1 if it protrudes outside of the rear MMU tube. Use eject if it is hidden in tube."
+msgstr "Uzyj opcji Rozladuj jesli filament wystaje z tylnej rurki MMU. Uzyj opcji Wysun jesli wciaz jest w srodku."
+
+# MSG_CHANGED_BOTH c=20 r=4
+#: Marlin_main.cpp:1511
+msgid "Warning: both printer type and motherboard type changed."
+msgstr "Ostrzezenie: typ drukarki i plyta glowna ulegly zmianie."
+
+# MSG_CHANGED_MOTHERBOARD c=20 r=4
+#: Marlin_main.cpp:1503
+msgid "Warning: motherboard type changed."
+msgstr "Ostrzezenie: plyta glowna ulegla zmianie."
+
+# MSG_CHANGED_PRINTER c=20 r=4
+#: Marlin_main.cpp:1507
+msgid "Warning: printer type changed."
+msgstr "Ostrzezenie: rodzaj drukarki ulegl zmianie"
+
+# MSG_UNLOAD_SUCCESSFUL c=20 r=2
+#: Marlin_main.cpp:3054
+msgid "Was filament unload successful?"
+msgstr "Rozladowanie fil. ok?"
+
+# MSG_SELFTEST_WIRINGERROR
+#: messages.c:85
+msgid "Wiring error"
+msgstr "Blad polaczenia"
+
+# MSG_WIZARD c=17 r=1
+#: ultralcd.cpp:5747
+msgid "Wizard"
+msgstr "Asystent"
+
+# MSG_XYZ_DETAILS c=19 r=1
+#: ultralcd.cpp:2243
+msgid "XYZ cal. details"
+msgstr "Szczegoly kal. XYZ"
+
+# MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
+#: messages.c:19
+msgid "XYZ calibration failed. Please consult the manual."
+msgstr "Kalibracja XYZ nieudana. Sprawdz przyczyny i rozwiazania w instrukcji."
+
+# MSG_YES
+#: messages.c:104
+msgid "Yes"
+msgstr "Tak"
+
+# MSG_WIZARD_QUIT c=20 r=8
+#: messages.c:103
+msgid "You can always resume the Wizard from Calibration -> Wizard."
+msgstr "Zawsze mozesz uruchomic Asystenta ponownie przez Kalibracja -> Asystent."
+
+# MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
+#: ultralcd.cpp:3922
+msgid "XYZ calibration all right. Skew will be corrected automatically."
+msgstr "Kalibracja XYZ pomyslna. Skos bedzie automatycznie korygowany."
+
+# MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
+#: ultralcd.cpp:3919
+msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
+msgstr "Kalibracja XYZ prawidlowa. Osie X/Y lekko skosne. Dobra robota!"
+
+# 
+#: ultralcd.cpp:5130
+msgid "X-correct:"
+msgstr "Korekcja-X:"
+
+# MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
+#: ultralcd.cpp:3916
+msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
+msgstr "Kalibracja XYZ ok. Osie X/Y sa prostopadle. Gratulacje!"
+
+# MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
+#: ultralcd.cpp:3900
+msgid "XYZ calibration compromised. Front calibration points not reachable."
+msgstr "Kalibr. XYZ niedokladna. Przednie punkty kalibr. nieosiagalne."
+
+# MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
+#: ultralcd.cpp:3903
+msgid "XYZ calibration compromised. Right front calibration point not reachable."
+msgstr "Kalibracja XYZ niedokladna. Prawy przedni punkt nieosiagalny."
+
+# MSG_LOAD_ALL c=17
+#: ultralcd.cpp:6166
+msgid "Load all"
+msgstr "Zalad. wszystkie"
+
+# 
+#: ultralcd.cpp:3882
+msgid "XYZ calibration failed. Bed calibration point was not found."
+msgstr "Kalibracja XYZ nieudana. Nie znaleziono punktow kalibracyjnych."
+
+# 
+#: ultralcd.cpp:3888
+msgid "XYZ calibration failed. Front calibration points not reachable."
+msgstr "Kalibr. XYZ nieudana. Przednie punkty kalibr. nieosiagalne. Nalezy poprawic montaz drukarki."
+
+# 
+#: ultralcd.cpp:3891
+msgid "XYZ calibration failed. Right front calibration point not reachable."
+msgstr "Kalibr. XYZ nieudana. Prawy przedni punkt nieosiagalny. Nalezy poprawic montaz drukarki."
+
+# 
+#: ultralcd.cpp:3016
+msgid "Y distance from min"
+msgstr "Dystans od 0 w osi Y"
+
+# 
+#: ultralcd.cpp:5131
+msgid "Y-correct:"
+msgstr "Korekcja-Y:"
+
+# MSG_OFF
+#: menu.cpp:426
+msgid " [off]"
+msgstr " [wyl]"
+
+# 
+#: messages.c:57
+msgid "Back"
+msgstr "Wstecz"
+
+# 
+#: ultralcd.cpp:5639
+msgid "Checks"
+msgstr "Testy"
+
+# 
+#: ultralcd.cpp:7973
+msgid "False triggering"
+msgstr "Falszywy alarm"
+
+# 
+#: ultralcd.cpp:4030
+msgid "FINDA:"
+msgstr ""
+
+# 
+#: ultralcd.cpp:5545
+msgid "Firmware   [none]"
+msgstr "Firmware   [brak]"
+
+# 
+#: ultralcd.cpp:5551
+msgid "Firmware [strict]"
+msgstr "Firmware [restr.]"
+
+# 
+#: ultralcd.cpp:5548
+msgid "Firmware   [warn]"
+msgstr "Firmware[ostrzez]"
+
+# 
+#: messages.c:87
+msgid "HW Setup"
+msgstr "Ustawienia HW"
+
+# 
+#: ultralcd.cpp:4034
+msgid "IR:"
+msgstr ""
+
+# 
+#: ultralcd.cpp:7046
+msgid "Magnets comp.[N/A]"
+msgstr "Kor. magnesow[N/D]"
+
+# 
+#: ultralcd.cpp:7044
+msgid "Magnets comp.[Off]"
+msgstr "Kor. magnesow[wyl]"
+
+# 
+#: ultralcd.cpp:7043
+msgid "Magnets comp. [On]"
+msgstr "Kor. magnesow [wl]"
+
+# 
+#: ultralcd.cpp:7035
+msgid "Mesh         [3x3]"
+msgstr "Siatka       [3x3]"
+
+# 
+#: ultralcd.cpp:7036
+msgid "Mesh         [7x7]"
+msgstr "Siatka       [7x7]"
+
+# 
+#: ultralcd.cpp:5677
+msgid "Mesh bed leveling"
+msgstr "Poziomowanie stolu"
+
+# 
+#: Marlin_main.cpp:856
+msgid "MK3S firmware detected on MK3 printer"
+msgstr "Wykryto firmware MK3S w drukarce MK3"
+
+# 
+#: ultralcd.cpp:5306
+msgid "MMU Mode [Normal]"
+msgstr "Tryb MMU[Normaln]"
+
+# 
+#: ultralcd.cpp:5307
+msgid "MMU Mode[Stealth]"
+msgstr "Tryb MMU[Stealth]"
+
+# 
+#: ultralcd.cpp:4511
+msgid "Mode change in progress ..."
+msgstr "Trwa zmiana trybu..."
+
+# 
+#: ultralcd.cpp:5506
+msgid "Model      [none]"
+msgstr "Model      [brak]"
+
+# 
+#: ultralcd.cpp:5512
+msgid "Model    [strict]"
+msgstr "Model [restrykc.]"
+
+# 
+#: ultralcd.cpp:5509
+msgid "Model      [warn]"
+msgstr "Model  [ostrzez.]"
+
+# 
+#: ultralcd.cpp:5467
+msgid "Nozzle d.  [0.25]"
+msgstr "Sr. dyszy  [0,25]"
+
+# 
+#: ultralcd.cpp:5470
+msgid "Nozzle d.  [0.40]"
+msgstr "Sr. dyszy  [0,40]"
+
+# 
+#: ultralcd.cpp:5473
+msgid "Nozzle d.  [0.60]"
+msgstr "Sr. dyszy  [0,60]"
+
+# 
+#: ultralcd.cpp:5421
+msgid "Nozzle     [none]"
+msgstr "Dysza      [brak]"
+
+# 
+#: ultralcd.cpp:5427
+msgid "Nozzle   [strict]"
+msgstr "Dysza [restrykc.]"
+
+# 
+#: ultralcd.cpp:5424
+msgid "Nozzle     [warn]"
+msgstr "Dysza  [ostrzez.]"
 
 # 
 #: util.cpp:510
 msgid "G-code sliced for a different level. Continue?"
-msgstr "G-code pociety na innym poziomie. Kontynuowac?"
+msgstr ""
 
 # 
 #: util.cpp:516
@@ -852,895 +1740,20 @@ msgstr "G-code pociety dla nowszego firmware. Kontynuowac?"
 msgid "G-code sliced for a newer firmware. Please update the firmware. Print cancelled."
 msgstr "G-code pociety dla nowszego firmware. Zaktualizuj firmware. Druk anulowany."
 
-# MSG_SELFTEST_HEATERTHERMISTOR
-#: ultralcd.cpp:7801
-msgid "Heater/Thermistor"
-msgstr "Grzalka/Termistor"
-
-# MSG_HEATING
-#: messages.c:46
-msgid "Heating"
-msgstr "Grzanie..."
-
-# MSG_BED_HEATING_SAFETY_DISABLED
-#: Marlin_main.cpp:8411
-msgid "Heating disabled by safety timer."
-msgstr "Grzanie wylaczone przez wyl. czasowy"
-
-# MSG_HEATING_COMPLETE c=20
-#: messages.c:47
-msgid "Heating done."
-msgstr "Grzanie zakonczone"
-
-# MSG_WIZARD_WELCOME c=20 r=7
-#: ultralcd.cpp:4859
-msgid "Hi, I am your Original Prusa i3 printer. Would you like me to guide you through the setup process?"
-msgstr "Czesc, jestem Twoja drukarka Original Prusa i3. Czy potrzebujesz pomocy z ustawieniem?"
-
-# MSG_PRUSA3D_HOWTO
-#: ultralcd.cpp:2100
-msgid "howto.prusa3d.com"
-msgstr "howto.prusa3d.com"
-
 # 
-#: messages.c:87
-msgid "HW Setup"
-msgstr "Ustawienia HW"
-
-# MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ultralcd.cpp:4889
-msgid "I will run xyz calibration now. It will take approx. 12 mins."
-msgstr "Przeprowadze teraz kalibracje XYZ. Zajmie ok. 12 min."
-
-# MSG_WIZARD_Z_CAL c=20 r=8
-#: ultralcd.cpp:4897
-msgid "I will run z calibration now."
-msgstr "Przeprowadze kalibracje Z."
-
-# MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ultralcd.cpp:4962
-msgid "I will start to print line and you will gradually lower the nozzle by rotating the knob, until you reach optimal height. Check the pictures in our handbook in chapter Calibration."
-msgstr "Zaczne drukowac linie. Stopniowo opuszczaj dysze przekrecajac pokretlo, poki nie uzyskasz optymalnej wysokosci. Sprawdz obrazki w naszym Podreczniku w rozdz. Kalibracja"
-
-# MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=60
-#: mesh_bed_calibration.cpp:2481
-msgid "Improving bed calibration point"
-msgstr "Poprawiam precyzje punktu kalibracyjnego"
-
-# MSG_WATCH
-#: messages.c:99
-msgid "Info screen"
-msgstr "Ekran informacyjny"
-
-# MSG_INIT_SDCARD
-#: ultralcd.cpp:5785
-msgid "Init. SD card"
-msgstr "Inicjalizacja karty SD"
-
-# MSG_INSERT_FILAMENT c=20
-#: ultralcd.cpp:2569
-msgid "Insert filament"
-msgstr "Wprowadz filament"
-
-# MSG_FILAMENT_LOADING_T0 c=20 r=4
-#: messages.c:33
-msgid "Insert filament into extruder 1. Click when done."
-msgstr "Wloz filament do ekstrudera 1. Potwierdz naciskajac pokretlo."
-
-# MSG_FILAMENT_LOADING_T1 c=20 r=4
-#: messages.c:34
-msgid "Insert filament into extruder 2. Click when done."
-msgstr "Wloz filament do ekstrudera 2. Potwierdz naciskajac pokretlo."
-
-# MSG_FILAMENT_LOADING_T2 c=20 r=4
-#: messages.c:35
-msgid "Insert filament into extruder 3. Click when done."
-msgstr "Wloz filament do ekstrudera 3. Potwierdz naciskajac pokretlo."
-
-# MSG_FILAMENT_LOADING_T3 c=20 r=4
-#: messages.c:36
-msgid "Insert filament into extruder 4. Click when done."
-msgstr "Wloz filament do ekstrudera 4. Potwierdz naciskajac pokretlo."
-
-# 
-#: ultralcd.cpp:3947
-msgid "IR:"
-msgstr "IR:"
-
-# 
-#: ultralcd.cpp:4922
-msgid "Is filament 1 loaded?"
-msgstr "Filament 1 zaladowany?"
-
-# MSG_WIZARD_FILAMENT_LOADED c=20 r=2
-#: ultralcd.cpp:4925
-msgid "Is filament loaded?"
-msgstr "Filament jest zaladowany?"
-
-# MSG_WIZARD_PLA_FILAMENT c=20 r=2
-#: ultralcd.cpp:4956
-msgid "Is it PLA filament?"
-msgstr "Czy to filament PLA?"
-
-# MSG_PLA_FILAMENT_LOADED c=20 r=2
-#: ultralcd.cpp:4701
-msgid "Is PLA filament loaded?"
-msgstr "Fialment PLA jest zaladowany?"
-
-# MSG_STEEL_SHEET_CHECK c=20 r=2
-#: messages.c:92
-msgid "Is steel sheet on heatbed?"
-msgstr "Czy plyta stal. jest na podgrzew. stole?"
-
-# MSG_FIND_BED_OFFSET_AND_SKEW_ITERATION c=20
-#: mesh_bed_calibration.cpp:2223
-msgid "Iteration "
-msgstr "Iteracja "
-
-# MSG_KILLED
-#: Marlin_main.cpp:7552
-msgid "KILLED. "
-msgstr "PRZERWANE."
-
-# 
-#: ultralcd.cpp:1828
-msgid "Last print"
-msgstr "Ost. wydruk"
-
-# 
-#: ultralcd.cpp:1845
-msgid "Last print failures"
-msgstr "Ostatnie bledy druku"
-
-# 
-#: ultralcd.cpp:2967
-msgid "Left"
-msgstr "Lewa"
-
-# MSG_SELFTEST_EXTRUDER_FAN c=20
-#: messages.c:76
-msgid "Left hotend fan?"
-msgstr "Lewy went hotendu?"
-
-# MSG_BED_CORRECTION_LEFT c=14 r=1
-#: ultralcd.cpp:3215
-msgid "Left side [um]"
-msgstr "Lewo [um]"
-
-# MSG_LEFT c=12 r=1
-#: ultralcd.cpp:2308
-msgid "Left:"
-msgstr "Lewo:"
-
-# 
-#: ultralcd.cpp:5575
-msgid "Lin. correction"
-msgstr "Korekcja lin."
-
-# MSG_BABYSTEP_Z
-#: messages.c:13
-msgid "Live adjust Z"
-msgstr "Ustaw. Live Z"
-
-# MSG_LOAD_ALL c=17
-#: ultralcd.cpp:6059
-msgid "Load all"
-msgstr "Zalad. wszystkie"
-
-# MSG_LOAD_FILAMENT c=17
-#: messages.c:51
-msgid "Load filament"
-msgstr "Ladowanie fil."
-
-# MSG_LOAD_FILAMENT_1 c=17
-#: ultralcd.cpp:5576
-msgid "Load filament 1"
-msgstr "Zaladuj fil. 1"
-
-# MSG_LOAD_FILAMENT_2 c=17
-#: ultralcd.cpp:5577
-msgid "Load filament 2"
-msgstr "Zaladuj fil. 2"
-
-# MSG_LOAD_FILAMENT_3 c=17
-#: ultralcd.cpp:5578
-msgid "Load filament 3"
-msgstr "Zaladuj fil. 3"
-
-# MSG_LOAD_FILAMENT_4 c=17
-#: ultralcd.cpp:5579
-msgid "Load filament 4"
-msgstr "Zaladuj fil. 4"
-
-# MSG_LOAD_FILAMENT_5 c=17
-#: ultralcd.cpp:5582
-msgid "Load filament 5"
-msgstr "Laduj filament 5"
-
-# 
-#: ultralcd.cpp:6714
-msgid "Load to nozzle"
-msgstr "Zaladuj do dyszy"
-
-# MSG_LOADING_COLOR
-#: ultralcd.cpp:2609
-msgid "Loading color"
-msgstr "Czyszcz. koloru"
-
-# MSG_LOADING_FILAMENT c=20
-#: messages.c:52
-msgid "Loading filament"
-msgstr "Laduje filament"
-
-# MSG_LOOSE_PULLEY c=20 r=1
-#: ultralcd.cpp:7855
-msgid "Loose pulley"
-msgstr "Luzne kolo pasowe"
-
-# MSG_M104_INVALID_EXTRUDER
-#: Marlin_main.cpp:7675
-msgid "M104 Invalid extruder "
-msgstr "M104 Nieprawidlowy ekstruder"
-
-# MSG_M105_INVALID_EXTRUDER
-#: Marlin_main.cpp:7678
-msgid "M105 Invalid extruder "
-msgstr "M105 Nieprawidlowy ekstruder"
-
-# MSG_M109_INVALID_EXTRUDER
-#: Marlin_main.cpp:7681
-msgid "M109 Invalid extruder "
-msgstr "M109 Nieprawidlowy ekstruder"
-
-# MSG_M117_V2_CALIBRATION c=25 r=1
-#: messages.c:55
-msgid "M117 First layer cal."
-msgstr "M117 Kal. 1. warstwy"
-
-# MSG_M200_INVALID_EXTRUDER
-#: Marlin_main.cpp:5857
-msgid "M200 Invalid extruder "
-msgstr "M200 Nieprawidlowy ekstruder"
-
-# MSG_M218_INVALID_EXTRUDER
-#: Marlin_main.cpp:7684
-msgid "M218 Invalid extruder "
-msgstr "M218 Nieprawidlowy ekstruder"
-
-# MSG_M221_INVALID_EXTRUDER
-#: Marlin_main.cpp:7687
-msgid "M221 Invalid extruder "
-msgstr "M221 Nieprawidlowy ekstruder"
-
-# 
-#: ultralcd.cpp:6957
-msgid "Magnets comp. [On]"
-msgstr "Kor. magnesow[wl]"
-
-# 
-#: ultralcd.cpp:6960
-msgid "Magnets comp.[N/A]"
-msgstr "Kor. magnesow[nd]"
-
-# 
-#: ultralcd.cpp:6958
-msgid "Magnets comp.[Off]"
-msgstr "Kor. magnesow[wyl]"
-
-# MSG_MAIN
-#: messages.c:56
-msgid "Main"
-msgstr "Menu glowne"
-
-# MSG_MARK_FIL c=20 r=8
-#: ultralcd.cpp:3840
-msgid "Mark filament 100mm from extruder body. Click when done."
-msgstr "Zaznacz filament na wysokosci 100 mm od korpusu ekstrudera i potwierdz naciskajac pokretlo."
-
-# 
-#: ultralcd.cpp:3002
-msgid "Measured skew"
-msgstr "Zmierzony skos"
-
-# MSG_MEASURED_SKEW c=15 r=1
-#: ultralcd.cpp:2335
-msgid "Measured skew:"
-msgstr "Zmierzony skos:"
-
-# MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=60
-#: messages.c:59
-msgid "Measuring reference height of calibration point"
-msgstr "Okreslam wysokosc odniesienia punktu kalibracyjnego"
-
-# 
-#: ultralcd.cpp:6949
-msgid "Mesh         [3x3]"
-msgstr "Siatka [3x3]"
-
-# 
-#: ultralcd.cpp:6950
-msgid "Mesh         [7x7]"
-msgstr "Siatka [7x7]"
-
-# MSG_MESH_BED_LEVELING
-#: ultralcd.cpp:5658
-msgid "Mesh Bed Leveling"
-msgstr "Poziomowanie stolu wg siatki"
-
-# 
-#: ultralcd.cpp:5572
-msgid "Mesh bed leveling"
-msgstr "Poziomowanie wg siatki"
-
-# 
-#: Marlin_main.cpp:881
-msgid "MK3 firmware detected on MK3S printer"
-msgstr "Wykryto firmware MK3 w drukarce MK3S"
-
-# 
-#: Marlin_main.cpp:856
-msgid "MK3S firmware detected on MK3 printer"
-msgstr "Wykryto firmware MK3S w drukarce MK3"
-
-# 
-#: ultralcd.cpp:1845
-msgid "MMU fails"
-msgstr "Bledy MMU"
-
-# 
-#: mmu.cpp:1617
-msgid "MMU load failed     "
-msgstr "Blad ladowania MMU"
-
-# 
-#: ultralcd.cpp:1845
-msgid "MMU load fails"
-msgstr "Bledy ladow. MMU"
-
-# 
-#: ultralcd.cpp:5204
-msgid "MMU Mode [Normal]"
-msgstr "Tryb MMU [Normalny]"
-
-# 
-#: ultralcd.cpp:5205
-msgid "MMU Mode[Stealth]"
-msgstr "Tryb MMU [Stealth]"
-
-# 
-#: mmu.cpp:719
-msgid "MMU needs user attention."
-msgstr "MMU wymaga uwagi uzytkownika."
-
-# MSG_MMU_NEEDS_ATTENTION c=20 r=4
-#: mmu.cpp:359
-msgid "MMU needs user attention. Fix the issue and then press button on MMU unit."
-msgstr "MMU wymaga uwagi. Napraw usterke i wcisnij przycisk na korpusie MMU."
-
-# MSG_MMU_OK_RESUMING_POSITION c=20 r=4
-#: mmu.cpp:762
-msgid "MMU OK. Resuming position..."
-msgstr "MMU OK. Wznawianie pozycji."
-
-# MSG_MMU_OK_RESUMING_TEMPERATURE c=20 r=4
-#: mmu.cpp:755
-msgid "MMU OK. Resuming temperature..."
-msgstr "MMU OK. Wznawiam nagrzewanie..."
-
-# MSG_MMU_OK_RESUMING c=20 r=4
-#: mmu.cpp:773
-msgid "MMU OK. Resuming..."
-msgstr "MMU OK. Wznawianie..."
-
-# 
-#: ultralcd.cpp:1862
-msgid "MMU power fails"
-msgstr "Zaniki zasil. MMU"
-
-# 
-#: ultralcd.cpp:2112
-msgid "MMU2 connected"
-msgstr "MMU podlaczone"
-
-# MSG_STEALTH_MODE_OFF
-#: messages.c:90
-msgid "Mode     [Normal]"
-msgstr "Tryb   [normalny]"
-
-# MSG_SILENT_MODE_ON
-#: messages.c:89
-msgid "Mode     [silent]"
-msgstr "Tryb      [cichy]"
-
-# MSG_STEALTH_MODE_ON
-#: messages.c:91
-msgid "Mode    [Stealth]"
-msgstr "Tryb    [Stealth]"
-
-# 
-#: ultralcd.cpp:4424
-msgid "Mode change in progress ..."
-msgstr "Trwa zmiana trybu..."
-
-# MSG_AUTO_MODE_ON
-#: messages.c:12
-msgid "Mode [auto power]"
-msgstr "Tryb [automatycz]"
-
-# MSG_SILENT_MODE_OFF
-#: messages.c:88
-msgid "Mode [high power]"
-msgstr "Tryb[wysoka wyd.]"
-
-# 
-#: ultralcd.cpp:5404
-msgid "Model      [none]"
-msgstr "Model [brak]"
-
-# 
-#: ultralcd.cpp:5407
-msgid "Model      [warn]"
-msgstr "Model [ostrzez.]"
-
-# 
-#: ultralcd.cpp:5410
-msgid "Model    [strict]"
-msgstr "Model [restrykc.]"
-
-# MSG_SELFTEST_MOTOR
-#: messages.c:83
-msgid "Motor"
-msgstr "Silnik"
-
-# MSG_MOVE_AXIS
-#: ultralcd.cpp:5550
-msgid "Move axis"
-msgstr "Ruch osi"
-
-# MSG_MOVE_X
-#: ultralcd.cpp:4291
-msgid "Move X"
-msgstr "Ruch osi X"
-
-# MSG_MOVE_Y
-#: ultralcd.cpp:4292
-msgid "Move Y"
-msgstr "Ruch osi Y"
-
-# MSG_MOVE_Z
-#: ultralcd.cpp:4293
-msgid "Move Z"
-msgstr "Ruch osi Z"
-
-# 
-#: ultralcd.cpp:2973
-msgid "N/A"
-msgstr "N/D"
-
-# 
-#: util.cpp:293
-msgid "New firmware version available:"
-msgstr "Dostepna nowa wersja firmware:"
-
-# MSG_NO
-#: messages.c:62
-msgid "No"
-msgstr "Nie"
-
-# 
-#:
-msgid "No "
-msgstr "Nie"
-
-# MSG_ERR_NO_CHECKSUM
-#: cmdqueue.cpp:456
-msgid "No Checksum with line number, Last Line: "
-msgstr "Brak sumy kontrolnej z numerem linii, ostatnia linia:"
-
-# MSG_NO_MOVE
-#: Marlin_main.cpp:5254
-msgid "No move."
-msgstr "Brak ruchu."
-
-# MSG_NO_CARD
-#: ultralcd.cpp:6694
-msgid "No SD card"
-msgstr "Brak karty SD"
-
-# MSG_ERR_NO_THERMISTORS
-#: Marlin_main.cpp:4946
-msgid "No thermistors - no temperature"
-msgstr "Brak termistorow - brak odczytu temperatury"
-
-# MSG_SELFTEST_NOTCONNECTED
-#: ultralcd.cpp:7803
-msgid "Not connected"
-msgstr "Nie podlaczono "
-
-# MSG_SELFTEST_FAN_NO c=19
-#: messages.c:79
-msgid "Not spinning"
-msgstr "Nie kreci sie"
-
-# MSG_WIZARD_V2_CAL c=20 r=8
-#: ultralcd.cpp:4961
-msgid "Now I will calibrate distance between tip of the nozzle and heatbed surface."
-msgstr "Kalibruje odleglosc miedzy koncowka dyszy a powierzchnia druku."
-
-# MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ultralcd.cpp:4905
-msgid "Now I will preheat nozzle for PLA."
-msgstr "Nagrzewam dysze dla PLA."
-
-# 
-#: ultralcd.cpp:4896
-msgid "Now remove the test print from steel sheet."
-msgstr "Teraz zdejmij wydruk testowy ze stolu."
-
-# MSG_NOZZLE
-#: messages.c:63
-msgid "Nozzle"
-msgstr "Dysza"
-
-# 
-#: ultralcd.cpp:5319
-msgid "Nozzle     [none]"
-msgstr "Dysza [brak]"
-
-# 
-#: ultralcd.cpp:5322
-msgid "Nozzle     [warn]"
-msgstr "Dysza [ostrzez.]"
-
-# 
-#: ultralcd.cpp:5325
-msgid "Nozzle   [strict]"
-msgstr "Dysza [restrykc.]"
-
-# 
-#: ultralcd.cpp:5365
-msgid "Nozzle d.  [0.25]"
-msgstr "Sr. dyszy [0,25]"
-
-# 
-#: ultralcd.cpp:5368
-msgid "Nozzle d.  [0.40]"
-msgstr "Sr. dyszy [0,40]"
-
-# 
-#: ultralcd.cpp:5371
-msgid "Nozzle d.  [0.60]"
-msgstr "Sr. dyszy [0,60]"
-
-# 
-#: ultralcd.cpp:1787
-msgid "Nozzle FAN"
-msgstr "Went. hotendu"
-
-# MSG_INFO_NOZZLE_FAN c=11 r=1
-#: ultralcd.cpp:1537
-msgid "Nozzle FAN:"
-msgstr "Went. dyszy:"
-
-# MSG_NOZZLE1
-#: ultralcd.cpp:5995
-msgid "Nozzle2"
-msgstr "Dysza2"
-
-# MSG_NOZZLE2
-#: ultralcd.cpp:5998
-msgid "Nozzle3"
-msgstr "Dysza3"
-
-# MSG_OK
-#: Marlin_main.cpp:6333
-msgid "ok"
-msgstr "ok"
-
-# MSG_DEFAULT_SETTINGS_LOADED c=20 r=4
-#: Marlin_main.cpp:1535
-msgid "Old settings found. Default PID, Esteps etc. will be set."
-msgstr "Znaleziono stare ustawienia. Zostana przywrocone domyslne ust. PID, Esteps, itp."
-
-# MSG_ENDSTOP_OPEN
-#: messages.c:29
-msgid "open"
-msgstr "otworz"
-
-# MSG_SD_OPEN_FILE_FAIL
-#: messages.c:79
-msgid "open failed, File: "
-msgstr "niepowodzenie otwarcia, Plik:"
-
-# MSG_SD_OPENROOT_FAIL
-#: cardreader.cpp:196
-msgid "openRoot failed"
-msgstr "niepowodzenie openRoot "
-
-# MSG_PAUSE_PRINT
-#: ultralcd.cpp:6657
-msgid "Pause print"
-msgstr "Wstrzymanie wydruku"
-
-# MSG_PICK_Z
-#: ultralcd.cpp:3463
-msgid "Pick print"
-msgstr "Wybierz wydruk"
-
-# MSG_PID_RUNNING c=20 r=1
-#: ultralcd.cpp:1613
-msgid "PID cal.           "
-msgstr "Kalibracja PID"
-
-# MSG_PID_FINISHED c=20 r=1
-#: ultralcd.cpp:1619
-msgid "PID cal. finished"
-msgstr "Kal. PID zakonczona"
-
-# MSG_PID_EXTRUDER c=17 r=1
-#: ultralcd.cpp:5664
-msgid "PID calibration"
-msgstr "Kalibracja PID"
-
-# MSG_PINDA_PREHEAT c=20 r=1
-#: ultralcd.cpp:862
-msgid "PINDA Heating"
-msgstr "Grzanie sondy PINDA"
-
-# 
-#: ultralcd.cpp:3939
+#: ultralcd.cpp:4026
 msgid "PINDA:"
-msgstr "PINDA:"
-
-# MSG_PAPER c=20 r=8
-#: messages.c:64
-msgid "Place a sheet of paper under the nozzle during the calibration of first 4 points. If the nozzle catches the paper, power off the printer immediately."
-msgstr "Umiesc kartke papieru na stole roboczym i podczas pomiaru pierwszych 4 punktow. Jesli dysza zahaczy o papier, natychmiast wylacz drukarke."
-
-# MSG_SELFTEST_PLEASECHECK
-#: ultralcd.cpp:7795
-msgid "Please check :"
-msgstr "Sprawdz :"
-
-# MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: messages.c:100
-msgid "Please check our handbook and fix the problem. Then resume the Wizard by rebooting the printer."
-msgstr "Przeczytaj nasz Podrecznik druku 3D aby naprawic problem. Potem wznow Asystenta przez restart drukarki."
-
-# MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ultralcd.cpp:4970
-msgid "Please clean heatbed and then press the knob."
-msgstr "Oczysc powierzchnie druku i nacisnij pokretlo."
-
-# MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: messages.c:22
-msgid "Please clean the nozzle for calibration. Click when done."
-msgstr "Dla prawidl. kalibracji nalezy oczyscic dysze. Potw. guzikiem."
-
-# MSG_WIZARD_LOAD_FILAMENT c=20 r=8
-#: ultralcd.cpp:4804
-msgid "Please insert PLA filament to the extruder, then press knob to load it."
-msgstr "Umiesc filament PLA w ekstruderze i nacisnij pokretlo, aby zaladowac."
+msgstr ""
 
 # 
-#: ultralcd.cpp:4800
-msgid "Please insert PLA filament to the first tube of MMU, then press the knob to load it."
-msgstr "Wsun filament PLA do pierwszej rurki MMU i nacisnij pokretlo aby go zaladowac."
-
-# MSG_WIZARD_INSERT_CORRECT_FILAMENT c=20 r=8
-#: ultralcd.cpp:4109
-msgid "Please load PLA filament and then resume Wizard by rebooting the printer."
-msgstr "Zaladuj filament PLA i przywroc Asystenta przez restart drukarki."
-
-# MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ultralcd.cpp:4706
-msgid "Please load PLA filament first."
-msgstr "Najpierw zaladuj filament PLA."
-
-# MSG_CHECK_IDLER c=20 r=4
-#: Marlin_main.cpp:3083
-msgid "Please open idler and remove filament manually."
-msgstr "Prosze odciagnac dzwignie dociskowa ekstrudera i recznie usunac filament."
-
-# MSG_PLACE_STEEL_SHEET c=20 r=4
-#: messages.c:65
-msgid "Please place steel sheet on heatbed."
-msgstr "Prosze umiescic plyte stalowa na stole podgrzewanym."
-
-# MSG_PRESS_TO_UNLOAD c=20 r=4
-#: messages.c:68
-msgid "Please press the knob to unload filament"
-msgstr "Nacisnij pokretlo aby rozladowac filament"
-
-# MSG_PULL_OUT_FILAMENT c=20 r=4
-#: messages.c:70
-msgid "Please pull out filament immediately"
-msgstr "Wyciagnij filament teraz"
-
-# MSG_EJECT_REMOVE c=20 r=4
-#: mmu.cpp:1441
-msgid "Please remove filament and then press the knob."
-msgstr "Wyciagnij filament i wcisnij pokretlo."
-
-# 
-#: ultralcd.cpp:4895
-msgid "Please remove shipping helpers first."
-msgstr "Najpierw usun zabezpieczenia transportowe"
-
-# MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: messages.c:74
-msgid "Please remove steel sheet from heatbed."
-msgstr "Prosze zdjac plyte stalowa z podgrzewanego stolu."
-
-# MSG_RUN_XYZ c=20 r=4
-#: Marlin_main.cpp:4317
-msgid "Please run XYZ calibration first."
-msgstr "Prosze najpierw uruchomic kalibracje XYZ"
-
-# MSG_UPDATE_MMU2_FW c=20 r=4
-#: mmu.cpp:1360
-msgid "Please update firmware in your MMU2. Waiting for reset."
-msgstr "Prosze zaktualizowac Firmware MMU2. Czekam na reset."
-
-# 
-#: util.cpp:297
-msgid "Please upgrade."
-msgstr "Prosze zaktualizowac."
-
-# MSG_PLEASE_WAIT c=20
-#: messages.c:66
-msgid "Please wait"
-msgstr "Prosze czekac"
-
-# 
-#: ultralcd.cpp:1881
-msgid "Power failures"
-msgstr "Zaniki zasilania"
-
-# MSG_POWERUP
-#: messages.c:69
-msgid "PowerUp"
-msgstr "Uruchamianie"
-
-# MSG_PREHEAT
-#: ultralcd.cpp:6644
-msgid "Preheat"
-msgstr "Grzanie"
-
-# MSG_PREHEAT_NOZZLE c=20
-#: messages.c:67
-msgid "Preheat the nozzle!"
-msgstr "Nagrzej dysze!"
-
-# MSG_WIZARD_HEATING c=20 r=3
-#: messages.c:102
-msgid "Preheating nozzle. Please wait."
-msgstr "Nagrzewanie dyszy. Prosze czekac."
-
-# 
-#: ultralcd.cpp:2290
+#: ultralcd.cpp:2465
 msgid "Preheating to cut"
 msgstr "Nagrzewanie do obciecia"
 
 # 
-#: ultralcd.cpp:2287
+#: ultralcd.cpp:2462
 msgid "Preheating to eject"
 msgstr "Nagrzewanie do wysuniecia"
-
-# 
-#: ultralcd.cpp:2280
-msgid "Preheating to load"
-msgstr "Nagrzew. do ladowania"
-
-# 
-#: ultralcd.cpp:2284
-msgid "Preheating to unload"
-msgstr "Nagrzew. do rozlad."
-
-# MSG_PREPARE_FILAMENT c=20 r=1
-#: ultralcd.cpp:1911
-msgid "Prepare new filament"
-msgstr "Przygotuj filament"
-
-# MSG_PRESS_TO_PREHEAT c=20 r=4
-#: Marlin_main.cpp:10312
-msgid "Press knob to preheat nozzle and continue."
-msgstr "Wcisnij pokretlo aby rozgrzac dysze i kontynuowac."
-
-# 
-#: ultralcd.cpp:2210
-msgid "Press the knob"
-msgstr "Wcisnij pokretlo"
-
-# 
-#: mmu.cpp:723
-msgid "Press the knob to resume nozzle temperature."
-msgstr "Wcisnij pokretlo aby wznowic podgrzewanie dyszy."
-
-# MSG_PRINT_ABORTED c=20
-#: messages.c:69
-msgid "Print aborted"
-msgstr "Druk przerwany"
-
-# 
-#: ultralcd.cpp:1789
-msgid "Print FAN"
-msgstr "Went. wydruku"
-
-# MSG_INFO_PRINT_FAN c=11 r=1
-#: ultralcd.cpp:1549
-msgid "Print FAN: "
-msgstr "Went. wydr:"
-
-# MSG_SELFTEST_PRINT_FAN_SPEED c=18
-#: ultralcd.cpp:8221
-msgid "Print fan:"
-msgstr "Went. wydruku:"
-
-# MSG_CARD_MENU
-#: messages.c:21
-msgid "Print from SD"
-msgstr "Druk z karty SD"
-
-# MSG_PRINT_PAUSED c=20 r=1
-#: ultralcd.cpp:1080
-msgid "Print paused"
-msgstr "Druk wstrzymany"
-
-# MSG_PRINT_TIME c=19 r=1
-#: ultralcd.cpp:2838
-msgid "Print time"
-msgstr "Czas druku"
-
-# MSG_STATS_PRINTTIME c=20
-#: ultralcd.cpp:2151
-msgid "Print time:  "
-msgstr "Czas druku: "
-
-# MSG_PRINTER_DISCONNECTED c=20 r=1
-#: ultralcd.cpp:607
-msgid "Printer disconnected"
-msgstr "Drukarka rozlaczona"
-
-# 
-#: util.cpp:473
-msgid "Printer FW version differs from the G-code. Continue?"
-msgstr "Wersja FW drukarki rozni sie w G-code. Kontynuowac?"
-
-# 
-#: util.cpp:480
-msgid "Printer FW version differs from the G-code. Please check the value in settings. Print cancelled."
-msgstr "FW drukarki rozni sie od tego w G-code. Sprawdz ustawienia. Druk anulowany."
-
-# 
-#: util.cpp:506
-msgid "Printer G-code level differs from the G-code. Continue?"
-msgstr "Poziom G-code drukarki rozni sie od pliku G-code. Kontynuowac?"
-
-# 
-#: util.cpp:513
-msgid "Printer G-code level differs from the G-code. Please check the value in settings. Print cancelled."
-msgstr "Poziom G-code drukarki rozni sie od pliku G-code. Sprawdz ustawienia. Druk anulowany"
-
-# MSG_ERR_KILLED
-#: Marlin_main.cpp:7547
-msgid "Printer halted. kill() called!"
-msgstr "Drukarka zatrzymana. Wywolano komende kill()!"
-
-# MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: messages.c:41
-msgid "Printer has not been calibrated yet. Please follow the manual, chapter First steps, section Calibration flow."
-msgstr "Drukarka nie zostala jeszcze skalibrowana. Kieruj sie Samouczkiem: rozdzial Pierwsze Kroki, sekcja Konfiguracja przed drukowaniem."
-
-# 
-#: util.cpp:423
-msgid "Printer model differs from the G-code. Continue?"
-msgstr "Model drukarki rozni sie od tego w G-code. Kontynuowac?"
-
-# 
-#: util.cpp:430
-msgid "Printer model differs from the G-code. Please check the value in settings. Print cancelled."
-msgstr "Model drukarki rozni sie od tego w G-code. Sprawdz ustawienia. Druk anulowany."
 
 # 
 #: util.cpp:390
@@ -1752,807 +1765,48 @@ msgstr "Srednica dyszy drukarki rozni sie od tej w G-code. Kontynuowac?"
 msgid "Printer nozzle diameter differs from the G-code. Please check the value in settings. Print cancelled."
 msgstr "Srednica dyszy rozni sie od tej w G-code. Sprawdz ustawienia. Druk anulowany."
 
-# MSG_ERR_STOPPED
-#: messages.c:32
-msgid "Printer stopped due to errors. Fix the error and use M999 to restart. (Temperature is reset. Set it after restarting)"
-msgstr "Drukarka zatrzymana z powodu bledow. Usun problem i uzyj M999 aby zrestartowac. (Temperatura jest zresetowana, ustaw ja po restarcie)"
-
 # 
-#:
-msgid "Prusa i3 MK2 ready."
-msgstr "Prusa i3 MK2 gotowa"
-
-# WELCOME_MSG c=20
-#:
-msgid "Prusa i3 MK2.5 ready."
-msgstr "Prusa i3 MK2.5 gotowa"
-
-# 
-#:
-msgid "Prusa i3 MK3 OK."
-msgstr "Prusa i3 MK3 OK"
-
-# WELCOME_MSG c=20
-#:
-msgid "Prusa i3 MK3 ready."
-msgstr "Prusa i3 MK3 gotowa"
-
-# 
-#:
-msgid "Prusa i3 MK3S OK."
-msgstr "Prusa i3 MK3S OK"
-
-# MSG_PRUSA3D
-#: ultralcd.cpp:2098
-msgid "prusa3d.com"
-msgstr "prusa3d.com"
-
-# MSG_BED_CORRECTION_REAR c=14 r=1
-#: ultralcd.cpp:3218
-msgid "Rear side [um]"
-msgstr "Tyl [um]"
-
-# MSG_RECOVERING_PRINT c=20 r=1
-#: Marlin_main.cpp:9712
-msgid "Recovering print    "
-msgstr "Wznawianie wydruku"
-
-# MSG_REFRESH
-#:
-msgid "Refresh"
-msgstr "Odswiez"
-
-# MSG_REMOVE_OLD_FILAMENT c=20 r=4
-#: mmu.cpp:830
-msgid "Remove old filament and press the knob to start loading new filament."
-msgstr "Wyciagnij poprzedni filament i nacisnij pokretlo aby zaladowac nowy."
-
-# 
-#: ultralcd.cpp:6605
+#: ultralcd.cpp:6683
 msgid "Rename"
 msgstr "Zmien nazwe"
 
-# MSG_M119_REPORT
-#: Marlin_main.cpp:5297
-msgid "Reporting endstop status"
-msgstr "Raportowanie statusu krancowek"
-
 # 
-#: Marlin_main.cpp:7076
-msgid "Resend"
-msgstr "Wyslij ponownie"
-
-# MSG_RESEND
-#: Marlin_main.cpp:6911
-msgid "Resend: "
-msgstr "Wyslij ponownie:"
-
-# MSG_BED_CORRECTION_RESET
-#: ultralcd.cpp:3219
-msgid "Reset"
-msgstr "Reset"
-
-# MSG_CALIBRATE_BED_RESET
-#: ultralcd.cpp:5669
-msgid "Reset XYZ calibr."
-msgstr "Reset kalibr. XYZ"
-
-# MSG_RESUME_PRINT
-#: ultralcd.cpp:6664
-msgid "Resume print"
-msgstr "Wznowic wydruk"
-
-# MSG_RESUMING_PRINT c=20 r=1
-#: messages.c:73
-msgid "Resuming print"
-msgstr "Wznawianie druku"
-
-# 
-#: ultralcd.cpp:2968
-msgid "Right"
-msgstr "Prawa"
-
-# MSG_BED_CORRECTION_RIGHT c=14 r=1
-#: ultralcd.cpp:3216
-msgid "Right side[um]"
-msgstr "Prawo [um]"
-
-# MSG_RIGHT c=12 r=1
-#: ultralcd.cpp:2309
-msgid "Right:"
-msgstr "Prawo:"
-
-# MSG_E_CAL_KNOB c=20 r=8
-#: ultralcd.cpp:3835
-msgid "Rotate knob until mark reaches extruder body. Click when done."
-msgstr "Obracaj pokretlo az znacznik zrowna sie z korpusem ekstrudera i potwierdz naciskajac pokretlo."
-
-# MSG_SECOND_SERIAL_ON c=17 r=1
-#: ultralcd.cpp:5587
-msgid "RPi port     [on]"
-msgstr "Port RPi     [wl]"
-
-# MSG_SECOND_SERIAL_OFF c=17 r=1
-#: ultralcd.cpp:5585
-msgid "RPi port    [off]"
-msgstr "Port RPi    [wyl]"
-
-# MSG_WIZARD_RERUN c=20 r=7
-#: ultralcd.cpp:4723
-msgid "Running Wizard will delete current calibration results and start from the beginning. Continue?"
-msgstr "Wlaczenie Asystenta usunie obecne dane kalibracyjne i zacznie od poczatku. Kontynuowac?"
-
-# MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_OFF c=19 r=1
-#: ultralcd.cpp:5220
-msgid "SD card  [normal]"
-msgstr "Karta SD [normal]"
-
-# MSG_SD_CARD_OK
-#: cardreader.cpp:202
-msgid "SD card ok"
-msgstr "Karta SD OK"
-
-# MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_ON c=19 r=1
-#: ultralcd.cpp:4238
-msgid "SD card [FlshAir]"
-msgstr "Karta SD [FlashAir]"
-
-# MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_ON c=19 r=1
-#: ultralcd.cpp:5218
-msgid "SD card [flshAir]"
-msgstr "Karta SD[FlshAir]"
-
-# MSG_SD_INIT_FAIL
-#: cardreader.cpp:186
-msgid "SD init fail"
-msgstr "Inicjalizacja karty SD nieudana"
-
-# MSG_SD_PRINTING_BYTE
-#: cardreader.cpp:516
-msgid "SD printing byte "
-msgstr "SD printing byte "
-
-# MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=60
-#: messages.c:38
-msgid "Searching bed calibration point"
-msgstr "Szukam punktu kalibracyjnego na stole"
-
-# 
-#: ultralcd.cpp:6601
+#: ultralcd.cpp:6679
 msgid "Select"
 msgstr "Wybierz"
 
-# MSG_LANGUAGE_SELECT
-#: ultralcd.cpp:5594
-msgid "Select language"
-msgstr "Wybor jezyka"
-
 # 
-#: ultralcd.cpp:4943
-msgid "Select nozzle preheat temperature which matches your material."
-msgstr "Wybierz temperature grzania dyszy odpowiednia dla materialu."
-
-# 
-#: ultralcd.cpp:4692
-msgid "Select PLA filament:"
-msgstr "Wybierz filament PLA:"
-
-# MSG_SELFTEST_OK
-#: ultralcd.cpp:7366
-msgid "Self test OK"
-msgstr "Selftest OK"
-
-# MSG_SELFTEST_START c=20
-#: ultralcd.cpp:7152
-msgid "Self test start  "
-msgstr "Rozpoczynanie Selftestu"
-
-# MSG_SELFTEST
-#: ultralcd.cpp:5645
-msgid "Selftest         "
-msgstr "Selftest "
-
-# MSG_SELFTEST_ERROR
-#: ultralcd.cpp:7793
-msgid "Selftest error !"
-msgstr "Blad selftest !"
-
-# MSG_SELFTEST_FAILED c=20
-#: messages.c:77
-msgid "Selftest failed  "
-msgstr "Selftest nieudany"
-
-# MSG_FORCE_SELFTEST c=20 r=8
-#: Marlin_main.cpp:1567
-msgid "Selftest will be run to calibrate accurate sensorless rehoming."
-msgstr "Zostanie uruchomiony Selftest aby dokladnie skalibrowac punkt bazowy bez krancowek"
-
-# 
-#: ultralcd.cpp:2138
+#: ultralcd.cpp:2245
 msgid "Sensor info"
 msgstr "Info o sensorach"
-
-# 
-#: ultralcd.cpp:3938
-msgid "Sensor state"
-msgstr "Stan czujnikow"
-
-# 
-#:
-msgid "Sensors info"
-msgstr "Info o czujnikach"
-
-# MSG_SET_TEMPERATURE c=19 r=1
-#: ultralcd.cpp:3227
-msgid "Set temperature:"
-msgstr "Ustaw. temperatury:"
-
-# MSG_SETTINGS
-#: messages.c:86
-msgid "Settings"
-msgstr "Ustawienia"
-
-# 
-#: ultralcd.cpp:3005
-msgid "Severe skew"
-msgstr "Znaczny skos"
-
-# MSG_SEVERE_SKEW c=15 r=1
-#: ultralcd.cpp:2346
-msgid "Severe skew:"
-msgstr "Powazny skos:"
 
 # 
 #: messages.c:58
 msgid "Sheet"
 msgstr "Plyta"
 
-# MSG_SHOW_END_STOPS c=17 r=1
-#: ultralcd.cpp:5666
-msgid "Show end stops"
-msgstr "Pokaz krancowki"
-
-# 
-#:
-msgid "Show pinda state"
-msgstr "Stan sondy PINDA"
-
-# MSG_DWELL
-#: Marlin_main.cpp:3752
-msgid "Sleep..."
-msgstr "Czuwanie..."
-
-# 
-#: ultralcd.cpp:3004
-msgid "Slight skew"
-msgstr "Lekki skos"
-
-# MSG_SLIGHT_SKEW c=15 r=1
-#: ultralcd.cpp:2342
-msgid "Slight skew:"
-msgstr "Lekki skos:"
-
-# MSG_FILE_CNT c=20 r=4
-#: cardreader.cpp:739
-msgid "Some files will not be sorted. Max. No. of files in 1 folder for sorting is 100."
-msgstr "Niektore pliki nie zostana posortowane. Max. liczba plikow w 1 folderze = 100."
-
-# 
-#: Marlin_main.cpp:4833
-msgid "Some problem encountered, Z-leveling enforced ..."
-msgstr "Wykryto problem, wymuszono poziomowanie osi Z ..."
-
-# MSG_SORT_NONE c=17 r=1
-#: ultralcd.cpp:5230
-msgid "Sort       [none]"
-msgstr "Sortowanie [brak]"
-
-# MSG_SORT_TIME c=17 r=1
-#: ultralcd.cpp:5228
-msgid "Sort       [time]"
-msgstr "Sortowanie [czas]"
-
-# MSG_SORT_ALPHA c=17 r=1
-#: ultralcd.cpp:5229
-msgid "Sort   [alphabet]"
-msgstr "Sort. [alfabet]"
-
-# MSG_SORT_NONE c=17 r=1
-#: ultralcd.cpp:4250
-msgid "Sort:      [None]"
-msgstr "Sortuj: [brak]"
-
-# MSG_SORT_NONE c=17 r=1
-#: ultralcd.cpp:5043
-msgid "Sort:      [none]"
-msgstr "Sortuj:    [brak]"
-
-# MSG_SORT_TIME c=17 r=1
-#: ultralcd.cpp:4248
-msgid "Sort:      [Time]"
-msgstr "Sortuj: [czas]"
-
-# MSG_SORT_TIME c=17 r=1
-#: ultralcd.cpp:5041
-msgid "Sort:      [time]"
-msgstr "Sortuj:    [czas]"
-
-# MSG_SORT_ALPHA c=17 r=1
-#: ultralcd.cpp:4249
-msgid "Sort:  [Alphabet]"
-msgstr "Sortuj:[alfabet]"
-
-# MSG_SORT_ALPHA c=17 r=1
-#: ultralcd.cpp:5042
-msgid "Sort:  [alphabet]"
-msgstr "Sortuj: [alfabet]"
-
-# MSG_SORT_NONE c=17 r=1
-#:
-msgid "Sort:  [none]"
-msgstr "Sortuj: [brak]"
-
-# MSG_SORT_TIME c=17 r=1
-#:
-msgid "Sort:  [time]"
-msgstr "Sortuj: [czas]"
-
-# MSG_SORTING c=20 r=1
-#: cardreader.cpp:746
-msgid "Sorting files"
-msgstr "Sortowanie plikow"
-
-# MSG_SOUND_LOUD c=17 r=1
-#: sound.h:6
-msgid "Sound      [loud]"
-msgstr "Dzwiek   [Glosny]"
-
-# MSG_SOUND_MUTE c=17 r=1
-#:
-msgid "Sound      [mute]"
-msgstr "Dzwiek[Wylaczony]"
-
-# MSG_SOUND_ONCE c=17 r=1
-#: sound.h:7
-msgid "Sound      [once]"
-msgstr "Dzwiek    [1-raz]"
-
-# 
-#:
-msgid "Sound     [assist]"
-msgstr "Dzwiek [asyst.]"
-
 # 
 #: sound.h:9
-msgid "Sound     [blind]"
-msgstr "Dzwiek[niewidomy]"
-
-# MSG_SOUND_SILENT c=17 r=1
-#: sound.h:8
-msgid "Sound    [silent]"
-msgstr "Dzwiek    [Cichy]"
-
-# MSG_SPEED
-#: ultralcd.cpp:6840
-msgid "Speed"
-msgstr "Predkosc"
-
-# MSG_SELFTEST_FAN_YES c=19
-#: messages.c:80
-msgid "Spinning"
-msgstr "Kreci sie"
-
-# MSG_AUTO_DEPLETE_ON c=17 r=1
-#: ultralcd.cpp:5098
-msgid "SpoolJoin    [on]"
-msgstr "SpoolJoin    [wl]"
+msgid "Sound    [assist]"
+msgstr "Dzwiek   [asyst.]"
 
 # 
-#: ultralcd.cpp:5094
-msgid "SpoolJoin   [N/A]"
-msgstr "SpoolJoin    [nd]"
-
-# MSG_AUTO_DEPLETE_OFF c=17 r=1
-#: ultralcd.cpp:5102
-msgid "SpoolJoin   [off]"
-msgstr "SpoolJoin   [wyl]"
-
-# MSG_TEMP_CAL_WARNING c=20 r=4
-#: Marlin_main.cpp:4330
-msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
-msgstr "Potrzebna jest stabilna temperatura otoczenia 21-26C i stabilne podloze."
-
-# MSG_STATISTICS
-#: ultralcd.cpp:6753
-msgid "Statistics  "
-msgstr "Statystyki"
-
-# 
-#: ultralcd.cpp:5551
+#: ultralcd.cpp:5637
 msgid "Steel sheets"
 msgstr "Plyty stalowe"
 
-# MSG_STEPPER_TOO_HIGH
-#: stepper.cpp:345
-msgid "Steprate too high: "
-msgstr "Liczba krokow zbyt wysoka:"
-
-# MSG_STOP_PRINT
-#: messages.c:93
-msgid "Stop print"
-msgstr "Przerwanie druku"
-
-# MSG_STOPPED
-#: messages.c:94
-msgid "STOPPED. "
-msgstr "ZATRZYMANO."
-
-# MSG_SUPPORT
-#: ultralcd.cpp:6762
-msgid "Support"
-msgstr "Wsparcie"
-
-# MSG_SELFTEST_SWAPPED
-#: ultralcd.cpp:7873
-msgid "Swapped"
-msgstr "Zamieniono"
-
-# MSG_TEMP_CALIBRATION c=20 r=1
-#: messages.c:95
-msgid "Temp. cal.          "
-msgstr "Kalibracja temp."
-
-# MSG_TEMP_CALIBRATION_ON c=20 r=1
-#: ultralcd.cpp:5581
-msgid "Temp. cal.   [on]"
-msgstr "Kalibr. temp.[wl]"
-
-# MSG_TEMP_CALIBRATION_OFF c=20 r=1
-#: ultralcd.cpp:5579
-msgid "Temp. cal.  [off]"
-msgstr "Kalibr.temp.[wyl]"
-
-# MSG_CALIBRATION_PINDA_MENU c=17 r=1
-#: ultralcd.cpp:5675
-msgid "Temp. calibration"
-msgstr "Kalibracja temp."
-
-# MSG_TEMPERATURE
-#: ultralcd.cpp:5548
-msgid "Temperature"
-msgstr "Temperatura"
-
-# MSG_TEMP_CAL_FAILED c=20 r=8
-#: ultralcd.cpp:3864
-msgid "Temperature calibration failed"
-msgstr "Kalibracja temperaturowa nieudana"
-
-# MSG_PINDA_NOT_CALIBRATED c=20 r=4
-#: Marlin_main.cpp:1403
-msgid "Temperature calibration has not been run yet"
-msgstr "Kalibracja temperaturowa nie zostala jeszcze przeprowadzona"
-
-# MSG_TEMP_CALIBRATION_DONE c=20 r=12
-#: messages.c:96
-msgid "Temperature calibration is finished and active. Temp. calibration can be disabled in menu Settings->Temp. cal."
-msgstr "Kalibracja temperaturowa zakonczona i wlaczona. Moze byc wylaczona z menu Ustawienia -> Kalibracja temp."
-
-# MSG_MENU_TEMPERATURES c=15 r=1
-#: ultralcd.cpp:2144
-msgid "Temperatures"
-msgstr "Temperatury"
-
-# MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=4
-#: messages.c:42
-msgid "There is still a need to make Z calibration. Please follow the manual, chapter First steps, section Calibration flow."
-msgstr "Musimy przeprowadzic kalibracje Z. Kieruj sie Samouczkiem: rozdzial Pierwsze Kroki, sekcja Kalibracja."
-
 # 
-#: ultralcd.cpp:2217
-msgid "to load filament"
-msgstr "aby zaladow. fil."
-
-# 
-#: ultralcd.cpp:2221
-msgid "to unload filament"
-msgstr "aby rozlad. filament"
-
-# 
-#: ultralcd.cpp:1829
-msgid "Total"
-msgstr "Suma"
-
-# 
-#: ultralcd.cpp:1862
-msgid "Total failures"
-msgstr "Suma bledow"
-
-# 
-#: ultralcd.cpp:2860
-msgid "Total filament"
-msgstr "Calkowita dlugosc filamentu"
-
-# MSG_STATS_TOTALFILAMENT c=20
-#: ultralcd.cpp:2186
-msgid "Total filament :"
-msgstr "Filament lacznie :"
-
-# 
-#: ultralcd.cpp:2860
-msgid "Total print time"
-msgstr "Calkowity czas druku"
-
-# MSG_STATS_TOTALPRINTTIME c=20
-#: ultralcd.cpp:2203
-msgid "Total print time :"
-msgstr "Calkowity czas druku:"
-
-# MSG_ENDSTOP_HIT
-#: messages.c:28
-msgid "TRIGGERED"
-msgstr "AKTYWOWANO"
-
-# MSG_TUNE
-#: ultralcd.cpp:6641
-msgid "Tune"
-msgstr "Strojenie"
-
-# 
-#: ultralcd.cpp:2120
-msgid "unknown"
-msgstr "nieznane"
-
-# 
-#: ultralcd.cpp:4780
-msgid "Unload"
-msgstr "Rozladuj"
-
-# 
-#: ultralcd.cpp:5617
-msgid "Unload all"
-msgstr "Rozladuj wszystkie"
-
-# MSG_UNLOAD_FILAMENT c=17
-#: messages.c:97
-msgid "Unload filament"
-msgstr "Rozladowanie fil."
-
-# MSG_UNLOAD_FILAMENT_1 c=17
-#: ultralcd.cpp:5406
-msgid "Unload filament 1"
-msgstr "Rozladuj fil. 1"
-
-# MSG_UNLOAD_FILAMENT_2 c=17
-#: ultralcd.cpp:5407
-msgid "Unload filament 2"
-msgstr "Rozladuj fil. 2"
-
-# MSG_UNLOAD_FILAMENT_3 c=17
-#: ultralcd.cpp:5408
-msgid "Unload filament 3"
-msgstr "Rozladuj fil. 3"
-
-# MSG_UNLOAD_FILAMENT_4 c=17
-#: ultralcd.cpp:5409
-msgid "Unload filament 4"
-msgstr "Rozladuj fil. 4"
-
-# MSG_UNLOADING_FILAMENT c=20 r=1
-#: messages.c:98
-msgid "Unloading filament"
-msgstr "Rozladowuje filament"
-
-# 
-#: ultralcd.cpp:4779
-msgid "Use unload to remove filament 1 if it protrudes outside of the rear MMU tube. Use eject if it is hidden in tube."
-msgstr "Uzyj opcji Rozladuj jesli filament wystaje z tylnej rurki MMU. Uzyj opcji Wysun jesli wciaz jest w srodku."
-
-# MSG_USED c=19 r=1
-#: ultralcd.cpp:5803
-msgid "Used during print"
-msgstr "Uzyte podczas druku"
-
-# MSG_MENU_VOLTAGES c=15 r=1
-#: ultralcd.cpp:2147
-msgid "Voltages"
-msgstr "Napiecia"
-
-# MSG_SD_VOL_INIT_FAIL
-#: cardreader.cpp:191
-msgid "volume.init failed"
-msgstr "niepowodzenie volume.init "
-
-# MSG_USERWAIT
-#: Marlin_main.cpp:5225
-msgid "Wait for user..."
-msgstr "Czekam na uzytkownika..."
-
-# MSG_WAITING_TEMP c=20 r=3
-#: ultralcd.cpp:3371
-msgid "Waiting for nozzle and bed cooling"
-msgstr "Oczekiwanie na wychlodzenie dyszy i stolu"
-
-# MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ultralcd.cpp:3335
-msgid "Waiting for PINDA probe cooling"
-msgstr "Czekam az spadnie temp. sondy PINDA"
-
-# MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#:
-msgid "WARNING:\nCrash detection\ndisabled in\nStealth mode"
-msgstr "UWAGA:\nWykrywanie zderzen\nwylaczone\nw trybie Stealth"
-
-# MSG_CHANGED_BOTH c=20 r=4
-#: Marlin_main.cpp:1527
-msgid "Warning: both printer type and motherboard type changed."
-msgstr "Ostrzezenie: typ drukarki i plyta glowna ulegly zmianie."
-
-# MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: Marlin_main.cpp:1519
-msgid "Warning: motherboard type changed."
-msgstr "Ostrzezenie: plyta glowna ulegla zmianie."
-
-# MSG_CHANGED_PRINTER c=20 r=4
-#: Marlin_main.cpp:1523
-msgid "Warning: printer type changed."
-msgstr "Ostrzezenie: rodzaj drukarki ulegl zmianie"
-
-# MSG_FW_VERSION_UNKNOWN c=20 r=8
-#: Marlin_main.cpp:946
-msgid "WARNING: This is an unofficial, unsupported build. Use at your own risk!"
-msgstr "OSTRZEZENIE: To jest nieoficjalna, niewspierana wersja firmware. Uzywasz na wlasna odpowiedzialnosc!"
-
-# MSG_UNLOAD_SUCCESSFUL c=20 r=2
-#: Marlin_main.cpp:3072
-msgid "Was filament unload successful?"
-msgstr "Rozladowanie fil. ok?"
-
-# MSG_SELFTEST_WIRINGERROR
-#: messages.c:85
-msgid "Wiring error"
-msgstr "Blad polaczenia"
-
-# MSG_WIZARD c=17 r=1
-#: ultralcd.cpp:5642
-msgid "Wizard"
-msgstr "Asystent"
-
-# MSG_SD_WORKDIR_FAIL
-#: messages.c:78
-msgid "workDir open failed"
-msgstr "blad otwierania workDir"
-
-# MSG_SD_WRITE_TO_FILE
-#: cardreader.cpp:424
-msgid "Writing to file: "
-msgstr "Zapis do pliku:"
-
-# 
-#: ultralcd.cpp:4885
-msgid "X-correct"
-msgstr "Korekcja X"
-
-# 
-#: ultralcd.cpp:5028
-msgid "X-correct:"
-msgstr "Korekcja-X:"
-
-# MSG_XYZ_DETAILS c=19 r=1
-#: ultralcd.cpp:2136
-msgid "XYZ cal. details"
-msgstr "Szczegoly kal. XYZ"
-
-# MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ultralcd.cpp:3835
-msgid "XYZ calibration all right. Skew will be corrected automatically."
-msgstr "Kalibracja XYZ pomyslna. Skos bedzie automatycznie korygowany."
-
-# MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ultralcd.cpp:3832
-msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
-msgstr "Kalibracja XYZ prawidlowa. Osie X/Y lekko skosne. Dobra robota!"
-
-# MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ultralcd.cpp:3813
-msgid "XYZ calibration compromised. Front calibration points not reachable."
-msgstr "Kalibr. XYZ niedokladna. Przednie punkty kalibr. nieosiagalne."
-
-# MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_LEFT_FAR c=20 r=8
-#: ultralcd.cpp:3699
-msgid "XYZ calibration compromised. Left front calibration point not reachable."
-msgstr "Kalibracja XYZ niedokladna. Lewy przedni punkt nieosiagalny."
-
-# MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ultralcd.cpp:3816
-msgid "XYZ calibration compromised. Right front calibration point not reachable."
-msgstr "Kalibracja XYZ niedokladna. Prawy przedni punkt nieosiagalny."
-
-# 
-#: ultralcd.cpp:3795
-msgid "XYZ calibration failed. Bed calibration point was not found."
-msgstr "Kalibracja XYZ nieudana. Nie znaleziono punktow kalibracyjnych."
-
-# 
-#: ultralcd.cpp:3801
-msgid "XYZ calibration failed. Front calibration points not reachable."
-msgstr "Kalibr. XYZ nieudana. Przednie punkty kalibr. nieosiagalne. Nalezy poprawic montaz drukarki."
-
-# 
-#: ultralcd.cpp:3687
-msgid "XYZ calibration failed. Left front calibration point not reachable."
-msgstr "Kalibr. XYZ nieudana. Lewy przedni punkt nieosiagalny. Nalezy poprawic montaz drukarki."
-
-# MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: messages.c:19
-msgid "XYZ calibration failed. Please consult the manual."
-msgstr "Kalibracja XYZ nieudana. Sprawdz przyczyny i rozwiazania w instrukcji."
-
-# 
-#: ultralcd.cpp:3804
-msgid "XYZ calibration failed. Right front calibration point not reachable."
-msgstr "Kalibr. XYZ nieudana. Prawy przedni punkt nieosiagalny. Nalezy poprawic montaz drukarki."
-
-# MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ultralcd.cpp:3829
-msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
-msgstr "Kalibracja XYZ ok. Osie X/Y sa prostopadle. Gratulacje!"
-
-# 
-#: ultralcd.cpp:2965
-msgid "Y distance from min"
-msgstr "Dystans od 0 w osi Y"
-
-# MSG_Y_DISTANCE_FROM_MIN c=20 r=1
-#: ultralcd.cpp:2306
-msgid "Y distance from min:"
-msgstr "Min. odleglosc od Y:"
-
-# 
-#: ultralcd.cpp:4886
-msgid "Y-correct"
-msgstr "Korekcja Y"
-
-# 
-#: ultralcd.cpp:5029
-msgid "Y-correct:"
-msgstr "Korekcja-Y:"
-
-# MSG_YES
-#: messages.c:104
-msgid "Yes"
-msgstr "Tak"
-
-# MSG_FW_VERSION_ALPHA c=20 r=8
-#: Marlin_main.cpp:930
-msgid "You are using firmware alpha version. This is development version. Using this version is not recommended and may cause printer damage."
-msgstr "Uzywasz firmware w wersji alpha. Jest to niezalecana wersja rozwojowa. Moze spowodowac uszkodzenie drukarki."
-
-# MSG_FW_VERSION_BETA c=20 r=8
-#: Marlin_main.cpp:931
-msgid "You are using firmware beta version. This is development version. Using this version is not recommended and may cause printer damage."
-msgstr "Uzywasz firmware w wersji beta. Ta wersja jest rozwojowa. Uzywanie jej nie jest zalecane i moze spowodowac uszkodzenie drukarki."
-
-# MSG_WIZARD_QUIT c=20 r=8
-#: messages.c:103
-msgid "You can always resume the Wizard from Calibration -> Wizard."
-msgstr "Zawsze mozesz uruchomic Asystenta ponownie przez Kalibracja -> Asystent."
-
-# 
-#: ultralcd.cpp:5030
+#: ultralcd.cpp:5132
 msgid "Z-correct:"
 msgstr "Korekcja-Z:"
 
 # 
-#: ultralcd.cpp:6952
+#: ultralcd.cpp:7038
 msgid "Z-probe nr.    [1]"
-msgstr "Pomiar-Z [1]"
+msgstr "Ilosc Pomiarow [1]"
 
 # 
-#: ultralcd.cpp:6954
+#: ultralcd.cpp:7040
 msgid "Z-probe nr.    [3]"
-msgstr "Pomiar-Z [3]"
+msgstr "Ilosc Pomiarow [3]"
 
-# MSG_MEASURED_OFFSET
-#: ultralcd.cpp:3024
-msgid "[0;0] point offset"
-msgstr "[0;0] przesuniecie punktu"


### PR DESCRIPTION
All translated files `lang_en_xx.txt` (xx=language) should contain the same format, syntax and text lines, except the translation itself of course.

I ran two scripts `/lang/lang-export.sh` and `/lang/lang-import.sh` scripts to be able to point to it as I will open another issue related to translations as well.

As you can see some aren't consistent and that might generate an issue with `.po` files which are send to translators or even generate issue compiling the language firmware.

You can see already here that the `/lang/po/Firmware.dot` file and other `/lang/po/Firmware_xx.po` files **do not** have the last message from `/lang/lang_en.txt` and `/lang/langen_xx.txt`  except the French translation file is consistent.
