### PR TITLE
Reuse Gcode M123 in Prusa "FAN" command

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -4489,7 +4489,7 @@ void process_commands()
         } else if( code_seen_P(PSTR("FANPINTST"))){
             gcode_PRUSA_BadRAMBoFanTest();
         }else if (code_seen_P(PSTR("FAN"))) { // PRUSA FAN
-			printf_P(_N("E0:%d RPM\nPRN0:%d RPM\n"), 60*fan_speed[0], 60*fan_speed[1]);
+            gcode_M123();
 		}
 		else if (code_seen_P(PSTR("thx"))) // PRUSA thx
 		{


### PR DESCRIPTION
Changes save 90 bytes of flash

The `FAN` prusa command now not only shows RPM for both fans but also the fan speed (same as Gcode M123). I'm not sure if the format of the message breaks anything internally at Prusa. Please let me know. I mainly want to reduce the occurrences of `fan_speed[]` in the code.
