### PR TITLE
Increase E-jerk LA10->15 flattened zone

### DIFF
--- a/Firmware/la10compat.cpp
+++ b/Firmware/la10compat.cpp
@@ -78,10 +78,10 @@ float la10c_jerk(float j)
         return j;
 
     // bring low E-jerk values into equivalent LA 1.5 values by
-    // flattening the response in the (1-4.5) range using a piecewise
+    // flattening the response in the (0.3-4.5) range using a piecewise
     // function. Is it truly worth to preserve the difference between
     // 1.5/2.5 E-jerk for LA1.0? Probably not, but we try nonetheless.
-    j = j < 1.0? j * 3.625:
+    j = j < 0.3? j * 11.5:
         j < 4.5? j * 0.25 + 3.375:
         j;
 


### PR DESCRIPTION
Increase the flattened response in the e-jerk conversion from the 1-4.5 region to 0.3-4.5 (same slope). This brings a 0.3 LA10 e-jerk from 1.08 LA15 equivalent to a 3.45, which is more reasonable.

![2020-05-18T013243](https://user-images.githubusercontent.com/1017726/82162841-b6ad6a00-98a7-11ea-8e94-427b702c67eb.png)

This could better handle the legacy Pretty PETG/CFPETG v3 profiles, which use an unusually low e-jerk of 0.33/0.4 respectively, avoiding some of the surprise in #2664 as opposed to a release note (unless it is too late for 3.9)