### PR TITLE
Fix M81 Turn off Power Supply...

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -6165,7 +6165,6 @@ Sigma_Exit:
           LCD_MESSAGERPGM(_T(WELCOME_MSG));
           lcd_update(0);
         break;
-      #endif
 
       //! ### M81 - Turn off Power Supply
       // --------------------------------------
@@ -6189,6 +6188,7 @@ Sigma_Exit:
         LCD_MESSAGERPGM(CAT4(CUSTOM_MENDEL_NAME,PSTR(" "),MSG_OFF,PSTR(".")));
         lcd_update(0);
 	  break;
+    #endif
 
     //! ### M82 - Set E axis to absolute mode
     // ---------------------------------------


### PR DESCRIPTION
... as it should be only active if PS_ON_PIN is defined and assigned to an actual pin.

During documentation of the G-codes to RepRap wiki G-codes I am testing several/suspicious  G-codes to see the results.

M81 can be executed and generates strange artifacts on LCD and the printer has to be reset.

PFW-1072