### PR TITLE
Fix unexpected timeout for accessing SD card

### DIFF
--- a/Firmware/Sd2Card.cpp
+++ b/Firmware/Sd2Card.cpp
@@ -287,7 +287,7 @@ bool Sd2Card::init(uint8_t sckRateID, uint8_t chipSelectPin) {
   errorCode_ = type_ = 0;
   chipSelectPin_ = chipSelectPin;
   // 16-bit init start time allows over a minute
-  uint16_t t0 = (uint16_t)_millis();
+  uint32_t t0 = _millis();
   uint32_t arg;
 
   // set pin modes
@@ -314,20 +314,20 @@ bool Sd2Card::init(uint8_t sckRateID, uint8_t chipSelectPin) {
 
   // command to go idle in SPI mode
   while ((status_ = cardCommand(CMD0, 0)) != R1_IDLE_STATE) {
-    if (((uint16_t)_millis() - t0) > SD_INIT_TIMEOUT) {
+    if ((_millis() - t0) > SD_INIT_TIMEOUT) {
       error(SD_CARD_ERROR_CMD0);
       goto fail;
     }
   }
 
   // send 0xFF until 0xFF received to give card some clock cycles
-  t0 = (uint16_t)_millis();
+  t0 = _millis();
   SERIAL_ECHOLNRPGM(PSTR("Sending 0xFF"));
   spiSend(0XFF);
   while ((status_ = spiRec()) != 0xFF)
   {
     spiSend(0XFF);
-    if (((uint16_t)_millis() - t0) > SD_CARD_ERROR_FF_TIMEOUT)
+    if ((_millis() - t0) > SD_CARD_ERROR_FF_TIMEOUT)
     {
       error(SD_CARD_ERROR_CMD8);
       SERIAL_ECHOLNRPGM(PSTR("No 0xFF received"));
@@ -352,7 +352,7 @@ bool Sd2Card::init(uint8_t sckRateID, uint8_t chipSelectPin) {
 
   while ((status_ = cardAcmd(ACMD41, arg)) != R1_READY_STATE) {
     // check for timeout
-    if (((uint16_t)_millis() - t0) > SD_INIT_TIMEOUT) {
+    if ((_millis() - t0) > SD_INIT_TIMEOUT) {
       error(SD_CARD_ERROR_ACMD41);
       goto fail;
     }
@@ -485,9 +485,9 @@ static uint16_t CRC_CCITT(const uint8_t* data, size_t n) {
 //------------------------------------------------------------------------------
 bool Sd2Card::readData(uint8_t* dst, uint16_t count) {
   // wait for start block token
-  uint16_t t0 = _millis();
+  uint32_t t0 = _millis();
   while ((status_ = spiRec()) == 0XFF) {
-    if (((uint16_t)_millis() - t0) > SD_READ_TIMEOUT) {
+    if ((_millis() - t0) > SD_READ_TIMEOUT) {
       error(SD_CARD_ERROR_READ_TIMEOUT);
       goto fail;
     }
@@ -609,9 +609,9 @@ bool Sd2Card::setSckRate(uint8_t sckRateID) {
 //------------------------------------------------------------------------------
 // wait for card to go not busy
 bool Sd2Card::waitNotBusy(uint16_t timeoutMillis) {
-  uint16_t t0 = _millis();
+  uint32_t t0 = _millis();
   while (spiRec() != 0XFF) {
-    if (((uint16_t)_millis() - t0) >= timeoutMillis) goto fail;
+    if ((_millis() - t0) >= timeoutMillis) goto fail;
   }
   return true;
 
@@ -747,9 +747,9 @@ bool Sd2Card::writeStop() {
 //FIXME Vojtech: Copied from a current version of Sd2Card Arduino code.
 // We shall likely upgrade the rest of the Sd2Card.
 uint8_t Sd2Card::waitStartBlock(void) {
-  uint16_t t0 = _millis();
+  uint32_t t0 = _millis();
   while ((status_ = spiRec()) == 0XFF) {
-    if (((uint16_t)_millis() - t0) > SD_READ_TIMEOUT) {
+    if ((_millis() - t0) > SD_READ_TIMEOUT) {
       error(SD_CARD_ERROR_READ_TIMEOUT);
       goto fail;
     }

--- a/Firmware/Sd2Card.cpp
+++ b/Firmware/Sd2Card.cpp
@@ -287,6 +287,8 @@ bool Sd2Card::init(uint8_t sckRateID, uint8_t chipSelectPin) {
   errorCode_ = type_ = 0;
   chipSelectPin_ = chipSelectPin;
   // 16-bit init start time allows over a minute
+  // However, when considering reinitializing the SD card,
+  // it is necessary to change from 16-bits to 32-bits.
   uint32_t t0 = _millis();
   uint32_t arg;
 


### PR DESCRIPTION
Prusa-Firmware has a 32-bit millisecond counter for various timeout checks.
However, when accessing the SD card via SPI, the millisecond timer value is treated as a 16-bit timer (the maximum is 65.5 seconds).
So, if the lower 16 bits of the system's millisecond timer were close to 0xffff, the timeout was too early (in a bad case, 1 millisecond instead of 300 milliseconds).

Therefore, the counter variable was changed from 16 bits to 32 bits.

---
For example, if the timing of inserting the SD card happens to be the value of 0x00001ffff millis of the system timer, this condition will occur.