### PR TITLE
Do not send CR on the serial line

### DIFF
--- a/Firmware/MarlinSerial.cpp
+++ b/Firmware/MarlinSerial.cpp
@@ -255,7 +255,7 @@ void MarlinSerial::print(double n, int digits)
 
 void MarlinSerial::println(void)
 {
-  print('\r');
+  // print('\r');
   print('\n');  
 }
 


### PR DESCRIPTION
Make the serial output format uniform by not sending CRLF in some places while only sending LF in others. From now on all Serial output should be LF only (just like in stdio).

PR is a draft since compatibility must be tested