### PR TITLE
xfdump: correctly erase all sectors in xfdump_erase

### DIFF
--- a/Firmware/xflash_dump.cpp
+++ b/Firmware/xflash_dump.cpp
@@ -44,7 +44,7 @@ static void xfdump_erase()
         addr += 4096)
     {
         xflash_enable_wr();
-        xflash_sector_erase(DUMP_OFFSET);
+        xflash_sector_erase(addr);
         xflash_wait_busy();
     }
 }


### PR DESCRIPTION
The old code fails to use the updated address in the erase loop.