### PR TITLE
Fix missing start on MK3/S

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1065,7 +1065,7 @@ void setup()
 	}
 	MYSERIAL.begin(BAUDRATE);
 	fdev_setup_stream(uartout, uart_putchar, NULL, _FDEV_SETUP_WRITE); //setup uart out stream
-#if !((LANG_MODE == 1) && defined(W25X20CL)) || (LANG_MODE == 0)
+#ifndef W25X20CL
 	SERIAL_PROTOCOLLNPGM("start");
 #else
 	if (optiboot_status == 1)

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1014,8 +1014,9 @@ void setup()
 	lcd_splash();
     Sound_Init();                                // also guarantee "SET_OUTPUT(BEEPER)"
 
-	selectedSerialPort = eeprom_read_byte((uint8_t*)EEPROM_SECOND_SERIAL_ACTIVE);
+	selectedSerialPort = eeprom_read_byte((uint8_t *)EEPROM_SECOND_SERIAL_ACTIVE);
 	if (selectedSerialPort == 0xFF) selectedSerialPort = 0;
+	eeprom_update_byte((uint8_t *)EEPROM_SECOND_SERIAL_ACTIVE, selectedSerialPort);
 	MYSERIAL.begin(BAUDRATE);
 	fdev_setup_stream(uartout, uart_putchar, NULL, _FDEV_SETUP_WRITE); //setup uart out stream
 	stdout = uartout;
@@ -1070,7 +1071,7 @@ void setup()
 #ifndef W25X20CL
 	SERIAL_PROTOCOLLNPGM("start");
 #else
-	if (optiboot_status == 1)
+	if ((optiboot_status != 0) || (selectedSerialPort != 0))
 		SERIAL_PROTOCOLLNPGM("start");
 #endif
 	SERIAL_ECHO_START;

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1016,9 +1016,10 @@ void setup()
 
 #ifdef W25X20CL
     bool w25x20cl_success = w25x20cl_init();
+	uint8_t optiboot_status = 1;
 	if (w25x20cl_success)
 	{
-	    optiboot_w25x20cl_enter();
+		optiboot_status = optiboot_w25x20cl_enter();
 #if (LANG_MODE != 0) //secondary language support
         update_sec_lang_from_external_flash();
 #endif //(LANG_MODE != 0)
@@ -1064,9 +1065,12 @@ void setup()
 	}
 	MYSERIAL.begin(BAUDRATE);
 	fdev_setup_stream(uartout, uart_putchar, NULL, _FDEV_SETUP_WRITE); //setup uart out stream
-#ifndef W25X20CL
+#if !((LANG_MODE == 1) && defined(W25X20CL)) || (LANG_MODE == 0)
 	SERIAL_PROTOCOLLNPGM("start");
-#endif //W25X20CL
+#else
+	if (optiboot_status == 1)
+		SERIAL_PROTOCOLLNPGM("start");
+#endif
 	stdout = uartout;
 	SERIAL_ECHO_START;
 	printf_P(PSTR(" " FW_VERSION_FULL "\n"));

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1014,6 +1014,12 @@ void setup()
 	lcd_splash();
     Sound_Init();                                // also guarantee "SET_OUTPUT(BEEPER)"
 
+	selectedSerialPort = eeprom_read_byte((uint8_t*)EEPROM_SECOND_SERIAL_ACTIVE);
+	if (selectedSerialPort == 0xFF) selectedSerialPort = 0;
+	MYSERIAL.begin(BAUDRATE);
+	fdev_setup_stream(uartout, uart_putchar, NULL, _FDEV_SETUP_WRITE); //setup uart out stream
+	stdout = uartout;
+
 #ifdef W25X20CL
     bool w25x20cl_success = w25x20cl_init();
 	uint8_t optiboot_status = 1;
@@ -1041,15 +1047,13 @@ void setup()
 	if ((farm_mode == 0xFF && farm_no == 0) || ((uint16_t)farm_no == 0xFFFF)) 
 		farm_mode = false; //if farm_mode has not been stored to eeprom yet and farm number is set to zero or EEPROM is fresh, deactivate farm mode
 	if ((uint16_t)farm_no == 0xFFFF) farm_no = 0;
-	
-	selectedSerialPort = eeprom_read_byte((uint8_t*)EEPROM_SECOND_SERIAL_ACTIVE);
-	if (selectedSerialPort == 0xFF) selectedSerialPort = 0;
 	if (farm_mode)
 	{
 		no_response = true; //we need confirmation by recieving PRUSA thx
 		important_status = 8;
 		prusa_statistics(8);
 		selectedSerialPort = 1;
+		MYSERIAL.begin(BAUDRATE);
 #ifdef TMC2130
 		//increased extruder current (PFW363)
 		tmc2130_current_h[E_AXIS] = 36;
@@ -1063,15 +1067,12 @@ void setup()
           if(!(eeprom_read_byte((uint8_t*)EEPROM_FAN_CHECK_ENABLED)))
                eeprom_update_byte((unsigned char *)EEPROM_FAN_CHECK_ENABLED,true);
 	}
-	MYSERIAL.begin(BAUDRATE);
-	fdev_setup_stream(uartout, uart_putchar, NULL, _FDEV_SETUP_WRITE); //setup uart out stream
 #ifndef W25X20CL
 	SERIAL_PROTOCOLLNPGM("start");
 #else
 	if (optiboot_status == 1)
 		SERIAL_PROTOCOLLNPGM("start");
 #endif
-	stdout = uartout;
 	SERIAL_ECHO_START;
 	printf_P(PSTR(" " FW_VERSION_FULL "\n"));
 

--- a/Firmware/optiboot_w25x20cl.cpp
+++ b/Firmware/optiboot_w25x20cl.cpp
@@ -99,6 +99,8 @@ struct block_t;
 extern struct block_t *block_buffer;
 
 //! @brief Enter an STK500 compatible Optiboot boot loader waiting for flashing the languages to an external flash memory.
+//! @return 1 if "start\n" was not sent. Optiboot was skipped
+//! @return 0 if "start\n" was sent. Optiboot ran normally. No need to send "start\n" in setup()
 uint8_t optiboot_w25x20cl_enter()
 {
   if (boot_app_flags & BOOT_APP_FLG_USER0) return 1;

--- a/Firmware/optiboot_w25x20cl.cpp
+++ b/Firmware/optiboot_w25x20cl.cpp
@@ -99,9 +99,9 @@ struct block_t;
 extern struct block_t *block_buffer;
 
 //! @brief Enter an STK500 compatible Optiboot boot loader waiting for flashing the languages to an external flash memory.
-void optiboot_w25x20cl_enter()
+uint8_t optiboot_w25x20cl_enter()
 {
-  if (boot_app_flags & BOOT_APP_FLG_USER0) return;
+  if (boot_app_flags & BOOT_APP_FLG_USER0) return 1;
   uint8_t ch;
   uint8_t rampz = 0;
   register uint16_t address = 0;
@@ -144,12 +144,12 @@ void optiboot_w25x20cl_enter()
         delayMicroseconds(1);
         if (++ boot_timer > boot_timeout)
           // Timeout expired, continue with the application.
-          return;
+          return 0;
       }
       ch = UDR0;
       if (pgm_read_byte(ptr ++) != ch)
           // Magic was not received correctly, continue with the application
-          return;
+          return 0;
       watchdogReset();
     }
     // Send the cfm magic string.

--- a/Firmware/optiboot_w25x20cl.h
+++ b/Firmware/optiboot_w25x20cl.h
@@ -1,6 +1,6 @@
 #ifndef OPTIBOOT_W25X20CL_H
 #define OPTIBOOT_W25X20CL_H
 
-extern void optiboot_w25x20cl_enter();
+extern uint8_t optiboot_w25x20cl_enter();
 
 #endif /* OPTIBOOT_W25X20CL_H */


### PR DESCRIPTION
In some cases, the bootloader would skip sending "start\n" on reset with LANG_MODE 1.
In LANG_MODE 0 the "start" wasn't sent at all.

PFW-1110