### PR TITLE
Fix lcd "Stop" when used within a pause

### DIFF
--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -455,6 +455,7 @@ extern void print_mesh_bed_leveling_table();
 
 extern void stop_and_save_print_to_ram(float z_move, float e_move);
 extern void restore_print_from_ram_and_continue(float e_move);
+extern void cancel_saved_printing();
 
 
 //estimated time to end of the print

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -10343,6 +10343,14 @@ void restore_print_from_ram_and_continue(float e_move)
     waiting_inside_plan_buffer_line_print_aborted = true; //unroll the stack
 }
 
+// Cancel the state related to a currently saved print
+void cancel_saved_printing()
+{
+    saved_target[0] = SAVED_TARGET_UNSET;
+    saved_printing_type = PRINTING_TYPE_NONE;
+    saved_printing = false;
+}
+
 void print_world_coordinates()
 {
 	printf_P(_N("world coordinates: (%.3f, %.3f, %.3f)\n"), current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS]);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -7258,30 +7258,25 @@ static void lcd_sd_updir()
 
 void lcd_print_stop()
 {
-//-//
-     if(!card.sdprinting)
-          {
-          SERIAL_ECHOLNRPGM(MSG_OCTOPRINT_CANCEL);   // for Octoprint
-          }
-	saved_printing = false;
-    saved_printing_type = PRINTING_TYPE_NONE;
+    if (!card.sdprinting) {
+        SERIAL_ECHOLNRPGM(MSG_OCTOPRINT_CANCEL);   // for Octoprint
+    }
+
+    cli();
+
+    // Clear any saved printing state
+    cancel_saved_printing();
 	cancel_heatup = true;
-#ifdef MESH_BED_LEVELING
-	mbl.active = false;
-#endif
-	// Stop the stoppers, update the position from the stoppers.
-	if (mesh_bed_leveling_flag == false && homing_flag == false)
-	{
-		planner_abort_hard();
-		// Because the planner_abort_hard() initialized current_position[Z] from the stepper,
-		// Z baystep is no more applied. Reset it.
-		babystep_reset();
-	}
-	// Clean the input command queue.
+
+    // Abort the planner/queue/sd
+    planner_abort_hard();
 	cmdqueue_reset();
-	lcd_setstatuspgm(_T(MSG_PRINT_ABORTED));
 	card.sdprinting = false;
 	card.closefile();
+    st_reset_timer();
+    sei();
+
+	lcd_setstatuspgm(_T(MSG_PRINT_ABORTED));
 	stoptime = _millis();
 	unsigned long t = (stoptime - starttime - pause_time) / 1000; //time in s
 	pause_time = 0;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -7262,7 +7262,7 @@ void lcd_print_stop()
         SERIAL_ECHOLNRPGM(MSG_OCTOPRINT_CANCEL);   // for Octoprint
     }
 
-    cli();
+    CRITICAL_SECTION_START;
 
     // Clear any saved printing state
     cancel_saved_printing();
@@ -7274,7 +7274,8 @@ void lcd_print_stop()
 	card.sdprinting = false;
 	card.closefile();
     st_reset_timer();
-    sei();
+
+    CRITICAL_SECTION_END;
 
 	lcd_setstatuspgm(_T(MSG_PRINT_ABORTED));
 	stoptime = _millis();


### PR DESCRIPTION
The "Stop" function, when called within the paused state, was broken with PR #2274: the ``saved_target`` variable is not correctly cleared when stop is called since it bypasses resume.

We introduce a new helper function ``cancel_saved_printing`` and reset the state within it to avoid having to do this in multiple places.

We also always call ``plan_abort_hard()`` and clear the queued commands within a critical section in order to cancel any currently processed ``mesh_plan_buffer_line()``, exactly as in the pause scenario.

PFW-1075

Additionally, we do not deactivate the mbl state as previously done: we *cannot* do that if we want to support resuming with M999.