### PR TITLE
:construction: Add Long press event to cancel Live Z adjustments

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -9481,7 +9481,6 @@ void manage_inactivity(bool ignore_stepper_queue/*=false*/) //default argument s
       if (lcd_longpress_func && lcd_update_enabled)
       {
           lcd_longpress_func();
-          lcd_longpress_trigger = 0;
       }
   }
 

--- a/Firmware/mesh_bed_calibration.h
+++ b/Firmware/mesh_bed_calibration.h
@@ -189,6 +189,12 @@ extern bool scan_bed_induction_points(int8_t verbosity_level);
 // after power panic, when it is expected, that the baby step has been already applied.
 extern void babystep_load();
 
+// Intended to revert the Z-offset changes when the Z-offset
+// is changed in "Live Z Adjustment" but the user cancels the
+// operation by long pressing out of the menu, then the printer 
+// should move the Z-axis to reflect the Z-offset stored in EEPROM.
+void babystep_revert();
+
 // Apply Z babystep value from the EEPROM through the planner.
 extern void babystep_apply();
 

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -168,6 +168,8 @@ extern uint8_t SilentModeMenu_MMU;
 extern bool cancel_heatup;
 extern bool isPrintPaused;
 
+extern float unsaved_live_z_adjust;
+
 extern uint8_t scrollstuff;
 
 


### PR DESCRIPTION
My attempt at resolving https://github.com/prusa3d/Prusa-Firmware/issues/3352

This is just a draft currently. I need to test the menus more. But the cancelation seems to be working on my end.

Problems I saw while looking into this:

1. The `current_position` array does not take into account the value of the Z offset.
2. When the Z offset is adjusted in the menu, the value is not saved until the user clicks the knob. But if we want to cancel the operation we must grab this value.

Change in memory footprint:
Flash: +258 bytes
SRAM: +4 bytes