### PR TITLE
Change Travis to Ubuntu 20.04 LTS (focal)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: focal
 before_install:
   - sudo apt-get install -y ninja-build
   # Arduino IDE adds a lot of noise caused by network traffic, trying to firewall it off

--- a/PF-build.sh
+++ b/PF-build.sh
@@ -166,6 +166,7 @@
 # 24 Jun 2021, 3d-gussner, Fix MK404 user interaction not to show if compiling 'All' variants
 # 24 Jun 2021, 3d-gussner, MK404 is only supported on Linux at this moment.
 
+
 SCRIPT_PATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
 #### Start: Failures


### PR DESCRIPTION
Travis runs on Ubuntu 14.0.5 LTS (trusty) which
- Isn't supported anymore
- EOF soon
- causes issues with Python3 script `lang-check.py`
- Doesn't represent the environment of
  - PF-build.sh
  - build server

As we compile with Arduino IDE the different gcc version between trusty and focal don't affect the firmware build.
Only the `test.sh` uses the newer gcc version.

