### PR TITLE
Fix compiler warning unused variable kill_message.

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -4977,7 +4977,6 @@ if(eSoundMode!=e_SOUND_MODE_SILENT)
 		}
 		#endif // SUPPORT_VERBOSITY
 		int l_feedmultiply = setup_for_endstop_move(false); //save feedrate and feedmultiply, sets feedmultiply to 100
-		const char *kill_message = NULL;
 		while (mesh_point != nMeasPoints * nMeasPoints) {
 			// Get coords of a measuring point.
 			uint8_t ix = mesh_point % nMeasPoints; // from 0 to MESH_NUM_X_POINTS - 1


### PR DESCRIPTION
(cherry picked from commit 54e2b6a829a221cc3abbff3a39ca7d3cafed3a09)
Pick only unused kill_message.
#2454
leptun  1:59 PM
@mkbel How should we handle the "kill_message"? Are there any plans for these or is that just forgotten code?
mkbel  2:01 PM
Right fix would be to print kill_message to USB in my opinion.
leptun  2:01 PM
I think we already do that inside kill()
mkbel  2:02 PM
if we do this, this variable wouldn't be unused.
leptun  2:03 PM
On kill we print Printer halted. kill() called! and then on the next line the error message and also put the message on the screen (edited) 
mkbel 2:08 PM
Oh, the source code has changed from time this kill_message warning appeared for the first time. When this appeared for the first time, the kill message was set to several possible error strings, but it was not used. (Due to change, that those errors no more leads to printer kill, but to Z calibration and restarting MBL) Now I see, that it is no more set to any meaningful string.
2:09
So my idea was to print this kill message, probably rename it to something like warning before restarting MBL.
leptun  2:11 PM
Well, it's not used anywhere else, so we can probably just remove it now and everything should be ok.
mkbel  2:11 PM
But now when it is never set to anything meaningful we can remove it completely.
2:12
It is probably more than year ago and no one was bugging about printer restarting MBL in infinite loop without meaningful debug info.