### PR TITLE
Unused function warning fix.

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5602,6 +5602,7 @@ do\
 }\
 while (0)
 
+#if 0 // temporarily unused
 static void lcd_check_gcode_set(void)
 {
 switch(oCheckGcode)
@@ -5620,6 +5621,7 @@ switch(oCheckGcode)
      }
 eeprom_update_byte((uint8_t*)EEPROM_CHECK_GCODE,(uint8_t)oCheckGcode);
 }
+#endif
 
 #define SETTINGS_GCODE \
 do\


### PR DESCRIPTION
(cherry picked from commit 54e2b6a829a221cc3abbff3a39ca7d3cafed3a09)
Pick only unused function warning fix.
#2454