### PR TITLE
Put credit where credit is due

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Prusa Firmware MK3
 
-This repository contains the source code and the development versions of the firmware running on the [Prusa](https://prusa3d.com/) MK3S/MK3/MK2.5S/MK2.5 line of printers.
+This repository contains the source code and the development versions of the firmware running on the [Original Prusa i3](https://prusa3d.com/) MK3S/MK3/MK2.5S/MK2.5 line of printers.
 
 The latest official builds can be downloaded from [Prusa Drivers](https://www.prusa3d.com/drivers/). Pre-built development releases are also [available here](https://github.com/prusa3d/Prusa-Firmware/releases).
 
-The MK3 firmware is proudly based on [Marlin 1.0.x](https://github.com/MarlinFirmware/Marlin/) by Scott Lahteine (@thinkyhead) et al. and is distributed under the terms of the [GNU GPL 3 license](LICENSE).
+The firmware for the Original Prusa i3 printers is proudly based on [Marlin 1.0.x](https://github.com/MarlinFirmware/Marlin/) by Scott Lahteine (@thinkyhead) et al. and is distributed under the terms of the [GNU GPL 3 license](LICENSE).
 
 
 # Table of contents

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+# Prusa Firmware MK3
+
+This repository contains the source code and the development versions of the firmware running on the [Prusa](https://prusa3d.com/) MK3S/MK3/MK2.5S/MK2.5 line of printers.
+
+The latest official builds can be downloaded from [Prusa Drivers](https://www.prusa3d.com/drivers/). Pre-built development releases are also [available here](https://github.com/prusa3d/Prusa-Firmware/releases).
+
+The MK3 firmware is proudly based on [Marlin 1.0.x](https://github.com/MarlinFirmware/Marlin/) by Scott Lahteine (@thinkyhead) et al. and is distributed under the terms of the [GNU GPL 3 license](LICENSE).
+
+
 # Table of contents
 
 <!--ts-->


### PR DESCRIPTION
We wouldn't be here without Marlin and all the contributors!

Digging deep into the source, I didn't realize this was forked as early as Marlin 1.0.x. If this is incorrect, I'll happily fix the reference.

The diff shows a lot of changes, but it's due to EOL conversions: rich view shows it best. There's just a new section added in the beginning giving credit as well as a better description for newcomers which I loosely based on the PrusaSlicer repository.

Fixes #2625