### PR TITLE
Initial stale issue workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,29 @@
+name: Mark stale issues
+
+on:
+  schedule:
+  # 1:30 AM on MON/THU
+  - cron: "30 1 * * 1,4"
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        # Don't ever mark PRs as stale.
+        days-before-pr-stale: -1
+        stale-issue-message: 'This issue is stale because it has been open for 60 days with no activity. The issue will be closed in 7 days unless you remove the "stale" label or add a comment.'
+        close-issue-message: 'This issue has been closed due to lack of activity.' 
+        # Don't act on things assigned to a milestone or assigned to someone. 
+        exempt-all-milestones: true
+        exempt-all-assignees: true
+        enable-statistics: true
+        # Disable this and change the operations per run back to 30 when this goes live.
+        debug-only: true
+        operations-per-run: 1000
+        stale-issue-label: 'stale-issue'
+        stale-pr-label: 'stale-pr'


### PR DESCRIPTION
Per discussion, initial template for consideration and review. 

- Does not touch PRs
- Issues tagged stale-issue after 60 days
- Closed after a further 7 days without activity
- Anything with an assignee or milestone assigned is not touched
- Runs at 1:30 on Monday/Thursday
- Debug mode, should not actually alter the issues.