### PR TITLE
Remove one call to `lcd_timeoutToStatus.start`

### DIFF
--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -741,7 +741,6 @@ void lcd_buttons_update(void)
 
     if (READ(BTN_ENC) == 0)
     { //button is pressed
-        lcd_timeoutToStatus.start();
         if (!buttonBlanking.running() || buttonBlanking.expired(BUTTON_BLANKING_TIME)) {
             buttonBlanking.start();
             safetyTimer.start();


### PR DESCRIPTION

While looking into #3262 I noticed that `lcd_timeoutToStatus.start()` is called multiple times in `lcd_buttons_update()` before finally being called once in `menu_lcd_lcdupdate_func()`. (See image below of serial stream)

I noticed this because I added a serial message everywhere `lcd_timeoutToStatus` is used just to get a better picture of when it is started and stopped.

`lcd_timeoutToStatus.start()` is called from `menu_lcd_lcdupdate_func()` once when the knob is clicked. The change reduces flash memory usage by 8 bytes. This change affects the temperature ISR because it calls `lcd_buttons_update()`.

I have not found any issues so far on my printer.

![image](https://user-images.githubusercontent.com/8218499/130325341-678867a0-3026-453e-b667-ec4f74da5f66.png)
