### PR TITLE
Re-adjust LA10->15 conversion

### DIFF
--- a/Firmware/la10compat.cpp
+++ b/Firmware/la10compat.cpp
@@ -38,7 +38,7 @@ void la10c_mode_change(LA10C_MODE mode)
 // Approximate a LA10 value to a LA15 equivalent.
 static float la10c_convert(float k)
 {
-    float new_K = k * 0.004 - 0.05;
+    float new_K = k * 0.002 - 0.01;
     return new_K < 0? 0:
            new_K > (LA_K_MAX - FLT_EPSILON)? (LA_K_MAX - FLT_EPSILON):
            new_K;


### PR DESCRIPTION
After fixing some LA15 issues, the strength of LA15 increased.
As such, re-adjust the conversion factor so that:

```
Start K10 => 0.01 (previous minimum was K15)
PLA   K30 => 0.05 (was 0.07, optimal 0.045-0.06)
PETG  K45 => 0.08 (was 0.13, optimal 0.07-0.11 depending on material/temp)
```

To be tested if these values capture a good balance for the various materials/brands out there!

PFW-1137