### PR TITLE
Fix crashDet timer overflow handling

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -200,7 +200,7 @@ unsigned long pause_time = 0;
 unsigned long start_pause_print = _millis();
 unsigned long t_fan_rising_edge = _millis();
 LongTimer safetyTimer;
-static ShortTimer crashDetTimer;
+static LongTimer crashDetTimer;
 
 //unsigned long load_filament_time;
 

--- a/Firmware/cmdqueue.cpp
+++ b/Firmware/cmdqueue.cpp
@@ -24,7 +24,7 @@ int serial_count = 0;  //index of character read from serial line
 bool comment_mode = false;
 char *strchr_pointer; // just a pointer to find chars in the command string like X, Y, Z, E, etc
 
-ShortTimer farm_incomplete_command_timeout_timer;
+LongTimer farm_incomplete_command_timeout_timer;
 
 long gcode_N = 0;
 long gcode_LastN = 0;

--- a/Firmware/mmu.cpp
+++ b/Firmware/mmu.cpp
@@ -75,9 +75,9 @@ int16_t mmu_version = -1;
 
 int16_t mmu_buildnr = -1;
 
-ShortTimer mmu_last_request;
-ShortTimer mmu_last_response;
-ShortTimer mmu_last_finda_response;
+LongTimer mmu_last_request;
+LongTimer mmu_last_response;
+LongTimer mmu_last_finda_response;
 
 MmuCmd mmu_last_cmd = MmuCmd::None;
 uint16_t mmu_power_failures = 0;

--- a/Firmware/mmu.h
+++ b/Firmware/mmu.h
@@ -15,7 +15,7 @@ extern uint8_t mmu_extruder;
 extern uint8_t tmp_extruder;
 
 extern int8_t mmu_finda;
-extern ShortTimer mmu_last_finda_response;
+extern LongTimer mmu_last_finda_response;
 extern bool ir_sensor_detected;
 
 extern int16_t mmu_version;


### PR DESCRIPTION
I'm pretty confident that the crashDet timer was not expiring properly. Consider the following scenario:
- We get a crash detected at millis=1000
- The print recovers. At crashDet timer gets started at millis=1000
- Another crash happens at millis = 71000
- The crashDet timer is checked again for .expired(), but because it is a shortTimer, the time value is actually millis=5464 in the shortTimer code. In this scenario a shortTimer would say NOT expired (wrong), while a LongTimer would say that it expired and reset the crashDet_counter to 0 (correct). This happens because we are not constantly polling .expired(). So if the time between polls is more than shortTimer can handle (~65s), the expired event will be missed entirely.

I hope my scenario makes sense. If anyone can test the claims I'd be grateful.
Uses 8B of flash and 2B of ram (code size increase). So negligible.

I git blame @gudnimg :) . Can we check the optimizations PR to see if any similar case exists?