### PR TITLE
Added descriptions about MMU commands in code

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3808,6 +3808,7 @@ static void gcode_M600(bool automatic, float x_position, float y_position, float
                 lcd_clear();
                 lcd_puts_at_P(0, 2, _T(MSG_PLEASE_WAIT));
 
+                // R0 Recover after eject filament
                 mmu_command(MmuCmd::R0);
                 manage_response(false, false);
             }

--- a/Firmware/mmu.cpp
+++ b/Firmware/mmu.cpp
@@ -1357,17 +1357,17 @@ void lcd_mmu_load_to_nozzle(uint8_t filament_nr)
     bFilamentAction = false;                            // NOT in "mmu_load_to_nozzle_menu()"
     if (degHotend0() > EXTRUDE_MINTEMP)
     {
-        tmp_extruder = filament_nr;
         lcd_update_enable(false);
         lcd_clear();
         lcd_puts_at_P(0, 1, _T(MSG_LOADING_FILAMENT));
         lcd_print(' ');
+        lcd_print(filament_nr + 1);
 
         // Change filament to 'filament_nr'
         mmu_command(MmuCmd::T0 + filament_nr);
         manage_response(true, true, MMU_TCODE_MOVE);
         mmu_continue_loading(false);
-        mmu_extruder = tmp_extruder; //filament change is finished
+        mmu_extruder = filament_nr; //filament change is finished
         raise_z_above(MIN_Z_FOR_LOAD, false);
         mmu_load_to_nozzle();
         load_filament_final_feed();

--- a/Firmware/mmu.cpp
+++ b/Firmware/mmu.cpp
@@ -280,72 +280,83 @@ void mmu_loop(void)
 		{
 			if ((mmu_cmd >= MmuCmd::T0) && (mmu_cmd <= MmuCmd::T4))
 			{
+				// T<nr.> Change filament <nr.> to filament <nr.>
 				const uint8_t filament = mmu_cmd - MmuCmd::T0;
 				DEBUG_PRINTF_P(PSTR("MMU <= 'T%d'\n"), filament);
 				mmu_printf_P(PSTR("T%d\n"), filament);
-				mmu_state = S::WaitCmd; // wait for response
+				mmu_state = S::WaitCmd;
 				mmu_fil_loaded = true;
 				mmu_idl_sens = 1;
 			}
 			else if ((mmu_cmd >= MmuCmd::L0) && (mmu_cmd <= MmuCmd::L4))
 			{
-			    const uint8_t filament = mmu_cmd - MmuCmd::L0;
-			    DEBUG_PRINTF_P(PSTR("MMU <= 'L%d'\n"), filament);
-			    mmu_printf_P(PSTR("L%d\n"), filament);
-			    mmu_state = S::WaitCmd; // wait for response
+				// L<.nr> Load filament 
+				const uint8_t filament = mmu_cmd - MmuCmd::L0;
+				DEBUG_PRINTF_P(PSTR("MMU <= 'L%d'\n"), filament);
+				mmu_printf_P(PSTR("L%d\n"), filament);
+				mmu_state = S::WaitCmd;
 			}
 			else if (mmu_cmd == MmuCmd::C0)
 			{
-			    DEBUG_PRINTF_P(PSTR("MMU <= 'C0'\n"));
-				mmu_puts_P(PSTR("C0\n")); //send 'continue loading'
+				// C0 Continue loading current filament (used after T-code)
+				DEBUG_PRINTF_P(PSTR("MMU <= 'C0'\n"));
+				mmu_puts_P(PSTR("C0\n"));
 				mmu_state = S::WaitCmd;
 				mmu_idl_sens = 1;
 			}
 			else if (mmu_cmd == MmuCmd::U0)
 			{
-			    DEBUG_PRINTF_P(PSTR("MMU <= 'U0'\n"));
-				mmu_puts_P(PSTR("U0\n")); //send 'unload current filament'
+				// U0 Unload current filament
+				DEBUG_PRINTF_P(PSTR("MMU <= 'U0'\n"));
+				mmu_puts_P(PSTR("U0\n")); 
 				mmu_fil_loaded = false;
 				mmu_state = S::WaitCmd;
 			}
 			else if ((mmu_cmd >= MmuCmd::E0) && (mmu_cmd <= MmuCmd::E4))
 			{
-			    const uint8_t filament = mmu_cmd - MmuCmd::E0;
+				// E<nr.> Eject filament <nr.>
+				const uint8_t filament = mmu_cmd - MmuCmd::E0;
 				DEBUG_PRINTF_P(PSTR("MMU <= 'E%d'\n"), filament);
-				mmu_printf_P(PSTR("E%d\n"), filament); //send eject filament
+				mmu_printf_P(PSTR("E%d\n"), filament);
 				mmu_fil_loaded = false;
 				mmu_state = S::WaitCmd;
 			}
 			else if ((mmu_cmd >= MmuCmd::K0) && (mmu_cmd <= MmuCmd::K4))
-            {
-                const uint8_t filament = mmu_cmd - MmuCmd::K0;
-                DEBUG_PRINTF_P(PSTR("MMU <= 'K%d'\n"), filament);
-                mmu_printf_P(PSTR("K%d\n"), filament); //send eject filament
-                mmu_fil_loaded = false;
-                mmu_state = S::WaitCmd;
-            }
+			{
+				// K<nr.> Cut filament <nr.>
+				const uint8_t filament = mmu_cmd - MmuCmd::K0;
+				DEBUG_PRINTF_P(PSTR("MMU <= 'K%d'\n"), filament);
+				mmu_printf_P(PSTR("K%d\n"), filament);
+				mmu_fil_loaded = false;
+				mmu_state = S::WaitCmd;
+			}
 			else if (mmu_cmd == MmuCmd::R0)
 			{
-			    DEBUG_PRINTF_P(PSTR("MMU <= 'R0'\n"));
-				mmu_puts_P(PSTR("R0\n")); //send recover after eject
+				// Recover after eject filament
+				DEBUG_PRINTF_P(PSTR("MMU <= 'R0'\n"));
+				mmu_puts_P(PSTR("R0\n"));
 				mmu_state = S::WaitCmd;
 			}
 			else if (mmu_cmd == MmuCmd::S3)
 			{
-			    DEBUG_PRINTF_P(PSTR("MMU <= 'S3'\n"));
-				mmu_puts_P(PSTR("S3\n")); //send power failures request
+				// Power failures request
+				DEBUG_PRINTF_P(PSTR("MMU <= 'S3'\n"));
+				mmu_puts_P(PSTR("S3\n")); 
 				mmu_state = S::GetDrvError;
 			}
 			else if (mmu_cmd == MmuCmd::W0)
 			{
-			    DEBUG_PRINTF_P(PSTR("MMU <= 'W0'\n"));
-			    mmu_puts_P(PSTR("W0\n"));
-			    mmu_state = S::Pause;
+				// Wait for user click
+				DEBUG_PRINTF_P(PSTR("MMU <= 'W0'\n"));
+				mmu_puts_P(PSTR("W0\n"));
+				mmu_state = S::Pause;
 			}
 			mmu_last_cmd = mmu_cmd;
 			mmu_cmd = MmuCmd::None;
 		}
 		else if ((eeprom_read_byte((uint8_t*)EEPROM_MMU_STEALTH) != SilentModeMenu_MMU) && mmu_ready) {
+				// M0 Set MMU to normal mode
+				// M1 Set MMU to stealth mode
 				DEBUG_PRINTF_P(PSTR("MMU <= 'M%d'\n"), SilentModeMenu_MMU);
 				mmu_printf_P(PSTR("M%d\n"), SilentModeMenu_MMU);
 				mmu_state = S::SwitchMode;
@@ -1100,16 +1111,15 @@ void extr_unload()
 	{
 #ifndef SNMM
 		st_synchronize();
-
-        menu_submenu(extr_unload_view);
-
+		menu_submenu(extr_unload_view);
 		mmu_filament_ramming();
 
+		// Unload filament
 		mmu_command(MmuCmd::U0);
+
 		// get response
 		manage_response(false, true, MMU_UNLOAD_MOVE);
-
-        menu_back();
+		menu_back();
 #else //SNMM
 
 		lcd_clear();
@@ -1352,8 +1362,9 @@ void lcd_mmu_load_to_nozzle(uint8_t filament_nr)
         lcd_clear();
         lcd_puts_at_P(0, 1, _T(MSG_LOADING_FILAMENT));
         lcd_print(' ');
-        lcd_print(tmp_extruder + 1);
-        mmu_command(MmuCmd::T0 + tmp_extruder);
+
+        // Change filament to 'filament_nr'
+        mmu_command(MmuCmd::T0 + filament_nr);
         manage_response(true, true, MMU_TCODE_MOVE);
         mmu_continue_loading(false);
         mmu_extruder = tmp_extruder; //filament change is finished
@@ -1419,6 +1430,8 @@ bFilamentAction=false;                            // NOT in "mmu_fil_eject_menu(
                 if (recover)
                 {
                     lcd_show_fullscreen_message_and_wait_P(_i("Please remove filament and then press the knob."));
+
+                    // R0 Recover after eject filament
                     mmu_command(MmuCmd::R0);
                     manage_response(false, false);
                 }
@@ -1492,6 +1505,8 @@ static bool load_more()
     {
         if (READ(IR_SENSOR_PIN) == 0) return true;
         DEBUG_PRINTF_P(PSTR("Additional load attempt nr. %d\n"), i);
+
+        // C0 Continue loading current filament (used after T-code)
         mmu_command(MmuCmd::C0);
         manage_response(true, true, MMU_LOAD_MOVE);
     }
@@ -1532,6 +1547,7 @@ void mmu_continue_loading(bool blocking)
 {
 	if (!ir_sensor_detected)
 	{
+		// C0 Continue loading current filament (used after T-code)
 	    mmu_command(MmuCmd::C0);
 	    return;
 	}
@@ -1580,6 +1596,7 @@ void mmu_continue_loading(bool blocking)
             stop_and_save_print_to_ram(0, 0);
             long_pause();
 
+            // U0 Unload filament
             mmu_command(MmuCmd::U0);
             manage_response(false, true, MMU_UNLOAD_MOVE);
 
@@ -1597,6 +1614,8 @@ void mmu_continue_loading(bool blocking)
             {
                 mmu_fil_loaded = false; //so we can retry same T-code again
                 isPrintPaused = true;
+
+                // W0 Wait for user click
                 mmu_command(MmuCmd::W0);
                 return;
             }

--- a/Firmware/mmu.h
+++ b/Firmware/mmu.h
@@ -35,32 +35,42 @@ extern uint16_t mmu_power_failures;
 enum class MmuCmd : uint_least8_t
 {
     None,
-    T0,
-    T1,
-    T2,
-    T3,
-    T4,
-    L0,
-    L1,
-    L2,
-    L3,
-    L4,
-    C0,
-    U0,
-    E0,
-    E1,
-    E2,
-    E3,
-    E4,
-    K0,
-    K1,
-    K2,
-    K3,
-    K4,
-    R0,
-    S3,
-    W0, //!< Wait and signal load error
+    T0, //!< T0 change to filament 0
+    T1, //!< T1 change to filament 1
+    T2, //!< T2 change to filament 2
+    T3, //!< T3 change to filament 3
+    T4, //!< T4 change to filament 4
+    L0, //!< Load filament 0
+    L1, //!< Load filament 1
+    L2, //!< Load filament 2
+    L3, //!< Load filament 3
+    L4, //!< Load filament 4
+    C0, //!< Continue loading current filament (used after T-code)
+    U0, //!< Unload filament
+    E0, //!< Eject filament 0
+    E1, //!< Eject filament 1
+    E2, //!< Eject filament 2
+    E3, //!< Eject filament 3
+    E4, //!< Eject filament 4
+    K0, //!< Cut filament 0
+    K1, //!< Cut filament 1
+    K2, //!< Cut filament 2
+    K3, //!< Cut filament 3
+    K4, //!< Cut filament 4
+    R0, //!< Recover after eject filament
+    S3, //!< Power failures request
+    W0, //!< Wait for user click
 };
+
+// Other MMU commands not included in the above enum:
+// X0 - MMU reset
+// P0 - Read finda
+// M0 - Set MMU to normal mode
+// M1 - Set MMU to stealth mode
+// S0 - return 'ok'
+// S1 - Read firmware version
+// S2 - Read firmware build number
+// F<nr.> \<type\> filament type. <nr.> filament number, \<type\> 0, 1 or 2. Does nothing.
 
 inline MmuCmd operator+ (MmuCmd cmd, uint8_t filament)
 {

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1508,6 +1508,7 @@ static void lcd_menu_fails_stats_mmu_print()
 //! @todo Positioning of the messages and values on LCD aren't fixed to their exact place. This causes issues with translations.
 static void lcd_menu_fails_stats_mmu_total()
 {
+	// S3 Power failures request
 	mmu_command(MmuCmd::S3);
 	lcd_timeoutToStatus.stop(); //infinite timeout
     lcd_home();
@@ -8192,6 +8193,8 @@ static bool selftest_irsensor()
         mmu_filament_ramming();
     }
     progress = lcd_selftest_screen(TestScreen::Fsensor, progress, 1, true, 0);
+
+    // U0 Unload filament
     mmu_command(MmuCmd::U0);
     manage_response(false, false);
 


### PR DESCRIPTION
* Added information about MMU commands to the code. I believe this will help with reading the code especially for someone that is not familiar with the commands. I had to look into the MMU firmware to understand them.
* Removed one usage of `tmp_extruder` variable in `lcd_mmu_load_to_nozzle()`, it saves 12 bytes of flash memory.
* Fixed some mixing between tabs and spacing in indentation to make the git diff appear ok on Github.