### PR TITLE
[WIP] Avoid strings in RAM if possible

### DIFF
--- a/Firmware/mmu.cpp
+++ b/Firmware/mmu.cpp
@@ -880,7 +880,7 @@ void mmu_M600_load_filament(bool automatic, float nozzle_temp)
     lcd_update_enable(false);
     lcd_clear();
     lcd_set_cursor(0, 1); lcd_puts_P(_T(MSG_LOADING_FILAMENT));
-    lcd_print(" ");
+    lcd_space(1);
     lcd_print(tmp_extruder + 1);
     snmm_filaments_used |= (1 << tmp_extruder); //for stop print
 
@@ -995,7 +995,7 @@ void extr_adj(uint8_t extruder) //loading filament for SNMM
 	lcd_set_cursor(0, 1); lcd_puts_P(_T(MSG_LOADING_FILAMENT));
 	//if(strlen(_T(MSG_LOADING_FILAMENT))>18) lcd.setCursor(0, 1);
 	//else lcd.print(" ");
-	lcd_print(" ");
+    lcd_space(1);
 	lcd_print(extruder + 1);
 
 	// get response
@@ -1035,7 +1035,7 @@ void extr_adj(uint8_t extruder) //loading filament for SNMM
 	lcd_clear();
 	lcd_set_cursor(0, 0); lcd_puts_P(_T(MSG_LOADING_FILAMENT));
 	if(strlen(_T(MSG_LOADING_FILAMENT))>18) lcd_set_cursor(0, 1);
-	else lcd_print(" ");
+    else lcd_space(1);
 	lcd_print(mmu_extruder + 1);
 	lcd_set_cursor(0, 2); lcd_puts_P(_T(MSG_PLEASE_WAIT));
 	st_synchronize();
@@ -1083,8 +1083,8 @@ void extr_unload_view()
 {
     lcd_clear();
     lcd_set_cursor(0, 1); lcd_puts_P(_T(MSG_UNLOADING_FILAMENT));
-    lcd_print(" ");
-    if (mmu_extruder == MMU_FILAMENT_UNKNOWN) lcd_print(" ");
+    lcd_space(1);
+    if (mmu_extruder == MMU_FILAMENT_UNKNOWN) lcd_space(1);
     else lcd_print(mmu_extruder + 1);
 }
 
@@ -1116,7 +1116,7 @@ void extr_unload()
 		lcd_display_message_fullscreen_P(PSTR(""));
 		max_feedrate[E_AXIS] = 50;
 		lcd_set_cursor(0, 0); lcd_puts_P(_T(MSG_UNLOADING_FILAMENT));
-		lcd_print(" ");
+        lcd_space(1);
 		lcd_print(mmu_extruder + 1);
 		lcd_set_cursor(0, 2); lcd_puts_P(_T(MSG_PLEASE_WAIT));
 		if (current_position[Z_AXIS] < 15) {
@@ -1352,7 +1352,7 @@ void lcd_mmu_load_to_nozzle(uint8_t filament_nr)
         lcd_clear();
         lcd_set_cursor(0, 1);
         lcd_puts_P(_T(MSG_LOADING_FILAMENT));
-        lcd_print(" ");
+        lcd_space(1);
         lcd_print(tmp_extruder + 1);
         mmu_command(MmuCmd::T0 + tmp_extruder);
         manage_response(true, true, MMU_TCODE_MOVE);
@@ -1386,7 +1386,7 @@ void mmu_cut_filament(uint8_t filament_nr)
         LcdUpdateDisabler disableLcdUpdate;
         lcd_clear();
         lcd_set_cursor(0, 1); lcd_puts_P(_i("Cutting filament")); //// c=18
-        lcd_print(" ");
+        lcd_space(1);
         lcd_print(filament_nr + 1);
         mmu_filament_ramming();
         mmu_command(MmuCmd::K0 + filament_nr);

--- a/Firmware/mmu.cpp
+++ b/Firmware/mmu.cpp
@@ -758,7 +758,7 @@ void manage_response(bool move_axes, bool turn_off_nozzle, uint8_t move)
 					lcd_display_message_fullscreen_P(_i("MMU OK. Resuming temperature..."));
 					delay_keep_alive(3000);
 				}
-                mmu_wait_for_heater_blocking();
+				mmu_wait_for_heater_blocking();
 			  }			  
 			  if (move_axes) {
 				  lcd_clear();
@@ -995,7 +995,7 @@ void extr_adj(uint8_t extruder) //loading filament for SNMM
 	lcd_set_cursor(0, 1); lcd_puts_P(_T(MSG_LOADING_FILAMENT));
 	//if(strlen(_T(MSG_LOADING_FILAMENT))>18) lcd.setCursor(0, 1);
 	//else lcd.print(" ");
-    lcd_space(1);
+	lcd_space(1);
 	lcd_print(extruder + 1);
 
 	// get response
@@ -1035,7 +1035,7 @@ void extr_adj(uint8_t extruder) //loading filament for SNMM
 	lcd_clear();
 	lcd_set_cursor(0, 0); lcd_puts_P(_T(MSG_LOADING_FILAMENT));
 	if(strlen(_T(MSG_LOADING_FILAMENT))>18) lcd_set_cursor(0, 1);
-    else lcd_space(1);
+	else lcd_space(1);
 	lcd_print(mmu_extruder + 1);
 	lcd_set_cursor(0, 2); lcd_puts_P(_T(MSG_PLEASE_WAIT));
 	st_synchronize();
@@ -1116,7 +1116,7 @@ void extr_unload()
 		lcd_display_message_fullscreen_P(PSTR(""));
 		max_feedrate[E_AXIS] = 50;
 		lcd_set_cursor(0, 0); lcd_puts_P(_T(MSG_UNLOADING_FILAMENT));
-        lcd_space(1);
+		lcd_space(1);
 		lcd_print(mmu_extruder + 1);
 		lcd_set_cursor(0, 2); lcd_puts_P(_T(MSG_PLEASE_WAIT));
 		if (current_position[Z_AXIS] < 15) {

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -114,6 +114,7 @@ static uint8_t lay1cal_filament = 0;
 
 
 static const char separator[] PROGMEM = "--------------------";
+static const char colon_space[] PROGMEM = ": ";
 
 /** forward declarations **/
 
@@ -896,7 +897,7 @@ void lcdui_print_status_line(void)
 			lcd_puts_P(_i("PINDA Heating"));////MSG_PINDA_PREHEAT c=20 r=1
 			if (custom_message_state <= PINDA_HEAT_T)
 			{
-				lcd_puts_P(PSTR(": "));
+                lcd_puts_P(colon_space);
 				lcd_print(custom_message_state); //seconds
 				lcd_print(' ');
 			}
@@ -2742,11 +2743,11 @@ void lcd_alright() {
 					Sound_MakeSound(e_SOUND_TYPE_BlindAlert);
         }
         lcd_set_cursor(0, 1);
-        lcd_print(" ");
+        lcd_space(1);
         lcd_set_cursor(0, 2);
-        lcd_print(" ");
+        lcd_space(1);
         lcd_set_cursor(0, 3);
-        lcd_print(" ");
+        lcd_space(1);
         lcd_set_cursor(0, cursor_pos);
         lcd_print(">");
         enc_dif = lcd_encoder_diff;
@@ -3347,9 +3348,9 @@ void lcd_adjust_z() {
           cursor_pos = 1;
         }
         lcd_set_cursor(0, 1);
-        lcd_print(" ");
+        lcd_space(1);
         lcd_set_cursor(0, 2);
-        lcd_print(" ");
+        lcd_space(1);
         lcd_set_cursor(0, cursor_pos);
         lcd_print(">");
         enc_dif = lcd_encoder_diff;
@@ -3397,7 +3398,7 @@ bool lcd_wait_for_pinda(float temp) {
 		lcd_set_cursor(0, 4);
 		lcd_print(LCD_STR_THERMOMETER[0]);
 		lcd_print(ftostr3(current_temperature_pinda));
-		lcd_print("/");
+        lcd_print("/");
 		lcd_print(ftostr3(temp));
 		lcd_print(LCD_STR_DEGREE);
 		delay_keep_alive(1000);
@@ -3419,7 +3420,7 @@ void lcd_wait_for_heater() {
 		lcd_set_cursor(0, 4);
 		lcd_print(LCD_STR_THERMOMETER[0]);
 		lcd_print(ftostr3(degHotend(active_extruder)));
-		lcd_print("/");
+        lcd_print("/");
 		lcd_print(ftostr3(degTargetHotend(active_extruder)));
 		lcd_print(LCD_STR_DEGREE);
 }
@@ -4316,13 +4317,13 @@ void lcd_pick_babystep(){
 
                 
                 lcd_set_cursor(1, 2);
-                lcd_print(" ");
+                lcd_space(1);
                 lcd_set_cursor(1, 3);
-                lcd_print(" ");
+                lcd_space(1);
                 lcd_set_cursor(10, 2);
-                lcd_print(" ");
+                lcd_space(1);
                 lcd_set_cursor(10, 3);
-                lcd_print(" ");
+                lcd_space(1);
                 
                 if (cursor_pos < 3) {
                     lcd_set_cursor(1, cursor_pos+1);
@@ -5878,16 +5879,17 @@ static void lcd_calibration_menu()
 }
 
 void bowden_menu() {
+    static const char extruder[] PROGMEM = "Extruder ";
 	int enc_dif = lcd_encoder_diff;
 	int cursor_pos = 0;
 	lcd_clear();
 	lcd_set_cursor(0, 0);
-	lcd_print(">");
+    lcd_print(">");
 	for (uint_least8_t i = 0; i < 4; i++) {
 		lcd_set_cursor(1, i);
-		lcd_print("Extruder ");
+        lcd_puts_P(extruder);
 		lcd_print(i);
-		lcd_print(": ");
+        lcd_puts_P(colon_space);
 		EEPROM_read_B(EEPROM_BOWDEN_LENGTH + i * 2, &bowden_length[i]);
 		lcd_print(bowden_length[i] - 48);
 
@@ -5920,15 +5922,15 @@ void bowden_menu() {
 				}
 
 				lcd_set_cursor(0, 0);
-				lcd_print(" ");
+                lcd_space(1);
 				lcd_set_cursor(0, 1);
-				lcd_print(" ");
+                lcd_space(1);
 				lcd_set_cursor(0, 2);
-				lcd_print(" ");
+                lcd_space(1);
 				lcd_set_cursor(0, 3);
-				lcd_print(" ");
+                lcd_space(1);
 				lcd_set_cursor(0, cursor_pos);
-				lcd_print(">");
+                lcd_print(">");
 				Sound_MakeSound(e_SOUND_TYPE_EncoderMove);
 				enc_dif = lcd_encoder_diff;
 				_delay(100);
@@ -5943,9 +5945,9 @@ void bowden_menu() {
 				manage_inactivity(true);
 
 				lcd_set_cursor(1, 1);
-				lcd_print("Extruder ");
+                lcd_puts_P(extruder);
 				lcd_print(cursor_pos);
-				lcd_print(": ");
+                lcd_puts_P(colon_space);
 				lcd_set_cursor(13, 1);
 				lcd_print(bowden_length[cursor_pos] - 48);
 
@@ -5973,12 +5975,12 @@ void bowden_menu() {
 						lcd_clear();
 						enc_dif = lcd_encoder_diff;
 						lcd_set_cursor(0, cursor_pos);
-						lcd_print(">");
+                        lcd_print(">");
 						for (uint_least8_t i = 0; i < 4; i++) {
 							lcd_set_cursor(1, i);
-							lcd_print("Extruder ");
+                            lcd_puts_P(extruder);
 							lcd_print(i);
-							lcd_print(": ");
+                            lcd_puts_P(colon_space);
 							EEPROM_read_B(EEPROM_BOWDEN_LENGTH + i * 2, &bowden_length[i]);
 							lcd_print(bowden_length[i] - 48);
 
@@ -5997,7 +5999,7 @@ void bowden_menu() {
 static char snmm_stop_print_menu() { //menu for choosing which filaments will be unloaded in stop print
 	lcd_clear();
 	lcd_puts_at_P(0,0,_T(MSG_UNLOAD_FILAMENT)); lcd_print(":");
-	lcd_set_cursor(0, 1); lcd_print(">");
+    lcd_set_cursor(0, 1); lcd_print(">");
 	lcd_puts_at_P(1,2,_i("Used during print"));////MSG_USED c=19 r=1
 	lcd_puts_at_P(1,3,_i("Current"));////MSG_CURRENT c=19 r=1
 	char cursor_pos = 1;
@@ -6022,13 +6024,13 @@ static char snmm_stop_print_menu() { //menu for choosing which filaments will be
 				}	
 
 				lcd_set_cursor(0, 1);
-				lcd_print(" ");
+                lcd_space(1);
 				lcd_set_cursor(0, 2);
-				lcd_print(" ");
+                lcd_space(1);
 				lcd_set_cursor(0, 3);
-				lcd_print(" ");
+                lcd_space(1);
 				lcd_set_cursor(0, cursor_pos);
-				lcd_print(">");
+                lcd_print(">");
 				enc_dif = lcd_encoder_diff;
 				Sound_MakeSound(e_SOUND_TYPE_EncoderMove);
 				_delay(100);
@@ -6132,11 +6134,11 @@ uint8_t choose_menu_P(const char *header, const char *item, const char *last_ite
         if (last_item&&last_visible) lcd_puts_at_P(1, 3, last_item);
 
         lcd_set_cursor(0, 1);
-        lcd_print(" ");
+        lcd_space(1);
         lcd_set_cursor(0, 2);
-        lcd_print(" ");
+        lcd_space(1);
         lcd_set_cursor(0, 3);
-        lcd_print(" ");
+        lcd_space(1);
         lcd_set_cursor(0, cursor_pos);
         lcd_print(">");
         _delay(100);
@@ -6461,16 +6463,16 @@ static void lcd_farm_no()
 		}
 
 		lcd_set_cursor(0, 2);
-		if (_farmno < 100) lcd_print("0");
-		if (_farmno < 10) lcd_print("0");
+        if (_farmno < 100) lcd_print("0");
+        if (_farmno < 10) lcd_print("0");
 		lcd_print(_farmno);
-		lcd_print("  ");
+        lcd_print("  ");
 		lcd_set_cursor(0, 3);
-		lcd_print("   ");
+        lcd_print("   ");
 
 
 		lcd_set_cursor(step, 3);
-		lcd_print("^");
+        lcd_print("^");
 		_delay(100);
 
 		if (lcd_clicked())
@@ -6508,7 +6510,7 @@ unsigned char lcd_choose_color() {
 	enc_dif = lcd_encoder_diff;
 	lcd_clear();
 	lcd_set_cursor(0, 1);
-	lcd_print(">");
+    lcd_print(">");
 
 	active_rows = items_no < 3 ? items_no : 3;
 	lcd_consume_click();
@@ -6550,13 +6552,13 @@ unsigned char lcd_choose_color() {
 					}
 				}
 				lcd_set_cursor(0, 1);
-				lcd_print(" ");
+                lcd_space(1);
 				lcd_set_cursor(0, 2);
-				lcd_print(" ");
+                lcd_space(1);
 				lcd_set_cursor(0, 3);
-				lcd_print(" ");
+                lcd_space(1);
 				lcd_set_cursor(0, cursor_pos);
-				lcd_print(">");
+                lcd_print(">");
 				Sound_MakeSound(e_SOUND_TYPE_EncoderMove);
 				enc_dif = lcd_encoder_diff;
 				_delay(100);
@@ -6588,7 +6590,7 @@ void lcd_confirm_print()
 	lcd_clear();
 
 	lcd_set_cursor(0, 0);
-	lcd_print("Print ok ?");
+    lcd_puts_P(PSTR("Print ok ?"));
 
 	do
 	{
@@ -6606,14 +6608,14 @@ void lcd_confirm_print()
 		if (cursor_pos > 2) { cursor_pos = 2; }
 		if (cursor_pos < 1) { cursor_pos = 1; }
 
-		lcd_set_cursor(0, 2); lcd_print("          ");
-		lcd_set_cursor(0, 3); lcd_print("          ");
+        lcd_set_cursor(0, 2); lcd_space(10);
+        lcd_set_cursor(0, 3); lcd_space(10);
 		lcd_set_cursor(2, 2);
 		lcd_puts_P(_T(MSG_YES));
 		lcd_set_cursor(2, 3);
 		lcd_puts_P(_T(MSG_NO));
 		lcd_set_cursor(0, 1 + cursor_pos);
-		lcd_print(">");
+        lcd_putc('>');
 		_delay(100);
 
 		_t = _t + 1;
@@ -7390,14 +7392,14 @@ void lcd_sdcard_stop()
 	lcd_puts_P(_T(MSG_NO));
 	lcd_set_cursor(2, 3);
 	lcd_puts_P(_T(MSG_YES));
-	lcd_set_cursor(0, 2); lcd_print(" ");
-	lcd_set_cursor(0, 3); lcd_print(" ");
+    lcd_set_cursor(0, 2); lcd_space(1);
+    lcd_set_cursor(0, 3); lcd_space(1);
 
 	if ((int32_t)lcd_encoder > 2) { lcd_encoder = 2; }
 	if ((int32_t)lcd_encoder < 1) { lcd_encoder = 1; }
 	
 	lcd_set_cursor(0, 1 + lcd_encoder);
-	lcd_print(">");
+    lcd_print(">");
 
 	if (lcd_clicked())
 	{
@@ -8492,7 +8494,7 @@ static bool lcd_selftest_manual_fan_check(int _fan, bool check_opposite,
 	_delay(500);
 
 	lcd_set_cursor(1, 2); lcd_puts_P(_T(MSG_SELFTEST_FAN_YES));
-	lcd_set_cursor(0, 3); lcd_print(">");
+    lcd_set_cursor(0, 3); lcd_print(">");
 	lcd_set_cursor(1, 3); lcd_puts_P(_T(MSG_SELFTEST_FAN_NO));
 
 	int8_t enc_dif = int(_default)*3;
@@ -8522,18 +8524,18 @@ static bool lcd_selftest_manual_fan_check(int _fan, bool check_opposite,
 		if (abs((enc_dif - lcd_encoder_diff)) > 2) {
 			if (enc_dif > lcd_encoder_diff) {
 				_result = !check_opposite;
-				lcd_set_cursor(0, 2); lcd_print(">");
-				lcd_set_cursor(1, 2); lcd_puts_P(_T(MSG_SELFTEST_FAN_YES));
-				lcd_set_cursor(0, 3); lcd_print(" ");
-				lcd_set_cursor(1, 3); lcd_puts_P(_T(MSG_SELFTEST_FAN_NO));
+                lcd_set_cursor(0, 2); lcd_print(">");
+                lcd_puts_at_P(1, 2, _T(MSG_SELFTEST_FAN_YES));
+                lcd_set_cursor(0, 3); lcd_space(1);
+                lcd_puts_at_P(1, 3, _T(MSG_SELFTEST_FAN_NO));
 			}
 
 			if (enc_dif < lcd_encoder_diff) {
 				_result = check_opposite;
-				lcd_set_cursor(0, 2); lcd_print(" ");
-				lcd_set_cursor(1, 2); lcd_puts_P(_T(MSG_SELFTEST_FAN_YES));
-				lcd_set_cursor(0, 3); lcd_print(">");
-				lcd_set_cursor(1, 3); lcd_puts_P(_T(MSG_SELFTEST_FAN_NO));
+                lcd_set_cursor(0, 2); lcd_space(1);
+                lcd_puts_at_P(1, 2, _T(MSG_SELFTEST_FAN_YES));
+                lcd_set_cursor(0, 3); lcd_print(">");
+                lcd_puts_at_P(1, 3, _T(MSG_SELFTEST_FAN_NO));
 			}
 			enc_dif = 0;
 			lcd_encoder_diff = 0;
@@ -8602,10 +8604,10 @@ static FanCheck lcd_selftest_fan_auto(int _fan)
 		for (uint8_t i = 0; i < 5; i++) {
 			delay_keep_alive(1000);
 			lcd_set_cursor(18, 3);
-			lcd_print("-");
+            lcd_print("-");
 			delay_keep_alive(1000);
 			lcd_set_cursor(18, 3);
-			lcd_print("|");
+            lcd_print("|");
 		}
 		fanSpeed = 0;
 
@@ -8659,7 +8661,10 @@ static int lcd_selftest_screen(TestScreen screen, int _progress, int _progress_s
 
     lcd_update_enable(false);
 
-	const char *_indicator = (_progress >= _progress_scale) ? "-" : "|";
+    static const char progress0[] PROGMEM = "-";
+    static const char progress1[] PROGMEM = "|";
+    static const char sOK[] PROGMEM = "OK";
+    const char *_indicator = (_progress >= _progress_scale) ? progress0 : progress1;
 
 	if (_clear) lcd_clear();
 
@@ -8683,23 +8688,20 @@ static int lcd_selftest_screen(TestScreen screen, int _progress, int _progress_s
 	if (screen == TestScreen::Home) lcd_puts_P(_i("Calibrating home"));////c=20 r=1
 
 	lcd_set_cursor(0, 1);
-	lcd_puts_P(separator);
-	if ((screen >= TestScreen::ExtruderFan) && (screen <= TestScreen::FansOk))
+    lcd_puts_P(separator);
+    if ((screen >= TestScreen::ExtruderFan) && (screen <= TestScreen::FansOk))
 	{
 		//SERIAL_ECHOLNPGM("Fan test");
 		lcd_puts_at_P(0, 2, _i("Extruder fan:"));////MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
-		lcd_set_cursor(18, 2);
-		(screen < TestScreen::PrintFan) ? lcd_print(_indicator) : lcd_print("OK");
+        lcd_puts_at_P(18, 2, (screen < TestScreen::PrintFan) ? _indicator : sOK );
 		lcd_puts_at_P(0, 3, _i("Print fan:"));////MSG_SELFTEST_PRINT_FAN_SPEED c=18
-		lcd_set_cursor(18, 3);
-		(screen < TestScreen::FansOk) ? lcd_print(_indicator) : lcd_print("OK");
+        lcd_puts_at_P(18, 3, (screen < TestScreen::FansOk) ? _indicator : sOK);
 	}
 	else if (screen >= TestScreen::Fsensor && screen <= TestScreen::FsensorOk)
 	{
 		lcd_puts_at_P(0, 2, _T(MSG_SELFTEST_FILAMENT_SENSOR));
 		lcd_putc(':');
-		lcd_set_cursor(18, 2);
-		(screen == TestScreen::Fsensor) ? lcd_print(_indicator) : lcd_print("OK");
+        lcd_puts_at_P(18, 2, (screen == TestScreen::Fsensor) ? _indicator : sOK);
 	}
 	else if (screen < TestScreen::Fsensor)
 	{
@@ -8736,16 +8738,16 @@ static void lcd_selftest_screen_step(int _row, int _col, int _state, const char 
 	case 1:
 		lcd_print(_name);
 		lcd_set_cursor(_col + strlen(_name), _row);
-		lcd_print(":");
+        lcd_print(":");
 		lcd_set_cursor(_col + strlen(_name) + 1, _row);
 		lcd_print(_indicator);
 		break;
 	case 2:
 		lcd_print(_name);
 		lcd_set_cursor(_col + strlen(_name), _row);
-		lcd_print(":");
+        lcd_print(":");
 		lcd_set_cursor(_col + strlen(_name) + 1, _row);
-		lcd_print("OK");
+        lcd_print("OK");
 		break;
 	default:
 		lcd_print(_name);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -6152,34 +6152,38 @@ uint8_t choose_menu_P(const char *header, const char *item, const char *last_ite
 }
 
 char reset_menu() {
+    const uint8_t items_no =
 #ifdef SNMM
-	int items_no = 5;
+        5;
 #else
-	int items_no = 4;
+        4;
 #endif
-	static int first = 0;
-	int enc_dif = 0;
+    static int8_t first = 0;
+    int8_t enc_dif = 0;
 	char cursor_pos = 0;
-	const char *item [items_no];
-	
-	item[0] = "Language";
-	item[1] = "Statistics";
-	item[2] = "Shipping prep";
-	item[3] = "All Data";
-#ifdef SNMM
-	item[4] = "Bowden length";
-#endif // SNMM
 
+    static const char iLa[] PROGMEM = "Language";
+    static const char iSt[] PROGMEM = "Statistics";
+    static const char iSh[] PROGMEM = "Shipping prep";
+    static const char iAl[] PROGMEM = "All Data";
+    static const char iBl[] PROGMEM = "Bowden length";
+
+    static const char *const item [items_no] PROGMEM = { iLa, iSt, iSh, iAl
+#ifdef SNMM
+        , iBl
+#endif
+    };
+	
 	enc_dif = lcd_encoder_diff;
 	lcd_clear();
 	lcd_set_cursor(0, 0);
-	lcd_print(">");
+    lcd_putc('>');
 	lcd_consume_click();
 	while (1) {		
 
 		for (uint_least8_t i = 0; i < 4; i++) {
 			lcd_set_cursor(1, i);
-			lcd_print(item[first + i]);
+            lcd_puts_P(item[first + i]);
 		}
 
 		manage_heater();
@@ -6214,15 +6218,15 @@ char reset_menu() {
 					}
 				}
 				lcd_set_cursor(0, 0);
-				lcd_print(" ");
+                lcd_space(1);
 				lcd_set_cursor(0, 1);
-				lcd_print(" ");
+                lcd_space(1);
 				lcd_set_cursor(0, 2);
-				lcd_print(" ");
+                lcd_space(1);
 				lcd_set_cursor(0, 3);
-				lcd_print(" ");
+                lcd_space(1);
 				lcd_set_cursor(0, cursor_pos);
-				lcd_print(">");
+                lcd_putc('>');
 				Sound_MakeSound(e_SOUND_TYPE_EncoderMove);
 				enc_dif = lcd_encoder_diff;
 				_delay(100);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -6498,10 +6498,10 @@ unsigned char lcd_choose_color() {
 	//function returns index of currently chosen item
 	//following part can be modified from 2 to 255 items:
 	//-----------------------------------------------------
-	unsigned char items_no = 2;
-	const char *item[items_no];
-	item[0] = "Orange";
-	item[1] = "Black";
+	static const unsigned char items_no = 2;
+	static const char orange[] PROGMEM = "Orange";
+	static const char black[] PROGMEM = "Black";
+	static const char * const item[items_no] PROGMEM = { orange, black };
 	//-----------------------------------------------------
 	uint_least8_t active_rows;
 	static int first = 0;
@@ -6518,7 +6518,7 @@ unsigned char lcd_choose_color() {
 		lcd_puts_at_P(0, 0, PSTR("Choose color:"));
 		for (uint_least8_t i = 0; i < active_rows; i++) {
 			lcd_set_cursor(1, i+1);
-			lcd_print(item[first + i]);
+			lcd_puts_P(item[first + i]);
 		}
 
 		manage_heater();

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -897,7 +897,7 @@ void lcdui_print_status_line(void)
 			lcd_puts_P(_i("PINDA Heating"));////MSG_PINDA_PREHEAT c=20 r=1
 			if (custom_message_state <= PINDA_HEAT_T)
 			{
-                lcd_puts_P(colon_space);
+				lcd_puts_P(colon_space);
 				lcd_print(custom_message_state); //seconds
 				lcd_print(' ');
 			}
@@ -3398,7 +3398,7 @@ bool lcd_wait_for_pinda(float temp) {
 		lcd_set_cursor(0, 4);
 		lcd_print(LCD_STR_THERMOMETER[0]);
 		lcd_print(ftostr3(current_temperature_pinda));
-        lcd_print("/");
+		lcd_print("/");
 		lcd_print(ftostr3(temp));
 		lcd_print(LCD_STR_DEGREE);
 		delay_keep_alive(1000);
@@ -3420,7 +3420,7 @@ void lcd_wait_for_heater() {
 		lcd_set_cursor(0, 4);
 		lcd_print(LCD_STR_THERMOMETER[0]);
 		lcd_print(ftostr3(degHotend(active_extruder)));
-        lcd_print("/");
+		lcd_print("/");
 		lcd_print(ftostr3(degTargetHotend(active_extruder)));
 		lcd_print(LCD_STR_DEGREE);
 }
@@ -5879,17 +5879,17 @@ static void lcd_calibration_menu()
 }
 
 void bowden_menu() {
-    static const char extruder[] PROGMEM = "Extruder ";
+	static const char extruder[] PROGMEM = "Extruder ";
 	int enc_dif = lcd_encoder_diff;
 	int cursor_pos = 0;
 	lcd_clear();
 	lcd_set_cursor(0, 0);
-    lcd_print(">");
+	lcd_print(">");
 	for (uint_least8_t i = 0; i < 4; i++) {
 		lcd_set_cursor(1, i);
-        lcd_puts_P(extruder);
+		lcd_puts_P(extruder);
 		lcd_print(i);
-        lcd_puts_P(colon_space);
+		lcd_puts_P(colon_space);
 		EEPROM_read_B(EEPROM_BOWDEN_LENGTH + i * 2, &bowden_length[i]);
 		lcd_print(bowden_length[i] - 48);
 
@@ -5922,15 +5922,15 @@ void bowden_menu() {
 				}
 
 				lcd_set_cursor(0, 0);
-                lcd_space(1);
+				lcd_space(1);
 				lcd_set_cursor(0, 1);
-                lcd_space(1);
+				lcd_space(1);
 				lcd_set_cursor(0, 2);
-                lcd_space(1);
+				lcd_space(1);
 				lcd_set_cursor(0, 3);
-                lcd_space(1);
+				lcd_space(1);
 				lcd_set_cursor(0, cursor_pos);
-                lcd_print(">");
+				lcd_print(">");
 				Sound_MakeSound(e_SOUND_TYPE_EncoderMove);
 				enc_dif = lcd_encoder_diff;
 				_delay(100);
@@ -5945,9 +5945,9 @@ void bowden_menu() {
 				manage_inactivity(true);
 
 				lcd_set_cursor(1, 1);
-                lcd_puts_P(extruder);
+				lcd_puts_P(extruder);
 				lcd_print(cursor_pos);
-                lcd_puts_P(colon_space);
+				lcd_puts_P(colon_space);
 				lcd_set_cursor(13, 1);
 				lcd_print(bowden_length[cursor_pos] - 48);
 
@@ -5975,12 +5975,12 @@ void bowden_menu() {
 						lcd_clear();
 						enc_dif = lcd_encoder_diff;
 						lcd_set_cursor(0, cursor_pos);
-                        lcd_print(">");
+						lcd_print(">");
 						for (uint_least8_t i = 0; i < 4; i++) {
 							lcd_set_cursor(1, i);
-                            lcd_puts_P(extruder);
+							lcd_puts_P(extruder);
 							lcd_print(i);
-                            lcd_puts_P(colon_space);
+							lcd_puts_P(colon_space);
 							EEPROM_read_B(EEPROM_BOWDEN_LENGTH + i * 2, &bowden_length[i]);
 							lcd_print(bowden_length[i] - 48);
 
@@ -5999,7 +5999,7 @@ void bowden_menu() {
 static char snmm_stop_print_menu() { //menu for choosing which filaments will be unloaded in stop print
 	lcd_clear();
 	lcd_puts_at_P(0,0,_T(MSG_UNLOAD_FILAMENT)); lcd_print(":");
-    lcd_set_cursor(0, 1); lcd_print(">");
+	lcd_set_cursor(0, 1); lcd_print(">");
 	lcd_puts_at_P(1,2,_i("Used during print"));////MSG_USED c=19 r=1
 	lcd_puts_at_P(1,3,_i("Current"));////MSG_CURRENT c=19 r=1
 	char cursor_pos = 1;
@@ -6024,13 +6024,13 @@ static char snmm_stop_print_menu() { //menu for choosing which filaments will be
 				}	
 
 				lcd_set_cursor(0, 1);
-                lcd_space(1);
+				lcd_space(1);
 				lcd_set_cursor(0, 2);
-                lcd_space(1);
+				lcd_space(1);
 				lcd_set_cursor(0, 3);
-                lcd_space(1);
+				lcd_space(1);
 				lcd_set_cursor(0, cursor_pos);
-                lcd_print(">");
+				lcd_print(">");
 				enc_dif = lcd_encoder_diff;
 				Sound_MakeSound(e_SOUND_TYPE_EncoderMove);
 				_delay(100);
@@ -6463,16 +6463,16 @@ static void lcd_farm_no()
 		}
 
 		lcd_set_cursor(0, 2);
-        if (_farmno < 100) lcd_print("0");
-        if (_farmno < 10) lcd_print("0");
+		if (_farmno < 100) lcd_print("0");
+		if (_farmno < 10) lcd_print("0");
 		lcd_print(_farmno);
-        lcd_print("  ");
+		lcd_print("  ");
 		lcd_set_cursor(0, 3);
-        lcd_print("   ");
+		lcd_print("   ");
 
 
 		lcd_set_cursor(step, 3);
-        lcd_print("^");
+		lcd_print("^");
 		_delay(100);
 
 		if (lcd_clicked())
@@ -6510,7 +6510,7 @@ unsigned char lcd_choose_color() {
 	enc_dif = lcd_encoder_diff;
 	lcd_clear();
 	lcd_set_cursor(0, 1);
-    lcd_print(">");
+	lcd_print(">");
 
 	active_rows = items_no < 3 ? items_no : 3;
 	lcd_consume_click();
@@ -6552,13 +6552,13 @@ unsigned char lcd_choose_color() {
 					}
 				}
 				lcd_set_cursor(0, 1);
-                lcd_space(1);
+				lcd_space(1);
 				lcd_set_cursor(0, 2);
-                lcd_space(1);
+				lcd_space(1);
 				lcd_set_cursor(0, 3);
-                lcd_space(1);
+				lcd_space(1);
 				lcd_set_cursor(0, cursor_pos);
-                lcd_print(">");
+				lcd_print(">");
 				Sound_MakeSound(e_SOUND_TYPE_EncoderMove);
 				enc_dif = lcd_encoder_diff;
 				_delay(100);
@@ -6590,7 +6590,7 @@ void lcd_confirm_print()
 	lcd_clear();
 
 	lcd_set_cursor(0, 0);
-    lcd_puts_P(PSTR("Print ok ?"));
+	lcd_puts_P(PSTR("Print ok ?"));
 
 	do
 	{
@@ -6608,14 +6608,14 @@ void lcd_confirm_print()
 		if (cursor_pos > 2) { cursor_pos = 2; }
 		if (cursor_pos < 1) { cursor_pos = 1; }
 
-        lcd_set_cursor(0, 2); lcd_space(10);
-        lcd_set_cursor(0, 3); lcd_space(10);
+		lcd_set_cursor(0, 2); lcd_space(10);
+		lcd_set_cursor(0, 3); lcd_space(10);
 		lcd_set_cursor(2, 2);
 		lcd_puts_P(_T(MSG_YES));
 		lcd_set_cursor(2, 3);
 		lcd_puts_P(_T(MSG_NO));
 		lcd_set_cursor(0, 1 + cursor_pos);
-        lcd_putc('>');
+		lcd_putc('>');
 		_delay(100);
 
 		_t = _t + 1;
@@ -7392,14 +7392,14 @@ void lcd_sdcard_stop()
 	lcd_puts_P(_T(MSG_NO));
 	lcd_set_cursor(2, 3);
 	lcd_puts_P(_T(MSG_YES));
-    lcd_set_cursor(0, 2); lcd_space(1);
-    lcd_set_cursor(0, 3); lcd_space(1);
+	lcd_set_cursor(0, 2); lcd_space(1);
+	lcd_set_cursor(0, 3); lcd_space(1);
 
 	if ((int32_t)lcd_encoder > 2) { lcd_encoder = 2; }
 	if ((int32_t)lcd_encoder < 1) { lcd_encoder = 1; }
 	
 	lcd_set_cursor(0, 1 + lcd_encoder);
-    lcd_print(">");
+	lcd_print(">");
 
 	if (lcd_clicked())
 	{
@@ -8494,7 +8494,7 @@ static bool lcd_selftest_manual_fan_check(int _fan, bool check_opposite,
 	_delay(500);
 
 	lcd_set_cursor(1, 2); lcd_puts_P(_T(MSG_SELFTEST_FAN_YES));
-    lcd_set_cursor(0, 3); lcd_print(">");
+	lcd_set_cursor(0, 3); lcd_print(">");
 	lcd_set_cursor(1, 3); lcd_puts_P(_T(MSG_SELFTEST_FAN_NO));
 
 	int8_t enc_dif = int(_default)*3;
@@ -8524,18 +8524,18 @@ static bool lcd_selftest_manual_fan_check(int _fan, bool check_opposite,
 		if (abs((enc_dif - lcd_encoder_diff)) > 2) {
 			if (enc_dif > lcd_encoder_diff) {
 				_result = !check_opposite;
-                lcd_set_cursor(0, 2); lcd_print(">");
-                lcd_puts_at_P(1, 2, _T(MSG_SELFTEST_FAN_YES));
-                lcd_set_cursor(0, 3); lcd_space(1);
-                lcd_puts_at_P(1, 3, _T(MSG_SELFTEST_FAN_NO));
+				lcd_set_cursor(0, 2); lcd_print(">");
+				lcd_puts_at_P(1, 2, _T(MSG_SELFTEST_FAN_YES));
+				lcd_set_cursor(0, 3); lcd_space(1);
+				lcd_puts_at_P(1, 3, _T(MSG_SELFTEST_FAN_NO));
 			}
 
 			if (enc_dif < lcd_encoder_diff) {
 				_result = check_opposite;
-                lcd_set_cursor(0, 2); lcd_space(1);
-                lcd_puts_at_P(1, 2, _T(MSG_SELFTEST_FAN_YES));
-                lcd_set_cursor(0, 3); lcd_print(">");
-                lcd_puts_at_P(1, 3, _T(MSG_SELFTEST_FAN_NO));
+				lcd_set_cursor(0, 2); lcd_space(1);
+				lcd_puts_at_P(1, 2, _T(MSG_SELFTEST_FAN_YES));
+				lcd_set_cursor(0, 3); lcd_print(">");
+				lcd_puts_at_P(1, 3, _T(MSG_SELFTEST_FAN_NO));
 			}
 			enc_dif = 0;
 			lcd_encoder_diff = 0;
@@ -8604,10 +8604,10 @@ static FanCheck lcd_selftest_fan_auto(int _fan)
 		for (uint8_t i = 0; i < 5; i++) {
 			delay_keep_alive(1000);
 			lcd_set_cursor(18, 3);
-            lcd_print("-");
+			lcd_print("-");
 			delay_keep_alive(1000);
 			lcd_set_cursor(18, 3);
-            lcd_print("|");
+			lcd_print("|");
 		}
 		fanSpeed = 0;
 
@@ -8659,12 +8659,12 @@ static FanCheck lcd_selftest_fan_auto(int _fan)
 static int lcd_selftest_screen(TestScreen screen, int _progress, int _progress_scale, bool _clear, int _delay)
 {
 
-    lcd_update_enable(false);
+	lcd_update_enable(false);
 
-    static const char progress0[] PROGMEM = "-";
-    static const char progress1[] PROGMEM = "|";
-    static const char sOK[] PROGMEM = "OK";
-    const char *_indicator = (_progress >= _progress_scale) ? progress0 : progress1;
+	static const char progress0[] PROGMEM = "-";
+	static const char progress1[] PROGMEM = "|";
+	static const char sOK[] PROGMEM = "OK";
+	const char *_indicator = (_progress >= _progress_scale) ? progress0 : progress1;
 
 	if (_clear) lcd_clear();
 
@@ -8688,26 +8688,26 @@ static int lcd_selftest_screen(TestScreen screen, int _progress, int _progress_s
 	if (screen == TestScreen::Home) lcd_puts_P(_i("Calibrating home"));////c=20 r=1
 
 	lcd_set_cursor(0, 1);
-    lcd_puts_P(separator);
-    if ((screen >= TestScreen::ExtruderFan) && (screen <= TestScreen::FansOk))
+	lcd_puts_P(separator);
+	if ((screen >= TestScreen::ExtruderFan) && (screen <= TestScreen::FansOk))
 	{
 		//SERIAL_ECHOLNPGM("Fan test");
 		lcd_puts_at_P(0, 2, _i("Extruder fan:"));////MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
-        lcd_puts_at_P(18, 2, (screen < TestScreen::PrintFan) ? _indicator : sOK );
+		lcd_puts_at_P(18, 2, (screen < TestScreen::PrintFan) ? _indicator : sOK );
 		lcd_puts_at_P(0, 3, _i("Print fan:"));////MSG_SELFTEST_PRINT_FAN_SPEED c=18
-        lcd_puts_at_P(18, 3, (screen < TestScreen::FansOk) ? _indicator : sOK);
+		lcd_puts_at_P(18, 3, (screen < TestScreen::FansOk) ? _indicator : sOK);
 	}
 	else if (screen >= TestScreen::Fsensor && screen <= TestScreen::FsensorOk)
 	{
 		lcd_puts_at_P(0, 2, _T(MSG_SELFTEST_FILAMENT_SENSOR));
 		lcd_putc(':');
-        lcd_puts_at_P(18, 2, (screen == TestScreen::Fsensor) ? _indicator : sOK);
+		lcd_puts_at_P(18, 2, (screen == TestScreen::Fsensor) ? _indicator : sOK);
 	}
 	else if (screen < TestScreen::Fsensor)
 	{
 		//SERIAL_ECHOLNPGM("Other tests");
 
-	    TestScreen _step_block = TestScreen::AxisX;
+		TestScreen _step_block = TestScreen::AxisX;
 		lcd_selftest_screen_step(2, 2, ((screen == _step_block) ? 1 : (screen < _step_block) ? 0 : 2), "X", _indicator);
 
 		_step_block = TestScreen::AxisY;
@@ -8719,8 +8719,8 @@ static int lcd_selftest_screen(TestScreen screen, int _progress, int _progress_s
 		_step_block = TestScreen::Bed;
 		lcd_selftest_screen_step(3, 0, ((screen == _step_block) ? 1 : (screen < _step_block) ? 0 : 2), "Bed", _indicator);
 
-        _step_block = TestScreen::Hotend;
-        lcd_selftest_screen_step(3, 9, ((screen == _step_block) ? 1 : (screen < _step_block) ? 0 : 2), "Hotend", _indicator);
+		_step_block = TestScreen::Hotend;
+		lcd_selftest_screen_step(3, 9, ((screen == _step_block) ? 1 : (screen < _step_block) ? 0 : 2), "Hotend", _indicator);
 	}
 
 	if (_delay > 0) delay_keep_alive(_delay);
@@ -8738,16 +8738,16 @@ static void lcd_selftest_screen_step(int _row, int _col, int _state, const char 
 	case 1:
 		lcd_print(_name);
 		lcd_set_cursor(_col + strlen(_name), _row);
-        lcd_print(":");
+		lcd_print(":");
 		lcd_set_cursor(_col + strlen(_name) + 1, _row);
 		lcd_print(_indicator);
 		break;
 	case 2:
 		lcd_print(_name);
 		lcd_set_cursor(_col + strlen(_name), _row);
-        lcd_print(":");
+		lcd_print(":");
 		lcd_set_cursor(_col + strlen(_name) + 1, _row);
-        lcd_print("OK");
+		lcd_print("OK");
 		break;
 	default:
 		lcd_print(_name);


### PR DESCRIPTION
- remove RAM located strings from reset_menu
- optimize calls printing one character
Saves 45B of RAM (!) and 60B of FLASH.

PFW-1123