### PR TITLE
Initialize EEPROM_SILENT in one place both for MK3 and MK25 printers …

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1242,8 +1242,8 @@ void setup()
         // Once a firmware boots up, it forces at least a language selection, which changes
         // EEPROM_LANG to number lower than 0x0ff.
         // 1) Set a high power mode.
+	    eeprom_update_byte((uint8_t*)EEPROM_SILENT, SILENT_MODE_OFF);
 #ifdef TMC2130
-        eeprom_write_byte((uint8_t*)EEPROM_SILENT, 0);
         tmc2130_mode = TMC2130_MODE_NORMAL;
 #endif //TMC2130
         eeprom_write_byte((uint8_t*)EEPROM_WIZARD_ACTIVE, 1); //run wizard

--- a/Firmware/stepper.cpp
+++ b/Firmware/stepper.cpp
@@ -1564,10 +1564,6 @@ void st_current_init() //Initialize Digipot Motor Current
 {
 #ifdef MOTOR_CURRENT_PWM_XY_PIN
   uint8_t SilentMode = eeprom_read_byte((uint8_t*)EEPROM_SILENT);
-  if (SilentMode == 0xff){ //set power to High Power (MK2.5) or Normal Power (MK3, unused)
-    SilentMode = SILENT_MODE_POWER;
-    eeprom_update_byte((uint8_t*)EEPROM_SILENT, SilentMode);
-  }
   SilentModeMenu = SilentMode;
     pinMode(MOTOR_CURRENT_PWM_XY_PIN, OUTPUT);
     pinMode(MOTOR_CURRENT_PWM_Z_PIN, OUTPUT);


### PR DESCRIPTION
…and make it more clear.