### PR TITLE
Remove `TEMP_STAT_LEDS` from firmware

### DIFF
--- a/Firmware/Configuration.h
+++ b/Firmware/Configuration.h
@@ -489,11 +489,6 @@ your extruder heater takes 2 minutes to hit the target on heating.
 // Increase the FAN pwm frequency. Removes the PWM noise but increases heating in the FET/Arduino
 //#define FAST_PWM_FAN
 
-// Temperature status LEDs that display the hotend and bet temperature.
-// If all hotends and bed temperature and temperature setpoint are < 54C then the BLUE led is on.
-// Otherwise the RED led is on. There is 1C hysteresis.
-//#define TEMP_STAT_LEDS
-
 // Use software PWM to drive the fan, as for the heaters. This uses a very low frequency
 // which is not ass annoying as with the hardware PWM. On the other hand, if this frequency
 // is too low, you should also increment SOFT_PWM_SCALE.

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -9814,39 +9814,6 @@ void controllerFan()
 }
 #endif
 
-#ifdef TEMP_STAT_LEDS
-static bool blue_led = false;
-static bool red_led = false;
-static uint32_t stat_update = 0;
-
-void handle_status_leds(void) {
-  float max_temp = 0.0;
-  if(_millis() > stat_update) {
-    stat_update += 500; // Update every 0.5s
-    for (int8_t cur_extruder = 0; cur_extruder < EXTRUDERS; ++cur_extruder) {
-       max_temp = max(max_temp, degHotend(cur_extruder));
-       max_temp = max(max_temp, degTargetHotend(cur_extruder));
-    }
-    #if defined(TEMP_BED_PIN) && TEMP_BED_PIN > -1
-      max_temp = max(max_temp, degTargetBed());
-      max_temp = max(max_temp, degBed());
-    #endif
-    if((max_temp > 55.0) && (red_led == false)) {
-      digitalWrite(STAT_LED_RED, 1);
-      digitalWrite(STAT_LED_BLUE, 0);
-      red_led = true;
-      blue_led = false;
-    }
-    if((max_temp < 54.0) && (blue_led == false)) {
-      digitalWrite(STAT_LED_RED, 0);
-      digitalWrite(STAT_LED_BLUE, 1);
-      red_led = false;
-      blue_led = true;
-    }
-  }
-}
-#endif
-
 #ifdef SAFETYTIMER
 /**
  * @brief Turn off heating after safetytimer_inactive_time milliseconds of inactivity
@@ -10089,9 +10056,6 @@ if(0)
      st_synchronize();
      WRITE(E0_ENABLE_PIN,oldstatus);
     }
-  #endif
-  #ifdef TEMP_STAT_LEDS
-      handle_status_leds();
   #endif
   check_axes_activity();
   mmu_loop();


### PR DESCRIPTION
This isn't used by MK3 printers.
It seems to be leftover code from Marlin

Motivation for removing this code
====
 
* Reduce code size
* Reduce dead code in firmware
* Resolve https://github.com/prusa3d/Prusa-Firmware/issues/3314

This Pull Request fixes issue https://github.com/prusa3d/Prusa-Firmware/issues/3314 where if `TEMP_STAT_LEDS` is defined manually then the firmware will not build because the definitions `STAT_LED_RED` and `STAT_LED_BLUE` do not exit and are intended to describe hardware pins. None of the Prusa printers have a dedicated Red or Blue LED for Temperature Indication as far as I know.
