### PR TITLE
Fix PowerPanic and Crash Detection during homing and bed leveling

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3036,6 +3036,8 @@ static void gcode_G80()
     plan_buffer_line_curposXYZE(XY_AXIS_FEEDRATE);
     // Wait until the move is finished.
     st_synchronize();
+    if (waiting_inside_plan_buffer_line_print_aborted)
+        return;
 
     uint8_t mesh_point = 0; //index number of calibration point
     int Z_LIFT_FEEDRATE = homing_feedrate[Z_AXIS] / 40;
@@ -3105,6 +3107,8 @@ static void gcode_G80()
         //printf_P(PSTR("after clamping: [%f;%f]\n"), current_position[X_AXIS], current_position[Y_AXIS]);
         plan_buffer_line_curposXYZE(XY_AXIS_FEEDRATE);
         st_synchronize();
+        if (waiting_inside_plan_buffer_line_print_aborted)
+            return;
 
         // Go down until endstop is hit
         const float Z_CALIBRATION_THRESHOLD = 1.f;

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -588,19 +588,6 @@ void crashdet_restore_print_and_continue()
 //	babystep_apply();
 }
 
-
-void crashdet_stop_and_save_print2()
-{
-	cli();
-	planner_abort_hard(); //abort printing
-	cmdqueue_reset(); //empty cmdqueue
-	card.sdprinting = false;
-	card.closefile();
-  // Reset and re-enable the stepper timer just before the global interrupts are enabled.
-  st_reset_timer();
-	sei();
-}
-
 void crashdet_detected(uint8_t mask)
 {
 	st_synchronize();

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3032,13 +3032,12 @@ static void gcode_G80()
     world2machine_clamp(current_position[X_AXIS], current_position[Y_AXIS]);
 #endif //SUPPORT_VERBOSITY
 
-    plan_buffer_line_curposXYZE(homing_feedrate[X_AXIS] / 30);
+    int XY_AXIS_FEEDRATE = homing_feedrate[X_AXIS] / 20;
+    plan_buffer_line_curposXYZE(XY_AXIS_FEEDRATE);
     // Wait until the move is finished.
     st_synchronize();
 
     uint8_t mesh_point = 0; //index number of calibration point
-
-    int XY_AXIS_FEEDRATE = homing_feedrate[X_AXIS] / 20;
     int Z_LIFT_FEEDRATE = homing_feedrate[Z_AXIS] / 40;
     bool has_z = is_bed_z_jitter_data_valid(); //checks if we have data from Z calibration (offsets of the Z heiths of the 8 calibration points from the first point)
 #ifdef SUPPORT_VERBOSITY

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -11247,7 +11247,7 @@ void restore_print_from_eeprom(bool mbl_was_active) {
 	int feedrate_rec;
 	int feedmultiply_rec;
 	uint8_t fan_speed_rec;
-	char cmd[30];
+	char cmd[48];
 	char filename[13];
 	uint8_t depth = 0;
 	char dir_name[9];

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3037,7 +3037,11 @@ static void gcode_G80()
     // Wait until the move is finished.
     st_synchronize();
     if (waiting_inside_plan_buffer_line_print_aborted)
+    {
+        custom_message_type = custom_message_type_old;
+        custom_message_state = custom_message_state_old;
         return;
+    }
 
     uint8_t mesh_point = 0; //index number of calibration point
     int Z_LIFT_FEEDRATE = homing_feedrate[Z_AXIS] / 40;
@@ -3108,7 +3112,11 @@ static void gcode_G80()
         plan_buffer_line_curposXYZE(XY_AXIS_FEEDRATE);
         st_synchronize();
         if (waiting_inside_plan_buffer_line_print_aborted)
+        {
+            custom_message_type = custom_message_type_old;
+            custom_message_state = custom_message_state_old;
             return;
+        }
 
         // Go down until endstop is hit
         const float Z_CALIBRATION_THRESHOLD = 1.f;
@@ -3206,7 +3214,9 @@ static void gcode_G80()
             enable_z_endstop(bState);
         } while (st_get_position_mm(Z_AXIS) > MESH_HOME_Z_SEARCH); // i.e. Z-leveling not o.k.
         //               plan_set_z_position(MESH_HOME_Z_SEARCH); // is not necessary ('do-while' loop always ends at the expected Z-position)
-        custom_message_type=CustomMsg::Status; // display / status-line recovery
+
+        custom_message_type = custom_message_type_old;
+        custom_message_state = custom_message_state_old;
         lcd_update_enable(true);           // display / status-line recovery
         gcode_G28(true, true, true);       // X & Y & Z-homing (must be after individual Z-homing (problem with spool-holder)!)
         repeatcommand_front();             // re-run (i.e. of "G80")

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -11169,11 +11169,6 @@ bool recover_machine_state_after_power_panic()
   // Recover last E axis position
   current_position[E_AXIS] = eeprom_read_float((float*)(EEPROM_UVLO_CURRENT_POSITION_E));
 
-  memcpy(destination, current_position, sizeof(destination));
-
-  SERIAL_ECHOPGM("recover_machine_state_after_power_panic, initial ");
-  print_world_coordinates();
-
   // 3) Initialize the logical to physical coordinate system transformation.
   world2machine_initialize();
 //  SERIAL_ECHOPGM("recover_machine_state_after_power_panic, initial ");
@@ -11185,7 +11180,11 @@ bool recover_machine_state_after_power_panic()
 
   // 5) Set the physical positions from the logical positions using the world2machine transformation
   // This is only done to inizialize Z/E axes with physical locations, since X/Y are unknown.
+  clamp_to_software_endstops(current_position);
+  memcpy(destination, current_position, sizeof(destination));
   plan_set_position_curposXYZE();
+  SERIAL_ECHOPGM("recover_machine_state_after_power_panic, initial ");
+  print_world_coordinates();
 
   // 6) Power up the Z motors, mark their positions as known.
   axis_known_position[Z_AXIS] = true;

--- a/Firmware/tmc2130.cpp
+++ b/Firmware/tmc2130.cpp
@@ -68,8 +68,9 @@ uint8_t tmc2130_sg_diag_mask = 0x00;
 uint8_t tmc2130_sg_crash = 0;
 uint16_t tmc2130_sg_err[4] = {0, 0, 0, 0};
 uint16_t tmc2130_sg_cnt[4] = {0, 0, 0, 0};
+#ifdef DEBUG_CRASHDET_COUNTERS
 bool tmc2130_sg_change = false;
-
+#endif
 
 bool skip_debug_msg = false;
 
@@ -255,7 +256,9 @@ void tmc2130_st_isr()
 		if (tmc2130_sg_cnt[axis] < tmc2130_sg_err[axis])
 		{
 			tmc2130_sg_cnt[axis] = tmc2130_sg_err[axis];
+#ifdef DEBUG_CRASHDET_COUNTERS
 			tmc2130_sg_change = true;
+#endif
 			uint8_t sg_thr = 64;
 //			if (axis == Y_AXIS) sg_thr = 64;
 			if (tmc2130_sg_err[axis] >= sg_thr)
@@ -409,7 +412,9 @@ void tmc2130_check_overtemp()
 
 		}
 		checktime = _millis();
+#ifdef DEBUG_CRASHDET_COUNTERS
 		tmc2130_sg_change = true;
+#endif
 	}
 #ifdef DEBUG_CRASHDET_COUNTERS
 	if (tmc2130_sg_change)


### PR DESCRIPTION
This PR fixes recovery from either power panic or crash detection that happen during bed leveling or homing.

In the current master, a crash detection during MBL will recover incorrectly, first by moving to the last MBL probe point, then level, and then start to extrude in a random spot of the bed prior to resume. If a crash happens during the second MBL run, a stack overflow is likely to happen. A similar situation happens if power panic triggers.

During crash detection, the MBL function needs to correctly check if the moves are aborted during st_synchronize() and unroll the stack if that's the case (that's true for any function that performs multiple moves - sadly a condition which is hardly checked-for currently).

In both PP and Crash detection, we now handle G28 and G80 specially by marking the current XY coordinates and saved target as invalid. When resuming we check is the saved coordinates are valid or not, and if not we avoid restoring them entirely. This is correct, because at a higher level both crash detection and power panic will always re-run the entirety of the last gcode instruction. This avoids both the useless move towards the last probed point and also the incorrect extrusion immediately following.

In d2be404 we also fix another race condition that can happen during PP recovery that I managed to trigger while debugging this issue. It's similar in behavior to previous #2469: a missing call to clamp_to_software_endstops during initialization can generate a phantom move, except that in this case it can result in an immediate axis crash right before homing.

PFW-1170