### PR TITLE
Work-around GCC LTO codegen bug in process_commands()

### DIFF
--- a/Firmware/temperature.cpp
+++ b/Firmware/temperature.cpp
@@ -287,8 +287,10 @@ bool checkAllHotends(void)
     return(result);
 }
 
-  void PID_autotune(float temp, int extruder, int ncycles)
-  {
+// WARNING: the following function has been marked noinline to avoid a GCC 4.9.2 LTO
+//          codegen bug causing a stack overwrite issue in process_commands()
+void __attribute__((noinline)) PID_autotune(float temp, int extruder, int ncycles)
+{
   pid_number_of_cycles = ncycles;
   pid_tuning_finished = false;
   float input = 0.0;


### PR DESCRIPTION
When building with GCC 4.9.2 (bundled with PF-build-env-1.0.6.*), -Os and LTO enabled, PID_autotune gets automatically inlined into process_commands() as it's the only call location.

Sadly, due to the massive size of process_commands(), it results in codegen bug doing a partial stack overwrite in process_commands() itself, manifesting as random behavior depending on the timing of interrupts and the codepath taken inside the merged function.

I believe this is the main reason behind #3147, #3151, #3175 and probably others. I verified the codegen issue was also present in 3.9.3 already and probably older FW versions.

In most cases, this results in a frameshift of the stack pointer. Due to the sheer size of process_commands and the many different branches it *usually* has no effect, except when run the first time. Since the time-to-first-run is influenced by the serial and some external ICs such as the xflash, it can cause absurd behavior depending on how the stack is built, such as the one seen in #3147.

I admit I didn't really read the _entire_ disassembly of the process_commands() function, it's just too large to keep track manually of all the registers and the stack allocations.

When I discovered the issue I tried a few approaches to avoid the bug. Shrinking process_commands() itself to at least half the size (splitting M/G handling blocks) seem to reduce the chances of hitting this (hinting to a register allocation issue as the basis), but it's not always reliable. Marking PID_autotune as noinline is more sensible and avoids the issue completely even when other code in process_commands() is modified.

Given how old this gcc version is there's not much to report upstream. I also don't think there's much we can do besides manual verification in the future to avoid hitting this again. I tried to manually trigger this issue on other large functions within process_commands(), but there's something specific to PID_autotune and it's position.

I didn't verify if this also applies to more recent versions of gcc that we could potentially use.
Nasty.

PFW-1254