### PR TITLE
Print temperatures only if filament loading is still active

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2317,8 +2317,10 @@ void mFilamentItem(uint16_t nTemp, uint16_t nTempBed)
             }
         }
 
-        lcd_set_cursor(0, 0);
-        lcdui_print_temp(LCD_STR_THERMOMETER[0], (int) degHotend(0), (int) degTargetHotend(0));
+        if (bFilamentWaitingFlag) {
+            lcd_set_cursor(0, 0);
+            lcdui_print_temp(LCD_STR_THERMOMETER[0], (int) degHotend(0), (int) degTargetHotend(0));
+        }
 
         if (lcd_clicked())
         {


### PR DESCRIPTION
A fix to a small glitch I've found.

Test case:
1. Disable filament auto-load
2. Reset printer
3. Select to Load filament and choose a material
4. During the initial Z axis raise, press the button to Cancel
5. The printer returns to the previous menu
6. After the Z axis raising has finished, the printer although inside the menu, it displays at the top row of the screen the hotend temperature.

With this fix, at the step 6, the printer skips the printing of the temperature.