### PR TITLE
Add satin sheets

### DIFF
--- a/Firmware/eeprom.cpp
+++ b/Firmware/eeprom.cpp
@@ -107,10 +107,10 @@ if (eeprom_read_byte((uint8_t*)EEPROM_PINDA_TEMP_COMPENSATION) == 0xff) eeprom_u
 //! | 1     | Smooth2   |
 //! | 2     | Textur1   |
 //! | 3     | Textur2   |
-//! | 4     | Custom1   |
-//! | 5     | Custom2   |
-//! | 6     | Custom3   |
-//! | 7     | Custom4   |
+//! | 4     | Satin 1   |
+//! | 5     | Satin 2   |
+//! | 6     | Custom1   |
+//! | 7     | Custom2   |
 //!
 //! @param[in] index
 //! @param[out] sheetName
@@ -125,6 +125,10 @@ void eeprom_default_sheet_name(uint8_t index, SheetName &sheetName)
     else if (index < 4)
     {
         strcpy_P(sheetName.c, PSTR("Textur"));
+    }
+    else if (index < 4)
+    {
+        strcpy_P(sheetName.c, PSTR("Satin "));
     }
     else
     {
@@ -152,10 +156,10 @@ void eeprom_default_sheet_name(uint8_t index, SheetName &sheetName)
         sheetName.c[6] = '2';
         break;
     case 6:
-        sheetName.c[6] = '3';
+        sheetName.c[6] = '1';
         break;
     case 7:
-        sheetName.c[6] = '4';
+        sheetName.c[6] = '2';
         break;
     default:
         break;

--- a/Firmware/eeprom.cpp
+++ b/Firmware/eeprom.cpp
@@ -135,7 +135,9 @@ void eeprom_default_sheet_name(uint8_t index, SheetName &sheetName)
         strcpy_P(sheetName.c, PSTR("Custom"));
     }
 
-    switch (index)
+    sheetName.c[6] = '0' + ((index % 2)+1);
+
+/*    switch (index)
     {
     case 0:
         sheetName.c[6] = '1';
@@ -163,7 +165,7 @@ void eeprom_default_sheet_name(uint8_t index, SheetName &sheetName)
         break;
     default:
         break;
-    }
+    }*/
 
     sheetName.c[7] = '\0';
 }

--- a/Firmware/eeprom.cpp
+++ b/Firmware/eeprom.cpp
@@ -136,37 +136,6 @@ void eeprom_default_sheet_name(uint8_t index, SheetName &sheetName)
     }
 
     sheetName.c[6] = '0' + ((index % 2)+1);
-
-/*    switch (index)
-    {
-    case 0:
-        sheetName.c[6] = '1';
-        break;
-    case 1:
-        sheetName.c[6] = '2';
-        break;
-    case 2:
-        sheetName.c[6] = '1';
-        break;
-    case 3:
-        sheetName.c[6] = '2';
-        break;
-    case 4:
-        sheetName.c[6] = '1';
-        break;
-    case 5:
-        sheetName.c[6] = '2';
-        break;
-    case 6:
-        sheetName.c[6] = '1';
-        break;
-    case 7:
-        sheetName.c[6] = '2';
-        break;
-    default:
-        break;
-    }*/
-
     sheetName.c[7] = '\0';
 }
 

--- a/Firmware/eeprom.cpp
+++ b/Firmware/eeprom.cpp
@@ -126,7 +126,7 @@ void eeprom_default_sheet_name(uint8_t index, SheetName &sheetName)
     {
         strcpy_P(sheetName.c, PSTR("Textur"));
     }
-    else if (index < 4)
+    else if (index < 6)
     {
         strcpy_P(sheetName.c, PSTR("Satin "));
     }

--- a/Firmware/eeprom.h
+++ b/Firmware/eeprom.h
@@ -276,19 +276,19 @@ static_assert(sizeof(Sheets) == EEPROM_SHEETS_SIZEOF, "Sizeof(Sheets) is not EEP
 | 0x0D71 3441		| uint16	| ^										| 00 00h 0		| ff ffh 65535			| 4th sheet - Z offset 								| ^				| D3 Ax0d71 C2	
 | 0x0D73 3443		| uint8		| ^										| 00h 0			| ffh 255				| 4th sheet - bed temp 								| ^				| D3 Ax0d73 C1	
 | 0x0D74 3444		| uint8		| ^										| 00h 0			| ffh 255				| 4th sheet - PINDA temp 							| ^				| D3 Ax0d74 C1	
-| 0x0D75 3445		| char		| _5th Sheet block_						| 437573746f6d31| ffffffffffffff		| 5th sheet - Name: 	_Custom1_					| ^				| D3 Ax0d75 C7
+| 0x0D75 3445		| char		| _5th Sheet block_						| 437573746f6d31| ffffffffffffff		| 5th sheet - Name: 	_Satin 1_					| ^				| D3 Ax0d75 C7
 | 0x0D7C 3452		| uint16	| ^										| 00 00h 0		| ff ffh 65535			| 5th sheet - Z offset 								| ^				| D3 Ax0d7c C2	
 | 0x0D7E 3454		| uint8		| ^										| 00h 0			| ffh 255				| 5th sheet - bed temp 								| ^				| D3 Ax0d7e C1	
 | 0x0D7F 3455		| uint8		| ^										| 00h 0			| ffh 255				| 5th sheet - PINDA temp 							| ^				| D3 Ax0d7f C1	
-| 0x0D80 3456		| char		| _6th Sheet block_						| 437573746f6d32| ffffffffffffff		| 6th sheet - Name: 	_Custom2_					| ^				| D3 Ax0d80 C7
+| 0x0D80 3456		| char		| _6th Sheet block_						| 437573746f6d32| ffffffffffffff		| 6th sheet - Name: 	_Satin 2_					| ^				| D3 Ax0d80 C7
 | 0x0D87 3463		| uint16	| ^										| 00 00h 0		| ff ffh 65535			| 6th sheet - Z offset 								| ^				| D3 Ax0d87 C2	
 | 0x0D89 3465		| uint8		| ^										| 00h 0			| ffh 255				| 6th sheet - bed temp 								| ^				| D3 Ax0d89 C1	
 | 0x0D8A 3466		| uint8		| ^										| 00h 0			| ffh 255				| 6th sheet - PINDA temp 							| ^				| D3 Ax0d8a C1	
-| 0x0D8B 3467		| char		| _7th Sheet block_						| 437573746f6d33| ffffffffffffff		| 7th sheet - Name: 	_Custom3_					| ^				| D3 Ax0d8b C7
+| 0x0D8B 3467		| char		| _7th Sheet block_						| 437573746f6d33| ffffffffffffff		| 7th sheet - Name: 	_Custom1_					| ^				| D3 Ax0d8b C7
 | 0x0D92 3474		| uint16	| ^										| 00 00h 0		| ff ffh 65535			| 7th sheet - Z offset 								| ^				| D3 Ax0d92 C2	
 | 0x0D94 3476		| uint8		| ^										| 00h 0			| ffh 255				| 7th sheet - bed temp 								| ^				| D3 Ax0d94 C1	
 | 0x0D95 3477		| uint8		| ^										| 00h 0			| ffh 255				| 7th sheet - PINDA temp 							| ^				| D3 Ax0d95 C1	
-| 0x0D96 3478		| char		| _8th Sheet block_						| 437573746f6d34| ffffffffffffff		| 8th sheet - Name: 	_Custom4_					| ^				| D3 Ax0d96 C7
+| 0x0D96 3478		| char		| _8th Sheet block_						| 437573746f6d34| ffffffffffffff		| 8th sheet - Name: 	_Custom2_					| ^				| D3 Ax0d96 C7
 | 0x0D9D 3485		| uint16	| ^										| 00 00h 0		| ff ffh 65535			| 8th sheet - Z offset 								| ^				| D3 Ax0d9d C2	
 | 0x0D9F 3487		| uint8		| ^										| 00h 0			| ffh 255				| 8th sheet - bed temp 								| ^				| D3 Ax0d9f C1	
 | 0x0DA0 3488		| uint8		| ^										| 00h 0			| ffh 255				| 8th sheet - PINDA temp 							| ^				| D3 Ax0da0 C1	

--- a/Firmware/eeprom.h
+++ b/Firmware/eeprom.h
@@ -276,11 +276,11 @@ static_assert(sizeof(Sheets) == EEPROM_SHEETS_SIZEOF, "Sizeof(Sheets) is not EEP
 | 0x0D71 3441		| uint16	| ^										| 00 00h 0		| ff ffh 65535			| 4th sheet - Z offset 								| ^				| D3 Ax0d71 C2	
 | 0x0D73 3443		| uint8		| ^										| 00h 0			| ffh 255				| 4th sheet - bed temp 								| ^				| D3 Ax0d73 C1	
 | 0x0D74 3444		| uint8		| ^										| 00h 0			| ffh 255				| 4th sheet - PINDA temp 							| ^				| D3 Ax0d74 C1	
-| 0x0D75 3445		| char		| _5th Sheet block_						| 437573746f6d31| ffffffffffffff		| 5th sheet - Name: 	_Satin 1_					| ^				| D3 Ax0d75 C7
+| 0x0D75 3445		| char		| _5th Sheet block_						| 536174696e2031| ffffffffffffff		| 5th sheet - Name: 	_Satin 1_					| ^				| D3 Ax0d75 C7
 | 0x0D7C 3452		| uint16	| ^										| 00 00h 0		| ff ffh 65535			| 5th sheet - Z offset 								| ^				| D3 Ax0d7c C2	
 | 0x0D7E 3454		| uint8		| ^										| 00h 0			| ffh 255				| 5th sheet - bed temp 								| ^				| D3 Ax0d7e C1	
 | 0x0D7F 3455		| uint8		| ^										| 00h 0			| ffh 255				| 5th sheet - PINDA temp 							| ^				| D3 Ax0d7f C1	
-| 0x0D80 3456		| char		| _6th Sheet block_						| 437573746f6d32| ffffffffffffff		| 6th sheet - Name: 	_Satin 2_					| ^				| D3 Ax0d80 C7
+| 0x0D80 3456		| char		| _6th Sheet block_						| 536174696e2032| ffffffffffffff		| 6th sheet - Name: 	_Satin 2_					| ^				| D3 Ax0d80 C7
 | 0x0D87 3463		| uint16	| ^										| 00 00h 0		| ff ffh 65535			| 6th sheet - Z offset 								| ^				| D3 Ax0d87 C2	
 | 0x0D89 3465		| uint8		| ^										| 00h 0			| ffh 255				| 6th sheet - bed temp 								| ^				| D3 Ax0d89 C1	
 | 0x0D8A 3466		| uint8		| ^										| 00h 0			| ffh 255				| 6th sheet - PINDA temp 							| ^				| D3 Ax0d8a C1	

--- a/Firmware/eeprom.h
+++ b/Firmware/eeprom.h
@@ -284,11 +284,11 @@ static_assert(sizeof(Sheets) == EEPROM_SHEETS_SIZEOF, "Sizeof(Sheets) is not EEP
 | 0x0D87 3463		| uint16	| ^										| 00 00h 0		| ff ffh 65535			| 6th sheet - Z offset 								| ^				| D3 Ax0d87 C2	
 | 0x0D89 3465		| uint8		| ^										| 00h 0			| ffh 255				| 6th sheet - bed temp 								| ^				| D3 Ax0d89 C1	
 | 0x0D8A 3466		| uint8		| ^										| 00h 0			| ffh 255				| 6th sheet - PINDA temp 							| ^				| D3 Ax0d8a C1	
-| 0x0D8B 3467		| char		| _7th Sheet block_						| 437573746f6d33| ffffffffffffff		| 7th sheet - Name: 	_Custom1_					| ^				| D3 Ax0d8b C7
+| 0x0D8B 3467		| char		| _7th Sheet block_						| 437573746f6d31| ffffffffffffff		| 7th sheet - Name: 	_Custom1_					| ^				| D3 Ax0d8b C7
 | 0x0D92 3474		| uint16	| ^										| 00 00h 0		| ff ffh 65535			| 7th sheet - Z offset 								| ^				| D3 Ax0d92 C2	
 | 0x0D94 3476		| uint8		| ^										| 00h 0			| ffh 255				| 7th sheet - bed temp 								| ^				| D3 Ax0d94 C1	
 | 0x0D95 3477		| uint8		| ^										| 00h 0			| ffh 255				| 7th sheet - PINDA temp 							| ^				| D3 Ax0d95 C1	
-| 0x0D96 3478		| char		| _8th Sheet block_						| 437573746f6d34| ffffffffffffff		| 8th sheet - Name: 	_Custom2_					| ^				| D3 Ax0d96 C7
+| 0x0D96 3478		| char		| _8th Sheet block_						| 437573746f6d32| ffffffffffffff		| 8th sheet - Name: 	_Custom2_					| ^				| D3 Ax0d96 C7
 | 0x0D9D 3485		| uint16	| ^										| 00 00h 0		| ff ffh 65535			| 8th sheet - Z offset 								| ^				| D3 Ax0d9d C2	
 | 0x0D9F 3487		| uint8		| ^										| 00h 0			| ffh 255				| 8th sheet - bed temp 								| ^				| D3 Ax0d9f C1	
 | 0x0DA0 3488		| uint8		| ^										| 00h 0			| ffh 255				| 8th sheet - PINDA temp 							| ^				| D3 Ax0da0 C1	


### PR DESCRIPTION
This changes the `Custom1` and `Custom2` sheets to be `Satin 1` and `Satin 2`. Additionally, as there are now only the numbers `1` and `2` at the end of sheets, this replaces the switch that was used to determine sheet numbers, now using modulo to assign the sheet a `1` or `2`. I believe that I have updated the table in `eeprom.h` correctly, if I haven't, let me know. 

To have the sheet names change, the sheet must be reset.

### New:
Index | Name
---|---
0 | Smooth1
1 | Smooth2
2 | Textur1
3 | Textur2
4 | Satin 1
5 | Satin 2
6 | Custom1
7 | Custom2

### Old:
Index | Name
---|---
0 | Smooth1
1 | Smooth2
2 | Textur1
3 | Textur2
4 | Custom1
5 | Custom2
6 | Custom3
7 | Custom4

![Picture of new names](https://user-images.githubusercontent.com/56133692/110244730-202d6080-7f2e-11eb-9433-74bba31cc3d9.jpg)


Resolves #3051 

PFW-1240