### PR TITLE
Linear Advance 1.5 Fixes

### DIFF
--- a/Firmware/Configuration_adv.h
+++ b/Firmware/Configuration_adv.h
@@ -288,6 +288,7 @@
   #define LA_K_DEF    0        // Default K factor (Unit: mm compression per 1mm/s extruder speed)
   #define LA_K_MAX    10       // Maximum acceptable K factor (exclusive, see notes in planner.cpp:plan_buffer_line)
   #define LA_LA10_MIN LA_K_MAX // Lin. Advance 1.0 threshold value (inclusive)
+  //#define LA_FLOWADJ         // Adjust LA along with flow/M221 for uniform width
   //#define LA_NOCOMPAT        // Disable Linear Advance 1.0 compatibility
   //#define LA_LIVE_K          // Allow adjusting K in the Tune menu
   //#define LA_DEBUG           // If enabled, this will generate debug information output over USB.

--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -299,7 +299,7 @@ extern float feedrate;
 extern int feedmultiply;
 extern int extrudemultiply; // Sets extrude multiply factor (in percent) for all extruders
 extern int extruder_multiply[EXTRUDERS]; // sets extrude multiply factor (in percent) for each extruder individually
-extern float volumetric_multiplier[EXTRUDERS]; // reciprocal of cross-sectional area of filament (in square millimeters), stored this way to reduce computational burden in planner
+extern float extruder_multiplier[EXTRUDERS]; // reciprocal of cross-sectional area of filament (in square millimeters), stored this way to reduce computational burden in planner
 extern float current_position[NUM_AXIS] ;
 extern float destination[NUM_AXIS] ;
 extern float min_pos[3];

--- a/Firmware/planner.cpp
+++ b/Firmware/planner.cpp
@@ -225,12 +225,15 @@ void calculate_trapezoid_for_block(block_t *block, float entry_speed, float exit
   uint32_t accel_decel_steps = accelerate_steps + decelerate_steps;
   // Size of Plateau of Nominal Rate.
   uint32_t plateau_steps     = 0;
+  // Maximum effective speed reached in the trapezoid (mm/s)
+  float max_speed;
 
   // Is the Plateau of Nominal Rate smaller than nothing? That means no cruising, and we will
   // have to use intersection_distance() to calculate when to abort acceleration and start braking
   // in order to reach the final_rate exactly at the end of this block.
   if (accel_decel_steps < block->step_event_count.wide) {
     plateau_steps = block->step_event_count.wide - accel_decel_steps;
+    max_speed = block->nominal_speed;
   } else {
     uint32_t acceleration_x4  = acceleration << 2;
     // Avoid negative numbers
@@ -263,12 +266,18 @@ void calculate_trapezoid_for_block(block_t *block, float entry_speed, float exit
             decelerate_steps = block->step_event_count.wide;
         accelerate_steps = block->step_event_count.wide - decelerate_steps;
     }
+
+    // TODO: not for production
+    float dist = intersection_distance(entry_speed, exit_speed, block->acceleration, block->millimeters);
+    max_speed = sqrt(2 * block->acceleration * dist + entry_speed*entry_speed);
   }
 
 #ifdef LIN_ADVANCE
   uint16_t final_adv_steps = 0;
+  uint16_t max_adv_steps = 0;
   if (block->use_advance_lead) {
       final_adv_steps = exit_speed * block->adv_comp;
+      max_adv_steps = max_speed * block->adv_comp;
   }
 #endif
 
@@ -284,6 +293,7 @@ void calculate_trapezoid_for_block(block_t *block, float entry_speed, float exit
     block->final_rate = final_rate;
 #ifdef LIN_ADVANCE
     block->final_adv_steps = final_adv_steps;
+    block->max_adv_steps = max_adv_steps;
 #endif
   }
   CRITICAL_SECTION_END;
@@ -1137,9 +1147,8 @@ Having the real displacement of the head, we can calculate the total movement le
 #ifdef LIN_ADVANCE
   if (block->use_advance_lead) {
       // the nominal speed doesn't change past this point: calculate the compression ratio for the
-      // segment and the required advance steps
+      // segment (the required advance steps are computed during trapezoid planning)
       block->adv_comp = extruder_advance_K * e_D_ratio * cs.axis_steps_per_unit[E_AXIS];
-      block->max_adv_steps = block->nominal_speed * block->adv_comp;
 
       float advance_speed;
       if (e_D_ratio > 0)

--- a/Firmware/planner.cpp
+++ b/Firmware/planner.cpp
@@ -267,9 +267,7 @@ void calculate_trapezoid_for_block(block_t *block, float entry_speed, float exit
         accelerate_steps = block->step_event_count.wide - decelerate_steps;
     }
 
-    // TODO: not for production
-    float dist = intersection_distance(entry_speed, exit_speed, block->acceleration, block->millimeters);
-    max_speed = sqrt(2 * block->acceleration * dist + entry_speed*entry_speed);
+    max_speed = sqrt(acceleration_x2 * accelerate_steps + initial_rate_sqr) / block->speed_factor;
   }
 
 #ifdef LIN_ADVANCE

--- a/Firmware/planner.cpp
+++ b/Firmware/planner.cpp
@@ -1096,12 +1096,20 @@ Having the real displacement of the head, we can calculate the total movement le
                               && delta_mm[E_AXIS] >= 0
                               && abs(delta_mm[Z_AXIS]) < 0.5;
     if (block->use_advance_lead) {
+#ifdef LA_FLOWADJ
+        // M221/FLOW should change uniformly the extrusion thickness
+        float delta_e = (e - position_float[E_AXIS]) / extruder_multiplier[extruder];
+#else
+        // M221/FLOW only adjusts for an incorrect source diameter
+        float delta_e = (e - position_float[E_AXIS]);
+#endif
+        float delta_D = sqrt(sq(x - position_float[X_AXIS])
+                             + sq(y - position_float[Y_AXIS])
+                             + sq(z - position_float[Z_AXIS]));
+
         // all extrusion moves with LA require a compression which is proportional to the
         // extrusion_length to distance ratio (e/D)
-        e_D_ratio = ((e - position_float[E_AXIS]) / extruder_multiplier[extruder]) /
-                    sqrt(sq(x - position_float[X_AXIS])
-                         + sq(y - position_float[Y_AXIS])
-                         + sq(z - position_float[Z_AXIS]));
+        e_D_ratio = delta_e / delta_D;
 
         // Check for unusual high e_D ratio to detect if a retract move was combined with the last
         // print move due to min. steps per segment. Never execute this with advance! This assumes

--- a/Firmware/planner.cpp
+++ b/Firmware/planner.cpp
@@ -283,7 +283,7 @@ void calculate_trapezoid_for_block(block_t *block, float entry_speed, float exit
             // decelerate_steps=0: acceleration-only ramp, max_rate _is_ final_rate
             max_adv_steps = final_adv_steps;
         } else {
-            uint16_t max_rate = sqrt(acceleration_x2 * accelerate_steps + initial_rate_sqr);
+            float max_rate = sqrt(acceleration_x2 * accelerate_steps + initial_rate_sqr);
             max_adv_steps = max_rate * block->adv_comp;
         }
     }

--- a/Firmware/planner.cpp
+++ b/Firmware/planner.cpp
@@ -1098,7 +1098,7 @@ Having the real displacement of the head, we can calculate the total movement le
     if (block->use_advance_lead) {
         // all extrusion moves with LA require a compression which is proportional to the
         // extrusion_length to distance ratio (e/D)
-        e_D_ratio = (e - position_float[E_AXIS]) /
+        e_D_ratio = ((e - position_float[E_AXIS]) / extruder_multiplier[extruder]) /
                     sqrt(sq(x - position_float[X_AXIS])
                          + sq(y - position_float[Y_AXIS])
                          + sq(z - position_float[Z_AXIS]));

--- a/Firmware/stepper.cpp
+++ b/Firmware/stepper.cpp
@@ -1016,7 +1016,7 @@ FORCE_INLINE void advance_isr_scheduler() {
 
     // Schedule the next closest tick, ignoring advance if scheduled too
     // soon in order to avoid skewing the regular stepper acceleration
-    if (nextAdvanceISR != ADV_NEVER && (nextAdvanceISR + TCNT1 + 40) < nextMainISR)
+    if (nextAdvanceISR != ADV_NEVER && (nextAdvanceISR + 40) < nextMainISR)
         OCR1A = nextAdvanceISR;
     else
         OCR1A = nextMainISR;

--- a/Firmware/stepper.cpp
+++ b/Firmware/stepper.cpp
@@ -883,11 +883,13 @@ FORCE_INLINE void isr() {
         advance_spread(main_Rate);
         if (LA_phase >= 0) {
             if (step_loops == e_step_loops)
-                LA_phase = (eISR_Rate > main_Rate);
+                LA_phase = (current_block->advance_rate > main_Rate);
             else {
                 // avoid overflow through division. warning: we need to _guarantee_ step_loops
                 // and e_step_loops are <= 4 due to fastdiv's limit
-                LA_phase = (fastdiv(eISR_Rate, step_loops) > fastdiv(main_Rate, e_step_loops));
+                auto adv_rate_n = fastdiv(current_block->advance_rate, step_loops);
+                auto main_rate_n = fastdiv(main_Rate, e_step_loops);
+                LA_phase = (adv_rate_n > main_rate_n);
             }
         }
     }

--- a/Firmware/stepper.cpp
+++ b/Firmware/stepper.cpp
@@ -809,8 +809,11 @@ FORCE_INLINE void isr() {
         acceleration_time += timer;
 #ifdef LIN_ADVANCE
         if (current_block->use_advance_lead) {
-            if (step_events_completed.wide <= (unsigned long int)step_loops)
+            if (step_events_completed.wide <= (unsigned long int)step_loops) {
                 la_state = ADV_INIT | ADV_ACC_VARY;
+                if (e_extruding && current_adv_steps > target_adv_steps)
+                    target_adv_steps = current_adv_steps;
+            }
         }
 #endif
       }
@@ -832,6 +835,8 @@ FORCE_INLINE void isr() {
             if (step_events_completed.wide <= (unsigned long int)current_block->decelerate_after + step_loops) {
                 target_adv_steps = current_block->final_adv_steps;
                 la_state = ADV_INIT | ADV_ACC_VARY;
+                if (e_extruding && current_adv_steps < target_adv_steps)
+                    target_adv_steps = current_adv_steps;
             }
         }
 #endif
@@ -849,6 +854,8 @@ FORCE_INLINE void isr() {
               // acceleration or deceleration can be skipped or joined with the previous block.
               // If LA was not previously active, re-check the pressure level
               la_state = ADV_INIT;
+              if (e_extruding)
+                  target_adv_steps = current_adv_steps;
           }
 #endif
         }

--- a/Firmware/stepper.cpp
+++ b/Firmware/stepper.cpp
@@ -848,12 +848,10 @@ FORCE_INLINE void isr() {
 
 #ifdef LIN_ADVANCE
           if(current_block->use_advance_lead) {
-              if (!nextAdvanceISR) {
-                  // Due to E-jerk, there can be discontinuities in pressure state where an
-                  // acceleration or deceleration can be skipped or joined with the previous block.
-                  // If LA was not previously active, re-check the pressure level
-                  la_state = ADV_INIT;
-              }
+              // Due to E-jerk, there can be discontinuities in pressure state where an
+              // acceleration or deceleration can be skipped or joined with the previous block.
+              // If LA was not previously active, re-check the pressure level
+              la_state = ADV_INIT;
           }
 #endif
         }
@@ -865,6 +863,7 @@ FORCE_INLINE void isr() {
 #ifdef LIN_ADVANCE
     // avoid multiple instances or function calls to advance_spread
     if (la_state & ADV_INIT) {
+        LA_phase = -1;
         if (current_adv_steps == target_adv_steps) {
             // nothing to be done in this phase
             la_state = 0;

--- a/Firmware/stepper.cpp
+++ b/Firmware/stepper.cpp
@@ -883,13 +883,13 @@ FORCE_INLINE void isr() {
         advance_spread(main_Rate);
         if (LA_phase >= 0) {
             if (step_loops == e_step_loops)
-                LA_phase = (current_block->advance_rate > main_Rate);
+                LA_phase = (current_block->advance_rate < main_Rate);
             else {
                 // avoid overflow through division. warning: we need to _guarantee_ step_loops
                 // and e_step_loops are <= 4 due to fastdiv's limit
                 auto adv_rate_n = fastdiv(current_block->advance_rate, step_loops);
                 auto main_rate_n = fastdiv(main_Rate, e_step_loops);
-                LA_phase = (adv_rate_n > main_rate_n);
+                LA_phase = (adv_rate_n < main_rate_n);
             }
         }
     }


### PR DESCRIPTION
This PR fixes multiple issues with LA1.5 for both stock and geared extruders, as discovered and reported by multiple users in #2543, #2674, #2693, #2751, #2757, #2760.

Major issues covered:

- A bad timer check prevented fast LA ticks to be scheduled, effectively limiting LA as speed increased or with shorter intervals due to geared extruders (173aa2d)
- A bad sign check would cause over-retraction as extrusion speed/nozzle size increased (c08f37d, fb5f09d)
- Tighter accounting for advance ticks (since #2591) lead to the discovery of two more subtle issues:
  - Bad compression factors calculated during segments without cruising would now propagate forward instead of being ignored, generally leading to bad corners and a final over-retract. Fixed by correctly calculating the compression factor at the junction (1554895, 753e651, 7c140bc, a36efcb)
  - Numerical errors in short segments (<0.1mm) would cause LA to continuously re-adjust the pressure in high-res models, starving the planner and further reducing the quality of the print in a vicious loop.
    Since the error can be large and difficult to overcome without further performance penalties, this was fixed by artificially limiting LA *back* to the acceleration/deceleration phase so that short segments can necessarily only have a limited influence. The effective compression will still converge to an average  result which is more stable than what is being calculated currently (c08f37d, c54474f). This still preserves the ability to handle chained wipes, but now is doing so only when wiping (no extrusion).

The code scheduling advance ticks has been simplified and speed-up (50a0982, feafc5e). Other commits only perform minor cleanups.

Notably, There is now also an optional automatic LA adjustment for flow control (9b8f642) which can change the behavior of M221 or the FLOW settings in the LCD. Since this behavior is highly dependent on the intended behavior of the adjustment, we believe that keeping this disabled is actually the intended behavior. See a08ca19 for a discussion.

PFW-1125