### PR TITLE
Fix crash when the 32u2 has no SN saved

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3958,17 +3958,17 @@ static uint8_t get_PRUSA_SN(char* SN)
         {
             if (timeout.expired(250u))
                 goto exit;
-            if (MYSERIAL.available() > 0)
-            {
-                SN[rxIndex] = MYSERIAL.read();
-                rxIndex++;
-            }
+            int c = MYSERIAL.read();
+            if (c >= 0)
+                SN[rxIndex++] = (char)c;
         }
         SN[rxIndex] = 0;
         // printf_P(PSTR("SN:%s\n"), SN);
         SN_valid = (strncmp_P(SN, PSTR("CZPX"), 4) == 0);
     }
 exit:
+    _delay(100); // flush any remaining characters from the 32u2. Prevents enqueuing garbage data
+    MYSERIAL.flush(); //clear RX buffer
     selectedSerialPort = selectedSerialPort_bak;
     return !SN_valid;
 }


### PR DESCRIPTION
Even though the 32u2 had the eeprom erased, it still sent 19 0x7F characters back as a supposed SN. There was an issue where the last ";S" attempt before the timeout actually didn't flush the uart rx buffer, so those 0x7F would then get queued by the cmdqueue once the firmware finished booting up. Starting a print would result in a crash because of that incomplete uart command in the buffer (the cmdqueue waits for a complete uart command to be received before it allows enqueuing commands from the SD card). Since the cmdqueue was locked up, check_file would also get stuck and trigger a watchdog reset trying (and failing) to feed data to the cmdqueue. With these changes, the cmdqueue should be clean after a failed SN get attempt on startup.

PFW-1284