### PR TITLE
🐛 Fix few LCD issues

### DIFF
--- a/Firmware/messages.c
+++ b/Firmware/messages.c
@@ -38,7 +38,7 @@ const char MSG_FINISHING_MOVEMENTS[] PROGMEM_I1 = ISTR("Finishing movements"); /
 const char MSG_FOLLOW_CALIBRATION_FLOW[] PROGMEM_I1 = ISTR("Printer has not been calibrated yet. Please follow the manual, chapter First steps, section Calibration flow."); ////c=20 r=8
 const char MSG_FOLLOW_Z_CALIBRATION_FLOW[] PROGMEM_I1 = ISTR("There is still a need to make Z calibration. Please follow the manual, chapter First steps, section Calibration flow."); ////c=20 r=8
 const char MSG_FSENSOR_AUTOLOAD[] PROGMEM_I1 = ISTR("F. autoload"); ////c=17 r=1
-const char MSG_FSENSOR[] PROGMEM_I1 = ISTR("Fil. sensor"); ////
+const char MSG_FSENSOR[] PROGMEM_I1 = ISTR("Fil. sensor"); ////c=11 r=1
 const char MSG_HEATING[] PROGMEM_I1 = ISTR("Heating"); ////
 const char MSG_HEATING_COMPLETE[] PROGMEM_I1 = ISTR("Heating done."); ////c=20
 const char MSG_HOMEYZ[] PROGMEM_I1 = ISTR("Calibrate Z"); ////

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -362,7 +362,7 @@ static void lcd_implementation_drawmenu_sdfile_selected(uint8_t row, const char*
         if(i==LCD_WIDTH){
           i=1;
           j++;
-          longFilenameTMP = longFilename + j;          
+          longFilenameTMP = longFilename + j;
           n = LCD_WIDTH - 1;
           for(int g = 0; g<300 ;g++){
 			  manage_heater();
@@ -374,7 +374,7 @@ static void lcd_implementation_drawmenu_sdfile_selected(uint8_t row, const char*
 				break;
             }else{
 				if (j == 1) _delay_ms(3);	//wait around 1.2 s to start scrolling text
-				_delay_ms(1);				//then scroll with redrawing every 300 ms 
+				_delay_ms(1);				//then scroll with redrawing every 300 ms
             }
 
           }
@@ -678,17 +678,17 @@ void lcdui_print_farm(void)
 		lcd_puts_P(PSTR(" F"));
 		lcd_print(farm_no);
 		lcd_puts_P(PSTR("  "));
-        
+
         // Beat display
         lcd_set_cursor(LCD_WIDTH - 1, 0);
         if ( (_millis() - kicktime) < 60000 ) {
-        
+
             lcd_puts_P(PSTR("L"));
-        
+
         }else{
             lcd_puts_P(PSTR(" "));
         }
-        
+
 	}
 	else {
 #ifdef SNMM
@@ -899,7 +899,7 @@ void lcdui_print_status_line(void)
 			break;
 		}
 	}
-    
+
     // Fill the rest of line to have nice and clean output
 	for(int fillspace = 0; fillspace < 20; fillspace++)
 		if ((lcd_status_message[fillspace] <= 31 ))
@@ -982,7 +982,7 @@ void lcdui_print_status_screen(void)
 // Main status screen. It's up to the implementation specific part to show what is needed. As this is very display dependent
 void lcd_status_screen()                          // NOT static due to using inside "Marlin_main" module ("manage_inactivity()")
 {
-	if (firstrun == 1) 
+	if (firstrun == 1)
 	{
 		firstrun = 0;
 		if(lcd_status_message_level == 0)
@@ -1520,7 +1520,7 @@ void lcd_commands()
 	}
 	if (lcd_commands_type == LcdCommands::PidExtruder) {
 		char cmd1[30];
-		
+
 		if (lcd_commands_step == 0) {
 			custom_message_type = CustomMsg::PidCal;
 			custom_message_state = 1;
@@ -1649,10 +1649,10 @@ void lcd_menu_extruder_info()                     // NOT static due to using ins
     char nozzle[maxChars], print[maxChars];
     pgmtext_with_colon(_i("Nozzle FAN"), nozzle, maxChars);  ////c=10 r=1
     pgmtext_with_colon(_i("Print FAN"), print, maxChars);  ////c=10 r=1
-    lcd_printf_P(_N("%s %4d RPM\n" "%s %4d RPM\n"), nozzle, 60*fan_speed[0], print, 60*fan_speed[1] ); 
+    lcd_printf_P(_N("%s %4d RPM\n" "%s %4d RPM\n"), nozzle, 60*fan_speed[0], print, 60*fan_speed[1] );
 
 #ifdef PAT9125
-	// Display X and Y difference from Filament sensor    
+	// Display X and Y difference from Filament sensor
     // Display Light intensity from Filament sensor
     //  Frame_Avg register represents the average brightness of all pixels within a frame (324 pixels). This
     //  value ranges from 0(darkest) to 255(brightest).
@@ -1679,7 +1679,7 @@ void lcd_menu_extruder_info()                     // NOT static due to using ins
 		}
 	}
 #endif //PAT9125
-    
+
     menu_back_if_clicked();
 }
 
@@ -1719,7 +1719,7 @@ static void lcd_menu_fails_stats_mmu_print()
     uint8_t fails = eeprom_read_byte((uint8_t*)EEPROM_MMU_FAIL);
     uint16_t load_fails = eeprom_read_byte((uint8_t*)EEPROM_MMU_LOAD_FAIL);
     lcd_home();
-    lcd_printf_P(PSTR("%S\n" " %-16.16S%-3d\n" " %-16.16S%-3d"), 
+    lcd_printf_P(PSTR("%S\n" " %-16.16S%-3d\n" " %-16.16S%-3d"),
         _i("Last print failures"), ////c=20 r=1
         _i("MMU fails"), fails, ////c=14 r=1
         _i("MMU load f."), load_fails); ////c=14 r=1
@@ -1744,7 +1744,7 @@ static void lcd_menu_fails_stats_mmu_total()
     uint16_t fails = eeprom_read_word((uint16_t*)EEPROM_MMU_FAIL_TOT);
     uint16_t load_fails = eeprom_read_word((uint16_t*)EEPROM_MMU_LOAD_FAIL_TOT);
     lcd_home();
-    lcd_printf_P(PSTR("%S\n" " %-14.14S%-5d\n" " %-14.14S%-5d\n" " %-16.16S%-3d"), 
+    lcd_printf_P(PSTR("%S\n" " %-14.14S%-5u\n" " %-14.14S%-5u\n" " %-16.16S%-3d"),
         _i("Total failures"), ////c=20 r=1
         _i("MMU fails"), fails, ////c=13 r=1
         _i("MMU load f."), load_fails, ////c=13 r=1
@@ -1753,16 +1753,16 @@ static void lcd_menu_fails_stats_mmu_total()
 }
 
 #if defined(TMC2130) && defined(FILAMENT_SENSOR)
-static const char failStatsFmt[] PROGMEM = "%S\n" " %-16.16S%-3d\n" " %-16.16S%-3d\n" " %-7.7SX %-3d  Y %-3d";
+//static const char failStatsFmt[] PROGMEM = "%S\n" " %-16.16S%-3d\n" " %-16.16S%-3d\n" " %-7.7SX %-3d  Y %-3d";
 
-//! @brief Show Total Failures Statistics MMU
+//! @brief Show Total Failures Statistics
 //!
 //! @code{.unparsed}
 //! |01234567890123456789|
 //! |Total failures      |	c=20 r=1
-//! | Power failures: 000|	c=14 r=1
-//! | Filam. runouts: 000|	c=14 r=1
-//! | Crash   X:000 Y:000|	c=7 r=1
+//! | Power fails   00000|	c=13 r=1
+//! | Filam.Sensor  00000|	c=13 r=1
+//! | Crash X00000 Y00000|	c=5 r=1
 //! ----------------------
 //! @endcode
 //! @todo Positioning of the messages and values on LCD aren't fixed to their exact place. This causes issues with translations.
@@ -1774,11 +1774,11 @@ static void lcd_menu_fails_stats_total()
     uint16_t crashX = eeprom_read_word((uint16_t*)EEPROM_CRASH_COUNT_X_TOT);
     uint16_t crashY = eeprom_read_word((uint16_t*)EEPROM_CRASH_COUNT_Y_TOT);
     lcd_home();
-    lcd_printf_P(failStatsFmt, 
+    lcd_printf_P(PSTR("%S\n" " %-14.14S%-5u\n" " %-14.14S%-5u\n" " %-6.6SX%-5u Y%-5u"),
         _i("Total failures"),   ////c=20 r=1
-        _i("Power failures"), power,   ////c=14 r=1
-        _i("Filam. runouts"), filam,   ////c=14 r=1
-        _i("Crash"), crashX, crashY);  ////c=7 r=1
+        _i("Power fails"), power,   ////c=13 r=1
+        _i("Filam.Sensor"), filam,   ////c=13 r=1
+        _i("Crash"), crashX, crashY);  ////c=5 r=1
     menu_back_if_clicked_fb();
 }
 
@@ -1787,9 +1787,9 @@ static void lcd_menu_fails_stats_total()
 //! @code{.unparsed}
 //! |01234567890123456789|
 //! |Last print failures |	c=20 r=1
-//! | Power failures  000|	c=14 r=1
-//! | Filam. runouts  000|	c=14 r=1
-//! | Crash   X:000 Y:000|	c=7 r=1
+//! | Power fails     000|	c=13 r=1
+//! | FilSens         000|	c=7 r=1
+//! | Crash   X 000 Y 000|	c=5 r=1
 //! ----------------------
 //! @endcode
 //! @todo Positioning of the messages and values on LCD aren't fixed to their exact place. This causes issues with translations.
@@ -1802,31 +1802,39 @@ static void lcd_menu_fails_stats_print()
     uint8_t crashY = eeprom_read_byte((uint8_t*)EEPROM_CRASH_COUNT_Y);
     lcd_home();
 #ifndef PAT9125
-    lcd_printf_P(failStatsFmt,
+    lcd_printf_P(PSTR("%S\n" " %-16.16S%-3d\n" " %-16.16S%-3d\n" " %-7.7SX %-3d  Y %-3d"),
         _i("Last print failures"),  ////c=20 r=1
-        _i("Power failures"), power,  ////c=14 r=1
-        _i("Filam. runouts"), filam,  ////c=14 r=1
-        _i("Crash"), crashX, crashY);  ////c=7 r=1
+        _i("Power fails"), power,  ////c=13 r=1
+        _i("FilSens"), filam,  ////c=7 r=1
+        _i("Crash"), crashX, crashY);  ////c=5 r=1
 #else
     // On the MK3 include detailed PAT9125 statistics about soft failures
+//! @brief Show Last Print Failures Statistics
+//!
+//! @code{.unparsed}
+//! |01234567890123456789|
+//! |Last print failures |	c=20 r=1
+//! | Power fails     000|	c=13 r=1
+//! | FilSens H 000 S 000|	c=7 r=1
+//! | Crash   X 000 Y 000|	c=5 r=1
+//! ----------------------
+//! @endcode
     lcd_printf_P(PSTR("%S\n"
-                      " %-16.16S%-3d\n"
-                      " %-7.7S H %-3d S %-3d\n"
-                      " %-7.7S X %-3d Y %-3d"),
+                      " %-16.16S%-3d\n" " %-7.7S H %-3d S %-3d\n" " %-7.7S X %-3d Y %-3d"),
                  _i("Last print failures"), ////c=20 r=1
-                 _i("Power failures"), power, ////c=14 r=1
-                 _i("Runouts"), filam, fsensor_softfail, //c=7 r=1
+                 _i("Power fails"), power, ////c=13 r=1
+                 _i("FilSens"), filam, fsensor_softfail, //c=7 r=1
                  _i("Crash"), crashX, crashY);  ////c=7 r=1
 #endif
     menu_back_if_clicked_fb();
 }
 
 //! @brief Open fail statistics menu
-//! 
+//!
 //! This version of function is used, when there is filament sensor,
 //! power failure and crash detection.
 //! There are Last print and Total menu items.
-//! 
+//!
 //! @code{.unparsed}
 //! |01234567890123456789|
 //! | Main               |	c=18 r=1
@@ -1847,12 +1855,12 @@ static void lcd_menu_fails_stats()
 
 #elif defined(FILAMENT_SENSOR)
 static const char failStatsFmt[] PROGMEM = "%S\n" " %-16.16S%-3d\n" "%S\n" " %-16.16S%-3d\n";
-//! 
+//!
 //! @brief Print last print and total filament run outs
-//! 
+//!
 //! This version of function is used, when there is filament sensor,
 //! but no other sensors (e.g. power failure, crash detection).
-//! 
+//!
 //! Example screen:
 //! @code{.unparsed}
 //! |01234567890123456789|
@@ -1869,7 +1877,7 @@ static void lcd_menu_fails_stats()
     uint8_t filamentLast = eeprom_read_byte((uint8_t*)EEPROM_FERROR_COUNT);
     uint16_t filamentTotal = eeprom_read_word((uint16_t*)EEPROM_FERROR_COUNT_TOT);
 	lcd_home();
-	lcd_printf_P(failStatsFmt, 
+	lcd_printf_P(failStatsFmt,
         _i("Last print failures"),   ////c=20 r=1
         _i("Filam. runouts"), filamentLast,   ////c=14 r=1
         _i("Total failures"),  ////c=20 r=1
@@ -1924,7 +1932,7 @@ static void lcd_menu_debug()
 //! @param [in] ipgmLabel pointer to string in PROGMEM
 //! @param [in] value to be printed behind the label
 static void lcd_menu_temperatures_line(const char *ipgmLabel, int value){
-    static const size_t maxChars = 15;    
+    static const size_t maxChars = 15;
     char tmp[maxChars];
     pgmtext_with_colon(ipgmLabel, tmp, maxChars);
     lcd_printf_P(PSTR(" %s%3d\x01 \n"), tmp, value); // no need to add -14.14 to string alignment
@@ -2008,7 +2016,7 @@ static void lcd_menu_belt_status()
 }
 #endif //TMC2130
 
-#ifdef RESUME_DEBUG 
+#ifdef RESUME_DEBUG
 extern void stop_and_save_print_to_ram(float z_move, float e_move);
 extern void restore_print_from_ram_and_continue(float e_move);
 
@@ -2021,7 +2029,7 @@ static void lcd_menu_test_restore()
 {
 	restore_print_from_ram_and_continue(0.8);
 }
-#endif //RESUME_DEBUG 
+#endif //RESUME_DEBUG
 
 //! @brief Show Preheat Menu
 static void lcd_preheat_menu()
@@ -2049,54 +2057,54 @@ static void lcd_preheat_menu()
 //! | MMM DD YYYY        |	__DATE__
 //! | --------------     |	STR_SEPARATOR
 //! @endcode
-//! 
+//!
 //! If MMU is connected
-//! 
+//!
 //! 	@code{.unparsed}
 //! 	| MMU2 connected     |	c=18 r=1
 //! 	|  FW: 1.0.6-7064523 |
 //! 	@endcode
-//! 
+//!
 //! If MMU is not connected
-//! 
+//!
 //! 	@code{.unparsed}
 //! 	| MMU2       N/A     |	c=18 r=1
 //! 	@endcode
-//! 
+//!
 //! If Flash Air is connected
-//! 
+//!
 //! 	@code{.unparsed}
 //! 	| --------------     |	STR_SEPARATOR
 //! 	| FlashAir IP Addr:  |	c=18 r=1
 //! 	|  192.168.1.100     |
 //! 	@endcode
-//! 
+//!
 //! @code{.unparsed}
 //! | --------------     |	STR_SEPARATOR
 //! | XYZ cal. details   |	MSG_XYZ_DETAILS
 //! | Extruder info      |	MSG_INFO_EXTRUDER
 //! | Sensor info        |	MSG_INFO_SENSORS
 //! @endcode
-//! 
+//!
 //! If TMC2130 defined
-//! 
+//!
 //! 	@code{.unparsed}
 //! 	| Belt status        |	MSG_MENU_BELT_STATUS
 //! @endcode
-//! 
+//!
 //! @code{.unparsed}
 //! | Temperatures       |	MSG_MENU_TEMPERATURES
 //! @endcode
-//! 
+//!
 //! If Voltage Bed and PWR Pin are defined
-//! 
+//!
 //! 	@code{.unparsed}
 //! 	| Voltages           |	MSG_MENU_VOLTAGES
 //! 	@endcode
-//! 
-//! 
+//!
+//!
 //! If DEBUG_BUILD is defined
-//! 
+//!
 //! 	@code{.unparsed}
 //! 	| Debug              |	c=18 r=1
 //! 	@endcode
@@ -2120,11 +2128,11 @@ static void lcd_support_menu()
         _md->status = 1;
         _md->is_flash_air = card.ToshibaFlashAir_isEnabled() && card.ToshibaFlashAir_GetIP(_md->ip);
         if (_md->is_flash_air)
-            sprintf_P(_md->ip_str, PSTR("%d.%d.%d.%d"), 
-                _md->ip[0], _md->ip[1], 
+            sprintf_P(_md->ip_str, PSTR("%d.%d.%d.%d"),
+                _md->ip[0], _md->ip[1],
                 _md->ip[2], _md->ip[3]);
-    } else if (_md->is_flash_air && 
-        _md->ip[0] == 0 && _md->ip[1] == 0 && 
+    } else if (_md->is_flash_air &&
+        _md->ip[0] == 0 && _md->ip[1] == 0 &&
         _md->ip[2] == 0 && _md->ip[3] == 0 &&
         ++ _md->status == 16)
 	{
@@ -2148,7 +2156,7 @@ static void lcd_support_menu()
   } else {
       MENU_ITEM_BACK_P(PSTR("FW - " FW_version));
   }*/
-      
+
   MENU_ITEM_BACK_P(_i("prusa3d.com"));////MSG_PRUSA3D
   MENU_ITEM_BACK_P(_i("forum.prusa3d.com"));////MSG_PRUSA3D_FORUM
   MENU_ITEM_BACK_P(_i("howto.prusa3d.com"));////MSG_PRUSA3D_HOWTO
@@ -2188,7 +2196,7 @@ static void lcd_support_menu()
 			if ((mmu_version > 0) && (mmu_buildnr > 0))
 				lcd_printf_P(PSTR("%d.%d.%d-%d"), mmu_version/100, mmu_version%100/10, mmu_version%10, mmu_buildnr);
 			else
-				lcd_puts_P(_i("unknown")); 
+				lcd_puts_P(_i("unknown"));
 		}
 	}
 	else
@@ -2211,7 +2219,7 @@ static void lcd_support_menu()
 #ifdef TMC2130
   MENU_ITEM_SUBMENU_P(_i("Belt status"), lcd_menu_belt_status);////MSG_MENU_BELT_STATUS c=18 r=1
 #endif //TMC2130
-    
+
   MENU_ITEM_SUBMENU_P(_i("Temperatures"), lcd_menu_temperatures);////MSG_MENU_TEMPERATURES c=18 r=1
 
 #if defined (VOLT_BED_PIN) || defined (VOLT_PWR_PIN)
@@ -2596,7 +2604,7 @@ void lcd_wait_interact() {
   lcd_clear();
 
   lcd_set_cursor(0, 1);
-#ifdef SNMM 
+#ifdef SNMM
   lcd_puts_P(_i("Prepare new filament"));////MSG_PREPARE_FILAMENT c=20 r=1
 #else
   lcd_puts_P(_i("Insert filament"));////MSG_INSERT_FILAMENT c=20
@@ -2619,7 +2627,7 @@ void lcd_change_success() {
 
 }
 
-static void lcd_loading_progress_bar(uint16_t loading_time_ms) { 
+static void lcd_loading_progress_bar(uint16_t loading_time_ms) {
 
 	for (uint_least8_t i = 0; i < 20; i++) {
 		lcd_set_cursor(i, 3);
@@ -2772,7 +2780,7 @@ void lcd_alright() {
 }
 
 void show_preheat_nozzle_warning()
-{	
+{
     lcd_clear();
     lcd_set_cursor(0, 0);
     lcd_puts_P(_T(MSG_ERROR));
@@ -3007,7 +3015,7 @@ float _deg(float rad)
 }
 
 //! @brief Show Measured XYZ Skew
-//! 
+//!
 //! @code{.unparsed}
 //! |01234567890123456789|
 //! |Measured skew: 0.00D|	c=13 r=1
@@ -3045,7 +3053,7 @@ static void lcd_menu_xyz_skew()
         menu_goto(lcd_menu_xyz_offset, 0, true, true);
 }
 //! @brief Show measured bed offset from expected position
-//! 
+//!
 //! @code{.unparsed}
 //! |01234567890123456789|
 //! |[0;0] point offset  |	c=20 r=1
@@ -3131,7 +3139,7 @@ static void lcd_babystep_z()
 		// Initialize its status.
 		_md->status = 1;
 		check_babystep();
-		
+
 		if(!eeprom_is_sheet_initialized(eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet)))){
 			_md->babystepMemZ = 0;
 		}
@@ -3152,7 +3160,7 @@ static void lcd_babystep_z()
 		lcd_timeoutToStatus.start();
 	}
 
-	if (lcd_encoder != 0) 
+	if (lcd_encoder != 0)
 	{
 		if (homing_flag) lcd_encoder = 0;
 		_md->babystepMemZ += (int)lcd_encoder;
@@ -3186,7 +3194,7 @@ static void lcd_babystep_z()
           uint8_t active_sheet=eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet));
 		eeprom_update_word(reinterpret_cast<uint16_t *>(&(EEPROM_Sheets_base->s[active_sheet].z_offset)),_md->babystepMemZ);
 		eeprom_update_byte(&(EEPROM_Sheets_base->s[active_sheet].bed_temp),target_temperature_bed);
-#ifdef PINDA_THERMISTOR        
+#ifdef PINDA_THERMISTOR
 		eeprom_update_byte(&(EEPROM_Sheets_base->s[active_sheet].pinda_temp),current_temperature_pinda);
 #endif //PINDA_THERMISTOR
 		calibration_status_store(CALIBRATION_STATUS_CALIBRATED);
@@ -3218,7 +3226,7 @@ void lcd_adjust_bed_reset(void)
 }
 
 //! @brief Show Bed level correct
-//! 
+//!
 //! @code{.unparsed}
 //! |01234567890123456789|
 //! |Settings:           |	MSG_SETTINGS
@@ -3267,7 +3275,7 @@ void lcd_adjust_bed(void)
 }
 
 //! @brief Show PID Extruder
-//! 
+//!
 //! @code{.unparsed}
 //! |01234567890123456789|
 //! | Set temperature:   |	MSG_SET_TEMPERATURE
@@ -3433,13 +3441,13 @@ void lcd_wait_for_cool_down() {
 		lcd_set_cursor(0, 4);
 		lcd_print(LCD_STR_THERMOMETER[0]);
 		lcd_print(ftostr3(degHotend(0)));
-		lcd_print("/0");		
+		lcd_print("/0");
 		lcd_print(LCD_STR_DEGREE);
 
 		lcd_set_cursor(9, 4);
 		lcd_print(LCD_STR_BEDTEMP[0]);
 		lcd_print(ftostr3(degBed()));
-		lcd_print("/0");		
+		lcd_print("/0");
 		lcd_print(LCD_STR_DEGREE);
 		lcd_set_custom_characters();
 		delay_keep_alive(1000);
@@ -3608,7 +3616,7 @@ const char* lcd_display_message_fullscreen_P(const char *msg, uint8_t &nlines)
 //	uint8_t nlines;
     return lcd_display_message_fullscreen_nonBlocking_P(msg, nlines);
 }
-const char* lcd_display_message_fullscreen_P(const char *msg) 
+const char* lcd_display_message_fullscreen_P(const char *msg)
 {
   uint8_t nlines;
   return lcd_display_message_fullscreen_P(msg, nlines);
@@ -3795,7 +3803,7 @@ int8_t lcd_show_fullscreen_message_yes_no_and_wait_P(const char *msg, bool allow
 {
 
 	lcd_display_message_fullscreen_P(msg);
-	
+
 	if (default_yes) {
 		lcd_set_cursor(0, 2);
 		lcd_puts_P(PSTR(">"));
@@ -3907,7 +3915,7 @@ void lcd_bed_calibration_show_result(BedSkewOffsetDetectionResultType result, ui
 }
 
 void lcd_temp_cal_show_result(bool result) {
-	
+
 	custom_message_type = CustomMsg::Status;
 	disable_x();
 	disable_y();
@@ -3981,7 +3989,7 @@ static void lcd_print_state(uint8_t state)
 		case STATE_OFF:
 			lcd_puts_P(_N("  0"));
 		break;
-		default: 
+		default:
 			lcd_puts_P(_T(MSG_NA));
 		break;
 	}
@@ -4006,11 +4014,11 @@ static void lcd_show_sensors_state()
 	lcd_puts_at_P(1, 1, _i("PINDA:"));
 	lcd_set_cursor(LCD_WIDTH - 4, 1);
 	lcd_print_state(pinda_state);
-	
+
 	lcd_puts_at_P(1, 2, _i("FINDA:"));
 	lcd_set_cursor(LCD_WIDTH - 4, 2);
 	lcd_print_state(finda_state);
-	
+
 	lcd_puts_at_P(1, 3, _i("IR:"));
 	lcd_set_cursor(LCD_WIDTH - 4, 3);
 	lcd_print_state(idler_state);
@@ -4049,8 +4057,8 @@ void prusa_statistics(int _message, uint8_t _fil_nr) {
 	{
 
 	case 0: // default message
-		if (busy_state == PAUSED_FOR_USER) 
-		{   
+		if (busy_state == PAUSED_FOR_USER)
+		{
 			prusa_statistics_case0(15);
 		}
 		else if (isPrintPaused)
@@ -4164,7 +4172,7 @@ void prusa_statistics(int _message, uint8_t _fil_nr) {
 		prusa_stat_farm_number();
 		status_number = 5;
         break;
-	
+
 	case 90: // Error - Thermal Runaway
 		prusa_statistics_err('1');
 		break;
@@ -4184,10 +4192,10 @@ void prusa_statistics(int _message, uint8_t _fil_nr) {
 		SERIAL_ECHO("[PFN:");
 		SERIAL_ECHO(farm_no);
 		SERIAL_ECHO(']');
-            
+
         break;
 	}
-	SERIAL_ECHOLN('}');	
+	SERIAL_ECHOLN('}');
 
 }
 
@@ -4253,65 +4261,65 @@ void lcd_pick_babystep(){
     int enc_dif = 0;
     int cursor_pos = 1;
     int fsm = 0;
-    
-    
-    
-    
+
+
+
+
     lcd_clear();
-    
+
     lcd_set_cursor(0, 0);
-    
+
     lcd_puts_P(_i("Pick print"));////MSG_PICK_Z
-    
-    
+
+
     lcd_set_cursor(3, 2);
-    
+
     lcd_print("1");
-    
+
     lcd_set_cursor(3, 3);
-    
+
     lcd_print("2");
-    
+
     lcd_set_cursor(12, 2);
-    
+
     lcd_print("3");
-    
+
     lcd_set_cursor(12, 3);
-    
+
     lcd_print("4");
-    
+
     lcd_set_cursor(1, 2);
-    
+
     lcd_print(">");
-    
-    
+
+
     enc_dif = lcd_encoder_diff;
-    
+
     while (fsm == 0) {
-        
+
         manage_heater();
         manage_inactivity(true);
-        
+
         if ( abs((enc_dif - lcd_encoder_diff)) > 4 ) {
-            
+
             if ( (abs(enc_dif - lcd_encoder_diff)) > 1 ) {
                 if (enc_dif > lcd_encoder_diff ) {
                     cursor_pos --;
                 }
-                
+
                 if (enc_dif < lcd_encoder_diff  ) {
                     cursor_pos ++;
                 }
-                
+
                 if (cursor_pos > 4) {
                     cursor_pos = 4;
                 }
-                
+
                 if (cursor_pos < 1) {
                     cursor_pos = 1;
                 }
 
-                
+
                 lcd_set_cursor(1, 2);
                 lcd_print(" ");
                 lcd_set_cursor(1, 3);
@@ -4320,7 +4328,7 @@ void lcd_pick_babystep(){
                 lcd_print(" ");
                 lcd_set_cursor(10, 3);
                 lcd_print(" ");
-                
+
                 if (cursor_pos < 3) {
                     lcd_set_cursor(1, cursor_pos+1);
                     lcd_print(">");
@@ -4328,14 +4336,14 @@ void lcd_pick_babystep(){
                     lcd_set_cursor(10, cursor_pos-1);
                     lcd_print(">");
                 }
-                
-   
+
+
                 enc_dif = lcd_encoder_diff;
                 _delay(100);
             }
-            
+
         }
-        
+
         if (lcd_clicked()) {
             fsm = cursor_pos;
             int babyStepZ;
@@ -4343,10 +4351,10 @@ void lcd_pick_babystep(){
             EEPROM_save_B(EEPROM_BABYSTEP_Z,&babyStepZ);
             calibration_status_store(CALIBRATION_STATUS_CALIBRATED);
             _delay(500);
-            
+
         }
     };
-    
+
     lcd_clear();
     lcd_return_to_status();
 }
@@ -4528,7 +4536,7 @@ static void crash_mode_switch()
 	else menu_goto(lcd_settings_menu, 9, true, true);
 }
 #endif //TMC2130
- 
+
 
 #ifdef FILAMENT_SENSOR
 static void lcd_fsensor_state_set()
@@ -4585,7 +4593,7 @@ static void lcd_language_menu()
 	}
 	uint8_t cnt = lang_get_count();
 #ifdef W25X20CL
-	if (cnt == 2) //display secondary language in case of clear xflash 
+	if (cnt == 2) //display secondary language in case of clear xflash
 	{
 		if (menu_item_text_P(lang_get_name_by_code(lang_get_code(1))))
 		{
@@ -4658,12 +4666,12 @@ void lcd_calibrate_pinda() {
 #ifndef SNMM
 
 /*void lcd_calibrate_extruder() {
-	
+
 	if (degHotend0() > EXTRUDE_MINTEMP)
 	{
 		current_position[E_AXIS] = 0;									//set initial position to zero
 		plan_set_e_position(current_position[E_AXIS]);
-		
+
 		//long steps_start = st_get_position(E_AXIS);
 
 		long steps_final;
@@ -4677,8 +4685,8 @@ void lcd_calibrate_pinda() {
 
 		lcd_show_fullscreen_message_and_wait_P(_i("Mark filament 100mm from extruder body. Click when done."));////MSG_MARK_FIL c=20 r=8
 		lcd_clear();
-		
-		
+
+
 		lcd_set_cursor(0, 1); lcd_puts_P(_T(MSG_PLEASE_WAIT));
 		current_position[E_AXIS] += e_shift_calibration;
 		plan_buffer_line_curposXYZE(feedrate, active_extruder);
@@ -4705,23 +4713,23 @@ void lcd_calibrate_pinda() {
 					current_position[E_AXIS] += float(abs((int)lcd_encoder)) * 0.01; //0.05
 					lcd_encoder = 0;
 					plan_buffer_line_curposXYZE(feedrate, active_extruder);
-					
+
 				}
-			}	
+			}
 		}
-		
+
 		steps_final = current_position[E_AXIS] * axis_steps_per_unit[E_AXIS];
 		//steps_final = st_get_position(E_AXIS);
 		lcd_draw_update = 1;
 		e_steps_per_unit = ((float)(steps_final)) / 100.0f;
-		if (e_steps_per_unit < MIN_E_STEPS_PER_UNIT) e_steps_per_unit = MIN_E_STEPS_PER_UNIT;				
+		if (e_steps_per_unit < MIN_E_STEPS_PER_UNIT) e_steps_per_unit = MIN_E_STEPS_PER_UNIT;
 		if (e_steps_per_unit > MAX_E_STEPS_PER_UNIT) e_steps_per_unit = MAX_E_STEPS_PER_UNIT;
 
 		lcd_clear();
 
 		axis_steps_per_unit[E_AXIS] = e_steps_per_unit;
 		enquecommand_P(PSTR("M500")); //store settings to eeprom
-	
+
 		//lcd_drawedit(PSTR("Result"), ftostr31(axis_steps_per_unit[E_AXIS]));
 		//delay_keep_alive(2000);
 		delay_keep_alive(500);
@@ -4908,7 +4916,7 @@ static void wait_preheat()
 		lcdui_print_temp(LCD_STR_THERMOMETER[0], (int)(degHotend(0) + 0.5), (int)(degTargetHotend(0) + 0.5));
         delay_keep_alive(1000);
     }
-	
+
 }
 
 static void lcd_wizard_load()
@@ -4917,11 +4925,11 @@ static void lcd_wizard_load()
 	{
 		lcd_show_fullscreen_message_and_wait_P(_i("Please insert filament into the first tube of the MMU, then press the knob to load it."));////c=20 r=8
 		tmp_extruder = 0;
-	} 
+	}
 	else
 	{
 		lcd_show_fullscreen_message_and_wait_P(_i("Please insert filament into the extruder, then press the knob to load it."));////MSG_WIZARD_LOAD_FILAMENT c=20 r=8
-	}	
+	}
 	lcd_update_enable(false);
 	lcd_clear();
 	lcd_puts_at_P(0, 2, _T(MSG_LOADING_FILAMENT));
@@ -5000,14 +5008,14 @@ void lcd_wizard(WizState state)
 	// Make sure EEPROM_WIZARD_ACTIVE is true if entering using different entry point
 	// other than WizState::Run - it is useful for debugging wizard.
 	if (state != S::Run) eeprom_update_byte((uint8_t*)EEPROM_WIZARD_ACTIVE, 1);
-    
+
     FORCE_BL_ON_START;
-	
+
     while (!end) {
 		printf_P(PSTR("Wizard state: %d\n"), state);
 		switch (state) {
 		case S::Run: //Run wizard?
-			
+
 			// 2019-08-07 brutal hack - solving the "viper" situation.
 			// It is caused by the fact, that tmc2130_st_isr makes a crash detection before the printers really starts.
 			// And thus it calles stop_and_save_print_to_ram which sets the saved_printing flag.
@@ -5016,9 +5024,9 @@ void lcd_wizard(WizState state)
 			// This primarily happens when the printer is new and parked in 0,0
 			// So any new printer will fail the first layer calibration unless being reset or the Stop function gets called.
 			// We really must find a way to prevent the crash from happening before the printer is started - that would be the correct solution.
-			// Btw. the flag may even trigger the viper situation on normal start this way and the user won't be able to find out why.			
+			// Btw. the flag may even trigger the viper situation on normal start this way and the user won't be able to find out why.
 			saved_printing = false;
-			
+
 			wizard_event = lcd_show_multiscreen_message_yes_no_and_wait_P(_i("Hi, I am your Original Prusa i3 printer. Would you like me to guide you through the setup process?"), false, true);////MSG_WIZARD_WELCOME c=20 r=7
 			if (wizard_event) {
 				state = S::Restore;
@@ -5038,7 +5046,7 @@ void lcd_wizard(WizState state)
 			case CALIBRATION_STATUS_CALIBRATED: end = true; eeprom_update_byte((uint8_t*)EEPROM_WIZARD_ACTIVE, 0); break;
 			default: state = S::Selftest; break; //if calibration status is unknown, run wizard from the beginning
 			}
-			break; 
+			break;
 		case S::Selftest:
 			lcd_show_fullscreen_message_and_wait_P(_i("First, I will run the selftest to check most common assembly problems."));////MSG_WIZARD_SELFTEST c=20 r=8
 			wizard_event = lcd_selftest();
@@ -5139,9 +5147,9 @@ void lcd_wizard(WizState state)
 		default: break;
 		}
 	}
-    
+
     FORCE_BL_ON_END;
-    
+
 	printf_P(_N("Wizard end state: %d\n"), state);
 	switch (state) { //final message
 	case S::Restore: //printer was already calibrated
@@ -5157,7 +5165,7 @@ void lcd_wizard(WizState state)
 		msg = _T(MSG_WIZARD_DONE);
 		lcd_reset_alert_level();
 		lcd_setstatuspgm(_T(WELCOME_MSG));
-		lcd_return_to_status(); 
+		lcd_return_to_status();
 		break;
 
 	default:
@@ -5359,7 +5367,7 @@ do\
 		else MENU_ITEM_TOGGLE_P(_T(MSG_MMU_MODE), _T(MSG_STEALTH), lcd_silent_mode_mmu_set);\
 	}\
 }\
-while (0) 
+while (0)
 #else //MMU_FORCE_STEALTH_MODE
 #define SETTINGS_MMU_MODE
 #endif //MMU_FORCE_STEALTH_MODE
@@ -5405,10 +5413,10 @@ do\
     switch(e_mbl_type)\
     {\
     case e_MBL_FAST:\
-        MENU_ITEM_FUNCTION_P(_i("Mode    [Fast]"),mbl_mode_set);\ 
+        MENU_ITEM_FUNCTION_P(_i("Mode    [Fast]"),mbl_mode_set);\
          break; \
     case e_MBL_OPTIMAL:\
-	    MENU_ITEM_FUNCTION_P(_i("Mode [Optimal]"), mbl_mode_set); \ 
+	    MENU_ITEM_FUNCTION_P(_i("Mode [Optimal]"), mbl_mode_set); \
 	     break; \
     case e_MBL_PREC:\
 	     MENU_ITEM_FUNCTION_P(_i("Mode [Precise]"), mbl_mode_set); \
@@ -5754,7 +5762,7 @@ static void lcd_settings_menu()
         bSettings=true;                              // flag ('fake parameter') for 'lcd_hw_setup_menu()' function
         MENU_ITEM_SUBMENU_P(_i("HW Setup"), lcd_hw_setup_menu);////MSG_HW_SETUP
     }
-    
+
 	SETTINGS_MMU_MODE;
 
 	MENU_ITEM_SUBMENU_P(_i("Mesh bed leveling"), lcd_mesh_bed_leveling_settings);////MSG_MBL_SETTINGS c=18 r=1
@@ -5852,7 +5860,7 @@ static void lcd_calibration_menu()
 #endif
     // "Mesh Bed Leveling"
     MENU_ITEM_SUBMENU_P(_i("Mesh Bed Leveling"), lcd_mesh_bedleveling);////MSG_MESH_BED_LEVELING
-	
+
 #endif //MK1BP
 
     MENU_ITEM_SUBMENU_P(_i("Bed level correct"), lcd_adjust_bed);////MSG_BED_CORRECTION_MENU
@@ -5870,7 +5878,7 @@ static void lcd_calibration_menu()
 	MENU_ITEM_SUBMENU_P(_i("Temp. calibration"), lcd_pinda_calibration_menu);////MSG_CALIBRATION_PINDA_MENU c=17 r=1
 #endif //MK1BP
   }
-  
+
   MENU_END();
 }
 
@@ -6016,7 +6024,7 @@ static char snmm_stop_print_menu() { //menu for choosing which filaments will be
 				if (cursor_pos < 1){
 					cursor_pos = 1;
 					Sound_MakeSound(e_SOUND_TYPE_BlindAlert);
-				}	
+				}
 
 				lcd_set_cursor(0, 1);
 				lcd_print(" ");
@@ -6037,7 +6045,7 @@ static char snmm_stop_print_menu() { //menu for choosing which filaments will be
 			return(cursor_pos - 1);
 		}
 	}
-	
+
 }
 
 #endif //SNMM
@@ -6062,7 +6070,7 @@ uint8_t choose_menu_P(const char *header, const char *item, const char *last_ite
 	int8_t first = 0;
 	int8_t enc_dif = lcd_encoder_diff;
 	int8_t cursor_pos = 1;
-	
+
 	lcd_clear();
 
 	KEEPALIVE_STATE(PAUSED_FOR_USER);
@@ -6087,7 +6095,7 @@ uint8_t choose_menu_P(const char *header, const char *item, const char *last_ite
 		}
 
 		if (cursor_pos > 3)
-		{		
+		{
             cursor_pos = 3;
             if (first < items_no - 3)
             {
@@ -6158,7 +6166,7 @@ char reset_menu() {
 	int enc_dif = 0;
 	char cursor_pos = 0;
 	const char *item [items_no];
-	
+
 	item[0] = "Language";
 	item[1] = "Statistics";
 	item[2] = "Shipping prep";
@@ -6172,7 +6180,7 @@ char reset_menu() {
 	lcd_set_cursor(0, 0);
 	lcd_print(">");
 	lcd_consume_click();
-	while (1) {		
+	while (1) {
 
 		for (uint_least8_t i = 0; i < 4; i++) {
 			lcd_set_cursor(1, i);
@@ -6246,7 +6254,7 @@ static void lcd_disable_farm_mode()
 	}
 	lcd_update_enable(true);
 	lcd_draw_update = 2;
-	
+
 }
 
 
@@ -6516,7 +6524,7 @@ unsigned char lcd_choose_color() {
 		manage_inactivity(true);
 		proc_commands();
 		if (abs((enc_dif - lcd_encoder_diff)) > 12) {
-					
+
 				if (enc_dif > lcd_encoder_diff) {
 					cursor_pos--;
 				}
@@ -6524,7 +6532,7 @@ unsigned char lcd_choose_color() {
 				if (enc_dif < lcd_encoder_diff) {
 					cursor_pos++;
 				}
-				
+
 				if (cursor_pos > active_rows) {
 					cursor_pos = active_rows;
 					Sound_MakeSound(e_SOUND_TYPE_BlindAlert);
@@ -6634,7 +6642,7 @@ void lcd_confirm_print()
 //				filament_type = lcd_choose_color();
 				prusa_statistics(5, filament_type);
 				no_response = true; //we need confirmation by recieving PRUSA thx
-				important_status = 5;				
+				important_status = 5;
 				saved_filament_type = filament_type;
 				NcTime = _millis();
 			}
@@ -6824,18 +6832,18 @@ static void lcd_main_menu()
 
  MENU_ITEM_BACK_P(_T(MSG_WATCH));
 
-#ifdef RESUME_DEBUG 
- if (!saved_printing) 
+#ifdef RESUME_DEBUG
+ if (!saved_printing)
   MENU_ITEM_FUNCTION_P(PSTR("tst - Save"), lcd_menu_test_save);
  else
   MENU_ITEM_FUNCTION_P(PSTR("tst - Restore"), lcd_menu_test_restore);
-#endif //RESUME_DEBUG 
+#endif //RESUME_DEBUG
 
 #ifdef TMC2130_DEBUG
  MENU_ITEM_FUNCTION_P(PSTR("recover print"), recover_print);
  MENU_ITEM_FUNCTION_P(PSTR("power panic"), uvlo_);
 #endif //TMC2130_DEBUG
- 
+
   if ( ( IS_SD_PRINTING || is_usb_printing || (lcd_commands_type == LcdCommands::Layer1Cal)) && (current_position[Z_AXIS] < Z_HEIGHT_HIDE_LIVE_ADJUST_MENU) && !homing_flag && !mesh_bed_leveling_flag)
   {
 	MENU_ITEM_SUBMENU_P(_T(MSG_BABYSTEP_Z), lcd_babystep_z);//8
@@ -6845,7 +6853,7 @@ static void lcd_main_menu()
   if ( moves_planned() || IS_SD_PRINTING || is_usb_printing || (lcd_commands_type == LcdCommands::Layer1Cal))
   {
     MENU_ITEM_SUBMENU_P(_i("Tune"), lcd_tune_menu);////MSG_TUNE
-  } else 
+  } else
   {
     MENU_ITEM_SUBMENU_P(_i("Preheat"), lcd_preheat_menu);////MSG_PREHEAT
   }
@@ -6901,8 +6909,8 @@ static void lcd_main_menu()
       MENU_ITEM_GCODE_P(_i("Change SD card"), PSTR("M21"));  // SD-card changed by user////MSG_CNG_SDCARD
 #endif
     }
-	
-  } else 
+
+  } else
   {
     bMain=true;                                   // flag (i.e. 'fake parameter') for 'lcd_sdcard_menu()' function
     MENU_ITEM_SUBMENU_P(_i("No SD card"), lcd_sdcard_menu);////MSG_NO_CARD
@@ -6932,8 +6940,8 @@ static void lcd_main_menu()
 	  {
 		  MENU_ITEM_SUBMENU_P(PSTR("Farm number"), lcd_farm_no);
 	  }
-  } 
-  else 
+  }
+  else
   {
 	if (mmu_enabled)
 	{
@@ -6969,12 +6977,12 @@ static void lcd_main_menu()
     if(!isPrintPaused) MENU_ITEM_SUBMENU_P(_T(MSG_MENU_CALIBRATION), lcd_calibration_menu);
 
   }
-  
+
   if (!is_usb_printing && (lcd_commands_type != LcdCommands::Layer1Cal))
   {
 	  MENU_ITEM_SUBMENU_P(_i("Statistics  "), lcd_menu_statistics);////MSG_STATISTICS
   }
-    
+
 #if defined(TMC2130) || defined(FILAMENT_SENSOR)
   MENU_ITEM_SUBMENU_P(_i("Fail stats"), lcd_menu_fails_stats);
 #endif
@@ -7019,7 +7027,7 @@ void stepper_timer_overflow() {
 
 
 static void lcd_colorprint_change() {
-	
+
 	enquecommand_P(PSTR("M600"));
 
 	custom_message_type = CustomMsg::FilamentLoading; //just print status message
@@ -7215,7 +7223,7 @@ static void mbl_probe_nr_toggle() {
 
 static void lcd_mesh_bed_leveling_settings()
 {
-	
+
 	bool magnet_elimination = (eeprom_read_byte((uint8_t*)EEPROM_MBL_MAGNET_ELIMINATION) > 0);
 	uint8_t points_nr = eeprom_read_byte((uint8_t*)EEPROM_MBL_POINTS_NR);
 	char sToggle[4]; //enough for nxn format
@@ -7254,13 +7262,13 @@ static void lcd_backlight_menu()
     ON_MENU_LEAVE(
         backlight_save();
     );
-    
+
     MENU_ITEM_BACK_P(_T(MSG_BACK));
     MENU_ITEM_EDIT_int3_P(_T(MSG_BL_HIGH), &backlightLevel_HIGH, backlightLevel_LOW, 255);
     MENU_ITEM_EDIT_int3_P(_T(MSG_BL_LOW), &backlightLevel_LOW, 0, backlightLevel_HIGH);
 	MENU_ITEM_TOGGLE_P(_T(MSG_MODE), ((backlightMode==BACKLIGHT_MODE_BRIGHT) ? _T(MSG_BRIGHT) : ((backlightMode==BACKLIGHT_MODE_DIM) ? _T(MSG_DIM) : _T(MSG_AUTO))), backlight_mode_toggle);
     MENU_ITEM_EDIT_int3_P(_T(MSG_TIMEOUT), &backlightTimer_period, 1, 999);
-    
+
     MENU_END();
 }
 #endif //LCD_BL_PIN
@@ -7368,9 +7376,9 @@ void lcd_print_stop()
     custom_message_type = CustomMsg::Status;
 
     planner_abort_hard(); //needs to be done since plan_buffer_line resets waiting_inside_plan_buffer_line_print_aborted to false. Also copies current to destination.
-    
+
     axis_relative_modes = E_AXIS_MASK; //XYZ absolute, E relative
-    
+
     isPrintPaused = false; //clear isPrintPaused flag to allow starting next print after pause->stop scenario.
 }
 
@@ -7388,7 +7396,7 @@ void lcd_sdcard_stop()
 
 	if ((int32_t)lcd_encoder > 2) { lcd_encoder = 2; }
 	if ((int32_t)lcd_encoder < 1) { lcd_encoder = 1; }
-	
+
 	lcd_set_cursor(0, 1 + lcd_encoder);
 	lcd_print(">");
 
@@ -7450,7 +7458,7 @@ void lcd_sdcard_menu()
 		#else
 			 card.getfilename(nr);
 		#endif
-			
+
 		if (card.filenameIsDir)
 			MENU_ITEM_SDDIR(card.filename, card.longFilename);
 		else
@@ -7485,17 +7493,17 @@ void lcd_belttest_print(const char* msg, uint16_t X, uint16_t Y)
 void lcd_belttest()
 {
     bool _result = true;
-    
+
     #ifdef TMC2130 // Belttest requires high power mode. Enable it.
 	    FORCE_HIGH_POWER_START;
     #endif
-    
+
     uint16_t   X = eeprom_read_word((uint16_t*)(EEPROM_BELTSTATUS_X));
     uint16_t   Y = eeprom_read_word((uint16_t*)(EEPROM_BELTSTATUS_Y));
     lcd_belttest_print(_i("Checking X..."), X, Y);
 
     KEEPALIVE_STATE(IN_HANDLER);
-    
+
     _result = lcd_selfcheck_axis_sg(X_AXIS);
     X = eeprom_read_word((uint16_t*)(EEPROM_BELTSTATUS_X));
     if (_result){
@@ -7503,17 +7511,17 @@ void lcd_belttest()
         _result = lcd_selfcheck_axis_sg(Y_AXIS);
         Y = eeprom_read_word((uint16_t*)(EEPROM_BELTSTATUS_Y));
     }
-    
+
     if (!_result) {
         lcd_belttest_print(_i("Error"), X, Y);
     } else {
         lcd_belttest_print(_i("Done"), X, Y);
-    }   
+    }
 
     #ifdef TMC2130
 	    FORCE_HIGH_POWER_END;
     #endif
-    
+
     KEEPALIVE_STATE(NOT_BUSY);
     _delay(3000);
 }
@@ -7786,7 +7794,7 @@ bool lcd_selftest()
     {
 
         if (mmu_enabled)
-        {        
+        {
 			_progress = lcd_selftest_screen(TestScreen::Fsensor, _progress, 3, true, 2000); //check filaments sensor
             _result = selftest_irsensor();
 		    if (_result)
@@ -7826,7 +7834,7 @@ bool lcd_selftest()
 	lcd_reset_alert_level();
 	enquecommand_P(PSTR("M84"));
 	lcd_update_enable(true);
-	
+
 	if (_result)
 	{
 		LCD_ALERTMESSAGERPGM(_i("Self test OK"));////MSG_SELFTEST_OK
@@ -7838,9 +7846,9 @@ bool lcd_selftest()
 	#ifdef TMC2130
 	  FORCE_HIGH_POWER_END;
 	#endif // TMC2130
-    
+
     FORCE_BL_ON_END;
-	
+
     KEEPALIVE_STATE(NOT_BUSY);
 	return(_result);
 }
@@ -7855,7 +7863,7 @@ static void reset_crash_det(unsigned char axis) {
 }
 
 static bool lcd_selfcheck_axis_sg(unsigned char axis) {
-// each axis length is measured twice	
+// each axis length is measured twice
 	float axis_length, current_position_init, current_position_final;
 	float measured_axis_length[2];
 	float margin = 60;
@@ -7877,12 +7885,12 @@ static bool lcd_selfcheck_axis_sg(unsigned char axis) {
 		tmc2130_home_exit();
 	}
 
-// first axis length measurement begin	
-	
+// first axis length measurement begin
+
 	current_position[axis] -= (axis_length + margin);
 	plan_buffer_line_curposXYZE(manual_feedrate[0] / 60, active_extruder);
 
-	
+
 	st_synchronize();
 
 	tmc2130_sg_meassure_start(axis);
@@ -7906,16 +7914,16 @@ static bool lcd_selfcheck_axis_sg(unsigned char axis) {
 	measured_axis_length[0] = abs(current_position_final - current_position_init);
 
 
-// first measurement end and second measurement begin	
+// first measurement end and second measurement begin
 
 
 	current_position[axis] -= margin;
 	plan_buffer_line_curposXYZE(manual_feedrate[0] / 60, active_extruder);
-	st_synchronize();	
+	st_synchronize();
 
 	current_position[axis] -= (axis_length + margin);
 	plan_buffer_line_curposXYZE(manual_feedrate[0] / 60, active_extruder);
-		
+
 	st_synchronize();
 
 	current_position_init = st_get_position_mm(axis);
@@ -7945,7 +7953,7 @@ static bool lcd_selfcheck_axis_sg(unsigned char axis) {
 	}
 
 		printf_P(_N("Axis length difference:%.3f\n"), abs(measured_axis_length[0] - measured_axis_length[1]));
-	
+
 		if (abs(measured_axis_length[0] - measured_axis_length[1]) > 1) { //check if difference between first and second measurement is low
 			//loose pulleys
 			const char *_error_1;
@@ -8067,7 +8075,7 @@ static bool lcd_selfcheck_axis(int _axis, int _travel)
 		{
 			lcd_selftest_error(TestError::Motor, _error_1, _error_2);
 		}
-	}    
+	}
 	current_position[_axis] = 0; //simulate axis home to avoid negative numbers for axis position, especially Z.
 	plan_set_position(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS]);
 
@@ -8086,7 +8094,7 @@ static bool lcd_selfcheck_pulleys(int axis)
 	refresh_cmd_timeout();
 	manage_inactivity(true);
 
-	if (axis == 0) move = 50; //X_AXIS 
+	if (axis == 0) move = 50; //X_AXIS
 	else move = 50; //Y_AXIS
 
 	current_position_init = current_position[axis];
@@ -8100,7 +8108,7 @@ static bool lcd_selfcheck_pulleys(int axis)
 		plan_buffer_line_curposXYZE(200, active_extruder);
 		st_synchronize();
           if (SilentModeMenu != SILENT_MODE_OFF) st_current_set(0, tmp_motor[0]); //set back to normal operation currents
-		else st_current_set(0, tmp_motor_loud[0]); //set motor current back			
+		else st_current_set(0, tmp_motor_loud[0]); //set motor current back
 		current_position[axis] = current_position[axis] - move;
 		plan_buffer_line_curposXYZE(50, active_extruder);
 		st_synchronize();
@@ -8205,7 +8213,7 @@ static bool lcd_selfcheck_check_heater(bool _isbed)
 		}*/
 		if(_counter%5 == 0) serialecho_temperatures(); //show temperatures once in two seconds
 
-	} while (_docycle); 
+	} while (_docycle);
 
 	target_temperature[0] = 0;
 	target_temperature_bed = 0;
@@ -8246,9 +8254,9 @@ static bool lcd_selfcheck_check_heater(bool _isbed)
 static void lcd_selftest_error(TestError testError, const char *_error_1, const char *_error_2)
 {
 	lcd_beeper_quick_feedback();
-    
+
     FORCE_BL_ON_END;
-    
+
 	target_temperature[0] = 0;
 	target_temperature_bed = 0;
 	manage_heater();
@@ -8471,7 +8479,7 @@ static bool lcd_selftest_manual_fan_check(int _fan, bool check_opposite,
 	case 0:
 		// extruder cooling fan
 		lcd_set_cursor(0, 1);
-		if(check_opposite == true) lcd_puts_P(_T(MSG_SELFTEST_COOLING_FAN)); 
+		if(check_opposite == true) lcd_puts_P(_T(MSG_SELFTEST_COOLING_FAN));
 		else lcd_puts_P(_T(MSG_SELFTEST_EXTRUDER_FAN));
 		SET_OUTPUT(EXTRUDER_0_AUTO_FAN_PIN);
 		WRITE(EXTRUDER_0_AUTO_FAN_PIN, 1);
@@ -8766,20 +8774,20 @@ static bool check_file(const char* filename) {
 	filesize = card.getFileSize();
 	if (filesize > END_FILE_SECTION) {
 		card.setIndex(filesize - END_FILE_SECTION);
-		
+
 	}
-	
+
 		while (!card.eof() && !result) {
 		card.sdprinting = true;
 		get_command();
 		result = check_commands();
-		
+
 	}
 	card.printingHasFinished();
 	strncpy_P(lcd_status_message, _T(WELCOME_MSG), LCD_WIDTH);
 	lcd_finishstatus();
 	return result;
-	
+
 }
 
 static void menu_action_sdfile(const char* filename)
@@ -8814,7 +8822,7 @@ static void menu_action_sdfile(const char* filename)
 		  eeprom_write_byte((uint8_t*)EEPROM_DIRS + j + 8 * i, dir_names[i][j]);
 	  }
   }
-  
+
   if (!check_file(filename)) {
 	  result = lcd_show_fullscreen_message_yes_no_and_wait_P(_i("File incomplete. Continue anyway?"), false, false);////MSG_FILE_INCOMPLETE c=20 r=2
 	  lcd_update_enable(true);
@@ -8896,16 +8904,16 @@ static void lcd_send_status() {
 static void lcd_connect_printer() {
 	lcd_update_enable(false);
 	lcd_clear();
-	
+
 	int i = 0;
 	int t = 0;
 	lcd_set_custom_characters_progress();
-	lcd_puts_at_P(0, 0, _i("Connect printer to")); 
+	lcd_puts_at_P(0, 0, _i("Connect printer to"));
 	lcd_puts_at_P(0, 1, _i("monitoring or hold"));
 	lcd_puts_at_P(0, 2, _i("the knob to continue"));
 	while (no_response) {
 		i++;
-		t++;		
+		t++;
 		delay_keep_alive(100);
 		proc_commands();
 		if (t == 10) {
@@ -8913,7 +8921,7 @@ static void lcd_connect_printer() {
 			t = 0;
 		}
 		if (READ(BTN_ENC)) { //if button is not pressed
-			i = 0; 
+			i = 0;
 			lcd_puts_at_P(0, 3, PSTR("                    "));
 		}
 		if (i!=0) lcd_puts_at_P((i * 20) / (NC_BUTTON_LONG_PRESS * 10), 3, "\x01");

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1761,7 +1761,7 @@ static void lcd_menu_fails_stats_mmu_total()
 //! |01234567890123456789|
 //! |Total failures      |	c=20 r=1
 //! | Power fails   00000|	c=13 r=1
-//! | FilSens       00000|	c=13 r=1
+//! | Fil. sensor   00000|	c=11 r=1
 //! | Crash X00000 Y00000|	c=5 r=1
 //! ----------------------
 //! @endcode
@@ -1777,7 +1777,7 @@ static void lcd_menu_fails_stats_total()
     lcd_printf_P(PSTR("%S\n" " %-14.14S%-5u\n" " %-14.14S%-5u\n" " %-6.6SX%-5u Y%-5u"),
         _i("Total failures"),   ////c=20 r=1
         _i("Power fails"), power,   ////c=13 r=1
-        _i("FilSens"), filam,   ////c=13 r=1
+        _i("Fil. sensor"), filam,   ////c=11 r=1
         _i("Crash"), crashX, crashY);  ////c=5 r=1
     menu_back_if_clicked_fb();
 }
@@ -1788,7 +1788,7 @@ static void lcd_menu_fails_stats_total()
 //! |01234567890123456789|
 //! |Last print failures |	c=20 r=1
 //! | Power fails     000|	c=13 r=1
-//! | FilSens         000|	c=7 r=1
+//! | Fil. sensor     000|	c=11 r=1
 //! | Crash   X 000 Y 000|	c=5 r=1
 //! ----------------------
 //! @endcode
@@ -1802,28 +1802,37 @@ static void lcd_menu_fails_stats_print()
     uint8_t crashY = eeprom_read_byte((uint8_t*)EEPROM_CRASH_COUNT_Y);
     lcd_home();
 #ifndef PAT9125
-    lcd_printf_P(PSTR("%S\n" " %-16.16S%-3d\n" " %-16.16S%-3d\n" " %-7.7SX %-3d  Y %-3d"),
-        _i("Last print failures"),  ////c=20 r=1
-        _i("Power fails"), power,  ////c=13 r=1
-        _i("FilSens"), filam,  ////c=7 r=1
-        _i("Crash"), crashX, crashY);  ////c=5 r=1
-#else
-    // On the MK3 include detailed PAT9125 statistics about soft failures
 //! @brief Show Last Print Failures Statistics
 //!
 //! @code{.unparsed}
 //! |01234567890123456789|
 //! |Last print failures |	c=20 r=1
 //! | Power fails     000|	c=13 r=1
-//! | FilSens H 000 S 000|	c=7 r=1
+//! | Fil. sensor     000|	c=11 r=1
 //! | Crash   X 000 Y 000|	c=5 r=1
 //! ----------------------
 //! @endcode
-    lcd_printf_P(PSTR("%S\n"
-                      " %-16.16S%-3d\n" " %-7.7S H %-3d S %-3d\n" " %-7.7S X %-3d Y %-3d"),
+    lcd_printf_P(PSTR("%S\n" " %-16.16S%-3d\n" " %-16.16S%-3d\n" " %-7.7SX %-3d  Y %-3d"),
+        _i("Last print failures"),  ////c=20 r=1
+        _i("Power fails"), power,  ////c=13 r=1
+        _i("Fil. sensor"), filam,  ////c=11 r=1
+        _i("Crash"), crashX, crashY);  ////c=5 r=1
+#else
+    // On the MK3 include detailed PAT9125 statistics about soft failures
+//! @brief Show Last Print Failures Statistics with PAT9125
+//!
+//! @code{.unparsed}
+//! |01234567890123456789|
+//! |Last print failures |	c=20 r=1
+//! | Power fails     000|	c=13 r=1
+//! | Fil. sensorH000S000|	c=11 r=1
+//! | Crash   X 000 Y 000|	c=5 r=1
+//! ----------------------
+//! @endcode
+    lcd_printf_P(PSTR("%S\n" " %-16.16S%-3d\n" " %-11.11SH%-3dS%-3d\n" " %-7.7S X %-3d Y %-3d"),
                  _i("Last print failures"), ////c=20 r=1
                  _i("Power fails"), power, ////c=13 r=1
-                 _i("FilSens"), filam, fsensor_softfail, //c=7 r=1
+                 _i("Fil. sensor"), filam, fsensor_softfail, //c=13 r=1
                  _i("Crash"), crashX, crashY);  ////c=7 r=1
 #endif
     menu_back_if_clicked_fb();
@@ -1854,7 +1863,7 @@ static void lcd_menu_fails_stats()
 }
 
 #elif defined(FILAMENT_SENSOR)
-static const char failStatsFmt[] PROGMEM = "%S\n" " %-16.16S%-3d\n" "%S\n" " %-16.16S%-3d\n";
+//static const char failStatsFmt[] PROGMEM = "%S\n" " %-16.16S%-3d\n" "%S\n" " %-16.16S%-3d\n";
 //! 
 //! @brief Print last print and total filament run outs
 //! 
@@ -1865,9 +1874,9 @@ static const char failStatsFmt[] PROGMEM = "%S\n" " %-16.16S%-3d\n" "%S\n" " %-1
 //! @code{.unparsed}
 //! |01234567890123456789|
 //! |Last print failures |	c=20 r=1
-//! | Filam. runouts  000|	c=14 r=1
+//! | Fil. sensor     000|	c=11 r=1
 //! |Total failures      |	c=20 r=1
-//! | Filam. runouts  000|	c=14 r=1
+//! | Fil. sensor   00000|	c=11 r=1
 //! ----------------------
 //! @endcode
 //! @todo Positioning of the messages and values on LCD aren't fixed to their exact place. This causes issues with translations.
@@ -1877,11 +1886,11 @@ static void lcd_menu_fails_stats()
     uint8_t filamentLast = eeprom_read_byte((uint8_t*)EEPROM_FERROR_COUNT);
     uint16_t filamentTotal = eeprom_read_word((uint16_t*)EEPROM_FERROR_COUNT_TOT);
 	lcd_home();
-	lcd_printf_P(failStatsFmt, 
+	lcd_printf_P(PSTR("%S\n" " %-16.16S%-3d\n" "%S\n" " %-14.14S%-5u\n"), 
         _i("Last print failures"),   ////c=20 r=1
-        _i("Filam. runouts"), filamentLast,   ////c=14 r=1
+        _i("Fil. sensor"), filamentLast,   ////c=11 r=1
         _i("Total failures"),  ////c=20 r=1
-        _i("Filam. runouts"), filamentTotal);   ////c=14 r=1
+        _i("Fil. sensor"), filamentTotal);   ////c=11 r=1
 
 	menu_back_if_clicked();
 }

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1717,7 +1717,7 @@ static void lcd_menu_fails_stats_mmu_print()
     lcd_printf_P(PSTR("%S\n" " %-16.16S%-3d\n" " %-16.16S%-3d"), 
         _i("Last print failures"), ////c=20 r=1
         _i("MMU fails"), fails, ////c=14 r=1
-        _i("MMU load fails"), load_fails); ////c=14 r=1
+        _i("MMU load f."), load_fails); ////c=14 r=1
     menu_back_if_clicked_fb();
 }
 
@@ -1726,9 +1726,9 @@ static void lcd_menu_fails_stats_mmu_print()
 //! @code{.unparsed}
 //! |01234567890123456789|
 //! |Total failures      |	c=20 r=1
-//! | MMU fails:      000|	c=14 r=1
-//! | MMU load fails: 000|	c=14 r=1
-//! | MMU power fails:000|	c=14 r=1
+//! | MMU fails:    00000|	c=13 r=1
+//! | MMU load f.:  00000|	c=13 r=1
+//! | MMU power f.:   000|	c=14 r=1
 //! ----------------------
 //! @endcode
 //! @todo Positioning of the messages and values on LCD aren't fixed to their exact place. This causes issues with translations.
@@ -1736,14 +1736,14 @@ static void lcd_menu_fails_stats_mmu_total()
 {
 	mmu_command(MmuCmd::S3);
 	lcd_timeoutToStatus.stop(); //infinite timeout
-    uint8_t fails = eeprom_read_byte((uint8_t*)EEPROM_MMU_FAIL_TOT);
-    uint16_t load_fails = eeprom_read_byte((uint8_t*)EEPROM_MMU_LOAD_FAIL_TOT);
+    uint16_t fails = eeprom_read_word((uint16_t*)EEPROM_MMU_FAIL_TOT);
+    uint16_t load_fails = eeprom_read_word((uint16_t*)EEPROM_MMU_LOAD_FAIL_TOT);
     lcd_home();
-    lcd_printf_P(PSTR("%S\n" " %-16.16S%-3d\n" " %-16.16S%-3d\n" " %-16.16S%-3d"), 
+    lcd_printf_P(PSTR("%S\n" " %-14.14S%-5d\n" " %-14.14S%-5d\n" " %-16.16S%-3d"), 
         _i("Total failures"), ////c=20 r=1
-        _i("MMU fails"), fails, ////c=14 r=1
-        _i("MMU load fails"), load_fails, ////c=14 r=1
-        _i("MMU power fails"), mmu_power_failures); ////c=14 r=1
+        _i("MMU fails"), fails, ////c=13 r=1
+        _i("MMU load f."), load_fails, ////c=13 r=1
+        _i("MMU power f."), mmu_power_failures); ////c=14 r=1
     menu_back_if_clicked_fb();
 }
 
@@ -2073,7 +2073,7 @@ static void lcd_preheat_menu()
 //! | --------------     |	STR_SEPARATOR
 //! | XYZ cal. details   |	MSG_XYZ_DETAILS
 //! | Extruder info      |	MSG_INFO_EXTRUDER
-//! | XYZ cal. details   |	MSG_INFO_SENSORS
+//! | Sensor info        |	MSG_INFO_SENSORS
 //! @endcode
 //! 
 //! If TMC2130 defined

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1777,7 +1777,7 @@ static void lcd_menu_fails_stats_total()
     lcd_printf_P(PSTR("%S\n" " %-14.14S%-5u\n" " %-14.14S%-5u\n" " %-6.6SX%-5u Y%-5u"),
         _i("Total failures"),   ////c=20 r=1
         _i("Power fails"), power,   ////c=13 r=1
-        _i("Fil. sensor"), filam,   ////c=11 r=1
+        _T(MSG_FSENSOR), filam,   ////c=11 r=1
         _i("Crash"), crashX, crashY);  ////c=5 r=1
     menu_back_if_clicked_fb();
 }
@@ -1815,7 +1815,7 @@ static void lcd_menu_fails_stats_print()
     lcd_printf_P(PSTR("%S\n" " %-16.16S%-3d\n" " %-16.16S%-3d\n" " %-7.7SX %-3d  Y %-3d"),
         _i("Last print failures"),  ////c=20 r=1
         _i("Power fails"), power,  ////c=13 r=1
-        _i("Fil. sensor"), filam,  ////c=11 r=1
+        _T(MSG_FSENSOR), filam,  ////c=11 r=1
         _i("Crash"), crashX, crashY);  ////c=5 r=1
 #else
     // On the MK3 include detailed PAT9125 statistics about soft failures
@@ -1832,7 +1832,7 @@ static void lcd_menu_fails_stats_print()
     lcd_printf_P(PSTR("%S\n" " %-16.16S%-3d\n" " %-11.11SH%-3dS%-3d\n" " %-7.7S X %-3d Y %-3d"),
                  _i("Last print failures"), ////c=20 r=1
                  _i("Power fails"), power, ////c=13 r=1
-                 _i("Fil. sensor"), filam, fsensor_softfail, //c=13 r=1
+                 _T(MSG_FSENSOR), filam, fsensor_softfail, //c=13 r=1
                  _i("Crash"), crashX, crashY);  ////c=7 r=1
 #endif
     menu_back_if_clicked_fb();
@@ -1888,9 +1888,9 @@ static void lcd_menu_fails_stats()
 	lcd_home();
 	lcd_printf_P(PSTR("%S\n" " %-16.16S%-3d\n" "%S\n" " %-14.14S%-5u\n"), 
         _i("Last print failures"),   ////c=20 r=1
-        _i("Fil. sensor"), filamentLast,   ////c=11 r=1
+        _T(MSG_FSENSOR), filamentLast,   ////c=11 r=1
         _i("Total failures"),  ////c=20 r=1
-        _i("Fil. sensor"), filamentTotal);   ////c=11 r=1
+        _T(MSG_FSENSOR), filamentTotal);   ////c=11 r=1
 
 	menu_back_if_clicked();
 }

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -362,7 +362,7 @@ static void lcd_implementation_drawmenu_sdfile_selected(uint8_t row, const char*
         if(i==LCD_WIDTH){
           i=1;
           j++;
-          longFilenameTMP = longFilename + j;
+          longFilenameTMP = longFilename + j;          
           n = LCD_WIDTH - 1;
           for(int g = 0; g<300 ;g++){
 			  manage_heater();
@@ -374,7 +374,7 @@ static void lcd_implementation_drawmenu_sdfile_selected(uint8_t row, const char*
 				break;
             }else{
 				if (j == 1) _delay_ms(3);	//wait around 1.2 s to start scrolling text
-				_delay_ms(1);				//then scroll with redrawing every 300 ms
+				_delay_ms(1);				//then scroll with redrawing every 300 ms 
             }
 
           }
@@ -678,17 +678,17 @@ void lcdui_print_farm(void)
 		lcd_puts_P(PSTR(" F"));
 		lcd_print(farm_no);
 		lcd_puts_P(PSTR("  "));
-
+        
         // Beat display
         lcd_set_cursor(LCD_WIDTH - 1, 0);
         if ( (_millis() - kicktime) < 60000 ) {
-
+        
             lcd_puts_P(PSTR("L"));
-
+        
         }else{
             lcd_puts_P(PSTR(" "));
         }
-
+        
 	}
 	else {
 #ifdef SNMM
@@ -899,7 +899,7 @@ void lcdui_print_status_line(void)
 			break;
 		}
 	}
-
+    
     // Fill the rest of line to have nice and clean output
 	for(int fillspace = 0; fillspace < 20; fillspace++)
 		if ((lcd_status_message[fillspace] <= 31 ))
@@ -982,7 +982,7 @@ void lcdui_print_status_screen(void)
 // Main status screen. It's up to the implementation specific part to show what is needed. As this is very display dependent
 void lcd_status_screen()                          // NOT static due to using inside "Marlin_main" module ("manage_inactivity()")
 {
-	if (firstrun == 1)
+	if (firstrun == 1) 
 	{
 		firstrun = 0;
 		if(lcd_status_message_level == 0)
@@ -1520,7 +1520,7 @@ void lcd_commands()
 	}
 	if (lcd_commands_type == LcdCommands::PidExtruder) {
 		char cmd1[30];
-
+		
 		if (lcd_commands_step == 0) {
 			custom_message_type = CustomMsg::PidCal;
 			custom_message_state = 1;
@@ -1649,10 +1649,10 @@ void lcd_menu_extruder_info()                     // NOT static due to using ins
     char nozzle[maxChars], print[maxChars];
     pgmtext_with_colon(_i("Nozzle FAN"), nozzle, maxChars);  ////c=10 r=1
     pgmtext_with_colon(_i("Print FAN"), print, maxChars);  ////c=10 r=1
-    lcd_printf_P(_N("%s %4d RPM\n" "%s %4d RPM\n"), nozzle, 60*fan_speed[0], print, 60*fan_speed[1] );
+    lcd_printf_P(_N("%s %4d RPM\n" "%s %4d RPM\n"), nozzle, 60*fan_speed[0], print, 60*fan_speed[1] ); 
 
 #ifdef PAT9125
-	// Display X and Y difference from Filament sensor
+	// Display X and Y difference from Filament sensor    
     // Display Light intensity from Filament sensor
     //  Frame_Avg register represents the average brightness of all pixels within a frame (324 pixels). This
     //  value ranges from 0(darkest) to 255(brightest).
@@ -1679,7 +1679,7 @@ void lcd_menu_extruder_info()                     // NOT static due to using ins
 		}
 	}
 #endif //PAT9125
-
+    
     menu_back_if_clicked();
 }
 
@@ -1707,8 +1707,8 @@ static void lcd_menu_fails_stats_mmu()
 //! @code{.unparsed}
 //! |01234567890123456789|
 //! |Last print failures |	c=20 r=1
-//! | MMU fails:      000|	c=14 r=1
-//! | MMU load fails: 000|	c=14 r=1
+//! | MMU fails       000|	c=13 r=1
+//! | MMU load f.     000|	c=13 r=1
 //! |                    |
 //! ----------------------
 //! @endcode
@@ -1719,10 +1719,10 @@ static void lcd_menu_fails_stats_mmu_print()
     uint8_t fails = eeprom_read_byte((uint8_t*)EEPROM_MMU_FAIL);
     uint16_t load_fails = eeprom_read_byte((uint8_t*)EEPROM_MMU_LOAD_FAIL);
     lcd_home();
-    lcd_printf_P(PSTR("%S\n" " %-16.16S%-3d\n" " %-16.16S%-3d"),
+    lcd_printf_P(PSTR("%S\n" " %-16.16S%-3d\n" " %-16.16S%-3d"), 
         _i("Last print failures"), ////c=20 r=1
-        _i("MMU fails"), fails, ////c=14 r=1
-        _i("MMU load f."), load_fails); ////c=14 r=1
+        _i("MMU fails"), fails, ////c=13 r=1
+        _i("MMU load f."), load_fails); ////c=13 r=1
     menu_back_if_clicked_fb();
 }
 
@@ -1731,9 +1731,9 @@ static void lcd_menu_fails_stats_mmu_print()
 //! @code{.unparsed}
 //! |01234567890123456789|
 //! |Total failures      |	c=20 r=1
-//! | MMU fails:    00000|	c=13 r=1
-//! | MMU load f.:  00000|	c=13 r=1
-//! | MMU power f.:   000|	c=14 r=1
+//! | MMU fails     00000|	c=13 r=1
+//! | MMU load f.   00000|	c=13 r=1
+//! | MMU power f.    000|	c=14 r=1
 //! ----------------------
 //! @endcode
 //! @todo Positioning of the messages and values on LCD aren't fixed to their exact place. This causes issues with translations.
@@ -1761,7 +1761,7 @@ static void lcd_menu_fails_stats_mmu_total()
 //! |01234567890123456789|
 //! |Total failures      |	c=20 r=1
 //! | Power fails   00000|	c=13 r=1
-//! | Filam.Sensor  00000|	c=13 r=1
+//! | FilSens       00000|	c=13 r=1
 //! | Crash X00000 Y00000|	c=5 r=1
 //! ----------------------
 //! @endcode
@@ -1777,7 +1777,7 @@ static void lcd_menu_fails_stats_total()
     lcd_printf_P(PSTR("%S\n" " %-14.14S%-5u\n" " %-14.14S%-5u\n" " %-6.6SX%-5u Y%-5u"),
         _i("Total failures"),   ////c=20 r=1
         _i("Power fails"), power,   ////c=13 r=1
-        _i("Filam.Sensor"), filam,   ////c=13 r=1
+        _i("FilSens"), filam,   ////c=13 r=1
         _i("Crash"), crashX, crashY);  ////c=5 r=1
     menu_back_if_clicked_fb();
 }
@@ -1830,11 +1830,11 @@ static void lcd_menu_fails_stats_print()
 }
 
 //! @brief Open fail statistics menu
-//!
+//! 
 //! This version of function is used, when there is filament sensor,
 //! power failure and crash detection.
 //! There are Last print and Total menu items.
-//!
+//! 
 //! @code{.unparsed}
 //! |01234567890123456789|
 //! | Main               |	c=18 r=1
@@ -1855,12 +1855,12 @@ static void lcd_menu_fails_stats()
 
 #elif defined(FILAMENT_SENSOR)
 static const char failStatsFmt[] PROGMEM = "%S\n" " %-16.16S%-3d\n" "%S\n" " %-16.16S%-3d\n";
-//!
+//! 
 //! @brief Print last print and total filament run outs
-//!
+//! 
 //! This version of function is used, when there is filament sensor,
 //! but no other sensors (e.g. power failure, crash detection).
-//!
+//! 
 //! Example screen:
 //! @code{.unparsed}
 //! |01234567890123456789|
@@ -1877,7 +1877,7 @@ static void lcd_menu_fails_stats()
     uint8_t filamentLast = eeprom_read_byte((uint8_t*)EEPROM_FERROR_COUNT);
     uint16_t filamentTotal = eeprom_read_word((uint16_t*)EEPROM_FERROR_COUNT_TOT);
 	lcd_home();
-	lcd_printf_P(failStatsFmt,
+	lcd_printf_P(failStatsFmt, 
         _i("Last print failures"),   ////c=20 r=1
         _i("Filam. runouts"), filamentLast,   ////c=14 r=1
         _i("Total failures"),  ////c=20 r=1
@@ -1932,7 +1932,7 @@ static void lcd_menu_debug()
 //! @param [in] ipgmLabel pointer to string in PROGMEM
 //! @param [in] value to be printed behind the label
 static void lcd_menu_temperatures_line(const char *ipgmLabel, int value){
-    static const size_t maxChars = 15;
+    static const size_t maxChars = 15;    
     char tmp[maxChars];
     pgmtext_with_colon(ipgmLabel, tmp, maxChars);
     lcd_printf_P(PSTR(" %s%3d\x01 \n"), tmp, value); // no need to add -14.14 to string alignment
@@ -2016,7 +2016,7 @@ static void lcd_menu_belt_status()
 }
 #endif //TMC2130
 
-#ifdef RESUME_DEBUG
+#ifdef RESUME_DEBUG 
 extern void stop_and_save_print_to_ram(float z_move, float e_move);
 extern void restore_print_from_ram_and_continue(float e_move);
 
@@ -2029,7 +2029,7 @@ static void lcd_menu_test_restore()
 {
 	restore_print_from_ram_and_continue(0.8);
 }
-#endif //RESUME_DEBUG
+#endif //RESUME_DEBUG 
 
 //! @brief Show Preheat Menu
 static void lcd_preheat_menu()
@@ -2057,54 +2057,54 @@ static void lcd_preheat_menu()
 //! | MMM DD YYYY        |	__DATE__
 //! | --------------     |	STR_SEPARATOR
 //! @endcode
-//!
+//! 
 //! If MMU is connected
-//!
+//! 
 //! 	@code{.unparsed}
 //! 	| MMU2 connected     |	c=18 r=1
 //! 	|  FW: 1.0.6-7064523 |
 //! 	@endcode
-//!
+//! 
 //! If MMU is not connected
-//!
+//! 
 //! 	@code{.unparsed}
 //! 	| MMU2       N/A     |	c=18 r=1
 //! 	@endcode
-//!
+//! 
 //! If Flash Air is connected
-//!
+//! 
 //! 	@code{.unparsed}
 //! 	| --------------     |	STR_SEPARATOR
 //! 	| FlashAir IP Addr:  |	c=18 r=1
 //! 	|  192.168.1.100     |
 //! 	@endcode
-//!
+//! 
 //! @code{.unparsed}
 //! | --------------     |	STR_SEPARATOR
 //! | XYZ cal. details   |	MSG_XYZ_DETAILS
 //! | Extruder info      |	MSG_INFO_EXTRUDER
-//! | Sensor info        |	MSG_INFO_SENSORS
+//! | XYZ cal. details   |	MSG_INFO_SENSORS
 //! @endcode
-//!
+//! 
 //! If TMC2130 defined
-//!
+//! 
 //! 	@code{.unparsed}
 //! 	| Belt status        |	MSG_MENU_BELT_STATUS
 //! @endcode
-//!
+//! 
 //! @code{.unparsed}
 //! | Temperatures       |	MSG_MENU_TEMPERATURES
 //! @endcode
-//!
+//! 
 //! If Voltage Bed and PWR Pin are defined
-//!
+//! 
 //! 	@code{.unparsed}
 //! 	| Voltages           |	MSG_MENU_VOLTAGES
 //! 	@endcode
-//!
-//!
+//! 
+//! 
 //! If DEBUG_BUILD is defined
-//!
+//! 
 //! 	@code{.unparsed}
 //! 	| Debug              |	c=18 r=1
 //! 	@endcode
@@ -2128,11 +2128,11 @@ static void lcd_support_menu()
         _md->status = 1;
         _md->is_flash_air = card.ToshibaFlashAir_isEnabled() && card.ToshibaFlashAir_GetIP(_md->ip);
         if (_md->is_flash_air)
-            sprintf_P(_md->ip_str, PSTR("%d.%d.%d.%d"),
-                _md->ip[0], _md->ip[1],
+            sprintf_P(_md->ip_str, PSTR("%d.%d.%d.%d"), 
+                _md->ip[0], _md->ip[1], 
                 _md->ip[2], _md->ip[3]);
-    } else if (_md->is_flash_air &&
-        _md->ip[0] == 0 && _md->ip[1] == 0 &&
+    } else if (_md->is_flash_air && 
+        _md->ip[0] == 0 && _md->ip[1] == 0 && 
         _md->ip[2] == 0 && _md->ip[3] == 0 &&
         ++ _md->status == 16)
 	{
@@ -2156,7 +2156,7 @@ static void lcd_support_menu()
   } else {
       MENU_ITEM_BACK_P(PSTR("FW - " FW_version));
   }*/
-
+      
   MENU_ITEM_BACK_P(_i("prusa3d.com"));////MSG_PRUSA3D
   MENU_ITEM_BACK_P(_i("forum.prusa3d.com"));////MSG_PRUSA3D_FORUM
   MENU_ITEM_BACK_P(_i("howto.prusa3d.com"));////MSG_PRUSA3D_HOWTO
@@ -2196,7 +2196,7 @@ static void lcd_support_menu()
 			if ((mmu_version > 0) && (mmu_buildnr > 0))
 				lcd_printf_P(PSTR("%d.%d.%d-%d"), mmu_version/100, mmu_version%100/10, mmu_version%10, mmu_buildnr);
 			else
-				lcd_puts_P(_i("unknown"));
+				lcd_puts_P(_i("unknown")); 
 		}
 	}
 	else
@@ -2219,7 +2219,7 @@ static void lcd_support_menu()
 #ifdef TMC2130
   MENU_ITEM_SUBMENU_P(_i("Belt status"), lcd_menu_belt_status);////MSG_MENU_BELT_STATUS c=18 r=1
 #endif //TMC2130
-
+    
   MENU_ITEM_SUBMENU_P(_i("Temperatures"), lcd_menu_temperatures);////MSG_MENU_TEMPERATURES c=18 r=1
 
 #if defined (VOLT_BED_PIN) || defined (VOLT_PWR_PIN)
@@ -2604,7 +2604,7 @@ void lcd_wait_interact() {
   lcd_clear();
 
   lcd_set_cursor(0, 1);
-#ifdef SNMM
+#ifdef SNMM 
   lcd_puts_P(_i("Prepare new filament"));////MSG_PREPARE_FILAMENT c=20 r=1
 #else
   lcd_puts_P(_i("Insert filament"));////MSG_INSERT_FILAMENT c=20
@@ -2627,7 +2627,7 @@ void lcd_change_success() {
 
 }
 
-static void lcd_loading_progress_bar(uint16_t loading_time_ms) {
+static void lcd_loading_progress_bar(uint16_t loading_time_ms) { 
 
 	for (uint_least8_t i = 0; i < 20; i++) {
 		lcd_set_cursor(i, 3);
@@ -2780,7 +2780,7 @@ void lcd_alright() {
 }
 
 void show_preheat_nozzle_warning()
-{
+{	
     lcd_clear();
     lcd_set_cursor(0, 0);
     lcd_puts_P(_T(MSG_ERROR));
@@ -3015,7 +3015,7 @@ float _deg(float rad)
 }
 
 //! @brief Show Measured XYZ Skew
-//!
+//! 
 //! @code{.unparsed}
 //! |01234567890123456789|
 //! |Measured skew: 0.00D|	c=13 r=1
@@ -3053,7 +3053,7 @@ static void lcd_menu_xyz_skew()
         menu_goto(lcd_menu_xyz_offset, 0, true, true);
 }
 //! @brief Show measured bed offset from expected position
-//!
+//! 
 //! @code{.unparsed}
 //! |01234567890123456789|
 //! |[0;0] point offset  |	c=20 r=1
@@ -3139,7 +3139,7 @@ static void lcd_babystep_z()
 		// Initialize its status.
 		_md->status = 1;
 		check_babystep();
-
+		
 		if(!eeprom_is_sheet_initialized(eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet)))){
 			_md->babystepMemZ = 0;
 		}
@@ -3160,7 +3160,7 @@ static void lcd_babystep_z()
 		lcd_timeoutToStatus.start();
 	}
 
-	if (lcd_encoder != 0)
+	if (lcd_encoder != 0) 
 	{
 		if (homing_flag) lcd_encoder = 0;
 		_md->babystepMemZ += (int)lcd_encoder;
@@ -3194,7 +3194,7 @@ static void lcd_babystep_z()
           uint8_t active_sheet=eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet));
 		eeprom_update_word(reinterpret_cast<uint16_t *>(&(EEPROM_Sheets_base->s[active_sheet].z_offset)),_md->babystepMemZ);
 		eeprom_update_byte(&(EEPROM_Sheets_base->s[active_sheet].bed_temp),target_temperature_bed);
-#ifdef PINDA_THERMISTOR
+#ifdef PINDA_THERMISTOR        
 		eeprom_update_byte(&(EEPROM_Sheets_base->s[active_sheet].pinda_temp),current_temperature_pinda);
 #endif //PINDA_THERMISTOR
 		calibration_status_store(CALIBRATION_STATUS_CALIBRATED);
@@ -3226,7 +3226,7 @@ void lcd_adjust_bed_reset(void)
 }
 
 //! @brief Show Bed level correct
-//!
+//! 
 //! @code{.unparsed}
 //! |01234567890123456789|
 //! |Settings:           |	MSG_SETTINGS
@@ -3275,7 +3275,7 @@ void lcd_adjust_bed(void)
 }
 
 //! @brief Show PID Extruder
-//!
+//! 
 //! @code{.unparsed}
 //! |01234567890123456789|
 //! | Set temperature:   |	MSG_SET_TEMPERATURE
@@ -3441,13 +3441,13 @@ void lcd_wait_for_cool_down() {
 		lcd_set_cursor(0, 4);
 		lcd_print(LCD_STR_THERMOMETER[0]);
 		lcd_print(ftostr3(degHotend(0)));
-		lcd_print("/0");
+		lcd_print("/0");		
 		lcd_print(LCD_STR_DEGREE);
 
 		lcd_set_cursor(9, 4);
 		lcd_print(LCD_STR_BEDTEMP[0]);
 		lcd_print(ftostr3(degBed()));
-		lcd_print("/0");
+		lcd_print("/0");		
 		lcd_print(LCD_STR_DEGREE);
 		lcd_set_custom_characters();
 		delay_keep_alive(1000);
@@ -3616,7 +3616,7 @@ const char* lcd_display_message_fullscreen_P(const char *msg, uint8_t &nlines)
 //	uint8_t nlines;
     return lcd_display_message_fullscreen_nonBlocking_P(msg, nlines);
 }
-const char* lcd_display_message_fullscreen_P(const char *msg)
+const char* lcd_display_message_fullscreen_P(const char *msg) 
 {
   uint8_t nlines;
   return lcd_display_message_fullscreen_P(msg, nlines);
@@ -3803,7 +3803,7 @@ int8_t lcd_show_fullscreen_message_yes_no_and_wait_P(const char *msg, bool allow
 {
 
 	lcd_display_message_fullscreen_P(msg);
-
+	
 	if (default_yes) {
 		lcd_set_cursor(0, 2);
 		lcd_puts_P(PSTR(">"));
@@ -3915,7 +3915,7 @@ void lcd_bed_calibration_show_result(BedSkewOffsetDetectionResultType result, ui
 }
 
 void lcd_temp_cal_show_result(bool result) {
-
+	
 	custom_message_type = CustomMsg::Status;
 	disable_x();
 	disable_y();
@@ -3989,7 +3989,7 @@ static void lcd_print_state(uint8_t state)
 		case STATE_OFF:
 			lcd_puts_P(_N("  0"));
 		break;
-		default:
+		default: 
 			lcd_puts_P(_T(MSG_NA));
 		break;
 	}
@@ -4014,11 +4014,11 @@ static void lcd_show_sensors_state()
 	lcd_puts_at_P(1, 1, _i("PINDA:"));
 	lcd_set_cursor(LCD_WIDTH - 4, 1);
 	lcd_print_state(pinda_state);
-
+	
 	lcd_puts_at_P(1, 2, _i("FINDA:"));
 	lcd_set_cursor(LCD_WIDTH - 4, 2);
 	lcd_print_state(finda_state);
-
+	
 	lcd_puts_at_P(1, 3, _i("IR:"));
 	lcd_set_cursor(LCD_WIDTH - 4, 3);
 	lcd_print_state(idler_state);
@@ -4057,8 +4057,8 @@ void prusa_statistics(int _message, uint8_t _fil_nr) {
 	{
 
 	case 0: // default message
-		if (busy_state == PAUSED_FOR_USER)
-		{
+		if (busy_state == PAUSED_FOR_USER) 
+		{   
 			prusa_statistics_case0(15);
 		}
 		else if (isPrintPaused)
@@ -4172,7 +4172,7 @@ void prusa_statistics(int _message, uint8_t _fil_nr) {
 		prusa_stat_farm_number();
 		status_number = 5;
         break;
-
+	
 	case 90: // Error - Thermal Runaway
 		prusa_statistics_err('1');
 		break;
@@ -4192,10 +4192,10 @@ void prusa_statistics(int _message, uint8_t _fil_nr) {
 		SERIAL_ECHO("[PFN:");
 		SERIAL_ECHO(farm_no);
 		SERIAL_ECHO(']');
-
+            
         break;
 	}
-	SERIAL_ECHOLN('}');
+	SERIAL_ECHOLN('}');	
 
 }
 
@@ -4261,65 +4261,65 @@ void lcd_pick_babystep(){
     int enc_dif = 0;
     int cursor_pos = 1;
     int fsm = 0;
-
-
-
-
+    
+    
+    
+    
     lcd_clear();
-
+    
     lcd_set_cursor(0, 0);
-
+    
     lcd_puts_P(_i("Pick print"));////MSG_PICK_Z
-
-
+    
+    
     lcd_set_cursor(3, 2);
-
+    
     lcd_print("1");
-
+    
     lcd_set_cursor(3, 3);
-
+    
     lcd_print("2");
-
+    
     lcd_set_cursor(12, 2);
-
+    
     lcd_print("3");
-
+    
     lcd_set_cursor(12, 3);
-
+    
     lcd_print("4");
-
+    
     lcd_set_cursor(1, 2);
-
+    
     lcd_print(">");
-
-
+    
+    
     enc_dif = lcd_encoder_diff;
-
+    
     while (fsm == 0) {
-
+        
         manage_heater();
         manage_inactivity(true);
-
+        
         if ( abs((enc_dif - lcd_encoder_diff)) > 4 ) {
-
+            
             if ( (abs(enc_dif - lcd_encoder_diff)) > 1 ) {
                 if (enc_dif > lcd_encoder_diff ) {
                     cursor_pos --;
                 }
-
+                
                 if (enc_dif < lcd_encoder_diff  ) {
                     cursor_pos ++;
                 }
-
+                
                 if (cursor_pos > 4) {
                     cursor_pos = 4;
                 }
-
+                
                 if (cursor_pos < 1) {
                     cursor_pos = 1;
                 }
 
-
+                
                 lcd_set_cursor(1, 2);
                 lcd_print(" ");
                 lcd_set_cursor(1, 3);
@@ -4328,7 +4328,7 @@ void lcd_pick_babystep(){
                 lcd_print(" ");
                 lcd_set_cursor(10, 3);
                 lcd_print(" ");
-
+                
                 if (cursor_pos < 3) {
                     lcd_set_cursor(1, cursor_pos+1);
                     lcd_print(">");
@@ -4336,14 +4336,14 @@ void lcd_pick_babystep(){
                     lcd_set_cursor(10, cursor_pos-1);
                     lcd_print(">");
                 }
-
-
+                
+   
                 enc_dif = lcd_encoder_diff;
                 _delay(100);
             }
-
+            
         }
-
+        
         if (lcd_clicked()) {
             fsm = cursor_pos;
             int babyStepZ;
@@ -4351,10 +4351,10 @@ void lcd_pick_babystep(){
             EEPROM_save_B(EEPROM_BABYSTEP_Z,&babyStepZ);
             calibration_status_store(CALIBRATION_STATUS_CALIBRATED);
             _delay(500);
-
+            
         }
     };
-
+    
     lcd_clear();
     lcd_return_to_status();
 }
@@ -4536,7 +4536,7 @@ static void crash_mode_switch()
 	else menu_goto(lcd_settings_menu, 9, true, true);
 }
 #endif //TMC2130
-
+ 
 
 #ifdef FILAMENT_SENSOR
 static void lcd_fsensor_state_set()
@@ -4593,7 +4593,7 @@ static void lcd_language_menu()
 	}
 	uint8_t cnt = lang_get_count();
 #ifdef W25X20CL
-	if (cnt == 2) //display secondary language in case of clear xflash
+	if (cnt == 2) //display secondary language in case of clear xflash 
 	{
 		if (menu_item_text_P(lang_get_name_by_code(lang_get_code(1))))
 		{
@@ -4666,12 +4666,12 @@ void lcd_calibrate_pinda() {
 #ifndef SNMM
 
 /*void lcd_calibrate_extruder() {
-
+	
 	if (degHotend0() > EXTRUDE_MINTEMP)
 	{
 		current_position[E_AXIS] = 0;									//set initial position to zero
 		plan_set_e_position(current_position[E_AXIS]);
-
+		
 		//long steps_start = st_get_position(E_AXIS);
 
 		long steps_final;
@@ -4685,8 +4685,8 @@ void lcd_calibrate_pinda() {
 
 		lcd_show_fullscreen_message_and_wait_P(_i("Mark filament 100mm from extruder body. Click when done."));////MSG_MARK_FIL c=20 r=8
 		lcd_clear();
-
-
+		
+		
 		lcd_set_cursor(0, 1); lcd_puts_P(_T(MSG_PLEASE_WAIT));
 		current_position[E_AXIS] += e_shift_calibration;
 		plan_buffer_line_curposXYZE(feedrate, active_extruder);
@@ -4713,23 +4713,23 @@ void lcd_calibrate_pinda() {
 					current_position[E_AXIS] += float(abs((int)lcd_encoder)) * 0.01; //0.05
 					lcd_encoder = 0;
 					plan_buffer_line_curposXYZE(feedrate, active_extruder);
-
+					
 				}
-			}
+			}	
 		}
-
+		
 		steps_final = current_position[E_AXIS] * axis_steps_per_unit[E_AXIS];
 		//steps_final = st_get_position(E_AXIS);
 		lcd_draw_update = 1;
 		e_steps_per_unit = ((float)(steps_final)) / 100.0f;
-		if (e_steps_per_unit < MIN_E_STEPS_PER_UNIT) e_steps_per_unit = MIN_E_STEPS_PER_UNIT;
+		if (e_steps_per_unit < MIN_E_STEPS_PER_UNIT) e_steps_per_unit = MIN_E_STEPS_PER_UNIT;				
 		if (e_steps_per_unit > MAX_E_STEPS_PER_UNIT) e_steps_per_unit = MAX_E_STEPS_PER_UNIT;
 
 		lcd_clear();
 
 		axis_steps_per_unit[E_AXIS] = e_steps_per_unit;
 		enquecommand_P(PSTR("M500")); //store settings to eeprom
-
+	
 		//lcd_drawedit(PSTR("Result"), ftostr31(axis_steps_per_unit[E_AXIS]));
 		//delay_keep_alive(2000);
 		delay_keep_alive(500);
@@ -4916,7 +4916,7 @@ static void wait_preheat()
 		lcdui_print_temp(LCD_STR_THERMOMETER[0], (int)(degHotend(0) + 0.5), (int)(degTargetHotend(0) + 0.5));
         delay_keep_alive(1000);
     }
-
+	
 }
 
 static void lcd_wizard_load()
@@ -4925,11 +4925,11 @@ static void lcd_wizard_load()
 	{
 		lcd_show_fullscreen_message_and_wait_P(_i("Please insert filament into the first tube of the MMU, then press the knob to load it."));////c=20 r=8
 		tmp_extruder = 0;
-	}
+	} 
 	else
 	{
 		lcd_show_fullscreen_message_and_wait_P(_i("Please insert filament into the extruder, then press the knob to load it."));////MSG_WIZARD_LOAD_FILAMENT c=20 r=8
-	}
+	}	
 	lcd_update_enable(false);
 	lcd_clear();
 	lcd_puts_at_P(0, 2, _T(MSG_LOADING_FILAMENT));
@@ -5008,14 +5008,14 @@ void lcd_wizard(WizState state)
 	// Make sure EEPROM_WIZARD_ACTIVE is true if entering using different entry point
 	// other than WizState::Run - it is useful for debugging wizard.
 	if (state != S::Run) eeprom_update_byte((uint8_t*)EEPROM_WIZARD_ACTIVE, 1);
-
+    
     FORCE_BL_ON_START;
-
+	
     while (!end) {
 		printf_P(PSTR("Wizard state: %d\n"), state);
 		switch (state) {
 		case S::Run: //Run wizard?
-
+			
 			// 2019-08-07 brutal hack - solving the "viper" situation.
 			// It is caused by the fact, that tmc2130_st_isr makes a crash detection before the printers really starts.
 			// And thus it calles stop_and_save_print_to_ram which sets the saved_printing flag.
@@ -5024,9 +5024,9 @@ void lcd_wizard(WizState state)
 			// This primarily happens when the printer is new and parked in 0,0
 			// So any new printer will fail the first layer calibration unless being reset or the Stop function gets called.
 			// We really must find a way to prevent the crash from happening before the printer is started - that would be the correct solution.
-			// Btw. the flag may even trigger the viper situation on normal start this way and the user won't be able to find out why.
+			// Btw. the flag may even trigger the viper situation on normal start this way and the user won't be able to find out why.			
 			saved_printing = false;
-
+			
 			wizard_event = lcd_show_multiscreen_message_yes_no_and_wait_P(_i("Hi, I am your Original Prusa i3 printer. Would you like me to guide you through the setup process?"), false, true);////MSG_WIZARD_WELCOME c=20 r=7
 			if (wizard_event) {
 				state = S::Restore;
@@ -5046,7 +5046,7 @@ void lcd_wizard(WizState state)
 			case CALIBRATION_STATUS_CALIBRATED: end = true; eeprom_update_byte((uint8_t*)EEPROM_WIZARD_ACTIVE, 0); break;
 			default: state = S::Selftest; break; //if calibration status is unknown, run wizard from the beginning
 			}
-			break;
+			break; 
 		case S::Selftest:
 			lcd_show_fullscreen_message_and_wait_P(_i("First, I will run the selftest to check most common assembly problems."));////MSG_WIZARD_SELFTEST c=20 r=8
 			wizard_event = lcd_selftest();
@@ -5147,9 +5147,9 @@ void lcd_wizard(WizState state)
 		default: break;
 		}
 	}
-
+    
     FORCE_BL_ON_END;
-
+    
 	printf_P(_N("Wizard end state: %d\n"), state);
 	switch (state) { //final message
 	case S::Restore: //printer was already calibrated
@@ -5165,7 +5165,7 @@ void lcd_wizard(WizState state)
 		msg = _T(MSG_WIZARD_DONE);
 		lcd_reset_alert_level();
 		lcd_setstatuspgm(_T(WELCOME_MSG));
-		lcd_return_to_status();
+		lcd_return_to_status(); 
 		break;
 
 	default:
@@ -5367,7 +5367,7 @@ do\
 		else MENU_ITEM_TOGGLE_P(_T(MSG_MMU_MODE), _T(MSG_STEALTH), lcd_silent_mode_mmu_set);\
 	}\
 }\
-while (0)
+while (0) 
 #else //MMU_FORCE_STEALTH_MODE
 #define SETTINGS_MMU_MODE
 #endif //MMU_FORCE_STEALTH_MODE
@@ -5413,10 +5413,10 @@ do\
     switch(e_mbl_type)\
     {\
     case e_MBL_FAST:\
-        MENU_ITEM_FUNCTION_P(_i("Mode    [Fast]"),mbl_mode_set);\
+        MENU_ITEM_FUNCTION_P(_i("Mode    [Fast]"),mbl_mode_set);\ 
          break; \
     case e_MBL_OPTIMAL:\
-	    MENU_ITEM_FUNCTION_P(_i("Mode [Optimal]"), mbl_mode_set); \
+	    MENU_ITEM_FUNCTION_P(_i("Mode [Optimal]"), mbl_mode_set); \ 
 	     break; \
     case e_MBL_PREC:\
 	     MENU_ITEM_FUNCTION_P(_i("Mode [Precise]"), mbl_mode_set); \
@@ -5762,7 +5762,7 @@ static void lcd_settings_menu()
         bSettings=true;                              // flag ('fake parameter') for 'lcd_hw_setup_menu()' function
         MENU_ITEM_SUBMENU_P(_i("HW Setup"), lcd_hw_setup_menu);////MSG_HW_SETUP
     }
-
+    
 	SETTINGS_MMU_MODE;
 
 	MENU_ITEM_SUBMENU_P(_i("Mesh bed leveling"), lcd_mesh_bed_leveling_settings);////MSG_MBL_SETTINGS c=18 r=1
@@ -5860,7 +5860,7 @@ static void lcd_calibration_menu()
 #endif
     // "Mesh Bed Leveling"
     MENU_ITEM_SUBMENU_P(_i("Mesh Bed Leveling"), lcd_mesh_bedleveling);////MSG_MESH_BED_LEVELING
-
+	
 #endif //MK1BP
 
     MENU_ITEM_SUBMENU_P(_i("Bed level correct"), lcd_adjust_bed);////MSG_BED_CORRECTION_MENU
@@ -5878,7 +5878,7 @@ static void lcd_calibration_menu()
 	MENU_ITEM_SUBMENU_P(_i("Temp. calibration"), lcd_pinda_calibration_menu);////MSG_CALIBRATION_PINDA_MENU c=17 r=1
 #endif //MK1BP
   }
-
+  
   MENU_END();
 }
 
@@ -6024,7 +6024,7 @@ static char snmm_stop_print_menu() { //menu for choosing which filaments will be
 				if (cursor_pos < 1){
 					cursor_pos = 1;
 					Sound_MakeSound(e_SOUND_TYPE_BlindAlert);
-				}
+				}	
 
 				lcd_set_cursor(0, 1);
 				lcd_print(" ");
@@ -6045,7 +6045,7 @@ static char snmm_stop_print_menu() { //menu for choosing which filaments will be
 			return(cursor_pos - 1);
 		}
 	}
-
+	
 }
 
 #endif //SNMM
@@ -6070,7 +6070,7 @@ uint8_t choose_menu_P(const char *header, const char *item, const char *last_ite
 	int8_t first = 0;
 	int8_t enc_dif = lcd_encoder_diff;
 	int8_t cursor_pos = 1;
-
+	
 	lcd_clear();
 
 	KEEPALIVE_STATE(PAUSED_FOR_USER);
@@ -6095,7 +6095,7 @@ uint8_t choose_menu_P(const char *header, const char *item, const char *last_ite
 		}
 
 		if (cursor_pos > 3)
-		{
+		{		
             cursor_pos = 3;
             if (first < items_no - 3)
             {
@@ -6166,7 +6166,7 @@ char reset_menu() {
 	int enc_dif = 0;
 	char cursor_pos = 0;
 	const char *item [items_no];
-
+	
 	item[0] = "Language";
 	item[1] = "Statistics";
 	item[2] = "Shipping prep";
@@ -6180,7 +6180,7 @@ char reset_menu() {
 	lcd_set_cursor(0, 0);
 	lcd_print(">");
 	lcd_consume_click();
-	while (1) {
+	while (1) {		
 
 		for (uint_least8_t i = 0; i < 4; i++) {
 			lcd_set_cursor(1, i);
@@ -6254,7 +6254,7 @@ static void lcd_disable_farm_mode()
 	}
 	lcd_update_enable(true);
 	lcd_draw_update = 2;
-
+	
 }
 
 
@@ -6524,7 +6524,7 @@ unsigned char lcd_choose_color() {
 		manage_inactivity(true);
 		proc_commands();
 		if (abs((enc_dif - lcd_encoder_diff)) > 12) {
-
+					
 				if (enc_dif > lcd_encoder_diff) {
 					cursor_pos--;
 				}
@@ -6532,7 +6532,7 @@ unsigned char lcd_choose_color() {
 				if (enc_dif < lcd_encoder_diff) {
 					cursor_pos++;
 				}
-
+				
 				if (cursor_pos > active_rows) {
 					cursor_pos = active_rows;
 					Sound_MakeSound(e_SOUND_TYPE_BlindAlert);
@@ -6642,7 +6642,7 @@ void lcd_confirm_print()
 //				filament_type = lcd_choose_color();
 				prusa_statistics(5, filament_type);
 				no_response = true; //we need confirmation by recieving PRUSA thx
-				important_status = 5;
+				important_status = 5;				
 				saved_filament_type = filament_type;
 				NcTime = _millis();
 			}
@@ -6832,18 +6832,18 @@ static void lcd_main_menu()
 
  MENU_ITEM_BACK_P(_T(MSG_WATCH));
 
-#ifdef RESUME_DEBUG
- if (!saved_printing)
+#ifdef RESUME_DEBUG 
+ if (!saved_printing) 
   MENU_ITEM_FUNCTION_P(PSTR("tst - Save"), lcd_menu_test_save);
  else
   MENU_ITEM_FUNCTION_P(PSTR("tst - Restore"), lcd_menu_test_restore);
-#endif //RESUME_DEBUG
+#endif //RESUME_DEBUG 
 
 #ifdef TMC2130_DEBUG
  MENU_ITEM_FUNCTION_P(PSTR("recover print"), recover_print);
  MENU_ITEM_FUNCTION_P(PSTR("power panic"), uvlo_);
 #endif //TMC2130_DEBUG
-
+ 
   if ( ( IS_SD_PRINTING || is_usb_printing || (lcd_commands_type == LcdCommands::Layer1Cal)) && (current_position[Z_AXIS] < Z_HEIGHT_HIDE_LIVE_ADJUST_MENU) && !homing_flag && !mesh_bed_leveling_flag)
   {
 	MENU_ITEM_SUBMENU_P(_T(MSG_BABYSTEP_Z), lcd_babystep_z);//8
@@ -6853,7 +6853,7 @@ static void lcd_main_menu()
   if ( moves_planned() || IS_SD_PRINTING || is_usb_printing || (lcd_commands_type == LcdCommands::Layer1Cal))
   {
     MENU_ITEM_SUBMENU_P(_i("Tune"), lcd_tune_menu);////MSG_TUNE
-  } else
+  } else 
   {
     MENU_ITEM_SUBMENU_P(_i("Preheat"), lcd_preheat_menu);////MSG_PREHEAT
   }
@@ -6909,8 +6909,8 @@ static void lcd_main_menu()
       MENU_ITEM_GCODE_P(_i("Change SD card"), PSTR("M21"));  // SD-card changed by user////MSG_CNG_SDCARD
 #endif
     }
-
-  } else
+	
+  } else 
   {
     bMain=true;                                   // flag (i.e. 'fake parameter') for 'lcd_sdcard_menu()' function
     MENU_ITEM_SUBMENU_P(_i("No SD card"), lcd_sdcard_menu);////MSG_NO_CARD
@@ -6940,8 +6940,8 @@ static void lcd_main_menu()
 	  {
 		  MENU_ITEM_SUBMENU_P(PSTR("Farm number"), lcd_farm_no);
 	  }
-  }
-  else
+  } 
+  else 
   {
 	if (mmu_enabled)
 	{
@@ -6977,12 +6977,12 @@ static void lcd_main_menu()
     if(!isPrintPaused) MENU_ITEM_SUBMENU_P(_T(MSG_MENU_CALIBRATION), lcd_calibration_menu);
 
   }
-
+  
   if (!is_usb_printing && (lcd_commands_type != LcdCommands::Layer1Cal))
   {
 	  MENU_ITEM_SUBMENU_P(_i("Statistics  "), lcd_menu_statistics);////MSG_STATISTICS
   }
-
+    
 #if defined(TMC2130) || defined(FILAMENT_SENSOR)
   MENU_ITEM_SUBMENU_P(_i("Fail stats"), lcd_menu_fails_stats);
 #endif
@@ -7027,7 +7027,7 @@ void stepper_timer_overflow() {
 
 
 static void lcd_colorprint_change() {
-
+	
 	enquecommand_P(PSTR("M600"));
 
 	custom_message_type = CustomMsg::FilamentLoading; //just print status message
@@ -7223,7 +7223,7 @@ static void mbl_probe_nr_toggle() {
 
 static void lcd_mesh_bed_leveling_settings()
 {
-
+	
 	bool magnet_elimination = (eeprom_read_byte((uint8_t*)EEPROM_MBL_MAGNET_ELIMINATION) > 0);
 	uint8_t points_nr = eeprom_read_byte((uint8_t*)EEPROM_MBL_POINTS_NR);
 	char sToggle[4]; //enough for nxn format
@@ -7262,13 +7262,13 @@ static void lcd_backlight_menu()
     ON_MENU_LEAVE(
         backlight_save();
     );
-
+    
     MENU_ITEM_BACK_P(_T(MSG_BACK));
     MENU_ITEM_EDIT_int3_P(_T(MSG_BL_HIGH), &backlightLevel_HIGH, backlightLevel_LOW, 255);
     MENU_ITEM_EDIT_int3_P(_T(MSG_BL_LOW), &backlightLevel_LOW, 0, backlightLevel_HIGH);
 	MENU_ITEM_TOGGLE_P(_T(MSG_MODE), ((backlightMode==BACKLIGHT_MODE_BRIGHT) ? _T(MSG_BRIGHT) : ((backlightMode==BACKLIGHT_MODE_DIM) ? _T(MSG_DIM) : _T(MSG_AUTO))), backlight_mode_toggle);
     MENU_ITEM_EDIT_int3_P(_T(MSG_TIMEOUT), &backlightTimer_period, 1, 999);
-
+    
     MENU_END();
 }
 #endif //LCD_BL_PIN
@@ -7376,9 +7376,9 @@ void lcd_print_stop()
     custom_message_type = CustomMsg::Status;
 
     planner_abort_hard(); //needs to be done since plan_buffer_line resets waiting_inside_plan_buffer_line_print_aborted to false. Also copies current to destination.
-
+    
     axis_relative_modes = E_AXIS_MASK; //XYZ absolute, E relative
-
+    
     isPrintPaused = false; //clear isPrintPaused flag to allow starting next print after pause->stop scenario.
 }
 
@@ -7396,7 +7396,7 @@ void lcd_sdcard_stop()
 
 	if ((int32_t)lcd_encoder > 2) { lcd_encoder = 2; }
 	if ((int32_t)lcd_encoder < 1) { lcd_encoder = 1; }
-
+	
 	lcd_set_cursor(0, 1 + lcd_encoder);
 	lcd_print(">");
 
@@ -7458,7 +7458,7 @@ void lcd_sdcard_menu()
 		#else
 			 card.getfilename(nr);
 		#endif
-
+			
 		if (card.filenameIsDir)
 			MENU_ITEM_SDDIR(card.filename, card.longFilename);
 		else
@@ -7493,17 +7493,17 @@ void lcd_belttest_print(const char* msg, uint16_t X, uint16_t Y)
 void lcd_belttest()
 {
     bool _result = true;
-
+    
     #ifdef TMC2130 // Belttest requires high power mode. Enable it.
 	    FORCE_HIGH_POWER_START;
     #endif
-
+    
     uint16_t   X = eeprom_read_word((uint16_t*)(EEPROM_BELTSTATUS_X));
     uint16_t   Y = eeprom_read_word((uint16_t*)(EEPROM_BELTSTATUS_Y));
     lcd_belttest_print(_i("Checking X..."), X, Y);
 
     KEEPALIVE_STATE(IN_HANDLER);
-
+    
     _result = lcd_selfcheck_axis_sg(X_AXIS);
     X = eeprom_read_word((uint16_t*)(EEPROM_BELTSTATUS_X));
     if (_result){
@@ -7511,17 +7511,17 @@ void lcd_belttest()
         _result = lcd_selfcheck_axis_sg(Y_AXIS);
         Y = eeprom_read_word((uint16_t*)(EEPROM_BELTSTATUS_Y));
     }
-
+    
     if (!_result) {
         lcd_belttest_print(_i("Error"), X, Y);
     } else {
         lcd_belttest_print(_i("Done"), X, Y);
-    }
+    }   
 
     #ifdef TMC2130
 	    FORCE_HIGH_POWER_END;
     #endif
-
+    
     KEEPALIVE_STATE(NOT_BUSY);
     _delay(3000);
 }
@@ -7794,7 +7794,7 @@ bool lcd_selftest()
     {
 
         if (mmu_enabled)
-        {
+        {        
 			_progress = lcd_selftest_screen(TestScreen::Fsensor, _progress, 3, true, 2000); //check filaments sensor
             _result = selftest_irsensor();
 		    if (_result)
@@ -7834,7 +7834,7 @@ bool lcd_selftest()
 	lcd_reset_alert_level();
 	enquecommand_P(PSTR("M84"));
 	lcd_update_enable(true);
-
+	
 	if (_result)
 	{
 		LCD_ALERTMESSAGERPGM(_i("Self test OK"));////MSG_SELFTEST_OK
@@ -7846,9 +7846,9 @@ bool lcd_selftest()
 	#ifdef TMC2130
 	  FORCE_HIGH_POWER_END;
 	#endif // TMC2130
-
+    
     FORCE_BL_ON_END;
-
+	
     KEEPALIVE_STATE(NOT_BUSY);
 	return(_result);
 }
@@ -7863,7 +7863,7 @@ static void reset_crash_det(unsigned char axis) {
 }
 
 static bool lcd_selfcheck_axis_sg(unsigned char axis) {
-// each axis length is measured twice
+// each axis length is measured twice	
 	float axis_length, current_position_init, current_position_final;
 	float measured_axis_length[2];
 	float margin = 60;
@@ -7885,12 +7885,12 @@ static bool lcd_selfcheck_axis_sg(unsigned char axis) {
 		tmc2130_home_exit();
 	}
 
-// first axis length measurement begin
-
+// first axis length measurement begin	
+	
 	current_position[axis] -= (axis_length + margin);
 	plan_buffer_line_curposXYZE(manual_feedrate[0] / 60, active_extruder);
 
-
+	
 	st_synchronize();
 
 	tmc2130_sg_meassure_start(axis);
@@ -7914,16 +7914,16 @@ static bool lcd_selfcheck_axis_sg(unsigned char axis) {
 	measured_axis_length[0] = abs(current_position_final - current_position_init);
 
 
-// first measurement end and second measurement begin
+// first measurement end and second measurement begin	
 
 
 	current_position[axis] -= margin;
 	plan_buffer_line_curposXYZE(manual_feedrate[0] / 60, active_extruder);
-	st_synchronize();
+	st_synchronize();	
 
 	current_position[axis] -= (axis_length + margin);
 	plan_buffer_line_curposXYZE(manual_feedrate[0] / 60, active_extruder);
-
+		
 	st_synchronize();
 
 	current_position_init = st_get_position_mm(axis);
@@ -7953,7 +7953,7 @@ static bool lcd_selfcheck_axis_sg(unsigned char axis) {
 	}
 
 		printf_P(_N("Axis length difference:%.3f\n"), abs(measured_axis_length[0] - measured_axis_length[1]));
-
+	
 		if (abs(measured_axis_length[0] - measured_axis_length[1]) > 1) { //check if difference between first and second measurement is low
 			//loose pulleys
 			const char *_error_1;
@@ -8075,7 +8075,7 @@ static bool lcd_selfcheck_axis(int _axis, int _travel)
 		{
 			lcd_selftest_error(TestError::Motor, _error_1, _error_2);
 		}
-	}
+	}    
 	current_position[_axis] = 0; //simulate axis home to avoid negative numbers for axis position, especially Z.
 	plan_set_position(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS]);
 
@@ -8094,7 +8094,7 @@ static bool lcd_selfcheck_pulleys(int axis)
 	refresh_cmd_timeout();
 	manage_inactivity(true);
 
-	if (axis == 0) move = 50; //X_AXIS
+	if (axis == 0) move = 50; //X_AXIS 
 	else move = 50; //Y_AXIS
 
 	current_position_init = current_position[axis];
@@ -8108,7 +8108,7 @@ static bool lcd_selfcheck_pulleys(int axis)
 		plan_buffer_line_curposXYZE(200, active_extruder);
 		st_synchronize();
           if (SilentModeMenu != SILENT_MODE_OFF) st_current_set(0, tmp_motor[0]); //set back to normal operation currents
-		else st_current_set(0, tmp_motor_loud[0]); //set motor current back
+		else st_current_set(0, tmp_motor_loud[0]); //set motor current back			
 		current_position[axis] = current_position[axis] - move;
 		plan_buffer_line_curposXYZE(50, active_extruder);
 		st_synchronize();
@@ -8213,7 +8213,7 @@ static bool lcd_selfcheck_check_heater(bool _isbed)
 		}*/
 		if(_counter%5 == 0) serialecho_temperatures(); //show temperatures once in two seconds
 
-	} while (_docycle);
+	} while (_docycle); 
 
 	target_temperature[0] = 0;
 	target_temperature_bed = 0;
@@ -8254,9 +8254,9 @@ static bool lcd_selfcheck_check_heater(bool _isbed)
 static void lcd_selftest_error(TestError testError, const char *_error_1, const char *_error_2)
 {
 	lcd_beeper_quick_feedback();
-
+    
     FORCE_BL_ON_END;
-
+    
 	target_temperature[0] = 0;
 	target_temperature_bed = 0;
 	manage_heater();
@@ -8479,7 +8479,7 @@ static bool lcd_selftest_manual_fan_check(int _fan, bool check_opposite,
 	case 0:
 		// extruder cooling fan
 		lcd_set_cursor(0, 1);
-		if(check_opposite == true) lcd_puts_P(_T(MSG_SELFTEST_COOLING_FAN));
+		if(check_opposite == true) lcd_puts_P(_T(MSG_SELFTEST_COOLING_FAN)); 
 		else lcd_puts_P(_T(MSG_SELFTEST_EXTRUDER_FAN));
 		SET_OUTPUT(EXTRUDER_0_AUTO_FAN_PIN);
 		WRITE(EXTRUDER_0_AUTO_FAN_PIN, 1);
@@ -8774,20 +8774,20 @@ static bool check_file(const char* filename) {
 	filesize = card.getFileSize();
 	if (filesize > END_FILE_SECTION) {
 		card.setIndex(filesize - END_FILE_SECTION);
-
+		
 	}
-
+	
 		while (!card.eof() && !result) {
 		card.sdprinting = true;
 		get_command();
 		result = check_commands();
-
+		
 	}
 	card.printingHasFinished();
 	strncpy_P(lcd_status_message, _T(WELCOME_MSG), LCD_WIDTH);
 	lcd_finishstatus();
 	return result;
-
+	
 }
 
 static void menu_action_sdfile(const char* filename)
@@ -8822,7 +8822,7 @@ static void menu_action_sdfile(const char* filename)
 		  eeprom_write_byte((uint8_t*)EEPROM_DIRS + j + 8 * i, dir_names[i][j]);
 	  }
   }
-
+  
   if (!check_file(filename)) {
 	  result = lcd_show_fullscreen_message_yes_no_and_wait_P(_i("File incomplete. Continue anyway?"), false, false);////MSG_FILE_INCOMPLETE c=20 r=2
 	  lcd_update_enable(true);
@@ -8904,16 +8904,16 @@ static void lcd_send_status() {
 static void lcd_connect_printer() {
 	lcd_update_enable(false);
 	lcd_clear();
-
+	
 	int i = 0;
 	int t = 0;
 	lcd_set_custom_characters_progress();
-	lcd_puts_at_P(0, 0, _i("Connect printer to"));
+	lcd_puts_at_P(0, 0, _i("Connect printer to")); 
 	lcd_puts_at_P(0, 1, _i("monitoring or hold"));
 	lcd_puts_at_P(0, 2, _i("the knob to continue"));
 	while (no_response) {
 		i++;
-		t++;
+		t++;		
 		delay_keep_alive(100);
 		proc_commands();
 		if (t == 10) {
@@ -8921,7 +8921,7 @@ static void lcd_connect_printer() {
 			t = 0;
 		}
 		if (READ(BTN_ENC)) { //if button is not pressed
-			i = 0;
+			i = 0; 
 			lcd_puts_at_P(0, 3, PSTR("                    "));
 		}
 		if (i!=0) lcd_puts_at_P((i * 20) / (NC_BUTTON_LONG_PRESS * 10), 3, "\x01");

--- a/lang/lang_en.txt
+++ b/lang/lang_en.txt
@@ -207,11 +207,8 @@
 #MSG_FANS_CHECK
 "Fans check"
 
-#MSG_FSENSOR
+#MSG_FSENSOR c=11 r=1
 "Fil. sensor"
-
-# c=13 r=1
-"FilSens"
 
 #MSG_FILAMENT_CLEAN c=20 r=2
 "Filament extruding & with correct color?"

--- a/lang/lang_en.txt
+++ b/lang/lang_en.txt
@@ -333,7 +333,7 @@
 #MSG_STEEL_SHEET_CHECK c=20 r=2
 "Is steel sheet on heatbed?"
 
-#
+# c=20 r=1
 "Last print failures"
 
 #
@@ -417,7 +417,7 @@
 #
 "MMU needs user attention."
 
-# c=13 r=1
+# c=14 r=1
 "MMU power f."
 
 #MSG_STEALTH
@@ -786,7 +786,7 @@
 #
 "Unload"
 
-#
+# c=20 r=1
 "Total failures"
 
 #

--- a/lang/lang_en.txt
+++ b/lang/lang_en.txt
@@ -393,14 +393,14 @@
 #
 "Measured skew"
 
-#
+# c=13 r=1
 "MMU fails"
 
 #
 "MMU load failed     "
 
-#
-"MMU load fails"
+# c=13 r=1
+"MMU load f."
 
 #MSG_MMU_OK_RESUMING c=20 r=4
 "MMU OK. Resuming..."
@@ -417,8 +417,8 @@
 #
 "MMU needs user attention."
 
-#
-"MMU power fails"
+# c=14 r=1
+"MMU power f."
 
 #MSG_STEALTH
 "Stealth"

--- a/lang/lang_en.txt
+++ b/lang/lang_en.txt
@@ -135,7 +135,7 @@
 #
 "Crash detected. Resume print?"
 
-#
+# c=5 r=1
 "Crash"
 
 #MSG_CURRENT c=19 r=1
@@ -210,8 +210,8 @@
 #MSG_FSENSOR
 "Fil. sensor"
 
-#
-"Filam. runouts"
+# c=13 r=1
+"FilSens"
 
 #MSG_FILAMENT_CLEAN c=20 r=2
 "Filament extruding & with correct color?"
@@ -417,7 +417,7 @@
 #
 "MMU needs user attention."
 
-# c=14 r=1
+# c=13 r=1
 "MMU power f."
 
 #MSG_STEALTH
@@ -561,8 +561,8 @@
 #MSG_PRESS_TO_PREHEAT c=20 r=4
 "Press knob to preheat nozzle and continue."
 
-#
-"Power failures"
+# c=13 r=1
+"Power fails"
 
 #MSG_PRINT_ABORTED c=20
 "Print aborted"

--- a/lang/lang_en_cz.txt
+++ b/lang/lang_en_cz.txt
@@ -526,7 +526,7 @@
 "Measured skew"
 "Merene zkoseni"
 
-#
+# c=13 r=1
 "MMU fails"
 "Selhani MMU"
 
@@ -534,8 +534,8 @@
 "MMU load failed     "
 "Zavedeni MMU selhalo"
 
-#
-"MMU load fails"
+# c=13 r=1
+"MMU load f."
 "MMU selhani zavadeni"
 
 #MSG_MMU_OK_RESUMING c=20 r=4
@@ -558,8 +558,8 @@
 "MMU needs user attention."
 "MMU potrebuje zasah uzivatele."
 
-#
-"MMU power fails"
+# c=14 r=1
+"MMU power f."
 "MMU vypadky proudu"
 
 #MSG_STEALTH

--- a/lang/lang_en_cz.txt
+++ b/lang/lang_en_cz.txt
@@ -182,7 +182,7 @@
 "Crash detected. Resume print?"
 "Detekovan naraz. Obnovit tisk?"
 
-#
+# c=5 r=1
 "Crash"
 "Naraz"
 
@@ -282,8 +282,8 @@
 "Fil. sensor"
 "Fil. senzor"
 
-#
-"Filam. runouts"
+# c=13 r=1
+"FilSens"
 "Vypadky filam."
 
 #MSG_FILAMENT_CLEAN c=20 r=2
@@ -558,7 +558,7 @@
 "MMU needs user attention."
 "MMU potrebuje zasah uzivatele."
 
-# c=14 r=1
+# c=13 r=1
 "MMU power f."
 "MMU vypadky proudu"
 
@@ -750,8 +750,8 @@
 "Press knob to preheat nozzle and continue."
 "Pro nahrati trysky a pokracovani stisknete tlacitko."
 
-#
-"Power failures"
+# c=13 r=1
+"Power fails"
 "Vypadky proudu"
 
 #MSG_PRINT_ABORTED c=20

--- a/lang/lang_en_cz.txt
+++ b/lang/lang_en_cz.txt
@@ -446,7 +446,7 @@
 "Is steel sheet on heatbed?"
 "Je tiskovy plat na podlozce?"
 
-#
+# c=20 r=1
 "Last print failures"
 "Selhani posl. tisku"
 
@@ -558,7 +558,7 @@
 "MMU needs user attention."
 "MMU potrebuje zasah uzivatele."
 
-# c=13 r=1
+# c=14 r=1
 "MMU power f."
 "MMU vypadky proudu"
 
@@ -1050,7 +1050,7 @@
 "Unload"
 "Vysunout"
 
-#
+# c=20 r=1
 "Total failures"
 "Celkem selhani"
 

--- a/lang/lang_en_cz.txt
+++ b/lang/lang_en_cz.txt
@@ -278,13 +278,9 @@
 "Fans check"
 "Kontr. vent."
 
-#MSG_FSENSOR
+#MSG_FSENSOR c=11 r=1
 "Fil. sensor"
 "Fil. senzor"
-
-# c=13 r=1
-"FilSens"
-"Vypadky filam."
 
 #MSG_FILAMENT_CLEAN c=20 r=2
 "Filament extruding & with correct color?"

--- a/lang/lang_en_de.txt
+++ b/lang/lang_en_de.txt
@@ -278,13 +278,9 @@
 "Fans check"
 "Luefter Chk."
 
-#MSG_FSENSOR
+#MSG_FSENSOR c=11 r=1
 "Fil. sensor"
 "\x00"
-
-# c=13 r=1
-"FilSens"
-"Filam. Maengel"
 
 #MSG_FILAMENT_CLEAN c=20 r=2
 "Filament extruding & with correct color?"

--- a/lang/lang_en_de.txt
+++ b/lang/lang_en_de.txt
@@ -526,7 +526,7 @@
 "Measured skew"
 "Schraeglauf"
 
-#
+# c=13 r=1
 "MMU fails"
 "MMU Fehler"
 
@@ -534,8 +534,8 @@
 "MMU load failed     "
 "MMU Ladefehler"
 
-#
-"MMU load fails"
+# c=13 r=1
+"MMU load f."
 "MMU Ladefehler"
 
 #MSG_MMU_OK_RESUMING c=20 r=4
@@ -558,8 +558,8 @@
 "MMU needs user attention."
 "MMU erfordert Benutzereingriff."
 
-#
-"MMU power fails"
+# c=14 r=1
+"MMU power f."
 "MMU Netzfehler"
 
 #MSG_STEALTH

--- a/lang/lang_en_de.txt
+++ b/lang/lang_en_de.txt
@@ -446,7 +446,7 @@
 "Is steel sheet on heatbed?"
 "Liegt das Stahlblech auf dem Heizbett?"
 
-#
+# c=20 r=1
 "Last print failures"
 "Letzte Druckfehler"
 
@@ -558,7 +558,7 @@
 "MMU needs user attention."
 "MMU erfordert Benutzereingriff."
 
-# c=13 r=1
+# c=14 r=1
 "MMU power f."
 "MMU Netzfehler"
 
@@ -1050,7 +1050,7 @@
 "Unload"
 "Entladen"
 
-#
+# c=20 r=1
 "Total failures"
 "Gesamte Fehler"
 

--- a/lang/lang_en_de.txt
+++ b/lang/lang_en_de.txt
@@ -182,7 +182,7 @@
 "Crash detected. Resume print?"
 "Crash erkannt. Druck fortfuehren?"
 
-#
+# c=5 r=1
 "Crash"
 "\x00"
 
@@ -282,8 +282,8 @@
 "Fil. sensor"
 "\x00"
 
-#
-"Filam. runouts"
+# c=13 r=1
+"FilSens"
 "Filam. Maengel"
 
 #MSG_FILAMENT_CLEAN c=20 r=2
@@ -558,7 +558,7 @@
 "MMU needs user attention."
 "MMU erfordert Benutzereingriff."
 
-# c=14 r=1
+# c=13 r=1
 "MMU power f."
 "MMU Netzfehler"
 
@@ -750,8 +750,8 @@
 "Press knob to preheat nozzle and continue."
 "Bitte druecken Sie den Knopf um die Duese vorzuheizen und fortzufahren."
 
-#
-"Power failures"
+# c=13 r=1
+"Power fails"
 "Netzfehler"
 
 #MSG_PRINT_ABORTED c=20

--- a/lang/lang_en_es.txt
+++ b/lang/lang_en_es.txt
@@ -182,7 +182,7 @@
 "Crash detected. Resume print?"
 "Choque detectado. Continuar impresion?"
 
-#
+# c=5 r=1
 "Crash"
 "Choque"
 
@@ -282,8 +282,8 @@
 "Fil. sensor"
 "Sensor Fil."
 
-#
-"Filam. runouts"
+# c=13 r=1
+"FilSens"
 "Filam. acabado"
 
 #MSG_FILAMENT_CLEAN c=20 r=2
@@ -558,7 +558,7 @@
 "MMU needs user attention."
 "MMU necesita atencion del usuario."
 
-# c=14 r=1
+# c=13 r=1
 "MMU power f."
 "Fallo de energia en MMU"
 
@@ -750,8 +750,8 @@
 "Press knob to preheat nozzle and continue."
 "Pulsa el dial para precalentar la boquilla y continue."
 
-#
-"Power failures"
+# c=13 r=1
+"Power fails"
 "Cortes de energia"
 
 #MSG_PRINT_ABORTED c=20

--- a/lang/lang_en_es.txt
+++ b/lang/lang_en_es.txt
@@ -278,13 +278,9 @@
 "Fans check"
 "Comprob.vent"
 
-#MSG_FSENSOR
+#MSG_FSENSOR c=11 r=1
 "Fil. sensor"
 "Sensor Fil."
-
-# c=13 r=1
-"FilSens"
-"Filam. acabado"
 
 #MSG_FILAMENT_CLEAN c=20 r=2
 "Filament extruding & with correct color?"

--- a/lang/lang_en_es.txt
+++ b/lang/lang_en_es.txt
@@ -446,7 +446,7 @@
 "Is steel sheet on heatbed?"
 "?Esta colocada la lamina de acero sobre la base?"
 
-#
+# c=20 r=1
 "Last print failures"
 "Ultimas impresiones fallidas"
 
@@ -558,7 +558,7 @@
 "MMU needs user attention."
 "MMU necesita atencion del usuario."
 
-# c=13 r=1
+# c=14 r=1
 "MMU power f."
 "Fallo de energia en MMU"
 
@@ -1050,7 +1050,7 @@
 "Unload"
 "Descargar"
 
-#
+# c=20 r=1
 "Total failures"
 "Fallos totales"
 

--- a/lang/lang_en_es.txt
+++ b/lang/lang_en_es.txt
@@ -526,7 +526,7 @@
 "Measured skew"
 "Desviacion med:"
 
-#
+# c=13 r=1
 "MMU fails"
 "Fallos MMU"
 
@@ -534,8 +534,8 @@
 "MMU load failed     "
 "Carga MMU fallida"
 
-#
-"MMU load fails"
+# c=13 r=1
+"MMU load f."
 "Carga MMU falla"
 
 #MSG_MMU_OK_RESUMING c=20 r=4
@@ -558,8 +558,8 @@
 "MMU needs user attention."
 "MMU necesita atencion del usuario."
 
-#
-"MMU power fails"
+# c=14 r=1
+"MMU power f."
 "Fallo de energia en MMU"
 
 #MSG_STEALTH

--- a/lang/lang_en_fr.txt
+++ b/lang/lang_en_fr.txt
@@ -261,6 +261,7 @@
 #MSG_FSENSOR_AUTOLOAD
 "F. autoload"
 "Autochargeur"
+
 #
 "Fail stats"
 "Stat. d'echec"
@@ -280,6 +281,7 @@
 #MSG_FSENSOR
 "Fil. sensor"
 "Capteur Fil."
+
 # c=13 r=1
 "FilSens"
 "Fins de filament"
@@ -444,7 +446,7 @@
 "Is steel sheet on heatbed?"
 "Plaque d'impression sur le lit chauffant?"
 
-#
+# c=20 r=1
 "Last print failures"
 "Echecs derniere imp."
 
@@ -556,7 +558,7 @@
 "MMU needs user attention."
 "Le MMU necessite l'attention de l'utilisateur."
 
-# c=13 r=1
+# c=14 r=1
 "MMU power f."
 "Echecs alim. MMU"
 
@@ -963,6 +965,7 @@
 #MSG_SOUND_ONCE
 "Once"
 "Une fois"
+
 #MSG_SPEED
 "Speed"
 "Vitesse"
@@ -1047,7 +1050,7 @@
 "Unload"
 "Decharger"
 
-#
+# c=20 r=1
 "Total failures"
 "Total des echecs"
 

--- a/lang/lang_en_fr.txt
+++ b/lang/lang_en_fr.txt
@@ -278,13 +278,9 @@
 "Fans check"
 "Verif vent."
 
-#MSG_FSENSOR
+#MSG_FSENSOR c=11 r=1
 "Fil. sensor"
 "Capteur Fil."
-
-# c=13 r=1
-"FilSens"
-"Fins de filament"
 
 #MSG_FILAMENT_CLEAN c=20 r=2
 "Filament extruding & with correct color?"

--- a/lang/lang_en_fr.txt
+++ b/lang/lang_en_fr.txt
@@ -524,7 +524,7 @@
 "Measured skew"
 "Deviat.mesuree"
 
-#
+# c=13 r=1
 "MMU fails"
 "Echecs MMU"
 
@@ -532,8 +532,8 @@
 "MMU load failed     "
 "Echec chargement MMU"
 
-#
-"MMU load fails"
+# c=13 r=1
+"MMU load f."
 "Echecs charg. MMU"
 
 #MSG_MMU_OK_RESUMING c=20 r=4
@@ -556,8 +556,8 @@
 "MMU needs user attention."
 "Le MMU necessite l'attention de l'utilisateur."
 
-#
-"MMU power fails"
+# c=14 r=1
+"MMU power f."
 "Echecs alim. MMU"
 
 #MSG_STEALTH

--- a/lang/lang_en_fr.txt
+++ b/lang/lang_en_fr.txt
@@ -182,7 +182,7 @@
 "Crash detected. Resume print?"
 "Crash detecte. Poursuivre l'impression?"
 
-#
+# c=5 r=1
 "Crash"
 "\x00"
 
@@ -280,8 +280,8 @@
 #MSG_FSENSOR
 "Fil. sensor"
 "Capteur Fil."
-#
-"Filam. runouts"
+# c=13 r=1
+"FilSens"
 "Fins de filament"
 
 #MSG_FILAMENT_CLEAN c=20 r=2
@@ -556,7 +556,7 @@
 "MMU needs user attention."
 "Le MMU necessite l'attention de l'utilisateur."
 
-# c=14 r=1
+# c=13 r=1
 "MMU power f."
 "Echecs alim. MMU"
 
@@ -748,8 +748,8 @@
 "Press knob to preheat nozzle and continue."
 "Appuyez sur le bouton pour prechauffer la buse et continuer."
 
-#
-"Power failures"
+# c=13 r=1
+"Power fails"
 "Coup.de courant"
 
 #MSG_PRINT_ABORTED c=20

--- a/lang/lang_en_it.txt
+++ b/lang/lang_en_it.txt
@@ -446,7 +446,7 @@
 "Is steel sheet on heatbed?"
 "La piastra d'acciaio e sul piano riscaldato?"
 
-#
+# c=20 r=1
 "Last print failures"
 "Fallimenti ultima stampa"
 
@@ -558,7 +558,7 @@
 "MMU needs user attention."
 "Il MMU richiede attenzione dall'utente."
 
-# c=13 r=1
+# c=14 r=1
 "MMU power f."
 "Manc. corr. MMU"
 
@@ -1050,7 +1050,7 @@
 "Unload"
 "Scarica"
 
-#
+# c=20 r=1
 "Total failures"
 "Totale fallimenti"
 

--- a/lang/lang_en_it.txt
+++ b/lang/lang_en_it.txt
@@ -278,13 +278,9 @@
 "Fans check"
 "Control.vent"
 
-#MSG_FSENSOR
+#MSG_FSENSOR c=11 r=1
 "Fil. sensor"
 "Sensore fil."
-
-# c=13 r=1
-"FilSens"
-"Filam. esauriti"
 
 #MSG_FILAMENT_CLEAN c=20 r=2
 "Filament extruding & with correct color?"

--- a/lang/lang_en_it.txt
+++ b/lang/lang_en_it.txt
@@ -182,7 +182,7 @@
 "Crash detected. Resume print?"
 "Scontro rilevato. Riprendere la stampa?"
 
-#
+# c=5 r=1
 "Crash"
 "Impatto"
 
@@ -281,8 +281,9 @@
 #MSG_FSENSOR
 "Fil. sensor"
 "Sensore fil."
-#
-"Filam. runouts"
+
+# c=13 r=1
+"FilSens"
 "Filam. esauriti"
 
 #MSG_FILAMENT_CLEAN c=20 r=2
@@ -557,7 +558,7 @@
 "MMU needs user attention."
 "Il MMU richiede attenzione dall'utente."
 
-# c=14 r=1
+# c=13 r=1
 "MMU power f."
 "Manc. corr. MMU"
 
@@ -749,8 +750,8 @@
 "Press knob to preheat nozzle and continue."
 "Premete la manopola per preriscaldare l'ugello e continuare."
 
-#
-"Power failures"
+# c=13 r=1
+"Power fails"
 "Mancanza corrente"
 
 #MSG_PRINT_ABORTED c=20

--- a/lang/lang_en_it.txt
+++ b/lang/lang_en_it.txt
@@ -525,7 +525,7 @@
 "Measured skew"
 "Deviazione mis"
 
-#
+# c=13 r=1
 "MMU fails"
 "Fallimenti MMU"
 
@@ -533,8 +533,8 @@
 "MMU load failed     "
 "Caricamento MMU fallito"
 
-#
-"MMU load fails"
+# c=13 r=1
+"MMU load f."
 "Caricamenti MMU falliti"
 
 #MSG_MMU_OK_RESUMING c=20 r=4
@@ -557,8 +557,8 @@
 "MMU needs user attention."
 "Il MMU richiede attenzione dall'utente."
 
-#
-"MMU power fails"
+# c=14 r=1
+"MMU power f."
 "Manc. corr. MMU"
 
 #MSG_STEALTH

--- a/lang/lang_en_pl.txt
+++ b/lang/lang_en_pl.txt
@@ -526,7 +526,7 @@
 "Measured skew"
 "Zmierzony skos"
 
-#
+# c=13 r=1
 "MMU fails"
 "Bledy MMU"
 
@@ -534,8 +534,8 @@
 "MMU load failed     "
 "Blad ladowania MMU"
 
-#
-"MMU load fails"
+# c=13 r=1
+"MMU load f."
 "Bledy ladow. MMU"
 
 #MSG_MMU_OK_RESUMING c=20 r=4
@@ -558,8 +558,8 @@
 "MMU needs user attention."
 "MMU wymaga uwagi uzytkownika."
 
-#
-"MMU power fails"
+# c=14 r=1
+"MMU power f."
 "Zaniki zasil. MMU"
 
 #MSG_STEALTH

--- a/lang/lang_en_pl.txt
+++ b/lang/lang_en_pl.txt
@@ -182,7 +182,7 @@
 "Crash detected. Resume print?"
 "Wykryto zderzenie. Wznowic druk?"
 
-#
+# c=5 r=1
 "Crash"
 "Zderzenie"
 
@@ -282,8 +282,8 @@
 "Fil. sensor"
 "Czuj. filam."
 
-#
-"Filam. runouts"
+# c=13 r=1
+"FilSens"
 "Konc. filamentu"
 
 #MSG_FILAMENT_CLEAN c=20 r=2
@@ -558,7 +558,7 @@
 "MMU needs user attention."
 "MMU wymaga uwagi uzytkownika."
 
-# c=14 r=1
+# c=13 r=1
 "MMU power f."
 "Zaniki zasil. MMU"
 
@@ -750,8 +750,8 @@
 "Press knob to preheat nozzle and continue."
 "Wcisnij pokretlo aby rozgrzac dysze i kontynuowac."
 
-#
-"Power failures"
+# c=13 r=1
+"Power fails"
 "Zaniki zasilania"
 
 #MSG_PRINT_ABORTED c=20

--- a/lang/lang_en_pl.txt
+++ b/lang/lang_en_pl.txt
@@ -446,7 +446,7 @@
 "Is steel sheet on heatbed?"
 "Czy plyta stal. jest na podgrzew. stole?"
 
-#
+# c=20 r=1
 "Last print failures"
 "Ostatnie bledy druku"
 
@@ -558,7 +558,7 @@
 "MMU needs user attention."
 "MMU wymaga uwagi uzytkownika."
 
-# c=13 r=1
+# c=14 r=1
 "MMU power f."
 "Zaniki zasil. MMU"
 
@@ -965,6 +965,7 @@
 #MSG_SOUND_ONCE
 "Once"
 "1-raz"
+
 #MSG_SPEED
 "Speed"
 "Predkosc"
@@ -1049,7 +1050,7 @@
 "Unload"
 "Rozladuj"
 
-#
+# c=20 r=1
 "Total failures"
 "Suma bledow"
 

--- a/lang/lang_en_pl.txt
+++ b/lang/lang_en_pl.txt
@@ -278,13 +278,9 @@
 "Fans check"
 "Sprawd.went."
 
-#MSG_FSENSOR
+#MSG_FSENSOR c=11 r=1
 "Fil. sensor"
 "Czuj. filam."
-
-# c=13 r=1
-"FilSens"
-"Konc. filamentu"
 
 #MSG_FILAMENT_CLEAN c=20 r=2
 "Filament extruding & with correct color?"

--- a/lang/po/Firmware.pot
+++ b/lang/po/Firmware.pot
@@ -7,26 +7,31 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: en\n"
 "Project-Id-Version: Prusa-Firmware\n"
-"POT-Creation-Date: Sun, Sep 22, 2019 2:01:55 PM\n"
-"PO-Revision-Date: Sun, Sep 22, 2019 2:01:55 PM\n"
+"POT-Creation-Date: Thu, Mar 26, 2020 8:51:46 AM\n"
+"PO-Revision-Date: Thu, Mar 26, 2020 8:51:46 AM\n"
 "Language-Team: \n"
 "X-Generator: Poedit 2.0.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 "Last-Translator: \n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
+# 
+#: 
+msgid "[%.7s]Live adj. Z\x0avalue set, continue\x0aor start from zero?\x0a%cContinue%cReset"
+msgstr ""
+
 # MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE2 c=14
-#: messages.c:39
+#: messages.c:36
 msgid " of 4"
 msgstr ""
 
 # MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE2 c=14
-#: messages.c:60
+#: messages.c:56
 msgid " of 9"
 msgstr ""
 
 # MSG_MEASURED_OFFSET
-#: ultralcd.cpp:3089
+#: ultralcd.cpp:3042
 msgid "[0;0] point offset"
 msgstr ""
 
@@ -41,53 +46,43 @@ msgid "WARNING:\x0aCrash detection\x0adisabled in\x0aStealth mode"
 msgstr ""
 
 # 
-#: ultralcd.cpp:2472
+#: ultralcd.cpp:2438
 msgid ">Cancel"
 msgstr ""
 
 # MSG_BABYSTEPPING_Z c=15
-#: ultralcd.cpp:3209
+#: ultralcd.cpp:3162
 msgid "Adjusting Z:"
 msgstr ""
 
 # MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ultralcd.cpp:8295
+#: ultralcd.cpp:8638
 msgid "All correct      "
 msgstr ""
 
 # MSG_WIZARD_DONE c=20 r=8
-#: messages.c:101
+#: messages.c:99
 msgid "All is done. Happy printing!"
 msgstr ""
 
 # 
-#: ultralcd.cpp:2009
+#: ultralcd.cpp:1947
 msgid "Ambient"
 msgstr ""
 
 # MSG_PRESS c=20
-#: ultralcd.cpp:2618
+#: ultralcd.cpp:2587
 msgid "and press the knob"
 msgstr ""
 
 # MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=2
-#: ultralcd.cpp:3529
+#: ultralcd.cpp:3484
 msgid "Are left and right Z~carriages all up?"
 msgstr ""
 
-# MSG_AUTO_DEPLETE_ON c=17 r=1
-#: ultralcd.cpp:5200
-msgid "SpoolJoin    [on]"
-msgstr ""
-
-# 
-#: ultralcd.cpp:5196
-msgid "SpoolJoin   [N/A]"
-msgstr ""
-
-# MSG_AUTO_DEPLETE_OFF c=17 r=1
-#: ultralcd.cpp:5204
-msgid "SpoolJoin   [off]"
+# MSG_AUTO_DEPLETE c=17 r=1
+#: messages.c:108
+msgid "SpoolJoin"
 msgstr ""
 
 # MSG_AUTO_HOME
@@ -96,747 +91,697 @@ msgid "Auto home"
 msgstr ""
 
 # MSG_AUTOLOAD_FILAMENT c=17
-#: ultralcd.cpp:6822
+#: ultralcd.cpp:6938
 msgid "AutoLoad filament"
 msgstr ""
 
 # MSG_AUTOLOADING_ONLY_IF_FSENS_ON c=20 r=4
-#: ultralcd.cpp:4462
+#: ultralcd.cpp:4423
 msgid "Autoloading filament available only when filament sensor is turned on..."
 msgstr ""
 
 # MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ultralcd.cpp:2813
+#: ultralcd.cpp:2782
 msgid "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
 
 # MSG_SELFTEST_AXIS_LENGTH
-#: ultralcd.cpp:7949
+#: ultralcd.cpp:8286
 msgid "Axis length"
 msgstr ""
 
 # MSG_SELFTEST_AXIS
-#: ultralcd.cpp:7951
+#: ultralcd.cpp:8288
 msgid "Axis"
 msgstr ""
 
 # MSG_SELFTEST_BEDHEATER
-#: ultralcd.cpp:7893
+#: ultralcd.cpp:8230
 msgid "Bed / Heater"
 msgstr ""
 
 # MSG_BED_DONE
-#: messages.c:16
+#: messages.c:15
 msgid "Bed done"
 msgstr ""
 
 # MSG_BED_HEATING
-#: messages.c:17
+#: messages.c:16
 msgid "Bed Heating"
 msgstr ""
 
 # MSG_BED_CORRECTION_MENU
-#: ultralcd.cpp:5768
+#: ultralcd.cpp:5838
 msgid "Bed level correct"
 msgstr ""
 
 # MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=4
-#: messages.c:18
+#: messages.c:17
 msgid "Bed leveling failed. Sensor didnt trigger. Debris on nozzle? Waiting for reset."
 msgstr ""
 
 # MSG_BED
-#: messages.c:15
+#: messages.c:14
 msgid "Bed"
 msgstr ""
 
 # MSG_MENU_BELT_STATUS c=15 r=1
-#: ultralcd.cpp:2059
+#: ultralcd.cpp:2004
 msgid "Belt status"
 msgstr ""
 
 # MSG_RECOVER_PRINT c=20 r=2
-#: messages.c:71
+#: messages.c:67
 msgid "Blackout occurred. Recover print?"
 msgstr ""
 
 # 
-#: ultralcd.cpp:8297
+#: ultralcd.cpp:8640
 msgid "Calibrating home"
 msgstr ""
 
 # MSG_CALIBRATE_BED
-#: ultralcd.cpp:5757
+#: ultralcd.cpp:5827
 msgid "Calibrate XYZ"
 msgstr ""
 
 # MSG_HOMEYZ
-#: messages.c:48
+#: messages.c:44
 msgid "Calibrate Z"
 msgstr ""
 
 # MSG_CALIBRATE_PINDA c=17 r=1
-#: ultralcd.cpp:4654
+#: ultralcd.cpp:4615
 msgid "Calibrate"
 msgstr ""
 
 # MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ultralcd.cpp:3492
+#: ultralcd.cpp:3447
 msgid "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end stoppers. Click when done."
 msgstr ""
 
 # MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: messages.c:20
+#: messages.c:19
 msgid "Calibrating Z"
 msgstr ""
 
 # MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ultralcd.cpp:3492
+#: ultralcd.cpp:3447
 msgid "Calibrating Z. Rotate the knob to move the Z carriage up to the end stoppers. Click when done."
 msgstr ""
 
 # MSG_HOMEYZ_DONE
-#: ultralcd.cpp:816
+#: ultralcd.cpp:856
 msgid "Calibration done"
 msgstr ""
 
 # MSG_MENU_CALIBRATION
-#: messages.c:61
+#: messages.c:57
 msgid "Calibration"
 msgstr ""
 
 # 
-#: ultralcd.cpp:4781
+#: ultralcd.cpp:4793
 msgid "Cancel"
 msgstr ""
 
 # MSG_SD_REMOVED
-#: ultralcd.cpp:8679
+#: ultralcd.cpp:9051
 msgid "Card removed"
 msgstr ""
 
 # MSG_NOT_COLOR
-#: ultralcd.cpp:2718
+#: ultralcd.cpp:2687
 msgid "Color not correct"
 msgstr ""
 
 # MSG_COOLDOWN
-#: messages.c:23
+#: messages.c:22
 msgid "Cooldown"
 msgstr ""
 
 # 
-#: ultralcd.cpp:4587
+#: ultralcd.cpp:4548
 msgid "Copy selected language?"
 msgstr ""
 
-# MSG_CRASHDETECT_ON
-#: messages.c:27
-msgid "Crash det.   [on]"
-msgstr ""
-
-# MSG_CRASHDETECT_NA
-#: messages.c:25
-msgid "Crash det.  [N/A]"
-msgstr ""
-
-# MSG_CRASHDETECT_OFF
-#: messages.c:26
-msgid "Crash det.  [off]"
-msgstr ""
+"Crash det."
+#: adc.c:3
+msgid #
+msgstr "Choose a filament for the First Layer Calibration and select it in the on-screen menu."
 
 # MSG_CRASH_DETECTED c=20 r=1
-#: messages.c:24
+#: messages.c:23
 msgid "Crash detected."
 msgstr ""
 
 # 
-#: Marlin_main.cpp:600
+#: Marlin_main.cpp:602
 msgid "Crash detected. Resume print?"
 msgstr ""
 
 # 
-#: ultralcd.cpp:1853
+#: ultralcd.cpp:1776
 msgid "Crash"
 msgstr ""
 
 # MSG_CURRENT c=19 r=1
-#: ultralcd.cpp:5909
+#: ultralcd.cpp:5979
 msgid "Current"
 msgstr ""
 
 # MSG_DATE c=17 r=1
-#: ultralcd.cpp:2213
+#: ultralcd.cpp:2158
 msgid "Date:"
 msgstr ""
 
 # MSG_DISABLE_STEPPERS
-#: ultralcd.cpp:5654
+#: ultralcd.cpp:5720
 msgid "Disable steppers"
 msgstr ""
 
 # MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: messages.c:14
+#: messages.c:13
 msgid "Distance between tip of the nozzle and the bed surface has not been set yet. Please follow the manual, chapter First steps, section First layer calibration."
 msgstr ""
 
 # MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ultralcd.cpp:5070
+#: ultralcd.cpp:5103
 msgid "Do you want to repeat last step to readjust distance between nozzle and heatbed?"
 msgstr ""
 
 # MSG_EXTRUDER_CORRECTION c=10
-#: ultralcd.cpp:5134
+#: ultralcd.cpp:5172
 msgid "E-correct:"
 msgstr ""
 
 # MSG_EJECT_FILAMENT c=17 r=1
-#: messages.c:53
+#: messages.c:49
 msgid "Eject filament"
 msgstr ""
 
-# 
-#: ultralcd.cpp:4869
-msgid "Eject"
-msgstr ""
-
 # MSG_EJECTING_FILAMENT c=20 r=1
-#: mmu.cpp:1434
+#: mmu.cpp:1415
 msgid "Ejecting filament"
 msgstr ""
 
 # MSG_SELFTEST_ENDSTOP_NOTHIT c=20 r=1
-#: ultralcd.cpp:7917
+#: ultralcd.cpp:8254
 msgid "Endstop not hit"
 msgstr ""
 
 # MSG_SELFTEST_ENDSTOP
-#: ultralcd.cpp:7911
+#: ultralcd.cpp:8248
 msgid "Endstop"
 msgstr ""
 
 # MSG_SELFTEST_ENDSTOPS
-#: ultralcd.cpp:7899
+#: ultralcd.cpp:8236
 msgid "Endstops"
 msgstr ""
 
 # MSG_STACK_ERROR c=20 r=4
-#: ultralcd.cpp:6859
+#: ultralcd.cpp:6975
 msgid "Error - static memory has been overwritten"
 msgstr ""
 
 # MSG_FSENS_NOT_RESPONDING c=20 r=4
-#: ultralcd.cpp:4475
+#: ultralcd.cpp:4436
 msgid "ERROR: Filament sensor is not responding, please check connection."
 msgstr ""
 
 # MSG_ERROR
-#: messages.c:28
+#: messages.c:25
 msgid "ERROR:"
 msgstr ""
 
 # MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
-#: ultralcd.cpp:8304
+#: ultralcd.cpp:8647
 msgid "Extruder fan:"
 msgstr ""
 
 # MSG_INFO_EXTRUDER c=15 r=1
-#: ultralcd.cpp:2244
+#: ultralcd.cpp:2189
 msgid "Extruder info"
 msgstr ""
 
 # MSG_MOVE_E
-#: messages.c:29
+#: messages.c:26
 msgid "Extruder"
 msgstr ""
 
 # 
-#: ultralcd.cpp:6846
+#: ultralcd.cpp:6962
 msgid "Fail stats MMU"
 msgstr ""
 
-# MSG_FSENS_AUTOLOAD_ON c=17 r=1
-#: ultralcd.cpp:5168
-msgid "F. autoload  [on]"
-msgstr ""
-
-# MSG_FSENS_AUTOLOAD_NA c=17 r=1
-#: messages.c:43
-msgid "F. autoload [N/A]"
-msgstr ""
-
-# MSG_FSENS_AUTOLOAD_OFF c=17 r=1
-#: ultralcd.cpp:5170
-msgid "F. autoload [off]"
+# MSG_FSENSOR_AUTOLOAD
+#: messages.c:40
+msgid "F. autoload"
 msgstr ""
 
 # 
-#: ultralcd.cpp:6843
+#: ultralcd.cpp:6959
 msgid "Fail stats"
 msgstr ""
 
 # MSG_FAN_SPEED c=14
-#: messages.c:31
+#: messages.c:28
 msgid "Fan speed"
 msgstr ""
 
 # MSG_SELFTEST_FAN c=20
-#: messages.c:78
+#: messages.c:74
 msgid "Fan test"
 msgstr ""
 
-# MSG_FANS_CHECK_ON c=17 r=1
-#: ultralcd.cpp:5663
-msgid "Fans check   [on]"
+# MSG_FANS_CHECK
+#: ultralcd.cpp:5728
+msgid "Fans check"
 msgstr ""
 
-# MSG_FANS_CHECK_OFF c=17 r=1
-#: ultralcd.cpp:5665
-msgid "Fans check  [off]"
-msgstr ""
-
-# MSG_FSENSOR_ON
-#: messages.c:45
-msgid "Fil. sensor  [on]"
-msgstr ""
-
-# MSG_FSENSOR_NA
-#: ultralcd.cpp:5148
-msgid "Fil. sensor [N/A]"
-msgstr ""
-
-# MSG_FSENSOR_OFF
-#: messages.c:44
-msgid "Fil. sensor [off]"
+# MSG_FSENSOR
+#: messages.c:41
+msgid "Fil. sensor"
 msgstr ""
 
 # 
-#: ultralcd.cpp:1852
+#: ultralcd.cpp:1775
 msgid "Filam. runouts"
 msgstr ""
 
 # MSG_FILAMENT_CLEAN c=20 r=2
-#: messages.c:32
+#: messages.c:29
 msgid "Filament extruding & with correct color?"
 msgstr ""
 
 # MSG_NOT_LOADED c=19
-#: ultralcd.cpp:2714
+#: ultralcd.cpp:2683
 msgid "Filament not loaded"
 msgstr ""
 
 # MSG_FILAMENT_SENSOR c=20
-#: messages.c:84
+#: messages.c:80
 msgid "Filament sensor"
 msgstr ""
 
 # MSG_FILAMENT_USED c=19 r=1
-#: ultralcd.cpp:2885
+#: ultralcd.cpp:2847
 msgid "Filament used"
 msgstr ""
 
 # MSG_PRINT_TIME c=19 r=1
-#: ultralcd.cpp:2886
+#: ultralcd.cpp:2848
 msgid "Print time"
 msgstr ""
 
 # MSG_FILE_INCOMPLETE c=20 r=2
-#: ultralcd.cpp:8432
+#: ultralcd.cpp:8775
 msgid "File incomplete. Continue anyway?"
 msgstr ""
 
 # MSG_FINISHING_MOVEMENTS c=20 r=1
-#: messages.c:40
+#: messages.c:37
 msgid "Finishing movements"
 msgstr ""
 
 # MSG_V2_CALIBRATION c=17 r=1
-#: messages.c:105
+#: messages.c:103
 msgid "First layer cal."
 msgstr ""
 
 # MSG_WIZARD_SELFTEST c=20 r=8
-#: ultralcd.cpp:4982
+#: ultralcd.cpp:5024
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 
 # 
-#: mmu.cpp:724
+#: mmu.cpp:726
 msgid "Fix the issue and then press button on MMU unit."
 msgstr ""
 
 # MSG_FLOW
-#: ultralcd.cpp:6932
+#: ultralcd.cpp:7102
 msgid "Flow"
 msgstr ""
 
 # MSG_PRUSA3D_FORUM
-#: ultralcd.cpp:2206
+#: ultralcd.cpp:2151
 msgid "forum.prusa3d.com"
 msgstr ""
 
 # MSG_SELFTEST_COOLING_FAN c=20
-#: messages.c:75
+#: messages.c:71
 msgid "Front print fan?"
 msgstr ""
 
 # MSG_BED_CORRECTION_FRONT c=14 r=1
-#: ultralcd.cpp:3294
+#: ultralcd.cpp:3244
 msgid "Front side[um]"
 msgstr ""
 
 # MSG_SELFTEST_FANS
-#: ultralcd.cpp:7957
+#: ultralcd.cpp:8294
 msgid "Front/left fans"
 msgstr ""
 
 # MSG_SELFTEST_HEATERTHERMISTOR
-#: ultralcd.cpp:7887
+#: ultralcd.cpp:8224
 msgid "Heater/Thermistor"
 msgstr ""
 
 # MSG_BED_HEATING_SAFETY_DISABLED
-#: Marlin_main.cpp:8467
+#: Marlin_main.cpp:9458
 msgid "Heating disabled by safety timer."
 msgstr ""
 
 # MSG_HEATING_COMPLETE c=20
-#: messages.c:47
+#: messages.c:43
 msgid "Heating done."
 msgstr ""
 
 # MSG_HEATING
-#: messages.c:46
+#: messages.c:42
 msgid "Heating"
 msgstr ""
 
 # MSG_WIZARD_WELCOME c=20 r=7
-#: ultralcd.cpp:4961
+#: ultralcd.cpp:5003
 msgid "Hi, I am your Original Prusa i3 printer. Would you like me to guide you through the setup process?"
 msgstr ""
 
 # MSG_PRUSA3D_HOWTO
-#: ultralcd.cpp:2207
+#: ultralcd.cpp:2152
 msgid "howto.prusa3d.com"
 msgstr ""
 
 # MSG_FILAMENTCHANGE
-#: messages.c:37
+#: messages.c:34
 msgid "Change filament"
 msgstr ""
 
 # MSG_CHANGE_SUCCESS
-#: ultralcd.cpp:2629
+#: ultralcd.cpp:2598
 msgid "Change success!"
 msgstr ""
 
 # MSG_CORRECTLY c=20
-#: ultralcd.cpp:2706
+#: ultralcd.cpp:2675
 msgid "Changed correctly?"
 msgstr ""
 
 # MSG_SELFTEST_CHECK_BED c=20
-#: messages.c:81
+#: messages.c:77
 msgid "Checking bed     "
 msgstr ""
 
 # MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ultralcd.cpp:8286
+#: ultralcd.cpp:8629
 msgid "Checking endstops"
 msgstr ""
 
 # MSG_SELFTEST_CHECK_HOTEND c=20
-#: ultralcd.cpp:8292
+#: ultralcd.cpp:8635
 msgid "Checking hotend  "
 msgstr ""
 
 # MSG_SELFTEST_CHECK_FSENSOR c=20
-#: messages.c:82
+#: messages.c:78
 msgid "Checking sensors "
 msgstr ""
 
 # MSG_SELFTEST_CHECK_X c=20
-#: ultralcd.cpp:8287
+#: ultralcd.cpp:8630
 msgid "Checking X axis  "
 msgstr ""
 
 # MSG_SELFTEST_CHECK_Y c=20
-#: ultralcd.cpp:8288
+#: ultralcd.cpp:8631
 msgid "Checking Y axis  "
 msgstr ""
 
 # MSG_SELFTEST_CHECK_Z c=20
-#: ultralcd.cpp:8289
+#: ultralcd.cpp:8632
 msgid "Checking Z axis  "
 msgstr ""
 
 # MSG_CHOOSE_EXTRUDER c=20 r=1
-#: messages.c:49
+#: messages.c:45
 msgid "Choose extruder:"
 msgstr ""
 
 # MSG_CHOOSE_FILAMENT c=20 r=1
-#: messages.c:50
+#: messages.c:46
 msgid "Choose filament:"
 msgstr ""
 
 # MSG_FILAMENT c=17 r=1
-#: messages.c:30
+#: messages.c:27
 msgid "Filament"
 msgstr ""
 
 # MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ultralcd.cpp:4991
+#: ultralcd.cpp:5033
 msgid "I will run xyz calibration now. It will take approx. 12 mins."
 msgstr ""
 
 # MSG_WIZARD_Z_CAL c=20 r=8
-#: ultralcd.cpp:4999
+#: ultralcd.cpp:5041
 msgid "I will run z calibration now."
 msgstr ""
 
-# MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ultralcd.cpp:5064
-msgid "I will start to print line and you will gradually lower the nozzle by rotating the knob, until you reach optimal height. Check the pictures in our handbook in chapter Calibration."
-msgstr ""
-
 # MSG_WATCH
-#: messages.c:99
+#: messages.c:97
 msgid "Info screen"
 msgstr ""
 
-# 
-#: ultralcd.cpp:5024
-msgid "Is filament 1 loaded?"
-msgstr ""
-
 # MSG_INSERT_FILAMENT c=20
-#: ultralcd.cpp:2614
+#: ultralcd.cpp:2583
 msgid "Insert filament"
 msgstr ""
 
 # MSG_WIZARD_FILAMENT_LOADED c=20 r=2
-#: ultralcd.cpp:5027
+#: ultralcd.cpp:4813
 msgid "Is filament loaded?"
 msgstr ""
 
-# MSG_WIZARD_PLA_FILAMENT c=20 r=2
-#: ultralcd.cpp:5058
-msgid "Is it PLA filament?"
-msgstr ""
-
-# MSG_PLA_FILAMENT_LOADED c=20 r=2
-#: ultralcd.cpp:4790
-msgid "Is PLA filament loaded?"
-msgstr ""
-
 # MSG_STEEL_SHEET_CHECK c=20 r=2
-#: messages.c:92
+#: messages.c:90
 msgid "Is steel sheet on heatbed?"
 msgstr ""
 
 # 
-#: ultralcd.cpp:1795
+#: ultralcd.cpp:1718
 msgid "Last print failures"
 msgstr ""
 
 # 
-#: ultralcd.cpp:1772
+#: ultralcd.cpp:5111
+msgid "If you have additional steel sheets, calibrate their presets in Settings - HW Setup - Steel sheets."
+msgstr ""
+
+# 
+#: ultralcd.cpp:1695
 msgid "Last print"
 msgstr ""
 
 # MSG_SELFTEST_EXTRUDER_FAN c=20
-#: messages.c:76
+#: messages.c:72
 msgid "Left hotend fan?"
 msgstr ""
 
 # 
-#: ultralcd.cpp:3018
+#: ultralcd.cpp:2971
 msgid "Left"
 msgstr ""
 
 # MSG_BED_CORRECTION_LEFT c=14 r=1
-#: ultralcd.cpp:3292
+#: ultralcd.cpp:3242
 msgid "Left side [um]"
 msgstr ""
 
 # 
-#: ultralcd.cpp:5680
+#: ultralcd.cpp:5743
 msgid "Lin. correction"
 msgstr ""
 
 # MSG_BABYSTEP_Z
-#: messages.c:13
+#: messages.c:12
 msgid "Live adjust Z"
 msgstr ""
 
 # MSG_LOAD_FILAMENT c=17
-#: messages.c:51
+#: messages.c:47
 msgid "Load filament"
 msgstr ""
 
 # MSG_LOADING_COLOR
-#: ultralcd.cpp:2654
+#: ultralcd.cpp:2623
 msgid "Loading color"
 msgstr ""
 
 # MSG_LOADING_FILAMENT c=20
-#: messages.c:52
+#: messages.c:48
 msgid "Loading filament"
 msgstr ""
 
 # MSG_LOOSE_PULLEY c=20 r=1
-#: ultralcd.cpp:7941
+#: ultralcd.cpp:8278
 msgid "Loose pulley"
 msgstr ""
 
 # 
-#: ultralcd.cpp:6805
+#: ultralcd.cpp:6921
 msgid "Load to nozzle"
 msgstr ""
 
 # MSG_M117_V2_CALIBRATION c=25 r=1
-#: messages.c:55
+#: messages.c:51
 msgid "M117 First layer cal."
 msgstr ""
 
 # MSG_MAIN
-#: messages.c:56
+#: messages.c:52
 msgid "Main"
 msgstr ""
 
 # MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=60
-#: messages.c:59
+#: messages.c:55
 msgid "Measuring reference height of calibration point"
 msgstr ""
 
 # MSG_MESH_BED_LEVELING
-#: ultralcd.cpp:5763
+#: ultralcd.cpp:5833
 msgid "Mesh Bed Leveling"
 msgstr ""
 
 # MSG_MMU_OK_RESUMING_POSITION c=20 r=4
-#: mmu.cpp:762
+#: mmu.cpp:764
 msgid "MMU OK. Resuming position..."
 msgstr ""
 
 # MSG_MMU_OK_RESUMING_TEMPERATURE c=20 r=4
-#: mmu.cpp:755
+#: mmu.cpp:757
 msgid "MMU OK. Resuming temperature..."
 msgstr ""
 
 # 
-#: ultralcd.cpp:3059
+#: ultralcd.cpp:3012
 msgid "Measured skew"
 msgstr ""
 
-# 
-#: ultralcd.cpp:1796
+#  c=13 r=1
+#: ultralcd.cpp:1719
 msgid "MMU fails"
 msgstr ""
 
 # 
-#: mmu.cpp:1613
+#: mmu.cpp:1587
 msgid "MMU load failed     "
 msgstr ""
 
-# 
-#: ultralcd.cpp:1797
-msgid "MMU load fails"
+#  c=13 r=1
+#: ultralcd.cpp:1720
+msgid "MMU load f."
 msgstr ""
 
 # MSG_MMU_OK_RESUMING c=20 r=4
-#: mmu.cpp:773
+#: mmu.cpp:775
 msgid "MMU OK. Resuming..."
 msgstr ""
 
-# MSG_STEALTH_MODE_OFF
-#: messages.c:90
-msgid "Mode     [Normal]"
+# MSG_MODE
+#: messages.c:84
+msgid "Mode"
 msgstr ""
 
-# MSG_SILENT_MODE_ON
-#: messages.c:89
-msgid "Mode     [silent]"
+# MSG_NORMAL
+#: messages.c:88
+msgid "Normal"
+msgstr ""
+
+# MSG_SILENT
+#: messages.c:87
+msgid "Silent"
 msgstr ""
 
 # 
-#: mmu.cpp:719
+#: mmu.cpp:721
 msgid "MMU needs user attention."
 msgstr ""
 
+#  c=14 r=1
+#: ultralcd.cpp:1746
+msgid "MMU power f."
+msgstr ""
+
+# MSG_STEALTH
+#: messages.c:89
+msgid "Stealth"
+msgstr ""
+
+# MSG_AUTO_POWER
+#: messages.c:86
+msgid "Auto power"
+msgstr ""
+
+# MSG_HIGH_POWER
+#: messages.c:85
+msgid "High power"
+msgstr ""
+
 # 
-#: ultralcd.cpp:1823
-msgid "MMU power fails"
-msgstr ""
-
-# MSG_STEALTH_MODE_ON
-#: messages.c:91
-msgid "Mode    [Stealth]"
-msgstr ""
-
-# MSG_AUTO_MODE_ON
-#: messages.c:12
-msgid "Mode [auto power]"
-msgstr ""
-
-# MSG_SILENT_MODE_OFF
-#: messages.c:88
-msgid "Mode [high power]"
-msgstr ""
-
-# 
-#: ultralcd.cpp:2219
+#: ultralcd.cpp:2164
 msgid "MMU2 connected"
 msgstr ""
 
 # MSG_SELFTEST_MOTOR
-#: messages.c:83
+#: messages.c:79
 msgid "Motor"
 msgstr ""
 
 # MSG_MOVE_AXIS
-#: ultralcd.cpp:5652
+#: ultralcd.cpp:5718
 msgid "Move axis"
 msgstr ""
 
 # MSG_MOVE_X
-#: ultralcd.cpp:4378
+#: ultralcd.cpp:4339
 msgid "Move X"
 msgstr ""
 
 # MSG_MOVE_Y
-#: ultralcd.cpp:4379
+#: ultralcd.cpp:4340
 msgid "Move Y"
 msgstr ""
 
 # MSG_MOVE_Z
-#: ultralcd.cpp:4380
+#: ultralcd.cpp:4341
 msgid "Move Z"
 msgstr ""
 
 # MSG_NO_MOVE
-#: Marlin_main.cpp:5292
+#: Marlin_main.cpp:5526
 msgid "No move."
 msgstr ""
 
 # MSG_NO_CARD
-#: ultralcd.cpp:6772
+#: ultralcd.cpp:6888
 msgid "No SD card"
 msgstr ""
 
-# 
-#: ultralcd.cpp:3024
+# MSG_NA
+#: messages.c:107
 msgid "N/A"
 msgstr ""
 
 # MSG_NO
-#: messages.c:62
+#: messages.c:58
 msgid "No"
 msgstr ""
 
 # MSG_SELFTEST_NOTCONNECTED
-#: ultralcd.cpp:7889
+#: ultralcd.cpp:8226
 msgid "Not connected"
 msgstr ""
 
@@ -846,167 +791,152 @@ msgid "New firmware version available:"
 msgstr ""
 
 # MSG_SELFTEST_FAN_NO c=19
-#: messages.c:79
+#: messages.c:75
 msgid "Not spinning"
 msgstr ""
 
 # MSG_WIZARD_V2_CAL c=20 r=8
-#: ultralcd.cpp:5063
+#: ultralcd.cpp:4924
 msgid "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr ""
 
 # MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ultralcd.cpp:5007
+#: ultralcd.cpp:5049
 msgid "Now I will preheat nozzle for PLA."
 msgstr ""
 
 # MSG_NOZZLE
-#: messages.c:63
+#: messages.c:59
 msgid "Nozzle"
 msgstr ""
 
 # MSG_DEFAULT_SETTINGS_LOADED c=20 r=4
-#: Marlin_main.cpp:1519
+#: Marlin_main.cpp:1500
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr ""
 
 # 
-#: ultralcd.cpp:4998
+#: ultralcd.cpp:5040
 msgid "Now remove the test print from steel sheet."
 msgstr ""
 
 # 
-#: ultralcd.cpp:1722
+#: ultralcd.cpp:1645
 msgid "Nozzle FAN"
 msgstr ""
 
 # MSG_PAUSE_PRINT
-#: ultralcd.cpp:6735
+#: ultralcd.cpp:6852
 msgid "Pause print"
 msgstr ""
 
 # MSG_PID_RUNNING c=20 r=1
-#: ultralcd.cpp:1606
+#: ultralcd.cpp:1530
 msgid "PID cal.           "
 msgstr ""
 
 # MSG_PID_FINISHED c=20 r=1
-#: ultralcd.cpp:1612
+#: ultralcd.cpp:1536
 msgid "PID cal. finished"
 msgstr ""
 
 # MSG_PID_EXTRUDER c=17 r=1
-#: ultralcd.cpp:5769
+#: ultralcd.cpp:5839
 msgid "PID calibration"
 msgstr ""
 
 # MSG_PINDA_PREHEAT c=20 r=1
-#: ultralcd.cpp:846
+#: ultralcd.cpp:887
 msgid "PINDA Heating"
 msgstr ""
 
 # MSG_PAPER c=20 r=8
-#: messages.c:64
+#: messages.c:60
 msgid "Place a sheet of paper under the nozzle during the calibration of first 4 points. If the nozzle catches the paper, power off the printer immediately."
 msgstr ""
 
 # MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ultralcd.cpp:5072
+#: ultralcd.cpp:5106
 msgid "Please clean heatbed and then press the knob."
 msgstr ""
 
 # MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: messages.c:22
+#: messages.c:21
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr ""
 
 # MSG_SELFTEST_PLEASECHECK
-#: ultralcd.cpp:7881
+#: ultralcd.cpp:8218
 msgid "Please check :"
 msgstr ""
 
 # MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: messages.c:100
+#: messages.c:98
 msgid "Please check our handbook and fix the problem. Then resume the Wizard by rebooting the printer."
 msgstr ""
 
-# MSG_WIZARD_LOAD_FILAMENT c=20 r=8
-#: ultralcd.cpp:4894
-msgid "Please insert PLA filament to the extruder, then press knob to load it."
-msgstr ""
-
-# MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ultralcd.cpp:4795
-msgid "Please load PLA filament first."
-msgstr ""
-
 # MSG_CHECK_IDLER c=20 r=4
-#: Marlin_main.cpp:3064
+#: Marlin_main.cpp:3116
 msgid "Please open idler and remove filament manually."
 msgstr ""
 
 # MSG_PLACE_STEEL_SHEET c=20 r=4
-#: messages.c:65
+#: messages.c:61
 msgid "Please place steel sheet on heatbed."
 msgstr ""
 
 # MSG_PRESS_TO_UNLOAD c=20 r=4
-#: messages.c:68
+#: messages.c:64
 msgid "Please press the knob to unload filament"
 msgstr ""
 
-# 
-#: ultralcd.cpp:4889
-msgid "Please insert PLA filament to the first tube of MMU, then press the knob to load it."
-msgstr ""
-
 # MSG_PULL_OUT_FILAMENT c=20 r=4
-#: messages.c:70
+#: messages.c:66
 msgid "Please pull out filament immediately"
 msgstr ""
 
 # MSG_EJECT_REMOVE c=20 r=4
-#: mmu.cpp:1440
+#: mmu.cpp:1421
 msgid "Please remove filament and then press the knob."
 msgstr ""
 
 # MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: messages.c:74
+#: messages.c:70
 msgid "Please remove steel sheet from heatbed."
 msgstr ""
 
 # MSG_RUN_XYZ c=20 r=4
-#: Marlin_main.cpp:4355
+#: Marlin_main.cpp:4561
 msgid "Please run XYZ calibration first."
 msgstr ""
 
 # MSG_UPDATE_MMU2_FW c=20 r=4
-#: mmu.cpp:1359
+#: mmu.cpp:1340
 msgid "Please update firmware in your MMU2. Waiting for reset."
 msgstr ""
 
 # MSG_PLEASE_WAIT c=20
-#: messages.c:66
+#: messages.c:62
 msgid "Please wait"
 msgstr ""
 
 # 
-#: ultralcd.cpp:4997
+#: ultralcd.cpp:5039
 msgid "Please remove shipping helpers first."
 msgstr ""
 
 # MSG_PREHEAT_NOZZLE c=20
-#: messages.c:67
+#: messages.c:63
 msgid "Preheat the nozzle!"
 msgstr ""
 
 # MSG_PREHEAT
-#: ultralcd.cpp:6722
+#: ultralcd.cpp:6830
 msgid "Preheat"
 msgstr ""
 
 # MSG_WIZARD_HEATING c=20 r=3
-#: messages.c:102
+#: messages.c:100
 msgid "Preheating nozzle. Please wait."
 msgstr ""
 
@@ -1016,82 +946,97 @@ msgid "Please upgrade."
 msgstr ""
 
 # MSG_PRESS_TO_PREHEAT c=20 r=4
-#: Marlin_main.cpp:10364
+#: Marlin_main.cpp:11469
 msgid "Press knob to preheat nozzle and continue."
 msgstr ""
 
 # 
-#: ultralcd.cpp:1851
+#: ultralcd.cpp:1774
 msgid "Power failures"
 msgstr ""
 
 # MSG_PRINT_ABORTED c=20
-#: messages.c:69
+#: messages.c:65
 msgid "Print aborted"
 msgstr ""
 
 # 
-#: ultralcd.cpp:2455
+#: ultralcd.cpp:2420
 msgid "Preheating to load"
 msgstr ""
 
 # 
-#: ultralcd.cpp:2459
+#: ultralcd.cpp:2424
 msgid "Preheating to unload"
 msgstr ""
 
 # MSG_SELFTEST_PRINT_FAN_SPEED c=18
-#: ultralcd.cpp:8307
+#: ultralcd.cpp:8650
 msgid "Print fan:"
 msgstr ""
 
 # MSG_CARD_MENU
-#: messages.c:21
+#: messages.c:20
 msgid "Print from SD"
 msgstr ""
 
 # 
-#: ultralcd.cpp:2317
+#: ultralcd.cpp:2267
 msgid "Press the knob"
 msgstr ""
 
 # MSG_PRINT_PAUSED c=20 r=1
-#: ultralcd.cpp:1069
+#: ultralcd.cpp:1109
 msgid "Print paused"
 msgstr ""
 
 # 
-#: mmu.cpp:723
+#: mmu.cpp:725
 msgid "Press the knob to resume nozzle temperature."
 msgstr ""
 
 # MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: messages.c:41
+#: messages.c:38
 msgid "Printer has not been calibrated yet. Please follow the manual, chapter First steps, section Calibration flow."
 msgstr ""
 
 # 
-#: ultralcd.cpp:1723
+#: ultralcd.cpp:1646
 msgid "Print FAN"
 msgstr ""
 
+# 
+#: ultralcd.cpp:4904
+msgid "Please insert filament into the extruder, then press the knob to load it."
+msgstr ""
+
+# 
+#: ultralcd.cpp:4899
+msgid "Please insert filament into the first tube of the MMU, then press the knob to load it."
+msgstr ""
+
+# 
+#: ultralcd.cpp:4821
+msgid "Please load filament first."
+msgstr ""
+
 # MSG_PRUSA3D
-#: ultralcd.cpp:2205
+#: ultralcd.cpp:2150
 msgid "prusa3d.com"
 msgstr ""
 
 # MSG_BED_CORRECTION_REAR c=14 r=1
-#: ultralcd.cpp:3295
+#: ultralcd.cpp:3245
 msgid "Rear side [um]"
 msgstr ""
 
 # MSG_RECOVERING_PRINT c=20 r=1
-#: Marlin_main.cpp:9764
+#: Marlin_main.cpp:10826
 msgid "Recovering print    "
 msgstr ""
 
 # MSG_REMOVE_OLD_FILAMENT c=20 r=4
-#: mmu.cpp:830
+#: mmu.cpp:832
 msgid "Remove old filament and press the knob to start loading new filament."
 msgstr ""
 
@@ -1101,712 +1046,647 @@ msgid "Prusa i3 MK3S OK."
 msgstr ""
 
 # MSG_CALIBRATE_BED_RESET
-#: ultralcd.cpp:5774
+#: ultralcd.cpp:5844
 msgid "Reset XYZ calibr."
 msgstr ""
 
 # MSG_BED_CORRECTION_RESET
-#: ultralcd.cpp:3296
+#: ultralcd.cpp:3246
 msgid "Reset"
 msgstr ""
 
 # MSG_RESUME_PRINT
-#: ultralcd.cpp:6742
+#: ultralcd.cpp:6838
 msgid "Resume print"
 msgstr ""
 
 # MSG_RESUMING_PRINT c=20 r=1
-#: messages.c:73
+#: messages.c:69
 msgid "Resuming print"
 msgstr ""
 
 # MSG_BED_CORRECTION_RIGHT c=14 r=1
-#: ultralcd.cpp:3293
+#: ultralcd.cpp:3243
 msgid "Right side[um]"
 msgstr ""
 
-# MSG_SECOND_SERIAL_ON c=17 r=1
-#: ultralcd.cpp:5692
-msgid "RPi port     [on]"
-msgstr ""
-
-# MSG_SECOND_SERIAL_OFF c=17 r=1
-#: ultralcd.cpp:5690
-msgid "RPi port    [off]"
+# MSG_RPI_PORT
+#: messages.c:123
+msgid "RPi port"
 msgstr ""
 
 # MSG_WIZARD_RERUN c=20 r=7
-#: ultralcd.cpp:4812
+#: ultralcd.cpp:4842
 msgid "Running Wizard will delete current calibration results and start from the beginning. Continue?"
 msgstr ""
 
-# MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_OFF c=19 r=1
-#: ultralcd.cpp:5322
-msgid "SD card  [normal]"
+# MSG_SD_CARD
+#: messages.c:118
+msgid "SD card"
 msgstr ""
 
-# MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_ON c=19 r=1
-#: ultralcd.cpp:5320
-msgid "SD card [flshAir]"
+# MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY
+#: messages.c:119
+msgid "FlashAir"
 msgstr ""
 
 # 
-#: ultralcd.cpp:3019
+#: ultralcd.cpp:2972
 msgid "Right"
 msgstr ""
 
 # MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=60
-#: messages.c:38
+#: messages.c:35
 msgid "Searching bed calibration point"
 msgstr ""
 
 # MSG_LANGUAGE_SELECT
-#: ultralcd.cpp:5699
+#: ultralcd.cpp:5756
 msgid "Select language"
 msgstr ""
 
 # MSG_SELFTEST_OK
-#: ultralcd.cpp:7452
+#: ultralcd.cpp:7784
 msgid "Self test OK"
 msgstr ""
 
 # MSG_SELFTEST_START c=20
-#: ultralcd.cpp:7238
+#: ultralcd.cpp:7558
 msgid "Self test start  "
 msgstr ""
 
 # MSG_SELFTEST
-#: ultralcd.cpp:5750
+#: ultralcd.cpp:5820
 msgid "Selftest         "
 msgstr ""
 
 # MSG_SELFTEST_ERROR
-#: ultralcd.cpp:7879
+#: ultralcd.cpp:8216
 msgid "Selftest error !"
 msgstr ""
 
 # MSG_SELFTEST_FAILED c=20
-#: messages.c:77
+#: messages.c:73
 msgid "Selftest failed  "
 msgstr ""
 
 # MSG_FORCE_SELFTEST c=20 r=8
-#: Marlin_main.cpp:1551
+#: Marlin_main.cpp:1532
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr ""
 
 # 
-#: ultralcd.cpp:5045
+#: ultralcd.cpp:5080
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr ""
 
-# 
-#: ultralcd.cpp:4780
-msgid "Select PLA filament:"
-msgstr ""
-
 # MSG_SET_TEMPERATURE c=19 r=1
-#: ultralcd.cpp:3314
+#: ultralcd.cpp:3264
 msgid "Set temperature:"
 msgstr ""
 
 # MSG_SETTINGS
-#: messages.c:86
+#: messages.c:82
 msgid "Settings"
 msgstr ""
 
 # MSG_SHOW_END_STOPS c=17 r=1
-#: ultralcd.cpp:5771
+#: ultralcd.cpp:5841
 msgid "Show end stops"
 msgstr ""
 
 # 
-#: ultralcd.cpp:4025
+#: ultralcd.cpp:3986
 msgid "Sensor state"
 msgstr ""
 
 # MSG_FILE_CNT c=20 r=4
-#: cardreader.cpp:739
+#: cardreader.cpp:729
 msgid "Some files will not be sorted. Max. No. of files in 1 folder for sorting is 100."
 msgstr ""
 
-# MSG_SORT_NONE c=17 r=1
-#: ultralcd.cpp:5332
-msgid "Sort       [none]"
+# MSG_SORT
+#: messages.c:120
+msgid "Sort"
 msgstr ""
 
-# MSG_SORT_TIME c=17 r=1
-#: ultralcd.cpp:5330
-msgid "Sort       [time]"
+# MSG_NONE
+#: messages.c:110
+msgid "None"
+msgstr ""
+
+# MSG_SORT_TIME
+#: messages.c:121
+msgid "Time"
 msgstr ""
 
 # 
-#: ultralcd.cpp:3062
+#: ultralcd.cpp:3015
 msgid "Severe skew:"
 msgstr ""
 
-# MSG_SORT_ALPHA c=17 r=1
-#: ultralcd.cpp:5331
-msgid "Sort   [alphabet]"
+# MSG_SORT_ALPHA
+#: messages.c:122
+msgid "Alphabet"
 msgstr ""
 
 # MSG_SORTING c=20 r=1
-#: cardreader.cpp:746
+#: cardreader.cpp:736
 msgid "Sorting files"
 msgstr ""
 
-# MSG_SOUND_LOUD c=17 r=1
-#: sound.h:6
-msgid "Sound      [loud]"
+# MSG_SOUND_LOUD
+#: messages.c:125
+msgid "Loud"
 msgstr ""
 
 # 
-#: ultralcd.cpp:3061
+#: ultralcd.cpp:3014
 msgid "Slight skew:"
 msgstr ""
 
-# MSG_SOUND_MUTE c=17 r=1
-#: 
-msgid "Sound      [mute]"
+# MSG_SOUND
+#: messages.c:124
+msgid "Sound"
 msgstr ""
 
 # 
-#: Marlin_main.cpp:4871
+#: Marlin_main.cpp:5084
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr ""
 
-# MSG_SOUND_ONCE c=17 r=1
-#: sound.h:7
-msgid "Sound      [once]"
-msgstr ""
-
-# MSG_SOUND_SILENT c=17 r=1
-#: sound.h:8
-msgid "Sound    [silent]"
+# MSG_SOUND_ONCE
+#: messages.c:126
+msgid "Once"
 msgstr ""
 
 # MSG_SPEED
-#: ultralcd.cpp:6926
+#: ultralcd.cpp:7096
 msgid "Speed"
 msgstr ""
 
 # MSG_SELFTEST_FAN_YES c=19
-#: messages.c:80
+#: messages.c:76
 msgid "Spinning"
 msgstr ""
 
 # MSG_TEMP_CAL_WARNING c=20 r=4
-#: Marlin_main.cpp:4368
+#: Marlin_main.cpp:4574
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr ""
 
 # MSG_STATISTICS
-#: ultralcd.cpp:6839
+#: ultralcd.cpp:6955
 msgid "Statistics  "
 msgstr ""
 
 # MSG_STOP_PRINT
-#: messages.c:93
+#: messages.c:91
 msgid "Stop print"
 msgstr ""
 
 # MSG_STOPPED
-#: messages.c:94
+#: messages.c:92
 msgid "STOPPED. "
 msgstr ""
 
 # MSG_SUPPORT
-#: ultralcd.cpp:6848
+#: ultralcd.cpp:6964
 msgid "Support"
 msgstr ""
 
 # MSG_SELFTEST_SWAPPED
-#: ultralcd.cpp:7959
+#: ultralcd.cpp:8296
 msgid "Swapped"
 msgstr ""
 
-# MSG_TEMP_CALIBRATION c=20 r=1
-#: messages.c:95
-msgid "Temp. cal.          "
+# 
+#: ultralcd.cpp:4792
+msgid "Select filament:"
 msgstr ""
 
-# MSG_TEMP_CALIBRATION_ON c=20 r=1
-#: ultralcd.cpp:5686
-msgid "Temp. cal.   [on]"
+# MSG_TEMP_CALIBRATION c=12 r=1
+#: messages.c:93
+msgid "Temp. cal."
 msgstr ""
 
-# MSG_TEMP_CALIBRATION_OFF c=20 r=1
-#: ultralcd.cpp:5684
-msgid "Temp. cal.  [off]"
+# 
+#: ultralcd.cpp:4933
+msgid "Select temperature which matches your material."
 msgstr ""
 
 # MSG_CALIBRATION_PINDA_MENU c=17 r=1
-#: ultralcd.cpp:5780
+#: ultralcd.cpp:5850
 msgid "Temp. calibration"
 msgstr ""
 
 # MSG_TEMP_CAL_FAILED c=20 r=8
-#: ultralcd.cpp:3951
+#: ultralcd.cpp:3911
 msgid "Temperature calibration failed"
 msgstr ""
 
 # MSG_TEMP_CALIBRATION_DONE c=20 r=12
-#: messages.c:96
+#: messages.c:94
 msgid "Temperature calibration is finished and active. Temp. calibration can be disabled in menu Settings->Temp. cal."
 msgstr ""
 
 # MSG_TEMPERATURE
-#: ultralcd.cpp:5650
+#: ultralcd.cpp:5716
 msgid "Temperature"
 msgstr ""
 
 # MSG_MENU_TEMPERATURES c=15 r=1
-#: ultralcd.cpp:2251
+#: ultralcd.cpp:2196
 msgid "Temperatures"
 msgstr ""
 
 # MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=4
-#: messages.c:42
+#: messages.c:39
 msgid "There is still a need to make Z calibration. Please follow the manual, chapter First steps, section Calibration flow."
 msgstr ""
 
 # 
-#: ultralcd.cpp:2908
+#: ultralcd.cpp:2869
 msgid "Total filament"
 msgstr ""
 
 # 
-#: ultralcd.cpp:2908
+#: ultralcd.cpp:2870
 msgid "Total print time"
 msgstr ""
 
 # MSG_TUNE
-#: ultralcd.cpp:6719
+#: ultralcd.cpp:6827
 msgid "Tune"
 msgstr ""
 
 # 
-#: ultralcd.cpp:4869
+#: 
 msgid "Unload"
 msgstr ""
 
 # 
-#: ultralcd.cpp:1820
+#: ultralcd.cpp:1743
 msgid "Total failures"
 msgstr ""
 
 # 
-#: ultralcd.cpp:2324
+#: ultralcd.cpp:2274
 msgid "to load filament"
 msgstr ""
 
 # 
-#: ultralcd.cpp:2328
+#: ultralcd.cpp:2278
 msgid "to unload filament"
 msgstr ""
 
 # MSG_UNLOAD_FILAMENT c=17
-#: messages.c:97
+#: messages.c:95
 msgid "Unload filament"
 msgstr ""
 
 # MSG_UNLOADING_FILAMENT c=20 r=1
-#: messages.c:98
+#: messages.c:96
 msgid "Unloading filament"
 msgstr ""
 
 # 
-#: ultralcd.cpp:1773
+#: ultralcd.cpp:1696
 msgid "Total"
 msgstr ""
 
 # MSG_USED c=19 r=1
-#: ultralcd.cpp:5908
+#: ultralcd.cpp:5978
 msgid "Used during print"
 msgstr ""
 
 # MSG_MENU_VOLTAGES c=15 r=1
-#: ultralcd.cpp:2254
+#: ultralcd.cpp:2199
 msgid "Voltages"
 msgstr ""
 
 # 
-#: ultralcd.cpp:2227
+#: ultralcd.cpp:2172
 msgid "unknown"
 msgstr ""
 
 # MSG_USERWAIT
-#: Marlin_main.cpp:5263
+#: Marlin_main.cpp:5496
 msgid "Wait for user..."
 msgstr ""
 
 # MSG_WAITING_TEMP c=20 r=3
-#: ultralcd.cpp:3458
+#: ultralcd.cpp:3412
 msgid "Waiting for nozzle and bed cooling"
 msgstr ""
 
 # MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ultralcd.cpp:3422
+#: ultralcd.cpp:3373
 msgid "Waiting for PINDA probe cooling"
 msgstr ""
 
 # 
-#: ultralcd.cpp:4868
+#: 
 msgid "Use unload to remove filament 1 if it protrudes outside of the rear MMU tube. Use eject if it is hidden in tube."
 msgstr ""
 
 # MSG_CHANGED_BOTH c=20 r=4
-#: Marlin_main.cpp:1511
+#: Marlin_main.cpp:1492
 msgid "Warning: both printer type and motherboard type changed."
 msgstr ""
 
 # MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: Marlin_main.cpp:1503
+#: Marlin_main.cpp:1484
 msgid "Warning: motherboard type changed."
 msgstr ""
 
 # MSG_CHANGED_PRINTER c=20 r=4
-#: Marlin_main.cpp:1507
+#: Marlin_main.cpp:1488
 msgid "Warning: printer type changed."
 msgstr ""
 
 # MSG_UNLOAD_SUCCESSFUL c=20 r=2
-#: Marlin_main.cpp:3054
+#: Marlin_main.cpp:3106
 msgid "Was filament unload successful?"
 msgstr ""
 
 # MSG_SELFTEST_WIRINGERROR
-#: messages.c:85
+#: messages.c:81
 msgid "Wiring error"
 msgstr ""
 
 # MSG_WIZARD c=17 r=1
-#: ultralcd.cpp:5747
+#: ultralcd.cpp:5811
 msgid "Wizard"
 msgstr ""
 
 # MSG_XYZ_DETAILS c=19 r=1
-#: ultralcd.cpp:2243
+#: ultralcd.cpp:2188
 msgid "XYZ cal. details"
 msgstr ""
 
 # MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: messages.c:19
+#: messages.c:18
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr ""
 
 # MSG_YES
-#: messages.c:104
+#: messages.c:102
 msgid "Yes"
 msgstr ""
 
 # MSG_WIZARD_QUIT c=20 r=8
-#: messages.c:103
+#: messages.c:101
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr ""
 
 # MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ultralcd.cpp:3922
+#: ultralcd.cpp:3882
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr ""
 
 # MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ultralcd.cpp:3919
+#: ultralcd.cpp:3879
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr ""
 
 # 
-#: ultralcd.cpp:5130
+#: ultralcd.cpp:5168
 msgid "X-correct:"
 msgstr ""
 
 # MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ultralcd.cpp:3916
+#: ultralcd.cpp:3876
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr ""
 
 # MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ultralcd.cpp:3900
+#: ultralcd.cpp:3860
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr ""
 
 # MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ultralcd.cpp:3903
+#: ultralcd.cpp:3863
 msgid "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr ""
 
 # MSG_LOAD_ALL c=17
-#: ultralcd.cpp:6166
+#: ultralcd.cpp:6238
 msgid "Load all"
 msgstr ""
 
 # 
-#: ultralcd.cpp:3882
+#: ultralcd.cpp:3842
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr ""
 
 # 
-#: ultralcd.cpp:3888
+#: ultralcd.cpp:3848
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr ""
 
 # 
-#: ultralcd.cpp:3891
+#: ultralcd.cpp:3851
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr ""
 
 # 
-#: ultralcd.cpp:3016
+#: ultralcd.cpp:2969
 msgid "Y distance from min"
 msgstr ""
 
 # 
-#: ultralcd.cpp:5131
+#: ultralcd.cpp:4936
+msgid "The printer will start printing a zig-zag line. Rotate the knob until you reach the optimal height. Check the pictures in the handbook (Calibration chapter)."
+msgstr ""
+
+# 
+#: ultralcd.cpp:5169
 msgid "Y-correct:"
 msgstr ""
 
 # MSG_OFF
-#: menu.cpp:426
-msgid " [off]"
+#: messages.c:105
+msgid "Off"
+msgstr ""
+
+# MSG_ON
+#: messages.c:106
+msgid "On"
 msgstr ""
 
 # 
-#: messages.c:57
+#: messages.c:53
 msgid "Back"
 msgstr ""
 
 # 
-#: ultralcd.cpp:5639
+#: ultralcd.cpp:5702
 msgid "Checks"
 msgstr ""
 
 # 
-#: ultralcd.cpp:7973
+#: ultralcd.cpp:8310
 msgid "False triggering"
 msgstr ""
 
 # 
-#: ultralcd.cpp:4030
+#: ultralcd.cpp:3991
 msgid "FINDA:"
 msgstr ""
 
-# 
-#: ultralcd.cpp:5545
-msgid "Firmware   [none]"
+# MSG_FIRMWARE
+#: language.h:21
+msgid "Firmware"
+msgstr ""
+
+# MSG_STRICT
+#: messages.c:112
+msgid "Strict"
+msgstr ""
+
+# MSG_WARN
+#: messages.c:111
+msgid "Warn"
 msgstr ""
 
 # 
-#: ultralcd.cpp:5551
-msgid "Firmware [strict]"
-msgstr ""
-
-# 
-#: ultralcd.cpp:5548
-msgid "Firmware   [warn]"
-msgstr ""
-
-# 
-#: messages.c:87
+#: messages.c:83
 msgid "HW Setup"
 msgstr ""
 
 # 
-#: ultralcd.cpp:4034
+#: ultralcd.cpp:3995
 msgid "IR:"
 msgstr ""
 
-# 
-#: ultralcd.cpp:7046
-msgid "Magnets comp.[N/A]"
+# MSG_MAGNETS_COMP
+#: messages.c:130
+msgid "Magnets comp."
+msgstr ""
+
+# MSG_MESH
+#: messages.c:128
+msgid "Mesh"
 msgstr ""
 
 # 
-#: ultralcd.cpp:7044
-msgid "Magnets comp.[Off]"
-msgstr ""
-
-# 
-#: ultralcd.cpp:7043
-msgid "Magnets comp. [On]"
-msgstr ""
-
-# 
-#: ultralcd.cpp:7035
-msgid "Mesh         [3x3]"
-msgstr ""
-
-# 
-#: ultralcd.cpp:7036
-msgid "Mesh         [7x7]"
-msgstr ""
-
-# 
-#: ultralcd.cpp:5677
+#: ultralcd.cpp:5740
 msgid "Mesh bed leveling"
 msgstr ""
 
 # 
-#: Marlin_main.cpp:856
+#: Marlin_main.cpp:861
 msgid "MK3S firmware detected on MK3 printer"
 msgstr ""
 
-# 
-#: ultralcd.cpp:5306
-msgid "MMU Mode [Normal]"
+# MSG_MMU_MODE
+#: messages.c:117
+msgid "MMU Mode"
 msgstr ""
 
 # 
-#: ultralcd.cpp:5307
-msgid "MMU Mode[Stealth]"
-msgstr ""
-
-# 
-#: ultralcd.cpp:4511
+#: ultralcd.cpp:4472
 msgid "Mode change in progress ..."
 msgstr ""
 
-# 
-#: ultralcd.cpp:5506
-msgid "Model      [none]"
+# MSG_MODEL
+#: messages.c:113
+msgid "Model"
+msgstr ""
+
+# MSG_NOZZLE_DIAMETER
+#: messages.c:116
+msgid "Nozzle d."
 msgstr ""
 
 # 
-#: ultralcd.cpp:5512
-msgid "Model    [strict]"
-msgstr ""
-
-# 
-#: ultralcd.cpp:5509
-msgid "Model      [warn]"
-msgstr ""
-
-# 
-#: ultralcd.cpp:5467
-msgid "Nozzle d.  [0.25]"
-msgstr ""
-
-# 
-#: ultralcd.cpp:5470
-msgid "Nozzle d.  [0.40]"
-msgstr ""
-
-# 
-#: ultralcd.cpp:5473
-msgid "Nozzle d.  [0.60]"
-msgstr ""
-
-# 
-#: ultralcd.cpp:5421
-msgid "Nozzle     [none]"
-msgstr ""
-
-# 
-#: ultralcd.cpp:5427
-msgid "Nozzle   [strict]"
-msgstr ""
-
-# 
-#: ultralcd.cpp:5424
-msgid "Nozzle     [warn]"
-msgstr ""
-
-# 
-#: util.cpp:510
+#: util.cpp:514
 msgid "G-code sliced for a different level. Continue?"
 msgstr ""
 
 # 
-#: util.cpp:516
+#: util.cpp:520
 msgid "G-code sliced for a different level. Please re-slice the model again. Print cancelled."
 msgstr ""
 
 # 
-#: util.cpp:427
+#: util.cpp:431
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr ""
 
 # 
-#: util.cpp:433
+#: util.cpp:437
 msgid "G-code sliced for a different printer type. Please re-slice the model again. Print cancelled."
 msgstr ""
 
 # 
-#: util.cpp:477
+#: util.cpp:481
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr ""
 
 # 
-#: util.cpp:483
+#: util.cpp:487
 msgid "G-code sliced for a newer firmware. Please update the firmware. Print cancelled."
 msgstr ""
 
 # 
-#: ultralcd.cpp:4026
+#: ultralcd.cpp:3987
 msgid "PINDA:"
 msgstr ""
 
 # 
-#: ultralcd.cpp:2465
+#: ultralcd.cpp:2430
 msgid "Preheating to cut"
 msgstr ""
 
 # 
-#: ultralcd.cpp:2462
+#: ultralcd.cpp:2427
 msgid "Preheating to eject"
 msgstr ""
 
 # 
-#: util.cpp:390
+#: util.cpp:394
 msgid "Printer nozzle diameter differs from the G-code. Continue?"
 msgstr ""
 
 # 
-#: util.cpp:397
+#: util.cpp:401
 msgid "Printer nozzle diameter differs from the G-code. Please check the value in settings. Print cancelled."
 msgstr ""
 
 # 
-#: ultralcd.cpp:6683
+#: ultralcd.cpp:6791
 msgid "Rename"
 msgstr ""
 
 # 
-#: ultralcd.cpp:6679
+#: ultralcd.cpp:6784
 msgid "Select"
 msgstr ""
 
 # 
-#: ultralcd.cpp:2245
+#: ultralcd.cpp:2190
 msgid "Sensor info"
 msgstr ""
 
 # 
-#: messages.c:58
+#: messages.c:54
 msgid "Sheet"
 msgstr ""
 
-# 
-#: sound.h:9
-msgid "Sound    [assist]"
+# MSG_SOUND_BLIND
+#: messages.c:127
+msgid "Assist"
 msgstr ""
 
 # 
-#: ultralcd.cpp:5637
+#: ultralcd.cpp:5700
 msgid "Steel sheets"
 msgstr ""
 
 # 
-#: ultralcd.cpp:5132
+#: ultralcd.cpp:5170
 msgid "Z-correct:"
-msgstr ""
-
-# 
-#: ultralcd.cpp:7038
-msgid "Z-probe nr.    [1]"
-msgstr ""
-
-# 
-#: ultralcd.cpp:7040
-msgid "Z-probe nr.    [3]"
 msgstr ""
 

--- a/lang/po/Firmware_cs.po
+++ b/lang/po/Firmware_cs.po
@@ -7,26 +7,31 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: cs\n"
 "Project-Id-Version: Prusa-Firmware\n"
-"POT-Creation-Date: Sun, Sep 22, 2019 2:03:01 PM\n"
-"PO-Revision-Date: Sun, Sep 22, 2019 2:03:01 PM\n"
+"POT-Creation-Date: Thu, Mar 26, 2020 8:52:39 AM\n"
+"PO-Revision-Date: Thu, Mar 26, 2020 8:52:39 AM\n"
 "Language-Team: \n"
 "X-Generator: Poedit 2.0.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 "Last-Translator: \n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
+# 
+#: 
+msgid "[%.7s]Live adj. Z\x0avalue set, continue\x0aor start from zero?\x0a%cContinue%cReset"
+msgstr "[%.7s]Doladeni Z\x0auz nastaveno, pouzit\x0anebo reset od nuly?\x0a%cPokracovat%cReset"
+
 # MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE2 c=14
-#: messages.c:39
+#: messages.c:36
 msgid " of 4"
 msgstr " z 4"
 
 # MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE2 c=14
-#: messages.c:60
+#: messages.c:56
 msgid " of 9"
 msgstr " z 9"
 
 # MSG_MEASURED_OFFSET
-#: ultralcd.cpp:3089
+#: ultralcd.cpp:3042
 msgid "[0;0] point offset"
 msgstr "[0;0] odsazeni bodu"
 
@@ -41,54 +46,44 @@ msgid "WARNING:\x0aCrash detection\x0adisabled in\x0aStealth mode"
 msgstr "POZOR:\x0aCrash detekce\x0adeaktivovana ve\x0aStealth modu"
 
 # 
-#: ultralcd.cpp:2472
+#: ultralcd.cpp:2438
 msgid ">Cancel"
 msgstr ">Zrusit"
 
 # MSG_BABYSTEPPING_Z c=15
-#: ultralcd.cpp:3209
+#: ultralcd.cpp:3162
 msgid "Adjusting Z:"
 msgstr "Doladeni Z:"
 
 # MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ultralcd.cpp:8295
+#: ultralcd.cpp:8638
 msgid "All correct      "
 msgstr "Vse OK "
 
 # MSG_WIZARD_DONE c=20 r=8
-#: messages.c:101
+#: messages.c:99
 msgid "All is done. Happy printing!"
 msgstr "Vse je hotovo."
 
 # 
-#: ultralcd.cpp:2009
+#: ultralcd.cpp:1947
 msgid "Ambient"
 msgstr "Okoli"
 
 # MSG_PRESS c=20
-#: ultralcd.cpp:2618
+#: ultralcd.cpp:2587
 msgid "and press the knob"
 msgstr "a stisknete tlacitko"
 
 # MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=2
-#: ultralcd.cpp:3529
+#: ultralcd.cpp:3484
 msgid "Are left and right Z~carriages all up?"
 msgstr "Dojely oba Z voziky k~hornimu dorazu?"
 
-# MSG_AUTO_DEPLETE_ON c=17 r=1
-#: ultralcd.cpp:5200
-msgid "SpoolJoin    [on]"
-msgstr "SpoolJoin   [zap]"
-
-# 
-#: ultralcd.cpp:5196
-msgid "SpoolJoin   [N/A]"
+# MSG_AUTO_DEPLETE c=17 r=1
+#: messages.c:108
+msgid "SpoolJoin"
 msgstr ""
-
-# MSG_AUTO_DEPLETE_OFF c=17 r=1
-#: ultralcd.cpp:5204
-msgid "SpoolJoin   [off]"
-msgstr "SpoolJoin   [vyp]"
 
 # MSG_AUTO_HOME
 #: messages.c:11
@@ -96,747 +91,702 @@ msgid "Auto home"
 msgstr ""
 
 # MSG_AUTOLOAD_FILAMENT c=17
-#: ultralcd.cpp:6822
+#: ultralcd.cpp:6938
 msgid "AutoLoad filament"
 msgstr "AutoZavedeni fil."
 
 # MSG_AUTOLOADING_ONLY_IF_FSENS_ON c=20 r=4
-#: ultralcd.cpp:4462
+#: ultralcd.cpp:4423
 msgid "Autoloading filament available only when filament sensor is turned on..."
-msgstr "Automaticke zavadeni filamentu je dostupne pouze pri zapnutem filament senzoru..."
+msgstr "Automaticke zavadeni filamentu je mozne pouze pri zapnutem filament senzoru..."
 
 # MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ultralcd.cpp:2813
+#: ultralcd.cpp:2782
 msgid "Autoloading filament is active, just press the knob and insert filament..."
 msgstr "Automaticke zavadeni filamentu aktivni, stisknete tlacitko a vlozte filament..."
 
 # MSG_SELFTEST_AXIS_LENGTH
-#: ultralcd.cpp:7949
+#: ultralcd.cpp:8286
 msgid "Axis length"
 msgstr "Delka osy"
 
 # MSG_SELFTEST_AXIS
-#: ultralcd.cpp:7951
+#: ultralcd.cpp:8288
 msgid "Axis"
 msgstr "Osa"
 
 # MSG_SELFTEST_BEDHEATER
-#: ultralcd.cpp:7893
+#: ultralcd.cpp:8230
 msgid "Bed / Heater"
 msgstr "Podlozka / Topeni"
 
 # MSG_BED_DONE
-#: messages.c:16
+#: messages.c:15
 msgid "Bed done"
 msgstr "Bed OK."
 
 # MSG_BED_HEATING
-#: messages.c:17
+#: messages.c:16
 msgid "Bed Heating"
 msgstr "Zahrivani bedu"
 
 # MSG_BED_CORRECTION_MENU
-#: ultralcd.cpp:5768
+#: ultralcd.cpp:5838
 msgid "Bed level correct"
 msgstr "Korekce podlozky"
 
 # MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=4
-#: messages.c:18
+#: messages.c:17
 msgid "Bed leveling failed. Sensor didnt trigger. Debris on nozzle? Waiting for reset."
 msgstr "Kalibrace Z selhala. Sensor nesepnul. Znecistena tryska? Cekam na reset."
 
 # MSG_BED
-#: messages.c:15
+#: messages.c:14
 msgid "Bed"
 msgstr "Podlozka"
 
 # MSG_MENU_BELT_STATUS c=15 r=1
-#: ultralcd.cpp:2059
+#: ultralcd.cpp:2004
 msgid "Belt status"
 msgstr "Stav remenu"
 
 # MSG_RECOVER_PRINT c=20 r=2
-#: messages.c:71
+#: messages.c:67
 msgid "Blackout occurred. Recover print?"
 msgstr "Detekovan vypadek proudu.Obnovit tisk?"
 
 # 
-#: ultralcd.cpp:8297
+#: ultralcd.cpp:8640
 msgid "Calibrating home"
 msgstr "Kalibruji vychozi poz."
 
 # MSG_CALIBRATE_BED
-#: ultralcd.cpp:5757
+#: ultralcd.cpp:5827
 msgid "Calibrate XYZ"
 msgstr "Kalibrace XYZ"
 
 # MSG_HOMEYZ
-#: messages.c:48
+#: messages.c:44
 msgid "Calibrate Z"
 msgstr "Kalibrovat Z"
 
 # MSG_CALIBRATE_PINDA c=17 r=1
-#: ultralcd.cpp:4654
+#: ultralcd.cpp:4615
 msgid "Calibrate"
 msgstr "Zkalibrovat"
 
 # MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ultralcd.cpp:3492
+#: ultralcd.cpp:3447
 msgid "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end stoppers. Click when done."
 msgstr "Kalibrace XYZ. Otacenim tlacitka posunte Z osu az k~hornimu dorazu. Potvrdte tlacitkem."
 
 # MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: messages.c:20
+#: messages.c:19
 msgid "Calibrating Z"
 msgstr "Kalibruji Z"
 
 # MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ultralcd.cpp:3492
+#: ultralcd.cpp:3447
 msgid "Calibrating Z. Rotate the knob to move the Z carriage up to the end stoppers. Click when done."
 msgstr "Kalibrace Z. Otacenim tlacitka posunte Z osu az k~hornimu dorazu. Potvrdte tlacitkem."
 
 # MSG_HOMEYZ_DONE
-#: ultralcd.cpp:816
+#: ultralcd.cpp:856
 msgid "Calibration done"
 msgstr "Kalibrace OK"
 
 # MSG_MENU_CALIBRATION
-#: messages.c:61
+#: messages.c:57
 msgid "Calibration"
 msgstr "Kalibrace"
 
 # 
-#: ultralcd.cpp:4781
+#: ultralcd.cpp:4793
 msgid "Cancel"
 msgstr "Zrusit"
 
 # MSG_SD_REMOVED
-#: ultralcd.cpp:8679
+#: ultralcd.cpp:9051
 msgid "Card removed"
 msgstr "Karta vyjmuta"
 
 # MSG_NOT_COLOR
-#: ultralcd.cpp:2718
+#: ultralcd.cpp:2687
 msgid "Color not correct"
 msgstr "Barva neni cista"
 
 # MSG_COOLDOWN
-#: messages.c:23
+#: messages.c:22
 msgid "Cooldown"
 msgstr "Zchladit"
 
 # 
-#: ultralcd.cpp:4587
+#: ultralcd.cpp:4548
 msgid "Copy selected language?"
 msgstr "Kopirovat vybrany jazyk?"
 
-# MSG_CRASHDETECT_ON
-#: messages.c:27
-msgid "Crash det.   [on]"
-msgstr "Crash det.  [zap]"
-
-# MSG_CRASHDETECT_NA
-#: messages.c:25
-msgid "Crash det.  [N/A]"
+# MSG_CRASHDETECT
+#: messages.c:24
+msgid "Crash det."
 msgstr ""
 
-# MSG_CRASHDETECT_OFF
-#: messages.c:26
-msgid "Crash det.  [off]"
-msgstr "Crash det.  [vyp]"
+# 
+#: 
+msgid "Zvolte filament pro kalibraci prvni vrstvy z nasledujiciho menu"
+msgstr "Choose a filament for the First Layer Calibration and select it in the on-screen menu."
 
 # MSG_CRASH_DETECTED c=20 r=1
-#: messages.c:24
+#: messages.c:23
 msgid "Crash detected."
 msgstr "Detekovan naraz."
 
 # 
-#: Marlin_main.cpp:600
+#: Marlin_main.cpp:602
 msgid "Crash detected. Resume print?"
 msgstr "Detekovan naraz. Obnovit tisk?"
 
 # 
-#: ultralcd.cpp:1853
+#: ultralcd.cpp:1776
 msgid "Crash"
 msgstr "Naraz"
 
 # MSG_CURRENT c=19 r=1
-#: ultralcd.cpp:5909
+#: ultralcd.cpp:5979
 msgid "Current"
 msgstr "Pouze aktualni"
 
 # MSG_DATE c=17 r=1
-#: ultralcd.cpp:2213
+#: ultralcd.cpp:2158
 msgid "Date:"
 msgstr "Datum:"
 
 # MSG_DISABLE_STEPPERS
-#: ultralcd.cpp:5654
+#: ultralcd.cpp:5720
 msgid "Disable steppers"
 msgstr "Vypnout motory"
 
 # MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: messages.c:14
+#: messages.c:13
 msgid "Distance between tip of the nozzle and the bed surface has not been set yet. Please follow the manual, chapter First steps, section First layer calibration."
 msgstr "Neni zkalibrovana vzdalenost trysky od tiskove podlozky. Postupujte prosim podle manualu, kapitola Zaciname, odstavec Nastaveni prvni vrstvy."
 
 # MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ultralcd.cpp:5070
+#: ultralcd.cpp:5103
 msgid "Do you want to repeat last step to readjust distance between nozzle and heatbed?"
 msgstr "Chcete opakovat posledni krok a pozmenit vzdalenost mezi tryskou a podlozkou?"
 
 # MSG_EXTRUDER_CORRECTION c=10
-#: ultralcd.cpp:5134
+#: ultralcd.cpp:5172
 msgid "E-correct:"
 msgstr "Korekce E:"
 
 # MSG_EJECT_FILAMENT c=17 r=1
-#: messages.c:53
+#: messages.c:49
 msgid "Eject filament"
 msgstr "Vysunout filament"
 
-# 
-#: ultralcd.cpp:4869
-msgid "Eject"
-msgstr "Vysunout"
-
 # MSG_EJECTING_FILAMENT c=20 r=1
-#: mmu.cpp:1434
+#: mmu.cpp:1415
 msgid "Ejecting filament"
 msgstr "Vysouvam filament"
 
 # MSG_SELFTEST_ENDSTOP_NOTHIT c=20 r=1
-#: ultralcd.cpp:7917
+#: ultralcd.cpp:8254
 msgid "Endstop not hit"
 msgstr "Kon. spinac nesepnut"
 
 # MSG_SELFTEST_ENDSTOP
-#: ultralcd.cpp:7911
+#: ultralcd.cpp:8248
 msgid "Endstop"
 msgstr "Koncovy spinac"
 
 # MSG_SELFTEST_ENDSTOPS
-#: ultralcd.cpp:7899
+#: ultralcd.cpp:8236
 msgid "Endstops"
 msgstr "Konc. spinace"
 
 # MSG_STACK_ERROR c=20 r=4
-#: ultralcd.cpp:6859
+#: ultralcd.cpp:6975
 msgid "Error - static memory has been overwritten"
 msgstr "Chyba - Doslo k prepisu staticke pameti!"
 
 # MSG_FSENS_NOT_RESPONDING c=20 r=4
-#: ultralcd.cpp:4475
+#: ultralcd.cpp:4436
 msgid "ERROR: Filament sensor is not responding, please check connection."
 msgstr "CHYBA: Filament senzor nereaguje, zkontrolujte zapojeni."
 
 # MSG_ERROR
-#: messages.c:28
+#: messages.c:25
 msgid "ERROR:"
 msgstr "CHYBA:"
 
 # MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
-#: ultralcd.cpp:8304
+#: ultralcd.cpp:8647
 msgid "Extruder fan:"
 msgstr "Levy vent.:"
 
 # MSG_INFO_EXTRUDER c=15 r=1
-#: ultralcd.cpp:2244
+#: ultralcd.cpp:2189
 msgid "Extruder info"
 msgstr ""
 
 # MSG_MOVE_E
-#: messages.c:29
+#: messages.c:26
 msgid "Extruder"
 msgstr ""
 
 # 
-#: ultralcd.cpp:6846
+#: ultralcd.cpp:6962
 msgid "Fail stats MMU"
 msgstr "Selhani MMU"
 
-# MSG_FSENS_AUTOLOAD_ON c=17 r=1
-#: ultralcd.cpp:5168
-msgid "F. autoload  [on]"
-msgstr "F. autozav. [zap]"
-
-# MSG_FSENS_AUTOLOAD_NA c=17 r=1
-#: messages.c:43
-msgid "F. autoload [N/A]"
-msgstr "F. autozav. [N/A]"
-
-# MSG_FSENS_AUTOLOAD_OFF c=17 r=1
-#: ultralcd.cpp:5170
-msgid "F. autoload [off]"
-msgstr "F. autozav. [vyp]"
+# MSG_FSENSOR_AUTOLOAD
+#: messages.c:40
+msgid "F. autoload"
+msgstr "F. autozav."
 
 # 
-#: ultralcd.cpp:6843
+#: ultralcd.cpp:6959
 msgid "Fail stats"
 msgstr "Selhani"
 
 # MSG_FAN_SPEED c=14
-#: messages.c:31
+#: messages.c:28
 msgid "Fan speed"
 msgstr "Rychlost vent."
 
 # MSG_SELFTEST_FAN c=20
-#: messages.c:78
+#: messages.c:74
 msgid "Fan test"
 msgstr "Test ventilatoru"
 
-# MSG_FANS_CHECK_ON c=17 r=1
-#: ultralcd.cpp:5663
-msgid "Fans check   [on]"
-msgstr "Kontr. vent.[zap]"
+# MSG_FANS_CHECK
+#: ultralcd.cpp:5728
+msgid "Fans check"
+msgstr "Kontr. vent."
 
-# MSG_FANS_CHECK_OFF c=17 r=1
-#: ultralcd.cpp:5665
-msgid "Fans check  [off]"
-msgstr "Kontr. vent.[vyp]"
-
-# MSG_FSENSOR_ON
-#: messages.c:45
-msgid "Fil. sensor  [on]"
-msgstr "Fil. senzor [zap]"
-
-# MSG_FSENSOR_NA
-#: ultralcd.cpp:5148
-msgid "Fil. sensor [N/A]"
-msgstr "Fil. senzor [N/A]"
-
-# MSG_FSENSOR_OFF
-#: messages.c:44
-msgid "Fil. sensor [off]"
-msgstr "Fil. senzor [vyp]"
+# MSG_FSENSOR
+#: messages.c:41
+msgid "Fil. sensor"
+msgstr "Fil. senzor"
 
 # 
-#: ultralcd.cpp:1852
+#: ultralcd.cpp:1775
 msgid "Filam. runouts"
 msgstr "Vypadky filam."
 
 # MSG_FILAMENT_CLEAN c=20 r=2
-#: messages.c:32
+#: messages.c:29
 msgid "Filament extruding & with correct color?"
 msgstr "Filament vytlacen a spravne barvy?"
 
 # MSG_NOT_LOADED c=19
-#: ultralcd.cpp:2714
+#: ultralcd.cpp:2683
 msgid "Filament not loaded"
 msgstr "Filament nezaveden"
 
 # MSG_FILAMENT_SENSOR c=20
-#: messages.c:84
+#: messages.c:80
 msgid "Filament sensor"
 msgstr "Senzor filamentu"
 
 # MSG_FILAMENT_USED c=19 r=1
-#: ultralcd.cpp:2885
+#: ultralcd.cpp:2847
 msgid "Filament used"
 msgstr "Spotrebovano filamentu"
 
 # MSG_PRINT_TIME c=19 r=1
-#: ultralcd.cpp:2886
+#: ultralcd.cpp:2848
 msgid "Print time"
 msgstr "Cas tisku"
 
 # MSG_FILE_INCOMPLETE c=20 r=2
-#: ultralcd.cpp:8432
+#: ultralcd.cpp:8775
 msgid "File incomplete. Continue anyway?"
 msgstr "Soubor nekompletni. Pokracovat?"
 
 # MSG_FINISHING_MOVEMENTS c=20 r=1
-#: messages.c:40
+#: messages.c:37
 msgid "Finishing movements"
 msgstr "Dokoncovani pohybu"
 
 # MSG_V2_CALIBRATION c=17 r=1
-#: messages.c:105
+#: messages.c:103
 msgid "First layer cal."
 msgstr "Kal. prvni vrstvy"
 
 # MSG_WIZARD_SELFTEST c=20 r=8
-#: ultralcd.cpp:4982
+#: ultralcd.cpp:5024
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr "Nejdriv pomoci selftestu zkontoluji nejcastejsi chyby vznikajici pri sestaveni tiskarny."
 
 # 
-#: mmu.cpp:724
+#: mmu.cpp:726
 msgid "Fix the issue and then press button on MMU unit."
 msgstr "Opravte chybu a pote stisknete tlacitko na jednotce MMU."
 
 # MSG_FLOW
-#: ultralcd.cpp:6932
+#: ultralcd.cpp:7102
 msgid "Flow"
 msgstr "Prutok"
 
 # MSG_PRUSA3D_FORUM
-#: ultralcd.cpp:2206
+#: ultralcd.cpp:2151
 msgid "forum.prusa3d.com"
 msgstr ""
 
 # MSG_SELFTEST_COOLING_FAN c=20
-#: messages.c:75
+#: messages.c:71
 msgid "Front print fan?"
 msgstr "Predni tiskovy vent?"
 
 # MSG_BED_CORRECTION_FRONT c=14 r=1
-#: ultralcd.cpp:3294
+#: ultralcd.cpp:3244
 msgid "Front side[um]"
 msgstr "Vpredu [um]"
 
 # MSG_SELFTEST_FANS
-#: ultralcd.cpp:7957
+#: ultralcd.cpp:8294
 msgid "Front/left fans"
 msgstr "Predni/levy vent."
 
 # MSG_SELFTEST_HEATERTHERMISTOR
-#: ultralcd.cpp:7887
+#: ultralcd.cpp:8224
 msgid "Heater/Thermistor"
 msgstr "Topeni/Termistor"
 
 # MSG_BED_HEATING_SAFETY_DISABLED
-#: Marlin_main.cpp:8467
+#: Marlin_main.cpp:9458
 msgid "Heating disabled by safety timer."
 msgstr "Zahrivani preruseno bezpecnostnim casovacem."
 
 # MSG_HEATING_COMPLETE c=20
-#: messages.c:47
+#: messages.c:43
 msgid "Heating done."
 msgstr "Zahrivani OK."
 
 # MSG_HEATING
-#: messages.c:46
+#: messages.c:42
 msgid "Heating"
 msgstr "Zahrivani"
 
 # MSG_WIZARD_WELCOME c=20 r=7
-#: ultralcd.cpp:4961
+#: ultralcd.cpp:5003
 msgid "Hi, I am your Original Prusa i3 printer. Would you like me to guide you through the setup process?"
 msgstr "Dobry den, jsem vase tiskarna Original Prusa i3. Chcete abych Vas provedla kalibracnim procesem?"
 
 # MSG_PRUSA3D_HOWTO
-#: ultralcd.cpp:2207
+#: ultralcd.cpp:2152
 msgid "howto.prusa3d.com"
 msgstr ""
 
 # MSG_FILAMENTCHANGE
-#: messages.c:37
+#: messages.c:34
 msgid "Change filament"
 msgstr "Vymenit filament"
 
 # MSG_CHANGE_SUCCESS
-#: ultralcd.cpp:2629
+#: ultralcd.cpp:2598
 msgid "Change success!"
 msgstr "Zmena uspesna!"
 
 # MSG_CORRECTLY c=20
-#: ultralcd.cpp:2706
+#: ultralcd.cpp:2675
 msgid "Changed correctly?"
 msgstr "Vymena ok?"
 
 # MSG_SELFTEST_CHECK_BED c=20
-#: messages.c:81
+#: messages.c:77
 msgid "Checking bed     "
 msgstr "Kontrola podlozky"
 
 # MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ultralcd.cpp:8286
+#: ultralcd.cpp:8629
 msgid "Checking endstops"
 msgstr "Kontrola endstopu"
 
 # MSG_SELFTEST_CHECK_HOTEND c=20
-#: ultralcd.cpp:8292
+#: ultralcd.cpp:8635
 msgid "Checking hotend  "
 msgstr "Kontrola hotend "
 
 # MSG_SELFTEST_CHECK_FSENSOR c=20
-#: messages.c:82
+#: messages.c:78
 msgid "Checking sensors "
 msgstr "Kontrola senzoru"
 
 # MSG_SELFTEST_CHECK_X c=20
-#: ultralcd.cpp:8287
+#: ultralcd.cpp:8630
 msgid "Checking X axis  "
 msgstr "Kontrola osy X"
 
 # MSG_SELFTEST_CHECK_Y c=20
-#: ultralcd.cpp:8288
+#: ultralcd.cpp:8631
 msgid "Checking Y axis  "
 msgstr "Kontrola osy Y"
 
 # MSG_SELFTEST_CHECK_Z c=20
-#: ultralcd.cpp:8289
+#: ultralcd.cpp:8632
 msgid "Checking Z axis  "
 msgstr "Kontrola osy Z"
 
 # MSG_CHOOSE_EXTRUDER c=20 r=1
-#: messages.c:49
+#: messages.c:45
 msgid "Choose extruder:"
 msgstr "Vyberte extruder:"
 
 # MSG_CHOOSE_FILAMENT c=20 r=1
-#: messages.c:50
+#: messages.c:46
 msgid "Choose filament:"
 msgstr "Vyber filament:"
 
 # MSG_FILAMENT c=17 r=1
-#: messages.c:30
+#: messages.c:27
 msgid "Filament"
 msgstr ""
 
 # MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ultralcd.cpp:4991
+#: ultralcd.cpp:5033
 msgid "I will run xyz calibration now. It will take approx. 12 mins."
 msgstr "Nyni provedu xyz kalibraci. Zabere to priblizne 12 min."
 
 # MSG_WIZARD_Z_CAL c=20 r=8
-#: ultralcd.cpp:4999
+#: ultralcd.cpp:5041
 msgid "I will run z calibration now."
 msgstr "Nyni provedu z kalibraci."
 
-# MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ultralcd.cpp:5064
-msgid "I will start to print line and you will gradually lower the nozzle by rotating the knob, until you reach optimal height. Check the pictures in our handbook in chapter Calibration."
-msgstr "Zacnu tisknout linku a Vy budete postupne snizovat trysku otacenim tlacitka dokud nedosahnete optimalni vysky. Prohlednete si obrazky v nasi prirucce v kapitole Kalibrace."
-
 # MSG_WATCH
-#: messages.c:99
+#: messages.c:97
 msgid "Info screen"
 msgstr "Informace"
 
-# 
-#: ultralcd.cpp:5024
-msgid "Is filament 1 loaded?"
-msgstr "Je filament 1 zaveden?"
-
 # MSG_INSERT_FILAMENT c=20
-#: ultralcd.cpp:2614
+#: ultralcd.cpp:2583
 msgid "Insert filament"
 msgstr "Vlozte filament"
 
 # MSG_WIZARD_FILAMENT_LOADED c=20 r=2
-#: ultralcd.cpp:5027
+#: ultralcd.cpp:4813
 msgid "Is filament loaded?"
 msgstr "Je filament zaveden?"
 
-# MSG_WIZARD_PLA_FILAMENT c=20 r=2
-#: ultralcd.cpp:5058
-msgid "Is it PLA filament?"
-msgstr "Je to PLA filament?"
-
-# MSG_PLA_FILAMENT_LOADED c=20 r=2
-#: ultralcd.cpp:4790
-msgid "Is PLA filament loaded?"
-msgstr "Je PLA filament zaveden?"
-
 # MSG_STEEL_SHEET_CHECK c=20 r=2
-#: messages.c:92
+#: messages.c:90
 msgid "Is steel sheet on heatbed?"
 msgstr "Je tiskovy plat na podlozce?"
 
 # 
-#: ultralcd.cpp:1795
+#: ultralcd.cpp:1718
 msgid "Last print failures"
 msgstr "Selhani posl. tisku"
 
 # 
-#: ultralcd.cpp:1772
+#: ultralcd.cpp:5111
+msgid "If you have additional steel sheets, calibrate their presets in Settings - HW Setup - Steel sheets."
+msgstr "Mate-li vice tiskovych platu, kalibrujte je v menu Nastaveni - HW nastaveni - Tiskove platy"
+
+# 
+#: ultralcd.cpp:1695
 msgid "Last print"
 msgstr "Posledni tisk"
 
 # MSG_SELFTEST_EXTRUDER_FAN c=20
-#: messages.c:76
+#: messages.c:72
 msgid "Left hotend fan?"
 msgstr "Levy vent na trysce?"
 
 # 
-#: ultralcd.cpp:3018
+#: ultralcd.cpp:2971
 msgid "Left"
 msgstr "Vlevo"
 
 # MSG_BED_CORRECTION_LEFT c=14 r=1
-#: ultralcd.cpp:3292
+#: ultralcd.cpp:3242
 msgid "Left side [um]"
 msgstr "Vlevo [um]"
 
 # 
-#: ultralcd.cpp:5680
+#: ultralcd.cpp:5743
 msgid "Lin. correction"
 msgstr "Korekce lin."
 
 # MSG_BABYSTEP_Z
-#: messages.c:13
+#: messages.c:12
 msgid "Live adjust Z"
 msgstr "Doladeni osy Z"
 
 # MSG_LOAD_FILAMENT c=17
-#: messages.c:51
+#: messages.c:47
 msgid "Load filament"
 msgstr "Zavest filament"
 
 # MSG_LOADING_COLOR
-#: ultralcd.cpp:2654
+#: ultralcd.cpp:2623
 msgid "Loading color"
 msgstr "Cisteni barvy"
 
 # MSG_LOADING_FILAMENT c=20
-#: messages.c:52
+#: messages.c:48
 msgid "Loading filament"
 msgstr "Zavadeni filamentu"
 
 # MSG_LOOSE_PULLEY c=20 r=1
-#: ultralcd.cpp:7941
+#: ultralcd.cpp:8278
 msgid "Loose pulley"
 msgstr "Uvolnena remenicka"
 
 # 
-#: ultralcd.cpp:6805
+#: ultralcd.cpp:6921
 msgid "Load to nozzle"
 msgstr "Zavest do trysky"
 
 # MSG_M117_V2_CALIBRATION c=25 r=1
-#: messages.c:55
+#: messages.c:51
 msgid "M117 First layer cal."
 msgstr "M117 Kal. prvni vrstvy"
 
 # MSG_MAIN
-#: messages.c:56
+#: messages.c:52
 msgid "Main"
 msgstr "Hlavni nabidka"
 
 # MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=60
-#: messages.c:59
+#: messages.c:55
 msgid "Measuring reference height of calibration point"
 msgstr "Merim referencni vysku kalibracniho bodu"
 
 # MSG_MESH_BED_LEVELING
-#: ultralcd.cpp:5763
+#: ultralcd.cpp:5833
 msgid "Mesh Bed Leveling"
 msgstr ""
 
 # MSG_MMU_OK_RESUMING_POSITION c=20 r=4
-#: mmu.cpp:762
+#: mmu.cpp:764
 msgid "MMU OK. Resuming position..."
 msgstr "MMU OK. Pokracuji v tisku..."
 
 # MSG_MMU_OK_RESUMING_TEMPERATURE c=20 r=4
-#: mmu.cpp:755
+#: mmu.cpp:757
 msgid "MMU OK. Resuming temperature..."
 msgstr "MMU OK. Pokracuji v nahrivani..."
 
 # 
-#: ultralcd.cpp:3059
+#: ultralcd.cpp:3012
 msgid "Measured skew"
 msgstr "Merene zkoseni"
 
-# 
-#: ultralcd.cpp:1796
+#  c=13 r=1
+#: ultralcd.cpp:1719
 msgid "MMU fails"
 msgstr "Selhani MMU"
 
 # 
-#: mmu.cpp:1613
+#: mmu.cpp:1587
 msgid "MMU load failed     "
 msgstr "Zavedeni MMU selhalo"
 
-# 
-#: ultralcd.cpp:1797
-msgid "MMU load fails"
+#  c=13 r=1
+#: ultralcd.cpp:1720
+msgid "MMU load f."
 msgstr "MMU selhani zavadeni"
 
 # MSG_MMU_OK_RESUMING c=20 r=4
-#: mmu.cpp:773
+#: mmu.cpp:775
 msgid "MMU OK. Resuming..."
 msgstr "MMU OK. Pokracuji..."
 
-# MSG_STEALTH_MODE_OFF
-#: messages.c:90
-msgid "Mode     [Normal]"
-msgstr "Mod      [Normal]"
+# MSG_MODE
+#: messages.c:84
+msgid "Mode"
+msgstr "Mod"
 
-# MSG_SILENT_MODE_ON
-#: messages.c:89
-msgid "Mode     [silent]"
-msgstr "Mod       [tichy]"
+# MSG_NORMAL
+#: messages.c:88
+msgid "Normal"
+msgstr ""
+
+# MSG_SILENT
+#: messages.c:87
+msgid "Silent"
+msgstr "Tichy"
 
 # 
-#: mmu.cpp:719
+#: mmu.cpp:721
 msgid "MMU needs user attention."
 msgstr "MMU potrebuje zasah uzivatele."
 
-# 
-#: ultralcd.cpp:1823
-msgid "MMU power fails"
+#  c=14 r=1
+#: ultralcd.cpp:1746
+msgid "MMU power f."
 msgstr "MMU vypadky proudu"
 
-# MSG_STEALTH_MODE_ON
-#: messages.c:91
-msgid "Mode    [Stealth]"
-msgstr "Mod       [tichy]"
+# MSG_STEALTH
+#: messages.c:89
+msgid "Stealth"
+msgstr "Tichy"
 
-# MSG_AUTO_MODE_ON
-#: messages.c:12
-msgid "Mode [auto power]"
-msgstr "Mod [automaticky]"
+# MSG_AUTO_POWER
+#: messages.c:86
+msgid "Auto power"
+msgstr "Automaticky"
 
-# MSG_SILENT_MODE_OFF
-#: messages.c:88
-msgid "Mode [high power]"
-msgstr "Mod  [vys. vykon]"
+# MSG_HIGH_POWER
+#: messages.c:85
+msgid "High power"
+msgstr "Vys. vykon"
 
 # 
-#: ultralcd.cpp:2219
+#: ultralcd.cpp:2164
 msgid "MMU2 connected"
 msgstr "MMU2 pripojeno"
 
 # MSG_SELFTEST_MOTOR
-#: messages.c:83
+#: messages.c:79
 msgid "Motor"
 msgstr ""
 
 # MSG_MOVE_AXIS
-#: ultralcd.cpp:5652
+#: ultralcd.cpp:5718
 msgid "Move axis"
 msgstr "Posunout osu"
 
 # MSG_MOVE_X
-#: ultralcd.cpp:4378
+#: ultralcd.cpp:4339
 msgid "Move X"
 msgstr "Posunout X"
 
 # MSG_MOVE_Y
-#: ultralcd.cpp:4379
+#: ultralcd.cpp:4340
 msgid "Move Y"
 msgstr "Posunout Y"
 
 # MSG_MOVE_Z
-#: ultralcd.cpp:4380
+#: ultralcd.cpp:4341
 msgid "Move Z"
 msgstr "Posunout Z"
 
 # MSG_NO_MOVE
-#: Marlin_main.cpp:5292
+#: Marlin_main.cpp:5526
 msgid "No move."
 msgstr "Bez pohybu."
 
 # MSG_NO_CARD
-#: ultralcd.cpp:6772
+#: ultralcd.cpp:6888
 msgid "No SD card"
 msgstr "Zadna SD karta"
 
-# 
-#: ultralcd.cpp:3024
+# MSG_NA
+#: messages.c:107
 msgid "N/A"
 msgstr ""
 
 # MSG_NO
-#: messages.c:62
+#: messages.c:58
 msgid "No"
 msgstr "Ne"
 
 # MSG_SELFTEST_NOTCONNECTED
-#: ultralcd.cpp:7889
+#: ultralcd.cpp:8226
 msgid "Not connected"
 msgstr "Nezapojeno "
 
@@ -846,167 +796,152 @@ msgid "New firmware version available:"
 msgstr "Vysla nova verze firmware:"
 
 # MSG_SELFTEST_FAN_NO c=19
-#: messages.c:79
+#: messages.c:75
 msgid "Not spinning"
 msgstr "Netoci se"
 
 # MSG_WIZARD_V2_CAL c=20 r=8
-#: ultralcd.cpp:5063
+#: ultralcd.cpp:4924
 msgid "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr "Nyni zkalibruji vzdalenost mezi koncem trysky a povrchem podlozky."
 
 # MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ultralcd.cpp:5007
+#: ultralcd.cpp:5049
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Nyni predehreji trysku pro PLA."
 
 # MSG_NOZZLE
-#: messages.c:63
+#: messages.c:59
 msgid "Nozzle"
 msgstr "Tryska"
 
 # MSG_DEFAULT_SETTINGS_LOADED c=20 r=4
-#: Marlin_main.cpp:1519
+#: Marlin_main.cpp:1500
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr "Neplatne hodnoty nastaveni. Bude pouzito vychozi PID, Esteps atd."
 
 # 
-#: ultralcd.cpp:4998
+#: ultralcd.cpp:5040
 msgid "Now remove the test print from steel sheet."
 msgstr "Nyni odstrante testovaci vytisk z tiskoveho platu."
 
 # 
-#: ultralcd.cpp:1722
+#: ultralcd.cpp:1645
 msgid "Nozzle FAN"
 msgstr "Vent. trysky"
 
 # MSG_PAUSE_PRINT
-#: ultralcd.cpp:6735
+#: ultralcd.cpp:6852
 msgid "Pause print"
 msgstr "Pozastavit tisk"
 
 # MSG_PID_RUNNING c=20 r=1
-#: ultralcd.cpp:1606
+#: ultralcd.cpp:1530
 msgid "PID cal.           "
 msgstr "PID kal. "
 
 # MSG_PID_FINISHED c=20 r=1
-#: ultralcd.cpp:1612
+#: ultralcd.cpp:1536
 msgid "PID cal. finished"
 msgstr "PID kal. ukoncena"
 
 # MSG_PID_EXTRUDER c=17 r=1
-#: ultralcd.cpp:5769
+#: ultralcd.cpp:5839
 msgid "PID calibration"
 msgstr "PID kalibrace"
 
 # MSG_PINDA_PREHEAT c=20 r=1
-#: ultralcd.cpp:846
+#: ultralcd.cpp:887
 msgid "PINDA Heating"
 msgstr "Nahrivani PINDA"
 
 # MSG_PAPER c=20 r=8
-#: messages.c:64
+#: messages.c:60
 msgid "Place a sheet of paper under the nozzle during the calibration of first 4 points. If the nozzle catches the paper, power off the printer immediately."
 msgstr "Umistete list papiru na podlozku a udrzujte jej pod tryskou behem mereni prvnich 4 bodu. Pokud tryska zachyti papir, okamzite vypnete tiskarnu."
 
 # MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ultralcd.cpp:5072
+#: ultralcd.cpp:5106
 msgid "Please clean heatbed and then press the knob."
 msgstr "Prosim ocistete podlozku a stisknete tlacitko."
 
 # MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: messages.c:22
+#: messages.c:21
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Pro uspesnou kalibraci ocistete prosim tiskovou trysku. Potvrdte tlacitkem."
 
 # MSG_SELFTEST_PLEASECHECK
-#: ultralcd.cpp:7881
+#: ultralcd.cpp:8218
 msgid "Please check :"
 msgstr "Zkontrolujte :"
 
 # MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: messages.c:100
+#: messages.c:98
 msgid "Please check our handbook and fix the problem. Then resume the Wizard by rebooting the printer."
 msgstr "Prosim nahlednete do prirucky 3D tiskare a opravte problem. Pote obnovte Pruvodce restartovanim tiskarny."
 
-# MSG_WIZARD_LOAD_FILAMENT c=20 r=8
-#: ultralcd.cpp:4894
-msgid "Please insert PLA filament to the extruder, then press knob to load it."
-msgstr "Prosim vlozte PLA filament do extruderu, pote stisknete tlacitko pro zavedeni filamentu."
-
-# MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ultralcd.cpp:4795
-msgid "Please load PLA filament first."
-msgstr "Nejdrive prosim zavedte PLA filament."
-
 # MSG_CHECK_IDLER c=20 r=4
-#: Marlin_main.cpp:3064
+#: Marlin_main.cpp:3116
 msgid "Please open idler and remove filament manually."
 msgstr "Prosim otevrete idler a manualne odstrante filament."
 
 # MSG_PLACE_STEEL_SHEET c=20 r=4
-#: messages.c:65
+#: messages.c:61
 msgid "Please place steel sheet on heatbed."
 msgstr "Umistete prosim tiskovy plat na podlozku"
 
 # MSG_PRESS_TO_UNLOAD c=20 r=4
-#: messages.c:68
+#: messages.c:64
 msgid "Please press the knob to unload filament"
 msgstr "Pro vysunuti filamentu stisknete prosim tlacitko"
 
-# 
-#: ultralcd.cpp:4889
-msgid "Please insert PLA filament to the first tube of MMU, then press the knob to load it."
-msgstr "Prosim vlozte PLA filament do trubicky MMU, pote stisknete tlacitko pro zavedeni filamentu."
-
 # MSG_PULL_OUT_FILAMENT c=20 r=4
-#: messages.c:70
+#: messages.c:66
 msgid "Please pull out filament immediately"
 msgstr "Prosim vyjmete urychlene filament"
 
 # MSG_EJECT_REMOVE c=20 r=4
-#: mmu.cpp:1440
+#: mmu.cpp:1421
 msgid "Please remove filament and then press the knob."
 msgstr "Prosim vyjmete filament a pote stisknete tlacitko."
 
 # MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: messages.c:74
+#: messages.c:70
 msgid "Please remove steel sheet from heatbed."
 msgstr "Odstrante prosim tiskovy plat z podlozky."
 
 # MSG_RUN_XYZ c=20 r=4
-#: Marlin_main.cpp:4355
+#: Marlin_main.cpp:4561
 msgid "Please run XYZ calibration first."
 msgstr "Nejprve spustte kalibraci XYZ."
 
 # MSG_UPDATE_MMU2_FW c=20 r=4
-#: mmu.cpp:1359
+#: mmu.cpp:1340
 msgid "Please update firmware in your MMU2. Waiting for reset."
 msgstr "Prosim aktualizujte firmware ve vasi MMU2 jednotce. Cekam na reset."
 
 # MSG_PLEASE_WAIT c=20
-#: messages.c:66
+#: messages.c:62
 msgid "Please wait"
 msgstr "Prosim cekejte"
 
 # 
-#: ultralcd.cpp:4997
+#: ultralcd.cpp:5039
 msgid "Please remove shipping helpers first."
 msgstr "Nejprve prosim sundejte transportni soucastky."
 
 # MSG_PREHEAT_NOZZLE c=20
-#: messages.c:67
+#: messages.c:63
 msgid "Preheat the nozzle!"
 msgstr "Predehrejte trysku!"
 
 # MSG_PREHEAT
-#: ultralcd.cpp:6722
+#: ultralcd.cpp:6830
 msgid "Preheat"
 msgstr "Predehrev"
 
 # MSG_WIZARD_HEATING c=20 r=3
-#: messages.c:102
+#: messages.c:100
 msgid "Preheating nozzle. Please wait."
 msgstr "Predehrev trysky. Prosim cekejte."
 
@@ -1016,82 +951,97 @@ msgid "Please upgrade."
 msgstr "Prosim aktualizujte."
 
 # MSG_PRESS_TO_PREHEAT c=20 r=4
-#: Marlin_main.cpp:10364
+#: Marlin_main.cpp:11469
 msgid "Press knob to preheat nozzle and continue."
 msgstr "Pro nahrati trysky a pokracovani stisknete tlacitko."
 
 # 
-#: ultralcd.cpp:1851
+#: ultralcd.cpp:1774
 msgid "Power failures"
 msgstr "Vypadky proudu"
 
 # MSG_PRINT_ABORTED c=20
-#: messages.c:69
+#: messages.c:65
 msgid "Print aborted"
 msgstr "Tisk prerusen"
 
 # 
-#: ultralcd.cpp:2455
+#: ultralcd.cpp:2420
 msgid "Preheating to load"
 msgstr "Predehrev k zavedeni"
 
 # 
-#: ultralcd.cpp:2459
+#: ultralcd.cpp:2424
 msgid "Preheating to unload"
 msgstr "Predehrev k vyjmuti"
 
 # MSG_SELFTEST_PRINT_FAN_SPEED c=18
-#: ultralcd.cpp:8307
+#: ultralcd.cpp:8650
 msgid "Print fan:"
 msgstr "Tiskovy vent.:"
 
 # MSG_CARD_MENU
-#: messages.c:21
+#: messages.c:20
 msgid "Print from SD"
 msgstr "Tisk z SD"
 
 # 
-#: ultralcd.cpp:2317
+#: ultralcd.cpp:2267
 msgid "Press the knob"
 msgstr "Stisknete hl. tlacitko"
 
 # MSG_PRINT_PAUSED c=20 r=1
-#: ultralcd.cpp:1069
+#: ultralcd.cpp:1109
 msgid "Print paused"
 msgstr "Tisk pozastaven"
 
 # 
-#: mmu.cpp:723
+#: mmu.cpp:725
 msgid "Press the knob to resume nozzle temperature."
 msgstr "Pro pokracovani nahrivani trysky stisknete tlacitko."
 
 # MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: messages.c:41
+#: messages.c:38
 msgid "Printer has not been calibrated yet. Please follow the manual, chapter First steps, section Calibration flow."
 msgstr "Tiskarna nebyla jeste zkalibrovana. Postupujte prosim podle manualu, kapitola Zaciname, odstavec Postup kalibrace."
 
 # 
-#: ultralcd.cpp:1723
+#: ultralcd.cpp:1646
 msgid "Print FAN"
 msgstr "Tiskovy vent."
 
+# 
+#: ultralcd.cpp:4904
+msgid "Please insert filament into the extruder, then press the knob to load it."
+msgstr "Prosim vlozte filament do extruderu a stisknete tlacitko k jeho zavedeni"
+
+# 
+#: ultralcd.cpp:4899
+msgid "Please insert filament into the first tube of the MMU, then press the knob to load it."
+msgstr "Prosim vlozte filament do prvni trubicky MMU a stisknete tlacitko k jeho zavedeni"
+
+# 
+#: ultralcd.cpp:4821
+msgid "Please load filament first."
+msgstr "Prosim nejdriv zavedte filament"
+
 # MSG_PRUSA3D
-#: ultralcd.cpp:2205
+#: ultralcd.cpp:2150
 msgid "prusa3d.com"
 msgstr ""
 
 # MSG_BED_CORRECTION_REAR c=14 r=1
-#: ultralcd.cpp:3295
+#: ultralcd.cpp:3245
 msgid "Rear side [um]"
 msgstr "Vzadu [um]"
 
 # MSG_RECOVERING_PRINT c=20 r=1
-#: Marlin_main.cpp:9764
+#: Marlin_main.cpp:10826
 msgid "Recovering print    "
 msgstr "Obnovovani tisku "
 
 # MSG_REMOVE_OLD_FILAMENT c=20 r=4
-#: mmu.cpp:830
+#: mmu.cpp:832
 msgid "Remove old filament and press the knob to start loading new filament."
 msgstr "Vyjmete stary filament a stisknete tlacitko pro zavedeni noveho."
 
@@ -1101,712 +1051,647 @@ msgid "Prusa i3 MK3S OK."
 msgstr ""
 
 # MSG_CALIBRATE_BED_RESET
-#: ultralcd.cpp:5774
+#: ultralcd.cpp:5844
 msgid "Reset XYZ calibr."
 msgstr "Reset XYZ kalibr."
 
 # MSG_BED_CORRECTION_RESET
-#: ultralcd.cpp:3296
+#: ultralcd.cpp:3246
 msgid "Reset"
 msgstr ""
 
 # MSG_RESUME_PRINT
-#: ultralcd.cpp:6742
+#: ultralcd.cpp:6838
 msgid "Resume print"
 msgstr "Pokracovat"
 
 # MSG_RESUMING_PRINT c=20 r=1
-#: messages.c:73
+#: messages.c:69
 msgid "Resuming print"
 msgstr "Obnoveni tisku"
 
 # MSG_BED_CORRECTION_RIGHT c=14 r=1
-#: ultralcd.cpp:3293
+#: ultralcd.cpp:3243
 msgid "Right side[um]"
 msgstr "Vpravo [um]"
 
-# MSG_SECOND_SERIAL_ON c=17 r=1
-#: ultralcd.cpp:5692
-msgid "RPi port     [on]"
-msgstr "RPi port    [zap]"
-
-# MSG_SECOND_SERIAL_OFF c=17 r=1
-#: ultralcd.cpp:5690
-msgid "RPi port    [off]"
-msgstr "RPi port    [vyp]"
+# MSG_RPI_PORT
+#: messages.c:123
+msgid "RPi port"
+msgstr ""
 
 # MSG_WIZARD_RERUN c=20 r=7
-#: ultralcd.cpp:4812
+#: ultralcd.cpp:4842
 msgid "Running Wizard will delete current calibration results and start from the beginning. Continue?"
 msgstr "Spusteni Pruvodce vymaze ulozene vysledky vsech kalibraci a spusti kalibracni proces od zacatku. Pokracovat?"
 
-# MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_OFF c=19 r=1
-#: ultralcd.cpp:5322
-msgid "SD card  [normal]"
+# MSG_SD_CARD
+#: messages.c:118
+msgid "SD card"
 msgstr ""
 
-# MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_ON c=19 r=1
-#: ultralcd.cpp:5320
-msgid "SD card [flshAir]"
-msgstr "SD card [FlshAir]"
+# MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY
+#: messages.c:119
+msgid "FlashAir"
+msgstr ""
 
 # 
-#: ultralcd.cpp:3019
+#: ultralcd.cpp:2972
 msgid "Right"
 msgstr "Vpravo"
 
 # MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=60
-#: messages.c:38
+#: messages.c:35
 msgid "Searching bed calibration point"
 msgstr "Hledam kalibracni bod podlozky"
 
 # MSG_LANGUAGE_SELECT
-#: ultralcd.cpp:5699
+#: ultralcd.cpp:5756
 msgid "Select language"
 msgstr "Vyber jazyka"
 
 # MSG_SELFTEST_OK
-#: ultralcd.cpp:7452
+#: ultralcd.cpp:7784
 msgid "Self test OK"
 msgstr ""
 
 # MSG_SELFTEST_START c=20
-#: ultralcd.cpp:7238
+#: ultralcd.cpp:7558
 msgid "Self test start  "
 msgstr "Self test start "
 
 # MSG_SELFTEST
-#: ultralcd.cpp:5750
+#: ultralcd.cpp:5820
 msgid "Selftest         "
 msgstr "Selftest "
 
 # MSG_SELFTEST_ERROR
-#: ultralcd.cpp:7879
+#: ultralcd.cpp:8216
 msgid "Selftest error !"
 msgstr "Chyba Selftestu!"
 
 # MSG_SELFTEST_FAILED c=20
-#: messages.c:77
+#: messages.c:73
 msgid "Selftest failed  "
 msgstr "Selftest selhal "
 
 # MSG_FORCE_SELFTEST c=20 r=8
-#: Marlin_main.cpp:1551
+#: Marlin_main.cpp:1532
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr "Pro kalibraci presneho rehomovani bude nyni spusten selftest."
 
 # 
-#: ultralcd.cpp:5045
+#: ultralcd.cpp:5080
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr "Vyberte teplotu predehrati trysky ktera odpovida vasemu materialu."
 
-# 
-#: ultralcd.cpp:4780
-msgid "Select PLA filament:"
-msgstr "Vyberte PLA filament:"
-
 # MSG_SET_TEMPERATURE c=19 r=1
-#: ultralcd.cpp:3314
+#: ultralcd.cpp:3264
 msgid "Set temperature:"
 msgstr "Nastavte teplotu:"
 
 # MSG_SETTINGS
-#: messages.c:86
+#: messages.c:82
 msgid "Settings"
 msgstr "Nastaveni"
 
 # MSG_SHOW_END_STOPS c=17 r=1
-#: ultralcd.cpp:5771
+#: ultralcd.cpp:5841
 msgid "Show end stops"
 msgstr "Stav konc. spin."
 
 # 
-#: ultralcd.cpp:4025
+#: ultralcd.cpp:3986
 msgid "Sensor state"
 msgstr "Stav senzoru"
 
 # MSG_FILE_CNT c=20 r=4
-#: cardreader.cpp:739
+#: cardreader.cpp:729
 msgid "Some files will not be sorted. Max. No. of files in 1 folder for sorting is 100."
 msgstr "Nektere soubory nebudou setrideny. Maximalni pocet souboru ve slozce pro setrideni je 100."
 
-# MSG_SORT_NONE c=17 r=1
-#: ultralcd.cpp:5332
-msgid "Sort       [none]"
-msgstr "Trideni   [Zadne]"
+# MSG_SORT
+#: messages.c:120
+msgid "Sort"
+msgstr "Trideni"
 
-# MSG_SORT_TIME c=17 r=1
-#: ultralcd.cpp:5330
-msgid "Sort       [time]"
-msgstr "Trideni     [cas]"
+# MSG_NONE
+#: messages.c:110
+msgid "None"
+msgstr "Zadne"
+
+# MSG_SORT_TIME
+#: messages.c:121
+msgid "Time"
+msgstr "Cas"
 
 # 
-#: ultralcd.cpp:3062
+#: ultralcd.cpp:3015
 msgid "Severe skew:"
 msgstr "Tezke zkoseni:"
 
-# MSG_SORT_ALPHA c=17 r=1
-#: ultralcd.cpp:5331
-msgid "Sort   [alphabet]"
-msgstr "Trideni [Abeceda]"
+# MSG_SORT_ALPHA
+#: messages.c:122
+msgid "Alphabet"
+msgstr "Abeceda"
 
 # MSG_SORTING c=20 r=1
-#: cardreader.cpp:746
+#: cardreader.cpp:736
 msgid "Sorting files"
 msgstr "Trideni souboru"
 
-# MSG_SOUND_LOUD c=17 r=1
-#: sound.h:6
-msgid "Sound      [loud]"
-msgstr "Zvuk    [hlasity]"
+# MSG_SOUND_LOUD
+#: messages.c:125
+msgid "Loud"
+msgstr "Hlasity"
 
 # 
-#: ultralcd.cpp:3061
+#: ultralcd.cpp:3014
 msgid "Slight skew:"
 msgstr "Lehke zkoseni:"
 
-# MSG_SOUND_MUTE c=17 r=1
-#: 
-msgid "Sound      [mute]"
-msgstr "Zvuk    [vypnuto]"
+# MSG_SOUND
+#: messages.c:124
+msgid "Sound"
+msgstr "Zvuk"
 
 # 
-#: Marlin_main.cpp:4871
+#: Marlin_main.cpp:5084
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Vyskytl se problem, srovnavam osu Z ..."
 
-# MSG_SOUND_ONCE c=17 r=1
-#: sound.h:7
-msgid "Sound      [once]"
-msgstr "Zvuk     [jednou]"
-
-# MSG_SOUND_SILENT c=17 r=1
-#: sound.h:8
-msgid "Sound    [silent]"
-msgstr "Zvuk      [tichy]"
+# MSG_SOUND_ONCE
+#: messages.c:126
+msgid "Once"
+msgstr "Jednou"
 
 # MSG_SPEED
-#: ultralcd.cpp:6926
+#: ultralcd.cpp:7096
 msgid "Speed"
 msgstr "Rychlost"
 
 # MSG_SELFTEST_FAN_YES c=19
-#: messages.c:80
+#: messages.c:76
 msgid "Spinning"
 msgstr "Toci se"
 
 # MSG_TEMP_CAL_WARNING c=20 r=4
-#: Marlin_main.cpp:4368
+#: Marlin_main.cpp:4574
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr "Je vyzadovana stabilni pokojova teplota 21-26C a pevna podlozka."
 
 # MSG_STATISTICS
-#: ultralcd.cpp:6839
+#: ultralcd.cpp:6955
 msgid "Statistics  "
 msgstr "Statistika "
 
 # MSG_STOP_PRINT
-#: messages.c:93
+#: messages.c:91
 msgid "Stop print"
 msgstr "Zastavit tisk"
 
 # MSG_STOPPED
-#: messages.c:94
+#: messages.c:92
 msgid "STOPPED. "
 msgstr "ZASTAVENO."
 
 # MSG_SUPPORT
-#: ultralcd.cpp:6848
+#: ultralcd.cpp:6964
 msgid "Support"
 msgstr "Podpora"
 
 # MSG_SELFTEST_SWAPPED
-#: ultralcd.cpp:7959
+#: ultralcd.cpp:8296
 msgid "Swapped"
 msgstr "Prohozene"
 
-# MSG_TEMP_CALIBRATION c=20 r=1
-#: messages.c:95
-msgid "Temp. cal.          "
-msgstr "Tepl. kal. "
+# 
+#: ultralcd.cpp:4792
+msgid "Select filament:"
+msgstr "Zvolte filament:"
 
-# MSG_TEMP_CALIBRATION_ON c=20 r=1
-#: ultralcd.cpp:5686
-msgid "Temp. cal.   [on]"
-msgstr "Tepl. kal.  [zap]"
+# MSG_TEMP_CALIBRATION c=12 r=1
+#: messages.c:93
+msgid "Temp. cal."
+msgstr "Tepl. kal."
 
-# MSG_TEMP_CALIBRATION_OFF c=20 r=1
-#: ultralcd.cpp:5684
-msgid "Temp. cal.  [off]"
-msgstr "Tepl. kal.  [vyp]"
+# 
+#: ultralcd.cpp:4933
+msgid "Select temperature which matches your material."
+msgstr "Zvolte teplotu, ktera odpovida vasemu materialu."
 
 # MSG_CALIBRATION_PINDA_MENU c=17 r=1
-#: ultralcd.cpp:5780
+#: ultralcd.cpp:5850
 msgid "Temp. calibration"
 msgstr "Teplot. kalibrace"
 
 # MSG_TEMP_CAL_FAILED c=20 r=8
-#: ultralcd.cpp:3951
+#: ultralcd.cpp:3911
 msgid "Temperature calibration failed"
 msgstr "Teplotni kalibrace selhala"
 
 # MSG_TEMP_CALIBRATION_DONE c=20 r=12
-#: messages.c:96
+#: messages.c:94
 msgid "Temperature calibration is finished and active. Temp. calibration can be disabled in menu Settings->Temp. cal."
 msgstr "Teplotni kalibrace dokoncena a je nyni aktivni. Teplotni kalibraci je mozno deaktivovat v menu Nastaveni->Tepl. kal."
 
 # MSG_TEMPERATURE
-#: ultralcd.cpp:5650
+#: ultralcd.cpp:5716
 msgid "Temperature"
 msgstr "Teplota"
 
 # MSG_MENU_TEMPERATURES c=15 r=1
-#: ultralcd.cpp:2251
+#: ultralcd.cpp:2196
 msgid "Temperatures"
 msgstr "Teploty"
 
 # MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=4
-#: messages.c:42
+#: messages.c:39
 msgid "There is still a need to make Z calibration. Please follow the manual, chapter First steps, section Calibration flow."
 msgstr "Je potreba kalibrovat osu Z. Prosim postupujte dle prirucky, kapitola Zaciname, sekce Postup kalibrace."
 
 # 
-#: ultralcd.cpp:2908
+#: ultralcd.cpp:2869
 msgid "Total filament"
 msgstr "Filament celkem"
 
 # 
-#: ultralcd.cpp:2908
+#: ultralcd.cpp:2870
 msgid "Total print time"
 msgstr "Celkovy cas tisku"
 
 # MSG_TUNE
-#: ultralcd.cpp:6719
+#: ultralcd.cpp:6827
 msgid "Tune"
 msgstr "Ladit"
 
 # 
-#: ultralcd.cpp:4869
+#: 
 msgid "Unload"
 msgstr "Vysunout"
 
 # 
-#: ultralcd.cpp:1820
+#: ultralcd.cpp:1743
 msgid "Total failures"
 msgstr "Celkem selhani"
 
 # 
-#: ultralcd.cpp:2324
+#: ultralcd.cpp:2274
 msgid "to load filament"
 msgstr "k zavedeni filamentu"
 
 # 
-#: ultralcd.cpp:2328
+#: ultralcd.cpp:2278
 msgid "to unload filament"
 msgstr "k vyjmuti filamentu"
 
 # MSG_UNLOAD_FILAMENT c=17
-#: messages.c:97
+#: messages.c:95
 msgid "Unload filament"
 msgstr "Vyjmout filament"
 
 # MSG_UNLOADING_FILAMENT c=20 r=1
-#: messages.c:98
+#: messages.c:96
 msgid "Unloading filament"
 msgstr "Vysouvam filament"
 
 # 
-#: ultralcd.cpp:1773
+#: ultralcd.cpp:1696
 msgid "Total"
 msgstr "Celkem"
 
 # MSG_USED c=19 r=1
-#: ultralcd.cpp:5908
+#: ultralcd.cpp:5978
 msgid "Used during print"
 msgstr "Pouzite behem tisku"
 
 # MSG_MENU_VOLTAGES c=15 r=1
-#: ultralcd.cpp:2254
+#: ultralcd.cpp:2199
 msgid "Voltages"
 msgstr "Napeti"
 
 # 
-#: ultralcd.cpp:2227
+#: ultralcd.cpp:2172
 msgid "unknown"
 msgstr "neznamy"
 
 # MSG_USERWAIT
-#: Marlin_main.cpp:5263
+#: Marlin_main.cpp:5496
 msgid "Wait for user..."
 msgstr "Ceka se na uzivatele..."
 
 # MSG_WAITING_TEMP c=20 r=3
-#: ultralcd.cpp:3458
+#: ultralcd.cpp:3412
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Cekani na zchladnuti trysky a podlozky."
 
 # MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ultralcd.cpp:3422
+#: ultralcd.cpp:3373
 msgid "Waiting for PINDA probe cooling"
 msgstr "Cekani na zchladnuti PINDA"
 
 # 
-#: ultralcd.cpp:4868
+#: 
 msgid "Use unload to remove filament 1 if it protrudes outside of the rear MMU tube. Use eject if it is hidden in tube."
 msgstr "Pouzijte vyjmout pro odstraneni filamentu 1 pokud presahuje z PTFE trubicky za tiskarnou. Pouzijte vysunout, pokud neni videt."
 
 # MSG_CHANGED_BOTH c=20 r=4
-#: Marlin_main.cpp:1511
+#: Marlin_main.cpp:1492
 msgid "Warning: both printer type and motherboard type changed."
 msgstr "Varovani: doslo ke zmene typu tiskarny a motherboardu."
 
 # MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: Marlin_main.cpp:1503
+#: Marlin_main.cpp:1484
 msgid "Warning: motherboard type changed."
 msgstr "Varovani: doslo ke zmene typu motherboardu."
 
 # MSG_CHANGED_PRINTER c=20 r=4
-#: Marlin_main.cpp:1507
+#: Marlin_main.cpp:1488
 msgid "Warning: printer type changed."
 msgstr "Varovani: doslo ke zmene typu tiskarny."
 
 # MSG_UNLOAD_SUCCESSFUL c=20 r=2
-#: Marlin_main.cpp:3054
+#: Marlin_main.cpp:3106
 msgid "Was filament unload successful?"
 msgstr "Bylo vysunuti filamentu uspesne?"
 
 # MSG_SELFTEST_WIRINGERROR
-#: messages.c:85
+#: messages.c:81
 msgid "Wiring error"
 msgstr "Chyba zapojeni"
 
 # MSG_WIZARD c=17 r=1
-#: ultralcd.cpp:5747
+#: ultralcd.cpp:5811
 msgid "Wizard"
 msgstr "Pruvodce"
 
 # MSG_XYZ_DETAILS c=19 r=1
-#: ultralcd.cpp:2243
+#: ultralcd.cpp:2188
 msgid "XYZ cal. details"
 msgstr "Detaily XYZ kal."
 
 # MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: messages.c:19
+#: messages.c:18
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "Kalibrace XYZ selhala. Nahlednete do manualu."
 
 # MSG_YES
-#: messages.c:104
+#: messages.c:102
 msgid "Yes"
 msgstr "Ano"
 
 # MSG_WIZARD_QUIT c=20 r=8
-#: messages.c:103
+#: messages.c:101
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr "Pruvodce muzete kdykoliv znovu spustit z menu Kalibrace -> Pruvodce"
 
 # MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ultralcd.cpp:3922
+#: ultralcd.cpp:3882
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr "Kalibrace XYZ v poradku. Zkoseni bude automaticky vyrovnano pri tisku."
 
 # MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ultralcd.cpp:3919
+#: ultralcd.cpp:3879
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr "Kalibrace XYZ v poradku. X/Y osy mirne zkosene. Dobra prace!"
 
 # 
-#: ultralcd.cpp:5130
+#: ultralcd.cpp:5168
 msgid "X-correct:"
 msgstr "Korekce X:"
 
 # MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ultralcd.cpp:3916
+#: ultralcd.cpp:3876
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "Kalibrace XYZ v poradku. X/Y osy jsou kolme. Gratuluji!"
 
 # MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ultralcd.cpp:3900
+#: ultralcd.cpp:3860
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr "Kalibrace XYZ nepresna. Predni kalibracni body moc vpredu."
 
 # MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ultralcd.cpp:3903
+#: ultralcd.cpp:3863
 msgid "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr "Kalibrace XYZ nepresna. Pravy predni bod moc vpredu."
 
 # MSG_LOAD_ALL c=17
-#: ultralcd.cpp:6166
+#: ultralcd.cpp:6238
 msgid "Load all"
 msgstr "Zavest vse"
 
 # 
-#: ultralcd.cpp:3882
+#: ultralcd.cpp:3842
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr "Kalibrace XYZ selhala. Kalibracni bod podlozky nenalezen."
 
 # 
-#: ultralcd.cpp:3888
+#: ultralcd.cpp:3848
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr "Kalibrace XYZ selhala. Predni kalibracni body moc vpredu. Srovnejte tiskarnu."
 
 # 
-#: ultralcd.cpp:3891
+#: ultralcd.cpp:3851
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr "Kalibrace XYZ selhala. Pravy predni bod moc vpredu. Srovnejte tiskarnu."
 
 # 
-#: ultralcd.cpp:3016
+#: ultralcd.cpp:2969
 msgid "Y distance from min"
 msgstr "Y vzdalenost od min"
 
 # 
-#: ultralcd.cpp:5131
+#: ultralcd.cpp:4936
+msgid "The printer will start printing a zig-zag line. Rotate the knob until you reach the optimal height. Check the pictures in the handbook (Calibration chapter)."
+msgstr "Tiskarna zacne tisknout lomenou caru. Otacenim tlacitka nastavte optimalni vysku. Postupujte podle obrazku v handbooku (kapitola Kalibrace)."
+
+# 
+#: ultralcd.cpp:5169
 msgid "Y-correct:"
 msgstr "Korekce Y:"
 
 # MSG_OFF
-#: menu.cpp:426
-msgid " [off]"
-msgstr " [vyp]"
+#: messages.c:105
+msgid "Off"
+msgstr "Vyp"
+
+# MSG_ON
+#: messages.c:106
+msgid "On"
+msgstr "Zap"
 
 # 
-#: messages.c:57
+#: messages.c:53
 msgid "Back"
 msgstr "Zpet"
 
 # 
-#: ultralcd.cpp:5639
+#: ultralcd.cpp:5702
 msgid "Checks"
 msgstr "Kontrola"
 
 # 
-#: ultralcd.cpp:7973
+#: ultralcd.cpp:8310
 msgid "False triggering"
 msgstr "Falesne spusteni"
 
 # 
-#: ultralcd.cpp:4030
+#: ultralcd.cpp:3991
 msgid "FINDA:"
 msgstr ""
 
-# 
-#: ultralcd.cpp:5545
-msgid "Firmware   [none]"
-msgstr "Firmware  [Zadne]"
+# MSG_FIRMWARE
+#: language.h:21
+msgid "Firmware"
+msgstr ""
+
+# MSG_STRICT
+#: messages.c:112
+msgid "Strict"
+msgstr "Prisne"
+
+# MSG_WARN
+#: messages.c:111
+msgid "Warn"
+msgstr "Varovat"
 
 # 
-#: ultralcd.cpp:5551
-msgid "Firmware [strict]"
-msgstr "Firmware [Prisne]"
-
-# 
-#: ultralcd.cpp:5548
-msgid "Firmware   [warn]"
-msgstr "Firmware[Varovat]"
-
-# 
-#: messages.c:87
+#: messages.c:83
 msgid "HW Setup"
 msgstr "HW nastaveni"
 
 # 
-#: ultralcd.cpp:4034
+#: ultralcd.cpp:3995
 msgid "IR:"
 msgstr ""
 
-# 
-#: ultralcd.cpp:7046
-msgid "Magnets comp.[N/A]"
-msgstr "Komp. magnetu[N/A]"
+# MSG_MAGNETS_COMP
+#: messages.c:130
+msgid "Magnets comp."
+msgstr "Komp. magnetu"
+
+# MSG_MESH
+#: messages.c:128
+msgid "Mesh"
+msgstr ""
 
 # 
-#: ultralcd.cpp:7044
-msgid "Magnets comp.[Off]"
-msgstr "Komp. magnetu[Vyp]"
-
-# 
-#: ultralcd.cpp:7043
-msgid "Magnets comp. [On]"
-msgstr "Komp. magnetu[Zap]"
-
-# 
-#: ultralcd.cpp:7035
-msgid "Mesh         [3x3]"
-msgstr "Mesh         [3x3]"
-
-# 
-#: ultralcd.cpp:7036
-msgid "Mesh         [7x7]"
-msgstr "Mesh         [7x7]"
-
-# 
-#: ultralcd.cpp:5677
+#: ultralcd.cpp:5740
 msgid "Mesh bed leveling"
 msgstr "Mesh Bed Leveling"
 
 # 
-#: Marlin_main.cpp:856
+#: Marlin_main.cpp:861
 msgid "MK3S firmware detected on MK3 printer"
 msgstr "MK3S firmware detekovan na tiskarne MK3"
 
-# 
-#: ultralcd.cpp:5306
-msgid "MMU Mode [Normal]"
-msgstr "MMU mod  [Normal]"
+# MSG_MMU_MODE
+#: messages.c:117
+msgid "MMU Mode"
+msgstr "MMU mod"
 
 # 
-#: ultralcd.cpp:5307
-msgid "MMU Mode[Stealth]"
-msgstr "MMU Mod   [Tichy]"
-
-# 
-#: ultralcd.cpp:4511
+#: ultralcd.cpp:4472
 msgid "Mode change in progress ..."
 msgstr "Probiha zmena modu..."
 
-# 
-#: ultralcd.cpp:5506
-msgid "Model      [none]"
-msgstr "Model     [Zadne]"
+# MSG_MODEL
+#: messages.c:113
+msgid "Model"
+msgstr ""
+
+# MSG_NOZZLE_DIAMETER
+#: messages.c:116
+msgid "Nozzle d."
+msgstr "Tryska"
 
 # 
-#: ultralcd.cpp:5512
-msgid "Model    [strict]"
-msgstr "Model    [Prisne]"
-
-# 
-#: ultralcd.cpp:5509
-msgid "Model      [warn]"
-msgstr "Model   [Varovat]"
-
-# 
-#: ultralcd.cpp:5467
-msgid "Nozzle d.  [0.25]"
-msgstr "Tryska     [0.25]"
-
-# 
-#: ultralcd.cpp:5470
-msgid "Nozzle d.  [0.40]"
-msgstr "Tryska     [0.40]"
-
-# 
-#: ultralcd.cpp:5473
-msgid "Nozzle d.  [0.60]"
-msgstr "Tryska     [0.60]"
-
-# 
-#: ultralcd.cpp:5421
-msgid "Nozzle     [none]"
-msgstr "Tryska    [Zadne]"
-
-# 
-#: ultralcd.cpp:5427
-msgid "Nozzle   [strict]"
-msgstr "Tryska   [Prisne]"
-
-# 
-#: ultralcd.cpp:5424
-msgid "Nozzle     [warn]"
-msgstr "Tryska  [Varovat]"
-
-# 
-#: util.cpp:510
+#: util.cpp:514
 msgid "G-code sliced for a different level. Continue?"
 msgstr ""
 
 # 
-#: util.cpp:516
+#: util.cpp:520
 msgid "G-code sliced for a different level. Please re-slice the model again. Print cancelled."
 msgstr ""
 
 # 
-#: util.cpp:427
+#: util.cpp:431
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr "G-code je pripraven pro jiny typ tiskarny. Pokracovat?"
 
 # 
-#: util.cpp:433
+#: util.cpp:437
 msgid "G-code sliced for a different printer type. Please re-slice the model again. Print cancelled."
 msgstr "G-code je pripraven pro jiny typ tiskarny. Prosim preslicujte model znovu. Tisk zrusen."
 
 # 
-#: util.cpp:477
+#: util.cpp:481
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "G-code je pripraven pro novejsi firmware. Pokracovat?"
 
 # 
-#: util.cpp:483
+#: util.cpp:487
 msgid "G-code sliced for a newer firmware. Please update the firmware. Print cancelled."
 msgstr "G-code je pripraven pro novejsi firmware. Prosim aktualizujte firmware. Tisk zrusen."
 
 # 
-#: ultralcd.cpp:4026
+#: ultralcd.cpp:3987
 msgid "PINDA:"
 msgstr ""
 
 # 
-#: ultralcd.cpp:2465
+#: ultralcd.cpp:2430
 msgid "Preheating to cut"
 msgstr "Predehrev k ustrizeni"
 
 # 
-#: ultralcd.cpp:2462
+#: ultralcd.cpp:2427
 msgid "Preheating to eject"
 msgstr "Predehrev k vysunuti"
 
 # 
-#: util.cpp:390
+#: util.cpp:394
 msgid "Printer nozzle diameter differs from the G-code. Continue?"
 msgstr "Prumer trysky tiskarny se lisi od G-code. Pokracovat?"
 
 # 
-#: util.cpp:397
+#: util.cpp:401
 msgid "Printer nozzle diameter differs from the G-code. Please check the value in settings. Print cancelled."
 msgstr "Prumer trysky tiskarny se lisi od G-code. Prosim zkontrolujte nastaveni. Tisk zrusen."
 
 # 
-#: ultralcd.cpp:6683
+#: ultralcd.cpp:6791
 msgid "Rename"
 msgstr "Prejmenovat"
 
 # 
-#: ultralcd.cpp:6679
+#: ultralcd.cpp:6784
 msgid "Select"
 msgstr "Vybrat"
 
 # 
-#: ultralcd.cpp:2245
+#: ultralcd.cpp:2190
 msgid "Sensor info"
 msgstr "Senzor info"
 
 # 
-#: messages.c:58
+#: messages.c:54
 msgid "Sheet"
 msgstr "Plat"
 
-# 
-#: sound.h:9
-msgid "Sound    [assist]"
-msgstr "Zvuk     [Asist.]"
+# MSG_SOUND_BLIND
+#: messages.c:127
+msgid "Assist"
+msgstr "Asist."
 
 # 
-#: ultralcd.cpp:5637
+#: ultralcd.cpp:5700
 msgid "Steel sheets"
 msgstr "Tiskove platy"
 
 # 
-#: ultralcd.cpp:5132
+#: ultralcd.cpp:5170
 msgid "Z-correct:"
 msgstr "Korekce Z:"
-
-# 
-#: ultralcd.cpp:7038
-msgid "Z-probe nr.    [1]"
-msgstr "Pocet mereni Z [1]"
-
-# 
-#: ultralcd.cpp:7040
-msgid "Z-probe nr.    [3]"
-msgstr "Pocet mereni Z [3]"
 

--- a/lang/po/Firmware_de.po
+++ b/lang/po/Firmware_de.po
@@ -7,26 +7,31 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: de\n"
 "Project-Id-Version: Prusa-Firmware\n"
-"POT-Creation-Date: Sun, Sep 22, 2019 2:04:09 PM\n"
-"PO-Revision-Date: Sun, Sep 22, 2019 2:04:09 PM\n"
+"POT-Creation-Date: Thu, Mar 26, 2020 8:53:33 AM\n"
+"PO-Revision-Date: Thu, Mar 26, 2020 8:53:33 AM\n"
 "Language-Team: \n"
 "X-Generator: Poedit 2.0.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 "Last-Translator: \n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
+# 
+#: 
+msgid "[%.7s]Live adj. Z\x0avalue set, continue\x0aor start from zero?\x0a%cContinue%cReset"
+msgstr "[%.7s]Z Einstell.\x0aWert gesetzt,weiter\x0aoder mit 0 beginnen?\x0a%cWeiter%cNeu beginnen"
+
 # MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE2 c=14
-#: messages.c:39
+#: messages.c:36
 msgid " of 4"
 msgstr " von 4"
 
 # MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE2 c=14
-#: messages.c:60
+#: messages.c:56
 msgid " of 9"
 msgstr " von 9"
 
 # MSG_MEASURED_OFFSET
-#: ultralcd.cpp:3089
+#: ultralcd.cpp:3042
 msgid "[0;0] point offset"
 msgstr "[0;0] Punktversatz"
 
@@ -41,54 +46,44 @@ msgid "WARNING:\x0aCrash detection\x0adisabled in\x0aStealth mode"
 msgstr "WARNUNG:\x0aCrash Erkennung\x0adeaktiviert im\x0aStealth Modus"
 
 # 
-#: ultralcd.cpp:2472
+#: ultralcd.cpp:2438
 msgid ">Cancel"
 msgstr ">Abbruch"
 
 # MSG_BABYSTEPPING_Z c=15
-#: ultralcd.cpp:3209
+#: ultralcd.cpp:3162
 msgid "Adjusting Z:"
 msgstr "Z Anpassen:"
 
 # MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ultralcd.cpp:8295
+#: ultralcd.cpp:8638
 msgid "All correct      "
 msgstr "Alles richtig    "
 
 # MSG_WIZARD_DONE c=20 r=8
-#: messages.c:101
+#: messages.c:99
 msgid "All is done. Happy printing!"
 msgstr "Alles abgeschlossen. Viel Spass beim Drucken!"
 
 # 
-#: ultralcd.cpp:2009
+#: ultralcd.cpp:1947
 msgid "Ambient"
 msgstr "Raumtemp."
 
 # MSG_PRESS c=20
-#: ultralcd.cpp:2618
+#: ultralcd.cpp:2587
 msgid "and press the knob"
 msgstr "und Knopf druecken"
 
 # MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=2
-#: ultralcd.cpp:3529
+#: ultralcd.cpp:3484
 msgid "Are left and right Z~carriages all up?"
 msgstr "Sind linke+rechte Z- Schlitten ganz oben?"
 
-# MSG_AUTO_DEPLETE_ON c=17 r=1
-#: ultralcd.cpp:5200
-msgid "SpoolJoin    [on]"
-msgstr "SpoolJoin    [an]"
-
-# 
-#: ultralcd.cpp:5196
-msgid "SpoolJoin   [N/A]"
-msgstr "SpoolJoin   [N/V]"
-
-# MSG_AUTO_DEPLETE_OFF c=17 r=1
-#: ultralcd.cpp:5204
-msgid "SpoolJoin   [off]"
-msgstr "SpoolJoin   [aus]"
+# MSG_AUTO_DEPLETE c=17 r=1
+#: messages.c:108
+msgid "SpoolJoin"
+msgstr ""
 
 # MSG_AUTO_HOME
 #: messages.c:11
@@ -96,747 +91,702 @@ msgid "Auto home"
 msgstr "Startposition"
 
 # MSG_AUTOLOAD_FILAMENT c=17
-#: ultralcd.cpp:6822
+#: ultralcd.cpp:6938
 msgid "AutoLoad filament"
 msgstr "AutoLaden Filament"
 
 # MSG_AUTOLOADING_ONLY_IF_FSENS_ON c=20 r=4
-#: ultralcd.cpp:4462
+#: ultralcd.cpp:4423
 msgid "Autoloading filament available only when filament sensor is turned on..."
-msgstr "Automatisches Laden Filament nur bei einge schaltetem Filament- sensor verfuegbar..."
+msgstr "Automatisches Laden Filament nur bei eingeschaltetem Fil. sensor verfuegbar..."
 
 # MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ultralcd.cpp:2813
+#: ultralcd.cpp:2782
 msgid "Autoloading filament is active, just press the knob and insert filament..."
 msgstr "Automatisches Laden Filament ist aktiv, Knopf druecken und Filament einlegen..."
 
 # MSG_SELFTEST_AXIS_LENGTH
-#: ultralcd.cpp:7949
+#: ultralcd.cpp:8286
 msgid "Axis length"
 msgstr "Achsenlaenge"
 
 # MSG_SELFTEST_AXIS
-#: ultralcd.cpp:7951
+#: ultralcd.cpp:8288
 msgid "Axis"
 msgstr "Achse"
 
 # MSG_SELFTEST_BEDHEATER
-#: ultralcd.cpp:7893
+#: ultralcd.cpp:8230
 msgid "Bed / Heater"
 msgstr "Bett / Heizung"
 
 # MSG_BED_DONE
-#: messages.c:16
+#: messages.c:15
 msgid "Bed done"
 msgstr "Bett OK"
 
 # MSG_BED_HEATING
-#: messages.c:17
+#: messages.c:16
 msgid "Bed Heating"
 msgstr "Bett aufwaermen"
 
 # MSG_BED_CORRECTION_MENU
-#: ultralcd.cpp:5768
+#: ultralcd.cpp:5838
 msgid "Bed level correct"
 msgstr "Ausgleich Bett ok"
 
 # MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=4
-#: messages.c:18
+#: messages.c:17
 msgid "Bed leveling failed. Sensor didnt trigger. Debris on nozzle? Waiting for reset."
 msgstr "Z-Kal. fehlgeschlg. Sensor nicht ausgeloest. Schmutzige Duese? Warte auf Reset."
 
 # MSG_BED
-#: messages.c:15
+#: messages.c:14
 msgid "Bed"
 msgstr "Bett"
 
 # MSG_MENU_BELT_STATUS c=15 r=1
-#: ultralcd.cpp:2059
+#: ultralcd.cpp:2004
 msgid "Belt status"
 msgstr "Gurtstatus"
 
 # MSG_RECOVER_PRINT c=20 r=2
-#: messages.c:71
+#: messages.c:67
 msgid "Blackout occurred. Recover print?"
 msgstr "Stromausfall! Druck wiederherstellen?"
 
 # 
-#: ultralcd.cpp:8297
+#: ultralcd.cpp:8640
 msgid "Calibrating home"
 msgstr "Kalibriere Start"
 
 # MSG_CALIBRATE_BED
-#: ultralcd.cpp:5757
+#: ultralcd.cpp:5827
 msgid "Calibrate XYZ"
 msgstr "Kalibrierung XYZ"
 
 # MSG_HOMEYZ
-#: messages.c:48
+#: messages.c:44
 msgid "Calibrate Z"
 msgstr "Kalibrierung Z"
 
 # MSG_CALIBRATE_PINDA c=17 r=1
-#: ultralcd.cpp:4654
+#: ultralcd.cpp:4615
 msgid "Calibrate"
 msgstr "Kalibrieren"
 
 # MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ultralcd.cpp:3492
+#: ultralcd.cpp:3447
 msgid "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end stoppers. Click when done."
 msgstr "XYZ Kalibrieren: Drehen Sie den Knopf bis der obere Anschlag erreicht wird. Anschliessend den Knopf druecken."
 
 # MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: messages.c:20
+#: messages.c:19
 msgid "Calibrating Z"
 msgstr "Kalibrierung Z"
 
 # MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ultralcd.cpp:3492
+#: ultralcd.cpp:3447
 msgid "Calibrating Z. Rotate the knob to move the Z carriage up to the end stoppers. Click when done."
 msgstr "Z Kalibrieren: Drehen Sie den Knopf bis der obere Anschlag erreicht wird. Anschliessend den Knopf druecken."
 
 # MSG_HOMEYZ_DONE
-#: ultralcd.cpp:816
+#: ultralcd.cpp:856
 msgid "Calibration done"
 msgstr "Kalibrierung OK"
 
 # MSG_MENU_CALIBRATION
-#: messages.c:61
+#: messages.c:57
 msgid "Calibration"
 msgstr "Kalibrierung"
 
 # 
-#: ultralcd.cpp:4781
+#: ultralcd.cpp:4793
 msgid "Cancel"
 msgstr "Abbruch"
 
 # MSG_SD_REMOVED
-#: ultralcd.cpp:8679
+#: ultralcd.cpp:9051
 msgid "Card removed"
 msgstr "SD Karte entfernt"
 
 # MSG_NOT_COLOR
-#: ultralcd.cpp:2718
+#: ultralcd.cpp:2687
 msgid "Color not correct"
 msgstr "Falsche Farbe"
 
 # MSG_COOLDOWN
-#: messages.c:23
+#: messages.c:22
 msgid "Cooldown"
 msgstr "Abkuehlen"
 
 # 
-#: ultralcd.cpp:4587
+#: ultralcd.cpp:4548
 msgid "Copy selected language?"
 msgstr "Gewaehlte Sprache kopieren?"
 
-# MSG_CRASHDETECT_ON
-#: messages.c:27
-msgid "Crash det.   [on]"
-msgstr "Crash Erk.   [an]"
+# MSG_CRASHDETECT
+#: messages.c:24
+msgid "Crash det."
+msgstr "Crash Erk."
 
-# MSG_CRASHDETECT_NA
-#: messages.c:25
-msgid "Crash det.  [N/A]"
-msgstr "Crash Erk.   [nv]"
-
-# MSG_CRASHDETECT_OFF
-#: messages.c:26
-msgid "Crash det.  [off]"
-msgstr "Crash Erk.  [aus]"
+# 
+#: ultralcd.cpp:4928
+msgid "Choose a filament for the First Layer Calibration and select it in the on-screen menu."
+msgstr "Waehlen Sie ein Filament fuer Erste Schichtkalibrierung aus und waehlen Sie es im On-Screen-Menu aus."
 
 # MSG_CRASH_DETECTED c=20 r=1
-#: messages.c:24
+#: messages.c:23
 msgid "Crash detected."
 msgstr "Crash erkannt."
 
 # 
-#: Marlin_main.cpp:600
+#: Marlin_main.cpp:602
 msgid "Crash detected. Resume print?"
 msgstr "Crash erkannt. Druck fortfuehren?"
 
 # 
-#: ultralcd.cpp:1853
+#: ultralcd.cpp:1776
 msgid "Crash"
 msgstr ""
 
 # MSG_CURRENT c=19 r=1
-#: ultralcd.cpp:5909
+#: ultralcd.cpp:5979
 msgid "Current"
 msgstr "Aktuelles"
 
 # MSG_DATE c=17 r=1
-#: ultralcd.cpp:2213
+#: ultralcd.cpp:2158
 msgid "Date:"
 msgstr "Datum:"
 
 # MSG_DISABLE_STEPPERS
-#: ultralcd.cpp:5654
+#: ultralcd.cpp:5720
 msgid "Disable steppers"
 msgstr "Motoren aus"
 
 # MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: messages.c:14
+#: messages.c:13
 msgid "Distance between tip of the nozzle and the bed surface has not been set yet. Please follow the manual, chapter First steps, section First layer calibration."
 msgstr "Der Abstand zwischen der Spitze der Duese und dem Bett ist noch nicht eingestellt. Bitte folgen Sie dem Handbuch, Kapitel Erste Schritte, Abschnitt Erste Schicht Kalibrierung."
 
 # MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ultralcd.cpp:5070
+#: ultralcd.cpp:5103
 msgid "Do you want to repeat last step to readjust distance between nozzle and heatbed?"
 msgstr "Moechten Sie den letzten Schritt wiederholen, um den Abstand zwischen Duese und Druckbett neu einzustellen?"
 
 # MSG_EXTRUDER_CORRECTION c=10
-#: ultralcd.cpp:5134
+#: ultralcd.cpp:5172
 msgid "E-correct:"
 msgstr "E-Korrektur:"
 
 # MSG_EJECT_FILAMENT c=17 r=1
-#: messages.c:53
+#: messages.c:49
 msgid "Eject filament"
 msgstr "Filamentauswurf"
 
-# 
-#: ultralcd.cpp:4869
-msgid "Eject"
-msgstr "Auswurf"
-
 # MSG_EJECTING_FILAMENT c=20 r=1
-#: mmu.cpp:1434
+#: mmu.cpp:1415
 msgid "Ejecting filament"
 msgstr "werfe Filament aus"
 
 # MSG_SELFTEST_ENDSTOP_NOTHIT c=20 r=1
-#: ultralcd.cpp:7917
+#: ultralcd.cpp:8254
 msgid "Endstop not hit"
 msgstr "Ende nicht getroffen"
 
 # MSG_SELFTEST_ENDSTOP
-#: ultralcd.cpp:7911
+#: ultralcd.cpp:8248
 msgid "Endstop"
 msgstr "Endanschlag"
 
 # MSG_SELFTEST_ENDSTOPS
-#: ultralcd.cpp:7899
+#: ultralcd.cpp:8236
 msgid "Endstops"
 msgstr "Endschalter"
 
 # MSG_STACK_ERROR c=20 r=4
-#: ultralcd.cpp:6859
+#: ultralcd.cpp:6975
 msgid "Error - static memory has been overwritten"
 msgstr "Fehler - statischer Speicher wurde ueberschrieben"
 
 # MSG_FSENS_NOT_RESPONDING c=20 r=4
-#: ultralcd.cpp:4475
+#: ultralcd.cpp:4436
 msgid "ERROR: Filament sensor is not responding, please check connection."
 msgstr "FEHLER: Filament- sensor reagiert nicht, bitte Verbindung pruefen."
 
 # MSG_ERROR
-#: messages.c:28
+#: messages.c:25
 msgid "ERROR:"
 msgstr "FEHLER:"
 
 # MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
-#: ultralcd.cpp:8304
+#: ultralcd.cpp:8647
 msgid "Extruder fan:"
 msgstr "Extruder Luefter:"
 
 # MSG_INFO_EXTRUDER c=15 r=1
-#: ultralcd.cpp:2244
+#: ultralcd.cpp:2189
 msgid "Extruder info"
 msgstr "Extruder Info"
 
 # MSG_MOVE_E
-#: messages.c:29
+#: messages.c:26
 msgid "Extruder"
 msgstr ""
 
 # 
-#: ultralcd.cpp:6846
+#: ultralcd.cpp:6962
 msgid "Fail stats MMU"
 msgstr "MMU-Fehler"
 
-# MSG_FSENS_AUTOLOAD_ON c=17 r=1
-#: ultralcd.cpp:5168
-msgid "F. autoload  [on]"
-msgstr "F.Autoladen  [an]"
-
-# MSG_FSENS_AUTOLOAD_NA c=17 r=1
-#: messages.c:43
-msgid "F. autoload [N/A]"
-msgstr "F. Autoload  [nv]"
-
-# MSG_FSENS_AUTOLOAD_OFF c=17 r=1
-#: ultralcd.cpp:5170
-msgid "F. autoload [off]"
-msgstr "F. Autoload [aus]"
+# MSG_FSENSOR_AUTOLOAD
+#: messages.c:40
+msgid "F. autoload"
+msgstr "F. autoladen"
 
 # 
-#: ultralcd.cpp:6843
+#: ultralcd.cpp:6959
 msgid "Fail stats"
 msgstr "Fehlerstatistik"
 
 # MSG_FAN_SPEED c=14
-#: messages.c:31
+#: messages.c:28
 msgid "Fan speed"
 msgstr "Luefter-Tempo"
 
 # MSG_SELFTEST_FAN c=20
-#: messages.c:78
+#: messages.c:74
 msgid "Fan test"
 msgstr "Lueftertest"
 
-# MSG_FANS_CHECK_ON c=17 r=1
-#: ultralcd.cpp:5663
-msgid "Fans check   [on]"
-msgstr "Luefter Chk. [an]"
+# MSG_FANS_CHECK
+#: ultralcd.cpp:5728
+msgid "Fans check"
+msgstr "Luefter Chk."
 
-# MSG_FANS_CHECK_OFF c=17 r=1
-#: ultralcd.cpp:5665
-msgid "Fans check  [off]"
-msgstr "Luefter Chk.[aus]"
-
-# MSG_FSENSOR_ON
-#: messages.c:45
-msgid "Fil. sensor  [on]"
-msgstr "Fil. Sensor  [an]"
-
-# MSG_FSENSOR_NA
-#: ultralcd.cpp:5148
-msgid "Fil. sensor [N/A]"
-msgstr "Fil. Sensor  [nv]"
-
-# MSG_FSENSOR_OFF
-#: messages.c:44
-msgid "Fil. sensor [off]"
-msgstr "Fil. Sensor [aus]"
+# MSG_FSENSOR
+#: messages.c:41
+msgid "Fil. sensor"
+msgstr ""
 
 # 
-#: ultralcd.cpp:1852
+#: ultralcd.cpp:1775
 msgid "Filam. runouts"
 msgstr "Filam. Maengel"
 
 # MSG_FILAMENT_CLEAN c=20 r=2
-#: messages.c:32
+#: messages.c:29
 msgid "Filament extruding & with correct color?"
 msgstr "Filament extrudiert mit richtiger Farbe?"
 
 # MSG_NOT_LOADED c=19
-#: ultralcd.cpp:2714
+#: ultralcd.cpp:2683
 msgid "Filament not loaded"
 msgstr "Fil. nicht geladen"
 
 # MSG_FILAMENT_SENSOR c=20
-#: messages.c:84
+#: messages.c:80
 msgid "Filament sensor"
 msgstr "Filamentsensor"
 
 # MSG_FILAMENT_USED c=19 r=1
-#: ultralcd.cpp:2885
+#: ultralcd.cpp:2847
 msgid "Filament used"
 msgstr "Filament benutzt"
 
 # MSG_PRINT_TIME c=19 r=1
-#: ultralcd.cpp:2886
+#: ultralcd.cpp:2848
 msgid "Print time"
 msgstr "Druckzeit"
 
 # MSG_FILE_INCOMPLETE c=20 r=2
-#: ultralcd.cpp:8432
+#: ultralcd.cpp:8775
 msgid "File incomplete. Continue anyway?"
 msgstr "Datei unvollstaendig Trotzdem fortfahren?"
 
 # MSG_FINISHING_MOVEMENTS c=20 r=1
-#: messages.c:40
+#: messages.c:37
 msgid "Finishing movements"
 msgstr "Bewegung beenden"
 
 # MSG_V2_CALIBRATION c=17 r=1
-#: messages.c:105
+#: messages.c:103
 msgid "First layer cal."
 msgstr "Erste-Schicht Kal."
 
 # MSG_WIZARD_SELFTEST c=20 r=8
-#: ultralcd.cpp:4982
+#: ultralcd.cpp:5024
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr "Zunaechst fuehre ich den Selbsttest durch, um die haeufigsten Probleme beim Zusammenbau zu ueberpruefen."
 
 # 
-#: mmu.cpp:724
+#: mmu.cpp:726
 msgid "Fix the issue and then press button on MMU unit."
 msgstr "Beseitigen Sie das Problem und druecken Sie dann den Knopf am MMU."
 
 # MSG_FLOW
-#: ultralcd.cpp:6932
+#: ultralcd.cpp:7102
 msgid "Flow"
 msgstr "Durchfluss"
 
 # MSG_PRUSA3D_FORUM
-#: ultralcd.cpp:2206
+#: ultralcd.cpp:2151
 msgid "forum.prusa3d.com"
 msgstr ""
 
 # MSG_SELFTEST_COOLING_FAN c=20
-#: messages.c:75
+#: messages.c:71
 msgid "Front print fan?"
 msgstr "Vorderer Luefter?"
 
 # MSG_BED_CORRECTION_FRONT c=14 r=1
-#: ultralcd.cpp:3294
+#: ultralcd.cpp:3244
 msgid "Front side[um]"
 msgstr "Vorne [um]"
 
 # MSG_SELFTEST_FANS
-#: ultralcd.cpp:7957
+#: ultralcd.cpp:8294
 msgid "Front/left fans"
 msgstr "Vorderer/linke Luefter"
 
 # MSG_SELFTEST_HEATERTHERMISTOR
-#: ultralcd.cpp:7887
+#: ultralcd.cpp:8224
 msgid "Heater/Thermistor"
 msgstr "Heizung/Thermistor"
 
 # MSG_BED_HEATING_SAFETY_DISABLED
-#: Marlin_main.cpp:8467
+#: Marlin_main.cpp:9458
 msgid "Heating disabled by safety timer."
 msgstr "Heizung durch Sicherheitstimer deaktiviert."
 
 # MSG_HEATING_COMPLETE c=20
-#: messages.c:47
+#: messages.c:43
 msgid "Heating done."
 msgstr "Aufwaermen OK."
 
 # MSG_HEATING
-#: messages.c:46
+#: messages.c:42
 msgid "Heating"
 msgstr "Aufwaermen"
 
 # MSG_WIZARD_WELCOME c=20 r=7
-#: ultralcd.cpp:4961
+#: ultralcd.cpp:5003
 msgid "Hi, I am your Original Prusa i3 printer. Would you like me to guide you through the setup process?"
 msgstr "Hallo, ich bin Ihr Original Prusa i3 Drucker. Moechten Sie, dass ich Sie durch den Einrich- tungsablauf fuehre?"
 
 # MSG_PRUSA3D_HOWTO
-#: ultralcd.cpp:2207
+#: ultralcd.cpp:2152
 msgid "howto.prusa3d.com"
 msgstr ""
 
 # MSG_FILAMENTCHANGE
-#: messages.c:37
+#: messages.c:34
 msgid "Change filament"
 msgstr "Filament-Wechsel"
 
 # MSG_CHANGE_SUCCESS
-#: ultralcd.cpp:2629
+#: ultralcd.cpp:2598
 msgid "Change success!"
 msgstr "Wechsel erfolgr.!"
 
 # MSG_CORRECTLY c=20
-#: ultralcd.cpp:2706
+#: ultralcd.cpp:2675
 msgid "Changed correctly?"
 msgstr "Wechsel ok?"
 
 # MSG_SELFTEST_CHECK_BED c=20
-#: messages.c:81
+#: messages.c:77
 msgid "Checking bed     "
 msgstr "Pruefe Bett "
 
 # MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ultralcd.cpp:8286
+#: ultralcd.cpp:8629
 msgid "Checking endstops"
 msgstr "Pruefe Endschalter"
 
 # MSG_SELFTEST_CHECK_HOTEND c=20
-#: ultralcd.cpp:8292
+#: ultralcd.cpp:8635
 msgid "Checking hotend  "
 msgstr "Pruefe Duese  "
 
 # MSG_SELFTEST_CHECK_FSENSOR c=20
-#: messages.c:82
+#: messages.c:78
 msgid "Checking sensors "
 msgstr "Pruefe Sensoren "
 
 # MSG_SELFTEST_CHECK_X c=20
-#: ultralcd.cpp:8287
+#: ultralcd.cpp:8630
 msgid "Checking X axis  "
 msgstr "Pruefe X Achse "
 
 # MSG_SELFTEST_CHECK_Y c=20
-#: ultralcd.cpp:8288
+#: ultralcd.cpp:8631
 msgid "Checking Y axis  "
 msgstr "Pruefe Y Achse "
 
 # MSG_SELFTEST_CHECK_Z c=20
-#: ultralcd.cpp:8289
+#: ultralcd.cpp:8632
 msgid "Checking Z axis  "
 msgstr "Pruefe Z Achse "
 
 # MSG_CHOOSE_EXTRUDER c=20 r=1
-#: messages.c:49
+#: messages.c:45
 msgid "Choose extruder:"
 msgstr "Extruder waehlen:"
 
 # MSG_CHOOSE_FILAMENT c=20 r=1
-#: messages.c:50
+#: messages.c:46
 msgid "Choose filament:"
 msgstr "Waehle Filament:"
 
 # MSG_FILAMENT c=17 r=1
-#: messages.c:30
+#: messages.c:27
 msgid "Filament"
 msgstr ""
 
 # MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ultralcd.cpp:4991
+#: ultralcd.cpp:5033
 msgid "I will run xyz calibration now. It will take approx. 12 mins."
 msgstr "Ich werde jetzt die XYZ-Kalibrierung durchfuehren. Es wird ca. 12 Minuten dauern."
 
 # MSG_WIZARD_Z_CAL c=20 r=8
-#: ultralcd.cpp:4999
+#: ultralcd.cpp:5041
 msgid "I will run z calibration now."
 msgstr "Ich werde jetzt die Z Kalibrierung durchfuehren."
 
-# MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ultralcd.cpp:5064
-msgid "I will start to print line and you will gradually lower the nozzle by rotating the knob, until you reach optimal height. Check the pictures in our handbook in chapter Calibration."
-msgstr "Ich werde jetzt eine Linie drucken. Waehrend des Druckes koennen Sie die Duese allmaehlich senken, indem Sie den Knopf drehen, bis Sie die optimale Hoehe erreichen. Sehen Sie sich die Bilder in unserem Handbuch im Kapitel Kalibrierung an."
-
 # MSG_WATCH
-#: messages.c:99
+#: messages.c:97
 msgid "Info screen"
 msgstr "Infoanzeige"
 
-# 
-#: ultralcd.cpp:5024
-msgid "Is filament 1 loaded?"
-msgstr "Wurde Filament 1 geladen?"
-
 # MSG_INSERT_FILAMENT c=20
-#: ultralcd.cpp:2614
+#: ultralcd.cpp:2583
 msgid "Insert filament"
 msgstr "Filament einlegen"
 
 # MSG_WIZARD_FILAMENT_LOADED c=20 r=2
-#: ultralcd.cpp:5027
+#: ultralcd.cpp:4813
 msgid "Is filament loaded?"
 msgstr "Ist das Filament geladen?"
 
-# MSG_WIZARD_PLA_FILAMENT c=20 r=2
-#: ultralcd.cpp:5058
-msgid "Is it PLA filament?"
-msgstr "Ist es wirklich PLA Filament?"
-
-# MSG_PLA_FILAMENT_LOADED c=20 r=2
-#: ultralcd.cpp:4790
-msgid "Is PLA filament loaded?"
-msgstr "Ist PLA Filament geladen?"
-
 # MSG_STEEL_SHEET_CHECK c=20 r=2
-#: messages.c:92
+#: messages.c:90
 msgid "Is steel sheet on heatbed?"
 msgstr "Liegt das Stahlblech auf dem Heizbett?"
 
 # 
-#: ultralcd.cpp:1795
+#: ultralcd.cpp:1718
 msgid "Last print failures"
 msgstr "Letzte Druckfehler"
 
 # 
-#: ultralcd.cpp:1772
+#: ultralcd.cpp:5111
+msgid "If you have additional steel sheets, calibrate their presets in Settings - HW Setup - Steel sheets."
+msgstr "Wenn Sie zusaetzliche Stahlbleche haben, kalibrieren Sie deren Voreinstellungen unter Einstellungen - HW Setup - Stahlbleche."
+
+# 
+#: ultralcd.cpp:1695
 msgid "Last print"
 msgstr "Letzter Druck"
 
 # MSG_SELFTEST_EXTRUDER_FAN c=20
-#: messages.c:76
+#: messages.c:72
 msgid "Left hotend fan?"
 msgstr "Linker Luefter?"
 
 # 
-#: ultralcd.cpp:3018
+#: ultralcd.cpp:2971
 msgid "Left"
 msgstr "Links"
 
 # MSG_BED_CORRECTION_LEFT c=14 r=1
-#: ultralcd.cpp:3292
+#: ultralcd.cpp:3242
 msgid "Left side [um]"
 msgstr "Links [um]"
 
 # 
-#: ultralcd.cpp:5680
+#: ultralcd.cpp:5743
 msgid "Lin. correction"
 msgstr "Lineare Korrektur"
 
 # MSG_BABYSTEP_Z
-#: messages.c:13
+#: messages.c:12
 msgid "Live adjust Z"
 msgstr "Z einstellen"
 
 # MSG_LOAD_FILAMENT c=17
-#: messages.c:51
+#: messages.c:47
 msgid "Load filament"
 msgstr "Filament laden"
 
 # MSG_LOADING_COLOR
-#: ultralcd.cpp:2654
+#: ultralcd.cpp:2623
 msgid "Loading color"
 msgstr "Lade Farbe"
 
 # MSG_LOADING_FILAMENT c=20
-#: messages.c:52
+#: messages.c:48
 msgid "Loading filament"
 msgstr "Filament laedt"
 
 # MSG_LOOSE_PULLEY c=20 r=1
-#: ultralcd.cpp:7941
+#: ultralcd.cpp:8278
 msgid "Loose pulley"
 msgstr "Lose Riemenscheibe"
 
 # 
-#: ultralcd.cpp:6805
+#: ultralcd.cpp:6921
 msgid "Load to nozzle"
 msgstr "In Druckduese laden"
 
 # MSG_M117_V2_CALIBRATION c=25 r=1
-#: messages.c:55
+#: messages.c:51
 msgid "M117 First layer cal."
 msgstr "M117 Erste-Schicht Kal."
 
 # MSG_MAIN
-#: messages.c:56
+#: messages.c:52
 msgid "Main"
 msgstr "Hauptmenue"
 
 # MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=60
-#: messages.c:59
+#: messages.c:55
 msgid "Measuring reference height of calibration point"
 msgstr "Messen der Referenzhoehe des Kalibrierpunktes"
 
 # MSG_MESH_BED_LEVELING
-#: ultralcd.cpp:5763
+#: ultralcd.cpp:5833
 msgid "Mesh Bed Leveling"
 msgstr "MeshBett Ausgleich"
 
 # MSG_MMU_OK_RESUMING_POSITION c=20 r=4
-#: mmu.cpp:762
+#: mmu.cpp:764
 msgid "MMU OK. Resuming position..."
 msgstr "MMU OK. Position wiederherstellen..."
 
 # MSG_MMU_OK_RESUMING_TEMPERATURE c=20 r=4
-#: mmu.cpp:755
+#: mmu.cpp:757
 msgid "MMU OK. Resuming temperature..."
 msgstr "MMU OK. Temperatur wiederherstellen..."
 
 # 
-#: ultralcd.cpp:3059
+#: ultralcd.cpp:3012
 msgid "Measured skew"
 msgstr "Schraeglauf"
 
-# 
-#: ultralcd.cpp:1796
+#  c=13 r=1
+#: ultralcd.cpp:1719
 msgid "MMU fails"
 msgstr "MMU Fehler"
 
 # 
-#: mmu.cpp:1613
+#: mmu.cpp:1587
 msgid "MMU load failed     "
 msgstr "MMU Ladefehler"
 
-# 
-#: ultralcd.cpp:1797
-msgid "MMU load fails"
+#  c=13 r=1
+#: ultralcd.cpp:1720
+msgid "MMU load f."
 msgstr "MMU Ladefehler"
 
 # MSG_MMU_OK_RESUMING c=20 r=4
-#: mmu.cpp:773
+#: mmu.cpp:775
 msgid "MMU OK. Resuming..."
 msgstr "MMU OK.  Weiterdrucken..."
 
-# MSG_STEALTH_MODE_OFF
-#: messages.c:90
-msgid "Mode     [Normal]"
-msgstr "Modus    [Normal]"
+# MSG_MODE
+#: messages.c:84
+msgid "Mode"
+msgstr "Modus"
 
-# MSG_SILENT_MODE_ON
-#: messages.c:89
-msgid "Mode     [silent]"
-msgstr "Modus     [leise]"
+# MSG_NORMAL
+#: messages.c:88
+msgid "Normal"
+msgstr ""
+
+# MSG_SILENT
+#: messages.c:87
+msgid "Silent"
+msgstr "Leise"
 
 # 
-#: mmu.cpp:719
+#: mmu.cpp:721
 msgid "MMU needs user attention."
 msgstr "MMU erfordert Benutzereingriff."
 
-# 
-#: ultralcd.cpp:1823
-msgid "MMU power fails"
+#  c=14 r=1
+#: ultralcd.cpp:1746
+msgid "MMU power f."
 msgstr "MMU Netzfehler"
 
-# MSG_STEALTH_MODE_ON
-#: messages.c:91
-msgid "Mode    [Stealth]"
-msgstr "Modus   [Stealth]"
+# MSG_STEALTH
+#: messages.c:89
+msgid "Stealth"
+msgstr ""
 
-# MSG_AUTO_MODE_ON
-#: messages.c:12
-msgid "Mode [auto power]"
-msgstr "Modus[Auto Power]"
+# MSG_AUTO_POWER
+#: messages.c:86
+msgid "Auto power"
+msgstr ""
 
-# MSG_SILENT_MODE_OFF
-#: messages.c:88
-msgid "Mode [high power]"
-msgstr "Modus[Hohe Leist]"
+# MSG_HIGH_POWER
+#: messages.c:85
+msgid "High power"
+msgstr "Hohe leist"
 
 # 
-#: ultralcd.cpp:2219
+#: ultralcd.cpp:2164
 msgid "MMU2 connected"
 msgstr "MMU2 verbunden"
 
 # MSG_SELFTEST_MOTOR
-#: messages.c:83
+#: messages.c:79
 msgid "Motor"
 msgstr ""
 
 # MSG_MOVE_AXIS
-#: ultralcd.cpp:5652
+#: ultralcd.cpp:5718
 msgid "Move axis"
 msgstr "Achse bewegen"
 
 # MSG_MOVE_X
-#: ultralcd.cpp:4378
+#: ultralcd.cpp:4339
 msgid "Move X"
 msgstr "Bewege X"
 
 # MSG_MOVE_Y
-#: ultralcd.cpp:4379
+#: ultralcd.cpp:4340
 msgid "Move Y"
 msgstr "Bewege Y"
 
 # MSG_MOVE_Z
-#: ultralcd.cpp:4380
+#: ultralcd.cpp:4341
 msgid "Move Z"
 msgstr "Bewege Z"
 
 # MSG_NO_MOVE
-#: Marlin_main.cpp:5292
+#: Marlin_main.cpp:5526
 msgid "No move."
 msgstr "Keine Bewegung."
 
 # MSG_NO_CARD
-#: ultralcd.cpp:6772
+#: ultralcd.cpp:6888
 msgid "No SD card"
 msgstr "Keine SD Karte"
 
-# 
-#: ultralcd.cpp:3024
+# MSG_NA
+#: messages.c:107
 msgid "N/A"
-msgstr "N.V."
+msgstr "N/V"
 
 # MSG_NO
-#: messages.c:62
+#: messages.c:58
 msgid "No"
 msgstr "Nein"
 
 # MSG_SELFTEST_NOTCONNECTED
-#: ultralcd.cpp:7889
+#: ultralcd.cpp:8226
 msgid "Not connected"
 msgstr "Nicht angeschlossen"
 
@@ -846,167 +796,152 @@ msgid "New firmware version available:"
 msgstr "Neue Firmware- Version verfuegbar:"
 
 # MSG_SELFTEST_FAN_NO c=19
-#: messages.c:79
+#: messages.c:75
 msgid "Not spinning"
 msgstr "Dreht sich nicht"
 
 # MSG_WIZARD_V2_CAL c=20 r=8
-#: ultralcd.cpp:5063
+#: ultralcd.cpp:4924
 msgid "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr "Jetzt werde ich den Abstand zwischen Duesenspitze und Druckbett kalibrieren."
 
 # MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ultralcd.cpp:5007
+#: ultralcd.cpp:5049
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Jetzt werde ich die Duese fuer PLA vorheizen."
 
 # MSG_NOZZLE
-#: messages.c:63
+#: messages.c:59
 msgid "Nozzle"
 msgstr "Duese"
 
 # MSG_DEFAULT_SETTINGS_LOADED c=20 r=4
-#: Marlin_main.cpp:1519
+#: Marlin_main.cpp:1500
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr "Alte Einstellungen gefunden. Standard PID, E-Steps u.s.w. werden gesetzt."
 
 # 
-#: ultralcd.cpp:4998
+#: ultralcd.cpp:5040
 msgid "Now remove the test print from steel sheet."
 msgstr "Testdruck jetzt von Stahlblech entfernen."
 
 # 
-#: ultralcd.cpp:1722
+#: ultralcd.cpp:1645
 msgid "Nozzle FAN"
 msgstr "Duesevent."
 
 # MSG_PAUSE_PRINT
-#: ultralcd.cpp:6735
+#: ultralcd.cpp:6852
 msgid "Pause print"
 msgstr "Druck pausieren"
 
 # MSG_PID_RUNNING c=20 r=1
-#: ultralcd.cpp:1606
+#: ultralcd.cpp:1530
 msgid "PID cal.           "
 msgstr "PID Kal.           "
 
 # MSG_PID_FINISHED c=20 r=1
-#: ultralcd.cpp:1612
+#: ultralcd.cpp:1536
 msgid "PID cal. finished"
 msgstr "PID Kalib. fertig"
 
 # MSG_PID_EXTRUDER c=17 r=1
-#: ultralcd.cpp:5769
+#: ultralcd.cpp:5839
 msgid "PID calibration"
 msgstr "PID Kalibrierung"
 
 # MSG_PINDA_PREHEAT c=20 r=1
-#: ultralcd.cpp:846
+#: ultralcd.cpp:887
 msgid "PINDA Heating"
 msgstr "PINDA erwaermen"
 
 # MSG_PAPER c=20 r=8
-#: messages.c:64
+#: messages.c:60
 msgid "Place a sheet of paper under the nozzle during the calibration of first 4 points. If the nozzle catches the paper, power off the printer immediately."
 msgstr "Legen Sie ein Blatt Papier unter die Duese waehrend der Kalibrierung der ersten 4 Punkte. Wenn die Duese das Papier erfasst, den Drucker sofort ausschalten."
 
 # MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ultralcd.cpp:5072
+#: ultralcd.cpp:5106
 msgid "Please clean heatbed and then press the knob."
 msgstr "Bitte reinigen Sie das Heizbett und druecken Sie dann den Knopf."
 
 # MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: messages.c:22
+#: messages.c:21
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Bitte entfernen Sie ueberstehendes Filament von der Duese. Klicken wenn sauber."
 
 # MSG_SELFTEST_PLEASECHECK
-#: ultralcd.cpp:7881
+#: ultralcd.cpp:8218
 msgid "Please check :"
 msgstr "Bitte pruefe:"
 
 # MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: messages.c:100
+#: messages.c:98
 msgid "Please check our handbook and fix the problem. Then resume the Wizard by rebooting the printer."
 msgstr "Bitte lesen Sie unser Handbuch und beheben Sie das Problem. Fahren Sie dann mit dem Assistenten fort, indem Sie den Drucker neu starten."
 
-# MSG_WIZARD_LOAD_FILAMENT c=20 r=8
-#: ultralcd.cpp:4894
-msgid "Please insert PLA filament to the extruder, then press knob to load it."
-msgstr "Legen Sie bitte PLA Filament in den Extruder und druecken Sie den Knopf,  um es zu laden."
-
-# MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ultralcd.cpp:4795
-msgid "Please load PLA filament first."
-msgstr "Bitte laden Sie zuerst PLA Filament."
-
 # MSG_CHECK_IDLER c=20 r=4
-#: Marlin_main.cpp:3064
+#: Marlin_main.cpp:3116
 msgid "Please open idler and remove filament manually."
 msgstr "Bitte Spannrolle oeffnen und Fila- ment von Hand entfernen"
 
 # MSG_PLACE_STEEL_SHEET c=20 r=4
-#: messages.c:65
+#: messages.c:61
 msgid "Please place steel sheet on heatbed."
 msgstr "Bitte legen Sie das Stahlblech auf das Heizbett."
 
 # MSG_PRESS_TO_UNLOAD c=20 r=4
-#: messages.c:68
+#: messages.c:64
 msgid "Please press the knob to unload filament"
 msgstr "Bitte druecken Sie den Knopf um das Filament zu entladen."
 
-# 
-#: ultralcd.cpp:4889
-msgid "Please insert PLA filament to the first tube of MMU, then press the knob to load it."
-msgstr "Legen Sie bitte PLA Filament in den ersten Schlauch der MMU und druecken Sie den Knopf,  um es zu laden."
-
 # MSG_PULL_OUT_FILAMENT c=20 r=4
-#: messages.c:70
+#: messages.c:66
 msgid "Please pull out filament immediately"
 msgstr "Bitte ziehen Sie das Filament sofort heraus"
 
 # MSG_EJECT_REMOVE c=20 r=4
-#: mmu.cpp:1440
+#: mmu.cpp:1421
 msgid "Please remove filament and then press the knob."
 msgstr "Bitte Filament entfernen und dann den Knopf druecken"
 
 # MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: messages.c:74
+#: messages.c:70
 msgid "Please remove steel sheet from heatbed."
 msgstr "Bitte entfernen Sie das Stahlblech vom Heizbett."
 
 # MSG_RUN_XYZ c=20 r=4
-#: Marlin_main.cpp:4355
+#: Marlin_main.cpp:4561
 msgid "Please run XYZ calibration first."
 msgstr "Bitte zuerst XYZ Kalibrierung ausfuehren."
 
 # MSG_UPDATE_MMU2_FW c=20 r=4
-#: mmu.cpp:1359
+#: mmu.cpp:1340
 msgid "Please update firmware in your MMU2. Waiting for reset."
 msgstr "Bitte aktualisieren Sie die Firmware in der MMU2. Warte auf Reset."
 
 # MSG_PLEASE_WAIT c=20
-#: messages.c:66
+#: messages.c:62
 msgid "Please wait"
 msgstr "Bitte warten"
 
 # 
-#: ultralcd.cpp:4997
+#: ultralcd.cpp:5039
 msgid "Please remove shipping helpers first."
 msgstr "Bitte zuerst Transportsicherungen entfernen."
 
 # MSG_PREHEAT_NOZZLE c=20
-#: messages.c:67
+#: messages.c:63
 msgid "Preheat the nozzle!"
 msgstr "Duese vorheizen!"
 
 # MSG_PREHEAT
-#: ultralcd.cpp:6722
+#: ultralcd.cpp:6830
 msgid "Preheat"
 msgstr "Vorheizen"
 
 # MSG_WIZARD_HEATING c=20 r=3
-#: messages.c:102
+#: messages.c:100
 msgid "Preheating nozzle. Please wait."
 msgstr "Vorheizen der Duese. Bitte warten."
 
@@ -1016,82 +951,97 @@ msgid "Please upgrade."
 msgstr "Bitte aktualisieren."
 
 # MSG_PRESS_TO_PREHEAT c=20 r=4
-#: Marlin_main.cpp:10364
+#: Marlin_main.cpp:11469
 msgid "Press knob to preheat nozzle and continue."
 msgstr "Bitte druecken Sie den Knopf um die Duese vorzuheizen und fortzufahren."
 
 # 
-#: ultralcd.cpp:1851
+#: ultralcd.cpp:1774
 msgid "Power failures"
 msgstr "Netzfehler"
 
 # MSG_PRINT_ABORTED c=20
-#: messages.c:69
+#: messages.c:65
 msgid "Print aborted"
 msgstr "Druck abgebrochen"
 
 # 
-#: ultralcd.cpp:2455
+#: ultralcd.cpp:2420
 msgid "Preheating to load"
 msgstr "Heizen zum Laden"
 
 # 
-#: ultralcd.cpp:2459
+#: ultralcd.cpp:2424
 msgid "Preheating to unload"
 msgstr "Heizen zum Entladen"
 
 # MSG_SELFTEST_PRINT_FAN_SPEED c=18
-#: ultralcd.cpp:8307
+#: ultralcd.cpp:8650
 msgid "Print fan:"
 msgstr "Druckvent.:"
 
 # MSG_CARD_MENU
-#: messages.c:21
+#: messages.c:20
 msgid "Print from SD"
 msgstr "Drucken von SD"
 
 # 
-#: ultralcd.cpp:2317
+#: ultralcd.cpp:2267
 msgid "Press the knob"
 msgstr "Knopf druecken zum"
 
 # MSG_PRINT_PAUSED c=20 r=1
-#: ultralcd.cpp:1069
+#: ultralcd.cpp:1109
 msgid "Print paused"
 msgstr "Druck pausiert"
 
 # 
-#: mmu.cpp:723
+#: mmu.cpp:725
 msgid "Press the knob to resume nozzle temperature."
 msgstr "Druecken Sie den Knopf um die Duesentemperatur wiederherzustellen"
 
 # MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: messages.c:41
+#: messages.c:38
 msgid "Printer has not been calibrated yet. Please follow the manual, chapter First steps, section Calibration flow."
 msgstr "Drucker wurde noch nicht kalibriert. Bitte folgen Sie dem Handbuch, Kapitel Erste Schritte, Abschnitt Kalibrie- rungsablauf."
 
 # 
-#: ultralcd.cpp:1723
+#: ultralcd.cpp:1646
 msgid "Print FAN"
 msgstr "Druckvent."
 
+# 
+#: ultralcd.cpp:4904
+msgid "Please insert filament into the extruder, then press the knob to load it."
+msgstr "Bitte legen Sie das Filament in den Extruder ein und druecken Sie dann den Knopf, um es zu laden."
+
+# 
+#: ultralcd.cpp:4899
+msgid "Please insert filament into the first tube of the MMU, then press the knob to load it."
+msgstr "Bitte stecken Sie das Filament in den ersten Schlauch der MMU und druecken Sie dann den Knopf, um es zu laden."
+
+# 
+#: ultralcd.cpp:4821
+msgid "Please load filament first."
+msgstr "Bitte laden Sie zuerst das Filament."
+
 # MSG_PRUSA3D
-#: ultralcd.cpp:2205
+#: ultralcd.cpp:2150
 msgid "prusa3d.com"
 msgstr ""
 
 # MSG_BED_CORRECTION_REAR c=14 r=1
-#: ultralcd.cpp:3295
+#: ultralcd.cpp:3245
 msgid "Rear side [um]"
 msgstr "Hinten [um]"
 
 # MSG_RECOVERING_PRINT c=20 r=1
-#: Marlin_main.cpp:9764
+#: Marlin_main.cpp:10826
 msgid "Recovering print    "
 msgstr "Druck wiederherst    "
 
 # MSG_REMOVE_OLD_FILAMENT c=20 r=4
-#: mmu.cpp:830
+#: mmu.cpp:832
 msgid "Remove old filament and press the knob to start loading new filament."
 msgstr "Entfernen Sie das alte Filament und druecken Sie den Knopf, um das neue zu laden."
 
@@ -1101,717 +1051,647 @@ msgid "Prusa i3 MK3S OK."
 msgstr ""
 
 # MSG_CALIBRATE_BED_RESET
-#: ultralcd.cpp:5774
+#: ultralcd.cpp:5844
 msgid "Reset XYZ calibr."
 msgstr "Reset XYZ Kalibr."
 
 # MSG_BED_CORRECTION_RESET
-#: ultralcd.cpp:3296
+#: ultralcd.cpp:3246
 msgid "Reset"
 msgstr "Ruecksetzen"
 
 # MSG_RESUME_PRINT
-#: ultralcd.cpp:6742
+#: ultralcd.cpp:6838
 msgid "Resume print"
 msgstr "Druck fortsetzen"
 
 # MSG_RESUMING_PRINT c=20 r=1
-#: messages.c:73
+#: messages.c:69
 msgid "Resuming print"
 msgstr "Druck fortgesetzt"
 
 # MSG_BED_CORRECTION_RIGHT c=14 r=1
-#: ultralcd.cpp:3293
+#: ultralcd.cpp:3243
 msgid "Right side[um]"
-msgstr "Rechts    [um]"
+msgstr "Rechts [um]"
 
-# MSG_SECOND_SERIAL_ON c=17 r=1
-#: ultralcd.cpp:5692
-msgid "RPi port     [on]"
-msgstr "RPi Port     [an]"
-
-# MSG_SECOND_SERIAL_OFF c=17 r=1
-#: ultralcd.cpp:5690
-msgid "RPi port    [off]"
-msgstr "RPi Port    [aus]"
+# MSG_RPI_PORT
+#: messages.c:123
+msgid "RPi port"
+msgstr ""
 
 # MSG_WIZARD_RERUN c=20 r=7
-#: ultralcd.cpp:4812
+#: ultralcd.cpp:4842
 msgid "Running Wizard will delete current calibration results and start from the beginning. Continue?"
 msgstr "Der Assistent wird die aktuellen Kalibrierungsdaten loeschen und von vorne beginnen. Weiterfahren?"
 
-# MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_OFF c=19 r=1
-#: ultralcd.cpp:5322
-msgid "SD card  [normal]"
-msgstr "SD Karte [normal]"
+# MSG_SD_CARD
+#: messages.c:118
+msgid "SD card"
+msgstr "SD Karte"
 
-# MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_ON c=19 r=1
-#: ultralcd.cpp:5320
-msgid "SD card [flshAir]"
-msgstr "SD Karte[flshAir]"
+# MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY
+#: messages.c:119
+msgid "FlashAir"
+msgstr ""
 
 # 
-#: ultralcd.cpp:3019
+#: ultralcd.cpp:2972
 msgid "Right"
 msgstr "Rechts"
 
 # MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=60
-#: messages.c:38
+#: messages.c:35
 msgid "Searching bed calibration point"
 msgstr "Suche Bett Kalibrierpunkt"
 
 # MSG_LANGUAGE_SELECT
-#: ultralcd.cpp:5699
+#: ultralcd.cpp:5756
 msgid "Select language"
 msgstr "Waehle Sprache"
 
 # MSG_SELFTEST_OK
-#: ultralcd.cpp:7452
+#: ultralcd.cpp:7784
 msgid "Self test OK"
 msgstr "Selbsttest OK"
 
 # MSG_SELFTEST_START c=20
-#: ultralcd.cpp:7238
+#: ultralcd.cpp:7558
 msgid "Self test start  "
 msgstr "Selbsttest start "
 
 # MSG_SELFTEST
-#: ultralcd.cpp:5750
+#: ultralcd.cpp:5820
 msgid "Selftest         "
 msgstr "Selbsttest       "
 
 # MSG_SELFTEST_ERROR
-#: ultralcd.cpp:7879
+#: ultralcd.cpp:8216
 msgid "Selftest error !"
 msgstr "Selbsttest Fehler!"
 
 # MSG_SELFTEST_FAILED c=20
-#: messages.c:77
+#: messages.c:73
 msgid "Selftest failed  "
 msgstr "Selbsttest Error "
 
 # MSG_FORCE_SELFTEST c=20 r=8
-#: Marlin_main.cpp:1551
+#: Marlin_main.cpp:1532
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr "Selbsttest im Gang, um die genaue Rueck- kehr zum Nullpunkt ohne Sensor zu kalibrieren"
 
 # 
-#: ultralcd.cpp:5045
+#: ultralcd.cpp:5080
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr "Bitte Vorheiztemperatur auswaehlen, die Ihrem Material entspricht."
 
-# 
-#: ultralcd.cpp:4780
-msgid "Select PLA filament:"
-msgstr "PLA Filament auswaehlen:"
-
 # MSG_SET_TEMPERATURE c=19 r=1
-#: ultralcd.cpp:3314
+#: ultralcd.cpp:3264
 msgid "Set temperature:"
 msgstr "Temp. einstellen:"
 
 # MSG_SETTINGS
-#: messages.c:86
+#: messages.c:82
 msgid "Settings"
 msgstr "Einstellungen"
 
 # MSG_SHOW_END_STOPS c=17 r=1
-#: ultralcd.cpp:5771
+#: ultralcd.cpp:5841
 msgid "Show end stops"
 msgstr "Endschalter Status"
 
 # 
-#: ultralcd.cpp:4025
+#: ultralcd.cpp:3986
 msgid "Sensor state"
 msgstr "Sensorstatus"
 
 # MSG_FILE_CNT c=20 r=4
-#: cardreader.cpp:739
+#: cardreader.cpp:729
 msgid "Some files will not be sorted. Max. No. of files in 1 folder for sorting is 100."
 msgstr "Einige Dateien wur- den nicht sortiert. Max. Dateien pro Verzeichnis = 100."
 
-# MSG_SORT_NONE c=17 r=1
-#: ultralcd.cpp:5332
-msgid "Sort       [none]"
-msgstr "Sort.      [ohne]"
+# MSG_SORT
+#: messages.c:120
+msgid "Sort"
+msgstr "Sort."
 
-# MSG_SORT_TIME c=17 r=1
-#: ultralcd.cpp:5330
-msgid "Sort       [time]"
-msgstr "Sort.      [Zeit]"
+# MSG_NONE
+#: messages.c:110
+msgid "None"
+msgstr "Ohne"
+
+# MSG_SORT_TIME
+#: messages.c:121
+msgid "Time"
+msgstr "Zeit"
 
 # 
-#: ultralcd.cpp:3062
+#: ultralcd.cpp:3015
 msgid "Severe skew:"
 msgstr "Schwer.Schr:"
 
-# MSG_SORT_ALPHA c=17 r=1
-#: ultralcd.cpp:5331
-msgid "Sort   [alphabet]"
-msgstr "Sort.  [Alphabet]"
+# MSG_SORT_ALPHA
+#: messages.c:122
+msgid "Alphabet"
+msgstr ""
 
 # MSG_SORTING c=20 r=1
-#: cardreader.cpp:746
+#: cardreader.cpp:736
 msgid "Sorting files"
 msgstr "Sortiere Dateien"
 
-# MSG_SOUND_LOUD c=17 r=1
-#: sound.h:6
-msgid "Sound      [loud]"
-msgstr "Sound      [laut]"
+# MSG_SOUND_LOUD
+#: messages.c:125
+msgid "Loud"
+msgstr "Laut"
 
 # 
-#: ultralcd.cpp:3061
+#: ultralcd.cpp:3014
 msgid "Slight skew:"
 msgstr "Leicht.Schr:"
 
-# MSG_SOUND_MUTE c=17 r=1
-#: 
-msgid "Sound      [mute]"
-msgstr "Sound     [stumm]"
+# MSG_SOUND
+#: messages.c:124
+msgid "Sound"
+msgstr ""
 
 # 
-#: Marlin_main.cpp:4871
+#: Marlin_main.cpp:5084
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Fehler aufgetreten, Z-Kalibrierung erforderlich..."
 
-# MSG_SOUND_ONCE c=17 r=1
-#: sound.h:7
-msgid "Sound      [once]"
-msgstr "Sound    [einmal]"
-
-# MSG_SOUND_SILENT c=17 r=1
-#: sound.h:8
-msgid "Sound    [silent]"
-msgstr "Sound     [leise]"
+# MSG_SOUND_ONCE
+#: messages.c:126
+msgid "Once"
+msgstr "Einmal"
 
 # MSG_SPEED
-#: ultralcd.cpp:6926
+#: ultralcd.cpp:7096
 msgid "Speed"
 msgstr "Geschwindigkeit"
 
 # MSG_SELFTEST_FAN_YES c=19
-#: messages.c:80
+#: messages.c:76
 msgid "Spinning"
 msgstr "Dreht sich"
 
 # MSG_TEMP_CAL_WARNING c=20 r=4
-#: Marlin_main.cpp:4368
+#: Marlin_main.cpp:4574
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr "Stabile Umgebungs- temperatur 21-26C und feste Stand- flaeche erforderlich"
 
 # MSG_STATISTICS
-#: ultralcd.cpp:6839
+#: ultralcd.cpp:6955
 msgid "Statistics  "
 msgstr "Statistiken "
 
 # MSG_STOP_PRINT
-#: messages.c:93
+#: messages.c:91
 msgid "Stop print"
 msgstr "Druck abbrechen"
 
 # MSG_STOPPED
-#: messages.c:94
+#: messages.c:92
 msgid "STOPPED. "
 msgstr "GESTOPPT."
 
 # MSG_SUPPORT
-#: ultralcd.cpp:6848
+#: ultralcd.cpp:6964
 msgid "Support"
 msgstr ""
 
 # MSG_SELFTEST_SWAPPED
-#: ultralcd.cpp:7959
+#: ultralcd.cpp:8296
 msgid "Swapped"
 msgstr "Ausgetauscht"
 
-# MSG_TEMP_CALIBRATION c=20 r=1
-#: messages.c:95
-msgid "Temp. cal.          "
-msgstr "Temp Kalib.         "
+# 
+#: ultralcd.cpp:4792
+msgid "Select filament:"
+msgstr "Filament auswaehlen:"
 
-# MSG_TEMP_CALIBRATION_ON c=20 r=1
-#: ultralcd.cpp:5686
-msgid "Temp. cal.   [on]"
-msgstr "Temp. Kal.   [an]"
+# MSG_TEMP_CALIBRATION c=12 r=1
+#: messages.c:93
+msgid "Temp. cal."
+msgstr "Temp Kalib."
 
-# MSG_TEMP_CALIBRATION_OFF c=20 r=1
-#: ultralcd.cpp:5684
-msgid "Temp. cal.  [off]"
-msgstr "Temp. Kal.  [aus]"
+# 
+#: ultralcd.cpp:4933
+msgid "Select temperature which matches your material."
+msgstr "Waehlen Sie die Temperatur, die zu Ihrem Material passt."
 
 # MSG_CALIBRATION_PINDA_MENU c=17 r=1
-#: ultralcd.cpp:5780
+#: ultralcd.cpp:5850
 msgid "Temp. calibration"
 msgstr "Temp. kalibrieren"
 
 # MSG_TEMP_CAL_FAILED c=20 r=8
-#: ultralcd.cpp:3951
+#: ultralcd.cpp:3911
 msgid "Temperature calibration failed"
 msgstr "Temperaturkalibrierung fehlgeschlagen"
 
 # MSG_TEMP_CALIBRATION_DONE c=20 r=12
-#: messages.c:96
+#: messages.c:94
 msgid "Temperature calibration is finished and active. Temp. calibration can be disabled in menu Settings->Temp. cal."
 msgstr "Temp.kalibrierung ist fertig + aktiv. Temp.kalibrierung kann ausgeschaltet werden im Menu Einstellungen -> Temp.kal."
 
 # MSG_TEMPERATURE
-#: ultralcd.cpp:5650
+#: ultralcd.cpp:5716
 msgid "Temperature"
 msgstr "Temperatur"
 
 # MSG_MENU_TEMPERATURES c=15 r=1
-#: ultralcd.cpp:2251
+#: ultralcd.cpp:2196
 msgid "Temperatures"
 msgstr "Temperaturen"
 
 # MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=4
-#: messages.c:42
+#: messages.c:39
 msgid "There is still a need to make Z calibration. Please follow the manual, chapter First steps, section Calibration flow."
 msgstr "Es ist noch notwendig die Z-Kalibrierung auszufuehren. Bitte befolgen Sie das Handbuch, Kapitel Erste Schritte, Abschnitt Kalibrierablauf."
 
 # 
-#: ultralcd.cpp:2908
+#: ultralcd.cpp:2869
 msgid "Total filament"
 msgstr "Gesamtes Filament"
 
 # 
-#: ultralcd.cpp:2908
+#: ultralcd.cpp:2870
 msgid "Total print time"
 msgstr "Gesamte Druckzeit"
 
 # MSG_TUNE
-#: ultralcd.cpp:6719
+#: ultralcd.cpp:6827
 msgid "Tune"
 msgstr "Feineinstellung"
 
 # 
-#: ultralcd.cpp:4869
+#: 
 msgid "Unload"
 msgstr "Entladen"
 
 # 
-#: ultralcd.cpp:1820
+#: ultralcd.cpp:1743
 msgid "Total failures"
 msgstr "Gesamte Fehler"
 
 # 
-#: ultralcd.cpp:2324
+#: ultralcd.cpp:2274
 msgid "to load filament"
 msgstr "Filament laden"
 
 # 
-#: ultralcd.cpp:2328
+#: ultralcd.cpp:2278
 msgid "to unload filament"
 msgstr "Filament entladen"
 
 # MSG_UNLOAD_FILAMENT c=17
-#: messages.c:97
+#: messages.c:95
 msgid "Unload filament"
 msgstr "Filament entladen"
 
 # MSG_UNLOADING_FILAMENT c=20 r=1
-#: messages.c:98
+#: messages.c:96
 msgid "Unloading filament"
 msgstr "Filament auswerfen"
 
 # 
-#: ultralcd.cpp:1773
+#: ultralcd.cpp:1696
 msgid "Total"
 msgstr "Gesamt"
 
 # MSG_USED c=19 r=1
-#: ultralcd.cpp:5908
+#: ultralcd.cpp:5978
 msgid "Used during print"
 msgstr "Beim Druck benutzt"
 
 # MSG_MENU_VOLTAGES c=15 r=1
-#: ultralcd.cpp:2254
+#: ultralcd.cpp:2199
 msgid "Voltages"
 msgstr "Spannungen"
 
 # 
-#: ultralcd.cpp:2227
+#: ultralcd.cpp:2172
 msgid "unknown"
 msgstr "unbekannt"
 
 # MSG_USERWAIT
-#: Marlin_main.cpp:5263
+#: Marlin_main.cpp:5496
 msgid "Wait for user..."
 msgstr "Warte auf Benutzer.."
 
 # MSG_WAITING_TEMP c=20 r=3
-#: ultralcd.cpp:3458
+#: ultralcd.cpp:3412
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Warten bis Heizung und Bett abgekuehlt sind"
 
 # MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ultralcd.cpp:3422
+#: ultralcd.cpp:3373
 msgid "Waiting for PINDA probe cooling"
 msgstr "Warten, bis PINDA- Sonde abgekuehlt ist"
 
 # 
-#: ultralcd.cpp:4868
+#: 
 msgid "Use unload to remove filament 1 if it protrudes outside of the rear MMU tube. Use eject if it is hidden in tube."
 msgstr "Entladen Sie das Filament 1, wenn er aus dem hinteren MMU-Rohr herausragt. Verwenden Sie den Auswurf, wenn er im Rohr versteckt ist."
 
 # MSG_CHANGED_BOTH c=20 r=4
-#: Marlin_main.cpp:1511
+#: Marlin_main.cpp:1492
 msgid "Warning: both printer type and motherboard type changed."
 msgstr "Warnung: Druckertyp und Platinentyp wurden beide geaendert."
 
 # MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: Marlin_main.cpp:1503
+#: Marlin_main.cpp:1484
 msgid "Warning: motherboard type changed."
 msgstr "Warnung: Platinentyp wurde geaendert."
 
 # MSG_CHANGED_PRINTER c=20 r=4
-#: Marlin_main.cpp:1507
+#: Marlin_main.cpp:1488
 msgid "Warning: printer type changed."
 msgstr "Warnung: Druckertyp wurde geaendert."
 
 # MSG_UNLOAD_SUCCESSFUL c=20 r=2
-#: Marlin_main.cpp:3054
+#: Marlin_main.cpp:3106
 msgid "Was filament unload successful?"
 msgstr "Konnten Sie das Filament entnehmen?"
 
 # MSG_SELFTEST_WIRINGERROR
-#: messages.c:85
+#: messages.c:81
 msgid "Wiring error"
 msgstr "Verdrahtungsfehler"
 
 # MSG_WIZARD c=17 r=1
-#: ultralcd.cpp:5747
+#: ultralcd.cpp:5811
 msgid "Wizard"
 msgstr "Assistent"
 
 # MSG_XYZ_DETAILS c=19 r=1
-#: ultralcd.cpp:2243
+#: ultralcd.cpp:2188
 msgid "XYZ cal. details"
 msgstr "XYZ Kal. Details"
 
 # MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: messages.c:19
+#: messages.c:18
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "XYZ-Kalibrierung fehlgeschlagen. Bitte schauen Sie in das Handbuch."
 
 # MSG_YES
-#: messages.c:104
+#: messages.c:102
 msgid "Yes"
 msgstr "Ja"
 
 # MSG_WIZARD_QUIT c=20 r=8
-#: messages.c:103
+#: messages.c:101
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr "Sie koennen den Assistenten immer im Menu neu starten: Kalibrierung -> Assistent"
 
 # MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ultralcd.cpp:3922
+#: ultralcd.cpp:3882
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr "XYZ Kalibrierung in Ordnung. Schraeglauf wird automatisch korrigiert."
 
 # MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ultralcd.cpp:3919
+#: ultralcd.cpp:3879
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr "XYZ Kalibrierung in Ordnung. X/Y Achsen sind etwas schraeg."
 
 # 
-#: ultralcd.cpp:5130
+#: ultralcd.cpp:5168
 msgid "X-correct:"
 msgstr "X-Korrektur:"
 
 # MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ultralcd.cpp:3916
+#: ultralcd.cpp:3876
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "XYZ-Kalibrierung ok. X/Y-Achsen sind senkrecht zueinander Glueckwunsch!"
 
 # MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ultralcd.cpp:3900
+#: ultralcd.cpp:3860
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr "XYZ-Kalibrierung beeintraechtigt. Vordere Kalibrierpunkte nicht erreichbar."
 
 # MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ultralcd.cpp:3903
+#: ultralcd.cpp:3863
 msgid "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr "XYZ-Kalibrierung beeintraechtigt. Rechter vorderer Kalibrierpunkt nicht erreichbar."
 
 # MSG_LOAD_ALL c=17
-#: ultralcd.cpp:6166
+#: ultralcd.cpp:6238
 msgid "Load all"
 msgstr "Alle laden"
 
 # 
-#: ultralcd.cpp:3882
+#: ultralcd.cpp:3842
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr "XYZ-Kalibrierung fehlgeschlagen. Bett-Kalibrierpunkt nicht gefunden."
 
 # 
-#: ultralcd.cpp:3888
+#: ultralcd.cpp:3848
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr "XYZ-Kalibrierung fehlgeschlagen. Vordere Kalibrierpunkte nicht erreichbar."
 
 # 
-#: ultralcd.cpp:3891
+#: ultralcd.cpp:3851
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr "XYZ-Kalibrierung fehlgeschlagen. Rechter vorderer Kalibrierpunkt ist nicht erreichbar."
 
-"XYZ calibration failed. Right front calibration point not reachable."
-#: 
-msgid "XYZ-Kalibrierung fehlgeschlagen. Rechter vorderer Kalibrierpunkt ist nicht erreichbar."
-msgstr 
-
 # 
-#: ultralcd.cpp:3016
+#: ultralcd.cpp:2969
 msgid "Y distance from min"
 msgstr "Y Entfernung vom Min"
 
 # 
-#: ultralcd.cpp:5131
+#: ultralcd.cpp:4936
+msgid "The printer will start printing a zig-zag line. Rotate the knob until you reach the optimal height. Check the pictures in the handbook (Calibration chapter)."
+msgstr "Der Drucker beginnt mit dem Drucken einer Zickzacklinie. Drehen Sie den Knopf, bis Sie die optimale Hoehe erreicht haben. Ueberpruefen Sie die Bilder im Handbuch (Kapitel Kalibrierung)."
+
+# 
+#: ultralcd.cpp:5169
 msgid "Y-correct:"
 msgstr "Y-Korrektur:"
 
 # MSG_OFF
-#: menu.cpp:426
-msgid " [off]"
-msgstr " [aus]"
+#: messages.c:105
+msgid "Off"
+msgstr "Aus"
+
+# MSG_ON
+#: messages.c:106
+msgid "On"
+msgstr "An"
 
 # 
-#: messages.c:57
+#: messages.c:53
 msgid "Back"
 msgstr "Zurueck"
 
 # 
-#: ultralcd.cpp:5639
+#: ultralcd.cpp:5702
 msgid "Checks"
 msgstr "Kontrolle"
 
 # 
-#: ultralcd.cpp:7973
+#: ultralcd.cpp:8310
 msgid "False triggering"
 msgstr "Falschtriggerung"
 
 # 
-#: ultralcd.cpp:4030
+#: ultralcd.cpp:3991
 msgid "FINDA:"
 msgstr ""
 
-# 
-#: ultralcd.cpp:5545
-msgid "Firmware   [none]"
-msgstr "Firmware   [ohne]"
+# MSG_FIRMWARE
+#: language.h:21
+msgid "Firmware"
+msgstr ""
+
+# MSG_STRICT
+#: messages.c:112
+msgid "Strict"
+msgstr "Strikt"
+
+# MSG_WARN
+#: messages.c:111
+msgid "Warn"
+msgstr "Warnen"
 
 # 
-#: ultralcd.cpp:5551
-msgid "Firmware [strict]"
-msgstr "Firmware [strikt]"
-
-# 
-#: ultralcd.cpp:5548
-msgid "Firmware   [warn]"
-msgstr "Firmware [warnen]"
-
-# 
-#: messages.c:87
+#: messages.c:83
 msgid "HW Setup"
 msgstr "HW Einstellungen"
 
 # 
-#: ultralcd.cpp:4034
+#: ultralcd.cpp:3995
 msgid "IR:"
 msgstr ""
 
-# 
-#: ultralcd.cpp:7046
-msgid "Magnets comp.[N/A]"
-msgstr "Magnet Komp.  [nv]"
+# MSG_MAGNETS_COMP
+#: messages.c:130
+msgid "Magnets comp."
+msgstr "Magnet Komp."
+
+# MSG_MESH
+#: messages.c:128
+msgid "Mesh"
+msgstr "Gitter"
 
 # 
-#: ultralcd.cpp:7044
-msgid "Magnets comp.[Off]"
-msgstr "Magnet Komp. [Aus]"
-
-# 
-#: ultralcd.cpp:7043
-msgid "Magnets comp. [On]"
-msgstr "Magnet Komp.  [An]"
-
-# 
-#: ultralcd.cpp:7035
-msgid "Mesh         [3x3]"
-msgstr "Gitter       [3x3]"
-
-# 
-#: ultralcd.cpp:7036
-msgid "Mesh         [7x7]"
-msgstr "Gitter       [7x7]"
-
-# 
-#: ultralcd.cpp:5677
+#: ultralcd.cpp:5740
 msgid "Mesh bed leveling"
 msgstr "MeshBett Ausgleich"
 
 # 
-#: Marlin_main.cpp:856
+#: Marlin_main.cpp:861
 msgid "MK3S firmware detected on MK3 printer"
 msgstr "MK3S-Firmware auf MK3-Drucker erkannt"
 
-# 
-#: ultralcd.cpp:5306
-msgid "MMU Mode [Normal]"
-msgstr "MMU Modus[Normal]"
+# MSG_MMU_MODE
+#: messages.c:117
+msgid "MMU Mode"
+msgstr "MMU Modus"
 
 # 
-#: ultralcd.cpp:5307
-msgid "MMU Mode[Stealth]"
-msgstr "MMU Mod.[Stealth]"
-
-# 
-#: ultralcd.cpp:4511
+#: ultralcd.cpp:4472
 msgid "Mode change in progress ..."
 msgstr "Moduswechsel erfolgt..."
 
-# 
-#: ultralcd.cpp:5506
-msgid "Model      [none]"
-msgstr "Modell     [ohne]"
+# MSG_MODEL
+#: messages.c:113
+msgid "Model"
+msgstr "Modell"
+
+# MSG_NOZZLE_DIAMETER
+#: messages.c:116
+msgid "Nozzle d."
+msgstr "Duese D."
 
 # 
-#: ultralcd.cpp:5512
-msgid "Model    [strict]"
-msgstr "Modell   [strikt]"
-
-# 
-#: ultralcd.cpp:5509
-msgid "Model      [warn]"
-msgstr "Modell   [warnen]"
-
-# 
-#: ultralcd.cpp:5467
-msgid "Nozzle d.  [0.25]"
-msgstr "Duese D.   [0.25]"
-
-# 
-#: ultralcd.cpp:5470
-msgid "Nozzle d.  [0.40]"
-msgstr "Duese D.   [0.40]"
-
-# 
-#: ultralcd.cpp:5473
-msgid "Nozzle d.  [0.60]"
-msgstr "Duese D.   [0.60]"
-
-# 
-#: ultralcd.cpp:5421
-msgid "Nozzle     [none]"
-msgstr "Duese      [ohne]"
-
-# 
-#: ultralcd.cpp:5427
-msgid "Nozzle   [strict]"
-msgstr "Duese    [strikt]"
-
-# 
-#: ultralcd.cpp:5424
-msgid "Nozzle     [warn]"
-msgstr "Duese    [warnen]"
-
-# 
-#: util.cpp:510
+#: util.cpp:514
 msgid "G-code sliced for a different level. Continue?"
 msgstr "G-Code ist fuer einen anderen Level geslict. Fortfahren?"
 
 # 
-#: util.cpp:516
+#: util.cpp:520
 msgid "G-code sliced for a different level. Please re-slice the model again. Print cancelled."
 msgstr "G-Code ist fuer einen anderen Level geslict. Bitte slicen Sie das Modell erneut. Druck abgebrochen."
 
 # 
-#: util.cpp:427
+#: util.cpp:431
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr "G-Code ist fuer einen anderen Drucker geslict. Fortfahren?"
 
 # 
-#: util.cpp:433
+#: util.cpp:437
 msgid "G-code sliced for a different printer type. Please re-slice the model again. Print cancelled."
 msgstr "G-Code ist fuer einen anderen Drucker geslict. Bitte slicen Sie das Modell erneut. Druck abgebrochen."
 
 # 
-#: util.cpp:477
+#: util.cpp:481
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "G-Code ist fuer eine neuere Firmware geslict. Fortfahren?"
 
 # 
-#: util.cpp:483
+#: util.cpp:487
 msgid "G-code sliced for a newer firmware. Please update the firmware. Print cancelled."
 msgstr "G-Code ist fuer eine neuere Firmware geslict. Bitte die Firmware updaten. Druck abgebrochen."
 
 # 
-#: ultralcd.cpp:4026
+#: ultralcd.cpp:3987
 msgid "PINDA:"
 msgstr ""
 
 # 
-#: ultralcd.cpp:2465
+#: ultralcd.cpp:2430
 msgid "Preheating to cut"
 msgstr "Heizen zum Schnitt"
 
 # 
-#: ultralcd.cpp:2462
+#: ultralcd.cpp:2427
 msgid "Preheating to eject"
 msgstr "Heizen zum Auswurf"
 
 # 
-#: util.cpp:390
+#: util.cpp:394
 msgid "Printer nozzle diameter differs from the G-code. Continue?"
 msgstr "Der Durchmesser der Druckerduese weicht vom G-Code ab. Fortfahren?"
 
 # 
-#: util.cpp:397
+#: util.cpp:401
 msgid "Printer nozzle diameter differs from the G-code. Please check the value in settings. Print cancelled."
 msgstr "Der Durchmesser der Druckerduese weicht vom G-Code ab. Bitte ueberpruefen Sie den Wert in den Einstellungen. Druck abgebrochen."
 
 # 
-#: ultralcd.cpp:6683
+#: ultralcd.cpp:6791
 msgid "Rename"
 msgstr "Umbenennen"
 
 # 
-#: ultralcd.cpp:6679
+#: ultralcd.cpp:6784
 msgid "Select"
 msgstr "Auswahl"
 
 # 
-#: ultralcd.cpp:2245
+#: ultralcd.cpp:2190
 msgid "Sensor info"
 msgstr "Sensor Info"
 
 # 
-#: messages.c:58
+#: messages.c:54
 msgid "Sheet"
 msgstr "Blech"
 
-# 
-#: sound.h:9
-msgid "Sound    [assist]"
-msgstr "Sound    [Assist]"
+# MSG_SOUND_BLIND
+#: messages.c:127
+msgid "Assist"
+msgstr ""
 
 # 
-#: ultralcd.cpp:5637
+#: ultralcd.cpp:5700
 msgid "Steel sheets"
 msgstr "Stahlbleche"
 
 # 
-#: ultralcd.cpp:5132
+#: ultralcd.cpp:5170
 msgid "Z-correct:"
 msgstr "Z-Korrektur:"
-
-# 
-#: ultralcd.cpp:7038
-msgid "Z-probe nr.    [1]"
-msgstr "Z-Probe Nr.    [1]"
-
-# 
-#: ultralcd.cpp:7040
-msgid "Z-probe nr.    [3]"
-msgstr "Z-Probe Nr.    [3]"
 

--- a/lang/po/Firmware_es.po
+++ b/lang/po/Firmware_es.po
@@ -7,26 +7,31 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: es\n"
 "Project-Id-Version: Prusa-Firmware\n"
-"POT-Creation-Date: Sun, Sep 22, 2019 2:05:16 PM\n"
-"PO-Revision-Date: Sun, Sep 22, 2019 2:05:16 PM\n"
+"POT-Creation-Date: Thu, Mar 26, 2020 8:54:27 AM\n"
+"PO-Revision-Date: Thu, Mar 26, 2020 8:54:27 AM\n"
 "Language-Team: \n"
 "X-Generator: Poedit 2.0.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 "Last-Translator: \n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
+# 
+#: 
+msgid "[%.7s]Live adj. Z\x0avalue set, continue\x0aor start from zero?\x0a%cContinue%cReset"
+msgstr "[%.7s]Ajuste Z\x0aAjustado, continuar\x0ao empezar de nuevo?\x0a%cContinuar%cRepetir"
+
 # MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE2 c=14
-#: messages.c:39
+#: messages.c:36
 msgid " of 4"
 msgstr " de 4"
 
 # MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE2 c=14
-#: messages.c:60
+#: messages.c:56
 msgid " of 9"
 msgstr " de 9"
 
 # MSG_MEASURED_OFFSET
-#: ultralcd.cpp:3089
+#: ultralcd.cpp:3042
 msgid "[0;0] point offset"
 msgstr "[0;0] punto offset"
 
@@ -41,53 +46,43 @@ msgid "WARNING:\x0aCrash detection\x0adisabled in\x0aStealth mode"
 msgstr "ATENCION:\x0aDec. choque\x0adesactivada en\x0aModo silencio"
 
 # 
-#: ultralcd.cpp:2472
+#: ultralcd.cpp:2438
 msgid ">Cancel"
 msgstr ">Cancelar"
 
 # MSG_BABYSTEPPING_Z c=15
-#: ultralcd.cpp:3209
+#: ultralcd.cpp:3162
 msgid "Adjusting Z:"
 msgstr "Ajustar-Z:"
 
 # MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ultralcd.cpp:8295
+#: ultralcd.cpp:8638
 msgid "All correct      "
 msgstr "Todo bien"
 
 # MSG_WIZARD_DONE c=20 r=8
-#: messages.c:101
+#: messages.c:99
 msgid "All is done. Happy printing!"
 msgstr "Terminado! Feliz impresion!"
 
 # 
-#: ultralcd.cpp:2009
+#: ultralcd.cpp:1947
 msgid "Ambient"
 msgstr "Ambiente"
 
 # MSG_PRESS c=20
-#: ultralcd.cpp:2618
+#: ultralcd.cpp:2587
 msgid "and press the knob"
 msgstr "Haz clic"
 
 # MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=2
-#: ultralcd.cpp:3529
+#: ultralcd.cpp:3484
 msgid "Are left and right Z~carriages all up?"
 msgstr "Carros Z izq./der. estan arriba maximo?"
 
-# MSG_AUTO_DEPLETE_ON c=17 r=1
-#: ultralcd.cpp:5200
-msgid "SpoolJoin    [on]"
-msgstr ""
-
-# 
-#: ultralcd.cpp:5196
-msgid "SpoolJoin   [N/A]"
-msgstr ""
-
-# MSG_AUTO_DEPLETE_OFF c=17 r=1
-#: ultralcd.cpp:5204
-msgid "SpoolJoin   [off]"
+# MSG_AUTO_DEPLETE c=17 r=1
+#: messages.c:108
+msgid "SpoolJoin"
 msgstr ""
 
 # MSG_AUTO_HOME
@@ -96,747 +91,702 @@ msgid "Auto home"
 msgstr "Llevar al origen"
 
 # MSG_AUTOLOAD_FILAMENT c=17
-#: ultralcd.cpp:6822
+#: ultralcd.cpp:6938
 msgid "AutoLoad filament"
 msgstr "Carga automatica de filamento"
 
 # MSG_AUTOLOADING_ONLY_IF_FSENS_ON c=20 r=4
-#: ultralcd.cpp:4462
+#: ultralcd.cpp:4423
 msgid "Autoloading filament available only when filament sensor is turned on..."
-msgstr "La carga automatica de filamento solo funciona si el sensor de filamento esta activado..."
+msgstr "La carga automatica solo funciona si el sensor de filamento esta activado..."
 
 # MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ultralcd.cpp:2813
+#: ultralcd.cpp:2782
 msgid "Autoloading filament is active, just press the knob and insert filament..."
-msgstr "La carga automatica de filamento esta activada, pulse el dial e inserte el filamento..."
+msgstr "La carga automatica esta activada, pulse el dial e inserte el filamento..."
 
 # MSG_SELFTEST_AXIS_LENGTH
-#: ultralcd.cpp:7949
+#: ultralcd.cpp:8286
 msgid "Axis length"
 msgstr "Longitud del eje"
 
 # MSG_SELFTEST_AXIS
-#: ultralcd.cpp:7951
+#: ultralcd.cpp:8288
 msgid "Axis"
 msgstr "Eje"
 
 # MSG_SELFTEST_BEDHEATER
-#: ultralcd.cpp:7893
+#: ultralcd.cpp:8230
 msgid "Bed / Heater"
 msgstr "Base / Calentador"
 
 # MSG_BED_DONE
-#: messages.c:16
+#: messages.c:15
 msgid "Bed done"
 msgstr "Base preparada"
 
 # MSG_BED_HEATING
-#: messages.c:17
+#: messages.c:16
 msgid "Bed Heating"
 msgstr "Calentando Base"
 
 # MSG_BED_CORRECTION_MENU
-#: ultralcd.cpp:5768
+#: ultralcd.cpp:5838
 msgid "Bed level correct"
 msgstr "Corr. de la cama"
 
 # MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=4
-#: messages.c:18
+#: messages.c:17
 msgid "Bed leveling failed. Sensor didnt trigger. Debris on nozzle? Waiting for reset."
 msgstr "Nivelacion fallada. Sensor no funciona. Restos en boquilla? Esperando reset."
 
 # MSG_BED
-#: messages.c:15
+#: messages.c:14
 msgid "Bed"
 msgstr "Base"
 
 # MSG_MENU_BELT_STATUS c=15 r=1
-#: ultralcd.cpp:2059
+#: ultralcd.cpp:2004
 msgid "Belt status"
 msgstr "Estado de la correa"
 
 # MSG_RECOVER_PRINT c=20 r=2
-#: messages.c:71
+#: messages.c:67
 msgid "Blackout occurred. Recover print?"
 msgstr "Se fue la luz. ?Reanudar la impresion?"
 
 # 
-#: ultralcd.cpp:8297
+#: ultralcd.cpp:8640
 msgid "Calibrating home"
 msgstr "Calibrando posicion inicial"
 
 # MSG_CALIBRATE_BED
-#: ultralcd.cpp:5757
+#: ultralcd.cpp:5827
 msgid "Calibrate XYZ"
 msgstr "Calibrar XYZ"
 
 # MSG_HOMEYZ
-#: messages.c:48
+#: messages.c:44
 msgid "Calibrate Z"
 msgstr "Calibrar Z"
 
 # MSG_CALIBRATE_PINDA c=17 r=1
-#: ultralcd.cpp:4654
+#: ultralcd.cpp:4615
 msgid "Calibrate"
 msgstr "Calibrar"
 
 # MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ultralcd.cpp:3492
+#: ultralcd.cpp:3447
 msgid "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end stoppers. Click when done."
 msgstr "Calibrando XYZ. Gira el dial para subir el extrusor hasta tocar los topes superiores. Despues haz clic."
 
 # MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: messages.c:20
+#: messages.c:19
 msgid "Calibrating Z"
 msgstr "Calibrando Z"
 
 # MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ultralcd.cpp:3492
+#: ultralcd.cpp:3447
 msgid "Calibrating Z. Rotate the knob to move the Z carriage up to the end stoppers. Click when done."
 msgstr "Calibrando Z. Gira el dial para subir el extrusor hasta tocar los topes superiores. Despues haz clic."
 
 # MSG_HOMEYZ_DONE
-#: ultralcd.cpp:816
+#: ultralcd.cpp:856
 msgid "Calibration done"
 msgstr "Calibracion OK"
 
 # MSG_MENU_CALIBRATION
-#: messages.c:61
+#: messages.c:57
 msgid "Calibration"
 msgstr "Calibracion"
 
 # 
-#: ultralcd.cpp:4781
+#: ultralcd.cpp:4793
 msgid "Cancel"
 msgstr "Cancelar"
 
 # MSG_SD_REMOVED
-#: ultralcd.cpp:8679
+#: ultralcd.cpp:9051
 msgid "Card removed"
 msgstr "Tarjeta retirada"
 
 # MSG_NOT_COLOR
-#: ultralcd.cpp:2718
+#: ultralcd.cpp:2687
 msgid "Color not correct"
 msgstr "Color no homogeneo"
 
 # MSG_COOLDOWN
-#: messages.c:23
+#: messages.c:22
 msgid "Cooldown"
 msgstr "Enfriar"
 
 # 
-#: ultralcd.cpp:4587
+#: ultralcd.cpp:4548
 msgid "Copy selected language?"
 msgstr "Copiar idioma seleccionado?"
 
-# MSG_CRASHDETECT_ON
-#: messages.c:27
-msgid "Crash det.   [on]"
-msgstr "Det. choque [act]"
+# MSG_CRASHDETECT
+#: messages.c:24
+msgid "Crash det."
+msgstr "Det. choque"
 
-# MSG_CRASHDETECT_NA
-#: messages.c:25
-msgid "Crash det.  [N/A]"
-msgstr "Dec. choque [N/D]"
-
-# MSG_CRASHDETECT_OFF
-#: messages.c:26
-msgid "Crash det.  [off]"
-msgstr "Det. choque [ina]"
+# 
+#: ultralcd.cpp:4928
+msgid "Choose a filament for the First Layer Calibration and select it in the on-screen menu."
+msgstr "Escoge un filamento para la Calibracion de la Primera Capa y seleccionalo en el menu en pantalla."
 
 # MSG_CRASH_DETECTED c=20 r=1
-#: messages.c:24
+#: messages.c:23
 msgid "Crash detected."
 msgstr "Choque detectado."
 
 # 
-#: Marlin_main.cpp:600
+#: Marlin_main.cpp:602
 msgid "Crash detected. Resume print?"
 msgstr "Choque detectado. Continuar impresion?"
 
 # 
-#: ultralcd.cpp:1853
+#: ultralcd.cpp:1776
 msgid "Crash"
 msgstr "Choque"
 
 # MSG_CURRENT c=19 r=1
-#: ultralcd.cpp:5909
+#: ultralcd.cpp:5979
 msgid "Current"
 msgstr "Actual"
 
 # MSG_DATE c=17 r=1
-#: ultralcd.cpp:2213
+#: ultralcd.cpp:2158
 msgid "Date:"
 msgstr "Fecha:"
 
 # MSG_DISABLE_STEPPERS
-#: ultralcd.cpp:5654
+#: ultralcd.cpp:5720
 msgid "Disable steppers"
 msgstr "Apagar motores"
 
 # MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: messages.c:14
+#: messages.c:13
 msgid "Distance between tip of the nozzle and the bed surface has not been set yet. Please follow the manual, chapter First steps, section First layer calibration."
 msgstr "Distancia entre la punta del boquilla y la superficie de la base aun no fijada. Por favor siga el manual, capitulo Primeros Pasos, Calibracion primera capa."
 
 # MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ultralcd.cpp:5070
+#: ultralcd.cpp:5103
 msgid "Do you want to repeat last step to readjust distance between nozzle and heatbed?"
 msgstr "Quieres repetir el ultimo paso para reajustar la distancia boquilla-base?"
 
 # MSG_EXTRUDER_CORRECTION c=10
-#: ultralcd.cpp:5134
+#: ultralcd.cpp:5172
 msgid "E-correct:"
 msgstr "Corregir-E:"
 
 # MSG_EJECT_FILAMENT c=17 r=1
-#: messages.c:53
+#: messages.c:49
 msgid "Eject filament"
 msgstr "Expulsar filamento"
 
-# 
-#: ultralcd.cpp:4869
-msgid "Eject"
-msgstr "Expulsar"
-
 # MSG_EJECTING_FILAMENT c=20 r=1
-#: mmu.cpp:1434
+#: mmu.cpp:1415
 msgid "Ejecting filament"
 msgstr "Expulsando filamento"
 
 # MSG_SELFTEST_ENDSTOP_NOTHIT c=20 r=1
-#: ultralcd.cpp:7917
+#: ultralcd.cpp:8254
 msgid "Endstop not hit"
 msgstr "Endstop no alcanzado"
 
 # MSG_SELFTEST_ENDSTOP
-#: ultralcd.cpp:7911
+#: ultralcd.cpp:8248
 msgid "Endstop"
 msgstr ""
 
 # MSG_SELFTEST_ENDSTOPS
-#: ultralcd.cpp:7899
+#: ultralcd.cpp:8236
 msgid "Endstops"
 msgstr ""
 
 # MSG_STACK_ERROR c=20 r=4
-#: ultralcd.cpp:6859
+#: ultralcd.cpp:6975
 msgid "Error - static memory has been overwritten"
 msgstr "Error - se ha sobre-escrito la memoria estatica"
 
 # MSG_FSENS_NOT_RESPONDING c=20 r=4
-#: ultralcd.cpp:4475
+#: ultralcd.cpp:4436
 msgid "ERROR: Filament sensor is not responding, please check connection."
 msgstr "ERROR: El sensor de filamento no responde, por favor comprueba la conexion."
 
 # MSG_ERROR
-#: messages.c:28
+#: messages.c:25
 msgid "ERROR:"
 msgstr ""
 
 # MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
-#: ultralcd.cpp:8304
+#: ultralcd.cpp:8647
 msgid "Extruder fan:"
 msgstr "Vent.extrusor:"
 
 # MSG_INFO_EXTRUDER c=15 r=1
-#: ultralcd.cpp:2244
+#: ultralcd.cpp:2189
 msgid "Extruder info"
 msgstr "Informacion del extrusor"
 
 # MSG_MOVE_E
-#: messages.c:29
+#: messages.c:26
 msgid "Extruder"
 msgstr "Extruir"
 
 # 
-#: ultralcd.cpp:6846
+#: ultralcd.cpp:6962
 msgid "Fail stats MMU"
 msgstr "Estadistica de fallos MMU"
 
-# MSG_FSENS_AUTOLOAD_ON c=17 r=1
-#: ultralcd.cpp:5168
-msgid "F. autoload  [on]"
-msgstr "Autocarg.Fil[act]"
-
-# MSG_FSENS_AUTOLOAD_NA c=17 r=1
-#: messages.c:43
-msgid "F. autoload [N/A]"
-msgstr "Autocarg.Fil[N/D]"
-
-# MSG_FSENS_AUTOLOAD_OFF c=17 r=1
-#: ultralcd.cpp:5170
-msgid "F. autoload [off]"
-msgstr "Autocarg.Fil[ina]"
+# MSG_FSENSOR_AUTOLOAD
+#: messages.c:40
+msgid "F. autoload"
+msgstr "Autocarg.fil."
 
 # 
-#: ultralcd.cpp:6843
+#: ultralcd.cpp:6959
 msgid "Fail stats"
 msgstr "Estadistica de fallos"
 
 # MSG_FAN_SPEED c=14
-#: messages.c:31
+#: messages.c:28
 msgid "Fan speed"
 msgstr "Velocidad Vent."
 
 # MSG_SELFTEST_FAN c=20
-#: messages.c:78
+#: messages.c:74
 msgid "Fan test"
 msgstr "Test ventiladores"
 
-# MSG_FANS_CHECK_ON c=17 r=1
-#: ultralcd.cpp:5663
-msgid "Fans check   [on]"
-msgstr "Comprob.vent[act]"
+# MSG_FANS_CHECK
+#: ultralcd.cpp:5728
+msgid "Fans check"
+msgstr "Comprob.vent"
 
-# MSG_FANS_CHECK_OFF c=17 r=1
-#: ultralcd.cpp:5665
-msgid "Fans check  [off]"
-msgstr "Comprob.vent[ina]"
-
-# MSG_FSENSOR_ON
-#: messages.c:45
-msgid "Fil. sensor  [on]"
-msgstr "Sensor Fil. [act]"
-
-# MSG_FSENSOR_NA
-#: ultralcd.cpp:5148
-msgid "Fil. sensor [N/A]"
-msgstr "Sensor Fil. [N/D]"
-
-# MSG_FSENSOR_OFF
-#: messages.c:44
-msgid "Fil. sensor [off]"
-msgstr "Sensor Fil. [ina]"
+# MSG_FSENSOR
+#: messages.c:41
+msgid "Fil. sensor"
+msgstr "Sensor Fil."
 
 # 
-#: ultralcd.cpp:1852
+#: ultralcd.cpp:1775
 msgid "Filam. runouts"
 msgstr "Filam. acabado"
 
 # MSG_FILAMENT_CLEAN c=20 r=2
-#: messages.c:32
+#: messages.c:29
 msgid "Filament extruding & with correct color?"
 msgstr "Es nitido el color nuevo?"
 
 # MSG_NOT_LOADED c=19
-#: ultralcd.cpp:2714
+#: ultralcd.cpp:2683
 msgid "Filament not loaded"
 msgstr "Fil. no introducido"
 
 # MSG_FILAMENT_SENSOR c=20
-#: messages.c:84
+#: messages.c:80
 msgid "Filament sensor"
 msgstr "Sensor de filamento"
 
 # MSG_FILAMENT_USED c=19 r=1
-#: ultralcd.cpp:2885
+#: ultralcd.cpp:2847
 msgid "Filament used"
 msgstr "Filamento usado"
 
 # MSG_PRINT_TIME c=19 r=1
-#: ultralcd.cpp:2886
+#: ultralcd.cpp:2848
 msgid "Print time"
 msgstr "Tiempo de imp.:"
 
 # MSG_FILE_INCOMPLETE c=20 r=2
-#: ultralcd.cpp:8432
+#: ultralcd.cpp:8775
 msgid "File incomplete. Continue anyway?"
 msgstr "Archivo incompleto. ?Continuar de todos modos?"
 
 # MSG_FINISHING_MOVEMENTS c=20 r=1
-#: messages.c:40
+#: messages.c:37
 msgid "Finishing movements"
 msgstr "Term. movimientos"
 
 # MSG_V2_CALIBRATION c=17 r=1
-#: messages.c:105
+#: messages.c:103
 msgid "First layer cal."
 msgstr "Cal. primera cap."
 
 # MSG_WIZARD_SELFTEST c=20 r=8
-#: ultralcd.cpp:4982
+#: ultralcd.cpp:5024
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr "Primero, hare el Selftest para comprobar los problemas de montaje mas comunes."
 
 # 
-#: mmu.cpp:724
+#: mmu.cpp:726
 msgid "Fix the issue and then press button on MMU unit."
 msgstr "Corrige el problema y pulsa el boton en la unidad MMU."
 
 # MSG_FLOW
-#: ultralcd.cpp:6932
+#: ultralcd.cpp:7102
 msgid "Flow"
 msgstr "Flujo"
 
 # MSG_PRUSA3D_FORUM
-#: ultralcd.cpp:2206
+#: ultralcd.cpp:2151
 msgid "forum.prusa3d.com"
 msgstr ""
 
 # MSG_SELFTEST_COOLING_FAN c=20
-#: messages.c:75
+#: messages.c:71
 msgid "Front print fan?"
 msgstr "Vent. frontal?"
 
 # MSG_BED_CORRECTION_FRONT c=14 r=1
-#: ultralcd.cpp:3294
+#: ultralcd.cpp:3244
 msgid "Front side[um]"
 msgstr "Frontal [um]"
 
 # MSG_SELFTEST_FANS
-#: ultralcd.cpp:7957
+#: ultralcd.cpp:8294
 msgid "Front/left fans"
 msgstr "Ventiladores frontal/izquierdo"
 
 # MSG_SELFTEST_HEATERTHERMISTOR
-#: ultralcd.cpp:7887
+#: ultralcd.cpp:8224
 msgid "Heater/Thermistor"
 msgstr "Calentador/Termistor"
 
 # MSG_BED_HEATING_SAFETY_DISABLED
-#: Marlin_main.cpp:8467
+#: Marlin_main.cpp:9458
 msgid "Heating disabled by safety timer."
 msgstr "Calentadores desactivados por el temporizador de seguridad."
 
 # MSG_HEATING_COMPLETE c=20
-#: messages.c:47
+#: messages.c:43
 msgid "Heating done."
 msgstr "Calentamiento acabado."
 
 # MSG_HEATING
-#: messages.c:46
+#: messages.c:42
 msgid "Heating"
 msgstr "Calentando..."
 
 # MSG_WIZARD_WELCOME c=20 r=7
-#: ultralcd.cpp:4961
+#: ultralcd.cpp:5003
 msgid "Hi, I am your Original Prusa i3 printer. Would you like me to guide you through the setup process?"
 msgstr "Hola, soy tu impresora Original Prusa i3. Quieres que te guie a traves de la configuracion?"
 
 # MSG_PRUSA3D_HOWTO
-#: ultralcd.cpp:2207
+#: ultralcd.cpp:2152
 msgid "howto.prusa3d.com"
 msgstr ""
 
 # MSG_FILAMENTCHANGE
-#: messages.c:37
+#: messages.c:34
 msgid "Change filament"
 msgstr "Cambiar filamento"
 
 # MSG_CHANGE_SUCCESS
-#: ultralcd.cpp:2629
+#: ultralcd.cpp:2598
 msgid "Change success!"
 msgstr "Cambio correcto"
 
 # MSG_CORRECTLY c=20
-#: ultralcd.cpp:2706
+#: ultralcd.cpp:2675
 msgid "Changed correctly?"
 msgstr "Cambio correcto?"
 
 # MSG_SELFTEST_CHECK_BED c=20
-#: messages.c:81
+#: messages.c:77
 msgid "Checking bed     "
 msgstr "Control base cal."
 
 # MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ultralcd.cpp:8286
+#: ultralcd.cpp:8629
 msgid "Checking endstops"
 msgstr "Control endstops"
 
 # MSG_SELFTEST_CHECK_HOTEND c=20
-#: ultralcd.cpp:8292
+#: ultralcd.cpp:8635
 msgid "Checking hotend  "
 msgstr "Control fusor"
 
 # MSG_SELFTEST_CHECK_FSENSOR c=20
-#: messages.c:82
+#: messages.c:78
 msgid "Checking sensors "
 msgstr "Comprobando los sensores"
 
 # MSG_SELFTEST_CHECK_X c=20
-#: ultralcd.cpp:8287
+#: ultralcd.cpp:8630
 msgid "Checking X axis  "
 msgstr "Control sensor X"
 
 # MSG_SELFTEST_CHECK_Y c=20
-#: ultralcd.cpp:8288
+#: ultralcd.cpp:8631
 msgid "Checking Y axis  "
 msgstr "Control sensor Y"
 
 # MSG_SELFTEST_CHECK_Z c=20
-#: ultralcd.cpp:8289
+#: ultralcd.cpp:8632
 msgid "Checking Z axis  "
 msgstr "Control sensor Z"
 
 # MSG_CHOOSE_EXTRUDER c=20 r=1
-#: messages.c:49
+#: messages.c:45
 msgid "Choose extruder:"
 msgstr "Elegir extrusor:"
 
 # MSG_CHOOSE_FILAMENT c=20 r=1
-#: messages.c:50
+#: messages.c:46
 msgid "Choose filament:"
 msgstr "Elije filamento:"
 
 # MSG_FILAMENT c=17 r=1
-#: messages.c:30
+#: messages.c:27
 msgid "Filament"
 msgstr "Filamento"
 
 # MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ultralcd.cpp:4991
+#: ultralcd.cpp:5033
 msgid "I will run xyz calibration now. It will take approx. 12 mins."
 msgstr "Hare la calibracion XYZ. Tardara 12 min. aproximadamente."
 
 # MSG_WIZARD_Z_CAL c=20 r=8
-#: ultralcd.cpp:4999
+#: ultralcd.cpp:5041
 msgid "I will run z calibration now."
 msgstr "Voy a hacer Calibracion Z ahora."
 
-# MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ultralcd.cpp:5064
-msgid "I will start to print line and you will gradually lower the nozzle by rotating the knob, until you reach optimal height. Check the pictures in our handbook in chapter Calibration."
-msgstr "Voy a comenzar a imprimir la linea y tu bajaras el nozzle gradualmente al rotar el dial, hasta que llegues a la altura optima. Mira las imagenes del capitulo Calibracion en el manual."
-
 # MSG_WATCH
-#: messages.c:99
+#: messages.c:97
 msgid "Info screen"
 msgstr "Monitorizar"
 
-# 
-#: ultralcd.cpp:5024
-msgid "Is filament 1 loaded?"
-msgstr "?Esta cargado el filamento 1?"
-
 # MSG_INSERT_FILAMENT c=20
-#: ultralcd.cpp:2614
+#: ultralcd.cpp:2583
 msgid "Insert filament"
 msgstr "Introducir filamento"
 
 # MSG_WIZARD_FILAMENT_LOADED c=20 r=2
-#: ultralcd.cpp:5027
+#: ultralcd.cpp:4813
 msgid "Is filament loaded?"
 msgstr "Esta el filamento cargado?"
 
-# MSG_WIZARD_PLA_FILAMENT c=20 r=2
-#: ultralcd.cpp:5058
-msgid "Is it PLA filament?"
-msgstr "Es el filamento PLA?"
-
-# MSG_PLA_FILAMENT_LOADED c=20 r=2
-#: ultralcd.cpp:4790
-msgid "Is PLA filament loaded?"
-msgstr "Esta el filamento PLA cargado?"
-
 # MSG_STEEL_SHEET_CHECK c=20 r=2
-#: messages.c:92
+#: messages.c:90
 msgid "Is steel sheet on heatbed?"
 msgstr "?Esta colocada la lamina de acero sobre la base?"
 
 # 
-#: ultralcd.cpp:1795
+#: ultralcd.cpp:1718
 msgid "Last print failures"
 msgstr "Ultimas impresiones fallidas"
 
 # 
-#: ultralcd.cpp:1772
+#: ultralcd.cpp:5111
+msgid "If you have additional steel sheets, calibrate their presets in Settings - HW Setup - Steel sheets."
+msgstr "Si tienes planchas de acero adicionales, calibra sus ajustes en Ajustes - Ajustes HW - Planchas acero."
+
+# 
+#: ultralcd.cpp:1695
 msgid "Last print"
 msgstr "Ultima impresion"
 
 # MSG_SELFTEST_EXTRUDER_FAN c=20
-#: messages.c:76
+#: messages.c:72
 msgid "Left hotend fan?"
 msgstr "Vent. izquierdo?"
 
 # 
-#: ultralcd.cpp:3018
+#: ultralcd.cpp:2971
 msgid "Left"
 msgstr "Izquierda"
 
 # MSG_BED_CORRECTION_LEFT c=14 r=1
-#: ultralcd.cpp:3292
+#: ultralcd.cpp:3242
 msgid "Left side [um]"
 msgstr "Izquierda [um]"
 
 # 
-#: ultralcd.cpp:5680
+#: ultralcd.cpp:5743
 msgid "Lin. correction"
 msgstr "Correccion de Linealidad"
 
 # MSG_BABYSTEP_Z
-#: messages.c:13
+#: messages.c:12
 msgid "Live adjust Z"
 msgstr "Micropaso Eje Z"
 
 # MSG_LOAD_FILAMENT c=17
-#: messages.c:51
+#: messages.c:47
 msgid "Load filament"
 msgstr "Introducir filam."
 
 # MSG_LOADING_COLOR
-#: ultralcd.cpp:2654
+#: ultralcd.cpp:2623
 msgid "Loading color"
 msgstr "Cambiando color"
 
 # MSG_LOADING_FILAMENT c=20
-#: messages.c:52
+#: messages.c:48
 msgid "Loading filament"
 msgstr "Introduciendo filam."
 
 # MSG_LOOSE_PULLEY c=20 r=1
-#: ultralcd.cpp:7941
+#: ultralcd.cpp:8278
 msgid "Loose pulley"
 msgstr "Polea suelta"
 
 # 
-#: ultralcd.cpp:6805
+#: ultralcd.cpp:6921
 msgid "Load to nozzle"
 msgstr "Cargar a la boquilla"
 
 # MSG_M117_V2_CALIBRATION c=25 r=1
-#: messages.c:55
+#: messages.c:51
 msgid "M117 First layer cal."
 msgstr "M117 Cal. primera cap."
 
 # MSG_MAIN
-#: messages.c:56
+#: messages.c:52
 msgid "Main"
 msgstr "Menu principal"
 
 # MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=60
-#: messages.c:59
+#: messages.c:55
 msgid "Measuring reference height of calibration point"
 msgstr "Midiendo altura del punto de calibracion"
 
 # MSG_MESH_BED_LEVELING
-#: ultralcd.cpp:5763
+#: ultralcd.cpp:5833
 msgid "Mesh Bed Leveling"
 msgstr "Nivelacion Mesh Level"
 
 # MSG_MMU_OK_RESUMING_POSITION c=20 r=4
-#: mmu.cpp:762
+#: mmu.cpp:764
 msgid "MMU OK. Resuming position..."
 msgstr "MMU OK. Restaurando posicion..."
 
 # MSG_MMU_OK_RESUMING_TEMPERATURE c=20 r=4
-#: mmu.cpp:755
+#: mmu.cpp:757
 msgid "MMU OK. Resuming temperature..."
 msgstr "MMU OK. Restaurando temperatura..."
 
 # 
-#: ultralcd.cpp:3059
+#: ultralcd.cpp:3012
 msgid "Measured skew"
 msgstr "Desviacion med:"
 
-# 
-#: ultralcd.cpp:1796
+#  c=13 r=1
+#: ultralcd.cpp:1719
 msgid "MMU fails"
 msgstr "Fallos MMU"
 
 # 
-#: mmu.cpp:1613
+#: mmu.cpp:1587
 msgid "MMU load failed     "
 msgstr "Carga MMU fallida"
 
-# 
-#: ultralcd.cpp:1797
-msgid "MMU load fails"
+#  c=13 r=1
+#: ultralcd.cpp:1720
+msgid "MMU load f."
 msgstr "Carga MMU falla"
 
 # MSG_MMU_OK_RESUMING c=20 r=4
-#: mmu.cpp:773
+#: mmu.cpp:775
 msgid "MMU OK. Resuming..."
 msgstr "MMU OK. Resumiendo..."
 
-# MSG_STEALTH_MODE_OFF
-#: messages.c:90
-msgid "Mode     [Normal]"
-msgstr "Modo     [Normal]"
+# MSG_MODE
+#: messages.c:84
+msgid "Mode"
+msgstr "Modo"
 
-# MSG_SILENT_MODE_ON
-#: messages.c:89
-msgid "Mode     [silent]"
-msgstr "Modo   [silencio]"
+# MSG_NORMAL
+#: messages.c:88
+msgid "Normal"
+msgstr ""
+
+# MSG_SILENT
+#: messages.c:87
+msgid "Silent"
+msgstr "Silencio"
 
 # 
-#: mmu.cpp:719
+#: mmu.cpp:721
 msgid "MMU needs user attention."
 msgstr "MMU necesita atencion del usuario."
 
-# 
-#: ultralcd.cpp:1823
-msgid "MMU power fails"
+#  c=14 r=1
+#: ultralcd.cpp:1746
+msgid "MMU power f."
 msgstr "Fallo de energia en MMU"
 
-# MSG_STEALTH_MODE_ON
-#: messages.c:91
-msgid "Mode    [Stealth]"
-msgstr "Modo   [Silencio]"
+# MSG_STEALTH
+#: messages.c:89
+msgid "Stealth"
+msgstr "Silencio"
 
-# MSG_AUTO_MODE_ON
-#: messages.c:12
-msgid "Mode [auto power]"
-msgstr "Modo[fuerza auto]"
+# MSG_AUTO_POWER
+#: messages.c:86
+msgid "Auto power"
+msgstr "Fuerza auto"
 
-# MSG_SILENT_MODE_OFF
-#: messages.c:88
-msgid "Mode [high power]"
-msgstr "Modo [rend.pleno]"
+# MSG_HIGH_POWER
+#: messages.c:85
+msgid "High power"
+msgstr "Rend.pleno"
 
 # 
-#: ultralcd.cpp:2219
+#: ultralcd.cpp:2164
 msgid "MMU2 connected"
 msgstr "MMU2 conectado"
 
 # MSG_SELFTEST_MOTOR
-#: messages.c:83
+#: messages.c:79
 msgid "Motor"
 msgstr ""
 
 # MSG_MOVE_AXIS
-#: ultralcd.cpp:5652
+#: ultralcd.cpp:5718
 msgid "Move axis"
 msgstr "Mover ejes"
 
 # MSG_MOVE_X
-#: ultralcd.cpp:4378
+#: ultralcd.cpp:4339
 msgid "Move X"
 msgstr "Mover X"
 
 # MSG_MOVE_Y
-#: ultralcd.cpp:4379
+#: ultralcd.cpp:4340
 msgid "Move Y"
 msgstr "Mover Y"
 
 # MSG_MOVE_Z
-#: ultralcd.cpp:4380
+#: ultralcd.cpp:4341
 msgid "Move Z"
 msgstr "Mover Z"
 
 # MSG_NO_MOVE
-#: Marlin_main.cpp:5292
+#: Marlin_main.cpp:5526
 msgid "No move."
 msgstr "Sin movimiento"
 
 # MSG_NO_CARD
-#: ultralcd.cpp:6772
+#: ultralcd.cpp:6888
 msgid "No SD card"
 msgstr "No hay tarjeta SD"
 
-# 
-#: ultralcd.cpp:3024
+# MSG_NA
+#: messages.c:107
 msgid "N/A"
 msgstr "N/A"
 
 # MSG_NO
-#: messages.c:62
+#: messages.c:58
 msgid "No"
 msgstr ""
 
 # MSG_SELFTEST_NOTCONNECTED
-#: ultralcd.cpp:7889
+#: ultralcd.cpp:8226
 msgid "Not connected"
 msgstr "No hay conexion "
 
@@ -846,167 +796,152 @@ msgid "New firmware version available:"
 msgstr "Nuevo firmware disponible:"
 
 # MSG_SELFTEST_FAN_NO c=19
-#: messages.c:79
+#: messages.c:75
 msgid "Not spinning"
 msgstr "Ventilador no gira"
 
 # MSG_WIZARD_V2_CAL c=20 r=8
-#: ultralcd.cpp:5063
+#: ultralcd.cpp:4924
 msgid "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr "Voy a calibrar la distancia entre la punta de la boquilla y la superficie de la base."
 
 # MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ultralcd.cpp:5007
+#: ultralcd.cpp:5049
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Ahora precalentare la boquilla para PLA."
 
 # MSG_NOZZLE
-#: messages.c:63
+#: messages.c:59
 msgid "Nozzle"
 msgstr "Boquilla"
 
 # MSG_DEFAULT_SETTINGS_LOADED c=20 r=4
-#: Marlin_main.cpp:1519
+#: Marlin_main.cpp:1500
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr "Se han encontrado ajustes anteriores. Se ajustara el PID, los pasos del extrusor, etc"
 
 # 
-#: ultralcd.cpp:4998
+#: ultralcd.cpp:5040
 msgid "Now remove the test print from steel sheet."
 msgstr "Ahora retira la prueba de la lamina de acero."
 
 # 
-#: ultralcd.cpp:1722
+#: ultralcd.cpp:1645
 msgid "Nozzle FAN"
 msgstr "Vent. capa"
 
 # MSG_PAUSE_PRINT
-#: ultralcd.cpp:6735
+#: ultralcd.cpp:6852
 msgid "Pause print"
 msgstr "Pausar impresion"
 
 # MSG_PID_RUNNING c=20 r=1
-#: ultralcd.cpp:1606
+#: ultralcd.cpp:1530
 msgid "PID cal.           "
 msgstr "Cal. PID "
 
 # MSG_PID_FINISHED c=20 r=1
-#: ultralcd.cpp:1612
+#: ultralcd.cpp:1536
 msgid "PID cal. finished"
 msgstr "Cal. PID terminada"
 
 # MSG_PID_EXTRUDER c=17 r=1
-#: ultralcd.cpp:5769
+#: ultralcd.cpp:5839
 msgid "PID calibration"
 msgstr "Calibracion PID"
 
 # MSG_PINDA_PREHEAT c=20 r=1
-#: ultralcd.cpp:846
+#: ultralcd.cpp:887
 msgid "PINDA Heating"
 msgstr "Calentando PINDA"
 
 # MSG_PAPER c=20 r=8
-#: messages.c:64
+#: messages.c:60
 msgid "Place a sheet of paper under the nozzle during the calibration of first 4 points. If the nozzle catches the paper, power off the printer immediately."
 msgstr "Colocar una hoja de papel sobre la superficie de impresion durante la calibracion de los primeros 4 puntos. Si la boquilla mueve el papel, apagar impresora inmediatamente."
 
 # MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ultralcd.cpp:5072
+#: ultralcd.cpp:5106
 msgid "Please clean heatbed and then press the knob."
 msgstr "Limpia la superficie de la base, por favor, y haz clic"
 
 # MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: messages.c:22
+#: messages.c:21
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Limpia boquilla para calibracion. Click cuando acabes."
 
 # MSG_SELFTEST_PLEASECHECK
-#: ultralcd.cpp:7881
+#: ultralcd.cpp:8218
 msgid "Please check :"
 msgstr "Controla :"
 
 # MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: messages.c:100
+#: messages.c:98
 msgid "Please check our handbook and fix the problem. Then resume the Wizard by rebooting the printer."
 msgstr "Lee el manual y resuelve el problema. Despues, reinicia la impresora y continua con el Wizard"
 
-# MSG_WIZARD_LOAD_FILAMENT c=20 r=8
-#: ultralcd.cpp:4894
-msgid "Please insert PLA filament to the extruder, then press knob to load it."
-msgstr "Inserta, por favor, filamento PLA en el extrusor. Despues haz clic para cargarlo."
-
-# MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ultralcd.cpp:4795
-msgid "Please load PLA filament first."
-msgstr "Carga el filamento PLA primero por favor."
-
 # MSG_CHECK_IDLER c=20 r=4
-#: Marlin_main.cpp:3064
+#: Marlin_main.cpp:3116
 msgid "Please open idler and remove filament manually."
 msgstr "Por favor abate el rodillo de empuje (idler) y retira el filamento manualmente."
 
 # MSG_PLACE_STEEL_SHEET c=20 r=4
-#: messages.c:65
+#: messages.c:61
 msgid "Please place steel sheet on heatbed."
 msgstr "Por favor coloca la chapa de acero en la base calefactable."
 
 # MSG_PRESS_TO_UNLOAD c=20 r=4
-#: messages.c:68
+#: messages.c:64
 msgid "Please press the knob to unload filament"
 msgstr "Por favor, pulsa el dial para descargar el filamento"
 
-# 
-#: ultralcd.cpp:4889
-msgid "Please insert PLA filament to the first tube of MMU, then press the knob to load it."
-msgstr "Por favor introduce el filamento al primer tubo MMU, despues presiona el dial para imprimirlo."
-
 # MSG_PULL_OUT_FILAMENT c=20 r=4
-#: messages.c:70
+#: messages.c:66
 msgid "Please pull out filament immediately"
 msgstr "Por favor retire el filamento de inmediato"
 
 # MSG_EJECT_REMOVE c=20 r=4
-#: mmu.cpp:1440
+#: mmu.cpp:1421
 msgid "Please remove filament and then press the knob."
 msgstr "Por favor quite el filamento y luego presione el dial."
 
 # MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: messages.c:74
+#: messages.c:70
 msgid "Please remove steel sheet from heatbed."
 msgstr "Por favor retire la chapa de acero de la base calefactable."
 
 # MSG_RUN_XYZ c=20 r=4
-#: Marlin_main.cpp:4355
+#: Marlin_main.cpp:4561
 msgid "Please run XYZ calibration first."
 msgstr "Por favor realiza la calibracion XYZ primero."
 
 # MSG_UPDATE_MMU2_FW c=20 r=4
-#: mmu.cpp:1359
+#: mmu.cpp:1340
 msgid "Please update firmware in your MMU2. Waiting for reset."
 msgstr "Por favor actualice el firmware en tu MMU2. Esperando el reseteo."
 
 # MSG_PLEASE_WAIT c=20
-#: messages.c:66
+#: messages.c:62
 msgid "Please wait"
 msgstr "Por Favor Espere"
 
 # 
-#: ultralcd.cpp:4997
+#: ultralcd.cpp:5039
 msgid "Please remove shipping helpers first."
 msgstr "Por favor retira los soportes de envio primero."
 
 # MSG_PREHEAT_NOZZLE c=20
-#: messages.c:67
+#: messages.c:63
 msgid "Preheat the nozzle!"
 msgstr "Precalienta extrusor!"
 
 # MSG_PREHEAT
-#: ultralcd.cpp:6722
+#: ultralcd.cpp:6830
 msgid "Preheat"
 msgstr "Precalentar"
 
 # MSG_WIZARD_HEATING c=20 r=3
-#: messages.c:102
+#: messages.c:100
 msgid "Preheating nozzle. Please wait."
 msgstr "Precalentando nozzle. Espera por favor."
 
@@ -1016,82 +951,97 @@ msgid "Please upgrade."
 msgstr "Actualize por favor"
 
 # MSG_PRESS_TO_PREHEAT c=20 r=4
-#: Marlin_main.cpp:10364
+#: Marlin_main.cpp:11469
 msgid "Press knob to preheat nozzle and continue."
 msgstr "Pulsa el dial para precalentar la boquilla y continue."
 
 # 
-#: ultralcd.cpp:1851
+#: ultralcd.cpp:1774
 msgid "Power failures"
 msgstr "Cortes de energia"
 
 # MSG_PRINT_ABORTED c=20
-#: messages.c:69
+#: messages.c:65
 msgid "Print aborted"
 msgstr "Impresion cancelada"
 
 # 
-#: ultralcd.cpp:2455
+#: ultralcd.cpp:2420
 msgid "Preheating to load"
 msgstr "Precalentar para cargar"
 
 # 
-#: ultralcd.cpp:2459
+#: ultralcd.cpp:2424
 msgid "Preheating to unload"
 msgstr "Precalentar para descargar"
 
 # MSG_SELFTEST_PRINT_FAN_SPEED c=18
-#: ultralcd.cpp:8307
+#: ultralcd.cpp:8650
 msgid "Print fan:"
 msgstr "Vent.fusor:"
 
 # MSG_CARD_MENU
-#: messages.c:21
+#: messages.c:20
 msgid "Print from SD"
 msgstr "Menu tarjeta SD"
 
 # 
-#: ultralcd.cpp:2317
+#: ultralcd.cpp:2267
 msgid "Press the knob"
 msgstr "Pulsa el dial"
 
 # MSG_PRINT_PAUSED c=20 r=1
-#: ultralcd.cpp:1069
+#: ultralcd.cpp:1109
 msgid "Print paused"
 msgstr "Impresion en pausa"
 
 # 
-#: mmu.cpp:723
+#: mmu.cpp:725
 msgid "Press the knob to resume nozzle temperature."
 msgstr "Presiona el dial para continuar con la temperatura de la boquilla."
 
 # MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: messages.c:41
+#: messages.c:38
 msgid "Printer has not been calibrated yet. Please follow the manual, chapter First steps, section Calibration flow."
 msgstr "Impresora no esta calibrada todavia. Por favor usa el manual capitulo Primeros pasos Calibracion flujo."
 
 # 
-#: ultralcd.cpp:1723
+#: ultralcd.cpp:1646
 msgid "Print FAN"
-msgstr "Vent.extr"
+msgstr "Vent. extr"
+
+# 
+#: ultralcd.cpp:4904
+msgid "Please insert filament into the extruder, then press the knob to load it."
+msgstr "Por favor, coloca el filamento en el extrusor, luego presiona el dial para cargarlo."
+
+# 
+#: ultralcd.cpp:4899
+msgid "Please insert filament into the first tube of the MMU, then press the knob to load it."
+msgstr "Por favor, coloca el filamento en el primer tubo de la MMU, luego pulsa el dial para cargarlo."
+
+# 
+#: ultralcd.cpp:4821
+msgid "Please load filament first."
+msgstr "Por favor, cargar primero el filamento. "
 
 # MSG_PRUSA3D
-#: ultralcd.cpp:2205
+#: ultralcd.cpp:2150
 msgid "prusa3d.com"
 msgstr "prusa3d.es"
 
 # MSG_BED_CORRECTION_REAR c=14 r=1
-#: ultralcd.cpp:3295
+#: ultralcd.cpp:3245
 msgid "Rear side [um]"
 msgstr "Trasera [um]"
 
 # MSG_RECOVERING_PRINT c=20 r=1
-#: Marlin_main.cpp:9764
+#: Marlin_main.cpp:10826
 msgid "Recovering print    "
 msgstr "Recuperando impresion"
 
 # MSG_REMOVE_OLD_FILAMENT c=20 r=4
-#: mmu.cpp:830
+#: mmu.cpp:832
 msgid "Remove old filament and press the knob to start loading new filament."
 msgstr "Retire el filamento viejo y presione el dial para comenzar a cargar el nuevo filamento."
 
@@ -1101,712 +1051,647 @@ msgid "Prusa i3 MK3S OK."
 msgstr ""
 
 # MSG_CALIBRATE_BED_RESET
-#: ultralcd.cpp:5774
+#: ultralcd.cpp:5844
 msgid "Reset XYZ calibr."
 msgstr ""
 
 # MSG_BED_CORRECTION_RESET
-#: ultralcd.cpp:3296
+#: ultralcd.cpp:3246
 msgid "Reset"
 msgstr ""
 
 # MSG_RESUME_PRINT
-#: ultralcd.cpp:6742
+#: ultralcd.cpp:6838
 msgid "Resume print"
 msgstr "Reanudar impres."
 
 # MSG_RESUMING_PRINT c=20 r=1
-#: messages.c:73
+#: messages.c:69
 msgid "Resuming print"
 msgstr "Continuando impresion"
 
 # MSG_BED_CORRECTION_RIGHT c=14 r=1
-#: ultralcd.cpp:3293
+#: ultralcd.cpp:3243
 msgid "Right side[um]"
 msgstr "Derecha [um]"
 
-# MSG_SECOND_SERIAL_ON c=17 r=1
-#: ultralcd.cpp:5692
-msgid "RPi port     [on]"
-msgstr "Puerto RPi  [act]"
-
-# MSG_SECOND_SERIAL_OFF c=17 r=1
-#: ultralcd.cpp:5690
-msgid "RPi port    [off]"
-msgstr "Puerto RPi  [ina]"
+# MSG_RPI_PORT
+#: messages.c:123
+msgid "RPi port"
+msgstr "Puerto RPi"
 
 # MSG_WIZARD_RERUN c=20 r=7
-#: ultralcd.cpp:4812
+#: ultralcd.cpp:4842
 msgid "Running Wizard will delete current calibration results and start from the beginning. Continue?"
 msgstr "Ejecutar el Wizard borrara los valores de calibracion actuales y comenzara de nuevo. Continuar?"
 
-# MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_OFF c=19 r=1
-#: ultralcd.cpp:5322
-msgid "SD card  [normal]"
-msgstr "Tarj. SD [normal]"
+# MSG_SD_CARD
+#: messages.c:118
+msgid "SD card"
+msgstr "Tarj. SD"
 
-# MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_ON c=19 r=1
-#: ultralcd.cpp:5320
-msgid "SD card [flshAir]"
-msgstr "Tarj. SD[FlshAir]"
+# MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY
+#: messages.c:119
+msgid "FlashAir"
+msgstr ""
 
 # 
-#: ultralcd.cpp:3019
+#: ultralcd.cpp:2972
 msgid "Right"
 msgstr "Derecha"
 
 # MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=60
-#: messages.c:38
+#: messages.c:35
 msgid "Searching bed calibration point"
 msgstr "Buscando punto de calibracion base"
 
 # MSG_LANGUAGE_SELECT
-#: ultralcd.cpp:5699
+#: ultralcd.cpp:5756
 msgid "Select language"
 msgstr "Cambiar el idioma"
 
 # MSG_SELFTEST_OK
-#: ultralcd.cpp:7452
+#: ultralcd.cpp:7784
 msgid "Self test OK"
 msgstr ""
 
 # MSG_SELFTEST_START c=20
-#: ultralcd.cpp:7238
+#: ultralcd.cpp:7558
 msgid "Self test start  "
 msgstr "Iniciar Selftest"
 
 # MSG_SELFTEST
-#: ultralcd.cpp:5750
+#: ultralcd.cpp:5820
 msgid "Selftest         "
 msgstr "Selftest"
 
 # MSG_SELFTEST_ERROR
-#: ultralcd.cpp:7879
+#: ultralcd.cpp:8216
 msgid "Selftest error !"
 msgstr "Error Selftest !"
 
 # MSG_SELFTEST_FAILED c=20
-#: messages.c:77
+#: messages.c:73
 msgid "Selftest failed  "
 msgstr "Fallo Selftest"
 
 # MSG_FORCE_SELFTEST c=20 r=8
-#: Marlin_main.cpp:1551
+#: Marlin_main.cpp:1532
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr "Se realizara el auto-test para calibrar con precision la vuelta a la posicion inicial sin sensores."
 
 # 
-#: ultralcd.cpp:5045
+#: ultralcd.cpp:5080
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr "Selecciona la temperatura para precalentar la boquilla que se ajuste a tu material. "
 
-# 
-#: ultralcd.cpp:4780
-msgid "Select PLA filament:"
-msgstr "Seleccionar filamento PLA:"
-
 # MSG_SET_TEMPERATURE c=19 r=1
-#: ultralcd.cpp:3314
+#: ultralcd.cpp:3264
 msgid "Set temperature:"
 msgstr "Establecer temp.:"
 
 # MSG_SETTINGS
-#: messages.c:86
+#: messages.c:82
 msgid "Settings"
 msgstr "Configuracion"
 
 # MSG_SHOW_END_STOPS c=17 r=1
-#: ultralcd.cpp:5771
+#: ultralcd.cpp:5841
 msgid "Show end stops"
 msgstr "Mostrar endstops"
 
 # 
-#: ultralcd.cpp:4025
+#: ultralcd.cpp:3986
 msgid "Sensor state"
 msgstr "Estado del sensor"
 
 # MSG_FILE_CNT c=20 r=4
-#: cardreader.cpp:739
+#: cardreader.cpp:729
 msgid "Some files will not be sorted. Max. No. of files in 1 folder for sorting is 100."
 msgstr "Algunos archivos no se ordenaran. Maximo 100 archivos por carpeta para ordenar. "
 
-# MSG_SORT_NONE c=17 r=1
-#: ultralcd.cpp:5332
-msgid "Sort       [none]"
-msgstr "Ordenar [ninguno]"
+# MSG_SORT
+#: messages.c:120
+msgid "Sort"
+msgstr "Ordenar"
 
-# MSG_SORT_TIME c=17 r=1
-#: ultralcd.cpp:5330
-msgid "Sort       [time]"
-msgstr "Ordenar   [fecha]"
+# MSG_NONE
+#: messages.c:110
+msgid "None"
+msgstr "Ninguno"
+
+# MSG_SORT_TIME
+#: messages.c:121
+msgid "Time"
+msgstr "Fecha"
 
 # 
-#: ultralcd.cpp:3062
+#: ultralcd.cpp:3015
 msgid "Severe skew:"
 msgstr "Incl.severa:"
 
-# MSG_SORT_ALPHA c=17 r=1
-#: ultralcd.cpp:5331
-msgid "Sort   [alphabet]"
-msgstr "Ordenar [alfabet]"
+# MSG_SORT_ALPHA
+#: messages.c:122
+msgid "Alphabet"
+msgstr "Alfabet"
 
 # MSG_SORTING c=20 r=1
-#: cardreader.cpp:746
+#: cardreader.cpp:736
 msgid "Sorting files"
 msgstr "Ordenando archivos"
 
-# MSG_SOUND_LOUD c=17 r=1
-#: sound.h:6
-msgid "Sound      [loud]"
-msgstr "Sonido     [alto]"
+# MSG_SOUND_LOUD
+#: messages.c:125
+msgid "Loud"
+msgstr "Alto"
 
 # 
-#: ultralcd.cpp:3061
+#: ultralcd.cpp:3014
 msgid "Slight skew:"
 msgstr "Liger.incl.:"
 
-# MSG_SOUND_MUTE c=17 r=1
-#: 
-msgid "Sound      [mute]"
-msgstr "Sonido[silenciad]"
+# MSG_SOUND
+#: messages.c:124
+msgid "Sound"
+msgstr "Sonido"
 
 # 
-#: Marlin_main.cpp:4871
+#: Marlin_main.cpp:5084
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Problema encontrado, nivelacion Z forzosa ..."
 
-# MSG_SOUND_ONCE c=17 r=1
-#: sound.h:7
-msgid "Sound      [once]"
-msgstr "Sonido  [una vez]"
-
-# MSG_SOUND_SILENT c=17 r=1
-#: sound.h:8
-msgid "Sound    [silent]"
-msgstr "Sonido[silencios]"
+# MSG_SOUND_ONCE
+#: messages.c:126
+msgid "Once"
+msgstr "Una vez"
 
 # MSG_SPEED
-#: ultralcd.cpp:6926
+#: ultralcd.cpp:7096
 msgid "Speed"
 msgstr "Velocidad"
 
 # MSG_SELFTEST_FAN_YES c=19
-#: messages.c:80
+#: messages.c:76
 msgid "Spinning"
 msgstr "Ventilador girando"
 
 # MSG_TEMP_CAL_WARNING c=20 r=4
-#: Marlin_main.cpp:4368
+#: Marlin_main.cpp:4574
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr "Se necesita una temperatura ambiente ente 21 y 26C y un soporte rigido."
 
 # MSG_STATISTICS
-#: ultralcd.cpp:6839
+#: ultralcd.cpp:6955
 msgid "Statistics  "
 msgstr "Estadisticas "
 
 # MSG_STOP_PRINT
-#: messages.c:93
+#: messages.c:91
 msgid "Stop print"
 msgstr "Detener impresion"
 
 # MSG_STOPPED
-#: messages.c:94
+#: messages.c:92
 msgid "STOPPED. "
 msgstr "PARADA"
 
 # MSG_SUPPORT
-#: ultralcd.cpp:6848
+#: ultralcd.cpp:6964
 msgid "Support"
 msgstr "Soporte"
 
 # MSG_SELFTEST_SWAPPED
-#: ultralcd.cpp:7959
+#: ultralcd.cpp:8296
 msgid "Swapped"
 msgstr "Intercambiado"
 
-# MSG_TEMP_CALIBRATION c=20 r=1
-#: messages.c:95
-msgid "Temp. cal.          "
-msgstr "Cal. temp. "
+# 
+#: ultralcd.cpp:4792
+msgid "Select filament:"
+msgstr "Selecciona filamento:"
 
-# MSG_TEMP_CALIBRATION_ON c=20 r=1
-#: ultralcd.cpp:5686
-msgid "Temp. cal.   [on]"
-msgstr "Cal. temp.   [on]"
+# MSG_TEMP_CALIBRATION c=12 r=1
+#: messages.c:93
+msgid "Temp. cal."
+msgstr "Cal. temp."
 
-# MSG_TEMP_CALIBRATION_OFF c=20 r=1
-#: ultralcd.cpp:5684
-msgid "Temp. cal.  [off]"
-msgstr "Cal. temp.  [off]"
+# 
+#: ultralcd.cpp:4933
+msgid "Select temperature which matches your material."
+msgstr "Selecciona la temperatura adecuada a tu material."
 
 # MSG_CALIBRATION_PINDA_MENU c=17 r=1
-#: ultralcd.cpp:5780
+#: ultralcd.cpp:5850
 msgid "Temp. calibration"
 msgstr "Calibracion temp."
 
 # MSG_TEMP_CAL_FAILED c=20 r=8
-#: ultralcd.cpp:3951
+#: ultralcd.cpp:3911
 msgid "Temperature calibration failed"
 msgstr "Fallo de la calibracion de temperatura"
 
 # MSG_TEMP_CALIBRATION_DONE c=20 r=12
-#: messages.c:96
+#: messages.c:94
 msgid "Temperature calibration is finished and active. Temp. calibration can be disabled in menu Settings->Temp. cal."
 msgstr "Calibracion temperatura terminada. Haz clic para continuar."
 
 # MSG_TEMPERATURE
-#: ultralcd.cpp:5650
+#: ultralcd.cpp:5716
 msgid "Temperature"
 msgstr "Temperatura"
 
 # MSG_MENU_TEMPERATURES c=15 r=1
-#: ultralcd.cpp:2251
+#: ultralcd.cpp:2196
 msgid "Temperatures"
 msgstr "Temperaturas"
 
 # MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=4
-#: messages.c:42
+#: messages.c:39
 msgid "There is still a need to make Z calibration. Please follow the manual, chapter First steps, section Calibration flow."
 msgstr "Todavia es necesario hacer una calibracion Z. Por favor siga el manual, capitulo Primeros pasos, seccion Calibracion del flujo."
 
 # 
-#: ultralcd.cpp:2908
+#: ultralcd.cpp:2869
 msgid "Total filament"
-msgstr "Filamento total:"
+msgstr "Filamento total"
 
 # 
-#: ultralcd.cpp:2908
+#: ultralcd.cpp:2870
 msgid "Total print time"
-msgstr "Tiempo total :"
+msgstr "Tiempo total"
 
 # MSG_TUNE
-#: ultralcd.cpp:6719
+#: ultralcd.cpp:6827
 msgid "Tune"
 msgstr "Ajustar"
 
 # 
-#: ultralcd.cpp:4869
+#: 
 msgid "Unload"
 msgstr "Descargar"
 
 # 
-#: ultralcd.cpp:1820
+#: ultralcd.cpp:1743
 msgid "Total failures"
 msgstr "Fallos totales"
 
 # 
-#: ultralcd.cpp:2324
+#: ultralcd.cpp:2274
 msgid "to load filament"
 msgstr "para cargar el filamento"
 
 # 
-#: ultralcd.cpp:2328
+#: ultralcd.cpp:2278
 msgid "to unload filament"
 msgstr "para descargar el filamento"
 
 # MSG_UNLOAD_FILAMENT c=17
-#: messages.c:97
+#: messages.c:95
 msgid "Unload filament"
 msgstr "Soltar filamento"
 
 # MSG_UNLOADING_FILAMENT c=20 r=1
-#: messages.c:98
+#: messages.c:96
 msgid "Unloading filament"
 msgstr "Soltando filamento"
 
 # 
-#: ultralcd.cpp:1773
+#: ultralcd.cpp:1696
 msgid "Total"
 msgstr ""
 
 # MSG_USED c=19 r=1
-#: ultralcd.cpp:5908
+#: ultralcd.cpp:5978
 msgid "Used during print"
 msgstr "Usado en impresion"
 
 # MSG_MENU_VOLTAGES c=15 r=1
-#: ultralcd.cpp:2254
+#: ultralcd.cpp:2199
 msgid "Voltages"
 msgstr "Voltajes"
 
 # 
-#: ultralcd.cpp:2227
+#: ultralcd.cpp:2172
 msgid "unknown"
 msgstr "desconocido"
 
 # MSG_USERWAIT
-#: Marlin_main.cpp:5263
+#: Marlin_main.cpp:5496
 msgid "Wait for user..."
 msgstr "Esperando ordenes"
 
 # MSG_WAITING_TEMP c=20 r=3
-#: ultralcd.cpp:3458
+#: ultralcd.cpp:3412
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Esperando enfriamiento de la base y extrusor."
 
 # MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ultralcd.cpp:3422
+#: ultralcd.cpp:3373
 msgid "Waiting for PINDA probe cooling"
 msgstr "Esperando a que se enfrie la sonda PINDA"
 
 # 
-#: ultralcd.cpp:4868
+#: 
 msgid "Use unload to remove filament 1 if it protrudes outside of the rear MMU tube. Use eject if it is hidden in tube."
 msgstr "Usa unload para retirar el filamento 1 si sobresale por fuera de la parte trasera del tubo MMU. Usa Expulsar si esta escondido dentro del tubo"
 
 # MSG_CHANGED_BOTH c=20 r=4
-#: Marlin_main.cpp:1511
+#: Marlin_main.cpp:1492
 msgid "Warning: both printer type and motherboard type changed."
 msgstr "Aviso: tanto el tipo de impresora como el tipo de la placa han cambiado."
 
 # MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: Marlin_main.cpp:1503
+#: Marlin_main.cpp:1484
 msgid "Warning: motherboard type changed."
 msgstr "Cuidado: el tipo de placa ha cambiado."
 
 # MSG_CHANGED_PRINTER c=20 r=4
-#: Marlin_main.cpp:1507
+#: Marlin_main.cpp:1488
 msgid "Warning: printer type changed."
 msgstr "Cuidado: Ha cambiado el tipo de impresora."
 
 # MSG_UNLOAD_SUCCESSFUL c=20 r=2
-#: Marlin_main.cpp:3054
+#: Marlin_main.cpp:3106
 msgid "Was filament unload successful?"
 msgstr "?Se cargocon exito el filamento?"
 
 # MSG_SELFTEST_WIRINGERROR
-#: messages.c:85
+#: messages.c:81
 msgid "Wiring error"
 msgstr "Error de conexion"
 
 # MSG_WIZARD c=17 r=1
-#: ultralcd.cpp:5747
+#: ultralcd.cpp:5811
 msgid "Wizard"
 msgstr ""
 
 # MSG_XYZ_DETAILS c=19 r=1
-#: ultralcd.cpp:2243
+#: ultralcd.cpp:2188
 msgid "XYZ cal. details"
 msgstr "Detalles de calibracion XYZ"
 
 # MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: messages.c:19
+#: messages.c:18
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "Calibracion XYZ fallada. Consulta el manual por favor."
 
 # MSG_YES
-#: messages.c:104
+#: messages.c:102
 msgid "Yes"
 msgstr "Si"
 
 # MSG_WIZARD_QUIT c=20 r=8
-#: messages.c:103
+#: messages.c:101
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr "Siempre puedes acceder al asistente desde Calibracion -> Wizard"
 
 # MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ultralcd.cpp:3922
+#: ultralcd.cpp:3882
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr "Calibracion XYZ correcta. La inclinacion se corregira automaticamente."
 
 # MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ultralcd.cpp:3919
+#: ultralcd.cpp:3879
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr "Calibracion XYZ correcta. Los ejes X / Y estan ligeramente inclinados. Buen trabajo!"
 
 # 
-#: ultralcd.cpp:5130
+#: ultralcd.cpp:5168
 msgid "X-correct:"
 msgstr "Corregir-X:"
 
 # MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ultralcd.cpp:3916
+#: ultralcd.cpp:3876
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "Calibracion XYZ ok. Ejes X/Y perpendiculares. Enhorabuena!"
 
 # MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ultralcd.cpp:3900
+#: ultralcd.cpp:3860
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr "Calibrazion XYZ comprometida. Puntos frontales no alcanzables."
 
 # MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ultralcd.cpp:3903
+#: ultralcd.cpp:3863
 msgid "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr "Calibrazion XYZ comprometida. Punto frontal derecho no alcanzable."
 
 # MSG_LOAD_ALL c=17
-#: ultralcd.cpp:6166
+#: ultralcd.cpp:6238
 msgid "Load all"
 msgstr "Intr. todos fil."
 
 # 
-#: ultralcd.cpp:3882
+#: ultralcd.cpp:3842
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr "Calibracion XYZ fallada. Puntos de calibracion en la base no encontrados."
 
 # 
-#: ultralcd.cpp:3888
+#: ultralcd.cpp:3848
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr "Calibracion XYZ fallada. Puntos frontales no alcanzables."
 
 # 
-#: ultralcd.cpp:3891
+#: ultralcd.cpp:3851
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr "Calibracion XYZ fallad. Punto frontal derecho no alcanzable."
 
 # 
-#: ultralcd.cpp:3016
+#: ultralcd.cpp:2969
 msgid "Y distance from min"
 msgstr "Distancia en Y desde el min"
 
 # 
-#: ultralcd.cpp:5131
+#: ultralcd.cpp:4936
+msgid "The printer will start printing a zig-zag line. Rotate the knob until you reach the optimal height. Check the pictures in the handbook (Calibration chapter)."
+msgstr "La impresora comenzara a imprimir una linea en zig-zag. Gira el dial hasta que la linea alcance la altura optima. Mira las fotos del manual (Capitulo de calibracion)."
+
+# 
+#: ultralcd.cpp:5169
 msgid "Y-correct:"
 msgstr "Corregir-Y:"
 
 # MSG_OFF
-#: menu.cpp:426
-msgid " [off]"
-msgstr "[apag]"
+#: messages.c:105
+msgid "Off"
+msgstr "Ina"
+
+# MSG_ON
+#: messages.c:106
+msgid "On"
+msgstr "Act"
 
 # 
-#: messages.c:57
+#: messages.c:53
 msgid "Back"
 msgstr "atras"
 
 # 
-#: ultralcd.cpp:5639
+#: ultralcd.cpp:5702
 msgid "Checks"
 msgstr "Comprobaciones"
 
 # 
-#: ultralcd.cpp:7973
+#: ultralcd.cpp:8310
 msgid "False triggering"
 msgstr "Falsa activacion"
 
 # 
-#: ultralcd.cpp:4030
+#: ultralcd.cpp:3991
 msgid "FINDA:"
 msgstr "FINDA:"
 
-# 
-#: ultralcd.cpp:5545
-msgid "Firmware   [none]"
-msgstr "Firmware[ninguno]"
+# MSG_FIRMWARE
+#: language.h:21
+msgid "Firmware"
+msgstr ""
+
+# MSG_STRICT
+#: messages.c:112
+msgid "Strict"
+msgstr "Estrict"
+
+# MSG_WARN
+#: messages.c:111
+msgid "Warn"
+msgstr "Aviso"
 
 # 
-#: ultralcd.cpp:5551
-msgid "Firmware [strict]"
-msgstr "Firmware[estrict]"
-
-# 
-#: ultralcd.cpp:5548
-msgid "Firmware   [warn]"
-msgstr "Firmware  [aviso]"
-
-# 
-#: messages.c:87
+#: messages.c:83
 msgid "HW Setup"
 msgstr "Configuracion HW"
 
 # 
-#: ultralcd.cpp:4034
+#: ultralcd.cpp:3995
 msgid "IR:"
 msgstr ""
 
-# 
-#: ultralcd.cpp:7046
-msgid "Magnets comp.[N/A]"
-msgstr "Comp. imanes [N/A]"
+# MSG_MAGNETS_COMP
+#: messages.c:130
+msgid "Magnets comp."
+msgstr "Comp. imanes"
+
+# MSG_MESH
+#: messages.c:128
+msgid "Mesh"
+msgstr "Malla"
 
 # 
-#: ultralcd.cpp:7044
-msgid "Magnets comp.[Off]"
-msgstr "Comp. imanes [Off]"
-
-# 
-#: ultralcd.cpp:7043
-msgid "Magnets comp. [On]"
-msgstr "Comp. imanes  [On]"
-
-# 
-#: ultralcd.cpp:7035
-msgid "Mesh         [3x3]"
-msgstr "Malla        [3x3]"
-
-# 
-#: ultralcd.cpp:7036
-msgid "Mesh         [7x7]"
-msgstr "Malla        [7x7]"
-
-# 
-#: ultralcd.cpp:5677
+#: ultralcd.cpp:5740
 msgid "Mesh bed leveling"
 msgstr "Nivelacion Malla Base"
 
 # 
-#: Marlin_main.cpp:856
+#: Marlin_main.cpp:861
 msgid "MK3S firmware detected on MK3 printer"
 msgstr "Firmware MK3S detectado en impresora MK3"
 
-# 
-#: ultralcd.cpp:5306
-msgid "MMU Mode [Normal]"
-msgstr "Modo MMU [Normal]"
+# MSG_MMU_MODE
+#: messages.c:117
+msgid "MMU Mode"
+msgstr "Modo MMU"
 
 # 
-#: ultralcd.cpp:5307
-msgid "MMU Mode[Stealth]"
-msgstr "Modo MMU[Silenci]"
-
-# 
-#: ultralcd.cpp:4511
+#: ultralcd.cpp:4472
 msgid "Mode change in progress ..."
 msgstr "Cambio de modo progresando ..."
 
-# 
-#: ultralcd.cpp:5506
-msgid "Model      [none]"
-msgstr "Modelo  [ninguno]"
+# MSG_MODEL
+#: messages.c:113
+msgid "Model"
+msgstr "Modelo"
+
+# MSG_NOZZLE_DIAMETER
+#: messages.c:116
+msgid "Nozzle d."
+msgstr "Diam. nozzl"
 
 # 
-#: ultralcd.cpp:5512
-msgid "Model    [strict]"
-msgstr "Modelo [estricto]"
-
-# 
-#: ultralcd.cpp:5509
-msgid "Model      [warn]"
-msgstr "Modelo    [aviso]"
-
-# 
-#: ultralcd.cpp:5467
-msgid "Nozzle d.  [0.25]"
-msgstr "Diam. nozzl[0.25]"
-
-# 
-#: ultralcd.cpp:5470
-msgid "Nozzle d.  [0.40]"
-msgstr "Diam. nozzl[0.40]"
-
-# 
-#: ultralcd.cpp:5473
-msgid "Nozzle d.  [0.60]"
-msgstr "Diam. nozzl[0.60]"
-
-# 
-#: ultralcd.cpp:5421
-msgid "Nozzle     [none]"
-msgstr "Nozzle  [ninguno]"
-
-# 
-#: ultralcd.cpp:5427
-msgid "Nozzle   [strict]"
-msgstr "Nozzle [estricto]"
-
-# 
-#: ultralcd.cpp:5424
-msgid "Nozzle     [warn]"
-msgstr "Nozzle    [aviso]"
-
-# 
-#: util.cpp:510
+#: util.cpp:514
 msgid "G-code sliced for a different level. Continue?"
 msgstr "Codigo G laminado para un nivel diferente. ?Continuar?"
 
 # 
-#: util.cpp:516
+#: util.cpp:520
 msgid "G-code sliced for a different level. Please re-slice the model again. Print cancelled."
 msgstr "Codigo G laminado para un nivel diferente. Por favor relamina el modelo de nuevo. Impresion cancelada."
 
 # 
-#: util.cpp:427
+#: util.cpp:431
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr "Codigo G laminado para un tipo de impresora diferente. ?Continuar?"
 
 # 
-#: util.cpp:433
+#: util.cpp:437
 msgid "G-code sliced for a different printer type. Please re-slice the model again. Print cancelled."
 msgstr "Codigo G laminado para una impresora diferente. Por favor relamina el modelo de nuevo. Impresion cancelada."
 
 # 
-#: util.cpp:477
+#: util.cpp:481
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "Codigo G laminado para nuevo firmware. ?Continuar?"
 
 # 
-#: util.cpp:483
+#: util.cpp:487
 msgid "G-code sliced for a newer firmware. Please update the firmware. Print cancelled."
 msgstr "Codigo G laminado para nuevo firmware. Por favor actualiza el firmware. Impresion cancelada."
 
 # 
-#: ultralcd.cpp:4026
+#: ultralcd.cpp:3987
 msgid "PINDA:"
 msgstr "PINDA:"
 
 # 
-#: ultralcd.cpp:2465
+#: ultralcd.cpp:2430
 msgid "Preheating to cut"
 msgstr "Precalentando para laminar"
 
 # 
-#: ultralcd.cpp:2462
+#: ultralcd.cpp:2427
 msgid "Preheating to eject"
 msgstr "Precalentar para expulsar"
 
 # 
-#: util.cpp:390
+#: util.cpp:394
 msgid "Printer nozzle diameter differs from the G-code. Continue?"
 msgstr "Diametro nozzle impresora difiere de cod.G. ?Continuar?"
 
 # 
-#: util.cpp:397
+#: util.cpp:401
 msgid "Printer nozzle diameter differs from the G-code. Please check the value in settings. Print cancelled."
 msgstr "Diametro nozzle Impresora difiere de cod.G. Comprueba los valores en ajustes. Impresion cancelada."
 
 # 
-#: ultralcd.cpp:6683
+#: ultralcd.cpp:6791
 msgid "Rename"
 msgstr "Renombrar"
 
 # 
-#: ultralcd.cpp:6679
+#: ultralcd.cpp:6784
 msgid "Select"
 msgstr "Seleccionar"
 
 # 
-#: ultralcd.cpp:2245
+#: ultralcd.cpp:2190
 msgid "Sensor info"
 msgstr "Info sensor"
 
 # 
-#: messages.c:58
+#: messages.c:54
 msgid "Sheet"
 msgstr "Lamina"
 
-# 
-#: sound.h:9
-msgid "Sound    [assist]"
-msgstr "Sonido [asistido]"
+# MSG_SOUND_BLIND
+#: messages.c:127
+msgid "Assist"
+msgstr "Asistido"
 
 # 
-#: ultralcd.cpp:5637
+#: ultralcd.cpp:5700
 msgid "Steel sheets"
 msgstr "Lamina de acero"
 
 # 
-#: ultralcd.cpp:5132
+#: ultralcd.cpp:5170
 msgid "Z-correct:"
 msgstr "Corregir-Z:"
-
-# 
-#: ultralcd.cpp:7038
-msgid "Z-probe nr.    [1]"
-msgstr "Z-sensor nr.   [1]"
-
-# 
-#: ultralcd.cpp:7040
-msgid "Z-probe nr.    [3]"
-msgstr "Z-sensor nr.   [3]"
 

--- a/lang/po/Firmware_fr.po
+++ b/lang/po/Firmware_fr.po
@@ -7,26 +7,31 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: fr\n"
 "Project-Id-Version: Prusa-Firmware\n"
-"POT-Creation-Date: Sun, Sep 22, 2019 2:06:22 PM\n"
-"PO-Revision-Date: Sun, Sep 22, 2019 2:06:22 PM\n"
+"POT-Creation-Date: Thu, Mar 26, 2020 8:55:19 AM\n"
+"PO-Revision-Date: Thu, Mar 26, 2020 8:55:19 AM\n"
 "Language-Team: \n"
 "X-Generator: Poedit 2.0.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 "Last-Translator: \n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
+# 
+#: 
+msgid "[%.7s]Live adj. Z\x0avalue set, continue\x0aor start from zero?\x0a%cContinue%cReset"
+msgstr "[%.7s]Ajust. du Z\x0aValeur enreg, contin\x0aou depart a zero?\x0a%cContinuer%cReset"
+
 # MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE2 c=14
-#: messages.c:39
+#: messages.c:36
 msgid " of 4"
-msgstr "de 4"
+msgstr " de 4"
 
 # MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE2 c=14
-#: messages.c:60
+#: messages.c:56
 msgid " of 9"
-msgstr "de 9"
+msgstr " de 9"
 
 # MSG_MEASURED_OFFSET
-#: ultralcd.cpp:3089
+#: ultralcd.cpp:3042
 msgid "[0;0] point offset"
 msgstr "Offset point [0;0]"
 
@@ -41,53 +46,43 @@ msgid "WARNING:\x0aCrash detection\x0adisabled in\x0aStealth mode"
 msgstr "ATTENTION:\x0aDetection de crash\x0adesactivee en\x0amode feutre"
 
 # 
-#: ultralcd.cpp:2472
+#: ultralcd.cpp:2438
 msgid ">Cancel"
 msgstr ">Annuler"
 
 # MSG_BABYSTEPPING_Z c=15
-#: ultralcd.cpp:3209
+#: ultralcd.cpp:3162
 msgid "Adjusting Z:"
 msgstr "Ajuster Z:"
 
 # MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ultralcd.cpp:8295
+#: ultralcd.cpp:8638
 msgid "All correct      "
 msgstr "Tout est correct"
 
 # MSG_WIZARD_DONE c=20 r=8
-#: messages.c:101
+#: messages.c:99
 msgid "All is done. Happy printing!"
 msgstr "Tout est pret. Bonne impression!"
 
 # 
-#: ultralcd.cpp:2009
+#: ultralcd.cpp:1947
 msgid "Ambient"
 msgstr "Ambiant"
 
 # MSG_PRESS c=20
-#: ultralcd.cpp:2618
+#: ultralcd.cpp:2587
 msgid "and press the knob"
 msgstr "et pressez le bouton"
 
 # MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=2
-#: ultralcd.cpp:3529
+#: ultralcd.cpp:3484
 msgid "Are left and right Z~carriages all up?"
 msgstr "Z~carriages gauche + droite tout en haut?"
 
-# MSG_AUTO_DEPLETE_ON c=17 r=1
-#: ultralcd.cpp:5200
-msgid "SpoolJoin    [on]"
-msgstr ""
-
-# 
-#: ultralcd.cpp:5196
-msgid "SpoolJoin   [N/A]"
-msgstr ""
-
-# MSG_AUTO_DEPLETE_OFF c=17 r=1
-#: ultralcd.cpp:5204
-msgid "SpoolJoin   [off]"
+# MSG_AUTO_DEPLETE c=17 r=1
+#: messages.c:108
+msgid "SpoolJoin"
 msgstr ""
 
 # MSG_AUTO_HOME
@@ -96,747 +91,692 @@ msgid "Auto home"
 msgstr "Mise a 0 des axes"
 
 # MSG_AUTOLOAD_FILAMENT c=17
-#: ultralcd.cpp:6822
+#: ultralcd.cpp:6938
 msgid "AutoLoad filament"
 msgstr "Autocharge du fil."
 
 # MSG_AUTOLOADING_ONLY_IF_FSENS_ON c=20 r=4
-#: ultralcd.cpp:4462
+#: ultralcd.cpp:4423
 msgid "Autoloading filament available only when filament sensor is turned on..."
 msgstr "Chargement auto du filament uniquement si le capteur de filament est active."
 
 # MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ultralcd.cpp:2813
+#: ultralcd.cpp:2782
 msgid "Autoloading filament is active, just press the knob and insert filament..."
 msgstr "Chargement auto. du fil. active, appuyez sur le bouton et inserez le fil."
 
 # MSG_SELFTEST_AXIS_LENGTH
-#: ultralcd.cpp:7949
+#: ultralcd.cpp:8286
 msgid "Axis length"
 msgstr "Longueur de l'axe"
 
 # MSG_SELFTEST_AXIS
-#: ultralcd.cpp:7951
+#: ultralcd.cpp:8288
 msgid "Axis"
 msgstr "Axe"
 
 # MSG_SELFTEST_BEDHEATER
-#: ultralcd.cpp:7893
+#: ultralcd.cpp:8230
 msgid "Bed / Heater"
 msgstr "Lit / Chauffage"
 
 # MSG_BED_DONE
-#: messages.c:16
+#: messages.c:15
 msgid "Bed done"
 msgstr "Plateau termine"
 
 # MSG_BED_HEATING
-#: messages.c:17
+#: messages.c:16
 msgid "Bed Heating"
 msgstr "Chauffe du lit"
 
 # MSG_BED_CORRECTION_MENU
-#: ultralcd.cpp:5768
+#: ultralcd.cpp:5838
 msgid "Bed level correct"
 msgstr "Corr. niveau plateau"
 
 # MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=4
-#: messages.c:18
+#: messages.c:17
 msgid "Bed leveling failed. Sensor didnt trigger. Debris on nozzle? Waiting for reset."
 msgstr "Echec bed leveling. Capt. non declenche. Debris sur buse? En attente d'un reset."
 
 # MSG_BED
-#: messages.c:15
+#: messages.c:14
 msgid "Bed"
 msgstr "Lit"
 
 # MSG_MENU_BELT_STATUS c=15 r=1
-#: ultralcd.cpp:2059
+#: ultralcd.cpp:2004
 msgid "Belt status"
 msgstr "Statut courroie"
 
 # MSG_RECOVER_PRINT c=20 r=2
-#: messages.c:71
+#: messages.c:67
 msgid "Blackout occurred. Recover print?"
 msgstr "Coupure detectee. Reprendre impression?"
 
 # 
-#: ultralcd.cpp:8297
+#: ultralcd.cpp:8640
 msgid "Calibrating home"
 msgstr "Calib. mise a 0"
 
 # MSG_CALIBRATE_BED
-#: ultralcd.cpp:5757
+#: ultralcd.cpp:5827
 msgid "Calibrate XYZ"
 msgstr "Calibrer XYZ"
 
 # MSG_HOMEYZ
-#: messages.c:48
+#: messages.c:44
 msgid "Calibrate Z"
 msgstr "Calibrer Z"
 
 # MSG_CALIBRATE_PINDA c=17 r=1
-#: ultralcd.cpp:4654
+#: ultralcd.cpp:4615
 msgid "Calibrate"
 msgstr "Calibrer"
 
 # MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ultralcd.cpp:3492
+#: ultralcd.cpp:3447
 msgid "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end stoppers. Click when done."
 msgstr "Calibration de XYZ. Tournez le bouton pour faire monter l'extrudeur dans l'axe Z jusqu'aux butees. Cliquez une fois fait."
 
 # MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: messages.c:20
+#: messages.c:19
 msgid "Calibrating Z"
 msgstr "Calibration Z"
 
 # MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ultralcd.cpp:3492
+#: ultralcd.cpp:3447
 msgid "Calibrating Z. Rotate the knob to move the Z carriage up to the end stoppers. Click when done."
 msgstr "Calibration de Z. Tournez le bouton pour faire monter l'extrudeur dans l'axe Z jusqu'aux butees. Cliquez une fois fait."
 
 # MSG_HOMEYZ_DONE
-#: ultralcd.cpp:816
+#: ultralcd.cpp:856
 msgid "Calibration done"
 msgstr "Calibration terminee"
 
 # MSG_MENU_CALIBRATION
-#: messages.c:61
+#: messages.c:57
 msgid "Calibration"
 msgstr ""
 
 # 
-#: ultralcd.cpp:4781
+#: ultralcd.cpp:4793
 msgid "Cancel"
 msgstr "Annuler"
 
 # MSG_SD_REMOVED
-#: ultralcd.cpp:8679
+#: ultralcd.cpp:9051
 msgid "Card removed"
 msgstr "Carte retiree"
 
 # MSG_NOT_COLOR
-#: ultralcd.cpp:2718
+#: ultralcd.cpp:2687
 msgid "Color not correct"
 msgstr "Couleur incorrecte"
 
 # MSG_COOLDOWN
-#: messages.c:23
+#: messages.c:22
 msgid "Cooldown"
 msgstr "Refroidissement"
 
 # 
-#: ultralcd.cpp:4587
+#: ultralcd.cpp:4548
 msgid "Copy selected language?"
 msgstr "Copier la langue selectionne?"
 
-# MSG_CRASHDETECT_ON
-#: messages.c:27
-msgid "Crash det.   [on]"
-msgstr "Detect.crash [on]"
+# MSG_CRASHDETECT
+#: messages.c:24
+msgid "Crash det."
+msgstr "Detect.crash"
 
-# MSG_CRASHDETECT_NA
-#: messages.c:25
-msgid "Crash det.  [N/A]"
-msgstr "Detect.crash[N/A]"
-
-# MSG_CRASHDETECT_OFF
-#: messages.c:26
-msgid "Crash det.  [off]"
-msgstr "Detect.crash[off]"
+# 
+#: ultralcd.cpp:4928
+msgid "Choose a filament for the First Layer Calibration and select it in the on-screen menu."
+msgstr "Choisissez un filament pour la Calibration de la Premiere Couche et selectionnez-le depuis le menu a l'ecran."
 
 # MSG_CRASH_DETECTED c=20 r=1
-#: messages.c:24
+#: messages.c:23
 msgid "Crash detected."
 msgstr "Crash detecte."
 
 # 
-#: Marlin_main.cpp:600
+#: Marlin_main.cpp:602
 msgid "Crash detected. Resume print?"
 msgstr "Crash detecte. Poursuivre l'impression?"
 
 # 
-#: ultralcd.cpp:1853
+#: ultralcd.cpp:1776
 msgid "Crash"
 msgstr ""
 
 # MSG_CURRENT c=19 r=1
-#: ultralcd.cpp:5909
+#: ultralcd.cpp:5979
 msgid "Current"
 msgstr "Actuel"
 
 # MSG_DATE c=17 r=1
-#: ultralcd.cpp:2213
+#: ultralcd.cpp:2158
 msgid "Date:"
 msgstr "Date:"
 
 # MSG_DISABLE_STEPPERS
-#: ultralcd.cpp:5654
+#: ultralcd.cpp:5720
 msgid "Disable steppers"
 msgstr "Desactiver moteurs"
 
 # MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: messages.c:14
+#: messages.c:13
 msgid "Distance between tip of the nozzle and the bed surface has not been set yet. Please follow the manual, chapter First steps, section First layer calibration."
 msgstr "La distance entre la pointe de la buse et la surface du plateau n'a pas encore ete reglee. Suivez le manuel, chapitre Premiers pas, section Calibration de la premiere couche."
 
 # MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ultralcd.cpp:5070
+#: ultralcd.cpp:5103
 msgid "Do you want to repeat last step to readjust distance between nozzle and heatbed?"
 msgstr "Voulez-vous repeter la derniere etape pour reajuster la distance entre la buse et le plateau chauffant?"
 
 # MSG_EXTRUDER_CORRECTION c=10
-#: ultralcd.cpp:5134
+#: ultralcd.cpp:5172
 msgid "E-correct:"
 msgstr "Correct-E:"
 
 # MSG_EJECT_FILAMENT c=17 r=1
-#: messages.c:53
+#: messages.c:49
 msgid "Eject filament"
 msgstr "Remonter le fil."
 
-# 
-#: ultralcd.cpp:4869
-msgid "Eject"
-msgstr "Remonter"
-
 # MSG_EJECTING_FILAMENT c=20 r=1
-#: mmu.cpp:1434
+#: mmu.cpp:1415
 msgid "Ejecting filament"
 msgstr "Le fil. remonte"
 
 # MSG_SELFTEST_ENDSTOP_NOTHIT c=20 r=1
-#: ultralcd.cpp:7917
+#: ultralcd.cpp:8254
 msgid "Endstop not hit"
 msgstr "Butee non atteinte"
 
 # MSG_SELFTEST_ENDSTOP
-#: ultralcd.cpp:7911
+#: ultralcd.cpp:8248
 msgid "Endstop"
 msgstr "Butee"
 
 # MSG_SELFTEST_ENDSTOPS
-#: ultralcd.cpp:7899
+#: ultralcd.cpp:8236
 msgid "Endstops"
 msgstr "Butees"
 
 # MSG_STACK_ERROR c=20 r=4
-#: ultralcd.cpp:6859
+#: ultralcd.cpp:6975
 msgid "Error - static memory has been overwritten"
 msgstr "Erreur - la memoire statique a ete ecrasee"
 
 # MSG_FSENS_NOT_RESPONDING c=20 r=4
-#: ultralcd.cpp:4475
+#: ultralcd.cpp:4436
 msgid "ERROR: Filament sensor is not responding, please check connection."
 msgstr "ERREUR: Le capteur de filament ne repond pas, verifiez le branchement."
 
 # MSG_ERROR
-#: messages.c:28
+#: messages.c:25
 msgid "ERROR:"
 msgstr "ERREUR:"
 
 # MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
-#: ultralcd.cpp:8304
+#: ultralcd.cpp:8647
 msgid "Extruder fan:"
 msgstr "Ventilo extrudeur:"
 
 # MSG_INFO_EXTRUDER c=15 r=1
-#: ultralcd.cpp:2244
+#: ultralcd.cpp:2189
 msgid "Extruder info"
 msgstr "Infos extrudeur"
 
 # MSG_MOVE_E
-#: messages.c:29
+#: messages.c:26
 msgid "Extruder"
 msgstr "Extrudeur"
 
 # 
-#: ultralcd.cpp:6846
+#: ultralcd.cpp:6962
 msgid "Fail stats MMU"
 msgstr "Stat. d'echec MMU"
 
-# MSG_FSENS_AUTOLOAD_ON c=17 r=1
-#: ultralcd.cpp:5168
-msgid "F. autoload  [on]"
-msgstr "Autochargeur [on]"
-
-# MSG_FSENS_AUTOLOAD_NA c=17 r=1
-#: messages.c:43
-msgid "F. autoload [N/A]"
-msgstr "Autochargeur[N/A]"
-
-# MSG_FSENS_AUTOLOAD_OFF c=17 r=1
-#: ultralcd.cpp:5170
-msgid "F. autoload [off]"
-msgstr "Autochargeur[off]"
-
 # 
-#: ultralcd.cpp:6843
+#: ultralcd.cpp:6959
 msgid "Fail stats"
 msgstr "Stat. d'echec"
 
 # MSG_FAN_SPEED c=14
-#: messages.c:31
+#: messages.c:28
 msgid "Fan speed"
 msgstr "Vitesse vent."
 
 # MSG_SELFTEST_FAN c=20
-#: messages.c:78
+#: messages.c:74
 msgid "Fan test"
 msgstr "Test du ventilateur"
 
-# MSG_FANS_CHECK_ON c=17 r=1
-#: ultralcd.cpp:5663
-msgid "Fans check   [on]"
-msgstr "Verif vent.  [on]"
-
-# MSG_FANS_CHECK_OFF c=17 r=1
-#: ultralcd.cpp:5665
-msgid "Fans check  [off]"
-msgstr "Verif vent. [off]"
-
-# MSG_FSENSOR_ON
-#: messages.c:45
-msgid "Fil. sensor  [on]"
-msgstr "Capteur Fil. [on]"
-
-# MSG_FSENSOR_NA
-#: ultralcd.cpp:5148
-msgid "Fil. sensor [N/A]"
-msgstr "Capteur Fil.[N/A]"
-
-# MSG_FSENSOR_OFF
-#: messages.c:44
-msgid "Fil. sensor [off]"
-msgstr "Capteur Fil.[off]"
+# MSG_FANS_CHECK
+#: ultralcd.cpp:5728
+msgid "Fans check"
+msgstr "Verif vent."
 
 # 
-#: ultralcd.cpp:1852
+#: ultralcd.cpp:1775
 msgid "Filam. runouts"
 msgstr "Fins de filament"
 
 # MSG_FILAMENT_CLEAN c=20 r=2
-#: messages.c:32
+#: messages.c:29
 msgid "Filament extruding & with correct color?"
 msgstr "Filament extrude et avec bonne couleur?"
 
 # MSG_NOT_LOADED c=19
-#: ultralcd.cpp:2714
+#: ultralcd.cpp:2683
 msgid "Filament not loaded"
 msgstr "Filament non charge"
 
 # MSG_FILAMENT_SENSOR c=20
-#: messages.c:84
+#: messages.c:80
 msgid "Filament sensor"
 msgstr "Capteur de filament"
 
 # MSG_FILAMENT_USED c=19 r=1
-#: ultralcd.cpp:2885
+#: ultralcd.cpp:2847
 msgid "Filament used"
 msgstr "Filament utilise"
 
 # MSG_PRINT_TIME c=19 r=1
-#: ultralcd.cpp:2886
+#: ultralcd.cpp:2848
 msgid "Print time"
 msgstr "Temps d'impression"
 
 # MSG_FILE_INCOMPLETE c=20 r=2
-#: ultralcd.cpp:8432
+#: ultralcd.cpp:8775
 msgid "File incomplete. Continue anyway?"
 msgstr "Fichier incomplet. Continuer qd meme?"
 
 # MSG_FINISHING_MOVEMENTS c=20 r=1
-#: messages.c:40
+#: messages.c:37
 msgid "Finishing movements"
 msgstr "Mouvement final"
 
 # MSG_V2_CALIBRATION c=17 r=1
-#: messages.c:105
+#: messages.c:103
 msgid "First layer cal."
 msgstr "Cal. 1ere couche"
 
 # MSG_WIZARD_SELFTEST c=20 r=8
-#: ultralcd.cpp:4982
+#: ultralcd.cpp:5024
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr "D'abord, je vais lancer le Auto-test pour verifier les problemes d'assemblage les plus communs."
 
 # 
-#: mmu.cpp:724
+#: mmu.cpp:726
 msgid "Fix the issue and then press button on MMU unit."
 msgstr "Corrigez le probleme et appuyez sur le bouton sur la MMU."
 
 # MSG_FLOW
-#: ultralcd.cpp:6932
+#: ultralcd.cpp:7102
 msgid "Flow"
 msgstr "Flux"
 
 # MSG_PRUSA3D_FORUM
-#: ultralcd.cpp:2206
+#: ultralcd.cpp:2151
 msgid "forum.prusa3d.com"
 msgstr ""
 
 # MSG_SELFTEST_COOLING_FAN c=20
-#: messages.c:75
+#: messages.c:71
 msgid "Front print fan?"
 msgstr "Ventilo impr avant?"
 
 # MSG_BED_CORRECTION_FRONT c=14 r=1
-#: ultralcd.cpp:3294
+#: ultralcd.cpp:3244
 msgid "Front side[um]"
 msgstr "Avant [um]"
 
 # MSG_SELFTEST_FANS
-#: ultralcd.cpp:7957
+#: ultralcd.cpp:8294
 msgid "Front/left fans"
 msgstr "Ventilos avt/gauche"
 
 # MSG_SELFTEST_HEATERTHERMISTOR
-#: ultralcd.cpp:7887
+#: ultralcd.cpp:8224
 msgid "Heater/Thermistor"
 msgstr "Chauffage/Thermistor"
 
 # MSG_BED_HEATING_SAFETY_DISABLED
-#: Marlin_main.cpp:8467
+#: Marlin_main.cpp:9458
 msgid "Heating disabled by safety timer."
 msgstr "Chauffage desactivee par le compteur de securite."
 
 # MSG_HEATING_COMPLETE c=20
-#: messages.c:47
+#: messages.c:43
 msgid "Heating done."
 msgstr "Chauffe terminee."
 
 # MSG_HEATING
-#: messages.c:46
+#: messages.c:42
 msgid "Heating"
 msgstr "Chauffe"
 
 # MSG_WIZARD_WELCOME c=20 r=7
-#: ultralcd.cpp:4961
+#: ultralcd.cpp:5003
 msgid "Hi, I am your Original Prusa i3 printer. Would you like me to guide you through the setup process?"
 msgstr "Bonjour, je suis votre imprimante Original Prusa i3. Voulez-vous que je vous guide a travers le processus d'installation?"
 
 # MSG_PRUSA3D_HOWTO
-#: ultralcd.cpp:2207
+#: ultralcd.cpp:2152
 msgid "howto.prusa3d.com"
 msgstr ""
 
 # MSG_FILAMENTCHANGE
-#: messages.c:37
+#: messages.c:34
 msgid "Change filament"
 msgstr "Changer filament"
 
 # MSG_CHANGE_SUCCESS
-#: ultralcd.cpp:2629
+#: ultralcd.cpp:2598
 msgid "Change success!"
 msgstr "Changement reussi!"
 
 # MSG_CORRECTLY c=20
-#: ultralcd.cpp:2706
+#: ultralcd.cpp:2675
 msgid "Changed correctly?"
 msgstr "Change correctement?"
 
 # MSG_SELFTEST_CHECK_BED c=20
-#: messages.c:81
+#: messages.c:77
 msgid "Checking bed     "
 msgstr "Verification du lit"
 
 # MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ultralcd.cpp:8286
+#: ultralcd.cpp:8629
 msgid "Checking endstops"
 msgstr "Verification butees"
 
 # MSG_SELFTEST_CHECK_HOTEND c=20
-#: ultralcd.cpp:8292
+#: ultralcd.cpp:8635
 msgid "Checking hotend  "
 msgstr "Verif. du hotend"
 
 # MSG_SELFTEST_CHECK_FSENSOR c=20
-#: messages.c:82
+#: messages.c:78
 msgid "Checking sensors "
 msgstr "Verif. des capteurs"
 
 # MSG_SELFTEST_CHECK_X c=20
-#: ultralcd.cpp:8287
+#: ultralcd.cpp:8630
 msgid "Checking X axis  "
 msgstr "Verification axe X"
 
 # MSG_SELFTEST_CHECK_Y c=20
-#: ultralcd.cpp:8288
+#: ultralcd.cpp:8631
 msgid "Checking Y axis  "
 msgstr "Verification axe Y"
 
 # MSG_SELFTEST_CHECK_Z c=20
-#: ultralcd.cpp:8289
+#: ultralcd.cpp:8632
 msgid "Checking Z axis  "
 msgstr "Verification axe Z"
 
 # MSG_CHOOSE_EXTRUDER c=20 r=1
-#: messages.c:49
+#: messages.c:45
 msgid "Choose extruder:"
 msgstr "Choisir extrudeur:"
 
 # MSG_CHOOSE_FILAMENT c=20 r=1
-#: messages.c:50
+#: messages.c:46
 msgid "Choose filament:"
 msgstr "Choix du filament:"
 
 # MSG_FILAMENT c=17 r=1
-#: messages.c:30
+#: messages.c:27
 msgid "Filament"
 msgstr ""
 
 # MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ultralcd.cpp:4991
+#: ultralcd.cpp:5033
 msgid "I will run xyz calibration now. It will take approx. 12 mins."
 msgstr "Je vais maintenant lancer la calibration XYZ. Cela prendra 12 min environ."
 
 # MSG_WIZARD_Z_CAL c=20 r=8
-#: ultralcd.cpp:4999
+#: ultralcd.cpp:5041
 msgid "I will run z calibration now."
 msgstr "Je vais maintenant lancer la calibration Z."
 
-# MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ultralcd.cpp:5064
-msgid "I will start to print line and you will gradually lower the nozzle by rotating the knob, until you reach optimal height. Check the pictures in our handbook in chapter Calibration."
-msgstr "Je vais commencer a imprimer une ligne et vous baisserez au fur et a mesure la buse en tournant le bouton jusqu'a atteindre la hauteur optimale. Regardez les photos dans notre manuel au chapitre Calibration"
-
 # MSG_WATCH
-#: messages.c:99
+#: messages.c:97
 msgid "Info screen"
 msgstr "Ecran d'info"
 
-# 
-#: ultralcd.cpp:5024
-msgid "Is filament 1 loaded?"
-msgstr "Fil.1 est-il charge?"
-
 # MSG_INSERT_FILAMENT c=20
-#: ultralcd.cpp:2614
+#: ultralcd.cpp:2583
 msgid "Insert filament"
 msgstr "Inserez le filament"
 
 # MSG_WIZARD_FILAMENT_LOADED c=20 r=2
-#: ultralcd.cpp:5027
+#: ultralcd.cpp:4813
 msgid "Is filament loaded?"
 msgstr "Fil. est-il charge?"
 
-# MSG_WIZARD_PLA_FILAMENT c=20 r=2
-#: ultralcd.cpp:5058
-msgid "Is it PLA filament?"
-msgstr "Est-ce du filament PLA?"
-
-# MSG_PLA_FILAMENT_LOADED c=20 r=2
-#: ultralcd.cpp:4790
-msgid "Is PLA filament loaded?"
-msgstr "Fil. PLA est-il charge?"
-
 # MSG_STEEL_SHEET_CHECK c=20 r=2
-#: messages.c:92
+#: messages.c:90
 msgid "Is steel sheet on heatbed?"
 msgstr "Plaque d'impression sur le lit chauffant?"
 
 # 
-#: ultralcd.cpp:1795
+#: ultralcd.cpp:1718
 msgid "Last print failures"
 msgstr "Echecs derniere imp."
 
 # 
-#: ultralcd.cpp:1772
+#: ultralcd.cpp:5111
+msgid "If you have additional steel sheets, calibrate their presets in Settings - HW Setup - Steel sheets."
+msgstr "Si vous avez d'autres feuilles d'acier,  calibrez leurs pre-reglages dans Reglages - Config HW - Feuilles d'acier."
+
+# 
+#: ultralcd.cpp:1695
 msgid "Last print"
 msgstr "Derniere impres."
 
 # MSG_SELFTEST_EXTRUDER_FAN c=20
-#: messages.c:76
+#: messages.c:72
 msgid "Left hotend fan?"
 msgstr "Ventilo tete gauche?"
 
 # 
-#: ultralcd.cpp:3018
+#: ultralcd.cpp:2971
 msgid "Left"
 msgstr "Gauche"
 
 # MSG_BED_CORRECTION_LEFT c=14 r=1
-#: ultralcd.cpp:3292
+#: ultralcd.cpp:3242
 msgid "Left side [um]"
 msgstr "Gauche [um]"
 
 # 
-#: ultralcd.cpp:5680
+#: ultralcd.cpp:5743
 msgid "Lin. correction"
 msgstr "Correction lin."
 
 # MSG_BABYSTEP_Z
-#: messages.c:13
+#: messages.c:12
 msgid "Live adjust Z"
 msgstr "Ajuster Z en dir."
 
 # MSG_LOAD_FILAMENT c=17
-#: messages.c:51
+#: messages.c:47
 msgid "Load filament"
 msgstr "Charger filament"
 
 # MSG_LOADING_COLOR
-#: ultralcd.cpp:2654
+#: ultralcd.cpp:2623
 msgid "Loading color"
 msgstr "Charg. de la couleur"
 
 # MSG_LOADING_FILAMENT c=20
-#: messages.c:52
+#: messages.c:48
 msgid "Loading filament"
 msgstr "Chargement du fil."
 
 # MSG_LOOSE_PULLEY c=20 r=1
-#: ultralcd.cpp:7941
+#: ultralcd.cpp:8278
 msgid "Loose pulley"
 msgstr "Poulie lache"
 
 # 
-#: ultralcd.cpp:6805
+#: ultralcd.cpp:6921
 msgid "Load to nozzle"
 msgstr "Charger la buse"
 
 # MSG_M117_V2_CALIBRATION c=25 r=1
-#: messages.c:55
+#: messages.c:51
 msgid "M117 First layer cal."
 msgstr "M117 Cal. 1ere couche"
 
 # MSG_MAIN
-#: messages.c:56
+#: messages.c:52
 msgid "Main"
 msgstr "Menu principal"
 
 # MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=60
-#: messages.c:59
+#: messages.c:55
 msgid "Measuring reference height of calibration point"
 msgstr "Mesure de la hauteur de reference du point de calibration"
 
 # MSG_MESH_BED_LEVELING
-#: ultralcd.cpp:5763
+#: ultralcd.cpp:5833
 msgid "Mesh Bed Leveling"
 msgstr ""
 
 # MSG_MMU_OK_RESUMING_POSITION c=20 r=4
-#: mmu.cpp:762
+#: mmu.cpp:764
 msgid "MMU OK. Resuming position..."
 msgstr "MMU OK. Reprise de la position ..."
 
 # MSG_MMU_OK_RESUMING_TEMPERATURE c=20 r=4
-#: mmu.cpp:755
+#: mmu.cpp:757
 msgid "MMU OK. Resuming temperature..."
 msgstr "MMU OK. Rechauffage de la buse..."
 
 # 
-#: ultralcd.cpp:3059
+#: ultralcd.cpp:3012
 msgid "Measured skew"
 msgstr "Deviat.mesuree"
 
-# 
-#: ultralcd.cpp:1796
+#  c=13 r=1
+#: ultralcd.cpp:1719
 msgid "MMU fails"
 msgstr "Echecs MMU"
 
 # 
-#: mmu.cpp:1613
+#: mmu.cpp:1587
 msgid "MMU load failed     "
 msgstr "Echec chargement MMU"
 
-# 
-#: ultralcd.cpp:1797
-msgid "MMU load fails"
+#  c=13 r=1
+#: ultralcd.cpp:1720
+msgid "MMU load f."
 msgstr "Echecs charg. MMU"
 
 # MSG_MMU_OK_RESUMING c=20 r=4
-#: mmu.cpp:773
+#: mmu.cpp:775
 msgid "MMU OK. Resuming..."
 msgstr "MMU OK. Reprise ..."
 
-# MSG_STEALTH_MODE_OFF
-#: messages.c:90
-msgid "Mode     [Normal]"
+# MSG_MODE
+#: messages.c:84
+msgid "Mode"
 msgstr ""
 
-# MSG_SILENT_MODE_ON
-#: messages.c:89
-msgid "Mode     [silent]"
-msgstr "Mode     [feutre]"
+# MSG_NORMAL
+#: messages.c:88
+msgid "Normal"
+msgstr ""
+
+# MSG_SILENT
+#: messages.c:87
+msgid "Silent"
+msgstr "Feutre"
 
 # 
-#: mmu.cpp:719
+#: mmu.cpp:721
 msgid "MMU needs user attention."
 msgstr "Le MMU necessite l'attention de l'utilisateur."
 
-# 
-#: ultralcd.cpp:1823
-msgid "MMU power fails"
+#  c=14 r=1
+#: ultralcd.cpp:1746
+msgid "MMU power f."
 msgstr "Echecs alim. MMU"
 
-# MSG_STEALTH_MODE_ON
-#: messages.c:91
-msgid "Mode    [Stealth]"
-msgstr "Mode     [furtif]"
+# MSG_STEALTH
+#: messages.c:89
+msgid "Stealth"
+msgstr "Furtif"
 
-# MSG_AUTO_MODE_ON
-#: messages.c:12
-msgid "Mode [auto power]"
-msgstr "Mode [puiss.auto]"
+# MSG_AUTO_POWER
+#: messages.c:86
+msgid "Auto power"
+msgstr "Puiss.auto"
 
-# MSG_SILENT_MODE_OFF
-#: messages.c:88
-msgid "Mode [high power]"
-msgstr "Mode[haute puiss]"
+# MSG_HIGH_POWER
+#: messages.c:85
+msgid "High power"
+msgstr "Haute puiss"
 
 # 
-#: ultralcd.cpp:2219
+#: ultralcd.cpp:2164
 msgid "MMU2 connected"
 msgstr "MMU2 connecte"
 
 # MSG_SELFTEST_MOTOR
-#: messages.c:83
+#: messages.c:79
 msgid "Motor"
 msgstr "Moteur"
 
 # MSG_MOVE_AXIS
-#: ultralcd.cpp:5652
+#: ultralcd.cpp:5718
 msgid "Move axis"
 msgstr "Deplacer l'axe"
 
 # MSG_MOVE_X
-#: ultralcd.cpp:4378
+#: ultralcd.cpp:4339
 msgid "Move X"
 msgstr "Deplacer X"
 
 # MSG_MOVE_Y
-#: ultralcd.cpp:4379
+#: ultralcd.cpp:4340
 msgid "Move Y"
 msgstr "Deplacer Y"
 
 # MSG_MOVE_Z
-#: ultralcd.cpp:4380
+#: ultralcd.cpp:4341
 msgid "Move Z"
 msgstr "Deplacer Z"
 
 # MSG_NO_MOVE
-#: Marlin_main.cpp:5292
+#: Marlin_main.cpp:5526
 msgid "No move."
 msgstr "Pas de mouvement."
 
 # MSG_NO_CARD
-#: ultralcd.cpp:6772
+#: ultralcd.cpp:6888
 msgid "No SD card"
 msgstr "Pas de carte SD"
 
-# 
-#: ultralcd.cpp:3024
+# MSG_NA
+#: messages.c:107
 msgid "N/A"
 msgstr ""
 
 # MSG_NO
-#: messages.c:62
+#: messages.c:58
 msgid "No"
 msgstr "Non"
 
 # MSG_SELFTEST_NOTCONNECTED
-#: ultralcd.cpp:7889
+#: ultralcd.cpp:8226
 msgid "Not connected"
 msgstr "Non connecte"
 
@@ -846,167 +786,152 @@ msgid "New firmware version available:"
 msgstr "Nouvelle version de firmware disponible:"
 
 # MSG_SELFTEST_FAN_NO c=19
-#: messages.c:79
+#: messages.c:75
 msgid "Not spinning"
 msgstr "Ne tourne pas"
 
 # MSG_WIZARD_V2_CAL c=20 r=8
-#: ultralcd.cpp:5063
+#: ultralcd.cpp:4924
 msgid "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr "Maintenant je vais calibrer la distance entre la pointe de la buse et la surface du plateau chauffant."
 
 # MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ultralcd.cpp:5007
+#: ultralcd.cpp:5049
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Maintenant je vais prechauffer la buse pour du PLA."
 
 # MSG_NOZZLE
-#: messages.c:63
+#: messages.c:59
 msgid "Nozzle"
 msgstr "Buse"
 
 # MSG_DEFAULT_SETTINGS_LOADED c=20 r=4
-#: Marlin_main.cpp:1519
+#: Marlin_main.cpp:1500
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr "Anciens reglages trouves. Le PID, les Esteps etc. par defaut seront regles"
 
 # 
-#: ultralcd.cpp:4998
+#: ultralcd.cpp:5040
 msgid "Now remove the test print from steel sheet."
 msgstr "Retirez maintenant l'impression de test de la plaque en acier."
 
 # 
-#: ultralcd.cpp:1722
+#: ultralcd.cpp:1645
 msgid "Nozzle FAN"
 msgstr "Vent. buse"
 
 # MSG_PAUSE_PRINT
-#: ultralcd.cpp:6735
+#: ultralcd.cpp:6852
 msgid "Pause print"
 msgstr "Pause de l'impr."
 
 # MSG_PID_RUNNING c=20 r=1
-#: ultralcd.cpp:1606
+#: ultralcd.cpp:1530
 msgid "PID cal.           "
 msgstr "Calib. PID"
 
 # MSG_PID_FINISHED c=20 r=1
-#: ultralcd.cpp:1612
+#: ultralcd.cpp:1536
 msgid "PID cal. finished"
 msgstr "Calib. PID terminee"
 
 # MSG_PID_EXTRUDER c=17 r=1
-#: ultralcd.cpp:5769
+#: ultralcd.cpp:5839
 msgid "PID calibration"
 msgstr "Calibration PID"
 
 # MSG_PINDA_PREHEAT c=20 r=1
-#: ultralcd.cpp:846
+#: ultralcd.cpp:887
 msgid "PINDA Heating"
 msgstr "Chauffe de la PINDA"
 
 # MSG_PAPER c=20 r=8
-#: messages.c:64
+#: messages.c:60
 msgid "Place a sheet of paper under the nozzle during the calibration of first 4 points. If the nozzle catches the paper, power off the printer immediately."
 msgstr "Placez une feuille de papier sous la buse pendant la calibration des 4 premiers points. Si la buse accroche le papier, eteignez vite l'imprimante."
 
 # MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ultralcd.cpp:5072
+#: ultralcd.cpp:5106
 msgid "Please clean heatbed and then press the knob."
 msgstr "Nettoyez la plaque en acier et appuyez sur le bouton."
 
 # MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: messages.c:22
+#: messages.c:21
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Nettoyez la buse pour la calibration. Cliquez une fois fait."
 
 # MSG_SELFTEST_PLEASECHECK
-#: ultralcd.cpp:7881
+#: ultralcd.cpp:8218
 msgid "Please check :"
 msgstr "Verifiez:"
 
 # MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: messages.c:100
+#: messages.c:98
 msgid "Please check our handbook and fix the problem. Then resume the Wizard by rebooting the printer."
 msgstr "Merci de consulter notre manuel et de corriger le probleme. Poursuivez alors l'assistant en redemarrant l'imprimante."
 
-# MSG_WIZARD_LOAD_FILAMENT c=20 r=8
-#: ultralcd.cpp:4894
-msgid "Please insert PLA filament to the extruder, then press knob to load it."
-msgstr "Inserez du filament PLA dans l'extrudeur puis appuyez sur le bouton pour le charger."
-
-# MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ultralcd.cpp:4795
-msgid "Please load PLA filament first."
-msgstr "Chargez d'abord le filament PLA."
-
 # MSG_CHECK_IDLER c=20 r=4
-#: Marlin_main.cpp:3064
+#: Marlin_main.cpp:3116
 msgid "Please open idler and remove filament manually."
 msgstr "Ouvrez l'idler et retirez le filament manuellement."
 
 # MSG_PLACE_STEEL_SHEET c=20 r=4
-#: messages.c:65
+#: messages.c:61
 msgid "Please place steel sheet on heatbed."
 msgstr "Placez la plaque en acier sur le plateau chauffant."
 
 # MSG_PRESS_TO_UNLOAD c=20 r=4
-#: messages.c:68
+#: messages.c:64
 msgid "Please press the knob to unload filament"
 msgstr "Appuyez sur le bouton pour decharger le filament"
 
-# 
-#: ultralcd.cpp:4889
-msgid "Please insert PLA filament to the first tube of MMU, then press the knob to load it."
-msgstr "Inserez du PLA dans le 1er tube du MMU, appuyez sur le bouton pour le charger."
-
 # MSG_PULL_OUT_FILAMENT c=20 r=4
-#: messages.c:70
+#: messages.c:66
 msgid "Please pull out filament immediately"
 msgstr "Retirez immediatement le filament"
 
 # MSG_EJECT_REMOVE c=20 r=4
-#: mmu.cpp:1440
+#: mmu.cpp:1421
 msgid "Please remove filament and then press the knob."
 msgstr "Veuillez retirer le filament puis appuyez sur le bouton."
 
 # MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: messages.c:74
+#: messages.c:70
 msgid "Please remove steel sheet from heatbed."
 msgstr "Retirez la plaque en acier du plateau chauffant."
 
 # MSG_RUN_XYZ c=20 r=4
-#: Marlin_main.cpp:4355
+#: Marlin_main.cpp:4561
 msgid "Please run XYZ calibration first."
 msgstr "Veuillez d'abord lancer la calibration XYZ."
 
 # MSG_UPDATE_MMU2_FW c=20 r=4
-#: mmu.cpp:1359
+#: mmu.cpp:1340
 msgid "Please update firmware in your MMU2. Waiting for reset."
 msgstr "Veuillez mettre a jour le firmware de votre MMU2. En attente d'un reset."
 
 # MSG_PLEASE_WAIT c=20
-#: messages.c:66
+#: messages.c:62
 msgid "Please wait"
 msgstr "Merci de patienter"
 
 # 
-#: ultralcd.cpp:4997
+#: ultralcd.cpp:5039
 msgid "Please remove shipping helpers first."
 msgstr "Retirez d'abord les protections de transport."
 
 # MSG_PREHEAT_NOZZLE c=20
-#: messages.c:67
+#: messages.c:63
 msgid "Preheat the nozzle!"
 msgstr "Prechauffez la buse!"
 
 # MSG_PREHEAT
-#: ultralcd.cpp:6722
+#: ultralcd.cpp:6830
 msgid "Preheat"
 msgstr "Prechauffage"
 
 # MSG_WIZARD_HEATING c=20 r=3
-#: messages.c:102
+#: messages.c:100
 msgid "Preheating nozzle. Please wait."
 msgstr "Prechauffage de la buse. Merci de patienter."
 
@@ -1016,82 +941,97 @@ msgid "Please upgrade."
 msgstr "Mettez a jour le FW."
 
 # MSG_PRESS_TO_PREHEAT c=20 r=4
-#: Marlin_main.cpp:10364
+#: Marlin_main.cpp:11469
 msgid "Press knob to preheat nozzle and continue."
 msgstr "Appuyez sur le bouton pour prechauffer la buse et continuer."
 
 # 
-#: ultralcd.cpp:1851
+#: ultralcd.cpp:1774
 msgid "Power failures"
 msgstr "Coup.de courant"
 
 # MSG_PRINT_ABORTED c=20
-#: messages.c:69
+#: messages.c:65
 msgid "Print aborted"
 msgstr "Impression annulee"
 
 #  c=20 r=1
-#: ultralcd.cpp:2455
+#: ultralcd.cpp:2420
 msgid "Preheating to load"
 msgstr "Chauffe pour charger"
 
 #  c=20 r=1
-#: ultralcd.cpp:2459
+#: ultralcd.cpp:2424
 msgid "Preheating to unload"
 msgstr "Chauf.pour decharger"
 
 # MSG_SELFTEST_PRINT_FAN_SPEED c=18
-#: ultralcd.cpp:8307
+#: ultralcd.cpp:8650
 msgid "Print fan:"
 msgstr "Vent. impr:"
 
 # MSG_CARD_MENU
-#: messages.c:21
+#: messages.c:20
 msgid "Print from SD"
 msgstr "Impr. depuis la SD"
 
 # 
-#: ultralcd.cpp:2317
+#: ultralcd.cpp:2267
 msgid "Press the knob"
 msgstr "App. sur sur bouton"
 
 # MSG_PRINT_PAUSED c=20 r=1
-#: ultralcd.cpp:1069
+#: ultralcd.cpp:1109
 msgid "Print paused"
 msgstr "Impression en pause"
 
 # 
-#: mmu.cpp:723
+#: mmu.cpp:725
 msgid "Press the knob to resume nozzle temperature."
 msgstr "Appuyez sur le bouton pour rechauffer la buse."
 
 # MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: messages.c:41
+#: messages.c:38
 msgid "Printer has not been calibrated yet. Please follow the manual, chapter First steps, section Calibration flow."
 msgstr "L'imprimante n'a pas encore ete calibree. Suivez le manuel, chapitre Premiers pas, section Processus de calibration."
 
 # 
-#: ultralcd.cpp:1723
+#: ultralcd.cpp:1646
 msgid "Print FAN"
 msgstr "Vent. impr"
 
+# 
+#: ultralcd.cpp:4904
+msgid "Please insert filament into the extruder, then press the knob to load it."
+msgstr "Veuillez inserer le filament dans l'extrudeur, puis appuyez sur le bouton pour le charger."
+
+# 
+#: ultralcd.cpp:4899
+msgid "Please insert filament into the first tube of the MMU, then press the knob to load it."
+msgstr "Veuillez inserer le filament dans le premier tube du MMU, puis appuyez sur le bouton pour le charger."
+
+# 
+#: ultralcd.cpp:4821
+msgid "Please load filament first."
+msgstr "Veuillez d'abord charger un filament."
+
 # MSG_PRUSA3D
-#: ultralcd.cpp:2205
+#: ultralcd.cpp:2150
 msgid "prusa3d.com"
 msgstr ""
 
 # MSG_BED_CORRECTION_REAR c=14 r=1
-#: ultralcd.cpp:3295
+#: ultralcd.cpp:3245
 msgid "Rear side [um]"
 msgstr "Arriere [um]"
 
 # MSG_RECOVERING_PRINT c=20 r=1
-#: Marlin_main.cpp:9764
+#: Marlin_main.cpp:10826
 msgid "Recovering print    "
 msgstr "Recup. impression"
 
 # MSG_REMOVE_OLD_FILAMENT c=20 r=4
-#: mmu.cpp:830
+#: mmu.cpp:832
 msgid "Remove old filament and press the knob to start loading new filament."
 msgstr "Retirez l'ancien filament puis appuyez sur le bouton pour charger le nouveau."
 
@@ -1101,717 +1041,642 @@ msgid "Prusa i3 MK3S OK."
 msgstr ""
 
 # MSG_CALIBRATE_BED_RESET
-#: ultralcd.cpp:5774
+#: ultralcd.cpp:5844
 msgid "Reset XYZ calibr."
 msgstr "Reinit. calib. XYZ"
 
 # MSG_BED_CORRECTION_RESET
-#: ultralcd.cpp:3296
+#: ultralcd.cpp:3246
 msgid "Reset"
 msgstr "Reinitialiser"
 
 # MSG_RESUME_PRINT
-#: ultralcd.cpp:6742
+#: ultralcd.cpp:6838
 msgid "Resume print"
 msgstr "Reprendre impression"
 
 # MSG_RESUMING_PRINT c=20 r=1
-#: messages.c:73
+#: messages.c:69
 msgid "Resuming print"
 msgstr "Reprise de l'impr."
 
 # MSG_BED_CORRECTION_RIGHT c=14 r=1
-#: ultralcd.cpp:3293
+#: ultralcd.cpp:3243
 msgid "Right side[um]"
 msgstr "Droite [um]"
 
-# MSG_SECOND_SERIAL_ON c=17 r=1
-#: ultralcd.cpp:5692
-msgid "RPi port     [on]"
-msgstr "Port RPi     [on]"
-
-# MSG_SECOND_SERIAL_OFF c=17 r=1
-#: ultralcd.cpp:5690
-msgid "RPi port    [off]"
-msgstr "Port RPi    [off]"
+# MSG_RPI_PORT
+#: messages.c:123
+msgid "RPi port"
+msgstr "Port RPi"
 
 # MSG_WIZARD_RERUN c=20 r=7
-#: ultralcd.cpp:4812
+#: ultralcd.cpp:4842
 msgid "Running Wizard will delete current calibration results and start from the beginning. Continue?"
 msgstr "Lancement de l'Assistant supprimera les resultats actuels de calibration et commencera du debut. Continuer?"
 
-# MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_OFF c=19 r=1
-#: ultralcd.cpp:5322
-msgid "SD card  [normal]"
-msgstr "Carte SD [normal]"
+# MSG_SD_CARD
+#: messages.c:118
+msgid "SD card"
+msgstr "Carte SD"
 
-# MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_ON c=19 r=1
-#: ultralcd.cpp:5320
-msgid "SD card [flshAir]"
-msgstr "CarteSD [flshAir]"
+# MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY
+#: messages.c:119
+msgid "FlashAir"
+msgstr "FlshAir"
 
 # 
-#: ultralcd.cpp:3019
+#: ultralcd.cpp:2972
 msgid "Right"
 msgstr "Droite"
 
 # MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=60
-#: messages.c:38
+#: messages.c:35
 msgid "Searching bed calibration point"
 msgstr "Recherche du point de calibration du lit"
 
 # MSG_LANGUAGE_SELECT
-#: ultralcd.cpp:5699
+#: ultralcd.cpp:5756
 msgid "Select language"
 msgstr "Choisir langue"
 
 # MSG_SELFTEST_OK
-#: ultralcd.cpp:7452
+#: ultralcd.cpp:7784
 msgid "Self test OK"
 msgstr "Auto-test OK"
 
 # MSG_SELFTEST_START c=20
-#: ultralcd.cpp:7238
+#: ultralcd.cpp:7558
 msgid "Self test start  "
 msgstr "Debut auto-test"
 
 # MSG_SELFTEST
-#: ultralcd.cpp:5750
+#: ultralcd.cpp:5820
 msgid "Selftest         "
 msgstr "Auto-test"
 
 # MSG_SELFTEST_ERROR
-#: ultralcd.cpp:7879
+#: ultralcd.cpp:8216
 msgid "Selftest error !"
 msgstr "Erreur auto-test!"
 
 # MSG_SELFTEST_FAILED c=20
-#: messages.c:77
+#: messages.c:73
 msgid "Selftest failed  "
 msgstr "Echec de l'auto-test"
 
 # MSG_FORCE_SELFTEST c=20 r=8
-#: Marlin_main.cpp:1551
+#: Marlin_main.cpp:1532
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr "Le Selftest sera lance pour calibrer la remise a zero precise sans capteur"
 
 # 
-#: ultralcd.cpp:5045
+#: ultralcd.cpp:5080
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr "Selectionnez la temperature de prechauffage de la buse qui correspond a votre materiau."
 
-# 
-#: ultralcd.cpp:4780
-msgid "Select PLA filament:"
-msgstr "Selectionnez le fil. PLA:"
-
 # MSG_SET_TEMPERATURE c=19 r=1
-#: ultralcd.cpp:3314
+#: ultralcd.cpp:3264
 msgid "Set temperature:"
 msgstr "Regler temp.:"
 
 # MSG_SETTINGS
-#: messages.c:86
+#: messages.c:82
 msgid "Settings"
 msgstr "Reglages"
 
 # MSG_SHOW_END_STOPS c=17 r=1
-#: ultralcd.cpp:5771
+#: ultralcd.cpp:5841
 msgid "Show end stops"
 msgstr "Afficher butees"
 
 # 
-#: ultralcd.cpp:4025
+#: ultralcd.cpp:3986
 msgid "Sensor state"
 msgstr "Etat capteur"
 
 # MSG_FILE_CNT c=20 r=4
-#: cardreader.cpp:739
+#: cardreader.cpp:729
 msgid "Some files will not be sorted. Max. No. of files in 1 folder for sorting is 100."
 msgstr "Certains fichiers ne seront pas tries. Max 100 fichiers tries par dossier."
 
-# MSG_SORT_NONE c=17 r=1
-#: ultralcd.cpp:5332
-msgid "Sort       [none]"
-msgstr "Tri       [aucun]"
+# MSG_SORT
+#: messages.c:120
+msgid "Sort"
+msgstr "Tri"
 
-# MSG_SORT_TIME c=17 r=1
-#: ultralcd.cpp:5330
-msgid "Sort       [time]"
-msgstr "Tri       [heure]"
+# MSG_NONE
+#: messages.c:110
+msgid "None"
+msgstr "Aucun"
+
+# MSG_SORT_TIME
+#: messages.c:121
+msgid "Time"
+msgstr "Heure"
 
 # 
-#: ultralcd.cpp:3062
+#: ultralcd.cpp:3015
 msgid "Severe skew:"
 msgstr "Deviat.sev.:"
 
-# MSG_SORT_ALPHA c=17 r=1
-#: ultralcd.cpp:5331
-msgid "Sort   [alphabet]"
-msgstr "Tri    [alphabet]"
+# MSG_SORT_ALPHA
+#: messages.c:122
+msgid "Alphabet"
+msgstr ""
 
 # MSG_SORTING c=20 r=1
-#: cardreader.cpp:746
+#: cardreader.cpp:736
 msgid "Sorting files"
 msgstr "Tri des fichiers"
 
-# MSG_SOUND_LOUD c=17 r=1
-#: sound.h:6
-msgid "Sound      [loud]"
-msgstr "Son        [fort]"
+# MSG_SOUND_LOUD
+#: messages.c:125
+msgid "Loud"
+msgstr "Fort"
 
 # 
-#: ultralcd.cpp:3061
+#: ultralcd.cpp:3014
 msgid "Slight skew:"
 msgstr "Deviat.leg.:"
 
-# MSG_SOUND_MUTE c=17 r=1
-#: 
-msgid "Sound      [mute]"
-msgstr "Son        [muet]"
+# MSG_SOUND
+#: messages.c:124
+msgid "Sound"
+msgstr "Son"
 
 # 
-#: Marlin_main.cpp:4871
+#: Marlin_main.cpp:5084
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Probleme rencontre, cliquez sur le bouton pour niveller l'axe Z..."
 
-# MSG_SOUND_ONCE c=17 r=1
-#: sound.h:7
-msgid "Sound      [once]"
-msgstr "Son    [une fois]"
-
-# MSG_SOUND_SILENT c=17 r=1
-#: sound.h:8
-msgid "Sound    [silent]"
-msgstr "Son      [feutre]"
-
 # MSG_SPEED
-#: ultralcd.cpp:6926
+#: ultralcd.cpp:7096
 msgid "Speed"
 msgstr "Vitesse"
 
 # MSG_SELFTEST_FAN_YES c=19
-#: messages.c:80
+#: messages.c:76
 msgid "Spinning"
 msgstr "Tourne"
 
 # MSG_TEMP_CAL_WARNING c=20 r=4
-#: Marlin_main.cpp:4368
+#: Marlin_main.cpp:4574
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr "Une temperature ambiante stable de 21-26C et un support stable sont requis."
 
 # MSG_STATISTICS
-#: ultralcd.cpp:6839
+#: ultralcd.cpp:6955
 msgid "Statistics  "
 msgstr "Statistiques"
 
 # MSG_STOP_PRINT
-#: messages.c:93
+#: messages.c:91
 msgid "Stop print"
 msgstr "Arreter impression"
 
 # MSG_STOPPED
-#: messages.c:94
+#: messages.c:92
 msgid "STOPPED. "
 msgstr "ARRETE."
 
 # MSG_SUPPORT
-#: ultralcd.cpp:6848
+#: ultralcd.cpp:6964
 msgid "Support"
 msgstr ""
 
 # MSG_SELFTEST_SWAPPED
-#: ultralcd.cpp:7959
+#: ultralcd.cpp:8296
 msgid "Swapped"
 msgstr "Echange"
 
-# MSG_TEMP_CALIBRATION c=20 r=1
-#: messages.c:95
-msgid "Temp. cal.          "
+# 
+#: ultralcd.cpp:4792
+msgid "Select filament:"
+msgstr "Selectionnez le filament:"
+
+# MSG_TEMP_CALIBRATION c=12 r=1
+#: messages.c:93
+msgid "Temp. cal."
 msgstr "Calib. Temp."
 
-# MSG_TEMP_CALIBRATION_ON c=20 r=1
-#: ultralcd.cpp:5686
-msgid "Temp. cal.   [on]"
-msgstr "Calib. Temp. [on]"
-
-# MSG_TEMP_CALIBRATION_OFF c=20 r=1
-#: ultralcd.cpp:5684
-msgid "Temp. cal.  [off]"
-msgstr "Calib. Temp.[off]"
+# 
+#: ultralcd.cpp:4933
+msgid "Select temperature which matches your material."
+msgstr "Selectionnez la temperature qui correspond a votre materiau."
 
 # MSG_CALIBRATION_PINDA_MENU c=17 r=1
-#: ultralcd.cpp:5780
+#: ultralcd.cpp:5850
 msgid "Temp. calibration"
 msgstr "Calibration temp."
 
 # MSG_TEMP_CAL_FAILED c=20 r=8
-#: ultralcd.cpp:3951
+#: ultralcd.cpp:3911
 msgid "Temperature calibration failed"
 msgstr "Echec de la calibration en temperature"
 
 # MSG_TEMP_CALIBRATION_DONE c=20 r=12
-#: messages.c:96
+#: messages.c:94
 msgid "Temperature calibration is finished and active. Temp. calibration can be disabled in menu Settings->Temp. cal."
 msgstr "La calibration en temperature est terminee et activee. La calibration en temperature peut etre desactivee dans le menu Reglages-> Cal. Temp."
 
 # MSG_TEMPERATURE
-#: ultralcd.cpp:5650
+#: ultralcd.cpp:5716
 msgid "Temperature"
 msgstr ""
 
 # MSG_MENU_TEMPERATURES c=15 r=1
-#: ultralcd.cpp:2251
+#: ultralcd.cpp:2196
 msgid "Temperatures"
 msgstr ""
 
 # MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=4
-#: messages.c:42
+#: messages.c:39
 msgid "There is still a need to make Z calibration. Please follow the manual, chapter First steps, section Calibration flow."
 msgstr "Il faut toujours effectuer la Calibration Z. Veuillez suivre le manuel, chapitre Premiers pas, section Processus de calibration."
 
 # 
-#: ultralcd.cpp:2908
+#: ultralcd.cpp:2869
 msgid "Total filament"
 msgstr "Filament total"
 
 # 
-#: ultralcd.cpp:2908
+#: ultralcd.cpp:2870
 msgid "Total print time"
 msgstr "Temps total impr."
 
 # MSG_TUNE
-#: ultralcd.cpp:6719
+#: ultralcd.cpp:6827
 msgid "Tune"
 msgstr "Regler"
 
 # 
-#: ultralcd.cpp:4869
+#: 
 msgid "Unload"
 msgstr "Decharger"
 
 # 
-#: ultralcd.cpp:1820
+#: ultralcd.cpp:1743
 msgid "Total failures"
 msgstr "Total des echecs"
 
 # 
-#: ultralcd.cpp:2324
+#: ultralcd.cpp:2274
 msgid "to load filament"
 msgstr "pour charger le fil."
 
 # 
-#: ultralcd.cpp:2328
+#: ultralcd.cpp:2278
 msgid "to unload filament"
 msgstr "pour decharger fil."
 
 # MSG_UNLOAD_FILAMENT c=17
-#: messages.c:97
+#: messages.c:95
 msgid "Unload filament"
 msgstr "Decharger fil."
 
 # MSG_UNLOADING_FILAMENT c=20 r=1
-#: messages.c:98
+#: messages.c:96
 msgid "Unloading filament"
 msgstr "Dechargement fil."
 
 # 
-#: ultralcd.cpp:1773
+#: ultralcd.cpp:1696
 msgid "Total"
 msgstr ""
 
 # MSG_USED c=19 r=1
-#: ultralcd.cpp:5908
+#: ultralcd.cpp:5978
 msgid "Used during print"
 msgstr "Utilise pdt impr."
 
 # MSG_MENU_VOLTAGES c=15 r=1
-#: ultralcd.cpp:2254
+#: ultralcd.cpp:2199
 msgid "Voltages"
 msgstr "Tensions"
 
 # 
-#: ultralcd.cpp:2227
+#: ultralcd.cpp:2172
 msgid "unknown"
 msgstr "inconnu"
 
 # MSG_USERWAIT
-#: Marlin_main.cpp:5263
+#: Marlin_main.cpp:5496
 msgid "Wait for user..."
 msgstr "Attente utilisateur..."
 
 # MSG_WAITING_TEMP c=20 r=3
-#: ultralcd.cpp:3458
+#: ultralcd.cpp:3412
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Attente du refroidissement des buse et plateau"
 
 # MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ultralcd.cpp:3422
+#: ultralcd.cpp:3373
 msgid "Waiting for PINDA probe cooling"
 msgstr "Attente du refroidissement de la sonde PINDA"
 
 # 
-#: ultralcd.cpp:4868
+#: 
 msgid "Use unload to remove filament 1 if it protrudes outside of the rear MMU tube. Use eject if it is hidden in tube."
 msgstr "Utilisez Remonter le fil. pour retirer le filament 1 s'il depasse du tube arriere du MMU. Utilisez ejecter s'il est cache dans le tube."
 
 # MSG_CHANGED_BOTH c=20 r=4
-#: Marlin_main.cpp:1511
+#: Marlin_main.cpp:1492
 msgid "Warning: both printer type and motherboard type changed."
 msgstr "Attention: Types d'imprimante et de carte mere modifies"
 
 # MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: Marlin_main.cpp:1503
+#: Marlin_main.cpp:1484
 msgid "Warning: motherboard type changed."
 msgstr "Attention: Type de carte mere modifie."
 
 # MSG_CHANGED_PRINTER c=20 r=4
-#: Marlin_main.cpp:1507
+#: Marlin_main.cpp:1488
 msgid "Warning: printer type changed."
 msgstr "Attention: Type d'imprimante modifie"
 
 # MSG_UNLOAD_SUCCESSFUL c=20 r=2
-#: Marlin_main.cpp:3054
+#: Marlin_main.cpp:3106
 msgid "Was filament unload successful?"
 msgstr "Dechargement du filament reussi?"
 
 # MSG_SELFTEST_WIRINGERROR
-#: messages.c:85
+#: messages.c:81
 msgid "Wiring error"
 msgstr "Erreur de cablage"
 
 # MSG_WIZARD c=17 r=1
-#: ultralcd.cpp:5747
+#: ultralcd.cpp:5811
 msgid "Wizard"
 msgstr "Assistant"
 
 # MSG_XYZ_DETAILS c=19 r=1
-#: ultralcd.cpp:2243
+#: ultralcd.cpp:2188
 msgid "XYZ cal. details"
 msgstr "Details calib. XYZ"
 
 # MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: messages.c:19
+#: messages.c:18
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "Echec calibration XYZ. Consultez le manuel."
 
 # MSG_YES
-#: messages.c:104
+#: messages.c:102
 msgid "Yes"
 msgstr "Oui"
 
 # MSG_WIZARD_QUIT c=20 r=8
-#: messages.c:103
+#: messages.c:101
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr "Vous pouvez toujours relancer l'Assistant dans Calibration > Assistant."
 
 # MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ultralcd.cpp:3922
+#: ultralcd.cpp:3882
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr "Calibration XYZ OK. L'ecart sera corrige automatiquement."
 
 # MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ultralcd.cpp:3919
+#: ultralcd.cpp:3879
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr "Calibration XYZ OK. Les axes X/Y sont legerement non perpendiculaires. Bon boulot!"
 
 # 
-#: ultralcd.cpp:5130
+#: ultralcd.cpp:5168
 msgid "X-correct:"
 msgstr "Correct-X:"
 
 # MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ultralcd.cpp:3916
+#: ultralcd.cpp:3876
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "Calibration XYZ OK. Les axes X/Y sont perpendiculaires. Felicitations!"
 
 # MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ultralcd.cpp:3900
+#: ultralcd.cpp:3860
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr "Calibration XYZ compromise. Les points de calibration en avant ne sont pas atteignables."
 
 # MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ultralcd.cpp:3903
+#: ultralcd.cpp:3863
 msgid "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr "Calibration XYZ compromise. Le point de calibration avant droit n'est pas atteignable."
 
 # MSG_LOAD_ALL c=17
-#: ultralcd.cpp:6166
+#: ultralcd.cpp:6238
 msgid "Load all"
 msgstr "Charger un par un"
 
 # 
-#: ultralcd.cpp:3882
+#: ultralcd.cpp:3842
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr "Echec calibration XYZ. Le point de calibration du plateau n'a pas ete trouve."
 
 # 
-#: ultralcd.cpp:3888
+#: ultralcd.cpp:3848
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr "Echec calibration XYZ. Les points de calibration en avant ne sont pas atteignables."
 
 # 
-#: ultralcd.cpp:3891
+#: ultralcd.cpp:3851
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr "Echec calibration XYZ. Le point de calibration avant droit n'est pas atteignable."
 
 # 
-#: ultralcd.cpp:3016
+#: ultralcd.cpp:2969
 msgid "Y distance from min"
 msgstr "Distance Y du min"
 
 # 
-#: ultralcd.cpp:5131
+#: ultralcd.cpp:4936
+msgid "The printer will start printing a zig-zag line. Rotate the knob until you reach the optimal height. Check the pictures in the handbook (Calibration chapter)."
+msgstr "L'imprimante commencera a  imprimer une ligne en zig-zag. Tournez le bouton jusqu'a atteindre la hauteur optimale. Consultez les photos dans le manuel (chapitre Calibration)."
+
+# 
+#: ultralcd.cpp:5169
 msgid "Y-correct:"
 msgstr "Correct-Y:"
 
 # MSG_OFF
-#: menu.cpp:426
-msgid " [off]"
-msgstr " [off]"
+#: messages.c:105
+msgid "Off"
+msgstr ""
+
+# MSG_ON
+#: messages.c:106
+msgid "On"
+msgstr ""
 
 # 
-#: messages.c:57
+#: messages.c:53
 msgid "Back"
 msgstr "Retour"
 
 # 
-#: ultralcd.cpp:5639
+#: ultralcd.cpp:5702
 msgid "Checks"
 msgstr "Verifications"
 
 # 
-#: ultralcd.cpp:7973
+#: ultralcd.cpp:8310
 msgid "False triggering"
 msgstr "Faux declenchement"
 
 # 
-#: ultralcd.cpp:4030
+#: ultralcd.cpp:3991
 msgid "FINDA:"
 msgstr "FINDA:"
 
-# 
-#: ultralcd.cpp:5545
-msgid "Firmware   [none]"
-msgstr "Firmware [aucune]"
+# MSG_FIRMWARE
+#: language.h:21
+msgid "Firmware"
+msgstr ""
+
+# MSG_STRICT
+#: messages.c:112
+msgid "Strict"
+msgstr "Stricte"
+
+# MSG_WARN
+#: messages.c:111
+msgid "Warn"
+msgstr "Avert"
 
 # 
-#: ultralcd.cpp:5551
-msgid "Firmware [strict]"
-msgstr "Firmware[stricte]"
-
-# 
-#: ultralcd.cpp:5548
-msgid "Firmware   [warn]"
-msgstr "Firmware  [avert]"
-
-# 
-#: messages.c:87
+#: messages.c:83
 msgid "HW Setup"
 msgstr "Config HW"
 
 # 
-#: ultralcd.cpp:4034
+#: ultralcd.cpp:3995
 msgid "IR:"
 msgstr "IR:"
 
-# 
-#: ultralcd.cpp:7046
-msgid "Magnets comp.[N/A]"
-msgstr "Compens. aim.[N/A]"
+# MSG_MAGNETS_COMP
+#: messages.c:130
+msgid "Magnets comp."
+msgstr "Compens. aim."
 
-# 
-#: ultralcd.cpp:7044
-msgid "Magnets comp.[Off]"
-msgstr "Compens. aim.[off]"
-
-# 
-#: ultralcd.cpp:7043
-msgid "Magnets comp. [On]"
-msgstr "Compens. aim. [on]"
-
-# 
-#: ultralcd.cpp:7035
-msgid "Mesh         [3x3]"
+# MSG_MESH
+#: messages.c:128
+msgid "Mesh"
 msgstr ""
 
 # 
-#: ultralcd.cpp:7036
-msgid "Mesh         [7x7]"
-msgstr ""
-
-# 
-#: ultralcd.cpp:5677
+#: ultralcd.cpp:5740
 msgid "Mesh bed leveling"
 msgstr ""
 
 # 
-#: Marlin_main.cpp:856
+#: Marlin_main.cpp:861
 msgid "MK3S firmware detected on MK3 printer"
 msgstr "Firmware MK3S detecte sur imprimante MK3"
 
-# 
-#: ultralcd.cpp:5306
-msgid "MMU Mode [Normal]"
-msgstr "Mode MMU [normal]"
+# MSG_MMU_MODE
+#: messages.c:117
+msgid "MMU Mode"
+msgstr "Mode MMU"
 
 # 
-#: ultralcd.cpp:5307
-msgid "MMU Mode[Stealth]"
-msgstr "Mode MMU [feutre]"
-
-# 
-#: ultralcd.cpp:4511
+#: ultralcd.cpp:4472
 msgid "Mode change in progress ..."
 msgstr "Changement de mode en cours..."
 
-# 
-#: ultralcd.cpp:5506
-msgid "Model      [none]"
-msgstr "Modele   [aucune]"
+# MSG_MODEL
+#: messages.c:113
+msgid "Model"
+msgstr "Modele"
+
+# MSG_NOZZLE_DIAMETER
+#: messages.c:116
+msgid "Nozzle d."
+msgstr "Diam. buse"
 
 # 
-#: ultralcd.cpp:5512
-msgid "Model    [strict]"
-msgstr "Modele  [stricte]"
-
-# 
-#: ultralcd.cpp:5509
-msgid "Model      [warn]"
-msgstr "Modele    [avert]"
-
-# 
-#: ultralcd.cpp:5467
-msgid "Nozzle d.  [0.25]"
-msgstr "Diam. buse [0.25]"
-
-# 
-#: ultralcd.cpp:5470
-msgid "Nozzle d.  [0.40]"
-msgstr "Diam. buse [0.40]"
-
-# 
-#: ultralcd.cpp:5473
-msgid "Nozzle d.  [0.60]"
-msgstr "Diam. buse [0.60]"
-
-# 
-#: ultralcd.cpp:5421
-msgid "Nozzle     [none]"
-msgstr "Buse     [aucune]"
-
-# 
-#: ultralcd.cpp:5427
-msgid "Nozzle   [strict]"
-msgstr "Buse    [stricte]"
-
-# 
-#: ultralcd.cpp:5424
-msgid "Nozzle     [warn]"
-msgstr "Buse      [avert]"
-
-# 
-#: util.cpp:510
+#: util.cpp:514
 msgid "G-code sliced for a different level. Continue?"
 msgstr ""
 
 # 
-#: util.cpp:516
+#: util.cpp:520
 msgid "G-code sliced for a different level. Please re-slice the model again. Print cancelled."
 msgstr ""
 
 # 
-#: util.cpp:427
+#: util.cpp:431
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr "Le G-code a ete prepare pour une autre version de l'imprimante. Continuer?"
 
 # 
-#: util.cpp:433
+#: util.cpp:437
 msgid "G-code sliced for a different printer type. Please re-slice the model again. Print cancelled."
 msgstr "Le G-code a ete prepare pour une autre version de l'imprimante. Veuillez decouper le modele a nouveau. L'impression a ete annulee."
 
 # 
-#: util.cpp:477
+#: util.cpp:481
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "Le G-code a ete prepare pour une version plus recente du firmware. Continuer?"
 
 # 
-#: util.cpp:483
+#: util.cpp:487
 msgid "G-code sliced for a newer firmware. Please update the firmware. Print cancelled."
 msgstr "Le G-code a ete prepare pour une version plus recente du firmware. Veuillez mettre a jour le firmware. L'impression annulee."
 
 # 
-#: ultralcd.cpp:4026
+#: ultralcd.cpp:3987
 msgid "PINDA:"
 msgstr "PINDA:"
 
 #  c=20 r=1
-#: ultralcd.cpp:2465
+#: ultralcd.cpp:2430
 msgid "Preheating to cut"
 msgstr "Chauffe pour couper"
 
 #  c=20 r=1
-#: ultralcd.cpp:2462
+#: ultralcd.cpp:2427
 msgid "Preheating to eject"
 msgstr "Chauf. pour remonter"
 
 # 
-#: util.cpp:390
+#: util.cpp:394
 msgid "Printer nozzle diameter differs from the G-code. Continue?"
 msgstr "Diametre de la buse dans les reglages ne correspond pas a celui dans le G-Code. Continuer?"
 
 # 
-#: util.cpp:397
+#: util.cpp:401
 msgid "Printer nozzle diameter differs from the G-code. Please check the value in settings. Print cancelled."
 msgstr "Diametre de la buse dans les reglages ne correspond pas a celui dans le G-Code. Merci de verifier le parametre dans les reglages. Impression annulee."
 
 # 
-#: ultralcd.cpp:6683
+#: ultralcd.cpp:6791
 msgid "Rename"
 msgstr "Renommer"
 
 # 
-#: ultralcd.cpp:6679
+#: ultralcd.cpp:6784
 msgid "Select"
 msgstr "Selectionner"
 
 # 
-#: ultralcd.cpp:2245
+#: ultralcd.cpp:2190
 msgid "Sensor info"
 msgstr "Info capteur"
 
 # 
-#: messages.c:58
+#: messages.c:54
 msgid "Sheet"
 msgstr "Plaque"
 
-# 
-#: sound.h:9
-msgid "Sound    [assist]"
-msgstr "Son      [assist]"
+# MSG_SOUND_BLIND
+#: messages.c:127
+msgid "Assist"
+msgstr ""
 
 # 
-#: ultralcd.cpp:5637
+#: ultralcd.cpp:5700
 msgid "Steel sheets"
 msgstr "Plaques en acier"
 
 # 
-#: ultralcd.cpp:5132
+#: ultralcd.cpp:5170
 msgid "Z-correct:"
 msgstr "Correct-Z:"
-
-# 
-#: ultralcd.cpp:7038
-msgid "Z-probe nr.    [1]"
-msgstr "Mesurer x-fois [1]"
-
-# 
-#: ultralcd.cpp:7040
-msgid "Z-probe nr.    [3]"
-msgstr "Mesurer x-fois [3]"
-
-# 
-#: ultralcd.cpp:7039
-msgid "Z-probe nr.    [5]"
-msgstr "Mesurer x-fois [5]"
 

--- a/lang/po/Firmware_it.po
+++ b/lang/po/Firmware_it.po
@@ -7,26 +7,31 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: it\n"
 "Project-Id-Version: Prusa-Firmware\n"
-"POT-Creation-Date: Sun, Sep 22, 2019 2:07:29 PM\n"
-"PO-Revision-Date: Sun, Sep 22, 2019 2:07:29 PM\n"
+"POT-Creation-Date: Thu, Mar 26, 2020 8:56:13 AM\n"
+"PO-Revision-Date: Thu, Mar 26, 2020 8:56:13 AM\n"
 "Language-Team: \n"
 "X-Generator: Poedit 2.0.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 "Last-Translator: \n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
+# 
+#: 
+msgid "[%.7s]Live adj. Z\x0avalue set, continue\x0aor start from zero?\x0a%cContinue%cReset"
+msgstr "[%.7s]Set valori\x0aComp. Z, continuare\x0ao iniziare da zero?\x0a%cContinua%cReset"
+
 # MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE2 c=14
-#: messages.c:39
+#: messages.c:36
 msgid " of 4"
 msgstr " su 4"
 
 # MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE2 c=14
-#: messages.c:60
+#: messages.c:56
 msgid " of 9"
-msgstr "su 9"
+msgstr " su 9"
 
 # MSG_MEASURED_OFFSET
-#: ultralcd.cpp:3089
+#: ultralcd.cpp:3042
 msgid "[0;0] point offset"
 msgstr "[0;0] punto offset"
 
@@ -41,53 +46,43 @@ msgid "WARNING:\x0aCrash detection\x0adisabled in\x0aStealth mode"
 msgstr "ATTENZIONE:\x0aRilev. impatto\x0adisattivato in\x0aModalita silenziosa"
 
 # 
-#: ultralcd.cpp:2472
+#: ultralcd.cpp:2438
 msgid ">Cancel"
 msgstr ">Annulla"
 
 # MSG_BABYSTEPPING_Z c=15
-#: ultralcd.cpp:3209
+#: ultralcd.cpp:3162
 msgid "Adjusting Z:"
 msgstr "Compensaz. Z:"
 
 # MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ultralcd.cpp:8295
+#: ultralcd.cpp:8638
 msgid "All correct      "
 msgstr "Nessun errore"
 
 # MSG_WIZARD_DONE c=20 r=8
-#: messages.c:101
+#: messages.c:99
 msgid "All is done. Happy printing!"
 msgstr "Tutto fatto. Buona stampa!"
 
 # 
-#: ultralcd.cpp:2009
+#: ultralcd.cpp:1947
 msgid "Ambient"
 msgstr "Ambiente"
 
 # MSG_PRESS c=20
-#: ultralcd.cpp:2618
+#: ultralcd.cpp:2587
 msgid "and press the knob"
 msgstr "e cliccare manopola"
 
 # MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=2
-#: ultralcd.cpp:3529
+#: ultralcd.cpp:3484
 msgid "Are left and right Z~carriages all up?"
 msgstr "I carrelli Z sin/des sono altezza max?"
 
-# MSG_AUTO_DEPLETE_ON c=17 r=1
-#: ultralcd.cpp:5200
-msgid "SpoolJoin    [on]"
-msgstr ""
-
-# 
-#: ultralcd.cpp:5196
-msgid "SpoolJoin   [N/A]"
-msgstr ""
-
-# MSG_AUTO_DEPLETE_OFF c=17 r=1
-#: ultralcd.cpp:5204
-msgid "SpoolJoin   [off]"
+# MSG_AUTO_DEPLETE c=17 r=1
+#: messages.c:108
+msgid "SpoolJoin"
 msgstr ""
 
 # MSG_AUTO_HOME
@@ -96,747 +91,697 @@ msgid "Auto home"
 msgstr "Trova origine"
 
 # MSG_AUTOLOAD_FILAMENT c=17
-#: ultralcd.cpp:6822
+#: ultralcd.cpp:6938
 msgid "AutoLoad filament"
 msgstr "Autocaric. filam."
 
 # MSG_AUTOLOADING_ONLY_IF_FSENS_ON c=20 r=4
-#: ultralcd.cpp:4462
+#: ultralcd.cpp:4423
 msgid "Autoloading filament available only when filament sensor is turned on..."
 msgstr "Caricamento auto. filam. disp. solo con il sensore attivo..."
 
 # MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ultralcd.cpp:2813
+#: ultralcd.cpp:2782
 msgid "Autoloading filament is active, just press the knob and insert filament..."
 msgstr "Caricamento automatico attivo, premi la manopola e inserisci il filamento."
 
 # MSG_SELFTEST_AXIS_LENGTH
-#: ultralcd.cpp:7949
+#: ultralcd.cpp:8286
 msgid "Axis length"
 msgstr "Lunghezza dell'asse"
 
 # MSG_SELFTEST_AXIS
-#: ultralcd.cpp:7951
+#: ultralcd.cpp:8288
 msgid "Axis"
 msgstr "Assi"
 
 # MSG_SELFTEST_BEDHEATER
-#: ultralcd.cpp:7893
+#: ultralcd.cpp:8230
 msgid "Bed / Heater"
 msgstr "Letto/Riscald."
 
 # MSG_BED_DONE
-#: messages.c:16
+#: messages.c:15
 msgid "Bed done"
 msgstr "Piano fatto."
 
 # MSG_BED_HEATING
-#: messages.c:17
+#: messages.c:16
 msgid "Bed Heating"
 msgstr "Riscald. letto"
 
 # MSG_BED_CORRECTION_MENU
-#: ultralcd.cpp:5768
+#: ultralcd.cpp:5838
 msgid "Bed level correct"
 msgstr "Correz. liv.letto"
 
 # MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=4
-#: messages.c:18
+#: messages.c:17
 msgid "Bed leveling failed. Sensor didnt trigger. Debris on nozzle? Waiting for reset."
 msgstr "Livellamento letto fallito.NoRispSensore.Residui su ugello? In attesa di reset."
 
 # MSG_BED
-#: messages.c:15
+#: messages.c:14
 msgid "Bed"
 msgstr "Letto"
 
 # MSG_MENU_BELT_STATUS c=15 r=1
-#: ultralcd.cpp:2059
+#: ultralcd.cpp:2004
 msgid "Belt status"
 msgstr "Stato cinghie"
 
 # MSG_RECOVER_PRINT c=20 r=2
-#: messages.c:71
+#: messages.c:67
 msgid "Blackout occurred. Recover print?"
 msgstr "C'e stato un Blackout. Recuperare la stampa?"
 
 # 
-#: ultralcd.cpp:8297
+#: ultralcd.cpp:8640
 msgid "Calibrating home"
 msgstr "Calibrazione Home"
 
 # MSG_CALIBRATE_BED
-#: ultralcd.cpp:5757
+#: ultralcd.cpp:5827
 msgid "Calibrate XYZ"
 msgstr "Calibra XYZ"
 
 # MSG_HOMEYZ
-#: messages.c:48
+#: messages.c:44
 msgid "Calibrate Z"
 msgstr "Calibra Z"
 
 # MSG_CALIBRATE_PINDA c=17 r=1
-#: ultralcd.cpp:4654
+#: ultralcd.cpp:4615
 msgid "Calibrate"
 msgstr "Calibra"
 
 # MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ultralcd.cpp:3492
+#: ultralcd.cpp:3447
 msgid "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end stoppers. Click when done."
 msgstr "Calibrazione XYZ. Ruotare la manopola per alzare il carrello Z fino all'altezza massima. Click per terminare."
 
 # MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: messages.c:20
+#: messages.c:19
 msgid "Calibrating Z"
 msgstr "Calibrando Z"
 
 # MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ultralcd.cpp:3492
+#: ultralcd.cpp:3447
 msgid "Calibrating Z. Rotate the knob to move the Z carriage up to the end stoppers. Click when done."
 msgstr "Calibrazione Z. Ruotare la manopola per alzare il carrello Z fino all'altezza massima. Click per terminare."
 
 # MSG_HOMEYZ_DONE
-#: ultralcd.cpp:816
+#: ultralcd.cpp:856
 msgid "Calibration done"
 msgstr "Calibrazione completa"
 
 # MSG_MENU_CALIBRATION
-#: messages.c:61
+#: messages.c:57
 msgid "Calibration"
 msgstr "Calibrazione"
 
 # 
-#: ultralcd.cpp:4781
+#: ultralcd.cpp:4793
 msgid "Cancel"
 msgstr "Annulla"
 
 # MSG_SD_REMOVED
-#: ultralcd.cpp:8679
+#: ultralcd.cpp:9051
 msgid "Card removed"
 msgstr "SD rimossa"
 
 # MSG_NOT_COLOR
-#: ultralcd.cpp:2718
+#: ultralcd.cpp:2687
 msgid "Color not correct"
 msgstr "Colore non puro"
 
 # MSG_COOLDOWN
-#: messages.c:23
+#: messages.c:22
 msgid "Cooldown"
 msgstr "Raffredda"
 
 # 
-#: ultralcd.cpp:4587
+#: ultralcd.cpp:4548
 msgid "Copy selected language?"
 msgstr "Copiare la lingua selezionata?"
 
-# MSG_CRASHDETECT_ON
-#: messages.c:27
-msgid "Crash det.   [on]"
-msgstr "Rileva.crash [on]"
+# MSG_CRASHDETECT
+#: messages.c:24
+msgid "Crash det."
+msgstr "Rileva.crash"
 
-# MSG_CRASHDETECT_NA
-#: messages.c:25
-msgid "Crash det.  [N/A]"
-msgstr "Rileva.crash[N/A]"
-
-# MSG_CRASHDETECT_OFF
-#: messages.c:26
-msgid "Crash det.  [off]"
-msgstr "Rileva.crash[off]"
+# 
+#: ultralcd.cpp:4928
+msgid "Choose a filament for the First Layer Calibration and select it in the on-screen menu."
+msgstr "Scegli un filamento per la calibrazione del primo strato e selezionalo nel menu sullo schermo."
 
 # MSG_CRASH_DETECTED c=20 r=1
-#: messages.c:24
+#: messages.c:23
 msgid "Crash detected."
 msgstr "Rilevato impatto."
 
 # 
-#: Marlin_main.cpp:600
+#: Marlin_main.cpp:602
 msgid "Crash detected. Resume print?"
 msgstr "Scontro rilevato. Riprendere la stampa?"
 
 # 
-#: ultralcd.cpp:1853
+#: ultralcd.cpp:1776
 msgid "Crash"
 msgstr "Impatto"
 
 # MSG_CURRENT c=19 r=1
-#: ultralcd.cpp:5909
+#: ultralcd.cpp:5979
 msgid "Current"
 msgstr "Attuale"
 
 # MSG_DATE c=17 r=1
-#: ultralcd.cpp:2213
+#: ultralcd.cpp:2158
 msgid "Date:"
 msgstr "Data:"
 
 # MSG_DISABLE_STEPPERS
-#: ultralcd.cpp:5654
+#: ultralcd.cpp:5720
 msgid "Disable steppers"
 msgstr "Disabilita motori"
 
 # MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: messages.c:14
+#: messages.c:13
 msgid "Distance between tip of the nozzle and the bed surface has not been set yet. Please follow the manual, chapter First steps, section First layer calibration."
 msgstr "Distanza tra la punta dell'ugello e la superficie del letto non ancora imposta. Si prega di seguire il manuale, capitolo Primi Passi, sezione Calibrazione primo layer."
 
 # MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ultralcd.cpp:5070
+#: ultralcd.cpp:5103
 msgid "Do you want to repeat last step to readjust distance between nozzle and heatbed?"
 msgstr "Desideri ripetere l'ultimo passaggio per migliorare la distanza fra ugello e piatto?"
 
 # MSG_EXTRUDER_CORRECTION c=10
-#: ultralcd.cpp:5134
+#: ultralcd.cpp:5172
 msgid "E-correct:"
 msgstr "Correzione-E:"
 
 # MSG_EJECT_FILAMENT c=17 r=1
-#: messages.c:53
+#: messages.c:49
 msgid "Eject filament"
 msgstr "Espelli filamento "
 
-# 
-#: ultralcd.cpp:4869
-msgid "Eject"
-msgstr "Espellere"
-
 # MSG_EJECTING_FILAMENT c=20 r=1
-#: mmu.cpp:1434
+#: mmu.cpp:1415
 msgid "Ejecting filament"
 msgstr "Espellendo filamento "
 
 # MSG_SELFTEST_ENDSTOP_NOTHIT c=20 r=1
-#: ultralcd.cpp:7917
+#: ultralcd.cpp:8254
 msgid "Endstop not hit"
 msgstr "Finecorsa fuori portata"
 
 # MSG_SELFTEST_ENDSTOP
-#: ultralcd.cpp:7911
+#: ultralcd.cpp:8248
 msgid "Endstop"
 msgstr "Finecorsa"
 
 # MSG_SELFTEST_ENDSTOPS
-#: ultralcd.cpp:7899
+#: ultralcd.cpp:8236
 msgid "Endstops"
 msgstr "Finecorsa"
 
 # MSG_STACK_ERROR c=20 r=4
-#: ultralcd.cpp:6859
+#: ultralcd.cpp:6975
 msgid "Error - static memory has been overwritten"
 msgstr "Errore - la memoria statica e stata sovrascritta"
 
 # MSG_FSENS_NOT_RESPONDING c=20 r=4
-#: ultralcd.cpp:4475
+#: ultralcd.cpp:4436
 msgid "ERROR: Filament sensor is not responding, please check connection."
 msgstr "ERRORE: il sensore filam. non risponde,Controllare conness."
 
 # MSG_ERROR
-#: messages.c:28
+#: messages.c:25
 msgid "ERROR:"
 msgstr "ERRORE:"
 
 # MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
-#: ultralcd.cpp:8304
+#: ultralcd.cpp:8647
 msgid "Extruder fan:"
 msgstr "Ventola estr:"
 
 # MSG_INFO_EXTRUDER c=15 r=1
-#: ultralcd.cpp:2244
+#: ultralcd.cpp:2189
 msgid "Extruder info"
 msgstr "Info estrusore"
 
 # MSG_MOVE_E
-#: messages.c:29
+#: messages.c:26
 msgid "Extruder"
 msgstr "Estrusore"
 
 # 
-#: ultralcd.cpp:6846
+#: ultralcd.cpp:6962
 msgid "Fail stats MMU"
 msgstr "Stat.fall. MMU"
 
-# MSG_FSENS_AUTOLOAD_ON c=17 r=1
-#: ultralcd.cpp:5168
-msgid "F. autoload  [on]"
-msgstr "Autocar.fil. [on]"
-
-# MSG_FSENS_AUTOLOAD_NA c=17 r=1
-#: messages.c:43
-msgid "F. autoload [N/A]"
-msgstr "Autocar.fil.[N/A]"
-
-# MSG_FSENS_AUTOLOAD_OFF c=17 r=1
-#: ultralcd.cpp:5170
-msgid "F. autoload [off]"
-msgstr "Autocar.fil.[off]"
+# MSG_FSENSOR_AUTOLOAD
+#: messages.c:40
+msgid "F. autoload"
+msgstr "Autocar.fil."
 
 # 
-#: ultralcd.cpp:6843
+#: ultralcd.cpp:6959
 msgid "Fail stats"
 msgstr "Stat. fallimenti"
 
 # MSG_FAN_SPEED c=14
-#: messages.c:31
+#: messages.c:28
 msgid "Fan speed"
 msgstr "Velocita vent."
 
 # MSG_SELFTEST_FAN c=20
-#: messages.c:78
+#: messages.c:74
 msgid "Fan test"
 msgstr "Test ventola"
 
-# MSG_FANS_CHECK_ON c=17 r=1
-#: ultralcd.cpp:5663
-msgid "Fans check   [on]"
-msgstr "Control.vent [on]"
-
-# MSG_FANS_CHECK_OFF c=17 r=1
-#: ultralcd.cpp:5665
-msgid "Fans check  [off]"
-msgstr "Control.vent[off]"
-
-# MSG_FSENSOR_ON
-#: messages.c:45
-msgid "Fil. sensor  [on]"
-msgstr "Sensore fil. [on]"
-
-# MSG_FSENSOR_NA
-#: ultralcd.cpp:5148
-msgid "Fil. sensor [N/A]"
-msgstr "Sensore fil.[N/A]"
-
-# MSG_FSENSOR_OFF
-#: messages.c:44
-msgid "Fil. sensor [off]"
-msgstr "Sensore fil.[off]"
+# MSG_FANS_CHECK
+#: ultralcd.cpp:5728
+msgid "Fans check"
+msgstr "Control.vent"
 
 # 
-#: ultralcd.cpp:1852
+#: ultralcd.cpp:1775
 msgid "Filam. runouts"
 msgstr "Filam. esauriti"
 
 # MSG_FILAMENT_CLEAN c=20 r=2
-#: messages.c:32
+#: messages.c:29
 msgid "Filament extruding & with correct color?"
 msgstr "Filamento estruso & con il giusto colore?"
 
 # MSG_NOT_LOADED c=19
-#: ultralcd.cpp:2714
+#: ultralcd.cpp:2683
 msgid "Filament not loaded"
 msgstr "Fil. non caricato"
 
 # MSG_FILAMENT_SENSOR c=20
-#: messages.c:84
+#: messages.c:80
 msgid "Filament sensor"
 msgstr "Sensore filam."
 
 # MSG_FILAMENT_USED c=19 r=1
-#: ultralcd.cpp:2885
+#: ultralcd.cpp:2847
 msgid "Filament used"
 msgstr "Filamento utilizzato"
 
 # MSG_PRINT_TIME c=19 r=1
-#: ultralcd.cpp:2886
+#: ultralcd.cpp:2848
 msgid "Print time"
 msgstr "Tempo di stampa"
 
 # MSG_FILE_INCOMPLETE c=20 r=2
-#: ultralcd.cpp:8432
+#: ultralcd.cpp:8775
 msgid "File incomplete. Continue anyway?"
 msgstr "File incompleto. Continuare comunque?"
 
 # MSG_FINISHING_MOVEMENTS c=20 r=1
-#: messages.c:40
+#: messages.c:37
 msgid "Finishing movements"
 msgstr "Finalizzando gli spostamenti"
 
 # MSG_V2_CALIBRATION c=17 r=1
-#: messages.c:105
+#: messages.c:103
 msgid "First layer cal."
 msgstr "Cal. primo strato"
 
 # MSG_WIZARD_SELFTEST c=20 r=8
-#: ultralcd.cpp:4982
+#: ultralcd.cpp:5024
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr "Per primo avviero l'autotest per controllare gli errori di assemblaggio piu comuni."
 
 # 
-#: mmu.cpp:724
+#: mmu.cpp:726
 msgid "Fix the issue and then press button on MMU unit."
 msgstr "Risolvi il problema e quindi premi il bottone sull'unita MMU. "
 
 # MSG_FLOW
-#: ultralcd.cpp:6932
+#: ultralcd.cpp:7102
 msgid "Flow"
 msgstr "Flusso"
 
 # MSG_PRUSA3D_FORUM
-#: ultralcd.cpp:2206
+#: ultralcd.cpp:2151
 msgid "forum.prusa3d.com"
 msgstr ""
 
 # MSG_SELFTEST_COOLING_FAN c=20
-#: messages.c:75
+#: messages.c:71
 msgid "Front print fan?"
 msgstr "Ventola frontale?"
 
 # MSG_BED_CORRECTION_FRONT c=14 r=1
-#: ultralcd.cpp:3294
+#: ultralcd.cpp:3244
 msgid "Front side[um]"
 msgstr "Fronte [um]"
 
 # MSG_SELFTEST_FANS
-#: ultralcd.cpp:7957
+#: ultralcd.cpp:8294
 msgid "Front/left fans"
 msgstr "Ventola frontale/sinistra"
 
 # MSG_SELFTEST_HEATERTHERMISTOR
-#: ultralcd.cpp:7887
+#: ultralcd.cpp:8224
 msgid "Heater/Thermistor"
 msgstr "Riscald./Termist."
 
 # MSG_BED_HEATING_SAFETY_DISABLED
-#: Marlin_main.cpp:8467
+#: Marlin_main.cpp:9458
 msgid "Heating disabled by safety timer."
 msgstr "Riscaldamento fermato dal timer di sicurezza."
 
 # MSG_HEATING_COMPLETE c=20
-#: messages.c:47
+#: messages.c:43
 msgid "Heating done."
 msgstr "Riscald. completo"
 
 # MSG_HEATING
-#: messages.c:46
+#: messages.c:42
 msgid "Heating"
 msgstr "Riscaldamento..."
 
 # MSG_WIZARD_WELCOME c=20 r=7
-#: ultralcd.cpp:4961
+#: ultralcd.cpp:5003
 msgid "Hi, I am your Original Prusa i3 printer. Would you like me to guide you through the setup process?"
 msgstr "Ciao, sono la tua stampante Original Prusa i3. Gradiresti un aiuto nel processo di configurazione?"
 
 # MSG_PRUSA3D_HOWTO
-#: ultralcd.cpp:2207
+#: ultralcd.cpp:2152
 msgid "howto.prusa3d.com"
 msgstr ""
 
 # MSG_FILAMENTCHANGE
-#: messages.c:37
+#: messages.c:34
 msgid "Change filament"
 msgstr "Cambia filamento"
 
 # MSG_CHANGE_SUCCESS
-#: ultralcd.cpp:2629
+#: ultralcd.cpp:2598
 msgid "Change success!"
 msgstr "Cambio riuscito!"
 
 # MSG_CORRECTLY c=20
-#: ultralcd.cpp:2706
+#: ultralcd.cpp:2675
 msgid "Changed correctly?"
 msgstr "Cambiato correttamente?"
 
 # MSG_SELFTEST_CHECK_BED c=20
-#: messages.c:81
+#: messages.c:77
 msgid "Checking bed     "
 msgstr "Verifica piano"
 
 # MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ultralcd.cpp:8286
+#: ultralcd.cpp:8629
 msgid "Checking endstops"
 msgstr "Verifica finecorsa"
 
 # MSG_SELFTEST_CHECK_HOTEND c=20
-#: ultralcd.cpp:8292
+#: ultralcd.cpp:8635
 msgid "Checking hotend  "
 msgstr "Verifica ugello"
 
 # MSG_SELFTEST_CHECK_FSENSOR c=20
-#: messages.c:82
+#: messages.c:78
 msgid "Checking sensors "
 msgstr "Controllo sensori"
 
 # MSG_SELFTEST_CHECK_X c=20
-#: ultralcd.cpp:8287
+#: ultralcd.cpp:8630
 msgid "Checking X axis  "
 msgstr "Verifica asse X"
 
 # MSG_SELFTEST_CHECK_Y c=20
-#: ultralcd.cpp:8288
+#: ultralcd.cpp:8631
 msgid "Checking Y axis  "
 msgstr "Verifica asse Y"
 
 # MSG_SELFTEST_CHECK_Z c=20
-#: ultralcd.cpp:8289
+#: ultralcd.cpp:8632
 msgid "Checking Z axis  "
 msgstr "Verifica asse Z"
 
 # MSG_CHOOSE_EXTRUDER c=20 r=1
-#: messages.c:49
+#: messages.c:45
 msgid "Choose extruder:"
 msgstr "Seleziona estrusore:"
 
 # MSG_CHOOSE_FILAMENT c=20 r=1
-#: messages.c:50
+#: messages.c:46
 msgid "Choose filament:"
 msgstr "Scegliere filamento:"
 
 # MSG_FILAMENT c=17 r=1
-#: messages.c:30
+#: messages.c:27
 msgid "Filament"
 msgstr "Filamento"
 
 # MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ultralcd.cpp:4991
+#: ultralcd.cpp:5033
 msgid "I will run xyz calibration now. It will take approx. 12 mins."
 msgstr "Adesso avviero una Calibrazione XYZ. Puo durare circa 12 min."
 
 # MSG_WIZARD_Z_CAL c=20 r=8
-#: ultralcd.cpp:4999
+#: ultralcd.cpp:5041
 msgid "I will run z calibration now."
 msgstr "Adesso avviero la Calibrazione Z."
 
-# MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ultralcd.cpp:5064
-msgid "I will start to print line and you will gradually lower the nozzle by rotating the knob, until you reach optimal height. Check the pictures in our handbook in chapter Calibration."
-msgstr "Adesso iniziero a stampare una linea e tu dovrai abbassare l'ugello poco per volta ruotando la manopola sino a raggiungere una altezza ottimale. Per favore dai uno sguardo all'immagine del nostro manuale, cap.Calibrazione."
-
 # MSG_WATCH
-#: messages.c:99
+#: messages.c:97
 msgid "Info screen"
 msgstr "Schermata info"
 
-# 
-#: ultralcd.cpp:5024
-msgid "Is filament 1 loaded?"
-msgstr "Il filamento 1 e caricato?"
-
 # MSG_INSERT_FILAMENT c=20
-#: ultralcd.cpp:2614
+#: ultralcd.cpp:2583
 msgid "Insert filament"
 msgstr "Inserire filamento"
 
 # MSG_WIZARD_FILAMENT_LOADED c=20 r=2
-#: ultralcd.cpp:5027
+#: ultralcd.cpp:4813
 msgid "Is filament loaded?"
 msgstr "Il filamento e stato caricato?"
 
-# MSG_WIZARD_PLA_FILAMENT c=20 r=2
-#: ultralcd.cpp:5058
-msgid "Is it PLA filament?"
-msgstr "E' un filamento di PLA?"
-
-# MSG_PLA_FILAMENT_LOADED c=20 r=2
-#: ultralcd.cpp:4790
-msgid "Is PLA filament loaded?"
-msgstr "E' stato caricato il filamento di PLA?"
-
 # MSG_STEEL_SHEET_CHECK c=20 r=2
-#: messages.c:92
+#: messages.c:90
 msgid "Is steel sheet on heatbed?"
 msgstr "La piastra d'acciaio e sul piano riscaldato?"
 
 # 
-#: ultralcd.cpp:1795
+#: ultralcd.cpp:1718
 msgid "Last print failures"
 msgstr "Fallimenti ultima stampa"
 
 # 
-#: ultralcd.cpp:1772
+#: ultralcd.cpp:5111
+msgid "If you have additional steel sheets, calibrate their presets in Settings - HW Setup - Steel sheets."
+msgstr "Se hai piastre d'acciaio aggiuntive, calibra i preset in Impostazioni - Setup HW - Piastre in Acciaio."
+
+# 
+#: ultralcd.cpp:1695
 msgid "Last print"
 msgstr "Ultima stampa"
 
 # MSG_SELFTEST_EXTRUDER_FAN c=20
-#: messages.c:76
+#: messages.c:72
 msgid "Left hotend fan?"
 msgstr "Vent SX hotend?"
 
 # 
-#: ultralcd.cpp:3018
+#: ultralcd.cpp:2971
 msgid "Left"
 msgstr "Sinistra"
 
 # MSG_BED_CORRECTION_LEFT c=14 r=1
-#: ultralcd.cpp:3292
+#: ultralcd.cpp:3242
 msgid "Left side [um]"
-msgstr "Sinistra  [um]"
+msgstr "Sinistra [um]"
 
 # 
-#: ultralcd.cpp:5680
+#: ultralcd.cpp:5743
 msgid "Lin. correction"
 msgstr "Correzione lineare"
 
 # MSG_BABYSTEP_Z
-#: messages.c:13
+#: messages.c:12
 msgid "Live adjust Z"
 msgstr "Compensazione Z"
 
 # MSG_LOAD_FILAMENT c=17
-#: messages.c:51
+#: messages.c:47
 msgid "Load filament"
 msgstr "Carica filamento"
 
 # MSG_LOADING_COLOR
-#: ultralcd.cpp:2654
+#: ultralcd.cpp:2623
 msgid "Loading color"
 msgstr "Caricando colore"
 
 # MSG_LOADING_FILAMENT c=20
-#: messages.c:52
+#: messages.c:48
 msgid "Loading filament"
 msgstr "Caricando filamento"
 
 # MSG_LOOSE_PULLEY c=20 r=1
-#: ultralcd.cpp:7941
+#: ultralcd.cpp:8278
 msgid "Loose pulley"
 msgstr "Puleggia lenta"
 
 # 
-#: ultralcd.cpp:6805
+#: ultralcd.cpp:6921
 msgid "Load to nozzle"
 msgstr "Carica ugello"
 
 # MSG_M117_V2_CALIBRATION c=25 r=1
-#: messages.c:55
+#: messages.c:51
 msgid "M117 First layer cal."
 msgstr "M117 Calibrazione primo layer."
 
 # MSG_MAIN
-#: messages.c:56
+#: messages.c:52
 msgid "Main"
 msgstr "Menu principale"
 
 # MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=60
-#: messages.c:59
+#: messages.c:55
 msgid "Measuring reference height of calibration point"
 msgstr "Misura altezza di rif. del punto di calib."
 
 # MSG_MESH_BED_LEVELING
-#: ultralcd.cpp:5763
+#: ultralcd.cpp:5833
 msgid "Mesh Bed Leveling"
 msgstr "Livel. piatto"
 
 # MSG_MMU_OK_RESUMING_POSITION c=20 r=4
-#: mmu.cpp:762
+#: mmu.cpp:764
 msgid "MMU OK. Resuming position..."
 msgstr "MMU OK. riprendendo la posizione... "
 
 # MSG_MMU_OK_RESUMING_TEMPERATURE c=20 r=4
-#: mmu.cpp:755
+#: mmu.cpp:757
 msgid "MMU OK. Resuming temperature..."
 msgstr "MMU OK. Ripristino temperatura... "
 
 # 
-#: ultralcd.cpp:3059
+#: ultralcd.cpp:3012
 msgid "Measured skew"
 msgstr "Deviazione mis"
 
-# 
-#: ultralcd.cpp:1796
+#  c=13 r=1
+#: ultralcd.cpp:1719
 msgid "MMU fails"
 msgstr "Fallimenti MMU"
 
 # 
-#: mmu.cpp:1613
+#: mmu.cpp:1587
 msgid "MMU load failed     "
 msgstr "Caricamento MMU fallito"
 
-# 
-#: ultralcd.cpp:1797
-msgid "MMU load fails"
+#  c=13 r=1
+#: ultralcd.cpp:1720
+msgid "MMU load f."
 msgstr "Caricamenti MMU falliti"
 
 # MSG_MMU_OK_RESUMING c=20 r=4
-#: mmu.cpp:773
+#: mmu.cpp:775
 msgid "MMU OK. Resuming..."
 msgstr "MMU OK. Riprendendo... "
 
-# MSG_STEALTH_MODE_OFF
-#: messages.c:90
-msgid "Mode     [Normal]"
-msgstr "Mod.    [normale]"
+# MSG_MODE
+#: messages.c:84
+msgid "Mode"
+msgstr "Mod."
 
-# MSG_SILENT_MODE_ON
-#: messages.c:89
-msgid "Mode     [silent]"
-msgstr "Mod. [silenziosa]"
+# MSG_NORMAL
+#: messages.c:88
+msgid "Normal"
+msgstr "Normale"
+
+# MSG_SILENT
+#: messages.c:87
+msgid "Silent"
+msgstr "Silenzioso"
 
 # 
-#: mmu.cpp:719
+#: mmu.cpp:721
 msgid "MMU needs user attention."
 msgstr "Il MMU richiede attenzione dall'utente."
 
-# 
-#: ultralcd.cpp:1823
-msgid "MMU power fails"
+#  c=14 r=1
+#: ultralcd.cpp:1746
+msgid "MMU power f."
 msgstr "Manc. corr. MMU"
 
-# MSG_STEALTH_MODE_ON
-#: messages.c:91
-msgid "Mode    [Stealth]"
-msgstr "Mod. [silenziosa]"
+# MSG_STEALTH
+#: messages.c:89
+msgid "Stealth"
+msgstr "Silenziosa"
 
-# MSG_AUTO_MODE_ON
-#: messages.c:12
-msgid "Mode [auto power]"
-msgstr "Mod.       [auto]"
+# MSG_AUTO_POWER
+#: messages.c:86
+msgid "Auto power"
+msgstr "Auto"
 
-# MSG_SILENT_MODE_OFF
-#: messages.c:88
-msgid "Mode [high power]"
-msgstr "Mod.      [forte]"
+# MSG_HIGH_POWER
+#: messages.c:85
+msgid "High power"
+msgstr "Forte"
 
 # 
-#: ultralcd.cpp:2219
+#: ultralcd.cpp:2164
 msgid "MMU2 connected"
 msgstr "MMU2 connessa"
 
 # MSG_SELFTEST_MOTOR
-#: messages.c:83
+#: messages.c:79
 msgid "Motor"
 msgstr "Motore"
 
 # MSG_MOVE_AXIS
-#: ultralcd.cpp:5652
+#: ultralcd.cpp:5718
 msgid "Move axis"
 msgstr "Muovi asse"
 
 # MSG_MOVE_X
-#: ultralcd.cpp:4378
+#: ultralcd.cpp:4339
 msgid "Move X"
 msgstr "Sposta X"
 
 # MSG_MOVE_Y
-#: ultralcd.cpp:4379
+#: ultralcd.cpp:4340
 msgid "Move Y"
 msgstr "Sposta Y"
 
 # MSG_MOVE_Z
-#: ultralcd.cpp:4380
+#: ultralcd.cpp:4341
 msgid "Move Z"
 msgstr "Sposta Z"
 
 # MSG_NO_MOVE
-#: Marlin_main.cpp:5292
+#: Marlin_main.cpp:5526
 msgid "No move."
 msgstr "Nessun movimento."
 
 # MSG_NO_CARD
-#: ultralcd.cpp:6772
+#: ultralcd.cpp:6888
 msgid "No SD card"
 msgstr "Nessuna SD"
 
-# 
-#: ultralcd.cpp:3024
+# MSG_NA
+#: messages.c:107
 msgid "N/A"
 msgstr ""
 
 # MSG_NO
-#: messages.c:62
+#: messages.c:58
 msgid "No"
 msgstr ""
 
 # MSG_SELFTEST_NOTCONNECTED
-#: ultralcd.cpp:7889
+#: ultralcd.cpp:8226
 msgid "Not connected"
 msgstr "Non connesso"
 
@@ -846,167 +791,152 @@ msgid "New firmware version available:"
 msgstr "Nuova versione firmware disponibile:"
 
 # MSG_SELFTEST_FAN_NO c=19
-#: messages.c:79
+#: messages.c:75
 msgid "Not spinning"
 msgstr "Non gira"
 
 # MSG_WIZARD_V2_CAL c=20 r=8
-#: ultralcd.cpp:5063
+#: ultralcd.cpp:4924
 msgid "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr "Adesso calibro la distanza fra ugello e superfice del piatto."
 
 # MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ultralcd.cpp:5007
+#: ultralcd.cpp:5049
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Adesso preriscaldero l'ugello per PLA."
 
 # MSG_NOZZLE
-#: messages.c:63
+#: messages.c:59
 msgid "Nozzle"
 msgstr "Ugello"
 
 # MSG_DEFAULT_SETTINGS_LOADED c=20 r=4
-#: Marlin_main.cpp:1519
+#: Marlin_main.cpp:1500
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr "Sono state trovate impostazioni vecchie. Verranno impostati i valori predefiniti di PID, Esteps etc."
 
 # 
-#: ultralcd.cpp:4998
+#: ultralcd.cpp:5040
 msgid "Now remove the test print from steel sheet."
 msgstr "Ora rimuovete la stampa di prova dalla piastra in acciaio."
 
 # 
-#: ultralcd.cpp:1722
+#: ultralcd.cpp:1645
 msgid "Nozzle FAN"
 msgstr "Ventola estrusore"
 
 # MSG_PAUSE_PRINT
-#: ultralcd.cpp:6735
+#: ultralcd.cpp:6852
 msgid "Pause print"
 msgstr "Metti in pausa"
 
 # MSG_PID_RUNNING c=20 r=1
-#: ultralcd.cpp:1606
+#: ultralcd.cpp:1530
 msgid "PID cal.           "
 msgstr "Calibrazione PID"
 
 # MSG_PID_FINISHED c=20 r=1
-#: ultralcd.cpp:1612
+#: ultralcd.cpp:1536
 msgid "PID cal. finished"
 msgstr "Calib. PID completa"
 
 # MSG_PID_EXTRUDER c=17 r=1
-#: ultralcd.cpp:5769
+#: ultralcd.cpp:5839
 msgid "PID calibration"
 msgstr "Calibrazione PID"
 
 # MSG_PINDA_PREHEAT c=20 r=1
-#: ultralcd.cpp:846
+#: ultralcd.cpp:887
 msgid "PINDA Heating"
 msgstr "Riscaldamento PINDA"
 
 # MSG_PAPER c=20 r=8
-#: messages.c:64
+#: messages.c:60
 msgid "Place a sheet of paper under the nozzle during the calibration of first 4 points. If the nozzle catches the paper, power off the printer immediately."
 msgstr "Posizionare un foglio sotto l'ugello durante la calibrazione dei primi 4 punti. In caso l'ugello muova il foglio spegnere subito la stampante."
 
 # MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ultralcd.cpp:5072
+#: ultralcd.cpp:5106
 msgid "Please clean heatbed and then press the knob."
 msgstr "Per favore pulisci il piatto, poi premi la manopola."
 
 # MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: messages.c:22
+#: messages.c:21
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Pulire l'ugello per la calibrazione, poi fare click."
 
 # MSG_SELFTEST_PLEASECHECK
-#: ultralcd.cpp:7881
+#: ultralcd.cpp:8218
 msgid "Please check :"
 msgstr "Verifica:"
 
 # MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: messages.c:100
+#: messages.c:98
 msgid "Please check our handbook and fix the problem. Then resume the Wizard by rebooting the printer."
 msgstr "Per favore consulta il nostro manuale per risolvere il problema. Poi riprendi il Wizard dopo aver riavviato la stampante."
 
-# MSG_WIZARD_LOAD_FILAMENT c=20 r=8
-#: ultralcd.cpp:4894
-msgid "Please insert PLA filament to the extruder, then press knob to load it."
-msgstr "Per favore inserisci il filamento di PLA nell'estrusore, poi premi la manopola per caricare."
-
-# MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ultralcd.cpp:4795
-msgid "Please load PLA filament first."
-msgstr "Per favore prima carica il filamento di PLA."
-
 # MSG_CHECK_IDLER c=20 r=4
-#: Marlin_main.cpp:3064
+#: Marlin_main.cpp:3116
 msgid "Please open idler and remove filament manually."
 msgstr "Aprire la guida filam. e rimuovere il filam. a mano"
 
 # MSG_PLACE_STEEL_SHEET c=20 r=4
-#: messages.c:65
+#: messages.c:61
 msgid "Please place steel sheet on heatbed."
 msgstr "Per favore posizionate la piastra d'acciaio sul piano riscaldato."
 
 # MSG_PRESS_TO_UNLOAD c=20 r=4
-#: messages.c:68
+#: messages.c:64
 msgid "Please press the knob to unload filament"
 msgstr "Premete la manopola per scaricare il filamento "
 
-# 
-#: ultralcd.cpp:4889
-msgid "Please insert PLA filament to the first tube of MMU, then press the knob to load it."
-msgstr "Per favore inserite del filamento PLA nel primo tubo del MMU, poi premete la manopola per caricarlo."
-
 # MSG_PULL_OUT_FILAMENT c=20 r=4
-#: messages.c:70
+#: messages.c:66
 msgid "Please pull out filament immediately"
 msgstr "Estrarre il filamento immediatamente"
 
 # MSG_EJECT_REMOVE c=20 r=4
-#: mmu.cpp:1440
+#: mmu.cpp:1421
 msgid "Please remove filament and then press the knob."
 msgstr "Rimuovi il filamento e quindi premi la manopola. "
 
 # MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: messages.c:74
+#: messages.c:70
 msgid "Please remove steel sheet from heatbed."
 msgstr "Rimuovete la piastra di acciaio dal piano riscaldato"
 
 # MSG_RUN_XYZ c=20 r=4
-#: Marlin_main.cpp:4355
+#: Marlin_main.cpp:4561
 msgid "Please run XYZ calibration first."
 msgstr "Esegui la calibrazione XYZ prima. "
 
 # MSG_UPDATE_MMU2_FW c=20 r=4
-#: mmu.cpp:1359
+#: mmu.cpp:1340
 msgid "Please update firmware in your MMU2. Waiting for reset."
 msgstr "Aggiorna il firmware sul tuo MMU2. In attesa di reset. "
 
 # MSG_PLEASE_WAIT c=20
-#: messages.c:66
+#: messages.c:62
 msgid "Please wait"
 msgstr "Attendere"
 
 # 
-#: ultralcd.cpp:4997
+#: ultralcd.cpp:5039
 msgid "Please remove shipping helpers first."
 msgstr "Per favore rimuovete i materiali da spedizione"
 
 # MSG_PREHEAT_NOZZLE c=20
-#: messages.c:67
+#: messages.c:63
 msgid "Preheat the nozzle!"
 msgstr "Prerisc. ugello!"
 
 # MSG_PREHEAT
-#: ultralcd.cpp:6722
+#: ultralcd.cpp:6830
 msgid "Preheat"
 msgstr "Preriscalda"
 
 # MSG_WIZARD_HEATING c=20 r=3
-#: messages.c:102
+#: messages.c:100
 msgid "Preheating nozzle. Please wait."
 msgstr "Preriscaldando l'ugello. Attendere prego."
 
@@ -1016,82 +946,97 @@ msgid "Please upgrade."
 msgstr "Prego aggiornare."
 
 # MSG_PRESS_TO_PREHEAT c=20 r=4
-#: Marlin_main.cpp:10364
+#: Marlin_main.cpp:11469
 msgid "Press knob to preheat nozzle and continue."
 msgstr "Premete la manopola per preriscaldare l'ugello e continuare."
 
 # 
-#: ultralcd.cpp:1851
+#: ultralcd.cpp:1774
 msgid "Power failures"
 msgstr "Mancanza corrente"
 
 # MSG_PRINT_ABORTED c=20
-#: messages.c:69
+#: messages.c:65
 msgid "Print aborted"
 msgstr "Stampa interrotta"
 
 # 
-#: ultralcd.cpp:2455
+#: ultralcd.cpp:2420
 msgid "Preheating to load"
 msgstr "Preriscaldamento per caricare"
 
 # 
-#: ultralcd.cpp:2459
+#: ultralcd.cpp:2424
 msgid "Preheating to unload"
 msgstr "Preriscaldamento per scaricare"
 
 # MSG_SELFTEST_PRINT_FAN_SPEED c=18
-#: ultralcd.cpp:8307
+#: ultralcd.cpp:8650
 msgid "Print fan:"
 msgstr "Vent.stam:"
 
 # MSG_CARD_MENU
-#: messages.c:21
+#: messages.c:20
 msgid "Print from SD"
 msgstr "Stampa da SD"
 
 # 
-#: ultralcd.cpp:2317
+#: ultralcd.cpp:2267
 msgid "Press the knob"
 msgstr "Premere la manopola"
 
 # MSG_PRINT_PAUSED c=20 r=1
-#: ultralcd.cpp:1069
+#: ultralcd.cpp:1109
 msgid "Print paused"
 msgstr "Stampa in pausa"
 
 # 
-#: mmu.cpp:723
+#: mmu.cpp:725
 msgid "Press the knob to resume nozzle temperature."
 msgstr "Premete la manopola per recuperare la temperatura dell'ugello."
 
 # MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: messages.c:41
+#: messages.c:38
 msgid "Printer has not been calibrated yet. Please follow the manual, chapter First steps, section Calibration flow."
 msgstr "Stampante non ancora calibrata. Si prega di seguire il manuale, capitolo Primi Passi, sezione Sequenza di Calibrazione."
 
 # 
-#: ultralcd.cpp:1723
+#: ultralcd.cpp:1646
 msgid "Print FAN"
 msgstr "Ventola di stampa"
 
+# 
+#: ultralcd.cpp:4904
+msgid "Please insert filament into the extruder, then press the knob to load it."
+msgstr "Inserisci il filamento nell'estrusore, poi premi la manopola per caricarlo."
+
+# 
+#: ultralcd.cpp:4899
+msgid "Please insert filament into the first tube of the MMU, then press the knob to load it."
+msgstr "Per favore inserisci il filamento nel primo tubo del MMU, poi premi la manopola per caricarlo."
+
+# 
+#: ultralcd.cpp:4821
+msgid "Please load filament first."
+msgstr "Per favore prima carica il filamento."
+
 # MSG_PRUSA3D
-#: ultralcd.cpp:2205
+#: ultralcd.cpp:2150
 msgid "prusa3d.com"
 msgstr ""
 
 # MSG_BED_CORRECTION_REAR c=14 r=1
-#: ultralcd.cpp:3295
+#: ultralcd.cpp:3245
 msgid "Rear side [um]"
 msgstr "Retro [um]"
 
 # MSG_RECOVERING_PRINT c=20 r=1
-#: Marlin_main.cpp:9764
+#: Marlin_main.cpp:10826
 msgid "Recovering print    "
 msgstr "Recupero stampa"
 
 # MSG_REMOVE_OLD_FILAMENT c=20 r=4
-#: mmu.cpp:830
+#: mmu.cpp:832
 msgid "Remove old filament and press the knob to start loading new filament."
 msgstr "Rimuovi il filamento precedente e premi la manopola per caricare il nuovo filamento. "
 
@@ -1101,712 +1046,647 @@ msgid "Prusa i3 MK3S OK."
 msgstr ""
 
 # MSG_CALIBRATE_BED_RESET
-#: ultralcd.cpp:5774
+#: ultralcd.cpp:5844
 msgid "Reset XYZ calibr."
 msgstr "Reset calibrazione XYZ."
 
 # MSG_BED_CORRECTION_RESET
-#: ultralcd.cpp:3296
+#: ultralcd.cpp:3246
 msgid "Reset"
 msgstr ""
 
 # MSG_RESUME_PRINT
-#: ultralcd.cpp:6742
+#: ultralcd.cpp:6838
 msgid "Resume print"
 msgstr "Riprendi stampa"
 
 # MSG_RESUMING_PRINT c=20 r=1
-#: messages.c:73
+#: messages.c:69
 msgid "Resuming print"
 msgstr "Riprendi stampa"
 
 # MSG_BED_CORRECTION_RIGHT c=14 r=1
-#: ultralcd.cpp:3293
+#: ultralcd.cpp:3243
 msgid "Right side[um]"
 msgstr "Destra [um]"
 
-# MSG_SECOND_SERIAL_ON c=17 r=1
-#: ultralcd.cpp:5692
-msgid "RPi port     [on]"
-msgstr "Porta RPi    [on]"
-
-# MSG_SECOND_SERIAL_OFF c=17 r=1
-#: ultralcd.cpp:5690
-msgid "RPi port    [off]"
-msgstr "Porta RPi   [off]"
+# MSG_RPI_PORT
+#: messages.c:123
+msgid "RPi port"
+msgstr "Porta RPi"
 
 # MSG_WIZARD_RERUN c=20 r=7
-#: ultralcd.cpp:4812
+#: ultralcd.cpp:4842
 msgid "Running Wizard will delete current calibration results and start from the beginning. Continue?"
 msgstr "Se avvi il Wizard perderai la calibrazione preesistente e dovrai ricominciare dall'inizio. Continuare?"
 
-# MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_OFF c=19 r=1
-#: ultralcd.cpp:5322
-msgid "SD card  [normal]"
-msgstr "Mem. SD [normale]"
+# MSG_SD_CARD
+#: messages.c:118
+msgid "SD card"
+msgstr "Mem. SD"
 
-# MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_ON c=19 r=1
-#: ultralcd.cpp:5320
-msgid "SD card [flshAir]"
-msgstr "Mem. SD [flshAir]"
+# MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY
+#: messages.c:119
+msgid "FlashAir"
+msgstr ""
 
 # 
-#: ultralcd.cpp:3019
+#: ultralcd.cpp:2972
 msgid "Right"
 msgstr "Destra"
 
 # MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=60
-#: messages.c:38
+#: messages.c:35
 msgid "Searching bed calibration point"
 msgstr "Ricerca dei punti di calibrazione del piano"
 
 # MSG_LANGUAGE_SELECT
-#: ultralcd.cpp:5699
+#: ultralcd.cpp:5756
 msgid "Select language"
 msgstr "Seleziona lingua"
 
 # MSG_SELFTEST_OK
-#: ultralcd.cpp:7452
+#: ultralcd.cpp:7784
 msgid "Self test OK"
 msgstr "Autotest OK"
 
 # MSG_SELFTEST_START c=20
-#: ultralcd.cpp:7238
+#: ultralcd.cpp:7558
 msgid "Self test start  "
 msgstr "Avvia autotest"
 
 # MSG_SELFTEST
-#: ultralcd.cpp:5750
+#: ultralcd.cpp:5820
 msgid "Selftest         "
 msgstr "Autotest"
 
 # MSG_SELFTEST_ERROR
-#: ultralcd.cpp:7879
+#: ultralcd.cpp:8216
 msgid "Selftest error !"
 msgstr "Errore Autotest !"
 
 # MSG_SELFTEST_FAILED c=20
-#: messages.c:77
+#: messages.c:73
 msgid "Selftest failed  "
 msgstr "Autotest fallito"
 
 # MSG_FORCE_SELFTEST c=20 r=8
-#: Marlin_main.cpp:1551
+#: Marlin_main.cpp:1532
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr "Verra effettuato un self test per calibrare l'homing senza sensori"
 
 # 
-#: ultralcd.cpp:5045
+#: ultralcd.cpp:5080
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr "Selezionate la temperatura per il preriscaldamento dell'ugello adatta al vostro materiale."
 
-# 
-#: ultralcd.cpp:4780
-msgid "Select PLA filament:"
-msgstr "Selezionate filamento PLA:"
-
 # MSG_SET_TEMPERATURE c=19 r=1
-#: ultralcd.cpp:3314
+#: ultralcd.cpp:3264
 msgid "Set temperature:"
 msgstr "Imposta temperatura:"
 
 # MSG_SETTINGS
-#: messages.c:86
+#: messages.c:82
 msgid "Settings"
 msgstr "Impostazioni"
 
 # MSG_SHOW_END_STOPS c=17 r=1
-#: ultralcd.cpp:5771
+#: ultralcd.cpp:5841
 msgid "Show end stops"
 msgstr "Stato finecorsa"
 
 # 
-#: ultralcd.cpp:4025
+#: ultralcd.cpp:3986
 msgid "Sensor state"
 msgstr "Stato sensore"
 
 # MSG_FILE_CNT c=20 r=4
-#: cardreader.cpp:739
+#: cardreader.cpp:729
 msgid "Some files will not be sorted. Max. No. of files in 1 folder for sorting is 100."
 msgstr "Alcuni file non saranno ordinati. Il numero massimo di file in una cartella e 100 perche siano ordinati."
 
-# MSG_SORT_NONE c=17 r=1
-#: ultralcd.cpp:5332
-msgid "Sort       [none]"
-msgstr "Ordina  [nessuno]"
+# MSG_SORT
+#: messages.c:120
+msgid "Sort"
+msgstr "Ordina"
 
-# MSG_SORT_TIME c=17 r=1
-#: ultralcd.cpp:5330
-msgid "Sort       [time]"
-msgstr "Ordina    [cron.]"
+# MSG_NONE
+#: messages.c:110
+msgid "None"
+msgstr "Nessuno"
+
+# MSG_SORT_TIME
+#: messages.c:121
+msgid "Time"
+msgstr "Cron."
 
 # 
-#: ultralcd.cpp:3062
+#: ultralcd.cpp:3015
 msgid "Severe skew:"
 msgstr "Devia.grave:"
 
-# MSG_SORT_ALPHA c=17 r=1
-#: ultralcd.cpp:5331
-msgid "Sort   [alphabet]"
-msgstr "Ordine [alfabeti]"
+# MSG_SORT_ALPHA
+#: messages.c:122
+msgid "Alphabet"
+msgstr "Alfabeti"
 
 # MSG_SORTING c=20 r=1
-#: cardreader.cpp:746
+#: cardreader.cpp:736
 msgid "Sorting files"
 msgstr "Ordinando i file"
 
-# MSG_SOUND_LOUD c=17 r=1
-#: sound.h:6
-msgid "Sound      [loud]"
-msgstr "Suono     [forte]"
+# MSG_SOUND_LOUD
+#: messages.c:125
+msgid "Loud"
+msgstr "Forte"
 
 # 
-#: ultralcd.cpp:3061
+#: ultralcd.cpp:3014
 msgid "Slight skew:"
 msgstr "Devia.lieve:"
 
-# MSG_SOUND_MUTE c=17 r=1
-#: 
-msgid "Sound      [mute]"
-msgstr "Suono      [mute]"
+# MSG_SOUND
+#: messages.c:124
+msgid "Sound"
+msgstr "Suono"
 
 # 
-#: Marlin_main.cpp:4871
+#: Marlin_main.cpp:5084
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Sono stati rilevati problemi, avviato livellamento Z ..."
 
-# MSG_SOUND_ONCE c=17 r=1
-#: sound.h:7
-msgid "Sound      [once]"
-msgstr "Suono   [singolo]"
-
-# MSG_SOUND_SILENT c=17 r=1
-#: sound.h:8
-msgid "Sound    [silent]"
-msgstr "Suono[silenzioso]"
+# MSG_SOUND_ONCE
+#: messages.c:126
+msgid "Once"
+msgstr "Singolo"
 
 # MSG_SPEED
-#: ultralcd.cpp:6926
+#: ultralcd.cpp:7096
 msgid "Speed"
 msgstr "Velocita"
 
 # MSG_SELFTEST_FAN_YES c=19
-#: messages.c:80
+#: messages.c:76
 msgid "Spinning"
 msgstr "Gira"
 
 # MSG_TEMP_CAL_WARNING c=20 r=4
-#: Marlin_main.cpp:4368
+#: Marlin_main.cpp:4574
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr "Sono necessari una temperatura ambiente di 21-26C e una superficie rigida "
 
 # MSG_STATISTICS
-#: ultralcd.cpp:6839
+#: ultralcd.cpp:6955
 msgid "Statistics  "
 msgstr "Statistiche"
 
 # MSG_STOP_PRINT
-#: messages.c:93
+#: messages.c:91
 msgid "Stop print"
 msgstr "Arresta stampa"
 
 # MSG_STOPPED
-#: messages.c:94
+#: messages.c:92
 msgid "STOPPED. "
 msgstr "ARRESTATO."
 
 # MSG_SUPPORT
-#: ultralcd.cpp:6848
+#: ultralcd.cpp:6964
 msgid "Support"
 msgstr "Supporto"
 
 # MSG_SELFTEST_SWAPPED
-#: ultralcd.cpp:7959
+#: ultralcd.cpp:8296
 msgid "Swapped"
 msgstr "Scambiato"
 
-# MSG_TEMP_CALIBRATION c=20 r=1
-#: messages.c:95
-msgid "Temp. cal.          "
-msgstr "Calib. temp. "
+# 
+#: ultralcd.cpp:4792
+msgid "Select filament:"
+msgstr "Seleziona il filamento:"
 
-# MSG_TEMP_CALIBRATION_ON c=20 r=1
-#: ultralcd.cpp:5686
-msgid "Temp. cal.   [on]"
-msgstr "Calib. temp. [on]"
+# MSG_TEMP_CALIBRATION c=12 r=1
+#: messages.c:93
+msgid "Temp. cal."
+msgstr "Calib. temp."
 
-# MSG_TEMP_CALIBRATION_OFF c=20 r=1
-#: ultralcd.cpp:5684
-msgid "Temp. cal.  [off]"
-msgstr "Calib. temp.[off]"
+# 
+#: ultralcd.cpp:4933
+msgid "Select temperature which matches your material."
+msgstr "Seleziona la temperatura appropriata per il tuo materiale."
 
 # MSG_CALIBRATION_PINDA_MENU c=17 r=1
-#: ultralcd.cpp:5780
+#: ultralcd.cpp:5850
 msgid "Temp. calibration"
 msgstr "Calib. Temp."
 
 # MSG_TEMP_CAL_FAILED c=20 r=8
-#: ultralcd.cpp:3951
+#: ultralcd.cpp:3911
 msgid "Temperature calibration failed"
 msgstr "Calibrazione temperatura fallita"
 
 # MSG_TEMP_CALIBRATION_DONE c=20 r=12
-#: messages.c:96
+#: messages.c:94
 msgid "Temperature calibration is finished and active. Temp. calibration can be disabled in menu Settings->Temp. cal."
 msgstr "Calibrazione temperatura completata e attiva. Puo essere disattivata dal menu Impostazioni ->Cal. Temp."
 
 # MSG_TEMPERATURE
-#: ultralcd.cpp:5650
+#: ultralcd.cpp:5716
 msgid "Temperature"
 msgstr ""
 
 # MSG_MENU_TEMPERATURES c=15 r=1
-#: ultralcd.cpp:2251
+#: ultralcd.cpp:2196
 msgid "Temperatures"
 msgstr "Temperature"
 
 # MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=4
-#: messages.c:42
+#: messages.c:39
 msgid "There is still a need to make Z calibration. Please follow the manual, chapter First steps, section Calibration flow."
 msgstr "E ancora necessario effettuare la calibrazione Z. Segui il manuale, capitolo Primi Passi, sezione Sequenza di Calibrazione. "
 
 # 
-#: ultralcd.cpp:2908
+#: ultralcd.cpp:2869
 msgid "Total filament"
 msgstr "Filamento totale"
 
 # 
-#: ultralcd.cpp:2908
+#: ultralcd.cpp:2870
 msgid "Total print time"
 msgstr "Tempo stampa totale"
 
 # MSG_TUNE
-#: ultralcd.cpp:6719
+#: ultralcd.cpp:6827
 msgid "Tune"
 msgstr "Regola"
 
 # 
-#: ultralcd.cpp:4869
+#: 
 msgid "Unload"
 msgstr "Scarica"
 
 # 
-#: ultralcd.cpp:1820
+#: ultralcd.cpp:1743
 msgid "Total failures"
 msgstr "Totale fallimenti"
 
 # 
-#: ultralcd.cpp:2324
+#: ultralcd.cpp:2274
 msgid "to load filament"
 msgstr "per caricare il filamento"
 
 # 
-#: ultralcd.cpp:2328
+#: ultralcd.cpp:2278
 msgid "to unload filament"
 msgstr "per scaricare il filamento"
 
 # MSG_UNLOAD_FILAMENT c=17
-#: messages.c:97
+#: messages.c:95
 msgid "Unload filament"
 msgstr "Scarica filamento"
 
 # MSG_UNLOADING_FILAMENT c=20 r=1
-#: messages.c:98
+#: messages.c:96
 msgid "Unloading filament"
 msgstr "Scaricando filamento"
 
 # 
-#: ultralcd.cpp:1773
+#: ultralcd.cpp:1696
 msgid "Total"
 msgstr "Totale"
 
 # MSG_USED c=19 r=1
-#: ultralcd.cpp:5908
+#: ultralcd.cpp:5978
 msgid "Used during print"
 msgstr "Usati nella stampa"
 
 # MSG_MENU_VOLTAGES c=15 r=1
-#: ultralcd.cpp:2254
+#: ultralcd.cpp:2199
 msgid "Voltages"
 msgstr "Voltaggi"
 
 # 
-#: ultralcd.cpp:2227
+#: ultralcd.cpp:2172
 msgid "unknown"
 msgstr "sconosciuto"
 
 # MSG_USERWAIT
-#: Marlin_main.cpp:5263
+#: Marlin_main.cpp:5496
 msgid "Wait for user..."
 msgstr "Attendendo utente..."
 
 # MSG_WAITING_TEMP c=20 r=3
-#: ultralcd.cpp:3458
+#: ultralcd.cpp:3412
 msgid "Waiting for nozzle and bed cooling"
 msgstr "In attesa del raffreddamento dell'ugello e del piano"
 
 # MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ultralcd.cpp:3422
+#: ultralcd.cpp:3373
 msgid "Waiting for PINDA probe cooling"
 msgstr "In attesa del raffreddamento della sonda PINDA"
 
 # 
-#: ultralcd.cpp:4868
+#: 
 msgid "Use unload to remove filament 1 if it protrudes outside of the rear MMU tube. Use eject if it is hidden in tube."
 msgstr "Usate lo scaricamento per rimuovere il filamento 1 se protrude dal retro del tubo posteriore del MMu. Utilizzate l'espulsione se e nascosto nel tubo."
 
 # MSG_CHANGED_BOTH c=20 r=4
-#: Marlin_main.cpp:1511
+#: Marlin_main.cpp:1492
 msgid "Warning: both printer type and motherboard type changed."
 msgstr "Attenzione: tipo di stampante e di scheda madre cambiati."
 
 # MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: Marlin_main.cpp:1503
+#: Marlin_main.cpp:1484
 msgid "Warning: motherboard type changed."
 msgstr "Avviso: tipo di scheda madre cambiato"
 
 # MSG_CHANGED_PRINTER c=20 r=4
-#: Marlin_main.cpp:1507
+#: Marlin_main.cpp:1488
 msgid "Warning: printer type changed."
 msgstr "Avviso: tipo di stampante cambiato."
 
 # MSG_UNLOAD_SUCCESSFUL c=20 r=2
-#: Marlin_main.cpp:3054
+#: Marlin_main.cpp:3106
 msgid "Was filament unload successful?"
 msgstr "Filamento scaricato con successo?"
 
 # MSG_SELFTEST_WIRINGERROR
-#: messages.c:85
+#: messages.c:81
 msgid "Wiring error"
 msgstr "Errore cablaggio"
 
 # MSG_WIZARD c=17 r=1
-#: ultralcd.cpp:5747
+#: ultralcd.cpp:5811
 msgid "Wizard"
 msgstr ""
 
 # MSG_XYZ_DETAILS c=19 r=1
-#: ultralcd.cpp:2243
+#: ultralcd.cpp:2188
 msgid "XYZ cal. details"
 msgstr "XYZ Cal. dettagli"
 
 # MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: messages.c:19
+#: messages.c:18
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "Calibrazione XYZ fallita. Si prega di consultare il manuale."
 
 # MSG_YES
-#: messages.c:104
+#: messages.c:102
 msgid "Yes"
 msgstr "Si"
 
 # MSG_WIZARD_QUIT c=20 r=8
-#: messages.c:103
+#: messages.c:101
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr "E possibile riprendere il Wizard in qualsiasi momento attraverso Calibrazione -> Wizard."
 
 # MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ultralcd.cpp:3922
+#: ultralcd.cpp:3882
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr "Calibrazione XYZ corretta. La distorsione verra compensata automaticamente."
 
 # MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ultralcd.cpp:3919
+#: ultralcd.cpp:3879
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr "Calibrazion XYZ corretta. Assi X/Y leggermente storti. Ben fatto!"
 
 # 
-#: ultralcd.cpp:5130
+#: ultralcd.cpp:5168
 msgid "X-correct:"
 msgstr "Correzione-X:"
 
 # MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ultralcd.cpp:3916
+#: ultralcd.cpp:3876
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "Calibrazione XYZ OK. Gli assi X/Y sono perpendicolari. Complimenti!"
 
 # MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ultralcd.cpp:3900
+#: ultralcd.cpp:3860
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr "Calibrazione XYZ compromessa. Punti anteriori non raggiungibili."
 
 # MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ultralcd.cpp:3903
+#: ultralcd.cpp:3863
 msgid "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr "Calibrazione XYZ compromessa. Punto anteriore destro non raggiungibile."
 
 # MSG_LOAD_ALL c=17
-#: ultralcd.cpp:6166
+#: ultralcd.cpp:6238
 msgid "Load all"
 msgstr "Caricare tutti"
 
 # 
-#: ultralcd.cpp:3882
+#: ultralcd.cpp:3842
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr "Calibrazione XYZ fallita. Il punto di calibrazione sul letto non e' stato trovato."
 
 # 
-#: ultralcd.cpp:3888
+#: ultralcd.cpp:3848
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr "Calibrazione XYZ fallita. Punti anteriori non raggiungibili."
 
 # 
-#: ultralcd.cpp:3891
+#: ultralcd.cpp:3851
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr "Calibrazione XYZ fallita. Punto anteriore destro non raggiungibile."
 
 # 
-#: ultralcd.cpp:3016
+#: ultralcd.cpp:2969
 msgid "Y distance from min"
 msgstr "Distanza Y dal min"
 
 # 
-#: ultralcd.cpp:5131
+#: ultralcd.cpp:4936
+msgid "The printer will start printing a zig-zag line. Rotate the knob until you reach the optimal height. Check the pictures in the handbook (Calibration chapter)."
+msgstr "La stampante iniziera a stampare una linea a zig-zag. Gira la manopola fino a che non hai raggiungo l'altezza ottimale. Verifica con le immagini nel manuale (capitolo sulla calibrazione):"
+
+# 
+#: ultralcd.cpp:5169
 msgid "Y-correct:"
 msgstr "Correzione-Y:"
 
 # MSG_OFF
-#: menu.cpp:426
-msgid " [off]"
+#: messages.c:105
+msgid "Off"
+msgstr ""
+
+# MSG_ON
+#: messages.c:106
+msgid "On"
 msgstr ""
 
 # 
-#: messages.c:57
+#: messages.c:53
 msgid "Back"
 msgstr "Indietro"
 
 # 
-#: ultralcd.cpp:5639
+#: ultralcd.cpp:5702
 msgid "Checks"
 msgstr "Controlli"
 
 # 
-#: ultralcd.cpp:7973
+#: ultralcd.cpp:8310
 msgid "False triggering"
 msgstr "Falso innesco"
 
 # 
-#: ultralcd.cpp:4030
+#: ultralcd.cpp:3991
 msgid "FINDA:"
 msgstr ""
 
-# 
-#: ultralcd.cpp:5545
-msgid "Firmware   [none]"
-msgstr "Firmware[nessuno]"
+# MSG_FIRMWARE
+#: language.h:21
+msgid "Firmware"
+msgstr ""
+
+# MSG_STRICT
+#: messages.c:112
+msgid "Strict"
+msgstr "Esatto"
+
+# MSG_WARN
+#: messages.c:111
+msgid "Warn"
+msgstr "Avviso"
 
 # 
-#: ultralcd.cpp:5551
-msgid "Firmware [strict]"
-msgstr "Firmware [esatto]"
-
-# 
-#: ultralcd.cpp:5548
-msgid "Firmware   [warn]"
-msgstr "Firmware [avviso]"
-
-# 
-#: messages.c:87
+#: messages.c:83
 msgid "HW Setup"
 msgstr "Installazione HW"
 
 # 
-#: ultralcd.cpp:4034
+#: ultralcd.cpp:3995
 msgid "IR:"
 msgstr ""
 
-# 
-#: ultralcd.cpp:7046
-msgid "Magnets comp.[N/A]"
-msgstr "Comp. Magneti[N/A]"
+# MSG_MAGNETS_COMP
+#: messages.c:130
+msgid "Magnets comp."
+msgstr "Comp. Magneti"
+
+# MSG_MESH
+#: messages.c:128
+msgid "Mesh"
+msgstr "Griglia"
 
 # 
-#: ultralcd.cpp:7044
-msgid "Magnets comp.[Off]"
-msgstr "Comp. Magneti[off]"
-
-# 
-#: ultralcd.cpp:7043
-msgid "Magnets comp. [On]"
-msgstr "Comp. Magneti [on]"
-
-# 
-#: ultralcd.cpp:7035
-msgid "Mesh         [3x3]"
-msgstr "Griglia      [3x3]"
-
-# 
-#: ultralcd.cpp:7036
-msgid "Mesh         [7x7]"
-msgstr "Griglia      [7x7]"
-
-# 
-#: ultralcd.cpp:5677
+#: ultralcd.cpp:5740
 msgid "Mesh bed leveling"
 msgstr "Mesh livel. letto"
 
 # 
-#: Marlin_main.cpp:856
+#: Marlin_main.cpp:861
 msgid "MK3S firmware detected on MK3 printer"
 msgstr "Firmware MK3S rilevato su stampante MK3"
 
-# 
-#: ultralcd.cpp:5306
-msgid "MMU Mode [Normal]"
-msgstr "Modalita MMU [Normale]"
+# MSG_MMU_MODE
+#: messages.c:117
+msgid "MMU Mode"
+msgstr "Mod. MMU"
 
 # 
-#: ultralcd.cpp:5307
-msgid "MMU Mode[Stealth]"
-msgstr "Modalita MMU [Silenziosa]"
-
-# 
-#: ultralcd.cpp:4511
+#: ultralcd.cpp:4472
 msgid "Mode change in progress ..."
 msgstr "Cambio modalita in corso ..."
 
-# 
-#: ultralcd.cpp:5506
-msgid "Model      [none]"
-msgstr "Modello [nessuno]"
+# MSG_MODEL
+#: messages.c:113
+msgid "Model"
+msgstr "Modello"
+
+# MSG_NOZZLE_DIAMETER
+#: messages.c:116
+msgid "Nozzle d."
+msgstr "Diam.Ugello"
 
 # 
-#: ultralcd.cpp:5512
-msgid "Model    [strict]"
-msgstr "Modello  [esatto]"
-
-# 
-#: ultralcd.cpp:5509
-msgid "Model      [warn]"
-msgstr "Modello  [avviso]"
-
-# 
-#: ultralcd.cpp:5467
-msgid "Nozzle d.  [0.25]"
-msgstr "Diam.Ugello[0.25]"
-
-# 
-#: ultralcd.cpp:5470
-msgid "Nozzle d.  [0.40]"
-msgstr "Diam.Ugello[0.40]"
-
-# 
-#: ultralcd.cpp:5473
-msgid "Nozzle d.  [0.60]"
-msgstr "Diam.Ugello[0.60]"
-
-# 
-#: ultralcd.cpp:5421
-msgid "Nozzle     [none]"
-msgstr "Ugello  [nessuno]"
-
-# 
-#: ultralcd.cpp:5427
-msgid "Nozzle   [strict]"
-msgstr "Ugello   [esatto]"
-
-# 
-#: ultralcd.cpp:5424
-msgid "Nozzle     [warn]"
-msgstr "Ugello   [avviso]"
-
-# 
-#: util.cpp:510
+#: util.cpp:514
 msgid "G-code sliced for a different level. Continue?"
 msgstr "G-code processato per un livello diverso. Continuare?"
 
 # 
-#: util.cpp:516
+#: util.cpp:520
 msgid "G-code sliced for a different level. Please re-slice the model again. Print cancelled."
 msgstr "G-code processato per un livello diverso. Per favore esegui nuovamente lo slice del modello. Stampa annullata."
 
 # 
-#: util.cpp:427
+#: util.cpp:431
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr "G-code processato per una stampante diversa. Continuare?"
 
 # 
-#: util.cpp:433
+#: util.cpp:437
 msgid "G-code sliced for a different printer type. Please re-slice the model again. Print cancelled."
 msgstr "G-code processato per una stampante diversa. Per favore esegui nuovamente lo slice del modello. Stampa annullata."
 
 # 
-#: util.cpp:477
+#: util.cpp:481
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "G-code processato per un firmware piu recente. Continuare?"
 
 # 
-#: util.cpp:483
+#: util.cpp:487
 msgid "G-code sliced for a newer firmware. Please update the firmware. Print cancelled."
 msgstr "G-code processato per un firmware piu recente. Per favore aggiorna il firmware. Stampa annullata."
 
 # 
-#: ultralcd.cpp:4026
+#: ultralcd.cpp:3987
 msgid "PINDA:"
 msgstr ""
 
 # 
-#: ultralcd.cpp:2465
+#: ultralcd.cpp:2430
 msgid "Preheating to cut"
 msgstr "Preriscaldamento per taglio"
 
 # 
-#: ultralcd.cpp:2462
+#: ultralcd.cpp:2427
 msgid "Preheating to eject"
 msgstr "Preriscaldamento per espulsione"
 
 # 
-#: util.cpp:390
+#: util.cpp:394
 msgid "Printer nozzle diameter differs from the G-code. Continue?"
 msgstr "Diametro ugello diverso da G-Code. Continuare?"
 
 # 
-#: util.cpp:397
+#: util.cpp:401
 msgid "Printer nozzle diameter differs from the G-code. Please check the value in settings. Print cancelled."
 msgstr "Diametro ugello diverso dal G-Code. Controlla il valore nelle impostazioni. Stampa annullata."
 
 # 
-#: ultralcd.cpp:6683
+#: ultralcd.cpp:6791
 msgid "Rename"
 msgstr "Rinomina"
 
 # 
-#: ultralcd.cpp:6679
+#: ultralcd.cpp:6784
 msgid "Select"
 msgstr "Seleziona"
 
 # 
-#: ultralcd.cpp:2245
+#: ultralcd.cpp:2190
 msgid "Sensor info"
 msgstr "Info Sensore"
 
 # 
-#: messages.c:58
+#: messages.c:54
 msgid "Sheet"
 msgstr "Piano"
 
-# 
-#: sound.h:9
-msgid "Sound    [assist]"
-msgstr "Suono   [assist.]"
+# MSG_SOUND_BLIND
+#: messages.c:127
+msgid "Assist"
+msgstr "Assist."
 
 # 
-#: ultralcd.cpp:5637
+#: ultralcd.cpp:5700
 msgid "Steel sheets"
 msgstr "Piani d'acciaio"
 
 # 
-#: ultralcd.cpp:5132
+#: ultralcd.cpp:5170
 msgid "Z-correct:"
 msgstr "Correzione-Z:"
-
-# 
-#: ultralcd.cpp:7038
-msgid "Z-probe nr.    [1]"
-msgstr "Z-probe nr.    [1]"
-
-# 
-#: ultralcd.cpp:7040
-msgid "Z-probe nr.    [3]"
-msgstr "Z-probe nr.    [3]"
 

--- a/lang/po/Firmware_pl.po
+++ b/lang/po/Firmware_pl.po
@@ -7,26 +7,31 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: pl\n"
 "Project-Id-Version: Prusa-Firmware\n"
-"POT-Creation-Date: Sun, Sep 22, 2019 2:08:35 PM\n"
-"PO-Revision-Date: Sun, Sep 22, 2019 2:08:35 PM\n"
+"POT-Creation-Date: Thu, Mar 26, 2020 8:57:07 AM\n"
+"PO-Revision-Date: Thu, Mar 26, 2020 8:57:07 AM\n"
 "Language-Team: \n"
 "X-Generator: Poedit 2.0.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 "Last-Translator: \n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
+# 
+#: 
+msgid "[%.7s]Live adj. Z\x0avalue set, continue\x0aor start from zero?\x0a%cContinue%cReset"
+msgstr "[%.7s]Live Adj. Z\x0austaw., kontynuowac\x0aczy zaczac od 0?\x0a%cKontynuuj%cReset"
+
 # MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE2 c=14
-#: messages.c:39
+#: messages.c:36
 msgid " of 4"
 msgstr " z 4"
 
 # MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE2 c=14
-#: messages.c:60
+#: messages.c:56
 msgid " of 9"
 msgstr " z 9"
 
 # MSG_MEASURED_OFFSET
-#: ultralcd.cpp:3089
+#: ultralcd.cpp:3042
 msgid "[0;0] point offset"
 msgstr "[0;0] przesun.punktu"
 
@@ -41,54 +46,44 @@ msgid "WARNING:\x0aCrash detection\x0adisabled in\x0aStealth mode"
 msgstr "UWAGA:\x0aWykrywanie zderzen\x0awylaczone w\x0atrybie Stealth"
 
 # 
-#: ultralcd.cpp:2472
+#: ultralcd.cpp:2438
 msgid ">Cancel"
 msgstr ">Anuluj"
 
 # MSG_BABYSTEPPING_Z c=15
-#: ultralcd.cpp:3209
+#: ultralcd.cpp:3162
 msgid "Adjusting Z:"
 msgstr "Ustawianie Z:"
 
 # MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ultralcd.cpp:8295
+#: ultralcd.cpp:8638
 msgid "All correct      "
 msgstr "Wszystko OK "
 
 # MSG_WIZARD_DONE c=20 r=8
-#: messages.c:101
+#: messages.c:99
 msgid "All is done. Happy printing!"
 msgstr "Gotowe. Udanego drukowania!"
 
 # 
-#: ultralcd.cpp:2009
+#: ultralcd.cpp:1947
 msgid "Ambient"
 msgstr "Otoczenie"
 
 # MSG_PRESS c=20
-#: ultralcd.cpp:2618
+#: ultralcd.cpp:2587
 msgid "and press the knob"
 msgstr "i nacisnij pokretlo"
 
 # MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=2
-#: ultralcd.cpp:3529
+#: ultralcd.cpp:3484
 msgid "Are left and right Z~carriages all up?"
 msgstr "Obydwa konce osi sa na szczycie?"
 
-# MSG_AUTO_DEPLETE_ON c=17 r=1
-#: ultralcd.cpp:5200
-msgid "SpoolJoin    [on]"
-msgstr "SpoolJoin    [wl]"
-
-# 
-#: ultralcd.cpp:5196
-msgid "SpoolJoin   [N/A]"
-msgstr "SpoolJoin   [N/D]"
-
-# MSG_AUTO_DEPLETE_OFF c=17 r=1
-#: ultralcd.cpp:5204
-msgid "SpoolJoin   [off]"
-msgstr "SpoolJoin   [wyl]"
+# MSG_AUTO_DEPLETE c=17 r=1
+#: messages.c:108
+msgid "SpoolJoin"
+msgstr ""
 
 # MSG_AUTO_HOME
 #: messages.c:11
@@ -96,747 +91,702 @@ msgid "Auto home"
 msgstr "Auto zerowanie"
 
 # MSG_AUTOLOAD_FILAMENT c=17
-#: ultralcd.cpp:6822
+#: ultralcd.cpp:6938
 msgid "AutoLoad filament"
 msgstr "Autoladowanie fil."
 
 # MSG_AUTOLOADING_ONLY_IF_FSENS_ON c=20 r=4
-#: ultralcd.cpp:4462
+#: ultralcd.cpp:4423
 msgid "Autoloading filament available only when filament sensor is turned on..."
-msgstr "Autoladowanie filamentu dostepne tylko gdy czujnik filamentu jest wlaczony..."
+msgstr "Autoladowanie fil. dostepne tylko gdy czujnik filamentu jest wlaczony..."
 
 # MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ultralcd.cpp:2813
+#: ultralcd.cpp:2782
 msgid "Autoloading filament is active, just press the knob and insert filament..."
 msgstr "Autoladowanie filamentu wlaczone, nacisnij pokretlo i wsun filament..."
 
 # MSG_SELFTEST_AXIS_LENGTH
-#: ultralcd.cpp:7949
+#: ultralcd.cpp:8286
 msgid "Axis length"
 msgstr "Dlugosc osi"
 
 # MSG_SELFTEST_AXIS
-#: ultralcd.cpp:7951
+#: ultralcd.cpp:8288
 msgid "Axis"
 msgstr "Os"
 
 # MSG_SELFTEST_BEDHEATER
-#: ultralcd.cpp:7893
+#: ultralcd.cpp:8230
 msgid "Bed / Heater"
 msgstr "Stol / Grzanie"
 
 # MSG_BED_DONE
-#: messages.c:16
+#: messages.c:15
 msgid "Bed done"
 msgstr "Stol OK"
 
 # MSG_BED_HEATING
-#: messages.c:17
+#: messages.c:16
 msgid "Bed Heating"
 msgstr "Grzanie stolu.."
 
 # MSG_BED_CORRECTION_MENU
-#: ultralcd.cpp:5768
+#: ultralcd.cpp:5838
 msgid "Bed level correct"
 msgstr "Korekta stolu"
 
 # MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=4
-#: messages.c:18
+#: messages.c:17
 msgid "Bed leveling failed. Sensor didnt trigger. Debris on nozzle? Waiting for reset."
 msgstr "Kalibracja nieudana. Sensor nie aktywowal sie. Zanieczysz. dysza? Czekam na reset."
 
 # MSG_BED
-#: messages.c:15
+#: messages.c:14
 msgid "Bed"
 msgstr "Stol"
 
 # MSG_MENU_BELT_STATUS c=15 r=1
-#: ultralcd.cpp:2059
+#: ultralcd.cpp:2004
 msgid "Belt status"
 msgstr "Stan paskow"
 
 # MSG_RECOVER_PRINT c=20 r=2
-#: messages.c:71
+#: messages.c:67
 msgid "Blackout occurred. Recover print?"
 msgstr "Wykryto zanik napiecia. Kontynowac?"
 
 # 
-#: ultralcd.cpp:8297
+#: ultralcd.cpp:8640
 msgid "Calibrating home"
 msgstr "Zerowanie osi"
 
 # MSG_CALIBRATE_BED
-#: ultralcd.cpp:5757
+#: ultralcd.cpp:5827
 msgid "Calibrate XYZ"
 msgstr "Kalibracja XYZ"
 
 # MSG_HOMEYZ
-#: messages.c:48
+#: messages.c:44
 msgid "Calibrate Z"
 msgstr "Kalibruj Z"
 
 # MSG_CALIBRATE_PINDA c=17 r=1
-#: ultralcd.cpp:4654
+#: ultralcd.cpp:4615
 msgid "Calibrate"
 msgstr "Kalibruj"
 
 # MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ultralcd.cpp:3492
+#: ultralcd.cpp:3447
 msgid "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end stoppers. Click when done."
 msgstr "Kalibracja XYZ. Przekrec pokretlo, aby przesunac os Z do gornych ogranicznikow. Nacisnij, by potwierdzic."
 
 # MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: messages.c:20
+#: messages.c:19
 msgid "Calibrating Z"
 msgstr "Kalibruje Z"
 
 # MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ultralcd.cpp:3492
+#: ultralcd.cpp:3447
 msgid "Calibrating Z. Rotate the knob to move the Z carriage up to the end stoppers. Click when done."
 msgstr "Kalibracja XYZ. Przekrec pokretlo, aby przesunac os Z do gornych ogranicznikow. Nacisnij, by potwierdzic."
 
 # MSG_HOMEYZ_DONE
-#: ultralcd.cpp:816
+#: ultralcd.cpp:856
 msgid "Calibration done"
 msgstr "Kalibracja OK"
 
 # MSG_MENU_CALIBRATION
-#: messages.c:61
+#: messages.c:57
 msgid "Calibration"
 msgstr "Kalibracja"
 
 # 
-#: ultralcd.cpp:4781
+#: ultralcd.cpp:4793
 msgid "Cancel"
 msgstr "Anuluj"
 
 # MSG_SD_REMOVED
-#: ultralcd.cpp:8679
+#: ultralcd.cpp:9051
 msgid "Card removed"
 msgstr "Karta wyjeta"
 
 # MSG_NOT_COLOR
-#: ultralcd.cpp:2718
+#: ultralcd.cpp:2687
 msgid "Color not correct"
 msgstr "Kolor zanieczysz."
 
 # MSG_COOLDOWN
-#: messages.c:23
+#: messages.c:22
 msgid "Cooldown"
 msgstr "Chlodzenie"
 
 # 
-#: ultralcd.cpp:4587
+#: ultralcd.cpp:4548
 msgid "Copy selected language?"
 msgstr "Skopiowac wybrany jezyk?"
 
 # MSG_CRASHDETECT_ON
-#: messages.c:27
-msgid "Crash det.   [on]"
-msgstr "Wykr.zderzen [wl]"
+#: messages.c:24
+msgid "Crash det."
+msgstr "Wykr.zderzen"
 
-# MSG_CRASHDETECT_NA
-#: messages.c:25
-msgid "Crash det.  [N/A]"
-msgstr "Wykr.zderzen[N/D]"
-
-# MSG_CRASHDETECT_OFF
-#: messages.c:26
-msgid "Crash det.  [off]"
-msgstr "Wykr.zderzen[wyl]"
+# 
+#: ultralcd.cpp:4928
+msgid "Choose a filament for the First Layer Calibration and select it in the on-screen menu."
+msgstr "Wybierz filament do Kalibracji Pierwszej Warstwy i potwierdz w menu ekranowym."
 
 # MSG_CRASH_DETECTED c=20 r=1
-#: messages.c:24
+#: messages.c:23
 msgid "Crash detected."
 msgstr "Zderzenie wykryte"
 
 # 
-#: Marlin_main.cpp:600
+#: Marlin_main.cpp:602
 msgid "Crash detected. Resume print?"
 msgstr "Wykryto zderzenie. Wznowic druk?"
 
 # 
-#: ultralcd.cpp:1853
+#: ultralcd.cpp:1776
 msgid "Crash"
 msgstr "Zderzenie"
 
 # MSG_CURRENT c=19 r=1
-#: ultralcd.cpp:5909
+#: ultralcd.cpp:5979
 msgid "Current"
 msgstr "Aktualne"
 
 # MSG_DATE c=17 r=1
-#: ultralcd.cpp:2213
+#: ultralcd.cpp:2158
 msgid "Date:"
 msgstr "Data:"
 
 # MSG_DISABLE_STEPPERS
-#: ultralcd.cpp:5654
+#: ultralcd.cpp:5720
 msgid "Disable steppers"
 msgstr "Wylacz silniki"
 
 # MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: messages.c:14
+#: messages.c:13
 msgid "Distance between tip of the nozzle and the bed surface has not been set yet. Please follow the manual, chapter First steps, section First layer calibration."
 msgstr "Odleglosc dyszy od powierzchni druku nie jest skalibrowana. Postepuj zgodnie z instrukcja: rozdzial Wprowadzenie - Kalibracja pierwszej warstwy."
 
 # MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ultralcd.cpp:5070
+#: ultralcd.cpp:5103
 msgid "Do you want to repeat last step to readjust distance between nozzle and heatbed?"
 msgstr "Chcesz powtorzyc ostatni krok i ponownie ustawic odleglosc miedzy dysza a stolikiem?"
 
 # MSG_EXTRUDER_CORRECTION c=10
-#: ultralcd.cpp:5134
+#: ultralcd.cpp:5172
 msgid "E-correct:"
 msgstr "Korekcja-E:"
 
 # MSG_EJECT_FILAMENT c=17 r=1
-#: messages.c:53
+#: messages.c:49
 msgid "Eject filament"
 msgstr "Wysun filament"
 
-# 
-#: ultralcd.cpp:4869
-msgid "Eject"
-msgstr "Wysun"
-
 # MSG_EJECTING_FILAMENT c=20 r=1
-#: mmu.cpp:1434
+#: mmu.cpp:1415
 msgid "Ejecting filament"
 msgstr "Wysuwanie filamentu"
 
 # MSG_SELFTEST_ENDSTOP_NOTHIT c=20 r=1
-#: ultralcd.cpp:7917
+#: ultralcd.cpp:8254
 msgid "Endstop not hit"
 msgstr "Krancowka nie aktyw."
 
 # MSG_SELFTEST_ENDSTOP
-#: ultralcd.cpp:7911
+#: ultralcd.cpp:8248
 msgid "Endstop"
 msgstr "Krancowka"
 
 # MSG_SELFTEST_ENDSTOPS
-#: ultralcd.cpp:7899
+#: ultralcd.cpp:8236
 msgid "Endstops"
 msgstr "Krancowki"
 
 # MSG_STACK_ERROR c=20 r=4
-#: ultralcd.cpp:6859
+#: ultralcd.cpp:6975
 msgid "Error - static memory has been overwritten"
 msgstr "Blad - pamiec statyczna zostala nadpisana"
 
 # MSG_FSENS_NOT_RESPONDING c=20 r=4
-#: ultralcd.cpp:4475
+#: ultralcd.cpp:4436
 msgid "ERROR: Filament sensor is not responding, please check connection."
 msgstr "BLAD: Czujnik filamentu nie odpowiada, sprawdz polaczenie."
 
 # MSG_ERROR
-#: messages.c:28
+#: messages.c:25
 msgid "ERROR:"
 msgstr "BLAD:"
 
 # MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
-#: ultralcd.cpp:8304
+#: ultralcd.cpp:8647
 msgid "Extruder fan:"
 msgstr "WentHotend:"
 
 # MSG_INFO_EXTRUDER c=15 r=1
-#: ultralcd.cpp:2244
+#: ultralcd.cpp:2189
 msgid "Extruder info"
 msgstr "Ekstruder - info"
 
 # MSG_MOVE_E
-#: messages.c:29
+#: messages.c:26
 msgid "Extruder"
 msgstr "Ekstruder"
 
 # 
-#: ultralcd.cpp:6846
+#: ultralcd.cpp:6962
 msgid "Fail stats MMU"
 msgstr "Bledy MMU"
 
-# MSG_FSENS_AUTOLOAD_ON c=17 r=1
-#: ultralcd.cpp:5168
-msgid "F. autoload  [on]"
-msgstr "Autolad.fil. [wl]"
-
-# MSG_FSENS_AUTOLOAD_NA c=17 r=1
-#: messages.c:43
-msgid "F. autoload [N/A]"
-msgstr "Autolad.fil.[N/D]"
-
-# MSG_FSENS_AUTOLOAD_OFF c=17 r=1
-#: ultralcd.cpp:5170
-msgid "F. autoload [off]"
-msgstr "Autolad.fil.[wyl]"
+# MSG_FSENSOR_AUTOLOAD
+#: messages.c:40
+msgid "F. autoload"
+msgstr "Autolad. fil."
 
 # 
-#: ultralcd.cpp:6843
+#: ultralcd.cpp:6959
 msgid "Fail stats"
 msgstr "Statystyki bledow"
 
 # MSG_FAN_SPEED c=14
-#: messages.c:31
+#: messages.c:28
 msgid "Fan speed"
 msgstr "Predkosc went."
 
 # MSG_SELFTEST_FAN c=20
-#: messages.c:78
+#: messages.c:74
 msgid "Fan test"
 msgstr "Test wentylatora"
 
-# MSG_FANS_CHECK_ON c=17 r=1
-#: ultralcd.cpp:5663
-msgid "Fans check   [on]"
-msgstr "Sprawd.went. [wl]"
+# MSG_FANS_CHECK
+#: ultralcd.cpp:5728
+msgid "Fans check"
+msgstr "Sprawd.went."
 
-# MSG_FANS_CHECK_OFF c=17 r=1
-#: ultralcd.cpp:5665
-msgid "Fans check  [off]"
-msgstr "Sprawd.went.[wyl]"
-
-# MSG_FSENSOR_ON
-#: messages.c:45
-msgid "Fil. sensor  [on]"
-msgstr "Czuj. filam. [wl]"
-
-# MSG_FSENSOR_NA
-#: ultralcd.cpp:5148
-msgid "Fil. sensor [N/A]"
-msgstr "Czuj. filam.[N/D]"
-
-# MSG_FSENSOR_OFF
-#: messages.c:44
-msgid "Fil. sensor [off]"
-msgstr "Czuj. filam.[wyl]"
+# MSG_FSENSOR
+#: messages.c:41
+msgid "Fil. sensor"
+msgstr "Czuj. filam."
 
 # 
-#: ultralcd.cpp:1852
+#: ultralcd.cpp:1775
 msgid "Filam. runouts"
 msgstr "Konc. filamentu"
 
 # MSG_FILAMENT_CLEAN c=20 r=2
-#: messages.c:32
+#: messages.c:29
 msgid "Filament extruding & with correct color?"
 msgstr "Filament wychodzi z dyszy, kolor jest ok?"
 
 # MSG_NOT_LOADED c=19
-#: ultralcd.cpp:2714
+#: ultralcd.cpp:2683
 msgid "Filament not loaded"
 msgstr "Fil. nie zaladowany"
 
 # MSG_FILAMENT_SENSOR c=20
-#: messages.c:84
+#: messages.c:80
 msgid "Filament sensor"
 msgstr "Czujnik filamentu"
 
 # MSG_FILAMENT_USED c=19 r=1
-#: ultralcd.cpp:2885
+#: ultralcd.cpp:2847
 msgid "Filament used"
 msgstr "Uzyty filament"
 
 # MSG_PRINT_TIME c=19 r=1
-#: ultralcd.cpp:2886
+#: ultralcd.cpp:2848
 msgid "Print time"
 msgstr "Czas druku"
 
 # MSG_FILE_INCOMPLETE c=20 r=2
-#: ultralcd.cpp:8432
+#: ultralcd.cpp:8775
 msgid "File incomplete. Continue anyway?"
 msgstr "Plik niekompletny. Kontynowac?"
 
 # MSG_FINISHING_MOVEMENTS c=20 r=1
-#: messages.c:40
+#: messages.c:37
 msgid "Finishing movements"
 msgstr "Konczenie druku"
 
 # MSG_V2_CALIBRATION c=17 r=1
-#: messages.c:105
+#: messages.c:103
 msgid "First layer cal."
 msgstr "Kal. 1. warstwy"
 
 # MSG_WIZARD_SELFTEST c=20 r=8
-#: ultralcd.cpp:4982
+#: ultralcd.cpp:5024
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr "Najpierw wlacze selftest w celu sprawdzenia najczestszych problemow podczas montazu."
 
 # 
-#: mmu.cpp:724
+#: mmu.cpp:726
 msgid "Fix the issue and then press button on MMU unit."
 msgstr "Rozwiaz problem i wcisnij przycisk na MMU."
 
 # MSG_FLOW
-#: ultralcd.cpp:6932
+#: ultralcd.cpp:7102
 msgid "Flow"
 msgstr "Przeplyw"
 
 # MSG_PRUSA3D_FORUM
-#: ultralcd.cpp:2206
+#: ultralcd.cpp:2151
 msgid "forum.prusa3d.com"
 msgstr ""
 
 # MSG_SELFTEST_COOLING_FAN c=20
-#: messages.c:75
+#: messages.c:71
 msgid "Front print fan?"
 msgstr "Przedni went. druku?"
 
 # MSG_BED_CORRECTION_FRONT c=14 r=1
-#: ultralcd.cpp:3294
+#: ultralcd.cpp:3244
 msgid "Front side[um]"
 msgstr "Przod [um]"
 
 # MSG_SELFTEST_FANS
-#: ultralcd.cpp:7957
+#: ultralcd.cpp:8294
 msgid "Front/left fans"
 msgstr "Przedni/lewy wentylator"
 
 # MSG_SELFTEST_HEATERTHERMISTOR
-#: ultralcd.cpp:7887
+#: ultralcd.cpp:8224
 msgid "Heater/Thermistor"
 msgstr "Grzalka/Termistor"
 
 # MSG_BED_HEATING_SAFETY_DISABLED
-#: Marlin_main.cpp:8467
+#: Marlin_main.cpp:9458
 msgid "Heating disabled by safety timer."
 msgstr "Grzanie wylaczone przez wyl. czasowy"
 
 # MSG_HEATING_COMPLETE c=20
-#: messages.c:47
+#: messages.c:43
 msgid "Heating done."
 msgstr "Grzanie zakonczone"
 
 # MSG_HEATING
-#: messages.c:46
+#: messages.c:42
 msgid "Heating"
 msgstr "Grzanie..."
 
 # MSG_WIZARD_WELCOME c=20 r=7
-#: ultralcd.cpp:4961
+#: ultralcd.cpp:5003
 msgid "Hi, I am your Original Prusa i3 printer. Would you like me to guide you through the setup process?"
 msgstr "Czesc, jestem Twoja drukarka Original Prusa i3. Czy potrzebujesz pomocy z ustawieniem?"
 
 # MSG_PRUSA3D_HOWTO
-#: ultralcd.cpp:2207
+#: ultralcd.cpp:2152
 msgid "howto.prusa3d.com"
 msgstr ""
 
 # MSG_FILAMENTCHANGE
-#: messages.c:37
+#: messages.c:34
 msgid "Change filament"
 msgstr "Wymiana filamentu"
 
 # MSG_CHANGE_SUCCESS
-#: ultralcd.cpp:2629
+#: ultralcd.cpp:2598
 msgid "Change success!"
 msgstr "Wymiana ok!"
 
 # MSG_CORRECTLY c=20
-#: ultralcd.cpp:2706
+#: ultralcd.cpp:2675
 msgid "Changed correctly?"
 msgstr "Wymiana ok?"
 
 # MSG_SELFTEST_CHECK_BED c=20
-#: messages.c:81
+#: messages.c:77
 msgid "Checking bed     "
 msgstr "Kontrola stolu"
 
 # MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ultralcd.cpp:8286
+#: ultralcd.cpp:8629
 msgid "Checking endstops"
 msgstr "Kontrola krancowek"
 
 # MSG_SELFTEST_CHECK_HOTEND c=20
-#: ultralcd.cpp:8292
+#: ultralcd.cpp:8635
 msgid "Checking hotend  "
 msgstr "Kontrola hotendu"
 
 # MSG_SELFTEST_CHECK_FSENSOR c=20
-#: messages.c:82
+#: messages.c:78
 msgid "Checking sensors "
 msgstr "Sprawdzanie czujnikow"
 
 # MSG_SELFTEST_CHECK_X c=20
-#: ultralcd.cpp:8287
+#: ultralcd.cpp:8630
 msgid "Checking X axis  "
 msgstr "Kontrola osi X"
 
 # MSG_SELFTEST_CHECK_Y c=20
-#: ultralcd.cpp:8288
+#: ultralcd.cpp:8631
 msgid "Checking Y axis  "
 msgstr "Kontrola osi Y"
 
 # MSG_SELFTEST_CHECK_Z c=20
-#: ultralcd.cpp:8289
+#: ultralcd.cpp:8632
 msgid "Checking Z axis  "
 msgstr "Kontrola osi Z"
 
 # MSG_CHOOSE_EXTRUDER c=20 r=1
-#: messages.c:49
+#: messages.c:45
 msgid "Choose extruder:"
 msgstr "Wybierz ekstruder:"
 
 # MSG_CHOOSE_FILAMENT c=20 r=1
-#: messages.c:50
+#: messages.c:46
 msgid "Choose filament:"
 msgstr "Wybierz filament:"
 
 # MSG_FILAMENT c=17 r=1
-#: messages.c:30
+#: messages.c:27
 msgid "Filament"
 msgstr ""
 
 # MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ultralcd.cpp:4991
+#: ultralcd.cpp:5033
 msgid "I will run xyz calibration now. It will take approx. 12 mins."
 msgstr "Przeprowadze teraz kalibracje XYZ. Zajmie ok. 12 min."
 
 # MSG_WIZARD_Z_CAL c=20 r=8
-#: ultralcd.cpp:4999
+#: ultralcd.cpp:5041
 msgid "I will run z calibration now."
 msgstr "Przeprowadze kalibracje Z."
 
-# MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ultralcd.cpp:5064
-msgid "I will start to print line and you will gradually lower the nozzle by rotating the knob, until you reach optimal height. Check the pictures in our handbook in chapter Calibration."
-msgstr "Zaczne drukowac linie. Stopniowo opuszczaj dysze przekrecajac pokretlo, poki nie uzyskasz optymalnej wysokosci. Sprawdz obrazki w naszym Podreczniku w rozdz. Kalibracja"
-
 # MSG_WATCH
-#: messages.c:99
+#: messages.c:97
 msgid "Info screen"
 msgstr "Ekran informacyjny"
 
-# 
-#: ultralcd.cpp:5024
-msgid "Is filament 1 loaded?"
-msgstr "Filament 1 zaladowany?"
-
 # MSG_INSERT_FILAMENT c=20
-#: ultralcd.cpp:2614
+#: ultralcd.cpp:2583
 msgid "Insert filament"
 msgstr "Wprowadz filament"
 
 # MSG_WIZARD_FILAMENT_LOADED c=20 r=2
-#: ultralcd.cpp:5027
+#: ultralcd.cpp:4813
 msgid "Is filament loaded?"
 msgstr "Filament jest zaladowany?"
 
-# MSG_WIZARD_PLA_FILAMENT c=20 r=2
-#: ultralcd.cpp:5058
-msgid "Is it PLA filament?"
-msgstr "Czy to filament PLA?"
-
-# MSG_PLA_FILAMENT_LOADED c=20 r=2
-#: ultralcd.cpp:4790
-msgid "Is PLA filament loaded?"
-msgstr "Fialment PLA jest zaladowany?"
-
 # MSG_STEEL_SHEET_CHECK c=20 r=2
-#: messages.c:92
+#: messages.c:90
 msgid "Is steel sheet on heatbed?"
 msgstr "Czy plyta stal. jest na podgrzew. stole?"
 
 # 
-#: ultralcd.cpp:1795
+#: ultralcd.cpp:1718
 msgid "Last print failures"
 msgstr "Ostatnie bledy druku"
 
 # 
-#: ultralcd.cpp:1772
+#: ultralcd.cpp:5111
+msgid "If you have additional steel sheets, calibrate their presets in Settings - HW Setup - Steel sheets."
+msgstr "Jesli masz dodatkowe plyty stalowe, to skalibruj ich ustawienia w menu Ustawienia - Ustawienia HW - Plyty stalowe."
+
+# 
+#: ultralcd.cpp:1695
 msgid "Last print"
 msgstr "Ost. wydruk"
 
 # MSG_SELFTEST_EXTRUDER_FAN c=20
-#: messages.c:76
+#: messages.c:72
 msgid "Left hotend fan?"
 msgstr "Lewy went hotendu?"
 
 # 
-#: ultralcd.cpp:3018
+#: ultralcd.cpp:2971
 msgid "Left"
 msgstr "Lewa"
 
 # MSG_BED_CORRECTION_LEFT c=14 r=1
-#: ultralcd.cpp:3292
+#: ultralcd.cpp:3242
 msgid "Left side [um]"
 msgstr "Lewo [um]"
 
 # 
-#: ultralcd.cpp:5680
+#: ultralcd.cpp:5743
 msgid "Lin. correction"
 msgstr "Korekcja liniowa"
 
 # MSG_BABYSTEP_Z
-#: messages.c:13
+#: messages.c:12
 msgid "Live adjust Z"
 msgstr "Ustaw. Live Z"
 
 # MSG_LOAD_FILAMENT c=17
-#: messages.c:51
+#: messages.c:47
 msgid "Load filament"
 msgstr "Ladowanie fil."
 
 # MSG_LOADING_COLOR
-#: ultralcd.cpp:2654
+#: ultralcd.cpp:2623
 msgid "Loading color"
 msgstr "Czyszcz. koloru"
 
 # MSG_LOADING_FILAMENT c=20
-#: messages.c:52
+#: messages.c:48
 msgid "Loading filament"
 msgstr "Laduje filament"
 
 # MSG_LOOSE_PULLEY c=20 r=1
-#: ultralcd.cpp:7941
+#: ultralcd.cpp:8278
 msgid "Loose pulley"
 msgstr "Luzne kolo pasowe"
 
 # 
-#: ultralcd.cpp:6805
+#: ultralcd.cpp:6921
 msgid "Load to nozzle"
 msgstr "Zaladuj do dyszy"
 
 # MSG_M117_V2_CALIBRATION c=25 r=1
-#: messages.c:55
+#: messages.c:51
 msgid "M117 First layer cal."
 msgstr "M117 Kal. 1. warstwy"
 
 # MSG_MAIN
-#: messages.c:56
+#: messages.c:52
 msgid "Main"
 msgstr "Menu glowne"
 
 # MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=60
-#: messages.c:59
+#: messages.c:55
 msgid "Measuring reference height of calibration point"
 msgstr "Okreslam wysokosc odniesienia punktu kalibracyjnego"
 
 # MSG_MESH_BED_LEVELING
-#: ultralcd.cpp:5763
+#: ultralcd.cpp:5833
 msgid "Mesh Bed Leveling"
 msgstr "Poziomowanie stolu wg siatki"
 
 # MSG_MMU_OK_RESUMING_POSITION c=20 r=4
-#: mmu.cpp:762
+#: mmu.cpp:764
 msgid "MMU OK. Resuming position..."
 msgstr "MMU OK. Wznawianie pozycji."
 
 # MSG_MMU_OK_RESUMING_TEMPERATURE c=20 r=4
-#: mmu.cpp:755
+#: mmu.cpp:757
 msgid "MMU OK. Resuming temperature..."
 msgstr "MMU OK. Wznawiam nagrzewanie..."
 
 # 
-#: ultralcd.cpp:3059
+#: ultralcd.cpp:3012
 msgid "Measured skew"
 msgstr "Zmierzony skos"
 
-# 
-#: ultralcd.cpp:1796
+#  c=13 r=1
+#: ultralcd.cpp:1719
 msgid "MMU fails"
 msgstr "Bledy MMU"
 
 # 
-#: mmu.cpp:1613
+#: mmu.cpp:1587
 msgid "MMU load failed     "
 msgstr "Blad ladowania MMU"
 
-# 
-#: ultralcd.cpp:1797
-msgid "MMU load fails"
+#  c=13 r=1
+#: ultralcd.cpp:1720
+msgid "MMU load f."
 msgstr "Bledy ladow. MMU"
 
 # MSG_MMU_OK_RESUMING c=20 r=4
-#: mmu.cpp:773
+#: mmu.cpp:775
 msgid "MMU OK. Resuming..."
 msgstr "MMU OK. Wznawianie..."
 
-# MSG_STEALTH_MODE_OFF
-#: messages.c:90
-msgid "Mode     [Normal]"
-msgstr "Tryb   [normalny]"
+# MSG_MODE
+#: messages.c:84
+msgid "Mode"
+msgstr "Tryb"
 
-# MSG_SILENT_MODE_ON
-#: messages.c:89
-msgid "Mode     [silent]"
-msgstr "Tryb      [cichy]"
+# MSG_NORMAL
+#: messages.c:88
+msgid "Normal"
+msgstr "Normalny"
+
+# MSG_SILENT
+#: messages.c:87
+msgid "Silent"
+msgstr "Cichy"
 
 # 
-#: mmu.cpp:719
+#: mmu.cpp:721
 msgid "MMU needs user attention."
 msgstr "MMU wymaga uwagi uzytkownika."
 
-# 
-#: ultralcd.cpp:1823
-msgid "MMU power fails"
+#  c=14 r=1
+#: ultralcd.cpp:1746
+msgid "MMU power f."
 msgstr "Zaniki zasil. MMU"
 
-# MSG_STEALTH_MODE_ON
-#: messages.c:91
-msgid "Mode    [Stealth]"
-msgstr "Tryb      [cichy]"
+# MSG_STEALTH
+#: messages.c:89
+msgid "Stealth"
+msgstr "Cichy"
 
-# MSG_AUTO_MODE_ON
-#: messages.c:12
-msgid "Mode [auto power]"
-msgstr "Tryb [automatycz]"
+# MSG_AUTO_POWER
+#: messages.c:86
+msgid "Auto power"
+msgstr "Automatycz"
 
-# MSG_SILENT_MODE_OFF
-#: messages.c:88
-msgid "Mode [high power]"
-msgstr "Tryb[wysoka wyd.]"
+# MSG_HIGH_POWER
+#: messages.c:85
+msgid "High power"
+msgstr "Wysoka wyd."
 
 # 
-#: ultralcd.cpp:2219
+#: ultralcd.cpp:2164
 msgid "MMU2 connected"
 msgstr "MMU podlaczone"
 
 # MSG_SELFTEST_MOTOR
-#: messages.c:83
+#: messages.c:79
 msgid "Motor"
 msgstr "Silnik"
 
 # MSG_MOVE_AXIS
-#: ultralcd.cpp:5652
+#: ultralcd.cpp:5718
 msgid "Move axis"
 msgstr "Ruch osi"
 
 # MSG_MOVE_X
-#: ultralcd.cpp:4378
+#: ultralcd.cpp:4339
 msgid "Move X"
 msgstr "Ruch osi X"
 
 # MSG_MOVE_Y
-#: ultralcd.cpp:4379
+#: ultralcd.cpp:4340
 msgid "Move Y"
 msgstr "Ruch osi Y"
 
 # MSG_MOVE_Z
-#: ultralcd.cpp:4380
+#: ultralcd.cpp:4341
 msgid "Move Z"
 msgstr "Ruch osi Z"
 
 # MSG_NO_MOVE
-#: Marlin_main.cpp:5292
+#: Marlin_main.cpp:5526
 msgid "No move."
 msgstr "Brak ruchu."
 
 # MSG_NO_CARD
-#: ultralcd.cpp:6772
+#: ultralcd.cpp:6888
 msgid "No SD card"
 msgstr "Brak karty SD"
 
-# 
-#: ultralcd.cpp:3024
+# MSG_NA
+#: messages.c:107
 msgid "N/A"
 msgstr "N/D"
 
 # MSG_NO
-#: messages.c:62
+#: messages.c:58
 msgid "No"
 msgstr "Nie"
 
 # MSG_SELFTEST_NOTCONNECTED
-#: ultralcd.cpp:7889
+#: ultralcd.cpp:8226
 msgid "Not connected"
 msgstr "Nie podlaczono "
 
@@ -846,167 +796,152 @@ msgid "New firmware version available:"
 msgstr "Dostepna nowa wersja firmware:"
 
 # MSG_SELFTEST_FAN_NO c=19
-#: messages.c:79
+#: messages.c:75
 msgid "Not spinning"
 msgstr "Nie kreci sie"
 
 # MSG_WIZARD_V2_CAL c=20 r=8
-#: ultralcd.cpp:5063
+#: ultralcd.cpp:4924
 msgid "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr "Kalibruje odleglosc miedzy koncowka dyszy a powierzchnia druku."
 
 # MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ultralcd.cpp:5007
+#: ultralcd.cpp:5049
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Nagrzewam dysze dla PLA."
 
 # MSG_NOZZLE
-#: messages.c:63
+#: messages.c:59
 msgid "Nozzle"
 msgstr "Dysza"
 
 # MSG_DEFAULT_SETTINGS_LOADED c=20 r=4
-#: Marlin_main.cpp:1519
+#: Marlin_main.cpp:1500
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr "Znaleziono stare ustawienia. Zostana przywrocone domyslne ust. PID, Esteps, itp."
 
 # 
-#: ultralcd.cpp:4998
+#: ultralcd.cpp:5040
 msgid "Now remove the test print from steel sheet."
 msgstr "Teraz zdejmij wydruk testowy ze stolu."
 
 # 
-#: ultralcd.cpp:1722
+#: ultralcd.cpp:1645
 msgid "Nozzle FAN"
 msgstr "WentHotend"
 
 # MSG_PAUSE_PRINT
-#: ultralcd.cpp:6735
+#: ultralcd.cpp:6852
 msgid "Pause print"
 msgstr "Wstrzymanie wydruku"
 
 # MSG_PID_RUNNING c=20 r=1
-#: ultralcd.cpp:1606
+#: ultralcd.cpp:1530
 msgid "PID cal.           "
 msgstr "Kalibracja PID"
 
 # MSG_PID_FINISHED c=20 r=1
-#: ultralcd.cpp:1612
+#: ultralcd.cpp:1536
 msgid "PID cal. finished"
 msgstr "Kal. PID zakonczona"
 
 # MSG_PID_EXTRUDER c=17 r=1
-#: ultralcd.cpp:5769
+#: ultralcd.cpp:5839
 msgid "PID calibration"
 msgstr "Kalibracja PID"
 
 # MSG_PINDA_PREHEAT c=20 r=1
-#: ultralcd.cpp:846
+#: ultralcd.cpp:887
 msgid "PINDA Heating"
 msgstr "Grzanie sondy PINDA"
 
 # MSG_PAPER c=20 r=8
-#: messages.c:64
+#: messages.c:60
 msgid "Place a sheet of paper under the nozzle during the calibration of first 4 points. If the nozzle catches the paper, power off the printer immediately."
 msgstr "Umiesc kartke papieru na stole roboczym i podczas pomiaru pierwszych 4 punktow. Jesli dysza zahaczy o papier, natychmiast wylacz drukarke."
 
 # MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ultralcd.cpp:5072
+#: ultralcd.cpp:5106
 msgid "Please clean heatbed and then press the knob."
 msgstr "Oczysc powierzchnie druku i nacisnij pokretlo."
 
 # MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: messages.c:22
+#: messages.c:21
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Dla prawidlowej kalibracji nalezy oczyscic dysze. Potwierdz guzikiem."
 
 # MSG_SELFTEST_PLEASECHECK
-#: ultralcd.cpp:7881
+#: ultralcd.cpp:8218
 msgid "Please check :"
 msgstr "Sprawdz :"
 
 # MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: messages.c:100
+#: messages.c:98
 msgid "Please check our handbook and fix the problem. Then resume the Wizard by rebooting the printer."
 msgstr "Przeczytaj nasz Podrecznik druku 3D aby naprawic problem. Potem wznow Asystenta przez restart drukarki."
 
-# MSG_WIZARD_LOAD_FILAMENT c=20 r=8
-#: ultralcd.cpp:4894
-msgid "Please insert PLA filament to the extruder, then press knob to load it."
-msgstr "Umiesc filament PLA w ekstruderze i nacisnij pokretlo, aby zaladowac."
-
-# MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ultralcd.cpp:4795
-msgid "Please load PLA filament first."
-msgstr "Najpierw zaladuj filament PLA."
-
 # MSG_CHECK_IDLER c=20 r=4
-#: Marlin_main.cpp:3064
+#: Marlin_main.cpp:3116
 msgid "Please open idler and remove filament manually."
 msgstr "Prosze odciagnac dzwignie dociskowa ekstrudera i recznie usunac filament."
 
 # MSG_PLACE_STEEL_SHEET c=20 r=4
-#: messages.c:65
+#: messages.c:61
 msgid "Please place steel sheet on heatbed."
 msgstr "Prosze umiescic plyte stalowa na stole podgrzewanym."
 
 # MSG_PRESS_TO_UNLOAD c=20 r=4
-#: messages.c:68
+#: messages.c:64
 msgid "Please press the knob to unload filament"
 msgstr "Nacisnij pokretlo aby rozladowac filament"
 
-# 
-#: ultralcd.cpp:4889
-msgid "Please insert PLA filament to the first tube of MMU, then press the knob to load it."
-msgstr "Wsun filament PLA do pierwszej rurki MMU i nacisnij pokretlo aby go zaladowac."
-
 # MSG_PULL_OUT_FILAMENT c=20 r=4
-#: messages.c:70
+#: messages.c:66
 msgid "Please pull out filament immediately"
 msgstr "Wyciagnij filament teraz"
 
 # MSG_EJECT_REMOVE c=20 r=4
-#: mmu.cpp:1440
+#: mmu.cpp:1421
 msgid "Please remove filament and then press the knob."
 msgstr "Wyciagnij filament i wcisnij pokretlo."
 
 # MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: messages.c:74
+#: messages.c:70
 msgid "Please remove steel sheet from heatbed."
 msgstr "Prosze zdjac plyte stalowa z podgrzewanego stolu."
 
 # MSG_RUN_XYZ c=20 r=4
-#: Marlin_main.cpp:4355
+#: Marlin_main.cpp:4561
 msgid "Please run XYZ calibration first."
 msgstr "Prosze najpierw uruchomic kalibracje XYZ"
 
 # MSG_UPDATE_MMU2_FW c=20 r=4
-#: mmu.cpp:1359
+#: mmu.cpp:1340
 msgid "Please update firmware in your MMU2. Waiting for reset."
 msgstr "Prosze zaktualizowac Firmware MMU2. Czekam na reset."
 
 # MSG_PLEASE_WAIT c=20
-#: messages.c:66
+#: messages.c:62
 msgid "Please wait"
 msgstr "Prosze czekac"
 
 # 
-#: ultralcd.cpp:4997
+#: ultralcd.cpp:5039
 msgid "Please remove shipping helpers first."
 msgstr "Najpierw usun zabezpieczenia transportowe"
 
 # MSG_PREHEAT_NOZZLE c=20
-#: messages.c:67
+#: messages.c:63
 msgid "Preheat the nozzle!"
 msgstr "Nagrzej dysze!"
 
 # MSG_PREHEAT
-#: ultralcd.cpp:6722
+#: ultralcd.cpp:6830
 msgid "Preheat"
 msgstr "Grzanie"
 
 # MSG_WIZARD_HEATING c=20 r=3
-#: messages.c:102
+#: messages.c:100
 msgid "Preheating nozzle. Please wait."
 msgstr "Nagrzewanie dyszy. Prosze czekac."
 
@@ -1016,82 +951,97 @@ msgid "Please upgrade."
 msgstr "Prosze zaktualizowac."
 
 # MSG_PRESS_TO_PREHEAT c=20 r=4
-#: Marlin_main.cpp:10364
+#: Marlin_main.cpp:11469
 msgid "Press knob to preheat nozzle and continue."
 msgstr "Wcisnij pokretlo aby rozgrzac dysze i kontynuowac."
 
 # 
-#: ultralcd.cpp:1851
+#: ultralcd.cpp:1774
 msgid "Power failures"
 msgstr "Zaniki zasilania"
 
 # MSG_PRINT_ABORTED c=20
-#: messages.c:69
+#: messages.c:65
 msgid "Print aborted"
 msgstr "Druk przerwany"
 
 # 
-#: ultralcd.cpp:2455
+#: ultralcd.cpp:2420
 msgid "Preheating to load"
 msgstr "Nagrzew. do ladowania"
 
 # 
-#: ultralcd.cpp:2459
+#: ultralcd.cpp:2424
 msgid "Preheating to unload"
 msgstr "Nagrzew. do rozlad."
 
 # MSG_SELFTEST_PRINT_FAN_SPEED c=18
-#: ultralcd.cpp:8307
+#: ultralcd.cpp:8650
 msgid "Print fan:"
 msgstr "WentWydruk:"
 
 # MSG_CARD_MENU
-#: messages.c:21
+#: messages.c:20
 msgid "Print from SD"
 msgstr "Druk z karty SD"
 
 # 
-#: ultralcd.cpp:2317
+#: ultralcd.cpp:2267
 msgid "Press the knob"
 msgstr "Wcisnij pokretlo"
 
 # MSG_PRINT_PAUSED c=20 r=1
-#: ultralcd.cpp:1069
+#: ultralcd.cpp:1109
 msgid "Print paused"
 msgstr "Druk wstrzymany"
 
 # 
-#: mmu.cpp:723
+#: mmu.cpp:725
 msgid "Press the knob to resume nozzle temperature."
 msgstr "Wcisnij pokretlo aby wznowic podgrzewanie dyszy."
 
 # MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: messages.c:41
+#: messages.c:38
 msgid "Printer has not been calibrated yet. Please follow the manual, chapter First steps, section Calibration flow."
 msgstr "Drukarka nie byla jeszcze kalibrowana. Kieruj sie Samouczkiem: rozdzial Pierwsze Kroki, sekcja Konfiguracja przed drukowaniem."
 
 # 
-#: ultralcd.cpp:1723
+#: ultralcd.cpp:1646
 msgid "Print FAN"
 msgstr "WentWydruk"
 
+# 
+#: ultralcd.cpp:4904
+msgid "Please insert filament into the extruder, then press the knob to load it."
+msgstr "Wsun filament do ekstrudera i nacisnij pokretlo, aby go zaladowac."
+
+# 
+#: ultralcd.cpp:4899
+msgid "Please insert filament into the first tube of the MMU, then press the knob to load it."
+msgstr "Wsun filament do pierwszego kanalu w MMU2 i nacisnij pokretlo, aby go zaladowac."
+
+# 
+#: ultralcd.cpp:4821
+msgid "Please load filament first."
+msgstr "Najpierw zaladuj filament."
+
 # MSG_PRUSA3D
-#: ultralcd.cpp:2205
+#: ultralcd.cpp:2150
 msgid "prusa3d.com"
 msgstr ""
 
 # MSG_BED_CORRECTION_REAR c=14 r=1
-#: ultralcd.cpp:3295
+#: ultralcd.cpp:3245
 msgid "Rear side [um]"
 msgstr "Tyl [um]"
 
 # MSG_RECOVERING_PRINT c=20 r=1
-#: Marlin_main.cpp:9764
+#: Marlin_main.cpp:10826
 msgid "Recovering print    "
 msgstr "Wznawianie wydruku"
 
 # MSG_REMOVE_OLD_FILAMENT c=20 r=4
-#: mmu.cpp:830
+#: mmu.cpp:832
 msgid "Remove old filament and press the knob to start loading new filament."
 msgstr "Wyciagnij poprzedni filament i nacisnij pokretlo aby zaladowac nowy."
 
@@ -1101,712 +1051,642 @@ msgid "Prusa i3 MK3S OK."
 msgstr "Prusa i3 MK3S OK"
 
 # MSG_CALIBRATE_BED_RESET
-#: ultralcd.cpp:5774
+#: ultralcd.cpp:5844
 msgid "Reset XYZ calibr."
 msgstr "Reset kalibr. XYZ"
 
 # MSG_BED_CORRECTION_RESET
-#: ultralcd.cpp:3296
+#: ultralcd.cpp:3246
 msgid "Reset"
 msgstr ""
 
 # MSG_RESUME_PRINT
-#: ultralcd.cpp:6742
+#: ultralcd.cpp:6838
 msgid "Resume print"
 msgstr "Wznowic wydruk"
 
 # MSG_RESUMING_PRINT c=20 r=1
-#: messages.c:73
+#: messages.c:69
 msgid "Resuming print"
 msgstr "Wznawianie druku"
 
 # MSG_BED_CORRECTION_RIGHT c=14 r=1
-#: ultralcd.cpp:3293
+#: ultralcd.cpp:3243
 msgid "Right side[um]"
 msgstr "Prawo [um]"
 
-# MSG_SECOND_SERIAL_ON c=17 r=1
-#: ultralcd.cpp:5692
-msgid "RPi port     [on]"
-msgstr "Port RPi     [wl]"
-
-# MSG_SECOND_SERIAL_OFF c=17 r=1
-#: ultralcd.cpp:5690
-msgid "RPi port    [off]"
-msgstr "Port RPi    [wyl]"
+# MSG_RPI_PORT
+#: messages.c:123
+msgid "RPi port"
+msgstr "Port RPi"
 
 # MSG_WIZARD_RERUN c=20 r=7
-#: ultralcd.cpp:4812
+#: ultralcd.cpp:4842
 msgid "Running Wizard will delete current calibration results and start from the beginning. Continue?"
 msgstr "Wlaczenie Asystenta usunie obecne dane kalibracyjne i zacznie od poczatku. Kontynuowac?"
 
-# MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_OFF c=19 r=1
-#: ultralcd.cpp:5322
-msgid "SD card  [normal]"
-msgstr "Karta SD [normal]"
+# MSG_SD_CARD
+#: messages.c:118
+msgid "SD card"
+msgstr "Karta SD"
 
-# MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY_ON c=19 r=1
-#: ultralcd.cpp:5320
-msgid "SD card [flshAir]"
-msgstr "Karta SD[FlshAir]"
+# MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY
+#: messages.c:119
+msgid "FlashAir"
+msgstr ""
 
 # 
-#: ultralcd.cpp:3019
+#: ultralcd.cpp:2972
 msgid "Right"
 msgstr "Prawa"
 
 # MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=60
-#: messages.c:38
+#: messages.c:35
 msgid "Searching bed calibration point"
 msgstr "Szukam punktu kalibracyjnego na stole"
 
 # MSG_LANGUAGE_SELECT
-#: ultralcd.cpp:5699
+#: ultralcd.cpp:5756
 msgid "Select language"
 msgstr "Wybor jezyka"
 
 # MSG_SELFTEST_OK
-#: ultralcd.cpp:7452
+#: ultralcd.cpp:7784
 msgid "Self test OK"
 msgstr "Selftest OK"
 
 # MSG_SELFTEST_START c=20
-#: ultralcd.cpp:7238
+#: ultralcd.cpp:7558
 msgid "Self test start  "
 msgstr "Selftest startuje"
 
 # MSG_SELFTEST
-#: ultralcd.cpp:5750
+#: ultralcd.cpp:5820
 msgid "Selftest         "
 msgstr "Selftest "
 
 # MSG_SELFTEST_ERROR
-#: ultralcd.cpp:7879
+#: ultralcd.cpp:8216
 msgid "Selftest error !"
 msgstr "Blad selftest!"
 
 # MSG_SELFTEST_FAILED c=20
-#: messages.c:77
+#: messages.c:73
 msgid "Selftest failed  "
 msgstr "Selftest nieudany"
 
 # MSG_FORCE_SELFTEST c=20 r=8
-#: Marlin_main.cpp:1551
+#: Marlin_main.cpp:1532
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr "Zostanie uruchomiony Selftest aby dokladnie skalibrowac punkt bazowy bez krancowek"
 
 # 
-#: ultralcd.cpp:5045
+#: ultralcd.cpp:5080
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr "Wybierz temperature grzania dyszy odpowiednia dla materialu."
 
-# 
-#: ultralcd.cpp:4780
-msgid "Select PLA filament:"
-msgstr "Wybierz filament PLA:"
-
 # MSG_SET_TEMPERATURE c=19 r=1
-#: ultralcd.cpp:3314
+#: ultralcd.cpp:3264
 msgid "Set temperature:"
 msgstr "Ustaw temperature:"
 
 # MSG_SETTINGS
-#: messages.c:86
+#: messages.c:82
 msgid "Settings"
 msgstr "Ustawienia"
 
 # MSG_SHOW_END_STOPS c=17 r=1
-#: ultralcd.cpp:5771
+#: ultralcd.cpp:5841
 msgid "Show end stops"
 msgstr "Pokaz krancowki"
 
 # 
-#: ultralcd.cpp:4025
+#: ultralcd.cpp:3986
 msgid "Sensor state"
 msgstr "Stan czujnikow"
 
 # MSG_FILE_CNT c=20 r=4
-#: cardreader.cpp:739
+#: cardreader.cpp:729
 msgid "Some files will not be sorted. Max. No. of files in 1 folder for sorting is 100."
 msgstr "Niektore pliki nie zostana posortowane. Max. liczba plikow w 1 folderze = 100."
 
-# MSG_SORT_NONE c=17 r=1
-#: ultralcd.cpp:5332
-msgid "Sort       [none]"
-msgstr "Sortowanie [brak]"
+# MSG_SORT
+#: messages.c:120
+msgid "Sort"
+msgstr "Sortowanie"
 
-# MSG_SORT_TIME c=17 r=1
-#: ultralcd.cpp:5330
-msgid "Sort       [time]"
-msgstr "Sortowanie [czas]"
+# MSG_NONE
+#: messages.c:110
+msgid "None"
+msgstr "Brak"
+
+# MSG_SORT_TIME
+#: messages.c:121
+msgid "Time"
+msgstr "Czas"
 
 # 
-#: ultralcd.cpp:3062
+#: ultralcd.cpp:3015
 msgid "Severe skew:"
 msgstr "Znaczny skos:"
 
-# MSG_SORT_ALPHA c=17 r=1
-#: ultralcd.cpp:5331
-msgid "Sort   [alphabet]"
-msgstr "Sortowanie[alfab]"
+# MSG_SORT_ALPHA
+#: messages.c:122
+msgid "Alphabet"
+msgstr "Alfab"
 
 # MSG_SORTING c=20 r=1
-#: cardreader.cpp:746
+#: cardreader.cpp:736
 msgid "Sorting files"
 msgstr "Sortowanie plikow"
 
-# MSG_SOUND_LOUD c=17 r=1
-#: sound.h:6
-msgid "Sound      [loud]"
-msgstr "Dzwiek   [glosny]"
+# MSG_SOUND_LOUD
+#: messages.c:125
+msgid "Loud"
+msgstr "Glosny"
 
 # 
-#: ultralcd.cpp:3061
+#: ultralcd.cpp:3014
 msgid "Slight skew:"
 msgstr "Lekki skos:"
 
-# MSG_SOUND_MUTE c=17 r=1
-#: 
-msgid "Sound      [mute]"
-msgstr "Dzwiek[wylaczony]"
+# MSG_SOUND
+#: messages.c:124
+msgid "Sound"
+msgstr "Dzwiek"
 
 # 
-#: Marlin_main.cpp:4871
+#: Marlin_main.cpp:5084
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Wykryto problem, wymuszono poziomowanie osi Z."
 
-# MSG_SOUND_ONCE c=17 r=1
-#: sound.h:7
-msgid "Sound      [once]"
-msgstr "Dzwiek    [1-raz]"
-
-# MSG_SOUND_SILENT c=17 r=1
-#: sound.h:8
-msgid "Sound    [silent]"
-msgstr "Dzwiek    [cichy]"
-
 # MSG_SPEED
-#: ultralcd.cpp:6926
+#: ultralcd.cpp:7096
 msgid "Speed"
 msgstr "Predkosc"
 
 # MSG_SELFTEST_FAN_YES c=19
-#: messages.c:80
+#: messages.c:76
 msgid "Spinning"
 msgstr "Kreci sie"
 
 # MSG_TEMP_CAL_WARNING c=20 r=4
-#: Marlin_main.cpp:4368
+#: Marlin_main.cpp:4574
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr "Potrzebna jest stabilna temperatura otoczenia 21-26C i stabilne podloze."
 
 # MSG_STATISTICS
-#: ultralcd.cpp:6839
+#: ultralcd.cpp:6955
 msgid "Statistics  "
 msgstr "Statystyki"
 
 # MSG_STOP_PRINT
-#: messages.c:93
+#: messages.c:91
 msgid "Stop print"
 msgstr "Przerwanie druku"
 
 # MSG_STOPPED
-#: messages.c:94
+#: messages.c:92
 msgid "STOPPED. "
 msgstr "ZATRZYMANO."
 
 # MSG_SUPPORT
-#: ultralcd.cpp:6848
+#: ultralcd.cpp:6964
 msgid "Support"
 msgstr "Wsparcie"
 
 # MSG_SELFTEST_SWAPPED
-#: ultralcd.cpp:7959
+#: ultralcd.cpp:8296
 msgid "Swapped"
 msgstr "Zamieniono"
 
-# MSG_TEMP_CALIBRATION c=20 r=1
-#: messages.c:95
-msgid "Temp. cal.          "
+# 
+#: ultralcd.cpp:4792
+msgid "Select filament:"
+msgstr "Wybierz filament:"
+
+# MSG_TEMP_CALIBRATION c=12 r=1
+#: messages.c:93
+msgid "Temp. cal."
 msgstr "Kalibracja temp."
 
-# MSG_TEMP_CALIBRATION_ON c=20 r=1
-#: ultralcd.cpp:5686
-msgid "Temp. cal.   [on]"
-msgstr "Kalibr.temp. [wl]"
-
-# MSG_TEMP_CALIBRATION_OFF c=20 r=1
-#: ultralcd.cpp:5684
-msgid "Temp. cal.  [off]"
-msgstr "Kalibr.temp.[wyl]"
+# 
+#: ultralcd.cpp:4933
+msgid "Select temperature which matches your material."
+msgstr "Wybierz temperature, ktora odpowiada Twojemu filamentowi."
 
 # MSG_CALIBRATION_PINDA_MENU c=17 r=1
-#: ultralcd.cpp:5780
+#: ultralcd.cpp:5850
 msgid "Temp. calibration"
 msgstr "Kalibracja temp."
 
 # MSG_TEMP_CAL_FAILED c=20 r=8
-#: ultralcd.cpp:3951
+#: ultralcd.cpp:3911
 msgid "Temperature calibration failed"
 msgstr "Kalibracja temperaturowa nieudana"
 
 # MSG_TEMP_CALIBRATION_DONE c=20 r=12
-#: messages.c:96
+#: messages.c:94
 msgid "Temperature calibration is finished and active. Temp. calibration can be disabled in menu Settings->Temp. cal."
 msgstr "Kalibracja temperaturowa zakonczona i wlaczona. Moze byc wylaczona z menu Ustawienia -> Kalibracja temp."
 
 # MSG_TEMPERATURE
-#: ultralcd.cpp:5650
+#: ultralcd.cpp:5716
 msgid "Temperature"
 msgstr "Temperatura"
 
 # MSG_MENU_TEMPERATURES c=15 r=1
-#: ultralcd.cpp:2251
+#: ultralcd.cpp:2196
 msgid "Temperatures"
 msgstr "Temperatury"
 
 # MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=4
-#: messages.c:42
+#: messages.c:39
 msgid "There is still a need to make Z calibration. Please follow the manual, chapter First steps, section Calibration flow."
 msgstr "Musimy przeprowadzic kalibracje Z. Kieruj sie Samouczkiem: rozdzial Pierwsze Kroki, sekcja Kalibracja."
 
 # 
-#: ultralcd.cpp:2908
+#: ultralcd.cpp:2869
 msgid "Total filament"
 msgstr "Zuzycie filamentu"
 
 # 
-#: ultralcd.cpp:2908
+#: ultralcd.cpp:2870
 msgid "Total print time"
 msgstr "Laczny czas druku"
 
 # MSG_TUNE
-#: ultralcd.cpp:6719
+#: ultralcd.cpp:6827
 msgid "Tune"
 msgstr "Strojenie"
 
 # 
-#: ultralcd.cpp:4869
+#: 
 msgid "Unload"
 msgstr "Rozladuj"
 
 # 
-#: ultralcd.cpp:1820
+#: ultralcd.cpp:1743
 msgid "Total failures"
 msgstr "Suma bledow"
 
 # 
-#: ultralcd.cpp:2324
+#: ultralcd.cpp:2274
 msgid "to load filament"
 msgstr "aby zaladow. fil."
 
 # 
-#: ultralcd.cpp:2328
+#: ultralcd.cpp:2278
 msgid "to unload filament"
 msgstr "aby rozlad. filament"
 
 # MSG_UNLOAD_FILAMENT c=17
-#: messages.c:97
+#: messages.c:95
 msgid "Unload filament"
 msgstr "Rozladowanie fil."
 
 # MSG_UNLOADING_FILAMENT c=20 r=1
-#: messages.c:98
+#: messages.c:96
 msgid "Unloading filament"
 msgstr "Rozladowuje filament"
 
 # 
-#: ultralcd.cpp:1773
+#: ultralcd.cpp:1696
 msgid "Total"
 msgstr "Suma"
 
 # MSG_USED c=19 r=1
-#: ultralcd.cpp:5908
+#: ultralcd.cpp:5978
 msgid "Used during print"
 msgstr "Uzyte podczas druku"
 
 # MSG_MENU_VOLTAGES c=15 r=1
-#: ultralcd.cpp:2254
+#: ultralcd.cpp:2199
 msgid "Voltages"
 msgstr "Napiecia"
 
 # 
-#: ultralcd.cpp:2227
+#: ultralcd.cpp:2172
 msgid "unknown"
 msgstr "nieznane"
 
 # MSG_USERWAIT
-#: Marlin_main.cpp:5263
+#: Marlin_main.cpp:5496
 msgid "Wait for user..."
 msgstr "Czekam na uzytkownika..."
 
 # MSG_WAITING_TEMP c=20 r=3
-#: ultralcd.cpp:3458
+#: ultralcd.cpp:3412
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Oczekiwanie na wychlodzenie dyszy i stolu"
 
 # MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ultralcd.cpp:3422
+#: ultralcd.cpp:3373
 msgid "Waiting for PINDA probe cooling"
 msgstr "Czekam az spadnie temp. sondy PINDA"
 
 # 
-#: ultralcd.cpp:4868
+#: 
 msgid "Use unload to remove filament 1 if it protrudes outside of the rear MMU tube. Use eject if it is hidden in tube."
 msgstr "Uzyj opcji Rozladuj jesli filament wystaje z tylnej rurki MMU. Uzyj opcji Wysun jesli wciaz jest w srodku."
 
 # MSG_CHANGED_BOTH c=20 r=4
-#: Marlin_main.cpp:1511
+#: Marlin_main.cpp:1492
 msgid "Warning: both printer type and motherboard type changed."
 msgstr "Ostrzezenie: typ drukarki i plyta glowna ulegly zmianie."
 
 # MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: Marlin_main.cpp:1503
+#: Marlin_main.cpp:1484
 msgid "Warning: motherboard type changed."
 msgstr "Ostrzezenie: plyta glowna ulegla zmianie."
 
 # MSG_CHANGED_PRINTER c=20 r=4
-#: Marlin_main.cpp:1507
+#: Marlin_main.cpp:1488
 msgid "Warning: printer type changed."
 msgstr "Ostrzezenie: rodzaj drukarki ulegl zmianie"
 
 # MSG_UNLOAD_SUCCESSFUL c=20 r=2
-#: Marlin_main.cpp:3054
+#: Marlin_main.cpp:3106
 msgid "Was filament unload successful?"
 msgstr "Rozladowanie fil. ok?"
 
 # MSG_SELFTEST_WIRINGERROR
-#: messages.c:85
+#: messages.c:81
 msgid "Wiring error"
 msgstr "Blad polaczenia"
 
 # MSG_WIZARD c=17 r=1
-#: ultralcd.cpp:5747
+#: ultralcd.cpp:5811
 msgid "Wizard"
 msgstr "Asystent"
 
 # MSG_XYZ_DETAILS c=19 r=1
-#: ultralcd.cpp:2243
+#: ultralcd.cpp:2188
 msgid "XYZ cal. details"
 msgstr "Szczegoly kal. XYZ"
 
 # MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: messages.c:19
+#: messages.c:18
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "Kalibracja XYZ nieudana. Sprawdz przyczyny i rozwiazania w instrukcji."
 
 # MSG_YES
-#: messages.c:104
+#: messages.c:102
 msgid "Yes"
 msgstr "Tak"
 
 # MSG_WIZARD_QUIT c=20 r=8
-#: messages.c:103
+#: messages.c:101
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr "Zawsze mozesz uruchomic Asystenta ponownie przez Kalibracja -> Asystent."
 
 # MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ultralcd.cpp:3922
+#: ultralcd.cpp:3882
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr "Kalibracja XYZ pomyslna. Skos bedzie automatycznie korygowany."
 
 # MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ultralcd.cpp:3919
+#: ultralcd.cpp:3879
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr "Kalibracja XYZ prawidlowa. Osie X/Y lekko skosne. Dobra robota!"
 
 # 
-#: ultralcd.cpp:5130
+#: ultralcd.cpp:5168
 msgid "X-correct:"
 msgstr "Korekcja-X:"
 
 # MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ultralcd.cpp:3916
+#: ultralcd.cpp:3876
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "Kalibracja XYZ ok. Osie X/Y sa prostopadle. Gratulacje!"
 
 # MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ultralcd.cpp:3900
+#: ultralcd.cpp:3860
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr "Kalibr. XYZ niedokladna. Przednie punkty kalibr. nieosiagalne."
 
 # MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ultralcd.cpp:3903
+#: ultralcd.cpp:3863
 msgid "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr "Kalibracja XYZ niedokladna. Prawy przedni punkt nieosiagalny."
 
 # MSG_LOAD_ALL c=17
-#: ultralcd.cpp:6166
+#: ultralcd.cpp:6238
 msgid "Load all"
 msgstr "Zalad. wszystkie"
 
 # 
-#: ultralcd.cpp:3882
+#: ultralcd.cpp:3842
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr "Kalibracja XYZ nieudana. Nie znaleziono punktow kalibracyjnych."
 
 # 
-#: ultralcd.cpp:3888
+#: ultralcd.cpp:3848
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr "Kalibr. XYZ nieudana. Przednie punkty kalibr. nieosiagalne. Nalezy poprawic montaz drukarki."
 
 # 
-#: ultralcd.cpp:3891
+#: ultralcd.cpp:3851
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr "Kalibr. XYZ nieudana. Prawy przedni punkt nieosiagalny. Nalezy poprawic montaz drukarki."
 
 # 
-#: ultralcd.cpp:3016
+#: ultralcd.cpp:2969
 msgid "Y distance from min"
 msgstr "Dystans od 0 w osi Y"
 
 # 
-#: ultralcd.cpp:5131
+#: ultralcd.cpp:4936
+msgid "The printer will start printing a zig-zag line. Rotate the knob until you reach the optimal height. Check the pictures in the handbook (Calibration chapter)."
+msgstr "Drukarka zacznie drukowanie linii w ksztalcie zygzaka. Ustaw optymalna wysokosc obracajac pokretlo. Porownaj z ilustracjami w Podreczniku (rozdzial Kalibracja)."
+
+# 
+#: ultralcd.cpp:5169
 msgid "Y-correct:"
 msgstr "Korekcja-Y:"
 
 # MSG_OFF
-#: menu.cpp:426
-msgid " [off]"
-msgstr " [wyl]"
+#: messages.c:105
+msgid "Off"
+msgstr "Wyl"
+
+# MSG_ON
+#: messages.c:106
+msgid "On"
+msgstr "Wl"
 
 # 
-#: messages.c:57
+#: messages.c:53
 msgid "Back"
 msgstr "Wstecz"
 
 # 
-#: ultralcd.cpp:5639
+#: ultralcd.cpp:5702
 msgid "Checks"
 msgstr "Testy"
 
 # 
-#: ultralcd.cpp:7973
+#: ultralcd.cpp:8310
 msgid "False triggering"
 msgstr "Falszywy alarm"
 
 # 
-#: ultralcd.cpp:4030
+#: ultralcd.cpp:3991
 msgid "FINDA:"
 msgstr ""
 
-# 
-#: ultralcd.cpp:5545
-msgid "Firmware   [none]"
-msgstr "Firmware   [brak]"
+# MSG_FIRMWARE
+#: language.h:21
+msgid "Firmware"
+msgstr ""
+
+# MSG_STRICT
+#: messages.c:112
+msgid "Strict"
+msgstr "Restr."
+
+# MSG_WARN
+#: messages.c:111
+msgid "Warn"
+msgstr "Ostrzez"
 
 # 
-#: ultralcd.cpp:5551
-msgid "Firmware [strict]"
-msgstr "Firmware [restr.]"
-
-# 
-#: ultralcd.cpp:5548
-msgid "Firmware   [warn]"
-msgstr "Firmware[ostrzez]"
-
-# 
-#: messages.c:87
+#: messages.c:83
 msgid "HW Setup"
 msgstr "Ustawienia HW"
 
 # 
-#: ultralcd.cpp:4034
+#: ultralcd.cpp:3995
 msgid "IR:"
 msgstr ""
 
-# 
-#: ultralcd.cpp:7046
-msgid "Magnets comp.[N/A]"
-msgstr "Kor. magnesow[N/D]"
+# MSG_MAGNETS_COMP
+#: messages.c:130
+msgid "Magnets comp."
+msgstr "Kor. magnesow"
+
+# MSG_MESH
+#: messages.c:128
+msgid "Mesh"
+msgstr "Siatka"
 
 # 
-#: ultralcd.cpp:7044
-msgid "Magnets comp.[Off]"
-msgstr "Kor. magnesow[wyl]"
-
-# 
-#: ultralcd.cpp:7043
-msgid "Magnets comp. [On]"
-msgstr "Kor. magnesow [wl]"
-
-# 
-#: ultralcd.cpp:7035
-msgid "Mesh         [3x3]"
-msgstr "Siatka       [3x3]"
-
-# 
-#: ultralcd.cpp:7036
-msgid "Mesh         [7x7]"
-msgstr "Siatka       [7x7]"
-
-# 
-#: ultralcd.cpp:5677
+#: ultralcd.cpp:5740
 msgid "Mesh bed leveling"
 msgstr "Poziomowanie stolu"
 
 # 
-#: Marlin_main.cpp:856
+#: Marlin_main.cpp:861
 msgid "MK3S firmware detected on MK3 printer"
 msgstr "Wykryto firmware MK3S w drukarce MK3"
 
-# 
-#: ultralcd.cpp:5306
-msgid "MMU Mode [Normal]"
-msgstr "Tryb MMU[Normaln]"
+# MSG_MMU_MODE
+#: messages.c:117
+msgid "MMU Mode"
+msgstr "Tryb MMU"
 
 # 
-#: ultralcd.cpp:5307
-msgid "MMU Mode[Stealth]"
-msgstr "Tryb MMU[Stealth]"
-
-# 
-#: ultralcd.cpp:4511
+#: ultralcd.cpp:4472
 msgid "Mode change in progress ..."
 msgstr "Trwa zmiana trybu..."
 
-# 
-#: ultralcd.cpp:5506
-msgid "Model      [none]"
-msgstr "Model      [brak]"
+# MSG_MODEL
+#: messages.c:113
+msgid "Model"
+msgstr ""
+
+# MSG_NOZZLE_DIAMETER
+#: messages.c:116
+msgid "Nozzle d."
+msgstr "Sr. dyszy"
 
 # 
-#: ultralcd.cpp:5512
-msgid "Model    [strict]"
-msgstr "Model [restrykc.]"
-
-# 
-#: ultralcd.cpp:5509
-msgid "Model      [warn]"
-msgstr "Model  [ostrzez.]"
-
-# 
-#: ultralcd.cpp:5467
-msgid "Nozzle d.  [0.25]"
-msgstr "Sr. dyszy  [0,25]"
-
-# 
-#: ultralcd.cpp:5470
-msgid "Nozzle d.  [0.40]"
-msgstr "Sr. dyszy  [0,40]"
-
-# 
-#: ultralcd.cpp:5473
-msgid "Nozzle d.  [0.60]"
-msgstr "Sr. dyszy  [0,60]"
-
-# 
-#: ultralcd.cpp:5421
-msgid "Nozzle     [none]"
-msgstr "Dysza      [brak]"
-
-# 
-#: ultralcd.cpp:5427
-msgid "Nozzle   [strict]"
-msgstr "Dysza [restrykc.]"
-
-# 
-#: ultralcd.cpp:5424
-msgid "Nozzle     [warn]"
-msgstr "Dysza  [ostrzez.]"
-
-# 
-#: util.cpp:510
+#: util.cpp:514
 msgid "G-code sliced for a different level. Continue?"
 msgstr ""
 
 # 
-#: util.cpp:516
+#: util.cpp:520
 msgid "G-code sliced for a different level. Please re-slice the model again. Print cancelled."
 msgstr "G-code pociety na innym poziomie. Potnij model ponownie. Druk anulowany."
 
 # 
-#: util.cpp:427
+#: util.cpp:431
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr "G-code pociety dla innej drukarki. Kontynuowac?"
 
 # 
-#: util.cpp:433
+#: util.cpp:437
 msgid "G-code sliced for a different printer type. Please re-slice the model again. Print cancelled."
 msgstr "G-code pociety dla drukarki innego typu. Potnij model ponownie. Druk anulowany."
 
 # 
-#: util.cpp:477
+#: util.cpp:481
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "G-code pociety dla nowszego firmware. Kontynuowac?"
 
 # 
-#: util.cpp:483
+#: util.cpp:487
 msgid "G-code sliced for a newer firmware. Please update the firmware. Print cancelled."
 msgstr "G-code pociety dla nowszego firmware. Zaktualizuj firmware. Druk anulowany."
 
 # 
-#: ultralcd.cpp:4026
+#: ultralcd.cpp:3987
 msgid "PINDA:"
 msgstr ""
 
 # 
-#: ultralcd.cpp:2465
+#: ultralcd.cpp:2430
 msgid "Preheating to cut"
 msgstr "Nagrzewanie do obciecia"
 
 # 
-#: ultralcd.cpp:2462
+#: ultralcd.cpp:2427
 msgid "Preheating to eject"
 msgstr "Nagrzewanie do wysuniecia"
 
 # 
-#: util.cpp:390
+#: util.cpp:394
 msgid "Printer nozzle diameter differs from the G-code. Continue?"
 msgstr "Srednica dyszy drukarki rozni sie od tej w G-code. Kontynuowac?"
 
 # 
-#: util.cpp:397
+#: util.cpp:401
 msgid "Printer nozzle diameter differs from the G-code. Please check the value in settings. Print cancelled."
 msgstr "Srednica dyszy rozni sie od tej w G-code. Sprawdz ustawienia. Druk anulowany."
 
 # 
-#: ultralcd.cpp:6683
+#: ultralcd.cpp:6791
 msgid "Rename"
 msgstr "Zmien nazwe"
 
 # 
-#: ultralcd.cpp:6679
+#: ultralcd.cpp:6784
 msgid "Select"
 msgstr "Wybierz"
 
 # 
-#: ultralcd.cpp:2245
+#: ultralcd.cpp:2190
 msgid "Sensor info"
 msgstr "Info o sensorach"
 
 # 
-#: messages.c:58
+#: messages.c:54
 msgid "Sheet"
 msgstr "Plyta"
 
-# 
-#: sound.h:9
-msgid "Sound    [assist]"
-msgstr "Dzwiek   [asyst.]"
+# MSG_SOUND_BLIND
+#: messages.c:127
+msgid "Assist"
+msgstr "Asyst."
 
 # 
-#: ultralcd.cpp:5637
+#: ultralcd.cpp:5700
 msgid "Steel sheets"
 msgstr "Plyty stalowe"
 
 # 
-#: ultralcd.cpp:5132
+#: ultralcd.cpp:5170
 msgid "Z-correct:"
 msgstr "Korekcja-Z:"
-
-# 
-#: ultralcd.cpp:7038
-msgid "Z-probe nr.    [1]"
-msgstr "Ilosc Pomiarow [1]"
-
-# 
-#: ultralcd.cpp:7040
-msgid "Z-probe nr.    [3]"
-msgstr "Ilosc Pomiarow [3]"
 


### PR DESCRIPTION
#### Issue
Some EEPROM values are uint16 but have been read/displayed in LCD Fail Statistics as uint8 or limited to 000-999
This could cause strange results on display.
- EEPROM_MMU_FAIL_TOT is uint16 but it was read as uint8
- EEPROM_MMU_LOAD_FAIL_TOT is uint16 but it was read as uint8

Other values have been read correctly BUT limited to 000-999 on display.

#### Changes
Due to the limited LCD space I had to shorten few messages.

Also updated the `c=xx r=yy` information in the `lang_en.txt / lang_en_??.txt` files so translators know what the message limit is.

By using an existing `MSG_FSENSOR` instead of several `Fil. sensor` I could save 28bytes of program storage space.
It doesn't sound a lot, but by removing these "duplicate" messages from the `lang_en.txt/lang_en_??.txt` also the needed "2nd language" space got smaller and could save additional space on the internal flash.

So by re-using the MSG_FESNSOR we kind of saved ~ 28*2 bytes

#### Test
Tested the LCD changes with and without the MMU2 connected and used `D3` Dcode to manipulate the output on the display.

#### To-do
Maybe translators need to review the `lang_en_??.txt`files to ensure that the translation isn't too long.
With the `c=xx r=yy` they should now know the limit.

#### Known issue
Some Statistics are really at the 20x4 limit and may be hard to read, but I tried my best to keep them similar and readable.