### PR TITLE
IR-sensor activated during printing to detect filament breaking within PTFE tube

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -9253,12 +9253,16 @@ void update_currents() {
 void get_coordinates()
 {
   bool seen[4]={false,false,false,false};
+  const int e_movement_stop_ir_sensor = -10;
   for(int8_t i=0; i < NUM_AXIS; i++) {
     if(code_seen(axis_codes[i]))
     {
       bool relative = axis_relative_modes & (1 << i);
       destination[i] = (float)code_value();
       if (i == E_AXIS) {
+        if  (destination[E_AXIS] < e_movement_stop_ir_sensor) { // filament unload has (likely) begun
+            ir_sensor_print_window = false; 
+        } 
         float emult = extruder_multiplier[active_extruder];
         if (emult != 1.) {
           if (! relative) {

--- a/Firmware/mmu.h
+++ b/Firmware/mmu.h
@@ -22,6 +22,8 @@ extern int16_t mmu_buildnr;
 
 extern uint16_t mmu_power_failures;
 
+extern bool ir_sensor_print_window;
+
 #define MMU_FILAMENT_UNKNOWN 255
 
 #define MMU_NO_MOVE 0


### PR DESCRIPTION
** The issue **
During prints, fragile filaments easily breaks inside the PTFE-tube, that is, in between the MMU2S and the extruder. This is especially common at higher Z-levels with more prominent PTFE-tube bends. Filament breaks during single material prints as well as in MMU-prints.

The proposed modification activates the IR-sensor during the actual printing phase. If filament breaks within the PTFE-tube, the printing pauses and the user can correct the issue instead of ending up with a failed print. The "Filament sensor ON/OFF" menu setting controls whether the IR sensor is active during printing or not.

A side effect is, that if the MMU2S grinded the filament due to loading problems, or if grinding occurs as extrusion gets blocked, the print will pause as the grinding will in effect change the status of the IR-sensor.

** Design consideration **

There is no way knowing when filament is unloaded during an MMU print, as the unload is generated as gcode output by the slicer. Considering various options for handling this issue, the proposed implementation assumes an unload is on its way whenever more than 10 mm of filament is retracted in a single G1 command. 

The proposed unload detection was chosen in order to make the modification available also for existing gcodes. For exotic slicings not following the prediction, the sensor can be turned of using the menu setting.

As a future improvement, I suggest, a "Tu" gcode is added, which the slicer is supposed to print at the beginning of each gcode unload phase. Then the printer will exactly know when to turn off the IR-sensor (of course, after modifying the firmware accordingly).

** Tests **

The modification has been tested both for a set of single filament prints and for MMU prints, using MMU2S during a full weeks worth of prints. Both assumed cases (broken filament and excessive grinding) forced the printer to pause as expected in all cases. Changing "Filament sensor" to "OFF" via the menu works both between and during prints.
