### PR TITLE
Avoid more recursive behavior in fsensor_update

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -8606,7 +8606,8 @@ if(0)
 #ifdef PAT9125
 				fsensor_autoload_check_stop();
 #endif //PAT9125
-				fsensor_update();
+                if (fsensor_enabled && !saved_printing)
+                    fsensor_update();
 			}
 		}
 	}

--- a/Firmware/fsensor.cpp
+++ b/Firmware/fsensor.cpp
@@ -585,6 +585,11 @@ void fsensor_update(void)
 			bool oq_meassure_enabled_tmp = fsensor_oq_meassure_enabled;
 			fsensor_oq_meassure_enabled = true;
 
+            // move the nozzle away while checking the filament
+            current_position[Z_AXIS] += 0.8;
+            if(current_position[Z_AXIS] > Z_MAX_POS) current_position[Z_AXIS] = Z_MAX_POS;
+            plan_buffer_line_curposXYZE(max_feedrate[Z_AXIS], active_extruder);
+            st_synchronize();
 
 			fsensor_err_cnt = 0;
 			fsensor_oq_meassure_start(0);

--- a/Firmware/fsensor.cpp
+++ b/Firmware/fsensor.cpp
@@ -579,6 +579,7 @@ void fsensor_update(void)
 		if (fsensor_enabled && fsensor_watch_runout && (fsensor_err_cnt > FSENSOR_ERR_MAX))
 		{
 			fsensor_stop_and_save_print();
+            KEEPALIVE_STATE(IN_HANDLER);
 
 			bool autoload_enabled_tmp = fsensor_autoload_enabled;
 			fsensor_autoload_enabled = false;

--- a/Firmware/fsensor.cpp
+++ b/Firmware/fsensor.cpp
@@ -576,7 +576,7 @@ void fsensor_enque_M600(){
 void fsensor_update(void)
 {
 #ifdef PAT9125
-		if (fsensor_enabled && fsensor_watch_runout && (fsensor_err_cnt > FSENSOR_ERR_MAX))
+		if (fsensor_watch_runout && (fsensor_err_cnt > FSENSOR_ERR_MAX))
 		{
 			fsensor_stop_and_save_print();
             KEEPALIVE_STATE(IN_HANDLER);
@@ -621,7 +621,7 @@ void fsensor_update(void)
 				fsensor_enque_M600();
 		}
 #else //PAT9125
-		if (CHECK_FSENSOR && fsensor_enabled && ir_sensor_detected)
+		if (CHECK_FSENSOR && ir_sensor_detected)
         {
                if(digitalRead(IR_SENSOR_PIN))
                {                                  // IR_SENSOR_PIN ~ H

--- a/Firmware/fsensor.cpp
+++ b/Firmware/fsensor.cpp
@@ -591,20 +591,15 @@ void fsensor_update(void)
             plan_buffer_line_curposXYZE(max_feedrate[Z_AXIS], active_extruder);
             st_synchronize();
 
+            // check the filament in isolation
 			fsensor_err_cnt = 0;
 			fsensor_oq_meassure_start(0);
-
-			enquecommand_front_P((PSTR("G1 E-3 F200")));
-			process_commands();
-			KEEPALIVE_STATE(IN_HANDLER);
-			cmdqueue_pop_front();
-			st_synchronize();
-
-			enquecommand_front_P((PSTR("G1 E3 F200")));
-			process_commands();
-			KEEPALIVE_STATE(IN_HANDLER);
-			cmdqueue_pop_front();
-			st_synchronize();
+            float e_tmp = current_position[E_AXIS];
+            current_position[E_AXIS] -= 3;
+            plan_buffer_line_curposXYZE(200/60, active_extruder);
+            current_position[E_AXIS] = e_tmp;
+            plan_buffer_line_curposXYZE(200/60, active_extruder);
+            st_synchronize();
 
 			uint8_t err_cnt = fsensor_err_cnt;
 			fsensor_oq_meassure_stop();


### PR DESCRIPTION
In the MK3 (with the optical/laser sensor) ``fsensor_update`` enqueues commands to the main loop to check for the filament status. In some circumstances (mesh_plan_buffer_line->sync->mesh_plan_buffer_line->filament_update->process_commands->runout) the recursive call to ``process_commands()`` will cause a stack overflow. The stack at this point is so large that frequently the stack guard doesn't even trigger.

We remove the recursive call to process_commands and replace it instead by calling ``plan_buffer_line`` directly. We also move some filament status checks earlier up in the call chain to shrink the stack further while the nested check is being performed.

As an added bonus, while we check for the filament status, we briefly lift the extruder to avoid scorching the print during the 2-second pause.

PFW-1086