### PR TITLE
Tell user which filament is next by using M600 T<n>

### DIFF
--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -507,7 +507,7 @@ void gcode_M701();
 void proc_commands();
 
 
-void M600_load_filament();
+void M600_load_filament(int next_extruder);
 void M600_load_filament_movements();
 void M600_wait_for_user(float HotendTempBckp);
 void M600_check_state(float nozzle_temp);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2607,7 +2607,7 @@ static void mmu_unload_filament()
 }
 
 
-void lcd_wait_interact() {
+void lcd_wait_interact(int filament_index) {
 
   lcd_clear();
 
@@ -2616,6 +2616,10 @@ void lcd_wait_interact() {
   lcd_puts_P(_i("Prepare new filament"));////MSG_PREPARE_FILAMENT c=20 r=1
 #else
   lcd_puts_P(_i("Insert filament"));////MSG_INSERT_FILAMENT c=20
+  if (filament_index >= 0) {
+      lcd_puts_P(PSTR(" "));
+      lcd_print((int) (filament_index + 1));
+  }
 #endif
   if (!fsensor_autoload_enabled) {
 	  lcd_set_cursor(0, 2);

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -33,7 +33,7 @@ void lcd_alright();
 void show_preheat_nozzle_warning();
 void EEPROM_save_B(int pos, int* value);
 void EEPROM_read_B(int pos, int* value);
-void lcd_wait_interact();
+void lcd_wait_interact(int filament_index);
 void lcd_loading_filament();
 void lcd_change_success();
 void lcd_loading_color();


### PR DESCRIPTION
If the user slices a multicolour print in PrusaSlicer, but does not have an MMU, and has set their "Tool Change GCode" to "M600 T{next_extruder}", this patch changes the printer's filament-change prompt from "Insert filament and press the knob" to "Insert filament X and press the knob" where X is the 1-based index of the next extruder. This tells the user which filament to load next.

This is needed because otherwise if the print contains more than 2 colours, the user can't know which colour of filament they are supposed to insert next.

To demonstrate the utility of this system, here's my multicolour print in the slicer:

![sliced](https://user-images.githubusercontent.com/1921411/68067310-c94bd000-fda9-11e9-8fa8-7c6156a9cc95.png)

The completed print using the modified firmware, with all-manual filament swaps:

![IMG_20191102_194927630](https://user-images.githubusercontent.com/1921411/68067355-84746900-fdaa-11e9-94b8-8a23855ee64d.jpg)

And the 3MF project file:

[Plate.3mf.zip](https://github.com/prusa3d/Prusa-Firmware/files/3800206/Plate.3mf.zip)

In this print the displayed new messages over the course of the print were:

```
Layer 1

Insert filament 1 and press the knob
Insert filament 2 and press the knob
Insert filament 3 and press the knob
Insert filament 4 and press the knob
Insert filament 5 and press the knob

Layer 2

Insert filament 1 and press the knob
Insert filament 2 and press the knob
Insert filament 3 and press the knob
Insert filament 4 and press the knob

Layer 3

Insert filament 1 and press the knob
Insert filament 2 and press the knob
Insert filament 3 and press the knob
Insert filament 5 and press the knob

Layer 4

Insert filament 1 and press the knob
```

Without this firmware patch, I never would have picked the correct colours to insert!