### PR TITLE
Fix filament change behavior when issued in paused state

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3853,7 +3853,10 @@ static void gcode_M600(bool automatic, float x_position, float y_position, float
 	fsensor_check_autoload();
 #endif //IR_SENSOR
 
-    lcd_setstatuspgm(MSG_WELCOME);
+    if (isPrintPaused)
+        lcd_setstatuspgm(_i("Print paused"));////MSG_PRINT_PAUSED c=20 r=1
+    else
+        lcd_setstatuspgm(MSG_WELCOME);
     custom_message_type = CustomMsg::Status;
 }
 


### PR DESCRIPTION
Keep the "Tune" menu alive when the print is paused, disabling "Preheat" instead which doesn't make much sense.

All the actions which can be performed in Tune make sense during a pause, but this change is *especially* useful for the "Change filament" action, which moves the extruder to the front-left.

Most changes are related to gcode_M600 tweaks to handle a filament change correctly when issued from within the paused state via the LCD:
- re-heats the hotend to the saved temperature prior to unloading and cools it down again after reload
- keeps the filament in a retracted state, to be consistent with the paused state.

Fixes #2387

PFW-1097