### PR TITLE
Improve raise_z_above to always raise when at Z_MIN

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -2125,9 +2125,15 @@ void raise_z_above(float target, bool plan)
     // Z needs raising
     current_position[Z_AXIS] = target;
 
-    if (axis_known_position[Z_AXIS])
+#if defined(Z_MIN_PIN) && (Z_MIN_PIN > -1) && !defined(DEBUG_DISABLE_ZMINLIMIT)
+    bool z_min_endstop = (READ(Z_MIN_PIN) != Z_MIN_ENDSTOP_INVERTING);
+#else
+    bool z_min_endstop = false;
+#endif
+
+    if (axis_known_position[Z_AXIS] || z_min_endstop)
     {
-        // current position is known, it's safe to raise Z
+        // current position is known or very low, it's safe to raise Z
         if(plan) plan_buffer_line_curposXYZE(max_feedrate[Z_AXIS], active_extruder);
         return;
     }


### PR DESCRIPTION
When check_z_endstop is set, Z_MIN_PIN is checkend regardless of the
moving direction to support Z calibration. This prevents the ability
to use _just_ SG when moving upwards.

But since we know the extruder is at Z_MIN, it's always safe to raise
irregardless, so we can dodge the issue.

PFW-1074