### PR TITLE
Fix nozzle size menu

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5466,16 +5466,16 @@ uint16_t nDiameter;
 switch(oNozzleDiameter)
      {
      case ClNozzleDiameter::_Diameter_250:
+          oNozzleDiameter=ClNozzleDiameter::_Diameter_250;
+          nDiameter=250;
+          break;
+     case ClNozzleDiameter::_Diameter_400:
           oNozzleDiameter=ClNozzleDiameter::_Diameter_400;
           nDiameter=400;
           break;
-     case ClNozzleDiameter::_Diameter_400:
+     case ClNozzleDiameter::_Diameter_600:
           oNozzleDiameter=ClNozzleDiameter::_Diameter_600;
           nDiameter=600;
-          break;
-     case ClNozzleDiameter::_Diameter_600:
-          oNozzleDiameter=ClNozzleDiameter::_Diameter_250;
-          nDiameter=250;
           break;
      default:
           oNozzleDiameter=ClNozzleDiameter::_Diameter_400;


### PR DESCRIPTION
The switch statement is currently a bit confused, selecting 0.25mm will save 0.40, but selecting 0.40 will save 0.60 and selecting 0.60 will save 0.25.

Signed-off-by: Koen Kooi <koen@dominion.thruhere.net>