### PR TITLE
fix workDirDepth not reset after card init.

### DIFF
--- a/Firmware/cardreader.cpp
+++ b/Firmware/cardreader.cpp
@@ -203,6 +203,7 @@ void CardReader::initsd()
   }
   workDir=root;
   curDir=&root;
+  workDirDepth = 0;
 
   #ifdef SDCARD_SORT_ALPHA
 	presort();


### PR DESCRIPTION
@DRracer Fixes behavior described and discussed in #2163 and probably is also related #2196 and #2237. There might be more duplicates as the issue will manifest itself in random ways since memory is overwritten.
For example, before I got a "memory overwritten" error, the print fan was spinning for no reason, signaling that something has gone bad. Also in #2237, the planner buffer might have gotten overwritten.