### PR TITLE
Fix M105 from SD

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -6490,6 +6490,7 @@ Sigma_Exit:
       gcode_M105(extruder);
       
       cmdqueue_pop_front(); //prevent an ok after the command since this command uses an ok at the beginning.
+      cmdbuffer_front_already_processed = true;
       
       break;
     }


### PR DESCRIPTION
Fixes https://github.com/prusa3d/Prusa-Firmware/issues/3077#issuecomment-821963501

The M105 command would accidentally pop two commands from the cmdqueue. This did not affect the USB printing because there is ever only one command in the cmdqueue when USB printing. However, when SD printing, the cmdqueue is most of the time full, so the command after M105 would be popped as well. With this patch only one command is popped by the M105 handling.

PFW-1238