### PR TITLE
Add a uart RX timeout

### DIFF
--- a/Firmware/cmdqueue.h
+++ b/Firmware/cmdqueue.h
@@ -52,9 +52,6 @@ extern int serial_count;
 extern bool comment_mode;
 extern char *strchr_pointer;
 
-extern unsigned long TimeSent;
-extern unsigned long TimeNow;
-
 extern long gcode_N;
 extern long gcode_LastN;
 extern long Stopped_gcode_LastN;


### PR DESCRIPTION
This is an alternative to #3341

That PR doesn't seem to be foolproof and sometimes, even after waiting 500ms after the last ;S, the cmdqueue still receives some garbage characters.
So, instead of trying to prevent garbage from reaching and blocking the queue, instead this approach handles garbage data over the uart in a different way.
The way the cmdqueue is structured results in a lock-up whenever a serial string is being added to the cmdqueue. This is needed to avoid queuing incomplete commands from the uart while SD printing. The garbage characters from the 32u2 would look like a perfectly fine, but incomplete command from the uart, so the code would just wait indefinitely for an EOL character to be reached (which would never come).
With this PR, if the command is incomplete and 2 seconds have passed from the last received character, the command is considered broken and is discarded, unblocking the other cmdqueue sources (such as SD or internal commands). Whenever this happens, `RX timeout` is sent over serial to the host.
This approach was actually also used for the farm mode. I just refreshed the code and changed some dangerous behaviour. Farm mode has a 800ms timeout (kind of random if you ask me, but I kept is as it was before) and it used to queue the incomplete command on timeout. That behaviour was dangerous and broken in subtle ways, so I made it dump instructions instead. Also, shortTimer was used instead of 2 global uint32_t counters. It has the added benefit of only taking up 3B of ram instead of 8.

Example command getting dumped on startup due to 32u2 timeout + garbage characters:
```
start
;S
;S
;S
;S
;S
SN update failed
echo: 3.10.1-4697
echo: Last Updated: Jan 18 2022 17:47:47 | Author: (none, default config)
Compiled: Jan 18 2022
echo: Free Memory: 2049  PlannerBufferBytes: 1760
echo:Hardcoded Default Settings Loaded
adc_init
Extruder fan type: NOCTUA
CrashDetect DISABLED
FSensor ENABLED (sensor board revision:unknown state)
Sending 0xFF
echo:SD card ok
LCD status changed
echo:busy: paused for user
RX timeout              <-----------------This is where the timeout happens (2 seconds after the last garbage character)
echo:busy: paused for user
MMU => 'start'
MMU <= 'S1'
echo:busy: paused for user
echo:busy: paused for user
echo:busy: paused for user
MMU => '106ok'
MMU <= 'S2'
MMU => '372ok'
MMU version valid
MMU <= 'M1'
MMU - ENABLED
echo:busy: paused for user
```

As for disadvantages with this approach, it might cause problems when directly typing a command by hand in a terminal such as putty which sends every character as soon as it is typed. That being said, I think 2 seconds between characters is more than enough for sending quick commands if you already know what to type (and it's not like you don't get a message telling you that the command was discarded). This disadvantage could also be considered an advantage for when a mistake is done while writing a command by hand. This way the command can be aborted by simply waiting for a bit compared to previously where you had no way of altering what was already sent.

PFW-1284