### PR TITLE
Adjustable Linear Advance limits and thresholds

### DIFF
--- a/Firmware/Configuration_adv.h
+++ b/Firmware/Configuration_adv.h
@@ -285,11 +285,13 @@
 #define LIN_ADVANCE
 
 #ifdef LIN_ADVANCE
-  #define LIN_ADVANCE_K 0  // Unit: mm compression per 1mm/s extruder speed
-  //#define LA_NOCOMPAT    // Disable Linear Advance 1.0 compatibility
-  //#define LA_LIVE_K      // Allow adjusting K in the Tune menu
-  //#define LA_DEBUG       // If enabled, this will generate debug information output over USB.
-  //#define LA_DEBUG_LOGIC // @wavexx: setup logic channels for isr debugging
+  #define LA_K_DEF    0        // Default K factor (Unit: mm compression per 1mm/s extruder speed)
+  #define LA_K_MAX    10       // Maximum acceptable K factor (exclusive, see notes in planner.cpp:plan_buffer_line)
+  #define LA_LA10_MIN LA_K_MAX // Lin. Advance 1.0 threshold value (inclusive)
+  //#define LA_NOCOMPAT        // Disable Linear Advance 1.0 compatibility
+  //#define LA_LIVE_K          // Allow adjusting K in the Tune menu
+  //#define LA_DEBUG           // If enabled, this will generate debug information output over USB.
+  //#define LA_DEBUG_LOGIC     // @wavexx: setup logic channels for isr debugging
 #endif
 
 // Arc interpretation settings:

--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -238,8 +238,8 @@ void get_coordinates();
 void prepare_move();
 void kill(const char *full_screen_message = NULL, unsigned char id = 0);
 void Stop();
-
 bool IsStopped();
+void finishAndDisableSteppers();
 
 //put an ASCII command at the end of the current buffer.
 void enquecommand(const char *cmd, bool from_progmem = false);

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -4864,11 +4864,6 @@ if(eSoundMode!=e_SOUND_MODE_SILENT)
 	case_G80:
 	{
 		mesh_bed_leveling_flag = true;
-#ifndef LA_NOCOMPAT
-        // When printing via USB there's no clear boundary between prints. Abuse MBL to indicate
-        // the beginning of a new print, allowing a new autodetected setting just after G80.
-        la10c_reset();
-#endif
 #ifndef PINDA_THERMISTOR
         static bool run = false; // thermistor-less PINDA temperature compensation is running
 #endif // ndef PINDA_THERMISTOR
@@ -9697,6 +9692,24 @@ void Stop()
 }
 
 bool IsStopped() { return Stopped; };
+
+void finishAndDisableSteppers()
+{
+  st_synchronize();
+  disable_x();
+  disable_y();
+  disable_z();
+  disable_e0();
+  disable_e1();
+  disable_e2();
+
+#ifndef LA_NOCOMPAT
+  // Steppers are disabled both when a print is stopped and also via M84 (which is additionally
+  // checked-for to indicate a complete file), so abuse this function to reset the LA detection
+  // state for the next print.
+  la10c_reset();
+#endif
+}
 
 #ifdef FAST_PWM_FAN
 void setPwmFrequency(uint8_t pin, int val)

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -2066,7 +2066,7 @@ static float probe_pt(float x, float y, float z_before) {
 inline void gcode_M900() {
     float newK = code_seen('K') ? code_value_float() : -2;
 #ifdef LA_NOCOMPAT
-    if (newK >= 0 && newK < 10)
+    if (newK >= 0 && newK < LA_K_MAX)
         extruder_advance_K = newK;
     else
         SERIAL_ECHOLNPGM("K out of allowed range!");

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -2072,9 +2072,10 @@ inline void gcode_M900() {
         SERIAL_ECHOLNPGM("K out of allowed range!");
 #else
     if (newK == 0)
+    {
         extruder_advance_K = 0;
-    else if (newK == -1)
         la10c_reset();
+    }
     else
     {
         newK = la10c_value(newK);

--- a/Firmware/la10compat.cpp
+++ b/Firmware/la10compat.cpp
@@ -1,5 +1,6 @@
 #include "la10compat.h"
 #include "Marlin.h"
+#include <float.h>
 
 
 static LA10C_MODE la10c_mode = LA10C_UNKNOWN; // Current LA compatibility mode
@@ -38,7 +39,9 @@ void la10c_mode_change(LA10C_MODE mode)
 static float la10c_convert(float k)
 {
     float new_K = k * 0.004 - 0.05;
-    return (new_K < 0? 0: new_K);
+    return new_K < 0? 0:
+           new_K > (LA_K_MAX - FLT_EPSILON)? (LA_K_MAX - FLT_EPSILON):
+           new_K;
 }
 
 
@@ -52,11 +55,11 @@ float la10c_value(float k)
         else if(k < 0)
             return -1;
 
-        la10c_mode_change(k < 10? LA10C_LA15: LA10C_LA10);
+        la10c_mode_change(k < LA_LA10_MIN? LA10C_LA15: LA10C_LA10);
     }
 
     if(la10c_mode == LA10C_LA15)
-        return (k >= 0 && k < 10? k: -1);
+        return (k >= 0 && k < LA_K_MAX? k: -1);
     else
         return (k >= 0? la10c_convert(k): -1);
 }

--- a/Firmware/planner.cpp
+++ b/Firmware/planner.cpp
@@ -126,7 +126,7 @@ float extrude_min_temp=EXTRUDE_MINTEMP;
 #endif
 
 #ifdef LIN_ADVANCE
-float extruder_advance_K = LIN_ADVANCE_K;
+float extruder_advance_K = LA_K_DEF;
 float position_float[NUM_AXIS];
 #endif
 

--- a/Firmware/stepper.cpp
+++ b/Firmware/stepper.cpp
@@ -1356,17 +1356,6 @@ float st_get_position_mm(uint8_t axis)
 }
 
 
-void finishAndDisableSteppers()
-{
-  st_synchronize();
-  disable_x();
-  disable_y();
-  disable_z();
-  disable_e0();
-  disable_e1();
-  disable_e2();
-}
-
 void quickStop()
 {
   DISABLE_STEPPER_DRIVER_INTERRUPT();

--- a/Firmware/stepper.h
+++ b/Firmware/stepper.h
@@ -69,8 +69,6 @@ void invert_z_endstop(bool endstop_invert);
 
 void checkStepperErrors(); //Print errors detected by the stepper
 
-void finishAndDisableSteppers();
-
 extern block_t *current_block;  // A pointer to the block currently being traced
 extern bool x_min_endstop;
 extern bool x_max_endstop;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -51,6 +51,10 @@
 #include "adc.h"
 #include "config.h"
 
+#ifndef LA_NOCOMPAT
+#include "la10compat.h"
+#endif
+
 
 int scrollstuff = 0;
 char longFilenameOLD[LONG_FILENAME_LENGTH];
@@ -7335,6 +7339,9 @@ void lcd_print_stop()
 
 #ifdef MESH_BED_LEVELING
     mbl.active = false; //also prevents undoing the mbl compensation a second time in the second planner_abort_hard()
+#endif
+#ifndef LA_NOCOMPAT
+    la10c_reset();
 #endif
 
 	lcd_setstatuspgm(_T(MSG_PRINT_ABORTED));

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -7340,9 +7340,6 @@ void lcd_print_stop()
 #ifdef MESH_BED_LEVELING
     mbl.active = false; //also prevents undoing the mbl compensation a second time in the second planner_abort_hard()
 #endif
-#ifndef LA_NOCOMPAT
-    la10c_reset();
-#endif
 
 	lcd_setstatuspgm(_T(MSG_PRINT_ABORTED));
 	stoptime = _millis();


### PR DESCRIPTION
Based on PR #2627, we rename and add some constants to avoid hard-coding limits in several parts of the code. This PR also decouples the LA1.5 maximum value from the detection threshold, although it's now simply defined in terms of the first, matching existing behavior.

We also clamp the result of `la10c_convert()` to respect `LA_K_MAX` which would otherwise could be exceeded by a large LA10 value.

The mode detection is also reset when stopping a print, which is a perfectly safe thing to do (taking parts of PR #2623).

PFW-1113