### PR TITLE
Fix chained wipes in Linear Advance 1.5

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -7116,7 +7116,6 @@ Sigma_Exit:
       {
           float e = code_value();
 #ifndef LA_NOCOMPAT
-
           e = la10c_jerk(e);
 #endif
           cs.max_jerk[E_AXIS] = e;

--- a/Firmware/planner.cpp
+++ b/Firmware/planner.cpp
@@ -1065,10 +1065,12 @@ Having the real displacement of the head, we can calculate the total movement le
      * delta_mm[E_AXIS] >= 0    : Extruding or traveling, but _not_ retracting.
      * |delta_mm[Z_AXIS]| < 0.5 : Z is only moved for leveling (_not_ for priming)
      */
-    block->use_advance_lead = extruder_advance_K
+    block->use_advance_lead = extruder_advance_K > 0
                               && delta_mm[E_AXIS] >= 0
                               && abs(delta_mm[Z_AXIS]) < 0.5;
     if (block->use_advance_lead) {
+        // all extrusion moves with LA require a compression which is proportional to the
+        // extrusion_length to distance ratio (e/D)
         e_D_ratio = (e - position_float[E_AXIS]) /
                     sqrt(sq(x - position_float[X_AXIS])
                          + sq(y - position_float[Y_AXIS])

--- a/Firmware/planner.cpp
+++ b/Firmware/planner.cpp
@@ -1061,14 +1061,12 @@ Having the real displacement of the head, we can calculate the total movement le
     /**
      * Use LIN_ADVANCE within this block if all these are true:
      *
-     * block->steps_e           : This is a print move, because we checked for X, Y, Z steps before.
      * extruder_advance_K       : There is an advance factor set.
-     * delta_mm[E_AXIS] > 0     : Extruder is running forward (e.g., for "Wipe while retracting" (Slic3r) or "Combing" (Cura) moves)
+     * delta_mm[E_AXIS] >= 0    : Extruding or traveling, but _not_ retracting.
      * |delta_mm[Z_AXIS]| < 0.5 : Z is only moved for leveling (_not_ for priming)
      */
-    block->use_advance_lead = block->steps_e.wide
-                              && extruder_advance_K
-                              && delta_mm[E_AXIS] > 0
+    block->use_advance_lead = extruder_advance_K
+                              && delta_mm[E_AXIS] >= 0
                               && abs(delta_mm[Z_AXIS]) < 0.5;
     if (block->use_advance_lead) {
         e_D_ratio = (e - position_float[E_AXIS]) /
@@ -1082,7 +1080,7 @@ Having the real displacement of the head, we can calculate the total movement le
         // 100mm wide lines using 3mm filament or 35mm wide lines using 1.75mm filament.
         if (e_D_ratio > 3.0)
             block->use_advance_lead = false;
-        else {
+        else if (e_D_ratio > 0) {
             const uint32_t max_accel_steps_per_s2 = cs.max_jerk[E_AXIS] / (extruder_advance_K * e_D_ratio) * steps_per_mm;
             if (block->acceleration_st > max_accel_steps_per_s2) {
                 block->acceleration_st = max_accel_steps_per_s2;
@@ -1133,9 +1131,14 @@ Having the real displacement of the head, we can calculate the total movement le
       block->adv_comp = extruder_advance_K * e_D_ratio * cs.axis_steps_per_unit[E_AXIS];
       block->max_adv_steps = block->nominal_speed * block->adv_comp;
 
+      float advance_speed;
+      if (e_D_ratio > 0)
+          advance_speed = (extruder_advance_K * e_D_ratio * block->acceleration * cs.axis_steps_per_unit[E_AXIS]);
+      else
+          advance_speed = cs.max_jerk[E_AXIS] * cs.axis_steps_per_unit[E_AXIS];
+
       // to save more space we avoid another copy of calc_timer and go through slow division, but we
       // still need to replicate the *exact* same step grouping policy (see below)
-      float advance_speed = (extruder_advance_K * e_D_ratio * block->acceleration * cs.axis_steps_per_unit[E_AXIS]);
       if (advance_speed > MAX_STEP_FREQUENCY) advance_speed = MAX_STEP_FREQUENCY;
       float advance_rate = (F_CPU / 8.0) / advance_speed;
       if (advance_speed > 20000) {

--- a/Firmware/planner.cpp
+++ b/Firmware/planner.cpp
@@ -1081,9 +1081,9 @@ Having the real displacement of the head, we can calculate the total movement le
         if (e_D_ratio > 3.0)
             block->use_advance_lead = false;
         else if (e_D_ratio > 0) {
-            const uint32_t max_accel_steps_per_s2 = cs.max_jerk[E_AXIS] / (extruder_advance_K * e_D_ratio) * steps_per_mm;
-            if (block->acceleration_st > max_accel_steps_per_s2) {
-                block->acceleration_st = max_accel_steps_per_s2;
+            const float max_accel_per_s2 = cs.max_jerk[E_AXIS] / (extruder_advance_K * e_D_ratio);
+            if (cs.acceleration > max_accel_per_s2) {
+                block->acceleration_st = ceil(max_accel_per_s2 * steps_per_mm);
                 #ifdef LA_DEBUG
                 SERIAL_ECHOLNPGM("LA: Block acceleration limited due to max E-jerk");
                 #endif

--- a/Firmware/stepper.cpp
+++ b/Firmware/stepper.cpp
@@ -354,10 +354,10 @@ FORCE_INLINE void stepper_next_block()
         max_adv_steps = current_block->max_adv_steps;
         e_step_loops = current_block->advance_step_loops;
     } else {
-        e_steps = 0;
         e_step_loops = 1;
         current_adv_steps = 0;
     }
+    e_steps = 0;
     nextAdvanceISR = ADV_NEVER;
     LA_phase = -1;
 #endif


### PR DESCRIPTION
LA assumes all the nozzle pressure is released at the end of each
extrusion, which makes calculating the required pressure advance during
travels and retracts not normally necessary.

This is not always true in our planner, since the E axis is explicitly
ignored when not in use, but also due to E-jerk allowing a non-linear
jump in speed. And since the compression factor is currently tied by XYZ
axes and not independently calculated, this can result in a wrong
estimation of final pressure in several conditions.

In this PR we change the underlying assumptions about pressure:

1) Pressure is no longer lost when LA is disabled: if a retract is
followed by an unretract of the same length, the pressure will be likely
maintained entirely. This also holds true during travels, as long as the
retract length can overcome all the backpressure (which is the case in
all but the most noodly materials)

2) Pressure is released as soon as possible during travels: we now
enable LA also during travels, but under the sole condition of undoing
excess pressure.

If a wipe (or more generally, any travel) has been chained to an extrusion
move, the cruising phase will now also release any excess pressure so
that the subsequent extrusion re-starts from an ideal zero as previously
assumed in 1). This will reduce the amount of ooze during the wipe, but
most importantly avoids a small-but-constant build-up of material after
the travel if the wipe couldn't effectively lose the pressure in the first place.

This hopefully addresses #2543 

We also address the related issues #2570 and (partially) #2566. We now check
for zero e/D ratio as a special flag to handle wipes, which always avoids a 0
at the denominator. We also perform the acceleration limiting one step
earlier to avoid 32bit overflow, which did incorrectly limit low-compression
segments.

PFW-1105