### PR TITLE
"M20 L" support. Print long filenames

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -5674,6 +5674,11 @@ if(eSoundMode!=e_SOUND_MODE_SILENT)
 
     /*!
 	### M20 - SD Card file list <a href="https://reprap.org/wiki/G-code#M20:_List_SD_card">M20: List SD card</a>
+    #### Usage
+    
+        M20 [ L ]
+    #### Parameters
+    - `L` - Reports ling filenames instead of just short filenames. Requires host software parsing.
     */
     case 20:
       SERIAL_PROTOCOLLNRPGM(_N("Begin file list"));////MSG_BEGIN_FILE_LIST

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -5681,6 +5681,7 @@ if(eSoundMode!=e_SOUND_MODE_SILENT)
     - `L` - Reports ling filenames instead of just short filenames. Requires host software parsing.
     */
     case 20:
+      KEEPALIVE_STATE(NOT_BUSY); // do not send busy messages during listing. Inhibits the output of manage_heater()
       SERIAL_PROTOCOLLNRPGM(_N("Begin file list"));////MSG_BEGIN_FILE_LIST
       card.ls(code_seen('L'));
       SERIAL_PROTOCOLLNRPGM(_N("End file list"));////MSG_END_FILE_LIST

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -5677,7 +5677,7 @@ if(eSoundMode!=e_SOUND_MODE_SILENT)
     */
     case 20:
       SERIAL_PROTOCOLLNRPGM(_N("Begin file list"));////MSG_BEGIN_FILE_LIST
-      card.ls();
+      card.ls(code_seen('L'));
       SERIAL_PROTOCOLLNRPGM(_N("End file list"));////MSG_END_FILE_LIST
       break;
 

--- a/Firmware/cardreader.cpp
+++ b/Firmware/cardreader.cpp
@@ -133,6 +133,7 @@ void CardReader::lsDive(const char *prepend, SdFile parent, const char * const m
 							printf_P(PSTR("\"%s\" "), LONGEST_FILENAME);
 						
 						SERIAL_PROTOCOLLN(p.fileSize);
+						manage_heater();
 						break;
 				
 					case LS_GetFilename:

--- a/Firmware/cardreader.cpp
+++ b/Firmware/cardreader.cpp
@@ -62,9 +62,10 @@ char *createFilename(char *buffer,const dir_t &p) //buffer>12characters
 
 /**
 +* Dive into a folder and recurse depth-first to perform a pre-set operation lsAction:
-+*   LS_Count       - Add +1 to nrFiles for every file within the parent
-+*   LS_GetFilename - Get the filename of the file indexed by nrFiles
-+*   LS_SerialPrint - Print the full path and size of each file to serial output
++*   LS_Count           - Add +1 to nrFiles for every file within the parent
++*   LS_GetFilename     - Get the filename of the file indexed by nrFiles
++*   LS_SerialPrint     - Print the full path and size of each file to serial output
++*   LS_SerialPrint_LFN - Print the full path, long filename and size of each file to serial output
 +*/
 
 void CardReader::lsDive(const char *prepend, SdFile parent, const char * const match/*=NULL*/) {
@@ -90,9 +91,13 @@ void CardReader::lsDive(const char *prepend, SdFile parent, const char * const m
 				// Serial.print(path);
 				// Get a new directory object using the full path
 				// and dive recursively into it.
+				
+				if (lsAction == LS_SerialPrint_LFN)
+					printf_P(PSTR("DIR_ENTER: %s \"%s\"\n"), path, longFilename[0] ? longFilename : lfilename);
+				
 				SdFile dir;
 				if (!dir.open(parent, lfilename, O_READ)) {
-					if (lsAction == LS_SerialPrint) {
+					if (lsAction == LS_SerialPrint || lsAction == LS_SerialPrint_LFN) {
 						//SERIAL_ECHO_START();
 						//SERIAL_ECHOPGM(_i("Cannot open subdir"));////MSG_SD_CANT_OPEN_SUBDIR
 						//SERIAL_ECHOLN(lfilename);
@@ -100,6 +105,9 @@ void CardReader::lsDive(const char *prepend, SdFile parent, const char * const m
 				}
 				lsDive(path, dir);
 				// close() is done automatically by destructor of SdFile
+				
+				if (lsAction == LS_SerialPrint_LFN)
+					puts_P(PSTR("DIR_EXIT"));
 			}
 			else {
 				uint8_t pn0 = p.name[0];
@@ -114,11 +122,16 @@ void CardReader::lsDive(const char *prepend, SdFile parent, const char * const m
 						nrFiles++;
 						break;
 					
+					case LS_SerialPrint_LFN:
 					case LS_SerialPrint:
 						createFilename(filename, p);
 						SERIAL_PROTOCOL(prepend);
 						SERIAL_PROTOCOL(filename);
 						MYSERIAL.write(' ');
+						
+						if (lsAction == LS_SerialPrint_LFN)
+							printf_P(PSTR("\"%s\" "), LONGEST_FILENAME);
+						
 						SERIAL_PROTOCOLLN(p.fileSize);
 						break;
 				
@@ -160,9 +173,9 @@ void CardReader::lsDive(const char *prepend, SdFile parent, const char * const m
 		} // while readDir
 }
 
-void CardReader::ls() 
+void CardReader::ls(bool printLFN)
 {
-  lsAction=LS_SerialPrint;
+  lsAction = printLFN ? LS_SerialPrint_LFN : LS_SerialPrint;
   //if(lsAction==LS_Count)
   //nrFiles=0;
 

--- a/Firmware/cardreader.h
+++ b/Firmware/cardreader.h
@@ -6,7 +6,7 @@
 #define MAX_DIR_DEPTH 10
 
 #include "SdFile.h"
-enum LsAction {LS_SerialPrint,LS_Count,LS_GetFilename};
+enum LsAction {LS_SerialPrint,LS_SerialPrint_LFN,LS_Count,LS_GetFilename};
 class CardReader
 {
 public:
@@ -38,7 +38,7 @@ public:
   uint16_t getWorkDirDepth();
   
 
-  void ls();
+  void ls(bool printLFN);
   void chdir(const char * relpath);
   void updir();
   void setroot();


### PR DESCRIPTION
With this PR you can now build the entire file structure of the SD card including long filename support for both files and dirs. This is in contrast to M33 which would be a lot slower.
The `L` parameter to M20 isn't something used in standard Marlin, so support from some kind of plugin for octoprint will be required.

Example log from `M20` just like before in order to preserve compatibility
```
Begin file list
/OLDGCO~1/200X25~1.GCO 88905
/OLDGCO~1/24TEET~1.GCO 25573009
/OLDGCO~1/3DBENC~1.GCO 3741547
/OLDGCO~1/3D_PRI~1.GCO 3356955
/OLDGCO~1/608_BE~1.GCO 16133436
/OLDGCO~1/608_BE~2.GCO 4070364
/OLDGCO~1/AMOEBA~1.GCO 3256993
/OLDGCO~1/ANET_A~1.GCO 43601
/OLDGCO~1/ARTICU~1.GCO 4394355
/OLDGCO~1/ARTICU~2.GCO 4858396
/OLDGCO~1/CLASSI~1.GCO 22530145
/OLDGCO~1/COLORF~1.GCO 640849
/OLDGCO~1/DONOTT~1.GCO 5948818
/OLDGCO~1/DONOTT~2.GCO 4322412
/OLDGCO~1/FAN-NO~1.GCO 1212108
/OLDGCO~1/FAN-NO~2.GCO 1210219
/OLDGCO~1/FILAME~1.GCO 1557339
/OLDGCO~1/FILAME~2.GCO 450020
/OLDGCO~1/FILAME~3.GCO 547217
/OLDGCO~1/HAIRY_~1.GCO 8570655
/OLDGCO~1/IKEA_S~1.GCO 3211224
/OLDGCO~1/IKEA_S~2.GCO 18704965
/OLDGCO~1/IPHONE~1.GCO 1653809
/OLDGCO~1/JIG_RE~1.GCO 202512
/OLDGCO~1/KUORET~1.GCO 1454256
/OLDGCO~1/LATTIC~1.GCO 13326321
/OLDGCO~1/LATTIC~2.GCO 9688408
/OLDGCO~1/MAKER'~1.GCO 11029980
/OLDGCO~1/MAKERB~1.GCO 10616833
/OLDGCO~1/MAKERB~2.GCO 16797631
/OLDGCO~1/MAKERB~3.GCO 9780679
/OLDGCO~1/MOSORV~1.GCO 3415744
/OLDGCO~1/NEMA_E~1.GCO 390976
/OLDGCO~1/OCTOPU~1.GCO 3852457
/OLDGCO~1/PLA_NE~1.GCO 12323691
/OLDGCO~1/PLA_VA~1.GCO 11066083
/OLDGCO~1/PRUSAF~1.GCO 4618941
/OLDGCO~1/PRUSA_~1.GCO 2288900
/OLDGCO~1/RODAJX~1.GCO 792
/OLDGCO~1/RODAJY~1.GCO 792
/OLDGCO~1/RPI3-B~1.GCO 4449957
/OLDGCO~1/SCRIPE~1.GCO 1220553
/OLDGCO~1/SOLDER~1.GCO 2675301
/OLDGCO~1/SOTVL_~1.GCO 4941144
/OLDGCO~1/SPIRAL~1.GCO 18607016
/OLDGCO~1/SPOOL_~1.GCO 4371046
/OLDGCO~1/TUBEPV~1.GCO 4702895
/OLDGCO~1/UNSYMM~1.GCO 25242018
/OLDGCO~1/UPLOAD~1.GCO 1283046
/OLDGCO~1/XYZCAL~1.GCO 605461
/OLDGCO~1/XYZCAL~2.GCO 528262
/OLDGCO~1/Y-MOTO~1.GCO 2955446
/OLDGCO~1/!PC/FAN-NO~1.GCO 807386
/OLDGCO~1/!PC/FAN-NO~2.GCO 869352
/OLDGCO~1/!PC/KFACTO~1.GCO 15126
/OLDGCO~1/!PC/KFACTO~2.GCO 15153
/OLDGCO~1/!PC/XYZCAL~1.GCO 338335
/OLDGCO~1/!PC/XYZCAL~2.GCO 363907
/OLDGCO~1/!PC/XYZCAL~3.GCO 370883
/OLDGCO~1/!PC/XYZCAL~4.GCO 285344
/OLDGCO~1/!PC/XY7838~1.GCO 409728
/OLDGCO~1/!PC/XY0C4D~1.GCO 409560
/OLDGCO~1/!PETG/RAMBO-~1.GCO 8506637
/OLDGCO~1/!PETG/RAMBO-~2.GCO 10973122
/OLDGCO~1/!PETG/XYZCAL~1.GCO 608424
/OLDGCO~1/!ROBOT~1/OUTTAKE/HOLDER~1.GCO 3080815
/OLDGCO~1/!ROBOT~1/OUTTAKE/SCORPI~1.GCO 9967305
/OLDGCO~1/!ROBOT~1/OUTTAKE/SCORPI~2.GCO 9703984
/OLDGCO~1/CALIBR~1/KFACTO~1.GCO 14571
/OLDGCO~1/CALIBR~1/PLA_3D~1.GCO 5763413
/OLDGCO~1/DADU/SPACE-~1.GCO 62163047
/OLDGCO~1/MK2.5/RAMBOC~1.GCO 10989039
/OLDGCO~1/MK25SS/AM-401~1.GCO 1039747
/OLDGCO~1/MK25SS/MK25SS~1.GCO 1276088
/OLDGCO~1/MK25SS/X-END-~1.GCO 6290844
/OLDGCO~1/MK25SS/Y-BELT~1.GCO 1766091
/OLDGCO~1/MMU/04NOZZ~1.GCO 4111236
/OLDGCO~1/MMU/2C_SHE~1.GCO 3868808
/OLDGCO~1/MMU/3C_LIZ~1.GCO 2128204
/OLDGCO~1/MMU/3DBENC~1.GCO 6397378
/OLDGCO~1/MMU/3DBENC~2.GCO 2934092
/OLDGCO~1/MMU/BOBOMB~1.GCO 5224604
/OLDGCO~1/MMU/MINI-C~1.GCO 2170024
/OLDGCO~1/MMU/MINION~1.GCO 18373087
/OLDGCO~1/MMU/MINION~2.GCO 18364467
/OLDGCO~1/MMU/MINION~3.GCO 27768035
/OLDGCO~1/MMU/MINION~4.GCO 21773735
/OLDGCO~1/MMU/XYZCAL~1.GCO 1135097
/OLDGCO~1/PRUSABOX/DOORKN~1.GCO 817562
/OLDGCO~1/PRUSABOX/MK25_B~1.GCO 1579602
/OLDGCO~1/PRUSABOX/PRINTED/BOTTOM~1.GCO 20334095
/OLDGCO~1/PRUSABOX/PRINTED/BOTTOM~2.GCO 9063265
/OLDGCO~1/PRUSABOX/PRINTED/FILAME~1.GCO 2741239
/OLDGCO~1/PRUSABOX/PRINTED/FILAME~2.GCO 2815087
/OLDGCO~1/PRUSABOX/PRINTED/HEATBE~1.GCO 744256
/OLDGCO~1/PRUSABOX/PRINTED/PRUSA_~1.GCO 1183865
/OLDGCO~1/PRUSABOX/PRINTED/PRUSA_~2.GCO 2467681
/OLDGCO~1/PRUSABOX/PRINTED/PSUCLI~1.GCO 579005
/OLDGCO~1/PRUSABOX/PRINTED/PSUHOD~1.GCO 4130563
/OLDGCO~1/PRUSABOX/PRINTED/PSUHOD~2.GCO 4716194
/OLDGCO~1/PRUSABOX/PRINTED/TOP_1~1.GCO 5843841
/OLDGCO~1/PRUSABOX/PRINTED/TOP_23~1.GCO 15644057
/OLDGCO~1/PRUSABOX/PRINTED/TOP_HI~1.GCO 2838401
/OLDGCO~1/SPOOL/AXLE_V~1.GCO 498060
/OLDGCO~1/SPOOL/CLIP_V~1.GCO 120521
/OLDGCO~1/SPOOL/CLUTCH~1.GCO 2682264
/OLDGCO~1/SPOOL/HUB_V3~1.GCO 10081488
/OLDGCO~1/SPOOL/NUTCUR~1.GCO 2810578
/OLDGCO~1/SPOOL/PLAIND~1.GCO 1501100
/OLDGCO~1/SPOOL/SPRING~1.GCO 7151864
/OLDGCO~1/SPOOL/STAND_~1.GCO 11829545
/OLDGCO~1/SPOOL/TUBEHO~1.GCO 2080500
/OLDGCO~1/XBOXWH~1/FRAME~1.GCO 2422421
/OLDGCO~1/XBOXWH~1/RACKAN~1.GCO 1092900
/OLDGCO~1/XBOXWH~1/XBOX_W~1.GCO 6739435
/SPOOL/AXLE_V~1.GCO 498060
/SPOOL/CLIP_V~1.GCO 120521
/SPOOL/CLUTCH~1.GCO 2682264
/SPOOL/HUB_V3~1.GCO 10081488
/SPOOL/NUTCUR~1.GCO 2810578
/SPOOL/PLAIND~1.GCO 1501100
/SPOOL/SPRING~1.GCO 7151864
/SPOOL/STAND_~1.GCO 11829545
/SPOOL/TUBEHO~1.GCO 2080500
CARDGL~1.GCO 5495588
FASTCR~1.GCO 370
GOBILD~1.GCO 7642784
LATTIC~1.GCO 9688408
MK3_PL~1.GCO 3844567
MK3_PL~2.GCO 2313309
MK3_PL~3.GCO 23835763
MK3_PL~4.GCO 239362
MK6B5B~1.GCO 6136347
MKF5D8~1.GCO 25035842
MK57DB~1.GCO 7839966
MKDA03~1.GCO 19928963
MKBC79~1.GCO 320939
MK8F3E~1.GCO 1169490
MK4837~1.GCO 10370557
MKAB66~1.GCO 4042561
MK150C~1.GCO 18235410
MKD715~1.GCO 7550751
MK027C~1.GCO 796054
MK3_PR~1.GCO 409041
OPI3MK~1.GCO 5279914
TEST.GCO 27
THE_UL~1.GCO 2308374
THUMBN~1.GCO 682634
TO_AVO~1.GCO 24773561
WII.GCO 7720
Y-IDLE~1.GCO 552925
Y-MOTO~1.GCO 2608475
/A1/B1/B133ED~1.GCO 1135097
/A1/B2/B2.GCO 1135097
/MMU/2C_SHE~1.GCO 3868808
/MMU/3C_LIZ~1.GCO 2128204
/MMU/BOBOMB~1.GCO 5224604
/MMU/CLIMBB~1.GCO 2200912
/MMU/CLIMBB~2.GCO 2016774
/MMU/CUBE_1~1.GCO 27510
/MMU/MAR39B~1.GCO 1860297
/MMU/MINI-C~1.GCO 2170024
/MMU/MINION~1.GCO 18373087
/MMU/MINION~2.GCO 18364467
/MMU/MINION~3.GCO 4938023
/MMU/MINION~4.GCO 4676458
/MMU/PLATG_~1.GCO 441007
/MMU/XYZCAL~1.GCO 1135097
End file list
```
Example log from `M20 L`:
```
Begin file list
DIR_ENTER: /SYSTEM~1/ "System Volume Information"
DIR_EXIT
DIR_ENTER: /OLDGCO~1/ "old gcodes"
/OLDGCO~1/200X25~1.GCO "200X250mm_Z_Test.gcode" 88905
/OLDGCO~1/24TEET~1.GCO "24teeth_mecanum 7mmHUB_HS_x3.gcode" 25573009
/OLDGCO~1/3DBENC~1.GCO "3DBenchy_HS.gcode" 3741547
/OLDGCO~1/3D_PRI~1.GCO "3D_printer_test_mini.gcode" 3356955
/OLDGCO~1/608_BE~1.GCO "608_bearing_2 x4.gcode" 16133436
/OLDGCO~1/608_BE~2.GCO "608_bearing_2.gcode" 4070364
/OLDGCO~1/AMOEBA~1.GCO "amoeba_barrel_stabilizer.gcode" 3256993
/OLDGCO~1/ANET_A~1.GCO "Anet_A8_First_Layer_Test.gcode" 43601
/OLDGCO~1/ARTICU~1.GCO "Articulated_Butterfly.gcode" 4394355
/OLDGCO~1/ARTICU~2.GCO "Articulated_Monarch 75p.gcode" 4858396
/OLDGCO~1/CLASSI~1.GCO "classicspringo.gcode" 22530145
/OLDGCO~1/COLORF~1.GCO "Colorfabb_and_Filamentium_Clip x3.gcode" 640849
/OLDGCO~1/DONOTT~1.GCO "DONOTTOUCH.gcode" 5948818
/OLDGCO~1/DONOTT~2.GCO "DONOTTOUCH_2.gcode" 4322412
/OLDGCO~1/FAN-NO~1.GCO "fan-nozzle_thermistor_v1.0_PLA.gcode" 1212108
/OLDGCO~1/FAN-NO~2.GCO "fan-nozzle_thermistor_v2.0_PLA.gcode" 1210219
/OLDGCO~1/FILAME~1.GCO "filament clips x4.gcode" 1557339
/OLDGCO~1/FILAME~2.GCO "filament_feeder SCREW.gcode" 450020
/OLDGCO~1/FILAME~3.GCO "filament_feeder.gcode" 547217
/OLDGCO~1/HAIRY_~1.GCO "Hairy_Lion_small_with_brim.gcode" 8570655
/OLDGCO~1/IKEA_S~1.GCO "Ikea_Samla_Clip_45-65L_by_Wookbert_Rev._E3_PLA.gcode" 3211224
/OLDGCO~1/IKEA_S~2.GCO "Ikea_Samla_Clip_45-65L_by_Wookbert_Rev._E3_PLA_6x.gc" 18704965
/OLDGCO~1/IPHONE~1.GCO "iPhone5Case6.gcode" 1653809
/OLDGCO~1/JIG_RE~1.GCO "jig_redesigned.gcode" 202512
/OLDGCO~1/KUORET~1.GCO "kuoret2.gcode" 1454256
/OLDGCO~1/LATTIC~1.GCO "Lattice_Cube_by_LazerLord10.gcode" 13326321
/OLDGCO~1/LATTIC~2.GCO "Lattice_Cube_by_LazerLord10_0.15mm_PLA_MK3SMMU2S_2h1" 9688408
/OLDGCO~1/MAKER'~1.GCO "Maker's_Muse_Tolerance_Gauge.gcode" 11029980
/OLDGCO~1/MAKERB~1.GCO "MakerBot_Headphone_Stand.gcode" 10616833
/OLDGCO~1/MAKERB~2.GCO "MakerBot_Headphone_Stand_PETG v2.gcode" 16797631
/OLDGCO~1/MAKERB~3.GCO "MakerBot_Headphone_Stand_PETG.gcode" 9780679
/OLDGCO~1/MOSORV~1.GCO "Mosor v1.1MK3HS.gcode" 3415744
/OLDGCO~1/NEMA_E~1.GCO "NEMA_Extruder_motor_rotation_indicator_Windmill.gcod" 390976
/OLDGCO~1/OCTOPU~1.GCO "OctopusTPU.gcode" 3852457
/OLDGCO~1/PLA_NE~1.GCO "PLA_nest_holder.gcode" 12323691
/OLDGCO~1/PLA_VA~1.GCO "PLA_Vase_200um_7H.gcode" 11066083
/OLDGCO~1/PRUSAF~1.GCO "Prusa Filament Guide.gcode" 4618941
/OLDGCO~1/PRUSA_~1.GCO "Prusa_MK2S_Fan-Nozzle.gcode" 2288900
/OLDGCO~1/RODAJX~1.GCO "RodajX.gcode" 792
/OLDGCO~1/RODAJY~1.GCO "RodajY.gcode" 792
/OLDGCO~1/RPI3-B~1.GCO "rpi3-bottom_netfabb.gcode" 4449957
/OLDGCO~1/SCRIPE~1.GCO "scripete_LARGE.gcode" 1220553
/OLDGCO~1/SOLDER~1.GCO "Soldering_Fingers.gcode" 2675301
/OLDGCO~1/SOTVL_~1.GCO "sotvl_Spiral-Vase.gcode" 4941144
/OLDGCO~1/SPIRAL~1.GCO "Spiral_3.gcode" 18607016
/OLDGCO~1/SPOOL_~1.GCO "Spool_Holder_w_Holes_Clips3.gcode" 4371046
/OLDGCO~1/TUBEPV~1.GCO "Tube PVC holder x2.gcode" 4702895
/OLDGCO~1/UNSYMM~1.GCO "Unsymmetric_Lattice_Cube_by_LazerLord10.gcode" 25242018
/OLDGCO~1/UPLOAD~1.GCO "uploads_56_fb_e7_78_b0_GC_Thumbstick_v001.gcode" 1283046
/OLDGCO~1/XYZCAL~1.GCO "xyzCalibration_cube.gcode" 605461
/OLDGCO~1/XYZCAL~2.GCO "xyzCalibration_cube_DENSE_SPE.gcode" 528262
/OLDGCO~1/Y-MOTO~1.GCO "y-motor.gcode" 2955446
DIR_ENTER: /OLDGCO~1/!PC/ "!PC"
/OLDGCO~1/!PC/FAN-NO~1.GCO "fan-nozzle_thermistor_v2.gcode" 807386
/OLDGCO~1/!PC/FAN-NO~2.GCO "fan-nozzle_thermistor_v2_2.gcode" 869352
/OLDGCO~1/!PC/KFACTO~1.GCO "kfactor_PC.gcode" 15126
/OLDGCO~1/!PC/KFACTO~2.GCO "kfactor_PC_v2.gcode" 15153
/OLDGCO~1/!PC/XYZCAL~1.GCO "xyzCalibration_cube v1 PC.gcode" 338335
/OLDGCO~1/!PC/XYZCAL~2.GCO "xyzCalibration_cube v2 PC.gcode" 363907
/OLDGCO~1/!PC/XYZCAL~3.GCO "xyzCalibration_cube v3 PC.gcode" 370883
/OLDGCO~1/!PC/XYZCAL~4.GCO "xyzCalibration_cube v4 PC.gcode" 285344
/OLDGCO~1/!PC/XY7838~1.GCO "xyzCalibration_cube v5 PC.gcode" 409728
/OLDGCO~1/!PC/XY0C4D~1.GCO "xyzCalibration_cube v6 PC.gcode" 409560
DIR_EXIT
DIR_ENTER: /OLDGCO~1/!PETG/ "!PETG"
/OLDGCO~1/!PETG/RAMBO-~1.GCO "Rambo-Cover_MK2.5_Mk2.8_PETG.gcode" 8506637
/OLDGCO~1/!PETG/RAMBO-~2.GCO "Rambo-Cover_MK2.5_PETG.gcode" 10973122
/OLDGCO~1/!PETG/XYZCAL~1.GCO "xyzCalibration_cube_Mk2.8_PETG.gcode" 608424
DIR_EXIT
DIR_ENTER: /OLDGCO~1/!ROBOT~1/ "!Robotica"
DIR_ENTER: /OLDGCO~1/!ROBOT~1/OUTTAKE/ "Outtake"
/OLDGCO~1/!ROBOT~1/OUTTAKE/HOLDER~1.GCO "Holder_out_SPR2.gcode" 3080815
/OLDGCO~1/!ROBOT~1/OUTTAKE/SCORPI~1.GCO "Scorpion_SPR5 (L).gcode" 9967305
/OLDGCO~1/!ROBOT~1/OUTTAKE/SCORPI~2.GCO "Scorpion_SPR5 (R).gcode" 9703984
DIR_EXIT
DIR_EXIT
DIR_ENTER: /OLDGCO~1/CALIBR~1/ "calibration"
/OLDGCO~1/CALIBR~1/KFACTO~1.GCO "kfactor.gcode" 14571
/OLDGCO~1/CALIBR~1/PLA_3D~1.GCO "PLA_3DBenchy_150um_2H.gcode" 5763413
DIR_EXIT
DIR_ENTER: /OLDGCO~1/DADU/ "DADU"
/OLDGCO~1/DADU/SPACE-~1.GCO "Space-Race2018.gcode" 62163047
DIR_EXIT
DIR_ENTER: /OLDGCO~1/MK2.5/ "MK2.5"
/OLDGCO~1/MK2.5/RAMBOC~1.GCO "Rambo case.gcode" 10989039
DIR_EXIT
DIR_ENTER: /OLDGCO~1/MK25SS/ "MK25SS"
/OLDGCO~1/MK25SS/AM-401~1.GCO "am-4018_Stone_MK25SS-Draft.gcode" 1039747
/OLDGCO~1/MK25SS/MK25SS~1.GCO "MK25SS_Bed_Cable_60deg.gcode" 1276088
/OLDGCO~1/MK25SS/X-END-~1.GCO "x-end-motor_MK3.gcode" 6290844
/OLDGCO~1/MK25SS/Y-BELT~1.GCO "y-belt-SET.gcode" 1766091
DIR_EXIT
DIR_ENTER: /OLDGCO~1/MMU/ "MMU"
/OLDGCO~1/MMU/04NOZZ~1.GCO "0.4nozzle_0.2layer_mmu2-selector-finda_v2_m2x_0.2mm_" 4111236
/OLDGCO~1/MMU/2C_SHE~1.GCO "2C_Sheep_2_0.2mm_PLA_MK3SMMU2S_2h44m.gcode" 3868808
/OLDGCO~1/MMU/3C_LIZ~1.GCO "3C_Lizard_1_0.2mm_PLA_MK3SMMU2S_2h32m.gcode" 2128204
/OLDGCO~1/MMU/3DBENC~1.GCO "3DBenchy_-_Dualprint_-_Gunwale_Deck_Plate_Wheel_Fram" 6397378
/OLDGCO~1/MMU/3DBENC~2.GCO "3DBenchy_0.2mm_PLA_MK3SMMU2S_1h35m.gcode" 2934092
/OLDGCO~1/MMU/BOBOMB~1.GCO "Bobomb_Black_0.2mm_PLA_MK3SMMU2S_5h50m.gcode" 5224604
/OLDGCO~1/MMU/MINI-C~1.GCO "mini-cooper-logo-black_0.15mm_PLA_MK3SMMU2S_1h12m.gc" 2170024
/OLDGCO~1/MMU/MINION~1.GCO "MINIONS_NOPVA2_0.2mm_PLA_MK3SMMU2S_15h13m.gcode" 18373087
/OLDGCO~1/MMU/MINION~2.GCO "MINIONS_NOPVA3_0.2mm_PLA_MK3SMMU2S_15h15m.gcode" 18364467
/OLDGCO~1/MMU/MINION~3.GCO "MINIONS_NOPVA_0.2mm_PLA_MK3SMMU2S_15h36m.gcode" 27768035
/OLDGCO~1/MMU/MINION~4.GCO "MINIONS_V1_0.2mm_PLA_MK3SMMU2S_18h48m.gcode" 21773735
/OLDGCO~1/MMU/XYZCAL~1.GCO "xyzCalibration_cube_0.2mm_PLA_MK3SMMU2S_3h5m.gcode" 1135097
DIR_EXIT
DIR_ENTER: /OLDGCO~1/PRUSABOX/ "prusaBox"
/OLDGCO~1/PRUSABOX/DOORKN~1.GCO "Door Knobs PLA.gcode" 817562
/OLDGCO~1/PRUSABOX/MK25_B~1.GCO "MK25_Bed_cover.gcode" 1579602
DIR_ENTER: /OLDGCO~1/PRUSABOX/PRINTED/ "PRINTED"
/OLDGCO~1/PRUSABOX/PRINTED/BOTTOM~1.GCO "Bottom Corners And Hinges.gcode" 20334095
/OLDGCO~1/PRUSABOX/PRINTED/BOTTOM~2.GCO "Bottom Plugs.gcode" 9063265
/OLDGCO~1/PRUSABOX/PRINTED/FILAME~1.GCO "Filament Guide PLA.gcode" 2741239
/OLDGCO~1/PRUSABOX/PRINTED/FILAME~2.GCO "Filament guide.gcode" 2815087
/OLDGCO~1/PRUSABOX/PRINTED/HEATBE~1.GCO "heatbed_cable_cover_45_degree PETG.gcode" 744256
/OLDGCO~1/PRUSABOX/PRINTED/PRUSA_~1.GCO "Prusa_Enclosure_Door_Knob.gcode" 1183865
/OLDGCO~1/PRUSABOX/PRINTED/PRUSA_~2.GCO "prusa_i3mk2_framebrace_v2.gcode" 2467681
/OLDGCO~1/PRUSABOX/PRINTED/PSUCLI~1.GCO "PSU clip.gcode" 579005
/OLDGCO~1/PRUSABOX/PRINTED/PSUHOD~1.GCO "PSU HODL.gcode" 4130563
/OLDGCO~1/PRUSABOX/PRINTED/PSUHOD~2.GCO "PSU HODL_PLA.gcode" 4716194
/OLDGCO~1/PRUSABOX/PRINTED/TOP_1~1.GCO "Top_1.gcode" 5843841
/OLDGCO~1/PRUSABOX/PRINTED/TOP_23~1.GCO "Top_234.gcode" 15644057
/OLDGCO~1/PRUSABOX/PRINTED/TOP_HI~1.GCO "Top_Hinges.gcode" 2838401
DIR_EXIT
DIR_EXIT
DIR_ENTER: /OLDGCO~1/SPOOL/ "SPOOL"
/OLDGCO~1/SPOOL/AXLE_V~1.GCO "Axle_v3.3_0.2mm_PLA_MK3SMMU2S_26m.gcode" 498060
/OLDGCO~1/SPOOL/CLIP_V~1.GCO "Clip_v3.3_0.2mm_PLA_MK3SMMU2S_3m.gcode" 120521
/OLDGCO~1/SPOOL/CLUTCH~1.GCO "Clutch_v3.3_0.2mm_PLA_MK3SMMU2S_1h8m.gcode" 2682264
/OLDGCO~1/SPOOL/HUB_V3~1.GCO "Hub_v3.3_0.2mm_PLA_MK3SMMU2S_4h38m.gcode" 10081488
/OLDGCO~1/SPOOL/NUTCUR~1.GCO "NutCurved_v3.3_0.2mm_PLA_MK3SMMU2S_1h6m.gcode" 2810578
/OLDGCO~1/SPOOL/PLAIND~1.GCO "PlainDial_0.2mm_PLA_MK3SMMU2S_49m.gcode" 1501100
/OLDGCO~1/SPOOL/SPRING~1.GCO "SpringFlat_Stiff_v3.3_0.2mm_PLA_MK3SMMU2S_2h38m.gcod" 7151864
/OLDGCO~1/SPOOL/STAND_~1.GCO "Stand_v3.3_NO_TEXT_0.2mm_PLA_MK3SMMU2S_9h43m.gcode" 11829545
/OLDGCO~1/SPOOL/TUBEHO~1.GCO "TubeHolder_v3.3_0.2mm_PLA_MK3SMMU2S_1h11m.gcode" 2080500
DIR_EXIT
DIR_ENTER: /OLDGCO~1/XBOXWH~1/ "Xbox Wheel"
/OLDGCO~1/XBOXWH~1/FRAME~1.GCO "frame.gcode" 2422421
/OLDGCO~1/XBOXWH~1/RACKAN~1.GCO "rack and pivot.gcode" 1092900
/OLDGCO~1/XBOXWH~1/XBOX_W~1.GCO "XBOX_WHEEL.gcode" 6739435
DIR_EXIT
DIR_EXIT
DIR_ENTER: /SPOOL/ "SPOOL"
/SPOOL/AXLE_V~1.GCO "Axle_v3.3_0.2mm_PLA_MK3SMMU2S_26m.gcode" 498060
/SPOOL/CLIP_V~1.GCO "Clip_v3.3_0.2mm_PLA_MK3SMMU2S_3m.gcode" 120521
/SPOOL/CLUTCH~1.GCO "Clutch_v3.3_0.2mm_PLA_MK3SMMU2S_1h8m.gcode" 2682264
/SPOOL/HUB_V3~1.GCO "Hub_v3.3_0.2mm_PLA_MK3SMMU2S_4h38m.gcode" 10081488
/SPOOL/NUTCUR~1.GCO "NutCurved_v3.3_0.2mm_PLA_MK3SMMU2S_1h6m.gcode" 2810578
/SPOOL/PLAIND~1.GCO "PlainDial_0.2mm_PLA_MK3SMMU2S_49m.gcode" 1501100
/SPOOL/SPRING~1.GCO "SpringFlat_Stiff_v3.3_0.2mm_PLA_MK3SMMU2S_2h38m.gcod" 7151864
/SPOOL/STAND_~1.GCO "Stand_v3.3_NO_TEXT_0.2mm_PLA_MK3SMMU2S_9h43m.gcode" 11829545
/SPOOL/TUBEHO~1.GCO "TubeHolder_v3.3_0.2mm_PLA_MK3SMMU2S_1h11m.gcode" 2080500
DIR_EXIT
DIR_ENTER: /TESTLO~1/ "TEST LONG NAME abcdefghijk"
DIR_EXIT
CARDGL~1.GCO "cardglider_MKB.gcode" 5495588
FASTCR~1.GCO "FastCrash.gcode" 370
GOBILD~1.GCO "Gobilda HTD5 285_MKB_FAST.gcode" 7642784
LATTIC~1.GCO "Lattice_Cube_by_LazerLord10_0.15mm_PLA_MK3SMMU2S_2h1" 9688408
MK3_PL~1.GCO "MK3_PLA_3DBenchy_150um_2H.gcode" 3844567
MK3_PL~2.GCO "MK3_PLA_3DHubs_Marvin_100um_1H_7M.gcode" 2313309
MK3_PL~3.GCO "MK3_PLA_Adalinda_200um_7H_30M.gcode" 23835763
MK3_PL~4.GCO "MK3_PLA_Batman_200um_18M.gcode" 239362
MK6B5B~1.GCO "MK3_PLA_Buddy_150um_2H.gcode" 6136347
MKF5D8~1.GCO "MK3_PLA_Castle_100um_12H_30M.gcode" 25035842
MK57DB~1.GCO "MK3_PLA_Gear_Bearing_150um_2H.gcode" 7839966
MKDA03~1.GCO "MK3_PLA_Nefertiti_150um_7H.gcode" 19928963
MKBC79~1.GCO "MK3_PLA_Prusa_200um_20M.gcode" 320939
MK8F3E~1.GCO "MK3_PLA_PrusaBeerOpener_ColorPrint_200um_50M.gcode" 1169490
MK4837~1.GCO "MK3_PLA_Treefrog_50um_3H_40M.gcode" 10370557
MKAB66~1.GCO "MK3_PLA_Treefrog_150um_variable_1H_25M.gcode" 4042561
MK150C~1.GCO "MK3_PLA_Triceratops_Skull_150um_5H.gcode" 18235410
MKD715~1.GCO "MK3_PLA_Vase_200um_6H_25M.gcode" 7550751
MK027C~1.GCO "MK3_PLA_Whistle_200um_30M.gcode" 796054
MK3_PR~1.GCO "MK3_PRUSA_dual_color.gcode" 409041
OPI3MK~1.GCO "OPI3MK3_duet case bottom.gcode" 5279914
TEST.GCO "TEST.GCO" 27
THE_UL~1.GCO "The_Ultimate_Spool_Holder_v2_0.2mm_PLA_MK3SMMU2S_2h2" 2308374
THUMBN~1.GCO "thumbnail-reset.gcode" 682634
TO_AVO~1.GCO "TO_AVOID_INJURY_0.15mm_PLA_MK3SMMU2S_11h36m.gcode" 24773561
WII.GCO "WII.GCO" 7720
Y-IDLE~1.GCO "y-idler_0.2mm_PETG_MK3S_37m.gcode" 552925
Y-MOTO~1.GCO "y-motor_0.2mm_PETG_MK3S_1h19m.gcode" 2608475
DIR_ENTER: /A1/ "A1"
DIR_ENTER: /A1/B1/ "B1"
/A1/B1/B133ED~1.GCO "B1.gcode" 1135097
DIR_EXIT
DIR_ENTER: /A1/B2/ "B2"
/A1/B2/B2.GCO "B2.GCO" 1135097
DIR_EXIT
DIR_EXIT
DIR_ENTER: /MMU/ "MMU"
/MMU/2C_SHE~1.GCO "2C_Sheep_2_0.2mm_PLA_MK3SMMU2S_2h44m.gcode" 3868808
/MMU/3C_LIZ~1.GCO "3C_Lizard_1_0.2mm_PLA_MK3SMMU2S_2h32m.gcode" 2128204
/MMU/BOBOMB~1.GCO "Bobomb_Black_0.2mm_PLA_MK3SMMU2S_5h50m.gcode" 5224604
/MMU/CLIMBB~1.GCO "Climb Bearing Holder_Slider_PLATG.gcode" 2200912
/MMU/CLIMBB~2.GCO "Climb Bearing Holder_Tetrix_PLATG.gcode" 2016774
/MMU/CUBE_1~1.GCO "Cube_1x1x1_0.15mm_PLA_MK3SMMU2S_4m.gcode" 27510
/MMU/MAR39B~1.GCO "Mar39B0_16_v1.4_PLATG.gcode" 1860297
/MMU/MINI-C~1.GCO "mini-cooper-logo-black_0.15mm_PLA_MK3SMMU2S_1h12m.gc" 2170024
/MMU/MINION~1.GCO "MINIONS_NOPVA2_0.2mm_PLA_MK3SMMU2S_15h13m.gcode" 18373087
/MMU/MINION~2.GCO "MINIONS_NOPVA3_0.2mm_PLA_MK3SMMU2S_15h15m.gcode" 18364467
/MMU/MINION~3.GCO "MINION_BOB_PVAFULL_0.2mm_PLA_MK3SMMU2S_7h37m.gcode" 4938023
/MMU/MINION~4.GCO "MINION_BOB_PVAINTERFACE_0.2mm_PLA_MK3SMMU2S_7h22m.gc" 4676458
/MMU/PLATG_~1.GCO "PLATG_TEST_PART_PLATG.gcode" 441007
/MMU/XYZCAL~1.GCO "xyzCalibration_cube_0.2mm_PLA_MK3SMMU2S_3h5m.gcode" 1135097
DIR_EXIT
End file list
```

Empty directories should probably be filtered by the host software (eg: System Volume Information)

Just 146B more of code! 🎉. RAM consumption is identical

PFW-1144