### PR TITLE
Move autoreporting out of the temperature ISR

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -9909,6 +9909,7 @@ if(0)
 #if defined(AUTO_REPORT)
   host_autoreport();
 #endif //AUTO_REPORT
+  host_keepalive();
 }
 
 void kill(const char *full_screen_message, unsigned char id)

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1923,9 +1923,6 @@ void loop()
 	}
 #endif //TMC2130
 	mmu_loop();
-#if defined(AUTO_REPORT)
-    host_autoreport();
-#endif //AUTO_REPORT
 }
 
 #define DEFINE_PGM_READ_ANY(type, reader)       \
@@ -9909,6 +9906,9 @@ if(0)
   #endif
   check_axes_activity();
   mmu_loop();
+#if defined(AUTO_REPORT)
+  host_autoreport();
+#endif //AUTO_REPORT
 }
 
 void kill(const char *full_screen_message, unsigned char id)

--- a/Firmware/temperature.cpp
+++ b/Firmware/temperature.cpp
@@ -567,10 +567,7 @@ void checkFanSpeed()
 	static unsigned char fan_speed_errors[2] = { 0,0 };
 #if (defined(FANCHECK) && defined(TACH_0) && (TACH_0 >-1))
 	if ((fan_speed[0] < 20) && (current_temperature[0] > EXTRUDER_AUTO_FAN_TEMPERATURE)){ fan_speed_errors[0]++;}
-	else{
-    fan_speed_errors[0] = 0;
-    host_keepalive();
-  }
+	else fan_speed_errors[0] = 0;
 #endif
 #if (defined(FANCHECK) && defined(TACH_1) && (TACH_1 >-1))
 	if ((fan_speed[1] < 5) && ((blocks_queued() ? block_buffer[block_buffer_tail].fan_speed : fanSpeed) > MIN_PRINT_FAN_SPEED)) fan_speed_errors[1]++;
@@ -902,8 +899,6 @@ void manage_heater()
 		timer02_set_pwm0(soft_pwm_bed << 1);
 	  }
   #endif
-  
-  host_keepalive();
 }
 
 #define PGM_RD_W(x)   (short)pgm_read_word(&x)


### PR DESCRIPTION
Code running in the temperature ISR needs to be fully reentrant, which
is hard to track down.

Move autoreporting to the main processing loop. This can make the
autoreporting slower or pause at times, but removes the reentrant
restriction, which allows us to use printf_P.