### PR TITLE
Fix PR3032

### DIFF
--- a/Firmware/eeprom.h
+++ b/Firmware/eeprom.h
@@ -53,6 +53,7 @@ static_assert(sizeof(Sheets) == EEPROM_SHEETS_SIZEOF, "Sizeof(Sheets) is not EEP
    - __L__		Language
    - __S__ 		Statistics
    - __P__ 		Shipping prep
+   - __M__ 		Service/Maintenance prep
    - __S/P__	Statistics and Shipping prep
    
   will overwrite existing values to 0 or default.
@@ -157,6 +158,7 @@ static_assert(sizeof(Sheets) == EEPROM_SHEETS_SIZEOF, "Sizeof(Sheets) is not EEP
 | 0x0F60h 3936		| float		| EEPROM_XYZ_CAL_SKEW					| ???			| ff ff ff ffh			| XYZ skew value									| ???			| D3 Ax0f60 C4
 | 0x0F5Fh 3935		| uint8		| EEPROM_WIZARD_ACTIVE					| 01h 1			| 01h 1			__P__	| Wizard __active__									| ???			| D3 Ax0f5f C1
 | ^					| ^			| ^										| 00h 0			| ^						| Wizard __inactive__								| ^ 			| ^
+| ^					| ^			| ^										| 02h 2			| 02h 2			__M__	| Wizard active - Z cal after shipping/service prep | ^ 			| ^
 | 0x0F5Dh 3933		| uint16	| EEPROM_BELTSTATUS_X					| ???			| ff ffh				| X Beltstatus 										| ???			| D3 Ax0f5d C2
 | 0x0F5Bh 3931		| uint16	| EEPROM_BELTSTATUS_Y					| ???			| ff ffh				| Y Beltstatus 										| ???			| D3 Ax0f5b C2
 | 0x0F5Ah 3930		| uint8		| EEPROM_DIR_DEPTH						| 00h-ffh 0-255	| ffh 255				| Directory depth									| ???			| D3 Ax0f5a C1

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -4984,10 +4984,10 @@ void lcd_wizard(WizState state)
 			saved_printing = false;
 			
 			if( eeprom_read_byte((uint8_t*)EEPROM_WIZARD_ACTIVE)==2){
-				lcd_show_fullscreen_message_and_wait_P(MSG_WIZARD_WELCOME_SHIPPING);
+				lcd_show_fullscreen_message_and_wait_P(_T(MSG_WIZARD_WELCOME_SHIPPING));
 				state = S::Restore;
 			} else {
-				wizard_event = lcd_show_multiscreen_message_yes_no_and_wait_P(MSG_WIZARD_WELCOME, false, true);
+				wizard_event = lcd_show_multiscreen_message_yes_no_and_wait_P(_T(MSG_WIZARD_WELCOME), false, true);
 				if (wizard_event) {
 					state = S::Restore;
 					eeprom_update_byte((uint8_t*)EEPROM_WIZARD_ACTIVE, 1);


### PR DESCRIPTION
With PR#3032 the Welcome message on LCD got broken.
Also updated the EEPROM documentation adding the `Service prep`

Before this fix
![Before_MK3_Fix_PR3032](https://user-images.githubusercontent.com/25530011/109427934-f8517080-79f4-11eb-9c3b-edc5ad34d7a6.gif)
and here with this fix
![After_MK3_Fix_PR3032](https://user-images.githubusercontent.com/25530011/109427981-25058800-79f5-11eb-85df-1823cb05f2f5.gif)
