### PR TITLE
Reset acceleration rates when changing microstepping resolution

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -6952,6 +6952,7 @@ Sigma_Exit:
           }
         }
       }
+      reset_acceleration_rates();
       break;
 
     /*!
@@ -8789,6 +8790,7 @@ Sigma_Exit:
 				}
 			}
 		}
+		reset_acceleration_rates();
 	#else //TMC2130
       #if defined(X_MS1_PIN) && X_MS1_PIN > -1
         if(code_seen('S')) for(int i=0;i<=4;i++) microstep_mode(i,code_value());


### PR DESCRIPTION
If the the acceleration rate is not reset, then changing the microstepping resolution will result in wrong acceleration ramps.
Example:
If you send `M350 X8 Y8`, the acceleration is twice as fast as it should be.
If you send `M350 X32 Y32`, the acceleration is half of what it should be.

If we reset the acceleration rates, the correct acceleration ramp is used.