### PR TITLE
Fix build error when `TMC2130_SERVICE_CODES_M910_M918` is enabled

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -8625,7 +8625,7 @@ Sigma_Exit:
     */
 	case 910:
     {
-		tmc2130_init();
+		tmc2130_init(TMCInitParams(false, FarmOrUserECool()));
     }
     break;
 
@@ -8692,7 +8692,7 @@ Sigma_Exit:
     {
 		tmc2130_mode = TMC2130_MODE_NORMAL;
 		update_mode_profile();
-		tmc2130_init();
+		tmc2130_init(TMCInitParams(false, FarmOrUserECool()));
     }
     break;
 
@@ -8704,7 +8704,7 @@ Sigma_Exit:
     {
 		tmc2130_mode = TMC2130_MODE_SILENT;
 		update_mode_profile();
-		tmc2130_init();
+		tmc2130_init(TMCInitParams(false, FarmOrUserECool()));
     }
     break;
 


### PR DESCRIPTION
(cherry picked from commit 6ed4b79cc6685f31b6914881008e036424dab2eb)

Previous PR: https://github.com/prusa3d/Prusa-Firmware/pull/3285