### PR TITLE
Add SuperPINDA Support for MK2.5/S for MK3_3.9.3

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -4572,7 +4572,7 @@ if(eSoundMode!=e_SOUND_MODE_SILENT)
   The Original i3 Prusa MK2/s uses PINDAv1 and this calibration improves the temperature drift, but not as good as the PINDAv2.
 
   superPINDA sensor has internal temperature compensation and no thermistor output. There is no point of doing temperature calibration in such case.
-  If PINDA_THERMISTOR and DETECT_SUPERPINDA is defined during compilation, calibration is skipped with serial message "No PINDA thermistor".
+  If PINDA_THERMISTOR and SUPERPINDA_SUPPORT is defined during compilation, calibration is skipped with serial message "No PINDA thermistor".
   This can be caused also if PINDA thermistor connection is broken or PINDA temperature is lower than PINDA_MINTEMP.
 
   #### Example
@@ -10502,9 +10502,9 @@ float temp_comp_interpolation(float inp_temperature) {
 #ifdef PINDA_THERMISTOR
 		constexpr int start_compensating_temp = 35;
 		temp_C[i] = start_compensating_temp + i * 5; //temperature in degrees C
-#ifdef DETECT_SUPERPINDA
-		static_assert(start_compensating_temp >= PINDA_MINTEMP, "Temperature compensation start point is lower than PINDA_MINTEMP.");
-#endif //DETECT_SUPERPINDA
+#ifdef SUPERPINDA_SUPPORT
+    static_assert(start_compensating_temp >= PINDA_MINTEMP, "Temperature compensation start point is lower than PINDA_MINTEMP.");
+#endif //SUPERPINDA_SUPPORT
 #else
 		temp_C[i] = 50 + i * 10; //temperature in C
 #endif

--- a/Firmware/eeprom.cpp
+++ b/Firmware/eeprom.cpp
@@ -93,6 +93,10 @@ void eeprom_init()
         eeprom_switch_to_next_sheet();
     }
     check_babystep();
+
+#ifdef PINDA_TEMP_COMP
+if (eeprom_read_byte((uint8_t*)EEPROM_PINDA_TEMP_COMPENSATION) == 0xff) eeprom_update_byte((uint8_t *)EEPROM_PINDA_TEMP_COMPENSATION, 0);
+#endif //PINDA_TEMP_COMP
 }
 
 //! @brief Get default sheet name for index

--- a/Firmware/eeprom.h
+++ b/Firmware/eeprom.h
@@ -365,6 +365,9 @@ static_assert(sizeof(Sheets) == EEPROM_SHEETS_SIZEOF, "Sizeof(Sheets) is not EEP
 | 0x0D2A 3370		| uint8		| EEPROM_EXPERIMENTAL_VISIBILITY		| ffh 255		| ffh 255				| Experimental menu visibility unknown state		| LCD menu		| D3 Ax0d2a C1
 | ^					| ^			| ^										| 00h 0			| ^						| Experimental menu visibility hidden				| ^				| ^
 | ^					| ^			| ^										| 01h 1			| ^						| Experimental menu visibility visible				| ^				| ^
+| 0x0D29 3369		| uint8		| EEPROM_PINDA_TEMP_COMPENSATION   		| ffh 255		| ffh 255				| PINDA temp compensation unknown state	            | LCD menu		| D3 Ax0d29 C1
+| ^					| ^			| ^										| 00h 0			| ^						| PINDA has no temp compensation PINDA v1/2    		| ^				| ^
+| ^					| ^			| ^										| 01h 1			| ^						| PINDA has temp compensation aka SuperPINDA       	| ^				| ^
 
   
 | Address begin		| Bit/Type 	| Name 									| Valid values	| Default/FactoryReset	| Description 										| Gcode/Function| Debug code
@@ -569,9 +572,9 @@ static Sheets * const EEPROM_Sheets_base = (Sheets*)(EEPROM_SHEETS_BASE);
 
 #define EEPROM_ALTFAN_OVERRIDE (EEPROM_UVLO_LA_K-1) //uint8
 #define EEPROM_EXPERIMENTAL_VISIBILITY (EEPROM_ALTFAN_OVERRIDE-1) //uint8
-
+#define EEPROM_PINDA_TEMP_COMPENSATION (EEPROM_EXPERIMENTAL_VISIBILITY-1) //uint8
 //This is supposed to point to last item to allow EEPROM overrun check. Please update when adding new items.
-#define EEPROM_LAST_ITEM EEPROM_EXPERIMENTAL_VISIBILITY
+#define EEPROM_LAST_ITEM EEPROM_PINDA_TEMP_COMPENSATION
 // !!!!!
 // !!!!! this is end of EEPROM section ... all updates MUST BE inserted before this mark !!!!!
 // !!!!!

--- a/Firmware/temperature.cpp
+++ b/Firmware/temperature.cpp
@@ -2325,11 +2325,21 @@ float unscalePID_d(float d)
 //!
 //! @retval true firmware should do temperature compensation and allow calibration
 //! @retval false PINDA thermistor is not detected, disable temperature compensation and calibration
+//! @retval true/false when overwritten in LCD menu Settings->HW Setup->SuperPINDA
 //!
 bool has_temperature_compensation()
 {
-#ifdef DETECT_SUPERPINDA
-    return (current_temperature_pinda >= PINDA_MINTEMP) ? true : false;
+#ifdef SUPERPINDA_SUPPORT
+   	uint8_t pinda_temp_compensation = eeprom_read_byte((uint8_t*)EEPROM_PINDA_TEMP_COMPENSATION);
+    if (pinda_temp_compensation == EEPROM_EMPTY_VALUE) //Unkown PINDA temp compenstation, so check it.
+      {
+        //SERIAL_ECHOLNPGM("Current PINDATEMP:");
+        //SERIAL_ECHO(current_temperature_pinda);
+        //SERIAL_ECHOLN(PINDA_MINTEMP);
+        return (current_temperature_pinda >= PINDA_MINTEMP) ? true : false;
+      }
+    else if (pinda_temp_compensation == 0) return true; //Overwritten via LCD menu SuperPINDA [No]
+    else return false; //Overwritten via LCD menu SuperPINDA [YES]
 #else
     return true;
 #endif

--- a/Firmware/temperature.cpp
+++ b/Firmware/temperature.cpp
@@ -2330,13 +2330,17 @@ float unscalePID_d(float d)
 bool has_temperature_compensation()
 {
 #ifdef SUPERPINDA_SUPPORT
+#ifdef PINDA_TEMP_COMP
    	uint8_t pinda_temp_compensation = eeprom_read_byte((uint8_t*)EEPROM_PINDA_TEMP_COMPENSATION);
     if (pinda_temp_compensation == EEPROM_EMPTY_VALUE) //Unkown PINDA temp compenstation, so check it.
       {
+#endif //PINDA_TEMP_COMP
         return (current_temperature_pinda >= PINDA_MINTEMP) ? true : false;
+#ifdef PINDA_TEMP_COMP
       }
     else if (pinda_temp_compensation == 0) return true; //Overwritten via LCD menu SuperPINDA [No]
     else return false; //Overwritten via LCD menu SuperPINDA [YES]
+#endif //PINDA_TEMP_COMP
 #else
     return true;
 #endif

--- a/Firmware/temperature.cpp
+++ b/Firmware/temperature.cpp
@@ -2325,7 +2325,7 @@ float unscalePID_d(float d)
 //!
 //! @retval true firmware should do temperature compensation and allow calibration
 //! @retval false PINDA thermistor is not detected, disable temperature compensation and calibration
-//! @retval true/false when overwritten in LCD menu Settings->HW Setup->SuperPINDA
+//! @retval true/false when forced via LCD menu Settings->HW Setup->SuperPINDA
 //!
 bool has_temperature_compensation()
 {
@@ -2333,9 +2333,6 @@ bool has_temperature_compensation()
    	uint8_t pinda_temp_compensation = eeprom_read_byte((uint8_t*)EEPROM_PINDA_TEMP_COMPENSATION);
     if (pinda_temp_compensation == EEPROM_EMPTY_VALUE) //Unkown PINDA temp compenstation, so check it.
       {
-        //SERIAL_ECHOLNPGM("Current PINDATEMP:");
-        //SERIAL_ECHO(current_temperature_pinda);
-        //SERIAL_ECHOLN(PINDA_MINTEMP);
         return (current_temperature_pinda >= PINDA_MINTEMP) ? true : false;
       }
     else if (pinda_temp_compensation == 0) return true; //Overwritten via LCD menu SuperPINDA [No]

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5759,7 +5759,7 @@ void lcd_hw_setup_menu(void)                      // can not be "static"
 	//! as a disconnected SuperPINDA will show higher temps compared to an EINSY board.
 	//! 
 	//! This menu allows the user to en-/disable the SuperPINDA manualy
-	MENU_ITEM_TOGGLE_P(_N("SuperPINDA"), eeprom_read_byte((unsigned char *)EEPROM_PINDA_TEMP_COMPENSATION) ? _T(MSG_YES) : _T(MSG_NO), lcd_pinda_temp_compensation_toggle);
+	MENU_ITEM_TOGGLE_P(_N("SuperPINDA"), eeprom_read_byte((uint8_t *)EEPROM_PINDA_TEMP_COMPENSATION) ? _T(MSG_YES) : _T(MSG_NO), lcd_pinda_temp_compensation_toggle);
 #endif //PINDA_TEMP_COMP
 
     MENU_END();
@@ -9249,8 +9249,8 @@ void lcd_experimental_menu()
 void lcd_pinda_temp_compensation_toggle()
 {
 	uint8_t pinda_temp_compensation = eeprom_read_byte((uint8_t*)EEPROM_PINDA_TEMP_COMPENSATION);
-	if (pinda_temp_compensation == EEPROM_EMPTY_VALUE)
-		pinda_temp_compensation = 1;
+	if (pinda_temp_compensation == EEPROM_EMPTY_VALUE) // On MK2.5/S the EEPROM_EMPTY_VALUE will be set to 0 during eeprom_init.
+		pinda_temp_compensation = 1;                   // But for MK3/S it should be 1 so SuperPINDA is "active"
 	else
 		pinda_temp_compensation = !pinda_temp_compensation;
 	eeprom_update_byte((uint8_t*)EEPROM_PINDA_TEMP_COMPENSATION, pinda_temp_compensation);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5753,6 +5753,15 @@ void lcd_hw_setup_menu(void)                      // can not be "static"
         MENU_ITEM_SUBMENU_P(PSTR("Experimental"), lcd_experimental_menu);////MSG_MENU_EXPERIMENTAL c=18
     }
 
+#ifdef SUPERPINDA_SUPPORT
+	//! The SuperPINDA is detected when the PINDA temp is below its defined limit.
+	//! This works well on the EINSY board but not on the miniRAMBo board as
+	//! as a disconnected SuperPINDA will show higher temps compared to an EINSY board.
+	//! 
+	//! This menu allows the user to en-/disable the SuperPINDA manualy
+	MENU_ITEM_TOGGLE_P(_N("SuperPINDA"), eeprom_read_byte((unsigned char *)EEPROM_PINDA_TEMP_COMPENSATION) ? _T(MSG_YES) : _T(MSG_NO), lcd_pinda_temp_compensation_toggle);
+#endif //SUPERPINDA_SUPPORT
+
     MENU_END();
 }
 
@@ -9234,4 +9243,14 @@ void lcd_experimental_menu()
 #endif //EXTRUDER_ALTFAN_DETECT
 
     MENU_END();
+}
+
+void lcd_pinda_temp_compensation_toggle()
+{
+	uint8_t pinda_temp_compensation = eeprom_read_byte((uint8_t*)EEPROM_PINDA_TEMP_COMPENSATION);
+	if (pinda_temp_compensation == EEPROM_EMPTY_VALUE)
+		pinda_temp_compensation = 1;
+	else
+		pinda_temp_compensation = !pinda_temp_compensation;
+	eeprom_update_byte((uint8_t*)EEPROM_PINDA_TEMP_COMPENSATION, pinda_temp_compensation);
 }

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -9253,4 +9253,6 @@ void lcd_pinda_temp_compensation_toggle()
 	else
 		pinda_temp_compensation = !pinda_temp_compensation;
 	eeprom_update_byte((uint8_t*)EEPROM_PINDA_TEMP_COMPENSATION, pinda_temp_compensation);
+	SERIAL_ECHOLNPGM("LCD U SuperPINDA:");
+	SERIAL_ECHOLN(pinda_temp_compensation);
 }

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5753,14 +5753,14 @@ void lcd_hw_setup_menu(void)                      // can not be "static"
         MENU_ITEM_SUBMENU_P(PSTR("Experimental"), lcd_experimental_menu);////MSG_MENU_EXPERIMENTAL c=18
     }
 
-#ifdef SUPERPINDA_SUPPORT
+#ifdef PINDA_TEMP_COMP
 	//! The SuperPINDA is detected when the PINDA temp is below its defined limit.
 	//! This works well on the EINSY board but not on the miniRAMBo board as
 	//! as a disconnected SuperPINDA will show higher temps compared to an EINSY board.
 	//! 
 	//! This menu allows the user to en-/disable the SuperPINDA manualy
 	MENU_ITEM_TOGGLE_P(_N("SuperPINDA"), eeprom_read_byte((unsigned char *)EEPROM_PINDA_TEMP_COMPENSATION) ? _T(MSG_YES) : _T(MSG_NO), lcd_pinda_temp_compensation_toggle);
-#endif //SUPERPINDA_SUPPORT
+#endif //PINDA_TEMP_COMP
 
     MENU_END();
 }
@@ -9245,6 +9245,7 @@ void lcd_experimental_menu()
     MENU_END();
 }
 
+#ifdef PINDA_TEMP_COMP
 void lcd_pinda_temp_compensation_toggle()
 {
 	uint8_t pinda_temp_compensation = eeprom_read_byte((uint8_t*)EEPROM_PINDA_TEMP_COMPENSATION);
@@ -9253,6 +9254,7 @@ void lcd_pinda_temp_compensation_toggle()
 	else
 		pinda_temp_compensation = !pinda_temp_compensation;
 	eeprom_update_byte((uint8_t*)EEPROM_PINDA_TEMP_COMPENSATION, pinda_temp_compensation);
-	SERIAL_ECHOLNPGM("LCD U SuperPINDA:");
+	SERIAL_ECHOLNPGM("SuperPINDA:");
 	SERIAL_ECHOLN(pinda_temp_compensation);
 }
+#endif //PINDA_TEMP_COMP

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -262,6 +262,8 @@ void lcd_wizard(WizState state);
 extern void lcd_experimental_toggle();
 extern void lcd_experimental_menu();
 
+#ifdef PINDA_TEMP_COMP
 extern void lcd_pinda_temp_compensation_toggle();
+#endif //PINDA_TEMP_COMP
 
 #endif //ULTRALCD_H

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -262,4 +262,6 @@ void lcd_wizard(WizState state);
 extern void lcd_experimental_toggle();
 extern void lcd_experimental_menu();
 
+extern void lcd_pinda_temp_compensation_toggle();
+
 #endif //ULTRALCD_H

--- a/Firmware/variants/1_75mm_MK25-RAMBo10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK25-RAMBo10a-E3Dv6full.h
@@ -177,6 +177,7 @@
 #endif
 #define SUPERPINDA_SUPPORT
 #define PINDA_MINTEMP 30 //The miniRAMBo thermistor readings below 30°C aren't very accurate
+#define PINDA_TEMP_COMP //Used to enable SuperPINDA toggle menu/function
 
 // Maxtemps
 #if defined(E3D_PT100_EXTRUDER_WITH_AMP) || defined(E3D_PT100_EXTRUDER_NO_AMP)

--- a/Firmware/variants/1_75mm_MK25-RAMBo10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK25-RAMBo10a-E3Dv6full.h
@@ -175,6 +175,8 @@
 #if BED_MINTEMP_DELAY>USHRT_MAX
 #error "Check maximal allowed value @ ShortTimer (see BED_MINTEMP_DELAY definition)"
 #endif
+#define SUPERPINDA_SUPPORT
+#define PINDA_MINTEMP BED_MINTEMP //The miniRAMBo thermistor readings below 30°C aren't very accurate
 
 // Maxtemps
 #if defined(E3D_PT100_EXTRUDER_WITH_AMP) || defined(E3D_PT100_EXTRUDER_NO_AMP)

--- a/Firmware/variants/1_75mm_MK25-RAMBo10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK25-RAMBo10a-E3Dv6full.h
@@ -176,7 +176,7 @@
 #error "Check maximal allowed value @ ShortTimer (see BED_MINTEMP_DELAY definition)"
 #endif
 #define SUPERPINDA_SUPPORT
-#define PINDA_MINTEMP BED_MINTEMP //The miniRAMBo thermistor readings below 30°C aren't very accurate
+#define PINDA_MINTEMP 30 //The miniRAMBo thermistor readings below 30°C aren't very accurate
 
 // Maxtemps
 #if defined(E3D_PT100_EXTRUDER_WITH_AMP) || defined(E3D_PT100_EXTRUDER_NO_AMP)

--- a/Firmware/variants/1_75mm_MK25-RAMBo13a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK25-RAMBo13a-E3Dv6full.h
@@ -177,7 +177,7 @@
 #error "Check maximal allowed value @ ShortTimer (see BED_MINTEMP_DELAY definition)"
 #endif
 #define SUPERPINDA_SUPPORT
-#define PINDA_MINTEMP BED_MINTEMP //The miniRAMBo thermistor readings below 30°C aren't very accurate
+#define PINDA_MINTEMP 30 //The miniRAMBo thermistor readings below 30°C aren't very accurate
 
 // Maxtemps
 #if defined(E3D_PT100_EXTRUDER_WITH_AMP) || defined(E3D_PT100_EXTRUDER_NO_AMP)

--- a/Firmware/variants/1_75mm_MK25-RAMBo13a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK25-RAMBo13a-E3Dv6full.h
@@ -178,6 +178,7 @@
 #endif
 #define SUPERPINDA_SUPPORT
 #define PINDA_MINTEMP 30 //The miniRAMBo thermistor readings below 30°C aren't very accurate
+#define PINDA_TEMP_COMP //Used to enable SuperPINDA toggle menu/function
 
 // Maxtemps
 #if defined(E3D_PT100_EXTRUDER_WITH_AMP) || defined(E3D_PT100_EXTRUDER_NO_AMP)

--- a/Firmware/variants/1_75mm_MK25-RAMBo13a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK25-RAMBo13a-E3Dv6full.h
@@ -176,6 +176,8 @@
 #if BED_MINTEMP_DELAY>USHRT_MAX
 #error "Check maximal allowed value @ ShortTimer (see BED_MINTEMP_DELAY definition)"
 #endif
+#define SUPERPINDA_SUPPORT
+#define PINDA_MINTEMP BED_MINTEMP //The miniRAMBo thermistor readings below 30°C aren't very accurate
 
 // Maxtemps
 #if defined(E3D_PT100_EXTRUDER_WITH_AMP) || defined(E3D_PT100_EXTRUDER_NO_AMP)

--- a/Firmware/variants/1_75mm_MK25S-RAMBo10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK25S-RAMBo10a-E3Dv6full.h
@@ -177,6 +177,7 @@
 #endif
 #define SUPERPINDA_SUPPORT
 #define PINDA_MINTEMP 30 //The miniRAMBo thermistor readings below 30°C aren't very accurate
+#define PINDA_TEMP_COMP //Used to enable SuperPINDA toggle menu/function
 
 // Maxtemps
 #if defined(E3D_PT100_EXTRUDER_WITH_AMP) || defined(E3D_PT100_EXTRUDER_NO_AMP)

--- a/Firmware/variants/1_75mm_MK25S-RAMBo10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK25S-RAMBo10a-E3Dv6full.h
@@ -175,6 +175,8 @@
 #if BED_MINTEMP_DELAY>USHRT_MAX
 #error "Check maximal allowed value @ ShortTimer (see BED_MINTEMP_DELAY definition)"
 #endif
+#define SUPERPINDA_SUPPORT
+#define PINDA_MINTEMP BED_MINTEMP //The miniRAMBo thermistor readings below 30°C aren't very accurate
 
 // Maxtemps
 #if defined(E3D_PT100_EXTRUDER_WITH_AMP) || defined(E3D_PT100_EXTRUDER_NO_AMP)

--- a/Firmware/variants/1_75mm_MK25S-RAMBo10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK25S-RAMBo10a-E3Dv6full.h
@@ -176,7 +176,7 @@
 #error "Check maximal allowed value @ ShortTimer (see BED_MINTEMP_DELAY definition)"
 #endif
 #define SUPERPINDA_SUPPORT
-#define PINDA_MINTEMP BED_MINTEMP //The miniRAMBo thermistor readings below 30°C aren't very accurate
+#define PINDA_MINTEMP 30 //The miniRAMBo thermistor readings below 30°C aren't very accurate
 
 // Maxtemps
 #if defined(E3D_PT100_EXTRUDER_WITH_AMP) || defined(E3D_PT100_EXTRUDER_NO_AMP)

--- a/Firmware/variants/1_75mm_MK25S-RAMBo13a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK25S-RAMBo13a-E3Dv6full.h
@@ -177,7 +177,7 @@
 #error "Check maximal allowed value @ ShortTimer (see BED_MINTEMP_DELAY definition)"
 #endif
 #define SUPERPINDA_SUPPORT
-#define PINDA_MINTEMP BED_MINTEMP //The miniRAMBo thermistor readings below 30°C aren't very accurate
+#define PINDA_MINTEMP 30 //The miniRAMBo thermistor readings below 30°C aren't very accurate
 
 // Maxtemps
 #if defined(E3D_PT100_EXTRUDER_WITH_AMP) || defined(E3D_PT100_EXTRUDER_NO_AMP)

--- a/Firmware/variants/1_75mm_MK25S-RAMBo13a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK25S-RAMBo13a-E3Dv6full.h
@@ -178,6 +178,7 @@
 #endif
 #define SUPERPINDA_SUPPORT
 #define PINDA_MINTEMP 30 //The miniRAMBo thermistor readings below 30°C aren't very accurate
+#define PINDA_TEMP_COMP //Used to enable SuperPINDA toggle menu/function
 
 // Maxtemps
 #if defined(E3D_PT100_EXTRUDER_WITH_AMP) || defined(E3D_PT100_EXTRUDER_NO_AMP)

--- a/Firmware/variants/1_75mm_MK25S-RAMBo13a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK25S-RAMBo13a-E3Dv6full.h
@@ -176,6 +176,8 @@
 #if BED_MINTEMP_DELAY>USHRT_MAX
 #error "Check maximal allowed value @ ShortTimer (see BED_MINTEMP_DELAY definition)"
 #endif
+#define SUPERPINDA_SUPPORT
+#define PINDA_MINTEMP BED_MINTEMP //The miniRAMBo thermistor readings below 30°C aren't very accurate
 
 // Maxtemps
 #if defined(E3D_PT100_EXTRUDER_WITH_AMP) || defined(E3D_PT100_EXTRUDER_NO_AMP)

--- a/Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h
@@ -297,6 +297,7 @@
 #define SUPERPINDA_SUPPORT
 #define PINDA_MINTEMP 10
 #define AMBIENT_MINTEMP -30
+//#define PINDA_TEMP_COMP //Used to enable SuperPINDA toggle menu/function
 
 // Maxtemps
 #if defined(E3D_PT100_EXTRUDER_WITH_AMP) || defined(E3D_PT100_EXTRUDER_NO_AMP)

--- a/Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h
@@ -296,8 +296,8 @@
 #endif
 #define SUPERPINDA_SUPPORT
 #define PINDA_MINTEMP 10
-#define AMBIENT_MINTEMP -30
 //#define PINDA_TEMP_COMP //Used to enable SuperPINDA toggle menu/function
+#define AMBIENT_MINTEMP -30
 
 // Maxtemps
 #if defined(E3D_PT100_EXTRUDER_WITH_AMP) || defined(E3D_PT100_EXTRUDER_NO_AMP)

--- a/Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h
@@ -294,7 +294,7 @@
 #if BED_MINTEMP_DELAY>USHRT_MAX
 #error "Check maximal allowed value @ ShortTimer (see BED_MINTEMP_DELAY definition)"
 #endif
-#define DETECT_SUPERPINDA
+#define SUPERPINDA_SUPPORT
 #define PINDA_MINTEMP BED_MINTEMP
 #define AMBIENT_MINTEMP -30
 

--- a/Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h
@@ -295,7 +295,7 @@
 #error "Check maximal allowed value @ ShortTimer (see BED_MINTEMP_DELAY definition)"
 #endif
 #define SUPERPINDA_SUPPORT
-#define PINDA_MINTEMP BED_MINTEMP
+#define PINDA_MINTEMP 10
 #define AMBIENT_MINTEMP -30
 
 // Maxtemps

--- a/Firmware/variants/1_75mm_MK3S-EINSy10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK3S-EINSy10a-E3Dv6full.h
@@ -298,8 +298,8 @@
 #endif
 #define SUPERPINDA_SUPPORT
 #define PINDA_MINTEMP 10
-#define AMBIENT_MINTEMP -30
 //#define PINDA_TEMP_COMP //Used to enable SuperPINDA toggle menu/function
+#define AMBIENT_MINTEMP -30
 
 // Maxtemps
 #if defined(E3D_PT100_EXTRUDER_WITH_AMP) || defined(E3D_PT100_EXTRUDER_NO_AMP)

--- a/Firmware/variants/1_75mm_MK3S-EINSy10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK3S-EINSy10a-E3Dv6full.h
@@ -297,7 +297,7 @@
 #error "Check maximal allowed value @ ShortTimer (see BED_MINTEMP_DELAY definition)"
 #endif
 #define SUPERPINDA_SUPPORT
-#define PINDA_MINTEMP BED_MINTEMP
+#define PINDA_MINTEMP 10
 #define AMBIENT_MINTEMP -30
 
 // Maxtemps

--- a/Firmware/variants/1_75mm_MK3S-EINSy10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK3S-EINSy10a-E3Dv6full.h
@@ -299,6 +299,7 @@
 #define SUPERPINDA_SUPPORT
 #define PINDA_MINTEMP 10
 #define AMBIENT_MINTEMP -30
+//#define PINDA_TEMP_COMP //Used to enable SuperPINDA toggle menu/function
 
 // Maxtemps
 #if defined(E3D_PT100_EXTRUDER_WITH_AMP) || defined(E3D_PT100_EXTRUDER_NO_AMP)

--- a/Firmware/variants/1_75mm_MK3S-EINSy10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK3S-EINSy10a-E3Dv6full.h
@@ -296,7 +296,7 @@
 #if BED_MINTEMP_DELAY>USHRT_MAX
 #error "Check maximal allowed value @ ShortTimer (see BED_MINTEMP_DELAY definition)"
 #endif
-#define DETECT_SUPERPINDA
+#define SUPERPINDA_SUPPORT
 #define PINDA_MINTEMP BED_MINTEMP
 #define AMBIENT_MINTEMP -30
 


### PR DESCRIPTION
- Changed DETECT_SUPERPINDA to SUPERPINDA_SUPPORT as on miniRAMBo the thermistor readings below 30°C
  aren't accurate enough to determine if SUPERPINDA is connected or not
- Add LCD toggle menu Settings -> HW Setup -> SuperPINDA [Yes/No] to overwrite SuperPINDA detection
  - If EEPROM_PINDA_TEMP_COMPENSTATION is empty = 0xff then detect SuperPINDA by checking thermistor
  - If EEPROM_PINDA_TEMP_COMPENSTAION is 0 then force enable for temperature compensation menus and functions
  - If EEPROM_PINDA_TEMP_COMPENSATION is 1 then force disable for temperature compensation menus and functions


I have been testing quite a bit with MK404:

Starting MK404 with `--terminal` makes it quite easy to test the different scenarios:

_EEPROM values not set_
MK3/S will detect the SuperPINDA as before by checking the temperature
- Go to Calibration and check for "Temp. Calibration"
- Enter in MK404 terminal: `Thermistor2::Set(5)` and re-check

MK25/S will try to detect the SuperPINDA but this might be false detection with the "bad" temp readings on miniRAMBo
The MK404 starts with PINDA temp around 25°C the "Temp. Calibration" is not shown as the "PINDA_MINTEMP" is 30°C
- Enter in MK404 terminal: `Thermistor2::Set(35)` then you can see that the menu is shown.
- To overwrite the detection go to Settings -> HW Setup -> SuperPINDA and set it to [No] and recheck for the "Temp. Calibration" menu. It is always available even if the PINDA temp is above the 30°C limit of the miniRAMBo
Setting SuperPINDA to [Yes] overwrites the detection and disables the temperature compensation menus and functions.

Pros:
- SuperPINDA support for MK25/S printers
- Manual overwrite of SuperPINDA if the temps is below 10°C on MK3/S or 30°C on MK2.5S

Cons:
- Broken PINDAv2 signal cable or PINDAv1 will be detected as SuperPINDA if not set via LCD menu

Improvements ???:
- Add [Auto] to HW Setup -> SuperPINDA

This PR uses
- +0 bytes for MK3S build
- +408 bytes for MK25S build 
compared to the base MK3/MK25S build.

PFW-1167