### PR TITLE
My solution to solve the watchdog issues with custom sound generation

### DIFF
--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -391,7 +391,9 @@ extern void calculate_extruder_multipliers();
 
 // Similar to the default Arduino delay function, 
 // but it keeps the background tasks running.
-extern void delay_keep_alive(unsigned int ms);
+void _delay_keep_alive(unsigned int ms, bool do_update_lcd);
+#define delay_keep_alive(ms) _delay_keep_alive((ms), true)
+#define delay_keep_alive_headless(ms) _delay_keep_alive((ms), false)
 
 extern void check_babystep();
 

--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -391,9 +391,7 @@ extern void calculate_extruder_multipliers();
 
 // Similar to the default Arduino delay function, 
 // but it keeps the background tasks running.
-void _delay_keep_alive(unsigned int ms, bool do_update_lcd);
-#define delay_keep_alive(ms) _delay_keep_alive((ms), true)
-#define delay_keep_alive_headless(ms) _delay_keep_alive((ms), false)
+extern void delay_keep_alive(unsigned int ms, bool do_update_lcd = true);
 
 extern void check_babystep();
 

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -10349,7 +10349,7 @@ void calculate_extruder_multipliers() {
 #endif
 }
 
-void _delay_keep_alive(unsigned int ms, bool do_update_lcd)
+void delay_keep_alive(unsigned int ms, bool do_update_lcd /* = true */)
 {
     for (;;) {
         manage_heater();

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -10349,13 +10349,14 @@ void calculate_extruder_multipliers() {
 #endif
 }
 
-void delay_keep_alive(unsigned int ms)
+void _delay_keep_alive(unsigned int ms, bool do_update_lcd)
 {
     for (;;) {
         manage_heater();
         // Manage inactivity, but don't disable steppers on timeout.
         manage_inactivity(true);
-        lcd_update(0);
+        if (do_update_lcd)
+            lcd_update(0);
         if (ms == 0)
             break;
         else if (ms >= 50) {

--- a/Firmware/sound.cpp
+++ b/Firmware/sound.cpp
@@ -68,7 +68,7 @@ void Sound_Delay(uint16_t ms)
     if (ms < (SOUND_KEEPALIVE_MIN_MS))
         _delay(ms);
     else
-        delay_keep_alive_headless(ms);
+        delay_keep_alive(ms, false);
 }
 
 // Makes a custom sound

--- a/Firmware/sound.h
+++ b/Firmware/sound.h
@@ -13,6 +13,9 @@ typedef enum
 typedef enum
      {e_SOUND_CLASS_Echo,e_SOUND_CLASS_Prompt,e_SOUND_CLASS_Confirm,e_SOUND_CLASS_Warning,e_SOUND_CLASS_Alert} eSOUND_CLASS;
 
+// The minimum number of milliseconds of sound duration, to use the keep-alive method instead of the default delay
+// This is used to allow the printer to retain control in long-running sound output
+#define SOUND_KEEPALIVE_MIN_MS 1100
 
 extern eSOUND_MODE eSoundMode;
 


### PR DESCRIPTION
As discussed issue #2045, long sound durations often cause the watchdog timer to reset the printer, as the sound generation is currently using regular delays that don't feed the watchdog timer.
I am proposing a hybrid solution that uses regular delays for short beeps and a modified version of `delay_keep_alive` that doesn't update the LCD for long delays that exceed 1.1 seconds.