### PR TITLE
Add menu back arrow to the Preheat menu

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2384,7 +2384,6 @@ static void mFilamentItem_PVB()
 
 void mFilamentBack()
 {
-    menu_back();
     if (eFilamentAction == FilamentAction::AutoLoad ||
             eFilamentAction == FilamentAction::Preheat ||
             eFilamentAction == FilamentAction::Lay1Cal)
@@ -2398,13 +2397,16 @@ void lcd_generic_preheat_menu()
     MENU_BEGIN();
     if (!eeprom_read_byte((uint8_t*)EEPROM_WIZARD_ACTIVE))
     {
+        ON_MENU_LEAVE(
+            mFilamentBack();
+        );
         if (eFilamentAction == FilamentAction::Lay1Cal)
         {
-            MENU_ITEM_FUNCTION_P(_T(MSG_BACK), mFilamentBack);
+            MENU_ITEM_BACK_P(_T(MSG_BACK));
         }
         else
         {
-            MENU_ITEM_FUNCTION_P(_T(MSG_MAIN), mFilamentBack);
+            MENU_ITEM_BACK_P(_T(MSG_MAIN));
         }
     }
     if (farm_mode)

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2400,14 +2400,7 @@ void lcd_generic_preheat_menu()
         ON_MENU_LEAVE(
             mFilamentBack();
         );
-        if (eFilamentAction == FilamentAction::Lay1Cal)
-        {
-            MENU_ITEM_BACK_P(_T(MSG_BACK));
-        }
-        else
-        {
-            MENU_ITEM_BACK_P(_T(MSG_MAIN));
-        }
+        MENU_ITEM_BACK_P(_T(eFilamentAction == FilamentAction::Lay1Cal ? MSG_BACK : MSG_MAIN));
     }
     if (farm_mode)
     {


### PR DESCRIPTION
All other menus have this arrow on the back button ⬏
* The 1st commit  [70ee061](https://github.com/prusa3d/Prusa-Firmware/pull/3393/commits/70ee06144ebcdd903b74dc3a0f4d1cc194e3bcc6) actually saves 2 bytes of flash, unexpected but welcome 😄
* The 2nd commit [bd3a835](https://github.com/prusa3d/Prusa-Firmware/pull/3393/commits/bd3a8355163e58ceb30041885d651489c73ceacd) saves an additional 10 bytes.

Preheat before:
![image](https://user-images.githubusercontent.com/8218499/153712072-8e5d2ba1-54b3-4577-a57b-7c71a6a7772f.png)

Preheat after:
![image](https://user-images.githubusercontent.com/8218499/153712063-259b56b2-50d5-460e-b3c4-9a2c0e6ee133.png)
