### PR TITLE
Fix lang reserved area alignment

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1242,9 +1242,9 @@ void setup()
 		printf_P(_n("_SEC_LANG_TABLE checksum = %04x\n"), sum);
 		sum = (sum >> 8) | ((sum & 0xff) << 8); //swap bytes
 		if (sum == header.checksum)
-			puts_P(_n("Checksum OK"), sum);
+			printf_P(_n("Checksum OK\n"), sum);
 		else
-			puts_P(_n("Checksum NG"), sum);
+			printf_P(_n("Checksum NG\n"), sum);
 	}
 	else
 		puts_P(_n("lang_get_header failed!"));

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1242,9 +1242,9 @@ void setup()
 		printf_P(_n("_SEC_LANG_TABLE checksum = %04x\n"), sum);
 		sum = (sum >> 8) | ((sum & 0xff) << 8); //swap bytes
 		if (sum == header.checksum)
-			printf_P(_n("Checksum OK\n"), sum);
+			puts_P(_n("Checksum OK"));
 		else
-			printf_P(_n("Checksum NG\n"), sum);
+			puts_P(_n("Checksum NG"));
 	}
 	else
 		puts_P(_n("lang_get_header failed!"));

--- a/Firmware/language.c
+++ b/Firmware/language.c
@@ -264,7 +264,7 @@ uint16_t lang_print_sec_lang(FILE* out)
 	printf_P(_n(" _lt_resv0        = 0x%04x\n"), _lt_resv0);
 	printf_P(_n(" _lt_resv1        = 0x%08lx\n"), _lt_resv1);
 	if (_lt_magic != LANG_MAGIC) return 0;
-	puts_P(_n(" strings:\n"));
+	puts_P(_n(" strings:"));
 	uint16_t ui = _SEC_LANG_TABLE; //table pointer
 	for (ui = 0; ui < _lt_count; ui++)
 		fprintf_P(out, _n("  %3d %S\n"), ui, lang_get_sec_lang_str_by_id(ui));

--- a/Firmware/language.c
+++ b/Firmware/language.c
@@ -1,6 +1,7 @@
 //language.c
 #include "language.h"
 #include <avr/pgmspace.h>
+#include <avr/io.h>
 #include <avr/eeprom.h>
 #include "bootapp.h"
 
@@ -28,7 +29,7 @@ uint8_t lang_is_selected(void) { return 1; }
 #else //(LANG_MODE == 0) //secondary languages in progmem or xflash
 
 //reserved xx kbytes for secondary language table
-const char _SEC_LANG[LANG_SIZE_RESERVED] PROGMEM_I2 = "_SEC_LANG";
+const char _SEC_LANG[LANG_SIZE_RESERVED] __attribute__((aligned(SPM_PAGESIZE))) PROGMEM_I2 = "_SEC_LANG";
 
 //primary language signature
 const uint32_t _PRI_LANG_SIGNATURE[1] __attribute__((section(".progmem0"))) = {0xffffffff};

--- a/Firmware/language.h
+++ b/Firmware/language.h
@@ -117,7 +117,7 @@ extern const char _SEC_LANG[LANG_SIZE_RESERVED];
 extern const char* lang_get_translation(const char* s);
 /** @def _SEC_LANG_TABLE
  *  @brief Align table to start of 256 byte page */
-#define _SEC_LANG_TABLE ((((uint16_t)&_SEC_LANG) + 0x00ff) & 0xff00)
+#define _SEC_LANG_TABLE ((uint16_t)&_SEC_LANG)
 #endif //(LANG_MODE != 0)
 
 /** @brief selects language, eeprom is updated in case of success */


### PR DESCRIPTION
I found something weird with the secondary language reserved area. It would appear as if the buffer is just randomly thrown in the PROGMEM. That wouldn't be a problem, except for the fact that we need to erase it. That part makes sense. We need to have it aligned to the page boundary. However, what makes no sense is how that is done:
```
#if (LANG_MODE != 0)
extern const char _SEC_LANG[LANG_SIZE_RESERVED];
extern const char* lang_get_translation(const char* s);
/** @def _SEC_LANG_TABLE
 *  @brief Align table to start of 256 byte page */
#define _SEC_LANG_TABLE ((((uint16_t)&_SEC_LANG) + 0x00ff) & 0xff00)
#endif //(LANG_MODE != 0)
```
I'm especially troubled by that define. Yes, it does align the pointer to the beginning of the next page... but what about the unused space at the beginning? And if that doesn't worry you, what about the missing space at the end??
Think of the following scenario: _SEC_LANG is misaligned and we fill a language to the limit. When we copy the language from xflash, where does the end of the table go? Does it just overwrite a bit of the following progmem?
I think in order to fix this, we just tell the compiler to align the page, as it should have done from the beginning:
```
const char _SEC_LANG[LANG_SIZE_RESERVED] __attribute__((aligned(SPM_PAGESIZE))) PROGMEM_I2 = "_SEC_LANG";
and
#define _SEC_LANG_TABLE ((uint16_t)&_SEC_LANG)
```
Before the changes:
```
&_SEC_LANG        = 0x051e
sizeof(_SEC_LANG) = 0x3000
&_lang_table0     = 0x0600                <--- aligned to next page by the define
```
After the changes:
```
&_SEC_LANG        = 0x0600
sizeof(_SEC_LANG) = 0x3000
&_lang_table0     = 0x0600                <--- already aligned by the compiler
```

This does however consume a bit more flash since the space before the aligned area is simply unused unfortunately. Maybe gcc will be smart enough one day to use that space efficiently.