### PR TITLE
Report Long Filename to Octoprint

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -7886,6 +7886,8 @@ Sigma_Exit:
 		if (mmu_enabled && code_seen("AUTO"))
 			automatic = true;
 
+		SERIAL_PROTOCOLLNPGM("Filament change - M600");
+
 		gcode_M600(automatic, x_position, y_position, z_shift, e_shift_init, e_shift_late);
 	
 	}

--- a/Firmware/cardreader.cpp
+++ b/Firmware/cardreader.cpp
@@ -415,14 +415,14 @@ void CardReader::openFile(const char* name,bool read, bool replace_current/*=tru
     if (file.open(curDir, fname, O_READ)) 
     {
       filesize = file.fileSize();
+      getfilename(0, fname);
       SERIAL_PROTOCOLRPGM(_N("File opened: "));////MSG_SD_FILE_OPENED
-      SERIAL_PROTOCOL(fname);
+      SERIAL_PROTOCOL(longFilename[0] ? longFilename : fname);
       SERIAL_PROTOCOLRPGM(_n(" Size: "));////MSG_SD_SIZE
       SERIAL_PROTOCOLLN(filesize);
       sdpos = 0;
       
       SERIAL_PROTOCOLLNRPGM(_N("File selected"));////MSG_SD_FILE_SELECTED
-      getfilename(0, fname);
       lcd_setstatus(longFilename[0] ? longFilename : fname);
       lcd_setstatus("SD-PRINTING         ");
     }

--- a/Firmware/cardreader.cpp
+++ b/Firmware/cardreader.cpp
@@ -415,14 +415,14 @@ void CardReader::openFile(const char* name,bool read, bool replace_current/*=tru
     if (file.open(curDir, fname, O_READ)) 
     {
       filesize = file.fileSize();
-      getfilename(0, fname);
       SERIAL_PROTOCOLRPGM(_N("File opened: "));////MSG_SD_FILE_OPENED
-      SERIAL_PROTOCOL(longFilename[0] ? longFilename : fname);
+      SERIAL_PROTOCOL(fname);
       SERIAL_PROTOCOLRPGM(_n(" Size: "));////MSG_SD_SIZE
       SERIAL_PROTOCOLLN(filesize);
       sdpos = 0;
       
       SERIAL_PROTOCOLLNRPGM(_N("File selected"));////MSG_SD_FILE_SELECTED
+      getfilename(0, fname);
       lcd_setstatus(longFilename[0] ? longFilename : fname);
       lcd_setstatus("SD-PRINTING         ");
     }


### PR DESCRIPTION
Uses the long filename when outputting the SD open filename so that Octoprint can display the long filename during monitoring.