### PR TITLE
PFW-1298: Use PF-build-env 1.0.7

### DIFF
--- a/PF-build.sh
+++ b/PF-build.sh
@@ -56,7 +56,7 @@
 #   Some may argue that this is only used by a script, BUT as soon someone accidentally or on purpose starts Arduino IDE
 #   it will use the default Arduino IDE folders and so can corrupt the build environment.
 #
-# Version: 2.0.1-Build_66
+# Version: 2.0.1-Build_67
 # Change log:
 # 12 Jan 2019, 3d-gussner, Fixed "compiler.c.elf.flags=-w -Os -Wl,-u,vfprintf -lprintf_flt -lm -Wl,--gc-sections" in 'platform.txt'
 # 16 Jan 2019, 3d-gussner, Build_2, Added development check to modify 'Configuration.h' to prevent unwanted LCD messages that Firmware is unknown
@@ -168,6 +168,7 @@
 # 24 Feb 2021, 3d-gussner, Change to Arduino IDE 1.8.19 and Arduino boards 1.0.5
 #                          Fix DEV_STATUS to set correctly on RC/BETA/ALPHA/DEVEL
 #                          Fix atmegaMK404 Board mem and flash modifications
+#                          Limit atmegaMK404 boards mem to 8,16,32
 
 
 SCRIPT_PATH="$( cd "$(dirname "$0")" ; pwd -P )"
@@ -224,7 +225,7 @@ while getopts b:c:d:g:h:i:j:l:m:n:o:p:v:x:y:?h flag
 # '?' 'h' argument usage and help
 if [ "$help_flag" == "1" ] ; then
 echo "***************************************"
-echo "* PF-build.sh Version: 2.0.1-Build_66 *"
+echo "* PF-build.sh Version: 2.0.1-Build_67 *"
 echo "***************************************"
 echo "Arguments:"
 echo "$(tput setaf 2)-b$(tput sgr0) Build/commit number"
@@ -258,7 +259,7 @@ echo "  -n : '$(tput setaf 2)0$(tput sgr0)' no, '$(tput setaf 2)1$(tput sgr0)' y
 echo "  -o : '$(tput setaf 2)1$(tput sgr0)' force or '$(tput setaf 2)0$(tput sgr0)' block output and delays"
 echo "  -p : '$(tput setaf 2)0$(tput sgr0)' no, '$(tput setaf 2)1$(tput sgr0)' yes"
 echo "  -v : '$(tput setaf 2)All$(tput sgr0)' or variant file name"
-echo "  -x : '$(tput setaf 2)8$(tput sgr0)' or '$(tput setaf 2)64$(tput sgr0)' Kb."
+echo "  -x : '$(tput setaf 2)8$(tput sgr0)','$(tput setaf 2)16$(tput sgr0)'or'$(tput setaf 2)32$(tput sgr0)' Kb."
 echo "  -y : '$(tput setaf 2)256$(tput sgr0)','$(tput setaf 2)384$(tput sgr0)','$(tput setaf 2)512$(tput sgr0)','$(tput setaf 2)1024$(tput sgr0)''$(tput setaf 2)32M$(tput sgr0)'"
 echo
 echo "Example:"
@@ -334,12 +335,8 @@ if [ ! -z "$board_mem_flag" ] ; then
         BOARD_MEM="0x7DFF"
         echo "Board mem size   :    $board_mem_flag Kb, $BOARD_MEM (hex)"
         OUTPUT_FILENAME_SUFFIX="${OUTPUT_FILENAME_SUFFIX}_RAM-$board_mem_flag"
-    elif [ "$board_mem_flag" == "64" ] ; then
-        BOARD_MEM="0xFFFF"
-        echo "Board mem size   :    $board_mem_flag Kb, $BOARD_MEM (hex)"
-        OUTPUT_FILENAME_SUFFIX="${OUTPUT_FILENAME_SUFFIX}_RAM-$board_mem_flag"
     else
-        echo "Unsupported board mem size chosen. Only '8', '64' are allowed."
+        echo "Unsupported board mem size chosen. Only '8', '16' and '32' are allowed."
         failures 5
     fi
 fi
@@ -1185,7 +1182,7 @@ compile_en_firmware()
     ## Check board mem size
     CURRENT_BOARD_MEM=$(grep "#define RAMEND" $BUILD_ENV_PATH/hardware/tools/avr/avr/include/avr/iom2560.h | sed -e's/.* //g'|cut -d ' ' -f2 |tr -d ' \t\n\r')
     if [ $CURRENT_BOARD_MEM != "0x21FF" ] ; then
-        echo "Board mem has been already modified or not reset"
+        echo "$(tput setaf 1)Board mem has been modified or not reset$(tput sgr 0)"
         echo "Current:" $CURRENT_BOARD_MEM
         PS3="Select $(tput setaf 2)Yes$(tput sgr 0) if you want to reset it."
         select yn in "Yes" "No"; do
@@ -1221,7 +1218,7 @@ compile_en_firmware()
     CURRENT_BOARD_FLASH=$(grep "#define FLASHEND" $BUILD_ENV_PATH/hardware/tools/avr/avr/include/avr/iom2560.h | sed -e's/.* //g'|cut -d ' ' -f2 |tr -d ' \t\n\r')
     CURRENT_BOARD_maximum_size=$(grep "prusa_einsy_rambo.upload.maximum_size" $BUILD_ENV_PATH/portable/packages/$BOARD_PACKAGE_NAME/hardware/avr/$BOARD_VERSION/boards.txt |cut -d '=' -f2|tr -d ' \t\n\r')
     if [[ $CURRENT_BOARD_FLASH != "0x3FFFF" || $CURRENT_BOARD_maximum_size != "253952" ]] ; then
-        echo "$(tput setaf 3)Board flash has been already modified or not reset$(tput sgr 0)"
+        echo "$(tput setaf 1)Board flash has been modified or not reset$(tput sgr 0)"
         echo "Current flash size:" $CURRENT_BOARD_FLASH
         echo "Current max.  size:" $CURRENT_BOARD_maximum_size
         PS3="Select $(tput setaf 2)Yes$(tput sgr 0) if you want to reset it."
@@ -1242,11 +1239,11 @@ compile_en_firmware()
             esac
         done
     else
-        BOARD_FLASH_MODIFIED=0
+        BOARD_FLASH_MODIFIED=1
     fi
     ## Modify boad flash size
     if [[ ! -z $BOARD_FLASH && "$BOARD_FLASH" != "0x3FFFF" ]] ; then
-        echo "Modifying board flash size (hex):"
+        echo "$(tput setaf 3)Modifying board flash size (hex):$(tput sgr 0)"
         echo "Old flash size:" $CURRENT_BOARD_FLASH
         echo "New flash size:" $BOARD_FLASH
         echo "Old max.  size:" $CURRENT_BOARD_maximum_size

--- a/build.sh
+++ b/build.sh
@@ -9,8 +9,8 @@ cd build-env || exit 2
 
 if [ ! -d "../../PF-build-env-$BUILD_ENV" ]; then
     if [ ! -f "PF-build-env-Linux64-$BUILD_ENV.zip" ]; then
-        wget https://github.com/3d-gussner/PF-build-env-1/releases/download/$BUILD_ENV-Linux64/PF-build-env-Linux64-$BUILD_ENV.zip || exit 3
-        #wget https://github.com/prusa3d/PF-build-env/releases/download/$BUILD_ENV-Linux64/PF-build-env-Linux64-$BUILD_ENV.zip || exit 3
+        #wget https://github.com/3d-gussner/PF-build-env-1/releases/download/$BUILD_ENV-Linux64/PF-build-env-Linux64-$BUILD_ENV.zip || exit 3
+        wget https://github.com/prusa3d/PF-build-env/releases/download/$BUILD_ENV-Linux64/PF-build-env-Linux64-$BUILD_ENV.zip || exit 3
     fi
     unzip -q PF-build-env-Linux64-$BUILD_ENV.zip -d ../../PF-build-env-$BUILD_ENV || exit 4
 fi

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash 
-BUILD_ENV="1.0.6.1"
+BUILD_ENV="1.0.7"
 SCRIPT_PATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
 if [ ! -d "build-env" ]; then
@@ -7,12 +7,11 @@ if [ ! -d "build-env" ]; then
 fi
 cd build-env || exit 2
 
-if [ ! -f "PF-build-env-Linux64-$BUILD_ENV.zip" ]; then
-    #wget https://github.com/3d-gussner/PF-build-env-1/releases/download/$BUILD_ENV-Linux64/PF-build-env-Linux64-$BUILD_ENV.zip || exit 3
-	wget https://github.com/prusa3d/PF-build-env/releases/download/$BUILD_ENV-Linux64/PF-build-env-Linux64-$BUILD_ENV.zip || exit 3
-fi
-
 if [ ! -d "../../PF-build-env-$BUILD_ENV" ]; then
+    if [ ! -f "PF-build-env-Linux64-$BUILD_ENV.zip" ]; then
+        wget https://github.com/3d-gussner/PF-build-env-1/releases/download/$BUILD_ENV-Linux64/PF-build-env-Linux64-$BUILD_ENV.zip || exit 3
+        #wget https://github.com/prusa3d/PF-build-env/releases/download/$BUILD_ENV-Linux64/PF-build-env-Linux64-$BUILD_ENV.zip || exit 3
+    fi
     unzip -q PF-build-env-Linux64-$BUILD_ENV.zip -d ../../PF-build-env-$BUILD_ENV || exit 4
 fi
 
@@ -32,7 +31,7 @@ if [ ! -f "$SCRIPT_PATH/Firmware/Configuration_prusa.h" ]; then
     cp $SCRIPT_PATH/Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h $SCRIPT_PATH/Firmware/Configuration_prusa.h || exit 8
 fi
 
-$BUILD_ENV_PATH/arduino $SCRIPT_PATH/Firmware/Firmware.ino --verify --board PrusaResearchRambo:avr:rambo --pref build.path=$BUILD_PATH --pref compiler.warning_level=all || exit 9
+$BUILD_ENV_PATH/arduino $SCRIPT_PATH/Firmware/Firmware.ino --verify --board PrusaResearch:avr:prusa_einsy_rambo --pref build.path=$BUILD_PATH --pref compiler.warning_level=all || exit 9
 
 export ARDUINO=$BUILD_ENV_PATH
 


### PR DESCRIPTION
Dependencies:

- [x] Update `PF-build.sh` 
- [x] Remove [travis trigger commit](https://github.com/prusa3d/Prusa-Firmware/pull/3422/commits/c37811c5a6518d7170dcd5844d65f3c8d503efde)
- [x] Change url to [prusa3d](https://github.com/prusa3d/Prusa-Firmware/pull/3422/commits/ea6ec785535467b1bc94ea93a0937d53138b3e3c#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823R12-R13)
     - [x]  https://github.com/prusa3d/PF-build-env/pull/5 has been merged
        - [x] https://github.com/prusa3d/Arduino_Boards/pull/16 has been merged


Changes:
- Based on Arduino IDE 1.8.19
- with [Arduino_boards 1.0.5](https://github.com/prusa3d/Arduino_Boards/tree/devel)

Resource savings:
|Variant| before flash/mem | after flash/mem | diff flash/mem |
|---------|-------------------------|----------------------|---------------------|
|MK3S | [245842/5655](https://app.travis-ci.com/github/prusa3d/Prusa-Firmware/builds/246764483#L305-L306) | [244808//5639](https://app.travis-ci.com/github/prusa3d/Prusa-Firmware/builds/246995135#L305-L306)| -1034/-16|
|MK3 | [246998/5686](https://app.travis-ci.com/github/prusa3d/Prusa-Firmware/builds/246764483#L481-L482) | [245560//5668](https://app.travis-ci.com/github/prusa3d/Prusa-Firmware/builds/246995135#L480-L481)| -1438/-18|
|MK25S | [218348/5530](https://app.travis-ci.com/github/prusa3d/Prusa-Firmware/builds/246764483#L657-L658) | [217296//5500](https://app.travis-ci.com/github/prusa3d/Prusa-Firmware/builds/246995135#L655-L656)| -1052/-30|
