### PR TITLE
write_command() no line number handling

### DIFF
--- a/Firmware/cardreader.cpp
+++ b/Firmware/cardreader.cpp
@@ -596,20 +596,9 @@ void CardReader::getStatus(bool arg_P)
 }
 void CardReader::write_command(char *buf)
 {
-  char* begin = buf;
-  char* npos = 0;
-  char* end = buf + strlen(buf) - 1;
-
   file.writeError = false;
-  if((npos = strchr(buf, 'N')) != NULL)
-  {
-    begin = strchr(npos, ' ') + 1;
-    end = strchr(npos, '*') - 1;
-  }
-  end[1] = '\r';
-  end[2] = '\n';
-  end[3] = '\0';
-  file.write(begin);
+  file.write(buf); //write command
+  file.write("\r\n"); //write line termination
   if (file.writeError)
   {
     SERIAL_ERROR_START;


### PR DESCRIPTION
Do not handle the gcode line numbers in write_command(). The command always gets pre-parsed gcode strings from the cmdqueue that have the line numbering stripped. Besides this functionality not being needed, it was also implemented incorrectly. 
- If the gcode didn't have any line numbers, then any 'N' character inside the string would cause the algorithm to try to strip the marlin line numbering and checksum. The string would begin at that 'N' and would end at NULL since there was no '*' character in the string. As such, the string begins in the middle and ends at memory address 0.
- An even worse offender is probably how the line ending was applied. It just smashes through the next two bytes after the end of *buf. It's absurd how this issue hasn't been observed until now. Makes you wonder how few people actually upload to the SD card from host software. As a workaround, we just call file.write() twice to append the "\r\n" as well. It is less efficient, but even so the UART is still the bottleneck.

In issue #3193, both of the mentioned issues happen at the same time, static memory being overwritten without tripping the stack guard (only the lower region is overwritten a bit). With the patch I can upload the provided gcode with the DisplayLayerProgress plugin enabled.
The problematic command was `M117 INDICATOR-Layer1`. The 'N' in INDICATOR fooled the old algorithm. It also tried to find the first space after 'N', which also returned NULL. There is no star at the end, so it also returned NULL... It's an interesting combination of failures that weren't properly checked before calling file.write().

Steps to reproduce the initial issue:
```
M28 test.gco
M117 INDICATOR-Layer1
...
PROFIT!
```

Fixes #3193 