### PR TITLE
Add MMU2 capability line

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -4060,6 +4060,7 @@ static void extended_capabilities_report()
     cap_line(PSTR("AUTOREPORT_POSITION"), ENABLED(AUTO_REPORT));
     // EXTENDED_M20 (support for L and T parameters)
     cap_line(PSTR("EXTENDED_M20"), 1);
+    cap_line(PSTR("PRUSA_MMU2"), 1); //this will soon change to ENABLED(PRUSA_MMU2_SUPPORT)
 }
 #endif //EXTENDED_CAPABILITIES_REPORT
 


### PR DESCRIPTION
See related thread https://github.com/prusa3d/Prusa-Firmware/issues/3411

Response to M115 as of now:
```
FIRMWARE_NAME:Prusa-Firmware 3.10.1 based on Marlin FIRMWARE_URL:https://github.com/prusa3d/Prusa-Firmware PROTOCOL_VERSION:1.0 MACHINE_TYPE:Prusa i3 MK3S EXTRUDER_COUNT:1 UUID:00000000-0000-0000-0000-000000000000
Cap:AUTOREPORT_TEMP:1
Cap:AUTOREPORT_FANS:1
Cap:AUTOREPORT_POSITION:1
Cap:EXTENDED_M20:1
Cap:PRUSA_MMU2:1
ok
```