### PR TITLE
Added RC3 detection in PF-build.sh

### DIFF
--- a/PF-build.sh
+++ b/PF-build.sh
@@ -56,7 +56,7 @@
 #   Some may argue that this is only used by a script, BUT as soon someone accidentally or on purpose starts Arduino IDE
 #   it will use the default Arduino IDE folders and so can corrupt the build environment.
 #
-# Version: 1.0.6-Build_13
+# Version: 1.0.6-Build_14
 # Change log:
 # 12 Jan 2019, 3d-gussner, Fixed "compiler.c.elf.flags=-w -Os -Wl,-u,vfprintf -lprintf_flt -lm -Wl,--gc-sections" in 'platform.txt'
 # 16 Jan 2019, 3d-gussner, Build_2, Added development check to modify 'Configuration.h' to prevent unwanted LCD messages that Firmware is unknown
@@ -118,6 +118,7 @@
 # 15 Dec 2019, 3d-gussner, Prepare for switch to Prusa3d/PF-build-env repository
 # 15 Dec 2019, 3d-gussner, Fix Audrino user preferences for the chosen board.
 # 17 Dec 2019, 3d-gussner, Fix "timer0_fract = 0" warning by using Arduino_boards v1.0.3
+# 28 Apr 2020, 3d-gussner, Added RC3 detection
 #### Start check if OSTYPE is supported
 OS_FOUND=$( command -v uname)
 
@@ -527,7 +528,7 @@ do
 	# Check development status
 	DEV_CHECK=$(grep --max-count=1 "\bFW_VERSION\b" $SCRIPT_PATH/Firmware/Configuration.h | sed -e's/  */ /g'|cut -d '"' -f2|sed 's/\.//g'|cut -d '-' -f2)
 	if [ -z "$DEV_STATUS_SELECTED" ] ; then
-		if [[ "$DEV_CHECK" == "RC1"  ||  "$DEV_CHECK" == "RC2" ]] ; then
+		if [[ "$DEV_CHECK" == "RC1"  ||  "$DEV_CHECK" == "RC2"  ||  "$DEV_CHECK" == "RC3" ]] ; then
 			DEV_STATUS="RC"
 		elif [[ "$DEV_CHECK" == "ALPHA" ]]; then
 			DEV_STATUS="ALPHA"

--- a/PF-build.sh
+++ b/PF-build.sh
@@ -56,7 +56,7 @@
 #   Some may argue that this is only used by a script, BUT as soon someone accidentally or on purpose starts Arduino IDE
 #   it will use the default Arduino IDE folders and so can corrupt the build environment.
 #
-# Version: 1.0.6-Build_15
+# Version: 1.0.6-Build_16
 # Change log:
 # 12 Jan 2019, 3d-gussner, Fixed "compiler.c.elf.flags=-w -Os -Wl,-u,vfprintf -lprintf_flt -lm -Wl,--gc-sections" in 'platform.txt'
 # 16 Jan 2019, 3d-gussner, Build_2, Added development check to modify 'Configuration.h' to prevent unwanted LCD messages that Firmware is unknown
@@ -120,6 +120,8 @@
 # 17 Dec 2019, 3d-gussner, Fix "timer0_fract = 0" warning by using Arduino_boards v1.0.3
 # 28 Apr 2020, 3d-gussner, Added RC3 detection
 # 03 May 2020, deliopoulos, Accept all RCx as RC versions
+# 05 May 2020, 3d-gussner, Make a copy of `not_tran.txt`and `not_used.txt` as `not_tran_$VARIANT.txt`and `not_used_$VARIANT.txt`
+#                          After compiling All multilanguage vairants it makes it easier to find missing or unused transltions.  
 #### Start check if OSTYPE is supported
 OS_FOUND=$( command -v uname)
 
@@ -684,6 +686,8 @@ do
 		./lang-build.sh || exit 32
 		# Combine compiled firmware with languages 
 		./fw-build.sh || exit 33
+		cp not_tran.txt not_tran_$VARIANT.txt
+		cp not_used.txt not_used_$VARIANT.txt
 		echo "$(tput sgr 0)"
 		# Check if the motherboard is an EINSY and if so only one hex file will generated
 		MOTHERBOARD=$(grep --max-count=1 "\bMOTHERBOARD\b" $SCRIPT_PATH/Firmware/variants/$VARIANT.h | sed -e's/  */ /g' |cut -d ' ' -f3)

--- a/PF-build.sh
+++ b/PF-build.sh
@@ -56,7 +56,7 @@
 #   Some may argue that this is only used by a script, BUT as soon someone accidentally or on purpose starts Arduino IDE
 #   it will use the default Arduino IDE folders and so can corrupt the build environment.
 #
-# Version: 1.0.6-Build_14
+# Version: 1.0.6-Build_15
 # Change log:
 # 12 Jan 2019, 3d-gussner, Fixed "compiler.c.elf.flags=-w -Os -Wl,-u,vfprintf -lprintf_flt -lm -Wl,--gc-sections" in 'platform.txt'
 # 16 Jan 2019, 3d-gussner, Build_2, Added development check to modify 'Configuration.h' to prevent unwanted LCD messages that Firmware is unknown
@@ -119,6 +119,7 @@
 # 15 Dec 2019, 3d-gussner, Fix Audrino user preferences for the chosen board.
 # 17 Dec 2019, 3d-gussner, Fix "timer0_fract = 0" warning by using Arduino_boards v1.0.3
 # 28 Apr 2020, 3d-gussner, Added RC3 detection
+# 03 May 2020, deliopoulos, Accept all RCx as RC versions
 #### Start check if OSTYPE is supported
 OS_FOUND=$( command -v uname)
 
@@ -528,7 +529,7 @@ do
 	# Check development status
 	DEV_CHECK=$(grep --max-count=1 "\bFW_VERSION\b" $SCRIPT_PATH/Firmware/Configuration.h | sed -e's/  */ /g'|cut -d '"' -f2|sed 's/\.//g'|cut -d '-' -f2)
 	if [ -z "$DEV_STATUS_SELECTED" ] ; then
-		if [[ "$DEV_CHECK" == "RC1"  ||  "$DEV_CHECK" == "RC2"  ||  "$DEV_CHECK" == "RC3" ]] ; then
+		if [[ "$DEV_CHECK" == *"RC"* ]] ; then
 			DEV_STATUS="RC"
 		elif [[ "$DEV_CHECK" == "ALPHA" ]]; then
 			DEV_STATUS="ALPHA"


### PR DESCRIPTION
As we we have got a RC3 version I have updated also `PF-build.sh` to detect it correctly.

Test results the `PF-build.sh Version: 1.0.6-Build_14`
```
Variant    : 1_75mm_MK3S-EINSy10a-E3Dv6full
Firmware   : 390-RC3
Build #    : 3401
Dev Check  : RC3
DEV Status : RC
Motherboard: BOARD_EINSY_1_0a
Languages  : EN_ONLY
Hex-file Folder: PF-build-hex/FW390-RC3-Build3401/BOARD_EINSY_1_0a
```