### PR TITLE
PSU_DELTA fix force_high_power_mode()

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -2433,6 +2433,9 @@ void ramming() {
 
 #ifdef TMC2130
 void force_high_power_mode(bool start_high_power_section) {
+#ifdef PSU_Delta
+	if (start_high_power_section == true) enable_force_z();
+#endif //PSU_Delta
 	uint8_t silent;
 	silent = eeprom_read_byte((uint8_t*)EEPROM_SILENT);
 	if (silent == 1) {


### PR DESCRIPTION
This PR fixes an oversight that resulted in an instant stallGuard trigger when force_high_power_mode(true) was used for detecting axis end in calibrations. Closes #2255 

@DRracer @HannahKiekens @dminuoso @maurosanjo