### PR TITLE
Handle Long-Press in the main loop

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -9901,6 +9901,17 @@ if(0)
   #endif
   check_axes_activity();
   mmu_loop();
+
+  // handle longpress
+  if(lcd_longpress_trigger)
+  {
+      // long press is not possible in modal mode, wait until ready
+      if (lcd_longpress_func && lcd_update_enabled)
+      {
+          lcd_longpress_func();
+          lcd_longpress_trigger = 0;
+      }
+  }
 }
 
 void kill(const char *full_screen_message, unsigned char id)

--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -730,6 +730,8 @@ void lcd_update_enable(uint8_t enabled)
 
 bool lcd_longpress_trigger = 0;
 
+// WARNING: this function is called from the temperature ISR.
+//          Only update flags, but do not perform any menu/lcd operation!
 void lcd_buttons_update(void)
 {
     static uint8_t lcd_long_press_active = 0;

--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -728,6 +728,8 @@ void lcd_update_enable(uint8_t enabled)
 	}
 }
 
+bool lcd_longpress_trigger = 0;
+
 void lcd_buttons_update(void)
 {
     static uint8_t lcd_long_press_active = 0;
@@ -749,9 +751,7 @@ void lcd_buttons_update(void)
             else if (longPressTimer.expired(LONG_PRESS_TIME))
             {
                 lcd_long_press_active = 1;
-                //long press is not possible in modal mode
-                if (lcd_longpress_func && lcd_update_enabled)
-                    lcd_longpress_func();
+                lcd_longpress_trigger = 1;
             }
         }
     }

--- a/Firmware/lcd.h
+++ b/Firmware/lcd.h
@@ -110,6 +110,7 @@ extern uint32_t lcd_next_update_millis;
 extern uint8_t lcd_status_update_delay;
 
 extern lcd_longpress_func_t lcd_longpress_func;
+extern bool lcd_longpress_trigger;
 
 extern lcd_charsetup_func_t lcd_charsetup_func;
 


### PR DESCRIPTION
The longpress function is currently called within the temperature ISR,
which is bogus. Calling the longpress function at the wrong moment
can corrupt the menu buffers.

Move the call to the main loop by changing the logic slightly:

- still sample the lcd buttons inside the temperature ISR, which keeps
  scrollong/pressing responsive, but...
- set a flag to indicate that longpress has been triggered instead of
  calling the function directly
- call the function on the next manage_inactivity run

Combined with #3180 this removes _most_ unsafe operations out of the ISR
which can happen during a normal run (max/mintemp warnings are still an
exception).