### PR TITLE
Show ? near Z value if the position is unknown

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -586,7 +586,7 @@ void lcdui_print_Z_coord(void)
     if (custom_message_type == CustomMsg::MeshBedLeveling)
         lcd_puts_P(_N("Z   --- "));
     else
-		lcd_printf_P(_N("Z%6.2f "), current_position[Z_AXIS]);
+		lcd_printf_P(_N("Z%6.2f%c"), current_position[Z_AXIS], axis_known_position[Z_AXIS]?' ':'?');
 }
 
 #ifdef PLANNER_DIAGNOSTICS


### PR DESCRIPTION
If the Z axis was not homed since the last firmware reset, assume Z value is incorrect and show '?' near it just like with time remaining when speed multiplier is changed. After the first homing of the Z axis is done, the '?' is changed for ' ' just like before.

PFW-1074