### PR TITLE
Change `boolean` to `bool` everywhere

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -375,7 +375,7 @@ bool target_direction;
 //Insert variables if CHDK is defined
 #ifdef CHDK
 unsigned long chdkHigh = 0;
-boolean chdkActive = false;
+bool chdkActive = false;
 #endif
 
 //! @name RAM save/restore printing
@@ -9091,7 +9091,7 @@ Sigma_Exit:
               }
               else {
 #if EXTRUDERS > 1
-                  boolean make_move = false;
+                  bool make_move = false;
 #endif
                   if (code_seen('F')) {
 #if EXTRUDERS > 1

--- a/Firmware/Servo.cpp
+++ b/Firmware/Servo.cpp
@@ -231,7 +231,7 @@ static void finISR(timer16_Sequence_t timer)
 #endif
 }
 
-static boolean isTimerActive(timer16_Sequence_t timer)
+static bool isTimerActive(timer16_Sequence_t timer)
 {
   // returns true if any servo is active on this timer
   for(uint8_t channel=0; channel < SERVOS_PER_TIMER; channel++) {

--- a/Firmware/cmdqueue.cpp
+++ b/Firmware/cmdqueue.cpp
@@ -23,7 +23,7 @@ bool cmdbuffer_front_already_processed = false;
 bool cmdqueue_serial_disabled = false;
 
 int serial_count = 0;  //index of character read from serial line
-boolean comment_mode = false;
+bool comment_mode = false;
 char *strchr_pointer; // just a pointer to find chars in the command string like X, Y, Z, E, etc
 
 unsigned long TimeSent = _millis();

--- a/Firmware/cmdqueue.h
+++ b/Firmware/cmdqueue.h
@@ -49,7 +49,7 @@ extern bool cmdqueue_serial_disabled;
 extern uint32_t sdpos_atomic;
 
 extern int serial_count;
-extern boolean comment_mode;
+extern bool comment_mode;
 extern char *strchr_pointer;
 
 extern unsigned long TimeSent;


### PR DESCRIPTION
This closes #3199 

The use of `boolean` instead of `bool` are due to the Arduino framework, there is no benefit in using `boolean` since it is just a typedef for the built-in `bool` type.

Edit:

This change was also implemented in Marlin 2 in 2017: https://github.com/MarlinFirmware/Marlin/commit/fa26767efe50d278d4dfa66df9f48831f14c7af2