### PR TITLE
Remove unused setting `PID_ADD_EXTRUSION_RATE`

### DIFF
--- a/Firmware/ConfigurationStore.cpp
+++ b/Firmware/ConfigurationStore.cpp
@@ -336,9 +336,6 @@ void Config_ResetDefault()
     
 #ifdef PIDTEMP
     updatePID();
-#ifdef PID_ADD_EXTRUSION_RATE
-    Kc = DEFAULT_Kc; //this is not stored by Config_StoreSettings
-#endif//PID_ADD_EXTRUSION_RATE
 #endif//PIDTEMP
 
 	calculate_extruder_multipliers();

--- a/Firmware/Configuration_adv.h
+++ b/Firmware/Configuration_adv.h
@@ -10,16 +10,6 @@
 #endif
 #define BED_CHECK_INTERVAL 5000 //ms between checks in bang-bang control
 
-#ifdef PIDTEMP
-  // this adds an experimental additional term to the heating power, proportional to the extrusion speed.
-  // if Kc is chosen well, the additional required power due to increased melting should be compensated.
-  // #define PID_ADD_EXTRUSION_RATE
-  #ifdef PID_ADD_EXTRUSION_RATE
-    #define  DEFAULT_Kc (1) //heating power=Kc*(e_speed)
-  #endif
-#endif
-
-
 //automatic temperature: The hot end target temperature is calculated by all the buffered lines of gcode.
 //The maximum buffered steps/sec of the extruder motor are called "se".
 //You enter the autotemp mode by a M109 S<mintemp> B<maxtemp> F<factor>

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -7766,23 +7766,18 @@ Sigma_Exit:
     See also <a href="https://reprap.org/wiki/PID_Tuning">PID Tuning.</a>
     #### Usage
     
-        M301 [ P | I | D | C ]
+        M301 [ P | I | D ]
     
     #### Parameters
     - `P` - proportional (Kp)
     - `I` - integral (Ki)
     - `D` - derivative (Kd)
-    - `C` - heating power=Kc*(e_speed0)  
     */
     case 301:
       {
         if(code_seen('P')) cs.Kp = code_value();
         if(code_seen('I')) cs.Ki = scalePID_i(code_value());
         if(code_seen('D')) cs.Kd = scalePID_d(code_value());
-
-        #ifdef PID_ADD_EXTRUSION_RATE
-        if(code_seen('C')) Kc = code_value();
-        #endif
 
         updatePID();
         SERIAL_PROTOCOLRPGM(MSG_OK);
@@ -7792,11 +7787,6 @@ Sigma_Exit:
         SERIAL_PROTOCOL(unscalePID_i(cs.Ki));
         SERIAL_PROTOCOLPGM(" d:");
         SERIAL_PROTOCOL(unscalePID_d(cs.Kd));
-        #ifdef PID_ADD_EXTRUSION_RATE
-        SERIAL_PROTOCOLPGM(" c:");
-        //Kc does not have scaling applied above, or in resetting defaults
-        SERIAL_PROTOCOL(Kc);
-        #endif
         SERIAL_PROTOCOLLN();
       }
       break;

--- a/Firmware/temperature.cpp
+++ b/Firmware/temperature.cpp
@@ -88,9 +88,6 @@ float current_temperature_bed = 0.0;
   float _Kp, _Ki, _Kd;
   int pid_cycle, pid_number_of_cycles;
   bool pid_tuning_finished = false;
-  #ifdef PID_ADD_EXTRUSION_RATE
-    float Kc=DEFAULT_Kc;
-  #endif
 #endif //PIDTEMP
   
 #ifdef FAN_SOFT_PWM

--- a/Firmware/temperature.h
+++ b/Firmware/temperature.h
@@ -91,15 +91,11 @@ extern bool bedPWMDisabled;
 #ifdef PIDTEMP
   extern int pid_cycle, pid_number_of_cycles;
   extern float _Kp,_Ki,_Kd;
-#ifdef PID_ADD_EXTRUSION_RATE
-  extern float Kc;
-#endif
   extern bool pid_tuning_finished;
   float scalePID_i(float i);
   float scalePID_d(float d);
   float unscalePID_i(float i);
   float unscalePID_d(float d);
-
 #endif
 
 


### PR DESCRIPTION
Even if the setting was turned on, it doesn't do anything useful. `Kc` variable is set but is never actually used anywhere. Closes #3458 