### PR TITLE
Reprint function implemented for MK3S/MK3S+

### DIFF
--- a/Firmware/cardreader.cpp
+++ b/Firmware/cardreader.cpp
@@ -1085,4 +1085,16 @@ bool CardReader::ToshibaFlashAir_GetIP(uint8_t *ip)
     return card.readExtMemory(1, 1, 0x400+0x150, 4, ip);
 }
 
+bool CardReader::FileExists(const char* filename)
+{
+  bool exists = false;
+
+    if (file.open(curDir, filename, O_READ))
+    {
+      exists = true;
+      file.close();
+    }
+    return exists;
+}
+
 #endif //SDSUPPORT

--- a/Firmware/cardreader.h
+++ b/Firmware/cardreader.h
@@ -70,6 +70,7 @@ public:
   bool ToshibaFlashAir_isEnabled() const { return card.getFlashAirCompatible(); }
   void ToshibaFlashAir_enable(bool enable) { card.setFlashAirCompatible(enable); }
   bool ToshibaFlashAir_GetIP(uint8_t *ip);
+  bool FileExists(const char* filename);
 
 public:
   bool saving;

--- a/Firmware/cmdqueue.cpp
+++ b/Firmware/cmdqueue.cpp
@@ -653,6 +653,7 @@ void get_command()
       // cleared by printingHasFinished after peforming all remaining moves.
       if(!cmdqueue_calc_sd_length())
       {
+          isPrintFinished=true;
           SERIAL_PROTOCOLLNRPGM(_n("Done printing file"));////MSG_FILE_PRINTED
           stoptime=_millis();
           char time[30];

--- a/Firmware/cmdqueue.cpp
+++ b/Firmware/cmdqueue.cpp
@@ -653,7 +653,7 @@ void get_command()
       // cleared by printingHasFinished after peforming all remaining moves.
       if(!cmdqueue_calc_sd_length())
       {
-          isPrintFinished=true;
+          enableReprint=true;
           SERIAL_PROTOCOLLNRPGM(_n("Done printing file"));////MSG_FILE_PRINTED
           stoptime=_millis();
           char time[30];

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -6559,10 +6559,13 @@ static void lcd_main_menu()
     MENU_ITEM_FUNCTION_P(PSTR("power panic"), uvlo_);
 #endif //TMC2130_DEBUG
 
-	if ( (!PRINTER_ACTIVE) && isPrintFinished)
+	if ( (!PRINTER_ACTIVE) && isPrintFinished && card.cardOK)
   	{
 		MENU_ITEM_SUBMENU_P(_i("Reprint"), reprint_from_eeprom);
-  	}
+  	}else if (!card.cardOK)
+	  {	  //If the user remove the SD card the reprint will be disabled because you can't be sure that the gcode file will remain in the SD
+		  isPrintFinished = false; 
+	  }
 
     if ( ( IS_SD_PRINTING || is_usb_printing || (lcd_commands_type == LcdCommands::Layer1Cal)) && (current_position[Z_AXIS] < Z_HEIGHT_HIDE_LIVE_ADJUST_MENU) && !homing_flag && !mesh_bed_leveling_flag) {
         MENU_ITEM_SUBMENU_P(_T(MSG_BABYSTEP_Z), lcd_babystep_z);//8

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -8970,6 +8970,7 @@ void lcd_experimental_menu()
 void reprint_from_eeprom() {
 	char cmd[30];
 	char filename[13];
+	char altfilename[13];
 	uint8_t depth = 0;
 	char dir_name[9];
 
@@ -8994,10 +8995,21 @@ void reprint_from_eeprom() {
 		filename[i] = eeprom_read_byte((uint8_t*)EEPROM_FILENAME + i);
 	}
 	filename[8] = '\0';
-
-	MYSERIAL.print(filename);
-	strcat_P(filename, PSTR(".gco"));
-	sprintf_P(cmd, PSTR("M23 %s"), filename);
+	
+	strcpy(altfilename,filename);
+	if (!card.FileExists(altfilename))
+	{
+		strcat_P(filename, PSTR(".gco"));
+		if (card.FileExists(filename))
+		{
+			strcpy(altfilename,filename);
+		}else
+		{
+			strcat_P(altfilename, PSTR(".g"));
+		}
+	}
+	MYSERIAL.print(altfilename);
+	sprintf_P(cmd, PSTR("M23 %s"), altfilename);
 	enquecommand(cmd);
   	sprintf_P(cmd, PSTR("M24"));
 	enquecommand(cmd);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -79,7 +79,7 @@ static uint8_t lcd_commands_step = 0;
 CustomMsg custom_message_type = CustomMsg::Status;
 unsigned int custom_message_state = 0;
 
-bool isPrintFinished = false;
+bool enableReprint = false;
 bool isPrintPaused = false;
 uint8_t farm_mode = 0;
 int farm_timer = 8;
@@ -6559,12 +6559,12 @@ static void lcd_main_menu()
     MENU_ITEM_FUNCTION_P(PSTR("power panic"), uvlo_);
 #endif //TMC2130_DEBUG
 
-	if ( (!PRINTER_ACTIVE) && isPrintFinished && card.cardOK)
+	if ( (!PRINTER_ACTIVE) && enableReprint && card.cardOK)
   	{
 		MENU_ITEM_SUBMENU_P(_i("Reprint"), reprint_from_eeprom);
   	}else if (!card.cardOK)
 	  {	  //If the user remove the SD card the reprint will be disabled because you can't be sure that the gcode file will remain in the SD
-		  isPrintFinished = false; 
+		  enableReprint = false; 
 	  }
 
     if ( ( IS_SD_PRINTING || is_usb_printing || (lcd_commands_type == LcdCommands::Layer1Cal)) && (current_position[Z_AXIS] < Z_HEIGHT_HIDE_LIVE_ADJUST_MENU) && !homing_flag && !mesh_bed_leveling_flag) {
@@ -8973,7 +8973,7 @@ void reprint_from_eeprom() {
 	uint8_t depth = 0;
 	char dir_name[9];
 
-	isPrintFinished=false;
+	enableReprint=false;
 
 	//cmdqueue_reset();
 

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -15,6 +15,7 @@ extern void menu_lcd_charsetup_func(void);
 extern void menu_lcd_lcdupdate_func(void);
 
 // Call with a false parameter to suppress the LCD update from various places like the planner or the temp control.
+void reprint_from_eeprom();
 void ultralcd_init();
 void lcd_setstatus(const char* message);
 void lcd_setstatuspgm(const char* message);
@@ -154,6 +155,7 @@ extern uint8_t SilentModeMenu_MMU;
 
 extern bool cancel_heatup;
 extern bool isPrintPaused;
+extern bool isPrintFinished;
 
 extern uint8_t scrollstuff;
 

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -155,7 +155,7 @@ extern uint8_t SilentModeMenu_MMU;
 
 extern bool cancel_heatup;
 extern bool isPrintPaused;
-extern bool isPrintFinished;
+extern bool enableReprint;
 
 extern uint8_t scrollstuff;
 


### PR DESCRIPTION
We have created a new menu option that is displayed only when the previous print ends successfully. 
To support this functionality we have added a **extern bool variable** which can be read/set from **cmdqueue.cpp** and **ultralcd.cpp** so when the card reader reaches the EOF the variable isPrintFinished will be set to true and the main menu will show the **REPRINT** option. 
How do we know which file we need to reprint? We have read the code and we saw that all the information needed to perform the reprint was stored on the EEPROM in case of a power panic and we recover this information in order to start the print from SD again, this feature has been implemented on the function reprint_from_eeprom().