### PR TITLE
Fix crash detected message translation

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -655,7 +655,7 @@ void crashdet_detected(uint8_t mask)
 
         // ask whether to resume printing
         lcd_set_cursor(0, 1);
-        lcd_puts_P(MSG_RESUME_PRINT);
+        lcd_puts_P(_T(MSG_RESUME_PRINT));
         lcd_putc('?');
         bool yesno = lcd_show_yes_no_and_wait(false);
 		lcd_update_enable(true);


### PR DESCRIPTION
Fix a recent bug introduced in #3089. Missed that _T() because I only built EN-only up to that point.