### PR TITLE
Improve MK3 (PAT9125) optical sensor accuracy

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -634,13 +634,15 @@ void crashdet_cancel()
 
 void failstats_reset_print()
 {
-    fsensor_softfail = 0;
 	eeprom_update_byte((uint8_t *)EEPROM_CRASH_COUNT_X, 0);
 	eeprom_update_byte((uint8_t *)EEPROM_CRASH_COUNT_Y, 0);
 	eeprom_update_byte((uint8_t *)EEPROM_FERROR_COUNT, 0);
 	eeprom_update_byte((uint8_t *)EEPROM_POWER_COUNT, 0);
 	eeprom_update_byte((uint8_t *)EEPROM_MMU_FAIL, 0);
 	eeprom_update_byte((uint8_t *)EEPROM_MMU_LOAD_FAIL, 0);
+#if defined(FILAMENT_SENSOR) && defined(PAT9125)
+    fsensor_softfail = 0;
+#endif
 }
 
 
@@ -6682,7 +6684,9 @@ Sigma_Exit:
               axis_steps_per_sqr_second[i] *= factor;
             }
             cs.axis_steps_per_unit[i] = value;
+#if defined(FILAMENT_SENSOR) && defined(PAT9125)
             fsensor_set_axis_steps_per_unit(value);
+#endif
           }
           else {
             cs.axis_steps_per_unit[i] = code_value();
@@ -8446,8 +8450,10 @@ Sigma_Exit:
 						cs.axis_steps_per_unit[i] /= fac;
 						position[i] /= fac;
 					}
+#if defined(FILAMENT_SENSOR) && defined(PAT9125)
                     if (i == E_AXIS)
                         fsensor_set_axis_steps_per_unit(cs.axis_steps_per_unit[i]);
+#endif
 				}
 			}
 		}

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -6673,7 +6673,7 @@ Sigma_Exit:
       {
         if(code_seen(axis_codes[i]))
         {
-          if(i == 3) { // E
+          if(i == E_AXIS) { // E
             float value = code_value();
             if(value < 20.0) {
               float factor = cs.axis_steps_per_unit[i] / value; // increase e constants if M92 E14 is given for netfab.
@@ -6682,6 +6682,7 @@ Sigma_Exit:
               axis_steps_per_sqr_second[i] *= factor;
             }
             cs.axis_steps_per_unit[i] = value;
+            fsensor_set_axis_steps_per_unit(value);
           }
           else {
             cs.axis_steps_per_unit[i] = code_value();
@@ -8429,7 +8430,6 @@ Sigma_Exit:
 				res_valid |= (i == E_AXIS) && ((res_new == 64) || (res_new == 128)); // resolutions valid for E only
 				if (res_valid)
 				{
-					
 					st_synchronize();
 					uint16_t res = tmc2130_get_res(i);
 					tmc2130_set_res(i, res_new);
@@ -8446,6 +8446,8 @@ Sigma_Exit:
 						cs.axis_steps_per_unit[i] /= fac;
 						position[i] /= fac;
 					}
+                    if (i == E_AXIS)
+                        fsensor_set_axis_steps_per_unit(cs.axis_steps_per_unit[i]);
 				}
 			}
 		}

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -634,6 +634,7 @@ void crashdet_cancel()
 
 void failstats_reset_print()
 {
+    fsensor_softfail = 0;
 	eeprom_update_byte((uint8_t *)EEPROM_CRASH_COUNT_X, 0);
 	eeprom_update_byte((uint8_t *)EEPROM_CRASH_COUNT_Y, 0);
 	eeprom_update_byte((uint8_t *)EEPROM_FERROR_COUNT, 0);

--- a/Firmware/config.h
+++ b/Firmware/config.h
@@ -34,7 +34,8 @@
 //#define PAT9125_I2C_ADDR  0x79  //ID=HI
 //#define PAT9125_I2C_ADDR  0x73  //ID=NC
 #define PAT9125_XRES      0
-#define PAT9125_YRES      240
+#define PAT9125_YRES      240                   // maximum resolution (5*X cpi)
+#define PAT9124_YRES_MM   (5*PAT9125_YRES/25.4) // counts per mm
 
 //SM4 configuration
 #define SM4_DEFDELAY      500       //default step delay [us]

--- a/Firmware/fsensor.cpp
+++ b/Firmware/fsensor.cpp
@@ -149,6 +149,11 @@ void fsensor_checkpoint_print(void)
     restore_print_from_ram_and_continue(0);
 }
 
+void fsensor_set_axis_steps_per_unit(float u)
+{
+	fsensor_chunk_len = (int16_t)(FSENSOR_CHUNK_LEN * u);
+}
+
 void fsensor_init(void)
 {
 #ifdef PAT9125
@@ -161,7 +166,7 @@ void fsensor_init(void)
 #ifdef PAT9125
 	uint8_t oq_meassure_enabled = eeprom_read_byte((uint8_t*)EEPROM_FSENS_OQ_MEASS_ENABLED);
 	fsensor_oq_meassure_enabled = (oq_meassure_enabled == 1)?true:false;
-	fsensor_chunk_len = (int16_t)(FSENSOR_CHUNK_LEN * cs.axis_steps_per_unit[E_AXIS]);
+    fsensor_set_axis_steps_per_unit(cs.axis_steps_per_unit[E_AXIS]);
 
 	if (!pat9125)
 	{

--- a/Firmware/fsensor.cpp
+++ b/Firmware/fsensor.cpp
@@ -19,7 +19,7 @@
 //! @name Basic parameters
 //! @{
 #define FSENSOR_CHUNK_LEN    0.64F  //!< filament sensor chunk length 0.64mm
-#define FSENSOR_ERR_MAX         17  //!< filament sensor maximum error count for runout detection
+#define FSENSOR_ERR_MAX          9  //!< filament sensor maximum error count for runout detection
 //! @}
 
 //! @name Optical quality measurement parameters
@@ -453,10 +453,7 @@ ISR(FSENSOR_INT_PIN_VECT)
 		{
 			if (pat9125_y < 0)
 			{
-				if (fsensor_err_cnt)
-					fsensor_err_cnt += 2;
-				else
-					fsensor_err_cnt++;
+                fsensor_err_cnt++;
 			}
 			else if (pat9125_y > 0)
 			{

--- a/Firmware/fsensor.cpp
+++ b/Firmware/fsensor.cpp
@@ -460,12 +460,17 @@ ISR(FSENSOR_INT_PIN_VECT)
 	if (mmu_enabled || ir_sensor_detected) return;
 	if (!((fsensor_int_pin_old ^ FSENSOR_INT_PIN_PIN_REG) & FSENSOR_INT_PIN_MASK)) return;
 	fsensor_int_pin_old = FSENSOR_INT_PIN_PIN_REG;
+
+    // prevent isr re-entry
 	static bool _lock = false;
 	if (_lock) return;
 	_lock = true;
+
+    // fetch fsensor_st_cnt atomically
 	int st_cnt = fsensor_st_cnt;
 	fsensor_st_cnt = 0;
 	sei();
+
 	uint8_t old_err_cnt = fsensor_err_cnt;
 	uint8_t pat9125_res = fsensor_oq_meassure?pat9125_update():pat9125_update_y();
 	if (!pat9125_res)

--- a/Firmware/fsensor.cpp
+++ b/Firmware/fsensor.cpp
@@ -83,6 +83,8 @@ uint8_t fsensor_autoload_c;
 uint32_t fsensor_autoload_last_millis;
 //
 uint8_t fsensor_autoload_sum;
+//
+uint8_t fsensor_softfail = 0;
 //! @}
 
 
@@ -598,7 +600,10 @@ void fsensor_update(void)
 			fsensor_oq_meassure_enabled = oq_meassure_enabled_tmp;
 
 			if (!err)
+            {
 				printf_P(PSTR("fsensor_err_cnt = 0\n"));
+                ++fsensor_softfail;
+			}
 			else
 				fsensor_enque_M600();
 		}

--- a/Firmware/fsensor.cpp
+++ b/Firmware/fsensor.cpp
@@ -563,12 +563,10 @@ void fsensor_st_block_chunk(int cnt)
 {
 	if (!fsensor_enabled) return;
 	fsensor_st_cnt += cnt;
-	if (abs(fsensor_st_cnt) >= fsensor_chunk_len)
-	{
-// !!! bit toggling (PINxn <- 1) (for PinChangeInterrupt) does not work for some MCU pins
-		if (PIN_GET(FSENSOR_INT_PIN)) {PIN_VAL(FSENSOR_INT_PIN, LOW);}
-		else {PIN_VAL(FSENSOR_INT_PIN, HIGH);}
-	}
+
+    // !!! bit toggling (PINxn <- 1) (for PinChangeInterrupt) does not work for some MCU pins
+    if (PIN_GET(FSENSOR_INT_PIN)) {PIN_VAL(FSENSOR_INT_PIN, LOW);}
+    else {PIN_VAL(FSENSOR_INT_PIN, HIGH);}
 }
 #endif //PAT9125
 

--- a/Firmware/fsensor.cpp
+++ b/Firmware/fsensor.cpp
@@ -624,7 +624,7 @@ void fsensor_update(void)
 			fsensor_oq_meassure_start(0);
             float e_tmp = current_position[E_AXIS];
             current_position[E_AXIS] -= 3;
-            plan_buffer_line_curposXYZE(200/60, active_extruder);
+            plan_buffer_line_curposXYZE(250/60, active_extruder);
             current_position[E_AXIS] = e_tmp;
             plan_buffer_line_curposXYZE(200/60, active_extruder);
             st_synchronize();

--- a/Firmware/fsensor.h
+++ b/Firmware/fsensor.h
@@ -29,6 +29,9 @@ extern void fsensor_checkpoint_print(void);
 //! initialize
 extern void fsensor_init(void);
 
+//! update axis resolution
+extern void fsensor_set_axis_steps_per_unit(float u);
+
 //! @name enable/disable
 //! @{
 extern bool fsensor_enable(bool bUpdateEEPROM=true);

--- a/Firmware/fsensor.h
+++ b/Firmware/fsensor.h
@@ -6,16 +6,16 @@
 #include "config.h"
 
 
-//! minimum meassured chunk length in steps
-extern int16_t fsensor_chunk_len;
 // enable/disable flag
 extern bool fsensor_enabled;
 // not responding flag
 extern bool fsensor_not_responding;
-//enable/disable quality meassurement
-extern bool fsensor_oq_meassure_enabled;
+#ifdef PAT9125
+// optical checking "chunk lenght" (already in steps)
+extern int16_t fsensor_chunk_len;
+// count of soft failures
 extern uint8_t fsensor_softfail;
-
+#endif
 
 //! @name save restore printing
 //! @{
@@ -29,8 +29,10 @@ extern void fsensor_checkpoint_print(void);
 //! initialize
 extern void fsensor_init(void);
 
+#ifdef PAT9125
 //! update axis resolution
 extern void fsensor_set_axis_steps_per_unit(float u);
+#endif
 
 //! @name enable/disable
 //! @{
@@ -56,8 +58,10 @@ extern void fsensor_autoload_check_stop(void);
 extern bool fsensor_check_autoload(void);
 //! @}
 
+#ifdef PAT9125
 //! @name optical quality measurement support
 //! @{
+extern bool fsensor_oq_meassure_enabled;
 extern void fsensor_oq_meassure_set(bool State);
 extern void fsensor_oq_meassure_start(uint8_t skip);
 extern void fsensor_oq_meassure_stop(void);
@@ -74,6 +78,7 @@ extern void fsensor_st_block_chunk(int cnt);
 // to drain fsensor_st_cnt anyway at the beginning of the new block.
 #define fsensor_st_block_begin(rev) fsensor_st_block_chunk(0)
 //! @}
+#endif //PAT9125
 
 
 #if IR_SENSOR_ANALOG

--- a/Firmware/fsensor.h
+++ b/Firmware/fsensor.h
@@ -14,6 +14,7 @@ extern bool fsensor_enabled;
 extern bool fsensor_not_responding;
 //enable/disable quality meassurement
 extern bool fsensor_oq_meassure_enabled;
+extern uint8_t fsensor_softfail;
 
 
 //! @name save restore printing

--- a/Firmware/pat9125.c
+++ b/Firmware/pat9125.c
@@ -183,9 +183,9 @@ uint8_t pat9125_update(void)
 		if (pat9125_PID1 == 0xff) return 0;
 		if (ucMotion & 0x80)
 		{
-			uint8_t ucXL = pat9125_rd_reg(PAT9125_DELTA_XL);
-			uint8_t ucYL = pat9125_rd_reg(PAT9125_DELTA_YL);
-			uint8_t ucXYH = pat9125_rd_reg(PAT9125_DELTA_XYH);
+			uint16_t ucXL = pat9125_rd_reg(PAT9125_DELTA_XL);
+			uint16_t ucYL = pat9125_rd_reg(PAT9125_DELTA_YL);
+			uint16_t ucXYH = pat9125_rd_reg(PAT9125_DELTA_XYH);
 			if (pat9125_PID1 == 0xff) return 0;
 			int16_t iDX = ucXL | ((ucXYH << 4) & 0xf00);
 			int16_t iDY = ucYL | ((ucXYH << 8) & 0xf00);
@@ -207,8 +207,8 @@ uint8_t pat9125_update_y(void)
 		if (pat9125_PID1 == 0xff) return 0;
 		if (ucMotion & 0x80)
 		{
-			uint8_t ucYL = pat9125_rd_reg(PAT9125_DELTA_YL);
-			uint8_t ucXYH = pat9125_rd_reg(PAT9125_DELTA_XYH);
+			uint16_t ucYL = pat9125_rd_reg(PAT9125_DELTA_YL);
+			uint16_t ucXYH = pat9125_rd_reg(PAT9125_DELTA_XYH);
 			if (pat9125_PID1 == 0xff) return 0;
 			int16_t iDY = ucYL | ((ucXYH << 8) & 0xf00);
 			if (iDY & 0x800) iDY -= 4096;

--- a/Firmware/pat9125.c
+++ b/Firmware/pat9125.c
@@ -226,6 +226,7 @@ uint8_t pat9125_update_bs(void)
 		pat9125_b = pat9125_rd_reg(PAT9125_FRAME);
 		pat9125_s = pat9125_rd_reg(PAT9125_SHUTTER);
 		if (pat9125_PID1 == 0xff) return 0;
+		return 1;
 	}
 	return 0;
 }

--- a/Firmware/pat9125.c
+++ b/Firmware/pat9125.c
@@ -219,19 +219,13 @@ uint8_t pat9125_update_y(void)
 	return 0;
 }
 
-uint8_t pat9125_update_y2(void)
+uint8_t pat9125_update_bs(void)
 {
 	if ((pat9125_PID1 == 0x31) && (pat9125_PID2 == 0x91))
 	{
-		uint8_t ucMotion = pat9125_rd_reg(PAT9125_MOTION);
-		if (pat9125_PID1 == 0xff) return 0; //NOACK error
-		if (ucMotion & 0x80)
-		{
-			int8_t dy = pat9125_rd_reg(PAT9125_DELTA_YL);
-			if (pat9125_PID1 == 0xff) return 0; //NOACK error
-			pat9125_y -= dy; //negative number, because direction switching does not work
-		}
-		return 1;
+		pat9125_b = pat9125_rd_reg(PAT9125_FRAME);
+		pat9125_s = pat9125_rd_reg(PAT9125_SHUTTER);
+		if (pat9125_PID1 == 0xff) return 0;
 	}
 	return 0;
 }

--- a/Firmware/pat9125.h
+++ b/Firmware/pat9125.h
@@ -19,9 +19,9 @@ extern uint8_t pat9125_b;
 extern uint8_t pat9125_s;
 
 extern uint8_t pat9125_init(void);
-extern uint8_t pat9125_update(void);
-extern uint8_t pat9125_update_y(void);
-extern uint8_t pat9125_update_y2(void);
+extern uint8_t pat9125_update(void);    // update all sensor data
+extern uint8_t pat9125_update_y(void);  // update _y only
+extern uint8_t pat9125_update_bs(void); // update _b/_s only
 
 
 #if defined(__cplusplus)

--- a/Firmware/stepper.cpp
+++ b/Firmware/stepper.cpp
@@ -1357,8 +1357,6 @@ void quickStop()
 }
 
 #ifdef BABYSTEPPING
-
-
 void babystep(const uint8_t axis,const bool direction)
 {
   //MUST ONLY BE CALLED BY A ISR, it depends on that no other ISR interrupts this
@@ -1594,3 +1592,13 @@ void microstep_readings()
       #endif
 }
 #endif //TMC2130
+
+
+#if defined(FILAMENT_SENSOR) && defined(PAT9125)
+void st_reset_fsensor()
+{
+    CRITICAL_SECTION_START;
+    fsensor_counter = 0;
+    CRITICAL_SECTION_END;
+}
+#endif //FILAMENT_SENSOR

--- a/Firmware/stepper.cpp
+++ b/Firmware/stepper.cpp
@@ -422,7 +422,6 @@ FORCE_INLINE void stepper_next_block()
       count_direction[E_AXIS] = 1;
     }
 #if defined(FILAMENT_SENSOR) && defined(PAT9125)
-    fsensor_counter = 0;
     fsensor_st_block_begin(count_direction[E_AXIS] < 0);
 #endif //FILAMENT_SENSOR
   }

--- a/Firmware/stepper.cpp
+++ b/Firmware/stepper.cpp
@@ -36,9 +36,9 @@
 #include "tmc2130.h"
 #endif //TMC2130
 
-#ifdef FILAMENT_SENSOR
+#if defined(FILAMENT_SENSOR) && defined(PAT9125)
 #include "fsensor.h"
-int fsensor_counter = 0; //counter for e-steps
+int fsensor_counter; //counter for e-steps
 #endif //FILAMENT_SENSOR
 
 #include "mmu.h"
@@ -421,9 +421,9 @@ FORCE_INLINE void stepper_next_block()
 #endif /* LIN_ADVANCE */
       count_direction[E_AXIS] = 1;
     }
-#ifdef FILAMENT_SENSOR
-	fsensor_counter = 0;
-	fsensor_st_block_begin(count_direction[E_AXIS] < 0);
+#if defined(FILAMENT_SENSOR) && defined(PAT9125)
+    fsensor_counter = 0;
+    fsensor_st_block_begin(count_direction[E_AXIS] < 0);
 #endif //FILAMENT_SENSOR
   }
   else {
@@ -973,13 +973,13 @@ FORCE_INLINE void advance_isr_scheduler() {
             WRITE_NC(E0_STEP_PIN, !INVERT_E_STEP_PIN);
             e_steps += (rev? 1: -1);
             WRITE_NC(E0_STEP_PIN, INVERT_E_STEP_PIN);
-#ifdef FILAMENT_SENSOR
+#if defined(FILAMENT_SENSOR) && defined(PAT9125)
             fsensor_counter += (rev? -1: 1);
 #endif
         }
         while(--max_ticks);
 
-#ifdef FILAMENT_SENSOR
+#if defined(FILAMENT_SENSOR) && defined(PAT9125)
         if (abs(fsensor_counter) >= fsensor_chunk_len)
         {
             fsensor_st_block_chunk(fsensor_counter);

--- a/Firmware/stepper.h
+++ b/Firmware/stepper.h
@@ -92,7 +92,10 @@ void microstep_readings();
 #ifdef BABYSTEPPING
   void babystep(const uint8_t axis,const bool direction); // perform a short step with a single stepper motor, outside of any convention
 #endif
-     
 
+#if defined(FILAMENT_SENSOR) && defined(PAT9125)
+// reset the internal filament sensor state
+void st_reset_fsensor();
+#endif
 
 #endif

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1796,11 +1796,14 @@ static void lcd_menu_fails_stats_print()
     uint8_t crashX = eeprom_read_byte((uint8_t*)EEPROM_CRASH_COUNT_X);
     uint8_t crashY = eeprom_read_byte((uint8_t*)EEPROM_CRASH_COUNT_Y);
     lcd_home();
-    lcd_printf_P(failStatsFmt,
-        _i("Last print failures"),  ////c=20 r=1
-        _i("Power failures"), power,  ////c=14 r=1
-        _i("Filam. runouts"), filam,  ////c=14 r=1
-        _i("Crash"), crashX, crashY);  ////c=7 r=1
+    lcd_printf_P(PSTR("%S\n"
+                  " %S  %-3d\n"
+                  " %S H %-3d S %-3d\n"
+                  " %S   X %-3d Y %-3d"),
+             _i("Last print failures"),
+             _i("Power failures"), power,
+             _i("Runouts"), filam, fsensor_softfail,
+             _i("Crash"), crashX, crashY);
     menu_back_if_clicked_fb();
 }
 

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1796,14 +1796,23 @@ static void lcd_menu_fails_stats_print()
     uint8_t crashX = eeprom_read_byte((uint8_t*)EEPROM_CRASH_COUNT_X);
     uint8_t crashY = eeprom_read_byte((uint8_t*)EEPROM_CRASH_COUNT_Y);
     lcd_home();
+#ifndef PAT9125
+    lcd_printf_P(failStatsFmt,
+        _i("Last print failures"),  ////c=20 r=1
+        _i("Power failures"), power,  ////c=14 r=1
+        _i("Filam. runouts"), filam,  ////c=14 r=1
+        _i("Crash"), crashX, crashY);  ////c=7 r=1
+#else
+    // On the MK3 include detailed PAT9125 statistics about soft failures
     lcd_printf_P(PSTR("%S\n"
-                  " %S  %-3d\n"
-                  " %S H %-3d S %-3d\n"
-                  " %S   X %-3d Y %-3d"),
-             _i("Last print failures"),
-             _i("Power failures"), power,
-             _i("Runouts"), filam, fsensor_softfail,
-             _i("Crash"), crashX, crashY);
+                      " %-16.16S%-3d\n"
+                      " %-7.7S H %-3d S %-3d\n"
+                      " %-7.7S X %-3d Y %-3d"),
+                 _i("Last print failures"), ////c=20 r=1
+                 _i("Power failures"), power, ////c=14 r=1
+                 _i("Runouts"), filam, fsensor_softfail, //c=7 r=1
+                 _i("Crash"), crashX, crashY);  ////c=7 r=1
+#endif
     menu_back_if_clicked_fb();
 }
 
@@ -2234,10 +2243,12 @@ void lcd_set_filament_autoload() {
      fsensor_autoload_set(!fsensor_autoload_enabled);
 }
 
+#if defined(FILAMENT_SENSOR) && defined(PAT9125)
 void lcd_set_filament_oq_meass()
 {
      fsensor_oq_meassure_set(!fsensor_oq_meassure_enabled);
 }
+#endif
 
 
 FilamentAction eFilamentAction=FilamentAction::None; // must be initialized as 'non-autoLoad'


### PR DESCRIPTION
In this PR we partially rewrite the optical sensor tracking in the MK3 (aka PAT9125) to improve it's reliability.

Major improvements:

- The filament is now tracked accurately (with a fixed distance for each iteration), *and*  in both directions, so that retractions contribute to each reading, reducing the false error count.

- Improved handling during sensor triggering: the MK3 sensor now has "soft" and "hard" failure modes.

If the sensor fails to track the filament, a "soft" failure is triggered. The extruder is raised briefly, and re-checked by moving it. If the filament is present, we continue regularly. If not, we trigger a "hard" failure, which results in a regular filament change.

If three consecutive "soft" failures are triggered consecutively (within 5 seconds between each), we also trigger a hard failure. These cases can be triggered both by a clog or by a poorly tracking filament. In such cases it's pointless to continue: it's better to trigger a regular filament change to avoid destroying the print with blobs released during each pause.

- Both "hard" or "soft" failure counts are listed in the MK3 LCD under "Fail stats -> Last print". These are very useful to know if a filament has been tracking reliably over the course of a last print.

- Improved handling for poorly tracking filaments

The PAT9125 might fail to track a filament due to it's surface properties and/or speed of extrusion (the sensor can become completely blind if the reflections match the refresh rate of the sensor). In such cases, the sensor always returns zero distance traveled.

Since we cannot tune the refresh rate of the sensor, if we detect zero movement we fetch the camera parameters and rely on the exposure properties to determine if a filament is present or not. A poorly exposed image is likely a result of a far/missing reflecting surface (the filament).

The current thresholds are hardcoded, but could be likely be calibrated during filament autoload for optimal results.

General bug fixes:

- We fix the distance tracking inside the stepper isr: the lengths are now accumulated through multiple blocks, so that the effective optical distance should always match the traveled one.
- We update the internal optical sensor width every time we change the E axis resolution, since it is measured in stepper ticks. If the E axis resolution was changed at runtime, the sensor would previously fail to work at all (effective distance getting below the optical resolution)
- Read correctly the 12bit registers from the delta_y/x registers (which were truncated to 8 bits)

PFW-1086