### PR TITLE
Expand maximum language count

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -919,8 +919,8 @@ void update_sec_lang_from_external_flash()
 {
 	if ((boot_app_magic == BOOT_APP_MAGIC) && (boot_app_flags & BOOT_APP_FLG_USER0))
 	{
-		uint8_t lang = boot_reserved >> 4;
-		uint8_t state = boot_reserved & 0xf;
+		uint8_t lang = boot_reserved >> 3;
+		uint8_t state = boot_reserved & 0x07;
 		lang_table_header_t header;
 		uint32_t src_addr;
 		if (lang_get_header(lang, &header, &src_addr))
@@ -928,7 +928,7 @@ void update_sec_lang_from_external_flash()
 			lcd_puts_at_P(1,3,PSTR("Language update."));
 			for (uint8_t i = 0; i < state; i++) fputc('.', lcdout);
 			_delay(100);
-			boot_reserved = (state + 1) | (lang << 4);
+			boot_reserved = (boot_reserved & 0xF8) | ((state + 1) & 0x07);
 			if ((state * LANGBOOT_BLOCKSIZE) < header.size)
 			{
 				cli();

--- a/Firmware/config.h
+++ b/Firmware/config.h
@@ -58,7 +58,7 @@
 //#define LANG_MODE              0 // primary language only
 #define LANG_MODE              1 // sec. language support
 
-#define LANG_SIZE_RESERVED     0x3000 // reserved space for secondary language (12288 bytes)
+#define LANG_SIZE_RESERVED     0x3000 // reserved space for secondary language (12288 bytes). Maximum 23768 bytes
 
 //Community language support
 #define COMMUNITY_LANG_GROUP 1

--- a/Firmware/config.h
+++ b/Firmware/config.h
@@ -58,7 +58,7 @@
 //#define LANG_MODE              0 // primary language only
 #define LANG_MODE              1 // sec. language support
 
-#define LANG_SIZE_RESERVED     0x3000 // reserved space for secondary language (12288 bytes). Maximum 23768 bytes
+#define LANG_SIZE_RESERVED     0x3000 // reserved space for secondary language (12288 bytes). Maximum 32768 bytes
 
 //Community language support
 #define COMMUNITY_LANG_GROUP 1

--- a/Firmware/language.c
+++ b/Firmware/language.c
@@ -300,5 +300,5 @@ void lang_boot_update_start(uint8_t lang)
 {
 	uint8_t cnt = lang_get_count();
 	if ((lang < 2) || (lang > cnt)) return; //only languages from xflash can be selected
-	bootapp_reboot_user0(lang << 4);
+	bootapp_reboot_user0(lang << 3);
 }


### PR DESCRIPTION
Changed the bootapp split:
- 4 bits of lang id
- 4 bits of state
Now it is:
- 5 bits of lang id
- 3 bits of state

As a result, the maximum single language size is 32K instead of 64K. Right now LANG_SIZE_RESERVED is 12K, so it is safe.
Now up to 30 translations can be downloaded from xflash (compared to the previous 14 translations)

PFW-1283