### PR TITLE
Small change to reduce chance filament gets stuck during retraction for filament removal

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3286,6 +3286,14 @@ static void gcode_M600(bool automatic, float x_position, float y_position, float
     lastpos[Y_AXIS] = current_position[Y_AXIS];
     lastpos[Z_AXIS] = current_position[Z_AXIS];
     lastpos[E_AXIS] = current_position[E_AXIS];
+	
+	// Push through some filament to eliminate blobs
+	// If the system was sitting cold and is brought up to temp suddenly, without positive
+	// pressure to push some filament through the tip, when it retracts, the filament won't 
+	// have much to stick to in order to stretch thin, and the blob may get stuck on the way out.
+    current_position[E_AXIS] += (float)(FILAMENTCHANGE_RECFEED);
+    plan_buffer_line_curposXYZE((float)FILAMENTCHANGE_EXFEED);
+    st_synchronize();
 
     //Retract E
     current_position[E_AXIS] += e_shift;

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3286,14 +3286,6 @@ static void gcode_M600(bool automatic, float x_position, float y_position, float
     lastpos[Y_AXIS] = current_position[Y_AXIS];
     lastpos[Z_AXIS] = current_position[Z_AXIS];
     lastpos[E_AXIS] = current_position[E_AXIS];
-	
-	// Push through some filament to eliminate blobs
-	// If the system was sitting cold and is brought up to temp suddenly, without positive
-	// pressure to push some filament through the tip, when it retracts, the filament won't 
-	// have much to stick to in order to stretch thin, and the blob may get stuck on the way out.
-    current_position[E_AXIS] += (float)(FILAMENTCHANGE_RECFEED);
-    plan_buffer_line_curposXYZE((float)FILAMENTCHANGE_EXFEED);
-    st_synchronize();
 
     //Retract E
     current_position[E_AXIS] += e_shift;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -6304,6 +6304,13 @@ void unload_filament()
 
 	//		extr_unload2();
 
+    // Push through some filament to eliminate blobs
+    // If the system was sitting cold and is brought up to temp suddenly, without positive
+    // pressure to push some filament through the tip, when it retracts, the filament won't 
+    // have much to stick to in order to stretch thin, and the blob may get stuck on the way out.
+    current_position[E_AXIS] += 6;
+    plan_buffer_line_curposXYZE(140 / 60);
+    st_synchronize();
 	current_position[E_AXIS] -= 45;
 	plan_buffer_line_curposXYZE(5200 / 60);
 	st_synchronize();


### PR DESCRIPTION
The MK3S+ kit I received has a fairly narrow filament entry hole on the extruder. When I try to change filament when the system has been cold for a while, there is often a rather large blob at the tip, even after heating up to temperature, and the blob gets stuck on the way out, and I have to open the idler door and use tweezers to pull the filament out sideways to cut off the blob. It's a big hassle.

Some users recommended extruding a small amount of filament and then immediately retracting it to reduce the chances of it forming a large blob. 

I believe the reason for this is that it sticks some of the filament out of the tip, and when it retracts, it pulls thin and stretches, reducing any blobs that formed while the system is cold.

Otherwise if it's directly heated up from being cold and no positive pressure is put on the extruder, the blob at the tip is not going to be stuck against the nozzle, since it's shrunk away from the nozzle tip as it previously cooled. Putting positive pressure momentarily ensures it sticks and stretches thin a bit before being pulled out.