### PR TITLE
M-Code to get silent mode status

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -8417,6 +8417,15 @@ Sigma_Exit:
 
 #endif //TMC2130_SERVICE_CODES_M910_M918
 
+    */
+	case 919:
+    {
+#ifdef TMC2130
+		printf_P(_N("SILENT MODE: %S\n"), (tmc2130_mode==TMC2130_MODE_SILENT)?_N("ENABLED"):_N("DISABLED"));
+#endif //TMC2130
+    }
+    break;
+
     /*!
 	### M350 - Set microstepping mode <a href="https://reprap.org/wiki/G-code#M350:_Set_microstepping_mode">M350: Set microstepping mode</a>
     Printers with TMC2130 drivers have `X`, `Y`, `Z` and `E` as options. The steps-per-unit value is updated accordingly. Not all resolutions are valid!

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -8417,6 +8417,9 @@ Sigma_Exit:
 
 #endif //TMC2130_SERVICE_CODES_M910_M918
 
+    /*!
+	### M919 - Get silent mode status <a href="https://reprap.org/wiki/G-code#M919:_Report_silent_mode_status">M919: Report silent mode status</a>
+	
     */
 	case 919:
     {

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -8417,17 +8417,17 @@ Sigma_Exit:
 
 #endif //TMC2130_SERVICE_CODES_M910_M918
 
+#ifdef TMC2130
     /*!
 	### M919 - Get silent mode status <a href="https://reprap.org/wiki/G-code#M919:_Report_silent_mode_status">M919: Report silent mode status</a>
 	
     */
 	case 919:
     {
-#ifdef TMC2130
 		printf_P(_N("SILENT MODE: %S\n"), (tmc2130_mode==TMC2130_MODE_SILENT)?_N("ENABLED"):_N("DISABLED"));
-#endif //TMC2130
     }
     break;
+#endif //TMC2130
 
     /*!
 	### M350 - Set microstepping mode <a href="https://reprap.org/wiki/G-code#M350:_Set_microstepping_mode">M350: Set microstepping mode</a>


### PR DESCRIPTION
I'm really not sure what conventions are for adding codes, but in the spirit of sharing, here's what I did.  I'm using this to allow an Octoprint plugin to display embedded time estimates properly based on whether running in silent or normal mode.  A link to the plugin changes:
[https://github.com/kanocz/octopi_eta_override/pull/6](url)