### PR TITLE
PFW-910 Add remaining time to change/pause/user interaction to LCD Info screen

### DIFF
--- a/Firmware/Configuration.h
+++ b/Firmware/Configuration.h
@@ -17,7 +17,7 @@ extern PGM_P sPrinterName;
 
 // Firmware version
 #define FW_VERSION "3.9.3"
-#define FW_COMMIT_NR 3556
+#define FW_COMMIT_NR 5002
 // FW_VERSION_UNKNOWN means this is an unofficial build.
 // The firmware should only be checked into github with this symbol.
 #define FW_DEV_VERSION FW_VERSION_UNKNOWN

--- a/Firmware/Configuration.h
+++ b/Firmware/Configuration.h
@@ -17,7 +17,7 @@ extern PGM_P sPrinterName;
 
 // Firmware version
 #define FW_VERSION "3.9.3"
-#define FW_COMMIT_NR 5002
+#define FW_COMMIT_NR 3556
 // FW_VERSION_UNKNOWN means this is an unofficial build.
 // The firmware should only be checked into github with this symbol.
 #define FW_DEV_VERSION FW_VERSION_UNKNOWN

--- a/Firmware/Configuration_adv.h
+++ b/Firmware/Configuration_adv.h
@@ -339,10 +339,9 @@ const unsigned int dropsegments=5; //everything with less than this number of st
 //#define HEATERS_PARALLEL
 
 //LCD status clock interval timer to switch between
-// print time
 // remaining print time
 // and time to change/pause/interaction
-#define CLOCK_INTERVAL_TIME 5000
+#define CLOCK_INTERVAL_TIME 5
 
 //===========================================================================
 //=============================Buffers           ============================

--- a/Firmware/Configuration_adv.h
+++ b/Firmware/Configuration_adv.h
@@ -338,6 +338,12 @@ const unsigned int dropsegments=5; //everything with less than this number of st
 // Control heater 0 and heater 1 in parallel.
 //#define HEATERS_PARALLEL
 
+//LCD status clock interval timer to switch between
+// print time
+// remaining print time
+// and time to change/pause/interaction
+#define CLOCK_INTERVAL_TIME 5000
+
 //===========================================================================
 //=============================Buffers           ============================
 //===========================================================================

--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -366,7 +366,8 @@ extern uint8_t print_percent_done_normal;
 extern uint16_t print_time_remaining_normal;
 extern uint8_t print_percent_done_silent;
 extern uint16_t print_time_remaining_silent;
-extern uint16_t print_time_to_change;
+extern uint16_t print_time_to_change_normal;
+extern uint16_t print_time_to_change_silent;
 
 #define PRINT_TIME_REMAINING_INIT 0xffff
 

--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -438,8 +438,6 @@ extern void cancel_saved_printing();
 
 
 //estimated time to end of the print
-extern uint16_t print_time_remaining();
-extern uint16_t print_time_to_change_remaining();
 extern uint8_t calc_percent_done();
 
 

--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -366,6 +366,7 @@ extern uint8_t print_percent_done_normal;
 extern uint16_t print_time_remaining_normal;
 extern uint8_t print_percent_done_silent;
 extern uint16_t print_time_remaining_silent;
+extern uint16_t print_time_to_change;
 
 #define PRINT_TIME_REMAINING_INIT 0xffff
 
@@ -438,6 +439,7 @@ extern void cancel_saved_printing();
 
 //estimated time to end of the print
 extern uint16_t print_time_remaining();
+extern uint16_t print_time_to_change_remaining();
 extern uint8_t calc_percent_done();
 
 

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -11677,7 +11677,7 @@ uint16_t print_time_remaining() {
 
 uint16_t print_time_to_change_remaining() {
 	uint16_t print_t = PRINT_TIME_REMAINING_INIT;
-/#ifdef TMC2130 
+#ifdef TMC2130 
 	if (SilentModeMenu == SILENT_MODE_OFF) print_t = print_time_to_change;
   else print_t = print_time_to_change - (print_time_remaining_normal - print_time_remaining_silent);
 #else

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -316,7 +316,8 @@ uint8_t print_percent_done_normal = PRINT_PERCENT_DONE_INIT;
 uint16_t print_time_remaining_normal = PRINT_TIME_REMAINING_INIT; //estimated remaining print time in minutes
 uint8_t print_percent_done_silent = PRINT_PERCENT_DONE_INIT;
 uint16_t print_time_remaining_silent = PRINT_TIME_REMAINING_INIT; //estimated remaining print time in minutes
-uint16_t print_time_to_change = PRINT_TIME_REMAINING_INIT; //estimated remaining time to next change in minutes
+uint16_t print_time_to_change_normal = PRINT_TIME_REMAINING_INIT; //estimated remaining time to next change in minutes
+uint16_t print_time_to_change_silent = PRINT_TIME_REMAINING_INIT; //estimated remaining time to next change in minutes
 
 uint32_t IP_address = 0;
 
@@ -6419,11 +6420,13 @@ Sigma_Exit:
       printf_P(_msg_mode_done_remain, _N("SILENT"), int(print_percent_done_silent), print_time_remaining_silent);
     }
 
-    print_time_to_change = PRINT_TIME_REMAINING_INIT;
-    if(code_seen('C')) 
+    if(code_seen('C')) print_time_to_change_normal = code_value();
+    if(code_seen('D')) print_time_to_change_silent = code_value();
+    
     {
-      print_time_to_change = code_value();
-      printf_P(_N("Change in mins: %d\n"), print_time_to_change);
+      const char* _msg_mode_done_remain = _N("%S MODE: Change in mins: %d\n");
+      printf_P(_msg_mode_done_remain, _N("NORMAL"), print_time_to_change_normal);
+      printf_P(_msg_mode_done_remain, _N("SILENT"), print_time_to_change_silent);
     }
     break;
   }
@@ -11696,7 +11699,8 @@ static void print_time_remaining_init()
     print_percent_done_normal = PRINT_PERCENT_DONE_INIT;
     print_time_remaining_silent = PRINT_TIME_REMAINING_INIT;
     print_percent_done_silent = PRINT_PERCENT_DONE_INIT;
-    print_time_to_change = PRINT_TIME_REMAINING_INIT;
+    print_time_to_change_normal = PRINT_TIME_REMAINING_INIT;
+    print_time_to_change_silent = PRINT_TIME_REMAINING_INIT;
 }
 
 void load_filament_final_feed()

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -6393,43 +6393,37 @@ Sigma_Exit:
 #endif		// Z_PROBE_REPEATABILITY_TEST 
 #endif		// ENABLE_AUTO_BED_LEVELING
 
-  /*!
-  ### M73 - Set/get print progress <a href="https://reprap.org/wiki/G-code#M73:_Set.2FGet_build_percentage">M73: Set/Get build percentage</a>
-  #### Usage
-  
-      M73 [ P | R | Q | S | C ]
-
-  #### Parameters
-    - `P` - Percent in normal mode
-    - `R` - Time remaining in normal mode
-    - `Q` - Percent in silent mode
-    - `S` - Time in silent mode
-    - `C` - Time to change/pause/user interaction
-  */
-  //!@todo update RepRap Gcode wiki
-  case 73: //M73 show percent done and time remaining
-  {	
-    if(code_seen('P')) print_percent_done_normal = code_value();
-    if(code_seen('R')) print_time_remaining_normal = code_value();
-    if(code_seen('Q')) print_percent_done_silent = code_value();
-    if(code_seen('S')) print_time_remaining_silent = code_value();
-
-    {
-      const char* _msg_mode_done_remain = _N("%S MODE: Percent done: %d; print time remaining in mins: %d\n");
-      printf_P(_msg_mode_done_remain, _N("NORMAL"), int(print_percent_done_normal), print_time_remaining_normal);
-      printf_P(_msg_mode_done_remain, _N("SILENT"), int(print_percent_done_silent), print_time_remaining_silent);
-    }
-
-    if(code_seen('C')) print_time_to_change_normal = code_value();
-    if(code_seen('D')) print_time_to_change_silent = code_value();
+    /*!
+    ### M73 - Set/get print progress <a href="https://reprap.org/wiki/G-code#M73:_Set.2FGet_build_percentage">M73: Set/Get build percentage</a>
+    #### Usage
     
+        M73 [ P | R | Q | S | C | D ]
+
+    #### Parameters
+        - `P` - Percent in normal mode
+        - `R` - Time remaining in normal mode
+        - `Q` - Percent in silent mode
+        - `S` - Time in silent mode
+        - `C` - Time to change/pause/user interaction in normal mode
+        - `D` - Time to change/pause/user interaction in silent mode
+    */
+    //!@todo update RepRap Gcode wiki
+    case 73: //M73 show percent done, time remaining and time to change/pause
     {
-      const char* _msg_mode_done_remain = _N("%S MODE: Change in mins: %d\n");
-      printf_P(_msg_mode_done_remain, _N("NORMAL"), print_time_to_change_normal);
-      printf_P(_msg_mode_done_remain, _N("SILENT"), print_time_to_change_silent);
+        if(code_seen('P')) print_percent_done_normal = code_value();
+        if(code_seen('R')) print_time_remaining_normal = code_value();
+        if(code_seen('Q')) print_percent_done_silent = code_value();
+        if(code_seen('S')) print_time_remaining_silent = code_value();
+        if(code_seen('C')) print_time_to_change_normal = code_value();
+        if(code_seen('D')) print_time_to_change_silent = code_value();
+
+    {
+        const char* _msg_mode_done_remain = _N("%S MODE: Percent done: %d; print time remaining in mins: %d; Change in mins: %d\n");
+        printf_P(_msg_mode_done_remain, _N("NORMAL"), int(print_percent_done_normal), print_time_remaining_normal, print_time_to_change_normal);
+        printf_P(_msg_mode_done_remain, _N("SILENT"), int(print_percent_done_silent), print_time_remaining_silent, print_time_to_change_silent);
     }
-    break;
-  }
+        break;
+    }
     /*!
 	### M104 - Set hotend temperature <a href="https://reprap.org/wiki/G-code#M104:_Set_Extruder_Temperature">M104: Set Extruder Temperature</a>
 	#### Usage

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -6392,40 +6392,41 @@ Sigma_Exit:
 #endif		// Z_PROBE_REPEATABILITY_TEST 
 #endif		// ENABLE_AUTO_BED_LEVELING
 
-	/*!
-	### M73 - Set/get print progress <a href="https://reprap.org/wiki/G-code#M73:_Set.2FGet_build_percentage">M73: Set/Get build percentage</a>
-	#### Usage
-    
-	    M73 [ P | R | Q | S | C ]
-    
-	#### Parameters
+  /*!
+  ### M73 - Set/get print progress <a href="https://reprap.org/wiki/G-code#M73:_Set.2FGet_build_percentage">M73: Set/Get build percentage</a>
+  #### Usage
+  
+      M73 [ P | R | Q | S | C ]
+
+  #### Parameters
     - `P` - Percent in normal mode
     - `R` - Time remaining in normal mode
     - `Q` - Percent in silent mode
     - `S` - Time in silent mode
     - `C` - Time to change/pause/user interaction
-   */
-	case 73: //M73 show percent done and time remaining
-		if(code_seen('P')) print_percent_done_normal = code_value();
-		if(code_seen('R')) print_time_remaining_normal = code_value();
-		if(code_seen('Q')) print_percent_done_silent = code_value();
-		if(code_seen('S')) print_time_remaining_silent = code_value();
+  */
+  //!@todo update RepRap Gcode wiki
+  case 73: //M73 show percent done and time remaining
+  {	
+    if(code_seen('P')) print_percent_done_normal = code_value();
+    if(code_seen('R')) print_time_remaining_normal = code_value();
+    if(code_seen('Q')) print_percent_done_silent = code_value();
+    if(code_seen('S')) print_time_remaining_silent = code_value();
 
-		{
-			const char* _msg_mode_done_remain = _N("%S MODE: Percent done: %d; print time remaining in mins: %d\n");
-			printf_P(_msg_mode_done_remain, _N("NORMAL"), int(print_percent_done_normal), print_time_remaining_normal);
-			printf_P(_msg_mode_done_remain, _N("SILENT"), int(print_percent_done_silent), print_time_remaining_silent);
-		}
+    {
+      const char* _msg_mode_done_remain = _N("%S MODE: Percent done: %d; print time remaining in mins: %d\n");
+      printf_P(_msg_mode_done_remain, _N("NORMAL"), int(print_percent_done_normal), print_time_remaining_normal);
+      printf_P(_msg_mode_done_remain, _N("SILENT"), int(print_percent_done_silent), print_time_remaining_silent);
+    }
 
     print_time_to_change = PRINT_TIME_REMAINING_INIT;
- 		if(code_seen('C')) 
+    if(code_seen('C')) 
     {
       print_time_to_change = code_value();
-		  printf_P(_N("Time to next change in mins: %d\n"), print_time_to_change);
-	  }
-
-		break;
-
+      printf_P(_N("Time to next change in mins: %d\n"), print_time_to_change);
+    }
+    break;
+  }
     /*!
 	### M104 - Set hotend temperature <a href="https://reprap.org/wiki/G-code#M104:_Set_Extruder_Temperature">M104: Set Extruder Temperature</a>
 	#### Usage
@@ -11663,50 +11664,56 @@ void print_mesh_bed_leveling_table()
   SERIAL_ECHOLN();
 }
 
-uint16_t print_time_remaining() {
-	uint16_t print_t = PRINT_TIME_REMAINING_INIT;
+uint16_t print_time_remaining()
+{
+  uint16_t print_t = PRINT_TIME_REMAINING_INIT;
 #ifdef TMC2130 
-	if (SilentModeMenu == SILENT_MODE_OFF) print_t = print_time_remaining_normal;
-	else print_t = print_time_remaining_silent;
+  if (SilentModeMenu == SILENT_MODE_OFF) print_t = print_time_remaining_normal;
+  else print_t = print_time_remaining_silent;
 #else
-	print_t = print_time_remaining_normal;
+  print_t = print_time_remaining_normal;
 #endif //TMC2130
-	if ((print_t != PRINT_TIME_REMAINING_INIT) && (feedmultiply != 0)) print_t = 100ul * print_t / feedmultiply;
-	return print_t;
+  if ((print_t != PRINT_TIME_REMAINING_INIT) && (feedmultiply != 0)) print_t = 100ul * print_t / feedmultiply;
+  return print_t;
 }
 
-uint16_t print_time_to_change_remaining() {
-	uint16_t print_t = PRINT_TIME_REMAINING_INIT;
+uint16_t print_time_to_change_remaining()
+{
+  uint16_t print_t = PRINT_TIME_REMAINING_INIT;
 #ifdef TMC2130 
-	if (SilentModeMenu == SILENT_MODE_OFF) print_t = print_time_to_change;
+  if (SilentModeMenu == SILENT_MODE_OFF) print_t = print_time_to_change;
   else print_t = print_time_to_change - (print_time_remaining_normal - print_time_remaining_silent);
 #else
   print_t = print_time_to_change;
 #endif //TMC2130
-	if ((print_t != PRINT_TIME_REMAINING_INIT) && (feedmultiply != 0)) print_t = 100ul * print_t / feedmultiply;
-	return print_t;
+  if ((print_t != PRINT_TIME_REMAINING_INIT) && (feedmultiply != 0)) print_t = 100ul * print_t / feedmultiply;
+  return print_t;
 }
 
 uint8_t calc_percent_done()
 {
-	//in case that we have information from M73 gcode return percentage counted by slicer, else return percentage counted as byte_printed/filesize
-	uint8_t percent_done = 0;
+  //in case that we have information from M73 gcode return percentage counted by slicer, else return percentage counted as byte_printed/filesize
+  uint8_t percent_done = 0;
 #ifdef TMC2130
-	if (SilentModeMenu == SILENT_MODE_OFF && print_percent_done_normal <= 100) {
-		percent_done = print_percent_done_normal;
-	}
-	else if (print_percent_done_silent <= 100) {
+  if (SilentModeMenu == SILENT_MODE_OFF && print_percent_done_normal <= 100)
+  {
+    percent_done = print_percent_done_normal;
+  }
+	else if (print_percent_done_silent <= 100)
+  {
 		percent_done = print_percent_done_silent;
 	}
 #else
-	if (print_percent_done_normal <= 100) {
+	if (print_percent_done_normal <= 100)
+  {
 		percent_done = print_percent_done_normal;
 	}
 #endif //TMC2130
-	else {
-		percent_done = card.percentDone();
-	}
-	return percent_done;
+  else
+  {
+    percent_done = card.percentDone();
+  }
+  return percent_done;
 }
 
 static void print_time_remaining_init()

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -11663,28 +11663,28 @@ void print_mesh_bed_leveling_table()
 
 uint8_t calc_percent_done()
 {
-  //in case that we have information from M73 gcode return percentage counted by slicer, else return percentage counted as byte_printed/filesize
-  uint8_t percent_done = 0;
+    //in case that we have information from M73 gcode return percentage counted by slicer, else return percentage counted as byte_printed/filesize
+    uint8_t percent_done = 0;
 #ifdef TMC2130
-  if (SilentModeMenu == SILENT_MODE_OFF && print_percent_done_normal <= 100)
-  {
-    percent_done = print_percent_done_normal;
-  }
-	else if (print_percent_done_silent <= 100)
-  {
-		percent_done = print_percent_done_silent;
-	}
+    if (SilentModeMenu == SILENT_MODE_OFF && print_percent_done_normal <= 100)
+    {
+        percent_done = print_percent_done_normal;
+    }
+    else if (print_percent_done_silent <= 100)
+    {
+        percent_done = print_percent_done_silent;
+    }
 #else
-	if (print_percent_done_normal <= 100)
-  {
-		percent_done = print_percent_done_normal;
-	}
+    if (print_percent_done_normal <= 100)
+    {
+        percent_done = print_percent_done_normal;
+    }
 #endif //TMC2130
-  else
-  {
-    percent_done = card.percentDone();
-  }
-  return percent_done;
+    else
+    {
+        percent_done = card.percentDone();
+    }
+    return percent_done;
 }
 
 static void print_time_remaining_init()

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -11677,12 +11677,12 @@ uint16_t print_time_remaining() {
 
 uint16_t print_time_to_change_remaining() {
 	uint16_t print_t = PRINT_TIME_REMAINING_INIT;
-//#ifdef TMC2130 
-//	if (SilentModeMenu == SILENT_MODE_OFF) print_t = print_time_to_change;
-//  else print_t = print_time_to_change - (print_time_remaining_normal - print_time_remaining_silent);
-//#else
+/#ifdef TMC2130 
+	if (SilentModeMenu == SILENT_MODE_OFF) print_t = print_time_to_change;
+  else print_t = print_time_to_change - (print_time_remaining_normal - print_time_remaining_silent);
+#else
   print_t = print_time_to_change;
-//#endif //TMC2130
+#endif //TMC2130
 	if ((print_t != PRINT_TIME_REMAINING_INIT) && (feedmultiply != 0)) print_t = 100ul * print_t / feedmultiply;
 	return print_t;
 }

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -6423,7 +6423,7 @@ Sigma_Exit:
     if(code_seen('C')) 
     {
       print_time_to_change = code_value();
-      printf_P(_N("Time to next change in mins: %d\n"), print_time_to_change);
+      printf_P(_N("Change in mins: %d\n"), print_time_to_change);
     }
     break;
   }
@@ -11662,32 +11662,6 @@ void print_mesh_bed_leveling_table()
       SERIAL_ECHO(' ');
     }
   SERIAL_ECHOLN();
-}
-
-uint16_t print_time_remaining()
-{
-  uint16_t print_t = PRINT_TIME_REMAINING_INIT;
-#ifdef TMC2130 
-  if (SilentModeMenu == SILENT_MODE_OFF) print_t = print_time_remaining_normal;
-  else print_t = print_time_remaining_silent;
-#else
-  print_t = print_time_remaining_normal;
-#endif //TMC2130
-  if ((print_t != PRINT_TIME_REMAINING_INIT) && (feedmultiply != 0)) print_t = 100ul * print_t / feedmultiply;
-  return print_t;
-}
-
-uint16_t print_time_to_change_remaining()
-{
-  uint16_t print_t = PRINT_TIME_REMAINING_INIT;
-#ifdef TMC2130 
-  if (SilentModeMenu == SILENT_MODE_OFF) print_t = print_time_to_change;
-  else print_t = print_time_to_change - (print_time_remaining_normal - print_time_remaining_silent);
-#else
-  print_t = print_time_to_change;
-#endif //TMC2130
-  if ((print_t != PRINT_TIME_REMAINING_INIT) && (feedmultiply != 0)) print_t = 100ul * print_t / feedmultiply;
-  return print_t;
 }
 
 uint8_t calc_percent_done()

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -57,7 +57,7 @@
 
 int scrollstuff = 0;
 char longFilenameOLD[LONG_FILENAME_LENGTH];
-
+int clock_interval = 0;
 
 static void lcd_sd_updir();
 static void lcd_mesh_bed_leveling_settings();
@@ -680,53 +680,58 @@ void lcdui_print_time(void)
         uint16_t print_tc = 0;
         char suff = ' ';
         char suff_doubt = ' ';
-        static ShortTimer IntervalTimer;
 
-
-        #ifdef TMC2130
+#ifdef TMC2130
         if (SilentModeMenu != SILENT_MODE_OFF)
         {
             if (print_time_remaining_silent != PRINT_TIME_REMAINING_INIT)
             {
                 print_tr = print_time_remaining_silent;
             }
+//#ifdef CLOCK_INTERVAL_TIME
             if (print_time_to_change_silent != PRINT_TIME_REMAINING_INIT)
             {
                 print_tc = print_time_to_change_silent;
             }
+//#endif //CLOCK_INTERVAL_TIME
         }
         else
         {
-        #endif //TMC2130
+#endif //TMC2130
             if (print_time_remaining_normal != PRINT_TIME_REMAINING_INIT)
             {
                 print_tr = print_time_remaining_normal;
             }
+//#ifdef CLOCK_INTERVAL_TIME
             if (print_time_to_change_normal != PRINT_TIME_REMAINING_INIT)
             {
                 print_tc = print_time_to_change_normal;
             }
-        #ifdef TMC2130
+//#endif //CLOCK_INTERVAL_TIME
+#ifdef TMC2130
         }
-        #endif //TMC2130
+#endif //TMC2130
 
+//#ifdef CLOCK_INTERVAL_TIME
+        if (clock_interval == CLOCK_INTERVAL_TIME*2)
+        {
+            clock_interval = 0;
+        }
+        clock_interval++;
+
+        if (print_tc != 0 && clock_interval > CLOCK_INTERVAL_TIME)
+        {
+            print_t = print_tc;
+            suff = 'C';
+        }
+        else
+//#endif //CLOCK_INTERVAL_TIME 
         if (print_tr != 0)
         {
             print_t = print_tr;
             suff = 'R';
         }
-
-        if (print_tc != 0)
-        {
-            if (IntervalTimer.expired(CLOCK_INTERVAL_TIME))
-            {
-                print_t = print_tc;
-                suff = 'C';
-                IntervalTimer.start();
-            }
-        }
-
-        if (print_tr == 0)
+        else
         {
             print_t = _millis() / 60000 - starttime / 60000; 
         }

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -672,30 +672,37 @@ void lcdui_print_cmd_diag(void)
 void lcdui_print_time(void)
 {
     //if remaining print time estimation is available print it else print elapsed time
-    uint16_t print_t = 0;
     int chars = 0;
-    char suff = ' ';
-    char suff_doubt = ' ';
+    if ((PRINTER_ACTIVE) && (starttime != 0))
+    {
+        uint16_t print_t = 0;
+        char suff = ' ';
+        char suff_doubt = ' ';
 
-    if(print_time_to_change != PRINT_TIME_REMAINING_INIT)
-    {
-        print_t = print_time_to_change_remaining();
-        suff = 'C';
+        if (print_time_to_change != PRINT_TIME_REMAINING_INIT)
+        {
+            print_t = print_time_to_change;
+            suff = 'C';
+        }
+        else
+        {
+            suff = 'R';
+        #ifdef TMC2130
+        if (print_time_remaining_silent != PRINT_TIME_REMAINING_INIT && (SilentModeMenu != SILENT_MODE_OFF))
+        {
+            print_t = print_time_remaining_silent;
+        }
+        else
+        #endif //TMC2130
+            print_t = print_time_remaining_normal;
+        }
+		
         if (feedmultiply != 100)
+        {
             suff_doubt = '?';
-    }
-    else if (print_time_remaining_normal != PRINT_TIME_REMAINING_INIT)
-    {
-        print_t = print_time_remaining();
-        suff = 'R';
-        if (feedmultiply != 100)
-            suff_doubt = '?';
-    }
-    else if(starttime != 0)
-        print_t = _millis() / 60000 - starttime / 60000;
-
-    if ((PRINTER_ACTIVE) && ((print_time_remaining_normal != PRINT_TIME_REMAINING_INIT) || (print_time_to_change != PRINT_TIME_REMAINING_INIT) || (starttime != 0)))
-    {
+            print_t = 100ul * print_t / feedmultiply;
+        }
+		
         if (print_t < 6000) //time<100h
             chars = lcd_printf_P(_N("%c%02u:%02u%c%c"), LCD_STR_CLOCK[0], print_t / 60, print_t % 60, suff, suff_doubt);
         else //time>=100h

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -718,8 +718,12 @@ void lcdui_print_time(void)
             print_t = print_tr;
             suff = 'R';
         }
+        else
+        {
+            print_t = _millis() / 60000 - starttime / 60000; 
+        }
 
-        if (feedmultiply != 100)
+        if (feedmultiply != 100 && (print_tc != 0 || print_tr !=0))
         {
             suff_doubt = '?';
             print_t = 100ul * print_t / feedmultiply;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -671,39 +671,39 @@ void lcdui_print_cmd_diag(void)
 // Print time (8 chars total)
 void lcdui_print_time(void)
 {
-	//if remaining print time estimation is available print it else print elapsed time
-	uint16_t print_t = 0;
-	int chars = 0;
+    //if remaining print time estimation is available print it else print elapsed time
+    uint16_t print_t = 0;
+    int chars = 0;
     char suff = ' ';
     char suff_doubt = ' ';
 
-	if(print_time_to_change != PRINT_TIME_REMAINING_INIT)
-	{
-		print_t = print_time_to_change_remaining();
-		suff = 'C';
-		if (feedmultiply != 100)
-                    suff_doubt = '?';
-	}
-	else if (print_time_remaining_normal != PRINT_TIME_REMAINING_INIT)
-	{
-		print_t = print_time_remaining();
-		suff = 'R';
-		if (feedmultiply != 100)
-                    suff_doubt = '?';
-	}
-	else if(starttime != 0)
-		print_t = _millis() / 60000 - starttime / 60000;
+    if(print_time_to_change != PRINT_TIME_REMAINING_INIT)
+    {
+        print_t = print_time_to_change_remaining();
+        suff = 'C';
+        if (feedmultiply != 100)
+            suff_doubt = '?';
+    }
+    else if (print_time_remaining_normal != PRINT_TIME_REMAINING_INIT)
+    {
+        print_t = print_time_remaining();
+        suff = 'R';
+        if (feedmultiply != 100)
+            suff_doubt = '?';
+    }
+    else if(starttime != 0)
+        print_t = _millis() / 60000 - starttime / 60000;
 
-	if ((PRINTER_ACTIVE) && ((print_time_remaining_normal != PRINT_TIME_REMAINING_INIT) || (print_time_to_change != PRINT_TIME_REMAINING_INIT) || (starttime != 0)))
-	{
- 		if (print_t < 6000) //time<100h
-			chars = lcd_printf_P(_N("%c%02u:%02u%c%c"), LCD_STR_CLOCK[0], print_t / 60, print_t % 60, suff, suff_doubt);
-		else //time>=100h
-			chars = lcd_printf_P(_N("%c%3uh %c%c"), LCD_STR_CLOCK[0], print_t / 60, suff, suff_doubt);
-	}
-	else
-		chars = lcd_printf_P(_N("%c--:--  "), LCD_STR_CLOCK[0]);
-	lcd_space(8 - chars);
+    if ((PRINTER_ACTIVE) && ((print_time_remaining_normal != PRINT_TIME_REMAINING_INIT) || (print_time_to_change != PRINT_TIME_REMAINING_INIT) || (starttime != 0)))
+    {
+        if (print_t < 6000) //time<100h
+            chars = lcd_printf_P(_N("%c%02u:%02u%c%c"), LCD_STR_CLOCK[0], print_t / 60, print_t % 60, suff, suff_doubt);
+        else //time>=100h
+            chars = lcd_printf_P(_N("%c%3uh %c%c"), LCD_STR_CLOCK[0], print_t / 60, suff, suff_doubt);
+    }
+    else
+        chars = lcd_printf_P(_N("%c--:--  "), LCD_STR_CLOCK[0]);
+    lcd_space(8 - chars);
 }
 
 //Print status line on status screen

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -676,33 +676,55 @@ void lcdui_print_time(void)
     if ((PRINTER_ACTIVE) && (starttime != 0))
     {
         uint16_t print_t = 0;
+        uint16_t print_tr = 0;
+        uint16_t print_tc = 0;
         char suff = ' ';
         char suff_doubt = ' ';
 
-        if (print_time_to_change != PRINT_TIME_REMAINING_INIT)
+        #ifdef TMC2130
+        if (SilentModeMenu != SILENT_MODE_OFF)
         {
-            print_t = print_time_to_change;
+            if (print_time_remaining_silent != PRINT_TIME_REMAINING_INIT)
+            {
+                print_tr = print_time_remaining_silent;
+            }
+            if (print_time_to_change_silent != PRINT_TIME_REMAINING_INIT)
+            {
+                print_tc = print_time_to_change_silent;
+            }
+        }
+        else
+        {
+        #endif //TMC2130
+            if (print_time_remaining_normal != PRINT_TIME_REMAINING_INIT)
+            {
+                print_tr = print_time_remaining_normal;
+            }
+            if (print_time_to_change_normal != PRINT_TIME_REMAINING_INIT)
+            {
+                print_tc = print_time_to_change_normal;
+            }
+        #ifdef TMC2130
+        }
+        #endif //TMC2130
+
+        if (print_tc != 0)
+        {
+            print_t = print_tc;
             suff = 'C';
         }
-        else
+        else if (print_tr != 0)
         {
+            print_t = print_tr;
             suff = 'R';
-        #ifdef TMC2130
-        if (print_time_remaining_silent != PRINT_TIME_REMAINING_INIT && (SilentModeMenu != SILENT_MODE_OFF))
-        {
-            print_t = print_time_remaining_silent;
         }
-        else
-        #endif //TMC2130
-            print_t = print_time_remaining_normal;
-        }
-		
+
         if (feedmultiply != 100)
         {
             suff_doubt = '?';
             print_t = 100ul * print_t / feedmultiply;
         }
-		
+
         if (print_t < 6000) //time<100h
             chars = lcd_printf_P(_N("%c%02u:%02u%c%c"), LCD_STR_CLOCK[0], print_t / 60, print_t % 60, suff, suff_doubt);
         else //time>=100h

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -718,7 +718,7 @@ void lcdui_print_time(void)
 
         if (print_tc != 0)
         {
-            if (IntervalTimer.expired(5000))
+            if (IntervalTimer.expired(CLOCK_INTERVAL_TIME))
             {
                 print_t = print_tc;
                 suff = 'C';

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -723,7 +723,7 @@ void lcdui_print_time(void)
             print_t = _millis() / 60000 - starttime / 60000; 
         }
 
-        if (feedmultiply != 100 && (print_tc != 0 || print_tr !=0))
+        if (feedmultiply != 100 && (print_t == print_tr || print_t == print_tc))
         {
             suff_doubt = '?';
             print_t = 100ul * print_t / feedmultiply;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -673,22 +673,30 @@ void lcdui_print_time(void)
 {
 	//if remaining print time estimation is available print it else print elapsed time
 	uint16_t print_t = 0;
-	if (print_time_remaining_normal != PRINT_TIME_REMAINING_INIT)
+	int chars = 0;
+    char suff = ' ';
+    char suff_doubt = ' ';
+
+	if(print_time_to_change != PRINT_TIME_REMAINING_INIT)
+	{
+		print_t = print_time_to_change_remaining();
+		suff = 'C';
+		if (feedmultiply != 100)
+                    suff_doubt = '?';
+	}
+	else if (print_time_remaining_normal != PRINT_TIME_REMAINING_INIT)
+	{
 		print_t = print_time_remaining();
+		suff = 'R';
+		if (feedmultiply != 100)
+                    suff_doubt = '?';
+	}
 	else if(starttime != 0)
 		print_t = _millis() / 60000 - starttime / 60000;
-	int chars = 0;
-	if ((PRINTER_ACTIVE) && ((print_time_remaining_normal != PRINT_TIME_REMAINING_INIT) || (starttime != 0)))
+
+	if ((PRINTER_ACTIVE) && ((print_time_remaining_normal != PRINT_TIME_REMAINING_INIT) || (print_time_to_change != PRINT_TIME_REMAINING_INIT) || (starttime != 0)))
 	{
-          char suff = ' ';
-          char suff_doubt = ' ';
-		if (print_time_remaining_normal != PRINT_TIME_REMAINING_INIT)
-          {
-               suff = 'R';
-               if (feedmultiply != 100)
-                    suff_doubt = '?';
-          }
-		if (print_t < 6000) //time<100h
+ 		if (print_t < 6000) //time<100h
 			chars = lcd_printf_P(_N("%c%02u:%02u%c%c"), LCD_STR_CLOCK[0], print_t / 60, print_t % 60, suff, suff_doubt);
 		else //time>=100h
 			chars = lcd_printf_P(_N("%c%3uh %c%c"), LCD_STR_CLOCK[0], print_t / 60, suff, suff_doubt);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -673,6 +673,7 @@ void lcdui_print_time(void)
 {
     //if remaining print time estimation is available print it else print elapsed time
     int chars = 0;
+    ShortTimer IntervalTimer;
     if ((PRINTER_ACTIVE) && (starttime != 0))
     {
         uint16_t print_t = 0;
@@ -708,17 +709,18 @@ void lcdui_print_time(void)
         }
         #endif //TMC2130
 
-        if (print_tc != 0)
-        {
-            print_t = print_tc;
-            suff = 'C';
-        }
-        else if (print_tr != 0)
+        if (print_tr != 0)
         {
             print_t = print_tr;
             suff = 'R';
         }
-        else
+        else if (print_tc != 0)
+        {
+            print_t = print_tc;
+            suff = 'C';
+        }
+
+        if (print_tr == 0)
         {
             print_t = _millis() / 60000 - starttime / 60000; 
         }

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -673,7 +673,6 @@ void lcdui_print_time(void)
 {
     //if remaining print time estimation is available print it else print elapsed time
     int chars = 0;
-    ShortTimer IntervalTimer;
     if ((PRINTER_ACTIVE) && (starttime != 0))
     {
         uint16_t print_t = 0;
@@ -681,6 +680,8 @@ void lcdui_print_time(void)
         uint16_t print_tc = 0;
         char suff = ' ';
         char suff_doubt = ' ';
+        static ShortTimer IntervalTimer;
+
 
         #ifdef TMC2130
         if (SilentModeMenu != SILENT_MODE_OFF)
@@ -714,10 +715,15 @@ void lcdui_print_time(void)
             print_t = print_tr;
             suff = 'R';
         }
-        else if (print_tc != 0)
+
+        if (print_tc != 0)
         {
-            print_t = print_tc;
-            suff = 'C';
+            if (IntervalTimer.expired(5000))
+            {
+                print_t = print_tc;
+                suff = 'C';
+                IntervalTimer.start();
+            }
         }
 
         if (print_tr == 0)


### PR DESCRIPTION
 - Add parameter `C` to gcode `M73`
- LCD Info screen switches to change time if last `M73` gcode contains `C` parameter
  - Examples:
    - `M73 P5 R120` will display on LCD ` SD  5%      02:00R ` if it is printing at 100% speed
    - `M73 P5 R120 C60` will display on LCD ` SD  5%      01:00C ` if it is printing at 100% speed

Slicers can generate "Time to change/pause/user interaction" using `C<mins:0-65535>` parameter to "overwrite" the remaining print time.
To switch between time to change and remaining time just send in intervals `M73` with or without `C` parameter.