### PR TITLE
Implement MIN/MAX AMBIENT safety checks

### DIFF
--- a/Firmware/Configuration_adv.h
+++ b/Firmware/Configuration_adv.h
@@ -436,6 +436,10 @@ const unsigned int dropsegments=5; //everything with less than this number of st
   #undef BED_MINTEMP
   #undef BED_MAXTEMP
 #endif
+#if TEMP_SENSOR_AMBIENT == 0
+  #undef AMBIENT_MINTEMP
+  #undef AMBIENT_MAXTEMP
+#endif
 
 
 #endif //__CONFIGURATION_ADV_H

--- a/Firmware/temperature.cpp
+++ b/Firmware/temperature.cpp
@@ -639,6 +639,7 @@ void manage_heater()
     return; 
 // more precisely - this condition partially stabilizes time interval for regulation values evaluation (@ ~ 230ms)
 
+  // ADC values need to be converted before checking: converted values are later used in MINTEMP
   updateTemperaturesFromRawValues();
 
   check_max_temp();

--- a/Firmware/temperature.cpp
+++ b/Firmware/temperature.cpp
@@ -2002,7 +2002,6 @@ void check_max_temp()
 #else
     if (current_temperature_bed_raw >= bed_maxttemp_raw) {
 #endif
-       target_temperature_bed = 0;
        bed_max_temp_error();
     }
 #endif

--- a/Firmware/temperature.cpp
+++ b/Firmware/temperature.cpp
@@ -1452,6 +1452,7 @@ enum { LCDALERT_NONE = 0, LCDALERT_HEATERMINTEMP, LCDALERT_BEDMINTEMP, LCDALERT_
 uint8_t last_alert_sent_to_lcd = LCDALERT_NONE;
 
 void max_temp_error(uint8_t e) {
+  disable_heater();
   if(IsStopped() == false) {
     SERIAL_ERROR_START;
     SERIAL_ERRORLN((int)e);
@@ -1479,6 +1480,7 @@ void min_temp_error(uint8_t e) {
 #ifdef DEBUG_DISABLE_MINTEMP
 	return;
 #endif
+  disable_heater();
 //if (current_temperature_ambient < MINTEMP_MINAMBIENT) return;
 	static const char err[] PROGMEM = "Err: MINTEMP";
   if(IsStopped() == false) {
@@ -1504,6 +1506,7 @@ void min_temp_error(uint8_t e) {
 }
 
 void bed_max_temp_error(void) {
+  disable_heater();
   if(IsStopped() == false) {
     SERIAL_ERROR_START;
     SERIAL_ERRORLNPGM("Heaters switched off. MAXTEMP BED triggered !");
@@ -1518,7 +1521,8 @@ void bed_min_temp_error(void) {
 #ifdef DEBUG_DISABLE_MINTEMP
 	return;
 #endif
-	static const char err[] PROGMEM = "Err: MINTEMP BED";
+    disable_heater();
+	static const char err[] PROGMEM = "MINTEMP BED";
     if(IsStopped() == false) {
         SERIAL_ERROR_START;
         SERIAL_ERRORLNPGM("Heaters switched off. MINTEMP BED triggered !");
@@ -1537,6 +1541,7 @@ void bed_min_temp_error(void) {
 
 #ifdef AMBIENT_THERMISTOR
 void ambient_max_temp_error(void) {
+    disable_heater();
     if(IsStopped() == false) {
         SERIAL_ERROR_START;
         SERIAL_ERRORLNPGM("Heaters switched off. MAXTEMP AMBIENT triggered !");
@@ -1551,6 +1556,7 @@ void ambient_min_temp_error(void) {
 #ifdef DEBUG_DISABLE_MINTEMP
 	return;
 #endif
+    disable_heater();
     if(IsStopped() == false) {
         SERIAL_ERROR_START;
         SERIAL_ERRORLNPGM("Heaters switched off. MINTEMP AMBIENT triggered !");

--- a/Firmware/temperature.cpp
+++ b/Firmware/temperature.cpp
@@ -1165,7 +1165,6 @@ void tp_init()
 #endif //MAXTEMP 2
 
 #ifdef BED_MINTEMP
-  /* No bed MINTEMP error implemented?!? */
   while(analog2tempBed(bed_minttemp_raw) < BED_MINTEMP) {
 #if HEATER_BED_RAW_LO_TEMP < HEATER_BED_RAW_HI_TEMP
     bed_minttemp_raw += OVERSAMPLENR;
@@ -1173,7 +1172,6 @@ void tp_init()
     bed_minttemp_raw -= OVERSAMPLENR;
 #endif
   }
-  
 #endif //BED_MINTEMP
 #ifdef BED_MAXTEMP
   while(analog2tempBed(bed_maxttemp_raw) > BED_MAXTEMP) {

--- a/Firmware/temperature.cpp
+++ b/Firmware/temperature.cpp
@@ -1426,19 +1426,16 @@ enum { LCDALERT_NONE = 0, LCDALERT_HEATERMINTEMP, LCDALERT_BEDMINTEMP, LCDALERT_
 uint8_t last_alert_sent_to_lcd = LCDALERT_NONE;
 
 void max_temp_error(uint8_t e) {
-  disable_heater();
   if(IsStopped() == false) {
     SERIAL_ERROR_START;
     SERIAL_ERRORLN((int)e);
-    SERIAL_ERRORLNPGM(": Extruder switched off. MAXTEMP triggered !");
+    SERIAL_ERRORLNPGM(": Heaters switched off. MAXTEMP triggered !");
     LCD_ALERTMESSAGEPGM("Err: MAXTEMP");
   }
   #ifndef BOGUS_TEMPERATURE_FAILSAFE_OVERRIDE
   Stop();
-    
-
-    
   #endif
+
     SET_OUTPUT(FAN_PIN);
     SET_OUTPUT(BEEPER);
     WRITE(FAN_PIN, 1);
@@ -1457,12 +1454,11 @@ void min_temp_error(uint8_t e) {
 	return;
 #endif
 //if (current_temperature_ambient < MINTEMP_MINAMBIENT) return;
-  disable_heater();
 	static const char err[] PROGMEM = "Err: MINTEMP";
   if(IsStopped() == false) {
     SERIAL_ERROR_START;
     SERIAL_ERRORLN((int)e);
-    SERIAL_ERRORLNPGM(": Extruder switched off. MINTEMP triggered !");
+    SERIAL_ERRORLNPGM(": Heaters switched off. MINTEMP triggered !");
     lcd_setalertstatuspgm(err);
     last_alert_sent_to_lcd = LCDALERT_HEATERMINTEMP;
   } else if( last_alert_sent_to_lcd != LCDALERT_HEATERMINTEMP ){ // only update, if the lcd message is to be changed (i.e. not the same as last time)
@@ -1482,32 +1478,24 @@ void min_temp_error(uint8_t e) {
 }
 
 void bed_max_temp_error(void) {
-#if HEATER_BED_PIN > -1
-  //WRITE(HEATER_BED_PIN, 0);
-#endif
   if(IsStopped() == false) {
     SERIAL_ERROR_START;
-    SERIAL_ERRORLNPGM("Temperature heated bed switched off. MAXTEMP triggered !");
+    SERIAL_ERRORLNPGM("Heaters switched off. MAXTEMP BED triggered !");
     LCD_ALERTMESSAGEPGM("Err: MAXTEMP BED");
   }
   #ifndef BOGUS_TEMPERATURE_FAILSAFE_OVERRIDE
   Stop();
   #endif
-
 }
 
 void bed_min_temp_error(void) {
 #ifdef DEBUG_DISABLE_MINTEMP
 	return;
 #endif
-//if (current_temperature_ambient < MINTEMP_MINAMBIENT) return;
-#if HEATER_BED_PIN > -1
-    //WRITE(HEATER_BED_PIN, 0);
-#endif
 	static const char err[] PROGMEM = "Err: MINTEMP BED";
     if(IsStopped() == false) {
         SERIAL_ERROR_START;
-        SERIAL_ERRORLNPGM("Temperature heated bed switched off. MINTEMP triggered !");
+        SERIAL_ERRORLNPGM("Heaters switched off. MINTEMP BED triggered !");
 		lcd_setalertstatuspgm(err);
 		last_alert_sent_to_lcd = LCDALERT_BEDMINTEMP;
 	} else if( last_alert_sent_to_lcd != LCDALERT_BEDMINTEMP ){ // only update, if the lcd message is to be changed (i.e. not the same as last time)

--- a/Firmware/temperature.cpp
+++ b/Firmware/temperature.cpp
@@ -1546,7 +1546,7 @@ void bed_min_temp_error(void) {
 	return;
 #endif
     disable_heater();
-	static const char err[] PROGMEM = "MINTEMP BED";
+    static const char err[] PROGMEM = "MINTEMP BED";
     if(IsStopped() == false) {
         temp_error_messagepgm(err);
 		last_alert_sent_to_lcd = LCDALERT_BEDMINTEMP;

--- a/Firmware/thermistortables.h
+++ b/Firmware/thermistortables.h
@@ -1213,6 +1213,8 @@ const short temptable_1047[][2] PROGMEM = {
 #endif
 
 #if (THERMISTORAMBIENT == 2000) //100k thermistor NTCG104LH104JT1
+# define AMBIENT_RAW_HI_TEMP 0
+# define AMBIENT_RAW_LO_TEMP 16383
 const short temptable_2000[][2] PROGMEM = {
 // Source: https://product.tdk.com/info/en/catalog/datasheets/503021/tpd_ntc-thermistor_ntcg_en.pdf
 // Calculated using 4.7kohm pullup, voltage divider math, and manufacturer provided temp/resistance

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -8951,13 +8951,14 @@ void lcd_finishstatus() {
   lcd_draw_update = 2;
 
 }
+
 void lcd_setstatus(const char* message)
 {
   if (lcd_status_message_level > 0)
     return;
-  strncpy(lcd_status_message, message, LCD_WIDTH);
-  lcd_finishstatus();
+  lcd_updatestatus(message);
 }
+
 void lcd_updatestatuspgm(const char *message){
 	strncpy_P(lcd_status_message, message, LCD_WIDTH);
 	lcd_status_message[LCD_WIDTH] = 0;
@@ -8972,12 +8973,29 @@ void lcd_setstatuspgm(const char* message)
     return;
   lcd_updatestatuspgm(message);
 }
+
+void lcd_updatestatus(const char *message){
+	strncpy(lcd_status_message, message, LCD_WIDTH);
+	lcd_status_message[LCD_WIDTH] = 0;
+	lcd_finishstatus();
+	// hack lcd_draw_update to 1, i.e. without clear
+	lcd_draw_update = 1;
+}
+
 void lcd_setalertstatuspgm(const char* message)
 {
   lcd_setstatuspgm(message);
   lcd_status_message_level = 1;
   lcd_return_to_status();
 }
+
+void lcd_setalertstatus(const char* message)
+{
+  lcd_setstatus(message);
+  lcd_status_message_level = 1;
+  lcd_return_to_status();
+}
+
 void lcd_reset_alert_level()
 {
   lcd_status_message_level = 0;

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -23,9 +23,11 @@ void lcd_setstatuspgm(const char* message);
 //! - always returns the display to the main status screen
 //! - always makes lcd_reset (which is slow and causes flicker)
 //! - does not update the message if there is already one (i.e. lcd_status_message_level > 0)
+void lcd_setalertstatus(const char* message);
 void lcd_setalertstatuspgm(const char* message);
 //! only update the alert message on the main status screen
 //! has no sideeffects, may be called multiple times
+void lcd_updatestatus(const char *message);
 void lcd_updatestatuspgm(const char *message);
 
 void lcd_reset_alert_level();

--- a/Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h
@@ -296,6 +296,7 @@
 #endif
 #define DETECT_SUPERPINDA
 #define PINDA_MINTEMP BED_MINTEMP
+#define AMBIENT_MINTEMP -30
 
 // Maxtemps
 #if defined(E3D_PT100_EXTRUDER_WITH_AMP) || defined(E3D_PT100_EXTRUDER_NO_AMP)
@@ -306,6 +307,7 @@
 #define HEATER_1_MAXTEMP 305
 #define HEATER_2_MAXTEMP 305
 #define BED_MAXTEMP 125
+#define AMBIENT_MAXTEMP 100
 
 #if defined(E3D_PT100_EXTRUDER_WITH_AMP) || defined(E3D_PT100_EXTRUDER_NO_AMP)
 // Define PID constants for extruder with PT100

--- a/Firmware/variants/1_75mm_MK3S-EINSy10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK3S-EINSy10a-E3Dv6full.h
@@ -298,6 +298,7 @@
 #endif
 #define DETECT_SUPERPINDA
 #define PINDA_MINTEMP BED_MINTEMP
+#define AMBIENT_MINTEMP -30
 
 // Maxtemps
 #if defined(E3D_PT100_EXTRUDER_WITH_AMP) || defined(E3D_PT100_EXTRUDER_NO_AMP)
@@ -308,6 +309,7 @@
 #define HEATER_1_MAXTEMP 305
 #define HEATER_2_MAXTEMP 305
 #define BED_MAXTEMP 125
+#define AMBIENT_MAXTEMP 100
 
 #if defined(E3D_PT100_EXTRUDER_WITH_AMP) || defined(E3D_PT100_EXTRUDER_NO_AMP)
 // Define PID constants for extruder with PT100


### PR DESCRIPTION
Take advantage of the NTC thermistor found on the Einsy as an additional
safety measure, following the steps of the other MIN/MAXTEMP errors.

Introduce two configurable params AMBIENT_MINTEMP and AMBIENT_MAXTEMP
in the variant defines and set them for the MK3/MK3S to -30/+100
respectively.

AMBIENT_MINTEMP is primarily intended to catch a defective board
thermistor (to ensure MAXTEMP would be properly triggered) and thus the
trigger temperature is set just above the sensing limit and well below
the operating range.

AMBIENT_MAXTEMP is set at 100C, which is instead 20C above the maximum
recommended operating temperature of the Einsy. The NTC thermistor is
located just above the main power connector on the bottom of the board,
and could also help in detecting a faulty connection which can result in
rapid overheating of the contacts.

As for MAXTEMP, we cut power to the heaters, print fan and motors to
reduce power draw. Resume is not possible except by resetting the
printer, since the user is highly advised to inspect the board for
problems before attempting to continue.

PFW-1114