### PR TITLE
Fixup suspicious indentation in lcd_show_sensors_state

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3797,9 +3797,9 @@ static void lcd_print_state(uint8_t state)
 //! @code{.unparsed}
 //! |01234567890123456789|
 //! |PINDA N/A  FINDA N/A|  MSG_PINDA c=5 MSG_FINDA c=5
-//! |Fil. sensor      N/A|  MSG_FSENSOR 
-//! |Xd    000  Yd    000|  MSG_XD
-//! |Int   000  Shut  000|  
+//! |Fil. sensor      N/A|  MSG_FSENSOR
+//! | Xd   000    Yd  000|
+//! |Int   000  Shut  000|
 //! ----------------------
 //! @endcode
 static void lcd_show_sensors_state()
@@ -3850,8 +3850,8 @@ static void lcd_show_sensors_state()
             pat9125_update();
 
         lcd_set_cursor(0, 2);
-        lcd_printf_P(_N("Xd:  %3d  Yd:  %3d\n"
-                        "Int: %3d  Shut:  %3d"),
+        lcd_printf_P(_N(" Xd: %4d    Yd: %3d\n"
+                        "Int: %4d  Shut: %3d"),
                      pat9125_x, pat9125_y,
                      pat9125_b, pat9125_s);
     }

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3843,26 +3843,18 @@ static void lcd_show_sensors_state()
     //  Shutter register is an index of LASER shutter time. It is automatically controlled by the chip's internal
     //  auto-exposure algorithm. When the chip is tracking on a good reflection surface, the Shutter is small.
     //  When the chip is tracking on a poor reflection surface, the Shutter is large. Value ranges from 0 to 46.
-	if (mmu_enabled == false)
-	{
-		//if (!fsensor_enabled)
-		//	lcd_puts_P(_N("Filament sensor\n" "is disabled."));
-		//else
-		//{
-		if (!moves_planned() && !IS_SD_PRINTING && !is_usb_printing && (lcd_commands_type != LcdCommands::Layer1Cal))
-			pat9125_update();
-			lcd_set_cursor(0, 2);
-			lcd_printf_P(_N(
-				"Xd:  %3d  "
-				"Yd:  %3d\n" ////c=4
-				"Int: %3d  " ////c=4
-				"Shut:  %3d"  ////c=4
-			),
-				pat9125_x, pat9125_y,
-				pat9125_b, pat9125_s
-			);
-		//}
-	}
+    if (mmu_enabled == false)
+    {
+        // pat9125_update is already called while printing: only update manually when idling
+        if (!moves_planned() && !IS_SD_PRINTING && !is_usb_printing && (lcd_commands_type != LcdCommands::Layer1Cal))
+            pat9125_update();
+
+        lcd_set_cursor(0, 2);
+        lcd_printf_P(_N("Xd:  %3d  Yd:  %3d\n"
+                        "Int: %3d  Shut:  %3d"),
+                     pat9125_x, pat9125_y,
+                     pat9125_b, pat9125_s);
+    }
 #endif //PAT9125
 }
 

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3798,8 +3798,8 @@ static void lcd_print_state(uint8_t state)
 //! |01234567890123456789|
 //! |PINDA N/A  FINDA N/A|  MSG_PINDA c=5 MSG_FINDA c=5
 //! |Fil. sensor      N/A|  MSG_FSENSOR
-//! | Xd   000    Yd  000|
-//! |Int   000  Shut  000|
+//! | Int: 000  Xd:+00000|
+//! |Shut: 000  Yd:+00000|
 //! ----------------------
 //! @endcode
 static void lcd_show_sensors_state()
@@ -3850,10 +3850,10 @@ static void lcd_show_sensors_state()
             pat9125_update();
 
         lcd_set_cursor(0, 2);
-        lcd_printf_P(_N(" Xd: %4d    Yd: %3d\n"
-                        "Int: %4d  Shut: %3d"),
-                     pat9125_x, pat9125_y,
-                     pat9125_b, pat9125_s);
+        lcd_printf_P(_N(" Int: %3d  Xd:%6d\n"
+                        "Shut: %3d  Yd:%6d"),
+                     pat9125_b, pat9125_x,
+                     pat9125_s, pat9125_y);
     }
 #endif //PAT9125
 }


### PR DESCRIPTION
Cleanup some odd indentation in the function lcd_print_state(), which makes the missing braces highly suspicious.

- Expand all tabs in the block.
- Add a relevant comment about the pat9125_update() call
- Align the columns to make it look nice :)
- Remove useless //// comments and non-existing translation IDs