### PR TITLE
Remove unnecessary assignment

### DIFF
--- a/Firmware/heatbed_pwm.cpp
+++ b/Firmware/heatbed_pwm.cpp
@@ -153,7 +153,6 @@ ISR(TIMER0_OVF_vect)          // timer compare interrupt service routine
 			return;           // want full duty for the next ONE cycle again - so keep on heating and just wait for the next timer ovf
 		}
 		// otherwise moving towards FALL
-		state = States::ONE;//_TO_FALL;
 		state=States::FALL;
 		fastCounter = fastMax - 1;// we'll do 16-1 cycles of RISE
 		TCNT0 = 255;              // force overflow on the next clock cycle


### PR DESCRIPTION
In my opinion the assignment is not needed. The case statement  `case States::ONE: ` of `switch(state)` already ensures that the variable `state` is assigned to `States::ONE`. Also the case statement above is ended by a `break;` so there is no fall-through case where the state variable could be assigned to something else.