### PR TITLE
Clear the USB printing counter when cancelling a print

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -6265,6 +6265,9 @@ Sigma_Exit:
           disable_e1();
           disable_e2();
           finishAndDisableSteppers();
+
+          // Clear the USB printing counter, show "real" menus
+          usb_printing_counter = 0;
         }
         else
         {


### PR DESCRIPTION
Small patch to show the "real" menus immediately after printing is cancelled (i.e. steppers are off) when printing serially / via USB. Having to wait for the timeout doesn't make sense.