### PR TITLE
Update PF-build.sh for MK2.5/S community languages

### DIFF
--- a/PF-build.sh
+++ b/PF-build.sh
@@ -56,7 +56,7 @@
 #   Some may argue that this is only used by a script, BUT as soon someone accidentally or on purpose starts Arduino IDE
 #   it will use the default Arduino IDE folders and so can corrupt the build environment.
 #
-# Version: 2.0.0-Build_67
+# Version: 2.0.0-Build_69
 # Change log:
 # 12 Jan 2019, 3d-gussner, Fixed "compiler.c.elf.flags=-w -Os -Wl,-u,vfprintf -lprintf_flt -lm -Wl,--gc-sections" in 'platform.txt'
 # 16 Jan 2019, 3d-gussner, Build_2, Added development check to modify 'Configuration.h' to prevent unwanted LCD messages that Firmware is unknown
@@ -169,8 +169,13 @@
 # 21 Jan 2022, 3d-gussner, Sort variants
 #                          Add Arduino 1.8.19 as an option
 # 25 Jan 2022, 3d-gussner, Allow upper and lower case for MK404
+# 09 Feb 2022, 3d-gussner, Add community language firmware files for MK2.5/S
+#                          Add selection of language in MK404 for MK2.5/S
+# 10 Feb 2022, 3d-gussner, Add SRCDIR for compatibility with build server
+
 
 SCRIPT_PATH="$( cd "$(dirname "$0")" ; pwd -P )"
+export SRCDIR=$SCRIPT_PATH
 
 #### Start: Failures
 failures()
@@ -224,7 +229,7 @@ while getopts b:c:d:g:h:i:j:l:m:n:o:p:v:x:y:?h flag
 # '?' 'h' argument usage and help
 if [ "$help_flag" == "1" ] ; then
 echo "***************************************"
-echo "* PF-build.sh Version: 2.0.0-Build_67 *"
+echo "* PF-build.sh Version: 2.0.0-Build_69 *"
 echo "***************************************"
 echo "Arguments:"
 echo "$(tput setaf 2)-b$(tput sgr0) Build/commit number"

--- a/lang/config.sh
+++ b/lang/config.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Version 1.0.1 Build 9
+# Version 1.0.1 Build 10
 #
 # config.sh - multi-language support configuration script
 #  Definition of absolute paths etc.
@@ -19,8 +19,16 @@
 #                           and use these. More flexible for different build
 #                           scripts
 #                           Check correctly if files or dirs exist
+# 10 Feb. 2022, 3d-gussner, Add SRCDIR for compatibility with build server
 #############################################################################
 #
+if [ -z "$SRCDIR" ]; then
+    export SRCDIR=".."
+fi
+
+LNGDIR="$( cd "$(dirname "$0")" ; pwd -P )"
+export LNGDIR=$LNGDIR
+
 # Arduino main folder:
 if [ -z "$ARDUINO" ]; then
     export ARDUINO=../../PF-build-env-1.0.6/1.8.5-1.0.4-linux-64 #C:/arduino-1.8.5
@@ -68,15 +76,15 @@ fi
 MAX_COMMINITY_LANG=10 # Total 16 - 6 default
 COMMUNITY_LANGUAGES=""
 #Search Firmware/config.h for active community group
-COMMUNITY_LANG_GROUP=$(grep --max-count=1 "^#define COMMUNITY_LANG_GROUP" ../Firmware/config.h| cut -d ' ' -f3)
+COMMUNITY_LANG_GROUP=$(grep --max-count=1 "^#define COMMUNITY_LANG_GROUP" $SRCDIR/Firmware/config.h| cut -d ' ' -f3)
 
 # Search Firmware/config.h for active community languanges
 if [ "$COMMUNITY_LANG_GROUP" = "1" ]; then
-    COMMUNITY_LANGUAGES=$(grep --max-count=$MAX_COMMINITY_LANG "^#define COMMUNITY_LANG_GROUP1_" ../Firmware/config.h| cut -d '_' -f4 |cut -d ' ' -f1 |tr '[:upper:]' '[:lower:]'| tr '\n' ' ')
+    COMMUNITY_LANGUAGES=$(grep --max-count=$MAX_COMMINITY_LANG "^#define COMMUNITY_LANG_GROUP1_" $SRCDIR/Firmware/config.h| cut -d '_' -f4 |cut -d ' ' -f1 |tr '[:upper:]' '[:lower:]'| tr '\n' ' ')
 elif [ "$COMMUNITY_LANG_GROUP" = "2" ]; then
-    COMMUNITY_LANGUAGES=$(grep --max-count=$MAX_COMMINITY_LANG "^#define COMMUNITY_LANG_GROUP2_" ../Firmware/config.h| cut -d '_' -f4 |cut -d ' ' -f1 |tr '[:upper:]' '[:lower:]'| tr '\n' ' ')
+    COMMUNITY_LANGUAGES=$(grep --max-count=$MAX_COMMINITY_LANG "^#define COMMUNITY_LANG_GROUP2_" $SRCDIR/Firmware/config.h| cut -d '_' -f4 |cut -d ' ' -f1 |tr '[:upper:]' '[:lower:]'| tr '\n' ' ')
 elif [ "$COMMUNITY_LANG_GROUP" = "3" ]; then
-    COMMUNITY_LANGUAGES=$(grep --max-count=$MAX_COMMINITY_LANG "^#define COMMUNITY_LANG_GROUP3_" ../Firmware/config.h| cut -d '_' -f4 |cut -d ' ' -f1 |tr '[:upper:]' '[:lower:]'| tr '\n' ' ')
+    COMMUNITY_LANGUAGES=$(grep --max-count=$MAX_COMMINITY_LANG "^#define COMMUNITY_LANG_GROUP3_" $SRCDIR/Firmware/config.h| cut -d '_' -f4 |cut -d ' ' -f1 |tr '[:upper:]' '[:lower:]'| tr '\n' ' ')
 fi
 
 if [ -z "$COMMUNITY_LANGUAGES" ]; then

--- a/lang/lang-build.sh
+++ b/lang/lang-build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Version 1.0.2 Build 25
+# Version 1.0.2 Build 27
 #
 # lang-build.sh - multi-language support script
 #  generate lang_xx.bin (language binary file)
@@ -56,6 +56,7 @@
 #                           to get Build Nr
 # 25 Jan. 2022, 3d-gussner, Fix check
 #                           Update documentation
+# 10 Feb. 2022, 3d-gussner, Use SRCDIR for compatibility with build server
 #############################################################################
 #
 # Config:
@@ -170,7 +171,7 @@ generate_binary()
   #Calculate the number of strings and save to temporary file
   echo $count >lang_en.cnt
   #read the allowed maxsize from "../Firmware/config.h" and save to temporary file
-  maxsize=$(($(grep "#define LANG_SIZE_RESERVED" ../Firmware/config.h|sed -e's/  */ /g' |cut -d ' ' -f3)))
+  maxsize=$(($(grep "#define LANG_SIZE_RESERVED" $SRCDIR/Firmware/config.h|sed -e's/  */ /g' |cut -d ' ' -f3)))
 
   echo "maxsize="$maxsize >&2
   echo $maxsize >lang_en.max


### PR DESCRIPTION
Add community language firmware files for MK2.5/S

- [x] New community language `firmware_??.hex` files now are copied to PF-build-hex folder

Add selection of language in MK404 for MK2.5/S

- [x] Starting MK404 for a MK2.5/S after a build with `PF-build.sh` will give a selection of languages.

- [x] MK2.5/S hex files aren't removed after zip

- [x] Fix issues with build server by adding SRCDIR