### PR TITLE
Add dummy G21 to prevent UNKOWN warnings in serial

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -4277,6 +4277,14 @@ if(eSoundMode!=e_SOUND_MODE_SILENT)
     
 
     /*!
+	### G21 - Sets Units to Millimters <a href="https://reprap.org/wiki/G-code#G21:_Set_Units_to_Millimeters">G21: Set Units to Millimeters</a>
+	Units are in millimeters. Prusa doesn't support inches.
+    */
+    case 21: 
+      break; //Doing nothing. This is just to prevent serial UNKOWN warnings.
+    
+
+    /*!
     ### G28 - Home all Axes one at a time <a href="https://reprap.org/wiki/G-code#G28:_Move_to_Origin_.28Home.29">G28: Move to Origin (Home)</a>
     Using `G28` without any parameters will perfom homing of all axes AND mesh bed leveling, while `G28 W` will just home all axes (no mesh bed leveling).
     #### Usage


### PR DESCRIPTION
Prusa firmware operates ONLY in millimeters so it kind of does what G21 is supposed to do.

This is a non-essential PR I know, but the last weeks looking at thousand of terminal lines it is something that doesn't hurt but makes the serial output bit cleaner.

Before:
```
NORMAL MODE: Percent done: 0; print time remaining in mins: 218
SILENT MODE: Percent done: 0; print time remaining in mins: 228
NORMAL MODE: Percent done: 0; print time remaining in mins: 218
SILENT MODE: Percent done: 0; print time remaining in mins: 228
Unknown G code: $27 G21
LA10C: Linear Advance mode: 1.0
LA10C: Adjusted E-Jerk: 4.50
echo:Advance K=0.07
echo:busy: processing
```
and after
```
NORMAL MODE: Percent done: 0; print time remaining in mins: 218
SILENT MODE: Percent done: 0; print time remaining in mins: 228
NORMAL MODE: Percent done: 0; print time remaining in mins: 218
SILENT MODE: Percent done: 0; print time remaining in mins: 228
LA10C: Linear Advance mode: 1.0
LA10C: Adjusted E-Jerk: 4.50
echo:Advance K=0.07
echo:busy: processing
```

PR firmware has been compiled and tested as well the doxygen file created and verified.

If this non-essential PR ever makes it I will also update the RepRap Wiki.