### PR TITLE
Fix FINDA timer

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3497,7 +3497,7 @@ static void lcd_show_sensors_state()
 	uint8_t idler_state = STATE_NA;
 
 	pinda_state = READ(Z_MIN_PIN);
-	if (mmu_enabled && mmu_last_finda_response.expired(1000))
+	if (mmu_enabled && !mmu_last_finda_response.expired(1000))
 	{
 		finda_state = mmu_finda;
 	}


### PR DESCRIPTION
We want to set the FINDA state IF the timer has NOT expired.
It is helpful to see why by looking at the commit which broke
this https://github.com/prusa3d/Prusa-Firmware/pull/3365/commits/802b8860c862f1e8cca82146ab70c0a0cadf2629

Without this fix my FINDA sensor just shows N/A. But after this commit is works perfectly.