### PR TITLE
Make a special welcome message for Shipping/Service prep.

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -756,7 +756,7 @@ static void factory_reset(char level)
 		lang_reset();
 		// Force the "Follow calibration flow" message at the next boot up.
 		calibration_status_store(CALIBRATION_STATUS_Z_CALIBRATION);
-		eeprom_write_byte((uint8_t*)EEPROM_WIZARD_ACTIVE, 1); //run wizard
+		eeprom_write_byte((uint8_t*)EEPROM_WIZARD_ACTIVE, 2); //run wizard
 		farm_mode = false;
 		eeprom_update_byte((uint8_t*)EEPROM_FARM_MODE, farm_mode);
 
@@ -1564,7 +1564,7 @@ void setup()
 	  lcd_show_fullscreen_message_and_wait_P(_i("Old settings found. Default PID, Esteps etc. will be set.")); //if EEPROM version or printer type was changed, inform user that default setting were loaded////MSG_DEFAULT_SETTINGS_LOADED c=20 r=5
 	  Config_StoreSettings();
   }
-  if (eeprom_read_byte((uint8_t*)EEPROM_WIZARD_ACTIVE) == 1) {
+  if (eeprom_read_byte((uint8_t*)EEPROM_WIZARD_ACTIVE) >= 1) {
 	  lcd_wizard(WizState::Run);
   }
   if (eeprom_read_byte((uint8_t*)EEPROM_WIZARD_ACTIVE) == 0) { //dont show calibration status messages if wizard is currently active

--- a/Firmware/eeprom.h
+++ b/Firmware/eeprom.h
@@ -408,7 +408,7 @@ static_assert(sizeof(Sheets) == EEPROM_SHEETS_SIZEOF, "Sizeof(Sheets) is not EEP
 #define EEPROM_POWER_COUNT       (EEPROM_FERROR_COUNT - 1)                      // uint8 (orig EEPROM_UVLO_MESH_BED_LEVELING-17)
 
 #define EEPROM_XYZ_CAL_SKEW (EEPROM_POWER_COUNT - 4)                            // float for skew backup
-#define EEPROM_WIZARD_ACTIVE (EEPROM_XYZ_CAL_SKEW - 1)
+#define EEPROM_WIZARD_ACTIVE (EEPROM_XYZ_CAL_SKEW - 1)                          // 0: wizard not active, 1: wizard active, 2: wizard active without yes/no = forced calibrate Z after shipping/service prep.
 #define EEPROM_BELTSTATUS_X (EEPROM_WIZARD_ACTIVE - 2)                          // uint16
 #define EEPROM_BELTSTATUS_Y (EEPROM_BELTSTATUS_X - 2)                           // uint16
 

--- a/Firmware/messages.c
+++ b/Firmware/messages.c
@@ -116,6 +116,8 @@ const char MSG_WIZARD_CALIBRATION_FAILED[] PROGMEM_I1 = ISTR("Please check our h
 const char MSG_WIZARD_DONE[] PROGMEM_I1 = ISTR("All is done. Happy printing!"); ////c=20 r=8
 const char MSG_WIZARD_HEATING[] PROGMEM_I1 = ISTR("Preheating nozzle. Please wait."); ////c=20 r=3
 const char MSG_WIZARD_QUIT[] PROGMEM_I1 = ISTR("You can always resume the Wizard from Calibration -> Wizard."); ////c=20 r=8
+const char MSG_WIZARD_WELCOME[] PROGMEM_I1 = ISTR("Hi, I am your Original Prusa i3 printer. Would you like me to guide you through the setup process?"); //// c=20 r=7
+const char MSG_WIZARD_WELCOME_SHIPPING[] PROGMEM_I1 = ISTR("Hi, I am your Original Prusa i3 printer. I will guide you through a short setup process, in which the Z-axis will be calibrated. Then, you will be ready to print."); ////c=20 r=16
 const char MSG_YES[] PROGMEM_I1 = ISTR("Yes"); ////
 const char MSG_V2_CALIBRATION[] PROGMEM_I1 = ISTR("First layer cal."); ////c=18
 const char WELCOME_MSG[] PROGMEM_I1 = ISTR(CUSTOM_MENDEL_NAME " OK."); ////c=20

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -116,6 +116,8 @@ extern const char MSG_WIZARD_CALIBRATION_FAILED[];
 extern const char MSG_WIZARD_DONE[];
 extern const char MSG_WIZARD_HEATING[];
 extern const char MSG_WIZARD_QUIT[];
+extern const char MSG_WIZARD_WELCOME[];
+extern const char MSG_WIZARD_WELCOME_SHIPPING[];
 extern const char MSG_YES[];
 extern const char MSG_V2_CALIBRATION[];
 extern const char WELCOME_MSG[];

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -4988,17 +4988,16 @@ void lcd_wizard(WizState state)
 			
 			if( eeprom_read_byte((uint8_t*)EEPROM_WIZARD_ACTIVE)==2){
 				lcd_show_fullscreen_message_and_wait_P(_i("Hi, I am your Original Prusa i3 printer. I will guide you through a short setup process, in which the Z-axis will be calibrated. Then, you will be ready to print."));////MSG_WIZARD_WELCOME_SHIPPING c=20 r=7
-				wizard_event = 1;
+				state = S::Restore;
 			} else {
 				wizard_event = lcd_show_multiscreen_message_yes_no_and_wait_P(_i("Hi, I am your Original Prusa i3 printer. Would you like me to guide you through the setup process?"), false, true);////MSG_WIZARD_WELCOME c=20 r=7
-			}
-			if (wizard_event) {
-				state = S::Restore;
-				eeprom_update_byte((uint8_t*)EEPROM_WIZARD_ACTIVE, 1);
-			}
-			else {
-				eeprom_update_byte((uint8_t*)EEPROM_WIZARD_ACTIVE, 0);
-				end = true;
+				if (wizard_event) {
+					state = S::Restore;
+					eeprom_update_byte((uint8_t*)EEPROM_WIZARD_ACTIVE, 1);
+				} else {
+					eeprom_update_byte((uint8_t*)EEPROM_WIZARD_ACTIVE, 0);
+					end = true;
+				}
 			}
 			break;
 		case S::Restore:

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -4962,7 +4962,7 @@ void lcd_wizard(WizState state)
 {
     using S = WizState;
 	bool end = false;
-	int wizard_event;
+	int8_t wizard_event;
 	const char *msg = NULL;
 	// Make sure EEPROM_WIZARD_ACTIVE is true if entering using different entry point
 	// other than WizState::Run - it is useful for debugging wizard.
@@ -4986,7 +4986,12 @@ void lcd_wizard(WizState state)
 			// Btw. the flag may even trigger the viper situation on normal start this way and the user won't be able to find out why.			
 			saved_printing = false;
 			
-			wizard_event = lcd_show_multiscreen_message_yes_no_and_wait_P(_i("Hi, I am your Original Prusa i3 printer. Would you like me to guide you through the setup process?"), false, true);////MSG_WIZARD_WELCOME c=20 r=7
+			if( eeprom_read_byte((uint8_t*)EEPROM_WIZARD_ACTIVE)==2){
+				lcd_show_fullscreen_message_and_wait_P(_i("Hi, I am your Original Prusa i3 printer. I will guide you through a short setup process, in which the Z-axis will be calibrated. Then, you will be ready to print."));////MSG_WIZARD_WELCOME_SHIPPING c=20 r=7
+				wizard_event = 1;
+			} else {
+				wizard_event = lcd_show_multiscreen_message_yes_no_and_wait_P(_i("Hi, I am your Original Prusa i3 printer. Would you like me to guide you through the setup process?"), false, true);////MSG_WIZARD_WELCOME c=20 r=7
+			}
 			if (wizard_event) {
 				state = S::Restore;
 				eeprom_update_byte((uint8_t*)EEPROM_WIZARD_ACTIVE, 1);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -4987,10 +4987,10 @@ void lcd_wizard(WizState state)
 			saved_printing = false;
 			
 			if( eeprom_read_byte((uint8_t*)EEPROM_WIZARD_ACTIVE)==2){
-				lcd_show_fullscreen_message_and_wait_P(_i("Hi, I am your Original Prusa i3 printer. I will guide you through a short setup process, in which the Z-axis will be calibrated. Then, you will be ready to print."));////MSG_WIZARD_WELCOME_SHIPPING c=20 r=7
+				lcd_show_fullscreen_message_and_wait_P(MSG_WIZARD_WELCOME_SHIPPING);
 				state = S::Restore;
 			} else {
-				wizard_event = lcd_show_multiscreen_message_yes_no_and_wait_P(_i("Hi, I am your Original Prusa i3 printer. Would you like me to guide you through the setup process?"), false, true);////MSG_WIZARD_WELCOME c=20 r=7
+				wizard_event = lcd_show_multiscreen_message_yes_no_and_wait_P(MSG_WIZARD_WELCOME, false, true);
 				if (wizard_event) {
 					state = S::Restore;
 					eeprom_update_byte((uint8_t*)EEPROM_WIZARD_ACTIVE, 1);

--- a/lang/lang_en.txt
+++ b/lang/lang_en.txt
@@ -877,9 +877,6 @@
 #
 "Unload"
 
-#
-"Sheet %.7s\x0aZ offset: %+1.3f mm\x0a%cContinue\x0a%cStart from zero"
-
 #MSG_TOTAL_FAILURES c=20
 "Total failures"
 

--- a/lang/lang_en.txt
+++ b/lang/lang_en.txt
@@ -385,7 +385,7 @@
 #MSG_LAST_PRINT_FAILURES c=20
 "Last print failures"
 
-#
+#MSG_WIZARD_WELCOME_SHIPPING c=20 r=16
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short setup process, in which the Z-axis will be calibrated. Then, you will be ready to print."
 
 #

--- a/lang/lang_en.txt
+++ b/lang/lang_en.txt
@@ -142,6 +142,9 @@
 #MSG_SD_REMOVED
 "Card removed"
 
+#
+"Checking file"
+
 #MSG_NOT_COLOR
 "Color not correct"
 
@@ -381,6 +384,9 @@
 
 #MSG_LAST_PRINT_FAILURES c=20
 "Last print failures"
+
+#
+"Hi, I am your Original Prusa i3 printer. I will guide you through a short setup process, in which the Z-axis will be calibrated. Then, you will be ready to print."
 
 #
 "If you have additional steel sheets, calibrate their presets in Settings - HW Setup - Steel sheets."
@@ -870,6 +876,9 @@
 
 #
 "Unload"
+
+#
+"Sheet %.7s\x0aZ offset: %+1.3f mm\x0a%cContinue\x0a%cStart from zero"
 
 #MSG_TOTAL_FAILURES c=20
 "Total failures"

--- a/lang/lang_en_cz.txt
+++ b/lang/lang_en_cz.txt
@@ -1170,10 +1170,6 @@
 "Unload"
 "Vysunout"
 
-#
-"Sheet %.7s\x0aZ offset: %+1.3f mm\x0a%cContinue\x0a%cStart from zero"
-"\x00"
-
 #MSG_TOTAL_FAILURES c=20
 "Total failures"
 "Celkem selhani"

--- a/lang/lang_en_cz.txt
+++ b/lang/lang_en_cz.txt
@@ -190,6 +190,10 @@
 "Card removed"
 "Karta vyjmuta"
 
+#
+"Checking file"
+"\x00"
+
 #MSG_NOT_COLOR
 "Color not correct"
 "Barva neni cista"
@@ -509,6 +513,10 @@
 #MSG_LAST_PRINT_FAILURES c=20
 "Last print failures"
 "Selhani posl. tisku"
+
+#
+"Hi, I am your Original Prusa i3 printer. I will guide you through a short setup process, in which the Z-axis will be calibrated. Then, you will be ready to print."
+"Ahoj, jsem vase tiskarna Original Prusa i3. Provedu vas kratkym procesem nastaveni, ve kterem zkalibrujeme osu Z. Pak budete moct zacit tisknout."
 
 #
 "If you have additional steel sheets, calibrate their presets in Settings - HW Setup - Steel sheets."
@@ -1161,6 +1169,10 @@
 #
 "Unload"
 "Vysunout"
+
+#
+"Sheet %.7s\x0aZ offset: %+1.3f mm\x0a%cContinue\x0a%cStart from zero"
+"\x00"
 
 #MSG_TOTAL_FAILURES c=20
 "Total failures"

--- a/lang/lang_en_cz.txt
+++ b/lang/lang_en_cz.txt
@@ -514,7 +514,7 @@
 "Last print failures"
 "Selhani posl. tisku"
 
-#
+#MSG_WIZARD_WELCOME_SHIPPING c=20 r=16
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short setup process, in which the Z-axis will be calibrated. Then, you will be ready to print."
 "Ahoj, jsem vase tiskarna Original Prusa i3. Provedu vas kratkym procesem nastaveni, ve kterem zkalibrujeme osu Z. Pak budete moct zacit tisknout."
 

--- a/lang/lang_en_de.txt
+++ b/lang/lang_en_de.txt
@@ -514,7 +514,7 @@
 "Last print failures"
 "Letzte Druckfehler"
 
-#
+#MSG_WIZARD_WELCOME_SHIPPING c=20 r=16
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short setup process, in which the Z-axis will be calibrated. Then, you will be ready to print."
 "Hallo, ich bin Ihr Original Prusa i3 Drucker. Ich werde Sie durch einen kurzen Einrichtungsprozess fuehren, bei dem die Z-Achse kalibriert wird. Danach sind Sie bereit fuer den Druck."
 

--- a/lang/lang_en_de.txt
+++ b/lang/lang_en_de.txt
@@ -1170,10 +1170,6 @@
 "Unload"
 "Entladen"
 
-#
-"Sheet %.7s\x0aZ offset: %+1.3f mm\x0a%cContinue\x0a%cStart from zero"
-"\x00"
-
 #MSG_TOTAL_FAILURES c=20
 "Total failures"
 "Gesamte Fehler"

--- a/lang/lang_en_de.txt
+++ b/lang/lang_en_de.txt
@@ -190,6 +190,10 @@
 "Card removed"
 "SD Karte entfernt"
 
+#
+"Checking file"
+"\x00"
+
 #MSG_NOT_COLOR
 "Color not correct"
 "Falsche Farbe"
@@ -509,6 +513,10 @@
 #MSG_LAST_PRINT_FAILURES c=20
 "Last print failures"
 "Letzte Druckfehler"
+
+#
+"Hi, I am your Original Prusa i3 printer. I will guide you through a short setup process, in which the Z-axis will be calibrated. Then, you will be ready to print."
+"Hallo, ich bin Ihr Original Prusa i3 Drucker. Ich werde Sie durch einen kurzen Einrichtungsprozess fuehren, bei dem die Z-Achse kalibriert wird. Danach sind Sie bereit fuer den Druck."
 
 #
 "If you have additional steel sheets, calibrate their presets in Settings - HW Setup - Steel sheets."
@@ -1161,6 +1169,10 @@
 #
 "Unload"
 "Entladen"
+
+#
+"Sheet %.7s\x0aZ offset: %+1.3f mm\x0a%cContinue\x0a%cStart from zero"
+"\x00"
 
 #MSG_TOTAL_FAILURES c=20
 "Total failures"

--- a/lang/lang_en_es.txt
+++ b/lang/lang_en_es.txt
@@ -190,6 +190,10 @@
 "Card removed"
 "Tarjeta retirada"
 
+#
+"Checking file"
+"\x00"
+
 #MSG_NOT_COLOR
 "Color not correct"
 "Color no homogeneo"
@@ -509,6 +513,10 @@
 #MSG_LAST_PRINT_FAILURES c=20
 "Last print failures"
 "Ultimos imp. fallos"
+
+#
+"Hi, I am your Original Prusa i3 printer. I will guide you through a short setup process, in which the Z-axis will be calibrated. Then, you will be ready to print."
+"Hola, soy tu impresora Original Prusa i3. Te guiare a traves de un breve proceso de configuracion, en el que se calibrara el eje Z. Despues, estaras listo para imprimir."
 
 #
 "If you have additional steel sheets, calibrate their presets in Settings - HW Setup - Steel sheets."
@@ -1161,6 +1169,10 @@
 #
 "Unload"
 "Descargar"
+
+#
+"Sheet %.7s\x0aZ offset: %+1.3f mm\x0a%cContinue\x0a%cStart from zero"
+"\x00"
 
 #MSG_TOTAL_FAILURES c=20
 "Total failures"

--- a/lang/lang_en_es.txt
+++ b/lang/lang_en_es.txt
@@ -514,7 +514,7 @@
 "Last print failures"
 "Ultimos imp. fallos"
 
-#
+#MSG_WIZARD_WELCOME_SHIPPING c=20 r=16
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short setup process, in which the Z-axis will be calibrated. Then, you will be ready to print."
 "Hola, soy tu impresora Original Prusa i3. Te guiare a traves de un breve proceso de configuracion, en el que se calibrara el eje Z. Despues, estaras listo para imprimir."
 

--- a/lang/lang_en_es.txt
+++ b/lang/lang_en_es.txt
@@ -1170,10 +1170,6 @@
 "Unload"
 "Descargar"
 
-#
-"Sheet %.7s\x0aZ offset: %+1.3f mm\x0a%cContinue\x0a%cStart from zero"
-"\x00"
-
 #MSG_TOTAL_FAILURES c=20
 "Total failures"
 "Fallos totales"

--- a/lang/lang_en_fr.txt
+++ b/lang/lang_en_fr.txt
@@ -514,7 +514,7 @@
 "Last print failures"
 "Echecs derniere imp."
 
-#
+#MSG_WIZARD_WELCOME_SHIPPING c=20 r=16
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short setup process, in which the Z-axis will be calibrated. Then, you will be ready to print."
 "Bonjour, je suis votre imprimante Original Prusa i3. Je vais vous accompagner au cours d'un bref processus de reglage, qui permettra de calibrer le Z-axis. Apres cela, tout sera pret pour imprimer."
 

--- a/lang/lang_en_fr.txt
+++ b/lang/lang_en_fr.txt
@@ -190,6 +190,10 @@
 "Card removed"
 "Carte retiree"
 
+#
+"Checking file"
+"\x00"
+
 #MSG_NOT_COLOR
 "Color not correct"
 "Couleur incorrecte"
@@ -509,6 +513,10 @@
 #MSG_LAST_PRINT_FAILURES c=20
 "Last print failures"
 "Echecs derniere imp."
+
+#
+"Hi, I am your Original Prusa i3 printer. I will guide you through a short setup process, in which the Z-axis will be calibrated. Then, you will be ready to print."
+"Bonjour, je suis votre imprimante Original Prusa i3. Je vais vous accompagner au cours d'un bref processus de reglage, qui permettra de calibrer le Z-axis. Apres cela, tout sera pret pour imprimer."
 
 #
 "If you have additional steel sheets, calibrate their presets in Settings - HW Setup - Steel sheets."
@@ -1161,6 +1169,10 @@
 #
 "Unload"
 "Decharger"
+
+#
+"Sheet %.7s\x0aZ offset: %+1.3f mm\x0a%cContinue\x0a%cStart from zero"
+"\x00"
 
 #MSG_TOTAL_FAILURES c=20
 "Total failures"

--- a/lang/lang_en_fr.txt
+++ b/lang/lang_en_fr.txt
@@ -1170,10 +1170,6 @@
 "Unload"
 "Decharger"
 
-#
-"Sheet %.7s\x0aZ offset: %+1.3f mm\x0a%cContinue\x0a%cStart from zero"
-"\x00"
-
 #MSG_TOTAL_FAILURES c=20
 "Total failures"
 "Total des echecs"

--- a/lang/lang_en_it.txt
+++ b/lang/lang_en_it.txt
@@ -1170,10 +1170,6 @@
 "Unload"
 "Scarica"
 
-#
-"Sheet %.7s\x0aZ offset: %+1.3f mm\x0a%cContinue\x0a%cStart from zero"
-"\x00"
-
 #MSG_TOTAL_FAILURES c=20
 "Total failures"
 "Totale fallimenti"

--- a/lang/lang_en_it.txt
+++ b/lang/lang_en_it.txt
@@ -190,6 +190,10 @@
 "Card removed"
 "SD rimossa"
 
+#
+"Checking file"
+"\x00"
+
 #MSG_NOT_COLOR
 "Color not correct"
 "Colore non puro"
@@ -509,6 +513,10 @@
 #MSG_LAST_PRINT_FAILURES c=20
 "Last print failures"
 "Errori ultima stampa"
+
+#
+"Hi, I am your Original Prusa i3 printer. I will guide you through a short setup process, in which the Z-axis will be calibrated. Then, you will be ready to print."
+"Ciao, sono la tua stampante Original Prusa i3. Ti guidero attraverso un rapido processo in cui verra calibrato l'asse Z. Poi, sarai pronto a stampare."
 
 #
 "If you have additional steel sheets, calibrate their presets in Settings - HW Setup - Steel sheets."
@@ -1161,6 +1169,10 @@
 #
 "Unload"
 "Scarica"
+
+#
+"Sheet %.7s\x0aZ offset: %+1.3f mm\x0a%cContinue\x0a%cStart from zero"
+"\x00"
 
 #MSG_TOTAL_FAILURES c=20
 "Total failures"

--- a/lang/lang_en_it.txt
+++ b/lang/lang_en_it.txt
@@ -514,7 +514,7 @@
 "Last print failures"
 "Errori ultima stampa"
 
-#
+#MSG_WIZARD_WELCOME_SHIPPING c=20 r=16
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short setup process, in which the Z-axis will be calibrated. Then, you will be ready to print."
 "Ciao, sono la tua stampante Original Prusa i3. Ti guidero attraverso un rapido processo in cui verra calibrato l'asse Z. Poi, sarai pronto a stampare."
 

--- a/lang/lang_en_pl.txt
+++ b/lang/lang_en_pl.txt
@@ -514,7 +514,7 @@
 "Last print failures"
 "Ostatnie bledy druku"
 
-#
+#MSG_WIZARD_WELCOME_SHIPPING c=20 r=16
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short setup process, in which the Z-axis will be calibrated. Then, you will be ready to print."
 "Czesc, jestem Twoja drukarka Original Prusa i3. Przeprowadze Cie przez krotka kalibracje osi Z, po ktorej mozesz rozpoczac drukowanie."
 

--- a/lang/lang_en_pl.txt
+++ b/lang/lang_en_pl.txt
@@ -1170,10 +1170,6 @@
 "Unload"
 "Rozladuj"
 
-#
-"Sheet %.7s\x0aZ offset: %+1.3f mm\x0a%cContinue\x0a%cStart from zero"
-"\x00"
-
 #MSG_TOTAL_FAILURES c=20
 "Total failures"
 "Suma bledow"

--- a/lang/lang_en_pl.txt
+++ b/lang/lang_en_pl.txt
@@ -190,6 +190,10 @@
 "Card removed"
 "Karta wyjeta"
 
+#
+"Checking file"
+"\x00"
+
 #MSG_NOT_COLOR
 "Color not correct"
 "Kolor zanieczysz."
@@ -509,6 +513,10 @@
 #MSG_LAST_PRINT_FAILURES c=20
 "Last print failures"
 "Ostatnie bledy druku"
+
+#
+"Hi, I am your Original Prusa i3 printer. I will guide you through a short setup process, in which the Z-axis will be calibrated. Then, you will be ready to print."
+"Czesc, jestem Twoja drukarka Original Prusa i3. Przeprowadze Cie przez krotka kalibracje osi Z, po ktorej mozesz rozpoczac drukowanie."
 
 #
 "If you have additional steel sheets, calibrate their presets in Settings - HW Setup - Steel sheets."
@@ -1161,6 +1169,10 @@
 #
 "Unload"
 "Rozladuj"
+
+#
+"Sheet %.7s\x0aZ offset: %+1.3f mm\x0a%cContinue\x0a%cStart from zero"
+"\x00"
 
 #MSG_TOTAL_FAILURES c=20
 "Total failures"


### PR DESCRIPTION
Another request from our Service dept. - the user shall be prevented from skipping the intro wizard, because otherwise some preset/calibrated features will look like not done - especially live-z calibration.

And since there are users, who send a machine to service to perform 1st layer calibration only, they must not omit the Z-calibration at the start after shipping.

PFW-1161