### PR TITLE
Nozzle fan and print fan are swapped on lcd_extruder_info() function

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1442,7 +1442,7 @@ void lcd_menu_extruder_info()                     // NOT static due to using ins
     char nozzle[maxChars], print[maxChars];
     pgmtext_with_colon(_i("Nozzle FAN"), nozzle, maxChars);  ////c=10 r=1
     pgmtext_with_colon(_i("Print FAN"), print, maxChars);  ////c=10 r=1
-	lcd_printf_P(_N("%s %4d RPM\n" "%s %4d RPM\n"), nozzle, 60*fan_speed[0], print, 60*fan_speed[1] ); 
+	lcd_printf_P(_N("%s %4d RPM\n" "%s %4d RPM\n"), nozzle, 60*fan_speed[1], print, 60*fan_speed[0] ); 
     menu_back_if_clicked();
 }
 


### PR DESCRIPTION
Maybe I'm lost on translation, in that case, I would suggest changing the name of the FANs in order to avoid these mistakes. 

**HotFix**

This is a HotFix for the lcd_extruder_info() function because the nozzle fan is showing the RPM coming from position 0 of the array fan_speed[] but the correct position for this fan is the 1. So I swapped it to the correct assignment. 