### PR TITLE
🐛Even more fixes to lcd_print_stop

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -4699,8 +4699,13 @@ if(eSoundMode!=e_SOUND_MODE_SILENT)
 			// We don't know where we are! HOME!
 			// Push the commands to the front of the message queue in the reverse order!
 			// There shall be always enough space reserved for these commands.
-			repeatcommand_front(); // repeat G80 with all its parameters
-			enquecommand_front_P((PSTR("G28 W0")));
+			if (lcd_commands_type != LcdCommands::StopPrint) {
+				repeatcommand_front(); // repeat G80 with all its parameters
+				enquecommand_front_P((PSTR("G28 W0")));
+			}
+			else {
+				mesh_bed_leveling_flag = false;
+			}
 			break;
 		} 
 		
@@ -4730,14 +4735,23 @@ if(eSoundMode!=e_SOUND_MODE_SILENT)
 #ifndef PINDA_THERMISTOR
 		if (run == false && temp_cal_active == true && calibration_status_pinda() == true && target_temperature_bed >= 50)
 		{
-			temp_compensation_start();
-			run = true;
-			repeatcommand_front(); // repeat G80 with all its parameters
-			enquecommand_front_P((PSTR("G28 W0")));
+			if (lcd_commands_type != LcdCommands::StopPrint) {
+				temp_compensation_start();
+				run = true;
+				repeatcommand_front(); // repeat G80 with all its parameters
+				enquecommand_front_P((PSTR("G28 W0")));
+			}
+			else {
+				mesh_bed_leveling_flag = false;
+			}
 			break;
 		}
         run = false;
 #endif //PINDA_THERMISTOR
+		if (lcd_commands_type == LcdCommands::StopPrint) {
+			mesh_bed_leveling_flag = false;
+			break;
+		}
 		// Save custom message state, set a new custom message state to display: Calibrating point 9.
 		CustomMsg custom_message_type_old = custom_message_type;
 		unsigned int custom_message_state_old = custom_message_state;
@@ -6163,6 +6177,7 @@ Sigma_Exit:
           manage_heater();
           manage_inactivity();
           lcd_update(0);
+		  if (cancel_heatup) break;
         }
         LCD_MESSAGERPGM(_T(MSG_BED_DONE));
 		KEEPALIVE_STATE(IN_HANDLER);
@@ -7328,6 +7343,7 @@ Sigma_Exit:
 			manage_heater();
 			manage_inactivity();
 			lcd_update(0);
+			if (cancel_heatup) break;
 		}
 		LCD_MESSAGERPGM(MSG_OK);
 

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1500,12 +1500,7 @@ void lcd_commands()
 		lcd_setstatuspgm(_T(WELCOME_MSG));
 		custom_message_type = CustomMsg::Status;
 
-		// planner_abort_hard(); //needs to be done since plan_buffer_line resets waiting_inside_plan_buffer_line_print_aborted to false. Also copies current to destination.
-		
-		axis_relative_modes[X_AXIS] = false;
-		axis_relative_modes[Y_AXIS] = false;
-		axis_relative_modes[Z_AXIS] = false;
-		axis_relative_modes[E_AXIS] = true;
+		axis_relative_modes = E_AXIS_MASK; //XYZ absolute, E relative
 		
 		isPrintPaused = false; //clear isPrintPaused flag to allow starting next print after pause->stop scenario.
 	}

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1474,39 +1474,35 @@ void lcd_commands()
 
 	if (lcd_commands_type == LcdCommands::StopPrint)   /// stop print
 	{
-		if (lcd_commands_step == 0) lcd_commands_step = 1;
-		else if (lcd_commands_step == 1)
+		lcd_commands_step = 0;
+		lcd_commands_type = LcdCommands::Idle; //set idle. Also prevent recursive calls to the stop commands.
+		
+		current_position[Z_AXIS] += 10; //lift Z.
+		plan_buffer_line_curposXYZE(manual_feedrate[Z_AXIS] / 60, active_extruder);
+
+		if (axis_known_position[X_AXIS] && axis_known_position[Y_AXIS]) //if axis are homed, move to parked position.
 		{
-			current_position[Z_AXIS] += 10; //lift Z.
-			plan_buffer_line_curposXYZE(manual_feedrate[Z_AXIS] / 60, active_extruder);
-
-			if (axis_known_position[X_AXIS] && axis_known_position[Y_AXIS]) //if axis are homed, move to parked position.
-			{
-				current_position[X_AXIS] = X_CANCEL_POS;
-				current_position[Y_AXIS] = Y_CANCEL_POS;
-				plan_buffer_line_curposXYZE(manual_feedrate[0] / 60, active_extruder);
-			}
-			st_synchronize();
-
-			if (mmu_enabled) extr_unload(); //M702 C
-
-			finishAndDisableSteppers(); //M84
-
-			lcd_setstatuspgm(_T(WELCOME_MSG));
-			custom_message_type = CustomMsg::Status;
-
-			// planner_abort_hard(); //needs to be done since plan_buffer_line resets waiting_inside_plan_buffer_line_print_aborted to false. Also copies current to destination.
-			
-			axis_relative_modes[X_AXIS] = false;
-			axis_relative_modes[Y_AXIS] = false;
-			axis_relative_modes[Z_AXIS] = false;
-			axis_relative_modes[E_AXIS] = true;
-			
-			isPrintPaused = false; //clear isPrintPaused flag to allow starting next print after pause->stop scenario.
-			
-			lcd_commands_step = 0;
-			lcd_commands_type = LcdCommands::Idle;
+			current_position[X_AXIS] = X_CANCEL_POS;
+			current_position[Y_AXIS] = Y_CANCEL_POS;
+			plan_buffer_line_curposXYZE(manual_feedrate[0] / 60, active_extruder);
 		}
+		st_synchronize();
+
+		if (mmu_enabled) extr_unload(); //M702 C
+
+		finishAndDisableSteppers(); //M84
+
+		lcd_setstatuspgm(_T(WELCOME_MSG));
+		custom_message_type = CustomMsg::Status;
+
+		// planner_abort_hard(); //needs to be done since plan_buffer_line resets waiting_inside_plan_buffer_line_print_aborted to false. Also copies current to destination.
+		
+		axis_relative_modes[X_AXIS] = false;
+		axis_relative_modes[Y_AXIS] = false;
+		axis_relative_modes[Z_AXIS] = false;
+		axis_relative_modes[E_AXIS] = true;
+		
+		isPrintPaused = false; //clear isPrintPaused flag to allow starting next print after pause->stop scenario.
 	}
 
 	if (lcd_commands_type == LcdCommands::FarmModeConfirm)   /// farm mode confirm


### PR DESCRIPTION
I've been told that there are some issues sometimes with the lcd_print_stop where it would get stuck in the middle of the stop sequence inside a st_synchronize call. Weird issues would start to happen if you would play with the lcd, even to the point where the print randomly resumed. The probable cause is that the memory would get filled in certain edge cases and would result in this madness. We now unroll the stack and abort any ongoing functions before running the stop sequence. This should free up all the used ram and avoid the issue mentioned above.
Thanks @wavexx 
@DRracer 

PFW-1098