### PR TITLE
Show affected axes in crash detection messages

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -631,7 +631,7 @@ void crashdet_detected(uint8_t mask)
 	lcd_update_enable(true);
 	lcd_update(2);
 
-    // prepare the status message with the _current_ axes stauts
+    // prepare the status message with the _current_ axes status
     strcat(msg, " ");
     strcat_P(msg, _T(MSG_CRASH_DETECTED));
     lcd_setstatus(msg);

--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -24,7 +24,7 @@ const char MSG_COMMUNITY_MADE[] PROGMEM_I1 = ISTR("Community made"); ////c=18
 const char MSG_CONFIRM_NOZZLE_CLEAN[] PROGMEM_I1 = ISTR("Please clean the nozzle for calibration. Click when done."); ////c=20 r=8
 const char MSG_COOLDOWN[] PROGMEM_I1 = ISTR("Cooldown"); ////c=18
 const char MSG_CRASH[] PROGMEM_I1 = ISTR("Crash"); ////c=7
-const char MSG_CRASH_DETECTED[] PROGMEM_I1 = ISTR("Crash detected."); ////c=20
+const char MSG_CRASH_DETECTED[] PROGMEM_I1 = ISTR("Crash detected."); ////c=17 r=1
 const char MSG_CRASHDETECT[] PROGMEM_I1 = ISTR("Crash det."); ////c=13
 const char MSG_ERROR[] PROGMEM_I1 = ISTR("ERROR:"); ////c=10
 const char MSG_EXTRUDER[] PROGMEM_I1 = ISTR("Extruder"); ////c=17

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3579,18 +3579,14 @@ int8_t lcd_show_multiscreen_message_two_choices_and_wait_P(const char *msg, bool
 	}
 }
 
-//! @brief Show single screen message with yes and no possible choices and wait with possible timeout
-//! @param msg Message to show
+//! @brief Display and wait for a Yes/No choice using the last two lines of the LCD
 //! @param allow_timeouting if true, allows time outing of the screen
 //! @param default_yes if true, yes choice is selected by default, otherwise no choice is preselected
 //! @retval 1 yes choice selected by user
 //! @retval 0 no choice selected by user
 //! @retval -1 screen timed out
-int8_t lcd_show_fullscreen_message_yes_no_and_wait_P(const char *msg, bool allow_timeouting, bool default_yes)
+int8_t lcd_show_yes_no_and_wait(bool allow_timeouting, bool default_yes)
 {
-
-	lcd_display_message_fullscreen_P(msg);
-	
 	if (default_yes) {
 		lcd_putc_at(0, 2, '>');
 		lcd_puts_P(_T(MSG_YES));
@@ -3641,6 +3637,20 @@ int8_t lcd_show_fullscreen_message_yes_no_and_wait_P(const char *msg, bool allow
 	}
     lcd_encoder_diff = 0;
     return retval;
+}
+
+//! @brief Show single screen message with yes and no possible choices and wait with possible timeout
+//! @param msg Message to show
+//! @param allow_timeouting if true, allows time outing of the screen
+//! @param default_yes if true, yes choice is selected by default, otherwise no choice is preselected
+//! @retval 1 yes choice selected by user
+//! @retval 0 no choice selected by user
+//! @retval -1 screen timed out
+//! @relates lcd_show_yes_no_and_wait
+int8_t lcd_show_fullscreen_message_yes_no_and_wait_P(const char *msg, bool allow_timeouting, bool default_yes)
+{
+    lcd_display_message_fullscreen_P(msg);
+    return lcd_show_yes_no_and_wait(allow_timeouting, default_yes);
 }
 
 void lcd_bed_calibration_show_result(BedSkewOffsetDetectionResultType result, uint8_t point_too_far_mask)

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -72,6 +72,8 @@ extern void lcd_wait_for_click();
 extern bool lcd_wait_for_click_delay(uint16_t nDelay);
 extern void lcd_show_fullscreen_message_and_wait_P(const char *msg);
 // 0: no, 1: yes, -1: timeouted
+extern int8_t lcd_show_yes_no_and_wait(bool allow_timeouting = true, bool default_yes = false);
+// 0: no, 1: yes, -1: timeouted
 extern int8_t lcd_show_fullscreen_message_yes_no_and_wait_P(const char *msg, bool allow_timeouting = true, bool default_yes = false);
 extern int8_t lcd_show_multiscreen_message_two_choices_and_wait_P(const char *msg, bool allow_timeouting, bool default_yes,
         const char *first_choice, const char *second_choice);


### PR DESCRIPTION
Explicitly show which axes are affected on the status line when a crash
has been detected.

When the crash recovery prompt is triggered, also show all axes which
have been affected during the detection interval (currently X, Y, or
both).

The timer detection has been simplified to match the MK3 optical
filament timeout handling, which makes more sense: a crash immediately
following a crash recovery prompt will trigger the prompt again. The
timer needs to properly expire in order to reset the crash count.

This helps crash detection tuning (and help users reporting issues with
crash detection) without having to monitor the serial line.

This currently abuses the MSG_CRASH_DETECTED message by prepending the
[X][Y] labels to the message, which is ok in english but might not
translate that well for all languages without tuning the translations.

On English it's now: ``X Crash detected.``, optionally followed by ``Resume print?``.