### PR TITLE
🐛Fix check_file() wdt on second check if file is incomplete

### DIFF
--- a/Firmware/cmdqueue.cpp
+++ b/Firmware/cmdqueue.cpp
@@ -94,6 +94,7 @@ void cmdqueue_reset()
     bufindr = 0;
     bufindw = 0;
     buflen = 0;
+    serial_count = 0;
 
 	//commands are removed from command queue after process_command() function is finished
 	//reseting command queue and enqueing new commands during some (usually long running) command processing would cause that new commands are immediately removed from queue (or damaged)

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -8711,12 +8711,13 @@ static bool check_file(const char* filename) {
 		
 	}
 	
-		while (!card.eof() && !result) {
+    while (!card.eof() && !result) {
 		card.sdprinting = true;
 		get_command();
 		result = check_commands();
 		
 	}
+	cmdqueue_reset();
 	card.printingHasFinished();
 	strncpy_P(lcd_status_message, _T(WELCOME_MSG), LCD_WIDTH);
 	lcd_finishstatus();

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -8708,21 +8708,19 @@ static bool check_file(const char* filename) {
 	filesize = card.getFileSize();
 	if (filesize > END_FILE_SECTION) {
 		card.setIndex(filesize - END_FILE_SECTION);
-		
 	}
-	
-    while (!card.eof() && !result) {
+
+	while (!card.eof() && !result) {
 		card.sdprinting = true;
 		get_command();
 		result = check_commands();
-		
 	}
+
 	cmdqueue_reset();
 	card.printingHasFinished();
 	strncpy_P(lcd_status_message, _T(WELCOME_MSG), LCD_WIDTH);
 	lcd_finishstatus();
 	return result;
-	
 }
 
 static void menu_action_sdfile(const char* filename)


### PR DESCRIPTION
If you try to print an incomplete file, then the printer will detect that using `check_file()` and prompt you for confirmation. The issue is that an actual incomplete file is not ended with `'\n'` or `'\r'` and you would end up with an incomplete string in the buffer. The firmware might not "crash" right away sine the buffer is undisturbed in the meantime.
When you try to print another file (not important which file it is), the file_check() will be called again. Here is where that previous unfinished line comes into play. That string gets treated by the `get_command()` as if it was data originating from the serial interface. The code inside this function is designed to temporarily pause the sd queueing while a serial string is added to the queue as to not mix these two, but since that is not really a string from serial it is never finished. At this point, `get_command()` will always return early and won't queue any new sd command. When the second `check_file()` is triggered, it will get stuck in the `while (!card.eof() && !result)` block and after 4s the firmware is reset by the WDT.

To fix this problem, I also now clear `serial_count` in `cmdqueue_reset()` and also reset the cmdqueue after every `file_check()`.