### PR TITLE
M600 - Custom message at the Insert filament prompt

### DIFF
--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -443,7 +443,7 @@ void gcode_M701(float fastLoadLength, uint8_t mmuSlotIndex);
 #define UVLO !(PINE & (1<<4))
 
 
-void M600_load_filament();
+void M600_load_filament(const char* lcd_load_message);
 void M600_load_filament_movements();
 void M600_wait_for_user();
 void M600_check_state();

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2118,10 +2118,20 @@ static void lcd_unLoadFilament()
 }
 
 void lcd_wait_interact() {
+    char lcd_load_message[1] = "";
+    lcd_load_message[0] = '\0';
+    lcd_wait_interact(lcd_load_message);
+}
+
+void lcd_wait_interact(const char* lcd_load_message) {
 
   lcd_clear();
 
-  lcd_puts_at_P(0, 1, _i("Insert filament"));////MSG_INSERT_FILAMENT c=20
+  lcd_puts_at_P(0, 0, _i("Insert filament"));////MSG_INSERT_FILAMENT c=20
+  if (lcd_load_message) {
+      lcd_set_cursor(0, 1);
+      lcd_print(lcd_load_message);
+  }
 #ifdef FILAMENT_SENSOR
   if (!fsensor.getAutoLoadEnabled())
 #endif //FILAMENT_SENSOR

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -51,6 +51,7 @@ void lcd_pick_babystep();
 uint8_t lcd_alright();
 void show_preheat_nozzle_warning();
 void lcd_wait_interact();
+void lcd_wait_interact(const char* lcd_load_message);
 void lcd_loading_filament();
 void lcd_change_success();
 void lcd_loading_color();


### PR DESCRIPTION
The M600 is a very useful command because it allows the user to change the filament at selected points during the printing.
If the user do not have an automated system (like MMU or Palette) then the M600 is the only solution. But even with the MMU, the user is limited to 5 colors/materials.

Recently, I needed to use 16 different colors per layer on the same print. The current implementation of the M600 command, after unloading the previous filament, it only displays the message "Insert filament", leaving to the user the responsibility to find out which filament is next...

This pull request improves dramatically this functionality, introducing a new parameter that defines a custom message to be displayed after the Insert filament message. The new syntax is:
```
M600 X[pos] Y[pos] Z[relative lift] E[initial retract] L[later retract distance for removal] C[Custom message to show during loading]
```
The size of the custom message is limited to the width of the LCD display.

So, the command:

```
M600 X200 Y0 Z20 CTraffic Red
```
will move the extruder at x=200, y=0, z=z+20, do the unloading and then show the message
```
Insert filament
Traffic Red
```

The C parameter should be the last one and the custom message will include everything after the parameter. Because there are some limitation to the command parser, there are several words that should not be used inside the message because they will trigger other functions. Try for example:

```
M600 G1 X100
```
It will move the extruder at x=100!!

To prevent this, the message should be enclosed between double quotes ("). If double quotes are used, then it is not necessary for the C parameter to be the latest. So, the proposed syntax is:

```
M600 X200 Y0 Z20 C"Traffic Red"
```

Note:
To implement the double quote functionality, the  new method "code_value_string" was introduced at the cmdqueue.h. Also, the two existing "code_seen" methods where improved to exclude everything enclosed between double quotes.


I've been testing and using the improved M600 for a couple of months now and I haven't found any side effects.
The functionality of the M600 command was tested:
- without the MMU2 and with disabled/enabled filament sensor and with enabled the auto-loading
- with MMU2, where no changes were detected in the normal operation of the filament run-out event (spool join on/off).