### PR TITLE
PFW-1140 Add fan speed and position auto report

### DIFF
--- a/Firmware/Configuration_adv.h
+++ b/Firmware/Configuration_adv.h
@@ -74,24 +74,7 @@
  * bit 6 = free
  * bit 7 = free
 */
-#define AUTO_REPORT_ALL
-
-#ifndef AUTO_REPORT_ALL
-/**
- * Auto-report temperatures with M155 S<seconds> [C1]
- */
-#define AUTO_REPORT_TEMPERATURES
-
-/**
- * Auto-report fans with M155 S<seconds> C2
- */
-#define AUTO_REPORT_FANS
-
-/**
- * Auto-report position with M155 S<seconds> C4
- */
-#define AUTO_REPORT_POSITION
-#endif //NOT AUTO_REPORT_ALL
+#define AUTO_REPORT
 
 //===========================================================================
 //=============================Mechanical Settings===========================

--- a/Firmware/Configuration_adv.h
+++ b/Firmware/Configuration_adv.h
@@ -63,12 +63,35 @@
 #define FAN_KICKSTART_TIME 800
 
 /**
- * Auto-report temperatures with M155 S<seconds>
+ * Auto-report all at once with M155 S<seconds> C[bitmask] with single timer
+ * 
+ * bit 0 = Auto-report temperatures
+ * bit 1 = Auto-report fans
+ * bit 2 = Auto-report position
+ * bit 3 = free
+ * bit 4 = free
+ * bit 5 = free
+ * bit 6 = free
+ * bit 7 = free
+*/
+#define AUTO_REPORT_ALL
+
+#ifndef AUTO_REPORT_ALL
+/**
+ * Auto-report temperatures with M155 S<seconds> [C1]
  */
 #define AUTO_REPORT_TEMPERATURES
 
+/**
+ * Auto-report fans with M155 S<seconds> C2
+ */
+#define AUTO_REPORT_FANS
 
-
+/**
+ * Auto-report position with M155 S<seconds> C4
+ */
+#define AUTO_REPORT_POSITION
+#endif //NOT AUTO_REPORT_ALL
 
 //===========================================================================
 //=============================Mechanical Settings===========================

--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -481,7 +481,9 @@ void force_high_power_mode(bool start_high_power_section);
 
 bool gcode_M45(bool onlyZ, int8_t verbosity_level);
 void gcode_M114();
+#if (defined(FANCHECK) && (((defined(TACH_0) && (TACH_0 >-1)) || (defined(TACH_1) && (TACH_1 > -1)))))
 void gcode_M123();
+#endif //FANCHECK and TACH_0 and TACH_1
 void gcode_M701();
 
 #define UVLO !(PINE & (1<<4))

--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -289,6 +289,7 @@ extern float min_pos[3];
 extern float max_pos[3];
 extern bool axis_known_position[3];
 extern int fanSpeed;
+extern uint8_t newFanSpeed;
 extern int8_t lcd_change_fil_state;
 extern float default_retraction;
 
@@ -480,6 +481,7 @@ void force_high_power_mode(bool start_high_power_section);
 
 bool gcode_M45(bool onlyZ, int8_t verbosity_level);
 void gcode_M114();
+void gcode_M123();
 void gcode_M701();
 
 #define UVLO !(PINE & (1<<4))

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -6534,9 +6534,8 @@ Sigma_Exit:
         }
         if (code_seen('C')){
             autoReportFeatures.SetMask(code_value());
-            //arFunctionsActive.bits.ar_temp_active = 1; //auto-report temperatures always on
         } else{
-            autoReportFeatures.SetMask(1);
+            autoReportFeatures.SetMask(1); //Backwards compability to host systems like Octoprint to send only temp if paramerter `C`isn't used
         }
    }
     break;

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -270,6 +270,7 @@ float extruder_offset[NUM_EXTRUDER_OFFSETS][EXTRUDERS] = {
 
 uint8_t active_extruder = 0;
 int fanSpeed=0;
+uint8_t newFanSpeed = 0;
 
 #ifdef FWRETRACT
   bool retracted[EXTRUDERS]={false
@@ -3166,6 +3167,11 @@ void gcode_M114()
 	SERIAL_PROTOCOLLN("");
 }
 
+void gcode_M123()
+{
+  printf_P(_N("E0:%d RPM PRN1:%d RPM E0@:%u PRN1@:%d\n"), 60*fan_speed[active_extruder], 60*fan_speed[1], newFanSpeed, fanSpeed);
+}
+
 //! extracted code to compute z_shift for M600 in case of filament change operation 
 //! requested from fsensors.
 //! The function ensures, that the printhead lifts to at least 25mm above the heat bed
@@ -3606,6 +3612,7 @@ extern uint8_t st_backlash_y;
 //!@n M115 - Capabilities string
 //!@n M117 - display message
 //!@n M119 - Output Endstop status to serial port
+//!@n M123 - Tachometer value
 //!@n M126 - Solenoid Air Valve Open (BariCUDA support by jmil)
 //!@n M127 - Solenoid Air Valve Closed (BariCUDA vent to atmospheric pressure by jmil)
 //!@n M128 - EtoP Open (BariCUDA EtoP = electricity to air pressure transducer by jmil)
@@ -6965,7 +6972,14 @@ Sigma_Exit:
       #endif
       break;
       //!@todo update for all axes, use for loop
-    
+
+    /*!
+	### M123 - Tachometer value <a href="https://www.reprap.org/wiki/G-code#M123:_Tachometer_value_.28RepRap.29">M123: Tachometer value</a>
+    */
+    case 123:
+    gcode_M123();
+    break;
+
 
     #ifdef BLINKM
     /*!

--- a/Firmware/Timer.h
+++ b/Firmware/Timer.h
@@ -20,10 +20,10 @@ public:
     Timer();
     void start();
     void stop(){m_isRunning = false;}
-    bool running(){return m_isRunning;}
+    bool running()const {return m_isRunning;}
     bool expired(T msPeriod);
 protected:
-    T started(){return m_started;}
+    T started()const {return m_started;}
 private:
     bool m_isRunning;
     T m_started;

--- a/Firmware/temperature.cpp
+++ b/Firmware/temperature.cpp
@@ -522,7 +522,7 @@ void setExtruderAutoFanState(uint8_t state)
 	//the fan to either On or Off during certain tests/errors.
 
 	fanState = state;
-	uint8_t newFanSpeed = 0;
+	newFanSpeed = 0;
 	if (fanState & 0x01)
 	{
 #ifdef EXTRUDER_ALTFAN_DETECT


### PR DESCRIPTION
- Added gcode `M123` to show fan speed tacho and pwm values
- Added Capabilities in gcode `M115`
  - `AUTOREPORT_FANS`
  - `AUTOREPORT_POSITION`
- Added parameter `C`to gcode `M155` to de-/activate auto report output using a bitmask

Tested on MK404 MK3S and MK2.5S with Octoprint 1.5.2 + 1.5.3

output fans : ```E0:0 RPM PRN1:0 RPM E0@:0 PRN1@:0```
output posistion: ```X:0.00 Y:0.00 Z:0.15 E:0.00 Count X: 0.00 Y:0.00 Z:0.15 E:0.00```
