### PR TITLE
Fix #2306 hard reset homing fails

### DIFF
--- a/Firmware/tmc2130.cpp
+++ b/Firmware/tmc2130.cpp
@@ -807,15 +807,15 @@ void tmc2130_goto_step(uint8_t axis, uint8_t step, uint8_t dir, uint16_t delay_u
 	{
 		dir = tmc2130_get_inv(axis)?0:1;
 		int steps = (int)step - (int)(mscnt >> shift);
-		if (steps < 0)
-		{
-			dir ^= 1;
-			steps = -steps;
-		}
 		if (steps > static_cast<int>(cnt / 2))
 		{
 			dir ^= 1;
-			steps = cnt - steps;
+			steps = cnt - steps; // This can create a negative step value
+		}
+        if (steps < 0)
+		{
+			dir ^= 1;
+			steps = -steps;
 		}
 		cnt = steps;
 	}


### PR DESCRIPTION
If steps >> cnt by more than cnt/2, the subtraction in the second if() can result in a negative value for steps. This leads to an underflow in the while loop and the printer resets.

Swapping the order of the ifs so that the negative step check occurs later and corrects this issue; the printer no longer resets, and homing still appears to be well behaved.

PFW-1069