### PR TITLE
Remove double code from `M600_load_filament_movements()`

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -12069,10 +12069,7 @@ void M600_load_filament_movements()
 	plan_buffer_line_curposXYZE(400, active_extruder);
 	current_position[E_AXIS] += 10;
 	plan_buffer_line_curposXYZE(50, active_extruder);
-#else
-	current_position[E_AXIS]+= FILAMENTCHANGE_FIRSTFEED ;
-	plan_buffer_line_curposXYZE(FILAMENTCHANGE_EFEED_FIRST);
-#endif                
+#endif // SNMM
 	load_filament_final_feed();
 	lcd_loading_filament();
 	st_synchronize();


### PR DESCRIPTION
The code being removed is already included with `load_filament_final_feed()` function. This saves 48 bytes of flash memory.

Before:
Sketch uses **231758** bytes (91%) of program storage space. Maximum is 253952 bytes.
Global variables use 6103 bytes of dynamic memory.

After:
Sketch uses **231710** bytes (91%) of program storage space. Maximum is 253952 bytes.
Global variables use 6103 bytes of dynamic memory.

Note: this is how the functions is defined
```cpp
void load_filament_final_feed()
{
	current_position[E_AXIS]+= FILAMENTCHANGE_FINALFEED;
	plan_buffer_line_curposXYZE(FILAMENTCHANGE_EFEED_FINAL);
}
```
it's the exact same code