### PR TITLE
"M27 P" support. Get current file absolute filename (file path)

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -5816,6 +5816,12 @@ if(eSoundMode!=e_SOUND_MODE_SILENT)
 
     /*!
 	### M27 - Get SD status <a href="https://reprap.org/wiki/G-code#M27:_Report_SD_print_status">M27: Report SD print status</a>
+    #### Usage
+	
+	      M27 [ P ]
+	
+	#### Parameters
+	  - `P` - Show full SFN path instead of LFN only.
     */
     case 27:
       card.getStatus(code_seen('P'));

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -5818,7 +5818,7 @@ if(eSoundMode!=e_SOUND_MODE_SILENT)
 	### M27 - Get SD status <a href="https://reprap.org/wiki/G-code#M27:_Report_SD_print_status">M27: Report SD print status</a>
     */
     case 27:
-      card.getStatus(code_seen('L'));
+      card.getStatus(code_seen('P'));
       break;
 
     /*!

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -5818,7 +5818,7 @@ if(eSoundMode!=e_SOUND_MODE_SILENT)
 	### M27 - Get SD status <a href="https://reprap.org/wiki/G-code#M27:_Report_SD_print_status">M27: Report SD print status</a>
     */
     case 27:
-      card.getStatus();
+      card.getStatus(code_seen('L'));
       break;
 
     /*!

--- a/Firmware/cardreader.cpp
+++ b/Firmware/cardreader.cpp
@@ -502,31 +502,38 @@ uint32_t CardReader::getFileSize()
 	return filesize;
 }
 
-void CardReader::getStatus()
+void CardReader::getStatus(bool arg_L)
 {
-  if(sdprinting)
-  {
-      if (isPrintPaused) {
-          SERIAL_PROTOCOLLNPGM("SD print paused");
-      }
-      else if (saved_printing) {
-          SERIAL_PROTOCOLLNPGM("Print saved");
-      }
-      else {
-          SERIAL_PROTOCOLLN(LONGEST_FILENAME);
-          SERIAL_PROTOCOLRPGM(_N("SD printing byte "));////MSG_SD_PRINTING_BYTE
-          SERIAL_PROTOCOL(sdpos);
-          SERIAL_PROTOCOL('/');
-          SERIAL_PROTOCOLLN(filesize);
-          uint16_t time = ( _millis() - starttime ) / 60000U;
-          SERIAL_PROTOCOL(itostr2(time/60));
-          SERIAL_PROTOCOL(':');
-          SERIAL_PROTOCOLLN(itostr2(time%60));
-      }
-  }
-  else {
-    SERIAL_PROTOCOLLNPGM("Not SD printing");
-  }
+    if (isPrintPaused)
+    {
+        if (saved_printing && (saved_printing_type == PRINTING_TYPE_SD))
+            SERIAL_PROTOCOLLNPGM("SD print paused");
+        else
+            SERIAL_PROTOCOLLNPGM("Print saved");
+    }
+    else if (sdprinting)
+    {
+        if (arg_L)
+        {
+            SERIAL_PROTOCOL('/');
+            for (uint8_t i = 0; i < getWorkDirDepth(); i++)
+                printf_P(PSTR("%s/"), dir_names[i]);
+            puts(filename);
+        }
+        else
+            SERIAL_PROTOCOLLN(LONGEST_FILENAME);
+        
+        SERIAL_PROTOCOLRPGM(_N("SD printing byte "));////MSG_SD_PRINTING_BYTE
+        SERIAL_PROTOCOL(sdpos);
+        SERIAL_PROTOCOL('/');
+        SERIAL_PROTOCOLLN(filesize);
+        uint16_t time = ( _millis() - starttime ) / 60000U;
+        SERIAL_PROTOCOL(itostr2(time/60));
+        SERIAL_PROTOCOL(':');
+        SERIAL_PROTOCOLLN(itostr2(time%60));
+    }
+    else
+        SERIAL_PROTOCOLLNPGM("Not SD printing");
 }
 void CardReader::write_command(char *buf)
 {

--- a/Firmware/cardreader.cpp
+++ b/Firmware/cardreader.cpp
@@ -502,7 +502,7 @@ uint32_t CardReader::getFileSize()
 	return filesize;
 }
 
-void CardReader::getStatus(bool arg_L)
+void CardReader::getStatus(bool arg_P)
 {
     if (isPrintPaused)
     {
@@ -513,7 +513,7 @@ void CardReader::getStatus(bool arg_L)
     }
     else if (sdprinting)
     {
-        if (arg_L)
+        if (arg_P)
         {
             SERIAL_PROTOCOL('/');
             for (uint8_t i = 0; i < getWorkDirDepth(); i++)

--- a/Firmware/cardreader.h
+++ b/Firmware/cardreader.h
@@ -26,7 +26,7 @@ public:
   void release();
   void startFileprint();
   uint32_t getFileSize();
-  void getStatus();
+  void getStatus(bool arg_L);
   void printingHasFinished();
 
   void getfilename(uint16_t nr, const char* const match=NULL);

--- a/Firmware/cardreader.h
+++ b/Firmware/cardreader.h
@@ -26,7 +26,7 @@ public:
   void release();
   void startFileprint();
   uint32_t getFileSize();
-  void getStatus(bool arg_L);
+  void getStatus(bool arg_P);
   void printingHasFinished();
 
   void getfilename(uint16_t nr, const char* const match=NULL);


### PR DESCRIPTION
Refactored M27 as to be able to actually get `SD print paused` and `Print saved` as responses.
It works like this now:
`M27` without any arguments works just like before (same response format):
- When a file is being printed, the LFN (but without directory structure) is reported back alongside progress and time since start.
- When an SD print is paused, `SD print paused` is returned instead of `Not SD printing`
- When a USB print is paused, `Print saved` is returned.
- When USB printing or not printing at all, `Not SD printing` is returned.

`M27 P` works the same as without the `P` parameter, with the only exception that the the filename is SFN only and it also includes the full directory structure up to the printed file (file path).