### PR TITLE
Remove redundant `extern` variables and add `#ifdef` when using `extern` variables

### DIFF
--- a/Firmware/Dcodes.cpp
+++ b/Firmware/Dcodes.cpp
@@ -538,26 +538,20 @@ const char* dcode_9_ADC_name(uint8_t i)
 	return 0;
 }
 
-#ifdef AMBIENT_THERMISTOR
-extern int current_temperature_raw_ambient;
-#endif //AMBIENT_THERMISTOR
-
-#ifdef VOLT_PWR_PIN
-extern int current_voltage_raw_pwr;
-#endif //VOLT_PWR_PIN
-
-#ifdef VOLT_BED_PIN
-extern int current_voltage_raw_bed;
-#endif //VOLT_BED_PIN
-
 uint16_t dcode_9_ADC_val(uint8_t i)
 {
 	switch (i)
 	{
+#ifdef SHOW_TEMP_ADC_VALUES
 	case 0: return current_temperature_raw[0];
+#endif //SHOW_TEMP_ADC_VALUES
 	case 1: return 0;
+#ifdef SHOW_TEMP_ADC_VALUES
 	case 2: return current_temperature_bed_raw;
+#endif //SHOW_TEMP_ADC_VALUES
+#ifdef PINDA_THERMISTOR
 	case 3: return current_temperature_raw_pinda;
+#endif //PINDA_THERMISTOR
 #ifdef VOLT_PWR_PIN
 	case 4: return current_voltage_raw_pwr;
 #endif //VOLT_PWR_PIN

--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -350,7 +350,6 @@ extern unsigned long t_fan_rising_edge;
 extern bool mesh_bed_leveling_flag;
 extern bool mesh_bed_run_from_menu;
 
-extern int8_t lcd_change_fil_state;
 // save/restore printing
 extern bool saved_printing;
 extern uint8_t saved_printing_type;

--- a/Firmware/cmdqueue.cpp
+++ b/Firmware/cmdqueue.cpp
@@ -2,8 +2,6 @@
 #include "cardreader.h"
 #include "ultralcd.h"
 
-extern bool Stopped;
-
 // Reserve BUFSIZE lines of length MAX_CMD_SIZE plus CMDBUFFER_RESERVE_FRONT.
 char cmdbuffer[BUFSIZE * (MAX_CMD_SIZE + 1) + CMDBUFFER_RESERVE_FRONT];
 // Head of the circular buffer, where to read.

--- a/Firmware/menu.cpp
+++ b/Firmware/menu.cpp
@@ -14,8 +14,6 @@
 #include "static_assert.h"
 #include "sound.h"
 
-extern int32_t lcd_encoder;
-
 #define MENU_DEPTH_MAX       7
 
 static menu_record_t menu_stack[MENU_DEPTH_MAX];

--- a/Firmware/temperature.h
+++ b/Firmware/temperature.h
@@ -67,7 +67,7 @@ bool has_temperature_compensation();
 #endif
 
 #ifdef AMBIENT_THERMISTOR
-//extern int current_temperature_raw_ambient;
+extern int current_temperature_raw_ambient;
 extern float current_temperature_ambient;
 #endif
 

--- a/Firmware/tmc2130.cpp
+++ b/Firmware/tmc2130.cpp
@@ -243,8 +243,6 @@ uint8_t tmc2130_sample_diag()
 	return mask;
 }
 
-extern bool is_usb_printing;
-
 void tmc2130_st_isr()
 {
 	if (tmc2130_mode == TMC2130_MODE_SILENT || tmc2130_sg_stop_on_crash == false) return;


### PR DESCRIPTION
* Remove redundant `extern` already included with `temperature.h`.
* Add `#ifdef` in `Dcodes.cpp` when using `extern` variables. We don't want to use them if they're not defined.
* Removed one `extern` variable in `cmdqueue.cpp` which is already included by `cardreader.h`
* `lcd_change_fil_state` had two identical `extern`'s in `Marlin.h`, since only one is needed I removed one.
* Remove redundant `extern` variable `is_usb_printing` from `tmc2130.cpp`. It is included with `Marlin.h`
* Remove redundant `extern` variable `lcd_encoder` from `menu.cpp`. It is included with `lcd.h`