### PR TITLE
Fix issue when the SD card is inserted and the file menu may sometimes close immediately due to a timeout

### DIFF
--- a/Firmware/cardreader.cpp
+++ b/Firmware/cardreader.cpp
@@ -1030,7 +1030,6 @@ void CardReader::presort() {
 
 	lcd_update(2);
 	KEEPALIVE_STATE(NOT_BUSY);
-	lcd_timeoutToStatus.start();
 }
 
 void CardReader::flush_presort() {

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -8858,6 +8858,7 @@ void menu_lcd_lcdupdate_func(void)
 			LCD_MESSAGERPGM(_T(WELCOME_MSG));
 			bMain=false;                       // flag (i.e. 'fake parameter') for 'lcd_sdcard_menu()' function
 			menu_submenu(lcd_sdcard_menu);
+			lcd_timeoutToStatus.start();
 		}
 		else
 		{


### PR DESCRIPTION

In this PR I propose to make sure `lcd_timeoutToStatus.start()` is called in the specific case when the SD card is inserted into the printer after it was removed beforehand.