### PR TITLE
Print temperatures only if filament loading is still active

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2317,8 +2317,10 @@ void mFilamentItem(uint16_t nTemp, uint16_t nTempBed)
             }
         }
 
-        lcd_set_cursor(0, 0);
-        lcdui_print_temp(LCD_STR_THERMOMETER[0], (int) degHotend(0), (int) degTargetHotend(0));
+        if (bFilamentWaitingFlag) {
+            lcd_set_cursor(0, 0);
+            lcdui_print_temp(LCD_STR_THERMOMETER[0], (int) degHotend(0), (int) degTargetHotend(0));
+        }
 
         if (lcd_clicked())
         {


### PR DESCRIPTION
Implement the change of the https://github.com/prusa3d/Prusa-Firmware/pull/3214 on the MK3_3.10.1 branch 
