### PR TITLE
Use combined creation/modification file time stamps for sorting

### DIFF
--- a/Firmware/cardreader.h
+++ b/Firmware/cardreader.h
@@ -75,7 +75,9 @@ public:
   bool sdprinting ;  
   bool cardOK ;
   char filename[13];
-  uint16_t modificationTime, modificationDate;
+  // There are scenarios when simple modification time is not enough (on MS Windows)
+  // Therefore these timestamps hold the most recent one of creation/modification date/times
+  uint16_t crmodTime, crmodDate;
   uint32_t cluster, position;
   char longFilename[LONG_FILENAME_LENGTH];
   bool filenameIsDir;


### PR DESCRIPTION
There are scenarios when simple modification time is not enough (on MS Windows) - for example - extract an old g-code from an archive onto the SD card.
In such case the file's creation time is the current time (which is correct), but the modification time stays the same - i.e. old. 
Therefore let's pick the most recent timestamp from both creation and modification timestamps.
PFW-1093