### PR TITLE
Optimize `farm_mode` initialisation in `setup()`

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1101,8 +1101,10 @@ void setup()
 	setup_powerhold();
 
 	farm_mode = eeprom_read_byte((uint8_t*)EEPROM_FARM_MODE); 
-	if (farm_mode == 0xFF) 
+	if (farm_mode == 0xFF) {
 		farm_mode = false; //if farm_mode has not been stored to eeprom yet and farm number is set to zero or EEPROM is fresh, deactivate farm mode
+  	eeprom_update_byte((uint8_t*)EEPROM_FARM_MODE, farm_mode);
+  }
 	if (farm_mode)
 	{
 		no_response = true; //we need confirmation by recieving PRUSA thx
@@ -1439,13 +1441,6 @@ void setup()
 #if defined(Z_AXIS_ALWAYS_ON)
     enable_z();
 #endif
-
-	farm_mode = eeprom_read_byte((uint8_t*)EEPROM_FARM_MODE);
-	if (farm_mode == 0xFF) farm_mode = false; //if farm_mode has not been stored to eeprom yet and farm number is set to zero or EEPROM is fresh, deactivate farm mode
-	if (farm_mode)
-	{
-		prusa_statistics(8);
-	}
 
 	// Enable Toshiba FlashAir SD card / WiFi enahanced card.
 	card.ToshibaFlashAir_enable(eeprom_read_byte((unsigned char*)EEPROM_TOSHIBA_FLASH_AIR_COMPATIBLITY) == 1);

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1439,6 +1439,12 @@ void setup()
     enable_z();
 #endif
 
+    if (farm_mode) {
+        // The farm monitoring SW may accidentally expect 
+        // 2 messages of "printer started" to consider a printer working.
+        prusa_statistics(8);
+    }
+
 	// Enable Toshiba FlashAir SD card / WiFi enahanced card.
 	card.ToshibaFlashAir_enable(eeprom_read_byte((unsigned char*)EEPROM_TOSHIBA_FLASH_AIR_COMPATIBLITY) == 1);
 

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1103,10 +1103,8 @@ void setup()
 	farm_mode = eeprom_read_byte((uint8_t*)EEPROM_FARM_MODE); 
 	if (farm_mode == 0xFF) {
 		farm_mode = false; //if farm_mode has not been stored to eeprom yet and farm number is set to zero or EEPROM is fresh, deactivate farm mode
-  	eeprom_update_byte((uint8_t*)EEPROM_FARM_MODE, farm_mode);
-  }
-	if (farm_mode)
-	{
+		eeprom_update_byte((uint8_t*)EEPROM_FARM_MODE, farm_mode);
+	} else if (farm_mode) {
 		no_response = true; //we need confirmation by recieving PRUSA thx
 		important_status = 8;
 		prusa_statistics(8);
@@ -1118,9 +1116,9 @@ void setup()
 		//disabled filament autoload (PFW360)
 		fsensor_autoload_set(false);
 #endif //FILAMENT_SENSOR
-          // ~ FanCheck -> on
-          if(!(eeprom_read_byte((uint8_t*)EEPROM_FAN_CHECK_ENABLED)))
-               eeprom_update_byte((unsigned char *)EEPROM_FAN_CHECK_ENABLED,true);
+		// ~ FanCheck -> on
+		if(!(eeprom_read_byte((uint8_t*)EEPROM_FAN_CHECK_ENABLED)))
+			eeprom_update_byte((uint8_t*)EEPROM_FAN_CHECK_ENABLED,true);
 	}
 
 #ifdef TMC2130

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1117,8 +1117,7 @@ void setup()
 		fsensor_autoload_set(false);
 #endif //FILAMENT_SENSOR
 		// ~ FanCheck -> on
-		if(!(eeprom_read_byte((uint8_t*)EEPROM_FAN_CHECK_ENABLED)))
-			eeprom_update_byte((uint8_t*)EEPROM_FAN_CHECK_ENABLED,true);
+		eeprom_update_byte((uint8_t*)EEPROM_FAN_CHECK_ENABLED, true);
 	}
 
 #ifdef TMC2130


### PR DESCRIPTION
This saves 28 bytes of flash memory. It looks like to me `farm_mode` is initialised twice in the `setup()` function. I also added an `eeprom_update_byte()` call in case the EEPROM memory has not been set. That way if `farm_mode` is never activated, this is only called on the first boot-up instead of on every boot-up.

Before:
Sketch uses **231746** bytes (91%) of program storage space. Maximum is 253952 bytes.
Global variables use **6103** bytes of dynamic memory.

After:
Sketch uses **231718** bytes (91%) of program storage space. Maximum is 253952 bytes.
Global variables use **6103** bytes of dynamic memory.
