### PR TITLE
constexpr's which contain a reinterpret_cast are not valid C++ - here is the fix

### DIFF
--- a/Firmware/eeprom.h
+++ b/Firmware/eeprom.h
@@ -591,7 +591,7 @@ static Sheets * const EEPROM_Sheets_base = (Sheets*)(EEPROM_SHEETS_BASE);
 #ifdef __cplusplus
 #include "ConfigurationStore.h"
 static_assert(EEPROM_FIRMWARE_VERSION_END < 20, "Firmware version EEPROM address conflicts with EEPROM_M500_base");
-static constexpr M500_conf * const EEPROM_M500_base = reinterpret_cast<M500_conf*>(20); //offset for storing settings using M500
+static M500_conf * const EEPROM_M500_base = reinterpret_cast<M500_conf*>(20); //offset for storing settings using M500
 static_assert(((sizeof(M500_conf) + 20) < EEPROM_LAST_ITEM), "M500_conf address space conflicts with previous items.");
 #endif
 


### PR DESCRIPTION
This line in `eeprom.h` is not valid C++:

```C++
static constexpr M500_conf * const EEPROM_M500_base = reinterpret_cast<M500_conf*>(20);
```

I'm not trying to be harsh, but it is explicitly forbidden by the C++ standard, therefore this line is not valid C++.

From [[expr.const] section 5](https://eel.is/c++draft/expr.const#5) of the official C++ 11 spec:

>5. An expression E is a core constant expression unless the evaluation of E, following the rules of the abstract machine ([intro.execution]), would evaluate one of the following:
  ...
  5.15. a reinterpret_­cast ([expr.reinterpret.cast]);

As you can see, C++ **[explicitly forbids](https://eel.is/c++draft/expr.const#5.15)** any expression containing a reinterpret_cast from being a constexpr.  

The only reason the firmware compiles is because of a **compiler bug in older versions of gcc that failed to throw an error for this**.  That behavior is incorrect and a bug.  This is, as far as I know, the reason this firmware 'needs' (note:  it doesn't) to be compiled with certain supported versions of the Arduino IDE which are old enough is because newer versions have more recent versions of avr-gcc which fixed this bug.

The issue is with the code, not the compiler.  Production firmware should not be relying on an unfixed compiler bug to be able to build successfully.  

I have been compiling this firmware with the latest Arduino IDE version (and the version of avr-gcc that implies) for ages and running it on my printer.  As near as I can tell, there are no issues that would demand the Firmware be locked to outdated, buggier compiler versions as it works great and continues to work great if compiled with any version of the Arduino IDE that is too new to be 'supported' by the firmware.  


I understand the intent here, which is to ensure a fixed address location at compile time so the compiler doesn't do anything weird and decide to use a different address and now all the EEPROM data will be misaligned.  

However, the method being used is incorrect, and is not compiling to something that determines the address at compile time as reinterpret_cast is strictly done at runtime.  The compiler bug is, in fact, a bug, and the fact that it compiles does not mean it is behaving like the code would have one believe.  It is _**not**_ behaving like a constexpr compile time constant at all, but it compiles anyway and silently converts it to a regular runtime const without error.   That is the bug.  

So the change I've made to that line is functionally identical to the code as is.  It results in the same hex file.  Only now it can compile with any of the more recent versions of the Arduino IDE because it is now valid C++.  


Simply creating a static * const pointer to the cast address is the accepted way of ensuring a fixed address with avr-gcc.  The EEPROM on AVRs are not part of the MCU's addressable memory space, but rather their own independent region with addresses that always span 0..N.  Even if the address of 20 is technically relative and determined at runtime, this cannot ever be a problem as the address will always be relative to the start of the EEPROM, which is always 0 on every AVR in existence, and will never change for any reason.  Nothing programwise will change it because its not even part of that memory space.  

In other words, while I think the intent here was to be extremely careful and make sure the EEPROM settings data is correctly aligned, this caution is not necessary, and the method used to try and enforce it isn't enforcing it and doesn't work anyway.  

Can we please fix this line of code so people don't just get stuck and unable to compile just because they used an unsupported/too recent version of the Arduino IDE/avr-gcc?  