### PR TITLE
Fix high speed deceleration

### DIFF
--- a/Firmware/planner.h
+++ b/Firmware/planner.h
@@ -77,8 +77,8 @@ typedef struct {
   unsigned char direction_bits;             // The direction bit set for this block (refers to *_DIRECTION_BIT in config.h)
   unsigned char active_extruder;            // Selects the active extruder
   // accelerate_until and decelerate_after are set by calculate_trapezoid_for_block() and they need to be synchronized with the stepper interrupt controller.
-  long accelerate_until;                    // The index of the step event on which to stop acceleration
-  long decelerate_after;                    // The index of the step event on which to start decelerating
+  uint32_t accelerate_until;                    // The index of the step event on which to stop acceleration
+  uint32_t decelerate_after;                    // The index of the step event on which to start decelerating
 
   // Fields used by the motion planner to manage acceleration
 //  float speed_x, speed_y, speed_z, speed_e;        // Nominal mm/sec for each axis
@@ -100,13 +100,12 @@ typedef struct {
 
   // Settings for the trapezoid generator (runs inside an interrupt handler).
   // Changing the following values in the planner needs to be synchronized with the interrupt handler by disabling the interrupts.
-  //FIXME nominal_rate, initial_rate and final_rate are limited to uint16_t by MultiU24X24toH16 in the stepper interrupt anyway!
   unsigned long nominal_rate;                        // The nominal step rate for this block in step_events/sec 
   unsigned long initial_rate;                        // The jerk-adjusted step rate at start of block  
   unsigned long final_rate;                          // The minimal rate at exit
   unsigned long acceleration_st;                     // acceleration steps/sec^2
-  //FIXME does it have to be unsigned long? Probably uint8_t would be just fine.
-  unsigned long fan_speed;
+  //FIXME does it have to be int? Probably uint8_t would be just fine. Need to change in other places as well
+  int fan_speed;
   volatile char busy;
 
 


### PR DESCRIPTION
If you run the steppers at high speed (350mm/s+) or use higher microstepping (x32+), then you would soon begin to notice that high speed motion accelerates just fine, but once it starts decelerating the axes jerk twice and the speed behaves very weird.
Here is the issue in action: https://photos.app.goo.gl/JYH4MrEAuLz2v3W5A
To get that effect I simply home the axis, `M350 Y32` for higher microstepping and then do a move at 200mm/s. To see the issue easier I recommend lowering the acceleration with `M204 S350`. It really becomes visible at that acceleration.
With this commit the issue disappears entirely.