### PR TITLE
Refuse to start a print if power is lost before arming uvlo

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -10480,6 +10480,14 @@ void serialecho_temperatures() {
 }
 
 #ifdef UVLO_SUPPORT
+void uvlo_drain_reset()
+{
+    // burn all that residual power
+    wdt_enable(WDTO_1S);
+    WRITE(BEEPER,HIGH);
+    while(1);
+}
+
 
 void uvlo_()
 {
@@ -10709,11 +10717,7 @@ void uvlo_tiny()
     eeprom_update_word((uint16_t*)EEPROM_POWER_COUNT_TOT, eeprom_read_word((uint16_t*)EEPROM_POWER_COUNT_TOT) + 1);
 
     printf_P(_N("UVLO_TINY - end %d\n"), _millis() - time_start);
-
-    // burn all that residual power
-    wdt_enable(WDTO_1S);
-    WRITE(BEEPER,HIGH);
-    while(1);
+    uvlo_drain_reset();
 }
 #endif //UVLO_SUPPORT
 
@@ -10760,12 +10764,19 @@ void setup_uvlo_interrupt() {
 	DDRE &= ~(1 << 4); //input pin
 	PORTE &= ~(1 << 4); //no internal pull-up
 
-						//sensing falling edge
+    // sensing falling edge
 	EICRB |= (1 << 0);
 	EICRB &= ~(1 << 1);
 
-	//enable INT4 interrupt
+	// enable INT4 interrupt
 	EIMSK |= (1 << 4);
+
+    // check if power was lost before we armed the interrupt
+    if(!(PINE & (1 << 4)))
+    {
+        SERIAL_ECHOLNPGM("INT4");
+        uvlo_drain_reset();
+    }
 }
 
 ISR(INT4_vect) {

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -10485,6 +10485,8 @@ void uvlo_drain_reset()
     // burn all that residual power
     wdt_enable(WDTO_1S);
     WRITE(BEEPER,HIGH);
+    lcd_clear();
+    lcd_puts_at_P(0, 1, MSG_POWERPANIC_DETECTED);
     while(1);
 }
 

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -10772,7 +10772,7 @@ void setup_uvlo_interrupt() {
 	EIMSK |= (1 << 4);
 
     // check if power was lost before we armed the interrupt
-    if(!(PINE & (1 << 4)))
+    if(!(PINE & (1 << 4)) && eeprom_read_byte((uint8_t*)EEPROM_UVLO))
     {
         SERIAL_ECHOLNPGM("INT4");
         uvlo_drain_reset();

--- a/Firmware/messages.c
+++ b/Firmware/messages.c
@@ -171,3 +171,4 @@ const char MSG_M112_KILL[] PROGMEM_N1 = "M112 called. Emergency Stop."; ////c=20
 #ifdef LA_LIVE_K
 const char MSG_ADVANCE_K[] PROGMEM_N1 = "Advance K:"; ////c=13
 #endif
+const char MSG_POWERPANIC_DETECTED[] PROGMEM_N1 = "POWER PANIC DETECTED"; ////c=20

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -170,6 +170,7 @@ extern const char MSG_FANCHECK_EXTRUDER[];
 extern const char MSG_FANCHECK_PRINT[];
 extern const char MSG_M112_KILL[];
 extern const char MSG_ADVANCE_K[];
+extern const char MSG_POWERPANIC_DETECTED[];
 
 #if defined(__cplusplus)
 }


### PR DESCRIPTION
If power has been lost during startup already a falling edge would be
skipped, causing the print to continue and lose its state without
being able to save again.

Check for a low line after arming the interrupt and simply wait
for reset.

PFW-1079