### PR TITLE
Add more nozzles

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5465,7 +5465,19 @@ uint16_t nDiameter;
 
 switch(oNozzleDiameter)
      {
+     case ClNozzleDiameter::_Diameter_150:
+          oNozzleDiameter=ClNozzleDiameter::_Diameter_200;
+          nDiameter=200;
+          break;
+     case ClNozzleDiameter::_Diameter_200:
+          oNozzleDiameter=ClNozzleDiameter::_Diameter_250;
+          nDiameter=250;
+          break;
      case ClNozzleDiameter::_Diameter_250:
+          oNozzleDiameter=ClNozzleDiameter::_Diameter_300;
+          nDiameter=300;
+          break;
+     case ClNozzleDiameter::_Diameter_300:
           oNozzleDiameter=ClNozzleDiameter::_Diameter_400;
           nDiameter=400;
           break;
@@ -5474,6 +5486,14 @@ switch(oNozzleDiameter)
           nDiameter=600;
           break;
      case ClNozzleDiameter::_Diameter_600:
+          oNozzleDiameter=ClNozzleDiameter::_Diameter_800;
+          nDiameter=800;
+          break;
+     case ClNozzleDiameter::_Diameter_800:
+          oNozzleDiameter=ClNozzleDiameter::_Diameter_1000;
+          nDiameter=1000;
+          break;
+     case ClNozzleDiameter::_Diameter_1000:
           oNozzleDiameter=ClNozzleDiameter::_Diameter_250;
           nDiameter=250;
           break;
@@ -5491,9 +5511,14 @@ do\
     float fNozzleDiam;\
     switch(oNozzleDiameter)\
     {\
+        case ClNozzleDiameter::_Diameter_150: fNozzleDiam = 0.15f; break;\
+        case ClNozzleDiameter::_Diameter_200: fNozzleDiam = 0.20f; break;\
         case ClNozzleDiameter::_Diameter_250: fNozzleDiam = 0.25f; break;\
-        case ClNozzleDiameter::_Diameter_400: fNozzleDiam = 0.4f; break;\
-        case ClNozzleDiameter::_Diameter_600: fNozzleDiam = 0.6f; break;\
+        case ClNozzleDiameter::_Diameter_300: fNozzleDiam = 0.30f; break;\
+        case ClNozzleDiameter::_Diameter_400: fNozzleDiam = 0.40f; break;\
+        case ClNozzleDiameter::_Diameter_600: fNozzleDiam = 0.60f; break;\
+        case ClNozzleDiameter::_Diameter_800: fNozzleDiam = 0.80f; break;\
+        case ClNozzleDiameter::_Diameter_1000: fNozzleDiam = 1.0f; break;\
         default: fNozzleDiam = 0.4f; break;\
     }\
     MENU_ITEM_TOGGLE(_T(MSG_NOZZLE_DIAMETER), ftostr12ns(fNozzleDiam), lcd_nozzle_diameter_set);\

--- a/Firmware/util.h
+++ b/Firmware/util.h
@@ -48,9 +48,14 @@ enum class ClPrintChecking:uint_least8_t
 
 enum class ClNozzleDiameter:uint_least8_t
 {
+    _Diameter_150=15,
+    _Diameter_200=20,
     _Diameter_250=25,
+    _Diameter_300=30,
     _Diameter_400=40,
     _Diameter_600=60,
+    _Diameter_800=80,
+    _Diameter_1000=100,
     _Diameter_Undef=EEPROM_EMPTY_VALUE
 };
 

--- a/lang/po/Firmware.pot
+++ b/lang/po/Firmware.pot
@@ -1681,36 +1681,6 @@ msgid "Model      [warn]"
 msgstr ""
 
 # 
-#: ultralcd.cpp:5467
-msgid "Nozzle d.  [0.25]"
-msgstr ""
-
-# 
-#: ultralcd.cpp:5470
-msgid "Nozzle d.  [0.40]"
-msgstr ""
-
-# 
-#: ultralcd.cpp:5473
-msgid "Nozzle d.  [0.60]"
-msgstr ""
-
-# 
-#: ultralcd.cpp:5421
-msgid "Nozzle     [none]"
-msgstr ""
-
-# 
-#: ultralcd.cpp:5427
-msgid "Nozzle   [strict]"
-msgstr ""
-
-# 
-#: ultralcd.cpp:5424
-msgid "Nozzle     [warn]"
-msgstr ""
-
-# 
 #: util.cpp:510
 msgid "G-code sliced for a different level. Continue?"
 msgstr ""

--- a/lang/po/Firmware_cs.po
+++ b/lang/po/Firmware_cs.po
@@ -1681,36 +1681,6 @@ msgid "Model      [warn]"
 msgstr "Model   [Varovat]"
 
 # 
-#: ultralcd.cpp:5467
-msgid "Nozzle d.  [0.25]"
-msgstr "Tryska     [0.25]"
-
-# 
-#: ultralcd.cpp:5470
-msgid "Nozzle d.  [0.40]"
-msgstr "Tryska     [0.40]"
-
-# 
-#: ultralcd.cpp:5473
-msgid "Nozzle d.  [0.60]"
-msgstr "Tryska     [0.60]"
-
-# 
-#: ultralcd.cpp:5421
-msgid "Nozzle     [none]"
-msgstr "Tryska    [Zadne]"
-
-# 
-#: ultralcd.cpp:5427
-msgid "Nozzle   [strict]"
-msgstr "Tryska   [Prisne]"
-
-# 
-#: ultralcd.cpp:5424
-msgid "Nozzle     [warn]"
-msgstr "Tryska  [Varovat]"
-
-# 
 #: util.cpp:510
 msgid "G-code sliced for a different level. Continue?"
 msgstr ""

--- a/lang/po/Firmware_de.po
+++ b/lang/po/Firmware_de.po
@@ -1686,36 +1686,6 @@ msgid "Model      [warn]"
 msgstr "Modell   [warnen]"
 
 # 
-#: ultralcd.cpp:5467
-msgid "Nozzle d.  [0.25]"
-msgstr "Duese D.   [0.25]"
-
-# 
-#: ultralcd.cpp:5470
-msgid "Nozzle d.  [0.40]"
-msgstr "Duese D.   [0.40]"
-
-# 
-#: ultralcd.cpp:5473
-msgid "Nozzle d.  [0.60]"
-msgstr "Duese D.   [0.60]"
-
-# 
-#: ultralcd.cpp:5421
-msgid "Nozzle     [none]"
-msgstr "Duese      [ohne]"
-
-# 
-#: ultralcd.cpp:5427
-msgid "Nozzle   [strict]"
-msgstr "Duese    [strikt]"
-
-# 
-#: ultralcd.cpp:5424
-msgid "Nozzle     [warn]"
-msgstr "Duese    [warnen]"
-
-# 
 #: util.cpp:510
 msgid "G-code sliced for a different level. Continue?"
 msgstr "G-Code ist fuer einen anderen Level geslict. Fortfahren?"

--- a/lang/po/Firmware_es.po
+++ b/lang/po/Firmware_es.po
@@ -1681,36 +1681,6 @@ msgid "Model      [warn]"
 msgstr "Modelo    [aviso]"
 
 # 
-#: ultralcd.cpp:5467
-msgid "Nozzle d.  [0.25]"
-msgstr "Diam. nozzl[0.25]"
-
-# 
-#: ultralcd.cpp:5470
-msgid "Nozzle d.  [0.40]"
-msgstr "Diam. nozzl[0.40]"
-
-# 
-#: ultralcd.cpp:5473
-msgid "Nozzle d.  [0.60]"
-msgstr "Diam. nozzl[0.60]"
-
-# 
-#: ultralcd.cpp:5421
-msgid "Nozzle     [none]"
-msgstr "Nozzle  [ninguno]"
-
-# 
-#: ultralcd.cpp:5427
-msgid "Nozzle   [strict]"
-msgstr "Nozzle [estricto]"
-
-# 
-#: ultralcd.cpp:5424
-msgid "Nozzle     [warn]"
-msgstr "Nozzle    [aviso]"
-
-# 
 #: util.cpp:510
 msgid "G-code sliced for a different level. Continue?"
 msgstr "Codigo G laminado para un nivel diferente. ?Continuar?"

--- a/lang/po/Firmware_fr.po
+++ b/lang/po/Firmware_fr.po
@@ -1681,36 +1681,6 @@ msgid "Model      [warn]"
 msgstr "Modele    [avert]"
 
 # 
-#: ultralcd.cpp:5467
-msgid "Nozzle d.  [0.25]"
-msgstr "Diam. buse [0.25]"
-
-# 
-#: ultralcd.cpp:5470
-msgid "Nozzle d.  [0.40]"
-msgstr "Diam. buse [0.40]"
-
-# 
-#: ultralcd.cpp:5473
-msgid "Nozzle d.  [0.60]"
-msgstr "Diam. buse [0.60]"
-
-# 
-#: ultralcd.cpp:5421
-msgid "Nozzle     [none]"
-msgstr "Buse     [aucune]"
-
-# 
-#: ultralcd.cpp:5427
-msgid "Nozzle   [strict]"
-msgstr "Buse    [stricte]"
-
-# 
-#: ultralcd.cpp:5424
-msgid "Nozzle     [warn]"
-msgstr "Buse      [avert]"
-
-# 
 #: util.cpp:510
 msgid "G-code sliced for a different level. Continue?"
 msgstr ""

--- a/lang/po/Firmware_it.po
+++ b/lang/po/Firmware_it.po
@@ -1681,36 +1681,6 @@ msgid "Model      [warn]"
 msgstr "Modello  [avviso]"
 
 # 
-#: ultralcd.cpp:5467
-msgid "Nozzle d.  [0.25]"
-msgstr "Diam.Ugello[0.25]"
-
-# 
-#: ultralcd.cpp:5470
-msgid "Nozzle d.  [0.40]"
-msgstr "Diam.Ugello[0.40]"
-
-# 
-#: ultralcd.cpp:5473
-msgid "Nozzle d.  [0.60]"
-msgstr "Diam.Ugello[0.60]"
-
-# 
-#: ultralcd.cpp:5421
-msgid "Nozzle     [none]"
-msgstr "Ugello  [nessuno]"
-
-# 
-#: ultralcd.cpp:5427
-msgid "Nozzle   [strict]"
-msgstr "Ugello   [esatto]"
-
-# 
-#: ultralcd.cpp:5424
-msgid "Nozzle     [warn]"
-msgstr "Ugello   [avviso]"
-
-# 
 #: util.cpp:510
 msgid "G-code sliced for a different level. Continue?"
 msgstr "G-code processato per un livello diverso. Continuare?"

--- a/lang/po/Firmware_pl.po
+++ b/lang/po/Firmware_pl.po
@@ -1681,36 +1681,6 @@ msgid "Model      [warn]"
 msgstr "Model  [ostrzez.]"
 
 # 
-#: ultralcd.cpp:5467
-msgid "Nozzle d.  [0.25]"
-msgstr "Sr. dyszy  [0,25]"
-
-# 
-#: ultralcd.cpp:5470
-msgid "Nozzle d.  [0.40]"
-msgstr "Sr. dyszy  [0,40]"
-
-# 
-#: ultralcd.cpp:5473
-msgid "Nozzle d.  [0.60]"
-msgstr "Sr. dyszy  [0,60]"
-
-# 
-#: ultralcd.cpp:5421
-msgid "Nozzle     [none]"
-msgstr "Dysza      [brak]"
-
-# 
-#: ultralcd.cpp:5427
-msgid "Nozzle   [strict]"
-msgstr "Dysza [restrykc.]"
-
-# 
-#: ultralcd.cpp:5424
-msgid "Nozzle     [warn]"
-msgstr "Dysza  [ostrzez.]"
-
-# 
 #: util.cpp:510
 msgid "G-code sliced for a different level. Continue?"
 msgstr ""

--- a/lang/po/new/cs.po
+++ b/lang/po/new/cs.po
@@ -1681,36 +1681,6 @@ msgid "Model      [warn]"
 msgstr "Model   [Varovat]"
 
 # 
-#: ultralcd.cpp:5467
-msgid "Nozzle d.  [0.25]"
-msgstr "Tryska     [0.25]"
-
-# 
-#: ultralcd.cpp:5470
-msgid "Nozzle d.  [0.40]"
-msgstr "Tryska     [0.40]"
-
-# 
-#: ultralcd.cpp:5473
-msgid "Nozzle d.  [0.60]"
-msgstr "Tryska     [0.60]"
-
-# 
-#: ultralcd.cpp:5421
-msgid "Nozzle     [none]"
-msgstr "Tryska    [Zadne]"
-
-# 
-#: ultralcd.cpp:5427
-msgid "Nozzle   [strict]"
-msgstr "Tryska   [Prisne]"
-
-# 
-#: ultralcd.cpp:5424
-msgid "Nozzle     [warn]"
-msgstr "Tryska  [Varovat]"
-
-# 
 #: util.cpp:510
 msgid "G-code sliced for a different level. Continue?"
 msgstr ""

--- a/lang/po/new/de.po
+++ b/lang/po/new/de.po
@@ -1686,36 +1686,6 @@ msgid "Model      [warn]"
 msgstr "Modell   [warnen]"
 
 # 
-#: ultralcd.cpp:5467
-msgid "Nozzle d.  [0.25]"
-msgstr "Duese D.   [0.25]"
-
-# 
-#: ultralcd.cpp:5470
-msgid "Nozzle d.  [0.40]"
-msgstr "Duese D.   [0.40]"
-
-# 
-#: ultralcd.cpp:5473
-msgid "Nozzle d.  [0.60]"
-msgstr "Duese D.   [0.60]"
-
-# 
-#: ultralcd.cpp:5421
-msgid "Nozzle     [none]"
-msgstr "Duese      [ohne]"
-
-# 
-#: ultralcd.cpp:5427
-msgid "Nozzle   [strict]"
-msgstr "Duese    [strikt]"
-
-# 
-#: ultralcd.cpp:5424
-msgid "Nozzle     [warn]"
-msgstr "Duese    [warnen]"
-
-# 
 #: util.cpp:510
 msgid "G-code sliced for a different level. Continue?"
 msgstr "G-Code ist fuer einen anderen Level geslict. Fortfahren?"

--- a/lang/po/new/es.po
+++ b/lang/po/new/es.po
@@ -1681,36 +1681,6 @@ msgid "Model      [warn]"
 msgstr "Modelo    [aviso]"
 
 # 
-#: ultralcd.cpp:5467
-msgid "Nozzle d.  [0.25]"
-msgstr "Diam. nozzl[0.25]"
-
-# 
-#: ultralcd.cpp:5470
-msgid "Nozzle d.  [0.40]"
-msgstr "Diam. nozzl[0.40]"
-
-# 
-#: ultralcd.cpp:5473
-msgid "Nozzle d.  [0.60]"
-msgstr "Diam. nozzl[0.60]"
-
-# 
-#: ultralcd.cpp:5421
-msgid "Nozzle     [none]"
-msgstr "Nozzle  [ninguno]"
-
-# 
-#: ultralcd.cpp:5427
-msgid "Nozzle   [strict]"
-msgstr "Nozzle [estricto]"
-
-# 
-#: ultralcd.cpp:5424
-msgid "Nozzle     [warn]"
-msgstr "Nozzle    [aviso]"
-
-# 
 #: util.cpp:510
 msgid "G-code sliced for a different level. Continue?"
 msgstr "Codigo G laminado para un nivel diferente. ?Continuar?"

--- a/lang/po/new/fr.po
+++ b/lang/po/new/fr.po
@@ -1681,36 +1681,6 @@ msgid "Model      [warn]"
 msgstr "Modele    [avert]"
 
 # 
-#: ultralcd.cpp:5467
-msgid "Nozzle d.  [0.25]"
-msgstr "Diam. buse [0.25]"
-
-# 
-#: ultralcd.cpp:5470
-msgid "Nozzle d.  [0.40]"
-msgstr "Diam. buse [0.40]"
-
-# 
-#: ultralcd.cpp:5473
-msgid "Nozzle d.  [0.60]"
-msgstr "Diam. buse [0.60]"
-
-# 
-#: ultralcd.cpp:5421
-msgid "Nozzle     [none]"
-msgstr "Buse     [aucune]"
-
-# 
-#: ultralcd.cpp:5427
-msgid "Nozzle   [strict]"
-msgstr "Buse    [stricte]"
-
-# 
-#: ultralcd.cpp:5424
-msgid "Nozzle     [warn]"
-msgstr "Buse      [avert]"
-
-# 
 #: util.cpp:510
 msgid "G-code sliced for a different level. Continue?"
 msgstr ""

--- a/lang/po/new/it.po
+++ b/lang/po/new/it.po
@@ -1681,36 +1681,6 @@ msgid "Model      [warn]"
 msgstr "Modello  [avviso]"
 
 # 
-#: ultralcd.cpp:5467
-msgid "Nozzle d.  [0.25]"
-msgstr "Diam.Ugello[0.25]"
-
-# 
-#: ultralcd.cpp:5470
-msgid "Nozzle d.  [0.40]"
-msgstr "Diam.Ugello[0.40]"
-
-# 
-#: ultralcd.cpp:5473
-msgid "Nozzle d.  [0.60]"
-msgstr "Diam.Ugello[0.60]"
-
-# 
-#: ultralcd.cpp:5421
-msgid "Nozzle     [none]"
-msgstr "Ugello  [nessuno]"
-
-# 
-#: ultralcd.cpp:5427
-msgid "Nozzle   [strict]"
-msgstr "Ugello   [esatto]"
-
-# 
-#: ultralcd.cpp:5424
-msgid "Nozzle     [warn]"
-msgstr "Ugello   [avviso]"
-
-# 
 #: util.cpp:510
 msgid "G-code sliced for a different level. Continue?"
 msgstr "G-code processato per un livello diverso. Continuare?"

--- a/lang/po/new/pl.po
+++ b/lang/po/new/pl.po
@@ -1681,36 +1681,6 @@ msgid "Model      [warn]"
 msgstr "Model  [ostrzez.]"
 
 # 
-#: ultralcd.cpp:5467
-msgid "Nozzle d.  [0.25]"
-msgstr "Sr. dyszy  [0,25]"
-
-# 
-#: ultralcd.cpp:5470
-msgid "Nozzle d.  [0.40]"
-msgstr "Sr. dyszy  [0,40]"
-
-# 
-#: ultralcd.cpp:5473
-msgid "Nozzle d.  [0.60]"
-msgstr "Sr. dyszy  [0,60]"
-
-# 
-#: ultralcd.cpp:5421
-msgid "Nozzle     [none]"
-msgstr "Dysza      [brak]"
-
-# 
-#: ultralcd.cpp:5427
-msgid "Nozzle   [strict]"
-msgstr "Dysza [restrykc.]"
-
-# 
-#: ultralcd.cpp:5424
-msgid "Nozzle     [warn]"
-msgstr "Dysza  [ostrzez.]"
-
-# 
 #: util.cpp:510
 msgid "G-code sliced for a different level. Continue?"
 msgstr ""


### PR DESCRIPTION
There are more commonly used nozzle diameters than 0.25/0.4/0.6mm.

This patch adds some of them. A better fix would probably be to freely change the current diameter in 0.05mm increments, but this way works for me.