### PR TITLE
Remove a few redundant lines from ultralcd code

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -241,9 +241,7 @@ static void lcd_detect_IRsensor();
 #endif //IR_SENSOR_ANALOG
 static void lcd_selftest_error(TestError error, const char *_error_1, const char *_error_2);
 static void lcd_colorprint_change();
-#ifdef SNMM
-static int get_ext_nr();
-#endif //SNMM
+
 #if defined (SNMM) || defined(SNMM_V2)
 static void fil_load_menu();
 static void fil_unload_menu();

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -162,15 +162,6 @@ void lcd_commands();
 extern bool bSettings;                            // flag (i.e. 'fake parameter') for 'lcd_hw_setup_menu()' function
 void lcd_hw_setup_menu(void);                     // NOT static due to using inside "util" module ("nozzle_diameter_check()")
 
-
-void change_extr(int extr);
-
-#ifdef SNMM
-void extr_unload_all(); 
-void extr_unload_used();
-#endif //SNMM
-void extr_unload();
-
 enum class FilamentAction : uint_least8_t
 {
     None, //!< 'none' state is used as flag for (filament) autoLoad (i.e. opposite for 'autoLoad' state)
@@ -217,8 +208,6 @@ uint8_t choose_menu_P(const char *header, const char *item, const char *last_ite
 void lcd_pinda_calibration_menu();
 void lcd_calibrate_pinda();
 void lcd_temp_calibration_set();
-
-void display_loading();
 
 void lcd_set_degree();
 


### PR DESCRIPTION
In this PR I propose to remove a few redundant lines from the ultralcd code. The code being removed is already available from `mmu.cpp`/`mmu.h`. Creating copies of these lines in `ultralcd.cpp`/`ultralcd.h` is just confusing.

These are mostly function declarations that are not used.