### PR TITLE
MK3 fix language debug

### DIFF
--- a/Firmware/language.h
+++ b/Firmware/language.h
@@ -6,7 +6,9 @@
 
 #include "config.h"
 #include <inttypes.h>
-//#include <stdio.h>
+#ifdef DEBUG_SEC_LANG
+    #include <stdio.h>
+#endif //DEBUG_SEC_LANG
 
 #define PROTOCOL_VERSION "1.0"
 


### PR DESCRIPTION
This fixes the compiling error when you try to use `DEBUG_SEC_LANG` in a variant file.
Thanks to @leptun 