### PR TITLE
Implement first layer cal with calculated extrusion amounts

### DIFF
--- a/Firmware/first_lay_cal.cpp
+++ b/Firmware/first_lay_cal.cpp
@@ -60,8 +60,8 @@ bool lay1cal_load_filament(char *cmd_buffer, uint8_t filament)
     if (MMU2::mmu2.Enabled())
     {
         enquecommand_P(PSTR("M83"));
-        enquecommand_P(PSTR("G1 Y-3.0 F1000.0"));
-        enquecommand_P(PSTR("G1 Z0.4 F1000.0"));
+        enquecommand_P(PSTR("G1 Y-3 F1000"));
+        enquecommand_P(PSTR("G1 Z0.4 F1000"));
 
         uint8_t currentTool = MMU2::mmu2.get_current_tool();
         if(currentTool == filament ){
@@ -90,16 +90,16 @@ bool lay1cal_load_filament(char *cmd_buffer, uint8_t filament)
 //! @param extrusion_width the width of the extrusion layer 
 void lay1cal_intro_line(bool extraPurgeNeeded, float layer_height, float extrusion_width)
 {
-    static const char cmd_intro_mmu_3[] PROGMEM = "G1 X55.0 E29.0 F1073.0";
-    static const char cmd_intro_mmu_4[] PROGMEM = "G1 X5.0 E29.0 F1800.0";
-    static const char cmd_intro_mmu_5[] PROGMEM = "G1 X55.0 E8.0 F2000.0";
-    static const char cmd_intro_mmu_6[] PROGMEM = "G1 Z0.3 F1000.0";
-    static const char cmd_intro_mmu_7[] PROGMEM = "G92 E0.0";
-    static const char cmd_intro_mmu_8[] PROGMEM = "G1 X240.0 E25.0  F2200.0";
-    static const char cmd_intro_mmu_9[] PROGMEM = "G1 Y-2.0 F1000.0";
-    static const char cmd_intro_mmu_10[] PROGMEM = "G1 X55.0 E25 F1400.0";
-    static const char cmd_intro_mmu_11[] PROGMEM = "G1 Z0.20 F1000.0";
-    static const char cmd_intro_mmu_12[] PROGMEM = "G1 X5.0 E4.0 F1000.0";
+    static const char cmd_intro_mmu_3[] PROGMEM = "G1 X55 E29 F1073";
+    static const char cmd_intro_mmu_4[] PROGMEM = "G1 X5 E29 F1800";
+    static const char cmd_intro_mmu_5[] PROGMEM = "G1 X55 E8 F2000";
+    static const char cmd_intro_mmu_6[] PROGMEM = "G1 Z0.3 F1000";
+    static const char cmd_intro_mmu_7[] PROGMEM = "G92 E0";
+    static const char cmd_intro_mmu_8[] PROGMEM = "G1 X240 E25  F2200";
+    static const char cmd_intro_mmu_9[] PROGMEM = "G1 Y-2 F1000";
+    static const char cmd_intro_mmu_10[] PROGMEM = "G1 X55 E25 F1400";
+    static const char cmd_intro_mmu_11[] PROGMEM = "G1 Z0.2 F1000";
+    static const char cmd_intro_mmu_12[] PROGMEM = "G1 X5 E4 F1000";
 
     static const char * const intro_mmu_cmd[] PROGMEM =
     {
@@ -127,7 +127,7 @@ void lay1cal_intro_line(bool extraPurgeNeeded, float layer_height, float extrusi
     else
     {
         char cmd_buffer[30];
-        static const char fmt1[] PROGMEM = "G1 X%d E%-.3f F1000.0";
+        static const char fmt1[] PROGMEM = "G1 X%d E%-.3f F1000";
         sprintf_P(cmd_buffer, fmt1, 60, count_e(layer_height, extrusion_width * 4.f, 60));
         enquecommand(cmd_buffer);
         sprintf_P(cmd_buffer, fmt1, 100, count_e(layer_height, extrusion_width * 8.f, 40));
@@ -138,12 +138,12 @@ void lay1cal_intro_line(bool extraPurgeNeeded, float layer_height, float extrusi
 //! @brief Setup for printing meander
 void lay1cal_before_meander()
 {
-    static const char cmd_pre_meander_0[] PROGMEM = "G92 E0.0";
+    static const char cmd_pre_meander_0[] PROGMEM = "G92 E0";
     static const char cmd_pre_meander_1[] PROGMEM = "G21"; //set units to millimeters TODO unsupported command
     static const char cmd_pre_meander_2[] PROGMEM = "G90"; //use absolute coordinates
     static const char cmd_pre_meander_3[] PROGMEM = "M83"; //use relative distances for extrusion TODO: duplicate
-    static const char cmd_pre_meander_4[] PROGMEM = "G1 E-1.50000 F2100.00000";
-    static const char cmd_pre_meander_5[] PROGMEM = "G1 Z5 F7200.000";
+    static const char cmd_pre_meander_4[] PROGMEM = "G1 E-1.5 F2100";
+    static const char cmd_pre_meander_5[] PROGMEM = "G1 Z5 F7200";
     static const char cmd_pre_meander_6[] PROGMEM = "M204 S1000"; //set acceleration
     static const char cmd_pre_meander_7[] PROGMEM = "G1 F4000";
 
@@ -171,7 +171,7 @@ void lay1cal_meander_start(float layer_height, float extrusion_width)
     char cmd_buffer[30];
     enquecommand_P(PSTR("G1 X50 Y155"));
 
-    static const char fmt1[] PROGMEM = "G1 Z%-.3f F7200.000";
+    static const char fmt1[] PROGMEM = "G1 Z%-.3f F7200";
     sprintf_P(cmd_buffer, fmt1, layer_height);
     enquecommand(cmd_buffer);
 

--- a/Firmware/first_lay_cal.cpp
+++ b/Firmware/first_lay_cal.cpp
@@ -33,6 +33,9 @@ static constexpr float spacing(float layer_height, float extrusion_width, float 
     return extrusion_width - layer_height * (overlap_factor - M_PI/4);
 }
 
+static const char extrude_fmt[] PROGMEM = "G1 X%d Y%d E%-.5f";
+static const char zero_extrusion[] PROGMEM = "G92 E0";
+
 //! @brief Wait for preheat
 void lay1cal_wait_preheat()
 {
@@ -43,6 +46,7 @@ void lay1cal_wait_preheat()
         PSTR("M109"),
         PSTR("G28"),
         PSTR("G92 E0.0")
+        zero_extrusion
     };
 
     for (uint8_t i = 0; i < (sizeof(preheat_cmd)/sizeof(preheat_cmd[0])); ++i)
@@ -94,7 +98,6 @@ void lay1cal_intro_line(bool extraPurgeNeeded, float layer_height, float extrusi
     static const char cmd_intro_mmu_4[] PROGMEM = "G1 X5 E29 F1800";
     static const char cmd_intro_mmu_5[] PROGMEM = "G1 X55 E8 F2000";
     static const char cmd_intro_mmu_6[] PROGMEM = "G1 Z0.3 F1000";
-    static const char cmd_intro_mmu_7[] PROGMEM = "G92 E0";
     static const char cmd_intro_mmu_8[] PROGMEM = "G1 X240 E25  F2200";
     static const char cmd_intro_mmu_9[] PROGMEM = "G1 Y-2 F1000";
     static const char cmd_intro_mmu_10[] PROGMEM = "G1 X55 E25 F1400";
@@ -109,7 +112,7 @@ void lay1cal_intro_line(bool extraPurgeNeeded, float layer_height, float extrusi
 
         cmd_intro_mmu_5,
         cmd_intro_mmu_6,
-        cmd_intro_mmu_7,
+        zero_extrusion,
         cmd_intro_mmu_8,
         cmd_intro_mmu_9,
         cmd_intro_mmu_10,
@@ -138,7 +141,6 @@ void lay1cal_intro_line(bool extraPurgeNeeded, float layer_height, float extrusi
 //! @brief Setup for printing meander
 void lay1cal_before_meander()
 {
-    static const char cmd_pre_meander_0[] PROGMEM = "G92 E0";
     static const char cmd_pre_meander_1[] PROGMEM = "G21"; //set units to millimeters TODO unsupported command
     static const char cmd_pre_meander_2[] PROGMEM = "G90"; //use absolute coordinates
     static const char cmd_pre_meander_3[] PROGMEM = "M83"; //use relative distances for extrusion TODO: duplicate
@@ -149,7 +151,7 @@ void lay1cal_before_meander()
 
     static const char * const cmd_pre_meander[] PROGMEM =
     {
-            cmd_pre_meander_0,
+            zero_extrusion,
             cmd_pre_meander_1,
             cmd_pre_meander_2,
             cmd_pre_meander_3,
@@ -177,14 +179,13 @@ void lay1cal_meander_start(float layer_height, float extrusion_width)
 
     enquecommand_P(PSTR("G1 F1080"));
 
-    static const char fmt2[] PROGMEM = "G1 X%d Y%d E%-.5f";
-    sprintf_P(cmd_buffer, fmt2,  75, 155, count_e(layer_height, extrusion_width * 4.f, 25));
+    sprintf_P(cmd_buffer, extrude_fmt,  75, 155, count_e(layer_height, extrusion_width * 4.f, 25));
     enquecommand(cmd_buffer);
-    sprintf_P(cmd_buffer, fmt2, 100, 155, count_e(layer_height, extrusion_width * 2.f, 25));
+    sprintf_P(cmd_buffer, extrude_fmt, 100, 155, count_e(layer_height, extrusion_width * 2.f, 25));
     enquecommand(cmd_buffer);
-    sprintf_P(cmd_buffer, fmt2, 200, 155, count_e(layer_height, extrusion_width, 100));
+    sprintf_P(cmd_buffer, extrude_fmt, 200, 155, count_e(layer_height, extrusion_width, 100));
     enquecommand(cmd_buffer);
-    sprintf_P(cmd_buffer, fmt2, 200, 135, count_e(layer_height, extrusion_width, 20));
+    sprintf_P(cmd_buffer, extrude_fmt, 200, 135, count_e(layer_height, extrusion_width, 20));
     enquecommand(cmd_buffer);
 }
 
@@ -193,7 +194,7 @@ void lay1cal_meander_start(float layer_height, float extrusion_width)
 void lay1cal_meander(float layer_height, float extrusion_width)
 {
     char cmd_buffer[30];
-    static const char fmt1[] PROGMEM = "G1 X%d Y%d E%-.5f";
+
     const float short_length = 20;
     float long_length = 150;
     const float long_extrusion = count_e(layer_height, extrusion_width, long_length);
@@ -203,12 +204,12 @@ void lay1cal_meander(float layer_height, float extrusion_width)
     uint8_t x_pos = 50;
     for(uint8_t i = 0; i <= 4; ++i)
     {
-        sprintf_P(cmd_buffer, fmt1, x_pos, y_pos, long_extrusion);
+        sprintf_P(cmd_buffer, extrude_fmt, x_pos, y_pos, long_extrusion);
         enquecommand(cmd_buffer);
 
         y_pos -= short_length;
 
-        sprintf_P(cmd_buffer, fmt1, x_pos, y_pos, short_extrusion);
+        sprintf_P(cmd_buffer, extrude_fmt, x_pos, y_pos, short_extrusion);
         enquecommand(cmd_buffer);
 
         x_pos += long_length;

--- a/Firmware/first_lay_cal.cpp
+++ b/Firmware/first_lay_cal.cpp
@@ -221,26 +221,30 @@ void lay1cal_meander(float layer_height, float extrusion_width)
 
 //! @brief Print square
 //!
-//! This function needs to be called 16 times for i from 0 to 15.
+//! This function needs to be called 4 times with step of 0,4,8,12
 //!
 //! @param cmd_buffer character buffer needed to format gcodes
 //! @param i iteration
-void lay1cal_square(char *cmd_buffer, uint8_t i, float layer_height, float extrusion_width)
+void lay1cal_square(uint8_t step, float layer_height, float extrusion_width)
 {
+    char cmd_buffer[30];
     const float long_length = 20;
     const float short_length = spacing(layer_height, extrusion_width);
     const float long_extrusion = count_e(layer_height, extrusion_width, long_length);
     const float short_extrusion = count_e(layer_height, extrusion_width, short_length);
-
     static const char fmt1[] PROGMEM = "G1 X%d Y%-.2f E%-.3f";
-    sprintf_P(cmd_buffer, fmt1, 70, (35 - i*short_length * 2), long_extrusion);
-    enquecommand(cmd_buffer);
-    sprintf_P(cmd_buffer, fmt1, 70, (35 - (2 * i + 1)*short_length), short_extrusion);
-    enquecommand(cmd_buffer);
-    sprintf_P(cmd_buffer, fmt1, 50, (35 - (2 * i + 1)*short_length), long_extrusion);
-    enquecommand(cmd_buffer);
-    sprintf_P(cmd_buffer, fmt1, 50, (35 - (i + 1)*short_length * 2), short_extrusion);
-    enquecommand(cmd_buffer);
+
+    for (uint8_t i = step; i < step+4; ++i)
+    {
+        sprintf_P(cmd_buffer, fmt1, 70, (35 - i*short_length * 2), long_extrusion);
+        enquecommand(cmd_buffer);
+        sprintf_P(cmd_buffer, fmt1, 70, (35 - (2 * i + 1)*short_length), short_extrusion);
+        enquecommand(cmd_buffer);
+        sprintf_P(cmd_buffer, fmt1, 50, (35 - (2 * i + 1)*short_length), long_extrusion);
+        enquecommand(cmd_buffer);
+        sprintf_P(cmd_buffer, fmt1, 50, (35 - (i + 1)*short_length * 2), short_extrusion);
+        enquecommand(cmd_buffer);
+    }
 }
 
 void lay1cal_finish(bool mmu_enabled)

--- a/Firmware/first_lay_cal.cpp
+++ b/Firmware/first_lay_cal.cpp
@@ -46,7 +46,6 @@ void lay1cal_wait_preheat()
         PSTR("M190"),
         PSTR("M109"),
         PSTR("G28"),
-        PSTR("G92 E0.0")
         zero_extrusion
     };
 

--- a/Firmware/first_lay_cal.cpp
+++ b/Firmware/first_lay_cal.cpp
@@ -18,6 +18,7 @@
 //! @param extrusion_width extrusion width in mm
 //! @param extrusion_length extrusion length in mm
 //! @return filament length in mm which needs to be extruded to form line
+__attribute__((noinline))
 static constexpr float count_e(float layer_height, float extrusion_width, float extrusion_length, float filament_diameter=1.75f)
 {
     return (extrusion_length * ((M_PI * pow(layer_height, 2)) / 4 + layer_height * (extrusion_width - layer_height))) / ((M_PI * pow(filament_diameter, 2)) / 4);

--- a/Firmware/first_lay_cal.cpp
+++ b/Firmware/first_lay_cal.cpp
@@ -241,3 +241,33 @@ void lay1cal_square(char *cmd_buffer, uint8_t i, float layer_height, float extru
     sprintf_P(cmd_buffer, fmt1, 50, (35 - (i + 1)*short_length * 2), short_extrusion);
     enquecommand(cmd_buffer);
 }
+
+void lay1cal_finish(bool mmu_enabled)
+{
+    static const char cmd_cal_finish_0[] PROGMEM = "M107"; //turn off printer fan
+    static const char cmd_cal_finish_1[] PROGMEM = "G1 E-0.075 F2100"; //retract
+    static const char cmd_cal_finish_2[] PROGMEM = "M104 S0"; // turn off temperature
+    static const char cmd_cal_finish_3[] PROGMEM = "M140 S0"; // turn off heatbed
+    static const char cmd_cal_finish_4[] PROGMEM = "G1 Z10 F1300"; //lift Z
+    static const char cmd_cal_finish_5[] PROGMEM = "G1 X10 Y180 F4000"; //Go to parking position
+    static const char cmd_cal_finish_6[] PROGMEM = "M702 C"; //unload from nozzle
+    static const char cmd_cal_finish_7[] PROGMEM = "M84";// disable motors
+
+    static const char * const cmd_cal_finish[] PROGMEM =
+    {
+            cmd_cal_finish_0,
+            cmd_cal_finish_1,
+            cmd_cal_finish_2,
+            cmd_cal_finish_3,
+            cmd_cal_finish_4,
+            cmd_cal_finish_5
+    };
+
+    for (uint8_t i = 0; i < (sizeof(cmd_cal_finish)/sizeof(cmd_cal_finish[0])); ++i)
+    {
+        enquecommand_P(static_cast<char*>(pgm_read_ptr(&cmd_cal_finish[i])));
+    }
+
+    if (mmu_enabled) enquecommand_P(cmd_cal_finish_6); //unload from nozzle
+    enquecommand_P(cmd_cal_finish_7);// disable motors
+}

--- a/Firmware/first_lay_cal.cpp
+++ b/Firmware/first_lay_cal.cpp
@@ -254,7 +254,7 @@ void lay1cal_finish(bool mmu_enabled)
     static const char cmd_cal_finish_3[] PROGMEM = "M140 S0"; // turn off heatbed
     static const char cmd_cal_finish_4[] PROGMEM = "G1 Z10 F1300"; //lift Z
     static const char cmd_cal_finish_5[] PROGMEM = "G1 X10 Y180 F4000"; //Go to parking position
-    static const char cmd_cal_finish_6[] PROGMEM = "M702 C"; //unload from nozzle
+    static const char cmd_cal_finish_6[] PROGMEM = "M702"; //unload from nozzle
     static const char cmd_cal_finish_7[] PROGMEM = "M84";// disable motors
 
     static const char * const cmd_cal_finish[] PROGMEM =

--- a/Firmware/first_lay_cal.cpp
+++ b/Firmware/first_lay_cal.cpp
@@ -18,8 +18,7 @@
 //! @param extrusion_width extrusion width in mm
 //! @param extrusion_length extrusion length in mm
 //! @return filament length in mm which needs to be extruded to form line
-__attribute__((noinline))
-static constexpr float count_e(float layer_height, float extrusion_width, float extrusion_length, float filament_diameter=1.75f)
+static constexpr float __attribute__((noinline)) count_e(float layer_height, float extrusion_width, float extrusion_length, float filament_diameter=1.75f)
 {
     return (extrusion_length * ((M_PI * pow(layer_height, 2)) / 4 + layer_height * (extrusion_width - layer_height))) / ((M_PI * pow(filament_diameter, 2)) / 4);
 }

--- a/Firmware/first_lay_cal.h
+++ b/Firmware/first_lay_cal.h
@@ -8,9 +8,10 @@
 
 void lay1cal_wait_preheat();
 [[nodiscard]] bool lay1cal_load_filament(char *cmd_buffer, uint8_t filament);
-void lay1cal_intro_line(bool skipExtraPurge);
+void lay1cal_intro_line(bool skipExtraPurge, float layer_height, float extrusion_width);
 void lay1cal_before_meander();
-void lay1cal_meander(char *cmd_buffer);
-void lay1cal_square(char *cmd_buffer, uint8_t i);
+void lay1cal_meander_start(float layer_height, float extrusion_width);
+void lay1cal_meander(float layer_height, float extrusion_width);
+void lay1cal_square(char *cmd_buffer, uint8_t i, float layer_height, float extrusion_width);
 
 #endif /* FIRMWARE_FIRST_LAY_CAL_H_ */

--- a/Firmware/first_lay_cal.h
+++ b/Firmware/first_lay_cal.h
@@ -12,7 +12,7 @@ void lay1cal_intro_line(bool skipExtraPurge, float layer_height, float extrusion
 void lay1cal_before_meander();
 void lay1cal_meander_start(float layer_height, float extrusion_width);
 void lay1cal_meander(float layer_height, float extrusion_width);
-void lay1cal_square(char *cmd_buffer, uint8_t i, float layer_height, float extrusion_width);
+void lay1cal_square(uint8_t step, float layer_height, float extrusion_width);
 void lay1cal_finish(bool mmu_enabled);
 
 #endif /* FIRMWARE_FIRST_LAY_CAL_H_ */

--- a/Firmware/first_lay_cal.h
+++ b/Firmware/first_lay_cal.h
@@ -13,5 +13,6 @@ void lay1cal_before_meander();
 void lay1cal_meander_start(float layer_height, float extrusion_width);
 void lay1cal_meander(float layer_height, float extrusion_width);
 void lay1cal_square(char *cmd_buffer, uint8_t i, float layer_height, float extrusion_width);
+void lay1cal_finish(bool mmu_enabled);
 
 #endif /* FIRMWARE_FIRST_LAY_CAL_H_ */

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -832,70 +832,49 @@ void lcd_commands()
 
         if (!blocks_queued() && cmd_buffer_empty() && !saved_printing)
         {
+            if (lcd_commands_step == 0)
+                lcd_commands_step = 12;
+            else
+                lcd_commands_step--;
+
             switch(lcd_commands_step)
             {
-            case 0:
-                lcd_commands_step = 12;
-                break;
             case 12:
                 lay1cal_wait_preheat();
-                lcd_commands_step = 11;
                 break;
             case 11:
                 extraPurgeNeeded = lay1cal_load_filament(cmd1, lay1cal_filament);
-                lcd_commands_step = 10;
                 break;
             case 10:
                 lcd_clear();
                 menu_depth = 0;
                 menu_submenu(lcd_babystep_z);
                 lay1cal_intro_line(extraPurgeNeeded, layer_height, extrusion_width);
-                lcd_commands_step = 9;
                 break;
             case 9:
                 lay1cal_before_meander();
-                lcd_commands_step = 8;
                 break;
             case 8:
                 lay1cal_meander_start(layer_height, extrusion_width);
-                lcd_commands_step = 7;
                 break;
             case 7:
                 lay1cal_meander(layer_height, extrusion_width);
-                lcd_commands_step = 6;
                 break;
             case 6:
-                for (uint8_t i = 0; i < 4; i++)
-                {
-                    lay1cal_square(cmd1, i, layer_height, extrusion_width);
-                }
-                lcd_commands_step = 5;
+                lay1cal_square(0, layer_height, extrusion_width);
                 break;
             case 5:
-                for (uint8_t i = 4; i < 8; i++)
-                {
-                    lay1cal_square(cmd1, i, layer_height, extrusion_width);
-                }
-                lcd_commands_step = 4;
+                lay1cal_square(4, layer_height, extrusion_width);
                 break;
             case 4:
-                for (uint8_t i = 8; i < 12; i++)
-                {
-                    lay1cal_square(cmd1, i, layer_height, extrusion_width);
-                }
-                lcd_commands_step = 3;
+                lay1cal_square(8, layer_height, extrusion_width);
                 break;
             case 3:
-                for (uint8_t i = 12; i < 16; i++)
-                {
-                    lay1cal_square(cmd1, i, layer_height, extrusion_width);
-                }
-                lcd_commands_step = 2;
+                lay1cal_square(12, layer_height, extrusion_width);
                 break;
             case 2:
                 lay1cal_finish(MMU2::mmu2.Enabled());
                 menu_leaving = 1; //if user dont confirm live adjust Z value by pressing the knob, we are saving last value by timeout to status screen
-                lcd_commands_step = 1;
                 break;
             case 1:
                 lcd_setstatuspgm(MSG_WELCOME);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -893,14 +893,7 @@ void lcd_commands()
                 lcd_commands_step = 2;
                 break;
             case 2:
-                enquecommand_P(PSTR("M107")); //turn off printer fan
-                enquecommand_P(PSTR("G1 E-0.07500 F2100.00000")); //retract
-                enquecommand_P(PSTR("M104 S0")); // turn off temperature
-                enquecommand_P(PSTR("M140 S0")); // turn off heatbed
-                enquecommand_P(PSTR("G1 Z10 F1300.000")); //lift Z
-                enquecommand_P(PSTR("G1 X10 Y180 F4000")); //Go to parking position
-                if (MMU2::mmu2.Enabled()) enquecommand_P(PSTR("M702")); //unload from nozzle
-                enquecommand_P(PSTR("M84"));// disable motors
+                lay1cal_finish(MMU2::mmu2.Enabled());
                 menu_leaving = 1; //if user dont confirm live adjust Z value by pressing the knob, we are saving last value by timeout to status screen
                 lcd_commands_step = 1;
                 break;


### PR DESCRIPTION
This is a fix for #2177 (and #2238 ) It calculates the extrusion amount based on the extrusion width and layer height making at least as wide as the nozzle_diameter.

The extrusion width for the original hardcoded implementation was reverse-engineered using the following formula:

![image](https://user-images.githubusercontent.com/444143/146038151-2cb3f904-7329-42ca-b322-f5ef56396b54.png)

This was then used as the basis for checking the calculated values.

Notes for release:

* First layer calibration height changed from 0.15 to 0.2

* First layer calibration is calculated based on nozzle dia. If you use a custom nozzle different from the default 0.4mm, set nozzle dia in HW setup menu before running the calibration.

* First layer calibration square uses slightly more advanced flow math based on Prusa Slicer math https://manual.slic3r.org/advanced/flow-math

PFW-1009