### PR TITLE
Fix the c limit for a few translations

### DIFF
--- a/Firmware/messages.c
+++ b/Firmware/messages.c
@@ -111,7 +111,7 @@ const char MSG_STOP_PRINT[] PROGMEM_I1 = ISTR("Stop print"); ////c=18
 const char MSG_STOPPED[] PROGMEM_I1 = ISTR("STOPPED."); ////c=20
 const char MSG_TEMP_CALIBRATION[] PROGMEM_I1 = ISTR("Temp. cal."); ////c=14
 const char MSG_TEMP_CALIBRATION_DONE[] PROGMEM_I1 = ISTR("Temperature calibration is finished and active. Temp. calibration can be disabled in menu Settings->Temp. cal."); ////c=20 r=12
-const char MSG_UNLOAD_FILAMENT[] PROGMEM_I1 = ISTR("Unload filament"); ////Number 1 to 5 is added behind text e.g. "Unload filament" c=16
+const char MSG_UNLOAD_FILAMENT[] PROGMEM_I1 = ISTR("Unload filament"); ////c=18
 const char MSG_UNLOADING_FILAMENT[] PROGMEM_I1 = ISTR("Unloading filament"); ////c=20
 const char MSG_WATCH[] PROGMEM_I1 = ISTR("Info screen"); ////c=18
 const char MSG_WIZARD_CALIBRATION_FAILED[] PROGMEM_I1 = ISTR("Please check our handbook and fix the problem. Then resume the Wizard by rebooting the printer."); ////c=20 r=8

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5920,7 +5920,7 @@ void bowden_menu() {
 }
 
 #ifdef SNMM
-
+#error broken MSG_UNLOAD_FILAMENT translation
 static char snmm_stop_print_menu() { //menu for choosing which filaments will be unloaded in stop print
 	lcd_clear();
 	lcd_puts_at_P(0,0,_T(MSG_UNLOAD_FILAMENT)); lcd_print(':');
@@ -6638,14 +6638,14 @@ static void lcd_main_menu()
             MENU_ITEM_SUBMENU_P(_i("Load to nozzle"), mmu_load_to_nozzle_menu);////MSG_LOAD_TO_NOZZLE c=18
 //-//          MENU_ITEM_FUNCTION_P(_T(MSG_UNLOAD_FILAMENT), extr_unload);
 //bFilamentFirstRun=true;
-            MENU_ITEM_SUBMENU_P(_T(MSG_UNLOAD_FILAMENT), mmu_unload_filament);
+            MENU_ITEM_SUBMENU_P(_T(MSG_UNLOAD_FILAMENT), mmu_unload_filament); ////MSG_UNLOAD_FILAMENT c=18
             MENU_ITEM_SUBMENU_P(_T(MSG_EJECT_FILAMENT), mmu_fil_eject_menu);
 #ifdef  MMU_HAS_CUTTER
             MENU_ITEM_SUBMENU_P(_T(MSG_CUT_FILAMENT), mmu_cut_filament_menu);
 #endif //MMU_HAS_CUTTER
         } else {
 #ifdef SNMM
-            MENU_ITEM_SUBMENU_P(_T(MSG_UNLOAD_FILAMENT), fil_unload_menu);
+            MENU_ITEM_SUBMENU_P(_T(MSG_UNLOAD_FILAMENT), fil_unload_menu); ////MSG_UNLOAD_FILAMENT c=18
             MENU_ITEM_SUBMENU_P(_i("Change extruder"), change_extr_menu);////MSG_CHANGE_EXTR c=20
 #endif
 #ifdef FILAMENT_SENSOR
@@ -6658,7 +6658,7 @@ static void lcd_main_menu()
                 MENU_ITEM_SUBMENU_P(_T(MSG_LOAD_FILAMENT), lcd_LoadFilament);
             }
             bFilamentFirstRun=true;
-            MENU_ITEM_SUBMENU_P(_T(MSG_UNLOAD_FILAMENT), lcd_unLoadFilament);
+            MENU_ITEM_SUBMENU_P(_T(MSG_UNLOAD_FILAMENT), lcd_unLoadFilament); ////MSG_UNLOAD_FILAMENT c=18
         }
     MENU_ITEM_SUBMENU_P(_T(MSG_SETTINGS), lcd_settings_menu);
     if(!isPrintPaused) MENU_ITEM_SUBMENU_P(_T(MSG_MENU_CALIBRATION), lcd_calibration_menu);

--- a/lang/lang_en.txt
+++ b/lang/lang_en.txt
@@ -844,7 +844,7 @@
 #MSG_TO_UNLOAD_FIL c=20
 "to unload filament"
 
-#MSG_UNLOAD_FILAMENT c=16
+#MSG_UNLOAD_FILAMENT c=18
 "Unload filament"
 
 #MSG_UNLOADING_FILAMENT c=20

--- a/lang/lang_en.txt
+++ b/lang/lang_en.txt
@@ -253,7 +253,7 @@
 #MSG_NOT_LOADED c=19
 "Filament not loaded"
 
-#MSG_FILAMENT_SENSOR c=20
+#MSG_SELFTEST_FILAMENT_SENSOR c=17
 "Filament sensor"
 
 #MSG_FILAMENT_USED c=19

--- a/lang/lang_en_cz.txt
+++ b/lang/lang_en_cz.txt
@@ -1126,7 +1126,7 @@
 "to unload filament"
 "k vyjmuti filamentu"
 
-#MSG_UNLOAD_FILAMENT c=16
+#MSG_UNLOAD_FILAMENT c=18
 "Unload filament"
 "Vyjmout filament"
 

--- a/lang/lang_en_cz.txt
+++ b/lang/lang_en_cz.txt
@@ -338,7 +338,7 @@
 "Filament not loaded"
 "Filament nezaveden"
 
-#MSG_FILAMENT_SENSOR c=20
+#MSG_SELFTEST_FILAMENT_SENSOR c=17
 "Filament sensor"
 "Senzor filamentu"
 

--- a/lang/lang_en_da.txt
+++ b/lang/lang_en_da.txt
@@ -1126,7 +1126,7 @@
 "to unload filament"
 "\x00"
 
-#MSG_UNLOAD_FILAMENT c=16
+#MSG_UNLOAD_FILAMENT c=18
 "Unload filament"
 "\x00"
 

--- a/lang/lang_en_da.txt
+++ b/lang/lang_en_da.txt
@@ -338,7 +338,7 @@
 "Filament not loaded"
 "\x00"
 
-#MSG_FILAMENT_SENSOR c=20
+#MSG_SELFTEST_FILAMENT_SENSOR c=17
 "Filament sensor"
 "\x00"
 

--- a/lang/lang_en_de.txt
+++ b/lang/lang_en_de.txt
@@ -338,7 +338,7 @@
 "Filament not loaded"
 "Fil. nicht geladen"
 
-#MSG_FILAMENT_SENSOR c=20
+#MSG_SELFTEST_FILAMENT_SENSOR c=17
 "Filament sensor"
 "Filamentsensor"
 

--- a/lang/lang_en_de.txt
+++ b/lang/lang_en_de.txt
@@ -1126,7 +1126,7 @@
 "to unload filament"
 "um Filament entladen"
 
-#MSG_UNLOAD_FILAMENT c=16
+#MSG_UNLOAD_FILAMENT c=18
 "Unload filament"
 "Fil. entladen"
 

--- a/lang/lang_en_es.txt
+++ b/lang/lang_en_es.txt
@@ -338,7 +338,7 @@
 "Filament not loaded"
 "Fil. no introducido"
 
-#MSG_FILAMENT_SENSOR c=20
+#MSG_SELFTEST_FILAMENT_SENSOR c=17
 "Filament sensor"
 "Sensor de filamento"
 

--- a/lang/lang_en_es.txt
+++ b/lang/lang_en_es.txt
@@ -1126,7 +1126,7 @@
 "to unload filament"
 "para descargar fil."
 
-#MSG_UNLOAD_FILAMENT c=16
+#MSG_UNLOAD_FILAMENT c=18
 "Unload filament"
 "Soltar filamento"
 

--- a/lang/lang_en_es.txt
+++ b/lang/lang_en_es.txt
@@ -340,7 +340,7 @@
 
 #MSG_SELFTEST_FILAMENT_SENSOR c=17
 "Filament sensor"
-"Sensor de filamento"
+"Sensor de fil."
 
 #MSG_FILAMENT_USED c=19
 "Filament used"

--- a/lang/lang_en_fr.txt
+++ b/lang/lang_en_fr.txt
@@ -1126,7 +1126,7 @@
 "to unload filament"
 "pour decharger fil."
 
-#MSG_UNLOAD_FILAMENT c=16
+#MSG_UNLOAD_FILAMENT c=18
 "Unload filament"
 "Decharger fil."
 

--- a/lang/lang_en_fr.txt
+++ b/lang/lang_en_fr.txt
@@ -338,7 +338,7 @@
 "Filament not loaded"
 "Filament non charge"
 
-#MSG_FILAMENT_SENSOR c=20
+#MSG_SELFTEST_FILAMENT_SENSOR c=17
 "Filament sensor"
 "Capteur de filament"
 

--- a/lang/lang_en_fr.txt
+++ b/lang/lang_en_fr.txt
@@ -340,7 +340,7 @@
 
 #MSG_SELFTEST_FILAMENT_SENSOR c=17
 "Filament sensor"
-"Capteur de filament"
+"Capteur de fil."
 
 #MSG_FILAMENT_USED c=19
 "Filament used"

--- a/lang/lang_en_hr.txt
+++ b/lang/lang_en_hr.txt
@@ -1126,7 +1126,7 @@
 "to unload filament"
 "\x00"
 
-#MSG_UNLOAD_FILAMENT c=16
+#MSG_UNLOAD_FILAMENT c=18
 "Unload filament"
 "\x00"
 

--- a/lang/lang_en_hr.txt
+++ b/lang/lang_en_hr.txt
@@ -338,7 +338,7 @@
 "Filament not loaded"
 "\x00"
 
-#MSG_FILAMENT_SENSOR c=20
+#MSG_SELFTEST_FILAMENT_SENSOR c=17
 "Filament sensor"
 "\x00"
 

--- a/lang/lang_en_hu.txt
+++ b/lang/lang_en_hu.txt
@@ -1126,7 +1126,7 @@
 "to unload filament"
 "\x00"
 
-#MSG_UNLOAD_FILAMENT c=16
+#MSG_UNLOAD_FILAMENT c=18
 "Unload filament"
 "\x00"
 

--- a/lang/lang_en_hu.txt
+++ b/lang/lang_en_hu.txt
@@ -338,7 +338,7 @@
 "Filament not loaded"
 "\x00"
 
-#MSG_FILAMENT_SENSOR c=20
+#MSG_SELFTEST_FILAMENT_SENSOR c=17
 "Filament sensor"
 "\x00"
 

--- a/lang/lang_en_it.txt
+++ b/lang/lang_en_it.txt
@@ -338,7 +338,7 @@
 "Filament not loaded"
 "Fil. non caricato"
 
-#MSG_FILAMENT_SENSOR c=20
+#MSG_SELFTEST_FILAMENT_SENSOR c=17
 "Filament sensor"
 "Sensore filam."
 

--- a/lang/lang_en_it.txt
+++ b/lang/lang_en_it.txt
@@ -1126,7 +1126,7 @@
 "to unload filament"
 "per scaricare fil."
 
-#MSG_UNLOAD_FILAMENT c=16
+#MSG_UNLOAD_FILAMENT c=18
 "Unload filament"
 "Scarica filam."
 

--- a/lang/lang_en_lb.txt
+++ b/lang/lang_en_lb.txt
@@ -1126,7 +1126,7 @@
 "to unload filament"
 "\x00"
 
-#MSG_UNLOAD_FILAMENT c=16
+#MSG_UNLOAD_FILAMENT c=18
 "Unload filament"
 "\x00"
 

--- a/lang/lang_en_lb.txt
+++ b/lang/lang_en_lb.txt
@@ -338,7 +338,7 @@
 "Filament not loaded"
 "\x00"
 
-#MSG_FILAMENT_SENSOR c=20
+#MSG_SELFTEST_FILAMENT_SENSOR c=17
 "Filament sensor"
 "\x00"
 

--- a/lang/lang_en_lt.txt
+++ b/lang/lang_en_lt.txt
@@ -1126,7 +1126,7 @@
 "to unload filament"
 "\x00"
 
-#MSG_UNLOAD_FILAMENT c=16
+#MSG_UNLOAD_FILAMENT c=18
 "Unload filament"
 "\x00"
 

--- a/lang/lang_en_lt.txt
+++ b/lang/lang_en_lt.txt
@@ -338,7 +338,7 @@
 "Filament not loaded"
 "\x00"
 
-#MSG_FILAMENT_SENSOR c=20
+#MSG_SELFTEST_FILAMENT_SENSOR c=17
 "Filament sensor"
 "\x00"
 

--- a/lang/lang_en_nl.txt
+++ b/lang/lang_en_nl.txt
@@ -1126,7 +1126,7 @@
 "to unload filament"
 "om fil. uitwerpen"
 
-#MSG_UNLOAD_FILAMENT c=16
+#MSG_UNLOAD_FILAMENT c=18
 "Unload filament"
 "Fil. uitwerpen"
 

--- a/lang/lang_en_nl.txt
+++ b/lang/lang_en_nl.txt
@@ -338,7 +338,7 @@
 "Filament not loaded"
 "Fil. niet geladen"
 
-#MSG_FILAMENT_SENSOR c=20
+#MSG_SELFTEST_FILAMENT_SENSOR c=17
 "Filament sensor"
 "Filamentsensor"
 

--- a/lang/lang_en_pl.txt
+++ b/lang/lang_en_pl.txt
@@ -338,7 +338,7 @@
 "Filament not loaded"
 "Fil. nie zaladowany"
 
-#MSG_FILAMENT_SENSOR c=20
+#MSG_SELFTEST_FILAMENT_SENSOR c=17
 "Filament sensor"
 "Czujnik filamentu"
 

--- a/lang/lang_en_pl.txt
+++ b/lang/lang_en_pl.txt
@@ -1126,7 +1126,7 @@
 "to unload filament"
 "aby rozlad. filament"
 
-#MSG_UNLOAD_FILAMENT c=16
+#MSG_UNLOAD_FILAMENT c=18
 "Unload filament"
 "Rozladowanie fil"
 

--- a/lang/lang_en_sl.txt
+++ b/lang/lang_en_sl.txt
@@ -1126,7 +1126,7 @@
 "to unload filament"
 "\x00"
 
-#MSG_UNLOAD_FILAMENT c=16
+#MSG_UNLOAD_FILAMENT c=18
 "Unload filament"
 "\x00"
 

--- a/lang/lang_en_sl.txt
+++ b/lang/lang_en_sl.txt
@@ -338,7 +338,7 @@
 "Filament not loaded"
 "\x00"
 
-#MSG_FILAMENT_SENSOR c=20
+#MSG_SELFTEST_FILAMENT_SENSOR c=17
 "Filament sensor"
 "\x00"
 

--- a/lang/lang_en_sv.txt
+++ b/lang/lang_en_sv.txt
@@ -1126,7 +1126,7 @@
 "to unload filament"
 "\x00"
 
-#MSG_UNLOAD_FILAMENT c=16
+#MSG_UNLOAD_FILAMENT c=18
 "Unload filament"
 "\x00"
 

--- a/lang/lang_en_sv.txt
+++ b/lang/lang_en_sv.txt
@@ -338,7 +338,7 @@
 "Filament not loaded"
 "\x00"
 
-#MSG_FILAMENT_SENSOR c=20
+#MSG_SELFTEST_FILAMENT_SENSOR c=17
 "Filament sensor"
 "\x00"
 


### PR DESCRIPTION
- "Filament sensor" was changed from `MSG_FILAMENT_SENSOR` with c=20 to the correct `MSG_SELFTEST_FILAMENT_SENSOR` with c=17. This shorter limit conflicts with the following languages: ES, FR. Those translations need to be fixed.
- "Unload filament" c limit was increased from 16 to 18. The 16 limit was imposed by the SNMM, but as that is no longer supported, c=18 is possible. I also needed it for the RO translation

PFW-1283