### PR TITLE
Pre-release updates and some fixes

### DIFF
--- a/Firmware/messages.c
+++ b/Firmware/messages.c
@@ -120,7 +120,7 @@ const char MSG_WIZARD_HEATING[] PROGMEM_I1 = ISTR("Preheating nozzle. Please wai
 const char MSG_WIZARD_QUIT[] PROGMEM_I1 = ISTR("You can always resume the Wizard from Calibration -> Wizard."); ////c=20 r=8
 const char MSG_WIZARD_WELCOME[] PROGMEM_I1 = ISTR("Hi, I am your Original Prusa i3 printer. Would you like me to guide you through the setup process?"); //// c=20 r=7
 const char MSG_WIZARD_WELCOME_SHIPPING[] PROGMEM_I1 = ISTR("Hi, I am your Original Prusa i3 printer. I will guide you through a short setup process, in which the Z-axis will be calibrated. Then, you will be ready to print."); ////c=20 r=16
-const char MSG_YES[] PROGMEM_I1 = ISTR("Yes"); ////c=3
+const char MSG_YES[] PROGMEM_I1 = ISTR("Yes"); ////c=4
 const char MSG_V2_CALIBRATION[] PROGMEM_I1 = ISTR("First layer cal."); ////c=18
 const char MSG_OFF[] PROGMEM_I1 = ISTR("Off"); ////c=3
 const char MSG_ON[] PROGMEM_I1 = ISTR("On"); ////c=3

--- a/Firmware/messages.c
+++ b/Firmware/messages.c
@@ -115,7 +115,7 @@ const char MSG_UNLOAD_FILAMENT[] PROGMEM_I1 = ISTR("Unload filament"); ////c=18
 const char MSG_UNLOADING_FILAMENT[] PROGMEM_I1 = ISTR("Unloading filament"); ////c=20
 const char MSG_WATCH[] PROGMEM_I1 = ISTR("Info screen"); ////c=18
 const char MSG_WIZARD_CALIBRATION_FAILED[] PROGMEM_I1 = ISTR("Please check our handbook and fix the problem. Then resume the Wizard by rebooting the printer."); ////c=20 r=8
-const char MSG_WIZARD_DONE[] PROGMEM_I1 = ISTR("All is done. Happy printing!"); ////c=20 r=8
+const char MSG_WIZARD_DONE[] PROGMEM_I1 = ISTR("All is done. Happy printing!"); ////c=20 r=3
 const char MSG_WIZARD_HEATING[] PROGMEM_I1 = ISTR("Preheating nozzle. Please wait."); ////c=20 r=3
 const char MSG_WIZARD_QUIT[] PROGMEM_I1 = ISTR("You can always resume the Wizard from Calibration -> Wizard."); ////c=20 r=8
 const char MSG_WIZARD_WELCOME[] PROGMEM_I1 = ISTR("Hi, I am your Original Prusa i3 printer. Would you like me to guide you through the setup process?"); //// c=20 r=7

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3075,10 +3075,10 @@ void lcd_adjust_bed_reset(void)
 //! @code{.unparsed}
 //! |01234567890123456789|
 //! |Settings:           |	MSG_SETTINGS
-//! |Left side [um]:     |	MSG_BED_CORRECTION_LEFT
-//! |Right side[um]:     |	MSG_BED_CORRECTION_RIGHT
-//! |Front side[um]:     |	MSG_BED_CORRECTION_FRONT
-//! |Rear side [um]:     |	MSG_BED_CORRECTION_REAR
+//! |Left side [μm]:     |	MSG_BED_CORRECTION_LEFT
+//! |Right side[μm]:     |	MSG_BED_CORRECTION_RIGHT
+//! |Front side[μm]:     |	MSG_BED_CORRECTION_FRONT
+//! |Rear side [μm]:     |	MSG_BED_CORRECTION_REAR
 //! |Reset               |	MSG_BED_CORRECTION_RESET
 //! ----------------------
 //! @endcode
@@ -3111,10 +3111,10 @@ void lcd_adjust_bed(void)
         eeprom_update_byte((unsigned char*)EEPROM_BED_CORRECTION_VALID, 1);
     );
     MENU_ITEM_BACK_P(_T(MSG_SETTINGS));
-	MENU_ITEM_EDIT_int3_P(_i("Left side [um]"),  &_md->left,  -BED_ADJUSTMENT_UM_MAX, BED_ADJUSTMENT_UM_MAX);////MSG_BED_CORRECTION_LEFT c=14
-    MENU_ITEM_EDIT_int3_P(_i("Right side[um]"), &_md->right, -BED_ADJUSTMENT_UM_MAX, BED_ADJUSTMENT_UM_MAX);////MSG_BED_CORRECTION_RIGHT c=14
-    MENU_ITEM_EDIT_int3_P(_i("Front side[um]"), &_md->front, -BED_ADJUSTMENT_UM_MAX, BED_ADJUSTMENT_UM_MAX);////MSG_BED_CORRECTION_FRONT c=14
-    MENU_ITEM_EDIT_int3_P(_i("Rear side [um]"),  &_md->rear,  -BED_ADJUSTMENT_UM_MAX, BED_ADJUSTMENT_UM_MAX);////MSG_BED_CORRECTION_REAR c=14
+	MENU_ITEM_EDIT_int3_P(_i("Left side [\xe4m]"),  &_md->left,  -BED_ADJUSTMENT_UM_MAX, BED_ADJUSTMENT_UM_MAX);////MSG_BED_CORRECTION_LEFT c=14
+    MENU_ITEM_EDIT_int3_P(_i("Right side[\xe4m]"), &_md->right, -BED_ADJUSTMENT_UM_MAX, BED_ADJUSTMENT_UM_MAX);////MSG_BED_CORRECTION_RIGHT c=14
+    MENU_ITEM_EDIT_int3_P(_i("Front side[\xe4m]"), &_md->front, -BED_ADJUSTMENT_UM_MAX, BED_ADJUSTMENT_UM_MAX);////MSG_BED_CORRECTION_FRONT c=14
+    MENU_ITEM_EDIT_int3_P(_i("Rear side [\xe4m]"),  &_md->rear,  -BED_ADJUSTMENT_UM_MAX, BED_ADJUSTMENT_UM_MAX);////MSG_BED_CORRECTION_REAR c=14
     MENU_ITEM_FUNCTION_P(_T(MSG_RESET), lcd_adjust_bed_reset);////MSG_RESET c=14
     MENU_END();
 }

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3110,7 +3110,7 @@ void lcd_adjust_bed(void)
         eeprom_update_int8((unsigned char*)EEPROM_BED_CORRECTION_REAR,  _md->rear);
         eeprom_update_byte((unsigned char*)EEPROM_BED_CORRECTION_VALID, 1);
     );
-    MENU_ITEM_BACK_P(_T(MSG_SETTINGS));
+    MENU_ITEM_BACK_P(_T(MSG_BACK));
 	MENU_ITEM_EDIT_int3_P(_i("Left side [\xe4m]"),  &_md->left,  -BED_ADJUSTMENT_UM_MAX, BED_ADJUSTMENT_UM_MAX);////MSG_BED_CORRECTION_LEFT c=14
     MENU_ITEM_EDIT_int3_P(_i("Right side[\xe4m]"), &_md->right, -BED_ADJUSTMENT_UM_MAX, BED_ADJUSTMENT_UM_MAX);////MSG_BED_CORRECTION_RIGHT c=14
     MENU_ITEM_EDIT_int3_P(_i("Front side[\xe4m]"), &_md->front, -BED_ADJUSTMENT_UM_MAX, BED_ADJUSTMENT_UM_MAX);////MSG_BED_CORRECTION_FRONT c=14

--- a/lang/lang-clean.sh
+++ b/lang/lang-clean.sh
@@ -82,9 +82,13 @@ echo "$(tput setaf 2)lang-clean.sh started$(tput sgr0)" >&2
 
 #Clean languages
 echo "lang-clean languages:$(tput setaf 2)$LANGUAGES$(tput sgr0)" >&2
+if [ -e $1 ]; then
  for lang in $LANGUAGES; do
   clean_lang $lang
  done
+else
+  clean_lang $1
+fi
 
 if [ $result -eq 0 ]; then
  echo "$(tput setaf 2) lang-clean.sh with success$(tput sgr0)" >&2

--- a/lang/lang-export.sh
+++ b/lang/lang-export.sh
@@ -202,6 +202,11 @@ if [ "$LNG" = "de" ]; then
   sed -i 's/\\xe2/\xc3\x9f/g' $OUTFILE
 fi
 
+#replace HD44780 A00 'μ' to UTF-8 'μ'
+#replace 'A00 ROMμ' with ' μ'
+sed -i 's/\\xe4/\xce\xbc/g' $OUTFILE
+
+
 echo >&2
 echo "$(tput setaf 2)lang-export.sh finished$(tput sgr 0)">&2
 exit 0

--- a/lang/lang-import.sh
+++ b/lang/lang-import.sh
@@ -350,6 +350,10 @@ fi
 #if [ "$LNG" = "pl" ]; then
 #fi
 
+#replace UTF-8 'μ' to HD44780 A00 'μ'
+ #replace 'μ' with 'A00 ROM μ'
+ sed -i 's/\xce\xbc/\\xe4/g' $LNG'_filtered.po'
+
 #check for nonasci characters except HD44780 ROM A00 'äöüß'
 if grep --color='auto' -P -n '[^\x00-\x7F]' $LNG'_filtered.po' >nonascii.txt; then
  exit

--- a/lang/lang_en.txt
+++ b/lang/lang_en.txt
@@ -287,7 +287,7 @@
 "Front print fan?"
 
 #MSG_BED_CORRECTION_FRONT c=14
-"Front side[um]"
+"Front side[\xe4m]"
 
 #MSG_SELFTEST_FANS c=20
 "Front/left fans"
@@ -383,7 +383,7 @@
 "Left"
 
 #MSG_BED_CORRECTION_LEFT c=14
-"Left side [um]"
+"Left side [\xe4m]"
 
 #MSG_LIN_CORRECTION c=18
 "Lin. correction"
@@ -656,7 +656,7 @@
 "Please load filament first."
 
 #MSG_BED_CORRECTION_REAR c=14
-"Rear side [um]"
+"Rear side [\xe4m]"
 
 #MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
 "Please unload the filament first, then repeat this action."
@@ -683,7 +683,7 @@
 "Resuming print"
 
 #MSG_BED_CORRECTION_RIGHT c=14
-"Right side[um]"
+"Right side[\xe4m]"
 
 #MSG_RPI_PORT c=13
 "RPi port"

--- a/lang/lang_en.txt
+++ b/lang/lang_en.txt
@@ -28,7 +28,7 @@
 #MSG_SELFTEST_CHECK_ALLCORRECT c=20
 "All correct"
 
-#MSG_WIZARD_DONE c=20 r=8
+#MSG_WIZARD_DONE c=20 r=3
 "All is done. Happy printing!"
 
 #MSG_AMBIENT c=14

--- a/lang/lang_en.txt
+++ b/lang/lang_en.txt
@@ -895,7 +895,7 @@
 #MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
 "XYZ calibration failed. Please consult the manual."
 
-#MSG_YES c=3
+#MSG_YES c=4
 "Yes"
 
 #MSG_WIZARD_QUIT c=20 r=8

--- a/lang/lang_en_cz.txt
+++ b/lang/lang_en_cz.txt
@@ -338,7 +338,7 @@
 "Filament not loaded"
 "Filament nezaveden"
 
-#MSG_FILAMENT_SENSOR c=20
+#MSG_SELFTEST_FILAMENT_SENSOR c=17
 "Filament sensor"
 "Senzor filamentu"
 
@@ -1126,7 +1126,7 @@
 "to unload filament"
 "k vyjmuti filamentu"
 
-#MSG_UNLOAD_FILAMENT c=16
+#MSG_UNLOAD_FILAMENT c=18
 "Unload filament"
 "Vyjmout filament"
 

--- a/lang/lang_en_cz.txt
+++ b/lang/lang_en_cz.txt
@@ -1194,7 +1194,7 @@
 "XYZ calibration failed. Please consult the manual."
 "Kalibrace XYZ selhala. Nahlednete do manualu."
 
-#MSG_YES c=3
+#MSG_YES c=4
 "Yes"
 "Ano"
 

--- a/lang/lang_en_cz.txt
+++ b/lang/lang_en_cz.txt
@@ -383,8 +383,8 @@
 "Predni tiskovy vent?"
 
 #MSG_BED_CORRECTION_FRONT c=14
-"Front side[um]"
-"Vpredu [um]"
+"Front side[\xe4m]"
+"Vpredu [\xe4m]"
 
 #MSG_SELFTEST_FANS c=20
 "Front/left fans"
@@ -511,8 +511,8 @@
 "Vlevo"
 
 #MSG_BED_CORRECTION_LEFT c=14
-"Left side [um]"
-"Vlevo [um]"
+"Left side [\xe4m]"
+"Vlevo [\xe4m]"
 
 #MSG_LIN_CORRECTION c=18
 "Lin. correction"
@@ -875,8 +875,8 @@
 "Prosim nejdriv zavedte filament"
 
 #MSG_BED_CORRECTION_REAR c=14
-"Rear side [um]"
-"Vzadu [um]"
+"Rear side [\xe4m]"
+"Vzadu [\xe4m]"
 
 #MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
 "Please unload the filament first, then repeat this action."
@@ -911,8 +911,8 @@
 "Obnoveni tisku"
 
 #MSG_BED_CORRECTION_RIGHT c=14
-"Right side[um]"
-"Vpravo [um]"
+"Right side[\xe4m]"
+"Vpravo [\xe4m]"
 
 #MSG_RPI_PORT c=13
 "RPi port"

--- a/lang/lang_en_cz.txt
+++ b/lang/lang_en_cz.txt
@@ -38,7 +38,7 @@
 "All correct"
 "Vse OK"
 
-#MSG_WIZARD_DONE c=20 r=8
+#MSG_WIZARD_DONE c=20 r=3
 "All is done. Happy printing!"
 "Vse je hotovo. Tisku zdar!"
 

--- a/lang/lang_en_da.txt
+++ b/lang/lang_en_da.txt
@@ -1194,7 +1194,7 @@
 "XYZ calibration failed. Please consult the manual."
 "\x00"
 
-#MSG_YES c=3
+#MSG_YES c=4
 "Yes"
 "\x00"
 

--- a/lang/lang_en_da.txt
+++ b/lang/lang_en_da.txt
@@ -383,7 +383,7 @@
 "\x00"
 
 #MSG_BED_CORRECTION_FRONT c=14
-"Front side[um]"
+"Front side[\xe4m]"
 "\x00"
 
 #MSG_SELFTEST_FANS c=20
@@ -511,7 +511,7 @@
 "\x00"
 
 #MSG_BED_CORRECTION_LEFT c=14
-"Left side [um]"
+"Left side [\xe4m]"
 "\x00"
 
 #MSG_LIN_CORRECTION c=18
@@ -875,7 +875,7 @@
 "\x00"
 
 #MSG_BED_CORRECTION_REAR c=14
-"Rear side [um]"
+"Rear side [\xe4m]"
 "\x00"
 
 #MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
@@ -911,7 +911,7 @@
 "\x00"
 
 #MSG_BED_CORRECTION_RIGHT c=14
-"Right side[um]"
+"Right side[\xe4m]"
 "\x00"
 
 #MSG_RPI_PORT c=13

--- a/lang/lang_en_da.txt
+++ b/lang/lang_en_da.txt
@@ -38,7 +38,7 @@
 "All correct"
 "\x00"
 
-#MSG_WIZARD_DONE c=20 r=8
+#MSG_WIZARD_DONE c=20 r=3
 "All is done. Happy printing!"
 "\x00"
 

--- a/lang/lang_en_de.txt
+++ b/lang/lang_en_de.txt
@@ -383,8 +383,8 @@
 "Druckl\xf5fter?"
 
 #MSG_BED_CORRECTION_FRONT c=14
-"Front side[um]"
-"Vorne [um]"
+"Front side[\xe4m]"
+"Vorne [\xe4m]"
 
 #MSG_SELFTEST_FANS c=20
 "Front/left fans"
@@ -511,8 +511,8 @@
 "Links"
 
 #MSG_BED_CORRECTION_LEFT c=14
-"Left side [um]"
-"Links [um]"
+"Left side [\xe4m]"
+"Links [\xe4m]"
 
 #MSG_LIN_CORRECTION c=18
 "Lin. correction"
@@ -875,8 +875,8 @@
 "Bitte laden Sie zuerst das Filament."
 
 #MSG_BED_CORRECTION_REAR c=14
-"Rear side [um]"
-"Hinten [um]"
+"Rear side [\xe4m]"
+"Hinten [\xe4m]"
 
 #MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
 "Please unload the filament first, then repeat this action."
@@ -911,8 +911,8 @@
 "Druck fortgesetzt"
 
 #MSG_BED_CORRECTION_RIGHT c=14
-"Right side[um]"
-"Rechts [um]"
+"Right side[\xe4m]"
+"Rechts [\xe4m]"
 
 #MSG_RPI_PORT c=13
 "RPi port"

--- a/lang/lang_en_de.txt
+++ b/lang/lang_en_de.txt
@@ -38,7 +38,7 @@
 "All correct"
 "Alles richtig"
 
-#MSG_WIZARD_DONE c=20 r=8
+#MSG_WIZARD_DONE c=20 r=3
 "All is done. Happy printing!"
 "Alles abgeschlossen. Viel Spa\xe2 beim Drucken!"
 

--- a/lang/lang_en_de.txt
+++ b/lang/lang_en_de.txt
@@ -1194,7 +1194,7 @@
 "XYZ calibration failed. Please consult the manual."
 "XYZ-Kalibrierung fehlgeschlagen. Bitte schauen Sie in das Handbuch."
 
-#MSG_YES c=3
+#MSG_YES c=4
 "Yes"
 "Ja"
 

--- a/lang/lang_en_de.txt
+++ b/lang/lang_en_de.txt
@@ -96,7 +96,7 @@
 
 #MSG_BED_CORRECTION_MENU c=18
 "Bed level correct"
-"Ausgleich Bett ok"
+"Bett Level Korr."
 
 #MSG_BELTTEST c=18
 "Belt test"

--- a/lang/lang_en_es.txt
+++ b/lang/lang_en_es.txt
@@ -38,7 +38,7 @@
 "All correct"
 "Todo bien"
 
-#MSG_WIZARD_DONE c=20 r=8
+#MSG_WIZARD_DONE c=20 r=3
 "All is done. Happy printing!"
 "Terminado! Feliz impresion!"
 

--- a/lang/lang_en_es.txt
+++ b/lang/lang_en_es.txt
@@ -383,8 +383,8 @@
 "Vent. frontal?"
 
 #MSG_BED_CORRECTION_FRONT c=14
-"Front side[um]"
-"Frontal [um]"
+"Front side[\xe4m]"
+"Frontal [\xe4m]"
 
 #MSG_SELFTEST_FANS c=20
 "Front/left fans"
@@ -511,8 +511,8 @@
 "Izquierda"
 
 #MSG_BED_CORRECTION_LEFT c=14
-"Left side [um]"
-"Izquierda [um]"
+"Left side [\xe4m]"
+"Izquierda [\xe4m]"
 
 #MSG_LIN_CORRECTION c=18
 "Lin. correction"
@@ -875,8 +875,8 @@
 "Por favor, cargar primero el filamento."
 
 #MSG_BED_CORRECTION_REAR c=14
-"Rear side [um]"
-"Trasera [um]"
+"Rear side [\xe4m]"
+"Trasera [\xe4m]"
 
 #MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
 "Please unload the filament first, then repeat this action."
@@ -911,8 +911,8 @@
 "Continuan. impresion"
 
 #MSG_BED_CORRECTION_RIGHT c=14
-"Right side[um]"
-"Derecha [um]"
+"Right side[\xe4m]"
+"Derecha [\xe4m]"
 
 #MSG_RPI_PORT c=13
 "RPi port"

--- a/lang/lang_en_es.txt
+++ b/lang/lang_en_es.txt
@@ -1194,7 +1194,7 @@
 "XYZ calibration failed. Please consult the manual."
 "Calibracion XYZ fallada. Consulta el manual por favor."
 
-#MSG_YES c=3
+#MSG_YES c=4
 "Yes"
 "Si"
 

--- a/lang/lang_en_fr.txt
+++ b/lang/lang_en_fr.txt
@@ -38,7 +38,7 @@
 "All correct"
 "Tout est correct"
 
-#MSG_WIZARD_DONE c=20 r=8
+#MSG_WIZARD_DONE c=20 r=3
 "All is done. Happy printing!"
 "Tout est pret. Bonne impression!"
 

--- a/lang/lang_en_fr.txt
+++ b/lang/lang_en_fr.txt
@@ -1194,7 +1194,7 @@
 "XYZ calibration failed. Please consult the manual."
 "Echec calibration XYZ. Consultez le manuel."
 
-#MSG_YES c=3
+#MSG_YES c=4
 "Yes"
 "Oui"
 

--- a/lang/lang_en_fr.txt
+++ b/lang/lang_en_fr.txt
@@ -383,8 +383,8 @@
 "Ventilo impr avant?"
 
 #MSG_BED_CORRECTION_FRONT c=14
-"Front side[um]"
-"Avant [um]"
+"Front side[\xe4m]"
+"Avant [\xe4m]"
 
 #MSG_SELFTEST_FANS c=20
 "Front/left fans"
@@ -511,8 +511,8 @@
 "Gauche"
 
 #MSG_BED_CORRECTION_LEFT c=14
-"Left side [um]"
-"Gauche [um]"
+"Left side [\xe4m]"
+"Gauche [\xe4m]"
 
 #MSG_LIN_CORRECTION c=18
 "Lin. correction"
@@ -875,8 +875,8 @@
 "Veuillez d'abord charger un filament."
 
 #MSG_BED_CORRECTION_REAR c=14
-"Rear side [um]"
-"Arriere [um]"
+"Rear side [\xe4m]"
+"Arriere [\xe4m]"
 
 #MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
 "Please unload the filament first, then repeat this action."
@@ -911,8 +911,8 @@
 "Reprise de l'impr."
 
 #MSG_BED_CORRECTION_RIGHT c=14
-"Right side[um]"
-"Droite [um]"
+"Right side[\xe4m]"
+"Droite [\xe4m]"
 
 #MSG_RPI_PORT c=13
 "RPi port"

--- a/lang/lang_en_hr.txt
+++ b/lang/lang_en_hr.txt
@@ -383,8 +383,8 @@
 "Prednji print vent?"
 
 #MSG_BED_CORRECTION_FRONT c=14
-"Front side[um]"
-"Prednj str[um]"
+"Front side[\xe4m]"
+"Prednj str[\xe4m]"
 
 #MSG_SELFTEST_FANS c=20
 "Front/left fans"
@@ -511,8 +511,8 @@
 "Lijevo"
 
 #MSG_BED_CORRECTION_LEFT c=14
-"Left side [um]"
-"Lijeva str[um]"
+"Left side [\xe4m]"
+"Lijeva str[\xe4m]"
 
 #MSG_LIN_CORRECTION c=18
 "Lin. correction"
@@ -875,8 +875,8 @@
 "Molimo prvo ubacite filament."
 
 #MSG_BED_CORRECTION_REAR c=14
-"Rear side [um]"
-"Zad. str.[um]"
+"Rear side [\xe4m]"
+"Zad. str.[\xe4m]"
 
 #MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
 "Please unload the filament first, then repeat this action."
@@ -911,8 +911,8 @@
 "Nastavak printa"
 
 #MSG_BED_CORRECTION_RIGHT c=14
-"Right side[um]"
-"Desna str.[um]"
+"Right side[\xe4m]"
+"Desna str.[\xe4m]"
 
 #MSG_RPI_PORT c=13
 "RPi port"

--- a/lang/lang_en_hr.txt
+++ b/lang/lang_en_hr.txt
@@ -338,7 +338,7 @@
 "Filament not loaded"
 "Fil. nije napunjen"
 
-#MSG_FILAMENT_SENSOR c=20
+#MSG_SELFTEST_FILAMENT_SENSOR c=17
 "Filament sensor"
 "Senzor filamenta"
 

--- a/lang/lang_en_hr.txt
+++ b/lang/lang_en_hr.txt
@@ -38,7 +38,7 @@
 "All correct"
 "Sve je u redu"
 
-#MSG_WIZARD_DONE c=20 r=8
+#MSG_WIZARD_DONE c=20 r=3
 "All is done. Happy printing!"
 "Sve je gotovo. Sretno printanje!"
 

--- a/lang/lang_en_hr.txt
+++ b/lang/lang_en_hr.txt
@@ -1194,7 +1194,7 @@
 "XYZ calibration failed. Please consult the manual."
 "XYZ kalibracija nije uspjela. Molimo pogledajte prirucnik."
 
-#MSG_YES c=3
+#MSG_YES c=4
 "Yes"
 "Da"
 

--- a/lang/lang_en_hu.txt
+++ b/lang/lang_en_hu.txt
@@ -383,8 +383,8 @@
 "Elso targyhuto vent?"
 
 #MSG_BED_CORRECTION_FRONT c=14
-"Front side[um]"
-"Elulso old[um]"
+"Front side[\xe4m]"
+"Elulso old[\xe4m]"
 
 #MSG_SELFTEST_FANS c=20
 "Front/left fans"
@@ -511,8 +511,8 @@
 "Bal"
 
 #MSG_BED_CORRECTION_LEFT c=14
-"Left side [um]"
-"Bal [um]"
+"Left side [\xe4m]"
+"Bal [\xe4m]"
 
 #MSG_LIN_CORRECTION c=18
 "Lin. correction"
@@ -875,8 +875,8 @@
 "Kerlek eloszor toltsd be a filamentet."
 
 #MSG_BED_CORRECTION_REAR c=14
-"Rear side [um]"
-"Hatso old.[um]"
+"Rear side [\xe4m]"
+"Hatso old.[\xe4m]"
 
 #MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
 "Please unload the filament first, then repeat this action."
@@ -911,8 +911,8 @@
 "Nyomtatas folytatasa"
 
 #MSG_BED_CORRECTION_RIGHT c=14
-"Right side[um]"
-"Jobb old.[um]"
+"Right side[\xe4m]"
+"Jobb old.[\xe4m]"
 
 #MSG_RPI_PORT c=13
 "RPi port"

--- a/lang/lang_en_hu.txt
+++ b/lang/lang_en_hu.txt
@@ -1194,7 +1194,7 @@
 "XYZ calibration failed. Please consult the manual."
 "XYZ kalibracio sikertelen. Kerlek, nezz bele a kezikonyvbe."
 
-#MSG_YES c=3
+#MSG_YES c=4
 "Yes"
 "Igen"
 

--- a/lang/lang_en_hu.txt
+++ b/lang/lang_en_hu.txt
@@ -38,7 +38,7 @@
 "All correct"
 "Minden rendben"
 
-#MSG_WIZARD_DONE c=20 r=8
+#MSG_WIZARD_DONE c=20 r=3
 "All is done. Happy printing!"
 "Keszen vagyunk. Jo nyomtatast!"
 

--- a/lang/lang_en_it.txt
+++ b/lang/lang_en_it.txt
@@ -1194,7 +1194,7 @@
 "XYZ calibration failed. Please consult the manual."
 "Calibrazione XYZ fallita. Si prega di consultare il manuale."
 
-#MSG_YES c=3
+#MSG_YES c=4
 "Yes"
 "Si"
 

--- a/lang/lang_en_it.txt
+++ b/lang/lang_en_it.txt
@@ -383,8 +383,8 @@
 "Ventola frontale?"
 
 #MSG_BED_CORRECTION_FRONT c=14
-"Front side[um]"
-"Fronte [um]"
+"Front side[\xe4m]"
+"Fronte [\xe4m]"
 
 #MSG_SELFTEST_FANS c=20
 "Front/left fans"
@@ -511,8 +511,8 @@
 "Sinistra"
 
 #MSG_BED_CORRECTION_LEFT c=14
-"Left side [um]"
-"Sinistra [um]"
+"Left side [\xe4m]"
+"Sinistra [\xe4m]"
 
 #MSG_LIN_CORRECTION c=18
 "Lin. correction"
@@ -875,8 +875,8 @@
 "Per favore prima carica il filamento."
 
 #MSG_BED_CORRECTION_REAR c=14
-"Rear side [um]"
-"Retro [um]"
+"Rear side [\xe4m]"
+"Retro [\xe4m]"
 
 #MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
 "Please unload the filament first, then repeat this action."
@@ -911,8 +911,8 @@
 "Riprendi stampa"
 
 #MSG_BED_CORRECTION_RIGHT c=14
-"Right side[um]"
-"Destra [um]"
+"Right side[\xe4m]"
+"Destra [\xe4m]"
 
 #MSG_RPI_PORT c=13
 "RPi port"

--- a/lang/lang_en_it.txt
+++ b/lang/lang_en_it.txt
@@ -38,7 +38,7 @@
 "All correct"
 "Nessun errore"
 
-#MSG_WIZARD_DONE c=20 r=8
+#MSG_WIZARD_DONE c=20 r=3
 "All is done. Happy printing!"
 "Tutto fatto. Buona stampa!"
 

--- a/lang/lang_en_lb.txt
+++ b/lang/lang_en_lb.txt
@@ -1194,7 +1194,7 @@
 "XYZ calibration failed. Please consult the manual."
 "\x00"
 
-#MSG_YES c=3
+#MSG_YES c=4
 "Yes"
 "\x00"
 

--- a/lang/lang_en_lb.txt
+++ b/lang/lang_en_lb.txt
@@ -383,7 +383,7 @@
 "\x00"
 
 #MSG_BED_CORRECTION_FRONT c=14
-"Front side[um]"
+"Front side[\xe4m]"
 "\x00"
 
 #MSG_SELFTEST_FANS c=20
@@ -511,7 +511,7 @@
 "\x00"
 
 #MSG_BED_CORRECTION_LEFT c=14
-"Left side [um]"
+"Left side [\xe4m]"
 "\x00"
 
 #MSG_LIN_CORRECTION c=18
@@ -875,7 +875,7 @@
 "\x00"
 
 #MSG_BED_CORRECTION_REAR c=14
-"Rear side [um]"
+"Rear side [\xe4m]"
 "\x00"
 
 #MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
@@ -911,7 +911,7 @@
 "\x00"
 
 #MSG_BED_CORRECTION_RIGHT c=14
-"Right side[um]"
+"Right side[\xe4m]"
 "\x00"
 
 #MSG_RPI_PORT c=13

--- a/lang/lang_en_lb.txt
+++ b/lang/lang_en_lb.txt
@@ -38,7 +38,7 @@
 "All correct"
 "\x00"
 
-#MSG_WIZARD_DONE c=20 r=8
+#MSG_WIZARD_DONE c=20 r=3
 "All is done. Happy printing!"
 "\x00"
 

--- a/lang/lang_en_lt.txt
+++ b/lang/lang_en_lt.txt
@@ -1194,7 +1194,7 @@
 "XYZ calibration failed. Please consult the manual."
 "\x00"
 
-#MSG_YES c=3
+#MSG_YES c=4
 "Yes"
 "\x00"
 

--- a/lang/lang_en_lt.txt
+++ b/lang/lang_en_lt.txt
@@ -383,7 +383,7 @@
 "\x00"
 
 #MSG_BED_CORRECTION_FRONT c=14
-"Front side[um]"
+"Front side[\xe4m]"
 "\x00"
 
 #MSG_SELFTEST_FANS c=20
@@ -511,7 +511,7 @@
 "\x00"
 
 #MSG_BED_CORRECTION_LEFT c=14
-"Left side [um]"
+"Left side [\xe4m]"
 "\x00"
 
 #MSG_LIN_CORRECTION c=18
@@ -875,7 +875,7 @@
 "\x00"
 
 #MSG_BED_CORRECTION_REAR c=14
-"Rear side [um]"
+"Rear side [\xe4m]"
 "\x00"
 
 #MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
@@ -911,7 +911,7 @@
 "\x00"
 
 #MSG_BED_CORRECTION_RIGHT c=14
-"Right side[um]"
+"Right side[\xe4m]"
 "\x00"
 
 #MSG_RPI_PORT c=13

--- a/lang/lang_en_lt.txt
+++ b/lang/lang_en_lt.txt
@@ -38,7 +38,7 @@
 "All correct"
 "\x00"
 
-#MSG_WIZARD_DONE c=20 r=8
+#MSG_WIZARD_DONE c=20 r=3
 "All is done. Happy printing!"
 "\x00"
 

--- a/lang/lang_en_nl.txt
+++ b/lang/lang_en_nl.txt
@@ -38,7 +38,7 @@
 "All correct"
 "Allemaal goed"
 
-#MSG_WIZARD_DONE c=20 r=8
+#MSG_WIZARD_DONE c=20 r=3
 "All is done. Happy printing!"
 "Klaar. Happy printing!"
 

--- a/lang/lang_en_nl.txt
+++ b/lang/lang_en_nl.txt
@@ -383,8 +383,8 @@
 "Voorzijde fan?"
 
 #MSG_BED_CORRECTION_FRONT c=14
-"Front side[um]"
-"Voorkant  [um]"
+"Front side[\xe4m]"
+"Voorkant  [\xe4m]"
 
 #MSG_SELFTEST_FANS c=20
 "Front/left fans"
@@ -511,8 +511,8 @@
 "Links"
 
 #MSG_BED_CORRECTION_LEFT c=14
-"Left side [um]"
-"Linkerkant[um]"
+"Left side [\xe4m]"
+"Linkerkant[\xe4m]"
 
 #MSG_LIN_CORRECTION c=18
 "Lin. correction"
@@ -875,8 +875,8 @@
 "Laad a.u.b. eerst filament."
 
 #MSG_BED_CORRECTION_REAR c=14
-"Rear side [um]"
-"Achterkant[um]"
+"Rear side [\xe4m]"
+"Achterkant[\xe4m]"
 
 #MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
 "Please unload the filament first, then repeat this action."
@@ -911,8 +911,8 @@
 "Hervatten print"
 
 #MSG_BED_CORRECTION_RIGHT c=14
-"Right side[um]"
-"Recht.kant[um]"
+"Right side[\xe4m]"
+"Recht.kant[\xe4m]"
 
 #MSG_RPI_PORT c=13
 "RPi port"

--- a/lang/lang_en_nl.txt
+++ b/lang/lang_en_nl.txt
@@ -1194,7 +1194,7 @@
 "XYZ calibration failed. Please consult the manual."
 "XYZ-kalibratie mislukt. Raadpleeg de handleiding aub."
 
-#MSG_YES c=3
+#MSG_YES c=4
 "Yes"
 "Ja"
 

--- a/lang/lang_en_pl.txt
+++ b/lang/lang_en_pl.txt
@@ -383,8 +383,8 @@
 "Przedni went. druku?"
 
 #MSG_BED_CORRECTION_FRONT c=14
-"Front side[um]"
-"Przod [um]"
+"Front side[\xe4m]"
+"Przod [\xe4m]"
 
 #MSG_SELFTEST_FANS c=20
 "Front/left fans"
@@ -511,8 +511,8 @@
 "Lewa"
 
 #MSG_BED_CORRECTION_LEFT c=14
-"Left side [um]"
-"Lewo [um]"
+"Left side [\xe4m]"
+"Lewo [\xe4m]"
 
 #MSG_LIN_CORRECTION c=18
 "Lin. correction"
@@ -875,8 +875,8 @@
 "Najpierw zaladuj filament."
 
 #MSG_BED_CORRECTION_REAR c=14
-"Rear side [um]"
-"Tyl [um]"
+"Rear side [\xe4m]"
+"Tyl [\xe4m]"
 
 #MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
 "Please unload the filament first, then repeat this action."
@@ -911,8 +911,8 @@
 "Wznawianie druku"
 
 #MSG_BED_CORRECTION_RIGHT c=14
-"Right side[um]"
-"Prawo [um]"
+"Right side[\xe4m]"
+"Prawo [\xe4m]"
 
 #MSG_RPI_PORT c=13
 "RPi port"

--- a/lang/lang_en_pl.txt
+++ b/lang/lang_en_pl.txt
@@ -38,7 +38,7 @@
 "All correct"
 "Wszystko OK"
 
-#MSG_WIZARD_DONE c=20 r=8
+#MSG_WIZARD_DONE c=20 r=3
 "All is done. Happy printing!"
 "Gotowe. Udanego drukowania!"
 

--- a/lang/lang_en_pl.txt
+++ b/lang/lang_en_pl.txt
@@ -1194,7 +1194,7 @@
 "XYZ calibration failed. Please consult the manual."
 "Kalibracja XYZ nieudana. Sprawdz przyczyny i rozwiazania w instrukcji."
 
-#MSG_YES c=3
+#MSG_YES c=4
 "Yes"
 "Tak"
 

--- a/lang/lang_en_ro.txt
+++ b/lang/lang_en_ro.txt
@@ -1194,7 +1194,7 @@
 "XYZ calibration failed. Please consult the manual."
 "Calibrarea XYZ a esuat. Va rugam consultati manualul."
 
-#MSG_YES c=3
+#MSG_YES c=4
 "Yes"
 "Da"
 

--- a/lang/lang_en_ro.txt
+++ b/lang/lang_en_ro.txt
@@ -38,7 +38,7 @@
 "All correct"
 "Totul OK"
 
-#MSG_WIZARD_DONE c=20 r=8
+#MSG_WIZARD_DONE c=20 r=3
 "All is done. Happy printing!"
 "Totul este OK. Distractie placuta!"
 

--- a/lang/lang_en_ro.txt
+++ b/lang/lang_en_ro.txt
@@ -383,8 +383,8 @@
 "Vent. print?"
 
 #MSG_BED_CORRECTION_FRONT c=14
-"Front side[um]"
-"Fata [um]"
+"Front side[\xe4m]"
+"Fata [\xe4m]"
 
 #MSG_SELFTEST_FANS c=20
 "Front/left fans"
@@ -511,8 +511,8 @@
 "Stanga"
 
 #MSG_BED_CORRECTION_LEFT c=14
-"Left side [um]"
-"Stanga [um]"
+"Left side [\xe4m]"
+"Stanga [\xe4m]"
 
 #MSG_LIN_CORRECTION c=18
 "Lin. correction"
@@ -875,8 +875,8 @@
 "Va rugam incarcati filamentul mai intai."
 
 #MSG_BED_CORRECTION_REAR c=14
-"Rear side [um]"
-"Spate [um]"
+"Rear side [\xe4m]"
+"Spate [\xe4m]"
 
 #MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
 "Please unload the filament first, then repeat this action."
@@ -911,8 +911,8 @@
 "Reluare print..."
 
 #MSG_BED_CORRECTION_RIGHT c=14
-"Right side[um]"
-"Dreapta [um]"
+"Right side[\xe4m]"
+"Dreapta [\xe4m]"
 
 #MSG_RPI_PORT c=13
 "RPi port"

--- a/lang/lang_en_sl.txt
+++ b/lang/lang_en_sl.txt
@@ -1194,7 +1194,7 @@
 "XYZ calibration failed. Please consult the manual."
 "\x00"
 
-#MSG_YES c=3
+#MSG_YES c=4
 "Yes"
 "\x00"
 

--- a/lang/lang_en_sl.txt
+++ b/lang/lang_en_sl.txt
@@ -383,7 +383,7 @@
 "\x00"
 
 #MSG_BED_CORRECTION_FRONT c=14
-"Front side[um]"
+"Front side[\xe4m]"
 "\x00"
 
 #MSG_SELFTEST_FANS c=20
@@ -511,7 +511,7 @@
 "\x00"
 
 #MSG_BED_CORRECTION_LEFT c=14
-"Left side [um]"
+"Left side [\xe4m]"
 "\x00"
 
 #MSG_LIN_CORRECTION c=18
@@ -875,7 +875,7 @@
 "\x00"
 
 #MSG_BED_CORRECTION_REAR c=14
-"Rear side [um]"
+"Rear side [\xe4m]"
 "\x00"
 
 #MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
@@ -911,7 +911,7 @@
 "\x00"
 
 #MSG_BED_CORRECTION_RIGHT c=14
-"Right side[um]"
+"Right side[\xe4m]"
 "\x00"
 
 #MSG_RPI_PORT c=13

--- a/lang/lang_en_sl.txt
+++ b/lang/lang_en_sl.txt
@@ -38,7 +38,7 @@
 "All correct"
 "\x00"
 
-#MSG_WIZARD_DONE c=20 r=8
+#MSG_WIZARD_DONE c=20 r=3
 "All is done. Happy printing!"
 "\x00"
 

--- a/lang/lang_en_sv.txt
+++ b/lang/lang_en_sv.txt
@@ -1194,7 +1194,7 @@
 "XYZ calibration failed. Please consult the manual."
 "\x00"
 
-#MSG_YES c=3
+#MSG_YES c=4
 "Yes"
 "\x00"
 

--- a/lang/lang_en_sv.txt
+++ b/lang/lang_en_sv.txt
@@ -383,7 +383,7 @@
 "\x00"
 
 #MSG_BED_CORRECTION_FRONT c=14
-"Front side[um]"
+"Front side[\xe4m]"
 "\x00"
 
 #MSG_SELFTEST_FANS c=20
@@ -511,7 +511,7 @@
 "\x00"
 
 #MSG_BED_CORRECTION_LEFT c=14
-"Left side [um]"
+"Left side [\xe4m]"
 "\x00"
 
 #MSG_LIN_CORRECTION c=18
@@ -875,7 +875,7 @@
 "\x00"
 
 #MSG_BED_CORRECTION_REAR c=14
-"Rear side [um]"
+"Rear side [\xe4m]"
 "\x00"
 
 #MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
@@ -911,7 +911,7 @@
 "\x00"
 
 #MSG_BED_CORRECTION_RIGHT c=14
-"Right side[um]"
+"Right side[\xe4m]"
 "\x00"
 
 #MSG_RPI_PORT c=13

--- a/lang/lang_en_sv.txt
+++ b/lang/lang_en_sv.txt
@@ -38,7 +38,7 @@
 "All correct"
 "\x00"
 
-#MSG_WIZARD_DONE c=20 r=8
+#MSG_WIZARD_DONE c=20 r=3
 "All is done. Happy printing!"
 "\x00"
 

--- a/lang/po/Firmware.pot
+++ b/lang/po/Firmware.pot
@@ -7,8 +7,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: en\n"
 "Project-Id-Version: Prusa-Firmware\n"
-"POT-Creation-Date: Sun 19 Dec 2021 07:17:20 PM CET\n"
-"PO-Revision-Date: Sun 19 Dec 2021 07:17:20 PM CET\n"
+"POT-Creation-Date: Tue 08 Feb 2022 02:44:11 PM CET\n"
+"PO-Revision-Date: Tue 08 Feb 2022 02:44:11 PM CET\n"
 "Language-Team: \n"
 "X-Generator: Poedit 2.0.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
@@ -21,7 +21,7 @@ msgid " 0.3 or older"
 msgstr ""
 
 # MSG_FS_V_03_OR_OLDER c=18
-#: Marlin_main.cpp:9884
+#: Marlin_main.cpp:9887
 msgid "FS v0.3 or older"
 msgstr ""
 
@@ -31,7 +31,7 @@ msgid " 0.4 or newer"
 msgstr ""
 
 # MSG_FS_V_04_OR_NEWER c=18
-#: Marlin_main.cpp:9883
+#: Marlin_main.cpp:9886
 msgid "FS v0.4 or newer"
 msgstr ""
 
@@ -61,11 +61,11 @@ msgid "Adjusting Z:"
 msgstr ""
 
 # MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ultralcd.cpp:8490
+#: ultralcd.cpp:8411
 msgid "All correct"
 msgstr ""
 
-# MSG_WIZARD_DONE c=20 r=8
+# MSG_WIZARD_DONE c=20 r=3
 #: messages.c:118
 msgid "All is done. Happy printing!"
 msgstr ""
@@ -96,7 +96,7 @@ msgid "Auto home"
 msgstr ""
 
 # MSG_AUTOLOAD_FILAMENT c=18
-#: ultralcd.cpp:6732
+#: ultralcd.cpp:6653
 msgid "AutoLoad filament"
 msgstr ""
 
@@ -111,17 +111,17 @@ msgid "Autoloading filament is active, just press the knob and insert filament..
 msgstr ""
 
 # MSG_SELFTEST_AXIS_LENGTH c=20
-#: ultralcd.cpp:8173
+#: ultralcd.cpp:8094
 msgid "Axis length"
 msgstr ""
 
 # MSG_SELFTEST_AXIS c=16
-#: ultralcd.cpp:8174
+#: ultralcd.cpp:8095
 msgid "Axis"
 msgstr ""
 
 # MSG_SELFTEST_BEDHEATER c=20
-#: ultralcd.cpp:8131
+#: ultralcd.cpp:8052
 msgid "Bed/Heater"
 msgstr ""
 
@@ -176,7 +176,7 @@ msgid "Blackout occurred. Recover print?"
 msgstr ""
 
 # MSG_CALIBRATING_HOME c=20
-#: ultralcd.cpp:8492
+#: ultralcd.cpp:8413
 msgid "Calibrating home"
 msgstr ""
 
@@ -226,12 +226,12 @@ msgid "Calibration"
 msgstr ""
 
 # MSG_SD_REMOVED c=20
-#: ultralcd.cpp:8939
+#: ultralcd.cpp:8860
 msgid "Card removed"
 msgstr ""
 
 # MSG_CHECKING_FILE c=17
-#: ultralcd.cpp:8580
+#: ultralcd.cpp:8501
 msgid "Checking file"
 msgstr ""
 
@@ -326,17 +326,17 @@ msgid "Ejecting filament"
 msgstr ""
 
 # MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ultralcd.cpp:8149
+#: ultralcd.cpp:8070
 msgid "Endstop not hit"
 msgstr ""
 
 # MSG_SELFTEST_ENDSTOP c=16
-#: ultralcd.cpp:8144
+#: ultralcd.cpp:8065
 msgid "Endstop"
 msgstr ""
 
 # MSG_SELFTEST_ENDSTOPS c=20
-#: ultralcd.cpp:8135
+#: ultralcd.cpp:8056
 msgid "Endstops"
 msgstr ""
 
@@ -376,7 +376,7 @@ msgid "ERROR:"
 msgstr ""
 
 # MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
-#: ultralcd.cpp:8498
+#: ultralcd.cpp:8419
 msgid "Extruder fan:"
 msgstr ""
 
@@ -391,7 +391,7 @@ msgid "Extruder"
 msgstr ""
 
 # MSG_MMU_FAIL_STATS c=18
-#: ultralcd.cpp:6754
+#: ultralcd.cpp:6675
 msgid "Fail stats MMU"
 msgstr ""
 
@@ -401,7 +401,7 @@ msgid "F. autoload"
 msgstr ""
 
 # MSG_FAIL_STATS c=18
-#: ultralcd.cpp:6751
+#: ultralcd.cpp:6672
 msgid "Fail stats"
 msgstr ""
 
@@ -440,7 +440,7 @@ msgstr ""
 msgid "Filament not loaded"
 msgstr ""
 
-# MSG_FILAMENT_SENSOR c=20
+# MSG_SELFTEST_FILAMENT_SENSOR c=17
 #: messages.c:97
 msgid "Filament sensor"
 msgstr ""
@@ -461,7 +461,7 @@ msgid "FS Action"
 msgstr ""
 
 # MSG_FILE_INCOMPLETE c=20 r=3
-#: ultralcd.cpp:8634
+#: ultralcd.cpp:8555
 msgid "File incomplete. Continue anyway?"
 msgstr ""
 
@@ -486,7 +486,7 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr ""
 
 # MSG_FLOW c=15
-#: ultralcd.cpp:6888
+#: ultralcd.cpp:6809
 msgid "Flow"
 msgstr ""
 
@@ -497,21 +497,21 @@ msgstr ""
 
 # MSG_BED_CORRECTION_FRONT c=14
 #: ultralcd.cpp:3116
-msgid "Front side[um]"
+msgid "Front side[μm]"
 msgstr ""
 
 # MSG_SELFTEST_FANS c=20
-#: ultralcd.cpp:8179
+#: ultralcd.cpp:8100
 msgid "Front/left fans"
 msgstr ""
 
 # MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ultralcd.cpp:8127
+#: ultralcd.cpp:8048
 msgid "Heater/Thermistor"
 msgstr ""
 
 # MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: Marlin_main.cpp:9874
+#: Marlin_main.cpp:9877
 msgid "Heating disabled by safety timer."
 msgstr ""
 
@@ -551,12 +551,12 @@ msgid "Checking bed"
 msgstr ""
 
 # MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ultralcd.cpp:8481
+#: ultralcd.cpp:8402
 msgid "Checking endstops"
 msgstr ""
 
 # MSG_SELFTEST_CHECK_HOTEND c=20
-#: ultralcd.cpp:8487
+#: ultralcd.cpp:8408
 msgid "Checking hotend"
 msgstr ""
 
@@ -576,7 +576,7 @@ msgid "Checking Y axis"
 msgstr ""
 
 # MSG_SELFTEST_CHECK_Z c=20
-#: ultralcd.cpp:8484
+#: ultralcd.cpp:8405
 msgid "Checking Z axis"
 msgstr ""
 
@@ -657,7 +657,7 @@ msgstr ""
 
 # MSG_BED_CORRECTION_LEFT c=14
 #: ultralcd.cpp:3114
-msgid "Left side [um]"
+msgid "Left side [μm]"
 msgstr ""
 
 # MSG_LIN_CORRECTION c=18
@@ -671,7 +671,7 @@ msgid "Live adjust Z"
 msgstr ""
 
 # MSG_INSERT_FIL c=20 r=6
-#: ultralcd.cpp:7380
+#: ultralcd.cpp:7301
 msgid "Insert the filament (do not load it) into the extruder and then press the knob."
 msgstr ""
 
@@ -696,12 +696,12 @@ msgid "Iteration"
 msgstr ""
 
 # MSG_LOOSE_PULLEY c=20
-#: ultralcd.cpp:8167
+#: ultralcd.cpp:8088
 msgid "Loose pulley"
 msgstr ""
 
 # MSG_LOAD_TO_NOZZLE c=18
-#: ultralcd.cpp:6717
+#: ultralcd.cpp:6638
 msgid "Load to nozzle"
 msgstr ""
 
@@ -851,7 +851,7 @@ msgid "No move."
 msgstr ""
 
 # MSG_NO_CARD c=18
-#: ultralcd.cpp:6697
+#: ultralcd.cpp:6618
 msgid "No SD card"
 msgstr ""
 
@@ -866,7 +866,7 @@ msgid "No"
 msgstr ""
 
 # MSG_SELFTEST_NOTCONNECTED c=20
-#: ultralcd.cpp:8128
+#: ultralcd.cpp:8049
 msgid "Not connected"
 msgstr ""
 
@@ -951,7 +951,7 @@ msgid "Please clean the nozzle for calibration. Click when done."
 msgstr ""
 
 # MSG_SELFTEST_PLEASECHECK c=20
-#: ultralcd.cpp:8122
+#: ultralcd.cpp:8043
 msgid "Please check:"
 msgstr ""
 
@@ -1016,7 +1016,7 @@ msgid "Preheat the nozzle!"
 msgstr ""
 
 # MSG_PREHEAT c=18
-#: ultralcd.cpp:6655
+#: ultralcd.cpp:6576
 msgid "Preheat"
 msgstr ""
 
@@ -1031,7 +1031,7 @@ msgid "Please upgrade."
 msgstr ""
 
 # MSG_PRESS_TO_PREHEAT c=20 r=4
-#: Marlin_main.cpp:12049
+#: Marlin_main.cpp:12052
 msgid "Press the knob to preheat nozzle and continue."
 msgstr ""
 
@@ -1061,7 +1061,7 @@ msgid "Preheating to unload"
 msgstr ""
 
 # MSG_SELFTEST_PRINT_FAN_SPEED c=18
-#: ultralcd.cpp:8501
+#: ultralcd.cpp:8422
 msgid "Print fan:"
 msgstr ""
 
@@ -1112,21 +1112,21 @@ msgstr ""
 
 # MSG_BED_CORRECTION_REAR c=14
 #: ultralcd.cpp:3117
-msgid "Rear side [um]"
+msgid "Rear side [μm]"
 msgstr ""
 
 # MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ultralcd.cpp:7404
+#: ultralcd.cpp:7325
 msgid "Please unload the filament first, then repeat this action."
 msgstr ""
 
 # MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ultralcd.cpp:7407
+#: ultralcd.cpp:7328
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr ""
 
 # MSG_RECOVERING_PRINT c=20
-#: Marlin_main.cpp:11393
+#: Marlin_main.cpp:11396
 msgid "Recovering print"
 msgstr ""
 
@@ -1157,7 +1157,7 @@ msgstr ""
 
 # MSG_BED_CORRECTION_RIGHT c=14
 #: ultralcd.cpp:3115
-msgid "Right side[um]"
+msgid "Right side[μm]"
 msgstr ""
 
 # MSG_RPI_PORT c=13
@@ -1191,12 +1191,12 @@ msgid "Select language"
 msgstr ""
 
 # MSG_SELFTEST_OK c=20
-#: ultralcd.cpp:7679
+#: ultralcd.cpp:7600
 msgid "Self test OK"
 msgstr ""
 
 # MSG_SELFTEST_START c=20
-#: ultralcd.cpp:7447
+#: ultralcd.cpp:7368
 msgid "Self test start"
 msgstr ""
 
@@ -1206,7 +1206,7 @@ msgid "Selftest"
 msgstr ""
 
 # MSG_SELFTEST_ERROR c=20
-#: ultralcd.cpp:8121
+#: ultralcd.cpp:8042
 msgid "Selftest error!"
 msgstr ""
 
@@ -1225,7 +1225,7 @@ msgstr ""
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr ""
 
-# MSG_SET_TEMPERATURE c=19
+# MSG_SET_TEMPERATURE c=20
 #: ultralcd.cpp:3135
 msgid "Set temperature:"
 msgstr ""
@@ -1306,7 +1306,7 @@ msgid "Once"
 msgstr ""
 
 # MSG_SPEED c=15
-#: ultralcd.cpp:6882
+#: ultralcd.cpp:6803
 msgid "Speed"
 msgstr ""
 
@@ -1336,12 +1336,12 @@ msgid "STOPPED."
 msgstr ""
 
 # MSG_SUPPORT c=18
-#: ultralcd.cpp:6756
+#: ultralcd.cpp:6677
 msgid "Support"
 msgstr ""
 
 # MSG_SELFTEST_SWAPPED c=16
-#: ultralcd.cpp:8180
+#: ultralcd.cpp:8101
 msgid "Swapped"
 msgstr ""
 
@@ -1376,7 +1376,7 @@ msgid "Temperature calibration is finished and active. Temp. calibration can be 
 msgstr ""
 
 # MSG_FS_VERIFIED c=20 r=3
-#: ultralcd.cpp:7411
+#: ultralcd.cpp:7332
 msgid "Sensor verified, remove the filament now."
 msgstr ""
 
@@ -1406,7 +1406,7 @@ msgid "Total print time"
 msgstr ""
 
 # MSG_TUNE c=18
-#: ultralcd.cpp:6653
+#: ultralcd.cpp:6574
 msgid "Tune"
 msgstr ""
 
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "to unload filament"
 msgstr ""
 
-# MSG_UNLOAD_FILAMENT c=16
+# MSG_UNLOAD_FILAMENT c=18
 #: messages.c:114
 msgid "Unload filament"
 msgstr ""
@@ -1510,7 +1510,7 @@ msgstr ""
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr ""
 
-# MSG_YES c=3
+# MSG_YES c=4
 #: messages.c:123
 msgid "Yes"
 msgstr ""
@@ -1586,7 +1586,7 @@ msgid "The printer will start printing a zig-zag line. Rotate the knob until you
 msgstr ""
 
 # MSG_FIL_FAILED c=20 r=5
-#: ultralcd.cpp:7415
+#: ultralcd.cpp:7336
 msgid "Verification failed, remove the filament and try again."
 msgstr ""
 
@@ -1616,7 +1616,7 @@ msgid "Checks"
 msgstr ""
 
 # MSG_FALSE_TRIGGERING c=20
-#: ultralcd.cpp:8190
+#: ultralcd.cpp:8111
 msgid "False triggering"
 msgstr ""
 
@@ -1721,17 +1721,17 @@ msgid "Printer nozzle diameter differs from the G-code. Please check the value i
 msgstr ""
 
 # MSG_SELFTEST_FS_LEVEL c=20
-#: ultralcd.cpp:8195
+#: ultralcd.cpp:8116
 msgid "%s level expected"
 msgstr ""
 
 # MSG_RENAME c=18
-#: ultralcd.cpp:6579
+#: ultralcd.cpp:6500
 msgid "Rename"
 msgstr ""
 
 # MSG_SELECT c=18
-#: ultralcd.cpp:6572
+#: ultralcd.cpp:6493
 msgid "Select"
 msgstr ""
 

--- a/lang/po/Firmware_cs.po
+++ b/lang/po/Firmware_cs.po
@@ -7,8 +7,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: cs\n"
 "Project-Id-Version: Prusa-Firmware\n"
-"POT-Creation-Date: Wed 02 Feb 2022 02:58:49 PM CET\n"
-"PO-Revision-Date: Wed 02 Feb 2022 02:58:49 PM CET\n"
+"POT-Creation-Date: Tue 08 Feb 2022 02:44:14 PM CET\n"
+"PO-Revision-Date: Tue 08 Feb 2022 02:44:14 PM CET\n"
 "Language-Team: \n"
 "X-Generator: Poedit 2.0.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
@@ -65,7 +65,7 @@ msgstr "Doladeni Z:"
 msgid "All correct"
 msgstr "Vse OK"
 
-# MSG_WIZARD_DONE c=20 r=8
+# MSG_WIZARD_DONE c=20 r=3
 #: messages.c:118
 msgid "All is done. Happy printing!"
 msgstr "Vse je hotovo. Tisku zdar!"
@@ -253,7 +253,7 @@ msgstr "Kopirovat vybrany jazyk?"
 # MSG_CRASHDETECT c=13
 #: messages.c:30
 msgid "Crash det."
-msgstr "Det. narazu."
+msgstr "Det. narazu"
 
 # MSG_CHOOSE_FIL_1ST_LAYERCAL c=20 r=7
 #: ultralcd.cpp:4842
@@ -440,7 +440,7 @@ msgstr "Filament vytlacen a spravne barvy?"
 msgid "Filament not loaded"
 msgstr "Filament nezaveden"
 
-# MSG_FILAMENT_SENSOR c=20
+# MSG_SELFTEST_FILAMENT_SENSOR c=17
 #: messages.c:97
 msgid "Filament sensor"
 msgstr "Senzor filamentu"
@@ -497,8 +497,8 @@ msgstr "Predni tiskovy vent?"
 
 # MSG_BED_CORRECTION_FRONT c=14
 #: ultralcd.cpp:3116
-msgid "Front side[um]"
-msgstr "Vpredu [um]"
+msgid "Front side[μm]"
+msgstr "Vpredu [μm]"
 
 # MSG_SELFTEST_FANS c=20
 #: ultralcd.cpp:8100
@@ -657,8 +657,8 @@ msgstr "Vlevo"
 
 # MSG_BED_CORRECTION_LEFT c=14
 #: ultralcd.cpp:3114
-msgid "Left side [um]"
-msgstr "Vlevo [um]"
+msgid "Left side [μm]"
+msgstr "Vlevo [μm]"
 
 # MSG_LIN_CORRECTION c=18
 #: ultralcd.cpp:5702
@@ -1112,8 +1112,8 @@ msgstr "Prosim nejdriv zavedte filament"
 
 # MSG_BED_CORRECTION_REAR c=14
 #: ultralcd.cpp:3117
-msgid "Rear side [um]"
-msgstr "Vzadu [um]"
+msgid "Rear side [μm]"
+msgstr "Vzadu [μm]"
 
 # MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
 #: ultralcd.cpp:7325
@@ -1157,8 +1157,8 @@ msgstr "Obnoveni tisku"
 
 # MSG_BED_CORRECTION_RIGHT c=14
 #: ultralcd.cpp:3115
-msgid "Right side[um]"
-msgstr "Vpravo [um]"
+msgid "Right side[μm]"
+msgstr "Vpravo [μm]"
 
 # MSG_RPI_PORT c=13
 #: messages.c:142
@@ -1283,7 +1283,7 @@ msgstr "Hlasity"
 # MSG_SLIGHT_SKEW c=14
 #: ultralcd.cpp:2887
 msgid "Slight skew"
-msgstr ""
+msgstr "Lehke zkos."
 
 # MSG_SOUND c=7
 #: messages.c:143
@@ -1425,7 +1425,7 @@ msgstr "k zavedeni filamentu"
 msgid "to unload filament"
 msgstr "k vyjmuti filamentu"
 
-# MSG_UNLOAD_FILAMENT c=16
+# MSG_UNLOAD_FILAMENT c=18
 #: messages.c:114
 msgid "Unload filament"
 msgstr "Vyjmout filament"
@@ -1510,7 +1510,7 @@ msgstr "Detaily XYZ kal."
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "Kalibrace XYZ selhala. Nahlednete do manualu."
 
-# MSG_YES c=3
+# MSG_YES c=4
 #: messages.c:123
 msgid "Yes"
 msgstr "Ano"
@@ -1673,12 +1673,12 @@ msgstr "Tryska"
 # MSG_GCODE_DIFF_CONTINUE c=20 r=4
 #: util.cpp:414
 msgid "G-code sliced for a different level. Continue?"
-msgstr "G-code je pripraven pro jinou plochu. Pokracovat?"
+msgstr "G-code je pripraven pro jinou verzi. Pokracovat?"
 
 # MSG_GCODE_DIFF_CANCELLED c=20 r=7
 #: util.cpp:420
 msgid "G-code sliced for a different level. Please re-slice the model again. Print cancelled."
-msgstr "G-code je pripraven pro jinou plochu. Prosim preslicujte model znovu. Tisk zrusen."
+msgstr "G-code je pripraven pro jinou verzi. Prosim preslicujte model znovu. Tisk zrusen."
 
 # MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=5
 #: messages.c:134
@@ -1723,7 +1723,7 @@ msgstr "Prumer trysky tiskarny se lisi od G-code. Prosim zkontrolujte nastaveni.
 # MSG_SELFTEST_FS_LEVEL c=20
 #: ultralcd.cpp:8116
 msgid "%s level expected"
-msgstr "%s ocekavana uroven"
+msgstr "%s ocekavana verze"
 
 # MSG_RENAME c=18
 #: ultralcd.cpp:6500

--- a/lang/po/Firmware_da.po
+++ b/lang/po/Firmware_da.po
@@ -7,8 +7,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: da\n"
 "Project-Id-Version: Prusa-Firmware\n"
-"POT-Creation-Date: Tue 21 Dec 2021 02:56:33 PM CET\n"
-"PO-Revision-Date: Tue 21 Dec 2021 02:56:33 PM CET\n"
+"POT-Creation-Date: Tue 08 Feb 2022 02:44:55 PM CET\n"
+"PO-Revision-Date: Tue 08 Feb 2022 02:44:55 PM CET\n"
 "Language-Team: \n"
 "X-Generator: Poedit 2.0.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
@@ -21,7 +21,7 @@ msgid " 0.3 or older"
 msgstr ""
 
 # MSG_FS_V_03_OR_OLDER c=18
-#: Marlin_main.cpp:9884
+#: Marlin_main.cpp:9887
 msgid "FS v0.3 or older"
 msgstr ""
 
@@ -31,7 +31,7 @@ msgid " 0.4 or newer"
 msgstr ""
 
 # MSG_FS_V_04_OR_NEWER c=18
-#: Marlin_main.cpp:9883
+#: Marlin_main.cpp:9886
 msgid "FS v0.4 or newer"
 msgstr ""
 
@@ -61,11 +61,11 @@ msgid "Adjusting Z:"
 msgstr ""
 
 # MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ultralcd.cpp:8490
+#: ultralcd.cpp:8411
 msgid "All correct"
 msgstr ""
 
-# MSG_WIZARD_DONE c=20 r=8
+# MSG_WIZARD_DONE c=20 r=3
 #: messages.c:118
 msgid "All is done. Happy printing!"
 msgstr ""
@@ -96,7 +96,7 @@ msgid "Auto home"
 msgstr ""
 
 # MSG_AUTOLOAD_FILAMENT c=18
-#: ultralcd.cpp:6732
+#: ultralcd.cpp:6653
 msgid "AutoLoad filament"
 msgstr ""
 
@@ -111,17 +111,17 @@ msgid "Autoloading filament is active, just press the knob and insert filament..
 msgstr ""
 
 # MSG_SELFTEST_AXIS_LENGTH c=20
-#: ultralcd.cpp:8173
+#: ultralcd.cpp:8094
 msgid "Axis length"
 msgstr ""
 
 # MSG_SELFTEST_AXIS c=16
-#: ultralcd.cpp:8174
+#: ultralcd.cpp:8095
 msgid "Axis"
 msgstr ""
 
 # MSG_SELFTEST_BEDHEATER c=20
-#: ultralcd.cpp:8131
+#: ultralcd.cpp:8052
 msgid "Bed/Heater"
 msgstr ""
 
@@ -176,7 +176,7 @@ msgid "Blackout occurred. Recover print?"
 msgstr ""
 
 # MSG_CALIBRATING_HOME c=20
-#: ultralcd.cpp:8492
+#: ultralcd.cpp:8413
 msgid "Calibrating home"
 msgstr ""
 
@@ -226,12 +226,12 @@ msgid "Calibration"
 msgstr ""
 
 # MSG_SD_REMOVED c=20
-#: ultralcd.cpp:8939
+#: ultralcd.cpp:8860
 msgid "Card removed"
 msgstr ""
 
 # MSG_CHECKING_FILE c=17
-#: ultralcd.cpp:8580
+#: ultralcd.cpp:8501
 msgid "Checking file"
 msgstr ""
 
@@ -326,17 +326,17 @@ msgid "Ejecting filament"
 msgstr ""
 
 # MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ultralcd.cpp:8149
+#: ultralcd.cpp:8070
 msgid "Endstop not hit"
 msgstr ""
 
 # MSG_SELFTEST_ENDSTOP c=16
-#: ultralcd.cpp:8144
+#: ultralcd.cpp:8065
 msgid "Endstop"
 msgstr ""
 
 # MSG_SELFTEST_ENDSTOPS c=20
-#: ultralcd.cpp:8135
+#: ultralcd.cpp:8056
 msgid "Endstops"
 msgstr ""
 
@@ -376,7 +376,7 @@ msgid "ERROR:"
 msgstr ""
 
 # MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
-#: ultralcd.cpp:8498
+#: ultralcd.cpp:8419
 msgid "Extruder fan:"
 msgstr ""
 
@@ -391,7 +391,7 @@ msgid "Extruder"
 msgstr ""
 
 # MSG_MMU_FAIL_STATS c=18
-#: ultralcd.cpp:6754
+#: ultralcd.cpp:6675
 msgid "Fail stats MMU"
 msgstr ""
 
@@ -401,7 +401,7 @@ msgid "F. autoload"
 msgstr ""
 
 # MSG_FAIL_STATS c=18
-#: ultralcd.cpp:6751
+#: ultralcd.cpp:6672
 msgid "Fail stats"
 msgstr ""
 
@@ -440,7 +440,7 @@ msgstr ""
 msgid "Filament not loaded"
 msgstr ""
 
-# MSG_FILAMENT_SENSOR c=20
+# MSG_SELFTEST_FILAMENT_SENSOR c=17
 #: messages.c:97
 msgid "Filament sensor"
 msgstr ""
@@ -461,7 +461,7 @@ msgid "FS Action"
 msgstr ""
 
 # MSG_FILE_INCOMPLETE c=20 r=3
-#: ultralcd.cpp:8634
+#: ultralcd.cpp:8555
 msgid "File incomplete. Continue anyway?"
 msgstr ""
 
@@ -486,7 +486,7 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr ""
 
 # MSG_FLOW c=15
-#: ultralcd.cpp:6888
+#: ultralcd.cpp:6809
 msgid "Flow"
 msgstr ""
 
@@ -497,21 +497,21 @@ msgstr ""
 
 # MSG_BED_CORRECTION_FRONT c=14
 #: ultralcd.cpp:3116
-msgid "Front side[um]"
+msgid "Front side[μm]"
 msgstr ""
 
 # MSG_SELFTEST_FANS c=20
-#: ultralcd.cpp:8179
+#: ultralcd.cpp:8100
 msgid "Front/left fans"
 msgstr ""
 
 # MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ultralcd.cpp:8127
+#: ultralcd.cpp:8048
 msgid "Heater/Thermistor"
 msgstr ""
 
 # MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: Marlin_main.cpp:9874
+#: Marlin_main.cpp:9877
 msgid "Heating disabled by safety timer."
 msgstr ""
 
@@ -551,12 +551,12 @@ msgid "Checking bed"
 msgstr ""
 
 # MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ultralcd.cpp:8481
+#: ultralcd.cpp:8402
 msgid "Checking endstops"
 msgstr ""
 
 # MSG_SELFTEST_CHECK_HOTEND c=20
-#: ultralcd.cpp:8487
+#: ultralcd.cpp:8408
 msgid "Checking hotend"
 msgstr ""
 
@@ -576,7 +576,7 @@ msgid "Checking Y axis"
 msgstr ""
 
 # MSG_SELFTEST_CHECK_Z c=20
-#: ultralcd.cpp:8484
+#: ultralcd.cpp:8405
 msgid "Checking Z axis"
 msgstr ""
 
@@ -657,7 +657,7 @@ msgstr ""
 
 # MSG_BED_CORRECTION_LEFT c=14
 #: ultralcd.cpp:3114
-msgid "Left side [um]"
+msgid "Left side [μm]"
 msgstr ""
 
 # MSG_LIN_CORRECTION c=18
@@ -671,7 +671,7 @@ msgid "Live adjust Z"
 msgstr ""
 
 # MSG_INSERT_FIL c=20 r=6
-#: ultralcd.cpp:7380
+#: ultralcd.cpp:7301
 msgid "Insert the filament (do not load it) into the extruder and then press the knob."
 msgstr ""
 
@@ -696,12 +696,12 @@ msgid "Iteration"
 msgstr ""
 
 # MSG_LOOSE_PULLEY c=20
-#: ultralcd.cpp:8167
+#: ultralcd.cpp:8088
 msgid "Loose pulley"
 msgstr ""
 
 # MSG_LOAD_TO_NOZZLE c=18
-#: ultralcd.cpp:6717
+#: ultralcd.cpp:6638
 msgid "Load to nozzle"
 msgstr ""
 
@@ -851,7 +851,7 @@ msgid "No move."
 msgstr ""
 
 # MSG_NO_CARD c=18
-#: ultralcd.cpp:6697
+#: ultralcd.cpp:6618
 msgid "No SD card"
 msgstr ""
 
@@ -866,7 +866,7 @@ msgid "No"
 msgstr ""
 
 # MSG_SELFTEST_NOTCONNECTED c=20
-#: ultralcd.cpp:8128
+#: ultralcd.cpp:8049
 msgid "Not connected"
 msgstr ""
 
@@ -951,7 +951,7 @@ msgid "Please clean the nozzle for calibration. Click when done."
 msgstr ""
 
 # MSG_SELFTEST_PLEASECHECK c=20
-#: ultralcd.cpp:8122
+#: ultralcd.cpp:8043
 msgid "Please check:"
 msgstr ""
 
@@ -1016,7 +1016,7 @@ msgid "Preheat the nozzle!"
 msgstr ""
 
 # MSG_PREHEAT c=18
-#: ultralcd.cpp:6655
+#: ultralcd.cpp:6576
 msgid "Preheat"
 msgstr ""
 
@@ -1031,7 +1031,7 @@ msgid "Please upgrade."
 msgstr ""
 
 # MSG_PRESS_TO_PREHEAT c=20 r=4
-#: Marlin_main.cpp:12049
+#: Marlin_main.cpp:12052
 msgid "Press the knob to preheat nozzle and continue."
 msgstr ""
 
@@ -1061,7 +1061,7 @@ msgid "Preheating to unload"
 msgstr ""
 
 # MSG_SELFTEST_PRINT_FAN_SPEED c=18
-#: ultralcd.cpp:8501
+#: ultralcd.cpp:8422
 msgid "Print fan:"
 msgstr ""
 
@@ -1112,21 +1112,21 @@ msgstr ""
 
 # MSG_BED_CORRECTION_REAR c=14
 #: ultralcd.cpp:3117
-msgid "Rear side [um]"
+msgid "Rear side [μm]"
 msgstr ""
 
 # MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ultralcd.cpp:7404
+#: ultralcd.cpp:7325
 msgid "Please unload the filament first, then repeat this action."
 msgstr ""
 
 # MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ultralcd.cpp:7407
+#: ultralcd.cpp:7328
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr ""
 
 # MSG_RECOVERING_PRINT c=20
-#: Marlin_main.cpp:11393
+#: Marlin_main.cpp:11396
 msgid "Recovering print"
 msgstr ""
 
@@ -1157,7 +1157,7 @@ msgstr ""
 
 # MSG_BED_CORRECTION_RIGHT c=14
 #: ultralcd.cpp:3115
-msgid "Right side[um]"
+msgid "Right side[μm]"
 msgstr ""
 
 # MSG_RPI_PORT c=13
@@ -1191,12 +1191,12 @@ msgid "Select language"
 msgstr ""
 
 # MSG_SELFTEST_OK c=20
-#: ultralcd.cpp:7679
+#: ultralcd.cpp:7600
 msgid "Self test OK"
 msgstr ""
 
 # MSG_SELFTEST_START c=20
-#: ultralcd.cpp:7447
+#: ultralcd.cpp:7368
 msgid "Self test start"
 msgstr ""
 
@@ -1206,7 +1206,7 @@ msgid "Selftest"
 msgstr ""
 
 # MSG_SELFTEST_ERROR c=20
-#: ultralcd.cpp:8121
+#: ultralcd.cpp:8042
 msgid "Selftest error!"
 msgstr ""
 
@@ -1306,7 +1306,7 @@ msgid "Once"
 msgstr ""
 
 # MSG_SPEED c=15
-#: ultralcd.cpp:6882
+#: ultralcd.cpp:6803
 msgid "Speed"
 msgstr ""
 
@@ -1336,12 +1336,12 @@ msgid "STOPPED."
 msgstr ""
 
 # MSG_SUPPORT c=18
-#: ultralcd.cpp:6756
+#: ultralcd.cpp:6677
 msgid "Support"
 msgstr ""
 
 # MSG_SELFTEST_SWAPPED c=16
-#: ultralcd.cpp:8180
+#: ultralcd.cpp:8101
 msgid "Swapped"
 msgstr ""
 
@@ -1376,7 +1376,7 @@ msgid "Temperature calibration is finished and active. Temp. calibration can be 
 msgstr ""
 
 # MSG_FS_VERIFIED c=20 r=3
-#: ultralcd.cpp:7411
+#: ultralcd.cpp:7332
 msgid "Sensor verified, remove the filament now."
 msgstr ""
 
@@ -1406,7 +1406,7 @@ msgid "Total print time"
 msgstr ""
 
 # MSG_TUNE c=18
-#: ultralcd.cpp:6653
+#: ultralcd.cpp:6574
 msgid "Tune"
 msgstr ""
 
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "to unload filament"
 msgstr ""
 
-# MSG_UNLOAD_FILAMENT c=16
+# MSG_UNLOAD_FILAMENT c=18
 #: messages.c:114
 msgid "Unload filament"
 msgstr ""
@@ -1510,7 +1510,7 @@ msgstr ""
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr ""
 
-# MSG_YES c=3
+# MSG_YES c=4
 #: messages.c:123
 msgid "Yes"
 msgstr ""
@@ -1586,7 +1586,7 @@ msgid "The printer will start printing a zig-zag line. Rotate the knob until you
 msgstr ""
 
 # MSG_FIL_FAILED c=20 r=5
-#: ultralcd.cpp:7415
+#: ultralcd.cpp:7336
 msgid "Verification failed, remove the filament and try again."
 msgstr ""
 
@@ -1616,7 +1616,7 @@ msgid "Checks"
 msgstr ""
 
 # MSG_FALSE_TRIGGERING c=20
-#: ultralcd.cpp:8190
+#: ultralcd.cpp:8111
 msgid "False triggering"
 msgstr ""
 
@@ -1721,17 +1721,17 @@ msgid "Printer nozzle diameter differs from the G-code. Please check the value i
 msgstr ""
 
 # MSG_SELFTEST_FS_LEVEL c=20
-#: ultralcd.cpp:8195
+#: ultralcd.cpp:8116
 msgid "%s level expected"
 msgstr ""
 
 # MSG_RENAME c=18
-#: ultralcd.cpp:6579
+#: ultralcd.cpp:6500
 msgid "Rename"
 msgstr ""
 
 # MSG_SELECT c=18
-#: ultralcd.cpp:6572
+#: ultralcd.cpp:6493
 msgid "Select"
 msgstr ""
 

--- a/lang/po/Firmware_de.po
+++ b/lang/po/Firmware_de.po
@@ -7,8 +7,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: de\n"
 "Project-Id-Version: Prusa-Firmware\n"
-"POT-Creation-Date: Wed 26 Jan 2022 05:40:56 PM CET\n"
-"PO-Revision-Date: Wed 26 Jan 2022 05:40:56 PM CET\n"
+"POT-Creation-Date: Tue 08 Feb 2022 02:44:18 PM CET\n"
+"PO-Revision-Date: Tue 08 Feb 2022 02:44:18 PM CET\n"
 "Language-Team: \n"
 "X-Generator: Poedit 2.0.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
@@ -18,12 +18,12 @@ msgstr ""
 # MSG_IR_03_OR_OLDER c=18
 #: messages.c:164
 msgid " 0.3 or older"
-msgstr " 0.3 oder aelter"
+msgstr " 0.3 oder älter"
 
 # MSG_FS_V_03_OR_OLDER c=18
 #: Marlin_main.cpp:9887
 msgid "FS v0.3 or older"
-msgstr "FS 0.3 oder aelter"
+msgstr "FS v0.3 oder älter"
 
 # MSG_IR_04_OR_NEWER c=18
 #: messages.c:163
@@ -33,7 +33,7 @@ msgstr " 0.4 oder neuer"
 # MSG_FS_V_04_OR_NEWER c=18
 #: Marlin_main.cpp:9886
 msgid "FS v0.4 or newer"
-msgstr "FS 0.4 oder neuer"
+msgstr "FS v0.4 oder neuer"
 
 # MSG_IR_UNKNOWN c=18
 #: messages.c:165
@@ -65,10 +65,10 @@ msgstr "Z Anpassen:"
 msgid "All correct"
 msgstr "Alles richtig"
 
-# MSG_WIZARD_DONE c=20 r=8
+# MSG_WIZARD_DONE c=20 r=3
 #: messages.c:118
 msgid "All is done. Happy printing!"
-msgstr "Alles abgeschlossen. Viel Spass beim Drucken!"
+msgstr "Alles abgeschlossen. Viel Spaß beim Drucken!"
 
 # MSG_AMBIENT c=14
 #: ultralcd.cpp:1727
@@ -83,7 +83,7 @@ msgstr ""
 # MSG_PRESS c=20 r=2
 #: ultralcd.cpp:2485
 msgid "and press the knob"
-msgstr "und Knopf druecken"
+msgstr "und Knopf drücken"
 
 # MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=2
 #: ultralcd.cpp:3355
@@ -103,17 +103,17 @@ msgstr "AutoLaden Filament"
 # MSG_AUTOLOADING_ONLY_IF_FSENS_ON c=20 r=4
 #: ultralcd.cpp:4317
 msgid "Autoloading filament available only when filament sensor is turned on..."
-msgstr "Automatisches Laden Filament nur bei eingeschaltetem Fil. sensor verfuegbar..."
+msgstr "Automatisches Laden Filament nur bei eingeschaltetem Fil. sensor verfügbar..."
 
 # MSG_AUTOLOADING_ENABLED c=20 r=4
 #: ultralcd.cpp:2648
 msgid "Autoloading filament is active, just press the knob and insert filament..."
-msgstr "Automatisches Laden Filament ist aktiv, Knopf druecken und Filament einlegen..."
+msgstr "Automatisches Laden Filament ist aktiv, Knopf drücken und Filament einlegen..."
 
 # MSG_SELFTEST_AXIS_LENGTH c=20
 #: ultralcd.cpp:8094
 msgid "Axis length"
-msgstr "Achsenlaenge"
+msgstr "Achsenlänge"
 
 # MSG_SELFTEST_AXIS c=16
 #: ultralcd.cpp:8095
@@ -133,12 +133,12 @@ msgstr "Bett OK"
 # MSG_BED_HEATING c=20
 #: messages.c:16
 msgid "Bed Heating"
-msgstr "Bett aufwaermen"
+msgstr "Bett aufwärmen"
 
 # MSG_BED_CORRECTION_MENU c=18
 #: ultralcd.cpp:5798
 msgid "Bed level correct"
-msgstr "Ausgleich Bett ok"
+msgstr "Bett Level Korr."
 
 # MSG_BELTTEST c=18
 #: ultralcd.cpp:5778
@@ -148,7 +148,7 @@ msgstr "Riementest"
 # MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
 #: messages.c:17
 msgid "Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for reset."
-msgstr "Z-Kal. fehlgeschlg. Sensor nicht ausgeloest. Schmutzige Duese? Warte auf Reset."
+msgstr "Z-Kal. fehlgeschlg. Sensor nicht ausgelöst. Schmutzige Düse? Warte auf Reset."
 
 # MSG_BRIGHT c=6
 #: messages.c:158
@@ -203,7 +203,7 @@ msgstr ">Abbruch"
 # MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
 #: ultralcd.cpp:3318
 msgid "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end stoppers. Click when done."
-msgstr "XYZ Kalibrieren: Drehen Sie den Knopf bis der obere Anschlag erreicht wird. Anschliessend den Knopf druecken."
+msgstr "XYZ Kalibrieren: Drehen Sie den Knopf bis der obere Anschlag erreicht wird. Anschliessend den Knopf drücken."
 
 # MSG_CALIBRATE_Z_AUTO c=20 r=2
 #: messages.c:21
@@ -213,7 +213,7 @@ msgstr "Kalibrierung Z"
 # MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
 #: ultralcd.cpp:3318
 msgid "Calibrating Z. Rotate the knob to move the Z carriage up to the end stoppers. Click when done."
-msgstr "Z Kalibrieren: Drehen Sie den Knopf bis der obere Anschlag erreicht wird. Anschliessend den Knopf druecken."
+msgstr "Z Kalibrieren: Drehen Sie den Knopf bis der obere Anschlag erreicht wird. Anschliessend den Knopf drücken."
 
 # MSG_HOMEYZ_DONE c=20
 #: ultralcd.cpp:656
@@ -233,7 +233,7 @@ msgstr "SD Karte entfernt"
 # MSG_CHECKING_FILE c=17
 #: ultralcd.cpp:8501
 msgid "Checking file"
-msgstr "Ueberpruefe Datei"
+msgstr "überprüfe Datei"
 
 # MSG_NOT_COLOR c=19
 #: ultralcd.cpp:2565
@@ -243,12 +243,12 @@ msgstr "Falsche Farbe"
 # MSG_COOLDOWN c=18
 #: messages.c:27
 msgid "Cooldown"
-msgstr "Abkuehlen"
+msgstr "Abkühlen"
 
 # MSG_COPY_SEL_LANG c=20 r=3
 #: ultralcd.cpp:4435
 msgid "Copy selected language?"
-msgstr "Gewaehlte Sprache kopieren?"
+msgstr "Gewählte Sprache kopieren?"
 
 # MSG_CRASHDETECT c=13
 #: messages.c:30
@@ -258,7 +258,7 @@ msgstr "Crash Erk."
 # MSG_CHOOSE_FIL_1ST_LAYERCAL c=20 r=7
 #: ultralcd.cpp:4842
 msgid "Choose a filament for the First Layer Calibration and select it in the on-screen menu."
-msgstr "Waehlen Sie ein Filament fuer Erste Schichtkalibrierung aus und waehlen Sie es im On-Screen-Menu aus."
+msgstr "Wählen Sie ein Filament für Erste- Schichtkalibrierung aus und wählen Sie es im On-Screen-Menu aus."
 
 # MSG_CRASH_DETECTED c=20
 #: messages.c:29
@@ -268,7 +268,7 @@ msgstr "Crash erkannt."
 # MSG_CRASH_RESUME c=20 r=3
 #: Marlin_main.cpp:651
 msgid "Crash detected. Resume print?"
-msgstr "Crash erkannt. Druck fortfuehren?"
+msgstr "Crash erkannt. Druck fortführen?"
 
 # MSG_CRASH c=7
 #: messages.c:28
@@ -298,7 +298,7 @@ msgstr "Motoren aus"
 # MSG_BABYSTEP_Z_NOT_SET c=20 r=12
 #: messages.c:13
 msgid "Distance between tip of the nozzle and the bed surface has not been set yet. Please follow the manual, chapter First steps, section First layer calibration."
-msgstr "Der Abstand zwischen der Spitze der Duese und dem Bett ist noch nicht eingestellt. Bitte folgen Sie dem Handbuch, Kapitel Erste Schritte, Abschnitt Erste Schicht Kalibrierung."
+msgstr "Der Abstand zwischen der Spitze der Düse und dem Bett ist noch nicht eingestellt. Bitte folgen Sie dem Handbuch, Kapitel Erste Schritte, Abschnitt Erste Schicht Kalibrierung."
 
 # MSG_FS_CONTINUE c=5
 #: messages.c:152
@@ -308,7 +308,7 @@ msgstr ""
 # MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
 #: ultralcd.cpp:5021
 msgid "Do you want to repeat last step to readjust distance between nozzle and heatbed?"
-msgstr "Moechten Sie den letzten Schritt wiederholen, um den Abstand zwischen Duese und Druckbett neu einzustellen?"
+msgstr "Möchten Sie den letzten Schritt wiederholen, um den Abstand zwischen Düse und Druckbett neu einzustellen?"
 
 # MSG_EXTRUDER_CORRECTION c=13
 #: ultralcd.cpp:5090
@@ -343,7 +343,7 @@ msgstr "Endschalter"
 # MSG_STACK_ERROR c=20 r=4
 #: 
 msgid "Error - static memory has been overwritten"
-msgstr "Fehler - statischer Speicher wurde ueberschrieben"
+msgstr "Fehler - statischer Speicher wurde überschrieben"
 
 # MSG_CUT_FILAMENT c=16
 #: messages.c:61
@@ -363,7 +363,7 @@ msgstr "Schneide filament"
 # MSG_FSENS_NOT_RESPONDING c=20 r=4
 #: ultralcd.cpp:4330
 msgid "ERROR: Filament sensor is not responding, please check connection."
-msgstr "FEHLER: Filament- sensor reagiert nicht, bitte Verbindung pruefen."
+msgstr "FEHLER: Filament- sensor reagiert nicht, bitte Verbindung prüfen."
 
 # MSG_DIM c=6
 #: messages.c:159
@@ -378,7 +378,7 @@ msgstr "FEHLER:"
 # MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
 #: ultralcd.cpp:8419
 msgid "Extruder fan:"
-msgstr "Extruder Luefter:"
+msgstr "Extruderlüfter:"
 
 # MSG_INFO_EXTRUDER c=18
 #: ultralcd.cpp:2040
@@ -408,17 +408,17 @@ msgstr "Fehlerstatistik"
 # MSG_FAN_SPEED c=14
 #: messages.c:36
 msgid "Fan speed"
-msgstr "Luefter-Tempo"
+msgstr "Lüfter-Tempo"
 
 # MSG_SELFTEST_FAN c=20
 #: messages.c:91
 msgid "Fan test"
-msgstr "Lueftertest"
+msgstr "Lüftertest"
 
 # MSG_FANS_CHECK c=13
 #: messages.c:33
 msgid "Fans check"
-msgstr "Luefter Chk."
+msgstr "Lüfter Check"
 
 # MSG_FSENSOR c=12
 #: messages.c:49
@@ -428,7 +428,7 @@ msgstr "Fil. Sensor"
 # MSG_FIL_RUNOUTS c=15
 #: messages.c:34
 msgid "Fil. runouts"
-msgstr "Fil. Maengel"
+msgstr "Fil. Mängel"
 
 # MSG_FILAMENT_CLEAN c=20 r=2
 #: messages.c:37
@@ -440,7 +440,7 @@ msgstr "Filament extrudiert mit richtiger Farbe?"
 msgid "Filament not loaded"
 msgstr "Fil. nicht geladen"
 
-# MSG_FILAMENT_SENSOR c=20
+# MSG_SELFTEST_FILAMENT_SENSOR c=17
 #: messages.c:97
 msgid "Filament sensor"
 msgstr "Filamentsensor"
@@ -463,7 +463,7 @@ msgstr "FS Aktion"
 # MSG_FILE_INCOMPLETE c=20 r=3
 #: ultralcd.cpp:8555
 msgid "File incomplete. Continue anyway?"
-msgstr "Datei unvollstaendig Trotzdem fortfahren?"
+msgstr "Datei unvollständig Trotzdem fortfahren?"
 
 # MSG_FINISHING_MOVEMENTS c=20
 #: messages.c:45
@@ -478,12 +478,12 @@ msgstr "Erste-Schicht Kal."
 # MSG_WIZARD_SELFTEST c=20 r=8
 #: ultralcd.cpp:4942
 msgid "First, I will run the selftest to check most common assembly problems."
-msgstr "Zunaechst fuehre ich den Selbsttest durch, um die haeufigsten Probleme beim Zusammenbau zu ueberpruefen."
+msgstr "Zunächst führe ich den Selbsttest durch, um die häufigsten Probleme beim Zusammenbau zu überprüfen."
 
 # MSG_MMU_FIX_ISSUE c=20 r=4
 #: mmu.cpp:727
 msgid "Fix the issue and then press button on MMU unit."
-msgstr "Beseitigen Sie das Problem und druecken Sie dann den Knopf am MMU."
+msgstr "Beseitigen Sie das Problem und drücken Sie dann den Knopf am MMU."
 
 # MSG_FLOW c=15
 #: ultralcd.cpp:6809
@@ -493,17 +493,17 @@ msgstr "Durchfluss"
 # MSG_SELFTEST_COOLING_FAN c=20
 #: messages.c:88
 msgid "Front print fan?"
-msgstr "Teile Luefter?"
+msgstr "Drucklüfter?"
 
 # MSG_BED_CORRECTION_FRONT c=14
 #: ultralcd.cpp:3116
-msgid "Front side[um]"
-msgstr "Vorne [um]"
+msgid "Front side[μm]"
+msgstr "Vorne [μm]"
 
 # MSG_SELFTEST_FANS c=20
 #: ultralcd.cpp:8100
 msgid "Front/left fans"
-msgstr "Teile/Extr. Luefter"
+msgstr "Druck/Extr. Lüfter"
 
 # MSG_SELFTEST_HEATERTHERMISTOR c=20
 #: ultralcd.cpp:8048
@@ -518,17 +518,17 @@ msgstr "Heizung durch Sicherheitstimer deaktiviert."
 # MSG_HEATING_COMPLETE c=20
 #: messages.c:51
 msgid "Heating done."
-msgstr "Aufwaermen OK."
+msgstr "Aufwärmen OK."
 
 # MSG_HEATING c=20
 #: messages.c:50
 msgid "Heating"
-msgstr "Aufwaermen"
+msgstr "Aufwärmen"
 
 # MSG_WIZARD_WELCOME c=20 r=7
 #: messages.c:121
 msgid "Hi, I am your Original Prusa i3 printer. Would you like me to guide you through the setup process?"
-msgstr "Hallo, ich bin Ihr Original Prusa i3 Drucker. Moechten Sie, dass ich Sie durch den Einrich- tungsablauf fuehre?"
+msgstr "Hallo, ich bin Ihr Original Prusa i3 Drucker. Möchten Sie, dass ich Sie durch den Einricht- ungsablauf führe?"
 
 # MSG_FILAMENTCHANGE c=18
 #: messages.c:43
@@ -548,47 +548,47 @@ msgstr "Wechsel ok?"
 # MSG_SELFTEST_CHECK_BED c=20
 #: messages.c:94
 msgid "Checking bed"
-msgstr "Pruefe Bett"
+msgstr "Prüfe Bett"
 
 # MSG_SELFTEST_CHECK_ENDSTOPS c=20
 #: ultralcd.cpp:8402
 msgid "Checking endstops"
-msgstr "Pruefe Endschalter"
+msgstr "Prüfe Endschalter"
 
 # MSG_SELFTEST_CHECK_HOTEND c=20
 #: ultralcd.cpp:8408
 msgid "Checking hotend"
-msgstr "Pruefe Duese"
+msgstr "Prüfe Düse"
 
 # MSG_SELFTEST_CHECK_FSENSOR c=20
 #: messages.c:95
 msgid "Checking sensors"
-msgstr "Pruefe Sensoren"
+msgstr "Prüfe Sensoren"
 
 # MSG_CHECKING_X c=20
 #: messages.c:23
 msgid "Checking X axis"
-msgstr "Pruefe X Achse"
+msgstr "Prüfe X Achse"
 
 # MSG_CHECKING_Y c=20
 #: messages.c:24
 msgid "Checking Y axis"
-msgstr "Pruefe Y Achse"
+msgstr "Prüfe Y Achse"
 
 # MSG_SELFTEST_CHECK_Z c=20
 #: ultralcd.cpp:8405
 msgid "Checking Z axis"
-msgstr "Pruefe Z Achse"
+msgstr "Prüfe Z Achse"
 
 # MSG_CHOOSE_EXTRUDER c=20
 #: messages.c:54
 msgid "Choose extruder:"
-msgstr "Extruder waehlen:"
+msgstr "Extruder wählen:"
 
 # MSG_CHOOSE_FILAMENT c=20
 #: messages.c:55
 msgid "Choose filament:"
-msgstr "Waehle Filament:"
+msgstr "Wähle Filament:"
 
 # MSG_FILAMENT c=17
 #: messages.c:35
@@ -598,12 +598,12 @@ msgstr ""
 # MSG_WIZARD_XYZ_CAL c=20 r=8
 #: ultralcd.cpp:4951
 msgid "I will run xyz calibration now. It will take approx. 12 mins."
-msgstr "Ich werde jetzt die XYZ-Kalibrierung durchfuehren. Es wird ca. 12 Minuten dauern."
+msgstr "Ich werde jetzt die XYZ-Kalibrierung durchführen. Es wird ca. 12 Minuten dauern."
 
 # MSG_WIZARD_Z_CAL c=20 r=8
 #: ultralcd.cpp:4959
 msgid "I will run z calibration now."
-msgstr "Ich werde jetzt die Z Kalibrierung durchfuehren."
+msgstr "Ich werde jetzt die Z Kalibrierung durchführen."
 
 # MSG_WATCH c=18
 #: messages.c:116
@@ -633,12 +633,12 @@ msgstr "Letzte Druckfehler"
 # MSG_WIZARD_WELCOME_SHIPPING c=20 r=16
 #: messages.c:122
 msgid "Hi, I am your Original Prusa i3 printer. I will guide you through a short setup process, in which the Z-axis will be calibrated. Then, you will be ready to print."
-msgstr "Hallo, ich bin Ihr Original Prusa i3 Drucker. Ich werde Sie durch einen kurzen Einrichtungsprozess fuehren, bei dem die Z-Achse kalibriert wird. Danach sind Sie bereit fuer den Druck."
+msgstr "Hallo, ich bin Ihr Original Prusa i3 Drucker. Ich werde Sie durch einen kurzen Einrichtungsprozess führen, bei dem die Z-Achse kalibriert wird. Danach sind Sie bereit für den Druck."
 
 # MSG_ADDITIONAL_SHEETS c=20 r=9
 #: ultralcd.cpp:5029
 msgid "If you have additional steel sheets, calibrate their presets in Settings - HW Setup - Steel sheets."
-msgstr "Wenn Sie zusaetzliche Stahlbleche haben, kalibrieren Sie deren Voreinstellungen unter Einstellungen - HW Setup - Stahlbleche."
+msgstr "Wenn Sie zusätzliche Stahlbleche haben, kalibrieren Sie deren Voreinstellungen unter Einstellungen - HW Setup - Stahlbleche."
 
 # MSG_LAST_PRINT c=18
 #: messages.c:56
@@ -648,7 +648,7 @@ msgstr "Letzter Druck"
 # MSG_SELFTEST_EXTRUDER_FAN c=20
 #: messages.c:89
 msgid "Left hotend fan?"
-msgstr "Extruder Luefter?"
+msgstr "Extruderlüfter?"
 
 # MSG_LEFT c=10
 #: ultralcd.cpp:2844
@@ -657,8 +657,8 @@ msgstr "Links"
 
 # MSG_BED_CORRECTION_LEFT c=14
 #: ultralcd.cpp:3114
-msgid "Left side [um]"
-msgstr "Links [um]"
+msgid "Left side [μm]"
+msgstr "Links [μm]"
 
 # MSG_LIN_CORRECTION c=18
 #: ultralcd.cpp:5702
@@ -673,7 +673,7 @@ msgstr "Z einstellen"
 # MSG_INSERT_FIL c=20 r=6
 #: ultralcd.cpp:7301
 msgid "Insert the filament (do not load it) into the extruder and then press the knob."
-msgstr "Stecken Sie das Filament (nicht laden) in den Extruder und druecken Sie dann den Knopf."
+msgstr "Stecken Sie das Filament (nicht laden) in den Extruder und drücken Sie dann den Knopf."
 
 # MSG_LOAD_FILAMENT c=17
 #: messages.c:58
@@ -688,7 +688,7 @@ msgstr "Lade Farbe"
 # MSG_LOADING_FILAMENT c=20
 #: messages.c:59
 msgid "Loading filament"
-msgstr "Filament laedt"
+msgstr "Filament lädt"
 
 # MSG_ITERATION c=12
 #: messages.c:53
@@ -713,7 +713,7 @@ msgstr "M117 Erste-Schicht Kal."
 # MSG_MAIN c=18
 #: messages.c:63
 msgid "Main"
-msgstr "Hauptmenue"
+msgstr "Hauptmenü"
 
 # MSG_BL_HIGH c=12
 #: messages.c:155
@@ -728,7 +728,7 @@ msgstr "Dimmwert"
 # MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=20 r=3
 #: messages.c:67
 msgid "Measuring reference height of calibration point"
-msgstr "Messen der Referenzhoehe des Kalibrierpunktes"
+msgstr "Messen der Referenzhöhe des Kalibrierpunktes"
 
 # MSG_MESH_BED_LEVELING c=18
 #: messages.c:148
@@ -748,7 +748,7 @@ msgstr "MMU OK. Temperatur wiederherstellen..."
 # MSG_MEASURED_SKEW c=14
 #: ultralcd.cpp:2885
 msgid "Measured skew"
-msgstr "Schraeglauf"
+msgstr "Schräglauf"
 
 # MSG_MMU_FAILS c=15
 #: messages.c:69
@@ -873,7 +873,7 @@ msgstr "Nicht angeschlossen"
 # MSG_NEW_FIRMWARE_AVAILABLE c=20 r=2
 #: util.cpp:195
 msgid "New firmware version available:"
-msgstr "Neue Firmware- Version verfuegbar:"
+msgstr "Neue Firmware- Version verfügbar:"
 
 # MSG_SELFTEST_FAN_NO c=19
 #: messages.c:92
@@ -883,17 +883,17 @@ msgstr "Dreht sich nicht"
 # MSG_WIZARD_V2_CAL c=20 r=8
 #: ultralcd.cpp:4838
 msgid "Now I will calibrate distance between tip of the nozzle and heatbed surface."
-msgstr "Jetzt werde ich den Abstand zwischen Duesenspitze und Druckbett kalibrieren."
+msgstr "Jetzt werde ich den Abstand zwischen Düsenspitze und Druckbett kalibrieren."
 
 # MSG_WIZARD_WILL_PREHEAT c=20 r=4
 #: ultralcd.cpp:4967
 msgid "Now I will preheat nozzle for PLA."
-msgstr "Jetzt werde ich die Duese fuer PLA vorheizen."
+msgstr "Jetzt werde ich die Düse für PLA vorheizen."
 
 # MSG_NOZZLE c=12
 #: messages.c:72
 msgid "Nozzle"
-msgstr "Duese"
+msgstr "Düse"
 
 # MSG_DEFAULT_SETTINGS_LOADED c=20 r=6
 #: Marlin_main.cpp:1605
@@ -908,7 +908,7 @@ msgstr "Testdruck jetzt von Stahlblech entfernen."
 # MSG_NOZZLE_FAN c=10
 #: ultralcd.cpp:1446
 msgid "Nozzle FAN"
-msgstr "Duesevent."
+msgstr "Drucklüft."
 
 # MSG_PAUSE_PRINT c=18
 #: messages.c:74
@@ -933,27 +933,27 @@ msgstr "PID Kalibrierung"
 # MSG_PINDA_PREHEAT c=20
 #: ultralcd.cpp:683
 msgid "PINDA Heating"
-msgstr "PINDA erwaermen"
+msgstr "PINDA erwärmen"
 
 # MSG_PAPER c=20 r=10
 #: messages.c:73
 msgid "Place a sheet of paper under the nozzle during the calibration of first 4 points. If the nozzle catches the paper, power off the printer immediately."
-msgstr "Legen Sie ein Blatt Papier unter die Duese waehrend der Kalibrierung der ersten 4 Punkte. Wenn die Duese das Papier erfasst, den Drucker sofort ausschalten."
+msgstr "Legen Sie ein Blatt Papier unter die Düse während der Kalibrierung der ersten 4 Punkte. Wenn die Düse das Papier erfasst, den Drucker sofort ausschalten."
 
 # MSG_WIZARD_CLEAN_HEATBED c=20 r=8
 #: ultralcd.cpp:5024
 msgid "Please clean heatbed and then press the knob."
-msgstr "Bitte reinigen Sie das Heizbett und druecken Sie dann den Knopf."
+msgstr "Bitte reinigen Sie das Heizbett und drücken Sie dann den Knopf."
 
 # MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
 #: messages.c:26
 msgid "Please clean the nozzle for calibration. Click when done."
-msgstr "Bitte entfernen Sie ueberstehendes Filament von der Duese. Klicken wenn sauber."
+msgstr "Bitte entfernen Sie überstehendes Filament von der Düse. Klicken wenn sauber."
 
 # MSG_SELFTEST_PLEASECHECK c=20
 #: ultralcd.cpp:8043
 msgid "Please check:"
-msgstr "Bitte pruefe:"
+msgstr "Bitte prüfen:"
 
 # MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
 #: messages.c:117
@@ -963,7 +963,7 @@ msgstr "Bitte lesen Sie unser Handbuch und beheben Sie das Problem. Fahren Sie d
 # MSG_CHECK_IDLER c=20 r=5
 #: Marlin_main.cpp:3798
 msgid "Please open idler and remove filament manually."
-msgstr "Bitte Spannrolle oeffnen und Fila- ment von Hand entfernen"
+msgstr "Bitte Spannrolle öffnen und Filament von Hand entfernen"
 
 # MSG_PLACE_STEEL_SHEET c=20 r=5
 #: messages.c:75
@@ -973,7 +973,7 @@ msgstr "Bitte legen Sie das Stahlblech auf das Heizbett."
 # MSG_PRESS_TO_UNLOAD c=20 r=4
 #: messages.c:79
 msgid "Please press the knob to unload filament"
-msgstr "Bitte druecken Sie den Knopf um das Filament zu entladen."
+msgstr "Bitte drücken Sie den Knopf um das Filament zu entladen."
 
 # MSG_PULL_OUT_FILAMENT c=20 r=4
 #: messages.c:81
@@ -983,7 +983,7 @@ msgstr "Bitte ziehen Sie das Filament sofort heraus"
 # MSG_EJECT_REMOVE c=20 r=4
 #: mmu.cpp:1421
 msgid "Please remove filament and then press the knob."
-msgstr "Bitte Filament entfernen und dann den Knopf druecken"
+msgstr "Bitte Filament entfernen und dann den Knopf drücken"
 
 # MSG_REMOVE_STEEL_SHEET c=20 r=4
 #: messages.c:84
@@ -993,7 +993,7 @@ msgstr "Bitte entfernen Sie das Stahlblech vom Heizbett."
 # MSG_RUN_XYZ c=20 r=4
 #: Marlin_main.cpp:5338
 msgid "Please run XYZ calibration first."
-msgstr "Bitte zuerst XYZ Kalibrierung ausfuehren."
+msgstr "Bitte zuerst XYZ Kalibrierung ausführen."
 
 # MSG_UPDATE_MMU2_FW c=20 r=4
 #: mmu.cpp:1341
@@ -1013,7 +1013,7 @@ msgstr "Bitte zuerst Transportsicherungen entfernen."
 # MSG_PREHEAT_NOZZLE c=20
 #: messages.c:78
 msgid "Preheat the nozzle!"
-msgstr "Duese vorheizen!"
+msgstr "Düse vorheizen!"
 
 # MSG_PREHEAT c=18
 #: ultralcd.cpp:6576
@@ -1023,7 +1023,7 @@ msgstr "Vorheizen"
 # MSG_WIZARD_HEATING c=20 r=3
 #: messages.c:119
 msgid "Preheating nozzle. Please wait."
-msgstr "Vorheizen der Duese. Bitte warten."
+msgstr "Vorheizen der Düse. Bitte warten."
 
 # MSG_NEW_FIRMWARE_PLEASE_UPGRADE c=20
 #: util.cpp:199
@@ -1033,7 +1033,7 @@ msgstr "Bitte aktualisieren."
 # MSG_PRESS_TO_PREHEAT c=20 r=4
 #: Marlin_main.cpp:12052
 msgid "Press the knob to preheat nozzle and continue."
-msgstr "Bitte druecken Sie den Knopf um die Duese vorzuheizen und fortzufahren."
+msgstr "Bitte drücken Sie den Knopf um die Düse vorzuheizen und fortzufahren."
 
 # MSG_FS_PAUSE c=5
 #: fsensor.cpp:730
@@ -1063,7 +1063,7 @@ msgstr "Heizen zum Entladen"
 # MSG_SELFTEST_PRINT_FAN_SPEED c=18
 #: ultralcd.cpp:8422
 msgid "Print fan:"
-msgstr "Druckvent.:"
+msgstr "Drucklüfter:"
 
 # MSG_CARD_MENU c=18
 #: messages.c:22
@@ -1073,7 +1073,7 @@ msgstr "Drucken von SD"
 # MSG_PRESS_KNOB c=20
 #: ultralcd.cpp:2130
 msgid "Press the knob"
-msgstr "Knopf druecken zum"
+msgstr "Knopf drücken zum"
 
 # MSG_PRINT_PAUSED c=20
 #: ultralcd.cpp:907
@@ -1083,7 +1083,7 @@ msgstr "Druck pausiert"
 # MSG_RESUME_NOZZLE_TEMP c=20 r=4
 #: mmu.cpp:726
 msgid "Press the knob to resume nozzle temperature."
-msgstr "Druecken Sie den Knopf um die Duesentemperatur wiederherzustellen"
+msgstr "Drücken Sie den Knopf um die Düsentemperatur wiederherzustellen"
 
 # MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
 #: messages.c:46
@@ -1093,17 +1093,17 @@ msgstr "Drucker wurde noch nicht kalibriert. Bitte folgen Sie dem Handbuch, Kapi
 # MSG_PRINT_FAN c=10
 #: ultralcd.cpp:1447
 msgid "Print FAN"
-msgstr "Druckvent."
+msgstr "Drucklüft."
 
 # MSG_WIZARD_LOAD_FILAMENT c=20 r=6
 #: ultralcd.cpp:4818
 msgid "Please insert filament into the extruder, then press the knob to load it."
-msgstr "Bitte legen Sie das Filament in den Extruder ein und druecken Sie dann den Knopf, um es zu laden."
+msgstr "Bitte legen Sie das Filament in den Extruder ein und drücken Sie dann den Knopf, um es zu laden."
 
 # MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
 #: ultralcd.cpp:4813
 msgid "Please insert filament into the first tube of the MMU, then press the knob to load it."
-msgstr "Bitte stecken Sie das Filament in den ersten Schlauch der MMU und druecken Sie dann den Knopf, um es zu laden."
+msgstr "Bitte stecken Sie das Filament in den ersten Schlauch der MMU und drücken Sie dann den Knopf, um es zu laden."
 
 # MSG_PLEASE_LOAD_PLA c=20 r=4
 #: ultralcd.cpp:4735
@@ -1112,8 +1112,8 @@ msgstr "Bitte laden Sie zuerst das Filament."
 
 # MSG_BED_CORRECTION_REAR c=14
 #: ultralcd.cpp:3117
-msgid "Rear side [um]"
-msgstr "Hinten [um]"
+msgid "Rear side [μm]"
+msgstr "Hinten [μm]"
 
 # MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
 #: ultralcd.cpp:7325
@@ -1123,7 +1123,7 @@ msgstr "Bitte entladen Sie erst das Filament und versuchen Sie es nochmal."
 # MSG_CHECK_IR_CONNECTION c=20 r=4
 #: ultralcd.cpp:7328
 msgid "Please check the IR sensor connection, unload filament if present."
-msgstr "Bitte IR Sensor Verbindungen ueber- pruefen und Filament entladen ist."
+msgstr "Bitte IR Sensor Verbindungen über- prüfen und Filament entladen ist."
 
 # MSG_RECOVERING_PRINT c=20
 #: Marlin_main.cpp:11396
@@ -1133,7 +1133,7 @@ msgstr "Druck wiederherst"
 # MSG_REMOVE_OLD_FILAMENT c=20 r=5
 #: mmu.cpp:833
 msgid "Remove old filament and press the knob to start loading new filament."
-msgstr "Entfernen Sie das alte Filament und druecken Sie den Knopf, um das neue zu laden."
+msgstr "Entfernen Sie das alte Filament und drücken Sie den Knopf, um das neue zu laden."
 
 # MSG_CALIBRATE_BED_RESET c=18
 #: ultralcd.cpp:5804
@@ -1143,7 +1143,7 @@ msgstr "Reset XYZ Kalibr."
 # MSG_RESET c=14
 #: messages.c:85
 msgid "Reset"
-msgstr "Ruecksetzen"
+msgstr "Rücksetzen"
 
 # MSG_RESUME_PRINT c=18
 #: messages.c:86
@@ -1157,8 +1157,8 @@ msgstr "Druck fortgesetzt"
 
 # MSG_BED_CORRECTION_RIGHT c=14
 #: ultralcd.cpp:3115
-msgid "Right side[um]"
-msgstr "Rechts [um]"
+msgid "Right side[μm]"
+msgstr "Rechts [μm]"
 
 # MSG_RPI_PORT c=13
 #: messages.c:142
@@ -1168,7 +1168,7 @@ msgstr ""
 # MSG_WIZARD_RERUN c=20 r=7
 #: ultralcd.cpp:4756
 msgid "Running Wizard will delete current calibration results and start from the beginning. Continue?"
-msgstr "Der Assistent wird die aktuellen Kalibrierungsdaten loeschen und von vorne beginnen. Weiterfahren?"
+msgstr "Der Assistent wird die aktuellen Kalibrierungsdaten löschen und von vorne beginnen. Weiterfahren?"
 
 # MSG_SD_CARD c=8
 #: messages.c:138
@@ -1188,7 +1188,7 @@ msgstr "Suche Bett Kalibrierpunkt"
 # MSG_LANGUAGE_SELECT c=18
 #: ultralcd.cpp:4451
 msgid "Select language"
-msgstr "Waehle Sprache"
+msgstr "Wähle Sprache"
 
 # MSG_SELFTEST_OK c=20
 #: ultralcd.cpp:7600
@@ -1218,12 +1218,12 @@ msgstr "Selbsttest Error"
 # MSG_FORCE_SELFTEST c=20 r=8
 #: Marlin_main.cpp:1637
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
-msgstr "Selbsttest im Gang, um die genaue Rueck- kehr zum Nullpunkt ohne Sensor zu kalibrieren"
+msgstr "Selbsttest wird gestartet, um Startposition zu kalibrieren."
 
 # MSG_SEL_PREHEAT_TEMP c=20 r=6
 #: ultralcd.cpp:4998
 msgid "Select nozzle preheat temperature which matches your material."
-msgstr "Bitte Vorheiztemperatur auswaehlen, die Ihrem Material entspricht."
+msgstr "Bitte Vorheiztemperatur auswählen, die Ihrem Material entspricht."
 
 # MSG_SET_TEMPERATURE c=20
 #: ultralcd.cpp:3135
@@ -1263,7 +1263,7 @@ msgstr "Zeit"
 # MSG_SEVERE_SKEW c=14
 #: ultralcd.cpp:2888
 msgid "Severe skew"
-msgstr "Sehr Schraeg"
+msgstr "Sehr schräg"
 
 # MSG_SORT_ALPHA c=8
 #: messages.c:141
@@ -1283,7 +1283,7 @@ msgstr "Laut"
 # MSG_SLIGHT_SKEW c=14
 #: ultralcd.cpp:2887
 msgid "Slight skew"
-msgstr "Leicht Schraeg"
+msgstr "Leicht schräg"
 
 # MSG_SOUND c=7
 #: messages.c:143
@@ -1293,7 +1293,7 @@ msgstr "Ton"
 # MSG_RUNOUTS c=7
 #: ultralcd.cpp:1593
 msgid "Runouts"
-msgstr "Maengel"
+msgstr "Mängel"
 
 # MSG_Z-LEVELING_ENFORCED c=20 r=4
 #: Marlin_main.cpp:3303
@@ -1318,7 +1318,7 @@ msgstr "Dreht sich"
 # MSG_TEMP_CAL_WARNING c=20 r=4
 #: Marlin_main.cpp:5351
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
-msgstr "Stabile Umgebungs- temperatur 21-26C und feste Stand- flaeche erforderlich"
+msgstr "Stabile Umgebungs- temperatur 21-26C und feste Stand- fläche erforderlich"
 
 # MSG_STATISTICS c=18
 #: ultralcd.cpp:6081
@@ -1348,7 +1348,7 @@ msgstr "Ausgetauscht"
 # MSG_SELECT_FILAMENT c=20
 #: ultralcd.cpp:4706
 msgid "Select filament:"
-msgstr "Filament auswaehlen:"
+msgstr "Filament auswählen:"
 
 # MSG_TEMP_CALIBRATION c=14
 #: messages.c:112
@@ -1358,7 +1358,7 @@ msgstr "Temp Kalib."
 # MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
 #: ultralcd.cpp:4847
 msgid "Select temperature which matches your material."
-msgstr "Waehlen Sie die Temperatur, die zu Ihrem Material passt."
+msgstr "Wählen Sie die Temperatur, die zu Ihrem Material passt."
 
 # MSG_CALIBRATION_PINDA_MENU c=17
 #: ultralcd.cpp:5812
@@ -1378,7 +1378,7 @@ msgstr "Temp.kalibrierung ist fertig + aktiv. Temp.kalibrierung kann ausgeschalt
 # MSG_FS_VERIFIED c=20 r=3
 #: ultralcd.cpp:7332
 msgid "Sensor verified, remove the filament now."
-msgstr "Sensor ueberprueft, entladen Sie jetzt das Filament."
+msgstr "Sensor überprüft, entladen Sie jetzt das Filament."
 
 # MSG_TEMPERATURE c=18
 #: ultralcd.cpp:5673
@@ -1393,7 +1393,7 @@ msgstr "Temperaturen"
 # MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=9
 #: messages.c:47
 msgid "There is still a need to make Z calibration. Please follow the manual, chapter First steps, section Calibration flow."
-msgstr "Es ist noch not- wendig die Z- Kalibrierung aus- zufuehren. Bitte befolgen Sie das Handbuch, Kapitel Erste Schritte, Abschnitt Kalibrierablauf."
+msgstr "Es ist noch not- wendig die Z- Kalibrierung aus- zuführen. Bitte befolgen Sie das Handbuch, Kapitel Erste Schritte, Abschnitt Kalibrierablauf."
 
 # MSG_TOTAL_FILAMENT c=19
 #: ultralcd.cpp:2735
@@ -1425,7 +1425,7 @@ msgstr "Filament laden"
 msgid "to unload filament"
 msgstr "um Filament entladen"
 
-# MSG_UNLOAD_FILAMENT c=16
+# MSG_UNLOAD_FILAMENT c=18
 #: messages.c:114
 msgid "Unload filament"
 msgstr "Fil. entladen"
@@ -1463,27 +1463,27 @@ msgstr "Warte auf Benutzer.."
 # MSG_WAITING_TEMP c=20 r=4
 #: ultralcd.cpp:3283
 msgid "Waiting for nozzle and bed cooling"
-msgstr "Warten bis Heizung und Bett abgekuehlt sind"
+msgstr "Warten bis Heizung und Bett abgekühlt sind"
 
 # MSG_WAITING_TEMP_PINDA c=20 r=3
 #: ultralcd.cpp:3244
 msgid "Waiting for PINDA probe cooling"
-msgstr "Warten, bis PINDA- Sonde abgekuehlt ist"
+msgstr "Warten, bis PINDA- Sonde abgekühlt ist"
 
 # MSG_CHANGED_BOTH c=20 r=4
 #: Marlin_main.cpp:1597
 msgid "Warning: both printer type and motherboard type changed."
-msgstr "Warnung: Druckertyp und Platinentyp wurden beide geaendert."
+msgstr "Warnung: Druckertyp und Platinentyp wurden beide geändert."
 
 # MSG_CHANGED_MOTHERBOARD c=20 r=4
 #: Marlin_main.cpp:1589
 msgid "Warning: motherboard type changed."
-msgstr "Warnung: Platinentyp wurde geaendert."
+msgstr "Warnung: Platinentyp wurde geändert."
 
 # MSG_CHANGED_PRINTER c=20 r=4
 #: Marlin_main.cpp:1593
 msgid "Warning: printer type changed."
-msgstr "Warnung: Druckertyp wurde geaendert."
+msgstr "Warnung: Druckertyp wurde geändert."
 
 # MSG_UNLOAD_SUCCESSFUL c=20 r=2
 #: Marlin_main.cpp:3789
@@ -1510,7 +1510,7 @@ msgstr "XYZ Kal. Details"
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "XYZ-Kalibrierung fehlgeschlagen. Bitte schauen Sie in das Handbuch."
 
-# MSG_YES c=3
+# MSG_YES c=4
 #: messages.c:123
 msgid "Yes"
 msgstr "Ja"
@@ -1518,22 +1518,22 @@ msgstr "Ja"
 # MSG_WIZARD_QUIT c=20 r=8
 #: messages.c:120
 msgid "You can always resume the Wizard from Calibration -> Wizard."
-msgstr "Sie koennen den Assistenten immer im Menu neu starten: Kalibrierung -> Assistent"
+msgstr "Sie können den Assistenten immer im Menu neu starten: Kalibrierung -> Assistent"
 
 # MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
 #: ultralcd.cpp:3743
 msgid "XYZ calibration all right. Skew will be corrected automatically."
-msgstr "XYZ Kalibrierung in Ordnung. Schraeglauf wird automatisch korrigiert."
+msgstr "XYZ Kalibrierung in Ordnung. Schräglauf wird automatisch korrigiert."
 
 # MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
 #: ultralcd.cpp:3740
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
-msgstr "XYZ Kalibrierung in Ordnung. X/Y Achsen sind etwas schraeg. Gut gemacht!"
+msgstr "XYZ Kalibrierung in Ordnung. X/Y Achsen sind etwas schräg. Gut gemacht!"
 
 # MSG_TIMEOUT c=12
 #: messages.c:157
 msgid "Timeout"
-msgstr "Verzoegerung"
+msgstr ""
 
 # MSG_X_CORRECTION c=13
 #: ultralcd.cpp:5086
@@ -1543,17 +1543,17 @@ msgstr "X-Korrektur:"
 # MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
 #: ultralcd.cpp:3737
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
-msgstr "XYZ-Kalibrierung ok. X/Y-Achsen sind senkrecht zueinander Glueckwunsch!"
+msgstr "XYZ-Kalibrierung ok. X/Y-Achsen sind senkrecht zueinander Glückwunsch!"
 
 # MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
 #: ultralcd.cpp:3721
 msgid "XYZ calibration compromised. Front calibration points not reachable."
-msgstr "XYZ-Kalibrierung beeintraechtigt. Vordere Kalibrierpunkte nicht erreichbar."
+msgstr "XYZ-Kalibrierung beeinträchtigt. Vordere Kalibrierpunkte nicht erreichbar."
 
 # MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
 #: ultralcd.cpp:3724
 msgid "XYZ calibration compromised. Right front calibration point not reachable."
-msgstr "XYZ-Kalibrierung beeintraechtigt. Rechter vorderer Kalibrierpunkt nicht erreichbar."
+msgstr "XYZ-Kalibrierung beeinträchtigt. Rechter vorderer Kalibrierpunkt nicht erreichbar."
 
 # MSG_LOAD_ALL c=17
 #: ultralcd.cpp:6167
@@ -1583,12 +1583,12 @@ msgstr "Y Entfernung vom Min"
 # MSG_WIZARD_V2_CAL_2 c=20 r=12
 #: ultralcd.cpp:4850
 msgid "The printer will start printing a zig-zag line. Rotate the knob until you reach the optimal height. Check the pictures in the handbook (Calibration chapter)."
-msgstr "Der Drucker beginnt mit dem Drucken einer Zickzacklinie. Drehen Sie den Knopf, bis Sie die optimale Hoehe erreicht haben. Ueberpruefen Sie die Bilder im Handbuch (Kapitel Kalibrierung)."
+msgstr "Der Drucker beginnt mit dem Drucken einer Zickzacklinie. Drehen Sie den Knopf, bis Sie die optimale Höhe erreicht haben. überprüfen Sie die Bilder im Handbuch (Kapitel Kalibrierung)."
 
 # MSG_FIL_FAILED c=20 r=5
 #: ultralcd.cpp:7336
 msgid "Verification failed, remove the filament and try again."
-msgstr "Ueberpruefung fehl- geschlagen, entladen Sie das Filament und versuchen Sie es erneut."
+msgstr "überprüfung fehl- geschlagen, entladen Sie das Filament und versuchen Sie es erneut."
 
 # MSG_Y_CORRECTION c=13
 #: ultralcd.cpp:5087
@@ -1608,7 +1608,7 @@ msgstr "An"
 # MSG_BACK c=18
 #: messages.c:64
 msgid "Back"
-msgstr "Zurueck"
+msgstr "Zurück"
 
 # MSG_CHECKS c=18
 #: ultralcd.cpp:5641
@@ -1668,37 +1668,37 @@ msgstr "Modell"
 # MSG_NOZZLE_DIAMETER c=10
 #: messages.c:136
 msgid "Nozzle d."
-msgstr "Duese D."
+msgstr "Düsen Dia."
 
 # MSG_GCODE_DIFF_CONTINUE c=20 r=4
 #: util.cpp:414
 msgid "G-code sliced for a different level. Continue?"
-msgstr "G-Code ist fuer einen anderen Level geslict. Fortfahren?"
+msgstr "G-Code ist für einen anderen Level geslict. Fortfahren?"
 
 # MSG_GCODE_DIFF_CANCELLED c=20 r=7
 #: util.cpp:420
 msgid "G-code sliced for a different level. Please re-slice the model again. Print cancelled."
-msgstr "G-Code ist fuer einen anderen Level geslict. Bitte slicen Sie das Modell erneut. Druck abgebrochen."
+msgstr "G-Code ist für einen anderen Level geslict. Bitte slicen Sie das Modell erneut. Druck abgebrochen."
 
 # MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=5
 #: messages.c:134
 msgid "G-code sliced for a different printer type. Continue?"
-msgstr "G-Code ist fuer einen anderen Drucker geslict. Fortfahren?"
+msgstr "G-Code ist für einen anderen Drucker geslict. Fortfahren?"
 
 # MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
 #: messages.c:135
 msgid "G-code sliced for a different printer type. Please re-slice the model again. Print cancelled."
-msgstr "G-Code ist fuer einen anderen Drucker geslict. Bitte slicen Sie das Modell erneut. Druck abgebrochen."
+msgstr "G-Code ist für einen anderen Drucker geslict. Bitte slicen Sie das Modell erneut. Druck abgebrochen."
 
 # MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=5
 #: util.cpp:381
 msgid "G-code sliced for a newer firmware. Continue?"
-msgstr "G-Code ist fuer eine neuere Firmware geslict. Fortfahren?"
+msgstr "G-Code ist für eine neuere Firmware geslict. Fortfahren?"
 
 # MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
 #: util.cpp:387
 msgid "G-code sliced for a newer firmware. Please update the firmware. Print cancelled."
-msgstr "G-Code ist fuer eine neuere Firmware geslict. Bitte die Firmware updaten. Druck abgebrochen."
+msgstr "G-Code ist für eine neuere Firmware geslict. Bitte die Firmware updaten. Druck abgebrochen."
 
 # MSG_PREHEATING_TO_CUT c=20
 #: ultralcd.cpp:2309
@@ -1713,12 +1713,12 @@ msgstr "Heizen zum Auswurf"
 # MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=5
 #: util.cpp:294
 msgid "Printer nozzle diameter differs from the G-code. Continue?"
-msgstr "Der Durchmesser der Druckerduese weicht vom G-Code ab. Fortfahren?"
+msgstr "Der Durchmesser der Druckerdüse weicht vom G-Code ab. Fortfahren?"
 
 # MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=9
 #: util.cpp:301
 msgid "Printer nozzle diameter differs from the G-code. Please check the value in settings. Print cancelled."
-msgstr "Der Durchmesser der Druckerduese weicht vom G-Code ab. Bitte ueberpruefen Sie den Wert in den Einstellungen. Druck abgebrochen."
+msgstr "Der Durchmesser der Druckerdüse weicht vom G-Code ab. Bitte überprüfen Sie den Wert in den Einstellungen. Druck abgebrochen."
 
 # MSG_SELFTEST_FS_LEVEL c=20
 #: ultralcd.cpp:8116

--- a/lang/po/Firmware_es.po
+++ b/lang/po/Firmware_es.po
@@ -7,8 +7,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: es\n"
 "Project-Id-Version: Prusa-Firmware\n"
-"POT-Creation-Date: Sun 19 Dec 2021 07:17:30 PM CET\n"
-"PO-Revision-Date: Sun 19 Dec 2021 07:17:30 PM CET\n"
+"POT-Creation-Date: Tue 08 Feb 2022 02:44:22 PM CET\n"
+"PO-Revision-Date: Tue 08 Feb 2022 02:44:22 PM CET\n"
 "Language-Team: \n"
 "X-Generator: Poedit 2.0.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
@@ -21,7 +21,7 @@ msgid " 0.3 or older"
 msgstr " 0.3 o mayor"
 
 # MSG_FS_V_03_OR_OLDER c=18
-#: Marlin_main.cpp:9884
+#: Marlin_main.cpp:9887
 msgid "FS v0.3 or older"
 msgstr "FS 0.3 o mayor"
 
@@ -31,7 +31,7 @@ msgid " 0.4 or newer"
 msgstr " 0.4 o mas nueva"
 
 # MSG_FS_V_04_OR_NEWER c=18
-#: Marlin_main.cpp:9883
+#: Marlin_main.cpp:9886
 msgid "FS v0.4 or newer"
 msgstr "FS 0.4 o mas nueva"
 
@@ -61,11 +61,11 @@ msgid "Adjusting Z:"
 msgstr "Ajustar-Z:"
 
 # MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ultralcd.cpp:8490
+#: ultralcd.cpp:8411
 msgid "All correct"
 msgstr "Todo bien"
 
-# MSG_WIZARD_DONE c=20 r=8
+# MSG_WIZARD_DONE c=20 r=3
 #: messages.c:118
 msgid "All is done. Happy printing!"
 msgstr "Terminado! Feliz impresion!"
@@ -96,7 +96,7 @@ msgid "Auto home"
 msgstr "Llevar al origen"
 
 # MSG_AUTOLOAD_FILAMENT c=18
-#: ultralcd.cpp:6732
+#: ultralcd.cpp:6653
 msgid "AutoLoad filament"
 msgstr "Carga auto. filam."
 
@@ -111,17 +111,17 @@ msgid "Autoloading filament is active, just press the knob and insert filament..
 msgstr "La carga automatica esta activada, pulse el dial e inserte el filamento..."
 
 # MSG_SELFTEST_AXIS_LENGTH c=20
-#: ultralcd.cpp:8173
+#: ultralcd.cpp:8094
 msgid "Axis length"
 msgstr "Longitud del eje"
 
 # MSG_SELFTEST_AXIS c=16
-#: ultralcd.cpp:8174
+#: ultralcd.cpp:8095
 msgid "Axis"
 msgstr "Eje"
 
 # MSG_SELFTEST_BEDHEATER c=20
-#: ultralcd.cpp:8131
+#: ultralcd.cpp:8052
 msgid "Bed/Heater"
 msgstr "Base/Calentador"
 
@@ -176,7 +176,7 @@ msgid "Blackout occurred. Recover print?"
 msgstr "Se fue la luz. Re- anudar la impresion?"
 
 # MSG_CALIBRATING_HOME c=20
-#: ultralcd.cpp:8492
+#: ultralcd.cpp:8413
 msgid "Calibrating home"
 msgstr "Calibrar pos.inicial"
 
@@ -226,12 +226,12 @@ msgid "Calibration"
 msgstr "Calibracion"
 
 # MSG_SD_REMOVED c=20
-#: ultralcd.cpp:8939
+#: ultralcd.cpp:8860
 msgid "Card removed"
 msgstr "Tarjeta retirada"
 
 # MSG_CHECKING_FILE c=17
-#: ultralcd.cpp:8580
+#: ultralcd.cpp:8501
 msgid "Checking file"
 msgstr "Verif. archivo"
 
@@ -326,17 +326,17 @@ msgid "Ejecting filament"
 msgstr "Expulsando filamento"
 
 # MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ultralcd.cpp:8149
+#: ultralcd.cpp:8070
 msgid "Endstop not hit"
 msgstr "Endstop no alcanzado"
 
 # MSG_SELFTEST_ENDSTOP c=16
-#: ultralcd.cpp:8144
+#: ultralcd.cpp:8065
 msgid "Endstop"
 msgstr ""
 
 # MSG_SELFTEST_ENDSTOPS c=20
-#: ultralcd.cpp:8135
+#: ultralcd.cpp:8056
 msgid "Endstops"
 msgstr ""
 
@@ -376,7 +376,7 @@ msgid "ERROR:"
 msgstr ""
 
 # MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
-#: ultralcd.cpp:8498
+#: ultralcd.cpp:8419
 msgid "Extruder fan:"
 msgstr "Vent.extrusor:"
 
@@ -391,7 +391,7 @@ msgid "Extruder"
 msgstr "Extruir"
 
 # MSG_MMU_FAIL_STATS c=18
-#: ultralcd.cpp:6754
+#: ultralcd.cpp:6675
 msgid "Fail stats MMU"
 msgstr "Total Fallos MMU"
 
@@ -401,7 +401,7 @@ msgid "F. autoload"
 msgstr "Autocarg.fil."
 
 # MSG_FAIL_STATS c=18
-#: ultralcd.cpp:6751
+#: ultralcd.cpp:6672
 msgid "Fail stats"
 msgstr "Estadistica Fallos"
 
@@ -440,10 +440,10 @@ msgstr "Es nitido el color nuevo?"
 msgid "Filament not loaded"
 msgstr "Fil. no introducido"
 
-# MSG_FILAMENT_SENSOR c=20
+# MSG_SELFTEST_FILAMENT_SENSOR c=17
 #: messages.c:97
 msgid "Filament sensor"
-msgstr "Sensor de filamento"
+msgstr "Sensor de fil."
 
 # MSG_FILAMENT_USED c=19
 #: ultralcd.cpp:2713
@@ -461,7 +461,7 @@ msgid "FS Action"
 msgstr "FS accion"
 
 # MSG_FILE_INCOMPLETE c=20 r=3
-#: ultralcd.cpp:8634
+#: ultralcd.cpp:8555
 msgid "File incomplete. Continue anyway?"
 msgstr "Archivo incompleto. ?Continuar de todos modos?"
 
@@ -486,7 +486,7 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr "Corrige el problema y pulsa el boton en la unidad MMU."
 
 # MSG_FLOW c=15
-#: ultralcd.cpp:6888
+#: ultralcd.cpp:6809
 msgid "Flow"
 msgstr "Flujo"
 
@@ -497,21 +497,21 @@ msgstr "Vent. frontal?"
 
 # MSG_BED_CORRECTION_FRONT c=14
 #: ultralcd.cpp:3116
-msgid "Front side[um]"
-msgstr "Frontal [um]"
+msgid "Front side[μm]"
+msgstr "Frontal [μm]"
 
 # MSG_SELFTEST_FANS c=20
-#: ultralcd.cpp:8179
+#: ultralcd.cpp:8100
 msgid "Front/left fans"
 msgstr "Vents. front/izqui"
 
 # MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ultralcd.cpp:8127
+#: ultralcd.cpp:8048
 msgid "Heater/Thermistor"
 msgstr "Calentador/Termistor"
 
 # MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: Marlin_main.cpp:9874
+#: Marlin_main.cpp:9877
 msgid "Heating disabled by safety timer."
 msgstr "Calentadores desactivados por el temporizador de seguridad."
 
@@ -551,12 +551,12 @@ msgid "Checking bed"
 msgstr "Control base cal."
 
 # MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ultralcd.cpp:8481
+#: ultralcd.cpp:8402
 msgid "Checking endstops"
 msgstr "Control endstops"
 
 # MSG_SELFTEST_CHECK_HOTEND c=20
-#: ultralcd.cpp:8487
+#: ultralcd.cpp:8408
 msgid "Checking hotend"
 msgstr "Control fusor"
 
@@ -576,7 +576,7 @@ msgid "Checking Y axis"
 msgstr "Control sensor Y"
 
 # MSG_SELFTEST_CHECK_Z c=20
-#: ultralcd.cpp:8484
+#: ultralcd.cpp:8405
 msgid "Checking Z axis"
 msgstr "Control sensor Z"
 
@@ -657,8 +657,8 @@ msgstr "Izquierda"
 
 # MSG_BED_CORRECTION_LEFT c=14
 #: ultralcd.cpp:3114
-msgid "Left side [um]"
-msgstr "Izquierda [um]"
+msgid "Left side [μm]"
+msgstr "Izquierda [μm]"
 
 # MSG_LIN_CORRECTION c=18
 #: ultralcd.cpp:5702
@@ -671,7 +671,7 @@ msgid "Live adjust Z"
 msgstr "Micropaso Eje Z"
 
 # MSG_INSERT_FIL c=20 r=6
-#: ultralcd.cpp:7380
+#: ultralcd.cpp:7301
 msgid "Insert the filament (do not load it) into the extruder and then press the knob."
 msgstr "Inserte el filamento (no lo cargue) en el extrusor y luego presione el dial."
 
@@ -696,12 +696,12 @@ msgid "Iteration"
 msgstr "Iteracion"
 
 # MSG_LOOSE_PULLEY c=20
-#: ultralcd.cpp:8167
+#: ultralcd.cpp:8088
 msgid "Loose pulley"
 msgstr "Polea suelta"
 
 # MSG_LOAD_TO_NOZZLE c=18
-#: ultralcd.cpp:6717
+#: ultralcd.cpp:6638
 msgid "Load to nozzle"
 msgstr "Cargar a boquilla"
 
@@ -851,7 +851,7 @@ msgid "No move."
 msgstr "Sin movimiento"
 
 # MSG_NO_CARD c=18
-#: ultralcd.cpp:6697
+#: ultralcd.cpp:6618
 msgid "No SD card"
 msgstr "No hay tarjeta SD"
 
@@ -866,7 +866,7 @@ msgid "No"
 msgstr ""
 
 # MSG_SELFTEST_NOTCONNECTED c=20
-#: ultralcd.cpp:8128
+#: ultralcd.cpp:8049
 msgid "Not connected"
 msgstr "No hay conexion"
 
@@ -951,7 +951,7 @@ msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Limpia boquilla para calibracion. Click cuando acabes."
 
 # MSG_SELFTEST_PLEASECHECK c=20
-#: ultralcd.cpp:8122
+#: ultralcd.cpp:8043
 msgid "Please check:"
 msgstr "Controla:"
 
@@ -1016,7 +1016,7 @@ msgid "Preheat the nozzle!"
 msgstr "Precalienta extrusor"
 
 # MSG_PREHEAT c=18
-#: ultralcd.cpp:6655
+#: ultralcd.cpp:6576
 msgid "Preheat"
 msgstr "Precalentar"
 
@@ -1031,7 +1031,7 @@ msgid "Please upgrade."
 msgstr "Actualize por favor"
 
 # MSG_PRESS_TO_PREHEAT c=20 r=4
-#: Marlin_main.cpp:12049
+#: Marlin_main.cpp:12052
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Pulsa el dial para precalentar la boquilla y continue."
 
@@ -1061,7 +1061,7 @@ msgid "Preheating to unload"
 msgstr "Precalent. descargar"
 
 # MSG_SELFTEST_PRINT_FAN_SPEED c=18
-#: ultralcd.cpp:8501
+#: ultralcd.cpp:8422
 msgid "Print fan:"
 msgstr "Vent.fusor:"
 
@@ -1112,21 +1112,21 @@ msgstr "Por favor, cargar primero el filamento."
 
 # MSG_BED_CORRECTION_REAR c=14
 #: ultralcd.cpp:3117
-msgid "Rear side [um]"
-msgstr "Trasera [um]"
+msgid "Rear side [μm]"
+msgstr "Trasera [μm]"
 
 # MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ultralcd.cpp:7404
+#: ultralcd.cpp:7325
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Primero descargue el filamento, luego repita esta accion."
 
 # MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ultralcd.cpp:7407
+#: ultralcd.cpp:7328
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "Por favor comprueba la conexion del IR sensor y filamento esta descargado."
 
 # MSG_RECOVERING_PRINT c=20
-#: Marlin_main.cpp:11393
+#: Marlin_main.cpp:11396
 msgid "Recovering print"
 msgstr "Recuper. impresion"
 
@@ -1157,8 +1157,8 @@ msgstr "Continuan. impresion"
 
 # MSG_BED_CORRECTION_RIGHT c=14
 #: ultralcd.cpp:3115
-msgid "Right side[um]"
-msgstr "Derecha [um]"
+msgid "Right side[μm]"
+msgstr "Derecha [μm]"
 
 # MSG_RPI_PORT c=13
 #: messages.c:142
@@ -1191,12 +1191,12 @@ msgid "Select language"
 msgstr "Cambiar el idioma"
 
 # MSG_SELFTEST_OK c=20
-#: ultralcd.cpp:7679
+#: ultralcd.cpp:7600
 msgid "Self test OK"
 msgstr ""
 
 # MSG_SELFTEST_START c=20
-#: ultralcd.cpp:7447
+#: ultralcd.cpp:7368
 msgid "Self test start"
 msgstr "Iniciar Selftest"
 
@@ -1206,7 +1206,7 @@ msgid "Selftest"
 msgstr ""
 
 # MSG_SELFTEST_ERROR c=20
-#: ultralcd.cpp:8121
+#: ultralcd.cpp:8042
 msgid "Selftest error!"
 msgstr "Error Selftest!"
 
@@ -1306,7 +1306,7 @@ msgid "Once"
 msgstr "Una vez"
 
 # MSG_SPEED c=15
-#: ultralcd.cpp:6882
+#: ultralcd.cpp:6803
 msgid "Speed"
 msgstr "Velocidad"
 
@@ -1336,12 +1336,12 @@ msgid "STOPPED."
 msgstr "PARADA"
 
 # MSG_SUPPORT c=18
-#: ultralcd.cpp:6756
+#: ultralcd.cpp:6677
 msgid "Support"
 msgstr "Soporte"
 
 # MSG_SELFTEST_SWAPPED c=16
-#: ultralcd.cpp:8180
+#: ultralcd.cpp:8101
 msgid "Swapped"
 msgstr "Intercambiado"
 
@@ -1376,7 +1376,7 @@ msgid "Temperature calibration is finished and active. Temp. calibration can be 
 msgstr "Calibracion temperatura terminada. Haz clic para continuar."
 
 # MSG_FS_VERIFIED c=20 r=3
-#: ultralcd.cpp:7411
+#: ultralcd.cpp:7332
 msgid "Sensor verified, remove the filament now."
 msgstr "Sensor verificado, retire el filamento ahora."
 
@@ -1406,7 +1406,7 @@ msgid "Total print time"
 msgstr "Tiempo total"
 
 # MSG_TUNE c=18
-#: ultralcd.cpp:6653
+#: ultralcd.cpp:6574
 msgid "Tune"
 msgstr "Ajustar"
 
@@ -1425,7 +1425,7 @@ msgstr "para cargar el fil."
 msgid "to unload filament"
 msgstr "para descargar fil."
 
-# MSG_UNLOAD_FILAMENT c=16
+# MSG_UNLOAD_FILAMENT c=18
 #: messages.c:114
 msgid "Unload filament"
 msgstr "Soltar filamento"
@@ -1510,7 +1510,7 @@ msgstr "Detalles cal. XYZ"
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "Calibracion XYZ fallada. Consulta el manual por favor."
 
-# MSG_YES c=3
+# MSG_YES c=4
 #: messages.c:123
 msgid "Yes"
 msgstr "Si"
@@ -1586,7 +1586,7 @@ msgid "The printer will start printing a zig-zag line. Rotate the knob until you
 msgstr "La impresora comenzara a imprimir una linea en zig-zag. Gira el dial hasta que la linea alcance la altura optima. Mira las fotos del manual (Capitulo de calibracion)."
 
 # MSG_FIL_FAILED c=20 r=5
-#: ultralcd.cpp:7415
+#: ultralcd.cpp:7336
 msgid "Verification failed, remove the filament and try again."
 msgstr "La verificacion fallo, retire el filamento e intente nuevamente."
 
@@ -1616,7 +1616,7 @@ msgid "Checks"
 msgstr "Comprobaciones"
 
 # MSG_FALSE_TRIGGERING c=20
-#: ultralcd.cpp:8190
+#: ultralcd.cpp:8111
 msgid "False triggering"
 msgstr "Falsa activacion"
 
@@ -1721,17 +1721,17 @@ msgid "Printer nozzle diameter differs from the G-code. Please check the value i
 msgstr "Diametro nozzle Impresora difiere de cod.G. Comprueba los valores en ajustes. Impresion cancelada."
 
 # MSG_SELFTEST_FS_LEVEL c=20
-#: ultralcd.cpp:8195
+#: ultralcd.cpp:8116
 msgid "%s level expected"
 msgstr "%s nivel esperado"
 
 # MSG_RENAME c=18
-#: ultralcd.cpp:6579
+#: ultralcd.cpp:6500
 msgid "Rename"
 msgstr "Renombrar"
 
 # MSG_SELECT c=18
-#: ultralcd.cpp:6572
+#: ultralcd.cpp:6493
 msgid "Select"
 msgstr "Seleccionar"
 

--- a/lang/po/Firmware_fr.po
+++ b/lang/po/Firmware_fr.po
@@ -7,8 +7,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: fr\n"
 "Project-Id-Version: Prusa-Firmware\n"
-"POT-Creation-Date: Sun 19 Dec 2021 07:17:34 PM CET\n"
-"PO-Revision-Date: Sun 19 Dec 2021 07:17:34 PM CET\n"
+"POT-Creation-Date: Tue 08 Feb 2022 02:44:25 PM CET\n"
+"PO-Revision-Date: Tue 08 Feb 2022 02:44:25 PM CET\n"
 "Language-Team: \n"
 "X-Generator: Poedit 2.0.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
@@ -21,7 +21,7 @@ msgid " 0.3 or older"
 msgstr " 0.3 ou +ancien"
 
 # MSG_FS_V_03_OR_OLDER c=18
-#: Marlin_main.cpp:9884
+#: Marlin_main.cpp:9887
 msgid "FS v0.3 or older"
 msgstr "FS v0.3 ou +ancien"
 
@@ -31,7 +31,7 @@ msgid " 0.4 or newer"
 msgstr " 0.4 ou +recent"
 
 # MSG_FS_V_04_OR_NEWER c=18
-#: Marlin_main.cpp:9883
+#: Marlin_main.cpp:9886
 msgid "FS v0.4 or newer"
 msgstr "FS v0.4 ou +recent"
 
@@ -61,11 +61,11 @@ msgid "Adjusting Z:"
 msgstr "Ajuster Z:"
 
 # MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ultralcd.cpp:8490
+#: ultralcd.cpp:8411
 msgid "All correct"
 msgstr "Tout est correct"
 
-# MSG_WIZARD_DONE c=20 r=8
+# MSG_WIZARD_DONE c=20 r=3
 #: messages.c:118
 msgid "All is done. Happy printing!"
 msgstr "Tout est pret. Bonne impression!"
@@ -96,7 +96,7 @@ msgid "Auto home"
 msgstr "Mise a 0 des axes"
 
 # MSG_AUTOLOAD_FILAMENT c=18
-#: ultralcd.cpp:6732
+#: ultralcd.cpp:6653
 msgid "AutoLoad filament"
 msgstr "Autocharge du fil."
 
@@ -111,17 +111,17 @@ msgid "Autoloading filament is active, just press the knob and insert filament..
 msgstr "Chargement auto. du fil. active, appuyez sur le bouton et inserez le fil."
 
 # MSG_SELFTEST_AXIS_LENGTH c=20
-#: ultralcd.cpp:8173
+#: ultralcd.cpp:8094
 msgid "Axis length"
 msgstr "Longueur de l'axe"
 
 # MSG_SELFTEST_AXIS c=16
-#: ultralcd.cpp:8174
+#: ultralcd.cpp:8095
 msgid "Axis"
 msgstr "Axe"
 
 # MSG_SELFTEST_BEDHEATER c=20
-#: ultralcd.cpp:8131
+#: ultralcd.cpp:8052
 msgid "Bed/Heater"
 msgstr "Lit/Chauffage"
 
@@ -176,7 +176,7 @@ msgid "Blackout occurred. Recover print?"
 msgstr "Coupure detectee. Reprendre impres.?"
 
 # MSG_CALIBRATING_HOME c=20
-#: ultralcd.cpp:8492
+#: ultralcd.cpp:8413
 msgid "Calibrating home"
 msgstr "Calib. mise a 0"
 
@@ -226,12 +226,12 @@ msgid "Calibration"
 msgstr ""
 
 # MSG_SD_REMOVED c=20
-#: ultralcd.cpp:8939
+#: ultralcd.cpp:8860
 msgid "Card removed"
 msgstr "Carte retiree"
 
 # MSG_CHECKING_FILE c=17
-#: ultralcd.cpp:8580
+#: ultralcd.cpp:8501
 msgid "Checking file"
 msgstr "Verific. fichier"
 
@@ -326,17 +326,17 @@ msgid "Ejecting filament"
 msgstr "Le fil. remonte"
 
 # MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ultralcd.cpp:8149
+#: ultralcd.cpp:8070
 msgid "Endstop not hit"
 msgstr "Butee non atteinte"
 
 # MSG_SELFTEST_ENDSTOP c=16
-#: ultralcd.cpp:8144
+#: ultralcd.cpp:8065
 msgid "Endstop"
 msgstr "Butee"
 
 # MSG_SELFTEST_ENDSTOPS c=20
-#: ultralcd.cpp:8135
+#: ultralcd.cpp:8056
 msgid "Endstops"
 msgstr "Butees"
 
@@ -376,7 +376,7 @@ msgid "ERROR:"
 msgstr "ERREUR:"
 
 # MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
-#: ultralcd.cpp:8498
+#: ultralcd.cpp:8419
 msgid "Extruder fan:"
 msgstr "Ventilo extrudeur:"
 
@@ -391,7 +391,7 @@ msgid "Extruder"
 msgstr "Extrudeur"
 
 # MSG_MMU_FAIL_STATS c=18
-#: ultralcd.cpp:6754
+#: ultralcd.cpp:6675
 msgid "Fail stats MMU"
 msgstr "Stat. d'echec MMU"
 
@@ -401,7 +401,7 @@ msgid "F. autoload"
 msgstr "F. autocharg."
 
 # MSG_FAIL_STATS c=18
-#: ultralcd.cpp:6751
+#: ultralcd.cpp:6672
 msgid "Fail stats"
 msgstr "Stat. d'echec"
 
@@ -440,10 +440,10 @@ msgstr "Filament extrude et avec bonne couleur?"
 msgid "Filament not loaded"
 msgstr "Filament non charge"
 
-# MSG_FILAMENT_SENSOR c=20
+# MSG_SELFTEST_FILAMENT_SENSOR c=17
 #: messages.c:97
 msgid "Filament sensor"
-msgstr "Capteur de filament"
+msgstr "Capteur de fil."
 
 # MSG_FILAMENT_USED c=19
 #: ultralcd.cpp:2713
@@ -461,7 +461,7 @@ msgid "FS Action"
 msgstr ""
 
 # MSG_FILE_INCOMPLETE c=20 r=3
-#: ultralcd.cpp:8634
+#: ultralcd.cpp:8555
 msgid "File incomplete. Continue anyway?"
 msgstr "Fichier incomplet. Continuer qd meme?"
 
@@ -486,7 +486,7 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr "Corrigez le probleme et appuyez sur le bouton sur la MMU."
 
 # MSG_FLOW c=15
-#: ultralcd.cpp:6888
+#: ultralcd.cpp:6809
 msgid "Flow"
 msgstr "Flux"
 
@@ -497,21 +497,21 @@ msgstr "Ventilo impr avant?"
 
 # MSG_BED_CORRECTION_FRONT c=14
 #: ultralcd.cpp:3116
-msgid "Front side[um]"
-msgstr "Avant [um]"
+msgid "Front side[μm]"
+msgstr "Avant [μm]"
 
 # MSG_SELFTEST_FANS c=20
-#: ultralcd.cpp:8179
+#: ultralcd.cpp:8100
 msgid "Front/left fans"
 msgstr "Ventilos avt/gauche"
 
 # MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ultralcd.cpp:8127
+#: ultralcd.cpp:8048
 msgid "Heater/Thermistor"
 msgstr "Chauffage/Thermistor"
 
 # MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: Marlin_main.cpp:9874
+#: Marlin_main.cpp:9877
 msgid "Heating disabled by safety timer."
 msgstr "Chauffage desactivee par le compteur de securite."
 
@@ -551,12 +551,12 @@ msgid "Checking bed"
 msgstr "Verif. plateau chauf"
 
 # MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ultralcd.cpp:8481
+#: ultralcd.cpp:8402
 msgid "Checking endstops"
 msgstr "Verification butees"
 
 # MSG_SELFTEST_CHECK_HOTEND c=20
-#: ultralcd.cpp:8487
+#: ultralcd.cpp:8408
 msgid "Checking hotend"
 msgstr "Verif. du hotend"
 
@@ -576,7 +576,7 @@ msgid "Checking Y axis"
 msgstr "Verification axe Y"
 
 # MSG_SELFTEST_CHECK_Z c=20
-#: ultralcd.cpp:8484
+#: ultralcd.cpp:8405
 msgid "Checking Z axis"
 msgstr "Verification axe Z"
 
@@ -657,8 +657,8 @@ msgstr "Gauche"
 
 # MSG_BED_CORRECTION_LEFT c=14
 #: ultralcd.cpp:3114
-msgid "Left side [um]"
-msgstr "Gauche [um]"
+msgid "Left side [μm]"
+msgstr "Gauche [μm]"
 
 # MSG_LIN_CORRECTION c=18
 #: ultralcd.cpp:5702
@@ -671,7 +671,7 @@ msgid "Live adjust Z"
 msgstr "Ajuster Z en dir."
 
 # MSG_INSERT_FIL c=20 r=6
-#: ultralcd.cpp:7380
+#: ultralcd.cpp:7301
 msgid "Insert the filament (do not load it) into the extruder and then press the knob."
 msgstr "Veuillez inserer le filament ( ne le chargez pas) dans l'extrudeur, puis appuyez sur le bouton."
 
@@ -696,12 +696,12 @@ msgid "Iteration"
 msgstr ""
 
 # MSG_LOOSE_PULLEY c=20
-#: ultralcd.cpp:8167
+#: ultralcd.cpp:8088
 msgid "Loose pulley"
 msgstr "Poulie lache"
 
 # MSG_LOAD_TO_NOZZLE c=18
-#: ultralcd.cpp:6717
+#: ultralcd.cpp:6638
 msgid "Load to nozzle"
 msgstr "Charger la buse"
 
@@ -851,7 +851,7 @@ msgid "No move."
 msgstr "Pas de mouvement."
 
 # MSG_NO_CARD c=18
-#: ultralcd.cpp:6697
+#: ultralcd.cpp:6618
 msgid "No SD card"
 msgstr "Pas de carte SD"
 
@@ -866,7 +866,7 @@ msgid "No"
 msgstr "Non"
 
 # MSG_SELFTEST_NOTCONNECTED c=20
-#: ultralcd.cpp:8128
+#: ultralcd.cpp:8049
 msgid "Not connected"
 msgstr "Non connecte"
 
@@ -951,7 +951,7 @@ msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Nettoyez la buse pour la calibration. Cliquez une fois fait."
 
 # MSG_SELFTEST_PLEASECHECK c=20
-#: ultralcd.cpp:8122
+#: ultralcd.cpp:8043
 msgid "Please check:"
 msgstr "Verifiez:"
 
@@ -1016,7 +1016,7 @@ msgid "Preheat the nozzle!"
 msgstr "Prechauffez la buse!"
 
 # MSG_PREHEAT c=18
-#: ultralcd.cpp:6655
+#: ultralcd.cpp:6576
 msgid "Preheat"
 msgstr "Prechauffage"
 
@@ -1031,7 +1031,7 @@ msgid "Please upgrade."
 msgstr "Mettez a jour le FW."
 
 # MSG_PRESS_TO_PREHEAT c=20 r=4
-#: Marlin_main.cpp:12049
+#: Marlin_main.cpp:12052
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Appuyez sur le bouton pour prechauffer la buse et continuer."
 
@@ -1061,7 +1061,7 @@ msgid "Preheating to unload"
 msgstr "Chauf.pour decharger"
 
 # MSG_SELFTEST_PRINT_FAN_SPEED c=18
-#: ultralcd.cpp:8501
+#: ultralcd.cpp:8422
 msgid "Print fan:"
 msgstr "Vent. impr:"
 
@@ -1112,21 +1112,21 @@ msgstr "Veuillez d'abord charger un filament."
 
 # MSG_BED_CORRECTION_REAR c=14
 #: ultralcd.cpp:3117
-msgid "Rear side [um]"
-msgstr "Arriere [um]"
+msgid "Rear side [μm]"
+msgstr "Arriere [μm]"
 
 # MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ultralcd.cpp:7404
+#: ultralcd.cpp:7325
 msgid "Please unload the filament first, then repeat this action."
 msgstr "SVP, dechargez le filament et reessayez."
 
 # MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ultralcd.cpp:7407
+#: ultralcd.cpp:7328
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "SVP, verifiez la connexion du capteur IR et decharge le filament."
 
 # MSG_RECOVERING_PRINT c=20
-#: Marlin_main.cpp:11393
+#: Marlin_main.cpp:11396
 msgid "Recovering print"
 msgstr "Recup. impression"
 
@@ -1157,8 +1157,8 @@ msgstr "Reprise de l'impr."
 
 # MSG_BED_CORRECTION_RIGHT c=14
 #: ultralcd.cpp:3115
-msgid "Right side[um]"
-msgstr "Droite [um]"
+msgid "Right side[μm]"
+msgstr "Droite [μm]"
 
 # MSG_RPI_PORT c=13
 #: messages.c:142
@@ -1191,12 +1191,12 @@ msgid "Select language"
 msgstr "Choisir langue"
 
 # MSG_SELFTEST_OK c=20
-#: ultralcd.cpp:7679
+#: ultralcd.cpp:7600
 msgid "Self test OK"
 msgstr "Auto-test OK"
 
 # MSG_SELFTEST_START c=20
-#: ultralcd.cpp:7447
+#: ultralcd.cpp:7368
 msgid "Self test start"
 msgstr "Debut auto-test"
 
@@ -1206,7 +1206,7 @@ msgid "Selftest"
 msgstr "Auto-test"
 
 # MSG_SELFTEST_ERROR c=20
-#: ultralcd.cpp:8121
+#: ultralcd.cpp:8042
 msgid "Selftest error!"
 msgstr "Erreur auto-test!"
 
@@ -1306,7 +1306,7 @@ msgid "Once"
 msgstr "1 fois"
 
 # MSG_SPEED c=15
-#: ultralcd.cpp:6882
+#: ultralcd.cpp:6803
 msgid "Speed"
 msgstr "Vitesse"
 
@@ -1336,12 +1336,12 @@ msgid "STOPPED."
 msgstr "ARRETE."
 
 # MSG_SUPPORT c=18
-#: ultralcd.cpp:6756
+#: ultralcd.cpp:6677
 msgid "Support"
 msgstr ""
 
 # MSG_SELFTEST_SWAPPED c=16
-#: ultralcd.cpp:8180
+#: ultralcd.cpp:8101
 msgid "Swapped"
 msgstr "Echange"
 
@@ -1376,7 +1376,7 @@ msgid "Temperature calibration is finished and active. Temp. calibration can be 
 msgstr "La calibration en temperature est terminee et activee. La calibration en temperature peut etre desactivee dans le menu Reglages-> Cal. Temp."
 
 # MSG_FS_VERIFIED c=20 r=3
-#: ultralcd.cpp:7411
+#: ultralcd.cpp:7332
 msgid "Sensor verified, remove the filament now."
 msgstr "Capteur verifie, retirez le filament maintenant."
 
@@ -1406,7 +1406,7 @@ msgid "Total print time"
 msgstr "Temps total impr."
 
 # MSG_TUNE c=18
-#: ultralcd.cpp:6653
+#: ultralcd.cpp:6574
 msgid "Tune"
 msgstr "Regler"
 
@@ -1425,7 +1425,7 @@ msgstr "pour charger le fil."
 msgid "to unload filament"
 msgstr "pour decharger fil."
 
-# MSG_UNLOAD_FILAMENT c=16
+# MSG_UNLOAD_FILAMENT c=18
 #: messages.c:114
 msgid "Unload filament"
 msgstr "Decharger fil."
@@ -1510,7 +1510,7 @@ msgstr "Details calib. XYZ"
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "Echec calibration XYZ. Consultez le manuel."
 
-# MSG_YES c=3
+# MSG_YES c=4
 #: messages.c:123
 msgid "Yes"
 msgstr "Oui"
@@ -1586,7 +1586,7 @@ msgid "The printer will start printing a zig-zag line. Rotate the knob until you
 msgstr "L'imprimante commencera a  imprimer une ligne en zig-zag. Tournez le bouton jusqu'a atteindre la hauteur optimale. Consultez les photos dans le manuel (chapitre Calibration)."
 
 # MSG_FIL_FAILED c=20 r=5
-#: ultralcd.cpp:7415
+#: ultralcd.cpp:7336
 msgid "Verification failed, remove the filament and try again."
 msgstr "Verification en echec, retirez le filament et reessayez."
 
@@ -1616,7 +1616,7 @@ msgid "Checks"
 msgstr "Verifications"
 
 # MSG_FALSE_TRIGGERING c=20
-#: ultralcd.cpp:8190
+#: ultralcd.cpp:8111
 msgid "False triggering"
 msgstr "Faux declenchement"
 
@@ -1721,17 +1721,17 @@ msgid "Printer nozzle diameter differs from the G-code. Please check the value i
 msgstr "Diametre de la buse dans les reglages ne correspond pas a celui dans le G-Code. Merci de verifier le parametre dans les reglages. Impression annulee."
 
 # MSG_SELFTEST_FS_LEVEL c=20
-#: ultralcd.cpp:8195
+#: ultralcd.cpp:8116
 msgid "%s level expected"
 msgstr "niveau %s attendu"
 
 # MSG_RENAME c=18
-#: ultralcd.cpp:6579
+#: ultralcd.cpp:6500
 msgid "Rename"
 msgstr "Renommer"
 
 # MSG_SELECT c=18
-#: ultralcd.cpp:6572
+#: ultralcd.cpp:6493
 msgid "Select"
 msgstr "Selectionner"
 

--- a/lang/po/Firmware_hr.po
+++ b/lang/po/Firmware_hr.po
@@ -7,8 +7,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: hr\n"
 "Project-Id-Version: Prusa-Firmware\n"
-"POT-Creation-Date: Tue 01 Feb 2022 07:01:16 AM PST\n"
-"PO-Revision-Date: Tue 01 Feb 2022 07:01:16 AM PST\n"
+"POT-Creation-Date: Tue 08 Feb 2022 02:44:49 PM CET\n"
+"PO-Revision-Date: Tue 08 Feb 2022 02:44:49 PM CET\n"
 "Language-Team: \n"
 "X-Generator: Poedit 2.0.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
@@ -65,7 +65,7 @@ msgstr "Podesavanje Z:"
 msgid "All correct"
 msgstr "Sve je u redu"
 
-# MSG_WIZARD_DONE c=20 r=8
+# MSG_WIZARD_DONE c=20 r=3
 #: messages.c:118
 msgid "All is done. Happy printing!"
 msgstr "Sve je gotovo. Sretno printanje!"
@@ -408,7 +408,7 @@ msgstr "Neuspjesna stat"
 # MSG_FAN_SPEED c=14
 #: messages.c:36
 msgid "Fan speed"
-msgstr "Brzina vent."
+msgstr "Brzina vent"
 
 # MSG_SELFTEST_FAN c=20
 #: messages.c:91
@@ -418,7 +418,7 @@ msgstr "Test ventilatora"
 # MSG_FANS_CHECK c=13
 #: messages.c:33
 msgid "Fans check"
-msgstr "Provjera fana"
+msgstr "Provjera vent"
 
 # MSG_FSENSOR c=12
 #: messages.c:49
@@ -440,7 +440,7 @@ msgstr "Ekstrudiranje fil.s sa ispravnom bojom?"
 msgid "Filament not loaded"
 msgstr "Fil. nije napunjen"
 
-# MSG_FILAMENT_SENSOR c=20
+# MSG_SELFTEST_FILAMENT_SENSOR c=17
 #: messages.c:97
 msgid "Filament sensor"
 msgstr "Senzor filamenta"
@@ -497,13 +497,13 @@ msgstr "Prednji print vent?"
 
 # MSG_BED_CORRECTION_FRONT c=14
 #: ultralcd.cpp:3116
-msgid "Front side[um]"
-msgstr "Prednj str[um]"
+msgid "Front side[μm]"
+msgstr "Prednj str[μm]"
 
 # MSG_SELFTEST_FANS c=20
 #: ultralcd.cpp:8100
 msgid "Front/left fans"
-msgstr "Prednji/lijevi vent."
+msgstr "Prednji/lijevi vent"
 
 # MSG_SELFTEST_HEATERTHERMISTOR c=20
 #: ultralcd.cpp:8048
@@ -657,8 +657,8 @@ msgstr "Lijevo"
 
 # MSG_BED_CORRECTION_LEFT c=14
 #: ultralcd.cpp:3114
-msgid "Left side [um]"
-msgstr "Lijeva str[um]"
+msgid "Left side [μm]"
+msgstr "Lijeva str[μm]"
 
 # MSG_LIN_CORRECTION c=18
 #: ultralcd.cpp:5702
@@ -908,7 +908,7 @@ msgstr "Sada uklonite probni print sa celicne ploce."
 # MSG_NOZZLE_FAN c=10
 #: ultralcd.cpp:1446
 msgid "Nozzle FAN"
-msgstr "vent mlazn"
+msgstr "Fan mlazn"
 
 # MSG_PAUSE_PRINT c=18
 #: messages.c:74
@@ -1093,7 +1093,7 @@ msgstr "Printer jos nije kalibriran. Molimo slijedite prirucnik, poglavlje Prvi 
 # MSG_PRINT_FAN c=10
 #: ultralcd.cpp:1447
 msgid "Print FAN"
-msgstr "Print vent"
+msgstr ""
 
 # MSG_WIZARD_LOAD_FILAMENT c=20 r=6
 #: ultralcd.cpp:4818
@@ -1112,8 +1112,8 @@ msgstr "Molimo prvo ubacite filament."
 
 # MSG_BED_CORRECTION_REAR c=14
 #: ultralcd.cpp:3117
-msgid "Rear side [um]"
-msgstr "Zad. str.[um]"
+msgid "Rear side [μm]"
+msgstr "Zad. str.[μm]"
 
 # MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
 #: ultralcd.cpp:7325
@@ -1157,8 +1157,8 @@ msgstr "Nastavak printa"
 
 # MSG_BED_CORRECTION_RIGHT c=14
 #: ultralcd.cpp:3115
-msgid "Right side[um]"
-msgstr "Desna str.[um]"
+msgid "Right side[μm]"
+msgstr "Desna str.[μm]"
 
 # MSG_RPI_PORT c=13
 #: messages.c:142
@@ -1510,7 +1510,7 @@ msgstr "XYZ detalji kal"
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "XYZ kalibracija nije uspjela. Molimo pogledajte prirucnik."
 
-# MSG_YES c=3
+# MSG_YES c=4
 #: messages.c:123
 msgid "Yes"
 msgstr "Da"
@@ -1708,7 +1708,7 @@ msgstr "Predgr. za rezanje"
 # MSG_PREHEATING_TO_EJECT c=20
 #: ultralcd.cpp:2306
 msgid "Preheating to eject"
-msgstr "Predgr. za izbaciv."
+msgstr "Predgr. za izbaci."
 
 # MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=5
 #: util.cpp:294

--- a/lang/po/Firmware_hu.po
+++ b/lang/po/Firmware_hu.po
@@ -7,8 +7,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: hu\n"
 "Project-Id-Version: Prusa-Firmware\n"
-"POT-Creation-Date: Ut 18. január 2022, 13:48:40 CET\n"
-"PO-Revision-Date: Ut 18. január 2022, 13:48:40 CET\n"
+"POT-Creation-Date: Tue 08 Feb 2022 02:44:44 PM CET\n"
+"PO-Revision-Date: Tue 08 Feb 2022 02:44:44 PM CET\n"
 "Language-Team: \n"
 "X-Generator: Poedit 2.0.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
@@ -65,7 +65,7 @@ msgstr "Z allitasa:"
 msgid "All correct"
 msgstr "Minden rendben"
 
-# MSG_WIZARD_DONE c=20 r=8
+# MSG_WIZARD_DONE c=20 r=3
 #: messages.c:118
 msgid "All is done. Happy printing!"
 msgstr "Keszen vagyunk. Jo nyomtatast!"
@@ -497,8 +497,8 @@ msgstr "Elso targyhuto vent?"
 
 # MSG_BED_CORRECTION_FRONT c=14
 #: ultralcd.cpp:3116
-msgid "Front side[um]"
-msgstr "Elulso old[um]"
+msgid "Front side[μm]"
+msgstr "Elulso old[μm]"
 
 # MSG_SELFTEST_FANS c=20
 #: ultralcd.cpp:8100
@@ -657,8 +657,8 @@ msgstr "Bal"
 
 # MSG_BED_CORRECTION_LEFT c=14
 #: ultralcd.cpp:3114
-msgid "Left side [um]"
-msgstr "Bal [um]"
+msgid "Left side [μm]"
+msgstr "Bal [μm]"
 
 # MSG_LIN_CORRECTION c=18
 #: ultralcd.cpp:5702
@@ -1112,8 +1112,8 @@ msgstr "Kerlek eloszor toltsd be a filamentet."
 
 # MSG_BED_CORRECTION_REAR c=14
 #: ultralcd.cpp:3117
-msgid "Rear side [um]"
-msgstr "Hatso old.[um]"
+msgid "Rear side [μm]"
+msgstr "Hatso old.[μm]"
 
 # MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
 #: ultralcd.cpp:7325
@@ -1157,8 +1157,8 @@ msgstr "Nyomtatas folytatasa"
 
 # MSG_BED_CORRECTION_RIGHT c=14
 #: ultralcd.cpp:3115
-msgid "Right side[um]"
-msgstr "Jobb old.[um]"
+msgid "Right side[μm]"
+msgstr "Jobb old.[μm]"
 
 # MSG_RPI_PORT c=13
 #: messages.c:142
@@ -1510,7 +1510,7 @@ msgstr "XYZ kal. reszlet"
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "XYZ kalibracio sikertelen. Kerlek, nezz bele a kezikonyvbe."
 
-# MSG_YES c=3
+# MSG_YES c=4
 #: messages.c:123
 msgid "Yes"
 msgstr "Igen"

--- a/lang/po/Firmware_it.po
+++ b/lang/po/Firmware_it.po
@@ -7,8 +7,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: it\n"
 "Project-Id-Version: Prusa-Firmware\n"
-"POT-Creation-Date: Sun 19 Dec 2021 07:17:37 PM CET\n"
-"PO-Revision-Date: Sun 19 Dec 2021 07:17:37 PM CET\n"
+"POT-Creation-Date: Tue 08 Feb 2022 02:44:29 PM CET\n"
+"PO-Revision-Date: Tue 08 Feb 2022 02:44:29 PM CET\n"
 "Language-Team: \n"
 "X-Generator: Poedit 2.0.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
@@ -21,7 +21,7 @@ msgid " 0.3 or older"
 msgstr " 0.3 o inferiore"
 
 # MSG_FS_V_03_OR_OLDER c=18
-#: Marlin_main.cpp:9884
+#: Marlin_main.cpp:9887
 msgid "FS v0.3 or older"
 msgstr "FS 0.3 o inferiore"
 
@@ -31,7 +31,7 @@ msgid " 0.4 or newer"
 msgstr " 0.4 o superiore"
 
 # MSG_FS_V_04_OR_NEWER c=18
-#: Marlin_main.cpp:9883
+#: Marlin_main.cpp:9886
 msgid "FS v0.4 or newer"
 msgstr "FS 0.4 o superiore"
 
@@ -61,11 +61,11 @@ msgid "Adjusting Z:"
 msgstr "Compensaz. Z:"
 
 # MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ultralcd.cpp:8490
+#: ultralcd.cpp:8411
 msgid "All correct"
 msgstr "Nessun errore"
 
-# MSG_WIZARD_DONE c=20 r=8
+# MSG_WIZARD_DONE c=20 r=3
 #: messages.c:118
 msgid "All is done. Happy printing!"
 msgstr "Tutto fatto. Buona stampa!"
@@ -96,7 +96,7 @@ msgid "Auto home"
 msgstr "Trova origine"
 
 # MSG_AUTOLOAD_FILAMENT c=18
-#: ultralcd.cpp:6732
+#: ultralcd.cpp:6653
 msgid "AutoLoad filament"
 msgstr "Autocaric. filam."
 
@@ -111,17 +111,17 @@ msgid "Autoloading filament is active, just press the knob and insert filament..
 msgstr "Caricamento automatico attivo, premi la manopola e inserisci il filam."
 
 # MSG_SELFTEST_AXIS_LENGTH c=20
-#: ultralcd.cpp:8173
+#: ultralcd.cpp:8094
 msgid "Axis length"
 msgstr "Lunghezza dell'asse"
 
 # MSG_SELFTEST_AXIS c=16
-#: ultralcd.cpp:8174
+#: ultralcd.cpp:8095
 msgid "Axis"
 msgstr "Assi"
 
 # MSG_SELFTEST_BEDHEATER c=20
-#: ultralcd.cpp:8131
+#: ultralcd.cpp:8052
 msgid "Bed/Heater"
 msgstr "Piano/Riscald."
 
@@ -176,7 +176,7 @@ msgid "Blackout occurred. Recover print?"
 msgstr "Blackout rilevato. Recuperare stampa?"
 
 # MSG_CALIBRATING_HOME c=20
-#: ultralcd.cpp:8492
+#: ultralcd.cpp:8413
 msgid "Calibrating home"
 msgstr "Calibrazione Home"
 
@@ -226,12 +226,12 @@ msgid "Calibration"
 msgstr "Calibrazione"
 
 # MSG_SD_REMOVED c=20
-#: ultralcd.cpp:8939
+#: ultralcd.cpp:8860
 msgid "Card removed"
 msgstr "SD rimossa"
 
 # MSG_CHECKING_FILE c=17
-#: ultralcd.cpp:8580
+#: ultralcd.cpp:8501
 msgid "Checking file"
 msgstr "Verifica file"
 
@@ -326,17 +326,17 @@ msgid "Ejecting filament"
 msgstr "Espellendo filamento"
 
 # MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ultralcd.cpp:8149
+#: ultralcd.cpp:8070
 msgid "Endstop not hit"
 msgstr "Finec. fuori portata"
 
 # MSG_SELFTEST_ENDSTOP c=16
-#: ultralcd.cpp:8144
+#: ultralcd.cpp:8065
 msgid "Endstop"
 msgstr "Finecorsa"
 
 # MSG_SELFTEST_ENDSTOPS c=20
-#: ultralcd.cpp:8135
+#: ultralcd.cpp:8056
 msgid "Endstops"
 msgstr "Finecorsa"
 
@@ -376,7 +376,7 @@ msgid "ERROR:"
 msgstr "ERRORE:"
 
 # MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
-#: ultralcd.cpp:8498
+#: ultralcd.cpp:8419
 msgid "Extruder fan:"
 msgstr "Ventola estrusore:"
 
@@ -391,7 +391,7 @@ msgid "Extruder"
 msgstr "Estrusore"
 
 # MSG_MMU_FAIL_STATS c=18
-#: ultralcd.cpp:6754
+#: ultralcd.cpp:6675
 msgid "Fail stats MMU"
 msgstr "Stat.fall. MMU"
 
@@ -401,7 +401,7 @@ msgid "F. autoload"
 msgstr "Autocar.fil."
 
 # MSG_FAIL_STATS c=18
-#: ultralcd.cpp:6751
+#: ultralcd.cpp:6672
 msgid "Fail stats"
 msgstr "Stat. fallimenti"
 
@@ -440,7 +440,7 @@ msgstr "Filamento estruso e con colore corretto?"
 msgid "Filament not loaded"
 msgstr "Fil. non caricato"
 
-# MSG_FILAMENT_SENSOR c=20
+# MSG_SELFTEST_FILAMENT_SENSOR c=17
 #: messages.c:97
 msgid "Filament sensor"
 msgstr "Sensore filam."
@@ -461,7 +461,7 @@ msgid "FS Action"
 msgstr "Azione FS"
 
 # MSG_FILE_INCOMPLETE c=20 r=3
-#: ultralcd.cpp:8634
+#: ultralcd.cpp:8555
 msgid "File incomplete. Continue anyway?"
 msgstr "File incompleto. Continuare comunque?"
 
@@ -486,7 +486,7 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr "Risolvere il problema e premere il bottone sull'unita MMU."
 
 # MSG_FLOW c=15
-#: ultralcd.cpp:6888
+#: ultralcd.cpp:6809
 msgid "Flow"
 msgstr "Flusso"
 
@@ -497,21 +497,21 @@ msgstr "Ventola frontale?"
 
 # MSG_BED_CORRECTION_FRONT c=14
 #: ultralcd.cpp:3116
-msgid "Front side[um]"
-msgstr "Fronte [um]"
+msgid "Front side[μm]"
+msgstr "Fronte [μm]"
 
 # MSG_SELFTEST_FANS c=20
-#: ultralcd.cpp:8179
+#: ultralcd.cpp:8100
 msgid "Front/left fans"
 msgstr "Ventola frontale/sin"
 
 # MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ultralcd.cpp:8127
+#: ultralcd.cpp:8048
 msgid "Heater/Thermistor"
 msgstr "Riscald./Termist."
 
 # MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: Marlin_main.cpp:9874
+#: Marlin_main.cpp:9877
 msgid "Heating disabled by safety timer."
 msgstr "Riscaldamento fermato dal timer di sicurezza."
 
@@ -551,12 +551,12 @@ msgid "Checking bed"
 msgstr "Verifica piano"
 
 # MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ultralcd.cpp:8481
+#: ultralcd.cpp:8402
 msgid "Checking endstops"
 msgstr "Verifica finecorsa"
 
 # MSG_SELFTEST_CHECK_HOTEND c=20
-#: ultralcd.cpp:8487
+#: ultralcd.cpp:8408
 msgid "Checking hotend"
 msgstr "Verifica ugello"
 
@@ -576,7 +576,7 @@ msgid "Checking Y axis"
 msgstr "Verifica asse Y"
 
 # MSG_SELFTEST_CHECK_Z c=20
-#: ultralcd.cpp:8484
+#: ultralcd.cpp:8405
 msgid "Checking Z axis"
 msgstr "Verifica asse Z"
 
@@ -657,8 +657,8 @@ msgstr "Sinistra"
 
 # MSG_BED_CORRECTION_LEFT c=14
 #: ultralcd.cpp:3114
-msgid "Left side [um]"
-msgstr "Sinistra [um]"
+msgid "Left side [μm]"
+msgstr "Sinistra [μm]"
 
 # MSG_LIN_CORRECTION c=18
 #: ultralcd.cpp:5702
@@ -671,7 +671,7 @@ msgid "Live adjust Z"
 msgstr "Compensazione Z"
 
 # MSG_INSERT_FIL c=20 r=6
-#: ultralcd.cpp:7380
+#: ultralcd.cpp:7301
 msgid "Insert the filament (do not load it) into the extruder and then press the knob."
 msgstr "Inserire filamento (senza caricarlo) nell'estrusore e premere la manopola."
 
@@ -696,12 +696,12 @@ msgid "Iteration"
 msgstr "Iterazione"
 
 # MSG_LOOSE_PULLEY c=20
-#: ultralcd.cpp:8167
+#: ultralcd.cpp:8088
 msgid "Loose pulley"
 msgstr "Puleggia lenta"
 
 # MSG_LOAD_TO_NOZZLE c=18
-#: ultralcd.cpp:6717
+#: ultralcd.cpp:6638
 msgid "Load to nozzle"
 msgstr "Carica ugello"
 
@@ -851,7 +851,7 @@ msgid "No move."
 msgstr "Nessun movimento."
 
 # MSG_NO_CARD c=18
-#: ultralcd.cpp:6697
+#: ultralcd.cpp:6618
 msgid "No SD card"
 msgstr "Nessuna SD"
 
@@ -866,7 +866,7 @@ msgid "No"
 msgstr ""
 
 # MSG_SELFTEST_NOTCONNECTED c=20
-#: ultralcd.cpp:8128
+#: ultralcd.cpp:8049
 msgid "Not connected"
 msgstr "Non connesso"
 
@@ -951,7 +951,7 @@ msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Pulire l'ugello per la calibrazione, poi fare click."
 
 # MSG_SELFTEST_PLEASECHECK c=20
-#: ultralcd.cpp:8122
+#: ultralcd.cpp:8043
 msgid "Please check:"
 msgstr "Verifica:"
 
@@ -1016,7 +1016,7 @@ msgid "Preheat the nozzle!"
 msgstr "Prerisc. ugello!"
 
 # MSG_PREHEAT c=18
-#: ultralcd.cpp:6655
+#: ultralcd.cpp:6576
 msgid "Preheat"
 msgstr "Preriscalda"
 
@@ -1031,7 +1031,7 @@ msgid "Please upgrade."
 msgstr "Prego aggiornare."
 
 # MSG_PRESS_TO_PREHEAT c=20 r=4
-#: Marlin_main.cpp:12049
+#: Marlin_main.cpp:12052
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Premete la manopola per preriscaldare l'ugello e continuare."
 
@@ -1061,7 +1061,7 @@ msgid "Preheating to unload"
 msgstr "Preriscald. scarico"
 
 # MSG_SELFTEST_PRINT_FAN_SPEED c=18
-#: ultralcd.cpp:8501
+#: ultralcd.cpp:8422
 msgid "Print fan:"
 msgstr "Vent.stam:"
 
@@ -1112,21 +1112,21 @@ msgstr "Per favore prima carica il filamento."
 
 # MSG_BED_CORRECTION_REAR c=14
 #: ultralcd.cpp:3117
-msgid "Rear side [um]"
-msgstr "Retro [um]"
+msgid "Rear side [μm]"
+msgstr "Retro [μm]"
 
 # MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ultralcd.cpp:7404
+#: ultralcd.cpp:7325
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Scaricare prima il filamento, poi ripetere l'operazione."
 
 # MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ultralcd.cpp:7407
+#: ultralcd.cpp:7328
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "Controllare il collegamento al sensore e rimuovere il filamento."
 
 # MSG_RECOVERING_PRINT c=20
-#: Marlin_main.cpp:11393
+#: Marlin_main.cpp:11396
 msgid "Recovering print"
 msgstr "Recupero stampa"
 
@@ -1157,8 +1157,8 @@ msgstr "Riprendi stampa"
 
 # MSG_BED_CORRECTION_RIGHT c=14
 #: ultralcd.cpp:3115
-msgid "Right side[um]"
-msgstr "Destra [um]"
+msgid "Right side[μm]"
+msgstr "Destra [μm]"
 
 # MSG_RPI_PORT c=13
 #: messages.c:142
@@ -1191,12 +1191,12 @@ msgid "Select language"
 msgstr "Seleziona lingua"
 
 # MSG_SELFTEST_OK c=20
-#: ultralcd.cpp:7679
+#: ultralcd.cpp:7600
 msgid "Self test OK"
 msgstr "Autotest OK"
 
 # MSG_SELFTEST_START c=20
-#: ultralcd.cpp:7447
+#: ultralcd.cpp:7368
 msgid "Self test start"
 msgstr "Avvia autotest"
 
@@ -1206,7 +1206,7 @@ msgid "Selftest"
 msgstr "Autotest"
 
 # MSG_SELFTEST_ERROR c=20
-#: ultralcd.cpp:8121
+#: ultralcd.cpp:8042
 msgid "Selftest error!"
 msgstr "Errore Autotest!"
 
@@ -1306,7 +1306,7 @@ msgid "Once"
 msgstr "Singolo"
 
 # MSG_SPEED c=15
-#: ultralcd.cpp:6882
+#: ultralcd.cpp:6803
 msgid "Speed"
 msgstr "Velocita"
 
@@ -1336,12 +1336,12 @@ msgid "STOPPED."
 msgstr "ARRESTATO."
 
 # MSG_SUPPORT c=18
-#: ultralcd.cpp:6756
+#: ultralcd.cpp:6677
 msgid "Support"
 msgstr "Supporto"
 
 # MSG_SELFTEST_SWAPPED c=16
-#: ultralcd.cpp:8180
+#: ultralcd.cpp:8101
 msgid "Swapped"
 msgstr "Scambiato"
 
@@ -1376,7 +1376,7 @@ msgid "Temperature calibration is finished and active. Temp. calibration can be 
 msgstr "Calibrazione temperatura completata e attiva. Puo essere disattivata dal menu Impostazioni ->Cal. Temp."
 
 # MSG_FS_VERIFIED c=20 r=3
-#: ultralcd.cpp:7411
+#: ultralcd.cpp:7332
 msgid "Sensor verified, remove the filament now."
 msgstr "Sensore verificato, rimuovere il filamento."
 
@@ -1406,7 +1406,7 @@ msgid "Total print time"
 msgstr "Tempo stampa totale"
 
 # MSG_TUNE c=18
-#: ultralcd.cpp:6653
+#: ultralcd.cpp:6574
 msgid "Tune"
 msgstr "Regola"
 
@@ -1425,7 +1425,7 @@ msgstr "per caricare il fil."
 msgid "to unload filament"
 msgstr "per scaricare fil."
 
-# MSG_UNLOAD_FILAMENT c=16
+# MSG_UNLOAD_FILAMENT c=18
 #: messages.c:114
 msgid "Unload filament"
 msgstr "Scarica filam."
@@ -1510,7 +1510,7 @@ msgstr "XYZ Cal. dettagli"
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "Calibrazione XYZ fallita. Si prega di consultare il manuale."
 
-# MSG_YES c=3
+# MSG_YES c=4
 #: messages.c:123
 msgid "Yes"
 msgstr "Si"
@@ -1586,7 +1586,7 @@ msgid "The printer will start printing a zig-zag line. Rotate the knob until you
 msgstr "La stampante iniziera a stampare una linea a zig-zag. Gira la manopola fino a che non hai raggiungo l'altezza ottimale. Verifica con le immagini nel manuale (capitolo sulla calibrazione)."
 
 # MSG_FIL_FAILED c=20 r=5
-#: ultralcd.cpp:7415
+#: ultralcd.cpp:7336
 msgid "Verification failed, remove the filament and try again."
 msgstr "Verifica fallita, rimuovere il filamento e riprovare."
 
@@ -1616,7 +1616,7 @@ msgid "Checks"
 msgstr "Controlli"
 
 # MSG_FALSE_TRIGGERING c=20
-#: ultralcd.cpp:8190
+#: ultralcd.cpp:8111
 msgid "False triggering"
 msgstr "Falso innesco"
 
@@ -1721,17 +1721,17 @@ msgid "Printer nozzle diameter differs from the G-code. Please check the value i
 msgstr "Diametro ugello diverso dal G-Code. Controlla il valore nelle impostazioni. Stampa annullata."
 
 # MSG_SELFTEST_FS_LEVEL c=20
-#: ultralcd.cpp:8195
+#: ultralcd.cpp:8116
 msgid "%s level expected"
 msgstr "atteso livello %s"
 
 # MSG_RENAME c=18
-#: ultralcd.cpp:6579
+#: ultralcd.cpp:6500
 msgid "Rename"
 msgstr "Rinomina"
 
 # MSG_SELECT c=18
-#: ultralcd.cpp:6572
+#: ultralcd.cpp:6493
 msgid "Select"
 msgstr "Seleziona"
 

--- a/lang/po/Firmware_lb.po
+++ b/lang/po/Firmware_lb.po
@@ -7,8 +7,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: lb\n"
 "Project-Id-Version: Prusa-Firmware\n"
-"POT-Creation-Date: Tue 21 Dec 2021 03:32:02 PM CET\n"
-"PO-Revision-Date: Tue 21 Dec 2021 03:32:02 PM CET\n"
+"POT-Creation-Date: Tue 08 Feb 2022 02:45:05 PM CET\n"
+"PO-Revision-Date: Tue 08 Feb 2022 02:45:05 PM CET\n"
 "Language-Team: \n"
 "X-Generator: Poedit 2.0.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
@@ -21,7 +21,7 @@ msgid " 0.3 or older"
 msgstr ""
 
 # MSG_FS_V_03_OR_OLDER c=18
-#: Marlin_main.cpp:9884
+#: Marlin_main.cpp:9887
 msgid "FS v0.3 or older"
 msgstr ""
 
@@ -31,7 +31,7 @@ msgid " 0.4 or newer"
 msgstr ""
 
 # MSG_FS_V_04_OR_NEWER c=18
-#: Marlin_main.cpp:9883
+#: Marlin_main.cpp:9886
 msgid "FS v0.4 or newer"
 msgstr ""
 
@@ -61,11 +61,11 @@ msgid "Adjusting Z:"
 msgstr ""
 
 # MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ultralcd.cpp:8490
+#: ultralcd.cpp:8411
 msgid "All correct"
 msgstr ""
 
-# MSG_WIZARD_DONE c=20 r=8
+# MSG_WIZARD_DONE c=20 r=3
 #: messages.c:118
 msgid "All is done. Happy printing!"
 msgstr ""
@@ -96,7 +96,7 @@ msgid "Auto home"
 msgstr ""
 
 # MSG_AUTOLOAD_FILAMENT c=18
-#: ultralcd.cpp:6732
+#: ultralcd.cpp:6653
 msgid "AutoLoad filament"
 msgstr ""
 
@@ -111,17 +111,17 @@ msgid "Autoloading filament is active, just press the knob and insert filament..
 msgstr ""
 
 # MSG_SELFTEST_AXIS_LENGTH c=20
-#: ultralcd.cpp:8173
+#: ultralcd.cpp:8094
 msgid "Axis length"
 msgstr ""
 
 # MSG_SELFTEST_AXIS c=16
-#: ultralcd.cpp:8174
+#: ultralcd.cpp:8095
 msgid "Axis"
 msgstr ""
 
 # MSG_SELFTEST_BEDHEATER c=20
-#: ultralcd.cpp:8131
+#: ultralcd.cpp:8052
 msgid "Bed/Heater"
 msgstr ""
 
@@ -176,7 +176,7 @@ msgid "Blackout occurred. Recover print?"
 msgstr ""
 
 # MSG_CALIBRATING_HOME c=20
-#: ultralcd.cpp:8492
+#: ultralcd.cpp:8413
 msgid "Calibrating home"
 msgstr ""
 
@@ -226,12 +226,12 @@ msgid "Calibration"
 msgstr ""
 
 # MSG_SD_REMOVED c=20
-#: ultralcd.cpp:8939
+#: ultralcd.cpp:8860
 msgid "Card removed"
 msgstr ""
 
 # MSG_CHECKING_FILE c=17
-#: ultralcd.cpp:8580
+#: ultralcd.cpp:8501
 msgid "Checking file"
 msgstr ""
 
@@ -326,17 +326,17 @@ msgid "Ejecting filament"
 msgstr ""
 
 # MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ultralcd.cpp:8149
+#: ultralcd.cpp:8070
 msgid "Endstop not hit"
 msgstr ""
 
 # MSG_SELFTEST_ENDSTOP c=16
-#: ultralcd.cpp:8144
+#: ultralcd.cpp:8065
 msgid "Endstop"
 msgstr ""
 
 # MSG_SELFTEST_ENDSTOPS c=20
-#: ultralcd.cpp:8135
+#: ultralcd.cpp:8056
 msgid "Endstops"
 msgstr ""
 
@@ -376,7 +376,7 @@ msgid "ERROR:"
 msgstr ""
 
 # MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
-#: ultralcd.cpp:8498
+#: ultralcd.cpp:8419
 msgid "Extruder fan:"
 msgstr ""
 
@@ -391,7 +391,7 @@ msgid "Extruder"
 msgstr ""
 
 # MSG_MMU_FAIL_STATS c=18
-#: ultralcd.cpp:6754
+#: ultralcd.cpp:6675
 msgid "Fail stats MMU"
 msgstr ""
 
@@ -401,7 +401,7 @@ msgid "F. autoload"
 msgstr ""
 
 # MSG_FAIL_STATS c=18
-#: ultralcd.cpp:6751
+#: ultralcd.cpp:6672
 msgid "Fail stats"
 msgstr ""
 
@@ -440,7 +440,7 @@ msgstr ""
 msgid "Filament not loaded"
 msgstr ""
 
-# MSG_FILAMENT_SENSOR c=20
+# MSG_SELFTEST_FILAMENT_SENSOR c=17
 #: messages.c:97
 msgid "Filament sensor"
 msgstr ""
@@ -461,7 +461,7 @@ msgid "FS Action"
 msgstr ""
 
 # MSG_FILE_INCOMPLETE c=20 r=3
-#: ultralcd.cpp:8634
+#: ultralcd.cpp:8555
 msgid "File incomplete. Continue anyway?"
 msgstr ""
 
@@ -486,7 +486,7 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr ""
 
 # MSG_FLOW c=15
-#: ultralcd.cpp:6888
+#: ultralcd.cpp:6809
 msgid "Flow"
 msgstr ""
 
@@ -497,21 +497,21 @@ msgstr ""
 
 # MSG_BED_CORRECTION_FRONT c=14
 #: ultralcd.cpp:3116
-msgid "Front side[um]"
+msgid "Front side[μm]"
 msgstr ""
 
 # MSG_SELFTEST_FANS c=20
-#: ultralcd.cpp:8179
+#: ultralcd.cpp:8100
 msgid "Front/left fans"
 msgstr ""
 
 # MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ultralcd.cpp:8127
+#: ultralcd.cpp:8048
 msgid "Heater/Thermistor"
 msgstr ""
 
 # MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: Marlin_main.cpp:9874
+#: Marlin_main.cpp:9877
 msgid "Heating disabled by safety timer."
 msgstr ""
 
@@ -551,12 +551,12 @@ msgid "Checking bed"
 msgstr ""
 
 # MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ultralcd.cpp:8481
+#: ultralcd.cpp:8402
 msgid "Checking endstops"
 msgstr ""
 
 # MSG_SELFTEST_CHECK_HOTEND c=20
-#: ultralcd.cpp:8487
+#: ultralcd.cpp:8408
 msgid "Checking hotend"
 msgstr ""
 
@@ -576,7 +576,7 @@ msgid "Checking Y axis"
 msgstr ""
 
 # MSG_SELFTEST_CHECK_Z c=20
-#: ultralcd.cpp:8484
+#: ultralcd.cpp:8405
 msgid "Checking Z axis"
 msgstr ""
 
@@ -657,7 +657,7 @@ msgstr ""
 
 # MSG_BED_CORRECTION_LEFT c=14
 #: ultralcd.cpp:3114
-msgid "Left side [um]"
+msgid "Left side [μm]"
 msgstr ""
 
 # MSG_LIN_CORRECTION c=18
@@ -671,7 +671,7 @@ msgid "Live adjust Z"
 msgstr ""
 
 # MSG_INSERT_FIL c=20 r=6
-#: ultralcd.cpp:7380
+#: ultralcd.cpp:7301
 msgid "Insert the filament (do not load it) into the extruder and then press the knob."
 msgstr ""
 
@@ -696,12 +696,12 @@ msgid "Iteration"
 msgstr ""
 
 # MSG_LOOSE_PULLEY c=20
-#: ultralcd.cpp:8167
+#: ultralcd.cpp:8088
 msgid "Loose pulley"
 msgstr ""
 
 # MSG_LOAD_TO_NOZZLE c=18
-#: ultralcd.cpp:6717
+#: ultralcd.cpp:6638
 msgid "Load to nozzle"
 msgstr ""
 
@@ -851,7 +851,7 @@ msgid "No move."
 msgstr ""
 
 # MSG_NO_CARD c=18
-#: ultralcd.cpp:6697
+#: ultralcd.cpp:6618
 msgid "No SD card"
 msgstr ""
 
@@ -866,7 +866,7 @@ msgid "No"
 msgstr ""
 
 # MSG_SELFTEST_NOTCONNECTED c=20
-#: ultralcd.cpp:8128
+#: ultralcd.cpp:8049
 msgid "Not connected"
 msgstr ""
 
@@ -951,7 +951,7 @@ msgid "Please clean the nozzle for calibration. Click when done."
 msgstr ""
 
 # MSG_SELFTEST_PLEASECHECK c=20
-#: ultralcd.cpp:8122
+#: ultralcd.cpp:8043
 msgid "Please check:"
 msgstr ""
 
@@ -1016,7 +1016,7 @@ msgid "Preheat the nozzle!"
 msgstr ""
 
 # MSG_PREHEAT c=18
-#: ultralcd.cpp:6655
+#: ultralcd.cpp:6576
 msgid "Preheat"
 msgstr ""
 
@@ -1031,7 +1031,7 @@ msgid "Please upgrade."
 msgstr ""
 
 # MSG_PRESS_TO_PREHEAT c=20 r=4
-#: Marlin_main.cpp:12049
+#: Marlin_main.cpp:12052
 msgid "Press the knob to preheat nozzle and continue."
 msgstr ""
 
@@ -1061,7 +1061,7 @@ msgid "Preheating to unload"
 msgstr ""
 
 # MSG_SELFTEST_PRINT_FAN_SPEED c=18
-#: ultralcd.cpp:8501
+#: ultralcd.cpp:8422
 msgid "Print fan:"
 msgstr ""
 
@@ -1112,21 +1112,21 @@ msgstr ""
 
 # MSG_BED_CORRECTION_REAR c=14
 #: ultralcd.cpp:3117
-msgid "Rear side [um]"
+msgid "Rear side [μm]"
 msgstr ""
 
 # MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ultralcd.cpp:7404
+#: ultralcd.cpp:7325
 msgid "Please unload the filament first, then repeat this action."
 msgstr ""
 
 # MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ultralcd.cpp:7407
+#: ultralcd.cpp:7328
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr ""
 
 # MSG_RECOVERING_PRINT c=20
-#: Marlin_main.cpp:11393
+#: Marlin_main.cpp:11396
 msgid "Recovering print"
 msgstr ""
 
@@ -1157,7 +1157,7 @@ msgstr ""
 
 # MSG_BED_CORRECTION_RIGHT c=14
 #: ultralcd.cpp:3115
-msgid "Right side[um]"
+msgid "Right side[μm]"
 msgstr ""
 
 # MSG_RPI_PORT c=13
@@ -1191,12 +1191,12 @@ msgid "Select language"
 msgstr ""
 
 # MSG_SELFTEST_OK c=20
-#: ultralcd.cpp:7679
+#: ultralcd.cpp:7600
 msgid "Self test OK"
 msgstr ""
 
 # MSG_SELFTEST_START c=20
-#: ultralcd.cpp:7447
+#: ultralcd.cpp:7368
 msgid "Self test start"
 msgstr ""
 
@@ -1206,7 +1206,7 @@ msgid "Selftest"
 msgstr ""
 
 # MSG_SELFTEST_ERROR c=20
-#: ultralcd.cpp:8121
+#: ultralcd.cpp:8042
 msgid "Selftest error!"
 msgstr ""
 
@@ -1306,7 +1306,7 @@ msgid "Once"
 msgstr ""
 
 # MSG_SPEED c=15
-#: ultralcd.cpp:6882
+#: ultralcd.cpp:6803
 msgid "Speed"
 msgstr ""
 
@@ -1336,12 +1336,12 @@ msgid "STOPPED."
 msgstr ""
 
 # MSG_SUPPORT c=18
-#: ultralcd.cpp:6756
+#: ultralcd.cpp:6677
 msgid "Support"
 msgstr ""
 
 # MSG_SELFTEST_SWAPPED c=16
-#: ultralcd.cpp:8180
+#: ultralcd.cpp:8101
 msgid "Swapped"
 msgstr ""
 
@@ -1376,7 +1376,7 @@ msgid "Temperature calibration is finished and active. Temp. calibration can be 
 msgstr ""
 
 # MSG_FS_VERIFIED c=20 r=3
-#: ultralcd.cpp:7411
+#: ultralcd.cpp:7332
 msgid "Sensor verified, remove the filament now."
 msgstr ""
 
@@ -1406,7 +1406,7 @@ msgid "Total print time"
 msgstr ""
 
 # MSG_TUNE c=18
-#: ultralcd.cpp:6653
+#: ultralcd.cpp:6574
 msgid "Tune"
 msgstr ""
 
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "to unload filament"
 msgstr ""
 
-# MSG_UNLOAD_FILAMENT c=16
+# MSG_UNLOAD_FILAMENT c=18
 #: messages.c:114
 msgid "Unload filament"
 msgstr ""
@@ -1510,7 +1510,7 @@ msgstr ""
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr ""
 
-# MSG_YES c=3
+# MSG_YES c=4
 #: messages.c:123
 msgid "Yes"
 msgstr ""
@@ -1586,7 +1586,7 @@ msgid "The printer will start printing a zig-zag line. Rotate the knob until you
 msgstr ""
 
 # MSG_FIL_FAILED c=20 r=5
-#: ultralcd.cpp:7415
+#: ultralcd.cpp:7336
 msgid "Verification failed, remove the filament and try again."
 msgstr ""
 
@@ -1616,7 +1616,7 @@ msgid "Checks"
 msgstr ""
 
 # MSG_FALSE_TRIGGERING c=20
-#: ultralcd.cpp:8190
+#: ultralcd.cpp:8111
 msgid "False triggering"
 msgstr ""
 
@@ -1721,17 +1721,17 @@ msgid "Printer nozzle diameter differs from the G-code. Please check the value i
 msgstr ""
 
 # MSG_SELFTEST_FS_LEVEL c=20
-#: ultralcd.cpp:8195
+#: ultralcd.cpp:8116
 msgid "%s level expected"
 msgstr ""
 
 # MSG_RENAME c=18
-#: ultralcd.cpp:6579
+#: ultralcd.cpp:6500
 msgid "Rename"
 msgstr ""
 
 # MSG_SELECT c=18
-#: ultralcd.cpp:6572
+#: ultralcd.cpp:6493
 msgid "Select"
 msgstr ""
 

--- a/lang/po/Firmware_lt.po
+++ b/lang/po/Firmware_lt.po
@@ -7,8 +7,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: lt\n"
 "Project-Id-Version: Prusa-Firmware\n"
-"POT-Creation-Date: Mon 03 Jan 2022 02:56:21 PM CET\n"
-"PO-Revision-Date: Mon 03 Jan 2022 02:56:21 PM CET\n"
+"POT-Creation-Date: Tue 08 Feb 2022 02:45:10 PM CET\n"
+"PO-Revision-Date: Tue 08 Feb 2022 02:45:10 PM CET\n"
 "Language-Team: \n"
 "X-Generator: Poedit 2.0.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
@@ -65,7 +65,7 @@ msgstr ""
 msgid "All correct"
 msgstr ""
 
-# MSG_WIZARD_DONE c=20 r=8
+# MSG_WIZARD_DONE c=20 r=3
 #: messages.c:118
 msgid "All is done. Happy printing!"
 msgstr ""
@@ -440,7 +440,7 @@ msgstr ""
 msgid "Filament not loaded"
 msgstr ""
 
-# MSG_FILAMENT_SENSOR c=20
+# MSG_SELFTEST_FILAMENT_SENSOR c=17
 #: messages.c:97
 msgid "Filament sensor"
 msgstr ""
@@ -497,7 +497,7 @@ msgstr ""
 
 # MSG_BED_CORRECTION_FRONT c=14
 #: ultralcd.cpp:3116
-msgid "Front side[um]"
+msgid "Front side[μm]"
 msgstr ""
 
 # MSG_SELFTEST_FANS c=20
@@ -657,7 +657,7 @@ msgstr ""
 
 # MSG_BED_CORRECTION_LEFT c=14
 #: ultralcd.cpp:3114
-msgid "Left side [um]"
+msgid "Left side [μm]"
 msgstr ""
 
 # MSG_LIN_CORRECTION c=18
@@ -1112,7 +1112,7 @@ msgstr ""
 
 # MSG_BED_CORRECTION_REAR c=14
 #: ultralcd.cpp:3117
-msgid "Rear side [um]"
+msgid "Rear side [μm]"
 msgstr ""
 
 # MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
@@ -1157,7 +1157,7 @@ msgstr ""
 
 # MSG_BED_CORRECTION_RIGHT c=14
 #: ultralcd.cpp:3115
-msgid "Right side[um]"
+msgid "Right side[μm]"
 msgstr ""
 
 # MSG_RPI_PORT c=13
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "to unload filament"
 msgstr ""
 
-# MSG_UNLOAD_FILAMENT c=16
+# MSG_UNLOAD_FILAMENT c=18
 #: messages.c:114
 msgid "Unload filament"
 msgstr ""
@@ -1510,7 +1510,7 @@ msgstr ""
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr ""
 
-# MSG_YES c=3
+# MSG_YES c=4
 #: messages.c:123
 msgid "Yes"
 msgstr ""

--- a/lang/po/Firmware_nl.po
+++ b/lang/po/Firmware_nl.po
@@ -7,8 +7,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: nl\n"
 "Project-Id-Version: Prusa-Firmware\n"
-"POT-Creation-Date: Sun 19 Dec 2021 07:17:44 PM CET\n"
-"PO-Revision-Date: Sun 19 Dec 2021 07:17:44 PM CET\n"
+"POT-Creation-Date: Tue 08 Feb 2022 02:44:37 PM CET\n"
+"PO-Revision-Date: Tue 08 Feb 2022 02:44:37 PM CET\n"
 "Language-Team: \n"
 "X-Generator: Poedit 2.0.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
@@ -21,7 +21,7 @@ msgid " 0.3 or older"
 msgstr " 0.3 of ouder"
 
 # MSG_FS_V_03_OR_OLDER c=18
-#: Marlin_main.cpp:9884
+#: Marlin_main.cpp:9887
 msgid "FS v0.3 or older"
 msgstr "FS 0.3 of ouder"
 
@@ -31,7 +31,7 @@ msgid " 0.4 or newer"
 msgstr " 0.4 of nieuwer"
 
 # MSG_FS_V_04_OR_NEWER c=18
-#: Marlin_main.cpp:9883
+#: Marlin_main.cpp:9886
 msgid "FS v0.4 or newer"
 msgstr "FS 0.4 of nieuwer"
 
@@ -61,11 +61,11 @@ msgid "Adjusting Z:"
 msgstr "Z is ingesteld:"
 
 # MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ultralcd.cpp:8490
+#: ultralcd.cpp:8411
 msgid "All correct"
 msgstr "Allemaal goed"
 
-# MSG_WIZARD_DONE c=20 r=8
+# MSG_WIZARD_DONE c=20 r=3
 #: messages.c:118
 msgid "All is done. Happy printing!"
 msgstr "Klaar. Happy printing!"
@@ -96,7 +96,7 @@ msgid "Auto home"
 msgstr "Startpositie"
 
 # MSG_AUTOLOAD_FILAMENT c=18
-#: ultralcd.cpp:6732
+#: ultralcd.cpp:6653
 msgid "AutoLoad filament"
 msgstr "Autoladen filament"
 
@@ -111,17 +111,17 @@ msgid "Autoloading filament is active, just press the knob and insert filament..
 msgstr "Automatisch laden van flament is actief, druk de knop en laad filament..."
 
 # MSG_SELFTEST_AXIS_LENGTH c=20
-#: ultralcd.cpp:8173
+#: ultralcd.cpp:8094
 msgid "Axis length"
 msgstr "Aslengte"
 
 # MSG_SELFTEST_AXIS c=16
-#: ultralcd.cpp:8174
+#: ultralcd.cpp:8095
 msgid "Axis"
 msgstr "As"
 
 # MSG_SELFTEST_BEDHEATER c=20
-#: ultralcd.cpp:8131
+#: ultralcd.cpp:8052
 msgid "Bed/Heater"
 msgstr "Bed/Verwarming"
 
@@ -176,7 +176,7 @@ msgid "Blackout occurred. Recover print?"
 msgstr "Stroomstoring. Print herstellen?"
 
 # MSG_CALIBRATING_HOME c=20
-#: ultralcd.cpp:8492
+#: ultralcd.cpp:8413
 msgid "Calibrating home"
 msgstr "Kalibreren start"
 
@@ -226,12 +226,12 @@ msgid "Calibration"
 msgstr "Kalibratie"
 
 # MSG_SD_REMOVED c=20
-#: ultralcd.cpp:8939
+#: ultralcd.cpp:8860
 msgid "Card removed"
 msgstr "SD verwijderd"
 
 # MSG_CHECKING_FILE c=17
-#: ultralcd.cpp:8580
+#: ultralcd.cpp:8501
 msgid "Checking file"
 msgstr "Bestand controle"
 
@@ -326,17 +326,17 @@ msgid "Ejecting filament"
 msgstr "Fil. word ontladen"
 
 # MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ultralcd.cpp:8149
+#: ultralcd.cpp:8070
 msgid "Endstop not hit"
 msgstr "Endstop niet geraakt"
 
 # MSG_SELFTEST_ENDSTOP c=16
-#: ultralcd.cpp:8144
+#: ultralcd.cpp:8065
 msgid "Endstop"
 msgstr "Eindstop"
 
 # MSG_SELFTEST_ENDSTOPS c=20
-#: ultralcd.cpp:8135
+#: ultralcd.cpp:8056
 msgid "Endstops"
 msgstr "Eindstops"
 
@@ -376,7 +376,7 @@ msgid "ERROR:"
 msgstr "FOUT:"
 
 # MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
-#: ultralcd.cpp:8498
+#: ultralcd.cpp:8419
 msgid "Extruder fan:"
 msgstr ""
 
@@ -391,7 +391,7 @@ msgid "Extruder"
 msgstr ""
 
 # MSG_MMU_FAIL_STATS c=18
-#: ultralcd.cpp:6754
+#: ultralcd.cpp:6675
 msgid "Fail stats MMU"
 msgstr "MMU-Fouten"
 
@@ -401,7 +401,7 @@ msgid "F. autoload"
 msgstr "F. autoladen"
 
 # MSG_FAIL_STATS c=18
-#: ultralcd.cpp:6751
+#: ultralcd.cpp:6672
 msgid "Fail stats"
 msgstr "Foutstatistieken"
 
@@ -440,7 +440,7 @@ msgstr "Filament extrudeert met de juiste kleur?"
 msgid "Filament not loaded"
 msgstr "Fil. niet geladen"
 
-# MSG_FILAMENT_SENSOR c=20
+# MSG_SELFTEST_FILAMENT_SENSOR c=17
 #: messages.c:97
 msgid "Filament sensor"
 msgstr "Filamentsensor"
@@ -461,7 +461,7 @@ msgid "FS Action"
 msgstr "FS actie"
 
 # MSG_FILE_INCOMPLETE c=20 r=3
-#: ultralcd.cpp:8634
+#: ultralcd.cpp:8555
 msgid "File incomplete. Continue anyway?"
 msgstr "Bestand onvolledig. Toch doorgaan?"
 
@@ -486,7 +486,7 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr "Los het probleem op en druk vervolgens op de knop op de MMU-eenheid."
 
 # MSG_FLOW c=15
-#: ultralcd.cpp:6888
+#: ultralcd.cpp:6809
 msgid "Flow"
 msgstr "Stromen"
 
@@ -497,21 +497,21 @@ msgstr "Voorzijde fan?"
 
 # MSG_BED_CORRECTION_FRONT c=14
 #: ultralcd.cpp:3116
-msgid "Front side[um]"
-msgstr "Voorkant  [um]"
+msgid "Front side[μm]"
+msgstr "Voorkant  [μm]"
 
 # MSG_SELFTEST_FANS c=20
-#: ultralcd.cpp:8179
+#: ultralcd.cpp:8100
 msgid "Front/left fans"
 msgstr "Fans voor/links"
 
 # MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ultralcd.cpp:8127
+#: ultralcd.cpp:8048
 msgid "Heater/Thermistor"
 msgstr "Verwarmer/Therm."
 
 # MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: Marlin_main.cpp:9874
+#: Marlin_main.cpp:9877
 msgid "Heating disabled by safety timer."
 msgstr "Verwarming uitgeschakeld door veiligheidstimer."
 
@@ -551,12 +551,12 @@ msgid "Checking bed"
 msgstr "Controleer bed"
 
 # MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ultralcd.cpp:8481
+#: ultralcd.cpp:8402
 msgid "Checking endstops"
 msgstr "Controleer endstops"
 
 # MSG_SELFTEST_CHECK_HOTEND c=20
-#: ultralcd.cpp:8487
+#: ultralcd.cpp:8408
 msgid "Checking hotend"
 msgstr "Controleer hotend"
 
@@ -576,7 +576,7 @@ msgid "Checking Y axis"
 msgstr "Controleer Y as"
 
 # MSG_SELFTEST_CHECK_Z c=20
-#: ultralcd.cpp:8484
+#: ultralcd.cpp:8405
 msgid "Checking Z axis"
 msgstr "Controleer Z as"
 
@@ -657,8 +657,8 @@ msgstr "Links"
 
 # MSG_BED_CORRECTION_LEFT c=14
 #: ultralcd.cpp:3114
-msgid "Left side [um]"
-msgstr "Linkerkant[um]"
+msgid "Left side [μm]"
+msgstr "Linkerkant[μm]"
 
 # MSG_LIN_CORRECTION c=18
 #: ultralcd.cpp:5702
@@ -671,7 +671,7 @@ msgid "Live adjust Z"
 msgstr "Live Z aanpassen"
 
 # MSG_INSERT_FIL c=20 r=6
-#: ultralcd.cpp:7380
+#: ultralcd.cpp:7301
 msgid "Insert the filament (do not load it) into the extruder and then press the knob."
 msgstr "Steek a.u.b. filament (maar niet laden) in de extruder en druk op knop."
 
@@ -696,12 +696,12 @@ msgid "Iteration"
 msgstr "Iteratie"
 
 # MSG_LOOSE_PULLEY c=20
-#: ultralcd.cpp:8167
+#: ultralcd.cpp:8088
 msgid "Loose pulley"
 msgstr "Losse riemschijf"
 
 # MSG_LOAD_TO_NOZZLE c=18
-#: ultralcd.cpp:6717
+#: ultralcd.cpp:6638
 msgid "Load to nozzle"
 msgstr "Tot tuit laden"
 
@@ -851,7 +851,7 @@ msgid "No move."
 msgstr "Geen beweging."
 
 # MSG_NO_CARD c=18
-#: ultralcd.cpp:6697
+#: ultralcd.cpp:6618
 msgid "No SD card"
 msgstr "Geen SD kaart"
 
@@ -866,7 +866,7 @@ msgid "No"
 msgstr "Nee"
 
 # MSG_SELFTEST_NOTCONNECTED c=20
-#: ultralcd.cpp:8128
+#: ultralcd.cpp:8049
 msgid "Not connected"
 msgstr "Niet verbonden"
 
@@ -951,7 +951,7 @@ msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Reinig de tuit voor de kalibratie. Druk op de knop wanneer gereed."
 
 # MSG_SELFTEST_PLEASECHECK c=20
-#: ultralcd.cpp:8122
+#: ultralcd.cpp:8043
 msgid "Please check:"
 msgstr "Controleer aub:"
 
@@ -1016,7 +1016,7 @@ msgid "Preheat the nozzle!"
 msgstr "Tuit voorverwarmen!"
 
 # MSG_PREHEAT c=18
-#: ultralcd.cpp:6655
+#: ultralcd.cpp:6576
 msgid "Preheat"
 msgstr "Voorverwarmen"
 
@@ -1031,7 +1031,7 @@ msgid "Please upgrade."
 msgstr "Voer een upgrade uit"
 
 # MSG_PRESS_TO_PREHEAT c=20 r=4
-#: Marlin_main.cpp:12049
+#: Marlin_main.cpp:12052
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Druk op de knop om de tuit voor te verwarmen en door te gaan."
 
@@ -1061,7 +1061,7 @@ msgid "Preheating to unload"
 msgstr "Opwarmen uitwerpen"
 
 # MSG_SELFTEST_PRINT_FAN_SPEED c=18
-#: ultralcd.cpp:8501
+#: ultralcd.cpp:8422
 msgid "Print fan:"
 msgstr ""
 
@@ -1112,21 +1112,21 @@ msgstr "Laad a.u.b. eerst filament."
 
 # MSG_BED_CORRECTION_REAR c=14
 #: ultralcd.cpp:3117
-msgid "Rear side [um]"
-msgstr "Achterkant[um]"
+msgid "Rear side [μm]"
+msgstr "Achterkant[μm]"
 
 # MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ultralcd.cpp:7404
+#: ultralcd.cpp:7325
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Verwijder eerst het filament en probeer het opnieuw."
 
 # MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ultralcd.cpp:7407
+#: ultralcd.cpp:7328
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "AUB IR sensor ver- binding kontrolleren , verwijder filament indien aanwezig."
 
 # MSG_RECOVERING_PRINT c=20
-#: Marlin_main.cpp:11393
+#: Marlin_main.cpp:11396
 msgid "Recovering print"
 msgstr "Print herstellen"
 
@@ -1157,8 +1157,8 @@ msgstr "Hervatten print"
 
 # MSG_BED_CORRECTION_RIGHT c=14
 #: ultralcd.cpp:3115
-msgid "Right side[um]"
-msgstr "Recht.kant[um]"
+msgid "Right side[μm]"
+msgstr "Recht.kant[μm]"
 
 # MSG_RPI_PORT c=13
 #: messages.c:142
@@ -1191,12 +1191,12 @@ msgid "Select language"
 msgstr "Kies taal"
 
 # MSG_SELFTEST_OK c=20
-#: ultralcd.cpp:7679
+#: ultralcd.cpp:7600
 msgid "Self test OK"
 msgstr "Zelftest  OK"
 
 # MSG_SELFTEST_START c=20
-#: ultralcd.cpp:7447
+#: ultralcd.cpp:7368
 msgid "Self test start"
 msgstr "Zelftest start"
 
@@ -1206,7 +1206,7 @@ msgid "Selftest"
 msgstr "Zelftest"
 
 # MSG_SELFTEST_ERROR c=20
-#: ultralcd.cpp:8121
+#: ultralcd.cpp:8042
 msgid "Selftest error!"
 msgstr "Zelftest fout!"
 
@@ -1306,7 +1306,7 @@ msgid "Once"
 msgstr "Eenmaal"
 
 # MSG_SPEED c=15
-#: ultralcd.cpp:6882
+#: ultralcd.cpp:6803
 msgid "Speed"
 msgstr "Snelheid"
 
@@ -1336,12 +1336,12 @@ msgid "STOPPED."
 msgstr "GESTOPT."
 
 # MSG_SUPPORT c=18
-#: ultralcd.cpp:6756
+#: ultralcd.cpp:6677
 msgid "Support"
 msgstr ""
 
 # MSG_SELFTEST_SWAPPED c=16
-#: ultralcd.cpp:8180
+#: ultralcd.cpp:8101
 msgid "Swapped"
 msgstr "Gewisseld"
 
@@ -1376,7 +1376,7 @@ msgid "Temperature calibration is finished and active. Temp. calibration can be 
 msgstr "Temperatuurkalibratie kan uitgeschakeld worden in het menu Instellingen-> Tempkalibratie."
 
 # MSG_FS_VERIFIED c=20 r=3
-#: ultralcd.cpp:7411
+#: ultralcd.cpp:7332
 msgid "Sensor verified, remove the filament now."
 msgstr "Sensor geverifieerd, verwijder nu het filament."
 
@@ -1406,7 +1406,7 @@ msgid "Total print time"
 msgstr "Totaal printtijd"
 
 # MSG_TUNE c=18
-#: ultralcd.cpp:6653
+#: ultralcd.cpp:6574
 msgid "Tune"
 msgstr "Fijnafstemming"
 
@@ -1425,7 +1425,7 @@ msgstr "om filament te laden"
 msgid "to unload filament"
 msgstr "om fil. uitwerpen"
 
-# MSG_UNLOAD_FILAMENT c=16
+# MSG_UNLOAD_FILAMENT c=18
 #: messages.c:114
 msgid "Unload filament"
 msgstr "Fil. uitwerpen"
@@ -1510,7 +1510,7 @@ msgstr "XYZ kal. details"
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "XYZ-kalibratie mislukt. Raadpleeg de handleiding aub."
 
-# MSG_YES c=3
+# MSG_YES c=4
 #: messages.c:123
 msgid "Yes"
 msgstr "Ja"
@@ -1586,7 +1586,7 @@ msgid "The printer will start printing a zig-zag line. Rotate the knob until you
 msgstr "De printer begint een zigzaglijn printen. Draai aan de knop totdat je de optimale hoogte hebt bereikt. Bekijk de afbeeldingen in de handleiding (Calibration chapter)."
 
 # MSG_FIL_FAILED c=20 r=5
-#: ultralcd.cpp:7415
+#: ultralcd.cpp:7336
 msgid "Verification failed, remove the filament and try again."
 msgstr "Verificatie mislukt, verwijder het filament en probeer het opnieuw."
 
@@ -1616,7 +1616,7 @@ msgid "Checks"
 msgstr ""
 
 # MSG_FALSE_TRIGGERING c=20
-#: ultralcd.cpp:8190
+#: ultralcd.cpp:8111
 msgid "False triggering"
 msgstr "Valse triggering"
 
@@ -1721,17 +1721,17 @@ msgid "Printer nozzle diameter differs from the G-code. Please check the value i
 msgstr "De diameter van de tuit van de printer verschilt van de G-code. Controleer de waarde in de instellingen. Afdrukken geannuleerd."
 
 # MSG_SELFTEST_FS_LEVEL c=20
-#: ultralcd.cpp:8195
+#: ultralcd.cpp:8116
 msgid "%s level expected"
 msgstr "%s niveau verwacht"
 
 # MSG_RENAME c=18
-#: ultralcd.cpp:6579
+#: ultralcd.cpp:6500
 msgid "Rename"
 msgstr "Hernoem"
 
 # MSG_SELECT c=18
-#: ultralcd.cpp:6572
+#: ultralcd.cpp:6493
 msgid "Select"
 msgstr "Selecteer"
 

--- a/lang/po/Firmware_pl.po
+++ b/lang/po/Firmware_pl.po
@@ -7,8 +7,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: pl\n"
 "Project-Id-Version: Prusa-Firmware\n"
-"POT-Creation-Date: Sun 19 Dec 2021 07:17:40 PM CET\n"
-"PO-Revision-Date: Sun 19 Dec 2021 07:17:40 PM CET\n"
+"POT-Creation-Date: Tue 08 Feb 2022 02:44:33 PM CET\n"
+"PO-Revision-Date: Tue 08 Feb 2022 02:44:33 PM CET\n"
 "Language-Team: \n"
 "X-Generator: Poedit 2.0.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
@@ -21,7 +21,7 @@ msgid " 0.3 or older"
 msgstr " 0.3 lub starszy"
 
 # MSG_FS_V_03_OR_OLDER c=18
-#: Marlin_main.cpp:9884
+#: Marlin_main.cpp:9887
 msgid "FS v0.3 or older"
 msgstr "FS 0.3 lub starszy"
 
@@ -31,7 +31,7 @@ msgid " 0.4 or newer"
 msgstr " 0.4 lub nowszy"
 
 # MSG_FS_V_04_OR_NEWER c=18
-#: Marlin_main.cpp:9883
+#: Marlin_main.cpp:9886
 msgid "FS v0.4 or newer"
 msgstr "FS 0.4 lub nowszy"
 
@@ -61,11 +61,11 @@ msgid "Adjusting Z:"
 msgstr "Ustawianie Z:"
 
 # MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ultralcd.cpp:8490
+#: ultralcd.cpp:8411
 msgid "All correct"
 msgstr "Wszystko OK"
 
-# MSG_WIZARD_DONE c=20 r=8
+# MSG_WIZARD_DONE c=20 r=3
 #: messages.c:118
 msgid "All is done. Happy printing!"
 msgstr "Gotowe. Udanego drukowania!"
@@ -96,7 +96,7 @@ msgid "Auto home"
 msgstr "Auto zerowanie"
 
 # MSG_AUTOLOAD_FILAMENT c=18
-#: ultralcd.cpp:6732
+#: ultralcd.cpp:6653
 msgid "AutoLoad filament"
 msgstr "Autoladowanie fil."
 
@@ -111,17 +111,17 @@ msgid "Autoloading filament is active, just press the knob and insert filament..
 msgstr "Autoladowanie filamentu wlaczone, nacisnij pokretlo i wsun filament..."
 
 # MSG_SELFTEST_AXIS_LENGTH c=20
-#: ultralcd.cpp:8173
+#: ultralcd.cpp:8094
 msgid "Axis length"
 msgstr "Dlugosc osi"
 
 # MSG_SELFTEST_AXIS c=16
-#: ultralcd.cpp:8174
+#: ultralcd.cpp:8095
 msgid "Axis"
 msgstr "Os"
 
 # MSG_SELFTEST_BEDHEATER c=20
-#: ultralcd.cpp:8131
+#: ultralcd.cpp:8052
 msgid "Bed/Heater"
 msgstr "Stol/Grzanie"
 
@@ -176,7 +176,7 @@ msgid "Blackout occurred. Recover print?"
 msgstr "Wykryto zanik napiecia.Kontynowac?"
 
 # MSG_CALIBRATING_HOME c=20
-#: ultralcd.cpp:8492
+#: ultralcd.cpp:8413
 msgid "Calibrating home"
 msgstr "Zerowanie osi"
 
@@ -226,12 +226,12 @@ msgid "Calibration"
 msgstr "Kalibracja"
 
 # MSG_SD_REMOVED c=20
-#: ultralcd.cpp:8939
+#: ultralcd.cpp:8860
 msgid "Card removed"
 msgstr "Karta wyjeta"
 
 # MSG_CHECKING_FILE c=17
-#: ultralcd.cpp:8580
+#: ultralcd.cpp:8501
 msgid "Checking file"
 msgstr "Sprawdzanie pliku"
 
@@ -326,17 +326,17 @@ msgid "Ejecting filament"
 msgstr "Wysuwanie filamentu"
 
 # MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ultralcd.cpp:8149
+#: ultralcd.cpp:8070
 msgid "Endstop not hit"
 msgstr "Krancowka nie aktyw."
 
 # MSG_SELFTEST_ENDSTOP c=16
-#: ultralcd.cpp:8144
+#: ultralcd.cpp:8065
 msgid "Endstop"
 msgstr "Krancowka"
 
 # MSG_SELFTEST_ENDSTOPS c=20
-#: ultralcd.cpp:8135
+#: ultralcd.cpp:8056
 msgid "Endstops"
 msgstr "Krancowki"
 
@@ -376,7 +376,7 @@ msgid "ERROR:"
 msgstr "BLAD:"
 
 # MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
-#: ultralcd.cpp:8498
+#: ultralcd.cpp:8419
 msgid "Extruder fan:"
 msgstr "WentHotend:"
 
@@ -391,7 +391,7 @@ msgid "Extruder"
 msgstr "Ekstruder"
 
 # MSG_MMU_FAIL_STATS c=18
-#: ultralcd.cpp:6754
+#: ultralcd.cpp:6675
 msgid "Fail stats MMU"
 msgstr "Bledy MMU"
 
@@ -401,7 +401,7 @@ msgid "F. autoload"
 msgstr "Autolad. fil."
 
 # MSG_FAIL_STATS c=18
-#: ultralcd.cpp:6751
+#: ultralcd.cpp:6672
 msgid "Fail stats"
 msgstr "Statystyki bledow"
 
@@ -440,7 +440,7 @@ msgstr "Filament wychodzi z dyszy,kolor jest ok?"
 msgid "Filament not loaded"
 msgstr "Fil. nie zaladowany"
 
-# MSG_FILAMENT_SENSOR c=20
+# MSG_SELFTEST_FILAMENT_SENSOR c=17
 #: messages.c:97
 msgid "Filament sensor"
 msgstr "Czujnik filamentu"
@@ -461,7 +461,7 @@ msgid "FS Action"
 msgstr "Akcja FS"
 
 # MSG_FILE_INCOMPLETE c=20 r=3
-#: ultralcd.cpp:8634
+#: ultralcd.cpp:8555
 msgid "File incomplete. Continue anyway?"
 msgstr "Plik niekompletny. Kontynowac?"
 
@@ -486,7 +486,7 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr "Rozwiaz problem i wcisnij przycisk na MMU."
 
 # MSG_FLOW c=15
-#: ultralcd.cpp:6888
+#: ultralcd.cpp:6809
 msgid "Flow"
 msgstr "Przeplyw"
 
@@ -497,21 +497,21 @@ msgstr "Przedni went. druku?"
 
 # MSG_BED_CORRECTION_FRONT c=14
 #: ultralcd.cpp:3116
-msgid "Front side[um]"
-msgstr "Przod [um]"
+msgid "Front side[μm]"
+msgstr "Przod [μm]"
 
 # MSG_SELFTEST_FANS c=20
-#: ultralcd.cpp:8179
+#: ultralcd.cpp:8100
 msgid "Front/left fans"
 msgstr "Przedni/lewy wentyl."
 
 # MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ultralcd.cpp:8127
+#: ultralcd.cpp:8048
 msgid "Heater/Thermistor"
 msgstr "Grzalka/Termistor"
 
 # MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: Marlin_main.cpp:9874
+#: Marlin_main.cpp:9877
 msgid "Heating disabled by safety timer."
 msgstr "Grzanie wylaczone przez wyl. czasowy"
 
@@ -551,12 +551,12 @@ msgid "Checking bed"
 msgstr "Kontrola stolu"
 
 # MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ultralcd.cpp:8481
+#: ultralcd.cpp:8402
 msgid "Checking endstops"
 msgstr "Kontrola krancowek"
 
 # MSG_SELFTEST_CHECK_HOTEND c=20
-#: ultralcd.cpp:8487
+#: ultralcd.cpp:8408
 msgid "Checking hotend"
 msgstr "Kontrola hotendu"
 
@@ -576,7 +576,7 @@ msgid "Checking Y axis"
 msgstr "Kontrola osi Y"
 
 # MSG_SELFTEST_CHECK_Z c=20
-#: ultralcd.cpp:8484
+#: ultralcd.cpp:8405
 msgid "Checking Z axis"
 msgstr "Kontrola osi Z"
 
@@ -657,8 +657,8 @@ msgstr "Lewa"
 
 # MSG_BED_CORRECTION_LEFT c=14
 #: ultralcd.cpp:3114
-msgid "Left side [um]"
-msgstr "Lewo [um]"
+msgid "Left side [μm]"
+msgstr "Lewo [μm]"
 
 # MSG_LIN_CORRECTION c=18
 #: ultralcd.cpp:5702
@@ -671,7 +671,7 @@ msgid "Live adjust Z"
 msgstr "Ustaw. Live Z"
 
 # MSG_INSERT_FIL c=20 r=6
-#: ultralcd.cpp:7380
+#: ultralcd.cpp:7301
 msgid "Insert the filament (do not load it) into the extruder and then press the knob."
 msgstr "Wsun filament (nie uzywaj funkcji ladowania) do ekstrudera i nacisnij pokretlo."
 
@@ -696,12 +696,12 @@ msgid "Iteration"
 msgstr "Iteracja"
 
 # MSG_LOOSE_PULLEY c=20
-#: ultralcd.cpp:8167
+#: ultralcd.cpp:8088
 msgid "Loose pulley"
 msgstr "Luzne kolo pasowe"
 
 # MSG_LOAD_TO_NOZZLE c=18
-#: ultralcd.cpp:6717
+#: ultralcd.cpp:6638
 msgid "Load to nozzle"
 msgstr "Zaladuj do dyszy"
 
@@ -851,7 +851,7 @@ msgid "No move."
 msgstr "Brak ruchu."
 
 # MSG_NO_CARD c=18
-#: ultralcd.cpp:6697
+#: ultralcd.cpp:6618
 msgid "No SD card"
 msgstr "Brak karty SD"
 
@@ -866,7 +866,7 @@ msgid "No"
 msgstr "Nie"
 
 # MSG_SELFTEST_NOTCONNECTED c=20
-#: ultralcd.cpp:8128
+#: ultralcd.cpp:8049
 msgid "Not connected"
 msgstr "Nie podlaczono"
 
@@ -951,7 +951,7 @@ msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Dla prawidlowej kalibracji nalezy oczyscic dysze. Potwierdz guzikiem."
 
 # MSG_SELFTEST_PLEASECHECK c=20
-#: ultralcd.cpp:8122
+#: ultralcd.cpp:8043
 msgid "Please check:"
 msgstr "Sprawdz:"
 
@@ -1016,7 +1016,7 @@ msgid "Preheat the nozzle!"
 msgstr "Nagrzej dysze!"
 
 # MSG_PREHEAT c=18
-#: ultralcd.cpp:6655
+#: ultralcd.cpp:6576
 msgid "Preheat"
 msgstr "Grzanie"
 
@@ -1031,7 +1031,7 @@ msgid "Please upgrade."
 msgstr "Prosze zaktualizowac"
 
 # MSG_PRESS_TO_PREHEAT c=20 r=4
-#: Marlin_main.cpp:12049
+#: Marlin_main.cpp:12052
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Wcisnij pokretlo aby rozgrzac dysze i kontynuowac."
 
@@ -1061,7 +1061,7 @@ msgid "Preheating to unload"
 msgstr "Nagrzew. do rozlad."
 
 # MSG_SELFTEST_PRINT_FAN_SPEED c=18
-#: ultralcd.cpp:8501
+#: ultralcd.cpp:8422
 msgid "Print fan:"
 msgstr "WentWydruk:"
 
@@ -1112,21 +1112,21 @@ msgstr "Najpierw zaladuj filament."
 
 # MSG_BED_CORRECTION_REAR c=14
 #: ultralcd.cpp:3117
-msgid "Rear side [um]"
-msgstr "Tyl [um]"
+msgid "Rear side [μm]"
+msgstr "Tyl [μm]"
 
 # MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ultralcd.cpp:7404
+#: ultralcd.cpp:7325
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Najpierw rozladuj filament, nastepnie powtorz czynnosc."
 
 # MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ultralcd.cpp:7407
+#: ultralcd.cpp:7328
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "Sprawdz polaczenie czujnika IR, rozladuj filament, jesli zaladowany."
 
 # MSG_RECOVERING_PRINT c=20
-#: Marlin_main.cpp:11393
+#: Marlin_main.cpp:11396
 msgid "Recovering print"
 msgstr "Wznawianie wydruku"
 
@@ -1157,8 +1157,8 @@ msgstr "Wznawianie druku"
 
 # MSG_BED_CORRECTION_RIGHT c=14
 #: ultralcd.cpp:3115
-msgid "Right side[um]"
-msgstr "Prawo [um]"
+msgid "Right side[μm]"
+msgstr "Prawo [μm]"
 
 # MSG_RPI_PORT c=13
 #: messages.c:142
@@ -1191,12 +1191,12 @@ msgid "Select language"
 msgstr "Wybor jezyka"
 
 # MSG_SELFTEST_OK c=20
-#: ultralcd.cpp:7679
+#: ultralcd.cpp:7600
 msgid "Self test OK"
 msgstr "Selftest OK"
 
 # MSG_SELFTEST_START c=20
-#: ultralcd.cpp:7447
+#: ultralcd.cpp:7368
 msgid "Self test start"
 msgstr "Selftest startuje"
 
@@ -1206,7 +1206,7 @@ msgid "Selftest"
 msgstr ""
 
 # MSG_SELFTEST_ERROR c=20
-#: ultralcd.cpp:8121
+#: ultralcd.cpp:8042
 msgid "Selftest error!"
 msgstr "Blad selftest!"
 
@@ -1306,7 +1306,7 @@ msgid "Once"
 msgstr "1-raz"
 
 # MSG_SPEED c=15
-#: ultralcd.cpp:6882
+#: ultralcd.cpp:6803
 msgid "Speed"
 msgstr "Predkosc"
 
@@ -1336,12 +1336,12 @@ msgid "STOPPED."
 msgstr "ZATRZYMANO."
 
 # MSG_SUPPORT c=18
-#: ultralcd.cpp:6756
+#: ultralcd.cpp:6677
 msgid "Support"
 msgstr "Wsparcie"
 
 # MSG_SELFTEST_SWAPPED c=16
-#: ultralcd.cpp:8180
+#: ultralcd.cpp:8101
 msgid "Swapped"
 msgstr "Zamieniono"
 
@@ -1376,7 +1376,7 @@ msgid "Temperature calibration is finished and active. Temp. calibration can be 
 msgstr "Kalibracja temperaturowa zakonczona i wlaczona. Moze byc wylaczona z menu Ustawienia -> Kalibracja temp."
 
 # MSG_FS_VERIFIED c=20 r=3
-#: ultralcd.cpp:7411
+#: ultralcd.cpp:7332
 msgid "Sensor verified, remove the filament now."
 msgstr "Czujnik sprawdzony, wyciagnij filament."
 
@@ -1406,7 +1406,7 @@ msgid "Total print time"
 msgstr "Laczny czas druku"
 
 # MSG_TUNE c=18
-#: ultralcd.cpp:6653
+#: ultralcd.cpp:6574
 msgid "Tune"
 msgstr "Strojenie"
 
@@ -1425,7 +1425,7 @@ msgstr "aby zaladow. fil."
 msgid "to unload filament"
 msgstr "aby rozlad. filament"
 
-# MSG_UNLOAD_FILAMENT c=16
+# MSG_UNLOAD_FILAMENT c=18
 #: messages.c:114
 msgid "Unload filament"
 msgstr "Rozladowanie fil"
@@ -1510,7 +1510,7 @@ msgstr "Szczegoly kal. XYZ"
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "Kalibracja XYZ nieudana. Sprawdz przyczyny i rozwiazania w instrukcji."
 
-# MSG_YES c=3
+# MSG_YES c=4
 #: messages.c:123
 msgid "Yes"
 msgstr "Tak"
@@ -1586,7 +1586,7 @@ msgid "The printer will start printing a zig-zag line. Rotate the knob until you
 msgstr "Drukarka zacznie drukowanie linii w ksztalcie zygzaka. Ustaw optymalna wysokosc obracajac pokretlo. Porownaj z ilustracjami w Podreczniku (rozdzial Kalibracja)."
 
 # MSG_FIL_FAILED c=20 r=5
-#: ultralcd.cpp:7415
+#: ultralcd.cpp:7336
 msgid "Verification failed, remove the filament and try again."
 msgstr "Niepowodzenie sprawdzenia, wyciagnij filament i sprobuj ponownie."
 
@@ -1616,7 +1616,7 @@ msgid "Checks"
 msgstr "Testy"
 
 # MSG_FALSE_TRIGGERING c=20
-#: ultralcd.cpp:8190
+#: ultralcd.cpp:8111
 msgid "False triggering"
 msgstr "Falszywy alarm"
 
@@ -1721,17 +1721,17 @@ msgid "Printer nozzle diameter differs from the G-code. Please check the value i
 msgstr "Srednica dyszy rozni sie od tej w G-code. Sprawdz ustawienia. Druk anulowany."
 
 # MSG_SELFTEST_FS_LEVEL c=20
-#: ultralcd.cpp:8195
+#: ultralcd.cpp:8116
 msgid "%s level expected"
 msgstr "Oczekiwano wersji %s"
 
 # MSG_RENAME c=18
-#: ultralcd.cpp:6579
+#: ultralcd.cpp:6500
 msgid "Rename"
 msgstr "Zmien nazwe"
 
 # MSG_SELECT c=18
-#: ultralcd.cpp:6572
+#: ultralcd.cpp:6493
 msgid "Select"
 msgstr "Wybierz"
 

--- a/lang/po/Firmware_ro.po
+++ b/lang/po/Firmware_ro.po
@@ -7,8 +7,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ro\n"
 "Project-Id-Version: Prusa-Firmware\n"
-"POT-Creation-Date: Mon Jan 17 12:19:31 CET 2022\n"
-"PO-Revision-Date: Mon Jan 17 12:19:31 CET 2022\n"
+"POT-Creation-Date: Tue 08 Feb 2022 02:44:41 PM CET\n"
+"PO-Revision-Date: Tue 08 Feb 2022 02:44:41 PM CET\n"
 "Language-Team: \n"
 "X-Generator: Poedit 2.0.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
@@ -65,7 +65,7 @@ msgstr "Ajustare Z:"
 msgid "All correct"
 msgstr "Totul OK"
 
-# MSG_WIZARD_DONE c=20 r=8
+# MSG_WIZARD_DONE c=20 r=3
 #: messages.c:118
 msgid "All is done. Happy printing!"
 msgstr "Totul este OK. Distractie placuta!"
@@ -440,7 +440,7 @@ msgstr "Fil. curge si are culoarea corecta?"
 msgid "Filament not loaded"
 msgstr "Fil. nu e incarcat"
 
-# MSG_FILAMENT_SENSOR c=20
+# MSG_SELFTEST_FILAMENT_SENSOR c=17
 #: messages.c:97
 msgid "Filament sensor"
 msgstr "Senz. de filament"
@@ -497,8 +497,8 @@ msgstr "Vent. print?"
 
 # MSG_BED_CORRECTION_FRONT c=14
 #: ultralcd.cpp:3116
-msgid "Front side[um]"
-msgstr "Fata [um]"
+msgid "Front side[μm]"
+msgstr "Fata [μm]"
 
 # MSG_SELFTEST_FANS c=20
 #: ultralcd.cpp:8100
@@ -657,8 +657,8 @@ msgstr "Stanga"
 
 # MSG_BED_CORRECTION_LEFT c=14
 #: ultralcd.cpp:3114
-msgid "Left side [um]"
-msgstr "Stanga [um]"
+msgid "Left side [μm]"
+msgstr "Stanga [μm]"
 
 # MSG_LIN_CORRECTION c=18
 #: ultralcd.cpp:5702
@@ -1112,8 +1112,8 @@ msgstr "Va rugam incarcati filamentul mai intai."
 
 # MSG_BED_CORRECTION_REAR c=14
 #: ultralcd.cpp:3117
-msgid "Rear side [um]"
-msgstr "Spate [um]"
+msgid "Rear side [μm]"
+msgstr "Spate [μm]"
 
 # MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
 #: ultralcd.cpp:7325
@@ -1157,8 +1157,8 @@ msgstr "Reluare print..."
 
 # MSG_BED_CORRECTION_RIGHT c=14
 #: ultralcd.cpp:3115
-msgid "Right side[um]"
-msgstr "Dreapta [um]"
+msgid "Right side[μm]"
+msgstr "Dreapta [μm]"
 
 # MSG_RPI_PORT c=13
 #: messages.c:142
@@ -1425,7 +1425,7 @@ msgstr "a incarca filament"
 msgid "to unload filament"
 msgstr "a scoate filament"
 
-# MSG_UNLOAD_FILAMENT c=16
+# MSG_UNLOAD_FILAMENT c=18
 #: messages.c:114
 msgid "Unload filament"
 msgstr "Descarca filament"
@@ -1510,7 +1510,7 @@ msgstr "Detalii cal. XYZ"
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "Calibrarea XYZ a esuat. Va rugam consultati manualul."
 
-# MSG_YES c=3
+# MSG_YES c=4
 #: messages.c:123
 msgid "Yes"
 msgstr "Da"

--- a/lang/po/Firmware_sl.po
+++ b/lang/po/Firmware_sl.po
@@ -7,8 +7,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: sl\n"
 "Project-Id-Version: Prusa-Firmware\n"
-"POT-Creation-Date: Tue 21 Dec 2021 03:23:03 PM CET\n"
-"PO-Revision-Date: Tue 21 Dec 2021 03:23:03 PM CET\n"
+"POT-Creation-Date: Tue 08 Feb 2022 02:45:16 PM CET\n"
+"PO-Revision-Date: Tue 08 Feb 2022 02:45:16 PM CET\n"
 "Language-Team: \n"
 "X-Generator: Poedit 2.0.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
@@ -21,7 +21,7 @@ msgid " 0.3 or older"
 msgstr ""
 
 # MSG_FS_V_03_OR_OLDER c=18
-#: Marlin_main.cpp:9884
+#: Marlin_main.cpp:9887
 msgid "FS v0.3 or older"
 msgstr ""
 
@@ -31,7 +31,7 @@ msgid " 0.4 or newer"
 msgstr ""
 
 # MSG_FS_V_04_OR_NEWER c=18
-#: Marlin_main.cpp:9883
+#: Marlin_main.cpp:9886
 msgid "FS v0.4 or newer"
 msgstr ""
 
@@ -61,11 +61,11 @@ msgid "Adjusting Z:"
 msgstr ""
 
 # MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ultralcd.cpp:8490
+#: ultralcd.cpp:8411
 msgid "All correct"
 msgstr ""
 
-# MSG_WIZARD_DONE c=20 r=8
+# MSG_WIZARD_DONE c=20 r=3
 #: messages.c:118
 msgid "All is done. Happy printing!"
 msgstr ""
@@ -96,7 +96,7 @@ msgid "Auto home"
 msgstr ""
 
 # MSG_AUTOLOAD_FILAMENT c=18
-#: ultralcd.cpp:6732
+#: ultralcd.cpp:6653
 msgid "AutoLoad filament"
 msgstr ""
 
@@ -111,17 +111,17 @@ msgid "Autoloading filament is active, just press the knob and insert filament..
 msgstr ""
 
 # MSG_SELFTEST_AXIS_LENGTH c=20
-#: ultralcd.cpp:8173
+#: ultralcd.cpp:8094
 msgid "Axis length"
 msgstr ""
 
 # MSG_SELFTEST_AXIS c=16
-#: ultralcd.cpp:8174
+#: ultralcd.cpp:8095
 msgid "Axis"
 msgstr ""
 
 # MSG_SELFTEST_BEDHEATER c=20
-#: ultralcd.cpp:8131
+#: ultralcd.cpp:8052
 msgid "Bed/Heater"
 msgstr ""
 
@@ -176,7 +176,7 @@ msgid "Blackout occurred. Recover print?"
 msgstr ""
 
 # MSG_CALIBRATING_HOME c=20
-#: ultralcd.cpp:8492
+#: ultralcd.cpp:8413
 msgid "Calibrating home"
 msgstr ""
 
@@ -226,12 +226,12 @@ msgid "Calibration"
 msgstr ""
 
 # MSG_SD_REMOVED c=20
-#: ultralcd.cpp:8939
+#: ultralcd.cpp:8860
 msgid "Card removed"
 msgstr ""
 
 # MSG_CHECKING_FILE c=17
-#: ultralcd.cpp:8580
+#: ultralcd.cpp:8501
 msgid "Checking file"
 msgstr ""
 
@@ -326,17 +326,17 @@ msgid "Ejecting filament"
 msgstr ""
 
 # MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ultralcd.cpp:8149
+#: ultralcd.cpp:8070
 msgid "Endstop not hit"
 msgstr ""
 
 # MSG_SELFTEST_ENDSTOP c=16
-#: ultralcd.cpp:8144
+#: ultralcd.cpp:8065
 msgid "Endstop"
 msgstr ""
 
 # MSG_SELFTEST_ENDSTOPS c=20
-#: ultralcd.cpp:8135
+#: ultralcd.cpp:8056
 msgid "Endstops"
 msgstr ""
 
@@ -376,7 +376,7 @@ msgid "ERROR:"
 msgstr ""
 
 # MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
-#: ultralcd.cpp:8498
+#: ultralcd.cpp:8419
 msgid "Extruder fan:"
 msgstr ""
 
@@ -391,7 +391,7 @@ msgid "Extruder"
 msgstr ""
 
 # MSG_MMU_FAIL_STATS c=18
-#: ultralcd.cpp:6754
+#: ultralcd.cpp:6675
 msgid "Fail stats MMU"
 msgstr ""
 
@@ -401,7 +401,7 @@ msgid "F. autoload"
 msgstr ""
 
 # MSG_FAIL_STATS c=18
-#: ultralcd.cpp:6751
+#: ultralcd.cpp:6672
 msgid "Fail stats"
 msgstr ""
 
@@ -440,7 +440,7 @@ msgstr ""
 msgid "Filament not loaded"
 msgstr ""
 
-# MSG_FILAMENT_SENSOR c=20
+# MSG_SELFTEST_FILAMENT_SENSOR c=17
 #: messages.c:97
 msgid "Filament sensor"
 msgstr ""
@@ -461,7 +461,7 @@ msgid "FS Action"
 msgstr ""
 
 # MSG_FILE_INCOMPLETE c=20 r=3
-#: ultralcd.cpp:8634
+#: ultralcd.cpp:8555
 msgid "File incomplete. Continue anyway?"
 msgstr ""
 
@@ -486,7 +486,7 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr ""
 
 # MSG_FLOW c=15
-#: ultralcd.cpp:6888
+#: ultralcd.cpp:6809
 msgid "Flow"
 msgstr ""
 
@@ -497,21 +497,21 @@ msgstr ""
 
 # MSG_BED_CORRECTION_FRONT c=14
 #: ultralcd.cpp:3116
-msgid "Front side[um]"
+msgid "Front side[μm]"
 msgstr ""
 
 # MSG_SELFTEST_FANS c=20
-#: ultralcd.cpp:8179
+#: ultralcd.cpp:8100
 msgid "Front/left fans"
 msgstr ""
 
 # MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ultralcd.cpp:8127
+#: ultralcd.cpp:8048
 msgid "Heater/Thermistor"
 msgstr ""
 
 # MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: Marlin_main.cpp:9874
+#: Marlin_main.cpp:9877
 msgid "Heating disabled by safety timer."
 msgstr ""
 
@@ -551,12 +551,12 @@ msgid "Checking bed"
 msgstr ""
 
 # MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ultralcd.cpp:8481
+#: ultralcd.cpp:8402
 msgid "Checking endstops"
 msgstr ""
 
 # MSG_SELFTEST_CHECK_HOTEND c=20
-#: ultralcd.cpp:8487
+#: ultralcd.cpp:8408
 msgid "Checking hotend"
 msgstr ""
 
@@ -576,7 +576,7 @@ msgid "Checking Y axis"
 msgstr ""
 
 # MSG_SELFTEST_CHECK_Z c=20
-#: ultralcd.cpp:8484
+#: ultralcd.cpp:8405
 msgid "Checking Z axis"
 msgstr ""
 
@@ -657,7 +657,7 @@ msgstr ""
 
 # MSG_BED_CORRECTION_LEFT c=14
 #: ultralcd.cpp:3114
-msgid "Left side [um]"
+msgid "Left side [μm]"
 msgstr ""
 
 # MSG_LIN_CORRECTION c=18
@@ -671,7 +671,7 @@ msgid "Live adjust Z"
 msgstr ""
 
 # MSG_INSERT_FIL c=20 r=6
-#: ultralcd.cpp:7380
+#: ultralcd.cpp:7301
 msgid "Insert the filament (do not load it) into the extruder and then press the knob."
 msgstr ""
 
@@ -696,12 +696,12 @@ msgid "Iteration"
 msgstr ""
 
 # MSG_LOOSE_PULLEY c=20
-#: ultralcd.cpp:8167
+#: ultralcd.cpp:8088
 msgid "Loose pulley"
 msgstr ""
 
 # MSG_LOAD_TO_NOZZLE c=18
-#: ultralcd.cpp:6717
+#: ultralcd.cpp:6638
 msgid "Load to nozzle"
 msgstr ""
 
@@ -851,7 +851,7 @@ msgid "No move."
 msgstr ""
 
 # MSG_NO_CARD c=18
-#: ultralcd.cpp:6697
+#: ultralcd.cpp:6618
 msgid "No SD card"
 msgstr ""
 
@@ -866,7 +866,7 @@ msgid "No"
 msgstr ""
 
 # MSG_SELFTEST_NOTCONNECTED c=20
-#: ultralcd.cpp:8128
+#: ultralcd.cpp:8049
 msgid "Not connected"
 msgstr ""
 
@@ -951,7 +951,7 @@ msgid "Please clean the nozzle for calibration. Click when done."
 msgstr ""
 
 # MSG_SELFTEST_PLEASECHECK c=20
-#: ultralcd.cpp:8122
+#: ultralcd.cpp:8043
 msgid "Please check:"
 msgstr ""
 
@@ -1016,7 +1016,7 @@ msgid "Preheat the nozzle!"
 msgstr ""
 
 # MSG_PREHEAT c=18
-#: ultralcd.cpp:6655
+#: ultralcd.cpp:6576
 msgid "Preheat"
 msgstr ""
 
@@ -1031,7 +1031,7 @@ msgid "Please upgrade."
 msgstr ""
 
 # MSG_PRESS_TO_PREHEAT c=20 r=4
-#: Marlin_main.cpp:12049
+#: Marlin_main.cpp:12052
 msgid "Press the knob to preheat nozzle and continue."
 msgstr ""
 
@@ -1061,7 +1061,7 @@ msgid "Preheating to unload"
 msgstr ""
 
 # MSG_SELFTEST_PRINT_FAN_SPEED c=18
-#: ultralcd.cpp:8501
+#: ultralcd.cpp:8422
 msgid "Print fan:"
 msgstr ""
 
@@ -1112,21 +1112,21 @@ msgstr ""
 
 # MSG_BED_CORRECTION_REAR c=14
 #: ultralcd.cpp:3117
-msgid "Rear side [um]"
+msgid "Rear side [μm]"
 msgstr ""
 
 # MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ultralcd.cpp:7404
+#: ultralcd.cpp:7325
 msgid "Please unload the filament first, then repeat this action."
 msgstr ""
 
 # MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ultralcd.cpp:7407
+#: ultralcd.cpp:7328
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr ""
 
 # MSG_RECOVERING_PRINT c=20
-#: Marlin_main.cpp:11393
+#: Marlin_main.cpp:11396
 msgid "Recovering print"
 msgstr ""
 
@@ -1157,7 +1157,7 @@ msgstr ""
 
 # MSG_BED_CORRECTION_RIGHT c=14
 #: ultralcd.cpp:3115
-msgid "Right side[um]"
+msgid "Right side[μm]"
 msgstr ""
 
 # MSG_RPI_PORT c=13
@@ -1191,12 +1191,12 @@ msgid "Select language"
 msgstr ""
 
 # MSG_SELFTEST_OK c=20
-#: ultralcd.cpp:7679
+#: ultralcd.cpp:7600
 msgid "Self test OK"
 msgstr ""
 
 # MSG_SELFTEST_START c=20
-#: ultralcd.cpp:7447
+#: ultralcd.cpp:7368
 msgid "Self test start"
 msgstr ""
 
@@ -1206,7 +1206,7 @@ msgid "Selftest"
 msgstr ""
 
 # MSG_SELFTEST_ERROR c=20
-#: ultralcd.cpp:8121
+#: ultralcd.cpp:8042
 msgid "Selftest error!"
 msgstr ""
 
@@ -1306,7 +1306,7 @@ msgid "Once"
 msgstr ""
 
 # MSG_SPEED c=15
-#: ultralcd.cpp:6882
+#: ultralcd.cpp:6803
 msgid "Speed"
 msgstr ""
 
@@ -1336,12 +1336,12 @@ msgid "STOPPED."
 msgstr ""
 
 # MSG_SUPPORT c=18
-#: ultralcd.cpp:6756
+#: ultralcd.cpp:6677
 msgid "Support"
 msgstr ""
 
 # MSG_SELFTEST_SWAPPED c=16
-#: ultralcd.cpp:8180
+#: ultralcd.cpp:8101
 msgid "Swapped"
 msgstr ""
 
@@ -1376,7 +1376,7 @@ msgid "Temperature calibration is finished and active. Temp. calibration can be 
 msgstr ""
 
 # MSG_FS_VERIFIED c=20 r=3
-#: ultralcd.cpp:7411
+#: ultralcd.cpp:7332
 msgid "Sensor verified, remove the filament now."
 msgstr ""
 
@@ -1406,7 +1406,7 @@ msgid "Total print time"
 msgstr ""
 
 # MSG_TUNE c=18
-#: ultralcd.cpp:6653
+#: ultralcd.cpp:6574
 msgid "Tune"
 msgstr ""
 
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "to unload filament"
 msgstr ""
 
-# MSG_UNLOAD_FILAMENT c=16
+# MSG_UNLOAD_FILAMENT c=18
 #: messages.c:114
 msgid "Unload filament"
 msgstr ""
@@ -1510,7 +1510,7 @@ msgstr ""
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr ""
 
-# MSG_YES c=3
+# MSG_YES c=4
 #: messages.c:123
 msgid "Yes"
 msgstr ""
@@ -1586,7 +1586,7 @@ msgid "The printer will start printing a zig-zag line. Rotate the knob until you
 msgstr ""
 
 # MSG_FIL_FAILED c=20 r=5
-#: ultralcd.cpp:7415
+#: ultralcd.cpp:7336
 msgid "Verification failed, remove the filament and try again."
 msgstr ""
 
@@ -1616,7 +1616,7 @@ msgid "Checks"
 msgstr ""
 
 # MSG_FALSE_TRIGGERING c=20
-#: ultralcd.cpp:8190
+#: ultralcd.cpp:8111
 msgid "False triggering"
 msgstr ""
 
@@ -1721,17 +1721,17 @@ msgid "Printer nozzle diameter differs from the G-code. Please check the value i
 msgstr ""
 
 # MSG_SELFTEST_FS_LEVEL c=20
-#: ultralcd.cpp:8195
+#: ultralcd.cpp:8116
 msgid "%s level expected"
 msgstr ""
 
 # MSG_RENAME c=18
-#: ultralcd.cpp:6579
+#: ultralcd.cpp:6500
 msgid "Rename"
 msgstr ""
 
 # MSG_SELECT c=18
-#: ultralcd.cpp:6572
+#: ultralcd.cpp:6493
 msgid "Select"
 msgstr ""
 

--- a/lang/po/Firmware_sv.po
+++ b/lang/po/Firmware_sv.po
@@ -7,8 +7,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: sv\n"
 "Project-Id-Version: Prusa-Firmware\n"
-"POT-Creation-Date: Tue 21 Dec 2021 02:31:55 PM CET\n"
-"PO-Revision-Date: Tue 21 Dec 2021 02:31:55 PM CET\n"
+"POT-Creation-Date: Tue 08 Feb 2022 02:45:22 PM CET\n"
+"PO-Revision-Date: Tue 08 Feb 2022 02:45:22 PM CET\n"
 "Language-Team: \n"
 "X-Generator: Poedit 2.0.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
@@ -21,7 +21,7 @@ msgid " 0.3 or older"
 msgstr ""
 
 # MSG_FS_V_03_OR_OLDER c=18
-#: Marlin_main.cpp:9884
+#: Marlin_main.cpp:9887
 msgid "FS v0.3 or older"
 msgstr ""
 
@@ -31,7 +31,7 @@ msgid " 0.4 or newer"
 msgstr ""
 
 # MSG_FS_V_04_OR_NEWER c=18
-#: Marlin_main.cpp:9883
+#: Marlin_main.cpp:9886
 msgid "FS v0.4 or newer"
 msgstr ""
 
@@ -61,11 +61,11 @@ msgid "Adjusting Z:"
 msgstr ""
 
 # MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ultralcd.cpp:8490
+#: ultralcd.cpp:8411
 msgid "All correct"
 msgstr ""
 
-# MSG_WIZARD_DONE c=20 r=8
+# MSG_WIZARD_DONE c=20 r=3
 #: messages.c:118
 msgid "All is done. Happy printing!"
 msgstr ""
@@ -96,7 +96,7 @@ msgid "Auto home"
 msgstr ""
 
 # MSG_AUTOLOAD_FILAMENT c=18
-#: ultralcd.cpp:6732
+#: ultralcd.cpp:6653
 msgid "AutoLoad filament"
 msgstr ""
 
@@ -111,17 +111,17 @@ msgid "Autoloading filament is active, just press the knob and insert filament..
 msgstr ""
 
 # MSG_SELFTEST_AXIS_LENGTH c=20
-#: ultralcd.cpp:8173
+#: ultralcd.cpp:8094
 msgid "Axis length"
 msgstr ""
 
 # MSG_SELFTEST_AXIS c=16
-#: ultralcd.cpp:8174
+#: ultralcd.cpp:8095
 msgid "Axis"
 msgstr ""
 
 # MSG_SELFTEST_BEDHEATER c=20
-#: ultralcd.cpp:8131
+#: ultralcd.cpp:8052
 msgid "Bed/Heater"
 msgstr ""
 
@@ -176,7 +176,7 @@ msgid "Blackout occurred. Recover print?"
 msgstr ""
 
 # MSG_CALIBRATING_HOME c=20
-#: ultralcd.cpp:8492
+#: ultralcd.cpp:8413
 msgid "Calibrating home"
 msgstr ""
 
@@ -226,12 +226,12 @@ msgid "Calibration"
 msgstr ""
 
 # MSG_SD_REMOVED c=20
-#: ultralcd.cpp:8939
+#: ultralcd.cpp:8860
 msgid "Card removed"
 msgstr ""
 
 # MSG_CHECKING_FILE c=17
-#: ultralcd.cpp:8580
+#: ultralcd.cpp:8501
 msgid "Checking file"
 msgstr ""
 
@@ -326,17 +326,17 @@ msgid "Ejecting filament"
 msgstr ""
 
 # MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ultralcd.cpp:8149
+#: ultralcd.cpp:8070
 msgid "Endstop not hit"
 msgstr ""
 
 # MSG_SELFTEST_ENDSTOP c=16
-#: ultralcd.cpp:8144
+#: ultralcd.cpp:8065
 msgid "Endstop"
 msgstr ""
 
 # MSG_SELFTEST_ENDSTOPS c=20
-#: ultralcd.cpp:8135
+#: ultralcd.cpp:8056
 msgid "Endstops"
 msgstr ""
 
@@ -376,7 +376,7 @@ msgid "ERROR:"
 msgstr ""
 
 # MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
-#: ultralcd.cpp:8498
+#: ultralcd.cpp:8419
 msgid "Extruder fan:"
 msgstr ""
 
@@ -391,7 +391,7 @@ msgid "Extruder"
 msgstr ""
 
 # MSG_MMU_FAIL_STATS c=18
-#: ultralcd.cpp:6754
+#: ultralcd.cpp:6675
 msgid "Fail stats MMU"
 msgstr ""
 
@@ -401,7 +401,7 @@ msgid "F. autoload"
 msgstr ""
 
 # MSG_FAIL_STATS c=18
-#: ultralcd.cpp:6751
+#: ultralcd.cpp:6672
 msgid "Fail stats"
 msgstr ""
 
@@ -440,7 +440,7 @@ msgstr ""
 msgid "Filament not loaded"
 msgstr ""
 
-# MSG_FILAMENT_SENSOR c=20
+# MSG_SELFTEST_FILAMENT_SENSOR c=17
 #: messages.c:97
 msgid "Filament sensor"
 msgstr ""
@@ -461,7 +461,7 @@ msgid "FS Action"
 msgstr ""
 
 # MSG_FILE_INCOMPLETE c=20 r=3
-#: ultralcd.cpp:8634
+#: ultralcd.cpp:8555
 msgid "File incomplete. Continue anyway?"
 msgstr ""
 
@@ -486,7 +486,7 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr ""
 
 # MSG_FLOW c=15
-#: ultralcd.cpp:6888
+#: ultralcd.cpp:6809
 msgid "Flow"
 msgstr ""
 
@@ -497,21 +497,21 @@ msgstr ""
 
 # MSG_BED_CORRECTION_FRONT c=14
 #: ultralcd.cpp:3116
-msgid "Front side[um]"
+msgid "Front side[μm]"
 msgstr ""
 
 # MSG_SELFTEST_FANS c=20
-#: ultralcd.cpp:8179
+#: ultralcd.cpp:8100
 msgid "Front/left fans"
 msgstr ""
 
 # MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ultralcd.cpp:8127
+#: ultralcd.cpp:8048
 msgid "Heater/Thermistor"
 msgstr ""
 
 # MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: Marlin_main.cpp:9874
+#: Marlin_main.cpp:9877
 msgid "Heating disabled by safety timer."
 msgstr ""
 
@@ -551,12 +551,12 @@ msgid "Checking bed"
 msgstr ""
 
 # MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ultralcd.cpp:8481
+#: ultralcd.cpp:8402
 msgid "Checking endstops"
 msgstr ""
 
 # MSG_SELFTEST_CHECK_HOTEND c=20
-#: ultralcd.cpp:8487
+#: ultralcd.cpp:8408
 msgid "Checking hotend"
 msgstr ""
 
@@ -576,7 +576,7 @@ msgid "Checking Y axis"
 msgstr ""
 
 # MSG_SELFTEST_CHECK_Z c=20
-#: ultralcd.cpp:8484
+#: ultralcd.cpp:8405
 msgid "Checking Z axis"
 msgstr ""
 
@@ -657,7 +657,7 @@ msgstr ""
 
 # MSG_BED_CORRECTION_LEFT c=14
 #: ultralcd.cpp:3114
-msgid "Left side [um]"
+msgid "Left side [μm]"
 msgstr ""
 
 # MSG_LIN_CORRECTION c=18
@@ -671,7 +671,7 @@ msgid "Live adjust Z"
 msgstr ""
 
 # MSG_INSERT_FIL c=20 r=6
-#: ultralcd.cpp:7380
+#: ultralcd.cpp:7301
 msgid "Insert the filament (do not load it) into the extruder and then press the knob."
 msgstr ""
 
@@ -696,12 +696,12 @@ msgid "Iteration"
 msgstr ""
 
 # MSG_LOOSE_PULLEY c=20
-#: ultralcd.cpp:8167
+#: ultralcd.cpp:8088
 msgid "Loose pulley"
 msgstr ""
 
 # MSG_LOAD_TO_NOZZLE c=18
-#: ultralcd.cpp:6717
+#: ultralcd.cpp:6638
 msgid "Load to nozzle"
 msgstr ""
 
@@ -851,7 +851,7 @@ msgid "No move."
 msgstr ""
 
 # MSG_NO_CARD c=18
-#: ultralcd.cpp:6697
+#: ultralcd.cpp:6618
 msgid "No SD card"
 msgstr ""
 
@@ -866,7 +866,7 @@ msgid "No"
 msgstr ""
 
 # MSG_SELFTEST_NOTCONNECTED c=20
-#: ultralcd.cpp:8128
+#: ultralcd.cpp:8049
 msgid "Not connected"
 msgstr ""
 
@@ -951,7 +951,7 @@ msgid "Please clean the nozzle for calibration. Click when done."
 msgstr ""
 
 # MSG_SELFTEST_PLEASECHECK c=20
-#: ultralcd.cpp:8122
+#: ultralcd.cpp:8043
 msgid "Please check:"
 msgstr ""
 
@@ -1016,7 +1016,7 @@ msgid "Preheat the nozzle!"
 msgstr ""
 
 # MSG_PREHEAT c=18
-#: ultralcd.cpp:6655
+#: ultralcd.cpp:6576
 msgid "Preheat"
 msgstr ""
 
@@ -1031,7 +1031,7 @@ msgid "Please upgrade."
 msgstr ""
 
 # MSG_PRESS_TO_PREHEAT c=20 r=4
-#: Marlin_main.cpp:12049
+#: Marlin_main.cpp:12052
 msgid "Press the knob to preheat nozzle and continue."
 msgstr ""
 
@@ -1061,7 +1061,7 @@ msgid "Preheating to unload"
 msgstr ""
 
 # MSG_SELFTEST_PRINT_FAN_SPEED c=18
-#: ultralcd.cpp:8501
+#: ultralcd.cpp:8422
 msgid "Print fan:"
 msgstr ""
 
@@ -1112,21 +1112,21 @@ msgstr ""
 
 # MSG_BED_CORRECTION_REAR c=14
 #: ultralcd.cpp:3117
-msgid "Rear side [um]"
+msgid "Rear side [μm]"
 msgstr ""
 
 # MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ultralcd.cpp:7404
+#: ultralcd.cpp:7325
 msgid "Please unload the filament first, then repeat this action."
 msgstr ""
 
 # MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ultralcd.cpp:7407
+#: ultralcd.cpp:7328
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr ""
 
 # MSG_RECOVERING_PRINT c=20
-#: Marlin_main.cpp:11393
+#: Marlin_main.cpp:11396
 msgid "Recovering print"
 msgstr ""
 
@@ -1157,7 +1157,7 @@ msgstr ""
 
 # MSG_BED_CORRECTION_RIGHT c=14
 #: ultralcd.cpp:3115
-msgid "Right side[um]"
+msgid "Right side[μm]"
 msgstr ""
 
 # MSG_RPI_PORT c=13
@@ -1191,12 +1191,12 @@ msgid "Select language"
 msgstr ""
 
 # MSG_SELFTEST_OK c=20
-#: ultralcd.cpp:7679
+#: ultralcd.cpp:7600
 msgid "Self test OK"
 msgstr ""
 
 # MSG_SELFTEST_START c=20
-#: ultralcd.cpp:7447
+#: ultralcd.cpp:7368
 msgid "Self test start"
 msgstr ""
 
@@ -1206,7 +1206,7 @@ msgid "Selftest"
 msgstr ""
 
 # MSG_SELFTEST_ERROR c=20
-#: ultralcd.cpp:8121
+#: ultralcd.cpp:8042
 msgid "Selftest error!"
 msgstr ""
 
@@ -1306,7 +1306,7 @@ msgid "Once"
 msgstr ""
 
 # MSG_SPEED c=15
-#: ultralcd.cpp:6882
+#: ultralcd.cpp:6803
 msgid "Speed"
 msgstr ""
 
@@ -1336,12 +1336,12 @@ msgid "STOPPED."
 msgstr ""
 
 # MSG_SUPPORT c=18
-#: ultralcd.cpp:6756
+#: ultralcd.cpp:6677
 msgid "Support"
 msgstr ""
 
 # MSG_SELFTEST_SWAPPED c=16
-#: ultralcd.cpp:8180
+#: ultralcd.cpp:8101
 msgid "Swapped"
 msgstr ""
 
@@ -1376,7 +1376,7 @@ msgid "Temperature calibration is finished and active. Temp. calibration can be 
 msgstr ""
 
 # MSG_FS_VERIFIED c=20 r=3
-#: ultralcd.cpp:7411
+#: ultralcd.cpp:7332
 msgid "Sensor verified, remove the filament now."
 msgstr ""
 
@@ -1406,7 +1406,7 @@ msgid "Total print time"
 msgstr ""
 
 # MSG_TUNE c=18
-#: ultralcd.cpp:6653
+#: ultralcd.cpp:6574
 msgid "Tune"
 msgstr ""
 
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "to unload filament"
 msgstr ""
 
-# MSG_UNLOAD_FILAMENT c=16
+# MSG_UNLOAD_FILAMENT c=18
 #: messages.c:114
 msgid "Unload filament"
 msgstr ""
@@ -1510,7 +1510,7 @@ msgstr ""
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr ""
 
-# MSG_YES c=3
+# MSG_YES c=4
 #: messages.c:123
 msgid "Yes"
 msgstr ""
@@ -1586,7 +1586,7 @@ msgid "The printer will start printing a zig-zag line. Rotate the knob until you
 msgstr ""
 
 # MSG_FIL_FAILED c=20 r=5
-#: ultralcd.cpp:7415
+#: ultralcd.cpp:7336
 msgid "Verification failed, remove the filament and try again."
 msgstr ""
 
@@ -1616,7 +1616,7 @@ msgid "Checks"
 msgstr ""
 
 # MSG_FALSE_TRIGGERING c=20
-#: ultralcd.cpp:8190
+#: ultralcd.cpp:8111
 msgid "False triggering"
 msgstr ""
 
@@ -1721,17 +1721,17 @@ msgid "Printer nozzle diameter differs from the G-code. Please check the value i
 msgstr ""
 
 # MSG_SELFTEST_FS_LEVEL c=20
-#: ultralcd.cpp:8195
+#: ultralcd.cpp:8116
 msgid "%s level expected"
 msgstr ""
 
 # MSG_RENAME c=18
-#: ultralcd.cpp:6579
+#: ultralcd.cpp:6500
 msgid "Rename"
 msgstr ""
 
 # MSG_SELECT c=18
-#: ultralcd.cpp:6572
+#: ultralcd.cpp:6493
 msgid "Select"
 msgstr ""
 

--- a/lang/po/new/cs.po
+++ b/lang/po/new/cs.po
@@ -2,18 +2,18 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Prusa-Firmware\n"
-"POT-Creation-Date: Sun 19 Dec 2021 07:17:23 PM CET\n"
-"PO-Revision-Date: 2022-02-03 12:53+0100\n"
-"Last-Translator: \n"
-"Language-Team: \n"
-"Language: cs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
-"X-Generator: Poedit 3.0\n"
+"Language: cs\n"
+"Project-Id-Version: Prusa-Firmware\n"
+"POT-Creation-Date: Tue 08 Feb 2022 02:44:14 PM CET\n"
+"PO-Revision-Date: Tue 08 Feb 2022 02:44:14 PM CET\n"
+"Language-Team: \n"
+"X-Generator: Poedit 2.0.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
+"Last-Translator: \n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
 # MSG_IR_03_OR_OLDER c=18
 #: messages.c:164
@@ -21,7 +21,7 @@ msgid " 0.3 or older"
 msgstr " 0.3 nebo starsi"
 
 # MSG_FS_V_03_OR_OLDER c=18
-#: Marlin_main.cpp:9884
+#: Marlin_main.cpp:9887
 msgid "FS v0.3 or older"
 msgstr "FS 0.3 nebo starsi"
 
@@ -31,7 +31,7 @@ msgid " 0.4 or newer"
 msgstr " 0.4 nebo novejsi"
 
 # MSG_FS_V_04_OR_NEWER c=18
-#: Marlin_main.cpp:9883
+#: Marlin_main.cpp:9886
 msgid "FS v0.4 or newer"
 msgstr "FS 0.4 a novejsi"
 
@@ -46,10 +46,12 @@ msgid "[0;0] point offset"
 msgstr "[0;0] odsazeni bodu"
 
 # MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
+#: 
 msgid "Crash detection can\x0abe turned on only in\x0aNormal mode"
 msgstr "Crash detekce muze\x0abyt zapnuta pouze v\x0aNormal modu"
 
 # MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
+#: 
 msgid "WARNING:\x0aCrash detection\x0adisabled in\x0aStealth mode"
 msgstr "POZOR:\x0aCrash detekce\x0adeaktivovana ve\x0aStealth modu"
 
@@ -59,11 +61,11 @@ msgid "Adjusting Z:"
 msgstr "Doladeni Z:"
 
 # MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ultralcd.cpp:8490
+#: ultralcd.cpp:8411
 msgid "All correct"
 msgstr "Vse OK"
 
-# MSG_WIZARD_DONE c=20 r=8
+# MSG_WIZARD_DONE c=20 r=3
 #: messages.c:118
 msgid "All is done. Happy printing!"
 msgstr "Vse je hotovo. Tisku zdar!"
@@ -94,7 +96,7 @@ msgid "Auto home"
 msgstr ""
 
 # MSG_AUTOLOAD_FILAMENT c=18
-#: ultralcd.cpp:6732
+#: ultralcd.cpp:6653
 msgid "AutoLoad filament"
 msgstr "AutoZavedeni fil."
 
@@ -109,17 +111,17 @@ msgid "Autoloading filament is active, just press the knob and insert filament..
 msgstr "Automaticke zavadeni filamentu aktivni, stisknete tlacitko a vlozte filament..."
 
 # MSG_SELFTEST_AXIS_LENGTH c=20
-#: ultralcd.cpp:8173
+#: ultralcd.cpp:8094
 msgid "Axis length"
 msgstr "Delka osy"
 
 # MSG_SELFTEST_AXIS c=16
-#: ultralcd.cpp:8174
+#: ultralcd.cpp:8095
 msgid "Axis"
 msgstr "Osa"
 
 # MSG_SELFTEST_BEDHEATER c=20
-#: ultralcd.cpp:8131
+#: ultralcd.cpp:8052
 msgid "Bed/Heater"
 msgstr "Podlozka/Topeni"
 
@@ -174,7 +176,7 @@ msgid "Blackout occurred. Recover print?"
 msgstr "Detekovan vypadek proudu.Obnovit tisk?"
 
 # MSG_CALIBRATING_HOME c=20
-#: ultralcd.cpp:8492
+#: ultralcd.cpp:8413
 msgid "Calibrating home"
 msgstr "Kalibruji vychozi p."
 
@@ -224,12 +226,12 @@ msgid "Calibration"
 msgstr "Kalibrace"
 
 # MSG_SD_REMOVED c=20
-#: ultralcd.cpp:8939
+#: ultralcd.cpp:8860
 msgid "Card removed"
 msgstr "Karta vyjmuta"
 
 # MSG_CHECKING_FILE c=17
-#: ultralcd.cpp:8580
+#: ultralcd.cpp:8501
 msgid "Checking file"
 msgstr "Kontroluji soubor"
 
@@ -324,21 +326,22 @@ msgid "Ejecting filament"
 msgstr "Vysouvam filament"
 
 # MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ultralcd.cpp:8149
+#: ultralcd.cpp:8070
 msgid "Endstop not hit"
 msgstr "Kon. spinac nesepnut"
 
 # MSG_SELFTEST_ENDSTOP c=16
-#: ultralcd.cpp:8144
+#: ultralcd.cpp:8065
 msgid "Endstop"
 msgstr "Koncovy spinac"
 
 # MSG_SELFTEST_ENDSTOPS c=20
-#: ultralcd.cpp:8135
+#: ultralcd.cpp:8056
 msgid "Endstops"
 msgstr "Konc. spinace"
 
 # MSG_STACK_ERROR c=20 r=4
+#: 
 msgid "Error - static memory has been overwritten"
 msgstr "Chyba - Doslo k prepisu staticke pameti"
 
@@ -373,7 +376,7 @@ msgid "ERROR:"
 msgstr "CHYBA:"
 
 # MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
-#: ultralcd.cpp:8498
+#: ultralcd.cpp:8419
 msgid "Extruder fan:"
 msgstr "Levy vent.:"
 
@@ -388,7 +391,7 @@ msgid "Extruder"
 msgstr ""
 
 # MSG_MMU_FAIL_STATS c=18
-#: ultralcd.cpp:6754
+#: ultralcd.cpp:6675
 msgid "Fail stats MMU"
 msgstr "Selhani MMU"
 
@@ -398,7 +401,7 @@ msgid "F. autoload"
 msgstr "F. autozav."
 
 # MSG_FAIL_STATS c=18
-#: ultralcd.cpp:6751
+#: ultralcd.cpp:6672
 msgid "Fail stats"
 msgstr "Selhani"
 
@@ -437,7 +440,7 @@ msgstr "Filament vytlacen a spravne barvy?"
 msgid "Filament not loaded"
 msgstr "Filament nezaveden"
 
-# MSG_FILAMENT_SENSOR c=20
+# MSG_SELFTEST_FILAMENT_SENSOR c=17
 #: messages.c:97
 msgid "Filament sensor"
 msgstr "Senzor filamentu"
@@ -458,7 +461,7 @@ msgid "FS Action"
 msgstr "FS reakce"
 
 # MSG_FILE_INCOMPLETE c=20 r=3
-#: ultralcd.cpp:8634
+#: ultralcd.cpp:8555
 msgid "File incomplete. Continue anyway?"
 msgstr "Soubor nekompletni. Pokracovat?"
 
@@ -483,7 +486,7 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr "Opravte chybu a pote stisknete tlacitko na jednotce MMU."
 
 # MSG_FLOW c=15
-#: ultralcd.cpp:6888
+#: ultralcd.cpp:6809
 msgid "Flow"
 msgstr "Prutok"
 
@@ -494,21 +497,21 @@ msgstr "Predni tiskovy vent?"
 
 # MSG_BED_CORRECTION_FRONT c=14
 #: ultralcd.cpp:3116
-msgid "Front side[um]"
-msgstr "Vpredu [um]"
+msgid "Front side[μm]"
+msgstr "Vpredu [μm]"
 
 # MSG_SELFTEST_FANS c=20
-#: ultralcd.cpp:8179
+#: ultralcd.cpp:8100
 msgid "Front/left fans"
 msgstr "Predni/levy vent."
 
 # MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ultralcd.cpp:8127
+#: ultralcd.cpp:8048
 msgid "Heater/Thermistor"
 msgstr "Topeni/Termistor"
 
 # MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: Marlin_main.cpp:9874
+#: Marlin_main.cpp:9877
 msgid "Heating disabled by safety timer."
 msgstr "Zahrivani preruseno bezpecnostnim casovacem."
 
@@ -548,12 +551,12 @@ msgid "Checking bed"
 msgstr "Kontrola podlozky"
 
 # MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ultralcd.cpp:8481
+#: ultralcd.cpp:8402
 msgid "Checking endstops"
 msgstr "Kontrola endstopu"
 
 # MSG_SELFTEST_CHECK_HOTEND c=20
-#: ultralcd.cpp:8487
+#: ultralcd.cpp:8408
 msgid "Checking hotend"
 msgstr "Kontrola hotend"
 
@@ -573,7 +576,7 @@ msgid "Checking Y axis"
 msgstr "Kontrola osy Y"
 
 # MSG_SELFTEST_CHECK_Z c=20
-#: ultralcd.cpp:8484
+#: ultralcd.cpp:8405
 msgid "Checking Z axis"
 msgstr "Kontrola osy Z"
 
@@ -654,8 +657,8 @@ msgstr "Vlevo"
 
 # MSG_BED_CORRECTION_LEFT c=14
 #: ultralcd.cpp:3114
-msgid "Left side [um]"
-msgstr "Vlevo [um]"
+msgid "Left side [μm]"
+msgstr "Vlevo [μm]"
 
 # MSG_LIN_CORRECTION c=18
 #: ultralcd.cpp:5702
@@ -668,7 +671,7 @@ msgid "Live adjust Z"
 msgstr "Doladeni osy Z"
 
 # MSG_INSERT_FIL c=20 r=6
-#: ultralcd.cpp:7380
+#: ultralcd.cpp:7301
 msgid "Insert the filament (do not load it) into the extruder and then press the knob."
 msgstr "Vlozte filament (nezavadejte) do extruderu a stisknete tlacitko"
 
@@ -693,12 +696,12 @@ msgid "Iteration"
 msgstr "Opakovani"
 
 # MSG_LOOSE_PULLEY c=20
-#: ultralcd.cpp:8167
+#: ultralcd.cpp:8088
 msgid "Loose pulley"
 msgstr "Uvolnena remenicka"
 
 # MSG_LOAD_TO_NOZZLE c=18
-#: ultralcd.cpp:6717
+#: ultralcd.cpp:6638
 msgid "Load to nozzle"
 msgstr "Zavest do trysky"
 
@@ -848,7 +851,7 @@ msgid "No move."
 msgstr "Bez pohybu."
 
 # MSG_NO_CARD c=18
-#: ultralcd.cpp:6697
+#: ultralcd.cpp:6618
 msgid "No SD card"
 msgstr "Zadna SD karta"
 
@@ -863,7 +866,7 @@ msgid "No"
 msgstr "Ne"
 
 # MSG_SELFTEST_NOTCONNECTED c=20
-#: ultralcd.cpp:8128
+#: ultralcd.cpp:8049
 msgid "Not connected"
 msgstr "Nezapojeno"
 
@@ -948,7 +951,7 @@ msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Pro uspesnou kalibraci ocistete prosim tiskovou trysku. Potvrdte tlacitkem."
 
 # MSG_SELFTEST_PLEASECHECK c=20
-#: ultralcd.cpp:8122
+#: ultralcd.cpp:8043
 msgid "Please check:"
 msgstr "Zkontrolujte:"
 
@@ -1013,7 +1016,7 @@ msgid "Preheat the nozzle!"
 msgstr "Predehrejte trysku!"
 
 # MSG_PREHEAT c=18
-#: ultralcd.cpp:6655
+#: ultralcd.cpp:6576
 msgid "Preheat"
 msgstr "Predehrev"
 
@@ -1028,7 +1031,7 @@ msgid "Please upgrade."
 msgstr "Prosim aktualizujte."
 
 # MSG_PRESS_TO_PREHEAT c=20 r=4
-#: Marlin_main.cpp:12049
+#: Marlin_main.cpp:12052
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Pro nahrati trysky a pokracovani stisknete tlacitko."
 
@@ -1058,7 +1061,7 @@ msgid "Preheating to unload"
 msgstr "Predehrev k vyjmuti"
 
 # MSG_SELFTEST_PRINT_FAN_SPEED c=18
-#: ultralcd.cpp:8501
+#: ultralcd.cpp:8422
 msgid "Print fan:"
 msgstr "Tiskovy vent.:"
 
@@ -1109,21 +1112,21 @@ msgstr "Prosim nejdriv zavedte filament"
 
 # MSG_BED_CORRECTION_REAR c=14
 #: ultralcd.cpp:3117
-msgid "Rear side [um]"
-msgstr "Vzadu [um]"
+msgid "Rear side [μm]"
+msgstr "Vzadu [μm]"
 
 # MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ultralcd.cpp:7404
+#: ultralcd.cpp:7325
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Prosim vyjmete filament a zopakujte tuto akci"
 
 # MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ultralcd.cpp:7407
+#: ultralcd.cpp:7328
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "Prosim zkontrolujte zapojeni IR senzoru a vyjmuty filament"
 
 # MSG_RECOVERING_PRINT c=20
-#: Marlin_main.cpp:11393
+#: Marlin_main.cpp:11396
 msgid "Recovering print"
 msgstr "Obnovovani tisku"
 
@@ -1154,8 +1157,8 @@ msgstr "Obnoveni tisku"
 
 # MSG_BED_CORRECTION_RIGHT c=14
 #: ultralcd.cpp:3115
-msgid "Right side[um]"
-msgstr "Vpravo [um]"
+msgid "Right side[μm]"
+msgstr "Vpravo [μm]"
 
 # MSG_RPI_PORT c=13
 #: messages.c:142
@@ -1188,12 +1191,12 @@ msgid "Select language"
 msgstr "Vyber jazyka"
 
 # MSG_SELFTEST_OK c=20
-#: ultralcd.cpp:7679
+#: ultralcd.cpp:7600
 msgid "Self test OK"
 msgstr ""
 
 # MSG_SELFTEST_START c=20
-#: ultralcd.cpp:7447
+#: ultralcd.cpp:7368
 msgid "Self test start"
 msgstr ""
 
@@ -1203,7 +1206,7 @@ msgid "Selftest"
 msgstr ""
 
 # MSG_SELFTEST_ERROR c=20
-#: ultralcd.cpp:8121
+#: ultralcd.cpp:8042
 msgid "Selftest error!"
 msgstr "Chyba Selftestu!"
 
@@ -1278,8 +1281,9 @@ msgid "Loud"
 msgstr "Hlasity"
 
 # MSG_SLIGHT_SKEW c=14
-msgid "Slight skew:"
-msgstr "Lehke zkos.:"
+#: ultralcd.cpp:2887
+msgid "Slight skew"
+msgstr "Lehke zkos."
 
 # MSG_SOUND c=7
 #: messages.c:143
@@ -1302,7 +1306,7 @@ msgid "Once"
 msgstr "Jednou"
 
 # MSG_SPEED c=15
-#: ultralcd.cpp:6882
+#: ultralcd.cpp:6803
 msgid "Speed"
 msgstr "Rychlost"
 
@@ -1332,12 +1336,12 @@ msgid "STOPPED."
 msgstr "ZASTAVENO."
 
 # MSG_SUPPORT c=18
-#: ultralcd.cpp:6756
+#: ultralcd.cpp:6677
 msgid "Support"
 msgstr "Podpora"
 
 # MSG_SELFTEST_SWAPPED c=16
-#: ultralcd.cpp:8180
+#: ultralcd.cpp:8101
 msgid "Swapped"
 msgstr "Prohozene"
 
@@ -1372,7 +1376,7 @@ msgid "Temperature calibration is finished and active. Temp. calibration can be 
 msgstr "Teplotni kalibrace dokoncena a je nyni aktivni. Teplotni kalibraci je mozno deaktivovat v menu Nastaveni->Tepl. kal."
 
 # MSG_FS_VERIFIED c=20 r=3
-#: ultralcd.cpp:7411
+#: ultralcd.cpp:7332
 msgid "Sensor verified, remove the filament now."
 msgstr "Senzor overen, vyjmete filament."
 
@@ -1402,7 +1406,7 @@ msgid "Total print time"
 msgstr "Celkovy cas tisku"
 
 # MSG_TUNE c=18
-#: ultralcd.cpp:6653
+#: ultralcd.cpp:6574
 msgid "Tune"
 msgstr "Ladit"
 
@@ -1421,7 +1425,7 @@ msgstr "k zavedeni filamentu"
 msgid "to unload filament"
 msgstr "k vyjmuti filamentu"
 
-# MSG_UNLOAD_FILAMENT c=16
+# MSG_UNLOAD_FILAMENT c=18
 #: messages.c:114
 msgid "Unload filament"
 msgstr "Vyjmout filament"
@@ -1506,7 +1510,7 @@ msgstr "Detaily XYZ kal."
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "Kalibrace XYZ selhala. Nahlednete do manualu."
 
-# MSG_YES c=3
+# MSG_YES c=4
 #: messages.c:123
 msgid "Yes"
 msgstr "Ano"
@@ -1582,7 +1586,7 @@ msgid "The printer will start printing a zig-zag line. Rotate the knob until you
 msgstr "Tiskarna zacne tisknout lomenou caru. Otacenim tlacitka nastavte optimalni vysku. Postupujte podle obrazku v handbooku (kapitola Kalibrace)."
 
 # MSG_FIL_FAILED c=20 r=5
-#: ultralcd.cpp:7415
+#: ultralcd.cpp:7336
 msgid "Verification failed, remove the filament and try again."
 msgstr "Overeni selhalo, vyjmete filament a zkuste znovu."
 
@@ -1612,7 +1616,7 @@ msgid "Checks"
 msgstr "Kontrola"
 
 # MSG_FALSE_TRIGGERING c=20
-#: ultralcd.cpp:8190
+#: ultralcd.cpp:8111
 msgid "False triggering"
 msgstr "Falesne spusteni"
 
@@ -1717,17 +1721,17 @@ msgid "Printer nozzle diameter differs from the G-code. Please check the value i
 msgstr "Prumer trysky tiskarny se lisi od G-code. Prosim zkontrolujte nastaveni. Tisk zrusen."
 
 # MSG_SELFTEST_FS_LEVEL c=20
-#: ultralcd.cpp:8195
+#: ultralcd.cpp:8116
 msgid "%s level expected"
 msgstr "%s ocekavana verze"
 
 # MSG_RENAME c=18
-#: ultralcd.cpp:6579
+#: ultralcd.cpp:6500
 msgid "Rename"
 msgstr "Prejmenovat"
 
 # MSG_SELECT c=18
-#: ultralcd.cpp:6572
+#: ultralcd.cpp:6493
 msgid "Select"
 msgstr "Vybrat"
 
@@ -1765,3 +1769,4 @@ msgstr "Pocet mereni Z"
 #: ultralcd.cpp:2028
 msgid "Printer IP Addr:"
 msgstr "IP adr. tiskarny:"
+

--- a/lang/po/new/da.po
+++ b/lang/po/new/da.po
@@ -7,8 +7,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: da\n"
 "Project-Id-Version: Prusa-Firmware\n"
-"POT-Creation-Date: Tue 21 Dec 2021 02:56:33 PM CET\n"
-"PO-Revision-Date: Tue 21 Dec 2021 02:56:33 PM CET\n"
+"POT-Creation-Date: Tue 08 Feb 2022 02:44:55 PM CET\n"
+"PO-Revision-Date: Tue 08 Feb 2022 02:44:55 PM CET\n"
 "Language-Team: \n"
 "X-Generator: Poedit 2.0.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
@@ -21,7 +21,7 @@ msgid " 0.3 or older"
 msgstr ""
 
 # MSG_FS_V_03_OR_OLDER c=18
-#: Marlin_main.cpp:9884
+#: Marlin_main.cpp:9887
 msgid "FS v0.3 or older"
 msgstr ""
 
@@ -31,7 +31,7 @@ msgid " 0.4 or newer"
 msgstr ""
 
 # MSG_FS_V_04_OR_NEWER c=18
-#: Marlin_main.cpp:9883
+#: Marlin_main.cpp:9886
 msgid "FS v0.4 or newer"
 msgstr ""
 
@@ -61,11 +61,11 @@ msgid "Adjusting Z:"
 msgstr ""
 
 # MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ultralcd.cpp:8490
+#: ultralcd.cpp:8411
 msgid "All correct"
 msgstr ""
 
-# MSG_WIZARD_DONE c=20 r=8
+# MSG_WIZARD_DONE c=20 r=3
 #: messages.c:118
 msgid "All is done. Happy printing!"
 msgstr ""
@@ -96,7 +96,7 @@ msgid "Auto home"
 msgstr ""
 
 # MSG_AUTOLOAD_FILAMENT c=18
-#: ultralcd.cpp:6732
+#: ultralcd.cpp:6653
 msgid "AutoLoad filament"
 msgstr ""
 
@@ -111,17 +111,17 @@ msgid "Autoloading filament is active, just press the knob and insert filament..
 msgstr ""
 
 # MSG_SELFTEST_AXIS_LENGTH c=20
-#: ultralcd.cpp:8173
+#: ultralcd.cpp:8094
 msgid "Axis length"
 msgstr ""
 
 # MSG_SELFTEST_AXIS c=16
-#: ultralcd.cpp:8174
+#: ultralcd.cpp:8095
 msgid "Axis"
 msgstr ""
 
 # MSG_SELFTEST_BEDHEATER c=20
-#: ultralcd.cpp:8131
+#: ultralcd.cpp:8052
 msgid "Bed/Heater"
 msgstr ""
 
@@ -176,7 +176,7 @@ msgid "Blackout occurred. Recover print?"
 msgstr ""
 
 # MSG_CALIBRATING_HOME c=20
-#: ultralcd.cpp:8492
+#: ultralcd.cpp:8413
 msgid "Calibrating home"
 msgstr ""
 
@@ -226,12 +226,12 @@ msgid "Calibration"
 msgstr ""
 
 # MSG_SD_REMOVED c=20
-#: ultralcd.cpp:8939
+#: ultralcd.cpp:8860
 msgid "Card removed"
 msgstr ""
 
 # MSG_CHECKING_FILE c=17
-#: ultralcd.cpp:8580
+#: ultralcd.cpp:8501
 msgid "Checking file"
 msgstr ""
 
@@ -326,17 +326,17 @@ msgid "Ejecting filament"
 msgstr ""
 
 # MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ultralcd.cpp:8149
+#: ultralcd.cpp:8070
 msgid "Endstop not hit"
 msgstr ""
 
 # MSG_SELFTEST_ENDSTOP c=16
-#: ultralcd.cpp:8144
+#: ultralcd.cpp:8065
 msgid "Endstop"
 msgstr ""
 
 # MSG_SELFTEST_ENDSTOPS c=20
-#: ultralcd.cpp:8135
+#: ultralcd.cpp:8056
 msgid "Endstops"
 msgstr ""
 
@@ -376,7 +376,7 @@ msgid "ERROR:"
 msgstr ""
 
 # MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
-#: ultralcd.cpp:8498
+#: ultralcd.cpp:8419
 msgid "Extruder fan:"
 msgstr ""
 
@@ -391,7 +391,7 @@ msgid "Extruder"
 msgstr ""
 
 # MSG_MMU_FAIL_STATS c=18
-#: ultralcd.cpp:6754
+#: ultralcd.cpp:6675
 msgid "Fail stats MMU"
 msgstr ""
 
@@ -401,7 +401,7 @@ msgid "F. autoload"
 msgstr ""
 
 # MSG_FAIL_STATS c=18
-#: ultralcd.cpp:6751
+#: ultralcd.cpp:6672
 msgid "Fail stats"
 msgstr ""
 
@@ -440,7 +440,7 @@ msgstr ""
 msgid "Filament not loaded"
 msgstr ""
 
-# MSG_FILAMENT_SENSOR c=20
+# MSG_SELFTEST_FILAMENT_SENSOR c=17
 #: messages.c:97
 msgid "Filament sensor"
 msgstr ""
@@ -461,7 +461,7 @@ msgid "FS Action"
 msgstr ""
 
 # MSG_FILE_INCOMPLETE c=20 r=3
-#: ultralcd.cpp:8634
+#: ultralcd.cpp:8555
 msgid "File incomplete. Continue anyway?"
 msgstr ""
 
@@ -486,7 +486,7 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr ""
 
 # MSG_FLOW c=15
-#: ultralcd.cpp:6888
+#: ultralcd.cpp:6809
 msgid "Flow"
 msgstr ""
 
@@ -497,21 +497,21 @@ msgstr ""
 
 # MSG_BED_CORRECTION_FRONT c=14
 #: ultralcd.cpp:3116
-msgid "Front side[um]"
+msgid "Front side[μm]"
 msgstr ""
 
 # MSG_SELFTEST_FANS c=20
-#: ultralcd.cpp:8179
+#: ultralcd.cpp:8100
 msgid "Front/left fans"
 msgstr ""
 
 # MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ultralcd.cpp:8127
+#: ultralcd.cpp:8048
 msgid "Heater/Thermistor"
 msgstr ""
 
 # MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: Marlin_main.cpp:9874
+#: Marlin_main.cpp:9877
 msgid "Heating disabled by safety timer."
 msgstr ""
 
@@ -551,12 +551,12 @@ msgid "Checking bed"
 msgstr ""
 
 # MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ultralcd.cpp:8481
+#: ultralcd.cpp:8402
 msgid "Checking endstops"
 msgstr ""
 
 # MSG_SELFTEST_CHECK_HOTEND c=20
-#: ultralcd.cpp:8487
+#: ultralcd.cpp:8408
 msgid "Checking hotend"
 msgstr ""
 
@@ -576,7 +576,7 @@ msgid "Checking Y axis"
 msgstr ""
 
 # MSG_SELFTEST_CHECK_Z c=20
-#: ultralcd.cpp:8484
+#: ultralcd.cpp:8405
 msgid "Checking Z axis"
 msgstr ""
 
@@ -657,7 +657,7 @@ msgstr ""
 
 # MSG_BED_CORRECTION_LEFT c=14
 #: ultralcd.cpp:3114
-msgid "Left side [um]"
+msgid "Left side [μm]"
 msgstr ""
 
 # MSG_LIN_CORRECTION c=18
@@ -671,7 +671,7 @@ msgid "Live adjust Z"
 msgstr ""
 
 # MSG_INSERT_FIL c=20 r=6
-#: ultralcd.cpp:7380
+#: ultralcd.cpp:7301
 msgid "Insert the filament (do not load it) into the extruder and then press the knob."
 msgstr ""
 
@@ -696,12 +696,12 @@ msgid "Iteration"
 msgstr ""
 
 # MSG_LOOSE_PULLEY c=20
-#: ultralcd.cpp:8167
+#: ultralcd.cpp:8088
 msgid "Loose pulley"
 msgstr ""
 
 # MSG_LOAD_TO_NOZZLE c=18
-#: ultralcd.cpp:6717
+#: ultralcd.cpp:6638
 msgid "Load to nozzle"
 msgstr ""
 
@@ -851,7 +851,7 @@ msgid "No move."
 msgstr ""
 
 # MSG_NO_CARD c=18
-#: ultralcd.cpp:6697
+#: ultralcd.cpp:6618
 msgid "No SD card"
 msgstr ""
 
@@ -866,7 +866,7 @@ msgid "No"
 msgstr ""
 
 # MSG_SELFTEST_NOTCONNECTED c=20
-#: ultralcd.cpp:8128
+#: ultralcd.cpp:8049
 msgid "Not connected"
 msgstr ""
 
@@ -951,7 +951,7 @@ msgid "Please clean the nozzle for calibration. Click when done."
 msgstr ""
 
 # MSG_SELFTEST_PLEASECHECK c=20
-#: ultralcd.cpp:8122
+#: ultralcd.cpp:8043
 msgid "Please check:"
 msgstr ""
 
@@ -1016,7 +1016,7 @@ msgid "Preheat the nozzle!"
 msgstr ""
 
 # MSG_PREHEAT c=18
-#: ultralcd.cpp:6655
+#: ultralcd.cpp:6576
 msgid "Preheat"
 msgstr ""
 
@@ -1031,7 +1031,7 @@ msgid "Please upgrade."
 msgstr ""
 
 # MSG_PRESS_TO_PREHEAT c=20 r=4
-#: Marlin_main.cpp:12049
+#: Marlin_main.cpp:12052
 msgid "Press the knob to preheat nozzle and continue."
 msgstr ""
 
@@ -1061,7 +1061,7 @@ msgid "Preheating to unload"
 msgstr ""
 
 # MSG_SELFTEST_PRINT_FAN_SPEED c=18
-#: ultralcd.cpp:8501
+#: ultralcd.cpp:8422
 msgid "Print fan:"
 msgstr ""
 
@@ -1112,21 +1112,21 @@ msgstr ""
 
 # MSG_BED_CORRECTION_REAR c=14
 #: ultralcd.cpp:3117
-msgid "Rear side [um]"
+msgid "Rear side [μm]"
 msgstr ""
 
 # MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ultralcd.cpp:7404
+#: ultralcd.cpp:7325
 msgid "Please unload the filament first, then repeat this action."
 msgstr ""
 
 # MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ultralcd.cpp:7407
+#: ultralcd.cpp:7328
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr ""
 
 # MSG_RECOVERING_PRINT c=20
-#: Marlin_main.cpp:11393
+#: Marlin_main.cpp:11396
 msgid "Recovering print"
 msgstr ""
 
@@ -1157,7 +1157,7 @@ msgstr ""
 
 # MSG_BED_CORRECTION_RIGHT c=14
 #: ultralcd.cpp:3115
-msgid "Right side[um]"
+msgid "Right side[μm]"
 msgstr ""
 
 # MSG_RPI_PORT c=13
@@ -1191,12 +1191,12 @@ msgid "Select language"
 msgstr ""
 
 # MSG_SELFTEST_OK c=20
-#: ultralcd.cpp:7679
+#: ultralcd.cpp:7600
 msgid "Self test OK"
 msgstr ""
 
 # MSG_SELFTEST_START c=20
-#: ultralcd.cpp:7447
+#: ultralcd.cpp:7368
 msgid "Self test start"
 msgstr ""
 
@@ -1206,7 +1206,7 @@ msgid "Selftest"
 msgstr ""
 
 # MSG_SELFTEST_ERROR c=20
-#: ultralcd.cpp:8121
+#: ultralcd.cpp:8042
 msgid "Selftest error!"
 msgstr ""
 
@@ -1306,7 +1306,7 @@ msgid "Once"
 msgstr ""
 
 # MSG_SPEED c=15
-#: ultralcd.cpp:6882
+#: ultralcd.cpp:6803
 msgid "Speed"
 msgstr ""
 
@@ -1336,12 +1336,12 @@ msgid "STOPPED."
 msgstr ""
 
 # MSG_SUPPORT c=18
-#: ultralcd.cpp:6756
+#: ultralcd.cpp:6677
 msgid "Support"
 msgstr ""
 
 # MSG_SELFTEST_SWAPPED c=16
-#: ultralcd.cpp:8180
+#: ultralcd.cpp:8101
 msgid "Swapped"
 msgstr ""
 
@@ -1376,7 +1376,7 @@ msgid "Temperature calibration is finished and active. Temp. calibration can be 
 msgstr ""
 
 # MSG_FS_VERIFIED c=20 r=3
-#: ultralcd.cpp:7411
+#: ultralcd.cpp:7332
 msgid "Sensor verified, remove the filament now."
 msgstr ""
 
@@ -1406,7 +1406,7 @@ msgid "Total print time"
 msgstr ""
 
 # MSG_TUNE c=18
-#: ultralcd.cpp:6653
+#: ultralcd.cpp:6574
 msgid "Tune"
 msgstr ""
 
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "to unload filament"
 msgstr ""
 
-# MSG_UNLOAD_FILAMENT c=16
+# MSG_UNLOAD_FILAMENT c=18
 #: messages.c:114
 msgid "Unload filament"
 msgstr ""
@@ -1510,7 +1510,7 @@ msgstr ""
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr ""
 
-# MSG_YES c=3
+# MSG_YES c=4
 #: messages.c:123
 msgid "Yes"
 msgstr ""
@@ -1586,7 +1586,7 @@ msgid "The printer will start printing a zig-zag line. Rotate the knob until you
 msgstr ""
 
 # MSG_FIL_FAILED c=20 r=5
-#: ultralcd.cpp:7415
+#: ultralcd.cpp:7336
 msgid "Verification failed, remove the filament and try again."
 msgstr ""
 
@@ -1616,7 +1616,7 @@ msgid "Checks"
 msgstr ""
 
 # MSG_FALSE_TRIGGERING c=20
-#: ultralcd.cpp:8190
+#: ultralcd.cpp:8111
 msgid "False triggering"
 msgstr ""
 
@@ -1721,17 +1721,17 @@ msgid "Printer nozzle diameter differs from the G-code. Please check the value i
 msgstr ""
 
 # MSG_SELFTEST_FS_LEVEL c=20
-#: ultralcd.cpp:8195
+#: ultralcd.cpp:8116
 msgid "%s level expected"
 msgstr ""
 
 # MSG_RENAME c=18
-#: ultralcd.cpp:6579
+#: ultralcd.cpp:6500
 msgid "Rename"
 msgstr ""
 
 # MSG_SELECT c=18
-#: ultralcd.cpp:6572
+#: ultralcd.cpp:6493
 msgid "Select"
 msgstr ""
 

--- a/lang/po/new/de.po
+++ b/lang/po/new/de.po
@@ -7,8 +7,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: de\n"
 "Project-Id-Version: Prusa-Firmware\n"
-"POT-Creation-Date: Wed 26 Jan 2022 05:40:56 PM CET\n"
-"PO-Revision-Date: Wed 26 Jan 2022 05:40:56 PM CET\n"
+"POT-Creation-Date: Tue 08 Feb 2022 02:44:18 PM CET\n"
+"PO-Revision-Date: Tue 08 Feb 2022 02:44:18 PM CET\n"
 "Language-Team: \n"
 "X-Generator: Poedit 2.0.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
@@ -65,7 +65,7 @@ msgstr "Z Anpassen:"
 msgid "All correct"
 msgstr "Alles richtig"
 
-# MSG_WIZARD_DONE c=20 r=8
+# MSG_WIZARD_DONE c=20 r=3
 #: messages.c:118
 msgid "All is done. Happy printing!"
 msgstr "Alles abgeschlossen. Viel Spaß beim Drucken!"
@@ -138,7 +138,7 @@ msgstr "Bett aufwärmen"
 # MSG_BED_CORRECTION_MENU c=18
 #: ultralcd.cpp:5798
 msgid "Bed level correct"
-msgstr "Ausgleich Bett ok"
+msgstr "Bett Level Korr."
 
 # MSG_BELTTEST c=18
 #: ultralcd.cpp:5778
@@ -440,7 +440,7 @@ msgstr "Filament extrudiert mit richtiger Farbe?"
 msgid "Filament not loaded"
 msgstr "Fil. nicht geladen"
 
-# MSG_FILAMENT_SENSOR c=20
+# MSG_SELFTEST_FILAMENT_SENSOR c=17
 #: messages.c:97
 msgid "Filament sensor"
 msgstr "Filamentsensor"
@@ -497,8 +497,8 @@ msgstr "Drucklüfter?"
 
 # MSG_BED_CORRECTION_FRONT c=14
 #: ultralcd.cpp:3116
-msgid "Front side[um]"
-msgstr "Vorne [um]"
+msgid "Front side[μm]"
+msgstr "Vorne [μm]"
 
 # MSG_SELFTEST_FANS c=20
 #: ultralcd.cpp:8100
@@ -657,8 +657,8 @@ msgstr "Links"
 
 # MSG_BED_CORRECTION_LEFT c=14
 #: ultralcd.cpp:3114
-msgid "Left side [um]"
-msgstr "Links [um]"
+msgid "Left side [μm]"
+msgstr "Links [μm]"
 
 # MSG_LIN_CORRECTION c=18
 #: ultralcd.cpp:5702
@@ -1112,8 +1112,8 @@ msgstr "Bitte laden Sie zuerst das Filament."
 
 # MSG_BED_CORRECTION_REAR c=14
 #: ultralcd.cpp:3117
-msgid "Rear side [um]"
-msgstr "Hinten [um]"
+msgid "Rear side [μm]"
+msgstr "Hinten [μm]"
 
 # MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
 #: ultralcd.cpp:7325
@@ -1157,8 +1157,8 @@ msgstr "Druck fortgesetzt"
 
 # MSG_BED_CORRECTION_RIGHT c=14
 #: ultralcd.cpp:3115
-msgid "Right side[um]"
-msgstr "Rechts [um]"
+msgid "Right side[μm]"
+msgstr "Rechts [μm]"
 
 # MSG_RPI_PORT c=13
 #: messages.c:142
@@ -1425,7 +1425,7 @@ msgstr "Filament laden"
 msgid "to unload filament"
 msgstr "um Filament entladen"
 
-# MSG_UNLOAD_FILAMENT c=16
+# MSG_UNLOAD_FILAMENT c=18
 #: messages.c:114
 msgid "Unload filament"
 msgstr "Fil. entladen"
@@ -1510,7 +1510,7 @@ msgstr "XYZ Kal. Details"
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "XYZ-Kalibrierung fehlgeschlagen. Bitte schauen Sie in das Handbuch."
 
-# MSG_YES c=3
+# MSG_YES c=4
 #: messages.c:123
 msgid "Yes"
 msgstr "Ja"
@@ -1668,7 +1668,7 @@ msgstr "Modell"
 # MSG_NOZZLE_DIAMETER c=10
 #: messages.c:136
 msgid "Nozzle d."
-msgstr "Düsendiam."
+msgstr "Düsen Dia."
 
 # MSG_GCODE_DIFF_CONTINUE c=20 r=4
 #: util.cpp:414

--- a/lang/po/new/es.po
+++ b/lang/po/new/es.po
@@ -7,8 +7,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: es\n"
 "Project-Id-Version: Prusa-Firmware\n"
-"POT-Creation-Date: Sun 19 Dec 2021 07:17:30 PM CET\n"
-"PO-Revision-Date: Sun 19 Dec 2021 07:17:30 PM CET\n"
+"POT-Creation-Date: Tue 08 Feb 2022 02:44:22 PM CET\n"
+"PO-Revision-Date: Tue 08 Feb 2022 02:44:22 PM CET\n"
 "Language-Team: \n"
 "X-Generator: Poedit 2.0.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
@@ -21,7 +21,7 @@ msgid " 0.3 or older"
 msgstr " 0.3 o mayor"
 
 # MSG_FS_V_03_OR_OLDER c=18
-#: Marlin_main.cpp:9884
+#: Marlin_main.cpp:9887
 msgid "FS v0.3 or older"
 msgstr "FS 0.3 o mayor"
 
@@ -31,7 +31,7 @@ msgid " 0.4 or newer"
 msgstr " 0.4 o mas nueva"
 
 # MSG_FS_V_04_OR_NEWER c=18
-#: Marlin_main.cpp:9883
+#: Marlin_main.cpp:9886
 msgid "FS v0.4 or newer"
 msgstr "FS 0.4 o mas nueva"
 
@@ -61,11 +61,11 @@ msgid "Adjusting Z:"
 msgstr "Ajustar-Z:"
 
 # MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ultralcd.cpp:8490
+#: ultralcd.cpp:8411
 msgid "All correct"
 msgstr "Todo bien"
 
-# MSG_WIZARD_DONE c=20 r=8
+# MSG_WIZARD_DONE c=20 r=3
 #: messages.c:118
 msgid "All is done. Happy printing!"
 msgstr "Terminado! Feliz impresion!"
@@ -96,7 +96,7 @@ msgid "Auto home"
 msgstr "Llevar al origen"
 
 # MSG_AUTOLOAD_FILAMENT c=18
-#: ultralcd.cpp:6732
+#: ultralcd.cpp:6653
 msgid "AutoLoad filament"
 msgstr "Carga auto. filam."
 
@@ -111,17 +111,17 @@ msgid "Autoloading filament is active, just press the knob and insert filament..
 msgstr "La carga automatica esta activada, pulse el dial e inserte el filamento..."
 
 # MSG_SELFTEST_AXIS_LENGTH c=20
-#: ultralcd.cpp:8173
+#: ultralcd.cpp:8094
 msgid "Axis length"
 msgstr "Longitud del eje"
 
 # MSG_SELFTEST_AXIS c=16
-#: ultralcd.cpp:8174
+#: ultralcd.cpp:8095
 msgid "Axis"
 msgstr "Eje"
 
 # MSG_SELFTEST_BEDHEATER c=20
-#: ultralcd.cpp:8131
+#: ultralcd.cpp:8052
 msgid "Bed/Heater"
 msgstr "Base/Calentador"
 
@@ -176,7 +176,7 @@ msgid "Blackout occurred. Recover print?"
 msgstr "Se fue la luz. Re- anudar la impresion?"
 
 # MSG_CALIBRATING_HOME c=20
-#: ultralcd.cpp:8492
+#: ultralcd.cpp:8413
 msgid "Calibrating home"
 msgstr "Calibrar pos.inicial"
 
@@ -226,12 +226,12 @@ msgid "Calibration"
 msgstr "Calibracion"
 
 # MSG_SD_REMOVED c=20
-#: ultralcd.cpp:8939
+#: ultralcd.cpp:8860
 msgid "Card removed"
 msgstr "Tarjeta retirada"
 
 # MSG_CHECKING_FILE c=17
-#: ultralcd.cpp:8580
+#: ultralcd.cpp:8501
 msgid "Checking file"
 msgstr "Verif. archivo"
 
@@ -326,17 +326,17 @@ msgid "Ejecting filament"
 msgstr "Expulsando filamento"
 
 # MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ultralcd.cpp:8149
+#: ultralcd.cpp:8070
 msgid "Endstop not hit"
 msgstr "Endstop no alcanzado"
 
 # MSG_SELFTEST_ENDSTOP c=16
-#: ultralcd.cpp:8144
+#: ultralcd.cpp:8065
 msgid "Endstop"
 msgstr ""
 
 # MSG_SELFTEST_ENDSTOPS c=20
-#: ultralcd.cpp:8135
+#: ultralcd.cpp:8056
 msgid "Endstops"
 msgstr ""
 
@@ -376,7 +376,7 @@ msgid "ERROR:"
 msgstr ""
 
 # MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
-#: ultralcd.cpp:8498
+#: ultralcd.cpp:8419
 msgid "Extruder fan:"
 msgstr "Vent.extrusor:"
 
@@ -391,7 +391,7 @@ msgid "Extruder"
 msgstr "Extruir"
 
 # MSG_MMU_FAIL_STATS c=18
-#: ultralcd.cpp:6754
+#: ultralcd.cpp:6675
 msgid "Fail stats MMU"
 msgstr "Total Fallos MMU"
 
@@ -401,7 +401,7 @@ msgid "F. autoload"
 msgstr "Autocarg.fil."
 
 # MSG_FAIL_STATS c=18
-#: ultralcd.cpp:6751
+#: ultralcd.cpp:6672
 msgid "Fail stats"
 msgstr "Estadistica Fallos"
 
@@ -440,10 +440,10 @@ msgstr "Es nitido el color nuevo?"
 msgid "Filament not loaded"
 msgstr "Fil. no introducido"
 
-# MSG_FILAMENT_SENSOR c=20
+# MSG_SELFTEST_FILAMENT_SENSOR c=17
 #: messages.c:97
 msgid "Filament sensor"
-msgstr "Sensor de filamento"
+msgstr "Sensor de fil."
 
 # MSG_FILAMENT_USED c=19
 #: ultralcd.cpp:2713
@@ -461,7 +461,7 @@ msgid "FS Action"
 msgstr "FS accion"
 
 # MSG_FILE_INCOMPLETE c=20 r=3
-#: ultralcd.cpp:8634
+#: ultralcd.cpp:8555
 msgid "File incomplete. Continue anyway?"
 msgstr "Archivo incompleto. ?Continuar de todos modos?"
 
@@ -486,7 +486,7 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr "Corrige el problema y pulsa el boton en la unidad MMU."
 
 # MSG_FLOW c=15
-#: ultralcd.cpp:6888
+#: ultralcd.cpp:6809
 msgid "Flow"
 msgstr "Flujo"
 
@@ -497,21 +497,21 @@ msgstr "Vent. frontal?"
 
 # MSG_BED_CORRECTION_FRONT c=14
 #: ultralcd.cpp:3116
-msgid "Front side[um]"
-msgstr "Frontal [um]"
+msgid "Front side[μm]"
+msgstr "Frontal [μm]"
 
 # MSG_SELFTEST_FANS c=20
-#: ultralcd.cpp:8179
+#: ultralcd.cpp:8100
 msgid "Front/left fans"
 msgstr "Vents. front/izqui"
 
 # MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ultralcd.cpp:8127
+#: ultralcd.cpp:8048
 msgid "Heater/Thermistor"
 msgstr "Calentador/Termistor"
 
 # MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: Marlin_main.cpp:9874
+#: Marlin_main.cpp:9877
 msgid "Heating disabled by safety timer."
 msgstr "Calentadores desactivados por el temporizador de seguridad."
 
@@ -551,12 +551,12 @@ msgid "Checking bed"
 msgstr "Control base cal."
 
 # MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ultralcd.cpp:8481
+#: ultralcd.cpp:8402
 msgid "Checking endstops"
 msgstr "Control endstops"
 
 # MSG_SELFTEST_CHECK_HOTEND c=20
-#: ultralcd.cpp:8487
+#: ultralcd.cpp:8408
 msgid "Checking hotend"
 msgstr "Control fusor"
 
@@ -576,7 +576,7 @@ msgid "Checking Y axis"
 msgstr "Control sensor Y"
 
 # MSG_SELFTEST_CHECK_Z c=20
-#: ultralcd.cpp:8484
+#: ultralcd.cpp:8405
 msgid "Checking Z axis"
 msgstr "Control sensor Z"
 
@@ -657,8 +657,8 @@ msgstr "Izquierda"
 
 # MSG_BED_CORRECTION_LEFT c=14
 #: ultralcd.cpp:3114
-msgid "Left side [um]"
-msgstr "Izquierda [um]"
+msgid "Left side [μm]"
+msgstr "Izquierda [μm]"
 
 # MSG_LIN_CORRECTION c=18
 #: ultralcd.cpp:5702
@@ -671,7 +671,7 @@ msgid "Live adjust Z"
 msgstr "Micropaso Eje Z"
 
 # MSG_INSERT_FIL c=20 r=6
-#: ultralcd.cpp:7380
+#: ultralcd.cpp:7301
 msgid "Insert the filament (do not load it) into the extruder and then press the knob."
 msgstr "Inserte el filamento (no lo cargue) en el extrusor y luego presione el dial."
 
@@ -696,12 +696,12 @@ msgid "Iteration"
 msgstr "Iteracion"
 
 # MSG_LOOSE_PULLEY c=20
-#: ultralcd.cpp:8167
+#: ultralcd.cpp:8088
 msgid "Loose pulley"
 msgstr "Polea suelta"
 
 # MSG_LOAD_TO_NOZZLE c=18
-#: ultralcd.cpp:6717
+#: ultralcd.cpp:6638
 msgid "Load to nozzle"
 msgstr "Cargar a boquilla"
 
@@ -851,7 +851,7 @@ msgid "No move."
 msgstr "Sin movimiento"
 
 # MSG_NO_CARD c=18
-#: ultralcd.cpp:6697
+#: ultralcd.cpp:6618
 msgid "No SD card"
 msgstr "No hay tarjeta SD"
 
@@ -866,7 +866,7 @@ msgid "No"
 msgstr ""
 
 # MSG_SELFTEST_NOTCONNECTED c=20
-#: ultralcd.cpp:8128
+#: ultralcd.cpp:8049
 msgid "Not connected"
 msgstr "No hay conexion"
 
@@ -951,7 +951,7 @@ msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Limpia boquilla para calibracion. Click cuando acabes."
 
 # MSG_SELFTEST_PLEASECHECK c=20
-#: ultralcd.cpp:8122
+#: ultralcd.cpp:8043
 msgid "Please check:"
 msgstr "Controla:"
 
@@ -1016,7 +1016,7 @@ msgid "Preheat the nozzle!"
 msgstr "Precalienta extrusor"
 
 # MSG_PREHEAT c=18
-#: ultralcd.cpp:6655
+#: ultralcd.cpp:6576
 msgid "Preheat"
 msgstr "Precalentar"
 
@@ -1031,7 +1031,7 @@ msgid "Please upgrade."
 msgstr "Actualize por favor"
 
 # MSG_PRESS_TO_PREHEAT c=20 r=4
-#: Marlin_main.cpp:12049
+#: Marlin_main.cpp:12052
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Pulsa el dial para precalentar la boquilla y continue."
 
@@ -1061,7 +1061,7 @@ msgid "Preheating to unload"
 msgstr "Precalent. descargar"
 
 # MSG_SELFTEST_PRINT_FAN_SPEED c=18
-#: ultralcd.cpp:8501
+#: ultralcd.cpp:8422
 msgid "Print fan:"
 msgstr "Vent.fusor:"
 
@@ -1112,21 +1112,21 @@ msgstr "Por favor, cargar primero el filamento."
 
 # MSG_BED_CORRECTION_REAR c=14
 #: ultralcd.cpp:3117
-msgid "Rear side [um]"
-msgstr "Trasera [um]"
+msgid "Rear side [μm]"
+msgstr "Trasera [μm]"
 
 # MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ultralcd.cpp:7404
+#: ultralcd.cpp:7325
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Primero descargue el filamento, luego repita esta accion."
 
 # MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ultralcd.cpp:7407
+#: ultralcd.cpp:7328
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "Por favor comprueba la conexion del IR sensor y filamento esta descargado."
 
 # MSG_RECOVERING_PRINT c=20
-#: Marlin_main.cpp:11393
+#: Marlin_main.cpp:11396
 msgid "Recovering print"
 msgstr "Recuper. impresion"
 
@@ -1157,8 +1157,8 @@ msgstr "Continuan. impresion"
 
 # MSG_BED_CORRECTION_RIGHT c=14
 #: ultralcd.cpp:3115
-msgid "Right side[um]"
-msgstr "Derecha [um]"
+msgid "Right side[μm]"
+msgstr "Derecha [μm]"
 
 # MSG_RPI_PORT c=13
 #: messages.c:142
@@ -1191,12 +1191,12 @@ msgid "Select language"
 msgstr "Cambiar el idioma"
 
 # MSG_SELFTEST_OK c=20
-#: ultralcd.cpp:7679
+#: ultralcd.cpp:7600
 msgid "Self test OK"
 msgstr ""
 
 # MSG_SELFTEST_START c=20
-#: ultralcd.cpp:7447
+#: ultralcd.cpp:7368
 msgid "Self test start"
 msgstr "Iniciar Selftest"
 
@@ -1206,7 +1206,7 @@ msgid "Selftest"
 msgstr ""
 
 # MSG_SELFTEST_ERROR c=20
-#: ultralcd.cpp:8121
+#: ultralcd.cpp:8042
 msgid "Selftest error!"
 msgstr "Error Selftest!"
 
@@ -1306,7 +1306,7 @@ msgid "Once"
 msgstr "Una vez"
 
 # MSG_SPEED c=15
-#: ultralcd.cpp:6882
+#: ultralcd.cpp:6803
 msgid "Speed"
 msgstr "Velocidad"
 
@@ -1336,12 +1336,12 @@ msgid "STOPPED."
 msgstr "PARADA"
 
 # MSG_SUPPORT c=18
-#: ultralcd.cpp:6756
+#: ultralcd.cpp:6677
 msgid "Support"
 msgstr "Soporte"
 
 # MSG_SELFTEST_SWAPPED c=16
-#: ultralcd.cpp:8180
+#: ultralcd.cpp:8101
 msgid "Swapped"
 msgstr "Intercambiado"
 
@@ -1376,7 +1376,7 @@ msgid "Temperature calibration is finished and active. Temp. calibration can be 
 msgstr "Calibracion temperatura terminada. Haz clic para continuar."
 
 # MSG_FS_VERIFIED c=20 r=3
-#: ultralcd.cpp:7411
+#: ultralcd.cpp:7332
 msgid "Sensor verified, remove the filament now."
 msgstr "Sensor verificado, retire el filamento ahora."
 
@@ -1406,7 +1406,7 @@ msgid "Total print time"
 msgstr "Tiempo total"
 
 # MSG_TUNE c=18
-#: ultralcd.cpp:6653
+#: ultralcd.cpp:6574
 msgid "Tune"
 msgstr "Ajustar"
 
@@ -1425,7 +1425,7 @@ msgstr "para cargar el fil."
 msgid "to unload filament"
 msgstr "para descargar fil."
 
-# MSG_UNLOAD_FILAMENT c=16
+# MSG_UNLOAD_FILAMENT c=18
 #: messages.c:114
 msgid "Unload filament"
 msgstr "Soltar filamento"
@@ -1510,7 +1510,7 @@ msgstr "Detalles cal. XYZ"
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "Calibracion XYZ fallada. Consulta el manual por favor."
 
-# MSG_YES c=3
+# MSG_YES c=4
 #: messages.c:123
 msgid "Yes"
 msgstr "Si"
@@ -1586,7 +1586,7 @@ msgid "The printer will start printing a zig-zag line. Rotate the knob until you
 msgstr "La impresora comenzara a imprimir una linea en zig-zag. Gira el dial hasta que la linea alcance la altura optima. Mira las fotos del manual (Capitulo de calibracion)."
 
 # MSG_FIL_FAILED c=20 r=5
-#: ultralcd.cpp:7415
+#: ultralcd.cpp:7336
 msgid "Verification failed, remove the filament and try again."
 msgstr "La verificacion fallo, retire el filamento e intente nuevamente."
 
@@ -1616,7 +1616,7 @@ msgid "Checks"
 msgstr "Comprobaciones"
 
 # MSG_FALSE_TRIGGERING c=20
-#: ultralcd.cpp:8190
+#: ultralcd.cpp:8111
 msgid "False triggering"
 msgstr "Falsa activacion"
 
@@ -1721,17 +1721,17 @@ msgid "Printer nozzle diameter differs from the G-code. Please check the value i
 msgstr "Diametro nozzle Impresora difiere de cod.G. Comprueba los valores en ajustes. Impresion cancelada."
 
 # MSG_SELFTEST_FS_LEVEL c=20
-#: ultralcd.cpp:8195
+#: ultralcd.cpp:8116
 msgid "%s level expected"
 msgstr "%s nivel esperado"
 
 # MSG_RENAME c=18
-#: ultralcd.cpp:6579
+#: ultralcd.cpp:6500
 msgid "Rename"
 msgstr "Renombrar"
 
 # MSG_SELECT c=18
-#: ultralcd.cpp:6572
+#: ultralcd.cpp:6493
 msgid "Select"
 msgstr "Seleccionar"
 

--- a/lang/po/new/fr.po
+++ b/lang/po/new/fr.po
@@ -7,8 +7,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: fr\n"
 "Project-Id-Version: Prusa-Firmware\n"
-"POT-Creation-Date: Sun 19 Dec 2021 07:17:34 PM CET\n"
-"PO-Revision-Date: Sun 19 Dec 2021 07:17:34 PM CET\n"
+"POT-Creation-Date: Tue 08 Feb 2022 02:44:25 PM CET\n"
+"PO-Revision-Date: Tue 08 Feb 2022 02:44:25 PM CET\n"
 "Language-Team: \n"
 "X-Generator: Poedit 2.0.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
@@ -21,7 +21,7 @@ msgid " 0.3 or older"
 msgstr " 0.3 ou +ancien"
 
 # MSG_FS_V_03_OR_OLDER c=18
-#: Marlin_main.cpp:9884
+#: Marlin_main.cpp:9887
 msgid "FS v0.3 or older"
 msgstr "FS v0.3 ou +ancien"
 
@@ -31,7 +31,7 @@ msgid " 0.4 or newer"
 msgstr " 0.4 ou +recent"
 
 # MSG_FS_V_04_OR_NEWER c=18
-#: Marlin_main.cpp:9883
+#: Marlin_main.cpp:9886
 msgid "FS v0.4 or newer"
 msgstr "FS v0.4 ou +recent"
 
@@ -61,11 +61,11 @@ msgid "Adjusting Z:"
 msgstr "Ajuster Z:"
 
 # MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ultralcd.cpp:8490
+#: ultralcd.cpp:8411
 msgid "All correct"
 msgstr "Tout est correct"
 
-# MSG_WIZARD_DONE c=20 r=8
+# MSG_WIZARD_DONE c=20 r=3
 #: messages.c:118
 msgid "All is done. Happy printing!"
 msgstr "Tout est pret. Bonne impression!"
@@ -96,7 +96,7 @@ msgid "Auto home"
 msgstr "Mise a 0 des axes"
 
 # MSG_AUTOLOAD_FILAMENT c=18
-#: ultralcd.cpp:6732
+#: ultralcd.cpp:6653
 msgid "AutoLoad filament"
 msgstr "Autocharge du fil."
 
@@ -111,17 +111,17 @@ msgid "Autoloading filament is active, just press the knob and insert filament..
 msgstr "Chargement auto. du fil. active, appuyez sur le bouton et inserez le fil."
 
 # MSG_SELFTEST_AXIS_LENGTH c=20
-#: ultralcd.cpp:8173
+#: ultralcd.cpp:8094
 msgid "Axis length"
 msgstr "Longueur de l'axe"
 
 # MSG_SELFTEST_AXIS c=16
-#: ultralcd.cpp:8174
+#: ultralcd.cpp:8095
 msgid "Axis"
 msgstr "Axe"
 
 # MSG_SELFTEST_BEDHEATER c=20
-#: ultralcd.cpp:8131
+#: ultralcd.cpp:8052
 msgid "Bed/Heater"
 msgstr "Lit/Chauffage"
 
@@ -176,7 +176,7 @@ msgid "Blackout occurred. Recover print?"
 msgstr "Coupure detectee. Reprendre impres.?"
 
 # MSG_CALIBRATING_HOME c=20
-#: ultralcd.cpp:8492
+#: ultralcd.cpp:8413
 msgid "Calibrating home"
 msgstr "Calib. mise a 0"
 
@@ -226,12 +226,12 @@ msgid "Calibration"
 msgstr ""
 
 # MSG_SD_REMOVED c=20
-#: ultralcd.cpp:8939
+#: ultralcd.cpp:8860
 msgid "Card removed"
 msgstr "Carte retiree"
 
 # MSG_CHECKING_FILE c=17
-#: ultralcd.cpp:8580
+#: ultralcd.cpp:8501
 msgid "Checking file"
 msgstr "Verific. fichier"
 
@@ -326,17 +326,17 @@ msgid "Ejecting filament"
 msgstr "Le fil. remonte"
 
 # MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ultralcd.cpp:8149
+#: ultralcd.cpp:8070
 msgid "Endstop not hit"
 msgstr "Butee non atteinte"
 
 # MSG_SELFTEST_ENDSTOP c=16
-#: ultralcd.cpp:8144
+#: ultralcd.cpp:8065
 msgid "Endstop"
 msgstr "Butee"
 
 # MSG_SELFTEST_ENDSTOPS c=20
-#: ultralcd.cpp:8135
+#: ultralcd.cpp:8056
 msgid "Endstops"
 msgstr "Butees"
 
@@ -376,7 +376,7 @@ msgid "ERROR:"
 msgstr "ERREUR:"
 
 # MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
-#: ultralcd.cpp:8498
+#: ultralcd.cpp:8419
 msgid "Extruder fan:"
 msgstr "Ventilo extrudeur:"
 
@@ -391,7 +391,7 @@ msgid "Extruder"
 msgstr "Extrudeur"
 
 # MSG_MMU_FAIL_STATS c=18
-#: ultralcd.cpp:6754
+#: ultralcd.cpp:6675
 msgid "Fail stats MMU"
 msgstr "Stat. d'echec MMU"
 
@@ -401,7 +401,7 @@ msgid "F. autoload"
 msgstr "F. autocharg."
 
 # MSG_FAIL_STATS c=18
-#: ultralcd.cpp:6751
+#: ultralcd.cpp:6672
 msgid "Fail stats"
 msgstr "Stat. d'echec"
 
@@ -440,10 +440,10 @@ msgstr "Filament extrude et avec bonne couleur?"
 msgid "Filament not loaded"
 msgstr "Filament non charge"
 
-# MSG_FILAMENT_SENSOR c=20
+# MSG_SELFTEST_FILAMENT_SENSOR c=17
 #: messages.c:97
 msgid "Filament sensor"
-msgstr "Capteur de filament"
+msgstr "Capteur de fil."
 
 # MSG_FILAMENT_USED c=19
 #: ultralcd.cpp:2713
@@ -461,7 +461,7 @@ msgid "FS Action"
 msgstr ""
 
 # MSG_FILE_INCOMPLETE c=20 r=3
-#: ultralcd.cpp:8634
+#: ultralcd.cpp:8555
 msgid "File incomplete. Continue anyway?"
 msgstr "Fichier incomplet. Continuer qd meme?"
 
@@ -486,7 +486,7 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr "Corrigez le probleme et appuyez sur le bouton sur la MMU."
 
 # MSG_FLOW c=15
-#: ultralcd.cpp:6888
+#: ultralcd.cpp:6809
 msgid "Flow"
 msgstr "Flux"
 
@@ -497,21 +497,21 @@ msgstr "Ventilo impr avant?"
 
 # MSG_BED_CORRECTION_FRONT c=14
 #: ultralcd.cpp:3116
-msgid "Front side[um]"
-msgstr "Avant [um]"
+msgid "Front side[μm]"
+msgstr "Avant [μm]"
 
 # MSG_SELFTEST_FANS c=20
-#: ultralcd.cpp:8179
+#: ultralcd.cpp:8100
 msgid "Front/left fans"
 msgstr "Ventilos avt/gauche"
 
 # MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ultralcd.cpp:8127
+#: ultralcd.cpp:8048
 msgid "Heater/Thermistor"
 msgstr "Chauffage/Thermistor"
 
 # MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: Marlin_main.cpp:9874
+#: Marlin_main.cpp:9877
 msgid "Heating disabled by safety timer."
 msgstr "Chauffage desactivee par le compteur de securite."
 
@@ -551,12 +551,12 @@ msgid "Checking bed"
 msgstr "Verif. plateau chauf"
 
 # MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ultralcd.cpp:8481
+#: ultralcd.cpp:8402
 msgid "Checking endstops"
 msgstr "Verification butees"
 
 # MSG_SELFTEST_CHECK_HOTEND c=20
-#: ultralcd.cpp:8487
+#: ultralcd.cpp:8408
 msgid "Checking hotend"
 msgstr "Verif. du hotend"
 
@@ -576,7 +576,7 @@ msgid "Checking Y axis"
 msgstr "Verification axe Y"
 
 # MSG_SELFTEST_CHECK_Z c=20
-#: ultralcd.cpp:8484
+#: ultralcd.cpp:8405
 msgid "Checking Z axis"
 msgstr "Verification axe Z"
 
@@ -657,8 +657,8 @@ msgstr "Gauche"
 
 # MSG_BED_CORRECTION_LEFT c=14
 #: ultralcd.cpp:3114
-msgid "Left side [um]"
-msgstr "Gauche [um]"
+msgid "Left side [μm]"
+msgstr "Gauche [μm]"
 
 # MSG_LIN_CORRECTION c=18
 #: ultralcd.cpp:5702
@@ -671,7 +671,7 @@ msgid "Live adjust Z"
 msgstr "Ajuster Z en dir."
 
 # MSG_INSERT_FIL c=20 r=6
-#: ultralcd.cpp:7380
+#: ultralcd.cpp:7301
 msgid "Insert the filament (do not load it) into the extruder and then press the knob."
 msgstr "Veuillez inserer le filament ( ne le chargez pas) dans l'extrudeur, puis appuyez sur le bouton."
 
@@ -696,12 +696,12 @@ msgid "Iteration"
 msgstr ""
 
 # MSG_LOOSE_PULLEY c=20
-#: ultralcd.cpp:8167
+#: ultralcd.cpp:8088
 msgid "Loose pulley"
 msgstr "Poulie lache"
 
 # MSG_LOAD_TO_NOZZLE c=18
-#: ultralcd.cpp:6717
+#: ultralcd.cpp:6638
 msgid "Load to nozzle"
 msgstr "Charger la buse"
 
@@ -851,7 +851,7 @@ msgid "No move."
 msgstr "Pas de mouvement."
 
 # MSG_NO_CARD c=18
-#: ultralcd.cpp:6697
+#: ultralcd.cpp:6618
 msgid "No SD card"
 msgstr "Pas de carte SD"
 
@@ -866,7 +866,7 @@ msgid "No"
 msgstr "Non"
 
 # MSG_SELFTEST_NOTCONNECTED c=20
-#: ultralcd.cpp:8128
+#: ultralcd.cpp:8049
 msgid "Not connected"
 msgstr "Non connecte"
 
@@ -951,7 +951,7 @@ msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Nettoyez la buse pour la calibration. Cliquez une fois fait."
 
 # MSG_SELFTEST_PLEASECHECK c=20
-#: ultralcd.cpp:8122
+#: ultralcd.cpp:8043
 msgid "Please check:"
 msgstr "Verifiez:"
 
@@ -1016,7 +1016,7 @@ msgid "Preheat the nozzle!"
 msgstr "Prechauffez la buse!"
 
 # MSG_PREHEAT c=18
-#: ultralcd.cpp:6655
+#: ultralcd.cpp:6576
 msgid "Preheat"
 msgstr "Prechauffage"
 
@@ -1031,7 +1031,7 @@ msgid "Please upgrade."
 msgstr "Mettez a jour le FW."
 
 # MSG_PRESS_TO_PREHEAT c=20 r=4
-#: Marlin_main.cpp:12049
+#: Marlin_main.cpp:12052
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Appuyez sur le bouton pour prechauffer la buse et continuer."
 
@@ -1061,7 +1061,7 @@ msgid "Preheating to unload"
 msgstr "Chauf.pour decharger"
 
 # MSG_SELFTEST_PRINT_FAN_SPEED c=18
-#: ultralcd.cpp:8501
+#: ultralcd.cpp:8422
 msgid "Print fan:"
 msgstr "Vent. impr:"
 
@@ -1112,21 +1112,21 @@ msgstr "Veuillez d'abord charger un filament."
 
 # MSG_BED_CORRECTION_REAR c=14
 #: ultralcd.cpp:3117
-msgid "Rear side [um]"
-msgstr "Arriere [um]"
+msgid "Rear side [μm]"
+msgstr "Arriere [μm]"
 
 # MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ultralcd.cpp:7404
+#: ultralcd.cpp:7325
 msgid "Please unload the filament first, then repeat this action."
 msgstr "SVP, dechargez le filament et reessayez."
 
 # MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ultralcd.cpp:7407
+#: ultralcd.cpp:7328
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "SVP, verifiez la connexion du capteur IR et decharge le filament."
 
 # MSG_RECOVERING_PRINT c=20
-#: Marlin_main.cpp:11393
+#: Marlin_main.cpp:11396
 msgid "Recovering print"
 msgstr "Recup. impression"
 
@@ -1157,8 +1157,8 @@ msgstr "Reprise de l'impr."
 
 # MSG_BED_CORRECTION_RIGHT c=14
 #: ultralcd.cpp:3115
-msgid "Right side[um]"
-msgstr "Droite [um]"
+msgid "Right side[μm]"
+msgstr "Droite [μm]"
 
 # MSG_RPI_PORT c=13
 #: messages.c:142
@@ -1191,12 +1191,12 @@ msgid "Select language"
 msgstr "Choisir langue"
 
 # MSG_SELFTEST_OK c=20
-#: ultralcd.cpp:7679
+#: ultralcd.cpp:7600
 msgid "Self test OK"
 msgstr "Auto-test OK"
 
 # MSG_SELFTEST_START c=20
-#: ultralcd.cpp:7447
+#: ultralcd.cpp:7368
 msgid "Self test start"
 msgstr "Debut auto-test"
 
@@ -1206,7 +1206,7 @@ msgid "Selftest"
 msgstr "Auto-test"
 
 # MSG_SELFTEST_ERROR c=20
-#: ultralcd.cpp:8121
+#: ultralcd.cpp:8042
 msgid "Selftest error!"
 msgstr "Erreur auto-test!"
 
@@ -1306,7 +1306,7 @@ msgid "Once"
 msgstr "1 fois"
 
 # MSG_SPEED c=15
-#: ultralcd.cpp:6882
+#: ultralcd.cpp:6803
 msgid "Speed"
 msgstr "Vitesse"
 
@@ -1336,12 +1336,12 @@ msgid "STOPPED."
 msgstr "ARRETE."
 
 # MSG_SUPPORT c=18
-#: ultralcd.cpp:6756
+#: ultralcd.cpp:6677
 msgid "Support"
 msgstr ""
 
 # MSG_SELFTEST_SWAPPED c=16
-#: ultralcd.cpp:8180
+#: ultralcd.cpp:8101
 msgid "Swapped"
 msgstr "Echange"
 
@@ -1376,7 +1376,7 @@ msgid "Temperature calibration is finished and active. Temp. calibration can be 
 msgstr "La calibration en temperature est terminee et activee. La calibration en temperature peut etre desactivee dans le menu Reglages-> Cal. Temp."
 
 # MSG_FS_VERIFIED c=20 r=3
-#: ultralcd.cpp:7411
+#: ultralcd.cpp:7332
 msgid "Sensor verified, remove the filament now."
 msgstr "Capteur verifie, retirez le filament maintenant."
 
@@ -1406,7 +1406,7 @@ msgid "Total print time"
 msgstr "Temps total impr."
 
 # MSG_TUNE c=18
-#: ultralcd.cpp:6653
+#: ultralcd.cpp:6574
 msgid "Tune"
 msgstr "Regler"
 
@@ -1425,7 +1425,7 @@ msgstr "pour charger le fil."
 msgid "to unload filament"
 msgstr "pour decharger fil."
 
-# MSG_UNLOAD_FILAMENT c=16
+# MSG_UNLOAD_FILAMENT c=18
 #: messages.c:114
 msgid "Unload filament"
 msgstr "Decharger fil."
@@ -1510,7 +1510,7 @@ msgstr "Details calib. XYZ"
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "Echec calibration XYZ. Consultez le manuel."
 
-# MSG_YES c=3
+# MSG_YES c=4
 #: messages.c:123
 msgid "Yes"
 msgstr "Oui"
@@ -1586,7 +1586,7 @@ msgid "The printer will start printing a zig-zag line. Rotate the knob until you
 msgstr "L'imprimante commencera a  imprimer une ligne en zig-zag. Tournez le bouton jusqu'a atteindre la hauteur optimale. Consultez les photos dans le manuel (chapitre Calibration)."
 
 # MSG_FIL_FAILED c=20 r=5
-#: ultralcd.cpp:7415
+#: ultralcd.cpp:7336
 msgid "Verification failed, remove the filament and try again."
 msgstr "Verification en echec, retirez le filament et reessayez."
 
@@ -1616,7 +1616,7 @@ msgid "Checks"
 msgstr "Verifications"
 
 # MSG_FALSE_TRIGGERING c=20
-#: ultralcd.cpp:8190
+#: ultralcd.cpp:8111
 msgid "False triggering"
 msgstr "Faux declenchement"
 
@@ -1721,17 +1721,17 @@ msgid "Printer nozzle diameter differs from the G-code. Please check the value i
 msgstr "Diametre de la buse dans les reglages ne correspond pas a celui dans le G-Code. Merci de verifier le parametre dans les reglages. Impression annulee."
 
 # MSG_SELFTEST_FS_LEVEL c=20
-#: ultralcd.cpp:8195
+#: ultralcd.cpp:8116
 msgid "%s level expected"
 msgstr "niveau %s attendu"
 
 # MSG_RENAME c=18
-#: ultralcd.cpp:6579
+#: ultralcd.cpp:6500
 msgid "Rename"
 msgstr "Renommer"
 
 # MSG_SELECT c=18
-#: ultralcd.cpp:6572
+#: ultralcd.cpp:6493
 msgid "Select"
 msgstr "Selectionner"
 

--- a/lang/po/new/hr.po
+++ b/lang/po/new/hr.po
@@ -7,8 +7,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: hr\n"
 "Project-Id-Version: Prusa-Firmware\n"
-"POT-Creation-Date: Tue 01 Feb 2022 07:01:16 AM PST\n"
-"PO-Revision-Date: Tue 01 Feb 2022 07:01:16 AM PST\n"
+"POT-Creation-Date: Tue 08 Feb 2022 02:44:49 PM CET\n"
+"PO-Revision-Date: Tue 08 Feb 2022 02:44:49 PM CET\n"
 "Language-Team: \n"
 "X-Generator: Poedit 2.0.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
@@ -65,7 +65,7 @@ msgstr "Podesavanje Z:"
 msgid "All correct"
 msgstr "Sve je u redu"
 
-# MSG_WIZARD_DONE c=20 r=8
+# MSG_WIZARD_DONE c=20 r=3
 #: messages.c:118
 msgid "All is done. Happy printing!"
 msgstr "Sve je gotovo. Sretno printanje!"
@@ -408,7 +408,7 @@ msgstr "Neuspjesna stat"
 # MSG_FAN_SPEED c=14
 #: messages.c:36
 msgid "Fan speed"
-msgstr "Brzina vent."
+msgstr "Brzina vent"
 
 # MSG_SELFTEST_FAN c=20
 #: messages.c:91
@@ -418,7 +418,7 @@ msgstr "Test ventilatora"
 # MSG_FANS_CHECK c=13
 #: messages.c:33
 msgid "Fans check"
-msgstr "Provjera fana"
+msgstr "Provjera vent"
 
 # MSG_FSENSOR c=12
 #: messages.c:49
@@ -440,7 +440,7 @@ msgstr "Ekstrudiranje fil.s sa ispravnom bojom?"
 msgid "Filament not loaded"
 msgstr "Fil. nije napunjen"
 
-# MSG_FILAMENT_SENSOR c=20
+# MSG_SELFTEST_FILAMENT_SENSOR c=17
 #: messages.c:97
 msgid "Filament sensor"
 msgstr "Senzor filamenta"
@@ -497,13 +497,13 @@ msgstr "Prednji print vent?"
 
 # MSG_BED_CORRECTION_FRONT c=14
 #: ultralcd.cpp:3116
-msgid "Front side[um]"
-msgstr "Prednj str[um]"
+msgid "Front side[μm]"
+msgstr "Prednj str[μm]"
 
 # MSG_SELFTEST_FANS c=20
 #: ultralcd.cpp:8100
 msgid "Front/left fans"
-msgstr "Prednji/lijevi vent."
+msgstr "Prednji/lijevi vent"
 
 # MSG_SELFTEST_HEATERTHERMISTOR c=20
 #: ultralcd.cpp:8048
@@ -657,8 +657,8 @@ msgstr "Lijevo"
 
 # MSG_BED_CORRECTION_LEFT c=14
 #: ultralcd.cpp:3114
-msgid "Left side [um]"
-msgstr "Lijeva str[um]"
+msgid "Left side [μm]"
+msgstr "Lijeva str[μm]"
 
 # MSG_LIN_CORRECTION c=18
 #: ultralcd.cpp:5702
@@ -908,7 +908,7 @@ msgstr "Sada uklonite probni print sa celicne ploce."
 # MSG_NOZZLE_FAN c=10
 #: ultralcd.cpp:1446
 msgid "Nozzle FAN"
-msgstr "vent mlazn"
+msgstr "Fan mlazn"
 
 # MSG_PAUSE_PRINT c=18
 #: messages.c:74
@@ -1093,7 +1093,7 @@ msgstr "Printer jos nije kalibriran. Molimo slijedite prirucnik, poglavlje Prvi 
 # MSG_PRINT_FAN c=10
 #: ultralcd.cpp:1447
 msgid "Print FAN"
-msgstr "Print vent"
+msgstr ""
 
 # MSG_WIZARD_LOAD_FILAMENT c=20 r=6
 #: ultralcd.cpp:4818
@@ -1112,8 +1112,8 @@ msgstr "Molimo prvo ubacite filament."
 
 # MSG_BED_CORRECTION_REAR c=14
 #: ultralcd.cpp:3117
-msgid "Rear side [um]"
-msgstr "Zad. str.[um]"
+msgid "Rear side [μm]"
+msgstr "Zad. str.[μm]"
 
 # MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
 #: ultralcd.cpp:7325
@@ -1157,8 +1157,8 @@ msgstr "Nastavak printa"
 
 # MSG_BED_CORRECTION_RIGHT c=14
 #: ultralcd.cpp:3115
-msgid "Right side[um]"
-msgstr "Desna str.[um]"
+msgid "Right side[μm]"
+msgstr "Desna str.[μm]"
 
 # MSG_RPI_PORT c=13
 #: messages.c:142
@@ -1510,7 +1510,7 @@ msgstr "XYZ detalji kal"
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "XYZ kalibracija nije uspjela. Molimo pogledajte prirucnik."
 
-# MSG_YES c=3
+# MSG_YES c=4
 #: messages.c:123
 msgid "Yes"
 msgstr "Da"
@@ -1708,7 +1708,7 @@ msgstr "Predgr. za rezanje"
 # MSG_PREHEATING_TO_EJECT c=20
 #: ultralcd.cpp:2306
 msgid "Preheating to eject"
-msgstr "Predgr. za izbaciv."
+msgstr "Predgr. za izbaci."
 
 # MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=5
 #: util.cpp:294

--- a/lang/po/new/hu.po
+++ b/lang/po/new/hu.po
@@ -2,18 +2,18 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Prusa-Firmware\n"
-"POT-Creation-Date: Tue 21 Dec 2021 03:27:31 PM CET\n"
-"PO-Revision-Date: 2022-01-12 11:41+0100\n"
-"Last-Translator: \n"
-"Language-Team: \n"
-"Language: hu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
-"X-Generator: Poedit 3.0.1\n"
+"Language: hu\n"
+"Project-Id-Version: Prusa-Firmware\n"
+"POT-Creation-Date: Tue 08 Feb 2022 02:44:44 PM CET\n"
+"PO-Revision-Date: Tue 08 Feb 2022 02:44:44 PM CET\n"
+"Language-Team: \n"
+"X-Generator: Poedit 2.0.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
+"Last-Translator: \n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
 # MSG_IR_03_OR_OLDER c=18
 #: messages.c:164
@@ -21,7 +21,7 @@ msgid " 0.3 or older"
 msgstr " 0.3 vagy regebbi"
 
 # MSG_FS_V_03_OR_OLDER c=18
-#: Marlin_main.cpp:9884
+#: Marlin_main.cpp:9887
 msgid "FS v0.3 or older"
 msgstr "FS v0.3 v. regebbi"
 
@@ -31,7 +31,7 @@ msgid " 0.4 or newer"
 msgstr " 0.4 v. ujabb"
 
 # MSG_FS_V_04_OR_NEWER c=18
-#: Marlin_main.cpp:9883
+#: Marlin_main.cpp:9886
 msgid "FS v0.4 or newer"
 msgstr "FS v0.4 vagy ujabb"
 
@@ -46,12 +46,14 @@ msgid "[0;0] point offset"
 msgstr "[0;0] pont offszet"
 
 # MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-msgid "Crash detection can\\x0abe turned on only in\\x0aNormal mode"
-msgstr "Utkozes erzekeles csak\\x0anormal modban\\x0akapcsolhato be"
+#: 
+msgid "Crash detection can\x0abe turned on only in\x0aNormal mode"
+msgstr "Utkozes erzekeles csak\x0anormal modban\x0akapcsolhato be"
 
 # MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-msgid "WARNING:\\x0aCrash detection\\x0adisabled in\\x0aStealth mode"
-msgstr "FIGYELEM:\\x0aUtkozes erzekeles\\x0akikapcsolva\\x0aHalk modban"
+#: 
+msgid "WARNING:\x0aCrash detection\x0adisabled in\x0aStealth mode"
+msgstr "FIGYELEM:\x0aUtkozes erzekeles\x0akikapcsolva\x0aHalk modban"
 
 # MSG_BABYSTEPPING_Z c=15
 #: ultralcd.cpp:3034
@@ -59,11 +61,11 @@ msgid "Adjusting Z:"
 msgstr "Z allitasa:"
 
 # MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ultralcd.cpp:8490
+#: ultralcd.cpp:8411
 msgid "All correct"
 msgstr "Minden rendben"
 
-# MSG_WIZARD_DONE c=20 r=8
+# MSG_WIZARD_DONE c=20 r=3
 #: messages.c:118
 msgid "All is done. Happy printing!"
 msgstr "Keszen vagyunk. Jo nyomtatast!"
@@ -94,7 +96,7 @@ msgid "Auto home"
 msgstr "Auto home"
 
 # MSG_AUTOLOAD_FILAMENT c=18
-#: ultralcd.cpp:6732
+#: ultralcd.cpp:6653
 msgid "AutoLoad filament"
 msgstr "Fil. auto.betolt."
 
@@ -109,17 +111,17 @@ msgid "Autoloading filament is active, just press the knob and insert filament..
 msgstr "Autom. betoltes be, nyomd meg a gombot es helyzed be a filamentet."
 
 # MSG_SELFTEST_AXIS_LENGTH c=20
-#: ultralcd.cpp:8173
+#: ultralcd.cpp:8094
 msgid "Axis length"
 msgstr "Tengely hossz"
 
 # MSG_SELFTEST_AXIS c=16
-#: ultralcd.cpp:8174
+#: ultralcd.cpp:8095
 msgid "Axis"
 msgstr "Tengely"
 
 # MSG_SELFTEST_BEDHEATER c=20
-#: ultralcd.cpp:8131
+#: ultralcd.cpp:8052
 msgid "Bed/Heater"
 msgstr "Asztal/Fej futes"
 
@@ -174,7 +176,7 @@ msgid "Blackout occurred. Recover print?"
 msgstr "Aramkieses volt, nyomt. folytatasa?"
 
 # MSG_CALIBRATING_HOME c=20
-#: ultralcd.cpp:8492
+#: ultralcd.cpp:8413
 msgid "Calibrating home"
 msgstr "Home poz. kalibralas"
 
@@ -224,12 +226,12 @@ msgid "Calibration"
 msgstr "Kalibracio"
 
 # MSG_SD_REMOVED c=20
-#: ultralcd.cpp:8939
+#: ultralcd.cpp:8860
 msgid "Card removed"
 msgstr "Kartya eltavolitva"
 
 # MSG_CHECKING_FILE c=17
-#: ultralcd.cpp:8580
+#: ultralcd.cpp:8501
 msgid "Checking file"
 msgstr "Fajl ellenorzese"
 
@@ -324,21 +326,22 @@ msgid "Ejecting filament"
 msgstr "Filament kiadasa"
 
 # MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ultralcd.cpp:8149
+#: ultralcd.cpp:8070
 msgid "Endstop not hit"
 msgstr "Vegallask. nem kapcs"
 
 # MSG_SELFTEST_ENDSTOP c=16
-#: ultralcd.cpp:8144
+#: ultralcd.cpp:8065
 msgid "Endstop"
 msgstr "Vegallaskapcsolo"
 
 # MSG_SELFTEST_ENDSTOPS c=20
-#: ultralcd.cpp:8135
+#: ultralcd.cpp:8056
 msgid "Endstops"
 msgstr "Vegallaskapcsolok"
 
 # MSG_STACK_ERROR c=20 r=4
+#: 
 msgid "Error - static memory has been overwritten"
 msgstr "Hiba - a sztatikus memoria felulirodott"
 
@@ -373,7 +376,7 @@ msgid "ERROR:"
 msgstr "HIBA:"
 
 # MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
-#: ultralcd.cpp:8498
+#: ultralcd.cpp:8419
 msgid "Extruder fan:"
 msgstr "Extruder vent.:"
 
@@ -388,7 +391,7 @@ msgid "Extruder"
 msgstr "Extruder"
 
 # MSG_MMU_FAIL_STATS c=18
-#: ultralcd.cpp:6754
+#: ultralcd.cpp:6675
 msgid "Fail stats MMU"
 msgstr "MMU hiba stat."
 
@@ -398,7 +401,7 @@ msgid "F. autoload"
 msgstr "F. autobetolt"
 
 # MSG_FAIL_STATS c=18
-#: ultralcd.cpp:6751
+#: ultralcd.cpp:6672
 msgid "Fail stats"
 msgstr "Hiba statisztika"
 
@@ -437,7 +440,7 @@ msgstr "Filament es a szine rendben?"
 msgid "Filament not loaded"
 msgstr "Fil. nincs betoltve"
 
-# MSG_FILAMENT_SENSOR c=20
+# MSG_SELFTEST_FILAMENT_SENSOR c=17
 #: messages.c:97
 msgid "Filament sensor"
 msgstr "Filament szenzor"
@@ -458,7 +461,7 @@ msgid "FS Action"
 msgstr "FSz akcio"
 
 # MSG_FILE_INCOMPLETE c=20 r=3
-#: ultralcd.cpp:8634
+#: ultralcd.cpp:8555
 msgid "File incomplete. Continue anyway?"
 msgstr "A fajl vege hianyzik. Folytatod igy is?"
 
@@ -483,7 +486,7 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr "Hozd helyre a hibat, majd nyomd meg a gombot az MMU egysegen."
 
 # MSG_FLOW c=15
-#: ultralcd.cpp:6888
+#: ultralcd.cpp:6809
 msgid "Flow"
 msgstr "Flow"
 
@@ -494,21 +497,21 @@ msgstr "Elso targyhuto vent?"
 
 # MSG_BED_CORRECTION_FRONT c=14
 #: ultralcd.cpp:3116
-msgid "Front side[um]"
-msgstr "Elulso old[um]"
+msgid "Front side[μm]"
+msgstr "Elulso old[μm]"
 
 # MSG_SELFTEST_FANS c=20
-#: ultralcd.cpp:8179
+#: ultralcd.cpp:8100
 msgid "Front/left fans"
 msgstr "Elso/bal ventillator"
 
 # MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ultralcd.cpp:8127
+#: ultralcd.cpp:8048
 msgid "Heater/Thermistor"
 msgstr "Futotest/Termisztor"
 
 # MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: Marlin_main.cpp:9874
+#: Marlin_main.cpp:9877
 msgid "Heating disabled by safety timer."
 msgstr "A bizonsagi idozito leallitotta a futest"
 
@@ -548,12 +551,12 @@ msgid "Checking bed"
 msgstr "Asztal ellenorzese"
 
 # MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ultralcd.cpp:8481
+#: ultralcd.cpp:8402
 msgid "Checking endstops"
 msgstr "Vegallaskapcs. ellen"
 
 # MSG_SELFTEST_CHECK_HOTEND c=20
-#: ultralcd.cpp:8487
+#: ultralcd.cpp:8408
 msgid "Checking hotend"
 msgstr "Hotend ellenorzese"
 
@@ -573,7 +576,7 @@ msgid "Checking Y axis"
 msgstr "Y tengely ellenorzes"
 
 # MSG_SELFTEST_CHECK_Z c=20
-#: ultralcd.cpp:8484
+#: ultralcd.cpp:8405
 msgid "Checking Z axis"
 msgstr "Z tengely ellenorzes"
 
@@ -654,8 +657,8 @@ msgstr "Bal"
 
 # MSG_BED_CORRECTION_LEFT c=14
 #: ultralcd.cpp:3114
-msgid "Left side [um]"
-msgstr "Bal [um]"
+msgid "Left side [μm]"
+msgstr "Bal [μm]"
 
 # MSG_LIN_CORRECTION c=18
 #: ultralcd.cpp:5702
@@ -668,7 +671,7 @@ msgid "Live adjust Z"
 msgstr "Z magassag beall."
 
 # MSG_INSERT_FIL c=20 r=6
-#: ultralcd.cpp:7380
+#: ultralcd.cpp:7301
 msgid "Insert the filament (do not load it) into the extruder and then press the knob."
 msgstr "Helyezd be a filamentet az extruderbe (ne toltsd be), majd nyomtd meg a gombot."
 
@@ -693,12 +696,12 @@ msgid "Iteration"
 msgstr "Iteracio"
 
 # MSG_LOOSE_PULLEY c=20
-#: ultralcd.cpp:8167
+#: ultralcd.cpp:8088
 msgid "Loose pulley"
 msgstr "Laza szijtarcsa"
 
 # MSG_LOAD_TO_NOZZLE c=18
-#: ultralcd.cpp:6717
+#: ultralcd.cpp:6638
 msgid "Load to nozzle"
 msgstr "Betolt. fuvokahoz"
 
@@ -848,7 +851,7 @@ msgid "No move."
 msgstr "Nincs mozgas."
 
 # MSG_NO_CARD c=18
-#: ultralcd.cpp:6697
+#: ultralcd.cpp:6618
 msgid "No SD card"
 msgstr "Nincs SD kartya"
 
@@ -863,7 +866,7 @@ msgid "No"
 msgstr "Nem"
 
 # MSG_SELFTEST_NOTCONNECTED c=20
-#: ultralcd.cpp:8128
+#: ultralcd.cpp:8049
 msgid "Not connected"
 msgstr "Nincs csatlakoztatva"
 
@@ -948,7 +951,7 @@ msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Kerlek, tisztisd meg a fuvokat kalibracio elott. Nyomd meg a gombot, ha keszen vagy."
 
 # MSG_SELFTEST_PLEASECHECK c=20
-#: ultralcd.cpp:8122
+#: ultralcd.cpp:8043
 msgid "Please check:"
 msgstr "Kerlek ellenorizd:"
 
@@ -1013,7 +1016,7 @@ msgid "Preheat the nozzle!"
 msgstr "Futsd fel a fuvokat!"
 
 # MSG_PREHEAT c=18
-#: ultralcd.cpp:6655
+#: ultralcd.cpp:6576
 msgid "Preheat"
 msgstr "Elofutes"
 
@@ -1028,7 +1031,7 @@ msgid "Please upgrade."
 msgstr "Kerlek frissits."
 
 # MSG_PRESS_TO_PREHEAT c=20 r=4
-#: Marlin_main.cpp:12049
+#: Marlin_main.cpp:12052
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Nyomd meg a gombot a folytatashoz es a fuvoka felfutesehez."
 
@@ -1058,7 +1061,7 @@ msgid "Preheating to unload"
 msgstr "Felfutes kiadashoz"
 
 # MSG_SELFTEST_PRINT_FAN_SPEED c=18
-#: ultralcd.cpp:8501
+#: ultralcd.cpp:8422
 msgid "Print fan:"
 msgstr "Targyhuto:"
 
@@ -1109,21 +1112,21 @@ msgstr "Kerlek eloszor toltsd be a filamentet."
 
 # MSG_BED_CORRECTION_REAR c=14
 #: ultralcd.cpp:3117
-msgid "Rear side [um]"
-msgstr "Hatso old.[um]"
+msgid "Rear side [μm]"
+msgstr "Hatso old.[μm]"
 
 # MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ultralcd.cpp:7404
+#: ultralcd.cpp:7325
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Kerlek eloszor vedd ki a filamentet, majd probalkozz ujra."
 
 # MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ultralcd.cpp:7407
+#: ultralcd.cpp:7328
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "Nezd meg az IR szenzor csatlakoz., vedd ki a filam., ha bent van."
 
 # MSG_RECOVERING_PRINT c=20
-#: Marlin_main.cpp:11393
+#: Marlin_main.cpp:11396
 msgid "Recovering print"
 msgstr "Nyomt. visszaallit"
 
@@ -1154,8 +1157,8 @@ msgstr "Nyomtatas folytatasa"
 
 # MSG_BED_CORRECTION_RIGHT c=14
 #: ultralcd.cpp:3115
-msgid "Right side[um]"
-msgstr "Jobb old.[um]"
+msgid "Right side[μm]"
+msgstr "Jobb old.[μm]"
 
 # MSG_RPI_PORT c=13
 #: messages.c:142
@@ -1188,12 +1191,12 @@ msgid "Select language"
 msgstr "Valassz nyelvet"
 
 # MSG_SELFTEST_OK c=20
-#: ultralcd.cpp:7679
+#: ultralcd.cpp:7600
 msgid "Self test OK"
 msgstr "Ondiagnosztika OK"
 
 # MSG_SELFTEST_START c=20
-#: ultralcd.cpp:7447
+#: ultralcd.cpp:7368
 msgid "Self test start"
 msgstr "Ondiagnosztika indul"
 
@@ -1203,7 +1206,7 @@ msgid "Selftest"
 msgstr "Ondiagnosztika"
 
 # MSG_SELFTEST_ERROR c=20
-#: ultralcd.cpp:8121
+#: ultralcd.cpp:8042
 msgid "Selftest error!"
 msgstr "Ondiagnosztika hiba!"
 
@@ -1303,7 +1306,7 @@ msgid "Once"
 msgstr "Egyszer"
 
 # MSG_SPEED c=15
-#: ultralcd.cpp:6882
+#: ultralcd.cpp:6803
 msgid "Speed"
 msgstr "Sebesseg"
 
@@ -1333,12 +1336,12 @@ msgid "STOPPED."
 msgstr "MEGALLITVA."
 
 # MSG_SUPPORT c=18
-#: ultralcd.cpp:6756
+#: ultralcd.cpp:6677
 msgid "Support"
 msgstr "Tamogatas"
 
 # MSG_SELFTEST_SWAPPED c=16
-#: ultralcd.cpp:8180
+#: ultralcd.cpp:8101
 msgid "Swapped"
 msgstr "Felcserelve"
 
@@ -1373,7 +1376,7 @@ msgid "Temperature calibration is finished and active. Temp. calibration can be 
 msgstr "Homerseklet kalibracio sikeres es aktiv. Kikapcsolhato a Beallitasok ->Homers. kal menuben."
 
 # MSG_FS_VERIFIED c=20 r=3
-#: ultralcd.cpp:7411
+#: ultralcd.cpp:7332
 msgid "Sensor verified, remove the filament now."
 msgstr "Szenzor OK, vedd ki a filamentet most."
 
@@ -1403,7 +1406,7 @@ msgid "Total print time"
 msgstr "Ossz. nyomt. ido"
 
 # MSG_TUNE c=18
-#: ultralcd.cpp:6653
+#: ultralcd.cpp:6574
 msgid "Tune"
 msgstr "Finomhangolas"
 
@@ -1422,7 +1425,7 @@ msgstr "filam. betoltesehez"
 msgid "to unload filament"
 msgstr "filament kiadasahoz"
 
-# MSG_UNLOAD_FILAMENT c=16
+# MSG_UNLOAD_FILAMENT c=18
 #: messages.c:114
 msgid "Unload filament"
 msgstr "Filament kiadasa"
@@ -1507,7 +1510,7 @@ msgstr "XYZ kal. reszlet"
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "XYZ kalibracio sikertelen. Kerlek, nezz bele a kezikonyvbe."
 
-# MSG_YES c=3
+# MSG_YES c=4
 #: messages.c:123
 msgid "Yes"
 msgstr "Igen"
@@ -1583,7 +1586,7 @@ msgid "The printer will start printing a zig-zag line. Rotate the knob until you
 msgstr "A nyomtato egy cikk-cakkos vonalat fog nyomtatni. Tekerd a gombot addig, amig el nem ered az optimalis magassagot. Nezd meg a kepeket a kezikonyv Kalibracio fejezeteben."
 
 # MSG_FIL_FAILED c=20 r=5
-#: ultralcd.cpp:7415
+#: ultralcd.cpp:7336
 msgid "Verification failed, remove the filament and try again."
 msgstr "Ellenorzes sikertelen, vedd ki a filamentet es probald ujra."
 
@@ -1613,7 +1616,7 @@ msgid "Checks"
 msgstr "Ellenorzesek"
 
 # MSG_FALSE_TRIGGERING c=20
-#: ultralcd.cpp:8190
+#: ultralcd.cpp:8111
 msgid "False triggering"
 msgstr "Hamis kivalto ok"
 
@@ -1718,17 +1721,17 @@ msgid "Printer nozzle diameter differs from the G-code. Please check the value i
 msgstr "A nyomtato fuvoka atmeroje elter a G-kodtol. Ellenorizd az erteket a beallitasokban. Nyomtatas megallitva."
 
 # MSG_SELFTEST_FS_LEVEL c=20
-#: ultralcd.cpp:8195
+#: ultralcd.cpp:8116
 msgid "%s level expected"
 msgstr "Vart szint: %s"
 
 # MSG_RENAME c=18
-#: ultralcd.cpp:6579
+#: ultralcd.cpp:6500
 msgid "Rename"
 msgstr "Atnevezes"
 
 # MSG_SELECT c=18
-#: ultralcd.cpp:6572
+#: ultralcd.cpp:6493
 msgid "Select"
 msgstr "Kivalasztas"
 
@@ -1766,3 +1769,4 @@ msgstr "Z meres szama"
 #: ultralcd.cpp:2028
 msgid "Printer IP Addr:"
 msgstr "Nyomtato IP cime:"
+

--- a/lang/po/new/it.po
+++ b/lang/po/new/it.po
@@ -7,8 +7,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: it\n"
 "Project-Id-Version: Prusa-Firmware\n"
-"POT-Creation-Date: Sun 19 Dec 2021 07:17:37 PM CET\n"
-"PO-Revision-Date: Sun 19 Dec 2021 07:17:37 PM CET\n"
+"POT-Creation-Date: Tue 08 Feb 2022 02:44:29 PM CET\n"
+"PO-Revision-Date: Tue 08 Feb 2022 02:44:29 PM CET\n"
 "Language-Team: \n"
 "X-Generator: Poedit 2.0.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
@@ -21,7 +21,7 @@ msgid " 0.3 or older"
 msgstr " 0.3 o inferiore"
 
 # MSG_FS_V_03_OR_OLDER c=18
-#: Marlin_main.cpp:9884
+#: Marlin_main.cpp:9887
 msgid "FS v0.3 or older"
 msgstr "FS 0.3 o inferiore"
 
@@ -31,7 +31,7 @@ msgid " 0.4 or newer"
 msgstr " 0.4 o superiore"
 
 # MSG_FS_V_04_OR_NEWER c=18
-#: Marlin_main.cpp:9883
+#: Marlin_main.cpp:9886
 msgid "FS v0.4 or newer"
 msgstr "FS 0.4 o superiore"
 
@@ -61,11 +61,11 @@ msgid "Adjusting Z:"
 msgstr "Compensaz. Z:"
 
 # MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ultralcd.cpp:8490
+#: ultralcd.cpp:8411
 msgid "All correct"
 msgstr "Nessun errore"
 
-# MSG_WIZARD_DONE c=20 r=8
+# MSG_WIZARD_DONE c=20 r=3
 #: messages.c:118
 msgid "All is done. Happy printing!"
 msgstr "Tutto fatto. Buona stampa!"
@@ -96,7 +96,7 @@ msgid "Auto home"
 msgstr "Trova origine"
 
 # MSG_AUTOLOAD_FILAMENT c=18
-#: ultralcd.cpp:6732
+#: ultralcd.cpp:6653
 msgid "AutoLoad filament"
 msgstr "Autocaric. filam."
 
@@ -111,17 +111,17 @@ msgid "Autoloading filament is active, just press the knob and insert filament..
 msgstr "Caricamento automatico attivo, premi la manopola e inserisci il filam."
 
 # MSG_SELFTEST_AXIS_LENGTH c=20
-#: ultralcd.cpp:8173
+#: ultralcd.cpp:8094
 msgid "Axis length"
 msgstr "Lunghezza dell'asse"
 
 # MSG_SELFTEST_AXIS c=16
-#: ultralcd.cpp:8174
+#: ultralcd.cpp:8095
 msgid "Axis"
 msgstr "Assi"
 
 # MSG_SELFTEST_BEDHEATER c=20
-#: ultralcd.cpp:8131
+#: ultralcd.cpp:8052
 msgid "Bed/Heater"
 msgstr "Piano/Riscald."
 
@@ -176,7 +176,7 @@ msgid "Blackout occurred. Recover print?"
 msgstr "Blackout rilevato. Recuperare stampa?"
 
 # MSG_CALIBRATING_HOME c=20
-#: ultralcd.cpp:8492
+#: ultralcd.cpp:8413
 msgid "Calibrating home"
 msgstr "Calibrazione Home"
 
@@ -226,12 +226,12 @@ msgid "Calibration"
 msgstr "Calibrazione"
 
 # MSG_SD_REMOVED c=20
-#: ultralcd.cpp:8939
+#: ultralcd.cpp:8860
 msgid "Card removed"
 msgstr "SD rimossa"
 
 # MSG_CHECKING_FILE c=17
-#: ultralcd.cpp:8580
+#: ultralcd.cpp:8501
 msgid "Checking file"
 msgstr "Verifica file"
 
@@ -326,17 +326,17 @@ msgid "Ejecting filament"
 msgstr "Espellendo filamento"
 
 # MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ultralcd.cpp:8149
+#: ultralcd.cpp:8070
 msgid "Endstop not hit"
 msgstr "Finec. fuori portata"
 
 # MSG_SELFTEST_ENDSTOP c=16
-#: ultralcd.cpp:8144
+#: ultralcd.cpp:8065
 msgid "Endstop"
 msgstr "Finecorsa"
 
 # MSG_SELFTEST_ENDSTOPS c=20
-#: ultralcd.cpp:8135
+#: ultralcd.cpp:8056
 msgid "Endstops"
 msgstr "Finecorsa"
 
@@ -376,7 +376,7 @@ msgid "ERROR:"
 msgstr "ERRORE:"
 
 # MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
-#: ultralcd.cpp:8498
+#: ultralcd.cpp:8419
 msgid "Extruder fan:"
 msgstr "Ventola estrusore:"
 
@@ -391,7 +391,7 @@ msgid "Extruder"
 msgstr "Estrusore"
 
 # MSG_MMU_FAIL_STATS c=18
-#: ultralcd.cpp:6754
+#: ultralcd.cpp:6675
 msgid "Fail stats MMU"
 msgstr "Stat.fall. MMU"
 
@@ -401,7 +401,7 @@ msgid "F. autoload"
 msgstr "Autocar.fil."
 
 # MSG_FAIL_STATS c=18
-#: ultralcd.cpp:6751
+#: ultralcd.cpp:6672
 msgid "Fail stats"
 msgstr "Stat. fallimenti"
 
@@ -440,7 +440,7 @@ msgstr "Filamento estruso e con colore corretto?"
 msgid "Filament not loaded"
 msgstr "Fil. non caricato"
 
-# MSG_FILAMENT_SENSOR c=20
+# MSG_SELFTEST_FILAMENT_SENSOR c=17
 #: messages.c:97
 msgid "Filament sensor"
 msgstr "Sensore filam."
@@ -461,7 +461,7 @@ msgid "FS Action"
 msgstr "Azione FS"
 
 # MSG_FILE_INCOMPLETE c=20 r=3
-#: ultralcd.cpp:8634
+#: ultralcd.cpp:8555
 msgid "File incomplete. Continue anyway?"
 msgstr "File incompleto. Continuare comunque?"
 
@@ -486,7 +486,7 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr "Risolvere il problema e premere il bottone sull'unita MMU."
 
 # MSG_FLOW c=15
-#: ultralcd.cpp:6888
+#: ultralcd.cpp:6809
 msgid "Flow"
 msgstr "Flusso"
 
@@ -497,21 +497,21 @@ msgstr "Ventola frontale?"
 
 # MSG_BED_CORRECTION_FRONT c=14
 #: ultralcd.cpp:3116
-msgid "Front side[um]"
-msgstr "Fronte [um]"
+msgid "Front side[μm]"
+msgstr "Fronte [μm]"
 
 # MSG_SELFTEST_FANS c=20
-#: ultralcd.cpp:8179
+#: ultralcd.cpp:8100
 msgid "Front/left fans"
 msgstr "Ventola frontale/sin"
 
 # MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ultralcd.cpp:8127
+#: ultralcd.cpp:8048
 msgid "Heater/Thermistor"
 msgstr "Riscald./Termist."
 
 # MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: Marlin_main.cpp:9874
+#: Marlin_main.cpp:9877
 msgid "Heating disabled by safety timer."
 msgstr "Riscaldamento fermato dal timer di sicurezza."
 
@@ -551,12 +551,12 @@ msgid "Checking bed"
 msgstr "Verifica piano"
 
 # MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ultralcd.cpp:8481
+#: ultralcd.cpp:8402
 msgid "Checking endstops"
 msgstr "Verifica finecorsa"
 
 # MSG_SELFTEST_CHECK_HOTEND c=20
-#: ultralcd.cpp:8487
+#: ultralcd.cpp:8408
 msgid "Checking hotend"
 msgstr "Verifica ugello"
 
@@ -576,7 +576,7 @@ msgid "Checking Y axis"
 msgstr "Verifica asse Y"
 
 # MSG_SELFTEST_CHECK_Z c=20
-#: ultralcd.cpp:8484
+#: ultralcd.cpp:8405
 msgid "Checking Z axis"
 msgstr "Verifica asse Z"
 
@@ -657,8 +657,8 @@ msgstr "Sinistra"
 
 # MSG_BED_CORRECTION_LEFT c=14
 #: ultralcd.cpp:3114
-msgid "Left side [um]"
-msgstr "Sinistra [um]"
+msgid "Left side [μm]"
+msgstr "Sinistra [μm]"
 
 # MSG_LIN_CORRECTION c=18
 #: ultralcd.cpp:5702
@@ -671,7 +671,7 @@ msgid "Live adjust Z"
 msgstr "Compensazione Z"
 
 # MSG_INSERT_FIL c=20 r=6
-#: ultralcd.cpp:7380
+#: ultralcd.cpp:7301
 msgid "Insert the filament (do not load it) into the extruder and then press the knob."
 msgstr "Inserire filamento (senza caricarlo) nell'estrusore e premere la manopola."
 
@@ -696,12 +696,12 @@ msgid "Iteration"
 msgstr "Iterazione"
 
 # MSG_LOOSE_PULLEY c=20
-#: ultralcd.cpp:8167
+#: ultralcd.cpp:8088
 msgid "Loose pulley"
 msgstr "Puleggia lenta"
 
 # MSG_LOAD_TO_NOZZLE c=18
-#: ultralcd.cpp:6717
+#: ultralcd.cpp:6638
 msgid "Load to nozzle"
 msgstr "Carica ugello"
 
@@ -851,7 +851,7 @@ msgid "No move."
 msgstr "Nessun movimento."
 
 # MSG_NO_CARD c=18
-#: ultralcd.cpp:6697
+#: ultralcd.cpp:6618
 msgid "No SD card"
 msgstr "Nessuna SD"
 
@@ -866,7 +866,7 @@ msgid "No"
 msgstr ""
 
 # MSG_SELFTEST_NOTCONNECTED c=20
-#: ultralcd.cpp:8128
+#: ultralcd.cpp:8049
 msgid "Not connected"
 msgstr "Non connesso"
 
@@ -951,7 +951,7 @@ msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Pulire l'ugello per la calibrazione, poi fare click."
 
 # MSG_SELFTEST_PLEASECHECK c=20
-#: ultralcd.cpp:8122
+#: ultralcd.cpp:8043
 msgid "Please check:"
 msgstr "Verifica:"
 
@@ -1016,7 +1016,7 @@ msgid "Preheat the nozzle!"
 msgstr "Prerisc. ugello!"
 
 # MSG_PREHEAT c=18
-#: ultralcd.cpp:6655
+#: ultralcd.cpp:6576
 msgid "Preheat"
 msgstr "Preriscalda"
 
@@ -1031,7 +1031,7 @@ msgid "Please upgrade."
 msgstr "Prego aggiornare."
 
 # MSG_PRESS_TO_PREHEAT c=20 r=4
-#: Marlin_main.cpp:12049
+#: Marlin_main.cpp:12052
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Premete la manopola per preriscaldare l'ugello e continuare."
 
@@ -1061,7 +1061,7 @@ msgid "Preheating to unload"
 msgstr "Preriscald. scarico"
 
 # MSG_SELFTEST_PRINT_FAN_SPEED c=18
-#: ultralcd.cpp:8501
+#: ultralcd.cpp:8422
 msgid "Print fan:"
 msgstr "Vent.stam:"
 
@@ -1112,21 +1112,21 @@ msgstr "Per favore prima carica il filamento."
 
 # MSG_BED_CORRECTION_REAR c=14
 #: ultralcd.cpp:3117
-msgid "Rear side [um]"
-msgstr "Retro [um]"
+msgid "Rear side [μm]"
+msgstr "Retro [μm]"
 
 # MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ultralcd.cpp:7404
+#: ultralcd.cpp:7325
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Scaricare prima il filamento, poi ripetere l'operazione."
 
 # MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ultralcd.cpp:7407
+#: ultralcd.cpp:7328
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "Controllare il collegamento al sensore e rimuovere il filamento."
 
 # MSG_RECOVERING_PRINT c=20
-#: Marlin_main.cpp:11393
+#: Marlin_main.cpp:11396
 msgid "Recovering print"
 msgstr "Recupero stampa"
 
@@ -1157,8 +1157,8 @@ msgstr "Riprendi stampa"
 
 # MSG_BED_CORRECTION_RIGHT c=14
 #: ultralcd.cpp:3115
-msgid "Right side[um]"
-msgstr "Destra [um]"
+msgid "Right side[μm]"
+msgstr "Destra [μm]"
 
 # MSG_RPI_PORT c=13
 #: messages.c:142
@@ -1191,12 +1191,12 @@ msgid "Select language"
 msgstr "Seleziona lingua"
 
 # MSG_SELFTEST_OK c=20
-#: ultralcd.cpp:7679
+#: ultralcd.cpp:7600
 msgid "Self test OK"
 msgstr "Autotest OK"
 
 # MSG_SELFTEST_START c=20
-#: ultralcd.cpp:7447
+#: ultralcd.cpp:7368
 msgid "Self test start"
 msgstr "Avvia autotest"
 
@@ -1206,7 +1206,7 @@ msgid "Selftest"
 msgstr "Autotest"
 
 # MSG_SELFTEST_ERROR c=20
-#: ultralcd.cpp:8121
+#: ultralcd.cpp:8042
 msgid "Selftest error!"
 msgstr "Errore Autotest!"
 
@@ -1306,7 +1306,7 @@ msgid "Once"
 msgstr "Singolo"
 
 # MSG_SPEED c=15
-#: ultralcd.cpp:6882
+#: ultralcd.cpp:6803
 msgid "Speed"
 msgstr "Velocita"
 
@@ -1336,12 +1336,12 @@ msgid "STOPPED."
 msgstr "ARRESTATO."
 
 # MSG_SUPPORT c=18
-#: ultralcd.cpp:6756
+#: ultralcd.cpp:6677
 msgid "Support"
 msgstr "Supporto"
 
 # MSG_SELFTEST_SWAPPED c=16
-#: ultralcd.cpp:8180
+#: ultralcd.cpp:8101
 msgid "Swapped"
 msgstr "Scambiato"
 
@@ -1376,7 +1376,7 @@ msgid "Temperature calibration is finished and active. Temp. calibration can be 
 msgstr "Calibrazione temperatura completata e attiva. Puo essere disattivata dal menu Impostazioni ->Cal. Temp."
 
 # MSG_FS_VERIFIED c=20 r=3
-#: ultralcd.cpp:7411
+#: ultralcd.cpp:7332
 msgid "Sensor verified, remove the filament now."
 msgstr "Sensore verificato, rimuovere il filamento."
 
@@ -1406,7 +1406,7 @@ msgid "Total print time"
 msgstr "Tempo stampa totale"
 
 # MSG_TUNE c=18
-#: ultralcd.cpp:6653
+#: ultralcd.cpp:6574
 msgid "Tune"
 msgstr "Regola"
 
@@ -1425,7 +1425,7 @@ msgstr "per caricare il fil."
 msgid "to unload filament"
 msgstr "per scaricare fil."
 
-# MSG_UNLOAD_FILAMENT c=16
+# MSG_UNLOAD_FILAMENT c=18
 #: messages.c:114
 msgid "Unload filament"
 msgstr "Scarica filam."
@@ -1510,7 +1510,7 @@ msgstr "XYZ Cal. dettagli"
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "Calibrazione XYZ fallita. Si prega di consultare il manuale."
 
-# MSG_YES c=3
+# MSG_YES c=4
 #: messages.c:123
 msgid "Yes"
 msgstr "Si"
@@ -1586,7 +1586,7 @@ msgid "The printer will start printing a zig-zag line. Rotate the knob until you
 msgstr "La stampante iniziera a stampare una linea a zig-zag. Gira la manopola fino a che non hai raggiungo l'altezza ottimale. Verifica con le immagini nel manuale (capitolo sulla calibrazione)."
 
 # MSG_FIL_FAILED c=20 r=5
-#: ultralcd.cpp:7415
+#: ultralcd.cpp:7336
 msgid "Verification failed, remove the filament and try again."
 msgstr "Verifica fallita, rimuovere il filamento e riprovare."
 
@@ -1616,7 +1616,7 @@ msgid "Checks"
 msgstr "Controlli"
 
 # MSG_FALSE_TRIGGERING c=20
-#: ultralcd.cpp:8190
+#: ultralcd.cpp:8111
 msgid "False triggering"
 msgstr "Falso innesco"
 
@@ -1721,17 +1721,17 @@ msgid "Printer nozzle diameter differs from the G-code. Please check the value i
 msgstr "Diametro ugello diverso dal G-Code. Controlla il valore nelle impostazioni. Stampa annullata."
 
 # MSG_SELFTEST_FS_LEVEL c=20
-#: ultralcd.cpp:8195
+#: ultralcd.cpp:8116
 msgid "%s level expected"
 msgstr "atteso livello %s"
 
 # MSG_RENAME c=18
-#: ultralcd.cpp:6579
+#: ultralcd.cpp:6500
 msgid "Rename"
 msgstr "Rinomina"
 
 # MSG_SELECT c=18
-#: ultralcd.cpp:6572
+#: ultralcd.cpp:6493
 msgid "Select"
 msgstr "Seleziona"
 

--- a/lang/po/new/lb.po
+++ b/lang/po/new/lb.po
@@ -7,8 +7,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: lb\n"
 "Project-Id-Version: Prusa-Firmware\n"
-"POT-Creation-Date: Tue 21 Dec 2021 03:32:02 PM CET\n"
-"PO-Revision-Date: Tue 21 Dec 2021 03:32:02 PM CET\n"
+"POT-Creation-Date: Tue 08 Feb 2022 02:45:05 PM CET\n"
+"PO-Revision-Date: Tue 08 Feb 2022 02:45:05 PM CET\n"
 "Language-Team: \n"
 "X-Generator: Poedit 2.0.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
@@ -21,7 +21,7 @@ msgid " 0.3 or older"
 msgstr ""
 
 # MSG_FS_V_03_OR_OLDER c=18
-#: Marlin_main.cpp:9884
+#: Marlin_main.cpp:9887
 msgid "FS v0.3 or older"
 msgstr ""
 
@@ -31,7 +31,7 @@ msgid " 0.4 or newer"
 msgstr ""
 
 # MSG_FS_V_04_OR_NEWER c=18
-#: Marlin_main.cpp:9883
+#: Marlin_main.cpp:9886
 msgid "FS v0.4 or newer"
 msgstr ""
 
@@ -61,11 +61,11 @@ msgid "Adjusting Z:"
 msgstr ""
 
 # MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ultralcd.cpp:8490
+#: ultralcd.cpp:8411
 msgid "All correct"
 msgstr ""
 
-# MSG_WIZARD_DONE c=20 r=8
+# MSG_WIZARD_DONE c=20 r=3
 #: messages.c:118
 msgid "All is done. Happy printing!"
 msgstr ""
@@ -96,7 +96,7 @@ msgid "Auto home"
 msgstr ""
 
 # MSG_AUTOLOAD_FILAMENT c=18
-#: ultralcd.cpp:6732
+#: ultralcd.cpp:6653
 msgid "AutoLoad filament"
 msgstr ""
 
@@ -111,17 +111,17 @@ msgid "Autoloading filament is active, just press the knob and insert filament..
 msgstr ""
 
 # MSG_SELFTEST_AXIS_LENGTH c=20
-#: ultralcd.cpp:8173
+#: ultralcd.cpp:8094
 msgid "Axis length"
 msgstr ""
 
 # MSG_SELFTEST_AXIS c=16
-#: ultralcd.cpp:8174
+#: ultralcd.cpp:8095
 msgid "Axis"
 msgstr ""
 
 # MSG_SELFTEST_BEDHEATER c=20
-#: ultralcd.cpp:8131
+#: ultralcd.cpp:8052
 msgid "Bed/Heater"
 msgstr ""
 
@@ -176,7 +176,7 @@ msgid "Blackout occurred. Recover print?"
 msgstr ""
 
 # MSG_CALIBRATING_HOME c=20
-#: ultralcd.cpp:8492
+#: ultralcd.cpp:8413
 msgid "Calibrating home"
 msgstr ""
 
@@ -226,12 +226,12 @@ msgid "Calibration"
 msgstr ""
 
 # MSG_SD_REMOVED c=20
-#: ultralcd.cpp:8939
+#: ultralcd.cpp:8860
 msgid "Card removed"
 msgstr ""
 
 # MSG_CHECKING_FILE c=17
-#: ultralcd.cpp:8580
+#: ultralcd.cpp:8501
 msgid "Checking file"
 msgstr ""
 
@@ -326,17 +326,17 @@ msgid "Ejecting filament"
 msgstr ""
 
 # MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ultralcd.cpp:8149
+#: ultralcd.cpp:8070
 msgid "Endstop not hit"
 msgstr ""
 
 # MSG_SELFTEST_ENDSTOP c=16
-#: ultralcd.cpp:8144
+#: ultralcd.cpp:8065
 msgid "Endstop"
 msgstr ""
 
 # MSG_SELFTEST_ENDSTOPS c=20
-#: ultralcd.cpp:8135
+#: ultralcd.cpp:8056
 msgid "Endstops"
 msgstr ""
 
@@ -376,7 +376,7 @@ msgid "ERROR:"
 msgstr ""
 
 # MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
-#: ultralcd.cpp:8498
+#: ultralcd.cpp:8419
 msgid "Extruder fan:"
 msgstr ""
 
@@ -391,7 +391,7 @@ msgid "Extruder"
 msgstr ""
 
 # MSG_MMU_FAIL_STATS c=18
-#: ultralcd.cpp:6754
+#: ultralcd.cpp:6675
 msgid "Fail stats MMU"
 msgstr ""
 
@@ -401,7 +401,7 @@ msgid "F. autoload"
 msgstr ""
 
 # MSG_FAIL_STATS c=18
-#: ultralcd.cpp:6751
+#: ultralcd.cpp:6672
 msgid "Fail stats"
 msgstr ""
 
@@ -440,7 +440,7 @@ msgstr ""
 msgid "Filament not loaded"
 msgstr ""
 
-# MSG_FILAMENT_SENSOR c=20
+# MSG_SELFTEST_FILAMENT_SENSOR c=17
 #: messages.c:97
 msgid "Filament sensor"
 msgstr ""
@@ -461,7 +461,7 @@ msgid "FS Action"
 msgstr ""
 
 # MSG_FILE_INCOMPLETE c=20 r=3
-#: ultralcd.cpp:8634
+#: ultralcd.cpp:8555
 msgid "File incomplete. Continue anyway?"
 msgstr ""
 
@@ -486,7 +486,7 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr ""
 
 # MSG_FLOW c=15
-#: ultralcd.cpp:6888
+#: ultralcd.cpp:6809
 msgid "Flow"
 msgstr ""
 
@@ -497,21 +497,21 @@ msgstr ""
 
 # MSG_BED_CORRECTION_FRONT c=14
 #: ultralcd.cpp:3116
-msgid "Front side[um]"
+msgid "Front side[μm]"
 msgstr ""
 
 # MSG_SELFTEST_FANS c=20
-#: ultralcd.cpp:8179
+#: ultralcd.cpp:8100
 msgid "Front/left fans"
 msgstr ""
 
 # MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ultralcd.cpp:8127
+#: ultralcd.cpp:8048
 msgid "Heater/Thermistor"
 msgstr ""
 
 # MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: Marlin_main.cpp:9874
+#: Marlin_main.cpp:9877
 msgid "Heating disabled by safety timer."
 msgstr ""
 
@@ -551,12 +551,12 @@ msgid "Checking bed"
 msgstr ""
 
 # MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ultralcd.cpp:8481
+#: ultralcd.cpp:8402
 msgid "Checking endstops"
 msgstr ""
 
 # MSG_SELFTEST_CHECK_HOTEND c=20
-#: ultralcd.cpp:8487
+#: ultralcd.cpp:8408
 msgid "Checking hotend"
 msgstr ""
 
@@ -576,7 +576,7 @@ msgid "Checking Y axis"
 msgstr ""
 
 # MSG_SELFTEST_CHECK_Z c=20
-#: ultralcd.cpp:8484
+#: ultralcd.cpp:8405
 msgid "Checking Z axis"
 msgstr ""
 
@@ -657,7 +657,7 @@ msgstr ""
 
 # MSG_BED_CORRECTION_LEFT c=14
 #: ultralcd.cpp:3114
-msgid "Left side [um]"
+msgid "Left side [μm]"
 msgstr ""
 
 # MSG_LIN_CORRECTION c=18
@@ -671,7 +671,7 @@ msgid "Live adjust Z"
 msgstr ""
 
 # MSG_INSERT_FIL c=20 r=6
-#: ultralcd.cpp:7380
+#: ultralcd.cpp:7301
 msgid "Insert the filament (do not load it) into the extruder and then press the knob."
 msgstr ""
 
@@ -696,12 +696,12 @@ msgid "Iteration"
 msgstr ""
 
 # MSG_LOOSE_PULLEY c=20
-#: ultralcd.cpp:8167
+#: ultralcd.cpp:8088
 msgid "Loose pulley"
 msgstr ""
 
 # MSG_LOAD_TO_NOZZLE c=18
-#: ultralcd.cpp:6717
+#: ultralcd.cpp:6638
 msgid "Load to nozzle"
 msgstr ""
 
@@ -851,7 +851,7 @@ msgid "No move."
 msgstr ""
 
 # MSG_NO_CARD c=18
-#: ultralcd.cpp:6697
+#: ultralcd.cpp:6618
 msgid "No SD card"
 msgstr ""
 
@@ -866,7 +866,7 @@ msgid "No"
 msgstr ""
 
 # MSG_SELFTEST_NOTCONNECTED c=20
-#: ultralcd.cpp:8128
+#: ultralcd.cpp:8049
 msgid "Not connected"
 msgstr ""
 
@@ -951,7 +951,7 @@ msgid "Please clean the nozzle for calibration. Click when done."
 msgstr ""
 
 # MSG_SELFTEST_PLEASECHECK c=20
-#: ultralcd.cpp:8122
+#: ultralcd.cpp:8043
 msgid "Please check:"
 msgstr ""
 
@@ -1016,7 +1016,7 @@ msgid "Preheat the nozzle!"
 msgstr ""
 
 # MSG_PREHEAT c=18
-#: ultralcd.cpp:6655
+#: ultralcd.cpp:6576
 msgid "Preheat"
 msgstr ""
 
@@ -1031,7 +1031,7 @@ msgid "Please upgrade."
 msgstr ""
 
 # MSG_PRESS_TO_PREHEAT c=20 r=4
-#: Marlin_main.cpp:12049
+#: Marlin_main.cpp:12052
 msgid "Press the knob to preheat nozzle and continue."
 msgstr ""
 
@@ -1061,7 +1061,7 @@ msgid "Preheating to unload"
 msgstr ""
 
 # MSG_SELFTEST_PRINT_FAN_SPEED c=18
-#: ultralcd.cpp:8501
+#: ultralcd.cpp:8422
 msgid "Print fan:"
 msgstr ""
 
@@ -1112,21 +1112,21 @@ msgstr ""
 
 # MSG_BED_CORRECTION_REAR c=14
 #: ultralcd.cpp:3117
-msgid "Rear side [um]"
+msgid "Rear side [μm]"
 msgstr ""
 
 # MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ultralcd.cpp:7404
+#: ultralcd.cpp:7325
 msgid "Please unload the filament first, then repeat this action."
 msgstr ""
 
 # MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ultralcd.cpp:7407
+#: ultralcd.cpp:7328
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr ""
 
 # MSG_RECOVERING_PRINT c=20
-#: Marlin_main.cpp:11393
+#: Marlin_main.cpp:11396
 msgid "Recovering print"
 msgstr ""
 
@@ -1157,7 +1157,7 @@ msgstr ""
 
 # MSG_BED_CORRECTION_RIGHT c=14
 #: ultralcd.cpp:3115
-msgid "Right side[um]"
+msgid "Right side[μm]"
 msgstr ""
 
 # MSG_RPI_PORT c=13
@@ -1191,12 +1191,12 @@ msgid "Select language"
 msgstr ""
 
 # MSG_SELFTEST_OK c=20
-#: ultralcd.cpp:7679
+#: ultralcd.cpp:7600
 msgid "Self test OK"
 msgstr ""
 
 # MSG_SELFTEST_START c=20
-#: ultralcd.cpp:7447
+#: ultralcd.cpp:7368
 msgid "Self test start"
 msgstr ""
 
@@ -1206,7 +1206,7 @@ msgid "Selftest"
 msgstr ""
 
 # MSG_SELFTEST_ERROR c=20
-#: ultralcd.cpp:8121
+#: ultralcd.cpp:8042
 msgid "Selftest error!"
 msgstr ""
 
@@ -1306,7 +1306,7 @@ msgid "Once"
 msgstr ""
 
 # MSG_SPEED c=15
-#: ultralcd.cpp:6882
+#: ultralcd.cpp:6803
 msgid "Speed"
 msgstr ""
 
@@ -1336,12 +1336,12 @@ msgid "STOPPED."
 msgstr ""
 
 # MSG_SUPPORT c=18
-#: ultralcd.cpp:6756
+#: ultralcd.cpp:6677
 msgid "Support"
 msgstr ""
 
 # MSG_SELFTEST_SWAPPED c=16
-#: ultralcd.cpp:8180
+#: ultralcd.cpp:8101
 msgid "Swapped"
 msgstr ""
 
@@ -1376,7 +1376,7 @@ msgid "Temperature calibration is finished and active. Temp. calibration can be 
 msgstr ""
 
 # MSG_FS_VERIFIED c=20 r=3
-#: ultralcd.cpp:7411
+#: ultralcd.cpp:7332
 msgid "Sensor verified, remove the filament now."
 msgstr ""
 
@@ -1406,7 +1406,7 @@ msgid "Total print time"
 msgstr ""
 
 # MSG_TUNE c=18
-#: ultralcd.cpp:6653
+#: ultralcd.cpp:6574
 msgid "Tune"
 msgstr ""
 
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "to unload filament"
 msgstr ""
 
-# MSG_UNLOAD_FILAMENT c=16
+# MSG_UNLOAD_FILAMENT c=18
 #: messages.c:114
 msgid "Unload filament"
 msgstr ""
@@ -1510,7 +1510,7 @@ msgstr ""
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr ""
 
-# MSG_YES c=3
+# MSG_YES c=4
 #: messages.c:123
 msgid "Yes"
 msgstr ""
@@ -1586,7 +1586,7 @@ msgid "The printer will start printing a zig-zag line. Rotate the knob until you
 msgstr ""
 
 # MSG_FIL_FAILED c=20 r=5
-#: ultralcd.cpp:7415
+#: ultralcd.cpp:7336
 msgid "Verification failed, remove the filament and try again."
 msgstr ""
 
@@ -1616,7 +1616,7 @@ msgid "Checks"
 msgstr ""
 
 # MSG_FALSE_TRIGGERING c=20
-#: ultralcd.cpp:8190
+#: ultralcd.cpp:8111
 msgid "False triggering"
 msgstr ""
 
@@ -1721,17 +1721,17 @@ msgid "Printer nozzle diameter differs from the G-code. Please check the value i
 msgstr ""
 
 # MSG_SELFTEST_FS_LEVEL c=20
-#: ultralcd.cpp:8195
+#: ultralcd.cpp:8116
 msgid "%s level expected"
 msgstr ""
 
 # MSG_RENAME c=18
-#: ultralcd.cpp:6579
+#: ultralcd.cpp:6500
 msgid "Rename"
 msgstr ""
 
 # MSG_SELECT c=18
-#: ultralcd.cpp:6572
+#: ultralcd.cpp:6493
 msgid "Select"
 msgstr ""
 

--- a/lang/po/new/lt.po
+++ b/lang/po/new/lt.po
@@ -7,8 +7,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: lt\n"
 "Project-Id-Version: Prusa-Firmware\n"
-"POT-Creation-Date: Mon 03 Jan 2022 02:53:20 PM CET\n"
-"PO-Revision-Date: Mon 03 Jan 2022 02:53:20 PM CET\n"
+"POT-Creation-Date: Tue 08 Feb 2022 02:45:10 PM CET\n"
+"PO-Revision-Date: Tue 08 Feb 2022 02:45:10 PM CET\n"
 "Language-Team: \n"
 "X-Generator: Poedit 2.0.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
@@ -65,7 +65,7 @@ msgstr ""
 msgid "All correct"
 msgstr ""
 
-# MSG_WIZARD_DONE c=20 r=8
+# MSG_WIZARD_DONE c=20 r=3
 #: messages.c:118
 msgid "All is done. Happy printing!"
 msgstr ""
@@ -440,7 +440,7 @@ msgstr ""
 msgid "Filament not loaded"
 msgstr ""
 
-# MSG_FILAMENT_SENSOR c=20
+# MSG_SELFTEST_FILAMENT_SENSOR c=17
 #: messages.c:97
 msgid "Filament sensor"
 msgstr ""
@@ -497,7 +497,7 @@ msgstr ""
 
 # MSG_BED_CORRECTION_FRONT c=14
 #: ultralcd.cpp:3116
-msgid "Front side[um]"
+msgid "Front side[μm]"
 msgstr ""
 
 # MSG_SELFTEST_FANS c=20
@@ -657,7 +657,7 @@ msgstr ""
 
 # MSG_BED_CORRECTION_LEFT c=14
 #: ultralcd.cpp:3114
-msgid "Left side [um]"
+msgid "Left side [μm]"
 msgstr ""
 
 # MSG_LIN_CORRECTION c=18
@@ -1112,7 +1112,7 @@ msgstr ""
 
 # MSG_BED_CORRECTION_REAR c=14
 #: ultralcd.cpp:3117
-msgid "Rear side [um]"
+msgid "Rear side [μm]"
 msgstr ""
 
 # MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
@@ -1157,7 +1157,7 @@ msgstr ""
 
 # MSG_BED_CORRECTION_RIGHT c=14
 #: ultralcd.cpp:3115
-msgid "Right side[um]"
+msgid "Right side[μm]"
 msgstr ""
 
 # MSG_RPI_PORT c=13
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "to unload filament"
 msgstr ""
 
-# MSG_UNLOAD_FILAMENT c=16
+# MSG_UNLOAD_FILAMENT c=18
 #: messages.c:114
 msgid "Unload filament"
 msgstr ""
@@ -1510,7 +1510,7 @@ msgstr ""
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr ""
 
-# MSG_YES c=3
+# MSG_YES c=4
 #: messages.c:123
 msgid "Yes"
 msgstr ""

--- a/lang/po/new/nl.po
+++ b/lang/po/new/nl.po
@@ -7,8 +7,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: nl\n"
 "Project-Id-Version: Prusa-Firmware\n"
-"POT-Creation-Date: Sun 19 Dec 2021 07:17:44 PM CET\n"
-"PO-Revision-Date: Sun 19 Dec 2021 07:17:44 PM CET\n"
+"POT-Creation-Date: Tue 08 Feb 2022 02:44:37 PM CET\n"
+"PO-Revision-Date: Tue 08 Feb 2022 02:44:37 PM CET\n"
 "Language-Team: \n"
 "X-Generator: Poedit 2.0.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
@@ -21,7 +21,7 @@ msgid " 0.3 or older"
 msgstr " 0.3 of ouder"
 
 # MSG_FS_V_03_OR_OLDER c=18
-#: Marlin_main.cpp:9884
+#: Marlin_main.cpp:9887
 msgid "FS v0.3 or older"
 msgstr "FS 0.3 of ouder"
 
@@ -31,7 +31,7 @@ msgid " 0.4 or newer"
 msgstr " 0.4 of nieuwer"
 
 # MSG_FS_V_04_OR_NEWER c=18
-#: Marlin_main.cpp:9883
+#: Marlin_main.cpp:9886
 msgid "FS v0.4 or newer"
 msgstr "FS 0.4 of nieuwer"
 
@@ -61,11 +61,11 @@ msgid "Adjusting Z:"
 msgstr "Z is ingesteld:"
 
 # MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ultralcd.cpp:8490
+#: ultralcd.cpp:8411
 msgid "All correct"
 msgstr "Allemaal goed"
 
-# MSG_WIZARD_DONE c=20 r=8
+# MSG_WIZARD_DONE c=20 r=3
 #: messages.c:118
 msgid "All is done. Happy printing!"
 msgstr "Klaar. Happy printing!"
@@ -96,7 +96,7 @@ msgid "Auto home"
 msgstr "Startpositie"
 
 # MSG_AUTOLOAD_FILAMENT c=18
-#: ultralcd.cpp:6732
+#: ultralcd.cpp:6653
 msgid "AutoLoad filament"
 msgstr "Autoladen filament"
 
@@ -111,17 +111,17 @@ msgid "Autoloading filament is active, just press the knob and insert filament..
 msgstr "Automatisch laden van flament is actief, druk de knop en laad filament..."
 
 # MSG_SELFTEST_AXIS_LENGTH c=20
-#: ultralcd.cpp:8173
+#: ultralcd.cpp:8094
 msgid "Axis length"
 msgstr "Aslengte"
 
 # MSG_SELFTEST_AXIS c=16
-#: ultralcd.cpp:8174
+#: ultralcd.cpp:8095
 msgid "Axis"
 msgstr "As"
 
 # MSG_SELFTEST_BEDHEATER c=20
-#: ultralcd.cpp:8131
+#: ultralcd.cpp:8052
 msgid "Bed/Heater"
 msgstr "Bed/Verwarming"
 
@@ -176,7 +176,7 @@ msgid "Blackout occurred. Recover print?"
 msgstr "Stroomstoring. Print herstellen?"
 
 # MSG_CALIBRATING_HOME c=20
-#: ultralcd.cpp:8492
+#: ultralcd.cpp:8413
 msgid "Calibrating home"
 msgstr "Kalibreren start"
 
@@ -226,12 +226,12 @@ msgid "Calibration"
 msgstr "Kalibratie"
 
 # MSG_SD_REMOVED c=20
-#: ultralcd.cpp:8939
+#: ultralcd.cpp:8860
 msgid "Card removed"
 msgstr "SD verwijderd"
 
 # MSG_CHECKING_FILE c=17
-#: ultralcd.cpp:8580
+#: ultralcd.cpp:8501
 msgid "Checking file"
 msgstr "Bestand controle"
 
@@ -326,17 +326,17 @@ msgid "Ejecting filament"
 msgstr "Fil. word ontladen"
 
 # MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ultralcd.cpp:8149
+#: ultralcd.cpp:8070
 msgid "Endstop not hit"
 msgstr "Endstop niet geraakt"
 
 # MSG_SELFTEST_ENDSTOP c=16
-#: ultralcd.cpp:8144
+#: ultralcd.cpp:8065
 msgid "Endstop"
 msgstr "Eindstop"
 
 # MSG_SELFTEST_ENDSTOPS c=20
-#: ultralcd.cpp:8135
+#: ultralcd.cpp:8056
 msgid "Endstops"
 msgstr "Eindstops"
 
@@ -376,7 +376,7 @@ msgid "ERROR:"
 msgstr "FOUT:"
 
 # MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
-#: ultralcd.cpp:8498
+#: ultralcd.cpp:8419
 msgid "Extruder fan:"
 msgstr ""
 
@@ -391,7 +391,7 @@ msgid "Extruder"
 msgstr ""
 
 # MSG_MMU_FAIL_STATS c=18
-#: ultralcd.cpp:6754
+#: ultralcd.cpp:6675
 msgid "Fail stats MMU"
 msgstr "MMU-Fouten"
 
@@ -401,7 +401,7 @@ msgid "F. autoload"
 msgstr "F. autoladen"
 
 # MSG_FAIL_STATS c=18
-#: ultralcd.cpp:6751
+#: ultralcd.cpp:6672
 msgid "Fail stats"
 msgstr "Foutstatistieken"
 
@@ -440,7 +440,7 @@ msgstr "Filament extrudeert met de juiste kleur?"
 msgid "Filament not loaded"
 msgstr "Fil. niet geladen"
 
-# MSG_FILAMENT_SENSOR c=20
+# MSG_SELFTEST_FILAMENT_SENSOR c=17
 #: messages.c:97
 msgid "Filament sensor"
 msgstr "Filamentsensor"
@@ -461,7 +461,7 @@ msgid "FS Action"
 msgstr "FS actie"
 
 # MSG_FILE_INCOMPLETE c=20 r=3
-#: ultralcd.cpp:8634
+#: ultralcd.cpp:8555
 msgid "File incomplete. Continue anyway?"
 msgstr "Bestand onvolledig. Toch doorgaan?"
 
@@ -486,7 +486,7 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr "Los het probleem op en druk vervolgens op de knop op de MMU-eenheid."
 
 # MSG_FLOW c=15
-#: ultralcd.cpp:6888
+#: ultralcd.cpp:6809
 msgid "Flow"
 msgstr "Stromen"
 
@@ -497,21 +497,21 @@ msgstr "Voorzijde fan?"
 
 # MSG_BED_CORRECTION_FRONT c=14
 #: ultralcd.cpp:3116
-msgid "Front side[um]"
-msgstr "Voorkant  [um]"
+msgid "Front side[μm]"
+msgstr "Voorkant  [μm]"
 
 # MSG_SELFTEST_FANS c=20
-#: ultralcd.cpp:8179
+#: ultralcd.cpp:8100
 msgid "Front/left fans"
 msgstr "Fans voor/links"
 
 # MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ultralcd.cpp:8127
+#: ultralcd.cpp:8048
 msgid "Heater/Thermistor"
 msgstr "Verwarmer/Therm."
 
 # MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: Marlin_main.cpp:9874
+#: Marlin_main.cpp:9877
 msgid "Heating disabled by safety timer."
 msgstr "Verwarming uitgeschakeld door veiligheidstimer."
 
@@ -551,12 +551,12 @@ msgid "Checking bed"
 msgstr "Controleer bed"
 
 # MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ultralcd.cpp:8481
+#: ultralcd.cpp:8402
 msgid "Checking endstops"
 msgstr "Controleer endstops"
 
 # MSG_SELFTEST_CHECK_HOTEND c=20
-#: ultralcd.cpp:8487
+#: ultralcd.cpp:8408
 msgid "Checking hotend"
 msgstr "Controleer hotend"
 
@@ -576,7 +576,7 @@ msgid "Checking Y axis"
 msgstr "Controleer Y as"
 
 # MSG_SELFTEST_CHECK_Z c=20
-#: ultralcd.cpp:8484
+#: ultralcd.cpp:8405
 msgid "Checking Z axis"
 msgstr "Controleer Z as"
 
@@ -657,8 +657,8 @@ msgstr "Links"
 
 # MSG_BED_CORRECTION_LEFT c=14
 #: ultralcd.cpp:3114
-msgid "Left side [um]"
-msgstr "Linkerkant[um]"
+msgid "Left side [μm]"
+msgstr "Linkerkant[μm]"
 
 # MSG_LIN_CORRECTION c=18
 #: ultralcd.cpp:5702
@@ -671,7 +671,7 @@ msgid "Live adjust Z"
 msgstr "Live Z aanpassen"
 
 # MSG_INSERT_FIL c=20 r=6
-#: ultralcd.cpp:7380
+#: ultralcd.cpp:7301
 msgid "Insert the filament (do not load it) into the extruder and then press the knob."
 msgstr "Steek a.u.b. filament (maar niet laden) in de extruder en druk op knop."
 
@@ -696,12 +696,12 @@ msgid "Iteration"
 msgstr "Iteratie"
 
 # MSG_LOOSE_PULLEY c=20
-#: ultralcd.cpp:8167
+#: ultralcd.cpp:8088
 msgid "Loose pulley"
 msgstr "Losse riemschijf"
 
 # MSG_LOAD_TO_NOZZLE c=18
-#: ultralcd.cpp:6717
+#: ultralcd.cpp:6638
 msgid "Load to nozzle"
 msgstr "Tot tuit laden"
 
@@ -851,7 +851,7 @@ msgid "No move."
 msgstr "Geen beweging."
 
 # MSG_NO_CARD c=18
-#: ultralcd.cpp:6697
+#: ultralcd.cpp:6618
 msgid "No SD card"
 msgstr "Geen SD kaart"
 
@@ -866,7 +866,7 @@ msgid "No"
 msgstr "Nee"
 
 # MSG_SELFTEST_NOTCONNECTED c=20
-#: ultralcd.cpp:8128
+#: ultralcd.cpp:8049
 msgid "Not connected"
 msgstr "Niet verbonden"
 
@@ -951,7 +951,7 @@ msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Reinig de tuit voor de kalibratie. Druk op de knop wanneer gereed."
 
 # MSG_SELFTEST_PLEASECHECK c=20
-#: ultralcd.cpp:8122
+#: ultralcd.cpp:8043
 msgid "Please check:"
 msgstr "Controleer aub:"
 
@@ -1016,7 +1016,7 @@ msgid "Preheat the nozzle!"
 msgstr "Tuit voorverwarmen!"
 
 # MSG_PREHEAT c=18
-#: ultralcd.cpp:6655
+#: ultralcd.cpp:6576
 msgid "Preheat"
 msgstr "Voorverwarmen"
 
@@ -1031,7 +1031,7 @@ msgid "Please upgrade."
 msgstr "Voer een upgrade uit"
 
 # MSG_PRESS_TO_PREHEAT c=20 r=4
-#: Marlin_main.cpp:12049
+#: Marlin_main.cpp:12052
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Druk op de knop om de tuit voor te verwarmen en door te gaan."
 
@@ -1061,7 +1061,7 @@ msgid "Preheating to unload"
 msgstr "Opwarmen uitwerpen"
 
 # MSG_SELFTEST_PRINT_FAN_SPEED c=18
-#: ultralcd.cpp:8501
+#: ultralcd.cpp:8422
 msgid "Print fan:"
 msgstr ""
 
@@ -1112,21 +1112,21 @@ msgstr "Laad a.u.b. eerst filament."
 
 # MSG_BED_CORRECTION_REAR c=14
 #: ultralcd.cpp:3117
-msgid "Rear side [um]"
-msgstr "Achterkant[um]"
+msgid "Rear side [μm]"
+msgstr "Achterkant[μm]"
 
 # MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ultralcd.cpp:7404
+#: ultralcd.cpp:7325
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Verwijder eerst het filament en probeer het opnieuw."
 
 # MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ultralcd.cpp:7407
+#: ultralcd.cpp:7328
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "AUB IR sensor ver- binding kontrolleren , verwijder filament indien aanwezig."
 
 # MSG_RECOVERING_PRINT c=20
-#: Marlin_main.cpp:11393
+#: Marlin_main.cpp:11396
 msgid "Recovering print"
 msgstr "Print herstellen"
 
@@ -1157,8 +1157,8 @@ msgstr "Hervatten print"
 
 # MSG_BED_CORRECTION_RIGHT c=14
 #: ultralcd.cpp:3115
-msgid "Right side[um]"
-msgstr "Recht.kant[um]"
+msgid "Right side[μm]"
+msgstr "Recht.kant[μm]"
 
 # MSG_RPI_PORT c=13
 #: messages.c:142
@@ -1191,12 +1191,12 @@ msgid "Select language"
 msgstr "Kies taal"
 
 # MSG_SELFTEST_OK c=20
-#: ultralcd.cpp:7679
+#: ultralcd.cpp:7600
 msgid "Self test OK"
 msgstr "Zelftest  OK"
 
 # MSG_SELFTEST_START c=20
-#: ultralcd.cpp:7447
+#: ultralcd.cpp:7368
 msgid "Self test start"
 msgstr "Zelftest start"
 
@@ -1206,7 +1206,7 @@ msgid "Selftest"
 msgstr "Zelftest"
 
 # MSG_SELFTEST_ERROR c=20
-#: ultralcd.cpp:8121
+#: ultralcd.cpp:8042
 msgid "Selftest error!"
 msgstr "Zelftest fout!"
 
@@ -1306,7 +1306,7 @@ msgid "Once"
 msgstr "Eenmaal"
 
 # MSG_SPEED c=15
-#: ultralcd.cpp:6882
+#: ultralcd.cpp:6803
 msgid "Speed"
 msgstr "Snelheid"
 
@@ -1336,12 +1336,12 @@ msgid "STOPPED."
 msgstr "GESTOPT."
 
 # MSG_SUPPORT c=18
-#: ultralcd.cpp:6756
+#: ultralcd.cpp:6677
 msgid "Support"
 msgstr ""
 
 # MSG_SELFTEST_SWAPPED c=16
-#: ultralcd.cpp:8180
+#: ultralcd.cpp:8101
 msgid "Swapped"
 msgstr "Gewisseld"
 
@@ -1376,7 +1376,7 @@ msgid "Temperature calibration is finished and active. Temp. calibration can be 
 msgstr "Temperatuurkalibratie kan uitgeschakeld worden in het menu Instellingen-> Tempkalibratie."
 
 # MSG_FS_VERIFIED c=20 r=3
-#: ultralcd.cpp:7411
+#: ultralcd.cpp:7332
 msgid "Sensor verified, remove the filament now."
 msgstr "Sensor geverifieerd, verwijder nu het filament."
 
@@ -1406,7 +1406,7 @@ msgid "Total print time"
 msgstr "Totaal printtijd"
 
 # MSG_TUNE c=18
-#: ultralcd.cpp:6653
+#: ultralcd.cpp:6574
 msgid "Tune"
 msgstr "Fijnafstemming"
 
@@ -1425,7 +1425,7 @@ msgstr "om filament te laden"
 msgid "to unload filament"
 msgstr "om fil. uitwerpen"
 
-# MSG_UNLOAD_FILAMENT c=16
+# MSG_UNLOAD_FILAMENT c=18
 #: messages.c:114
 msgid "Unload filament"
 msgstr "Fil. uitwerpen"
@@ -1510,7 +1510,7 @@ msgstr "XYZ kal. details"
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "XYZ-kalibratie mislukt. Raadpleeg de handleiding aub."
 
-# MSG_YES c=3
+# MSG_YES c=4
 #: messages.c:123
 msgid "Yes"
 msgstr "Ja"
@@ -1586,7 +1586,7 @@ msgid "The printer will start printing a zig-zag line. Rotate the knob until you
 msgstr "De printer begint een zigzaglijn printen. Draai aan de knop totdat je de optimale hoogte hebt bereikt. Bekijk de afbeeldingen in de handleiding (Calibration chapter)."
 
 # MSG_FIL_FAILED c=20 r=5
-#: ultralcd.cpp:7415
+#: ultralcd.cpp:7336
 msgid "Verification failed, remove the filament and try again."
 msgstr "Verificatie mislukt, verwijder het filament en probeer het opnieuw."
 
@@ -1616,7 +1616,7 @@ msgid "Checks"
 msgstr ""
 
 # MSG_FALSE_TRIGGERING c=20
-#: ultralcd.cpp:8190
+#: ultralcd.cpp:8111
 msgid "False triggering"
 msgstr "Valse triggering"
 
@@ -1721,17 +1721,17 @@ msgid "Printer nozzle diameter differs from the G-code. Please check the value i
 msgstr "De diameter van de tuit van de printer verschilt van de G-code. Controleer de waarde in de instellingen. Afdrukken geannuleerd."
 
 # MSG_SELFTEST_FS_LEVEL c=20
-#: ultralcd.cpp:8195
+#: ultralcd.cpp:8116
 msgid "%s level expected"
 msgstr "%s niveau verwacht"
 
 # MSG_RENAME c=18
-#: ultralcd.cpp:6579
+#: ultralcd.cpp:6500
 msgid "Rename"
 msgstr "Hernoem"
 
 # MSG_SELECT c=18
-#: ultralcd.cpp:6572
+#: ultralcd.cpp:6493
 msgid "Select"
 msgstr "Selecteer"
 

--- a/lang/po/new/pl.po
+++ b/lang/po/new/pl.po
@@ -7,8 +7,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: pl\n"
 "Project-Id-Version: Prusa-Firmware\n"
-"POT-Creation-Date: Sun 19 Dec 2021 07:17:40 PM CET\n"
-"PO-Revision-Date: Sun 19 Dec 2021 07:17:40 PM CET\n"
+"POT-Creation-Date: Tue 08 Feb 2022 02:44:33 PM CET\n"
+"PO-Revision-Date: Tue 08 Feb 2022 02:44:33 PM CET\n"
 "Language-Team: \n"
 "X-Generator: Poedit 2.0.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
@@ -21,7 +21,7 @@ msgid " 0.3 or older"
 msgstr " 0.3 lub starszy"
 
 # MSG_FS_V_03_OR_OLDER c=18
-#: Marlin_main.cpp:9884
+#: Marlin_main.cpp:9887
 msgid "FS v0.3 or older"
 msgstr "FS 0.3 lub starszy"
 
@@ -31,7 +31,7 @@ msgid " 0.4 or newer"
 msgstr " 0.4 lub nowszy"
 
 # MSG_FS_V_04_OR_NEWER c=18
-#: Marlin_main.cpp:9883
+#: Marlin_main.cpp:9886
 msgid "FS v0.4 or newer"
 msgstr "FS 0.4 lub nowszy"
 
@@ -61,11 +61,11 @@ msgid "Adjusting Z:"
 msgstr "Ustawianie Z:"
 
 # MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ultralcd.cpp:8490
+#: ultralcd.cpp:8411
 msgid "All correct"
 msgstr "Wszystko OK"
 
-# MSG_WIZARD_DONE c=20 r=8
+# MSG_WIZARD_DONE c=20 r=3
 #: messages.c:118
 msgid "All is done. Happy printing!"
 msgstr "Gotowe. Udanego drukowania!"
@@ -96,7 +96,7 @@ msgid "Auto home"
 msgstr "Auto zerowanie"
 
 # MSG_AUTOLOAD_FILAMENT c=18
-#: ultralcd.cpp:6732
+#: ultralcd.cpp:6653
 msgid "AutoLoad filament"
 msgstr "Autoladowanie fil."
 
@@ -111,17 +111,17 @@ msgid "Autoloading filament is active, just press the knob and insert filament..
 msgstr "Autoladowanie filamentu wlaczone, nacisnij pokretlo i wsun filament..."
 
 # MSG_SELFTEST_AXIS_LENGTH c=20
-#: ultralcd.cpp:8173
+#: ultralcd.cpp:8094
 msgid "Axis length"
 msgstr "Dlugosc osi"
 
 # MSG_SELFTEST_AXIS c=16
-#: ultralcd.cpp:8174
+#: ultralcd.cpp:8095
 msgid "Axis"
 msgstr "Os"
 
 # MSG_SELFTEST_BEDHEATER c=20
-#: ultralcd.cpp:8131
+#: ultralcd.cpp:8052
 msgid "Bed/Heater"
 msgstr "Stol/Grzanie"
 
@@ -176,7 +176,7 @@ msgid "Blackout occurred. Recover print?"
 msgstr "Wykryto zanik napiecia.Kontynowac?"
 
 # MSG_CALIBRATING_HOME c=20
-#: ultralcd.cpp:8492
+#: ultralcd.cpp:8413
 msgid "Calibrating home"
 msgstr "Zerowanie osi"
 
@@ -226,12 +226,12 @@ msgid "Calibration"
 msgstr "Kalibracja"
 
 # MSG_SD_REMOVED c=20
-#: ultralcd.cpp:8939
+#: ultralcd.cpp:8860
 msgid "Card removed"
 msgstr "Karta wyjeta"
 
 # MSG_CHECKING_FILE c=17
-#: ultralcd.cpp:8580
+#: ultralcd.cpp:8501
 msgid "Checking file"
 msgstr "Sprawdzanie pliku"
 
@@ -326,17 +326,17 @@ msgid "Ejecting filament"
 msgstr "Wysuwanie filamentu"
 
 # MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ultralcd.cpp:8149
+#: ultralcd.cpp:8070
 msgid "Endstop not hit"
 msgstr "Krancowka nie aktyw."
 
 # MSG_SELFTEST_ENDSTOP c=16
-#: ultralcd.cpp:8144
+#: ultralcd.cpp:8065
 msgid "Endstop"
 msgstr "Krancowka"
 
 # MSG_SELFTEST_ENDSTOPS c=20
-#: ultralcd.cpp:8135
+#: ultralcd.cpp:8056
 msgid "Endstops"
 msgstr "Krancowki"
 
@@ -376,7 +376,7 @@ msgid "ERROR:"
 msgstr "BLAD:"
 
 # MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
-#: ultralcd.cpp:8498
+#: ultralcd.cpp:8419
 msgid "Extruder fan:"
 msgstr "WentHotend:"
 
@@ -391,7 +391,7 @@ msgid "Extruder"
 msgstr "Ekstruder"
 
 # MSG_MMU_FAIL_STATS c=18
-#: ultralcd.cpp:6754
+#: ultralcd.cpp:6675
 msgid "Fail stats MMU"
 msgstr "Bledy MMU"
 
@@ -401,7 +401,7 @@ msgid "F. autoload"
 msgstr "Autolad. fil."
 
 # MSG_FAIL_STATS c=18
-#: ultralcd.cpp:6751
+#: ultralcd.cpp:6672
 msgid "Fail stats"
 msgstr "Statystyki bledow"
 
@@ -440,7 +440,7 @@ msgstr "Filament wychodzi z dyszy,kolor jest ok?"
 msgid "Filament not loaded"
 msgstr "Fil. nie zaladowany"
 
-# MSG_FILAMENT_SENSOR c=20
+# MSG_SELFTEST_FILAMENT_SENSOR c=17
 #: messages.c:97
 msgid "Filament sensor"
 msgstr "Czujnik filamentu"
@@ -461,7 +461,7 @@ msgid "FS Action"
 msgstr "Akcja FS"
 
 # MSG_FILE_INCOMPLETE c=20 r=3
-#: ultralcd.cpp:8634
+#: ultralcd.cpp:8555
 msgid "File incomplete. Continue anyway?"
 msgstr "Plik niekompletny. Kontynowac?"
 
@@ -486,7 +486,7 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr "Rozwiaz problem i wcisnij przycisk na MMU."
 
 # MSG_FLOW c=15
-#: ultralcd.cpp:6888
+#: ultralcd.cpp:6809
 msgid "Flow"
 msgstr "Przeplyw"
 
@@ -497,21 +497,21 @@ msgstr "Przedni went. druku?"
 
 # MSG_BED_CORRECTION_FRONT c=14
 #: ultralcd.cpp:3116
-msgid "Front side[um]"
-msgstr "Przod [um]"
+msgid "Front side[μm]"
+msgstr "Przod [μm]"
 
 # MSG_SELFTEST_FANS c=20
-#: ultralcd.cpp:8179
+#: ultralcd.cpp:8100
 msgid "Front/left fans"
 msgstr "Przedni/lewy wentyl."
 
 # MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ultralcd.cpp:8127
+#: ultralcd.cpp:8048
 msgid "Heater/Thermistor"
 msgstr "Grzalka/Termistor"
 
 # MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: Marlin_main.cpp:9874
+#: Marlin_main.cpp:9877
 msgid "Heating disabled by safety timer."
 msgstr "Grzanie wylaczone przez wyl. czasowy"
 
@@ -551,12 +551,12 @@ msgid "Checking bed"
 msgstr "Kontrola stolu"
 
 # MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ultralcd.cpp:8481
+#: ultralcd.cpp:8402
 msgid "Checking endstops"
 msgstr "Kontrola krancowek"
 
 # MSG_SELFTEST_CHECK_HOTEND c=20
-#: ultralcd.cpp:8487
+#: ultralcd.cpp:8408
 msgid "Checking hotend"
 msgstr "Kontrola hotendu"
 
@@ -576,7 +576,7 @@ msgid "Checking Y axis"
 msgstr "Kontrola osi Y"
 
 # MSG_SELFTEST_CHECK_Z c=20
-#: ultralcd.cpp:8484
+#: ultralcd.cpp:8405
 msgid "Checking Z axis"
 msgstr "Kontrola osi Z"
 
@@ -657,8 +657,8 @@ msgstr "Lewa"
 
 # MSG_BED_CORRECTION_LEFT c=14
 #: ultralcd.cpp:3114
-msgid "Left side [um]"
-msgstr "Lewo [um]"
+msgid "Left side [μm]"
+msgstr "Lewo [μm]"
 
 # MSG_LIN_CORRECTION c=18
 #: ultralcd.cpp:5702
@@ -671,7 +671,7 @@ msgid "Live adjust Z"
 msgstr "Ustaw. Live Z"
 
 # MSG_INSERT_FIL c=20 r=6
-#: ultralcd.cpp:7380
+#: ultralcd.cpp:7301
 msgid "Insert the filament (do not load it) into the extruder and then press the knob."
 msgstr "Wsun filament (nie uzywaj funkcji ladowania) do ekstrudera i nacisnij pokretlo."
 
@@ -696,12 +696,12 @@ msgid "Iteration"
 msgstr "Iteracja"
 
 # MSG_LOOSE_PULLEY c=20
-#: ultralcd.cpp:8167
+#: ultralcd.cpp:8088
 msgid "Loose pulley"
 msgstr "Luzne kolo pasowe"
 
 # MSG_LOAD_TO_NOZZLE c=18
-#: ultralcd.cpp:6717
+#: ultralcd.cpp:6638
 msgid "Load to nozzle"
 msgstr "Zaladuj do dyszy"
 
@@ -851,7 +851,7 @@ msgid "No move."
 msgstr "Brak ruchu."
 
 # MSG_NO_CARD c=18
-#: ultralcd.cpp:6697
+#: ultralcd.cpp:6618
 msgid "No SD card"
 msgstr "Brak karty SD"
 
@@ -866,7 +866,7 @@ msgid "No"
 msgstr "Nie"
 
 # MSG_SELFTEST_NOTCONNECTED c=20
-#: ultralcd.cpp:8128
+#: ultralcd.cpp:8049
 msgid "Not connected"
 msgstr "Nie podlaczono"
 
@@ -951,7 +951,7 @@ msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Dla prawidlowej kalibracji nalezy oczyscic dysze. Potwierdz guzikiem."
 
 # MSG_SELFTEST_PLEASECHECK c=20
-#: ultralcd.cpp:8122
+#: ultralcd.cpp:8043
 msgid "Please check:"
 msgstr "Sprawdz:"
 
@@ -1016,7 +1016,7 @@ msgid "Preheat the nozzle!"
 msgstr "Nagrzej dysze!"
 
 # MSG_PREHEAT c=18
-#: ultralcd.cpp:6655
+#: ultralcd.cpp:6576
 msgid "Preheat"
 msgstr "Grzanie"
 
@@ -1031,7 +1031,7 @@ msgid "Please upgrade."
 msgstr "Prosze zaktualizowac"
 
 # MSG_PRESS_TO_PREHEAT c=20 r=4
-#: Marlin_main.cpp:12049
+#: Marlin_main.cpp:12052
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Wcisnij pokretlo aby rozgrzac dysze i kontynuowac."
 
@@ -1061,7 +1061,7 @@ msgid "Preheating to unload"
 msgstr "Nagrzew. do rozlad."
 
 # MSG_SELFTEST_PRINT_FAN_SPEED c=18
-#: ultralcd.cpp:8501
+#: ultralcd.cpp:8422
 msgid "Print fan:"
 msgstr "WentWydruk:"
 
@@ -1112,21 +1112,21 @@ msgstr "Najpierw zaladuj filament."
 
 # MSG_BED_CORRECTION_REAR c=14
 #: ultralcd.cpp:3117
-msgid "Rear side [um]"
-msgstr "Tyl [um]"
+msgid "Rear side [μm]"
+msgstr "Tyl [μm]"
 
 # MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ultralcd.cpp:7404
+#: ultralcd.cpp:7325
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Najpierw rozladuj filament, nastepnie powtorz czynnosc."
 
 # MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ultralcd.cpp:7407
+#: ultralcd.cpp:7328
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "Sprawdz polaczenie czujnika IR, rozladuj filament, jesli zaladowany."
 
 # MSG_RECOVERING_PRINT c=20
-#: Marlin_main.cpp:11393
+#: Marlin_main.cpp:11396
 msgid "Recovering print"
 msgstr "Wznawianie wydruku"
 
@@ -1157,8 +1157,8 @@ msgstr "Wznawianie druku"
 
 # MSG_BED_CORRECTION_RIGHT c=14
 #: ultralcd.cpp:3115
-msgid "Right side[um]"
-msgstr "Prawo [um]"
+msgid "Right side[μm]"
+msgstr "Prawo [μm]"
 
 # MSG_RPI_PORT c=13
 #: messages.c:142
@@ -1191,12 +1191,12 @@ msgid "Select language"
 msgstr "Wybor jezyka"
 
 # MSG_SELFTEST_OK c=20
-#: ultralcd.cpp:7679
+#: ultralcd.cpp:7600
 msgid "Self test OK"
 msgstr "Selftest OK"
 
 # MSG_SELFTEST_START c=20
-#: ultralcd.cpp:7447
+#: ultralcd.cpp:7368
 msgid "Self test start"
 msgstr "Selftest startuje"
 
@@ -1206,7 +1206,7 @@ msgid "Selftest"
 msgstr ""
 
 # MSG_SELFTEST_ERROR c=20
-#: ultralcd.cpp:8121
+#: ultralcd.cpp:8042
 msgid "Selftest error!"
 msgstr "Blad selftest!"
 
@@ -1306,7 +1306,7 @@ msgid "Once"
 msgstr "1-raz"
 
 # MSG_SPEED c=15
-#: ultralcd.cpp:6882
+#: ultralcd.cpp:6803
 msgid "Speed"
 msgstr "Predkosc"
 
@@ -1336,12 +1336,12 @@ msgid "STOPPED."
 msgstr "ZATRZYMANO."
 
 # MSG_SUPPORT c=18
-#: ultralcd.cpp:6756
+#: ultralcd.cpp:6677
 msgid "Support"
 msgstr "Wsparcie"
 
 # MSG_SELFTEST_SWAPPED c=16
-#: ultralcd.cpp:8180
+#: ultralcd.cpp:8101
 msgid "Swapped"
 msgstr "Zamieniono"
 
@@ -1376,7 +1376,7 @@ msgid "Temperature calibration is finished and active. Temp. calibration can be 
 msgstr "Kalibracja temperaturowa zakonczona i wlaczona. Moze byc wylaczona z menu Ustawienia -> Kalibracja temp."
 
 # MSG_FS_VERIFIED c=20 r=3
-#: ultralcd.cpp:7411
+#: ultralcd.cpp:7332
 msgid "Sensor verified, remove the filament now."
 msgstr "Czujnik sprawdzony, wyciagnij filament."
 
@@ -1406,7 +1406,7 @@ msgid "Total print time"
 msgstr "Laczny czas druku"
 
 # MSG_TUNE c=18
-#: ultralcd.cpp:6653
+#: ultralcd.cpp:6574
 msgid "Tune"
 msgstr "Strojenie"
 
@@ -1425,7 +1425,7 @@ msgstr "aby zaladow. fil."
 msgid "to unload filament"
 msgstr "aby rozlad. filament"
 
-# MSG_UNLOAD_FILAMENT c=16
+# MSG_UNLOAD_FILAMENT c=18
 #: messages.c:114
 msgid "Unload filament"
 msgstr "Rozladowanie fil"
@@ -1510,7 +1510,7 @@ msgstr "Szczegoly kal. XYZ"
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "Kalibracja XYZ nieudana. Sprawdz przyczyny i rozwiazania w instrukcji."
 
-# MSG_YES c=3
+# MSG_YES c=4
 #: messages.c:123
 msgid "Yes"
 msgstr "Tak"
@@ -1586,7 +1586,7 @@ msgid "The printer will start printing a zig-zag line. Rotate the knob until you
 msgstr "Drukarka zacznie drukowanie linii w ksztalcie zygzaka. Ustaw optymalna wysokosc obracajac pokretlo. Porownaj z ilustracjami w Podreczniku (rozdzial Kalibracja)."
 
 # MSG_FIL_FAILED c=20 r=5
-#: ultralcd.cpp:7415
+#: ultralcd.cpp:7336
 msgid "Verification failed, remove the filament and try again."
 msgstr "Niepowodzenie sprawdzenia, wyciagnij filament i sprobuj ponownie."
 
@@ -1616,7 +1616,7 @@ msgid "Checks"
 msgstr "Testy"
 
 # MSG_FALSE_TRIGGERING c=20
-#: ultralcd.cpp:8190
+#: ultralcd.cpp:8111
 msgid "False triggering"
 msgstr "Falszywy alarm"
 
@@ -1721,17 +1721,17 @@ msgid "Printer nozzle diameter differs from the G-code. Please check the value i
 msgstr "Srednica dyszy rozni sie od tej w G-code. Sprawdz ustawienia. Druk anulowany."
 
 # MSG_SELFTEST_FS_LEVEL c=20
-#: ultralcd.cpp:8195
+#: ultralcd.cpp:8116
 msgid "%s level expected"
 msgstr "Oczekiwano wersji %s"
 
 # MSG_RENAME c=18
-#: ultralcd.cpp:6579
+#: ultralcd.cpp:6500
 msgid "Rename"
 msgstr "Zmien nazwe"
 
 # MSG_SELECT c=18
-#: ultralcd.cpp:6572
+#: ultralcd.cpp:6493
 msgid "Select"
 msgstr "Wybierz"
 

--- a/lang/po/new/ro.po
+++ b/lang/po/new/ro.po
@@ -7,8 +7,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ro\n"
 "Project-Id-Version: Prusa-Firmware\n"
-"POT-Creation-Date: Mon Jan 17 12:19:31 CET 2022\n"
-"PO-Revision-Date: Mon Jan 17 12:19:31 CET 2022\n"
+"POT-Creation-Date: Tue 08 Feb 2022 02:44:41 PM CET\n"
+"PO-Revision-Date: Tue 08 Feb 2022 02:44:41 PM CET\n"
 "Language-Team: \n"
 "X-Generator: Poedit 2.0.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
@@ -65,7 +65,7 @@ msgstr "Ajustare Z:"
 msgid "All correct"
 msgstr "Totul OK"
 
-# MSG_WIZARD_DONE c=20 r=8
+# MSG_WIZARD_DONE c=20 r=3
 #: messages.c:118
 msgid "All is done. Happy printing!"
 msgstr "Totul este OK. Distractie placuta!"
@@ -440,7 +440,7 @@ msgstr "Fil. curge si are culoarea corecta?"
 msgid "Filament not loaded"
 msgstr "Fil. nu e incarcat"
 
-# MSG_FILAMENT_SENSOR c=20
+# MSG_SELFTEST_FILAMENT_SENSOR c=17
 #: messages.c:97
 msgid "Filament sensor"
 msgstr "Senz. de filament"
@@ -497,8 +497,8 @@ msgstr "Vent. print?"
 
 # MSG_BED_CORRECTION_FRONT c=14
 #: ultralcd.cpp:3116
-msgid "Front side[um]"
-msgstr "Fata [um]"
+msgid "Front side[μm]"
+msgstr "Fata [μm]"
 
 # MSG_SELFTEST_FANS c=20
 #: ultralcd.cpp:8100
@@ -657,8 +657,8 @@ msgstr "Stanga"
 
 # MSG_BED_CORRECTION_LEFT c=14
 #: ultralcd.cpp:3114
-msgid "Left side [um]"
-msgstr "Stanga [um]"
+msgid "Left side [μm]"
+msgstr "Stanga [μm]"
 
 # MSG_LIN_CORRECTION c=18
 #: ultralcd.cpp:5702
@@ -1112,8 +1112,8 @@ msgstr "Va rugam incarcati filamentul mai intai."
 
 # MSG_BED_CORRECTION_REAR c=14
 #: ultralcd.cpp:3117
-msgid "Rear side [um]"
-msgstr "Spate [um]"
+msgid "Rear side [μm]"
+msgstr "Spate [μm]"
 
 # MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
 #: ultralcd.cpp:7325
@@ -1157,8 +1157,8 @@ msgstr "Reluare print..."
 
 # MSG_BED_CORRECTION_RIGHT c=14
 #: ultralcd.cpp:3115
-msgid "Right side[um]"
-msgstr "Dreapta [um]"
+msgid "Right side[μm]"
+msgstr "Dreapta [μm]"
 
 # MSG_RPI_PORT c=13
 #: messages.c:142
@@ -1425,7 +1425,7 @@ msgstr "a incarca filament"
 msgid "to unload filament"
 msgstr "a scoate filament"
 
-# MSG_UNLOAD_FILAMENT c=16
+# MSG_UNLOAD_FILAMENT c=18
 #: messages.c:114
 msgid "Unload filament"
 msgstr "Descarca filament"
@@ -1510,7 +1510,7 @@ msgstr "Detalii cal. XYZ"
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "Calibrarea XYZ a esuat. Va rugam consultati manualul."
 
-# MSG_YES c=3
+# MSG_YES c=4
 #: messages.c:123
 msgid "Yes"
 msgstr "Da"

--- a/lang/po/new/sl.po
+++ b/lang/po/new/sl.po
@@ -7,8 +7,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: sl\n"
 "Project-Id-Version: Prusa-Firmware\n"
-"POT-Creation-Date: Tue 21 Dec 2021 03:23:03 PM CET\n"
-"PO-Revision-Date: Tue 21 Dec 2021 03:23:03 PM CET\n"
+"POT-Creation-Date: Tue 08 Feb 2022 02:45:16 PM CET\n"
+"PO-Revision-Date: Tue 08 Feb 2022 02:45:16 PM CET\n"
 "Language-Team: \n"
 "X-Generator: Poedit 2.0.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
@@ -21,7 +21,7 @@ msgid " 0.3 or older"
 msgstr ""
 
 # MSG_FS_V_03_OR_OLDER c=18
-#: Marlin_main.cpp:9884
+#: Marlin_main.cpp:9887
 msgid "FS v0.3 or older"
 msgstr ""
 
@@ -31,7 +31,7 @@ msgid " 0.4 or newer"
 msgstr ""
 
 # MSG_FS_V_04_OR_NEWER c=18
-#: Marlin_main.cpp:9883
+#: Marlin_main.cpp:9886
 msgid "FS v0.4 or newer"
 msgstr ""
 
@@ -61,11 +61,11 @@ msgid "Adjusting Z:"
 msgstr ""
 
 # MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ultralcd.cpp:8490
+#: ultralcd.cpp:8411
 msgid "All correct"
 msgstr ""
 
-# MSG_WIZARD_DONE c=20 r=8
+# MSG_WIZARD_DONE c=20 r=3
 #: messages.c:118
 msgid "All is done. Happy printing!"
 msgstr ""
@@ -96,7 +96,7 @@ msgid "Auto home"
 msgstr ""
 
 # MSG_AUTOLOAD_FILAMENT c=18
-#: ultralcd.cpp:6732
+#: ultralcd.cpp:6653
 msgid "AutoLoad filament"
 msgstr ""
 
@@ -111,17 +111,17 @@ msgid "Autoloading filament is active, just press the knob and insert filament..
 msgstr ""
 
 # MSG_SELFTEST_AXIS_LENGTH c=20
-#: ultralcd.cpp:8173
+#: ultralcd.cpp:8094
 msgid "Axis length"
 msgstr ""
 
 # MSG_SELFTEST_AXIS c=16
-#: ultralcd.cpp:8174
+#: ultralcd.cpp:8095
 msgid "Axis"
 msgstr ""
 
 # MSG_SELFTEST_BEDHEATER c=20
-#: ultralcd.cpp:8131
+#: ultralcd.cpp:8052
 msgid "Bed/Heater"
 msgstr ""
 
@@ -176,7 +176,7 @@ msgid "Blackout occurred. Recover print?"
 msgstr ""
 
 # MSG_CALIBRATING_HOME c=20
-#: ultralcd.cpp:8492
+#: ultralcd.cpp:8413
 msgid "Calibrating home"
 msgstr ""
 
@@ -226,12 +226,12 @@ msgid "Calibration"
 msgstr ""
 
 # MSG_SD_REMOVED c=20
-#: ultralcd.cpp:8939
+#: ultralcd.cpp:8860
 msgid "Card removed"
 msgstr ""
 
 # MSG_CHECKING_FILE c=17
-#: ultralcd.cpp:8580
+#: ultralcd.cpp:8501
 msgid "Checking file"
 msgstr ""
 
@@ -326,17 +326,17 @@ msgid "Ejecting filament"
 msgstr ""
 
 # MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ultralcd.cpp:8149
+#: ultralcd.cpp:8070
 msgid "Endstop not hit"
 msgstr ""
 
 # MSG_SELFTEST_ENDSTOP c=16
-#: ultralcd.cpp:8144
+#: ultralcd.cpp:8065
 msgid "Endstop"
 msgstr ""
 
 # MSG_SELFTEST_ENDSTOPS c=20
-#: ultralcd.cpp:8135
+#: ultralcd.cpp:8056
 msgid "Endstops"
 msgstr ""
 
@@ -376,7 +376,7 @@ msgid "ERROR:"
 msgstr ""
 
 # MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
-#: ultralcd.cpp:8498
+#: ultralcd.cpp:8419
 msgid "Extruder fan:"
 msgstr ""
 
@@ -391,7 +391,7 @@ msgid "Extruder"
 msgstr ""
 
 # MSG_MMU_FAIL_STATS c=18
-#: ultralcd.cpp:6754
+#: ultralcd.cpp:6675
 msgid "Fail stats MMU"
 msgstr ""
 
@@ -401,7 +401,7 @@ msgid "F. autoload"
 msgstr ""
 
 # MSG_FAIL_STATS c=18
-#: ultralcd.cpp:6751
+#: ultralcd.cpp:6672
 msgid "Fail stats"
 msgstr ""
 
@@ -440,7 +440,7 @@ msgstr ""
 msgid "Filament not loaded"
 msgstr ""
 
-# MSG_FILAMENT_SENSOR c=20
+# MSG_SELFTEST_FILAMENT_SENSOR c=17
 #: messages.c:97
 msgid "Filament sensor"
 msgstr ""
@@ -461,7 +461,7 @@ msgid "FS Action"
 msgstr ""
 
 # MSG_FILE_INCOMPLETE c=20 r=3
-#: ultralcd.cpp:8634
+#: ultralcd.cpp:8555
 msgid "File incomplete. Continue anyway?"
 msgstr ""
 
@@ -486,7 +486,7 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr ""
 
 # MSG_FLOW c=15
-#: ultralcd.cpp:6888
+#: ultralcd.cpp:6809
 msgid "Flow"
 msgstr ""
 
@@ -497,21 +497,21 @@ msgstr ""
 
 # MSG_BED_CORRECTION_FRONT c=14
 #: ultralcd.cpp:3116
-msgid "Front side[um]"
+msgid "Front side[μm]"
 msgstr ""
 
 # MSG_SELFTEST_FANS c=20
-#: ultralcd.cpp:8179
+#: ultralcd.cpp:8100
 msgid "Front/left fans"
 msgstr ""
 
 # MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ultralcd.cpp:8127
+#: ultralcd.cpp:8048
 msgid "Heater/Thermistor"
 msgstr ""
 
 # MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: Marlin_main.cpp:9874
+#: Marlin_main.cpp:9877
 msgid "Heating disabled by safety timer."
 msgstr ""
 
@@ -551,12 +551,12 @@ msgid "Checking bed"
 msgstr ""
 
 # MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ultralcd.cpp:8481
+#: ultralcd.cpp:8402
 msgid "Checking endstops"
 msgstr ""
 
 # MSG_SELFTEST_CHECK_HOTEND c=20
-#: ultralcd.cpp:8487
+#: ultralcd.cpp:8408
 msgid "Checking hotend"
 msgstr ""
 
@@ -576,7 +576,7 @@ msgid "Checking Y axis"
 msgstr ""
 
 # MSG_SELFTEST_CHECK_Z c=20
-#: ultralcd.cpp:8484
+#: ultralcd.cpp:8405
 msgid "Checking Z axis"
 msgstr ""
 
@@ -657,7 +657,7 @@ msgstr ""
 
 # MSG_BED_CORRECTION_LEFT c=14
 #: ultralcd.cpp:3114
-msgid "Left side [um]"
+msgid "Left side [μm]"
 msgstr ""
 
 # MSG_LIN_CORRECTION c=18
@@ -671,7 +671,7 @@ msgid "Live adjust Z"
 msgstr ""
 
 # MSG_INSERT_FIL c=20 r=6
-#: ultralcd.cpp:7380
+#: ultralcd.cpp:7301
 msgid "Insert the filament (do not load it) into the extruder and then press the knob."
 msgstr ""
 
@@ -696,12 +696,12 @@ msgid "Iteration"
 msgstr ""
 
 # MSG_LOOSE_PULLEY c=20
-#: ultralcd.cpp:8167
+#: ultralcd.cpp:8088
 msgid "Loose pulley"
 msgstr ""
 
 # MSG_LOAD_TO_NOZZLE c=18
-#: ultralcd.cpp:6717
+#: ultralcd.cpp:6638
 msgid "Load to nozzle"
 msgstr ""
 
@@ -851,7 +851,7 @@ msgid "No move."
 msgstr ""
 
 # MSG_NO_CARD c=18
-#: ultralcd.cpp:6697
+#: ultralcd.cpp:6618
 msgid "No SD card"
 msgstr ""
 
@@ -866,7 +866,7 @@ msgid "No"
 msgstr ""
 
 # MSG_SELFTEST_NOTCONNECTED c=20
-#: ultralcd.cpp:8128
+#: ultralcd.cpp:8049
 msgid "Not connected"
 msgstr ""
 
@@ -951,7 +951,7 @@ msgid "Please clean the nozzle for calibration. Click when done."
 msgstr ""
 
 # MSG_SELFTEST_PLEASECHECK c=20
-#: ultralcd.cpp:8122
+#: ultralcd.cpp:8043
 msgid "Please check:"
 msgstr ""
 
@@ -1016,7 +1016,7 @@ msgid "Preheat the nozzle!"
 msgstr ""
 
 # MSG_PREHEAT c=18
-#: ultralcd.cpp:6655
+#: ultralcd.cpp:6576
 msgid "Preheat"
 msgstr ""
 
@@ -1031,7 +1031,7 @@ msgid "Please upgrade."
 msgstr ""
 
 # MSG_PRESS_TO_PREHEAT c=20 r=4
-#: Marlin_main.cpp:12049
+#: Marlin_main.cpp:12052
 msgid "Press the knob to preheat nozzle and continue."
 msgstr ""
 
@@ -1061,7 +1061,7 @@ msgid "Preheating to unload"
 msgstr ""
 
 # MSG_SELFTEST_PRINT_FAN_SPEED c=18
-#: ultralcd.cpp:8501
+#: ultralcd.cpp:8422
 msgid "Print fan:"
 msgstr ""
 
@@ -1112,21 +1112,21 @@ msgstr ""
 
 # MSG_BED_CORRECTION_REAR c=14
 #: ultralcd.cpp:3117
-msgid "Rear side [um]"
+msgid "Rear side [μm]"
 msgstr ""
 
 # MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ultralcd.cpp:7404
+#: ultralcd.cpp:7325
 msgid "Please unload the filament first, then repeat this action."
 msgstr ""
 
 # MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ultralcd.cpp:7407
+#: ultralcd.cpp:7328
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr ""
 
 # MSG_RECOVERING_PRINT c=20
-#: Marlin_main.cpp:11393
+#: Marlin_main.cpp:11396
 msgid "Recovering print"
 msgstr ""
 
@@ -1157,7 +1157,7 @@ msgstr ""
 
 # MSG_BED_CORRECTION_RIGHT c=14
 #: ultralcd.cpp:3115
-msgid "Right side[um]"
+msgid "Right side[μm]"
 msgstr ""
 
 # MSG_RPI_PORT c=13
@@ -1191,12 +1191,12 @@ msgid "Select language"
 msgstr ""
 
 # MSG_SELFTEST_OK c=20
-#: ultralcd.cpp:7679
+#: ultralcd.cpp:7600
 msgid "Self test OK"
 msgstr ""
 
 # MSG_SELFTEST_START c=20
-#: ultralcd.cpp:7447
+#: ultralcd.cpp:7368
 msgid "Self test start"
 msgstr ""
 
@@ -1206,7 +1206,7 @@ msgid "Selftest"
 msgstr ""
 
 # MSG_SELFTEST_ERROR c=20
-#: ultralcd.cpp:8121
+#: ultralcd.cpp:8042
 msgid "Selftest error!"
 msgstr ""
 
@@ -1306,7 +1306,7 @@ msgid "Once"
 msgstr ""
 
 # MSG_SPEED c=15
-#: ultralcd.cpp:6882
+#: ultralcd.cpp:6803
 msgid "Speed"
 msgstr ""
 
@@ -1336,12 +1336,12 @@ msgid "STOPPED."
 msgstr ""
 
 # MSG_SUPPORT c=18
-#: ultralcd.cpp:6756
+#: ultralcd.cpp:6677
 msgid "Support"
 msgstr ""
 
 # MSG_SELFTEST_SWAPPED c=16
-#: ultralcd.cpp:8180
+#: ultralcd.cpp:8101
 msgid "Swapped"
 msgstr ""
 
@@ -1376,7 +1376,7 @@ msgid "Temperature calibration is finished and active. Temp. calibration can be 
 msgstr ""
 
 # MSG_FS_VERIFIED c=20 r=3
-#: ultralcd.cpp:7411
+#: ultralcd.cpp:7332
 msgid "Sensor verified, remove the filament now."
 msgstr ""
 
@@ -1406,7 +1406,7 @@ msgid "Total print time"
 msgstr ""
 
 # MSG_TUNE c=18
-#: ultralcd.cpp:6653
+#: ultralcd.cpp:6574
 msgid "Tune"
 msgstr ""
 
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "to unload filament"
 msgstr ""
 
-# MSG_UNLOAD_FILAMENT c=16
+# MSG_UNLOAD_FILAMENT c=18
 #: messages.c:114
 msgid "Unload filament"
 msgstr ""
@@ -1510,7 +1510,7 @@ msgstr ""
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr ""
 
-# MSG_YES c=3
+# MSG_YES c=4
 #: messages.c:123
 msgid "Yes"
 msgstr ""
@@ -1586,7 +1586,7 @@ msgid "The printer will start printing a zig-zag line. Rotate the knob until you
 msgstr ""
 
 # MSG_FIL_FAILED c=20 r=5
-#: ultralcd.cpp:7415
+#: ultralcd.cpp:7336
 msgid "Verification failed, remove the filament and try again."
 msgstr ""
 
@@ -1616,7 +1616,7 @@ msgid "Checks"
 msgstr ""
 
 # MSG_FALSE_TRIGGERING c=20
-#: ultralcd.cpp:8190
+#: ultralcd.cpp:8111
 msgid "False triggering"
 msgstr ""
 
@@ -1721,17 +1721,17 @@ msgid "Printer nozzle diameter differs from the G-code. Please check the value i
 msgstr ""
 
 # MSG_SELFTEST_FS_LEVEL c=20
-#: ultralcd.cpp:8195
+#: ultralcd.cpp:8116
 msgid "%s level expected"
 msgstr ""
 
 # MSG_RENAME c=18
-#: ultralcd.cpp:6579
+#: ultralcd.cpp:6500
 msgid "Rename"
 msgstr ""
 
 # MSG_SELECT c=18
-#: ultralcd.cpp:6572
+#: ultralcd.cpp:6493
 msgid "Select"
 msgstr ""
 

--- a/lang/po/new/sv.po
+++ b/lang/po/new/sv.po
@@ -7,8 +7,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: sv\n"
 "Project-Id-Version: Prusa-Firmware\n"
-"POT-Creation-Date: Tue 21 Dec 2021 02:31:55 PM CET\n"
-"PO-Revision-Date: Tue 21 Dec 2021 02:31:55 PM CET\n"
+"POT-Creation-Date: Tue 08 Feb 2022 02:45:22 PM CET\n"
+"PO-Revision-Date: Tue 08 Feb 2022 02:45:22 PM CET\n"
 "Language-Team: \n"
 "X-Generator: Poedit 2.0.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
@@ -21,7 +21,7 @@ msgid " 0.3 or older"
 msgstr ""
 
 # MSG_FS_V_03_OR_OLDER c=18
-#: Marlin_main.cpp:9884
+#: Marlin_main.cpp:9887
 msgid "FS v0.3 or older"
 msgstr ""
 
@@ -31,7 +31,7 @@ msgid " 0.4 or newer"
 msgstr ""
 
 # MSG_FS_V_04_OR_NEWER c=18
-#: Marlin_main.cpp:9883
+#: Marlin_main.cpp:9886
 msgid "FS v0.4 or newer"
 msgstr ""
 
@@ -61,11 +61,11 @@ msgid "Adjusting Z:"
 msgstr ""
 
 # MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ultralcd.cpp:8490
+#: ultralcd.cpp:8411
 msgid "All correct"
 msgstr ""
 
-# MSG_WIZARD_DONE c=20 r=8
+# MSG_WIZARD_DONE c=20 r=3
 #: messages.c:118
 msgid "All is done. Happy printing!"
 msgstr ""
@@ -96,7 +96,7 @@ msgid "Auto home"
 msgstr ""
 
 # MSG_AUTOLOAD_FILAMENT c=18
-#: ultralcd.cpp:6732
+#: ultralcd.cpp:6653
 msgid "AutoLoad filament"
 msgstr ""
 
@@ -111,17 +111,17 @@ msgid "Autoloading filament is active, just press the knob and insert filament..
 msgstr ""
 
 # MSG_SELFTEST_AXIS_LENGTH c=20
-#: ultralcd.cpp:8173
+#: ultralcd.cpp:8094
 msgid "Axis length"
 msgstr ""
 
 # MSG_SELFTEST_AXIS c=16
-#: ultralcd.cpp:8174
+#: ultralcd.cpp:8095
 msgid "Axis"
 msgstr ""
 
 # MSG_SELFTEST_BEDHEATER c=20
-#: ultralcd.cpp:8131
+#: ultralcd.cpp:8052
 msgid "Bed/Heater"
 msgstr ""
 
@@ -176,7 +176,7 @@ msgid "Blackout occurred. Recover print?"
 msgstr ""
 
 # MSG_CALIBRATING_HOME c=20
-#: ultralcd.cpp:8492
+#: ultralcd.cpp:8413
 msgid "Calibrating home"
 msgstr ""
 
@@ -226,12 +226,12 @@ msgid "Calibration"
 msgstr ""
 
 # MSG_SD_REMOVED c=20
-#: ultralcd.cpp:8939
+#: ultralcd.cpp:8860
 msgid "Card removed"
 msgstr ""
 
 # MSG_CHECKING_FILE c=17
-#: ultralcd.cpp:8580
+#: ultralcd.cpp:8501
 msgid "Checking file"
 msgstr ""
 
@@ -326,17 +326,17 @@ msgid "Ejecting filament"
 msgstr ""
 
 # MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ultralcd.cpp:8149
+#: ultralcd.cpp:8070
 msgid "Endstop not hit"
 msgstr ""
 
 # MSG_SELFTEST_ENDSTOP c=16
-#: ultralcd.cpp:8144
+#: ultralcd.cpp:8065
 msgid "Endstop"
 msgstr ""
 
 # MSG_SELFTEST_ENDSTOPS c=20
-#: ultralcd.cpp:8135
+#: ultralcd.cpp:8056
 msgid "Endstops"
 msgstr ""
 
@@ -376,7 +376,7 @@ msgid "ERROR:"
 msgstr ""
 
 # MSG_SELFTEST_EXTRUDER_FAN_SPEED c=18
-#: ultralcd.cpp:8498
+#: ultralcd.cpp:8419
 msgid "Extruder fan:"
 msgstr ""
 
@@ -391,7 +391,7 @@ msgid "Extruder"
 msgstr ""
 
 # MSG_MMU_FAIL_STATS c=18
-#: ultralcd.cpp:6754
+#: ultralcd.cpp:6675
 msgid "Fail stats MMU"
 msgstr ""
 
@@ -401,7 +401,7 @@ msgid "F. autoload"
 msgstr ""
 
 # MSG_FAIL_STATS c=18
-#: ultralcd.cpp:6751
+#: ultralcd.cpp:6672
 msgid "Fail stats"
 msgstr ""
 
@@ -440,7 +440,7 @@ msgstr ""
 msgid "Filament not loaded"
 msgstr ""
 
-# MSG_FILAMENT_SENSOR c=20
+# MSG_SELFTEST_FILAMENT_SENSOR c=17
 #: messages.c:97
 msgid "Filament sensor"
 msgstr ""
@@ -461,7 +461,7 @@ msgid "FS Action"
 msgstr ""
 
 # MSG_FILE_INCOMPLETE c=20 r=3
-#: ultralcd.cpp:8634
+#: ultralcd.cpp:8555
 msgid "File incomplete. Continue anyway?"
 msgstr ""
 
@@ -486,7 +486,7 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr ""
 
 # MSG_FLOW c=15
-#: ultralcd.cpp:6888
+#: ultralcd.cpp:6809
 msgid "Flow"
 msgstr ""
 
@@ -497,21 +497,21 @@ msgstr ""
 
 # MSG_BED_CORRECTION_FRONT c=14
 #: ultralcd.cpp:3116
-msgid "Front side[um]"
+msgid "Front side[μm]"
 msgstr ""
 
 # MSG_SELFTEST_FANS c=20
-#: ultralcd.cpp:8179
+#: ultralcd.cpp:8100
 msgid "Front/left fans"
 msgstr ""
 
 # MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ultralcd.cpp:8127
+#: ultralcd.cpp:8048
 msgid "Heater/Thermistor"
 msgstr ""
 
 # MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: Marlin_main.cpp:9874
+#: Marlin_main.cpp:9877
 msgid "Heating disabled by safety timer."
 msgstr ""
 
@@ -551,12 +551,12 @@ msgid "Checking bed"
 msgstr ""
 
 # MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ultralcd.cpp:8481
+#: ultralcd.cpp:8402
 msgid "Checking endstops"
 msgstr ""
 
 # MSG_SELFTEST_CHECK_HOTEND c=20
-#: ultralcd.cpp:8487
+#: ultralcd.cpp:8408
 msgid "Checking hotend"
 msgstr ""
 
@@ -576,7 +576,7 @@ msgid "Checking Y axis"
 msgstr ""
 
 # MSG_SELFTEST_CHECK_Z c=20
-#: ultralcd.cpp:8484
+#: ultralcd.cpp:8405
 msgid "Checking Z axis"
 msgstr ""
 
@@ -657,7 +657,7 @@ msgstr ""
 
 # MSG_BED_CORRECTION_LEFT c=14
 #: ultralcd.cpp:3114
-msgid "Left side [um]"
+msgid "Left side [μm]"
 msgstr ""
 
 # MSG_LIN_CORRECTION c=18
@@ -671,7 +671,7 @@ msgid "Live adjust Z"
 msgstr ""
 
 # MSG_INSERT_FIL c=20 r=6
-#: ultralcd.cpp:7380
+#: ultralcd.cpp:7301
 msgid "Insert the filament (do not load it) into the extruder and then press the knob."
 msgstr ""
 
@@ -696,12 +696,12 @@ msgid "Iteration"
 msgstr ""
 
 # MSG_LOOSE_PULLEY c=20
-#: ultralcd.cpp:8167
+#: ultralcd.cpp:8088
 msgid "Loose pulley"
 msgstr ""
 
 # MSG_LOAD_TO_NOZZLE c=18
-#: ultralcd.cpp:6717
+#: ultralcd.cpp:6638
 msgid "Load to nozzle"
 msgstr ""
 
@@ -851,7 +851,7 @@ msgid "No move."
 msgstr ""
 
 # MSG_NO_CARD c=18
-#: ultralcd.cpp:6697
+#: ultralcd.cpp:6618
 msgid "No SD card"
 msgstr ""
 
@@ -866,7 +866,7 @@ msgid "No"
 msgstr ""
 
 # MSG_SELFTEST_NOTCONNECTED c=20
-#: ultralcd.cpp:8128
+#: ultralcd.cpp:8049
 msgid "Not connected"
 msgstr ""
 
@@ -951,7 +951,7 @@ msgid "Please clean the nozzle for calibration. Click when done."
 msgstr ""
 
 # MSG_SELFTEST_PLEASECHECK c=20
-#: ultralcd.cpp:8122
+#: ultralcd.cpp:8043
 msgid "Please check:"
 msgstr ""
 
@@ -1016,7 +1016,7 @@ msgid "Preheat the nozzle!"
 msgstr ""
 
 # MSG_PREHEAT c=18
-#: ultralcd.cpp:6655
+#: ultralcd.cpp:6576
 msgid "Preheat"
 msgstr ""
 
@@ -1031,7 +1031,7 @@ msgid "Please upgrade."
 msgstr ""
 
 # MSG_PRESS_TO_PREHEAT c=20 r=4
-#: Marlin_main.cpp:12049
+#: Marlin_main.cpp:12052
 msgid "Press the knob to preheat nozzle and continue."
 msgstr ""
 
@@ -1061,7 +1061,7 @@ msgid "Preheating to unload"
 msgstr ""
 
 # MSG_SELFTEST_PRINT_FAN_SPEED c=18
-#: ultralcd.cpp:8501
+#: ultralcd.cpp:8422
 msgid "Print fan:"
 msgstr ""
 
@@ -1112,21 +1112,21 @@ msgstr ""
 
 # MSG_BED_CORRECTION_REAR c=14
 #: ultralcd.cpp:3117
-msgid "Rear side [um]"
+msgid "Rear side [μm]"
 msgstr ""
 
 # MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ultralcd.cpp:7404
+#: ultralcd.cpp:7325
 msgid "Please unload the filament first, then repeat this action."
 msgstr ""
 
 # MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ultralcd.cpp:7407
+#: ultralcd.cpp:7328
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr ""
 
 # MSG_RECOVERING_PRINT c=20
-#: Marlin_main.cpp:11393
+#: Marlin_main.cpp:11396
 msgid "Recovering print"
 msgstr ""
 
@@ -1157,7 +1157,7 @@ msgstr ""
 
 # MSG_BED_CORRECTION_RIGHT c=14
 #: ultralcd.cpp:3115
-msgid "Right side[um]"
+msgid "Right side[μm]"
 msgstr ""
 
 # MSG_RPI_PORT c=13
@@ -1191,12 +1191,12 @@ msgid "Select language"
 msgstr ""
 
 # MSG_SELFTEST_OK c=20
-#: ultralcd.cpp:7679
+#: ultralcd.cpp:7600
 msgid "Self test OK"
 msgstr ""
 
 # MSG_SELFTEST_START c=20
-#: ultralcd.cpp:7447
+#: ultralcd.cpp:7368
 msgid "Self test start"
 msgstr ""
 
@@ -1206,7 +1206,7 @@ msgid "Selftest"
 msgstr ""
 
 # MSG_SELFTEST_ERROR c=20
-#: ultralcd.cpp:8121
+#: ultralcd.cpp:8042
 msgid "Selftest error!"
 msgstr ""
 
@@ -1306,7 +1306,7 @@ msgid "Once"
 msgstr ""
 
 # MSG_SPEED c=15
-#: ultralcd.cpp:6882
+#: ultralcd.cpp:6803
 msgid "Speed"
 msgstr ""
 
@@ -1336,12 +1336,12 @@ msgid "STOPPED."
 msgstr ""
 
 # MSG_SUPPORT c=18
-#: ultralcd.cpp:6756
+#: ultralcd.cpp:6677
 msgid "Support"
 msgstr ""
 
 # MSG_SELFTEST_SWAPPED c=16
-#: ultralcd.cpp:8180
+#: ultralcd.cpp:8101
 msgid "Swapped"
 msgstr ""
 
@@ -1376,7 +1376,7 @@ msgid "Temperature calibration is finished and active. Temp. calibration can be 
 msgstr ""
 
 # MSG_FS_VERIFIED c=20 r=3
-#: ultralcd.cpp:7411
+#: ultralcd.cpp:7332
 msgid "Sensor verified, remove the filament now."
 msgstr ""
 
@@ -1406,7 +1406,7 @@ msgid "Total print time"
 msgstr ""
 
 # MSG_TUNE c=18
-#: ultralcd.cpp:6653
+#: ultralcd.cpp:6574
 msgid "Tune"
 msgstr ""
 
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "to unload filament"
 msgstr ""
 
-# MSG_UNLOAD_FILAMENT c=16
+# MSG_UNLOAD_FILAMENT c=18
 #: messages.c:114
 msgid "Unload filament"
 msgstr ""
@@ -1510,7 +1510,7 @@ msgstr ""
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr ""
 
-# MSG_YES c=3
+# MSG_YES c=4
 #: messages.c:123
 msgid "Yes"
 msgstr ""
@@ -1586,7 +1586,7 @@ msgid "The printer will start printing a zig-zag line. Rotate the knob until you
 msgstr ""
 
 # MSG_FIL_FAILED c=20 r=5
-#: ultralcd.cpp:7415
+#: ultralcd.cpp:7336
 msgid "Verification failed, remove the filament and try again."
 msgstr ""
 
@@ -1616,7 +1616,7 @@ msgid "Checks"
 msgstr ""
 
 # MSG_FALSE_TRIGGERING c=20
-#: ultralcd.cpp:8190
+#: ultralcd.cpp:8111
 msgid "False triggering"
 msgstr ""
 
@@ -1721,17 +1721,17 @@ msgid "Printer nozzle diameter differs from the G-code. Please check the value i
 msgstr ""
 
 # MSG_SELFTEST_FS_LEVEL c=20
-#: ultralcd.cpp:8195
+#: ultralcd.cpp:8116
 msgid "%s level expected"
 msgstr ""
 
 # MSG_RENAME c=18
-#: ultralcd.cpp:6579
+#: ultralcd.cpp:6500
 msgid "Rename"
 msgstr ""
 
 # MSG_SELECT c=18
-#: ultralcd.cpp:6572
+#: ultralcd.cpp:6493
 msgid "Select"
 msgstr ""
 


### PR DESCRIPTION
- [x] `MSG_WIZARD_DONE c=20 r=8` to `c=20 r=3`
- [x] `MSG_YES c=3` change to `c=4`
- [x] Change `[um]` to `[μm]`
    - [x] Including `lang-im/export.sh` to convert HD44780 to UTF-8 and vice versa
- [x] Enable `lang-clean.sh` to clean up non active languages
- [x] Update German translation
- [x] `Bed level correct` is a submenu of `Calibration`. Changed the return from `Settings` to `Back`
- [x] Fix MSG in cz and hu as these have been different to other lang_en*.txt files
- [x] Update all po files 