### PR TITLE
Do not wait forever if the heater on the extruder is disabled

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -8864,6 +8864,8 @@ void delay_keep_alive(unsigned int ms)
 }
 
 static void wait_for_heater(long codenum, uint8_t extruder) {
+    if (!degTargetHotend(extruder))
+        return;
 
 #ifdef TEMP_RESIDENCY_TIME
 	long residencyStart;


### PR DESCRIPTION
wait_for_heater can wait forever if the set temperature for the extruder is 0.