### PR TITLE
🚧 Bootloader rpi port support

### DIFF
--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -77,17 +77,17 @@ extern FILE _uartout;
 
 #define SERIAL_PROTOCOL(x) (MYSERIAL.print(x))
 #define SERIAL_PROTOCOL_F(x,y) (MYSERIAL.print(x,y))
-#define SERIAL_PROTOCOLPGM(x) (serialprintPGM(PSTR(x)))
-#define SERIAL_PROTOCOLRPGM(x) (serialprintPGM((x)))
+#define SERIAL_PROTOCOLPGM(x) (MYSERIAL.printPGM(PSTR(x)))
+#define SERIAL_PROTOCOLRPGM(x) (MYSERIAL.printPGM((x)))
 #define SERIAL_PROTOCOLLN(x) (MYSERIAL.println(x))
-#define SERIAL_PROTOCOLLNPGM(x) (serialprintlnPGM(PSTR(x)))
-#define SERIAL_PROTOCOLLNRPGM(x) (serialprintlnPGM((x)))
+#define SERIAL_PROTOCOLLNPGM(x) (MYSERIAL.printlnPGM(PSTR(x)))
+#define SERIAL_PROTOCOLLNRPGM(x) (MYSERIAL.printlnPGM((x)))
 
 
 extern const char errormagic[] PROGMEM;
 extern const char echomagic[] PROGMEM;
 
-#define SERIAL_ERROR_START (serialprintPGM(errormagic))
+#define SERIAL_ERROR_START (MYSERIAL.printPGM(errormagic))
 #define SERIAL_ERROR(x) SERIAL_PROTOCOL(x)
 #define SERIAL_ERRORPGM(x) SERIAL_PROTOCOLPGM(x)
 #define SERIAL_ERRORRPGM(x) SERIAL_PROTOCOLRPGM(x)
@@ -95,7 +95,7 @@ extern const char echomagic[] PROGMEM;
 #define SERIAL_ERRORLNPGM(x) SERIAL_PROTOCOLLNPGM(x)
 #define SERIAL_ERRORLNRPGM(x) SERIAL_PROTOCOLLNRPGM(x)
 
-#define SERIAL_ECHO_START (serialprintPGM(echomagic))
+#define SERIAL_ECHO_START (MYSERIAL.printPGM(echomagic))
 #define SERIAL_ECHO(x) SERIAL_PROTOCOL(x)
 #define SERIAL_ECHOPGM(x) SERIAL_PROTOCOLPGM(x)
 #define SERIAL_ECHORPGM(x) SERIAL_PROTOCOLRPGM(x)
@@ -108,15 +108,6 @@ extern const char echomagic[] PROGMEM;
 void serial_echopair_P(const char *s_P, float v);
 void serial_echopair_P(const char *s_P, double v);
 void serial_echopair_P(const char *s_P, unsigned long v);
-
-
-//Things to write to serial from Program memory. Saves 400 to 2k of RAM.
-// Making this FORCE_INLINE is not a good idea when running out of FLASH
-// I'd rather skip a few CPU ticks than 5.5KB (!!) of FLASH
-void serialprintPGM(const char *str);
-
-//The "ln" variant of the function above.
-void serialprintlnPGM(const char *str);
 
 bool is_buffer_empty();
 void process_commands();

--- a/Firmware/MarlinSerial.cpp
+++ b/Firmware/MarlinSerial.cpp
@@ -307,6 +307,18 @@ void MarlinSerial::println(double n, int digits)
   println();
 }
 
+void MarlinSerial::printPGM(const char *str) {
+    while(uint8_t ch = pgm_read_byte(str)) {
+        MYSERIAL.write((char)ch);
+        ++str;
+    }
+}
+
+void MarlinSerial::printlnPGM(const char *str) {
+    printPGM(str);
+    MYSERIAL.println();
+}
+
 // Private Methods /////////////////////////////////////////////////////////////
 
 void MarlinSerial::printNumber(unsigned long n, uint8_t base)

--- a/Firmware/MarlinSerial.cpp
+++ b/Firmware/MarlinSerial.cpp
@@ -22,6 +22,7 @@
 
 #include "Marlin.h"
 #include "MarlinSerial.h"
+#include <util/atomic.h>
 
 uint8_t selectedSerialPort = 0;
 
@@ -191,6 +192,12 @@ void MarlinSerial::flush()
   // may be written to rx_buffer_tail, making it appear as if the buffer
   // were full, not empty.
   rx_buffer.head = rx_buffer.tail;
+}
+
+void MarlinSerial::rewind(int n) {
+  CRITICAL_SECTION_START;
+  rx_buffer.tail = (unsigned int)(rx_buffer.tail - n) % RX_BUFFER_SIZE;
+  CRITICAL_SECTION_END;
 }
 
 

--- a/Firmware/MarlinSerial.h
+++ b/Firmware/MarlinSerial.h
@@ -98,6 +98,7 @@ class MarlinSerial //: public Stream
     static int peek(void);
     static int read(void);
     static void flush(void);
+    static void rewind(int n); //go back n characters in the RX buffer. Hopefully nothing was overwritten.
     
     static /*FORCE_INLINE*/ int available(void)
     {

--- a/Firmware/MarlinSerial.h
+++ b/Firmware/MarlinSerial.h
@@ -81,8 +81,8 @@ extern uint8_t selectedSerialPort;
 struct ring_buffer
 {
   unsigned char buffer[RX_BUFFER_SIZE];
-  int head;
-  int tail;
+  volatile int head;
+  volatile int tail;
 };
 
 #ifdef HAS_UART

--- a/Firmware/MarlinSerial.h
+++ b/Firmware/MarlinSerial.h
@@ -218,6 +218,8 @@ class MarlinSerial //: public Stream
     static void print(long, int = DEC);
     static void print(unsigned long, int = DEC);
     static void print(double, int = 2);
+    static void printPGM(const char *str);
+    static void printlnPGM(const char *str);
 
 //    static void println(const String &s);
     static void println(const char[]);

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -461,23 +461,11 @@ uint16_t gcode_in_progress = 0;
 uint16_t mcode_in_progress = 0;
 
 void serial_echopair_P(const char *s_P, float v)
-    { serialprintPGM(s_P); SERIAL_ECHO(v); }
+    { MYSERIAL.printPGM(s_P); SERIAL_ECHO(v); }
 void serial_echopair_P(const char *s_P, double v)
-    { serialprintPGM(s_P); SERIAL_ECHO(v); }
+    { MYSERIAL.printPGM(s_P); SERIAL_ECHO(v); }
 void serial_echopair_P(const char *s_P, unsigned long v)
-    { serialprintPGM(s_P); SERIAL_ECHO(v); }
-
-void serialprintPGM(const char *str) {
-    while(uint8_t ch = pgm_read_byte(str)) {
-        MYSERIAL.write((char)ch);
-        ++str;
-    }
-}
-
-void serialprintlnPGM(const char *str) {
-    serialprintPGM(str);
-    MYSERIAL.println();
-}
+    { MYSERIAL.printPGM(s_P); SERIAL_ECHO(v); }
 
 #ifdef SDSUPPORT
   #include "SdFatUtil.h"

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1134,7 +1134,7 @@ void setup()
 #ifndef XFLASH
 	SERIAL_PROTOCOLLNPGM("start");
 #else
-	if ((optiboot_status != 0) || (selectedSerialPort != 0))
+	if (optiboot_status != 0)
 		SERIAL_PROTOCOLLNPGM("start");
 #endif
 	SERIAL_ECHO_START;


### PR DESCRIPTION
Using information from the bootloader, decide which action to take when running the second bootloader.
- ~Allows skipping the second bootloader if the first one is not used.~
- If the first bootloader used the primart uart port, then the second bootloader should do the same thing
- If the first bootloader used the secondary uart port, then the second bootloader should do the same thing
- If the bootloader is an older version which doesn't report anything, default to the primary uart port.

Used in combination with https://github.com/prusa3d/stk500v2-prusa/pull/3