### PR TITLE
Disable pullup crash test

### DIFF
--- a/Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h
@@ -168,7 +168,7 @@
 #define DEBUG_DCODE3
 #define DEBUG_DCODE6
 
-#define DEBUG_PULLUP_CRASH //Test Pullup crash
+//#define DEBUG_PULLUP_CRASH //Test Pullup crash
 
 //#define DEBUG_BUILD
 //#define DEBUG_SEC_LANG   //secondary language debug output at startup

--- a/Firmware/variants/1_75mm_MK3S-EINSy10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK3S-EINSy10a-E3Dv6full.h
@@ -170,7 +170,7 @@
 #define DEBUG_DCODE3
 #define DEBUG_DCODE6
 
-#define DEBUG_PULLUP_CRASH //Test Pullup crash
+//#define DEBUG_PULLUP_CRASH //Test Pullup crash
 
 //#define DEBUG_BUILD
 //#define DEBUG_SEC_LANG   //secondary language debug output at startup


### PR DESCRIPTION
Disable the pullup test now. Only constantly clear the pullups for the adc pins with digital circuitry disabled.