### PR TITLE
PFW-1182 Fix too long translations during Load/Unload Filament

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -11786,7 +11786,7 @@ void M600_wait_for_user(float HotendTempBckp) {
 				delay_keep_alive(4);
 
 				if (_millis() > waiting_start_time + (unsigned long)M600_TIMEOUT * 1000) {
-					lcd_display_message_fullscreen_P(_i("Press knob to preheat nozzle and continue."));////MSG_PRESS_TO_PREHEAT c=20 r=4
+					lcd_display_message_fullscreen_P(_i("Press the knob to preheat nozzle and continue."));////MSG_PRESS_TO_PREHEAT c=20 r=4
 					wait_for_user_state = 1;
 					setAllTargetHotends(0);
 					st_synchronize();

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2242,11 +2242,11 @@ switch(eFilamentAction)
      case FilamentAction::Load:
      case FilamentAction::AutoLoad:
      case FilamentAction::MmuLoad:
-          lcd_puts_P(_i("to load filament"));     ////MSG_ c=20 r=2
+          lcd_puts_P(_i("to load filament"));     ////MSG_ c=20
           break;
      case FilamentAction::UnLoad:
      case FilamentAction::MmuUnLoad:
-          lcd_puts_P(_i("to unload filament"));   ////MSG_ c=20 r=2
+          lcd_puts_P(_i("to unload filament"));   ////MSG_ c=20
           break;
      case FilamentAction::MmuEject:
      case FilamentAction::MmuCut:

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2235,18 +2235,18 @@ uint8_t nLevel;
 
 lcd_set_cursor(0,0);
 lcdui_print_temp(LCD_STR_THERMOMETER[0],(int)degHotend(0),(int)degTargetHotend(0));
-lcd_puts_at_P(0,2, _i("Press the knob"));                 ////MSG_ c=20 r=1
-lcd_set_cursor(0,3);
+lcd_puts_at_P(0,1, _i("Press the knob"));                 ////MSG_ c=20
+lcd_set_cursor(0,2);
 switch(eFilamentAction)
      {
      case FilamentAction::Load:
      case FilamentAction::AutoLoad:
      case FilamentAction::MmuLoad:
-          lcd_puts_P(_i("to load filament"));     ////MSG_ c=20 r=1
+          lcd_puts_P(_i("to load filament"));     ////MSG_ c=20 r=2
           break;
      case FilamentAction::UnLoad:
      case FilamentAction::MmuUnLoad:
-          lcd_puts_P(_i("to unload filament"));   ////MSG_ c=20 r=1
+          lcd_puts_P(_i("to unload filament"));   ////MSG_ c=20 r=2
           break;
      case FilamentAction::MmuEject:
      case FilamentAction::MmuCut:

--- a/lang/lang_en.txt
+++ b/lang/lang_en.txt
@@ -644,7 +644,7 @@
 "Print from SD"
 
 #
-"Press the knob"
+"Press the knob" c=20 r=2
 
 #MSG_PRINT_PAUSED c=20 r=1
 "Print paused"
@@ -875,10 +875,10 @@
 "Total failures"
 
 #
-"to load filament"
+"to load filament" c=20 r=2
 
 #
-"to unload filament"
+"to unload filament" c=20 r=2
 
 #MSG_UNLOAD_FILAMENT c=17
 "Unload filament"

--- a/lang/lang_en.txt
+++ b/lang/lang_en.txt
@@ -643,8 +643,8 @@
 #MSG_CARD_MENU
 "Print from SD"
 
-#
-"Press the knob" c=20 r=2
+# c=20
+"Press the knob"
 
 #MSG_PRINT_PAUSED c=20 r=1
 "Print paused"
@@ -874,11 +874,11 @@
 #MSG_TOTAL_FAILURES c=20
 "Total failures"
 
-#
-"to load filament" c=20 r=2
+# c=20
+"to load filament"
 
-#
-"to unload filament" c=20 r=2
+# c=20
+"to unload filament"
 
 #MSG_UNLOAD_FILAMENT c=17
 "Unload filament"

--- a/lang/lang_en.txt
+++ b/lang/lang_en.txt
@@ -620,7 +620,7 @@
 "Please upgrade."
 
 #MSG_PRESS_TO_PREHEAT c=20 r=4
-"Press knob to preheat nozzle and continue."
+"Press the knob to preheat nozzle and continue."
 
 #MSG_FS_PAUSE c=5
 "Pause"

--- a/lang/lang_en_cz.txt
+++ b/lang/lang_en_cz.txt
@@ -859,7 +859,7 @@
 "Tisk z SD"
 
 #
-"Press the knob"
+"Press the knob" c=20 r=2
 "Stisknete hl. tlacitko"
 
 #MSG_PRINT_PAUSED c=20 r=1
@@ -1167,11 +1167,11 @@
 "Celkem selhani"
 
 #
-"to load filament"
+"to load filament" c=20 r=2
 "k zavedeni filamentu"
 
 #
-"to unload filament"
+"to unload filament" c=20 r=2
 "k vyjmuti filamentu"
 
 #MSG_UNLOAD_FILAMENT c=17

--- a/lang/lang_en_cz.txt
+++ b/lang/lang_en_cz.txt
@@ -827,7 +827,7 @@
 "Prosim aktualizujte."
 
 #MSG_PRESS_TO_PREHEAT c=20 r=4
-"Press knob to preheat nozzle and continue."
+"Press the knob to preheat nozzle and continue."
 "Pro nahrati trysky a pokracovani stisknete tlacitko."
 
 #MSG_FS_PAUSE c=5

--- a/lang/lang_en_cz.txt
+++ b/lang/lang_en_cz.txt
@@ -858,8 +858,8 @@
 "Print from SD"
 "Tisk z SD"
 
-#
-"Press the knob" c=20 r=2
+# c=20
+"Press the knob"
 "Stisknete hl. tlacitko"
 
 #MSG_PRINT_PAUSED c=20 r=1
@@ -1166,12 +1166,12 @@
 "Total failures"
 "Celkem selhani"
 
-#
-"to load filament" c=20 r=2
+# c=20
+"to load filament"
 "k zavedeni filamentu"
 
-#
-"to unload filament" c=20 r=2
+# c=20
+"to unload filament"
 "k vyjmuti filamentu"
 
 #MSG_UNLOAD_FILAMENT c=17

--- a/lang/lang_en_de.txt
+++ b/lang/lang_en_de.txt
@@ -858,8 +858,8 @@
 "Print from SD"
 "Drucken von SD"
 
-#
-"Press the knob" c=20 r=2
+# c=20
+"Press the knob"
 "Knopf druecken zum"
 
 #MSG_PRINT_PAUSED c=20 r=1
@@ -1166,12 +1166,12 @@
 "Total failures"
 "Gesamte Fehler"
 
-#
-"to load filament" c=20 r=2
+# c=20
+"to load filament"
 "Filament laden"
 
-#
-"to unload filament" c=20 r=2
+# c=20
+"to unload filament"
 "Filament entladen"
 
 #MSG_UNLOAD_FILAMENT c=17

--- a/lang/lang_en_de.txt
+++ b/lang/lang_en_de.txt
@@ -859,7 +859,7 @@
 "Drucken von SD"
 
 #
-"Press the knob"
+"Press the knob" c=20 r=2
 "Knopf druecken zum"
 
 #MSG_PRINT_PAUSED c=20 r=1
@@ -1167,11 +1167,11 @@
 "Gesamte Fehler"
 
 #
-"to load filament"
+"to load filament" c=20 r=2
 "Filament laden"
 
 #
-"to unload filament"
+"to unload filament" c=20 r=2
 "Filament entladen"
 
 #MSG_UNLOAD_FILAMENT c=17

--- a/lang/lang_en_de.txt
+++ b/lang/lang_en_de.txt
@@ -827,7 +827,7 @@
 "Bitte aktualisieren."
 
 #MSG_PRESS_TO_PREHEAT c=20 r=4
-"Press knob to preheat nozzle and continue."
+"Press the knob to preheat nozzle and continue."
 "Bitte druecken Sie den Knopf um die Duese vorzuheizen und fortzufahren."
 
 #MSG_FS_PAUSE c=5

--- a/lang/lang_en_es.txt
+++ b/lang/lang_en_es.txt
@@ -827,7 +827,7 @@
 "Actualize por favor"
 
 #MSG_PRESS_TO_PREHEAT c=20 r=4
-"Press knob to preheat nozzle and continue."
+"Press the knob to preheat nozzle and continue."
 "Pulsa el dial para precalentar la boquilla y continue."
 
 #MSG_FS_PAUSE c=5

--- a/lang/lang_en_es.txt
+++ b/lang/lang_en_es.txt
@@ -859,7 +859,7 @@
 "Menu tarjeta SD"
 
 #
-"Press the knob"
+"Press the knob" c=20 r=2
 "Pulsa el dial"
 
 #MSG_PRINT_PAUSED c=20 r=1
@@ -1167,11 +1167,11 @@
 "Fallos totales"
 
 #
-"to load filament"
+"to load filament" c=20 r=2
 "para cargar el filamento"
 
 #
-"to unload filament"
+"to unload filament" c=20 r=2
 "para descargar el filamento"
 
 #MSG_UNLOAD_FILAMENT c=17

--- a/lang/lang_en_es.txt
+++ b/lang/lang_en_es.txt
@@ -858,8 +858,8 @@
 "Print from SD"
 "Menu tarjeta SD"
 
-#
-"Press the knob" c=20 r=2
+# c=20
+"Press the knob"
 "Pulsa el dial"
 
 #MSG_PRINT_PAUSED c=20 r=1
@@ -1166,13 +1166,13 @@
 "Total failures"
 "Fallos totales"
 
-#
-"to load filament" c=20 r=2
-"para cargar el filamento"
+# c=20
+"to load filament"
+"para cargar el fil."
 
-#
-"to unload filament" c=20 r=2
-"para descargar el filamento"
+# c=20
+"to unload filament"
+"para descargar fil."
 
 #MSG_UNLOAD_FILAMENT c=17
 "Unload filament"

--- a/lang/lang_en_fr.txt
+++ b/lang/lang_en_fr.txt
@@ -859,7 +859,7 @@
 "Impr. depuis la SD"
 
 #
-"Press the knob"
+"Press the knob" c=20 r=2
 "App. sur sur bouton"
 
 #MSG_PRINT_PAUSED c=20 r=1
@@ -1167,11 +1167,11 @@
 "Total des echecs"
 
 #
-"to load filament"
+"to load filament" c=20 r=2
 "pour charger le fil."
 
 #
-"to unload filament"
+"to unload filament" c=20 r=2
 "pour decharger fil."
 
 #MSG_UNLOAD_FILAMENT c=17

--- a/lang/lang_en_fr.txt
+++ b/lang/lang_en_fr.txt
@@ -827,7 +827,7 @@
 "Mettez a jour le FW."
 
 #MSG_PRESS_TO_PREHEAT c=20 r=4
-"Press knob to preheat nozzle and continue."
+"Press the knob to preheat nozzle and continue."
 "Appuyez sur le bouton pour prechauffer la buse et continuer."
 
 #MSG_FS_PAUSE c=5

--- a/lang/lang_en_fr.txt
+++ b/lang/lang_en_fr.txt
@@ -858,8 +858,8 @@
 "Print from SD"
 "Impr. depuis la SD"
 
-#
-"Press the knob" c=20 r=2
+# c=20
+"Press the knob"
 "App. sur sur bouton"
 
 #MSG_PRINT_PAUSED c=20 r=1
@@ -1166,12 +1166,12 @@
 "Total failures"
 "Total des echecs"
 
-#
-"to load filament" c=20 r=2
+# c=20
+"to load filament"
 "pour charger le fil."
 
-#
-"to unload filament" c=20 r=2
+# c=20
+"to unload filament"
 "pour decharger fil."
 
 #MSG_UNLOAD_FILAMENT c=17

--- a/lang/lang_en_it.txt
+++ b/lang/lang_en_it.txt
@@ -827,7 +827,7 @@
 "Prego aggiornare."
 
 #MSG_PRESS_TO_PREHEAT c=20 r=4
-"Press knob to preheat nozzle and continue."
+"Press the knob to preheat nozzle and continue."
 "Premete la manopola per preriscaldare l'ugello e continuare."
 
 #MSG_FS_PAUSE c=5

--- a/lang/lang_en_it.txt
+++ b/lang/lang_en_it.txt
@@ -859,7 +859,7 @@
 "Stampa da SD"
 
 #
-"Press the knob"
+"Press the knob" c=20 r=2
 "Premere la manopola"
 
 #MSG_PRINT_PAUSED c=20 r=1
@@ -1167,11 +1167,11 @@
 "Totale fallimenti"
 
 #
-"to load filament"
+"to load filament" c=20 r=2
 "per caricare il filamento"
 
 #
-"to unload filament"
+"to unload filament" c=20 r=2
 "per scaricare il filamento"
 
 #MSG_UNLOAD_FILAMENT c=17

--- a/lang/lang_en_it.txt
+++ b/lang/lang_en_it.txt
@@ -858,8 +858,8 @@
 "Print from SD"
 "Stampa da SD"
 
-#
-"Press the knob" c=20 r=2
+# c=20
+"Press the knob"
 "Premere la manopola"
 
 #MSG_PRINT_PAUSED c=20 r=1
@@ -1166,13 +1166,13 @@
 "Total failures"
 "Totale fallimenti"
 
-#
-"to load filament" c=20 r=2
-"per caricare il filamento"
+# c=20
+"to load filament"
+"per caricare il fil."
 
-#
-"to unload filament" c=20 r=2
-"per scaricare il filamento"
+# c=20
+"to unload filament"
+"per scaricare fil."
 
 #MSG_UNLOAD_FILAMENT c=17
 "Unload filament"

--- a/lang/lang_en_pl.txt
+++ b/lang/lang_en_pl.txt
@@ -859,7 +859,7 @@
 "Druk z karty SD"
 
 #
-"Press the knob"
+"Press the knob" c=20 r=2
 "Wcisnij pokretlo"
 
 #MSG_PRINT_PAUSED c=20 r=1
@@ -1167,11 +1167,11 @@
 "Suma bledow"
 
 #
-"to load filament"
+"to load filament" c=20 r=2
 "aby zaladow. fil."
 
 #
-"to unload filament"
+"to unload filament" c=20 r=2
 "aby rozlad. filament"
 
 #MSG_UNLOAD_FILAMENT c=17

--- a/lang/lang_en_pl.txt
+++ b/lang/lang_en_pl.txt
@@ -858,8 +858,8 @@
 "Print from SD"
 "Druk z karty SD"
 
-#
-"Press the knob" c=20 r=2
+# c=20
+"Press the knob"
 "Wcisnij pokretlo"
 
 #MSG_PRINT_PAUSED c=20 r=1
@@ -1166,12 +1166,12 @@
 "Total failures"
 "Suma bledow"
 
-#
-"to load filament" c=20 r=2
+# c=20
+"to load filament"
 "aby zaladow. fil."
 
-#
-"to unload filament" c=20 r=2
+# c=20
+"to unload filament"
 "aby rozlad. filament"
 
 #MSG_UNLOAD_FILAMENT c=17

--- a/lang/lang_en_pl.txt
+++ b/lang/lang_en_pl.txt
@@ -827,7 +827,7 @@
 "Prosze zaktualizowac."
 
 #MSG_PRESS_TO_PREHEAT c=20 r=4
-"Press knob to preheat nozzle and continue."
+"Press the knob to preheat nozzle and continue."
 "Wcisnij pokretlo aby rozgrzac dysze i kontynuowac."
 
 #MSG_FS_PAUSE c=5


### PR DESCRIPTION
- Spanish @David-DL can you please review the `lang_en_es.txt` changes I made? The LCD output is limited to 20 characters
- Italian @wavexx  can you please review the `lang_en_it.txt`changes I made?
fixes issue #2958 