### PR TITLE
MK2.x: move away from endstops after lcd_selfcheck_pulleys()

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -7705,8 +7705,8 @@ bool lcd_selftest()
 
 		//homeaxis(X_AXIS);
 		//homeaxis(Y_AXIS);
-        current_position[X_AXIS] += pgm_read_float(bed_ref_points_4);
-		current_position[Y_AXIS] += pgm_read_float(bed_ref_points_4+1);
+        current_position[X_AXIS] = pgm_read_float(bed_ref_points_4);
+		current_position[Y_AXIS] = pgm_read_float(bed_ref_points_4+1);
 #ifdef TMC2130
 		//current_position[X_AXIS] += 0;
 		current_position[Y_AXIS] += 4;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -7446,30 +7446,28 @@ void lcd_belttest()
     uint16_t   X = eeprom_read_word((uint16_t*)(EEPROM_BELTSTATUS_X));
     uint16_t   Y = eeprom_read_word((uint16_t*)(EEPROM_BELTSTATUS_Y));
 	lcd_puts_at_P(0,0,_i("Checking X axis  ")); // share message with selftest
-	lcd_set_cursor(0,1), lcd_printf_P(PSTR("X: %d "),X);
+	lcd_set_cursor(0,1), lcd_printf_P(PSTR("X: %d -> ..."),X);
     KEEPALIVE_STATE(IN_HANDLER);
     
 	// N.B: it doesn't make sense to handle !lcd_selfcheck...() because selftest_sg throws its own error screen
 	// that clobbers ours, with more info than we could provide. So on fail we just fall through to take us back to status.
     if (lcd_selfcheck_axis_sg(X_AXIS)){
 		X = eeprom_read_word((uint16_t*)(EEPROM_BELTSTATUS_X));
-		lcd_printf_P(PSTR("-> %d"),X); // Show new X value next to old one.
+		lcd_set_cursor(9,1), lcd_printf_P(PSTR("%d"),X); // Show new X value next to old one.
         lcd_puts_at_P(0,2,_i("Checking Y axis  "));
-		lcd_set_cursor(0,3), lcd_printf_P(PSTR("Y: %d "),Y);
+		lcd_set_cursor(0,3), lcd_printf_P(PSTR("Y: %d -> ..."),Y);
 		if (lcd_selfcheck_axis_sg(Y_AXIS))
 		{
 			Y = eeprom_read_word((uint16_t*)(EEPROM_BELTSTATUS_Y));
-			lcd_printf_P(PSTR("-> %d"),Y);
-			lcd_set_custom_characters_nextpage();
+			lcd_set_cursor(9,3),lcd_printf_P(PSTR("%d"),Y);
 			lcd_set_cursor(19, 3);
-			lcd_print(char(2));
+			lcd_print(LCD_STR_UPLEVEL);
 			lcd_wait_for_click_delay(10);
 		}
     }
 	
 	FORCE_HIGH_POWER_END;
     KEEPALIVE_STATE(NOT_BUSY);
-	lcd_set_custom_characters(); // restore status screen chars.
 }
 #endif //TMC2130
 

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -7832,7 +7832,7 @@ bool lcd_selftest()
 
 static void reset_crash_det(unsigned char axis) {
 	current_position[axis] += 10;
-	plan_buffer_line_curposXYZE(homing_feedrate[axis] / 60, active_extruder);
+	plan_buffer_line_curposXYZE(manual_feedrate[0] / 60, active_extruder);
 	st_synchronize();
 	if (eeprom_read_byte((uint8_t*)EEPROM_CRASH_DET)) tmc2130_sg_stop_on_crash = true;
 }
@@ -7861,7 +7861,7 @@ static bool lcd_selfcheck_axis_sg(unsigned char axis) {
 // first axis length measurement begin	
 	
 	current_position[axis] -= (axis_length + margin);
-	plan_buffer_line_curposXYZE(homing_feedrate[axis] / 60, active_extruder);
+	plan_buffer_line_curposXYZE(manual_feedrate[0] / 60, active_extruder);
 
 	
 	st_synchronize();
@@ -7871,11 +7871,11 @@ static bool lcd_selfcheck_axis_sg(unsigned char axis) {
 	current_position_init = st_get_position_mm(axis);
 
 	current_position[axis] += 2 * margin;
-	plan_buffer_line_curposXYZE(homing_feedrate[axis]  / 60, active_extruder);
+	plan_buffer_line_curposXYZE(manual_feedrate[0] / 60, active_extruder);
 	st_synchronize();
 
 	current_position[axis] += axis_length;
-	plan_buffer_line_curposXYZE(homing_feedrate[axis]  / 60, active_extruder);
+	plan_buffer_line_curposXYZE(hmanual_feedrate[0] / 60, active_extruder);
 
 	st_synchronize();
 
@@ -7891,11 +7891,11 @@ static bool lcd_selfcheck_axis_sg(unsigned char axis) {
 
 
 	current_position[axis] -= margin;
-	plan_buffer_line_curposXYZE(homing_feedrate[axis]  / 60, active_extruder);
+	plan_buffer_line_curposXYZE(manual_feedrate[0]  / 60, active_extruder);
 	st_synchronize();	
 
 	current_position[axis] -= (axis_length + margin);
-	plan_buffer_line_curposXYZE(homing_feedrate[axis]  / 60, active_extruder);
+	plan_buffer_line_curposXYZE(manual_feedrate[0]  / 60, active_extruder);
 		
 	st_synchronize();
 

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -8114,6 +8114,9 @@ static bool lcd_selfcheck_pulleys(int axis)
 			((READ(Y_MIN_PIN) ^ Y_MIN_ENDSTOP_INVERTING) == 1)) {
 			endstop_triggered = true;
 			if (current_position_init - 1 <= current_position[axis] && current_position_init + 1 >= current_position[axis]) {
+				current_position[axis] += 10;
+				plan_buffer_line_curposXYZE(manual_feedrate[0] / 60, active_extruder);
+				st_synchronize();
 				return(true);
 			}
 			else {

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -7797,9 +7797,7 @@ static bool lcd_selfcheck_axis_sg(unsigned char axis) {
 	enable_endstops(true);
 
 	if (axis == X_AXIS) { //there is collision between cables and PSU cover in X axis if Z coordinate is too low
-		
-		current_position[Z_AXIS] += 17;
-		plan_buffer_line_curposXYZE(manual_feedrate[0] / 60, active_extruder);
+		raise_z_above(17,true);
 		tmc2130_home_enter(Z_AXIS_MASK);
 		st_synchronize();
 		tmc2130_home_exit();

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -7476,21 +7476,21 @@ void lcd_belttest()
     
     uint16_t   X = eeprom_read_word((uint16_t*)(EEPROM_BELTSTATUS_X));
     uint16_t   Y = eeprom_read_word((uint16_t*)(EEPROM_BELTSTATUS_Y));
-	lcd_puts_at_P(0,0,_i("Checking X axis  ")); // share message with selftest
-	lcd_set_cursor(0,1), lcd_printf_P(PSTR("X: %d -> ..."),X);
+	lcd_printf_P(_i("Checking X axis  ")); // share message with selftest
+	lcd_set_cursor(0,1), lcd_printf_P(PSTR("X: %u -> ..."),X);
     KEEPALIVE_STATE(IN_HANDLER);
     
 	// N.B: it doesn't make sense to handle !lcd_selfcheck...() because selftest_sg throws its own error screen
 	// that clobbers ours, with more info than we could provide. So on fail we just fall through to take us back to status.
     if (lcd_selfcheck_axis_sg(X_AXIS)){
 		X = eeprom_read_word((uint16_t*)(EEPROM_BELTSTATUS_X));
-		lcd_set_cursor(9,1), lcd_printf_P(PSTR("%d"),X); // Show new X value next to old one.
+		lcd_set_cursor(10,1), lcd_printf_P(PSTR("%u"),X); // Show new X value next to old one.
         lcd_puts_at_P(0,2,_i("Checking Y axis  "));
-		lcd_set_cursor(0,3), lcd_printf_P(PSTR("Y: %d -> ..."),Y);
+		lcd_set_cursor(0,3), lcd_printf_P(PSTR("Y: %u -> ..."),Y);
 		if (lcd_selfcheck_axis_sg(Y_AXIS))
 		{
 			Y = eeprom_read_word((uint16_t*)(EEPROM_BELTSTATUS_Y));
-			lcd_set_cursor(9,3),lcd_printf_P(PSTR("%d"),Y);
+			lcd_set_cursor(10,3),lcd_printf_P(PSTR("%u"),Y);
 			lcd_set_cursor(19, 3);
 			lcd_print(LCD_STR_UPLEVEL);
 			lcd_wait_for_click_delay(10);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -7875,7 +7875,7 @@ static bool lcd_selfcheck_axis_sg(unsigned char axis) {
 	st_synchronize();
 
 	current_position[axis] += axis_length;
-	plan_buffer_line_curposXYZE(hmanual_feedrate[0] / 60, active_extruder);
+	plan_buffer_line_curposXYZE(manual_feedrate[0] / 60, active_extruder);
 
 	st_synchronize();
 
@@ -7891,11 +7891,11 @@ static bool lcd_selfcheck_axis_sg(unsigned char axis) {
 
 
 	current_position[axis] -= margin;
-	plan_buffer_line_curposXYZE(manual_feedrate[0]  / 60, active_extruder);
+	plan_buffer_line_curposXYZE(manual_feedrate[0] / 60, active_extruder);
 	st_synchronize();	
 
 	current_position[axis] -= (axis_length + margin);
-	plan_buffer_line_curposXYZE(manual_feedrate[0]  / 60, active_extruder);
+	plan_buffer_line_curposXYZE(manual_feedrate[0] / 60, active_extruder);
 		
 	st_synchronize();
 


### PR DESCRIPTION
Fix bug introduced in #2264 