### PR TITLE
Remove unnecessary delay in lcd_selftest

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -7554,9 +7554,7 @@ bool lcd_selftest()
 	  FORCE_HIGH_POWER_START;
 	#endif // TMC2130
 	FORCE_BL_ON_START;
-#if !IR_SENSOR_ANALOG
      _delay(2000);
-#endif //!IR_SENSOR_ANALOG
 	KEEPALIVE_STATE(IN_HANDLER);
 
 	_progress = lcd_selftest_screen(TestScreen::ExtruderFan, _progress, 3, true, 2000);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -7554,7 +7554,7 @@ bool lcd_selftest()
 	  FORCE_HIGH_POWER_START;
 	#endif // TMC2130
 	FORCE_BL_ON_START;
-     _delay(2000);
+	_delay(2000);
 	KEEPALIVE_STATE(IN_HANDLER);
 
 	_progress = lcd_selftest_screen(TestScreen::ExtruderFan, _progress, 3, true, 2000);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -7547,13 +7547,10 @@ bool lcd_selftest()
 	#ifdef TMC2130
 	  FORCE_HIGH_POWER_START;
 	#endif // TMC2130
+	FORCE_BL_ON_START;
 #if !IR_SENSOR_ANALOG
      _delay(2000);
 #endif //!IR_SENSOR_ANALOG
-    
-    FORCE_BL_ON_START;
-    
-	_delay(2000);
 	KEEPALIVE_STATE(IN_HANDLER);
 #if IR_SENSOR_ANALOG
      bool bAction;


### PR DESCRIPTION
Remove unnecessary delay in lcd_selftest, which occurred there as a result of previous merges.

PFW-1099