### PR TITLE
Improve `mc_arc()` parameters

### DIFF
--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -246,7 +246,7 @@ void finishAndDisableSteppers();
 //put an ASCII command at the begin of the current buffer, read from flash
 #define enquecommand_front_P(cmd) enquecommand_front(cmd, true)
 
-void prepare_arc_move(char isclockwise);
+void prepare_arc_move(bool isclockwise);
 void clamp_to_software_endstops(float target[3]);
 void refresh_cmd_timeout(void);
 

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -9746,7 +9746,7 @@ void prepare_move()
   set_current_to_destination();
 }
 
-void prepare_arc_move(char isclockwise) {
+void prepare_arc_move(bool isclockwise) {
   float r = hypot(offset[X_AXIS], offset[Y_AXIS]); // Compute arc radius for mc_arc
 
   // Trace the arc

--- a/Firmware/motion_control.cpp
+++ b/Firmware/motion_control.cpp
@@ -26,7 +26,7 @@
 // The arc is approximated by generating a huge number of tiny, linear segments. The length of each 
 // segment is configured in settings.mm_per_arc_segment.  
 void mc_arc(float *position, float *target, float *offset, uint8_t axis_0, uint8_t axis_1, 
-  uint8_t axis_linear, float feed_rate, float radius, uint8_t isclockwise, uint8_t extruder)
+  uint8_t axis_linear, float feed_rate, float radius, bool isclockwise, uint8_t extruder)
 {      
   //   int acceleration_manager_was_enabled = plan_is_acceleration_manager_enabled();
   //   plan_set_acceleration_manager_enabled(false); // disable acceleration management for the duration of the arc

--- a/Firmware/motion_control.h
+++ b/Firmware/motion_control.h
@@ -26,7 +26,7 @@
 // offset == offset from current xyz, axis_XXX defines circle plane in tool space, axis_linear is
 // the direction of helical travel, radius == circle radius, isclockwise boolean. Used
 // for vector transformation direction.
-void mc_arc(float *position, float *target, float *offset, unsigned char axis_0, unsigned char axis_1,
-  unsigned char axis_linear, float feed_rate, float radius, unsigned char isclockwise, uint8_t extruder);
+void mc_arc(float *position, float *target, float *offset, uint8_t axis_0, uint8_t axis_1,
+  uint8_t axis_linear, float feed_rate, float radius, bool isclockwise, uint8_t extruder);
   
 #endif


### PR DESCRIPTION
- Make the `mc_arc()` function declaration consistent with the definition (same parameter types).
- `isclockwise` is supposed to be `bool` type, given how it is used only with `false` and `true`.