### PR TITLE
Modify output from M20 to include full filename rather than 8.3 (memory usage unchages

### DIFF
--- a/Firmware/cardreader.cpp
+++ b/Firmware/cardreader.cpp
@@ -117,7 +117,7 @@ void CardReader::lsDive(const char *prepend, SdFile parent, const char * const m
 					case LS_SerialPrint:
 						createFilename(filename, p);
 						SERIAL_PROTOCOL(prepend);
-						SERIAL_PROTOCOL(filename);
+						SERIAL_PROTOCOL(longFilename[0] == '\0' ? filename: longFilename);
 						MYSERIAL.write(' ');
 						SERIAL_PROTOCOLLN(p.fileSize);
 						break;


### PR DESCRIPTION
Alternative to #2934 which does not increase memory usage.  This will only send the full filename, the path will still be in the 8.3 format.  This will not modify the stack usage as compared to master.  This is just using a variable that is already populated when sending the serial message