### PR TITLE
Fix flashing languages with inline wdr instructions

### DIFF
--- a/Firmware/optiboot_w25x20cl.cpp
+++ b/Firmware/optiboot_w25x20cl.cpp
@@ -126,6 +126,7 @@ uint8_t optiboot_w25x20cl_enter()
     }
     selectedSerialPort = 0; //switch to Serial0
     MYSERIAL.flush(); //clear RX buffer
+    int SerialHead = rx_buffer.head;
     // Send the initial magic string.
     while (ptr != end)
       putch(pgm_read_byte(ptr ++));
@@ -143,7 +144,6 @@ uint8_t optiboot_w25x20cl_enter()
       // With the volatile keyword the compiler generates exactly the same code as without it with only one difference:
       // the last brne instruction jumps onto the (*rx_head == SerialHead) check and NOT onto the wdr instruction bypassing the check.
       volatile int *rx_head = &rx_buffer.head;
-      int SerialHead = rx_buffer.head;
       while (*rx_head == SerialHead) {
         wdt_reset();
         if ( --boot_timer == 0) {

--- a/Firmware/optiboot_w25x20cl.cpp
+++ b/Firmware/optiboot_w25x20cl.cpp
@@ -165,6 +165,7 @@ uint8_t optiboot_w25x20cl_enter()
     cbi(UCSR0B, RXCIE0); //disable the MarlinSerial0 interrupt
     // Send the cfm magic string.
     ptr = entry_magic_cfm;
+    end = strlen_P(entry_magic_cfm) + ptr;
     while (ptr != end)
       putch(pgm_read_byte(ptr ++));
   }


### PR DESCRIPTION
A fairly mysterious situation happened recently in the MK3 branch.
After merging PR #3033 (change watchdogReset() into a single inline wdr instruction)
we were unable to flash languages.

Since it looked similarly suspicious like issue #2954 we started investigating deeply.
The problem was in the code as described in the comment in this PR.