### PR TITLE
🐛Fix: PF-build EN_ONLY argument

### DIFF
--- a/PF-build.sh
+++ b/PF-build.sh
@@ -15,7 +15,7 @@
 # 3. Install zip with 'apt-get install zip'
 # 4. Install python3 with 'apt-get install python3'
 # 5. Add command 'ln -sf /usr/bin/python3.5 /usr/bin/python' to link python3 to python.
-#    Donnot istall 'python' as python 2.x has end of life see https://pythonclock.org/
+#    Do not install 'python' as python 2.x has end of life see https://pythonclock.org/
 # 6. Add at top of ~/.bashrc following lines by using 'sudo nano ~/.bashrc'
 #
 #    export OS="Linux"
@@ -37,7 +37,7 @@
 # 2. Another great tool to compare your custom mod and stock firmware is WinMerge http://winmerge.org/downloads/?lang=en
 # 
 # Example for MK3: open git bash and change to your Firmware directory 
-# <username>@<machinename> MINGW64 /<drive>/path
+# <username>@<machine name> MINGW64 /<drive>/path
 # bash build.sh 1_75mm_MK3-EINSy10a-E3Dv6full
 #
 # Example for MK25: open git bash and change to your directory 
@@ -63,8 +63,8 @@
 # 17 Jan 2019, 3d-gussner, Build_3, Check for OS Windows or Linux and use the right build environment
 # 10 Feb 2019, ropaha, Pull Request, Select variant from list while using build.sh
 # 10 Feb 2019, ropaha, change FW_DEV_VERSION automatically depending on FW_VERSION RC/BETA/ALPHA
-# 10 Feb 2019, 3d-gussner, 1st tests with english only 
-# 10 Feb 2019, ropaha, added compiling of all variants and english only
+# 10 Feb 2019, 3d-gussner, 1st tests with English only 
+# 10 Feb 2019, ropaha, added compiling of all variants and English only
 # 10 Feb 2019, 3d-gussner, Set OUTPUT_FOLDER for hex files
 # 11 Feb 2019, 3d-gussner/ropaha, Minor changes and fixes
 # 11 Feb 2019, 3d-gussner, Ready for RC
@@ -80,52 +80,52 @@
 #                                              Configuration_prusa.h
 #                                              language build files
 #                                              multi language firmware files exist and clean them up
-# 15 Feb 2019, 3d-gussner, Fixed selction GOLD/UNKNOWN DEV_STATUS for ALL variants builds, so you have to choose only once
+# 15 Feb 2019, 3d-gussner, Fixed selection GOLD/UNKNOWN DEV_STATUS for ALL variants builds, so you have to choose only once
 # 15 Feb 2019, 3d-gussner, Added some colored output
 # 15 Feb 2019, 3d-gussner, troubleshooting and minor fixes
 # 16 Feb 2019, 3d-gussner, Script can be run using arguments
 #                          $1 = variant, example "1_75mm_MK3-EINSy10a-E3Dv6full.h" at this moment it is not possible to use ALL
-#                          $2 = multi language OR english only [ALL/EN_ONLY]
+#                          $2 = multi language OR English only [ALL/EN_ONLY]
 #                          $3 = development status [GOLD/RC/BETA/ALPHA/DEVEL/DEBUG]
 #                          If one argument is wrong a list of valid one will be shown
-# 13 Mar 2019, 3d-gussner, MKbel updated the linux build environment to version 1.0.2 with an Fix maximum firmware flash size.
+# 13 Mar 2019, 3d-gussner, MKbel updated the Linux build environment to version 1.0.2 with an Fix maximum firmware flash size.
 #                          So did I
 # 11 Jul 2019, deliopoulos,Updated to v1.0.6 as Prusa needs a new board definition for Firmware 3.8.x86_64
-#						   - Splitted the Download of Windows Arduino IDE 1.8.5 and Prusa specific part
+#						   - Split the Download of Windows Arduino IDE 1.8.5 and Prusa specific part
 #                            --> less download volume needed and saves some time
 #
-# 13 Jul 2019, deliopoulos,Splitting of Ardunio IDE and Prusa parts also for Linux64
+# 13 Jul 2019, deliopoulos,Splitting of Arduino IDE and Prusa parts also for Linux64
 # 13 Jul 2019, 3d-gussner, Added Linux 32-bit version (untested yet)
 #                          MacOS could be added in future if needs
 # 14 Jul 2019, 3d-gussner, Update preferences and make it really portable
-# 15 Jul 2019, 3d-gussner, New PF-build-env gihub branch
-# 16 Jul 2019, 3d-gussner, New Arduino_boards github fork
+# 15 Jul 2019, 3d-gussner, New PF-build-env GitHub branch
+# 16 Jul 2019, 3d-gussner, New Arduino_boards GitHub fork
 # 17 Jul 2019, 3d-gussner, Final tests under Windows 10 and Linux Subsystem for Windows   
 # 18 Jul 2019, 3d-gussner, Added python check
 # 18 Jul 2019, deliopoulos, No need more for changing 'platform.txt' file as it comes with the Arduino Boards.
 # 18 Jul 2019, deliopoulos, Modified 'PF_BUILD_FILE_URL' to use 'BUILD_ENV' variable
-# 22 Jul 2019, 3d-gussner, Modiffied checks to check folder and/or installation output exists.
+# 22 Jul 2019, 3d-gussner, Modified checks to check folder and/or installation output exists.
 # 22 Jul 2019, 3d-gussner, Added check if Arduino IDE 1.8.5 boards have been updated
 # 22 Jul 2019, 3d-gussner, Changed exit numbers 1-13 for prepare build env 21-28 for prepare compiling 31-36 compiling
-# 22 Jul 2019, 3d-gussner, Changed BOARD_URL to DRracers respository after he pulled my PR https://github.com/DRracer/Arduino_Boards/pull/1
+# 22 Jul 2019, 3d-gussner, Changed BOARD_URL to DRracers repository after he pulled my PR https://github.com/DRracer/Arduino_Boards/pull/1
 # 23 Jul 2019, 3d-gussner, Changed Build-env path to "PF-build-dl" as requested in PR https://github.com/prusa3d/Prusa-Firmware/pull/2028
 #                          Changed Hex-files folder to PF-build-hex as requested in PR
 # 23 Jul 2019, 3d-gussner, Added Finding OS version routine so supporting new OS should get easier
 # 26 Jul 2019, 3d-gussner, Change JSON repository to prusa3d after PR https://github.com/prusa3d/Arduino_Boards/pull/1 was merged
-# 23 Sep 2019, 3d-gussner, Prepare PF-build.sh for comming Prusa3d/Arduino_Boards version 1.0.2 Pull Request
-# 17 Oct 2019, 3d-gussner, Changed folder and check file names to have seperated build enviroments depening on Arduino IDE version and
+# 23 Sep 2019, 3d-gussner, Prepare PF-build.sh for coming Prusa3d/Arduino_Boards version 1.0.2 Pull Request
+# 17 Oct 2019, 3d-gussner, Changed folder and check file names to have separated build environments depending on Arduino IDE version and
 #                          board-versions.
 # 15 Dec 2019, 3d-gussner, Prepare for switch to Prusa3d/PF-build-env repository
-# 15 Dec 2019, 3d-gussner, Fix Audrino user preferences for the chosen board.
+# 15 Dec 2019, 3d-gussner, Fix Arduino user preferences for the chosen board.
 # 17 Dec 2019, 3d-gussner, Fix "timer0_fract = 0" warning by using Arduino_boards v1.0.3
 # 28 Apr 2020, 3d-gussner, Added RC3 detection
 # 03 May 2020, deliopoulos, Accept all RCx as RC versions
 # 05 May 2020, 3d-gussner, Make a copy of `not_tran.txt`and `not_used.txt` as `not_tran_$VARIANT.txt`and `not_used_$VARIANT.txt`
-#                          After compiling All multilanguage vairants it makes it easier to find missing or unused transltions.
+#                          After compiling All multi-language variants it makes it easier to find missing or unused translations.
 # 12 May 2020, DRracer   , Cleanup double MK2/s MK25/s `not_tran` and `not_used` files
 # 13 May 2020, leptun    , If cleanup files do not exist don't try to.
 # 01 Oct 2020, 3d-gussner, Bug fix if using argument EN_ONLY. Thank to @leptun for pointing out.
-#                          Change Build number to scrpit commits 'git rev-list --count HEAD PF-build.sh'
+#                          Change Build number to script commits 'git rev-list --count HEAD PF-build.sh'
 # 02 Oct 2020, 3d-gussner, Add UNKNOWN as argument option
 # 05 Oct 2020, 3d-gussner, Disable pause and warnings using command line with all needed arguments
 #                          Install needed apps under linux if needed.
@@ -265,7 +265,7 @@ echo "Script path :" $SCRIPT_PATH
 echo "OS          :" $OS
 echo "OS type     :" $TARGET_OS
 echo ""
-echo "Ardunio IDE :" $ARDUINO_ENV
+echo "Arduino IDE :" $ARDUINO_ENV
 echo "Build env   :" $BUILD_ENV
 echo "Board       :" $BOARD
 echo "Package name:" $BOARD_PACKAGE_NAME
@@ -446,9 +446,9 @@ fi
 #### Start 
 cd $SCRIPT_PATH
 
-# Check if git is availible
+# Check if git is available
 if type git > /dev/null; then
-	git_availible="1"
+	git_available="1"
 fi
 
 while getopts v:l:d:b:o:?h flag
@@ -478,7 +478,7 @@ echo "* PF-build.sh Version: 1.0.6-Build_33 *"
 echo "***************************************"
 echo "Arguments:"
 echo "$(tput setaf 2)-v$(tput sgr0) Variant '$(tput setaf 2)All$(tput sgr0)' or variant file name"
-echo "$(tput setaf 2)-l$(tput sgr0) Languages '$(tput setaf 2)ALL$(tput sgr0)' for multi language or '$(tput setaf 2)EN_ONLY$(tput sgr0)' for english only"
+echo "$(tput setaf 2)-l$(tput sgr0) Languages '$(tput setaf 2)ALL$(tput sgr0)' for multi language or '$(tput setaf 2)EN_ONLY$(tput sgr0)' for English only"
 echo "$(tput setaf 2)-d$(tput sgr0) Devel build '$(tput setaf 2)GOLD$(tput sgr0)', '$(tput setaf 2)RC$(tput sgr0)', '$(tput setaf 2)BETA$(tput sgr0)', '$(tput setaf 2)ALPHA$(tput sgr0)', '$(tput setaf 2)DEBUG$(tput sgr0)', '$(tput setaf 2)DEVEL$(tput sgr0)' and '$(tput setaf 2)UNKNOWN$(tput sgr0)'"
 echo "$(tput setaf 2)-b$(tput sgr0) Build/commit number '$(tput setaf 2)Auto$(tput sgr0)' needs git or a number"
 echo "$(tput setaf 2)-o$(tput sgr0) Output '$(tput setaf 2)1$(tput sgr0)' force or '$(tput setaf 2)0$(tput sgr0)' block output and delays"
@@ -547,7 +547,7 @@ else
 	fi
 fi
 
-#'-l' argument defines if it is an english only version. Known values EN_ONLY / ALL
+#'-l' argument defines if it is an English only version. Known values EN_ONLY / ALL
 #Check default language mode
 MULTI_LANGUAGE_CHECK=$(grep --max-count=1 "^#define LANG_MODE *" $SCRIPT_PATH/Firmware/config.h|sed -e's/  */ /g'|cut -d ' ' -f3)
 
@@ -592,7 +592,7 @@ fi
 
 #Check if Build is selected via argument '-b'
 if [ ! -z "$build_flag" ] ; then
-	if [[ "$build_flag" == "Auto" && "$git_availible" == "1" ]] ; then
+	if [[ "$build_flag" == "Auto" && "$git_available" == "1" ]] ; then
 		echo "Build changed to $build_flag"
 		BUILD=$(git rev-list --count HEAD)
 	elif [[ $build_flag =~ ^[0-9]+$ ]] ; then
@@ -615,7 +615,7 @@ fi
 #echo "Output is:" $OUTPUT
 
 #Check git branch has changed
-if [ ! -z "git_availible" ]; then
+if [ ! -z "git_available" ]; then
 	BRANCH=""
 	CLEAN_PF_FW_BUILD=0
 else
@@ -772,7 +772,7 @@ do
 	# set FW_REPOSITORY
 	sed -i -- 's/#define FW_REPOSITORY "Unknown"/#define FW_REPOSITORY "Prusa3d"/g' $SCRIPT_PATH/Firmware/Configuration.h
 
-	#Prepare english only or multilanguage version to be build
+	#Prepare English only or multi-language version to be build
 	if [ $LANGUAGES == "EN_ONLY" ]; then
 		echo " "
 		echo "English only language firmware will be built"

--- a/PF-build.sh
+++ b/PF-build.sh
@@ -56,7 +56,7 @@
 #   Some may argue that this is only used by a script, BUT as soon someone accidentally or on purpose starts Arduino IDE
 #   it will use the default Arduino IDE folders and so can corrupt the build environment.
 #
-# Version: 1.0.6-Build_18
+# Version: 1.0.6-Build_27
 # Change log:
 # 12 Jan 2019, 3d-gussner, Fixed "compiler.c.elf.flags=-w -Os -Wl,-u,vfprintf -lprintf_flt -lm -Wl,--gc-sections" in 'platform.txt'
 # 16 Jan 2019, 3d-gussner, Build_2, Added development check to modify 'Configuration.h' to prevent unwanted LCD messages that Firmware is unknown
@@ -124,6 +124,8 @@
 #                          After compiling All multilanguage vairants it makes it easier to find missing or unused transltions.
 # 12 May 2020, DRracer   , Cleanup double MK2/s MK25/s `not_tran` and `not_used` files
 # 13 May 2020, leptun    , If cleanup files do not exist don't try to.
+# 01 Oct 2020, 3d-gussner, Bug fix if using argument EN_ONLY. Thank to @leptun for pointing out.
+#                          Change Build number to scrpit commits
 #### Start check if OSTYPE is supported
 OS_FOUND=$( command -v uname)
 
@@ -473,12 +475,10 @@ if [ -z "$2" ] ; then
 		case $yn in
 			"Multi languages")
 				LANGUAGES="ALL"
-				sed -i -- "s/^#define LANG_MODE *0/#define LANG_MODE              1/g" $SCRIPT_PATH/Firmware/config.h
 				break
 				;;
 			"English only") 
 				LANGUAGES="EN_ONLY"
-				sed -i -- "s/^#define LANG_MODE *1/#define LANG_MODE              0/g" $SCRIPT_PATH/Firmware/config.h
 				break
 				;;
 			*)
@@ -622,13 +622,15 @@ do
 	sed -i -- 's/#define FW_REPOSITORY "Unknown"/#define FW_REPOSITORY "Prusa3d"/g' $SCRIPT_PATH/Firmware/Configuration.h
 
 	#Prepare english only or multilanguage version to be build
-	if [ $LANGUAGES == "ALL" ]; then
+	if [ $LANGUAGES == "EN_ONLY" ]; then
 		echo " "
-		echo "Multi-language firmware will be built"
+		echo "English only language firmware will be built"
+		sed -i -- "s/^#define LANG_MODE *1/#define LANG_MODE              0/g" $SCRIPT_PATH/Firmware/config.h
 		echo " "
 	else
 		echo " "
-		echo "English only language firmware will be built"
+		echo "Multi-language firmware will be built"
+		sed -i -- "s/^#define LANG_MODE *0/#define LANG_MODE              1/g" $SCRIPT_PATH/Firmware/config.h
 		echo " "
 	fi
 		

--- a/PF-build.sh
+++ b/PF-build.sh
@@ -731,7 +731,9 @@ do
 		cp -f $SCRIPT_PATH/Firmware/variants/$VARIANT.h $SCRIPT_PATH/Firmware/Configuration_prusa.h || exit 29
 	else
 		echo "$(tput setaf 6)Configuration_prusa.h already exist it will be overwritten in 10 seconds by the chosen variant.$(tput sgr 0)"
-		read -t 10 -p "Press Enter to continue..."
+		if [ $OUTPUT == "1" ] ; then
+			read -t 10 -p "Press Enter to continue..."
+		fi
 		cp -f $SCRIPT_PATH/Firmware/variants/$VARIANT.h $SCRIPT_PATH/Firmware/Configuration_prusa.h || exit 29
 	fi
 

--- a/PF-build.sh
+++ b/PF-build.sh
@@ -56,7 +56,7 @@
 #   Some may argue that this is only used by a script, BUT as soon someone accidentally or on purpose starts Arduino IDE
 #   it will use the default Arduino IDE folders and so can corrupt the build environment.
 #
-# Version: 1.0.6-Build_27
+# Version: 1.0.6-Build_28
 # Change log:
 # 12 Jan 2019, 3d-gussner, Fixed "compiler.c.elf.flags=-w -Os -Wl,-u,vfprintf -lprintf_flt -lm -Wl,--gc-sections" in 'platform.txt'
 # 16 Jan 2019, 3d-gussner, Build_2, Added development check to modify 'Configuration.h' to prevent unwanted LCD messages that Firmware is unknown
@@ -126,6 +126,7 @@
 # 13 May 2020, leptun    , If cleanup files do not exist don't try to.
 # 01 Oct 2020, 3d-gussner, Bug fix if using argument EN_ONLY. Thank to @leptun for pointing out.
 #                          Change Build number to scrpit commits
+# 02 Oct 2020, 3d-gussner, Add UNKNOWN as argument option
 #### Start check if OSTYPE is supported
 OS_FOUND=$( command -v uname)
 
@@ -497,11 +498,11 @@ else
 fi
 #Check if DEV_STATUS is selected via argument 3
 if [ ! -z "$3" ] ; then
-	if [[ "$3" == "GOLD" || "$3" == "RC" || "$3" == "BETA" || "$3" == "ALPHA" || "$3" == "DEVEL" || "$3" == "DEBUG" ]] ; then
+	if [[ "$3" == "GOLD" || "$3" == "RC" || "$3" == "BETA" || "$3" == "ALPHA" || "$3" == "DEVEL" || "$3" == "DEBUG" || "$3" == "UNKNOWN" ]] ; then
 		DEV_STATUS_SELECTED=$3
 	else
 		echo "$(tput setaf 1)Development argument is wrong!$(tput sgr0)"
-		echo "Only $(tput setaf 2)'GOLD', 'RC', 'BETA', 'ALPHA', 'DEVEL' or 'DEBUG'$(tput sgr0) are allowed as 3rd argument!$(tput sgr0)"
+		echo "Only $(tput setaf 2)'GOLD', 'RC', 'BETA', 'ALPHA', 'DEVEL', 'DEBUG' or 'UNKOWN' $(tput sgr0) are allowed as 3rd argument!$(tput sgr0)"
 		exit 23
 	fi
 fi

--- a/PF-build.sh
+++ b/PF-build.sh
@@ -502,7 +502,7 @@ if [ ! -z "$3" ] ; then
 		DEV_STATUS_SELECTED=$3
 	else
 		echo "$(tput setaf 1)Development argument is wrong!$(tput sgr0)"
-		echo "Only $(tput setaf 2)'GOLD', 'RC', 'BETA', 'ALPHA', 'DEVEL', 'DEBUG' or 'UNKOWN' $(tput sgr0) are allowed as 3rd argument!$(tput sgr0)"
+		echo "Only $(tput setaf 2)'GOLD', 'RC', 'BETA', 'ALPHA', 'DEVEL', 'DEBUG' or 'UNKNOWN' $(tput sgr0) are allowed as 3rd argument!$(tput sgr0)"
 		exit 23
 	fi
 fi

--- a/PF-build.sh
+++ b/PF-build.sh
@@ -56,7 +56,7 @@
 #   Some may argue that this is only used by a script, BUT as soon someone accidentally or on purpose starts Arduino IDE
 #   it will use the default Arduino IDE folders and so can corrupt the build environment.
 #
-# Version: 1.0.6-Build_32
+# Version: 1.0.6-Build_33
 # Change log:
 # 12 Jan 2019, 3d-gussner, Fixed "compiler.c.elf.flags=-w -Os -Wl,-u,vfprintf -lprintf_flt -lm -Wl,--gc-sections" in 'platform.txt'
 # 16 Jan 2019, 3d-gussner, Build_2, Added development check to modify 'Configuration.h' to prevent unwanted LCD messages that Firmware is unknown
@@ -133,6 +133,8 @@
 # 02 Nov 2020, 3d-gussner, Check for "gawk" on Linux
 #                          Add argument to change build number automatically to current commit or define own number
 #                          Update exit numbers 1-13 for prepare build env 21-29 for prepare compiling 30-36 compiling
+# 08 Jan 2021, 3d-gussner, Comment out 'sudo' auto installation
+#                          Add '-?' '-h' help option
 
 #### Start check if OSTYPE is supported
 OS_FOUND=$( command -v uname)
@@ -208,7 +210,7 @@ if ! type zip > /dev/null; then
 	elif [ $TARGET_OS == "linux" ]; then
 		echo "$(tput setaf 1)Missing 'zip' which is important to run this script"
 		echo "install it with the command $(tput setaf 2)'sudo apt-get install zip'$(tput sgr0)"
-		sudo apt-get update && apt-get install zip
+		#sudo apt-get update && apt-get install zip
 		exit 3
 	fi
 fi
@@ -223,7 +225,7 @@ if ! type python > /dev/null; then
 		echo "install it with the command $(tput setaf 2)'sudo apt-get install python3'."
 		echo "Check which version of Python3 has been installed using 'ls /usr/bin/python3*'"
 		echo "Use 'sudo ln -sf /usr/bin/python3.x /usr/bin/python' (where 'x' is your version number) to make it default.$(tput sgr0)"
-		sudo apt-get update && apt-get install python3 && ln -sf /usr/bin/python3 /usr/bin/python
+		#sudo apt-get update && apt-get install python3 && ln -sf /usr/bin/python3 /usr/bin/python
 		exit 4
 	fi
 fi
@@ -233,7 +235,7 @@ if ! type gawk > /dev/null; then
 	if [ $TARGET_OS == "linux" ]; then
 		echo "$(tput setaf 1)Missing 'gawk' which is important to run this script"
 		echo "install it with the command $(tput setaf 2)'sudo apt-get install gawk'."
-		sudo apt-get update && apt-get install gawk
+		#sudo apt-get update && apt-get install gawk
 		exit 4
 	fi
 fi
@@ -449,13 +451,7 @@ if type git > /dev/null; then
 	git_availible="1"
 fi
 
-#arguments
-#'-v' Variant "All" or variant file name
-#'-l' Languages "ALL" for multi language or "EN_ONLY" for english only
-#'-d' Devel build "GOLD", "RC", "BETA", "ALPHA", "DEBUG", "DEVEL" and "UNKNOWN"
-#'-b' Build/commit number "Auto" needs git or a number
-#'-o' Output "1" force or "0" block output and delays 
-while getopts v:l:d:b:o: flag
+while getopts v:l:d:b:o:?h flag
 	do
 	    case "${flag}" in
 	        v) variant_flag=${OPTARG};;
@@ -463,6 +459,8 @@ while getopts v:l:d:b:o: flag
 	        d) devel_flag=${OPTARG};;
 			b) build_flag=${OPTARG};;
 			o) output_flag=${OPTARG};;
+			?) help_flag=1;;
+			h) help_flag=1;;
 	    esac
 	done
 #echo "variant_flag: $variant_flag";
@@ -470,6 +468,37 @@ while getopts v:l:d:b:o: flag
 #echo "devel_flag: $devel_flag";
 #echo "build_flag: $build_flag";
 #echo "output_flag: $output_flag";
+#echo "help_flag: $help_flag"
+
+#
+# '?' 'h' argument usage and help
+if [ "$help_flag" == "1" ] ; then
+echo "***************************************"
+echo "* PF-build.sh Version: 1.0.6-Build_33 *"
+echo "***************************************"
+echo "Arguments:"
+echo "$(tput setaf 2)-v$(tput sgr0) Variant '$(tput setaf 2)All$(tput sgr0)' or variant file name"
+echo "$(tput setaf 2)-l$(tput sgr0) Languages '$(tput setaf 2)ALL$(tput sgr0)' for multi language or '$(tput setaf 2)EN_ONLY$(tput sgr0)' for english only"
+echo "$(tput setaf 2)-d$(tput sgr0) Devel build '$(tput setaf 2)GOLD$(tput sgr0)', '$(tput setaf 2)RC$(tput sgr0)', '$(tput setaf 2)BETA$(tput sgr0)', '$(tput setaf 2)ALPHA$(tput sgr0)', '$(tput setaf 2)DEBUG$(tput sgr0)', '$(tput setaf 2)DEVEL$(tput sgr0)' and '$(tput setaf 2)UNKNOWN$(tput sgr0)'"
+echo "$(tput setaf 2)-b$(tput sgr0) Build/commit number '$(tput setaf 2)Auto$(tput sgr0)' needs git or a number"
+echo "$(tput setaf 2)-o$(tput sgr0) Output '$(tput setaf 2)1$(tput sgr0)' force or '$(tput setaf 2)0$(tput sgr0)' block output and delays"
+echo "$(tput setaf 2)-?$(tput sgr0) Help"
+echo "$(tput setaf 2)-h$(tput sgr0) Help"
+echo 
+echo "Brief USAGE:"
+echo "  $(tput setaf 2)./PF-build.sh$(tput sgr0)  [-v] [-l] [-d] [-b] [-o]"
+echo
+echo "Example:"
+echo "  $(tput setaf 2)./PF-build.sh -v All -l ALL -d GOLD$(tput sgr0)"
+echo "  Will build all variants as multi language and final GOLD version"
+echo
+echo "  $(tput setaf 2) ./PF-build.sh -v 1_75mm_MK3S-EINSy10a-E3Dv6full.h -b Auto -l ALL -d GOLD -o 1$(tput sgr0)"
+echo "  Will build MK3S multi language final GOLD firmware "
+echo "  with current commit count number and output extra information"
+echo
+exit 
+
+fi
 
 #
 # '-v' argument defines which variant of the Prusa Firmware will be compiled 


### PR DESCRIPTION
**What was the issue?**
Using the `PF-build.sh` with command line arguments ignored the `EN_ONLY` option and compiled always a multi material firmware version without adding the languages.

Selecting the EN_ONLY on the other side while going through the process did work.

Thanks to @leptun for pointing it out.

Added also the `UNKNOWN` as an option next to `GOLD, RC, BETA, ALPHA, DEBUG, DEVEL`

**Tested by me and @leptun:**
The hex files generated "manually" going through the menu are the same as the generated one with arguments.