### PR TITLE
Ignore button long-press event, if not allowed

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -8048,7 +8048,7 @@ void menu_lcd_longpress_func(void)
     // explicitely listed menus which are allowed to rise the move-z or live-adj-z functions
     // The lists are not the same for both functions, so first decide which function is to be performed
     if ( (moves_planned() || IS_SD_PRINTING || usb_timer.running() )){ // long press as live-adj-z
-        if(( current_position[Z_AXIS] < Z_HEIGHT_HIDE_LIVE_ADJUST_MENU ) // only allow live-adj-z up to 2mm of print height
+        if (( current_position[Z_AXIS] < Z_HEIGHT_HIDE_LIVE_ADJUST_MENU ) // only allow live-adj-z up to 2mm of print height
         && ( menu_menu == lcd_status_screen // and in listed menus...
           || menu_menu == lcd_main_menu
           || menu_menu == lcd_tune_menu
@@ -8058,12 +8058,10 @@ void menu_lcd_longpress_func(void)
             lcd_clear();
             menu_submenu(lcd_babystep_z);
         } else {
-            // otherwise consume the long press as normal click
-            if( menu_menu != lcd_status_screen )
-                menu_back();
+            lcd_quick_feedback();
         }
     } else { // long press as move-z
-        if(menu_menu == lcd_status_screen
+        if (menu_menu == lcd_status_screen
         || menu_menu == lcd_main_menu
         || menu_menu == lcd_preheat_menu
         || menu_menu == lcd_sdcard_menu
@@ -8076,9 +8074,7 @@ void menu_lcd_longpress_func(void)
         ){
             menu_submenu(lcd_move_z);
         } else {
-            // otherwise consume the long press as normal click
-            if( menu_menu != lcd_status_screen )
-                menu_back();
+            lcd_quick_feedback();
         }
     }
 }


### PR DESCRIPTION
The button of the printer can register two kind of events:
- the click, which is triggered when the button is released after a short press
- the long-press, which at certain screens is triggered when the button is pressed continuously for some time.

At the screens where the long-press event is not allowed, currently the code executes the menu_back() method. This seems to breaks the functionality of some screens. For example, if the button is long-pressed during the preheating phase of the Load filament menu (which is a modal screen), then the user is returned to the previous menu and is not any more able to Cancel the preheat, not even by selecting again the Load filament menu.

This PR, simply ignores the long-press event where it is not allowed. This is a more natural behavior, since the button always triggers a click event (independently of the keypress duration), except for the screens where we want to trigger the long keypress functionality.
