### PR TITLE
LCD option to unload new filament on M600 (issue #2415)

### DIFF
--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -446,7 +446,7 @@ void gcode_M701(float fastLoadLength, uint8_t mmuSlotIndex);
 void M600_load_filament();
 void M600_load_filament_movements();
 void M600_wait_for_user();
-void M600_check_state();
+bool M600_check_state_and_repeat();
 void load_filament_final_feed();
 void marlin_wait_for_click();
 float raise_z(float delta);

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3473,7 +3473,6 @@ static void gcode_M600(const bool automatic, const float x_position, const float
         }
         if (!automatic)
             repeat = M600_check_state_and_repeat();
-        
     }
     while (repeat);
 
@@ -11107,7 +11106,7 @@ void M600_load_filament() {
 	}
 	KEEPALIVE_STATE(IN_HANDLER);
 
-    M600_load_filament_movements();
+	M600_load_filament_movements();
 
 	Sound_MakeCustom(50,1000,false);
 }

--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -122,7 +122,7 @@ const char MSG_STOP_PRINT[] PROGMEM_I1 = ISTR("Stop print"); ////MSG_STOP_PRINT 
 const char MSG_STOPPED[] PROGMEM_I1 = ISTR("STOPPED."); ////MSG_STOPPED c=20
 const char MSG_PINDA_CALIBRATION[] PROGMEM_I1 = ISTR("PINDA cal."); ////MSG_PINDA_CALIBRATION c=13
 const char MSG_PINDA_CALIBRATION_DONE[] PROGMEM_I1 = ISTR("PINDA calibration is finished and active. It can be disabled in menu Settings->PINDA cal."); ////MSG_PINDA_CALIBRATION_DONE c=20 r=8
-const char MSG_UNLOAD_FILAMENT[] PROGMEM_I1 = ISTR("Unload filament"); ////MSG_UNLOAD_FILAMENT c=16
+const char MSG_UNLOAD_FILAMENT[] PROGMEM_I1 = ISTR("Unload filament"); ////MSG_UNLOAD_FILAMENT c=18
 const char MSG_UNLOADING_FILAMENT[] PROGMEM_I1 = ISTR("Unloading filament"); ////MSG_UNLOADING_FILAMENT c=20
 const char MSG_INFO_SCREEN[] PROGMEM_I1 = ISTR("Info screen"); ////MSG_INFO_SCREEN c=18
 const char MSG_WIZARD_CALIBRATION_FAILED[] PROGMEM_I1 = ISTR("Please check our handbook and fix the problem. Then resume the Wizard by rebooting the printer."); ////MSG_WIZARD_CALIBRATION_FAILED c=20 r=8

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2179,14 +2179,14 @@ void lcd_loading_filament() {
 
 
 uint8_t lcd_alright() {
-    uint8_t cursor_pos = 1;
+    uint8_t cursor_pos = 0;
 
     lcd_clear();
-    lcd_puts_at_P(0, 0, _i("Changed correctly?"));////MSG_CORRECTLY c=20
-    lcd_puts_at_P(1, 1, _T(MSG_YES));
-    lcd_puts_at_P(1, 2, _i("Filament not loaded"));////MSG_NOT_LOADED c=19
-    lcd_puts_at_P(1, 3, _i("Color not correct"));////MSG_NOT_COLOR c=19
-    lcd_putc_at(0, 1, '>');
+    lcd_puts_at_P(1, 0, _i("Changed correctly"));////MSG_CORRECTLY c=20
+    lcd_puts_at_P(1, 1, _i("Filament not loaded"));////MSG_NOT_LOADED c=19
+    lcd_puts_at_P(1, 2, _i("Color not correct"));////MSG_NOT_COLOR c=19
+    lcd_puts_at_P(1, 3, _i("Unload filament"));////MSG_UNLOAD_FILAMENT c=17
+    lcd_putc_at(0, cursor_pos, '>');
 
     lcd_consume_click();
     while (1)
@@ -2199,21 +2199,20 @@ uint8_t lcd_alright() {
 
             if (lcd_encoder < 0 ) {
                 // Rotating knob counter clockwise
-                cursor_pos--;
+                if (cursor_pos > 0)
+                    cursor_pos--;
+                else 
+                    Sound_MakeSound(e_SOUND_TYPE_BlindAlert);
             } else if (lcd_encoder > 0) {
                 // Rotating knob clockwise
-                cursor_pos++;
-            }
-            if (cursor_pos > 3) {
-                cursor_pos = 3;
-                Sound_MakeSound(e_SOUND_TYPE_BlindAlert);
-            } else if (cursor_pos < 1) {
-                cursor_pos = 1;
-                Sound_MakeSound(e_SOUND_TYPE_BlindAlert);
+                if (cursor_pos < 3)
+                    cursor_pos++;
+                else
+                    Sound_MakeSound(e_SOUND_TYPE_BlindAlert);
             }
 
             // Update '>' render only
-            lcd_puts_at_P(0, 1, PSTR(" \n \n "));
+            lcd_puts_at_P(0, 0, PSTR(" \n \n \n "));
             lcd_putc_at(0, cursor_pos, '>');
 
             // Consume rotation event and make feedback sound

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2182,10 +2182,10 @@ uint8_t lcd_alright() {
     uint8_t cursor_pos = 0;
 
     lcd_clear();
-    lcd_puts_at_P(1, 0, _i("Changed correctly"));////MSG_CORRECTLY c=20
+    lcd_puts_at_P(1, 0, _i("Changed correctly"));////MSG_CORRECTLY c=19
     lcd_puts_at_P(1, 1, _i("Filament not loaded"));////MSG_NOT_LOADED c=19
     lcd_puts_at_P(1, 2, _i("Color not correct"));////MSG_NOT_COLOR c=19
-    lcd_puts_at_P(1, 3, _i("Unload filament"));////MSG_UNLOAD_FILAMENT c=17
+    lcd_puts_at_P(1, 3, _T(MSG_UNLOAD_FILAMENT));
     lcd_putc_at(0, cursor_pos, '>');
 
     lcd_consume_click();
@@ -2201,7 +2201,7 @@ uint8_t lcd_alright() {
                 // Rotating knob counter clockwise
                 if (cursor_pos > 0)
                     cursor_pos--;
-                else 
+                else
                     Sound_MakeSound(e_SOUND_TYPE_BlindAlert);
             } else if (lcd_encoder > 0) {
                 // Rotating knob clockwise

--- a/lang/po/Firmware.pot
+++ b/lang/po/Firmware.pot
@@ -269,9 +269,9 @@ msgstr ""
 msgid "Change success!"
 msgstr ""
 
-#. MSG_CORRECTLY c=20
+#. MSG_CORRECTLY c=19
 #: ../../Firmware/ultralcd.cpp:2179
-msgid "Changed correctly?"
+msgid "Changed correctly"
 msgstr ""
 
 #. MSG_CHECKING_X c=20
@@ -2240,7 +2240,7 @@ msgstr ""
 msgid "Unload"
 msgstr ""
 
-#. MSG_UNLOAD_FILAMENT c=16
+#. MSG_UNLOAD_FILAMENT c=18
 #: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5282
 #: ../../Firmware/ultralcd.cpp:5299
 msgid "Unload filament"

--- a/lang/po/Firmware_cs.po
+++ b/lang/po/Firmware_cs.po
@@ -285,10 +285,10 @@ msgstr "Vyměnit filament"
 msgid "Change success!"
 msgstr "Změna úspěšná!"
 
-#. MSG_CORRECTLY c=20
+#. MSG_CORRECTLY c=19
 #: ../../Firmware/ultralcd.cpp:2179
-msgid "Changed correctly?"
-msgstr "Výměna ok?"
+msgid "Changed correctly"
+msgstr "Výměna ok"
 
 #. MSG_CHECKING_X c=20
 #: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:5838
@@ -2189,7 +2189,7 @@ msgstr "MANUÁLNÍ VYJMUTÍ"
 msgid "Unload"
 msgstr "Vyjmout"
 
-#. MSG_UNLOAD_FILAMENT c=16
+#. MSG_UNLOAD_FILAMENT c=18
 #: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5282
 #: ../../Firmware/ultralcd.cpp:5299
 msgid "Unload filament"

--- a/lang/po/Firmware_de.po
+++ b/lang/po/Firmware_de.po
@@ -288,10 +288,10 @@ msgstr "Filament-Wechsel"
 msgid "Change success!"
 msgstr "Wechsel erfolgreich!"
 
-#. MSG_CORRECTLY c=20
+#. MSG_CORRECTLY c=19
 #: ../../Firmware/ultralcd.cpp:2179
-msgid "Changed correctly?"
-msgstr "Wechsel ok?"
+msgid "Changed correctly"
+msgstr "Wechsel ok"
 
 #. MSG_CHECKING_X c=20
 #: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:5838
@@ -2211,7 +2211,7 @@ msgstr "ENTLADE MANUELL"
 msgid "Unload"
 msgstr "Entla."
 
-#. MSG_UNLOAD_FILAMENT c=16
+#. MSG_UNLOAD_FILAMENT c=18
 #: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5282
 #: ../../Firmware/ultralcd.cpp:5299
 msgid "Unload filament"

--- a/lang/po/Firmware_es.po
+++ b/lang/po/Firmware_es.po
@@ -285,10 +285,10 @@ msgstr "Cambiar filamento"
 msgid "Change success!"
 msgstr "Cambio correcto!"
 
-#. MSG_CORRECTLY c=20
+#. MSG_CORRECTLY c=19
 #: ../../Firmware/ultralcd.cpp:2179
-msgid "Changed correctly?"
-msgstr "¿Cambio correcto?"
+msgid "Changed correctly"
+msgstr "Cambio correcto"
 
 #. MSG_CHECKING_X c=20
 #: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:5838
@@ -2216,7 +2216,7 @@ msgstr "DESCARGA MANUAL"
 msgid "Unload"
 msgstr "Desc."
 
-#. MSG_UNLOAD_FILAMENT c=16
+#. MSG_UNLOAD_FILAMENT c=18
 #: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5282
 #: ../../Firmware/ultralcd.cpp:5299
 msgid "Unload filament"

--- a/lang/po/Firmware_fr.po
+++ b/lang/po/Firmware_fr.po
@@ -287,10 +287,10 @@ msgstr "Changer filament"
 msgid "Change success!"
 msgstr "Changement réussi!"
 
-#. MSG_CORRECTLY c=20
+#. MSG_CORRECTLY c=19
 #: ../../Firmware/ultralcd.cpp:2179
-msgid "Changed correctly?"
-msgstr "Change correctement?"
+msgid "Changed correctly"
+msgstr "Change correctement"
 
 #. MSG_CHECKING_X c=20
 #: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:5838
@@ -2217,7 +2217,7 @@ msgstr "DÉCHARGER MANUEL.T"
 msgid "Unload"
 msgstr "Déch."
 
-#. MSG_UNLOAD_FILAMENT c=16
+#. MSG_UNLOAD_FILAMENT c=18
 #: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5282
 #: ../../Firmware/ultralcd.cpp:5299
 msgid "Unload filament"

--- a/lang/po/Firmware_hr.po
+++ b/lang/po/Firmware_hr.po
@@ -285,10 +285,10 @@ msgstr "Promijeni filament"
 msgid "Change success!"
 msgstr "Promijena uspjesna!"
 
-#. MSG_CORRECTLY c=20
+#. MSG_CORRECTLY c=19
 #: ../../Firmware/ultralcd.cpp:2179
-msgid "Changed correctly?"
-msgstr "Ispravno izmjenjeno?"
+msgid "Changed correctly"
+msgstr "Ispravno izmjenjeno"
 
 #. MSG_CHECKING_X c=20
 #: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:5838
@@ -2212,7 +2212,7 @@ msgstr "ISPRAZNI RUCNO"
 msgid "Unload"
 msgstr "Prazni"
 
-#. MSG_UNLOAD_FILAMENT c=16
+#. MSG_UNLOAD_FILAMENT c=18
 #: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5282
 #: ../../Firmware/ultralcd.cpp:5299
 msgid "Unload filament"

--- a/lang/po/Firmware_hu.po
+++ b/lang/po/Firmware_hu.po
@@ -285,10 +285,10 @@ msgstr "Filament csere"
 msgid "Change success!"
 msgstr "Csere sikerult!"
 
-#. MSG_CORRECTLY c=20
+#. MSG_CORRECTLY c=19
 #: ../../Firmware/ultralcd.cpp:2179
-msgid "Changed correctly?"
-msgstr "Sikerult a csere?"
+msgid "Changed correctly"
+msgstr "Sikerult a csere"
 
 #. MSG_CHECKING_X c=20
 #: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:5838
@@ -2212,7 +2212,7 @@ msgstr "VEDD KI KEZZEL"
 msgid "Unload"
 msgstr "Kiadas"
 
-#. MSG_UNLOAD_FILAMENT c=16
+#. MSG_UNLOAD_FILAMENT c=18
 #: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5282
 #: ../../Firmware/ultralcd.cpp:5299
 msgid "Unload filament"

--- a/lang/po/Firmware_it.po
+++ b/lang/po/Firmware_it.po
@@ -287,10 +287,10 @@ msgstr "Cambia filamento"
 msgid "Change success!"
 msgstr "Cambio riuscito!"
 
-#. MSG_CORRECTLY c=20
+#. MSG_CORRECTLY c=19
 #: ../../Firmware/ultralcd.cpp:2179
-msgid "Changed correctly?"
-msgstr "Cambio corretto?"
+msgid "Changed correctly"
+msgstr "Cambio corretto"
 
 #. MSG_CHECKING_X c=20
 #: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:5838
@@ -2215,7 +2215,7 @@ msgstr "SCARICA MANUALMENTE"
 msgid "Unload"
 msgstr "Scarica"
 
-#. MSG_UNLOAD_FILAMENT c=16
+#. MSG_UNLOAD_FILAMENT c=18
 #: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5282
 #: ../../Firmware/ultralcd.cpp:5299
 msgid "Unload filament"

--- a/lang/po/Firmware_nl.po
+++ b/lang/po/Firmware_nl.po
@@ -287,10 +287,10 @@ msgstr "Wissel filament"
 msgid "Change success!"
 msgstr "Wissel geslaagd!"
 
-#. MSG_CORRECTLY c=20
+#. MSG_CORRECTLY c=19
 #: ../../Firmware/ultralcd.cpp:2179
-msgid "Changed correctly?"
-msgstr "Wissel ok?"
+msgid "Changed correctly"
+msgstr "Wissel ok"
 
 #. MSG_CHECKING_X c=20
 #: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:5838
@@ -2221,7 +2221,7 @@ msgstr "ONTLAAD MANUEEL"
 msgid "Unload"
 msgstr "Ontla."
 
-#. MSG_UNLOAD_FILAMENT c=16
+#. MSG_UNLOAD_FILAMENT c=18
 #: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5282
 #: ../../Firmware/ultralcd.cpp:5299
 msgid "Unload filament"

--- a/lang/po/Firmware_no.po
+++ b/lang/po/Firmware_no.po
@@ -286,10 +286,10 @@ msgstr "Bytt filament"
 msgid "Change success!"
 msgstr "Bytte vellykket!"
 
-#. MSG_CORRECTLY c=20
+#. MSG_CORRECTLY c=19
 #: ../../Firmware/ultralcd.cpp:2179
-msgid "Changed correctly?"
-msgstr "Byttet riktig?"
+msgid "Changed correctly"
+msgstr "Byttet riktig"
 
 #. MSG_CHECKING_X c=20
 #: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:5838
@@ -2196,7 +2196,7 @@ msgstr "LAST UT MANUELT"
 msgid "Unload"
 msgstr "Last ut"
 
-#. MSG_UNLOAD_FILAMENT c=16
+#. MSG_UNLOAD_FILAMENT c=18
 #: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5282
 #: ../../Firmware/ultralcd.cpp:5299
 msgid "Unload filament"

--- a/lang/po/Firmware_pl.po
+++ b/lang/po/Firmware_pl.po
@@ -286,10 +286,10 @@ msgstr "Wymiana filamentu"
 msgid "Change success!"
 msgstr "Wymiana udana!"
 
-#. MSG_CORRECTLY c=20
+#. MSG_CORRECTLY c=19
 #: ../../Firmware/ultralcd.cpp:2179
-msgid "Changed correctly?"
-msgstr "Wymiana udała się?"
+msgid "Changed correctly"
+msgstr "Wymiana udała się"
 
 #. MSG_CHECKING_X c=20
 #: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:5838
@@ -2212,7 +2212,7 @@ msgstr "WYŁADUJ RĘCZNIE"
 msgid "Unload"
 msgstr "Wyładuj"
 
-#. MSG_UNLOAD_FILAMENT c=16
+#. MSG_UNLOAD_FILAMENT c=18
 #: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5282
 #: ../../Firmware/ultralcd.cpp:5299
 msgid "Unload filament"

--- a/lang/po/Firmware_ro.po
+++ b/lang/po/Firmware_ro.po
@@ -288,10 +288,10 @@ msgstr "Schimbă filamentul"
 msgid "Change success!"
 msgstr "Schimbare cu succes!"
 
-#. MSG_CORRECTLY c=20
+#. MSG_CORRECTLY c=19
 #: ../../Firmware/ultralcd.cpp:2179
-msgid "Changed correctly?"
-msgstr "Schimbat corect?"
+msgid "Changed correctly"
+msgstr "Schimbat corect"
 
 #. MSG_CHECKING_X c=20
 #: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:5838
@@ -2212,7 +2212,7 @@ msgstr "DESCĂRCARE MANUALĂ"
 msgid "Unload"
 msgstr "Descărc."
 
-#. MSG_UNLOAD_FILAMENT c=16
+#. MSG_UNLOAD_FILAMENT c=18
 #: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5282
 #: ../../Firmware/ultralcd.cpp:5299
 msgid "Unload filament"

--- a/lang/po/Firmware_sk.po
+++ b/lang/po/Firmware_sk.po
@@ -285,10 +285,10 @@ msgstr "Vymeniť filament"
 msgid "Change success!"
 msgstr "Výmena úspešná!"
 
-#. MSG_CORRECTLY c=20
+#. MSG_CORRECTLY c=19
 #: ../../Firmware/ultralcd.cpp:2179
-msgid "Changed correctly?"
-msgstr "Výmena ok?"
+msgid "Changed correctly"
+msgstr "Výmena ok"
 
 #. MSG_CHECKING_X c=20
 #: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:5838
@@ -2202,7 +2202,7 @@ msgstr "UNLOAD MANUALLY"
 msgid "Unload"
 msgstr "Výsuv"
 
-#. MSG_UNLOAD_FILAMENT c=16
+#. MSG_UNLOAD_FILAMENT c=18
 #: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5282
 #: ../../Firmware/ultralcd.cpp:5299
 msgid "Unload filament"

--- a/lang/po/Firmware_sv.po
+++ b/lang/po/Firmware_sv.po
@@ -286,10 +286,10 @@ msgstr "Ändra filament"
 msgid "Change success!"
 msgstr "Ändring utförd!"
 
-#. MSG_CORRECTLY c=20
+#. MSG_CORRECTLY c=19
 #: ../../Firmware/ultralcd.cpp:2179
-msgid "Changed correctly?"
-msgstr "Ändring korrekt?"
+msgid "Changed correctly"
+msgstr "Ändring korrekt"
 
 #. MSG_CHECKING_X c=20
 #: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:5838
@@ -2210,7 +2210,7 @@ msgstr "LADDA UR MANUELLT"
 msgid "Unload"
 msgstr "Ladda ur"
 
-#. MSG_UNLOAD_FILAMENT c=16
+#. MSG_UNLOAD_FILAMENT c=18
 #: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:5282
 #: ../../Firmware/ultralcd.cpp:5299
 msgid "Unload filament"


### PR DESCRIPTION
I have met sometimes the situation described at the issue #2415 and I think that it would be useful to add the option.

Since the screen was already filled with the header and the three choices, I assigned the "Yes" choice to the header. So the new screen is:
```
>Changed correctly
 Filament not loaded
 Color not correct
 Unload filament
```
