### PR TITLE
Improve filament sensor PCB upgrade logic 

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -9768,31 +9768,15 @@ static uint16_t nFSCheckCount=0;
 #ifdef PAT9125
 					fsensor_autoload_check_stop();
 #endif //PAT9125
-//-//					if (degHotend0() > EXTRUDE_MINTEMP)
-if(0)
-					{
-						Sound_MakeCustom(50,1000,false);
-						loading_flag = true;
-						enquecommand_front_P((PSTR("M701")));
-					}
-					else
-					{
-/*
-						lcd_update_enable(false);
-						show_preheat_nozzle_warning();
-						lcd_update_enable(true);
-*/
-						eFilamentAction=FilamentAction::AutoLoad;
-						bFilamentFirstRun=false;
-						if(target_temperature[0]>=EXTRUDE_MINTEMP){
-							bFilamentPreheatState=true;
-//							mFilamentItem(target_temperature[0],target_temperature_bed);
-							menu_submenu(mFilamentItemForce);
-						} else {
-							menu_submenu(lcd_generic_preheat_menu);
-							lcd_timeoutToStatus.start();
-						}
-					}
+                    eFilamentAction=FilamentAction::AutoLoad;
+                    bFilamentFirstRun=false;
+                    if(target_temperature[0]>=EXTRUDE_MINTEMP){
+                        bFilamentPreheatState=true;
+                        menu_submenu(mFilamentItemForce);
+                    } else {
+                        menu_submenu(lcd_generic_preheat_menu);
+                        lcd_timeoutToStatus.start();
+                    }
 				}
 			}
 			else

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -9755,7 +9755,6 @@ void manage_inactivity(bool ignore_stepper_queue/*=false*/) //default argument s
 
 	if (mmu_enabled == false)
 	{
-//-//		if (mcode_in_progress != 600) //M600 not in progress
 		if (!PRINTER_ACTIVE) bInhibitFlag=(menu_menu==lcd_menu_show_sensors_state); //Block Filament sensor actions if PRINTER is not active and Support::SensorInfo menu active
 #ifdef IR_SENSOR_ANALOG
 		bInhibitFlag=bInhibitFlag||bMenuFSDetect; // Block Filament sensor actions if Settings::HWsetup::FSdetect menu active
@@ -9764,6 +9763,7 @@ void manage_inactivity(bool ignore_stepper_queue/*=false*/) //default argument s
 		{
 			if (!moves_planned() && !IS_SD_PRINTING && !is_usb_printing && (lcd_commands_type != LcdCommands::Layer1Cal) && ! eeprom_read_byte((uint8_t*)EEPROM_WIZARD_ACTIVE))
 			{
+                // idling: housekeeping and autoload checks
 #ifdef IR_SENSOR_ANALOG
                 // Attempt to detect a change in the IR PCB version
                 manage_inactivity_IR_ANALOG_CheckPCB();
@@ -9786,6 +9786,7 @@ void manage_inactivity(bool ignore_stepper_queue/*=false*/) //default argument s
 			}
 			else
 			{
+                // printing: runout detection
 #ifdef PAT9125
 				fsensor_autoload_check_stop();
 #endif //PAT9125

--- a/Firmware/fsensor.cpp
+++ b/Firmware/fsensor.cpp
@@ -123,6 +123,7 @@ uint16_t fsensor_oq_sh_sum;
 #ifdef IR_SENSOR_ANALOG
 ClFsensorPCB oFsensorPCB;
 ClFsensorActionNA oFsensorActionNA;
+uint16_t oFSCheckCount = FS_CHECK_COUNT * 3;
 bool bIRsensorStateFlag=false;
 unsigned long nIRsensorLastTime;
 #endif //IR_SENSOR_ANALOG
@@ -207,6 +208,10 @@ void fsensor_init(void)
 	bIRsensorStateFlag=false;
 	oFsensorPCB = (ClFsensorPCB)eeprom_read_byte((uint8_t*)EEPROM_FSENSOR_PCB);
 	oFsensorActionNA = (ClFsensorActionNA)eeprom_read_byte((uint8_t*)EEPROM_FSENSOR_ACTION_NA);
+
+    // disable checking for PCB updates if already at the newest version
+    if(oFsensorPCB == ClFsensorPCB::_Newest)
+        oFSCheckCount = 0;
 
 	// If the fsensor is not responding even at the start of the printer,
 	// set this flag accordingly to show N/A in Settings->Filament sensor.

--- a/Firmware/fsensor.h
+++ b/Firmware/fsensor.h
@@ -84,8 +84,6 @@ extern uint8_t fsensor_log;
 #endif //PAT9125
 
 #ifdef IR_SENSOR_ANALOG
-#define VOLT_DIV_REF 5
-
 #define IR_SENSOR_STEADY 10                       // [ms]
 
 // number of required consistent consecutive filament sensor check attempts
@@ -112,12 +110,8 @@ extern ClFsensorActionNA oFsensorActionNA;
 extern const char* FsensorIRVersionText();
 
 extern bool fsensor_IR_check();
-constexpr uint16_t Voltage2Raw(float V){
-	return ( V * 1023 * OVERSAMPLENR / VOLT_DIV_REF ) + 0.5F;
-}
-constexpr float Raw2Voltage(uint16_t raw){
-	return VOLT_DIV_REF*(raw / (1023.F * OVERSAMPLENR) );
-}
+
+#include "temperature.h"
 constexpr uint16_t IRsensor_Ldiode_TRESHOLD = Voltage2Raw(0.3F); // ~0.3V, raw value=982
 constexpr uint16_t IRsensor_Lmax_TRESHOLD = Voltage2Raw(1.5F); // ~1.5V (0.3*Vcc), raw value=4910
 constexpr uint16_t IRsensor_Hmin_TRESHOLD = Voltage2Raw(3.0F); // ~3.0V (0.6*Vcc), raw value=9821

--- a/Firmware/fsensor.h
+++ b/Firmware/fsensor.h
@@ -83,15 +83,20 @@ extern uint8_t fsensor_log;
 //! @}
 #endif //PAT9125
 
+#ifdef IR_SENSOR_ANALOG
 #define VOLT_DIV_REF 5
 
-#ifdef IR_SENSOR_ANALOG
 #define IR_SENSOR_STEADY 10                       // [ms]
+
+// number of required consistent consecutive filament sensor check attempts
+#define FS_CHECK_COUNT 16
+// number of remaining filament sensor checks to be done
+extern uint16_t oFSCheckCount;
 
 enum class ClFsensorPCB:uint_least8_t
 {
     _Old=0,
-    _Rev04=1,
+    _Rev04=1, _Newest=1,
     _Undef=EEPROM_EMPTY_VALUE
 };
 

--- a/Firmware/temperature.h
+++ b/Firmware/temperature.h
@@ -42,6 +42,15 @@
 
 #endif //SYSTEM_TIMER_2
 
+// voltage conversion functions
+#define VOLT_DIV_REF 5
+
+constexpr uint16_t Voltage2Raw(float V){
+	return ( V * 1023 * OVERSAMPLENR / VOLT_DIV_REF ) + 0.5F;
+}
+constexpr float Raw2Voltage(uint16_t raw){
+	return VOLT_DIV_REF*(raw / (1023.F * OVERSAMPLENR) );
+}
 
 // public functions
 void tp_init();  //initialize the heating

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -7327,6 +7327,7 @@ static bool lcd_selftest_IRsensor(bool bStandalone)
     }
     if((bPCBrev04 ? 1 : 0) != (uint8_t)oFsensorPCB){        // safer then "(uint8_t)bPCBrev04"
         oFsensorPCB=bPCBrev04 ? ClFsensorPCB::_Rev04 : ClFsensorPCB::_Old;
+        oFSCheckCount = 0;
         printf_IRSensorAnalogBoardChange();
         eeprom_update_byte((uint8_t*)EEPROM_FSENSOR_PCB,(uint8_t)oFsensorPCB);
     }

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -7301,7 +7301,7 @@ void lcd_belttest()
 #ifdef IR_SENSOR_ANALOG
 // called also from marlin_main.cpp
 void printf_IRSensorAnalogBoardChange(){
-    printf_P(PSTR("Filament sensor board change detected: revision%S\n"), FsensorIRVersionText());
+    printf_P(PSTR("Filament sensor board change detected: revision %S\n"), FsensorIRVersionText());
 }
 
 static bool lcd_selftest_IRsensor(bool bStandalone)


### PR DESCRIPTION
The current code surrounding the IR filament sensor board upgrade is problematic in a few ways. It still checks for a PCB upgrade even though the FW already knows the PCB is at the newest version, wasting cycles. It allows downgrading the version after a previous successful detection, which doesn't make much sense.

In this PR:

- Ensure the upgrade logic only runs if the previous PCB version is unknown or if an upgrade is actually possible.
- Ensure the check only runs until a reliable detection can be made, then stop checking.
- Ensure the version detection doesn't run forever: limit the number of total autodetection attempts in a single session.
- Simplify and clarify the code surrounding the check.