### PR TITLE
Potential fix for incorrect boot app RAM location

### DIFF
--- a/Firmware/bootapp.c
+++ b/Firmware/bootapp.c
@@ -9,6 +9,10 @@
 extern FILE _uartout;
 #define uartout (&_uartout)
 
+uint8_t boot_reserved_copy_after_start;
+uint8_t boot_app_flags_copy_after_start;
+uint32_t boot_app_magic_copy_after_start;
+
 extern void softReset();
 
 void bootapp_print_vars(void)
@@ -16,18 +20,18 @@ void bootapp_print_vars(void)
 	fprintf_P(uartout, PSTR("boot_src_addr  =0x%08lx\n"), boot_src_addr);
 	fprintf_P(uartout, PSTR("boot_dst_addr  =0x%08lx\n"), boot_dst_addr);
 	fprintf_P(uartout, PSTR("boot_copy_size =0x%04x\n"), boot_copy_size);
-	fprintf_P(uartout, PSTR("boot_reserved  =0x%02x\n"), boot_reserved);
-	fprintf_P(uartout, PSTR("boot_app_flags =0x%02x\n"), boot_app_flags);
-	fprintf_P(uartout, PSTR("boot_app_magic =0x%08lx\n"), boot_app_magic);
+	fprintf_P(uartout, PSTR("boot_reserved  =0x%02x\n"), boot_reserved_in_the_middle_of_stack);
+	fprintf_P(uartout, PSTR("boot_app_flags =0x%02x\n"), boot_app_flags_in_the_middle_of_stack);
+	fprintf_P(uartout, PSTR("boot_app_magic =0x%08lx\n"), boot_app_magic_in_the_middle_of_stack);
 }
 
 
 void bootapp_ram2flash(uint16_t rptr, uint16_t fptr, uint16_t size)
 {
 	cli();
-	boot_app_magic = BOOT_APP_MAGIC;
-	boot_app_flags |= BOOT_APP_FLG_COPY;
-	boot_app_flags |= BOOT_APP_FLG_ERASE;
+	boot_app_magic_in_the_middle_of_stack = BOOT_APP_MAGIC;
+	boot_app_flags_in_the_middle_of_stack |= BOOT_APP_FLG_COPY;
+	boot_app_flags_in_the_middle_of_stack |= BOOT_APP_FLG_ERASE;
 /*	uint16_t ui; for (ui = 0; ui < size; ui++)
 	{
 		uint8_t uc = ram_array[ui+rptr];
@@ -47,9 +51,9 @@ void bootapp_ram2flash(uint16_t rptr, uint16_t fptr, uint16_t size)
 void bootapp_reboot_user0(uint8_t reserved)
 {
 	cli();
-	boot_app_magic = BOOT_APP_MAGIC;
-	boot_app_flags = BOOT_APP_FLG_USER0;
-	boot_reserved = reserved;
+	boot_app_magic_in_the_middle_of_stack = BOOT_APP_MAGIC;
+	boot_app_flags_in_the_middle_of_stack = BOOT_APP_FLG_USER0;
+	boot_reserved_in_the_middle_of_stack = reserved;
 	bootapp_print_vars();
 	softReset();
 }

--- a/Firmware/bootapp.h
+++ b/Firmware/bootapp.h
@@ -5,15 +5,20 @@
 #include "config.h"
 #include <inttypes.h>
 
-
+// This doesn't look correct as the end of RAM is at 0x21ff
+// thus it looks like the important boot variables are actually located in the middle of stack
+// -> may be the root cause of mysterious fails of language uploads and boot loops
+// Moreover, it looks like we cannot fix it as the bootloader probably uses the same memory area,
+// but at least we can copy the vars to a safe location right after the FW starts 
+// before the stack gets filled with stuff and overwrites the vars
 #define RAMSIZE        0x2000
 #define ram_array ((uint8_t*)(0))
 #define boot_src_addr  (*((uint32_t*)(RAMSIZE - 16)))
 #define boot_dst_addr  (*((uint32_t*)(RAMSIZE - 12)))
 #define boot_copy_size (*((uint16_t*)(RAMSIZE - 8)))
-#define boot_reserved  (*((uint8_t*)(RAMSIZE - 6)))
-#define boot_app_flags (*((uint8_t*)(RAMSIZE - 5)))
-#define boot_app_magic (*((uint32_t*)(RAMSIZE - 4)))
+#define boot_reserved_in_the_middle_of_stack  (*((uint8_t*)(RAMSIZE - 6)))
+#define boot_app_flags_in_the_middle_of_stack (*((uint8_t*)(RAMSIZE - 5)))
+#define boot_app_magic_in_the_middle_of_stack (*((uint32_t*)(RAMSIZE - 4)))
 #define BOOT_APP_FLG_ERASE 0x01
 #define BOOT_APP_FLG_COPY  0x02
 #define BOOT_APP_FLG_FLASH 0x04
@@ -27,6 +32,10 @@
 #if defined(__cplusplus)
 extern "C" {
 #endif //defined(__cplusplus)
+
+extern uint8_t boot_reserved_copy_after_start;
+extern uint8_t boot_app_flags_copy_after_start;
+extern uint32_t boot_app_magic_copy_after_start;
 
 extern void bootapp_print_vars(void);
 

--- a/Firmware/optiboot_w25x20cl.cpp
+++ b/Firmware/optiboot_w25x20cl.cpp
@@ -100,7 +100,7 @@ extern struct block_t *block_buffer;
 //! @return 0 if "start\n" was sent. Optiboot ran normally. No need to send "start\n" in setup()
 uint8_t optiboot_w25x20cl_enter()
 {
-  if (boot_app_flags & BOOT_APP_FLG_USER0) return 1;
+  if (boot_app_flags_copy_after_start & BOOT_APP_FLG_USER0) return 1;
   uint8_t ch;
   uint8_t rampz = 0;
   register uint16_t address = 0;


### PR DESCRIPTION
This is something we ran into investigating PR #3048 . Still a draft for discussion.
The root cause is the fact, that boot app flags are located in RAM at roughly 0x2000 which is NOT the end of RAM as everyone thought. The correct location would have been ~0x2100.
Because of that it looks like the boot app flags are located in the middle of stack, which can cause issues when trying to read them while the FW is running.