### PR TITLE
⚡Add Linear Advanced 1.5 Max value

### DIFF
--- a/Firmware/Configuration_adv.h
+++ b/Firmware/Configuration_adv.h
@@ -286,14 +286,12 @@
 
 #ifdef LIN_ADVANCE
   #define LIN_ADVANCE_K 0  // Unit: mm compression per 1mm/s extruder speed
-  #define LIN_ADVANCE_15_K_MAX 10 // Linear Advanced 1.5 max vaule to determine if it is LA15 or LA10
+  #define LIN_ADVANCE_15_K_MAX 9.99 // Linear Advanced 1.5 max vaule to determine if it is LA15 or LA10
   //#define LA_NOCOMPAT    // Disable Linear Advance 1.0 compatibility
   //#define LA_LIVE_K      // Allow adjusting K in the Tune menu
   //#define LA_DEBUG       // If enabled, this will generate debug information output over USB.
   //#define LA_DEBUG_LOGIC // @wavexx: setup logic channels for isr debugging
 #endif
-
-
 
 // Arc interpretation settings:
 #define MM_PER_ARC_SEGMENT 1

--- a/Firmware/Configuration_adv.h
+++ b/Firmware/Configuration_adv.h
@@ -286,7 +286,7 @@
 
 #ifdef LIN_ADVANCE
   #define LIN_ADVANCE_K 0  // Unit: mm compression per 1mm/s extruder speed
-  #define LIN_ADVANCE_15_K_MAX 9.99 // Linear Advanced 1.5 max vaule to determine if it is LA15 or LA10
+  #define LIN_ADVANCE_15_K_MAX 9.99 // Linear Advanced 1.5 max value to determine if it is LA15 or LA10
   //#define LA_NOCOMPAT    // Disable Linear Advance 1.0 compatibility
   //#define LA_LIVE_K      // Allow adjusting K in the Tune menu
   //#define LA_DEBUG       // If enabled, this will generate debug information output over USB.

--- a/Firmware/Configuration_adv.h
+++ b/Firmware/Configuration_adv.h
@@ -286,11 +286,14 @@
 
 #ifdef LIN_ADVANCE
   #define LIN_ADVANCE_K 0  // Unit: mm compression per 1mm/s extruder speed
+  #define LIN_ADVANCE_15_K_MAX 10 // Linear Advanced 1.5 max vaule to determine if it is LA15 or LA10
   //#define LA_NOCOMPAT    // Disable Linear Advance 1.0 compatibility
   //#define LA_LIVE_K      // Allow adjusting K in the Tune menu
   //#define LA_DEBUG       // If enabled, this will generate debug information output over USB.
   //#define LA_DEBUG_LOGIC // @wavexx: setup logic channels for isr debugging
 #endif
+
+
 
 // Arc interpretation settings:
 #define MM_PER_ARC_SEGMENT 1

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -2072,10 +2072,9 @@ inline void gcode_M900() {
         SERIAL_ECHOLNPGM("K out of allowed range!");
 #else
     if (newK == 0)
-    {
         extruder_advance_K = 0;
+    else if (newK == -1)
         la10c_reset();
-    }
     else
     {
         newK = la10c_value(newK);
@@ -4865,6 +4864,11 @@ if(eSoundMode!=e_SOUND_MODE_SILENT)
 	case_G80:
 	{
 		mesh_bed_leveling_flag = true;
+#ifndef LA_NOCOMPAT
+        // When printing via USB there's no clear boundary between prints. Abuse MBL to indicate
+        // the beginning of a new print, allowing a new autodetected setting just after G80.
+        la10c_reset();
+#endif
 #ifndef PINDA_THERMISTOR
         static bool run = false; // thermistor-less PINDA temperature compensation is running
 #endif // ndef PINDA_THERMISTOR

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -2072,9 +2072,10 @@ inline void gcode_M900() {
         SERIAL_ECHOLNPGM("K out of allowed range!");
 #else
     if (newK == 0)
+    {
         extruder_advance_K = 0;
-    else if (newK == -1)
         la10c_reset();
+    }
     else
     {
         newK = la10c_value(newK);
@@ -4864,11 +4865,6 @@ if(eSoundMode!=e_SOUND_MODE_SILENT)
 	case_G80:
 	{
 		mesh_bed_leveling_flag = true;
-#ifndef LA_NOCOMPAT
-        // When printing via USB there's no clear boundary between prints. Abuse MBL to indicate
-        // the beginning of a new print, allowing a new autodetected setting just after G80.
-        la10c_reset();
-#endif
 #ifndef PINDA_THERMISTOR
         static bool run = false; // thermistor-less PINDA temperature compensation is running
 #endif // ndef PINDA_THERMISTOR

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -2066,7 +2066,7 @@ static float probe_pt(float x, float y, float z_before) {
 inline void gcode_M900() {
     float newK = code_seen('K') ? code_value_float() : -2;
 #ifdef LA_NOCOMPAT
-    if (newK >= 0 && newK < 10)
+    if (newK >= 0 && newK <= LIN_ADVANCE_15_K_MAX)
         extruder_advance_K = newK;
     else
         SERIAL_ECHOLNPGM("K out of allowed range!");

--- a/Firmware/la10compat.cpp
+++ b/Firmware/la10compat.cpp
@@ -52,11 +52,11 @@ float la10c_value(float k)
         else if(k < 0)
             return -1;
 
-        la10c_mode_change(k < 10? LA10C_LA15: LA10C_LA10);
+        la10c_mode_change(k <= LIN_ADVANCE_15_K_MAX? LA10C_LA15: LA10C_LA10);
     }
 
     if(la10c_mode == LA10C_LA15)
-        return (k >= 0 && k < 10? k: -1);
+        return (k >= 0 && k <= LIN_ADVANCE_15_K_MAX? k: -1);
     else
         return (k >= 0? la10c_convert(k): -1);
 }

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -39,6 +39,10 @@
 #include "tmc2130.h"
 #endif //TMC2130
 
+#ifndef LA_NOCOMPAT
+#include "la10compat.h"
+#endif
+
 #include "sound.h"
 
 #include "mmu.h"
@@ -7351,6 +7355,10 @@ void lcd_print_stop()
 
     current_position[Z_AXIS] += 10; //lift Z.
     plan_buffer_line_curposXYZE(manual_feedrate[Z_AXIS] / 60, active_extruder);
+
+#ifndef LA_NOCOMPAT
+    la10c_reset(); //reset LA1.0 conversion lock
+#endif
 
     if (axis_known_position[X_AXIS] && axis_known_position[Y_AXIS]) //if axis are homed, move to parked position.
     {

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -39,10 +39,6 @@
 #include "tmc2130.h"
 #endif //TMC2130
 
-#ifndef LA_NOCOMPAT
-#include "la10compat.h"
-#endif
-
 #include "sound.h"
 
 #include "mmu.h"
@@ -7355,10 +7351,6 @@ void lcd_print_stop()
 
     current_position[Z_AXIS] += 10; //lift Z.
     plan_buffer_line_curposXYZE(manual_feedrate[Z_AXIS] / 60, active_extruder);
-
-#ifndef LA_NOCOMPAT
-    la10c_reset(); //reset LA1.0 conversion lock
-#endif
 
     if (axis_known_position[X_AXIS] && axis_known_position[Y_AXIS]) //if axis are homed, move to parked position.
     {


### PR DESCRIPTION
### Purpose of this PR
To determine if `M900 Kx` is a LA15 or LA10 value we had a "hard-coded" value of 10.
During testing and a lot of discussions we couldn't agree on one fixed value as we didn't have all Linear Advanced 1.5 Filament K values on hand.

### Solution
We decided to add one variable `LIN_ADVANCE_15_K_MAX` so this can be updated if needed just in one place.

### ToDo
- The LA15 K values for all "know"/supported filaments have to be defined by PrusaSlicer-settings team and the community.
- Update the `LIN_ADVANCE_15_K_MAX` if needed.

## Dependencies
No known dependencies to other PRs.
However, I tested it with https://github.com/prusa3d/Prusa-Firmware/pull/2623 as this PR also makes sense at this moment.

### Tests
- This firmware has been compiled and tested:
   - LA10 K values above `LIN_ADVANCE_15_K_MAX`  has been converted correctly.
   - LA15 K values below/equal to `LIN_ADVANCE_15_K_MAX` have been used correctly.
- As there is an option to disable the LA10 -> LA15 conversion I also compiled and tested this firmware:
   - LA10 K values above `LIN_ADVANCE_15_K_MAX` have been ignored and the LA15 K value was set to `K0.00`.
   - LA15 K values below/equal to `LIN_ADVANCE_15_K_MAX` have been used correctly.
   - LA15 K values above `LIN_ADVANCE_15_K_MAX` have been ignored and the LA15 K value was set to `K0.00`.

#### Test log:
- Firmware based on MK3 (today) + https://github.com/prusa3d/Prusa-Firmware/pull/2623 + `#define LIN_ADVANCE_15_K_MAX 9.99`.

```
Recv: FIRMWARE_NAME:Prusa-Firmware 3.9.0-RC2 based on Marlin FIRMWARE_URL:https://github.com/prusa3d/Prusa-Firmware PROTOCOL_VERSION:1.0 MACHINE_TYPE:Prusa i3 MK3S EXTRUDER_COUNT:1 UUID:00000000-0000-0000-0000-000000000000
[...]
Send: M900 K45
Recv: LA10C: Linear Advance mode: 1.0
Recv: LA10C: Adjusted E-Jerk: 4.50
Recv: echo:Advance K=0.13
Recv: ok
[...]
Send: M900 K0
Recv: LA10C: Linear Advance mode: UNKNOWN
Recv: echo:Advance K=0.00
Recv: ok
[...]
Send: M900 K9.999
Recv: LA10C: Linear Advance mode: 1.0
Recv: LA10C: Adjusted E-Jerk: 4.50
Recv: echo:Advance K=0.00
Recv: ok
[...]
Send: M900 K0
Recv: LA10C: Linear Advance mode: UNKNOWN
Recv: echo:Advance K=0.00
Recv: ok
[...]
Send: M900 K99
Recv: LA10C: Linear Advance mode: 1.0
Recv: LA10C: Adjusted E-Jerk: 4.50
Recv: echo:Advance K=0.35
Recv: ok
[...]
Send: M900 K0
Recv: LA10C: Linear Advance mode: UNKNOWN
Recv: echo:Advance K=0.00
Recv: ok
[...]
Send: M900 K9.99
Recv: LA10C: Linear Advance mode: 1.5
Recv: echo:Advance K=9.99
Recv: ok
[...]
Send: M900 K45
Recv: K out of allowed range!
Recv: echo:Advance K=9.99
Recv: ok
[...]
Send: M900 K0
Recv: LA10C: Linear Advance mode: UNKNOWN
Recv: echo:Advance K=0.00
Recv: ok
[...]
Send: M900 K9.991
Recv: LA10C: Linear Advance mode: 1.0
Recv: LA10C: Adjusted E-Jerk: 4.50
Recv: echo:Advance K=0.00
Recv: ok
```
- Firmware based on MK3 (today) + https://github.com/prusa3d/Prusa-Firmware/pull/2623 + `#define LIN_ADVANCE_15_K_MAX 9.99` + `#define LA_NOCOMPAT` (disable LA10 to LA15 conversion).
```
Recv: FIRMWARE_NAME:Prusa-Firmware 3.9.0-RC2 based on Marlin FIRMWARE_URL:https://github.com/prusa3d/Prusa-Firmware PROTOCOL_VERSION:1.0 MACHINE_TYPE:Prusa i3 MK3S EXTRUDER_COUNT:1 UUID:00000000-0000-0000-0000-000000000000
[...]
Send: M900 K9.99
Recv: echo:Advance K=9.99
Recv: ok
[...]
Send: M900 K0
Recv: echo:Advance K=0.00
Recv: ok
[...]
Send: M900 K10
Recv: K out of allowed range!
Recv: echo:Advance K=0.00
Recv: ok
[...]
Send: M900 K8.8
Recv: echo:Advance K=8.80
Recv: ok
[...]
Send: M900 K0
Recv: echo:Advance K=0.00
Recv: ok
```

PFW-1113