### PR TITLE
Implement/use xflash_rd_data_atomic to read from XFLASH 

### DIFF
--- a/Firmware/language.c
+++ b/Firmware/language.c
@@ -108,13 +108,12 @@ uint8_t lang_get_count()
 	if (pgm_read_dword(((uint32_t*)(_PRI_LANG_SIGNATURE))) == 0xffffffff)
 		return 1; //signature not set - only primary language will be available
 #ifdef XFLASH
-	XFLASH_SPI_ENTER();
 	uint8_t count = 2; //count = 1+n (primary + secondary + all in xflash)
 	uint32_t addr = 0x00000; //start of xflash
 	lang_table_header_t header; //table header structure
 	while (1)
 	{
-		xflash_rd_data(addr, (uint8_t*)&header, sizeof(lang_table_header_t)); //read table header from xflash
+		xflash_rd_data_atomic(addr, (uint8_t*)&header, sizeof(lang_table_header_t)); //read table header from xflash
 		if (header.magic != LANG_MAGIC) break; //break if magic not valid
 		addr += header.size; //calc address of next table
 		count++; //inc counter
@@ -175,13 +174,12 @@ uint16_t lang_get_code(uint8_t lang)
 		if (pgm_read_dword(((uint32_t*)(ui + 0))) != LANG_MAGIC) return LANG_CODE_XX; //magic not valid
 		return pgm_read_word(((uint32_t*)(ui + 10))); //return lang code from progmem
 	}
-	XFLASH_SPI_ENTER();
 	uint32_t addr = 0x00000; //start of xflash
 	lang_table_header_t header; //table header structure
 	lang--;
 	while (1)
 	{
-		xflash_rd_data(addr, (uint8_t*)&header, sizeof(lang_table_header_t)); //read table header from xflash
+		xflash_rd_data_atomic(addr, (uint8_t*)&header, sizeof(lang_table_header_t)); //read table header from xflash
 		if (header.magic != LANG_MAGIC) break; //break if not valid
 		if (--lang == 0) return header.code;
 		addr += header.size; //calc address of next table

--- a/Firmware/xflash.c
+++ b/Firmware/xflash.c
@@ -192,4 +192,15 @@ void xflash_wait_busy(void)
 	while (xflash_rd_status_reg() & XFLASH_STATUS_BUSY) ;
 }
 
+void xflash_rd_data_atomic(uint32_t addr, uint8_t* data, uint16_t cnt)
+{
+    // disable interrupts while we take over the SPI bus
+    uint8_t oldSREG = SREG;
+    cli();
+    XFLASH_SPI_ENTER();
+    xflash_rd_data(addr, data, cnt);
+    XFLASH_SPI_LEAVE();
+    SREG = oldSREG;
+}
+
 #endif //XFLASH

--- a/Firmware/xflash.h
+++ b/Firmware/xflash.h
@@ -20,12 +20,15 @@
 #define XFLASH_SPSR          SPI_SPSR(XFLASH_SPI_RATE)
 
 #define XFLASH_SPI_ENTER() spi_setup(XFLASH_SPCR, XFLASH_SPSR)
+#define XFLASH_SPI_LEAVE() // nothing to do
 
 #if defined(__cplusplus)
 extern "C" {
 #endif //defined(__cplusplus)
 
-
+// These functions assume exclusive control of the SPI bus when called and shouldn't be used when
+// another ISR requires SPI (such as the stepper ISR). XFLASH_SPI_ENTER needs to be used at least
+// once for setup.
 extern int8_t xflash_init(void);
 extern void xflash_enable_wr(void);
 extern void xflash_disable_wr(void);
@@ -43,6 +46,11 @@ extern void xflash_chip_erase(void);
 extern void xflash_page_program(uint32_t addr, uint8_t* data, uint16_t cnt);
 extern void xflash_rd_uid(uint8_t* uid);
 extern void xflash_wait_busy(void);
+
+// xflash_rd_data_atomic: setup SPI and read a chunk of XFLASH data atomically with interrupts
+//   disabled. This is safe to use while the stepper ISR is running, but it's slow and blocking.
+//   xflash needs to be already initialized.
+extern void xflash_rd_data_atomic(uint32_t addr, uint8_t* data, uint16_t cnt);
 
 #if defined(__cplusplus)
 }


### PR DESCRIPTION
When reading from the main loop the stepper ISR is potentially running and expects the SPI bus to be free.

As such any time we need to read from the XFLASH we need to do so with interrupts disabled to ensure we don't read garbled data. Implement xflash_rd_data_atomic to do this.

lang_get_count and lang_get_code get called in the menus while interrupts are enabled. Use the new xflash_rd_data_atomic to perform the reads.