### PR TITLE
D23 improvements for MK2.5

### DIFF
--- a/Firmware/Dcodes.cpp
+++ b/Firmware/Dcodes.cpp
@@ -1,5 +1,5 @@
-#include "Dcodes.h"
 #include "Marlin.h"
+#include "Dcodes.h"
 #include "Configuration.h"
 #include "language.h"
 #include "cmdqueue.h"

--- a/Firmware/Dcodes.cpp
+++ b/Firmware/Dcodes.cpp
@@ -974,6 +974,18 @@ void dcode_22()
 
 bool emergency_serial_dump = false;
 
+void dcode_23()
+{
+    if(code_seen('E'))
+        serial_dump_and_reset(dump_crash_reason::manual);
+    else
+    {
+        emergency_serial_dump = !code_seen('R');
+        SERIAL_ECHOPGM("serial dump ");
+        SERIAL_ECHOLNRPGM(emergency_serial_dump? _N("enabled"): _N("disabled"));
+    }
+}
+
 void __attribute__((noinline)) serial_dump_and_reset(dump_crash_reason reason)
 {
     uint16_t sp;

--- a/Firmware/Dcodes.h
+++ b/Firmware/Dcodes.h
@@ -37,7 +37,8 @@ extern void dcode_22(); //D22 - Clear crash dump state
 
 #ifdef EMERGENCY_SERIAL_DUMP
 #include "xflash_dump.h"
-extern bool emergency_serial_dump;
+extern void dcode_23(); //D23 - Request/generate an online serial crash dump
+extern bool emergency_serial_dump; //emergency dump enabled flag
 extern void serial_dump_and_reset(dump_crash_reason);
 #endif
 

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -9382,12 +9382,14 @@ Sigma_Exit:
     When online dumps are enabled, the FW will dump memory on the serial before resetting.
     #### Usage
 
-     D23 [R]
+     D23 [E] [R]
     #### Parameters
+    - `E` - Perform an emergency crash dump (resets the printer).
     - `R` - Disable online dumps.
     */
     case 23: {
-        emergency_serial_dump = !code_seen('R');
+        dcode_23();
+        break;
     };
 #endif
 


### PR DESCRIPTION
These are a few changes to improve D23 for MK2.5 printers in order to allow to trigger a dump immediately via g-code like we already can on the MK3 with ``D20 E``:

- Move D23 into it's own function inside Dcodes
- Correctly include a break in the switch statement
- Show the dumper status (enabled/disabled) after toggling
- Allow to generate an immediate dump via g-code using ``D23 E`` for symmetry with ``D20 E``