### PR TITLE
Fix edge case when SD card is inserted while user is inside the 'No SD card' submenu

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -8844,6 +8844,22 @@ void menu_lcd_lcdupdate_func(void)
 #if (SDCARDDETECT > 0)
 	if ((IS_SD_INSERTED != lcd_oldcardstatus))
 	{
+		if(menu_menu == lcd_sdcard_menu) {
+			// If the user is either inside the submenus
+			// 1. 'Print from SD' --> and SD card is removed
+			// 2. 'No SD card' --> and SD card is inserted
+			//
+			// 1. 'Print from SD': We want to back out of this submenu
+			//    and instead show the submenu title 'No SD card'.
+			//
+			// 2. 'No SD card': When the user inserts the SD card we want
+			//    to back out of this submenu. Not only to show 
+			//    'Print from SD' submenu title but also because the user
+			//    will be prompted with another menu with the sorted list of files.
+			//    Without backing out of the menu, the list will appear empty and
+			//    The user will need to back out of two nested submenus.
+			menu_back();
+		}
 		lcd_draw_update = 2;
 		lcd_oldcardstatus = IS_SD_INSERTED;
 		lcd_refresh(); // to maybe revive the LCD if static electricity killed it.
@@ -8861,8 +8877,6 @@ void menu_lcd_lcdupdate_func(void)
 		}
 		else
 		{
-			if(menu_menu==lcd_sdcard_menu)
-				menu_back();
 			card.release();
 			LCD_MESSAGERPGM(_i("Card removed"));////MSG_SD_REMOVED c=20
 		}


### PR DESCRIPTION
Fixes https://github.com/prusa3d/Prusa-Firmware/issues/3252

Video demonstrations:

* Before the fix: https://youtu.be/QGSbsQEuYTc
* After the fix: https://youtu.be/8fnGujT6t5Q

Memory footprint remains unchanged according the Arduino IDE.

Here is the HEX firmware file if somebody wants to test the fix: [Firmware.ino.zip](https://github.com/prusa3d/Prusa-Firmware/files/6895531/Firmware.ino.zip) I had to ZIP it because Github doesn't support .hex files as attachment.