### PR TITLE
Set build.sh to use PF-build-env version 1.0.6.1

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash 
-BUILD_ENV="1.0.6"
+BUILD_ENV="1.0.6.1"
 SCRIPT_PATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
 if [ ! -d "build-env" ]; then
@@ -8,7 +8,8 @@ fi
 cd build-env || exit 2
 
 if [ ! -f "PF-build-env-Linux64-$BUILD_ENV.zip" ]; then
-    wget https://github.com/mkbel/PF-build-env/releases/download/$BUILD_ENV/PF-build-env-Linux64-$BUILD_ENV.zip || exit 3
+    #wget https://github.com/3d-gussner/PF-build-env-1/releases/download/$BUILD_ENV-Linux64/PF-build-env-Linux64-$BUILD_ENV.zip || exit 3
+	wget https://github.com/prusa3d/PF-build-env/releases/download/$BUILD_ENV-Linux64/PF-build-env-Linux64-$BUILD_ENV.zip || exit 3
 fi
 
 if [ ! -d "../../PF-build-env-$BUILD_ENV" ]; then


### PR DESCRIPTION
### What for is this PR needed?
- Needed for PR https://github.com/prusa3d/Prusa-Firmware/pull/2149

### Dependencies and order
1. This PR depends on https://github.com/prusa3d/PF-build-env/pull/3 and a release
2. Will be updated after PR above have been pulled and tested
3. After successful test the updated version THIS PR can be pulled

### How can this PR been tested?
At this moment `build.sh` has a link to the head repository of https://github.com/prusa3d/PF-build-env/pull/3 and can be tested.

### Update:
Switched `PF-build-env-Linux64-1.0.6.1.zip` to one has been zipped under WLS.
