### PR TITLE
Prevent successful compiling when lang_en_xx.txt aren't correct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,8 @@ Firmware/Doc
 /lang/progmem1.var
 /lang/text.sym
 /lang/textaddr.txt
+/lang/lang_en*.cnt
+/lang/lang_en*.max
 /build-env/
 /Firmware/Firmware.vcxproj
 /Firmware/Configuration_prusa_bckp.h

--- a/Firmware/Configuration.h
+++ b/Firmware/Configuration.h
@@ -16,8 +16,8 @@ extern uint16_t nPrinterType;
 extern PGM_P sPrinterName;
 
 // Firmware version
-#define FW_VERSION "3.9.3"
-#define FW_COMMIT_NR 3556
+#define FW_VERSION "3.10.0-RC1"
+#define FW_COMMIT_NR 4078
 // FW_VERSION_UNKNOWN means this is an unofficial build.
 // The firmware should only be checked into github with this symbol.
 #define FW_DEV_VERSION FW_VERSION_UNKNOWN

--- a/Firmware/Configuration_adv.h
+++ b/Firmware/Configuration_adv.h
@@ -387,6 +387,12 @@ const unsigned int dropsegments=5; //everything with less than this number of st
  */
 #define EXTENDED_CAPABILITIES_REPORT
 
+/**
+ * Enable M120/M121 G-code commands
+ * 
+ */
+//#define M120_M121_ENABLED  //Be careful enabling and using these G-code commands.
+
 //===========================================================================
 //=============================  Define Defines  ============================
 //===========================================================================

--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -363,8 +363,8 @@ extern bool mmu_print_saved;
 
 //estimated time to end of the print
 extern uint8_t print_percent_done_normal;
-extern uint16_t print_time_remaining_normal;
 extern uint8_t print_percent_done_silent;
+extern uint16_t print_time_remaining_normal;
 extern uint16_t print_time_remaining_silent;
 extern uint16_t print_time_to_change_normal;
 extern uint16_t print_time_to_change_silent;
@@ -376,7 +376,7 @@ extern uint16_t gcode_in_progress;
 
 extern LongTimer safetyTimer;
 
-#define PRINT_PERCENT_DONE_INIT   0xff
+#define PRINT_PERCENT_DONE_INIT 0xff
 #define PRINTER_ACTIVE (IS_SD_PRINTING || is_usb_printing || isPrintPaused || (custom_message_type == CustomMsg::TempCal) || saved_printing || (lcd_commands_type == LcdCommands::Layer1Cal) || mmu_print_saved || homing_flag || mesh_bed_leveling_flag)
 
 //! Beware - mcode_in_progress is set as soon as the command gets really processed,

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -313,8 +313,8 @@ bool mmu_print_saved = false;
 
 // storing estimated time to end of print counted by slicer
 uint8_t print_percent_done_normal = PRINT_PERCENT_DONE_INIT;
-uint16_t print_time_remaining_normal = PRINT_TIME_REMAINING_INIT; //estimated remaining print time in minutes
 uint8_t print_percent_done_silent = PRINT_PERCENT_DONE_INIT;
+uint16_t print_time_remaining_normal = PRINT_TIME_REMAINING_INIT; //estimated remaining print time in minutes
 uint16_t print_time_remaining_silent = PRINT_TIME_REMAINING_INIT; //estimated remaining print time in minutes
 uint16_t print_time_to_change_normal = PRINT_TIME_REMAINING_INIT; //estimated remaining time to next change in minutes
 uint16_t print_time_to_change_silent = PRINT_TIME_REMAINING_INIT; //estimated remaining time to next change in minutes
@@ -6389,14 +6389,19 @@ Sigma_Exit:
         if(code_seen('R')) print_time_remaining_normal = code_value();
         if(code_seen('Q')) print_percent_done_silent = code_value();
         if(code_seen('S')) print_time_remaining_silent = code_value();
-        if(code_seen('C')) print_time_to_change_normal = code_value();
-        if(code_seen('D')) print_time_to_change_silent = code_value();
-
-    {
-        const char* _msg_mode_done_remain = _N("%S MODE: Percent done: %d; print time remaining in mins: %d; Change in mins: %d\n");
-        printf_P(_msg_mode_done_remain, _N("NORMAL"), int(print_percent_done_normal), print_time_remaining_normal, print_time_to_change_normal);
-        printf_P(_msg_mode_done_remain, _N("SILENT"), int(print_percent_done_silent), print_time_remaining_silent, print_time_to_change_silent);
-    }
+        if(code_seen('C')){
+            float print_time_to_change_normal_f = code_value_float();
+            print_time_to_change_normal = ( print_time_to_change_normal_f <= 0 ) ? PRINT_TIME_REMAINING_INIT : print_time_to_change_normal_f;
+        }
+        if(code_seen('D')){
+            float print_time_to_change_silent_f = code_value_float();
+            print_time_to_change_silent = ( print_time_to_change_silent_f <= 0 ) ? PRINT_TIME_REMAINING_INIT : print_time_to_change_silent_f;
+        }
+        {
+            const char* _msg_mode_done_remain = _N("%S MODE: Percent done: %hhd; print time remaining in mins: %d; Change in mins: %d\n");
+            printf_P(_msg_mode_done_remain, _N("NORMAL"), int8_t(print_percent_done_normal), print_time_remaining_normal, print_time_to_change_normal);
+            printf_P(_msg_mode_done_remain, _N("SILENT"), int8_t(print_percent_done_silent), print_time_remaining_silent, print_time_to_change_silent);
+        }
         break;
     }
     /*!

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -6967,19 +6967,21 @@ Sigma_Exit:
       lcd_setstatus(strchr_pointer + 5);
       break;*/
 
+#if 0 //Disable these for the time being
     /*!
-	### M120 - Enable endstops <a href="https://reprap.org/wiki/G-code#M120:_Enable_endstop_detection">M120: Enable endstop detection</a>
+    ### M120 - Enable endstops <a href="https://reprap.org/wiki/G-code#M120:_Enable_endstop_detection">M120: Enable endstop detection</a>
     */
     case 120:
       enable_endstops(true) ;
       break;
 
     /*!
-	### M121 - Disable endstops <a href="https://reprap.org/wiki/G-code#M121:_Disable_endstop_detection">M121: Disable endstop detection</a>
+    ### M121 - Disable endstops <a href="https://reprap.org/wiki/G-code#M121:_Disable_endstop_detection">M121: Disable endstop detection</a>
     */
     case 121:
       enable_endstops(false) ;
       break;
+#endif //0
 
     /*!
 	### M119 - Get endstop states <a href="https://reprap.org/wiki/G-code#M119:_Get_Endstop_Status">M119: Get Endstop Status</a>

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -6967,7 +6967,7 @@ Sigma_Exit:
       lcd_setstatus(strchr_pointer + 5);
       break;*/
 
-#if 0 //Disable these for the time being
+#ifdef M120_M121_ENABLED
     /*!
     ### M120 - Enable endstops <a href="https://reprap.org/wiki/G-code#M120:_Enable_endstop_detection">M120: Enable endstop detection</a>
     */
@@ -6981,7 +6981,7 @@ Sigma_Exit:
     case 121:
       enable_endstops(false) ;
       break;
-#endif //0
+#endif //M120_M121_ENABLED
 
     /*!
 	### M119 - Get endstop states <a href="https://reprap.org/wiki/G-code#M119:_Get_Endstop_Status">M119: Get Endstop Status</a>

--- a/Firmware/SdFile.cpp
+++ b/Firmware/SdFile.cpp
@@ -178,14 +178,17 @@ eof_or_fail:
 }
 
 bool SdFile::gfEnsureBlock(){
-    if ( vol_->cacheRawBlock(gfBlock, SdVolume::CACHE_FOR_READ)){
+    // this comparison is heavy-weight, especially when there is another one inside cacheRawBlock
+    // but it is necessary to avoid computing of terminateOfs if not needed
+    if( gfBlock != vol_->cacheBlockNumber_ ){
+        if ( ! vol_->cacheRawBlock(gfBlock, SdVolume::CACHE_FOR_READ)){
+            return false;
+        }
         // terminate with a '\n'
-        const uint16_t terminateOfs = fileSize_ - gfOffset;
+        const uint32_t terminateOfs = fileSize_ - gfOffset;
         vol_->cache()->data[ terminateOfs < 512 ? terminateOfs : 512 ] = '\n';
-        return true;
-    } else {
-        return false;
     }
+    return true;
 }
 
 bool SdFile::gfComputeNextFileBlock() {

--- a/Firmware/mesh_bed_calibration.cpp
+++ b/Firmware/mesh_bed_calibration.cpp
@@ -1,4 +1,3 @@
-#include "Marlin.h"
 #include "Configuration.h"
 #include "ConfigurationStore.h"
 #include "language.h"
@@ -1065,7 +1064,7 @@ error:
 }
 
 #ifdef NEW_XYZCAL
-bool xyzcal_find_bed_induction_sensor_point_xy();
+BedSkewOffsetDetectionResultType xyzcal_find_bed_induction_sensor_point_xy();
 #endif //NEW_XYZCAL
 // Search around the current_position[X,Y],
 // look for the induction sensor response.
@@ -1081,7 +1080,7 @@ bool xyzcal_find_bed_induction_sensor_point_xy();
 #endif //HEATBED_V2
 
 #ifdef HEATBED_V2
-bool find_bed_induction_sensor_point_xy(int
+BedSkewOffsetDetectionResultType find_bed_induction_sensor_point_xy(int
 #if !defined (NEW_XYZCAL) && defined (SUPPORT_VERBOSITY)
         verbosity_level
 #endif
@@ -1137,7 +1136,7 @@ bool find_bed_induction_sensor_point_xy(int
 
 		//        go_xyz(current_position[X_AXIS], current_position[Y_AXIS], MESH_HOME_Z_SEARCH, homing_feedrate[Z_AXIS]/60);
 		go_xyz(x0, y0, current_position[Z_AXIS], feedrate);
-		// Continously lower the Z axis.
+		// Continuously lower the Z axis.
 		endstops_hit_on_purpose();
 		enable_z_endstop(true);
 		bool direction = false;
@@ -1335,7 +1334,7 @@ bool find_bed_induction_sensor_point_xy(int
 #endif //NEW_XYZCAL
 }
 #else //HEATBED_V2
-bool find_bed_induction_sensor_point_xy(int verbosity_level)
+BedSkewOffsetDetectionResultType find_bed_induction_sensor_point_xy(int verbosity_level)
 {
 #ifdef NEW_XYZCAL
 	return xyzcal_find_bed_induction_sensor_point_xy();
@@ -1531,7 +1530,9 @@ bool find_bed_induction_sensor_point_xy(int verbosity_level)
 	}
 
 	enable_z_endstop(false);
-	return found;
+    if (found)
+        return BED_SKEW_OFFSET_DETECTION_POINT_FOUND;
+    return BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND;
 #endif //NEW_XYZCAL
 }
 
@@ -2238,9 +2239,15 @@ BedSkewOffsetDetectionResultType find_bed_offset_and_skew(int8_t verbosity_level
 
     // Collect the rear 2x3 points.
 	current_position[Z_AXIS] = MESH_HOME_Z_SEARCH + FIND_BED_INDUCTION_SENSOR_POINT_Z_STEP * iteration * 0.3;
-	for (int k = 0; k < 4; ++k) {
-		// Don't let the manage_inactivity() function remove power from the motors.
-		refresh_cmd_timeout();
+
+    /// Retry point scanning if a point with bad data appears.
+    /// Bad data could be cause by "cold" sensor.
+    /// This behavior vanishes after few point scans so retry will help.
+    for (int retries = 0; retries <= 1; ++retries) {
+        bool retry = false;
+        for (int k = 0; k < 4; ++k) {
+            // Don't let the manage_inactivity() function remove power from the motors.
+            refresh_cmd_timeout();
 #ifdef MESH_BED_CALIBRATION_SHOW_LCD
 		lcd_set_cursor(0, next_line);
 		lcd_print(k + 1);
@@ -2304,8 +2311,19 @@ BedSkewOffsetDetectionResultType find_bed_offset_and_skew(int8_t verbosity_level
 		if (verbosity_level >= 10)
 			delay_keep_alive(3000);
 		#endif // SUPPORT_VERBOSITY
-		if (!find_bed_induction_sensor_point_xy(verbosity_level))
-			return BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND;
+
+        BedSkewOffsetDetectionResultType result;
+        result = find_bed_induction_sensor_point_xy(verbosity_level);
+        switch(result){
+            case BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND:
+                return BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND;
+            case BED_SKEW_OFFSET_DETECTION_POINT_SCAN_FAILED:
+                retry = true;
+                break;
+            default:
+                break;
+        }
+
 #ifndef NEW_XYZCAL
 #ifndef HEATBED_V2
 		
@@ -2380,6 +2398,9 @@ BedSkewOffsetDetectionResultType find_bed_offset_and_skew(int8_t verbosity_level
 			}
 			#endif // SUPPORT_VERBOSITY
         }
+        if (!retry)
+            break;
+    }
         DBG(_n("All 4 calibration points found.\n"));
         delay_keep_alive(0); //manage_heater, reset watchdog, manage inactivity
 		

--- a/Firmware/mesh_bed_calibration.h
+++ b/Firmware/mesh_bed_calibration.h
@@ -1,5 +1,6 @@
-#ifndef MESH_BED_CALIBRATION_H
-#define MESH_BED_CALIBRATION_H
+#pragma once
+
+#include "Marlin.h"
 
 #define BED_ZERO_REF_X (- 22.f + X_PROBE_OFFSET_FROM_EXTRUDER) // -22 + 23 = 1
 #define BED_ZERO_REF_Y (- 0.6f + Y_PROBE_OFFSET_FROM_EXTRUDER + 4.f) // -0.6 + 5 + 4 = 8.4
@@ -145,11 +146,6 @@ inline bool world2machine_clamp(float &x, float &y)
         machine2world(tmpx, tmpy, x, y);
     return clamped;
 }
-
-bool find_bed_induction_sensor_point_z(float minimum_z = -10.f, uint8_t n_iter = 3, int verbosity_level = 0);
-bool find_bed_induction_sensor_point_xy(int verbosity_level = 0);
-void go_home_with_z_lift();
-
 /**
  * @brief Bed skew and offest detection result
  *
@@ -159,14 +155,20 @@ void go_home_with_z_lift();
 
 enum BedSkewOffsetDetectionResultType {
 	// Detection failed, some point was not found.
+	BED_SKEW_OFFSET_DETECTION_POINT_FOUND       =  0, //!< Point found
 	BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND   = -1, //!< Point not found.
 	BED_SKEW_OFFSET_DETECTION_FITTING_FAILED    = -2, //!< Fitting failed
+	BED_SKEW_OFFSET_DETECTION_POINT_SCAN_FAILED = -3, //!< Point scan failed, try again
 	
 	// Detection finished with success.
 	BED_SKEW_OFFSET_DETECTION_PERFECT 			= 0,  //!< Perfect.
 	BED_SKEW_OFFSET_DETECTION_SKEW_MILD			= 1,  //!< Mildly skewed.
 	BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME		= 2   //!< Extremely skewed.
 };
+
+bool find_bed_induction_sensor_point_z(float minimum_z = -10.f, uint8_t n_iter = 3, int verbosity_level = 0);
+BedSkewOffsetDetectionResultType find_bed_induction_sensor_point_xy(int verbosity_level = 0);
+void go_home_with_z_lift();
 
 extern BedSkewOffsetDetectionResultType find_bed_offset_and_skew(int8_t verbosity_level, uint8_t &too_far_mask);
 #ifndef NEW_XYZCAL
@@ -213,4 +215,3 @@ extern void mbl_settings_init();
 
 extern bool mbl_point_measurement_valid(uint8_t ix, uint8_t iy, uint8_t meas_points, bool zigzag);
 extern void mbl_interpolation(uint8_t meas_points);
-#endif /* MESH_BED_CALIBRATION_H */

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -510,9 +510,9 @@ void lcdui_print_time(void)
     //if remaining print time estimation is available print it else print elapsed time
     int chars = 0;
     if (PRINTER_ACTIVE) {
-        uint16_t print_t = 0;
-        uint16_t print_tr = 0;
-        uint16_t print_tc = 0;
+        uint16_t print_t = PRINT_TIME_REMAINING_INIT;
+        uint16_t print_tr = PRINT_TIME_REMAINING_INIT;
+        uint16_t print_tc = PRINT_TIME_REMAINING_INIT;
         char suff = ' ';
         char suff_doubt = ' ';
 
@@ -542,12 +542,12 @@ void lcdui_print_time(void)
 
         clock_interval++;
 
-        if (print_tc != 0 && clock_interval > CLOCK_INTERVAL_TIME) {
+        if (print_tc != PRINT_TIME_REMAINING_INIT && clock_interval > CLOCK_INTERVAL_TIME) {
             print_t = print_tc;
             suff = 'C';
         } else
 //#endif //CLOCK_INTERVAL_TIME 
-        if (print_tr != 0) {
+        if (print_tr != PRINT_TIME_REMAINING_INIT) {
             print_t = print_tr;
             suff = 'R';
         } else 

--- a/Firmware/xyzcal.h
+++ b/Firmware/xyzcal.h
@@ -1,9 +1,9 @@
 //xyzcal.h - xyz calibration with image processing
-#ifndef _XYZCAL_H
-#define _XYZCAL_H
+#pragma once
 
 #include <inttypes.h>
 
+#include "mesh_bed_calibration.h"
 
 extern void xyzcal_meassure_enter(void);
 
@@ -17,11 +17,4 @@ extern bool xyzcal_spiral8(int16_t cx, int16_t cy, int16_t z0, int16_t dz, int16
 
 //extern int8_t xyzcal_meassure_pinda_hysterezis(int16_t min_z, int16_t max_z, uint16_t delay_us, uint8_t samples);
 
-extern bool xyzcal_searchZ(void);
-
-extern bool xyzcal_scan_and_process(void);
-
-extern bool xyzcal_find_bed_induction_sensor_point_xy(void);
-
-
-#endif //_XYZCAL_H
+extern BedSkewOffsetDetectionResultType xyzcal_find_bed_induction_sensor_point_xy();

--- a/lang/config.sh
+++ b/lang/config.sh
@@ -1,8 +1,16 @@
 #!/bin/sh
 #
+# Version 1.0.1
+#
 # config.sh - multi-language support configuration script
 #  Definition of absolute paths etc.
 #  This file is 'included' in all scripts.
+#
+#############################################################################
+# Change log:
+# 9 June 2020, 3d-gussner, Added version and Change log
+# 9 June 2020, 3d-gussner, colored output
+#############################################################################
 #
 # Arduino main folder:
 if [ -z "$ARDUINO" ]; then
@@ -29,38 +37,38 @@ export INOELF="$OUTDIR/Firmware.ino.elf"
 export INOHEX="$OUTDIR/Firmware.ino.hex"
 
 
-echo "config.sh started" >&2
+echo "$(tput setaf 2)config.sh started$(tput sgr0)" >&2
 
 _err=0
 
 echo -n " Arduino main folder: " >&2
-if [ -e $ARDUINO ]; then echo 'OK' >&2; else echo 'NG!' >&2; _err=1; fi
+if [ -e $ARDUINO ]; then echo "$(tput setaf 2)OK$(tput sgr0)" >&2; else echo "$(tput setaf 1)NG!$(tput sgr0)" >&2; _err=1; fi
 
 echo -n " Arduino builder: " >&2
-if [ -e $BUILDER ]; then echo 'OK' >&2; else echo 'NG!' >&2; _err=2; fi
+if [ -e $BUILDER ]; then echo "$(tput setaf 2)OK$(tput sgr0)" >&2; else echo "$(tput setaf 1)NG!$(tput sgr0)" >&2; _err=2; fi
 
 echo " AVR gcc tools:" >&2
 echo -n "   objcopy " >&2
-if [ -e $OBJCOPY ]; then echo 'OK' >&2; else echo 'NG!' >&2; _err=3; fi
+if [ -e $OBJCOPY ]; then echo "$(tput setaf 2)OK$(tput sgr0)" >&2; else echo "$(tput setaf 1)NG!$(tput sgr0)" >&2; _err=3; fi
 echo -n "   objdump " >&2
-if [ -e $OBJDUMP ]; then echo 'OK' >&2; else echo 'NG!' >&2; _err=4; fi
+if [ -e $OBJDUMP ]; then echo "$(tput setaf 2)OK$(tput sgr0)" >&2; else echo "$(tput setaf 1)NG!$(tput sgr0)" >&2; _err=4; fi
 
 echo -n " Output folder: " >&2
-if [ -e $OUTDIR ]; then echo 'OK' >&2; else echo 'NG!' >&2; _err=5; fi
+if [ -e $OUTDIR ]; then echo "$(tput setaf 2)OK$(tput sgr0)" >&2; else echo "$(tput setaf 1)NG!$(tput sgr0)" >&2; _err=5; fi
 
 echo -n " Objects folder: " >&2
-if [ -e $OBJDIR ]; then echo 'OK' >&2; else echo 'NG!' >&2; _err=6; fi
+if [ -e $OBJDIR ]; then echo "$(tput setaf 2)OK$(tput sgr0)" >&2; else echo "$(tput setaf 1)NG!$(tput sgr0)" >&2; _err=6; fi
 
 echo -n " Generated elf file: " >&2
-if [ -e $INOELF ]; then echo 'OK' >&2; else echo 'NG!' >&2; _err=7; fi
+if [ -e $INOELF ]; then echo "$(tput setaf 2)OK$(tput sgr0)" >&2; else echo "$(tput setaf 1)NG!$(tput sgr0)" >&2; _err=7; fi
 
 echo -n " Generated hex file: " >&2
-if [ -e $INOHEX ]; then echo 'OK' >&2; else echo 'NG!' >&2; _err=8; fi
+if [ -e $INOHEX ]; then echo "$(tput setaf 2)OK$(tput sgr0)" >&2; else echo "$(tput setaf 1)NG!$(tput sgr0)" >&2; _err=8; fi
 
 if [ $_err -eq 0 ]; then
- echo "config.sh finished with success" >&2
+ echo "$(tput setaf 2)config.sh finished with success$(tput sgr0)" >&2
  export CONFIG_OK=1
 else
- echo "config.sh finished with errors!" >&2
+ echo "$(tput setaf 1)config.sh finished with errors!$(tput sgr0)" >&2
  export CONFIG_OK=0
 fi

--- a/lang/config.sh
+++ b/lang/config.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Version 1.0.1
+# Version 1.0.1 Build 6
 #
 # config.sh - multi-language support configuration script
 #  Definition of absolute paths etc.
@@ -8,8 +8,11 @@
 #
 #############################################################################
 # Change log:
-# 9 June 2020, 3d-gussner, Added version and Change log
-# 9 June 2020, 3d-gussner, colored output
+# 31 May 2018,  Xpilla,     Initial
+#  9 June 2020, 3d-gussner, Added version and Change log
+#  9 June 2020, 3d-gussner, colored output
+#  2 Apr. 2021, 3d-gussner, Use `git rev-list --count HEAD config.sh`
+#                           to get Build Nr
 #############################################################################
 #
 # Arduino main folder:

--- a/lang/fw-build.sh
+++ b/lang/fw-build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 #
+# Version 1.0.1
+#
 # postbuild.sh - multi-language support script
 #  Generate binary with secondary language.
 #
@@ -17,6 +19,10 @@
 #  $PROGMEM.txt
 #  textaddr.txt
 #
+#############################################################################
+# Change log:
+# 14 May 2020, 3d-gussner, Add check for not translated messages using a parameter
+#############################################################################
 #
 # Config:
 if [ -z "$CONFIG_OK" ]; then eval "$(cat config.sh)"; fi
@@ -24,11 +30,12 @@ if [ -z "$CONFIG_OK" ] | [ $CONFIG_OK -eq 0 ]; then echo 'Config NG!' >&2; exit 
 #
 # Selected language:
 LNG=$1
-#if [ -z "$LNG" ]; then LNG='cz'; fi
-#
-# Params:
-IGNORE_MISSING_TEXT=1
-
+#Set default to ignore missing text
+  CHECK_MISSING_TEXT=0
+#Check if script should check for missing messages in the source code aren't translated by using parameter "--check-missing-text"
+if [ "$1" = "--check-missing-text" ]; then
+  CHECK_MISSING_TEXT=1
+fi
 
 finish()
 {
@@ -36,7 +43,7 @@ finish()
  if [ "$1" = "0" ]; then
   echo "postbuild.sh finished with success" >&2
  else
-  echo "postbuild.sh finished with errors!" >&2
+  echo "$(tput setaf 1)postbuild.sh finished with errors!$(tput sgr 0)" >&2
  fi
  case "$-" in
   *i*) echo "press enter key"; read ;;
@@ -72,11 +79,13 @@ echo -n " checking textaddr.txt..." >&2
 cat textaddr.txt | grep "^TEXT NF" | sed "s/[^\"]*\"//;s/\"$//" >not_used.txt
 cat textaddr.txt | grep "^ADDR NF" | sed "s/[^\"]*\"//;s/\"$//" >not_tran.txt
 if cat textaddr.txt | grep "^ADDR NF" >/dev/null; then
- echo "NG! - some texts not found in lang_en.txt!"
- if [ $IGNORE_MISSING_TEXT -eq 0 ]; then
-  finish 1
+ echo "$(tput setaf 5)NG! - some texts not found in lang_en.txt!$(tput sgr0)"
+ if [ $CHECK_MISSING_TEXT -eq 1 ]; then
+  echo "$(tput setaf 1)Missing text found, please update the language files!$(tput setaf 6)" >&2
+  cat not_tran.txt >&2
+ finish 1
  else
-  echo "  missing text ignored!" >&2
+  echo "$(tput setaf 3)  missing text ignored!$(tput sgr0)" >&2
  fi
 else
  echo "OK" >&2

--- a/lang/fw-build.sh
+++ b/lang/fw-build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Version 1.0.1
+# Version 1.0.2
 #
 # postbuild.sh - multi-language support script
 #  Generate binary with secondary language.
@@ -22,11 +22,14 @@
 #############################################################################
 # Change log:
 # 14 May 2020, 3d-gussner, Add check for not translated messages using a parameter
+# 14 May 2020, 3d-gussner, Added version and Change log
+# 9 June 2020, 3d-gussner, colored output
+#############################################################################
 #############################################################################
 #
 # Config:
 if [ -z "$CONFIG_OK" ]; then eval "$(cat config.sh)"; fi
-if [ -z "$CONFIG_OK" ] | [ $CONFIG_OK -eq 0 ]; then echo 'Config NG!' >&2; exit 1; fi
+if [ -z "$CONFIG_OK" ] | [ $CONFIG_OK -eq 0 ]; then echo "$(tput setaf 1)Config NG!$(tput sgr0)" >&2; exit 1; fi
 #
 # Selected language:
 LNG=$1
@@ -41,7 +44,7 @@ finish()
 {
  echo
  if [ "$1" = "0" ]; then
-  echo "postbuild.sh finished with success" >&2
+  echo "$(tput setaf 2)postbuild.sh finished with success$(tput sgr 0)" >&2
  else
   echo "$(tput setaf 1)postbuild.sh finished with errors!$(tput sgr 0)" >&2
  fi
@@ -51,28 +54,28 @@ finish()
  exit $1
 }
 
-echo "postbuild.sh started" >&2
+echo "$(tput setaf 2)postbuild.sh started$(tput sgr 0)" >&2
 
 #check input files
 echo " checking files:" >&2
-if [ ! -e $OUTDIR ]; then echo "  folder '$OUTDIR' not found!" >&2; finish 1; fi
-echo "  folder  OK" >&2
-if [ ! -e $INOELF ]; then echo "  elf file '$INOELF' not found!" >&2; finish 1; fi
-echo "  elf     OK" >&2
-if ! ls $OBJDIR/*.o >/dev/null 2>&1; then echo "  no object files in '$OBJDIR/'!" >&2; finish 1; fi
-echo "  objects OK" >&2
+if [ ! -e $OUTDIR ]; then echo "$(tput setaf 1)  folder '$OUTDIR' not found!$(tput sgr 0)" >&2; finish 1; fi
+echo "  folder  $(tput setaf 2)OK$(tput sgr 0)" >&2
+if [ ! -e $INOELF ]; then echo "$(tput setaf 1)  elf file '$INOELF' not found!$(tput sgr 0)" >&2; finish 1; fi
+echo "  elf     $(tput setaf 2)OK$(tput sgr 0)" >&2
+if ! ls $OBJDIR/*.o >/dev/null 2>&1; then echo "$(tput setaf 1)  no object files in '$OBJDIR/'!$(tput sgr 0)" >&2; finish 1; fi
+echo "  objects $(tput setaf 2)OK$(tput sgr 0)" >&2
 
 #run progmem.sh - examine content of progmem1
 echo -n " running progmem.sh..." >&2
 ./progmem.sh 1 2>progmem.out
 if [ $? -ne 0 ]; then echo "NG! - check progmem.out file" >&2; finish 1; fi
-echo "OK" >&2
+echo "$(tput setaf 2)OK$(tput sgr 0)" >&2
 
 #run textaddr.sh - map progmem addreses to text identifiers
 echo -n " running textaddr.sh..." >&2
 ./textaddr.sh 2>textaddr.out
 if [ $? -ne 0 ]; then echo "NG! - check progmem.out file" >&2; finish 1; fi
-echo "OK" >&2
+echo "$(tput setaf 2)OK$(tput sgr 0)" >&2
 
 #check for messages declared in progmem1, but not found in lang_en.txt
 echo -n " checking textaddr.txt..." >&2
@@ -88,13 +91,13 @@ if cat textaddr.txt | grep "^ADDR NF" >/dev/null; then
   echo "$(tput setaf 3)  missing text ignored!$(tput sgr0)" >&2
  fi
 else
- echo "OK" >&2
+ echo "$(tput setaf 2)OK$(tput sgr 0)" >&2
 fi
 
 #extract binary file
 echo -n " extracting binary..." >&2
 $OBJCOPY -I ihex -O binary $INOHEX ./firmware.bin
-echo "OK" >&2
+echo "$(tput setaf 2)OK$(tput sgr 0)" >&2
 
 #update binary file
 echo " updating binary:" >&2
@@ -106,7 +109,7 @@ cat textaddr.txt | grep "^ADDR OK" | cut -f3- -d' ' | sed "s/^0000/0x/" |\
  while read addr data; do
   /bin/echo -n -e $data | dd of=./firmware.bin bs=1 count=2 seek=$addr conv=notrunc oflag=nonblock 2>/dev/null
  done
-echo "OK" >&2
+echo "$(tput setaf 2)OK$(tput sgr 0)" >&2
 
 #update primary language signature in binary file
 echo -n "  primary language signature..." >&2
@@ -122,7 +125,7 @@ if [ -e lang_en.bin ]; then
  chscnt=$(echo $header | cut -c18-29 | sed "s/ /\\\\x/g")
  /bin/echo -e -n "$chscnt" |\
   dd of=firmware.bin bs=1 count=4 seek=$(($pri_lang_addr)) conv=notrunc 2>/dev/null
- echo "OK" >&2
+ echo "$(tput setaf 2)OK$(tput sgr 0)" >&2
 else
  echo "NG! - file lang_en.bin not found!" >&2;
  finish 1
@@ -131,46 +134,46 @@ fi
 #convert bin to hex
 echo -n " converting to hex..." >&2
 $OBJCOPY -I binary -O ihex ./firmware.bin ./firmware.hex
-echo "OK" >&2
+echo "$(tput setaf 2)OK$(tput sgr 0)" >&2
 
 #update _SEC_LANG in binary file if language is selected
 echo -n "  secondary language data..." >&2
 if [ ! -z "$LNG" ]; then
  ./update_lang.sh $LNG 2>./update_lang.out
  if [ $? -ne 0 ]; then echo "NG! - check update_lang.out file" >&2; finish 1; fi
- echo "OK" >&2
+ echo "$(tput setaf 2)OK$(tput sgr 0)" >&2
  finish 0
 else
  echo "Updating languages:" >&2
  if [ -e lang_cz.bin ]; then
   echo -n " Czech  : " >&2
   ./update_lang.sh cz 2>./update_lang_cz.out 1>/dev/null
-  if [ $? -eq 0 ]; then echo 'OK' >&2; else echo 'NG!' >&2; finish 1; fi
+  if [ $? -eq 0 ]; then echo "$(tput setaf 2)OK$(tput sgr0)" >&2; else echo "$(tput setaf 1)NG!$(tput sgr0)" >&2; finish 1; fi
  fi
  if [ -e lang_de.bin ]; then
   echo -n " German : " >&2
   ./update_lang.sh de 2>./update_lang_de.out 1>/dev/null
-  if [ $? -eq 0 ]; then echo 'OK' >&2; else echo 'NG!' >&2; finish 1; fi
+  if [ $? -eq 0 ]; then echo "$(tput setaf 2)OK$(tput sgr0)" >&2; else echo "$(tput setaf 1)NG!$(tput sgr0)" >&2; finish 1; fi
  fi
  if [ -e lang_it.bin ]; then
   echo -n " Italian: " >&2
   ./update_lang.sh it 2>./update_lang_it.out 1>/dev/null
-  if [ $? -eq 0 ]; then echo 'OK' >&2; else echo 'NG!' >&2; finish 1; fi
+  if [ $? -eq 0 ]; then echo "$(tput setaf 2)OK$(tput sgr0)" >&2; else echo "$(tput setaf 1)NG!$(tput sgr0)" >&2; finish 1; fi
  fi
  if [ -e lang_es.bin ]; then
   echo -n " Spanish: " >&2
   ./update_lang.sh es 2>./update_lang_es.out 1>/dev/null
-  if [ $? -eq 0 ]; then echo 'OK' >&2; else echo 'NG!' >&2; finish 1; fi
+  if [ $? -eq 0 ]; then echo "$(tput setaf 2)OK$(tput sgr0)" >&2; else echo "$(tput setaf 1)NG!$(tput sgr0)" >&2; finish 1; fi
  fi
  if [ -e lang_fr.bin ]; then
   echo -n " French : " >&2
   ./update_lang.sh fr 2>./update_lang_fr.out 1>/dev/null
-  if [ $? -eq 0 ]; then echo 'OK' >&2; else echo 'NG!' >&2; finish 1; fi
+  if [ $? -eq 0 ]; then echo "$(tput setaf 2)OK$(tput sgr0)" >&2; else echo "$(tput setaf 1)NG!$(tput sgr0)" >&2; finish 1; fi
  fi
  if [ -e lang_pl.bin ]; then
   echo -n " Polish : " >&2
   ./update_lang.sh pl 2>./update_lang_pl.out 1>/dev/null
-  if [ $? -eq 0 ]; then echo 'OK' >&2; else echo 'NG!' >&2; finish 1; fi
+  if [ $? -eq 0 ]; then echo "$(tput setaf 2)OK$(tput sgr0)" >&2; else echo "$(tput setaf 1)NG!$(tput sgr0)" >&2; finish 1; fi
  fi
 #Community language support
 #Dutch
@@ -210,7 +213,7 @@ if [ -e lang_nl.bin ]; then cat lang_nl.bin >> lang.bin; fi
 #convert lang.bin to lang.hex
 echo -n " converting to hex..." >&2
 $OBJCOPY -I binary -O ihex ./lang.bin ./lang.hex
-echo "OK" >&2
+echo "$(tput setaf 2)OK$(tput sgr 0)" >&2
 
 #append languages to hex file
 cat ./lang.hex >> firmware.hex

--- a/lang/fw-build.sh
+++ b/lang/fw-build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Version 1.0.2
+# Version 1.0.2 Build 11
 #
 # postbuild.sh - multi-language support script
 #  Generate binary with secondary language.
@@ -21,9 +21,13 @@
 #
 #############################################################################
 # Change log:
-# 14 May 2020, 3d-gussner, Add check for not translated messages using a parameter
-# 14 May 2020, 3d-gussner, Added version and Change log
-# 9 June 2020, 3d-gussner, colored output
+# 31 May 2018,  Xpilla,     Initial
+# 14 May 2020,  3d-gussner, Add check for not translated messages using a parameter
+# 14 May 2020,  3d-gussner, Added version and Change log
+#  9 June 2020, 3d-gussner, colored output
+#  1 Mar. 2021, 3d-gussner, Add Community language support
+#  2 Apr. 2021, 3d-gussner, Use `git rev-list --count HEAD fw-build.sh`
+#                           to get Build Nr
 #############################################################################
 #############################################################################
 #
@@ -144,6 +148,7 @@ if [ ! -z "$LNG" ]; then
  echo "$(tput setaf 2)OK$(tput sgr 0)" >&2
  finish 0
 else
+ echo
  echo "Updating languages:" >&2
  if [ -e lang_cz.bin ]; then
   echo -n " Czech  : " >&2
@@ -180,7 +185,7 @@ else
  if [ -e lang_nl.bin ]; then
   echo -n " Dutch  : " >&2
   ./update_lang.sh nl 2>./update_lang_nl.out 1>/dev/null
-  if [ $? -eq 0 ]; then echo 'OK' >&2; else echo 'NG!' >&2; fi
+  if [ $? -eq 0 ]; then echo "$(tput setaf 2)OK$(tput sgr0)" >&2; else echo "$(tput setaf 1)NG!$(tput sgr0)" >&2; finish 1; fi
  fi
 
 #Use the 6 lines below as a template and replace 'qr' and 'New language'
@@ -188,7 +193,7 @@ else
 # if [ -e lang_qr.bin ]; then
 #  echo -n " New language  : " >&2
 #  ./update_lang.sh qr 2>./update_lang_qr.out 1>/dev/null
-#  if [ $? -eq 0 ]; then echo 'OK' >&2; else echo 'NG!' >&2; fi
+#  if [ $? -eq 0 ]; then echo "$(tput setaf 2)OK$(tput sgr0)" >&2; else echo "$(tput setaf 1)NG!$(tput sgr0)" >&2; finish 1; fi
 # fi
 
 # echo "skipped" >&2

--- a/lang/fw-clean.sh
+++ b/lang/fw-clean.sh
@@ -1,14 +1,17 @@
 #!/bin/bash
 #
-# Version 1.0.1
+# Version 1.0.1 Build 9
 #
 # fw-clean.sh - multi-language support script
 #  Remove all firmware output files from lang folder.
 #
 #############################################################################
 # Change log:
-# 9 June 2020, 3d-gussner, Added version and Change log
-# 9 June 2020, 3d-gussner, colored output
+# 21 June 2018, Xpilla,     Initial
+#  9 June 2020, 3d-gussner, Added version and Change log
+#  9 June 2020, 3d-gussner, colored output
+#  2 Apr. 2021, 3d-gussner, Use `git rev-list --count HEAD fw-clean.sh`
+#                           to get Build Nr
 #############################################################################
 
 result=0

--- a/lang/fw-clean.sh
+++ b/lang/fw-clean.sh
@@ -1,25 +1,32 @@
 #!/bin/bash
 #
+# Version 1.0.1
+#
 # fw-clean.sh - multi-language support script
 #  Remove all firmware output files from lang folder.
 #
+#############################################################################
+# Change log:
+# 9 June 2020, 3d-gussner, Added version and Change log
+# 9 June 2020, 3d-gussner, colored output
+#############################################################################
 
 result=0
 
 rm_if_exists()
 {
  if [ -e $1 ]; then
-  echo -n " removing '$1'..." >&2
+  echo -n "$(tput sgr0) removing '$1'...$(tput sgr0)" >&2
   if rm $1; then
-   echo "OK" >&2
+   echo "$(tput setaf 2)OK" >&2
   else
-   echo "NG!" >&2
+   echo "$(tput setaf 1)NG!" >&2
    result=1
   fi
  fi
 }
 
-echo "fw-clean.sh started" >&2
+echo "$(tput setaf 2)fw-clean.sh started$(tput sgr0)" >&2
 
 rm_if_exists text.sym
 rm_if_exists progmem1.sym
@@ -59,9 +66,9 @@ rm_if_exists firmware_nl.hex
 
 echo -n "fw-clean.sh finished" >&2
 if [ $result -eq 0 ]; then
- echo " with success" >&2
+ echo " with success$(tput sgr0)" >&2
 else
- echo " with errors!" >&2
+ echo " with errors!$(tput sgr0)" >&2
 fi
 
 case "$-" in

--- a/lang/lang-add.sh
+++ b/lang/lang-add.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 #
+# Version 1.0.1
+#
 # lang-add.sh - multi-language support script
 #  add new texts from list (lang_add.txt) to all dictionary files
 #
@@ -8,6 +10,11 @@
 # Updated files:
 #  lang_en.txt and all lang_en_xx.txt
 #
+#############################################################################
+# Change log:
+# 9 June 2020, 3d-gussner, Added version and Change log
+# 9 June 2020, 3d-gussner, colored output
+#############################################################################
 
 
 # insert single text to english dictionary

--- a/lang/lang-add.sh
+++ b/lang/lang-add.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Version 1.0.1
+# Version 1.0.1 Build 15
 #
 # lang-add.sh - multi-language support script
 #  add new texts from list (lang_add.txt) to all dictionary files
@@ -12,8 +12,12 @@
 #
 #############################################################################
 # Change log:
-# 9 June 2020, 3d-gussner, Added version and Change log
-# 9 June 2020, 3d-gussner, colored output
+#  1 Nov 2018,  Xpilla,     Initial
+#  9 June 2020, 3d-gussner, Added version and Change log
+#  9 June 2020, 3d-gussner, colored output
+#  1 Mar. 2021, 3d-gussner, Add Community language support
+#  2 Apr. 2021, 3d-gussner, Use `git rev-list --count HEAD lang-add.sh`
+#                           to get Build Nr
 #############################################################################
 
 

--- a/lang/lang-build.sh
+++ b/lang/lang-build.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 #
+# Version 1.0.1
+#
 # lang-build.sh - multi-language support script
 #  generate lang_xx.bin (language binary file)
 #
@@ -9,13 +11,20 @@
 # Output files:
 #  lang_xx.bin
 #
+# Depending on files:
+#  ../Firmware/config.h to read the max allowed size for translations
+#
 # Temporary files:
 #  lang_en.cnt //calculated number of messages in english
 #  lang_en.max //maximum size determined by reading "../Firmware/config.h"
 #  lang_xx.tmp
 #  lang_xx.dat
 #
-
+#############################################################################
+# Change log:
+# 14 May 2020, 3d-gussner, Add message and size count comparison
+#############################################################################
+#
 #awk code to format ui16 variables for dd
 awk_ui16='{ h=int($1/256); printf("\\x%02x\\x%02x\n", int($1-256*h), h); }'
 

--- a/lang/lang-build.sh
+++ b/lang/lang-build.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Version 1.0.2 Build 19
+# Version 1.0.2 Build 20
 #
 # lang-build.sh - multi-language support script
 #  generate lang_xx.bin (language binary file)
@@ -106,7 +106,7 @@ generate_binary()
  rm -f lang_$1.dat
  LNG=$1
  #check lang dictionary
- /usr/bin/env python lang-check.py $1 #--no-warning
+ ./lang-check.py $1 #--no-warning
  #create lang_xx.tmp - different processing for 'en' language
  if [ "$1" = "en" ]; then
   #remove comments and empty lines

--- a/lang/lang-build.sh
+++ b/lang/lang-build.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Version 1.0.2
+# Version 1.0.2 Build 19
 #
 # lang-build.sh - multi-language support script
 #  generate lang_xx.bin (language binary file)
@@ -22,9 +22,13 @@
 #
 #############################################################################
 # Change log:
-# 14 May 2020, 3d-gussner, Add message and size count comparison
-# 14 May 2020, 3d-gussner, Added version and Change log
-# 9 June 2020, 3d-gussner, colored output
+# 18 June 2018, Xpilla,     Initial
+# 14 May  2020, 3d-gussner, Add message and size count comparison
+# 14 May  2020, 3d-gussner, Added version and Change log
+#  9 June 2020, 3d-gussner, colored output
+#  1 Mar. 2021, 3d-gussner, Add Community language support
+#  2 Apr. 2021, 3d-gussner, Use `git rev-list --count HEAD lang-build.sh`
+#                           to get Build Nr
 #############################################################################
 #############################################################################
 #

--- a/lang/lang-build.sh
+++ b/lang/lang-build.sh
@@ -128,9 +128,9 @@ generate_binary()
  # read string count of English and compare it with the translation
  encount=$(cat lang_en.cnt)
  if [ "$count" -eq "$encount" ]; then
-	echo "OK:"$1"="$count" is equal to en="$encount >&2
+	echo "$(tput setaf 2)OK:"$1"="$count" is equal to en="$encount"$(tput sgr 0)" >&2
  else
-	echo "Error:"$1"="$count" is NOT equal to en="$encount >&2
+	echo "$(tput setaf 1)Error:"$1"="$count" is NOT equal to en="$encount"$(tput sgr 0)" >&2
 	finish 1
  fi
  #calculate text data offset
@@ -142,9 +142,10 @@ generate_binary()
  # read maxsize and compare with the translation
  maxsize=$(cat lang_en.max)
  if [ "$size" -lt "$maxsize" ]; then
-	echo "OK:"$1"="$size" is less than "$maxsize >&2
+	free_space=$(($maxsize - $size))
+	echo "$(tput setaf 2)OK:"$1"="$size" is less than "$maxsize". Free space:"$free_space"$(tput sgr 0)" >&2
  else
-	echo "Error:"$1"="$size" is higer than "$maxsize >&2
+	echo "$(tput setaf 1)Error:"$1"="$size" is higer than "$maxsize"$(tput sgr 0)" >&2
 	finish 1
  fi
 

--- a/lang/lang-build.sh
+++ b/lang/lang-build.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Version 1.0.1
+# Version 1.0.2
 #
 # lang-build.sh - multi-language support script
 #  generate lang_xx.bin (language binary file)
@@ -23,21 +23,24 @@
 #############################################################################
 # Change log:
 # 14 May 2020, 3d-gussner, Add message and size count comparison
+# 14 May 2020, 3d-gussner, Added version and Change log
+# 9 June 2020, 3d-gussner, colored output
+#############################################################################
 #############################################################################
 #
 #awk code to format ui16 variables for dd
 awk_ui16='{ h=int($1/256); printf("\\x%02x\\x%02x\n", int($1-256*h), h); }'
 
 #startup message
-echo "lang-build.sh started" >&2
+echo "$(tput setaf 2)lang-build.sh started$(tput sgr0)" >&2
 
 #exiting function
 finish()
 {
  if [ $1 -eq 0 ]; then
-  echo "lang-build.sh finished with success" >&2
+  echo "$(tput setaf 2)lang-build.sh finished with success$(tput sgr0)" >&2
  else
-  echo "lang-build.sh finished with errors!" >&2
+  echo "$(tput setaf 1)lang-build.sh finished with errors!$(tput sgr0)" >&2
  fi
  exit $1
 }
@@ -99,7 +102,11 @@ generate_binary()
  rm -f lang_$1.dat
  LNG=$1
  #check lang dictionary
+<<<<<<< HEAD
  ./lang-check.py $1 --no-warning
+=======
+ /usr/bin/env python lang-check.py $1 #--no-warning
+>>>>>>> 2e5b383f... Added textwrap to `lang-check.py`
  #create lang_xx.tmp - different processing for 'en' language
  if [ "$1" = "en" ]; then
   #remove comments and empty lines

--- a/lang/lang-build.sh
+++ b/lang/lang-build.sh
@@ -102,11 +102,7 @@ generate_binary()
  rm -f lang_$1.dat
  LNG=$1
  #check lang dictionary
-<<<<<<< HEAD
- ./lang-check.py $1 --no-warning
-=======
  /usr/bin/env python lang-check.py $1 #--no-warning
->>>>>>> 2e5b383f... Added textwrap to `lang-check.py`
  #create lang_xx.tmp - different processing for 'en' language
  if [ "$1" = "en" ]; then
   #remove comments and empty lines

--- a/lang/lang-check.py
+++ b/lang/lang-check.py
@@ -1,9 +1,23 @@
 #!/usr/bin/env python3
+#
+# Version 1.0.1
+#
+#############################################################################
+# Change log:
+# 9 June 2020, 3d-gussner, Added version and Change log
+# 9 June 2020, 3d-gussner, Wrap text to 20 char and rows
+# 9 June 2020, 3d-gussner, colored output
+#############################################################################
+#
 """Check lang files."""
 from argparse import ArgumentParser
 from traceback import print_exc
 from sys import stderr
+import textwrap
 
+red = lambda text: '\033[0;31m' + text + '\033[0m'
+green = lambda text: '\033[0;32m' + text + '\033[0m'
+yellow = lambda text: '\033[0;33m' + text + '\033[0m'
 
 def parse_txt(lang, no_warning):
     """Parse txt file and check strings to display definition."""
@@ -12,13 +26,27 @@ def parse_txt(lang, no_warning):
     else:
         file_path = "lang_en_%s.txt" % lang
 
+    print(green("Start %s lang-check" % lang))
+
     lines = 1
     with open(file_path) as src:
         while True:
             comment = src.readline().split(' ')
-            src.readline()  # source
+            source = src.readline()
             translation = src.readline()[:-1]
+#Wrap text to 20 chars and rows
+            wrapper = textwrap.TextWrapper(width=20)
+            #wrap original/source
+            rows_count_source = 0
+            for line in wrapper.wrap(source.strip('"')):
+                rows_count_source += 1
+            #wrap translation
+            rows_count_translation = 0
+            for line in wrapper.wrap(translation.strip('"')):
+                rows_count_translation += 1
+#End wrap text
 
+#Check if columns and rows are defined
             cols = None
             rows = None
             for item in comment[1:]:
@@ -33,20 +61,18 @@ def parse_txt(lang, no_warning):
                         (' '.join(comment), lines))
             if cols is None and rows is None:
                 if not no_warning:
-                    print("[W]: No display definition on line %d" % lines)
+                    print(yellow("[W]: No display definition on line %d" % lines))
                 cols = len(translation)     # propably fullscreen
             if rows is None:
                 rows = 1
 
-            if len(translation)-2 > cols*rows:
-                stderr.write(
-                    "[E]: Text %s is longer then definiton on line %d\n" %
-                    (translation, lines))
-                stderr.flush()
+            if rows_count_translation > rows_count_source and rows_count_translation > rows:
+                print(red("[E]: Text %s is longer then definiton on line %d rows diff=%d\n" % (translation, lines, rows_count_translation-rows)))
 
             if len(src.readline()) != 1:  # empty line
                 break
             lines += 4
+    print(green("End %s lang-check" % lang))
 
 
 def main():

--- a/lang/lang-check.py
+++ b/lang/lang-check.py
@@ -53,7 +53,7 @@ def main():
     """Main function."""
     parser = ArgumentParser(
         description=__doc__,
-        usage="$(prog)s lang")
+        usage="%(prog)s lang")
     parser.add_argument(
         "lang", nargs='?', default="en", type=str,
         help="Check lang file (en|cs|de|es|fr|nl|it|pl)")

--- a/lang/lang-check.py
+++ b/lang/lang-check.py
@@ -1,12 +1,16 @@
 #!/usr/bin/env python3
 #
-# Version 1.0.1
+# Version 1.0.1 Build 8
 #
 #############################################################################
 # Change log:
-# 9 June 2020, 3d-gussner, Added version and Change log
-# 9 June 2020, 3d-gussner, Wrap text to 20 char and rows
-# 9 June 2020, 3d-gussner, colored output
+#  7 May  2019, Ondrej Tuma, Initial
+#  9 June 2020, 3d-gussner,  Added version and Change log
+#  9 June 2020, 3d-gussner,  Wrap text to 20 char and rows
+#  9 June 2020, 3d-gussner,  colored output
+#  2 Apr. 2021, 3d-gussner,  Fix and improve text warp, add some Debug lines
+#                            Use `git rev-list --count HEAD lang-check.py`
+#                            to get Build Nr
 #############################################################################
 #
 """Check lang files."""
@@ -32,18 +36,23 @@ def parse_txt(lang, no_warning):
     with open(file_path) as src:
         while True:
             comment = src.readline().split(' ')
-            source = src.readline()
+            #print (comment) #Debug
+            source = src.readline()[:-1]
+            #print (source) #Debug
             translation = src.readline()[:-1]
+            #print (translation) #Debug
 #Wrap text to 20 chars and rows
             wrapper = textwrap.TextWrapper(width=20)
             #wrap original/source
             rows_count_source = 0
             for line in wrapper.wrap(source.strip('"')):
                 rows_count_source += 1
+                #print (line) #Debug
             #wrap translation
             rows_count_translation = 0
             for line in wrapper.wrap(translation.strip('"')):
                 rows_count_translation += 1
+                #print (line) #Debug
 #End wrap text
 
 #Check if columns and rows are defined
@@ -53,8 +62,10 @@ def parse_txt(lang, no_warning):
                 key, val = item.split('=')
                 if key == 'c':
                     cols = int(val)
+                    #print ("c=",cols) #Debug
                 elif key == 'r':
                     rows = int(val)
+                    #print ("r=",rows) #Debug
                 else:
                     raise RuntimeError(
                         "Unknown display definition %s on line %d" %

--- a/lang/lang-check.sh
+++ b/lang/lang-check.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 #
+# Version 1.0.1
+#
 # lang_check.sh - multi-language support script
 #  check lang_xx.bin (language binary file)
 #
@@ -7,6 +9,11 @@
 #  lang_$1.bin
 #  lang_en.txt or lang_en_$1.txt
 #  
+#############################################################################
+# Change log:
+# 9 June 2020, 3d-gussner, Added version and Change log
+# 9 June 2020, 3d-gussner, colored output
+#############################################################################
 #
 
 #set 'cz'
@@ -19,7 +26,7 @@ fn_b=lang_$1.bin
 
 #check txt dictionary file
 echo -n "dictionary file: $fn_t"
-if [ -e $fn_t ]; then echo " - OK"; else echo " - Not found!"; exit 1; fi
+if [ -e $fn_t ]; then echo "$(tput setaf 2) - OK$(tput sgr0)"; else echo " - Not found!$(tput sgr0)"; exit 1; fi
 
 #create lang_xx.tmp - different processing for 'en' language
 if [ "$1" = "en" ]; then
@@ -33,7 +40,7 @@ fi | sed 's/^\"\\x00\"$/\"\"/' > lang_$1.tmp
 count_txt=$(grep -c '^"' lang_$1.tmp)
 
 echo -n "language bin file: $fn_b"
-if [ -e $fn_b ]; then echo " - OK"; else echo " - Not found!"; exit 1; fi
+if [ -e $fn_b ]; then echo "$(tput setaf 2) - OK$(tput sgr0)"; else echo " - Not found!$(tput sgr0)"; exit 1; fi
 
 #read header and convert to hex
 header=$(dd if=$fn_b bs=1 count=16 2>/dev/null | xxd | cut -c11-49 | sed 's/\([0-9a-f][0-9a-f]\)[\ ]*/\1 /g')
@@ -66,9 +73,9 @@ cat lang_$1.tmp | sed 's/^\"/printf \"\\x22/;s/"$/\\x22\\x0a\"/' | sh >lang_$1_2
 diff -a lang_$1_1.tmp lang_$1_2.tmp >lang_$1_check.dif
 dif=$(cat lang_$1_check.dif)
 if [ -z "$dif" ]; then
- echo 'binary data OK'
+ echo "$(tput setaf 2)binary data OK$(tput sgr0)"
 else
- echo 'binary data NG!'
+ echo "$(tput setaf 1)binary data NG!$(tput sgr0)"
 fi
 
 read -t 5

--- a/lang/lang-check.sh
+++ b/lang/lang-check.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Version 1.0.1
+# Version 1.0.1 Build 7
 #
 # lang_check.sh - multi-language support script
 #  check lang_xx.bin (language binary file)
@@ -11,8 +11,11 @@
 #  
 #############################################################################
 # Change log:
-# 9 June 2020, 3d-gussner, Added version and Change log
-# 9 June 2020, 3d-gussner, colored output
+# 19 June 2018, Xpilla,     Initial
+#  9 June 2020, 3d-gussner, Added version and Change log
+#  9 June 2020, 3d-gussner, colored output
+#  2 Apr. 2021, 3d-gussner, Use `git rev-list --count HEAD lang-check.sh`
+#                           to get Build Nr
 #############################################################################
 #
 

--- a/lang/lang-clean.sh
+++ b/lang/lang-clean.sh
@@ -1,8 +1,15 @@
 #!/bin/sh
 #
+# Version 1.0.1
+#
 # clean.sh - multi-language support script
 #  Remove all language output files from lang folder.
 #
+#############################################################################
+# Change log:
+# 14 May 2020, 3d-gussner, Also remove temporally files which have been generated
+#                          for message and size count comparison
+#############################################################################
 
 result=0
 

--- a/lang/lang-clean.sh
+++ b/lang/lang-clean.sh
@@ -23,6 +23,8 @@ clean_lang()
 {
  if [ "$1" = "en" ]; then
   rm_if_exists lang_$1.tmp
+  rm_if_exists lang_$1.cnt
+  rm_if_exists lang_$1.max
  else
   rm_if_exists lang_$1.tmp
   rm_if_exists lang_en_$1.tmp

--- a/lang/lang-clean.sh
+++ b/lang/lang-clean.sh
@@ -1,16 +1,20 @@
 #!/bin/sh
 #
-# Version 1.0.2
+# Version 1.0.2 Build 10
 #
 # clean.sh - multi-language support script
 #  Remove all language output files from lang folder.
 #
 #############################################################################
 # Change log:
-# 14 May 2020, 3d-gussner, Also remove temporally files which have been generated
-#                          for message and size count comparison
-# 14 May 2020, 3d-gussner, Added version and Change log
-# 9 June 2020, 3d-gussner, colored output
+# 21 June 2018, Xpilla,     Initial
+# 14 May  2020, 3d-gussner, Also remove temporally files which have been generated
+#                           for message and size count comparison
+# 14 May  2020, 3d-gussner, Added version and Change log
+#  9 June 2020, 3d-gussner, colored output
+#  1 Mar. 2021, 3d-gussner, Add Community language support
+#  2 Apr. 2021, 3d-gussner, Use `git rev-list --count HEAD lang-clean.sh`
+#                           to get Build Nr
 #############################################################################
 #############################################################################
 

--- a/lang/lang-clean.sh
+++ b/lang/lang-clean.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Version 1.0.1
+# Version 1.0.2
 #
 # clean.sh - multi-language support script
 #  Remove all language output files from lang folder.
@@ -9,6 +9,9 @@
 # Change log:
 # 14 May 2020, 3d-gussner, Also remove temporally files which have been generated
 #                          for message and size count comparison
+# 14 May 2020, 3d-gussner, Added version and Change log
+# 9 June 2020, 3d-gussner, colored output
+#############################################################################
 #############################################################################
 
 result=0
@@ -16,11 +19,11 @@ result=0
 rm_if_exists()
 {
  if [ -e $1 ]; then
-  echo -n " removing '$1'..." >&2
+  echo -n "$(tput sgr0) removing '$1'...$(tput sgr0)" >&2
   if rm $1; then
-   echo "OK" >&2
+   echo "$(tput setaf 2)OK" >&2
   else
-   echo "NG!" >&2
+   echo "$(tput setaf 1)NG!" >&2
    result=1
   fi
  fi
@@ -46,7 +49,7 @@ clean_lang()
  rm_if_exists lang_$1_2.tmp
 }
 
-echo "lang-clean.sh started" >&2
+echo "$(tput setaf 2)lang-clean.sh started$(tput sgr0)" >&2
 
 clean_lang en
 clean_lang cz
@@ -65,9 +68,9 @@ clean_lang nl
 
 echo -n "lang-clean.sh finished" >&2
 if [ $result -eq 0 ]; then
- echo " with success" >&2
+ echo " with success$(tput sgr0)" >&2
 else
- echo " with errors!" >&2
+ echo " with errors!$(tput sgr0)" >&2
 fi
 
 case "$-" in

--- a/lang/lang-community.sh
+++ b/lang/lang-community.sh
@@ -1,8 +1,17 @@
 #!/bin/sh
 #
+# Version 1.0.2 Build 3
+#
 # lang-community.sh - Community language support script
 # Check community languages are defined in `config.h`
 #
+#############################################################################
+# Change log:
+#  1 Mar. 2021, 3d-gussner, Initial
+#  2 Apr. 2021, 3d-gussner, Use `git rev-list --count HEAD lang-community.sh`
+#                           to get Build Nr
+#############################################################################
+#############################################################################
 
 # Root path
 if [ -z "$ROOT_PATH" ]; then

--- a/lang/lang-export.sh
+++ b/lang/lang-export.sh
@@ -1,8 +1,15 @@
 #!/bin/bash
 #
+# Version 1.0.1
+#
 # lang-export.sh - multi-language support script
 #  for generating lang_xx.po
 #
+#############################################################################
+# Change log:
+# 9 June 2020, 3d-gussner, Added version and Change log
+# 9 June 2020, 3d-gussner, colored output
+#############################################################################
 
 # relative path to source folder
 SRCDIR="../Firmware"

--- a/lang/lang-export.sh
+++ b/lang/lang-export.sh
@@ -1,14 +1,18 @@
 #!/bin/bash
 #
-# Version 1.0.1
+# Version 1.0.1 Build 8
 #
 # lang-export.sh - multi-language support script
 #  for generating lang_xx.po
 #
 #############################################################################
 # Change log:
-# 9 June 2020, 3d-gussner, Added version and Change log
-# 9 June 2020, 3d-gussner, colored output
+#  9 Nov  2018, Xpilla,     Initial
+#  9 June 2020, 3d-gussner, Added version and Change log
+#  9 June 2020, 3d-gussner, colored output
+#  1 Mar. 2021, 3d-gussner, Add Community language support
+#  2 Apr. 2021, 3d-gussner, Use `git rev-list --count HEAD lang-export.sh`
+#                           to get Build Nr
 #############################################################################
 
 # relative path to source folder

--- a/lang/lang-import.sh
+++ b/lang/lang-import.sh
@@ -1,14 +1,18 @@
 #!/bin/bash
 #
-# Version 1.0.1
+# Version 1.0.1 Build 14
 #
 # lang-import.sh - multi-language support script
 #  for importing translated xx.po
 #
 #############################################################################
 # Change log:
-# 9 June 2020, 3d-gussner, Added version and Change log
-# 9 June 2020, 3d-gussner, colored output
+#  9 Nov  2018, Xpilla,     Initial
+#  9 June 2020, 3d-gussner, Added version and Change log
+#  9 June 2020, 3d-gussner, colored output
+#  1 Mar. 2021, 3d-gussner, Add Community language support
+#  2 Apr. 2021, 3d-gussner, Use `git rev-list --count HEAD lang-export.sh`
+#                           to get Build Nr
 #############################################################################
 
 LNG=$1

--- a/lang/lang-import.sh
+++ b/lang/lang-import.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
 #
+# Version 1.0.1
+#
 # lang-import.sh - multi-language support script
 #  for importing translated xx.po
+#
+#############################################################################
+# Change log:
+# 9 June 2020, 3d-gussner, Added version and Change log
+# 9 June 2020, 3d-gussner, colored output
+#############################################################################
 
 LNG=$1
 # if no arguments, 'all' is selected (all po and also pot will be generated)
@@ -29,7 +37,7 @@ cd po/new
 
 # check if input file exists
 if ! [ -e $LNGISO.po ]; then
- echo "Input file $LNGISO.po not found!" >&2
+ echo "$(tput setaf 1)Input file $LNGISO.po not found!$(tput sgr0)" >&2
  exit -1
 fi
 

--- a/lang/lang_en_it.txt
+++ b/lang/lang_en_it.txt
@@ -4,6 +4,7 @@
 
 #MSG_03_OR_OLDER c=18
 " 0.3 or older"
+" 0.3 o inferiore"
 
 # c=18
 "FS v0.3 or older"

--- a/lang/lang_en_it.txt
+++ b/lang/lang_en_it.txt
@@ -4,7 +4,6 @@
 
 #MSG_03_OR_OLDER c=18
 " 0.3 or older"
-" 0.3 o inferiore"
 
 # c=18
 "FS v0.3 or older"

--- a/lang/progmem.sh
+++ b/lang/progmem.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 #
+# Version 1.0.1
+#
 # progmem.sh - multi-language support script
 #  Examine content of progmem sections (default is progmem1).
 #
@@ -16,14 +18,19 @@
 #  $PROGMEM.var - variables - strings
 #  $PROGMEM.txt - text data only (not used)
 #
+#############################################################################
+# Change log:
+# 9 June 2020, 3d-gussner, Added version and Change log
+# 9 June 2020, 3d-gussner, colored output
+#############################################################################
 #
 # Config:
 if [ -z "$CONFIG_OK" ]; then eval "$(cat config.sh)"; fi
-if [ -z "$OUTDIR" ]; then echo 'variable OUTDIR not set!' >&2; exit 1; fi
-if [ -z "$OBJDIR" ]; then echo 'variable OBJDIR not set!' >&2; exit 1; fi
-if [ -z "$INOELF" ]; then echo 'variable INOELF not set!' >&2; exit 1; fi
-if [ -z "$OBJDUMP" ]; then echo 'variable OBJDUMP not set!' >&2; exit 1; fi
-if [ -z "$CONFIG_OK" ] | [ $CONFIG_OK -eq 0 ]; then echo 'Config NG!' >&2; exit 1; fi
+if [ -z "$OUTDIR" ]; then echo '$(tput setaf 1)variable OUTDIR not set!$(tput sgr0)' >&2; exit 1; fi
+if [ -z "$OBJDIR" ]; then echo '$(tput setaf 1)variable OBJDIR not set!$(tput sgr0)' >&2; exit 1; fi
+if [ -z "$INOELF" ]; then echo '$(tput setaf 1)variable INOELF not set!$(tput sgr0)' >&2; exit 1; fi
+if [ -z "$OBJDUMP" ]; then echo '$(tput setaf 1)variable OBJDUMP not set!$(tput sgr0)' >&2; exit 1; fi
+if [ -z "$CONFIG_OK" ] | [ $CONFIG_OK -eq 0 ]; then echo "$(tput setaf 1)Config NG!$(tput sgr0)" >&2; exit 1; fi
 #
 # Program memory used
 PROGMEM=progmem$1

--- a/lang/progmem.sh
+++ b/lang/progmem.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Version 1.0.1
+# Version 1.0.1 Build 13
 #
 # progmem.sh - multi-language support script
 #  Examine content of progmem sections (default is progmem1).
@@ -20,8 +20,11 @@
 #
 #############################################################################
 # Change log:
-# 9 June 2020, 3d-gussner, Added version and Change log
-# 9 June 2020, 3d-gussner, colored output
+# 31 May  2018, Xpilla,     Initial
+#  9 June 2020, 3d-gussner, Added version and Change log
+#  9 June 2020, 3d-gussner, colored output
+#  2 Apr. 2021, 3d-gussner, Use `git rev-list --count HEAD progmem.sh`
+#                           to get Build Nr
 #############################################################################
 #
 # Config:

--- a/lang/textaddr.sh
+++ b/lang/textaddr.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 #
+# Version 1.0.1
+#
 # textaddr.sh - multi-language support script
 #  Compile progmem1.var and lang_en.txt files to textaddr.txt file (mapping of progmem addreses to text idenifiers)
 #
@@ -19,11 +21,16 @@
 #  after sort this will generate pairs of lines (line from progmem1 first)
 #  result of sort is compiled with simple script and stored into file textaddr.txt
 #
+#############################################################################
+# Change log:
+# 9 June 2020, 3d-gussner, Added version and Change log
+# 9 June 2020, 3d-gussner, colored output
+#############################################################################
 
-echo "textaddr.sh started" >&2
+echo "$(tput setaf 2)textaddr.sh started$(tput sgr0)" >&2
 
-if [ ! -e progmem1.var ]; then echo 'textaddr.sh - file progmem1.var not found!' >&2; exit 1; fi 
-if [ ! -e lang_en.txt ]; then echo 'textaddr.sh - file lang_en.txt not found!' >&2; exit 1; fi 
+if [ ! -e progmem1.var ]; then echo '$(tput setaf 1)textaddr.sh - file progmem1.var not found!$(tput sgr0)' >&2; exit 1; fi 
+if [ ! -e lang_en.txt ]; then echo '$(tput setaf 1)textaddr.sh - file lang_en.txt not found!$(tput sgr0)' >&2; exit 1; fi 
 addr=''
 text=''
 (cat progmem1.var | sed -E "s/^([^ ]*) ([^ ]*) (.*)/\1 \"\3\"/";\
@@ -63,6 +70,6 @@ text=''
  fi
 done > textaddr.txt
 
-echo "textaddr.sh finished" >&2
+echo "$(tput setaf 2)textaddr.sh finished$(tput sgr0)" >&2
 
 exit 0

--- a/lang/textaddr.sh
+++ b/lang/textaddr.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Version 1.0.1
+# Version 1.0.1 Build 8
 #
 # textaddr.sh - multi-language support script
 #  Compile progmem1.var and lang_en.txt files to textaddr.txt file (mapping of progmem addreses to text idenifiers)
@@ -23,8 +23,11 @@
 #
 #############################################################################
 # Change log:
-# 9 June 2020, 3d-gussner, Added version and Change log
-# 9 June 2020, 3d-gussner, colored output
+# 30 May  2018, Xpilla,     Initial
+#  9 June 2020, 3d-gussner, Added version and Change log
+#  9 June 2020, 3d-gussner, colored output
+#  2 Apr. 2021, 3d-gussner, Use `git rev-list --count HEAD textaddr.sh`
+#                           to get Build Nr
 #############################################################################
 
 echo "$(tput setaf 2)textaddr.sh started$(tput sgr0)" >&2

--- a/lang/update_lang.sh
+++ b/lang/update_lang.sh
@@ -1,12 +1,20 @@
 #!/bin/sh
 #
+# Version 1.0.1
+#
 # update_lang.sh - multi-language support script
 #  Update secondary language in binary file.
 #
+#############################################################################
+# Change log:
+# 9 June 2020, 3d-gussner, Added version and Change log
+# 9 June 2020, 3d-gussner, colored output
+#############################################################################
+#
 # Config:
 if [ -z "$CONFIG_OK" ]; then eval "$(cat config.sh)"; fi
-if [ -z "$OBJCOPY" ]; then echo 'variable OBJCOPY not set!' >&2; exit 1; fi
-if [ -z "$CONFIG_OK" ] | [ $CONFIG_OK -eq 0 ]; then echo 'Config NG!' >&2; exit 1; fi
+if [ -z "$OBJCOPY" ]; then echo '$(tput setaf 1)variable OBJCOPY not set!$(tput sgr0)' >&2; exit 1; fi
+if [ -z "$CONFIG_OK" ] | [ $CONFIG_OK -eq 0 ]; then echo '$(tput setaf 1)Config NG!$(tput sgr0)' >&2; exit 1; fi
 #
 # Selected language:
 LNG=$1
@@ -17,9 +25,9 @@ finish()
 {
  echo
  if [ "$1" = "0" ]; then
-  echo "update_lang.sh finished with success" >&2
+  echo "$(tput setaf 2)update_lang.sh finished with success$(tput sgr0)" >&2
  else
-  echo "update_lang.sh finished with errors!" >&2
+  echo "$(tput setaf 1)update_lang.sh finished with errors!$(tput sgr0)" >&2
  fi
  case "$-" in
   *i*) echo "press enter key" >&2; read ;;
@@ -27,14 +35,14 @@ finish()
  exit $1
 }
 
-echo "update_lang.sh started" >&2
+echo "$(tput setaf 2)update_lang.sh started$(tput sgr0)" >&2
 echo " selected language=$LNG" >&2
 
 echo -n " checking files..." >&2
-if [ ! -e text.sym ]; then echo "NG!  file text.sym not found!" >&2; finish 1; fi
-if [ ! -e lang_$LNG.bin ]; then echo "NG!  file lang_$LNG.bin not found!" >&2; finish 1; fi
-if [ ! -e firmware.bin ]; then echo "NG!  file firmware.bin not found!" >&2; finish 1; fi
-echo "OK" >&2
+if [ ! -e text.sym ]; then echo "$(tput setaf 1)NG!  file text.sym not found!$(tput sgr0)" >&2; finish 1; fi
+if [ ! -e lang_$LNG.bin ]; then echo "$(tput setaf 1)NG!  file lang_$LNG.bin not found!$(tput sgr0)" >&2; finish 1; fi
+if [ ! -e firmware.bin ]; then echo "$(tput setaf 1)NG!  file firmware.bin not found!$(tput sgr0)" >&2; finish 1; fi
+echo "$(tput setaf 2)OK$(tput sgr0)" >&2
 
 echo -n " checking symbols..." >&2
 #find symbol _SEC_LANG in section '.text'
@@ -43,7 +51,7 @@ if [ -z "$sec_lang" ]; then echo "NG!\n  symbol _SEC_LANG not found!" >&2; finis
 #find symbol _PRI_LANG_SIGNATURE in section '.text'
 pri_lang=$(cat text.sym | grep -E "\b_PRI_LANG_SIGNATURE\b")
 if [ -z "$pri_lang" ]; then echo "NG!\n  symbol _PRI_LANG_SIGNATURE not found!" >&2; finish 1; fi
-echo "OK" >&2
+echo "$(tput setaf 2)OK$(tput sgr0)" >&2
 
 echo " calculating vars:" >&2
 #get pri_lang addres

--- a/lang/update_lang.sh
+++ b/lang/update_lang.sh
@@ -1,14 +1,17 @@
 #!/bin/sh
 #
-# Version 1.0.1
+# Version 1.0.1 Build 11
 #
 # update_lang.sh - multi-language support script
 #  Update secondary language in binary file.
 #
 #############################################################################
 # Change log:
-# 9 June 2020, 3d-gussner, Added version and Change log
-# 9 June 2020, 3d-gussner, colored output
+# 17 June 2018, Xpilla,     Initial
+#  9 June 2020, 3d-gussner, Added version and Change log
+#  9 June 2020, 3d-gussner, colored output
+#  2 Apr. 2021, 3d-gussner, Use `git rev-list --count HEAD update_lang.sh`
+#                           to get Build Nr
 #############################################################################
 #
 # Config:


### PR DESCRIPTION
Prevent successful compiling when the message count and size aren't correct.

Users or scripts may create/modify the `lang_en_??.txt` files in a way that the LCD output isn't correct.

Added some extra checks:
- The message count of the `lang_en.txt` will be stored temporally in `lang_en.cnt`
  - All other translations compare their message count against the English message count.
    - If the xx count is equal to EN count the script displays the information and continues to generate the lang_xx files needed for multi language support.
	- If the xx count is NOT equal to EN count the script displays the information and stops
- The maxsize for 2nd language will be extracted from `../Firmware/config.h` and will be stored temporally in `lang_en.max`
  - All other translations compare their size against the maxsize.
    - If the xx size is less than the maxsize the script displays the information and continues to generate the lang_xx files needed for multi language support.
	- If the xx size is greater or equal than the maxsize the script displays the information and stops