### PR TITLE
Output babystep (first layer calibration) value

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -5137,7 +5137,6 @@ if(eSoundMode!=e_SOUND_MODE_SILENT)
 		if(temp_cal_active == true && calibration_status_pinda() == true) temp_compensation_apply(); //apply PINDA temperature compensation
 #endif
 		babystep_apply(); // Apply Z height correction aka baby stepping before mesh bed leveing gets activated.
-//		SERIAL_ECHOLNPGM("babystep applied");
 		bool eeprom_bed_correction_valid = eeprom_read_byte((unsigned char*)EEPROM_BED_CORRECTION_VALID) == 1;
 		#ifdef SUPPORT_VERBOSITY
 		if (verbosity_level >= 1) {

--- a/Firmware/mesh_bed_calibration.cpp
+++ b/Firmware/mesh_bed_calibration.cpp
@@ -3054,7 +3054,9 @@ void babystep_apply()
 {
     babystep_load();
 #ifdef BABYSTEP_LOADZ_BY_PLANNER
-    shift_z(- float(babystepLoadZ) / float(cs.axis_steps_per_unit[Z_AXIS]));
+    float babysteps_mm = - float(babystepLoadZ) / float(cs.axis_steps_per_unit[Z_AXIS]);
+    shift_z(babysteps_mm);
+    printf_P(_N("babystep applied:%.3f\n"), babysteps_mm);
 #else
     babystepsTodoZadd(babystepLoadZ);
 #endif /* BABYSTEP_LOADZ_BY_PLANNER */


### PR DESCRIPTION
Useful for debugging this outputs the babystep value (the value set when doing first layer calibration) this is in addition to the z_shift_mm value output by `temp_compensation_apply`.

Expected output (after `G80`) is:

```
Recv: echo:busy: processing
Recv: clean up finished
Recv: Z shift applied:0.00
Recv: babystep applied:0.80
Recv: Bed leveling correction finished
```