### PR TITLE
Fix optiboot erase function after address 0xFFFF. Allows language files greater than 64K

### DIFF
--- a/Firmware/optiboot_w25x20cl.cpp
+++ b/Firmware/optiboot_w25x20cl.cpp
@@ -258,11 +258,11 @@ void optiboot_w25x20cl_enter()
         uint32_t addr = (((uint32_t)rampz) << 16) | address;
         // During a single bootloader run, only erase a 64kB block once.
         // An 8bit bitmask 'pages_erased' covers 512kB of FLASH memory.
-        if (address == 0 && (pages_erased & (1 << addr)) == 0) {
+        if ((address == 0) && (pages_erased & (1 << (addr >> 16))) == 0) {
           w25x20cl_wait_busy();
           w25x20cl_enable_wr();
           w25x20cl_block64_erase(addr);
-          pages_erased |= (1 << addr);
+          pages_erased |= (1 << (addr >> 16));
         }
         w25x20cl_wait_busy();
         w25x20cl_enable_wr();

--- a/lang/lang_en_cz.txt
+++ b/lang/lang_en_cz.txt
@@ -1188,7 +1188,7 @@
 
 #
 "The printer will start printing a zig-zag line. Rotate the knob until you reach the optimal height. Check the pictures in the handbook (Calibration chapter)."
-"\x00"
+"Tiskarna zacne tisknout lomenou caru. Otacenim tlacitka nastavte optimalni vysku. Postupujte podle obrazku v handbooku (kapitola Kalibrace)."
 
 #
 "Y-correct:"

--- a/lang/lang_en_de.txt
+++ b/lang/lang_en_de.txt
@@ -1188,7 +1188,7 @@
 
 #
 "The printer will start printing a zig-zag line. Rotate the knob until you reach the optimal height. Check the pictures in the handbook (Calibration chapter)."
-"\x00"
+"Der Drucker beginnt mit dem Drucken einer Zickzacklinie. Drehen Sie den Knopf, bis Sie die optimale Hoehe erreicht haben. Ueberpruefen Sie die Bilder im Handbuch (Kapitel Kalibrierung)."
 
 #
 "Y-correct:"

--- a/lang/lang_en_es.txt
+++ b/lang/lang_en_es.txt
@@ -1188,7 +1188,7 @@
 
 #
 "The printer will start printing a zig-zag line. Rotate the knob until you reach the optimal height. Check the pictures in the handbook (Calibration chapter)."
-"\x00"
+"La impresora comenzara a imprimir una linea en zig-zag. Gira el dial hasta que la linea alcance la altura optima. Mira las fotos del manual (Capitulo de calibracion)."
 
 #
 "Y-correct:"

--- a/lang/lang_en_fr.txt
+++ b/lang/lang_en_fr.txt
@@ -1185,7 +1185,7 @@
 
 #
 "The printer will start printing a zig-zag line. Rotate the knob until you reach the optimal height. Check the pictures in the handbook (Calibration chapter)."
-"\x00"
+"L'imprimante commencera a  imprimer une ligne en zig-zag. Tournez le bouton jusqu'a atteindre la hauteur optimale. Consultez les photos dans le manuel (chapitre Calibration)."
 
 #
 "Y-correct:"

--- a/lang/lang_en_it.txt
+++ b/lang/lang_en_it.txt
@@ -1187,7 +1187,7 @@
 
 #
 "The printer will start printing a zig-zag line. Rotate the knob until you reach the optimal height. Check the pictures in the handbook (Calibration chapter)."
-"\x00"
+"La stampante iniziera a stampare una linea a zig-zag. Gira la manopola fino a che non hai raggiungo l'altezza ottimale. Verifica con le immagini nel manuale (capitolo sulla calibrazione):"
 
 #
 "Y-correct:"

--- a/lang/lang_en_pl.txt
+++ b/lang/lang_en_pl.txt
@@ -1187,7 +1187,7 @@
 
 #
 "The printer will start printing a zig-zag line. Rotate the knob until you reach the optimal height. Check the pictures in the handbook (Calibration chapter)."
-"\x00"
+"Drukarka zacznie drukowanie linii w ksztalcie zygzaka. Ustaw optymalna wysokosc obracajac pokretlo. Porownaj z ilustracjami w Podreczniku (rozdzial Kalibracja)."
 
 #
 "Y-correct:"


### PR DESCRIPTION
This PR addresses an issue where if you tried to upload a language file greater than 64K, everything up to address 0xFFFF was fine, but the rest was only garbage data.
The issue might not have manifested to everyone **at first** since the rest of the flash was already erased and you would just write data on the erased portion. The problem starts when you want to change something in the already written area after 0xFFFF. The erase function didn't ever clear anything after 0xFFFF and you would get what appears to be as garbage data, but is in fact just a combination of what was before and what you just uploaded.

This issue has been encountered before by @3d-gussner when he tried packing two more languages into the firmware (resulting in ~80K of lang data), but some of the languages were unusable. It also was an issue with the recent release of fw 3.8 (@DRracer #2291 ), the total lang area was >64K and resulted in one unusable language and a failed upload.

With this PR, the upload process will once again be successful and will allow languages to expand in the near future. It also includes the omitted string from #2291 

PFW-1065