### PR TITLE
Add X-Y home to tune menu if print is paused

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5441,7 +5441,7 @@ static void lcd_tune_menu()
     if (!farm_mode)
         MENU_ITEM_FUNCTION_P(_T(MSG_FILAMENTCHANGE), lcd_colorprint_change);
 #endif
-    if (isPrintPaused) // Don't allow rehome if actively printing. Maaaaybe it could work to insert on the fly, seems too risky.
+    if (isPrintPaused) {// Don't allow rehome if actively printing. Maaaaybe it could work to insert on the fly, seems too risky.
         MENU_ITEM_GCODE_P(_T(MSG_AUTO_HOME), PSTR("G28 X Y"));
     }
 #ifdef FILAMENT_SENSOR

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5441,7 +5441,9 @@ static void lcd_tune_menu()
     if (!farm_mode)
         MENU_ITEM_FUNCTION_P(_T(MSG_FILAMENTCHANGE), lcd_colorprint_change);
 #endif
-
+    if (isPrintPaused) // Don't allow rehome if actively printing. Maaaaybe it could work to insert on the fly, seems too risky.
+        MENU_ITEM_GCODE_P(_T(MSG_AUTO_HOME), PSTR("G28 X Y"));
+    }
 #ifdef FILAMENT_SENSOR
     MENU_ITEM_SUBMENU_P(_T(MSG_FSENSOR), lcd_fsensor_settings_menu);
 #endif //FILAMENT_SENSOR

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -241,6 +241,8 @@ static void lcd_sheet_menu();
 static void menu_action_sdfile(const char* filename);
 static void menu_action_sddirectory(const char* filename);
 
+static void lcd_rehome_xy();
+
 #define ENCODER_FEEDRATE_DEADZONE 10
 
 #define STATE_NA 255
@@ -5335,6 +5337,15 @@ void stepper_timer_overflow() {
 }
 #endif /* DEBUG_STEPPER_TIMER_MISSED */
 
+static void lcd_rehome_xy() {
+	// Do home directly, G28 X Y resets MBL, which could be bad.
+	homeaxis(X_AXIS);
+	homeaxis(Y_AXIS);
+	lcd_setstatuspgm(_T(MSG_AUTO_HOME));
+	lcd_return_to_status();
+	lcd_draw_update = 3;
+}
+
 
 static void lcd_colorprint_change() {
 
@@ -5442,7 +5453,7 @@ static void lcd_tune_menu()
         MENU_ITEM_FUNCTION_P(_T(MSG_FILAMENTCHANGE), lcd_colorprint_change);
 #endif
     if (isPrintPaused) {// Don't allow rehome if actively printing. Maaaaybe it could work to insert on the fly, seems too risky.
-        MENU_ITEM_GCODE_P(_T(MSG_AUTO_HOME), PSTR("G28 X Y"));
+        MENU_ITEM_FUNCTION_P(_T(MSG_AUTO_HOME), lcd_rehome_xy);
     }
 #ifdef FILAMENT_SENSOR
     MENU_ITEM_SUBMENU_P(_T(MSG_FSENSOR), lcd_fsensor_settings_menu);


### PR DESCRIPTION
Fixes #2161. 

Note: This is intended to be merged after #2390 since it depends on the Tune menu being available while the print is paused. 

There are a number of reasons one might need this feature, e.g. accidental slip while dealing with filament change/jammed filament, catching a layer shift quickly enough, etc. 

I tested it on my printer (apologies in advance, I'm sure the forced X shift will make some people cringe...)

https://vimeo.com/390095133

and it homed and resumed flawlessly with only a tiny zit to show for it, about the same as you'd get anyway. 

I did also verify the menu item is not present if the print is not paused... inserting a G28 mid print stream seems like a bad idea.... :-)  