### PR TITLE
Refactored TMC2130 crash detection, save 12 bytes of dynamic mem, optimize performance

### DIFF
--- a/Firmware/tmc2130.cpp
+++ b/Firmware/tmc2130.cpp
@@ -251,7 +251,8 @@ void tmc2130_st_isr()
 	uint8_t crash = 0;
 	uint8_t diag_mask = tmc2130_sample_diag();
 //	for (uint8_t axis = X_AXIS; axis <= E_AXIS; axis++)
-	for (uint8_t axis = X_AXIS; axis <= Z_AXIS; axis++)
+//	for (uint8_t axis = X_AXIS; axis <= Z_AXIS; axis++)
+    for (uint8_t axis = X_AXIS; axis <= Y_AXIS; axis++)
 	{
 		uint8_t mask = (X_AXIS_MASK << axis);
 		if (diag_mask & mask) tmc2130_sg_err[axis]++;


### PR DESCRIPTION
Edit: See comment below for explanation on the majority of changes.

---

Within the TCM2130 ISR, it loops through each axis inclusive of the z-axis, despite the Z-axis driver's diagnostic bit flags never being read or checked in `tmc2130_sample_diag()`, where it has been commented away.

Thus, iterating over the z-axis in the associated ISR is unnecessary. 

After performing a diff on the compiled elf binaries (with and without z-axis included in loop), It looks like the compiler has already optimized away the unused loop anyway, but for explicit clarity, it may be best to exclude the unchecked axis unless it is added back in the associated diagnostic check.

Binary diff:
![image](https://user-images.githubusercontent.com/19617165/120252742-61928b00-c253-11eb-8aab-7e9fa1b126ba.png)

