### PR TITLE
#2089 fix sheet rename cursor

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5054,6 +5054,10 @@ static void lcd_rename_sheet_menu()
         lcd_putc(menuData->name[i]);
     }
     lcd_putc_at(menuData->selected, 1, '^');
+    if (menuData->selected > 0)
+    {
+        lcd_putc_at(menuData->selected-1, 1, ' ');
+    }
     if (lcd_clicked())
     {
         if ((menuData->selected + 1u) < sizeof(Sheet::name))


### PR DESCRIPTION
Fixes #2089 

No longer leaves a cursor trail: 

![image](https://github.com/prusa3d/Prusa-Firmware/assets/53943260/38b59bfb-4471-478d-afbd-744db6ad64fe)
