### PR TITLE
Fast skipping of large comment blocks

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -4005,7 +4005,7 @@ void process_commands()
     } else if (code_seen_P(PSTR("M28"))) { // PRUSA M28
         trace();
         prusa_sd_card_upload = true;
-        card.openFile(strchr_pointer+4,false);
+        card.openFileWrite(strchr_pointer+4);
 
 	} else if (code_seen_P(PSTR("SN"))) { // PRUSA SN
         gcode_PRUSA_SN();
@@ -5769,7 +5769,7 @@ if(eSoundMode!=e_SOUND_MODE_SILENT)
       starpos = (strchr(strchr_pointer + 4,'*'));
 	  if(starpos!=NULL)
         *(starpos)='\0';
-      card.openFileFilteredGcode(strchr_pointer + 4);
+      card.openFileReadFilteredGcode(strchr_pointer + 4);
       break;
 
     /*!
@@ -5833,7 +5833,7 @@ if(eSoundMode!=e_SOUND_MODE_SILENT)
         strchr_pointer = strchr(npos,' ') + 1;
         *(starpos) = '\0';
       }
-      card.openFile(strchr_pointer+4,false);
+      card.openFileWrite(strchr_pointer+4);
       break;
 
     /*! ### M29 - Stop SD write <a href="https://reprap.org/wiki/G-code#M29:_Stop_writing_to_SD_card">M29: Stop writing to SD card</a>
@@ -5894,7 +5894,7 @@ if(eSoundMode!=e_SOUND_MODE_SILENT)
 
       if( card.cardOK )
       {
-        card.openFile(namestartpos,true,!call_procedure);
+        card.openFileReadFilteredGcode(namestartpos,!call_procedure);
         if(code_seen('S'))
           if(strchr_pointer<namestartpos) //only if "S" is occuring _before_ the filename
             card.setIndex(code_value_long());

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3987,12 +3987,10 @@ void process_commands()
 #endif
 		}else if (code_seen_P("fv")) { // PRUSA fv
         // get file version
-        #if 0 
-            //@@TODO
-            def SDSUPPORT
-        card.openFile(strchr_pointer + 3,true);
+        #ifdef SDSUPPORT
+        card.openFileReadFilteredGcode(strchr_pointer + 3,true);
         while (true) {
-            uint16_t readByte = card.get();
+            uint16_t readByte = card.getFilteredGcodeChar();
             MYSERIAL.write(readByte);
             if (readByte=='\n') {
                 break;

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3987,7 +3987,9 @@ void process_commands()
 #endif
 		}else if (code_seen_P("fv")) { // PRUSA fv
         // get file version
-        #ifdef SDSUPPORT
+        #if 0 
+            //@@TODO
+            def SDSUPPORT
         card.openFile(strchr_pointer + 3,true);
         while (true) {
             uint16_t readByte = card.get();
@@ -5767,7 +5769,7 @@ if(eSoundMode!=e_SOUND_MODE_SILENT)
       starpos = (strchr(strchr_pointer + 4,'*'));
 	  if(starpos!=NULL)
         *(starpos)='\0';
-      card.openFile(strchr_pointer + 4,true);
+      card.openFileFilteredGcode(strchr_pointer + 4);
       break;
 
     /*!

--- a/Firmware/SdBaseFile.cpp
+++ b/Firmware/SdBaseFile.cpp
@@ -533,7 +533,6 @@ bool SdBaseFile::mkdir(SdBaseFile* parent, const uint8_t dname[11]) {
 bool SdBaseFile::open(const char* path, uint8_t oflag) {
   return open(cwd_, path, oflag);
 }
-  
 //------------------------------------------------------------------------------
 /** Open a file or directory by name.
  *
@@ -1031,7 +1030,6 @@ int16_t SdBaseFile::read() {
   uint8_t b;
   return read(&b, 1) == 1 ? b : -1;
 }
-
 //------------------------------------------------------------------------------
 /** Read data from a file starting at the current position.
  *

--- a/Firmware/SdBaseFile.cpp
+++ b/Firmware/SdBaseFile.cpp
@@ -534,17 +534,6 @@ bool SdBaseFile::open(const char* path, uint8_t oflag) {
   return open(cwd_, path, oflag);
 }
   
-bool SdBaseFile::openFilteredGcode(SdBaseFile* dirFile, const char* path){
-    if( open(dirFile, path, O_READ) ){
-        gf.reset(0,0);
-        // compute the block to start with
-        if( ! computeNextFileBlock(&gf.block, &gf.offset) )
-            return false;
-        return true;
-    } else {
-        return false;
-    }
-}
 //------------------------------------------------------------------------------
 /** Open a file or directory by name.
  *
@@ -1043,111 +1032,6 @@ int16_t SdBaseFile::read() {
   return read(&b, 1) == 1 ? b : -1;
 }
 
-int16_t SdBaseFile::readFilteredGcode() {
-    // avoid calling the default heavy-weight read() for just one byte
-    return gf.read_byte();
-}
-
-void GCodeInputFilter::reset(uint32_t blk, uint16_t ofs){
-    // @@TODO clean up
-    block = blk;
-    offset = ofs;
-    cachePBegin = sd->vol_->cache()->data;
-    // reset cache read ptr to its begin
-    cacheP = cachePBegin;
-}
-
-int16_t GCodeInputFilter::read_byte(){
-    EnsureBlock(); // this is unfortunate :( ... other calls are using the cache and we can loose the data block of our gcode file
-
-    // assume, we have the 512B block cache filled and terminated with a '\n'
-//    SERIAL_PROTOCOLPGM("read_byte enter:");
-//    for(uint8_t i = 0; i < 16; ++i){
-//        SERIAL_PROTOCOL( cacheP[i] );
-//    }
-    
-    const uint8_t *start = cacheP;
-    uint8_t consecutiveCommentLines = 0;
-    while( *cacheP == ';' ){
-        for(;;){
-            while( *(++cacheP) != '\n' ); // skip until a newline is found
-            // found a newline, prepare the next block if block cache end reached
-            if( cacheP - cachePBegin >= 512 ){
-                // at the end of block cache, fill new data in
-                sd->curPosition_ += cacheP - start;
-                if( ! sd->computeNextFileBlock(&block, &offset) )goto fail;
-                EnsureBlock(); // fetch it into RAM
-                cacheP = start = cachePBegin;
-            } else {
-                if(++consecutiveCommentLines == 255){
-                    // SERIAL_PROTOCOLLN(sd->curPosition_);
-                    goto forceExit;
-                }
-                // peek the next byte - we are inside the block at least at 511th index - still safe
-                if( *(cacheP+1) == ';' ){
-                    // consecutive comment
-                    ++cacheP;
-                    ++consecutiveCommentLines;
-                }
-                break; // found the real end of the line even across many blocks
-            }
-        }
-    }
-forceExit:
-    sd->curPosition_ += cacheP - start + 1;
-    {
-    int16_t rv = *cacheP++;
-    
-    // prepare next block if needed
-    if( cacheP - cachePBegin >= 512 ){
-//        SERIAL_PROTOCOLLN(sd->curPosition_);
-        if( ! sd->computeNextFileBlock(&block, &offset) )goto fail;
-        // don't need to force fetch the block here, it will get loaded on the next call
-        cacheP = cachePBegin;
-    }    
-    return rv;
-    }
-fail:
-//    SERIAL_PROTOCOLLNPGM("CacheFAIL");
-    return -1;
-}
-
-bool GCodeInputFilter::EnsureBlock(){
-    if ( sd->vol_->cacheRawBlock(block, SdVolume::CACHE_FOR_READ)){
-        // terminate with a '\n'
-        const uint16_t terminateOfs = (sd->fileSize_ - offset) < 512 ? (sd->fileSize_ - offset) : 512;
-        sd->vol_->cache()->data[ terminateOfs ] = '\n';
-        return true;
-    } else {
-        return false;
-    }
-}
-
-bool SdBaseFile::computeNextFileBlock(uint32_t *block, uint16_t *offset) {
-    // error if not open or write only
-    if (!isOpen() || !(flags_ & O_READ)) return false;
-
-    *offset = curPosition_ & 0X1FF;  // offset in block
-    if (type_ == FAT_FILE_TYPE_ROOT_FIXED) {
-        *block = vol_->rootDirStart() + (curPosition_ >> 9);
-    } else {
-        uint8_t blockOfCluster = vol_->blockOfCluster(curPosition_);
-        if (*offset == 0 && blockOfCluster == 0) {
-            // start of new cluster
-            if (curPosition_ == 0) {
-                // use first cluster in file
-                curCluster_ = firstCluster_;
-            } else {
-                // get next cluster from FAT
-                if (!vol_->fatGet(curCluster_, &curCluster_)) return false;
-            }
-        }
-        *block = vol_->clusterStartBlock(curCluster_) + blockOfCluster;
-    }
-    return true;
-}
-
-
 //------------------------------------------------------------------------------
 /** Read data from a file starting at the current position.
  *
@@ -1561,7 +1445,7 @@ bool SdBaseFile::rmRfStar() {
  * \param[in] oflag Values for \a oflag are constructed by a bitwise-inclusive
  * OR of open flags. see SdBaseFile::open(SdBaseFile*, const char*, uint8_t).
  */
-SdBaseFile::SdBaseFile(const char* path, uint8_t oflag):gf(this) {
+SdBaseFile::SdBaseFile(const char* path, uint8_t oflag) {
   type_ = FAT_FILE_TYPE_CLOSED;
   writeError = false;
   open(path, oflag);

--- a/Firmware/SdBaseFile.h
+++ b/Firmware/SdBaseFile.h
@@ -174,8 +174,6 @@ static inline uint8_t FAT_SECOND(uint16_t fatTime) {
 uint16_t const FAT_DEFAULT_DATE = ((2000 - 1980) << 9) | (1 << 5) | 1;
 /** Default time for file timestamp is 1 am */
 uint16_t const FAT_DEFAULT_TIME = (1 << 11);
-
-
 //------------------------------------------------------------------------------
 /**
  * \class SdBaseFile

--- a/Firmware/SdBaseFile.h
+++ b/Firmware/SdBaseFile.h
@@ -174,15 +174,34 @@ static inline uint8_t FAT_SECOND(uint16_t fatTime) {
 uint16_t const FAT_DEFAULT_DATE = ((2000 - 1980) << 9) | (1 << 5) | 1;
 /** Default time for file timestamp is 1 am */
 uint16_t const FAT_DEFAULT_TIME = (1 << 11);
+
+
+class SdBaseFile;
+class GCodeInputFilter {
+    SdBaseFile *sd; //@@TODO subject to removal - merge with some derived SdFileXX
+    const uint8_t *cachePBegin;
+    const uint8_t *cacheP;
+    bool EnsureBlock();
+public:
+    uint32_t block; // remember the current file block to be kept in cache - due to reuse of the memory, the block may fall out a must be read back
+    uint16_t offset;
+
+public:
+    inline GCodeInputFilter(SdBaseFile *sd):sd(sd){}
+    void reset(uint32_t blk, uint16_t ofs);
+    int16_t read_byte();
+};
+
 //------------------------------------------------------------------------------
 /**
  * \class SdBaseFile
  * \brief Base class for SdFile with Print and C++ streams.
  */
 class SdBaseFile {
+    GCodeInputFilter gf;
  public:
   /** Create an instance. */
-  SdBaseFile() : writeError(false), type_(FAT_FILE_TYPE_CLOSED) {}
+  SdBaseFile() : gf(this), writeError(false), type_(FAT_FILE_TYPE_CLOSED) {}
   SdBaseFile(const char* path, uint8_t oflag);
   ~SdBaseFile() {if(isOpen()) close();}
   /**
@@ -275,14 +294,21 @@ class SdBaseFile {
   bool open(SdBaseFile* dirFile, uint16_t index, uint8_t oflag);
   bool open(SdBaseFile* dirFile, const char* path, uint8_t oflag);
   bool open(const char* path, uint8_t oflag = O_READ);
+  bool openFilteredGcode(SdBaseFile* dirFile, const char* path);
   bool openNext(SdBaseFile* dirFile, uint8_t oflag);
   bool openRoot(SdVolume* vol);
   int peek();
   static void printFatDate(uint16_t fatDate);
   static void printFatTime( uint16_t fatTime);
   bool printName();
+  
+  int16_t readFilteredGcode();
+  bool computeNextFileBlock(uint32_t *block, uint16_t *offset);
+
+private:  
   int16_t read();
   int16_t read(void* buf, uint16_t nbyte);
+public:
   int8_t readDir(dir_t* dir, char* longFilename);
   static bool remove(SdBaseFile* dirFile, const char* path);
   bool remove();
@@ -322,6 +348,7 @@ class SdBaseFile {
   int16_t write(const void* buf, uint16_t nbyte);
 //------------------------------------------------------------------------------
  private:
+  friend class GCodeInputFilter;
   // allow SdFat to set cwd_
   friend class SdFat;
   // global pointer to cwd dir

--- a/Firmware/SdFile.cpp
+++ b/Firmware/SdFile.cpp
@@ -151,7 +151,9 @@ int16_t SdFile::readFilteredGcode(){
                 if( ! gfEnsureBlock() )goto eof_or_fail; // fetch it into RAM
                 rdPtr = start = blockBuffBegin;
             } else {
-                if(++consecutiveCommentLines == 255){
+                if(consecutiveCommentLines >= 250){
+//                    SERIAL_ECHO("ccl=");
+//                    SERIAL_ECHOLN((int)consecutiveCommentLines);
                     // SERIAL_PROTOCOLLN(sd->curPosition_);
                     --rdPtr; // unget the already consumed newline
                     goto emit_char;

--- a/Firmware/SdFile.cpp
+++ b/Firmware/SdFile.cpp
@@ -74,10 +74,12 @@ void __attribute__((noinline)) SdFile::gfUpdateCurrentPosition(uint16_t inc){
 
 #define find_endl(resultP, startP) \
 __asm__ __volatile__ (  \
+"adiw r30, 1     \n" /* workaround the ++gfCacheP into post increment Z+ */ \
 "cycle:          \n" \
 "ld  r22, Z+     \n" \
 "cpi r22, 0x0A   \n" \
 "brne cycle      \n" \
+"sbiw r30, 1     \n" /* workaround the ++gfCacheP into post increment Z+ */ \
 : "=z" (resultP) /* result of the ASM code - in our case the Z register (R30:R31) */ \
 : "z" (startP)   /* input of the ASM code - in our case the Z register as well (R30:R31) */ \
 : "r22"          /* modifying register R22 - so that the compiler knows */ \

--- a/Firmware/SdFile.cpp
+++ b/Firmware/SdFile.cpp
@@ -34,10 +34,10 @@ SdFile::SdFile(const char* path, uint8_t oflag) : SdBaseFile(path, oflag) {
 //size=100B
 bool SdFile::openFilteredGcode(SdBaseFile* dirFile, const char* path){
     if( open(dirFile, path, O_READ) ){
-        gfReset(0,0);
         // compute the block to start with
         if( ! gfComputeNextFileBlock() )
             return false;
+        gfReset();
         return true;
     } else {
         return false;
@@ -50,20 +50,15 @@ bool SdFile::seekSetFilteredGcode(uint32_t pos){
 //    SERIAL_PROTOCOLLN(pos);
     if(! seekSet(pos) )return false;
     if(! gfComputeNextFileBlock() )return false;
-    gfCachePBegin = vol_->cache()->data;
-    // reset cache read ptr to its begin
-    gfCacheP = gfCachePBegin + gfOffset;
+    gfReset();
     return true;
 }
 
 //size=50B
-void SdFile::gfReset(uint32_t blk, uint16_t ofs){
-    // @@TODO clean up
-    gfBlock = blk;
-    gfOffset = ofs;
+void SdFile::gfReset(){
     gfCachePBegin = vol_->cache()->data;
     // reset cache read ptr to its begin
-    gfCacheP = gfCachePBegin;
+    gfCacheP = gfCachePBegin + gfOffset;
 }
 
 //FORCE_INLINE const uint8_t * find_endl(const uint8_t *p){

--- a/Firmware/SdFile.h
+++ b/Firmware/SdFile.h
@@ -34,7 +34,16 @@
  * \brief SdBaseFile with Print.
  */
 class SdFile : public SdBaseFile/*, public Print*/ {
- public:
+  // GCode filtering vars and methods - due to optimization reasons not wrapped in a separate class
+  const uint8_t *gfCachePBegin;
+  const uint8_t *gfCacheP;
+  uint32_t gfBlock; // remember the current file block to be kept in cache - due to reuse of the memory, the block may fall out a must be read back
+  uint16_t gfOffset;
+  void gfReset(uint32_t blk, uint16_t ofs);
+  bool gfEnsureBlock();
+  bool gfComputeNextFileBlock();
+  void gfUpdateCurrentPosition(uint16_t inc);
+public:
   SdFile() {}
   SdFile(const char* name, uint8_t oflag);
   #if ARDUINO >= 100
@@ -43,6 +52,9 @@ class SdFile : public SdBaseFile/*, public Print*/ {
    void write(uint8_t b);
   #endif
   
+  bool openFilteredGcode(SdBaseFile* dirFile, const char* path);
+  int16_t readFilteredGcode();
+  bool seekSetFilteredGcode(uint32_t pos);
   int16_t write(const void* buf, uint16_t nbyte);
   void write(const char* str);
   void write_P(PGM_P str);

--- a/Firmware/SdFile.h
+++ b/Firmware/SdFile.h
@@ -38,7 +38,7 @@ class SdFile : public SdBaseFile/*, public Print*/ {
   
   // beware - this read ptr is manipulated inside just 2 methods - readFilteredGcode and gfReset
   // If you even want to call gfReset from readFilteredGcode, you must make sure
-  // to update gfCacheP inside readFilteredGcode from a local copy (see explanation of this trick in readFilteredGcode)
+  // to update gfReadPtr inside readFilteredGcode from a local copy (see explanation of this trick in readFilteredGcode)
   const uint8_t *gfReadPtr;
   
   uint32_t gfBlock; // remember the current file block to be kept in cache - due to reuse of the memory, the block may fall out a must be read back

--- a/Firmware/SdFile.h
+++ b/Firmware/SdFile.h
@@ -39,7 +39,7 @@ class SdFile : public SdBaseFile/*, public Print*/ {
   const uint8_t *gfCacheP;
   uint32_t gfBlock; // remember the current file block to be kept in cache - due to reuse of the memory, the block may fall out a must be read back
   uint16_t gfOffset;
-  void gfReset(uint32_t blk, uint16_t ofs);
+  void gfReset();
   bool gfEnsureBlock();
   bool gfComputeNextFileBlock();
   void gfUpdateCurrentPosition(uint16_t inc);

--- a/Firmware/SdFile.h
+++ b/Firmware/SdFile.h
@@ -35,11 +35,19 @@
  */
 class SdFile : public SdBaseFile/*, public Print*/ {
   // GCode filtering vars and methods - due to optimization reasons not wrapped in a separate class
-  const uint8_t *gfCachePBegin;
-  const uint8_t *gfCacheP;
+  
+  // beware - this read ptr is manipulated inside just 2 methods - readFilteredGcode and gfReset
+  // If you even want to call gfReset from readFilteredGcode, you must make sure
+  // to update gfCacheP inside readFilteredGcode from a local copy (see explanation of this trick in readFilteredGcode)
+  const uint8_t *gfReadPtr;
+  
   uint32_t gfBlock; // remember the current file block to be kept in cache - due to reuse of the memory, the block may fall out a must be read back
   uint16_t gfOffset;
+
+  const uint8_t *gfBlockBuffBegin()const;
+  
   void gfReset();
+  
   bool gfEnsureBlock();
   bool gfComputeNextFileBlock();
   void gfUpdateCurrentPosition(uint16_t inc);

--- a/Firmware/SdVolume.h
+++ b/Firmware/SdVolume.h
@@ -36,7 +36,7 @@
  */
 union cache_t {
            /** Used to access cached file data blocks. */
-  uint8_t  data[512];
+  uint8_t  data[512 + 1]; // abuse the last byte for saving '\n' - ugly optimization of read_filtered's inner skipping loop
            /** Used to access cached FAT16 entries. */
   uint16_t fat16[256];
            /** Used to access cached FAT32 entries. */
@@ -119,6 +119,7 @@ class SdVolume {
   bool dbgFat(uint32_t n, uint32_t* v) {return fatGet(n, v);}
 //------------------------------------------------------------------------------
  private:
+  friend class GCodeInputFilter;
   // Allow SdBaseFile access to SdVolume private data.
   friend class SdBaseFile;
 

--- a/Firmware/SdVolume.h
+++ b/Firmware/SdVolume.h
@@ -119,7 +119,7 @@ class SdVolume {
   bool dbgFat(uint32_t n, uint32_t* v) {return fatGet(n, v);}
 //------------------------------------------------------------------------------
  private:
-  friend class GCodeInputFilter;
+  friend class SdFile;
   // Allow SdBaseFile access to SdVolume private data.
   friend class SdBaseFile;
 

--- a/Firmware/cardreader.cpp
+++ b/Firmware/cardreader.cpp
@@ -456,8 +456,9 @@ void CardReader::openFileWrite(const char* name)
     if(!cardOK)
         return;
     if(file.isOpen()){  //replacing current file by new file, or subfile call
-
-        // @@TODO I doubt this is necessary for file saving:
+#if 0
+        // I doubt chained files support is necessary for file saving:
+        // Intentionally disabled because it takes a lot of code size while being not used
 
         if((int)file_subcall_ctr>(int)SD_PROCEDURE_DEPTH-1){
             // SERIAL_ERROR_START;
@@ -481,6 +482,9 @@ void CardReader::openFileWrite(const char* name)
         filespos[file_subcall_ctr]=sdpos;
         file_subcall_ctr++;
         file.close();
+#else
+        SERIAL_ECHOLNPGM("File already opened");
+#endif
     } else { //opening fresh file
         file_subcall_ctr=0; //resetting procedure depth in case user cancels print while in procedure
         SERIAL_ECHO_START;

--- a/Firmware/cardreader.cpp
+++ b/Firmware/cardreader.cpp
@@ -506,9 +506,9 @@ void CardReader::openFileWrite(const char* name)
     }
     sdprinting = false;
     
-    SdFile myDir;
     const char *fname=name;
-    diveSubfolder(fname,myDir);
+    if (!diveSubfolder(fname))
+      return;
     
     //write
     if (!file.open(curDir, fname, O_CREAT | O_APPEND | O_WRITE | O_TRUNC)){

--- a/Firmware/cardreader.cpp
+++ b/Firmware/cardreader.cpp
@@ -518,7 +518,7 @@ void CardReader::openFileWrite(const char* name)
     } else {
         saving = true;
         SERIAL_PROTOCOLRPGM(ofWritingToFile);////MSG_SD_WRITE_TO_FILE
-        SERIAL_PROTOCOLLN(name);
+        SERIAL_PROTOCOLLN(fname);
         lcd_setstatus(fname);
     }
 }

--- a/Firmware/cardreader.cpp
+++ b/Firmware/cardreader.cpp
@@ -277,7 +277,7 @@ void CardReader::startFileprint()
 void CardReader::openLogFile(const char* name)
 {
   logging = true;
-  openFile(name, false);
+  openFileWrite(name);
 }
 
 void CardReader::getDirName(char* name, uint8_t level)
@@ -375,8 +375,19 @@ void CardReader::diveSubfolder (const char *fileName, SdFile& dir)
     }
 }
 
-// @@TODO merge with openFile, too much duplicated code and texts
-void CardReader::openFileFilteredGcode(const char* name, bool replace_current/* = false*/){
+static const char ofKill[] PROGMEM = "trying to call sub-gcode files with too many levels.";
+static const char ofSubroutineCallTgt[] PROGMEM = "SUBROUTINE CALL target:\"";
+static const char ofParent[] PROGMEM = "\" parent:\"";
+static const char ofPos[] PROGMEM = "\" pos";
+static const char ofNowDoingFile[] PROGMEM = "Now doing file: ";
+static const char ofNowFreshFile[] PROGMEM = "Now fresh file: ";
+static const char ofFileOpened[] PROGMEM = "File opened: ";
+static const char ofSize[] PROGMEM = " Size: ";
+static const char ofFileSelected[] PROGMEM = "File selected";
+static const char ofSDPrinting[] PROGMEM = "SD-PRINTING         ";
+static const char ofWritingToFile[] PROGMEM = "Writing to file: ";
+
+void CardReader::openFileReadFilteredGcode(const char* name, bool replace_current/* = false*/){
     if(!cardOK)
         return;
     
@@ -386,33 +397,33 @@ void CardReader::openFileFilteredGcode(const char* name, bool replace_current/* 
                 // SERIAL_ERROR_START;
                 // SERIAL_ERRORPGM("trying to call sub-gcode files with too many levels. MAX level is:");
                 // SERIAL_ERRORLN(SD_PROCEDURE_DEPTH);
-                kill(_n("trying to call sub-gcode files with too many levels."), 1);
+                kill(ofKill, 1);
                 return;
             }
             
             SERIAL_ECHO_START;
-            SERIAL_ECHOPGM("SUBROUTINE CALL target:\"");
+            SERIAL_ECHORPGM(ofSubroutineCallTgt);
             SERIAL_ECHO(name);
-            SERIAL_ECHOPGM("\" parent:\"");
+            SERIAL_ECHORPGM(ofParent);
             
             //store current filename and position
             getAbsFilename(filenames[file_subcall_ctr]);
             
             SERIAL_ECHO(filenames[file_subcall_ctr]);
-            SERIAL_ECHOPGM("\" pos");
+            SERIAL_ECHORPGM(ofPos);
             SERIAL_ECHOLN(sdpos);
             filespos[file_subcall_ctr]=sdpos;
             file_subcall_ctr++;
         } else {
             SERIAL_ECHO_START;
-            SERIAL_ECHOPGM("Now doing file: ");
+            SERIAL_ECHORPGM(ofNowDoingFile);
             SERIAL_ECHOLN(name);
         }
         file.close();
     } else { //opening fresh file
         file_subcall_ctr=0; //resetting procedure depth in case user cancels print while in procedure
         SERIAL_ECHO_START;
-        SERIAL_ECHOPGM("Now fresh file: ");
+        SERIAL_ECHORPGM(ofNowFreshFile);
         SERIAL_ECHOLN(name);
     }
     sdprinting = false;
@@ -423,16 +434,16 @@ void CardReader::openFileFilteredGcode(const char* name, bool replace_current/* 
   
     if (file.openFilteredGcode(curDir, fname)) {
         filesize = file.fileSize();
-        SERIAL_PROTOCOLRPGM(_N("File opened: "));////MSG_SD_FILE_OPENED
+        SERIAL_PROTOCOLRPGM(ofFileOpened);////MSG_SD_FILE_OPENED
         SERIAL_PROTOCOL(fname);
-        SERIAL_PROTOCOLRPGM(_n(" Size: "));////MSG_SD_SIZE
+        SERIAL_PROTOCOLRPGM(ofSize);////MSG_SD_SIZE
         SERIAL_PROTOCOLLN(filesize);
         sdpos = 0;
         
-        SERIAL_PROTOCOLLNRPGM(_N("File selected"));////MSG_SD_FILE_SELECTED
+        SERIAL_PROTOCOLLNRPGM(ofFileSelected);////MSG_SD_FILE_SELECTED
         getfilename(0, fname);
         lcd_setstatus(longFilename[0] ? longFilename : fname);
-        lcd_setstatus("SD-PRINTING         ");
+        lcd_setstatuspgm(ofSDPrinting);
       } else {
         SERIAL_PROTOCOLRPGM(MSG_SD_OPEN_FILE_FAIL);
         SERIAL_PROTOCOL(fname);
@@ -440,98 +451,59 @@ void CardReader::openFileFilteredGcode(const char* name, bool replace_current/* 
       }
 }
 
-void CardReader::openFile(const char* name,bool read, bool replace_current/*=true*/)
+void CardReader::openFileWrite(const char* name)
 {
-  if(!cardOK)
-    return;
-  if(file.isOpen())  //replacing current file by new file, or subfile call
-  {
-    if(!replace_current)
-    {
-     if((int)file_subcall_ctr>(int)SD_PROCEDURE_DEPTH-1)
-     {
-       // SERIAL_ERROR_START;
-       // SERIAL_ERRORPGM("trying to call sub-gcode files with too many levels. MAX level is:");
-       // SERIAL_ERRORLN(SD_PROCEDURE_DEPTH);
-       kill(_n("trying to call sub-gcode files with too many levels."), 1);
-       return;
-     }
-     
-     SERIAL_ECHO_START;
-     SERIAL_ECHOPGM("SUBROUTINE CALL target:\"");
-     SERIAL_ECHO(name);
-     SERIAL_ECHOPGM("\" parent:\"");
-     
-     //store current filename and position
-     getAbsFilename(filenames[file_subcall_ctr]);
-     
-     SERIAL_ECHO(filenames[file_subcall_ctr]);
-     SERIAL_ECHOPGM("\" pos");
-     SERIAL_ECHOLN(sdpos);
-     filespos[file_subcall_ctr]=sdpos;
-     file_subcall_ctr++;
-    }
-    else
-    {
-     SERIAL_ECHO_START;
-     SERIAL_ECHOPGM("Now doing file: ");
-     SERIAL_ECHOLN(name);
-    }
-    file.close();
-  }
-  else //opening fresh file
-  {
-    file_subcall_ctr=0; //resetting procedure depth in case user cancels print while in procedure
-    SERIAL_ECHO_START;
-    SERIAL_ECHOPGM("Now fresh file: ");
-    SERIAL_ECHOLN(name);
-  }
-  sdprinting = false;
+    if(!cardOK)
+        return;
+    if(file.isOpen()){  //replacing current file by new file, or subfile call
 
-  SdFile myDir;
-  const char *fname=name;
-  diveSubfolder(fname,myDir);
+        // @@TODO I doubt this is necessary for file saving:
 
-  if(read)
-  {
-    if (file.open(curDir, fname, O_READ)) 
-    {
-      filesize = file.fileSize();
-      SERIAL_PROTOCOLRPGM(_N("File opened: "));////MSG_SD_FILE_OPENED
-      SERIAL_PROTOCOL(fname);
-      SERIAL_PROTOCOLRPGM(_n(" Size: "));////MSG_SD_SIZE
-      SERIAL_PROTOCOLLN(filesize);
-      sdpos = 0;
-      
-      SERIAL_PROTOCOLLNRPGM(_N("File selected"));////MSG_SD_FILE_SELECTED
-      getfilename(0, fname);
-      lcd_setstatus(longFilename[0] ? longFilename : fname);
-      lcd_setstatuspgm(PSTR("SD-PRINTING"));
+        if((int)file_subcall_ctr>(int)SD_PROCEDURE_DEPTH-1){
+            // SERIAL_ERROR_START;
+            // SERIAL_ERRORPGM("trying to call sub-gcode files with too many levels. MAX level is:");
+            // SERIAL_ERRORLN(SD_PROCEDURE_DEPTH);
+            kill(ofKill, 1);
+            return;
+        }
+        
+        SERIAL_ECHO_START;
+        SERIAL_ECHORPGM(ofSubroutineCallTgt);
+        SERIAL_ECHO(name);
+        SERIAL_ECHORPGM(ofParent);
+        
+        //store current filename and position
+        getAbsFilename(filenames[file_subcall_ctr]);
+        
+        SERIAL_ECHO(filenames[file_subcall_ctr]);
+        SERIAL_ECHORPGM(ofPos);
+        SERIAL_ECHOLN(sdpos);
+        filespos[file_subcall_ctr]=sdpos;
+        file_subcall_ctr++;
+        file.close();
+    } else { //opening fresh file
+        file_subcall_ctr=0; //resetting procedure depth in case user cancels print while in procedure
+        SERIAL_ECHO_START;
+        SERIAL_ECHORPGM(ofNowFreshFile);
+        SERIAL_ECHOLN(name);
     }
-    else
-    {
-      SERIAL_PROTOCOLRPGM(MSG_SD_OPEN_FILE_FAIL);
-      SERIAL_PROTOCOL(fname);
-      SERIAL_PROTOCOLLN('.');
+    sdprinting = false;
+    
+    SdFile myDir;
+    const char *fname=name;
+    diveSubfolder(fname,myDir);
+    
+    //write
+    if (!file.open(curDir, fname, O_CREAT | O_APPEND | O_WRITE | O_TRUNC)){
+        SERIAL_PROTOCOLRPGM(MSG_SD_OPEN_FILE_FAIL);
+        SERIAL_PROTOCOL(fname);
+        SERIAL_PROTOCOLLN('.');
+    } else {
+        saving = true;
+        SERIAL_PROTOCOLRPGM(ofWritingToFile);////MSG_SD_WRITE_TO_FILE
+        SERIAL_PROTOCOLLN(name);
+        lcd_setstatus(fname);
     }
-  }
-  else 
-  { //write
-    if (!file.open(curDir, fname, O_CREAT | O_APPEND | O_WRITE | O_TRUNC))
-    {
-      SERIAL_PROTOCOLRPGM(MSG_SD_OPEN_FILE_FAIL);
-      SERIAL_PROTOCOL(fname);
-      SERIAL_PROTOCOLLN('.');
-    }
-    else
-    {
-      saving = true;
-      SERIAL_PROTOCOLRPGM(_N("Writing to file: "));////MSG_SD_WRITE_TO_FILE
-      SERIAL_PROTOCOLLN(name);
-      lcd_setstatus(fname);
-    }
-  }
-  
 }
 
 void CardReader::removeFile(const char* name)
@@ -1069,7 +1041,7 @@ void CardReader::printingHasFinished()
     {
       file.close();
       file_subcall_ctr--;
-      openFile(filenames[file_subcall_ctr],true,true);
+      openFileReadFilteredGcode(filenames[file_subcall_ctr],true);
       setIndex(filespos[file_subcall_ctr]);
       startFileprint();
     }

--- a/Firmware/cardreader.h
+++ b/Firmware/cardreader.h
@@ -21,8 +21,8 @@ public:
   //this is to delay autostart and hence the initialisaiton of the sd card to some seconds after the normal init, so the device is available quick after a reset
 
   void checkautostart(bool x); 
-  void openFile(const char* name,bool read,bool replace_current=true);
-  void openFileFilteredGcode(const char* name, bool replace_current = false);
+  void openFileWrite(const char* name);
+  void openFileReadFilteredGcode(const char* name, bool replace_current = false);
   void openLogFile(const char* name);
   void removeFile(const char* name);
   void closefile(bool store_location=false);

--- a/Firmware/cardreader.h
+++ b/Firmware/cardreader.h
@@ -61,12 +61,11 @@ public:
   #endif
 
   FORCE_INLINE bool isFileOpen() { return file.isOpen(); }
-  FORCE_INLINE bool eof() { return sdpos>=filesize ;};
-//  FORCE_INLINE int16_t getX() {  sdpos = file.curPosition();return (int16_t)file.read();};
-  //@@TODO potential performance problem - when the comment reading fails, sdpos points to the last correctly read character.
+  bool eof() { return sdpos>=filesize; }
+  // There may be a potential performance problem - when the comment reading fails, sdpos points to the last correctly read character.
   // However, repeated reading (e.g. after power panic) the comment will be read again - it should survive correctly, it will just take a few moments to skip
   FORCE_INLINE int16_t getFilteredGcodeChar() {  sdpos = file.curPosition();return (int16_t)file.readFilteredGcode();};
-  /*FORCE_INLINE*/ void setIndex(long index) {sdpos = index;file.seekSetFilteredGcode(index);};
+  void setIndex(long index) {sdpos = index;file.seekSetFilteredGcode(index);};
   FORCE_INLINE uint8_t percentDone(){if(!isFileOpen()) return 0; if(filesize) return sdpos/((filesize+99)/100); else return 0;};
   FORCE_INLINE char* getWorkDirName(){workDir.getFilename(filename);return filename;};
   FORCE_INLINE uint32_t get_sdpos() { if (!isFileOpen()) return 0; else return(sdpos); };

--- a/Firmware/cardreader.h
+++ b/Firmware/cardreader.h
@@ -20,6 +20,7 @@ public:
 
   void checkautostart(bool x); 
   void openFile(const char* name,bool read,bool replace_current=true);
+  void openFileFilteredGcode(const char* name, bool replace_current = false);
   void openLogFile(const char* name);
   void removeFile(const char* name);
   void closefile(bool store_location=false);
@@ -59,7 +60,10 @@ public:
 
   FORCE_INLINE bool isFileOpen() { return file.isOpen(); }
   FORCE_INLINE bool eof() { return sdpos>=filesize ;};
-  FORCE_INLINE int16_t get() {  sdpos = file.curPosition();return (int16_t)file.read();};
+//  FORCE_INLINE int16_t getX() {  sdpos = file.curPosition();return (int16_t)file.read();};
+  //@@TODO potential performance problem - when the comment reading fails, sdpos points to the last correctly read character.
+  // However, repeated reading (e.g. after power panic) the comment will be read again - it should survive correctly, it will just take a few moments to skip
+  FORCE_INLINE int16_t getFilteredGcodeChar() {  sdpos = file.curPosition();return (int16_t)file.readFilteredGcode();};
   FORCE_INLINE void setIndex(long index) {sdpos = index;file.seekSet(index);};
   FORCE_INLINE uint8_t percentDone(){if(!isFileOpen()) return 0; if(filesize) return sdpos/((filesize+99)/100); else return 0;};
   FORCE_INLINE char* getWorkDirName(){workDir.getFilename(filename);return filename;};

--- a/Firmware/cardreader.h
+++ b/Firmware/cardreader.h
@@ -1,6 +1,8 @@
 #ifndef CARDREADER_H
 #define CARDREADER_H
 
+#define SDSUPPORT
+
 #ifdef SDSUPPORT
 
 #define MAX_DIR_DEPTH 10
@@ -64,7 +66,7 @@ public:
   //@@TODO potential performance problem - when the comment reading fails, sdpos points to the last correctly read character.
   // However, repeated reading (e.g. after power panic) the comment will be read again - it should survive correctly, it will just take a few moments to skip
   FORCE_INLINE int16_t getFilteredGcodeChar() {  sdpos = file.curPosition();return (int16_t)file.readFilteredGcode();};
-  FORCE_INLINE void setIndex(long index) {sdpos = index;file.seekSet(index);};
+  /*FORCE_INLINE*/ void setIndex(long index) {sdpos = index;file.seekSetFilteredGcode(index);};
   FORCE_INLINE uint8_t percentDone(){if(!isFileOpen()) return 0; if(filesize) return sdpos/((filesize+99)/100); else return 0;};
   FORCE_INLINE char* getWorkDirName(){workDir.getFilename(filename);return filename;};
   FORCE_INLINE uint32_t get_sdpos() { if (!isFileOpen()) return 0; else return(sdpos); };

--- a/Firmware/cmdqueue.cpp
+++ b/Firmware/cmdqueue.cpp
@@ -588,7 +588,7 @@ void get_command()
     char serial_char = (char)n;
     if( serial_char == '\n'
      || serial_char == '\r'
-     || ((serial_char == '#' || serial_char == ':') /*&& comment_mode == false*/)
+     || ((serial_char == '#' || serial_char == ':') )
      || serial_count >= (MAX_CMD_SIZE - 1)
      || n==-1
     ){
@@ -602,9 +602,7 @@ void get_command()
         // read from the sdcard into sd_count, 
         // so that the lenght of the already read empty lines and comments will be added
         // to the following non-empty line. 
-//        comment_mode = false;
         return; // prevent cycling indefinitely - let manage_heaters do their job
-//        continue; //if empty line
       }
       // The new command buffer could be updated non-atomically, because it is not yet considered
       // to be inside the active queue.
@@ -620,10 +618,10 @@ void get_command()
 //      MYSERIAL.print(sd_count.value, DEC);
 //      SERIAL_ECHOPGM(") ");
 //      SERIAL_ECHOLN(cmdbuffer+bufindw+CMDHDRSIZE);
-//    SERIAL_ECHOPGM("cmdbuffer:");
-//    MYSERIAL.print(cmdbuffer);
-//    SERIAL_ECHOPGM("buflen:");
-//    MYSERIAL.print(buflen+1);
+//      SERIAL_ECHOPGM("cmdbuffer:");
+//      MYSERIAL.print(cmdbuffer);
+//      SERIAL_ECHOPGM("buflen:");
+//      MYSERIAL.print(buflen+1);
       sd_count.value = 0;
 
       cli();
@@ -640,7 +638,6 @@ void get_command()
 
       comment_mode = false; //for new command
       serial_count = 0; //clear buffer
-//      consecutiveEmptyLines = 0; // reached a non-empty line which shall be enqueued
     
       if(card.eof()) break;
 
@@ -650,8 +647,6 @@ void get_command()
     }
     else
     {
-      /*if(serial_char == ';') comment_mode = true;
-      else if(!comment_mode)*/
         // there are no comments coming from the filtered file
         cmdbuffer[bufindw+CMDHDRSIZE+serial_count++] = serial_char;
     }

--- a/Firmware/cmdqueue.cpp
+++ b/Firmware/cmdqueue.cpp
@@ -573,7 +573,6 @@ void get_command()
   // this character _can_ occur in serial com, due to checksums. however, no checksums are used in SD printing
 
   static bool stop_buffering=false;
-//  static uint8_t consecutiveEmptyLines = 0;
   if(buflen==0) stop_buffering=false;
   union {
     struct {
@@ -604,10 +603,7 @@ void get_command()
         // so that the lenght of the already read empty lines and comments will be added
         // to the following non-empty line. 
 //        comment_mode = false;
-//        if( ++consecutiveEmptyLines > 10 ){
-//            consecutiveEmptyLines = 0;
-            return; // prevent cycling indefinitely - let manage_heaters do their job
-//        }
+        return; // prevent cycling indefinitely - let manage_heaters do their job
 //        continue; //if empty line
       }
       // The new command buffer could be updated non-atomically, because it is not yet considered

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -8473,10 +8473,8 @@ static void lcd_selftest_screen_step(int _row, int _col, int _state, const char 
 /** Menu action functions **/
 
 static bool check_file(const char* filename) {
-    return true; // @@TODO
-    
 	if (farm_mode) return true;
-	card.openFileFilteredGcode((char*)filename, true); //@@TODO
+	card.openFileFilteredGcode((char*)filename, true);
 	bool result = false;
 	const uint32_t filesize = card.getFileSize();
 	uint32_t startPos = 0;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -8473,8 +8473,10 @@ static void lcd_selftest_screen_step(int _row, int _col, int _state, const char 
 /** Menu action functions **/
 
 static bool check_file(const char* filename) {
+    return true; // @@TODO
+    
 	if (farm_mode) return true;
-	card.openFile((char*)filename, true);
+	card.openFileFilteredGcode((char*)filename, true); //@@TODO
 	bool result = false;
 	const uint32_t filesize = card.getFileSize();
 	uint32_t startPos = 0;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -8474,7 +8474,7 @@ static void lcd_selftest_screen_step(int _row, int _col, int _state, const char 
 
 static bool check_file(const char* filename) {
 	if (farm_mode) return true;
-	card.openFileFilteredGcode((char*)filename, true);
+	card.openFileReadFilteredGcode(filename, true);
 	bool result = false;
 	const uint32_t filesize = card.getFileSize();
 	uint32_t startPos = 0;


### PR DESCRIPTION
This is an extension/optimization of PR #2956.

It uses the cached 512B block buffer to avoid heavy-weight read() in SdBaseFile. Even though this principle allowed the AVR to skip ~600KB of data within ~5 seconds, the impact on code base is huge, especially into well proven and long-term stable
parts like reading a file from the SD card.

The original purpose of this PR was to show/verify the possibility of the AVR CPU in relation to adding thumbnails into MK3 G-codes. It has evolved into a viable solution which may bring performance gains even during printing.

All necessary features seem to be working.

PFW-1175