### PR TITLE
Extend M403 cmd with new parameters P, S and U giving extruder pulley and MMU load/unload speeds

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -7764,8 +7764,15 @@ Sigma_Exit:
 			if(code_seen('E')) extruder = code_value();
 			if(code_seen('F')) filament = code_value();
 			if(code_seen('S'))
-			  relative_speed = relative_unload_speed = code_value();
-			if(code_seen('U')) relative_unload_speed = code_value();
+			  relative_speed = code_value();
+			else if (filament == 1)
+			  relative_speed = 0.5; // default for flex
+			else
+			  relative_speed = 1.0;
+			if(code_seen('U'))
+			  relative_unload_speed = code_value();
+			else
+			  relative_unload_speed = relative_speed;
 			mmu_set_filament_type(extruder,
 					      filament,
 					      relative_speed,

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -7759,9 +7759,17 @@ Sigma_Exit:
 		{
 			uint8_t extruder = 255;
 			uint8_t filament = FILAMENT_UNDEFINED;
+			float relative_speed = 1.0;
+			float relative_unload_speed = 1.0;
 			if(code_seen('E')) extruder = code_value();
 			if(code_seen('F')) filament = code_value();
-			mmu_set_filament_type(extruder, filament);
+			if(code_seen('S'))
+			  relative_speed = relative_unload_speed = code_value();
+			if(code_seen('U')) relative_unload_speed = code_value();
+			mmu_set_filament_type(extruder,
+					      filament,
+					      relative_speed,
+					      relative_unload_speed);
 		}
 	}
 	break;

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -7744,11 +7744,14 @@ Sigma_Exit:
     And storing this information for different load/unload profiles etc. in the future firmware does not have to wait for "ok" from MMU.
     #### Usage
     
-        M403 [ E | F ]
+        M403 [ E | F | P | S | U ]
     
     #### Parameters
     - `E` - Extruder number. 0-indexed.
-    - `F` - Filament type
+    - `F` - Filament type (0, 1 = flex, 2 = PVA)
+    - `P` - Relative extruder pulley speed (defaults to MMU load speed)
+    - `S` - Relative MMU load speed (defaults to 1.0, or 0.5 for flex)
+    - `U` - Relative MMU unload speed (defaults to MMU load speed)
 	*/
     case 403:
 	{
@@ -7759,23 +7762,27 @@ Sigma_Exit:
 		{
 			uint8_t extruder = 255;
 			uint8_t filament = FILAMENT_UNDEFINED;
-			float relative_speed = 1.0;
-			float relative_unload_speed = 1.0;
+			float relative_pulley_speed = MMU_DEFAULT_REL_LOAD_SPEED;
+			float relative_load_speed = MMU_DEFAULT_REL_LOAD_SPEED;
+			float relative_unload_speed = MMU_DEFAULT_REL_LOAD_SPEED;
 			if(code_seen('E')) extruder = code_value();
 			if(code_seen('F')) filament = code_value();
 			if(code_seen('S'))
-			  relative_speed = code_value();
+			  relative_load_speed = code_value();
 			else if (filament == 1)
-			  relative_speed = 0.5; // default for flex
-			else
-			  relative_speed = 1.0;
+			  relative_load_speed = MMU_DEFAULT_REL_LOAD_SPEED_FLEX;
 			if(code_seen('U'))
 			  relative_unload_speed = code_value();
 			else
-			  relative_unload_speed = relative_speed;
+			  relative_unload_speed = relative_load_speed;
+			if(code_seen('P'))
+			  relative_pulley_speed = code_value();
+			else
+			  relative_pulley_speed = relative_load_speed;
 			mmu_set_filament_type(extruder,
 					      filament,
-					      relative_speed,
+					      relative_pulley_speed,
+					      relative_load_speed,
 					      relative_unload_speed);
 		}
 	}

--- a/Firmware/mmu.cpp
+++ b/Firmware/mmu.cpp
@@ -391,7 +391,7 @@ void mmu_loop(void)
 			mmu_last_finda_response = _millis();
 			FDEBUG_PRINTF_P(PSTR("MMU => '%dok'\n"), mmu_finda);
 			//printf_P(PSTR("Eact: %d\n"), int(e_active()));
-			if ((!mmu_finda || !(PIN_GET(IR_SENSOR_PIN) == 0)) && CHECK_FSENSOR && fsensor_enabled) {
+			if (!mmu_finda && CHECK_FSENSOR && fsensor_enabled) {
 				fsensor_checkpoint_print();
 				if (mmu_extruder != MMU_FILAMENT_UNKNOWN) // Can't deplete unknown extruder.
                     ad_markDepleted(mmu_extruder);

--- a/Firmware/mmu.cpp
+++ b/Firmware/mmu.cpp
@@ -508,17 +508,24 @@ void mmu_reset(void)
 #endif
 }
 
+static uint16_t
+to_fixed_point (float x)
+{
+  return x * 256.0f + 0.5f;
+}
+
 int8_t mmu_set_filament_type(uint8_t extruder,
 			     uint8_t filament,
+			     float rel_pulley_speed,
 			     float rel_load_speed,
 			     float rel_unload_speed)
 {
         if (extruder >= MMU_NUM_EXTRUDERS)
 	  return 0;
 	//mmu_filament_type[extruder] = filament;
-	mmu_relative_load_speed[extruder] = rel_load_speed;
-	uint16_t irel_load_speed = rel_load_speed * 256.0f + 0.5f;
-	uint16_t irel_unload_speed = rel_unload_speed * 256.0f + 0.5f;
+	mmu_relative_load_speed[extruder] = rel_pulley_speed;
+	uint16_t irel_load_speed = to_fixed_point (rel_load_speed);
+	uint16_t irel_unload_speed = to_fixed_point (rel_unload_speed);
         printf_P(PSTR("MMU <= 'F%d %d %d %d'\n"),
 		 extruder, filament, irel_load_speed, irel_unload_speed);
 	mmu_printf_P(PSTR("F%d %d %d %d\n"),

--- a/Firmware/mmu.h
+++ b/Firmware/mmu.h
@@ -24,12 +24,16 @@ extern uint16_t mmu_power_failures;
 
 #define MMU_FILAMENT_UNKNOWN 255
 
+#define MMU_NUM_EXTRUDERS 5
+#define MMU_NUM_FILAMENT_TYPES 3
+
 #define MMU_NO_MOVE 0
 #define MMU_UNLOAD_MOVE 1
 #define MMU_LOAD_MOVE 2
 #define MMU_TCODE_MOVE 3
 
-#define MMU_LOAD_FEEDRATE 19.02f //mm/s
+#define MMU_DEFAULT_LOAD_FEEDRATE 19.02f //mm/s
+#define MMU_LOAD_FEEDRATE mmu_load_feedrate()
 #define MMU_LOAD_TIME_MS 2000 //should be fine tuned to load time for shortest allowed PTFE tubing and maximum loading speed
 
 enum class MmuCmd : uint_least8_t
@@ -87,7 +91,7 @@ extern void mmu_loop(void);
 
 extern void mmu_reset(void);
 
-extern int8_t mmu_set_filament_type(uint8_t extruder, uint8_t filament);
+extern int8_t mmu_set_filament_type(uint8_t extruder, uint8_t filament, float rel_load_speed, float rel_unload_speed);
 
 extern void mmu_command(MmuCmd cmd);
 

--- a/Firmware/mmu.h
+++ b/Firmware/mmu.h
@@ -33,6 +33,8 @@ extern uint16_t mmu_power_failures;
 #define MMU_TCODE_MOVE 3
 
 #define MMU_DEFAULT_LOAD_FEEDRATE 19.02f //mm/s
+#define MMU_DEFAULT_REL_LOAD_SPEED 1.0
+#define MMU_DEFAULT_REL_LOAD_SPEED_FLEX 0.5
 #define MMU_LOAD_FEEDRATE mmu_load_feedrate()
 #define MMU_LOAD_TIME_MS 2000 //should be fine tuned to load time for shortest allowed PTFE tubing and maximum loading speed
 
@@ -91,7 +93,7 @@ extern void mmu_loop(void);
 
 extern void mmu_reset(void);
 
-extern int8_t mmu_set_filament_type(uint8_t extruder, uint8_t filament, float rel_load_speed, float rel_unload_speed);
+extern int8_t mmu_set_filament_type(uint8_t extruder, uint8_t filament, float rel_pulley_speed, float rel_load_speed, float rel_unload_speed);
 
 extern void mmu_command(MmuCmd cmd);
 


### PR DESCRIPTION
The following extensions to the M403 command are important when loading soft filaments. Especially, the ability to reduce the extruder pulley speed substantially decreases the probability of failed loads of softer flex materials.

M403 E\<n\> F\<t\> P\<p\> S\<l\> U\<u\>

sets the following parameters for extruder \<n\>:

t: filament type (0, 1=FLEX or 2=PVA).
p: relative extruder pulley speed factor; defaults to load speed (l)
l: relative load speed factor, 1.0 is normal load speed; defaults to 1.0, or 0.5 for FLEX
u: relative unload speed factor; defaults to load speed (l)

The P, S and U parameters are optional.

This change depends on PR #179 in MM-control-01.

* New function mmu_set_filament_type() sets fil. type and speeds

* New function mmu_load_feedrate computes feedrate based on extruder
and speed factor.

* Macro MMU_LOAD_FEEDRATE calls mmu_load_feedrate