### PR TITLE
Do not clear axis known position when Z is set to silent

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -11563,7 +11563,7 @@ if(!(bEnableForce_z||eeprom_read_byte((uint8_t*)EEPROM_SILENT)))
 
 void disable_force_z()
 {
-    uint16_t z_microsteps=0;
+    // uint16_t z_microsteps=0;
 
     if(!bEnableForce_z) return;   // motor already disabled (may be ;-p )
 
@@ -11576,7 +11576,7 @@ void disable_force_z()
     tmc2130_init(true);
 #endif // TMC2130
 
-    axis_known_position[Z_AXIS]=false;
+    // axis_known_position[Z_AXIS]=false;
 }
 
 

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -11563,8 +11563,6 @@ if(!(bEnableForce_z||eeprom_read_byte((uint8_t*)EEPROM_SILENT)))
 
 void disable_force_z()
 {
-    // uint16_t z_microsteps=0;
-
     if(!bEnableForce_z) return;   // motor already disabled (may be ;-p )
 
     bEnableForce_z=false;
@@ -11575,8 +11573,6 @@ void disable_force_z()
     update_mode_profile();
     tmc2130_init(true);
 #endif // TMC2130
-
-    // axis_known_position[Z_AXIS]=false;
 }
 
 


### PR DESCRIPTION
Also removed unused (forgotten) `z_microsteps` variable as we no longer unshift the Z axis to the next full step when we switch to silent mode.
@DRracer 

PFW-1083