### PR TITLE
Stop raise higher

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3688,6 +3688,7 @@ static void gcode_M600(bool automatic, float x_position, float y_position, float
 
     //Lift Z
     current_position[Z_AXIS] += z_shift;
+    clamp_to_software_endstops(current_position);
     plan_buffer_line_curposXYZE(FILAMENTCHANGE_ZFEED);
     st_synchronize();
 
@@ -10734,7 +10735,7 @@ void long_pause() //long pause print
 
 	//lift z
 	current_position[Z_AXIS] += Z_PAUSE_LIFT;
-	if (current_position[Z_AXIS] > Z_MAX_POS) current_position[Z_AXIS] = Z_MAX_POS;
+	clamp_to_software_endstops(current_position);
 	plan_buffer_line_curposXYZE(15);
 
 	//Move XY to side

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -6308,7 +6308,7 @@ void lcd_print_stop()
     lcd_cooldown(); //turns off heaters and fan; goes to status screen.
 
     if (axis_known_position[Z_AXIS]) {
-        current_position[Z_AXIS] += 50; //lift Z.
+        current_position[Z_AXIS] += Z_CANCEL_LIFT;
         plan_buffer_line_curposXYZE(manual_feedrate[Z_AXIS] / 60);
     }
 

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -6307,8 +6307,10 @@ void lcd_print_stop()
 
     lcd_cooldown(); //turns off heaters and fan; goes to status screen.
 
-    current_position[Z_AXIS] += 10; //lift Z.
-    plan_buffer_line_curposXYZE(manual_feedrate[Z_AXIS] / 60);
+    if (axis_known_position[Z_AXIS]) {
+        current_position[Z_AXIS] += 50; //lift Z.
+        plan_buffer_line_curposXYZE(manual_feedrate[Z_AXIS] / 60);
+    }
 
     if (axis_known_position[X_AXIS] && axis_known_position[Y_AXIS]) //if axis are homed, move to parked position.
     {

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -6309,6 +6309,7 @@ void lcd_print_stop()
 
     if (axis_known_position[Z_AXIS]) {
         current_position[Z_AXIS] += Z_CANCEL_LIFT;
+        clamp_to_software_endstops(current_position);
         plan_buffer_line_curposXYZE(manual_feedrate[Z_AXIS] / 60);
     }
 

--- a/Firmware/variants/1_75mm_MK25-RAMBo10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK25-RAMBo10a-E3Dv6full.h
@@ -71,6 +71,7 @@
 // Canceled home position
 #define X_CANCEL_POS 50
 #define Y_CANCEL_POS 190
+#define Z_CANCEL_LIFT 50
 
 //Pause print position
 #define X_PAUSE_POS 50

--- a/Firmware/variants/1_75mm_MK25-RAMBo13a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK25-RAMBo13a-E3Dv6full.h
@@ -71,6 +71,7 @@
 // Canceled home position
 #define X_CANCEL_POS 50
 #define Y_CANCEL_POS 190
+#define Z_CANCEL_LIFT 50
 
 //Pause print position
 #define X_PAUSE_POS 50

--- a/Firmware/variants/1_75mm_MK25S-RAMBo10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK25S-RAMBo10a-E3Dv6full.h
@@ -71,6 +71,7 @@
 // Canceled home position
 #define X_CANCEL_POS 50
 #define Y_CANCEL_POS 190
+#define Z_CANCEL_LIFT 50
 
 //Pause print position
 #define X_PAUSE_POS 50

--- a/Firmware/variants/1_75mm_MK25S-RAMBo13a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK25S-RAMBo13a-E3Dv6full.h
@@ -71,6 +71,7 @@
 // Canceled home position
 #define X_CANCEL_POS 50
 #define Y_CANCEL_POS 190
+#define Z_CANCEL_LIFT 50
 
 //Pause print position
 #define X_PAUSE_POS 50

--- a/Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h
@@ -73,6 +73,7 @@
 // Canceled home position
 #define X_CANCEL_POS 50
 #define Y_CANCEL_POS 190
+#define Z_CANCEL_LIFT 50
 
 //Pause print position
 #define X_PAUSE_POS 50

--- a/Firmware/variants/1_75mm_MK3S-EINSy10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK3S-EINSy10a-E3Dv6full.h
@@ -75,6 +75,7 @@
 // Canceled home position
 #define X_CANCEL_POS 50
 #define Y_CANCEL_POS 190
+#define Z_CANCEL_LIFT 50
 
 //Pause print position
 #define X_PAUSE_POS 50


### PR DESCRIPTION
Check if Z axis has been homed and, if so, raise Z at least 5cm after
stopping so that the steel sheet can be comfortably removed. This also makes the distance configurable in the variant file (similar to the pause park feature).

I'm the camp that believes pause/stop, as well as parking after a complete print should lift higher to allow easier removal of the steel sheet. See #2830 #3119

For the final raising distance, the gcode is responsible so there's nothing we can do in the FW (we should move it to the prusaslicer profiles).

This only affects "stop print"