### PR TITLE
New G-Code (M880) in order to check the Steel Sheet installed

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -8380,6 +8380,17 @@ Sigma_Exit:
                }
     break;
 
+  /*!
+  ### M880 - Check the Steel Sheet, the M880 code should be set before to start the print in order to ask the user about
+  the viability of use the current configured steel sheet and try to minimize the risk of use a sheet with the configuration 
+  of another sheet
+  ### Usage
+      M880
+  */
+    case 880:
+      steel_sheet_check();
+    break;
+
 #ifdef LIN_ADVANCE
     /*!
 	### M900 - Set Linear advance options <a href="https://reprap.org/wiki/G-code#M900_Set_Linear_Advance_Scaling_Factors">M900 Set Linear Advance Scaling Factors</a>

--- a/Firmware/messages.c
+++ b/Firmware/messages.c
@@ -203,3 +203,4 @@ const char MSG_M112_KILL[] PROGMEM_N1 = "M112 called. Emergency Stop."; ////c=20
 const char MSG_ADVANCE_K[] PROGMEM_N1 = "Advance K:"; ////c=13
 const char MSG_POWERPANIC_DETECTED[] PROGMEM_N1 = "POWER PANIC DETECTED"; ////c=20
 const char MSG_LCD_STATUS_CHANGED[] PROGMEM_N1 = "LCD status changed";
+const char MSG_CHECK_STEEL_SHEET[] PROGMEM_I1 = ISTR("Check the steel sheet installed");

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -203,6 +203,7 @@ extern const char MSG_M112_KILL[];
 extern const char MSG_ADVANCE_K[];
 extern const char MSG_POWERPANIC_DETECTED[];
 extern const char MSG_LCD_STATUS_CHANGED[];
+extern const char MSG_CHECK_STEEL_SHEET[];
 
 #if defined(__cplusplus)
 }

--- a/Firmware/util.cpp
+++ b/Firmware/util.cpp
@@ -611,3 +611,24 @@ void ip4_to_str(char* dest, uint8_t* IP)
 {
     sprintf_P(dest, PSTR("%u.%u.%u.%u"), IP[0], IP[1], IP[2], IP[3]);
 }
+
+void steel_sheet_check()
+{ 
+    if (!is_usb_printing)
+    {
+        const int8_t sheetNR = eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet));
+        const int8_t nextSheet = eeprom_next_initialized_sheet(sheetNR);
+        if ((nextSheet >= 0) && (sheetNR != nextSheet))
+	    {
+            char sheet[8];
+	        eeprom_read_block(sheet, EEPROM_Sheets_base->s[sheetNR].name, 7);
+	        sheet[7] = '\0';
+            lcd_display_message_fullscreen_P(_T(MSG_CHECK_STEEL_SHEET));
+            lcd_set_cursor(0,2);
+            lcd_printf_P(PSTR("%-7s, Continue?"),sheet);
+            if (!lcd_wait_for_click_delay(MSG_PRINT_CHECKING_FAILED_TIMEOUT))
+                lcd_print_stop();
+            lcd_update_enable(true);
+        }  
+    }
+} 

--- a/Firmware/util.h
+++ b/Firmware/util.h
@@ -109,6 +109,7 @@ void fw_version_check(const char *pVersion);
 void gcode_level_check(uint16_t nGcodeLevel);
 
 void fSetMmuMode(bool bMMu);
+void steel_sheet_check();
 
 #define IP4_STR_SIZE 16
 extern void ip4_to_str(char* dest, uint8_t* IP);


### PR DESCRIPTION
**Summary**

Suddenly I forgot about to change the steel sheet selected, obviously, I'm not using the same sheet with all the materials, so I use to get in a hurry to change the sheet before my PEI got damage by the nozzle, sadly this is something that sometimes happens and my PEI knows very well. 

**Why a gcode?**

I decided to generate a G-Code instead of modifying another piece of code because I understand that not everyone will like to have this reminder on the LCD screen before starting the print. So you can decide if you will use it on your "start G-Code" of your printer profile or not. 

**Why the gcode M880?**

I don't really sure how to choose a g-code, so I was looking at the g-codes that perform checks and I take a free slot near to them. 

**How it works?**

The M880 will check if you are printing from USB or not, if not will check how many steel sheets do you have stored on the EEPROM, if there are 2 or more steel sheets stored will recover the name of the one that is currently active and will show a fullscreen message with the question "Continue?". If there is no answer after 30 seconds will cancel the print. 

This is an example of the message:

```
----------------------------------
| Check the steel sheet installed|
| Texture1, Continue?            |
----------------------------------
```

**Example of start g-code on the printer profile:**
```

M862.3 P "[printer_model]" ; printer model check
M862.1 P[nozzle_diameter] ; nozzle diameter check
M115 U3.9.3 ; tell printer latest fw version
M880; check the steel sheet
G90 ; use absolute coordinates
M83 ; extruder relative mode
```
