### PR TITLE
Change `nrFiles` from `int16_t` to `uint16_t`

### DIFF
--- a/Firmware/cardreader.h
+++ b/Firmware/cardreader.h
@@ -135,7 +135,7 @@ private:
 
   bool autostart_stilltocheck; //the sd start is delayed, because otherwise the serial cannot answer fast enought to make contact with the hostsoftware.
   
-  int16_t nrFiles; //counter for the files in the current directory and recycled as position counter for getting the nrFiles'th name in the directory.
+  uint16_t nrFiles; //counter for the files in the current directory and recycled as position counter for getting the nrFiles'th name in the directory.
   char* diveDirName;
 
   bool diveSubfolder (const char *&fileName);


### PR DESCRIPTION
Change `nrFiles` from `int16_t` to `uint16_t`

It is never given a negative value and always used as an `uint16_t`. The variable can have twice the value now.

I propose this tiny change merely to keep things consistant. 👍 