### PR TITLE
Perform a small extrusion prior to unload

### DIFF
--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -496,7 +496,7 @@ void proc_commands();
 
 void M600_load_filament();
 void M600_load_filament_movements();
-void M600_wait_for_user(float HotendTempBckp);
+bool M600_wait_for_user(float HotendTempBckp);
 void M600_check_state(float nozzle_temp);
 void load_filament_final_feed();
 void marlin_wait_for_click();

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3720,6 +3720,7 @@ static void gcode_M600(bool automatic, bool runout, float x_position, float y_po
     int feedmultiplyBckp = feedmultiply;
     float HotendTempBckp = degTargetHotend(active_extruder);
     int fanSpeedBckp = fanSpeed;
+    bool cooldown = false;
 
     lastpos[X_AXIS] = current_position[X_AXIS];
     lastpos[Y_AXIS] = current_position[Y_AXIS];
@@ -3742,8 +3743,11 @@ static void gcode_M600(bool automatic, bool runout, float x_position, float y_po
     plan_buffer_line_curposXYZE(FILAMENTCHANGE_XYFEED);
     st_synchronize();
 
-    //Beep, manage nozzle heater and wait for user to start unload filament
-    if(!mmu_enabled) M600_wait_for_user(HotendTempBckp);
+    if(!mmu_enabled)
+    {
+        //Beep, manage nozzle heater and wait for user to start unload filament
+        cooldown = M600_wait_for_user(HotendTempBckp);
+    }
 
     lcd_change_fil_state = 0;
 
@@ -3756,7 +3760,9 @@ static void gcode_M600(bool automatic, bool runout, float x_position, float y_po
     else
     {
         // unload filament for single material (used also in M702)
-        unload_filament(runout? UnloadType::Runout: UnloadType::Swap);
+        unload_filament(runout? UnloadType::Runout:
+                        cooldown? UnloadType::Purge:
+                        UnloadType::Swap);
     }
 
     //finish moves
@@ -11891,7 +11897,8 @@ void M600_check_state(float nozzle_temp)
 //! If times out, active extruder temperature is set to 0.
 //!
 //! @param HotendTempBckp Temperature to be restored for active extruder, after user resolves MMU problem.
-void M600_wait_for_user(float HotendTempBckp) {
+//! @return True if the wait involved a hotend cooldown due to timeout.
+bool M600_wait_for_user(float HotendTempBckp) {
 
 		KEEPALIVE_STATE(PAUSED_FOR_USER);
 
@@ -11900,6 +11907,7 @@ void M600_wait_for_user(float HotendTempBckp) {
 		uint8_t wait_for_user_state = 0;
 		lcd_display_message_fullscreen_P(_T(MSG_PRESS_TO_UNLOAD));
 		bool bFirst=true;
+		bool bCooldown=false;
 
 		while (!(wait_for_user_state == 0 && lcd_clicked())){
 			manage_heater();
@@ -11932,6 +11940,7 @@ void M600_wait_for_user(float HotendTempBckp) {
 					lcd_display_message_fullscreen_P(_i("Press the knob to preheat nozzle and continue."));////MSG_PRESS_TO_PREHEAT c=20 r=4
 					wait_for_user_state = 1;
 					setAllTargetHotends(0);
+					bCooldown = true;
 					st_synchronize();
 					disable_e0();
 					disable_e1();
@@ -11966,6 +11975,7 @@ void M600_wait_for_user(float HotendTempBckp) {
 
 		}
 		WRITE(BEEPER, LOW);
+		return bCooldown;
 }
 
 void M600_load_filament_movements()

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3728,7 +3728,7 @@ static void gcode_M600(bool automatic, float x_position, float y_position, float
 
     //Retract E
     current_position[E_AXIS] += e_shift;
-    plan_buffer_line_curposXYZE(FILAMENTCHANGE_RFEED);
+    plan_buffer_line_curposXYZE(FILAMENTCHANGE_EFEED_RETRACT);
     st_synchronize();
 
     //Lift Z
@@ -3798,8 +3798,8 @@ static void gcode_M600(bool automatic, float x_position, float y_position, float
     //Feed a little of filament to stabilize pressure
     if (!automatic)
     {
-        current_position[E_AXIS] += FILAMENTCHANGE_RECFEED;
-        plan_buffer_line_curposXYZE(FILAMENTCHANGE_EXFEED);
+        current_position[E_AXIS] += FILAMENTCHANGE_PRIMEFEED;
+        plan_buffer_line_curposXYZE(FILAMENTCHANGE_EFEED_PRIME);
     }
 
     //Move XY back
@@ -11728,7 +11728,7 @@ void restore_print_from_ram_and_continue(float e_move)
 	//then move Z
 	plan_buffer_line(saved_pos[X_AXIS], saved_pos[Y_AXIS], saved_pos[Z_AXIS], saved_pos[E_AXIS] - e_move, homing_feedrate[Z_AXIS]/13, active_extruder);
 	//and finaly unretract (35mm/s)
-	plan_buffer_line(saved_pos[X_AXIS], saved_pos[Y_AXIS], saved_pos[Z_AXIS], saved_pos[E_AXIS], FILAMENTCHANGE_RFEED, active_extruder);
+	plan_buffer_line(saved_pos[X_AXIS], saved_pos[Y_AXIS], saved_pos[Z_AXIS], saved_pos[E_AXIS], FILAMENTCHANGE_EFEED_RETRACT, active_extruder);
 	st_synchronize();
 
   #ifdef FANCHECK

--- a/Firmware/fsensor.cpp
+++ b/Firmware/fsensor.cpp
@@ -620,7 +620,7 @@ void fsensor_enque_M600(){
 	puts_P(PSTR("fsensor_update - M600"));
 	eeprom_update_byte((uint8_t*)EEPROM_FERROR_COUNT, eeprom_read_byte((uint8_t*)EEPROM_FERROR_COUNT) + 1);
 	eeprom_update_word((uint16_t*)EEPROM_FERROR_COUNT_TOT, eeprom_read_word((uint16_t*)EEPROM_FERROR_COUNT_TOT) + 1);
-	enquecommand_front_P((PSTR("M600")));
+	enquecommand_front_P((PSTR("M600 R")));
 }
 
 //! @brief filament sensor update (perform M600 on filament runout)

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5579,7 +5579,7 @@ void unload_filament(UnloadType unload)
 	lcd_setstatuspgm(_T(MSG_UNLOADING_FILAMENT));
 
     raise_z_above(unload == UnloadType::Swap? MIN_Z_FOR_SWAP: MIN_Z_FOR_UNLOAD);
-    if (unload == UnloadType::User)
+    if (unload == UnloadType::Purge)
     {
         // extrude slowly
         current_position[E_AXIS] += FILAMENTCHANGE_UNLOADFEED;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5579,7 +5579,7 @@ void unload_filament(UnloadType unload)
 	lcd_setstatuspgm(_T(MSG_UNLOADING_FILAMENT));
 
     raise_z_above(unload == UnloadType::Swap? MIN_Z_FOR_SWAP: MIN_Z_FOR_UNLOAD);
-    if (unload != UnloadType::Runout)
+    if (unload == UnloadType::User)
     {
         // extrude slowly
         current_position[E_AXIS] += FILAMENTCHANGE_UNLOADFEED;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -4473,7 +4473,7 @@ void lcd_wizard(WizState state)
 				lcd_display_message_fullscreen_P(_i("Now I will preheat nozzle for PLA."));
 				wait_preheat();
 				//unload current filament
-				unload_filament(true);
+				unload_filament();
 				//load filament
 				lcd_wizard_load();
 				setTargetHotend(0, 0); //we are finished, cooldown nozzle
@@ -5573,23 +5573,24 @@ static void mmu_cut_filament_menu()
 
 
 // unload filament for single material printer (used in M702 gcode)
-// @param automatic: If true, unload_filament is part of a unload+load sequence (M600)
-void unload_filament(bool automatic)
+void unload_filament(UnloadType unload)
 {
 	custom_message_type = CustomMsg::FilamentLoading;
 	lcd_setstatuspgm(_T(MSG_UNLOADING_FILAMENT));
 
-    raise_z_above(automatic? MIN_Z_FOR_SWAP: MIN_Z_FOR_UNLOAD);
+    raise_z_above(unload == UnloadType::Swap? MIN_Z_FOR_SWAP: MIN_Z_FOR_UNLOAD);
+    if (unload != UnloadType::Runout)
+    {
+        // extrude slowly
+        current_position[E_AXIS] += FILAMENTCHANGE_UNLOADFEED;
+        plan_buffer_line_curposXYZE(FILAMENTCHANGE_EFEED_PRIME);
+        st_synchronize();
 
-    // extrude slowly
-    current_position[E_AXIS] += FILAMENTCHANGE_UNLOADFEED;
-    plan_buffer_line_curposXYZE(FILAMENTCHANGE_EFEED_PRIME);
-    st_synchronize();
-
-    // relieve leftover pressure
-    current_position[E_AXIS] += 0.1;
-    plan_buffer_line_curposXYZE(FILAMENTCHANGE_EFEED_PRIME / 2);
-    st_synchronize();
+        // relieve leftover pressure
+        current_position[E_AXIS] += 0.1;
+        plan_buffer_line_curposXYZE(FILAMENTCHANGE_EFEED_PRIME / 2);
+        st_synchronize();
+    }
 
     // retract & eject
     current_position[E_AXIS] += FILAMENTCHANGE_FIRSTRETRACT;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5581,17 +5581,23 @@ void unload_filament(bool automatic)
 
     raise_z_above(automatic? MIN_Z_FOR_SWAP: MIN_Z_FOR_UNLOAD);
 
-	//		extr_unload2();
+    // extrude slowly
+    current_position[E_AXIS] += FILAMENTCHANGE_UNLOADFEED;
+    plan_buffer_line_curposXYZE(FILAMENTCHANGE_EFEED_PRIME);
+    st_synchronize();
 
-	current_position[E_AXIS] -= 45;
-	plan_buffer_line_curposXYZE(5200 / 60);
-	st_synchronize();
-	current_position[E_AXIS] -= 15;
-	plan_buffer_line_curposXYZE(1000 / 60);
-	st_synchronize();
-	current_position[E_AXIS] -= 20;
-	plan_buffer_line_curposXYZE(1000 / 60);
-	st_synchronize();
+    // relieve leftover pressure
+    current_position[E_AXIS] += 0.1;
+    plan_buffer_line_curposXYZE(FILAMENTCHANGE_EFEED_PRIME / 2);
+    st_synchronize();
+
+    // retract & eject
+    current_position[E_AXIS] += FILAMENTCHANGE_FIRSTRETRACT;
+    plan_buffer_line_curposXYZE(FILAMENTCHANGE_EFEED_RETRACT);
+    st_synchronize();
+    current_position[E_AXIS] += FILAMENTCHANGE_FINALRETRACT;
+    plan_buffer_line_curposXYZE(FILAMENTCHANGE_EFEED_EJECT);
+    st_synchronize();
 
 	lcd_display_message_fullscreen_P(_T(MSG_PULL_OUT_FILAMENT));
 

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -190,12 +190,12 @@ void lcd_generic_preheat_menu();
 
 enum class UnloadType : uint8_t
 {
-    User,      // user-triggered unload
-    Swap,      // part of a M600 sequence
-    Runout,    // triggered by runout
+    Purge,     // user-triggered unload, perform an extra purge before unload
+    Swap,      // part of an M600 sequence (no extra purge necessary)
+    Runout,    // triggered by runout (extra purge not possible)
 };
 
-void unload_filament(UnloadType unload=UnloadType::User);
+void unload_filament(UnloadType unload=UnloadType::Purge);
 
 
 void lcd_printer_connected();

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -186,7 +186,17 @@ extern bool bFilamentAction;
 void mFilamentItem(uint16_t nTemp,uint16_t nTempBed);
 void mFilamentItemForce();
 void lcd_generic_preheat_menu();
-void unload_filament(bool automatic = false);
+
+
+enum class UnloadType : uint8_t
+{
+    User,      // user-triggered unload
+    Swap,      // part of a M600 sequence
+    Runout,    // triggered by runout
+};
+
+void unload_filament(UnloadType unload=UnloadType::User);
+
 
 void lcd_printer_connected();
 void lcd_ping();

--- a/Firmware/variants/1_75mm_MK25-RAMBo10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK25-RAMBo10a-E3Dv6full.h
@@ -242,21 +242,26 @@
 #ifdef FILAMENTCHANGEENABLE
 #define FILAMENTCHANGE_XPOS 211
 #define FILAMENTCHANGE_YPOS 0
-#define FILAMENTCHANGE_ZADD 2
-#define FILAMENTCHANGE_FIRSTRETRACT -2
-#define FILAMENTCHANGE_FINALRETRACT -80
+#define FILAMENTCHANGE_ZADD Z_PAUSE_LIFT
 
-#define FILAMENTCHANGE_FIRSTFEED 70 //E distance in mm for fast filament loading sequence used used in filament change (M600)
-#define FILAMENTCHANGE_FINALFEED 25 //E distance in mm for slow filament loading sequence used used in filament change (M600) and filament load (M701) 
-#define FILAMENTCHANGE_RECFEED 5
+#define FILAMENTCHANGE_FIRSTRETRACT -2   // Retraction performed before parking the extruder or unloading filament
+#define FILAMENTCHANGE_FINALRETRACT -80  // Full filament retraction length
+
+#define FILAMENTCHANGE_FIRSTFEED 70 // E distance in mm for fast filament loading sequence used used in filament change (M600)
+#define FILAMENTCHANGE_FINALFEED 25 // E distance in mm for slow filament loading sequence used used in filament change (M600) and filament load (M701)
+
+#define FILAMENTCHANGE_PRIMEFEED   2 // E priming distance performed after resuming
+#define FILAMENTCHANGE_UNLOADFEED 10 // E priming distance performed before unloading
 
 #define FILAMENTCHANGE_XYFEED 50
+#define FILAMENTCHANGE_ZFEED 15
+
 #define FILAMENTCHANGE_EFEED_FIRST 20 // feedrate in mm/s for fast filament loading sequence used in filament change (M600)
 #define FILAMENTCHANGE_EFEED_FINAL 3.3f // feedrate in mm/s for slow filament loading sequence used in filament change (M600) and filament load (M701) 
-//#define FILAMENTCHANGE_RFEED 400
-#define FILAMENTCHANGE_RFEED 7000 / 60
-#define FILAMENTCHANGE_EXFEED 2
-#define FILAMENTCHANGE_ZFEED 15
+
+#define FILAMENTCHANGE_EFEED_RETRACT (7000 / 60) // quick filament retract feedrate in mm/s
+#define FILAMENTCHANGE_EFEED_EJECT   (1000 / 60) // filament ejection feedrate in mm/s
+#define FILAMENTCHANGE_EFEED_PRIME   ( 120 / 60) // filament priming feedrate (used before unloading and after resuming a print)
 
 #endif
 

--- a/Firmware/variants/1_75mm_MK25-RAMBo13a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK25-RAMBo13a-E3Dv6full.h
@@ -243,21 +243,26 @@
 #ifdef FILAMENTCHANGEENABLE
 #define FILAMENTCHANGE_XPOS 211
 #define FILAMENTCHANGE_YPOS 0
-#define FILAMENTCHANGE_ZADD 2
-#define FILAMENTCHANGE_FIRSTRETRACT -2
-#define FILAMENTCHANGE_FINALRETRACT -80
+#define FILAMENTCHANGE_ZADD Z_PAUSE_LIFT
 
-#define FILAMENTCHANGE_FIRSTFEED 70 //E distance in mm for fast filament loading sequence used used in filament change (M600)
-#define FILAMENTCHANGE_FINALFEED 25 //E distance in mm for slow filament loading sequence used used in filament change (M600) and filament load (M701) 
-#define FILAMENTCHANGE_RECFEED 5
+#define FILAMENTCHANGE_FIRSTRETRACT -2   // Retraction performed before parking the extruder or unloading filament
+#define FILAMENTCHANGE_FINALRETRACT -80  // Full filament retraction length
+
+#define FILAMENTCHANGE_FIRSTFEED 70 // E distance in mm for fast filament loading sequence used used in filament change (M600)
+#define FILAMENTCHANGE_FINALFEED 25 // E distance in mm for slow filament loading sequence used used in filament change (M600) and filament load (M701)
+
+#define FILAMENTCHANGE_PRIMEFEED   2 // E priming distance performed after resuming
+#define FILAMENTCHANGE_UNLOADFEED 10 // E priming distance performed before unloading
 
 #define FILAMENTCHANGE_XYFEED 50
+#define FILAMENTCHANGE_ZFEED 15
+
 #define FILAMENTCHANGE_EFEED_FIRST 20 // feedrate in mm/s for fast filament loading sequence used in filament change (M600)
 #define FILAMENTCHANGE_EFEED_FINAL 3.3f // feedrate in mm/s for slow filament loading sequence used in filament change (M600) and filament load (M701) 
-//#define FILAMENTCHANGE_RFEED 400
-#define FILAMENTCHANGE_RFEED 7000 / 60
-#define FILAMENTCHANGE_EXFEED 2
-#define FILAMENTCHANGE_ZFEED 15
+
+#define FILAMENTCHANGE_EFEED_RETRACT (7000 / 60) // quick filament retract feedrate in mm/s
+#define FILAMENTCHANGE_EFEED_EJECT   (1000 / 60) // filament ejection feedrate in mm/s
+#define FILAMENTCHANGE_EFEED_PRIME   ( 120 / 60) // filament priming feedrate (used before unloading and after resuming a print)
 
 #endif
 

--- a/Firmware/variants/1_75mm_MK25S-RAMBo10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK25S-RAMBo10a-E3Dv6full.h
@@ -242,21 +242,26 @@
 #ifdef FILAMENTCHANGEENABLE
 #define FILAMENTCHANGE_XPOS 211
 #define FILAMENTCHANGE_YPOS 0
-#define FILAMENTCHANGE_ZADD 2
-#define FILAMENTCHANGE_FIRSTRETRACT -2
-#define FILAMENTCHANGE_FINALRETRACT -80
+#define FILAMENTCHANGE_ZADD Z_PAUSE_LIFT
 
-#define FILAMENTCHANGE_FIRSTFEED 70 //E distance in mm for fast filament loading sequence used used in filament change (M600)
-#define FILAMENTCHANGE_FINALFEED 25 //E distance in mm for slow filament loading sequence used used in filament change (M600) and filament load (M701) 
-#define FILAMENTCHANGE_RECFEED 5
+#define FILAMENTCHANGE_FIRSTRETRACT -2   // Retraction performed before parking the extruder or unloading filament
+#define FILAMENTCHANGE_FINALRETRACT -80  // Full filament retraction length
+
+#define FILAMENTCHANGE_FIRSTFEED 70 // E distance in mm for fast filament loading sequence used used in filament change (M600)
+#define FILAMENTCHANGE_FINALFEED 25 // E distance in mm for slow filament loading sequence used used in filament change (M600) and filament load (M701)
+
+#define FILAMENTCHANGE_PRIMEFEED   2 // E priming distance performed after resuming
+#define FILAMENTCHANGE_UNLOADFEED 10 // E priming distance performed before unloading
 
 #define FILAMENTCHANGE_XYFEED 50
+#define FILAMENTCHANGE_ZFEED 15
+
 #define FILAMENTCHANGE_EFEED_FIRST 20 // feedrate in mm/s for fast filament loading sequence used in filament change (M600)
 #define FILAMENTCHANGE_EFEED_FINAL 3.3f // feedrate in mm/s for slow filament loading sequence used in filament change (M600) and filament load (M701) 
-//#define FILAMENTCHANGE_RFEED 400
-#define FILAMENTCHANGE_RFEED 7000 / 60
-#define FILAMENTCHANGE_EXFEED 2
-#define FILAMENTCHANGE_ZFEED 15
+
+#define FILAMENTCHANGE_EFEED_RETRACT (7000 / 60) // quick filament retract feedrate in mm/s
+#define FILAMENTCHANGE_EFEED_EJECT   (1000 / 60) // filament ejection feedrate in mm/s
+#define FILAMENTCHANGE_EFEED_PRIME   ( 120 / 60) // filament priming feedrate (used before unloading and after resuming a print)
 
 #endif
 

--- a/Firmware/variants/1_75mm_MK25S-RAMBo13a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK25S-RAMBo13a-E3Dv6full.h
@@ -243,21 +243,26 @@
 #ifdef FILAMENTCHANGEENABLE
 #define FILAMENTCHANGE_XPOS 211
 #define FILAMENTCHANGE_YPOS 0
-#define FILAMENTCHANGE_ZADD 2
-#define FILAMENTCHANGE_FIRSTRETRACT -2
-#define FILAMENTCHANGE_FINALRETRACT -80
+#define FILAMENTCHANGE_ZADD Z_PAUSE_LIFT
 
-#define FILAMENTCHANGE_FIRSTFEED 70 //E distance in mm for fast filament loading sequence used used in filament change (M600)
-#define FILAMENTCHANGE_FINALFEED 25 //E distance in mm for slow filament loading sequence used used in filament change (M600) and filament load (M701) 
-#define FILAMENTCHANGE_RECFEED 5
+#define FILAMENTCHANGE_FIRSTRETRACT -2   // Retraction performed before parking the extruder or unloading filament
+#define FILAMENTCHANGE_FINALRETRACT -80  // Full filament retraction length
+
+#define FILAMENTCHANGE_FIRSTFEED 70 // E distance in mm for fast filament loading sequence used used in filament change (M600)
+#define FILAMENTCHANGE_FINALFEED 25 // E distance in mm for slow filament loading sequence used used in filament change (M600) and filament load (M701)
+
+#define FILAMENTCHANGE_PRIMEFEED   2 // E priming distance performed after resuming
+#define FILAMENTCHANGE_UNLOADFEED 10 // E priming distance performed before unloading
 
 #define FILAMENTCHANGE_XYFEED 50
+#define FILAMENTCHANGE_ZFEED 15
+
 #define FILAMENTCHANGE_EFEED_FIRST 20 // feedrate in mm/s for fast filament loading sequence used in filament change (M600)
 #define FILAMENTCHANGE_EFEED_FINAL 3.3f // feedrate in mm/s for slow filament loading sequence used in filament change (M600) and filament load (M701) 
-//#define FILAMENTCHANGE_RFEED 400
-#define FILAMENTCHANGE_RFEED 7000 / 60
-#define FILAMENTCHANGE_EXFEED 2
-#define FILAMENTCHANGE_ZFEED 15
+
+#define FILAMENTCHANGE_EFEED_RETRACT (7000 / 60) // quick filament retract feedrate in mm/s
+#define FILAMENTCHANGE_EFEED_EJECT   (1000 / 60) // filament ejection feedrate in mm/s
+#define FILAMENTCHANGE_EFEED_PRIME   ( 120 / 60) // filament priming feedrate (used before unloading and after resuming a print)
 
 #endif
 

--- a/Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h
@@ -379,21 +379,26 @@
 #ifdef FILAMENTCHANGEENABLE
 #define FILAMENTCHANGE_XPOS 211
 #define FILAMENTCHANGE_YPOS 0
-#define FILAMENTCHANGE_ZADD 2
-#define FILAMENTCHANGE_FIRSTRETRACT -2
-#define FILAMENTCHANGE_FINALRETRACT -80
+#define FILAMENTCHANGE_ZADD Z_PAUSE_LIFT
 
-#define FILAMENTCHANGE_FIRSTFEED 70 //E distance in mm for fast filament loading sequence used used in filament change (M600)
-#define FILAMENTCHANGE_FINALFEED 25 //E distance in mm for slow filament loading sequence used used in filament change (M600) and filament load (M701) 
-#define FILAMENTCHANGE_RECFEED 5
+#define FILAMENTCHANGE_FIRSTRETRACT -2   // Retraction performed before parking the extruder or unloading filament
+#define FILAMENTCHANGE_FINALRETRACT -80  // Full filament retraction length
+
+#define FILAMENTCHANGE_FIRSTFEED 70 // E distance in mm for fast filament loading sequence used used in filament change (M600)
+#define FILAMENTCHANGE_FINALFEED 25 // E distance in mm for slow filament loading sequence used used in filament change (M600) and filament load (M701)
+
+#define FILAMENTCHANGE_PRIMEFEED   2 // E priming distance performed after resuming
+#define FILAMENTCHANGE_UNLOADFEED 10 // E priming distance performed before unloading
 
 #define FILAMENTCHANGE_XYFEED 50
+#define FILAMENTCHANGE_ZFEED 15
+
 #define FILAMENTCHANGE_EFEED_FIRST 20 // feedrate in mm/s for fast filament loading sequence used in filament change (M600)
 #define FILAMENTCHANGE_EFEED_FINAL 3.3f // feedrate in mm/s for slow filament loading sequence used in filament change (M600) and filament load (M701) 
-//#define FILAMENTCHANGE_RFEED 400
-#define FILAMENTCHANGE_RFEED 7000 / 60
-#define FILAMENTCHANGE_EXFEED 2
-#define FILAMENTCHANGE_ZFEED 15
+
+#define FILAMENTCHANGE_EFEED_RETRACT (7000 / 60) // quick filament retract feedrate in mm/s
+#define FILAMENTCHANGE_EFEED_EJECT   (1000 / 60) // filament ejection feedrate in mm/s
+#define FILAMENTCHANGE_EFEED_PRIME   ( 120 / 60) // filament priming feedrate (used before unloading and after resuming a print)
 
 #endif
 

--- a/Firmware/variants/1_75mm_MK3S-EINSy10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK3S-EINSy10a-E3Dv6full.h
@@ -383,21 +383,26 @@
 #ifdef FILAMENTCHANGEENABLE
 #define FILAMENTCHANGE_XPOS 211
 #define FILAMENTCHANGE_YPOS 0
-#define FILAMENTCHANGE_ZADD 2
-#define FILAMENTCHANGE_FIRSTRETRACT -2
-#define FILAMENTCHANGE_FINALRETRACT -80
+#define FILAMENTCHANGE_ZADD Z_PAUSE_LIFT
 
-#define FILAMENTCHANGE_FIRSTFEED 70 //E distance in mm for fast filament loading sequence used used in filament change (M600)
-#define FILAMENTCHANGE_FINALFEED 25 //E distance in mm for slow filament loading sequence used used in filament change (M600) and filament load (M701) 
-#define FILAMENTCHANGE_RECFEED 5
+#define FILAMENTCHANGE_FIRSTRETRACT -2   // Retraction performed before parking the extruder or unloading filament
+#define FILAMENTCHANGE_FINALRETRACT -80  // Full filament retraction length
+
+#define FILAMENTCHANGE_FIRSTFEED 70 // E distance in mm for fast filament loading sequence used used in filament change (M600)
+#define FILAMENTCHANGE_FINALFEED 25 // E distance in mm for slow filament loading sequence used used in filament change (M600) and filament load (M701)
+
+#define FILAMENTCHANGE_PRIMEFEED   2 // E priming distance performed after resuming
+#define FILAMENTCHANGE_UNLOADFEED 10 // E priming distance performed before unloading
 
 #define FILAMENTCHANGE_XYFEED 50
+#define FILAMENTCHANGE_ZFEED 15
+
 #define FILAMENTCHANGE_EFEED_FIRST 20 // feedrate in mm/s for fast filament loading sequence used in filament change (M600)
 #define FILAMENTCHANGE_EFEED_FINAL 3.3f // feedrate in mm/s for slow filament loading sequence used in filament change (M600) and filament load (M701) 
-//#define FILAMENTCHANGE_RFEED 400
-#define FILAMENTCHANGE_RFEED 7000 / 60
-#define FILAMENTCHANGE_EXFEED 2
-#define FILAMENTCHANGE_ZFEED 15
+
+#define FILAMENTCHANGE_EFEED_RETRACT (7000 / 60) // quick filament retract feedrate in mm/s
+#define FILAMENTCHANGE_EFEED_EJECT   (1000 / 60) // filament ejection feedrate in mm/s
+#define FILAMENTCHANGE_EFEED_PRIME   ( 120 / 60) // filament priming feedrate (used before unloading and after resuming a print)
 
 #endif
 

--- a/Firmware/variants/obsolete/1_75mm_MK2-RAMBo10a-E3Dv6full.h
+++ b/Firmware/variants/obsolete/1_75mm_MK2-RAMBo10a-E3Dv6full.h
@@ -159,20 +159,26 @@ CHANGE FILAMENT SETTINGS
 #ifdef FILAMENTCHANGEENABLE
 #define FILAMENTCHANGE_XPOS 211
 #define FILAMENTCHANGE_YPOS 0
-#define FILAMENTCHANGE_ZADD 2
-#define FILAMENTCHANGE_FIRSTRETRACT -2
-#define FILAMENTCHANGE_FINALRETRACT -80
+#define FILAMENTCHANGE_ZADD Z_PAUSE_LIFT
 
-#define FILAMENTCHANGE_FIRSTFEED 70 //E distance in mm for fast filament loading sequence used used in filament change (M600)
-#define FILAMENTCHANGE_FINALFEED 50 //E distance in mm for slow filament loading sequence used used in filament change (M600) and filament load (M701) 
-#define FILAMENTCHANGE_RECFEED 5
+#define FILAMENTCHANGE_FIRSTRETRACT -2   // Retraction performed before parking the extruder or unloading filament
+#define FILAMENTCHANGE_FINALRETRACT -80  // Full filament retraction length
+
+#define FILAMENTCHANGE_FIRSTFEED 70 // E distance in mm for fast filament loading sequence used used in filament change (M600)
+#define FILAMENTCHANGE_FINALFEED 50 // E distance in mm for slow filament loading sequence used used in filament change (M600) and filament load (M701) 
+
+#define FILAMENTCHANGE_PRIMEFEED   2 // E priming distance performed after resuming
+#define FILAMENTCHANGE_UNLOADFEED 10 // E priming distance performed before unloading
 
 #define FILAMENTCHANGE_XYFEED 50
+#define FILAMENTCHANGE_ZFEED 15
+
 #define FILAMENTCHANGE_EFEED_FIRST 20 // feedrate in mm/s for fast filament loading sequence used in filament change (M600)
 #define FILAMENTCHANGE_EFEED_FINAL 3.3f // feedrate in mm/s for slow filament loading sequence used in filament change (M600) and filament load (M701) 
-#define FILAMENTCHANGE_RFEED 400
-#define FILAMENTCHANGE_EXFEED 2
-#define FILAMENTCHANGE_ZFEED 15
+
+#define FILAMENTCHANGE_EFEED_RETRACT (7000 / 60) // quick filament retract feedrate in mm/s
+#define FILAMENTCHANGE_EFEED_EJECT   (1000 / 60) // filament ejection feedrate in mm/s
+#define FILAMENTCHANGE_EFEED_PRIME   ( 120 / 60) // filament priming feedrate (used before unloading and after resuming a print)
 
 #endif
 

--- a/Firmware/variants/obsolete/1_75mm_MK2-RAMBo13a-E3Dv6full.h
+++ b/Firmware/variants/obsolete/1_75mm_MK2-RAMBo13a-E3Dv6full.h
@@ -158,20 +158,26 @@ CHANGE FILAMENT SETTINGS
 #ifdef FILAMENTCHANGEENABLE
 #define FILAMENTCHANGE_XPOS 211
 #define FILAMENTCHANGE_YPOS 0
-#define FILAMENTCHANGE_ZADD 2
-#define FILAMENTCHANGE_FIRSTRETRACT -2
-#define FILAMENTCHANGE_FINALRETRACT -80
+#define FILAMENTCHANGE_ZADD Z_PAUSE_LIFT
 
-#define FILAMENTCHANGE_FIRSTFEED 70 //E distance in mm for fast filament loading sequence used used in filament change (M600)
-#define FILAMENTCHANGE_FINALFEED 50 //E distance in mm for slow filament loading sequence used used in filament change (M600) and filament load (M701) 
-#define FILAMENTCHANGE_RECFEED 5
+#define FILAMENTCHANGE_FIRSTRETRACT -2   // Retraction performed before parking the extruder or unloading filament
+#define FILAMENTCHANGE_FINALRETRACT -80  // Full filament retraction length
+
+#define FILAMENTCHANGE_FIRSTFEED 70 // E distance in mm for fast filament loading sequence used used in filament change (M600)
+#define FILAMENTCHANGE_FINALFEED 50 // E distance in mm for slow filament loading sequence used used in filament change (M600) and filament load (M701) 
+
+#define FILAMENTCHANGE_PRIMEFEED   2 // E priming distance performed after resuming
+#define FILAMENTCHANGE_UNLOADFEED 10 // E priming distance performed before unloading
 
 #define FILAMENTCHANGE_XYFEED 50
+#define FILAMENTCHANGE_ZFEED 15
+
 #define FILAMENTCHANGE_EFEED_FIRST 20 // feedrate in mm/s for fast filament loading sequence used in filament change (M600)
 #define FILAMENTCHANGE_EFEED_FINAL 3.3f // feedrate in mm/s for slow filament loading sequence used in filament change (M600) and filament load (M701) 
-#define FILAMENTCHANGE_RFEED 400
-#define FILAMENTCHANGE_EXFEED 2
-#define FILAMENTCHANGE_ZFEED 15
+
+#define FILAMENTCHANGE_EFEED_RETRACT (7000 / 60) // quick filament retract feedrate in mm/s
+#define FILAMENTCHANGE_EFEED_EJECT   (1000 / 60) // filament ejection feedrate in mm/s
+#define FILAMENTCHANGE_EFEED_PRIME   ( 120 / 60) // filament priming feedrate (used before unloading and after resuming a print)
 
 #endif
 


### PR DESCRIPTION
When the filament is left inside the hot zone a larger tip is formed, caused by slow softening of the material. On an MK3, this larger tip will fail to unload as it will jam inside the lower PTFE section, sometimes on the gears, and and sometimes upper PTFE section as well (depending on the viscosity state of the hot tip as it gets ejected).

This PR will perform a small extrusion when unloading manually (though the LCD) using this sequence:

- slow 5mm extrusion
- very slow 0.1mm extrusion to relieve leftover pressure (mostly for flexible materials)
- 2mm retract at max speed
- filament ejection

This sequence essentially extrudes the entire large section of the tip, which avoids jams.
This is *not* done when MMU is operating and/or when a filament runout occurs.

This has been discussed at lengths on issue #1095, and requested on #2162.

In addition, we re-organize the various #defines related to filament change inside the variant files in order to be more meaningful (the actual values are left unchanged).