### PR TITLE
Avoid print speed oscilations when printing fast detailed arcs.

### DIFF
--- a/Firmware/planner.cpp
+++ b/Firmware/planner.cpp
@@ -1033,8 +1033,10 @@ Having the real displacement of the head, we can calculate the total movement le
     if (!moves_queued) {
     slowdown_multiplier = -1.f; // disable slow down on empty buffer
     }
-    else if (moves_queued < (BLOCK_BUFFER_SIZE - 3) && (moves_queued < last_moves_queued)) {
-    if (slowdown_multiplier > 0.02f) slowdown_multiplier *= 0.9f;
+    else if (moves_queued < (BLOCK_BUFFER_SIZE - 3) && (moves_queued < last_moves_queued)
+             && (slowdown_multiplier > 0.02f)
+             && (static_cast<unsigned long>(lround(1000000.0f / (inverse_second * slowdown_multiplier))) < cs.minsegmenttime)) {
+      slowdown_multiplier *= 0.9f;
     }
     else if (moves_queued > (BLOCK_BUFFER_SIZE - 3)) {
       slowdown_multiplier *= 1.1111111111f;

--- a/Firmware/planner.cpp
+++ b/Firmware/planner.cpp
@@ -1028,21 +1028,20 @@ Having the real displacement of the head, we can calculate the total movement le
   // slow down when de buffer starts to empty, rather than wait at the corner for a buffer refill
 #ifdef SLOWDOWN
   {
-    static float slowdown_multiplier = -1; // negative means disabled
+    static float slowdown_multiplier = 1;
     static uint8_t last_moves_queued = 0;
-    if (!moves_queued) {
-    slowdown_multiplier = -1.f; // disable slow down on empty buffer
-    }
-    else if (moves_queued < (BLOCK_BUFFER_SIZE - 3) && (moves_queued < last_moves_queued)
+
+    if (moves_queued < (BLOCK_BUFFER_SIZE - 3) && (moves_queued < last_moves_queued)
              && (slowdown_multiplier > 0.02f)
              && (static_cast<unsigned long>(lround(1000000.0f / (inverse_second * slowdown_multiplier))) < cs.minsegmenttime)) {
-      slowdown_multiplier *= 0.9f;
+      if (slowdown_multiplier > 0.5) slowdown_multiplier -= 0.07f/slowdown_multiplier;
+      else slowdown_multiplier *= 0.7f;
     }
     else if (moves_queued > (BLOCK_BUFFER_SIZE - 3)) {
       slowdown_multiplier *= 1.1111111111f;
-      if (slowdown_multiplier < 0.f || slowdown_multiplier > 1.f) slowdown_multiplier = 1.f;
+      if (slowdown_multiplier > 1.f) slowdown_multiplier = 1.f;
     }
-    if ((slowdown_multiplier > 0) && (block->steps_e.wide != 0)) inverse_second *= slowdown_multiplier;
+    if (block->steps_e.wide != 0) inverse_second *= slowdown_multiplier;
     last_moves_queued = moves_queued;
   }
 #endif // SLOWDOWN

--- a/Firmware/planner.cpp
+++ b/Firmware/planner.cpp
@@ -1028,17 +1028,18 @@ Having the real displacement of the head, we can calculate the total movement le
   // slow down when de buffer starts to empty, rather than wait at the corner for a buffer refill
 #ifdef SLOWDOWN
   {
-    static float slowdown_multiplier = 1;
+    static_assert(BLOCK_BUFFER_SIZE == 16, "Regulation constants hard-coded for exact BLOCK_BUFFER_SIZE.");
+    static float slowdown_multiplier = 1.f;
     static uint8_t last_moves_queued = 0;
 
     if (moves_queued < (BLOCK_BUFFER_SIZE - 3) && (moves_queued < last_moves_queued)
              && (slowdown_multiplier > 0.02f)
              && (static_cast<unsigned long>(lround(1000000.0f / (inverse_second * slowdown_multiplier))) < cs.minsegmenttime)) {
-      if (slowdown_multiplier > 0.5) slowdown_multiplier -= 0.07f/slowdown_multiplier;
-      else slowdown_multiplier *= 0.7f;
+      slowdown_multiplier -= 0.0833f * (last_moves_queued - moves_queued);
+      if (slowdown_multiplier < 0.02f) slowdown_multiplier = 0.02f;
     }
     else if (moves_queued > (BLOCK_BUFFER_SIZE - 3)) {
-      slowdown_multiplier *= 1.1111111111f;
+      slowdown_multiplier *= 1.09f;
       if (slowdown_multiplier > 1.f) slowdown_multiplier = 1.f;
     }
     if (block->steps_e.wide != 0) inverse_second *= slowdown_multiplier;

--- a/Firmware/planner.cpp
+++ b/Firmware/planner.cpp
@@ -1032,9 +1032,9 @@ Having the real displacement of the head, we can calculate the total movement le
     static float slowdown_multiplier = 1.f;
     static uint8_t last_moves_queued = 0;
     static bool const_rate_mode = false;
+    const float maximum_slowdown_multiplier = 1000000.0f / (inverse_second * cs.minsegmenttime);
 
     if (const_rate_mode) {
-      const float maximum_slowdown_multiplier = 1000000.0f / (inverse_second * cs.minsegmenttime);
       if (maximum_slowdown_multiplier > 1.f) {
         slowdown_multiplier = 1.f;
         const_rate_mode = false;
@@ -1046,16 +1046,18 @@ Having the real displacement of the head, we can calculate the total movement le
     else if (moves_queued < (BLOCK_BUFFER_SIZE - 3) && (moves_queued < last_moves_queued)
         && (static_cast<unsigned long>(lround(1000000.0f / (inverse_second * slowdown_multiplier))) < cs.minsegmenttime)) {
       slowdown_multiplier -= 0.0833f * (last_moves_queued - moves_queued);
-      const float maximum_slowdown_multiplier = 1000000.0f / (inverse_second * cs.minsegmenttime);
       if (slowdown_multiplier < maximum_slowdown_multiplier) {
         slowdown_multiplier = maximum_slowdown_multiplier;
         const_rate_mode = true;
       }
     }
+    else if ((maximum_slowdown_multiplier - slowdown_multiplier) > 0.12f) {
+      slowdown_multiplier = maximum_slowdown_multiplier;
+    }
     else if (moves_queued > (BLOCK_BUFFER_SIZE - 3)) {
       slowdown_multiplier += 0.0833f;
-      if (slowdown_multiplier > 1.f) slowdown_multiplier = 1.f;
     }
+    if (slowdown_multiplier > 1.f) slowdown_multiplier = 1.f;
     if (block->steps_e.wide != 0) inverse_second *= slowdown_multiplier;
     last_moves_queued = moves_queued;
   }

--- a/Firmware/planner.cpp
+++ b/Firmware/planner.cpp
@@ -1033,10 +1033,10 @@ Having the real displacement of the head, we can calculate the total movement le
     static uint8_t last_moves_queued = 0;
 
     if (moves_queued < (BLOCK_BUFFER_SIZE - 3) && (moves_queued < last_moves_queued)
-             && (slowdown_multiplier > 0.02f)
-             && (static_cast<unsigned long>(lround(1000000.0f / (inverse_second * slowdown_multiplier))) < cs.minsegmenttime)) {
+        && (static_cast<unsigned long>(lround(1000000.0f / (inverse_second * slowdown_multiplier))) < cs.minsegmenttime)) {
       slowdown_multiplier -= 0.0833f * (last_moves_queued - moves_queued);
-      if (slowdown_multiplier < 0.02f) slowdown_multiplier = 0.02f;
+      const float maximum_slowdown_multiplier = 1000000.0f / (inverse_second * cs.minsegmenttime);
+      if (slowdown_multiplier < maximum_slowdown_multiplier) slowdown_multiplier = maximum_slowdown_multiplier;
     }
     else if (moves_queued > (BLOCK_BUFFER_SIZE - 3)) {
       slowdown_multiplier *= 1.09f;

--- a/Firmware/planner.cpp
+++ b/Firmware/planner.cpp
@@ -1050,6 +1050,7 @@ Having the real displacement of the head, we can calculate the total movement le
         slowdown_multiplier = maximum_slowdown_multiplier;
         const_rate_mode = true;
       }
+      else if ((slowdown_multiplier - maximum_slowdown_multiplier) < 0.12f) const_rate_mode = true;
     }
     else if ((maximum_slowdown_multiplier - slowdown_multiplier) > 0.12f) {
       slowdown_multiplier = maximum_slowdown_multiplier;


### PR DESCRIPTION
Current firmware algorithm slows down up to Minimum segment time. Because there is some computation power margin buffer starts to be refilled in that moment up to moment printer speeds up, drains buffer and slows down again. So if you are printing high polygon count cylinder in high speed, printer is periodically slowing down and speeding up and it has some impact on surface finish. My proposed change is to lock speed to maximum sustained rate when the buffer is drained and don't speedup until segments with higher sustained speed are to be planned regardless of buffer filled earlier.
[Video before](https://streamable.com/tlwy57)
[Video after](https://streamable.com/x0z5bh)
[example gcode](https://github.com/prusa3d/Prusa-Firmware/files/5165677/Distancni_sloupek_patrova_postel_50_0.2mm_PLA_MK3S_57m.gcode.zip)