### PR TITLE
PFW-1168 Move Z up running xyz calibration

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -2974,6 +2974,8 @@ bool gcode_M45(bool onlyZ, int8_t verbosity_level)
 	//set_destination_to_current();
 	int l_feedmultiply = setup_for_endstop_move();
 	lcd_display_message_fullscreen_P(_T(MSG_AUTO_HOME));
+  raise_z_above(MESH_HOME_Z_SEARCH);
+  st_synchronize();
 	home_xy();
 
 	enable_endstops(false);


### PR DESCRIPTION
to prevent scratches on bed and sheet.

Tested on MK404 and physical MK3S

Replaces PR https://github.com/prusa3d/Prusa-Firmware/pull/2945