### PR TITLE
DIR depth adjustments

### DIFF
--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -352,7 +352,7 @@ extern bool mesh_bed_run_from_menu;
 
 extern bool sortAlpha;
 
-extern char dir_names[3][9];
+extern char dir_names[MAX_DIR_DEPTH][9];
 
 extern int8_t lcd_change_fil_state;
 // save/restore printing

--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -352,7 +352,7 @@ extern bool mesh_bed_run_from_menu;
 
 extern bool sortAlpha;
 
-extern char dir_names[MAX_DIR_DEPTH][9];
+extern char dir_names[][9];
 
 extern int8_t lcd_change_fil_state;
 // save/restore printing

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -228,7 +228,7 @@ bool fan_state[2];
 int fan_edge_counter[2];
 int fan_speed[2];
 
-char dir_names[3][9];
+char dir_names[MAX_DIR_DEPTH][9];
 
 bool sortAlpha = false;
 

--- a/Firmware/cardreader.h
+++ b/Firmware/cardreader.h
@@ -3,7 +3,7 @@
 
 #ifdef SDSUPPORT
 
-#define MAX_DIR_DEPTH 10
+#define MAX_DIR_DEPTH 6
 
 #include "SdFile.h"
 enum LsAction {LS_SerialPrint,LS_SerialPrint_LFN,LS_Count,LS_GetFilename};


### PR DESCRIPTION
Changed MAX_DIR_DEPTH from 10 to 6. It makes sense to reduce it a bit due to limitations in the cmdqueue.
fixed the dir_names array definition to stay true to the macro.