### PR TITLE
cmdqueue: Patches to Serial communication, pausing and file completion check

### DIFF
--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -240,22 +240,11 @@ void Stop();
 bool IsStopped();
 void finishAndDisableSteppers();
 
-//put an ASCII command at the end of the current buffer.
-void enquecommand(const char *cmd, bool from_progmem = false);
-
 //put an ASCII command at the end of the current buffer, read from flash
 #define enquecommand_P(cmd) enquecommand(cmd, true)
 
-//put an ASCII command at the begin of the current buffer
-void enquecommand_front(const char *cmd, bool from_progmem = false);
-
 //put an ASCII command at the begin of the current buffer, read from flash
 #define enquecommand_front_P(cmd) enquecommand_front(cmd, true)
-
-void repeatcommand_front();
-
-// Remove all lines from the command queue.
-void cmdqueue_reset();
 
 void prepare_arc_move(char isclockwise);
 void clamp_to_software_endstops(float target[3]);

--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -116,7 +116,6 @@ void serial_echopair_P(const char *s_P, unsigned long v);
 void serialprintPGM(const char *str);
 
 bool is_buffer_empty();
-void get_command();
 void process_commands();
 void ramming();
 

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -6863,12 +6863,10 @@ Sigma_Exit:
           SERIAL_ECHOPGM(STRINGIFY(EXTRUDERS)); 
           SERIAL_ECHOPGM(" UUID:"); 
           SERIAL_ECHOLNPGM(MACHINE_UUID);
-      }
-      
 #ifdef EXTENDED_CAPABILITIES_REPORT
-      extended_capabilities_report();
+          extended_capabilities_report();
 #endif //EXTENDED_CAPABILITIES_REPORT
-      
+      }
       break;
 
     /*!

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -631,7 +631,7 @@ void crashdet_cancel()
 		lcd_print_stop();
 	}else if(saved_printing_type == PRINTING_TYPE_USB){
 		SERIAL_ECHOLNRPGM(MSG_OCTOPRINT_CANCEL); //for Octoprint: works the same as clicking "Abort" button in Octoprint GUI
-		SERIAL_PROTOCOLLNRPGM(MSG_OK);
+		cmdqueue_reset();
 	}
 }
 
@@ -3678,14 +3678,12 @@ There are reasons why some G Codes aren't in numerical order.
 void process_commands()
 {
 #ifdef FANCHECK
-    if(fan_check_error){
-        if(fan_check_error == EFCE_DETECTED){
-            fan_check_error = EFCE_REPORTED;
-            // SERIAL_PROTOCOLLNRPGM(MSG_OCTOPRINT_PAUSED);
-            lcd_pause_print();
-        } // otherwise it has already been reported, so just ignore further processing
-        return; //ignore usb stream. It is reenabled by selecting resume from the lcd.
-    }
+	if(fan_check_error == EFCE_DETECTED){
+		fan_check_error = EFCE_REPORTED;
+		// SERIAL_PROTOCOLLNRPGM(MSG_OCTOPRINT_PAUSED);
+		lcd_pause_print();
+		cmdqueue_serial_disabled = true;
+	}
 #endif
 
 	if (!buflen) return; //empty command
@@ -11459,7 +11457,6 @@ void restore_print_from_ram_and_continue(float e_move)
 		//not sd printing nor usb printing
 	}
 
-	// SERIAL_PROTOCOLLNRPGM(MSG_OK); //dummy response because of octoprint is waiting for this
 	lcd_setstatuspgm(_T(WELCOME_MSG));
     saved_printing_type = PRINTING_TYPE_NONE;
 	saved_printing = false;

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -7994,6 +7994,7 @@ Sigma_Exit:
         if (!isPrintPaused)
         {
             st_synchronize();
+            ClearToSend(); //send OK even before the command finishes executing because we want to make sure it is not skipped because of cmdqueue_pop_front();
             cmdqueue_pop_front(); //trick because we want skip this command (M601) after restore
             lcd_pause_print();
         }

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -2631,7 +2631,6 @@ void gcode_M105(uint8_t extruder)
     }
 #endif
     SERIAL_PROTOCOLLN("");
-    KEEPALIVE_STATE(NOT_BUSY);
 }
 
 #ifdef TMC2130

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -11459,7 +11459,7 @@ void restore_print_from_ram_and_continue(float e_move)
 		//not sd printing nor usb printing
 	}
 
-	SERIAL_PROTOCOLLNRPGM(MSG_OK); //dummy response because of octoprint is waiting for this
+	// SERIAL_PROTOCOLLNRPGM(MSG_OK); //dummy response because of octoprint is waiting for this
 	lcd_setstatuspgm(_T(WELCOME_MSG));
     saved_printing_type = PRINTING_TYPE_NONE;
 	saved_printing = false;

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -6399,7 +6399,8 @@ Sigma_Exit:
       SERIAL_PROTOCOLPGM("ok ");
       gcode_M105(extruder);
       
-      return;
+      cmdqueue_pop_front(); //prevent an ok after the command since this command uses an ok at the beginning.
+      
       break;
     }
 

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -9205,8 +9205,8 @@ void FlushSerialRequestResend()
 // Execution of a command from a SD card will not be confirmed.
 void ClearToSend()
 {
-    previous_millis_cmd = _millis();
-	if ((CMDBUFFER_CURRENT_TYPE == CMDBUFFER_CURRENT_TYPE_USB) || (CMDBUFFER_CURRENT_TYPE == CMDBUFFER_CURRENT_TYPE_USB_WITH_LINENR)) 
+	previous_millis_cmd = _millis();
+	if (buflen && ((CMDBUFFER_CURRENT_TYPE == CMDBUFFER_CURRENT_TYPE_USB) || (CMDBUFFER_CURRENT_TYPE == CMDBUFFER_CURRENT_TYPE_USB_WITH_LINENR)))
 		SERIAL_PROTOCOLLNRPGM(MSG_OK);
 }
 

--- a/Firmware/cardreader.cpp
+++ b/Firmware/cardreader.cpp
@@ -498,7 +498,7 @@ void CardReader::getStatus()
           SERIAL_PROTOCOLLNPGM("Print saved");
       }
       else {
-          SERIAL_PROTOCOLLN(longFilename);
+          SERIAL_PROTOCOLLN(LONGEST_FILENAME);
           SERIAL_PROTOCOLRPGM(_N("SD printing byte "));////MSG_SD_PRINTING_BYTE
           SERIAL_PROTOCOL(sdpos);
           SERIAL_PROTOCOL('/');

--- a/Firmware/cardreader.cpp
+++ b/Firmware/cardreader.cpp
@@ -1,4 +1,5 @@
 #include "Marlin.h"
+#include "cmdqueue.h"
 #include "cardreader.h"
 #include "ultralcd.h"
 #include "stepper.h"

--- a/Firmware/cmdqueue.cpp
+++ b/Firmware/cmdqueue.cpp
@@ -97,8 +97,7 @@ void cmdqueue_reset()
 {
 	while (buflen)
 	{
-		uint8_t cmdqueue_current_type = *(cmdbuffer+bufindr);
-		// printf_P(PSTR("dumping: \"%s\" of type %hu\n"), cmdbuffer+bufindr+CMDHDRSIZE, cmdqueue_current_type);
+		// printf_P(PSTR("dumping: \"%s\" of type %hu\n"), cmdbuffer+bufindr+CMDHDRSIZE, CMDBUFFER_CURRENT_TYPE);
 		ClearToSend();
 		cmdqueue_pop_front();
 	}

--- a/Firmware/cmdqueue.cpp
+++ b/Firmware/cmdqueue.cpp
@@ -582,8 +582,6 @@ void get_command()
        ((serial_char == '#' || serial_char == ':') && comment_mode == false) ||
        serial_count >= (MAX_CMD_SIZE - 1) || n==-1)
     {
-      if(card.eof()) break;
-
       if(serial_char=='#')
         stop_buffering=true;
 
@@ -631,6 +629,9 @@ void get_command()
 
       comment_mode = false; //for new command
       serial_count = 0; //clear buffer
+    
+      if(card.eof()) break;
+    
       // The following line will reserve buffer space if available.
       if (! cmdqueue_could_enqueue_back(MAX_CMD_SIZE-1, true))
           return;

--- a/Firmware/cmdqueue.cpp
+++ b/Firmware/cmdqueue.cpp
@@ -18,6 +18,10 @@ int buflen = 0;
 // Therefore don't remove the command from the queue in the loop() function.
 bool cmdbuffer_front_already_processed = false;
 
+// Used for temporarely preventing accidental adding of Serial commands to the queue.
+// For now only check_file and the fancheck pause use this.
+bool cmdqueue_serial_disabled = false;
+
 int serial_count = 0;  //index of character read from serial line
 boolean comment_mode = false;
 char *strchr_pointer; // just a pointer to find chars in the command string like X, Y, Z, E, etc
@@ -91,14 +95,20 @@ bool cmdqueue_pop_front()
 
 void cmdqueue_reset()
 {
-    bufindr = 0;
-    bufindw = 0;
-    buflen = 0;
+	while (buflen)
+	{
+		uint8_t cmdqueue_current_type = *(cmdbuffer+bufindr);
+		// printf_P(PSTR("dumping: \"%s\" of type %hu\n"), cmdbuffer+bufindr+CMDHDRSIZE, cmdqueue_current_type);
+		ClearToSend();
+		cmdqueue_pop_front();
+	}
+	bufindr = 0;
+	bufindw = 0;
 
 	//commands are removed from command queue after process_command() function is finished
 	//reseting command queue and enqueing new commands during some (usually long running) command processing would cause that new commands are immediately removed from queue (or damaged)
 	//this will ensure that all new commands which are enqueued after cmdqueue reset, will be always executed
-    cmdbuffer_front_already_processed = true; 
+	cmdbuffer_front_already_processed = true; 
 }
 
 // How long a string could be pushed to the front of the command queue?
@@ -390,7 +400,7 @@ void get_command()
 	}
 
   // start of serial line processing loop
-  while ((MYSERIAL.available() > 0 && !saved_printing) || (MYSERIAL.available() > 0 && isPrintPaused)) {  //is print is saved (crash detection or filament detection), dont process data from serial line
+  while (((MYSERIAL.available() > 0 && !saved_printing) || (MYSERIAL.available() > 0 && isPrintPaused)) && !cmdqueue_serial_disabled) {  //is print is saved (crash detection or filament detection), dont process data from serial line
 	
     char serial_char = MYSERIAL.read();
 /*    if (selectedSerialPort == 1)

--- a/Firmware/cmdqueue.h
+++ b/Firmware/cmdqueue.h
@@ -35,6 +35,7 @@ extern char cmdbuffer[BUFSIZE * (MAX_CMD_SIZE + 1) + CMDBUFFER_RESERVE_FRONT];
 extern size_t bufindr;
 extern int buflen;
 extern bool cmdbuffer_front_already_processed;
+extern bool cmdqueue_serial_disabled;
 
 // Type of a command, which is to be executed right now.
 #define CMDBUFFER_CURRENT_TYPE   (cmdbuffer[bufindr])
@@ -65,8 +66,8 @@ extern void cmdqueue_dump_to_serial_single_line(int nr, const char *p);
 extern void cmdqueue_dump_to_serial();
 #endif /* CMDBUFFER_DEBUG */
 extern bool cmd_buffer_empty();
-extern void enquecommand(const char *cmd, bool from_progmem);
-extern void enquecommand_front(const char *cmd, bool from_progmem);
+extern void enquecommand(const char *cmd, bool from_progmem = false);
+extern void enquecommand_front(const char *cmd, bool from_progmem = false);
 extern void repeatcommand_front();
 extern bool is_buffer_empty();
 extern void get_command();

--- a/Firmware/first_lay_cal.cpp
+++ b/Firmware/first_lay_cal.cpp
@@ -7,6 +7,7 @@
 #include "Configuration_prusa.h"
 #include "language.h"
 #include "Marlin.h"
+#include "cmdqueue.h"
 #include "mmu.h"
 #include <avr/pgmspace.h>
 

--- a/Firmware/menu.cpp
+++ b/Firmware/menu.cpp
@@ -8,6 +8,7 @@
 #include "lcd.h"
 #include "Configuration.h"
 #include "Marlin.h"
+#include "cmdqueue.h"
 #include "ultralcd.h"
 #include "language.h"
 #include "static_assert.h"

--- a/Firmware/mmu.cpp
+++ b/Firmware/mmu.cpp
@@ -9,6 +9,7 @@
 #include "Configuration_prusa.h"
 #include "fsensor.h"
 #include "cardreader.h"
+#include "cmdqueue.h"
 #include "ultralcd.h"
 #include "sound.h"
 #include "printers.h"

--- a/Firmware/temperature.cpp
+++ b/Firmware/temperature.cpp
@@ -30,6 +30,7 @@
 
 
 #include "Marlin.h"
+#include "cmdqueue.h"
 #include "ultralcd.h"
 #include "sound.h"
 #include "temperature.h"
@@ -632,7 +633,6 @@ void fanSpeedError(unsigned char _fan) {
 		fanSpeedErrorBeep(PSTR("Print fan speed is lower than expected"), MSG_FANCHECK_PRINT);
 		break;
 	}
-    // SERIAL_PROTOCOLLNRPGM(MSG_OK); //This ok messes things up with octoprint.
 }
 #endif //(defined(TACH_0) && TACH_0 >-1) || (defined(TACH_1) && TACH_1 > -1)
 


### PR DESCRIPTION
This PR makes a lot of small changes all around the code regarding the cmdqueue.
Things fixed so far:
1) If for some odd reason octoprint decides to get a file list during an SD print (happened to me while I was running the firmware in the emulator), then the current filename will change to something else. I patched it so even if the long filename was for some reason broken, it would still send back to octoprint at least some filename for it to parse correctly the M27 response.
2) Fixed bug introduced with #2832 . Now keep-alive messages are sent correctly.
Closes #2854 
3) Fixed missing Ok in M601 and double Ok in M602.
Closes #2866 
4) M115 now sends the capabilities report only if it isn't provided any arguments. I found out later that M115 is also used for checking that the right firmware is used in gcode, so the report was sent to serial even when it shouldn't. Now only M115 without arguments prints the capabilities report.
5) Fixed a bug where if the last line in a SD file wasn't terminated by a EOL character, then it would leave the cmdqueue in an unfinished state (and possibly corrupted). Now if we encounter the end of file, we queue the line even if it was incomplete for some reason. This should allow file_check() to be able to parse a M84 at the end of the file correctly if it doesn't have a trailing '\n'
6) Instead of just dumping the queue with `cmdqueue_reset()`, now we pop the contents of the queue one after the other in order and check their source. In case we have Serial commands in the queue, we respond with Ok for each of them as to unclutch the Serial communication. If we didn't do this, then Octoprint or any other host for that matter would be waiting indefinitely for the Ok response for a command that no longer exists in the queue. With this, now fancheck works even better, without needing any Ok hacks like we did before.

Bonus: Now if a command is sent to the printer from Octoprint while starting a SD print from the lcd, it won't get discarded and it will be answered after the check_file finishes.

PFW-1150
PFW-1157