### PR TITLE
Linear Advance 1.5 fixes

### DIFF
--- a/Firmware/messages.c
+++ b/Firmware/messages.c
@@ -168,7 +168,5 @@ const char MSG_OCTOPRINT_CANCEL[] PROGMEM_N1 = "// action:cancel"; ////
 const char MSG_FANCHECK_EXTRUDER[] PROGMEM_N1 = "Err: EXTR. FAN ERROR"; ////c=20
 const char MSG_FANCHECK_PRINT[] PROGMEM_N1 = "Err: PRINT FAN ERROR"; ////c=20
 const char MSG_M112_KILL[] PROGMEM_N1 = "M112 called. Emergency Stop."; ////c=20
-#ifdef LA_LIVE_K
 const char MSG_ADVANCE_K[] PROGMEM_N1 = "Advance K:"; ////c=13
-#endif
 const char MSG_POWERPANIC_DETECTED[] PROGMEM_N1 = "POWER PANIC DETECTED"; ////c=20

--- a/Firmware/planner.cpp
+++ b/Firmware/planner.cpp
@@ -1137,17 +1137,24 @@ Having the real displacement of the head, we can calculate the total movement le
       // still need to replicate the *exact* same step grouping policy (see below)
       float advance_speed = (extruder_advance_K * e_D_ratio * block->acceleration * cs.axis_steps_per_unit[E_AXIS]);
       if (advance_speed > MAX_STEP_FREQUENCY) advance_speed = MAX_STEP_FREQUENCY;
-      block->advance_rate = (F_CPU / 8.0) / advance_speed;
-      if (block->advance_rate > 20000) {
-          block->advance_rate = (block->advance_rate >> 2)&0x3fff;
+      float advance_rate = (F_CPU / 8.0) / advance_speed;
+      if (advance_speed > 20000) {
+          block->advance_rate = advance_rate * 4;
           block->advance_step_loops = 4;
       }
-      else if (block->advance_rate > 10000) {
-          block->advance_rate = (block->advance_rate >> 1)&0x7fff;
+      else if (advance_speed > 10000) {
+          block->advance_rate = advance_rate * 2;
           block->advance_step_loops = 2;
       }
       else
+      {
+          // never overflow the internal accumulator with very low rates
+          if (advance_rate < UINT16_MAX)
+              block->advance_rate = advance_rate;
+          else
+              block->advance_rate = UINT16_MAX;
           block->advance_step_loops = 1;
+      }
 
       #ifdef LA_DEBUG
       if (block->advance_step_loops > 2)


### PR DESCRIPTION
Two fixes related to LA1.5:

- Fix the build when LA_LIVE_K is enabled
- Fix overflow and infinite loop with low step rates (eg: slow, thin layers or small nozzle sizes)

Very low step rates can result in values exceeding the internal uint16_t used for holding the step interval. A wrap-around can cause premature LA tick delivery, but an overflow resulting in 0 would cause a more serious infinite loop within advance_spread(), killing the print.

We fix this by checking for overflow and saturating the interval, which delays ticks (frequently none) to a subsequent block.

PFW-1087