### PR TITLE
Remove st_current_init() call from lcd_temp_calibration_set().

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -4637,7 +4637,6 @@ void lcd_pinda_calibration_menu()
 void lcd_temp_calibration_set() {
 	temp_cal_active = !temp_cal_active;
 	eeprom_update_byte((unsigned char *)EEPROM_TEMP_CAL_ACTIVE, temp_cal_active);
-	st_current_init();
 }
 
 #ifdef HAS_SECOND_SERIAL_PORT


### PR DESCRIPTION
There is no known purpose of this call.
lcd_temp_calibration_set() is switching on/off pinda temperature compensation from LCD settings menu (this is called "Temp. cal." on LCD).
st_current_init() does nothing on Einsy board, it enables and sets motor current selecting outputs on Rambo board (it used to be called digipot in history)