### PR TITLE
PFW-1297: lang-add.sh improvements

### DIFF
--- a/lang/lang-add.sh
+++ b/lang/lang-add.sh
@@ -26,6 +26,7 @@ echo "fw-clean languages:$LANGUAGES" >&2
 
 # insert single text to english dictionary
 # $1 - text to insert
+# $2 - metadata
 insert_en()
 {
 	#replace '[' and ']' in string with '\[' and '\]'
@@ -38,12 +39,13 @@ insert_en()
 	# insert new text
 	sed -i "$ln"'i\\' lang_en.txt
 	sed -i "$ln"'i\'"$1"'\' lang_en.txt
-	sed -i "$ln"'i\#\' lang_en.txt
+	sed -i "${ln}i\\#$2" lang_en.txt
 }
 
 # insert single text to translated dictionary
 # $1 - text to insert
-# $2 - sufix
+# $2 - suffix
+# $3 - metadata
 insert_xx()
 {
 	#replace '[' and ']' in string with '\[' and '\]'
@@ -57,7 +59,15 @@ insert_xx()
 	sed -i "$ln"'i\\' lang_en_$2.txt
 	sed -i "$ln"'i\"\x00"\' lang_en_$2.txt
 	sed -i "$ln"'i\'"$1"'\' lang_en_$2.txt
-	sed -i "$ln"'i\#\' lang_en_$2.txt
+	sed -i "${ln}i\\#$3" lang_en_$2.txt
+}
+
+# find the metadata for the specified string
+# TODO: this is unbeliveably crude
+# $1 - text to search for
+find_metadata()
+{
+    sed -ne "s^.*\(_[iI]\|ISTR\)($1).*////\(.*\)^\2^p" ../Firmware/*.[ch]* | head -1
 }
 
 # check if input file exists
@@ -72,13 +82,14 @@ cat lang_add.txt | sed 's/^/"/;s/$/"/' | while read new_s; do
 		echo "$new_s"
 		echo
 	else
+		meta=$(find_metadata "$new_s")
 		echo "adding text:"
-		echo "$new_s"
+		echo "$new_s ($meta)"
 		echo
 
-		insert_en "$new_s"
+		insert_en "$new_s" "$meta"
         for lang in $LANGUAGES; do
-            insert_xx "$new_s" "$lang"
+            insert_xx "$new_s" "$lang" "$meta"
         done
 	fi
 done

--- a/lang/lang-add.sh
+++ b/lang/lang-add.sh
@@ -7,7 +7,12 @@
 #  lang_add.txt
 # Updated files:
 #  lang_en.txt and all lang_en_xx.txt
-#
+
+# List of supported languages
+LANGUAGES="cz de es fr it pl"
+
+# Community languages
+LANGUAGES+=" nl" #Dutch
 
 # Config:
 if [ -z "$CONFIG_OK" ]; then eval "$(cat config.sh)"; fi
@@ -68,14 +73,11 @@ cat lang_add.txt | sed 's/^/"/;s/$/"/' | while read new_s; do
 		echo "adding text:"
 		echo "$new_s"
 		echo
-		#insert_en "$new_s"
-		for lang in $LANGUAGES; do
-			insert_xx "$new_s" "$lang"
-		done
 
-#Use the 2 lines below as a template and replace 'qr'
-##New language
-#		insert_xx "$new_s" 'qr'
+		insert_en "$new_s"
+        for lang in $LANGUAGES; do
+            insert_xx "$new_s" "$lang"
+        done
 	fi
 done
 

--- a/lang/lang-add.sh
+++ b/lang/lang-add.sh
@@ -31,9 +31,10 @@ insert_en()
 	#replace '[' and ']' in string with '\[' and '\]'
 	str=$(echo "$1" | sed "s/\[/\\\[/g;s/\]/\\\]/g")
 	# extract english texts, merge new text, grep line number
-	ln=$((cat lang_en.txt; echo "$1") | sed "/^$/d;/^#/d" | sort | grep -n "$str" | sed "s/:.*//")
+	ln=$((cat lang_en.txt; echo "$1") | sed "/^$/d;/^#/d" | sort | grep -n "$str" | sed "s/:.*//;q")
 	# calculate position for insertion
 	ln=$((3*(ln-2)+1))
+	[ "$ln" -lt 1 ] && ln=1
 	# insert new text
 	sed -i "$ln"'i\\' lang_en.txt
 	sed -i "$ln"'i\'"$1"'\' lang_en.txt
@@ -48,9 +49,10 @@ insert_xx()
 	#replace '[' and ']' in string with '\[' and '\]'
 	str=$(echo "$1" | sed "s/\[/\\\[/g;s/\]/\\\]/g")
 	# extract english texts, merge new text, grep line number
-	ln=$((cat lang_en_$2.txt; echo "$1") | sed "/^$/d;/^#/d" | sed -n 'p;n' | sort | grep -n "$str" | sed "s/:.*//")
+	ln=$((cat lang_en_$2.txt; echo "$1") | sed "/^$/d;/^#/d" | sed -n 'p;n' | sort | grep -n "$str" | sed "s/:.*//;q")
 	# calculate position for insertion
 	ln=$((4*(ln-2)+1))
+	[ "$ln" -lt 1 ] && ln=1
 	# insert new text
 	sed -i "$ln"'i\\' lang_en_$2.txt
 	sed -i "$ln"'i\"\x00"\' lang_en_$2.txt


### PR DESCRIPTION
This PR adds a few improvements to the ``lang/lang-add.sh`` script so that it can, in a good amount of cases, extract the string metadata directly from the source files.

This is currently **absolutely crude**, but it will recognize translatable strings (by using the macros _i/ISTR) and fetch the associated data when the comment at the end of the same line is using the syntax ``////ID c=columns r=rows``` (to be more exact, anything following the four slashes really).

Not only this eases the pain when adding new strings, but we can use this to re-verify/update the string data by doing the following:

- zeroing lang_en.txt (``echo > lang_en.txt``) and lang_en_* files
- running ``fw-build.sh`` to update the ``not_tran.txt`` file with **all** the strings
- copy ``not_tran.txt`` to ``lang_add.txt``
- run ``lang-add.sh`` to regenerate ``lang_en.txt`` with the string data copied from the source files.
- diff each against the git version (``git diff lang_en.txt``)

It's still bad, but not *as* bad as the "spot the difference" game as done currently.
There are _many_ changes to be updated... so marking this as a draft.

@3d-gussner