### PR TITLE
Optimise `autostart_stilltocheck` variable

### DIFF
--- a/Firmware/cardreader.cpp
+++ b/Firmware/cardreader.cpp
@@ -30,7 +30,6 @@ CardReader::CardReader()
    memset(workDirParents, 0, sizeof(workDirParents));
    presort_flag = false;
 
-   autostart_stilltocheck=true; //the SD start is delayed, because otherwise the serial cannot answer fast enough to make contact with the host software.
    lastnr=0;
   //power to SD reader
   #if SDPOWER > -1
@@ -614,6 +613,9 @@ void CardReader::write_command_no_newline(char *buf)
 
 void CardReader::checkautostart(bool force)
 {
+  // The SD start is delayed because otherwise the serial cannot answer
+  // fast enough to make contact with the host software.
+  static bool autostart_stilltocheck = true; 
   if(!force)
   {
     if(!autostart_stilltocheck)
@@ -621,7 +623,7 @@ void CardReader::checkautostart(bool force)
     if(autostart_atmillis.expired(5000))
       return;
   }
-  autostart_stilltocheck=false;
+  autostart_stilltocheck = false;
   if(!cardOK)
   {
     initsd();

--- a/Firmware/cardreader.h
+++ b/Firmware/cardreader.h
@@ -133,8 +133,6 @@ private:
   ShortTimer autostart_atmillis;
   uint32_t sdpos ;
 
-  bool autostart_stilltocheck; //the sd start is delayed, because otherwise the serial cannot answer fast enought to make contact with the hostsoftware.
-  
   uint16_t nrFiles; //counter for the files in the current directory and recycled as position counter for getting the nrFiles'th name in the directory.
 
   bool diveSubfolder (const char *&fileName);


### PR DESCRIPTION
Make the variable `static` within the `checkautostart()` function.
When the function is called for the first time `autostart_stilltocheck`
is set to `true` and will continue to live after the function is exited.
After it is set to `false` within `checkautostart()` it will continue to be
`false` forever.

Using `static` this way is more efficient than using a global variable.

Changes save 6 bytes of flash and 1 byte of SRAM