### PR TITLE
Knob long press fixes

### DIFF
--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -761,8 +761,7 @@ void lcd_buttons_update(void)
             //else if (menu_menu == lcd_move_z) lcd_quick_feedback();
             //lcd_button_pressed is set back to false via lcd_quick_feedback function
         }
-        else
-            lcd_long_press_active = 0;
+        lcd_long_press_active = 0;
     }
 
 	lcd_buttons = newbutton;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -8618,11 +8618,13 @@ void menu_lcd_longpress_func(void)
     // explicitely listed menus which are allowed to rise the move-z or live-adj-z functions
     // The lists are not the same for both functions, so first decide which function is to be performed
     // @@TODO - handle full-screen modal dialogs safely - i.e. they should not hang the printer while doing long press
-    if (current_position[Z_AXIS] < Z_HEIGHT_HIDE_LIVE_ADJUST_MENU && (moves_planned() || IS_SD_PRINTING || is_usb_printing ))
-    { // long press as live-adj-z
-        if(menu_menu == lcd_status_screen
-        || menu_menu == lcd_tune_menu
-        || menu_menu == lcd_support_menu
+    if ( (moves_planned() || IS_SD_PRINTING || is_usb_printing )){ // long press as live-adj-z
+        if(( current_position[Z_AXIS] < Z_HEIGHT_HIDE_LIVE_ADJUST_MENU ) // only allow live-adj-z up to 2mm of print height
+        && ( menu_menu == lcd_status_screen // and in listed menus...
+          || menu_menu == lcd_main_menu
+          || menu_menu == lcd_tune_menu
+          || menu_menu == lcd_support_menu
+           )
         ){
             lcd_clear();
             menu_submenu(lcd_babystep_z);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -8617,7 +8617,6 @@ void menu_lcd_longpress_func(void)
 
     // explicitely listed menus which are allowed to rise the move-z or live-adj-z functions
     // The lists are not the same for both functions, so first decide which function is to be performed
-    // @@TODO - handle full-screen modal dialogs safely - i.e. they should not hang the printer while doing long press
     if ( (moves_planned() || IS_SD_PRINTING || is_usb_printing )){ // long press as live-adj-z
         if(( current_position[Z_AXIS] < Z_HEIGHT_HIDE_LIVE_ADJUST_MENU ) // only allow live-adj-z up to 2mm of print height
         && ( menu_menu == lcd_status_screen // and in listed menus...
@@ -8630,8 +8629,8 @@ void menu_lcd_longpress_func(void)
             menu_submenu(lcd_babystep_z);
         } else {
             // otherwise consume the long press as normal click
-            // consume the loreturns to sheet menu
-            menu_back();
+            if( menu_menu != lcd_status_screen )
+                menu_back();
         }
     } else { // long press as move-z
         if(menu_menu == lcd_status_screen
@@ -8649,8 +8648,8 @@ void menu_lcd_longpress_func(void)
             menu_submenu(lcd_move_z);
         } else {
             // otherwise consume the long press as normal click
-            // consume the loreturns to sheet menu
-            menu_back();
+            if( menu_menu != lcd_status_screen )
+                menu_back();
         }
     }
 }

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -8606,7 +8606,6 @@ uint8_t get_message_level()
 	return lcd_status_message_level;
 }
 
-
 void menu_lcd_longpress_func(void)
 {
     if (homing_flag || mesh_bed_leveling_flag || menu_menu == lcd_babystep_z || menu_menu == lcd_move_z)
@@ -8616,15 +8615,41 @@ void menu_lcd_longpress_func(void)
         return;
     }
 
+    // explicitely listed menus which are allowed to rise the move-z or live-adj-z functions
+    // The lists are not the same for both functions, so first decide which function is to be performed
+    // @@TODO - handle full-screen modal dialogs safely - i.e. they should not hang the printer while doing long press
     if (current_position[Z_AXIS] < Z_HEIGHT_HIDE_LIVE_ADJUST_MENU && (moves_planned() || IS_SD_PRINTING || is_usb_printing ))
-    {
-        lcd_clear();
-        menu_submenu(lcd_babystep_z);
-    }
-    else
-    {
-        move_menu_scale = 1.0;
-        menu_submenu(lcd_move_z);
+    { // long press as live-adj-z
+        if(menu_menu == lcd_status_screen
+        || menu_menu == lcd_tune_menu
+        || menu_menu == lcd_support_menu
+        ){
+            lcd_clear();
+            menu_submenu(lcd_babystep_z);
+        } else {
+            // otherwise consume the long press as normal click
+            // consume the loreturns to sheet menu
+            menu_back();
+        }
+    } else { // long press as move-z
+        if(menu_menu == lcd_status_screen
+        || menu_menu == lcd_main_menu
+        || menu_menu == lcd_preheat_menu
+        || menu_menu == lcd_sdcard_menu
+        || menu_menu == lcd_settings_menu
+        || menu_menu == lcd_control_temperature_menu
+#if (LANG_MODE != 0)
+        || menu_menu == lcd_language
+#endif
+        || menu_menu == lcd_support_menu
+        ){
+            move_menu_scale = 1.0;
+            menu_submenu(lcd_move_z);
+        } else {
+            // otherwise consume the long press as normal click
+            // consume the loreturns to sheet menu
+            menu_back();
+        }
     }
 }
 


### PR DESCRIPTION
The task has been discussed and given as follows:
allow Move Z only in screens:
❏ Info screen
❏ Main menu
❏ Preheat
❏ Print from SD
❏ Settings
❏ Temperature
❏ Select language
❏ Support

Allow live-adjust-Z only in screens:
❏ Info screen
❏ Main menu
❏ Tune (during the printing process only)
❏ Support

move-z is performed when NOT printing
live-adj-z is performed when printing and only up to 1mm of z-height

Along with these functional requirements a solution was found to a long-term bug which caused hanging the printer when doing long-press in modal dialogs (e.g. in "safety timer disabled heater" dialog).