### PR TITLE
Print busy messages while waiting for heaters

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -5353,7 +5353,6 @@ if(eSoundMode!=e_SOUND_MODE_SILENT)
         homing_flag = true; // keep homing on to avoid babystepping while the LCD is enabled
 
         lcd_update_enable(true);
-        KEEPALIVE_STATE(NOT_BUSY); //no need to print busy messages as we print current temperatures periodicaly
         SERIAL_ECHOLNPGM("PINDA probe calibration start");
 
         float zero_z;
@@ -6671,15 +6670,12 @@ Sigma_Exit:
 
       /* See if we are heating up or cooling down */
       target_direction = isHeatingHotend(extruder); // true if heating, false if cooling
-	  
-	  KEEPALIVE_STATE(NOT_BUSY);
 
       cancel_heatup = false;
 
 	  wait_for_heater(codenum, extruder); //loops until target temperature is reached
 
         LCD_MESSAGERPGM(_T(MSG_HEATING_COMPLETE));
-		KEEPALIVE_STATE(IN_HANDLER);
 		heating_status = HeatingStatus::EXTRUDER_HEATING_COMPLETE;
 		if (farm_mode) { prusa_statistics(2); };
         
@@ -6722,7 +6718,6 @@ Sigma_Exit:
         cancel_heatup = false;
         target_direction = isHeatingBed(); // true if heating, false if cooling
 
-		KEEPALIVE_STATE(NOT_BUSY);
         while ( (!cancel_heatup) && (target_direction ? (isHeatingBed()) : (isCoolingBed()&&(CooldownNoWait==false))) )
         {
           if(( _millis() - codenum) > 1000 ) //Print Temp Reading every 1 second while heating up.
@@ -6745,7 +6740,6 @@ Sigma_Exit:
           lcd_update(0);
         }
         LCD_MESSAGERPGM(_T(MSG_BED_DONE));
-		KEEPALIVE_STATE(IN_HANDLER);
 		heating_status = HeatingStatus::BED_HEATING_COMPLETE;
 
         previous_millis_cmd.start();

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -7263,7 +7263,6 @@ static bool lcd_selfcheck_check_heater(bool _isbed)
 	target_temperature_bed = (_isbed) ? 100 : 0;
 	manage_heater();
 	manage_inactivity(true);
-	KEEPALIVE_STATE(NOT_BUSY); //we are sending temperatures on serial line, so no need to send host keepalive messages
 
 	do {
 		_counter++;
@@ -7316,7 +7315,6 @@ static bool lcd_selfcheck_check_heater(bool _isbed)
 
 	manage_heater();
 	manage_inactivity(true);
-	KEEPALIVE_STATE(IN_HANDLER);
 	return _stepresult;
 
 }


### PR DESCRIPTION
This brings Prusa-Firmware more in line with Marlin 2.0

```
T:21.84 E:0 B:23.0
echo:busy: processing
T:22.00 E:0 B:22.9
T:21.94 E:0 B:23.0
echo:busy: processing
T:21.97 E:0 B:23.0
T:21.87 E:0 B:23.0
echo:busy: processing
T:21.91 E:0 B:22.9
T:21.94 E:0 B:23.1
echo:busy: processing
T:21.81 E:0 B:23.3
T:21.91 E:0 B:23.4
echo:busy: processing
T:21.87 E:0 B:23.5
T:21.91 E:0 B:23.9
echo:busy: processing
T:21.94 E:0 B:24.1
T:21.81 E:0 B:24.2
```