### PR TITLE
Changed sheet menu to enable easy z height tweaks

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -6770,6 +6770,12 @@ static void activate_calibrate_sheet()
     lcd_first_layer_calibration_reset();
 }
 
+static void activate_adjust_sheet()
+{
+	eeprom_update_byte(&(EEPROM_Sheets_base->active_sheet), selected_sheet);
+	lcd_babystep_z();
+}
+
 static void lcd_sheet_menu()
 {
     MENU_BEGIN();
@@ -6783,6 +6789,7 @@ static void lcd_sheet_menu()
     {
         MENU_ITEM_SUBMENU_P(_T(MSG_V2_CALIBRATION), activate_calibrate_sheet);
     }
+	MENU_ITEM_SUBMENU_P(_T(MSG_BABYSTEP_Z), activate_adjust_sheet);
     MENU_ITEM_SUBMENU_P(_i("Rename"), lcd_rename_sheet_menu); //// c=18
 	MENU_ITEM_FUNCTION_P(_i("Reset"), lcd_reset_sheet); //// c=18
 


### PR DESCRIPTION
I absolutely love the new sheet menu that was introduced with the latest firmware version.

However it is quite tedious to manually adjust the z height of one of the sheets without starting a print or first layer calibration.
You had to select the sheet first, then go back to the settings menu, scroll all the way down to _Live adjust Z_ and then tweak your height.

So I made a small change and added the _Live adjust Z_ menu point to the lcd_sheet_menu, which activates the selected sheet and brings up the Z height selector.

I have already testet it and as far as I can tell it works nice.