### PR TITLE
Changed sound modes

### DIFF
--- a/Firmware/sound.cpp
+++ b/Firmware/sound.cpp
@@ -6,6 +6,13 @@
 //#include <avr/eeprom.h>
 //#include "eeprom.h"
 
+/*
+SOUND MODES:
+SILENT: 1 beep alerts
+ONCE: 1 beep alerts, prompts, custom sounds
+LOUD: 3 beep alerts, prompts, custom sounds, menu click
+ASSIST: 3 beep alerts, prompts, custom sounds, menu click+assist
+*/
 
 //eSOUND_MODE eSoundMode=e_SOUND_MODE_LOUD;
 // nema vyznam, pokud se bude volat Sound_Init (tzn. poc. hodnota je v EEPROM)

--- a/Firmware/sound.cpp
+++ b/Firmware/sound.cpp
@@ -105,8 +105,6 @@ switch(eSoundMode)
                Sound_DoSound_Alert(false);
           break;
      case e_SOUND_MODE_ONCE:
-          if(eSoundType==e_SOUND_TYPE_ButtonEcho)
-              Sound_DoSound_Echo();
           if(eSoundType==e_SOUND_TYPE_StandardPrompt)
                Sound_DoSound_Prompt();
           if(eSoundType==e_SOUND_TYPE_StandardAlert)


### PR DESCRIPTION
I removed the button sound from the ONCE sound mode so there is a sound mode for people who want all the prompt and custom sounds but dont like the annoying click sound every time you press the encoder.
So now there is a clear distinction between the 4 sound modes:
SILENT: no sounds except for alerts
ONCE: 1 beep alerts, prompts, custom sounds
LOUD: 3 beep alerts, prompts, custom sounds, click
ASSIST: 3 beep alerts, prompts, custom sounds, click, accessibiliy menu sounds