### PR TITLE
Add oversighted ‘break’ statement at the M603 command's source

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -7250,9 +7250,10 @@ Sigma_Exit:
 
   //! ### M603 - Stop print
   // -------------------------------
-  case 603: {
+	case 603: {
 		lcd_print_stop();
 	}
+	break;
 
 #ifdef PINDA_THERMISTOR
   //! ### M860 - Wait for extruder temperature (PINDA)


### PR DESCRIPTION
Fix for the issue https://github.com/prusa3d/Prusa-Firmware/issues/2321.
