### PR TITLE
Turn off print fan while resuming print from RAM

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -11260,12 +11260,17 @@ void restore_print_from_ram_and_continue(float e_move)
 	if ((fan_check_error != EFCE_OK) && (fan_check_error != EFCE_FIXED)) return;
     if (fan_check_error == EFCE_FIXED) fan_check_error = EFCE_OK; //reenable serial stream processing if printing from usb
 #endif
-	
+
+    // Make sure fan is turned off
+    fanSpeed = 0;
+
     // restore bed temperature (bed can be disabled during a thermal warning)
     if (degBed() != saved_bed_temperature)
         setTargetBed(saved_bed_temperature);
-    fanSpeed = saved_fan_speed;
     restore_extruder_temperature_from_ram();
+
+    // Restore saved fan speed
+    fanSpeed = saved_fan_speed;
     axis_relative_modes ^= (-saved_extruder_relative_mode ^ axis_relative_modes) & E_AXIS_MASK;
     float e = saved_pos[E_AXIS] - e_move;
     plan_set_e_position(e);


### PR DESCRIPTION
When a print is restored from RAM the nozzle is heating up. While heating is taking place the print fan will be turned **OFF** to speed up the process.

Testing:
1.  Start a print
2. After the purge line is finished, go into the Tune menu and raise the speed of the fan
3. Wait and confirm the print fan is spinning.
4. Pause the print
5. Wait for the temperature to drop a bit
6. Resume the print
7. **Test 1:** While heating the nozzle, the print fan is forced off
8. **Test 2:** When heating is finished, the print is spinning with same speed as in Step 3

Change in memory:
Flash: +8 bytes
SRAM: 0 bytes