### PR TITLE
Save and restore fixes

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -10798,10 +10798,13 @@ void recover_print(uint8_t automatic) {
   // Recover position, temperatures and extrude_multipliers
   bool mbl_was_active = recover_machine_state_after_power_panic();
 
-  // Attempt to lift the print head on the first recovery, so one may remove the excess priming material.
-  bool raise_z = (eeprom_read_byte((uint8_t*)EEPROM_UVLO) == 1);
-  if(raise_z && (current_position[Z_AXIS]<25))
-      enquecommand_P(PSTR("G1 Z25 F800"));
+  // Lift the print head 25mm, first to avoid collisions with oozed material with the print,
+  // and second also so one may remove the excess priming material.
+  if(eeprom_read_byte((uint8_t*)EEPROM_UVLO) == 1)
+  {
+      sprintf_P(cmd, PSTR("G1 Z%.3f F800"), current_position[Z_AXIS] + 25);
+      enquecommand(cmd);
+  }
 
   // Home X and Y axes. Homing just X and Y shall not touch the babystep and the world2machine
   // transformation status. G28 will not touch Z when MBL is off.

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -10529,7 +10529,7 @@ void uvlo_()
 
     // save the global state at planning time
     uint16_t feedrate_bckp;
-    if (blocks_queued())
+    if (current_block)
     {
         memcpy(saved_target, current_block->gcode_target, sizeof(saved_target));
         feedrate_bckp = current_block->gcode_feedrate;
@@ -11129,7 +11129,7 @@ void stop_and_save_print_to_ram(float z_move, float e_move)
 #endif
 
   // save the global state at planning time
-  if (blocks_queued())
+  if (current_block)
   {
       memcpy(saved_target, current_block->gcode_target, sizeof(saved_target));
       saved_feedrate2 = current_block->gcode_feedrate;


### PR DESCRIPTION
Two more fixes related to the save/restore machinery:

- While saving the current state (for both pause/filament checks/power panic), there is a non-zero chance that current_block can be NULL despite the queue being non-empty. This can happen early after a block has been queued, but before the isr has picked it up for processing, and/or when the current block is *at* the last step and is being discarded. We fix that by checking the pointer directly.

This should fix some reported scenarios of the printer crashing into the print just after being resumed, and/or seeming go to a random position just before resuming.

- When doing the first recover from a power panic, always raise the extruder 25mm now that we can properly do so. This avoids oozed material to scrape/detach the print while homing X again.