### PR TITLE
Consolidate `menu_lcd_lcdupdate_func()` to create "Button Echo" and "Encoder Move" sounds.

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -9578,12 +9578,12 @@ void manage_inactivity(bool ignore_stepper_queue/*=false*/) //default argument s
   // handle longpress
   if(lcd_longpress_trigger)
   {
-      // Consume the long-press click and give feedback
-      lcd_consume_click();
-      Sound_MakeSound(e_SOUND_TYPE_ButtonEcho);
       // long press is not possible in modal mode, wait until ready
       if (lcd_longpress_func && lcd_update_enabled)
       {
+      // Consume the long-press click and give feedback
+      lcd_consume_click();
+      Sound_MakeSound(e_SOUND_TYPE_ButtonEcho);
           lcd_longpress_func();
           lcd_longpress_trigger = 0;
       }

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -9578,6 +9578,9 @@ void manage_inactivity(bool ignore_stepper_queue/*=false*/) //default argument s
   // handle longpress
   if(lcd_longpress_trigger)
   {
+      // Consume the long-press click and give feedback
+      lcd_consume_click();
+      Sound_MakeSound(e_SOUND_TYPE_ButtonEcho);
       // long press is not possible in modal mode, wait until ready
       if (lcd_longpress_func && lcd_update_enabled)
       {

--- a/Firmware/menu.cpp
+++ b/Firmware/menu.cpp
@@ -117,15 +117,6 @@ void menu_back_if_clicked(void)
 		menu_back();
 }
 
-void menu_back_if_clicked_fb(void)
-{
-	if (lcd_clicked())
-	{
-        lcd_quick_feedback();
-		menu_back();
-	}
-}
-
 void menu_submenu(menu_func_t submenu)
 {
 	if (menu_depth < MENU_DEPTH_MAX)

--- a/Firmware/menu.cpp
+++ b/Firmware/menu.cpp
@@ -45,7 +45,7 @@ void menu_data_reset(void)
 	memset(&menu_data, 0, sizeof(menu_data));
 }
 
-void menu_goto(menu_func_t menu, const uint32_t encoder, const bool feedback, bool reset_menu_state)
+void menu_goto(menu_func_t menu, const uint32_t encoder, bool reset_menu_state)
 {
 	CRITICAL_SECTION_START;
 	if (menu_menu != menu)
@@ -56,8 +56,6 @@ void menu_goto(menu_func_t menu, const uint32_t encoder, const bool feedback, bo
 		CRITICAL_SECTION_END;
 		if (reset_menu_state)
 			menu_data_reset();
-
-		if (feedback) lcd_quick_feedback();
 	}
 	else
 		CRITICAL_SECTION_END;
@@ -96,7 +94,7 @@ void menu_end(void)
 void menu_back(uint8_t nLevel)
 {
      menu_depth = ((menu_depth > nLevel) ? (menu_depth - nLevel) : 0);
-     menu_goto(menu_stack[menu_depth].menu, menu_stack[menu_depth].position, true, true);
+     menu_goto(menu_stack[menu_depth].menu, menu_stack[menu_depth].position, true);
 }
 
 void menu_back(void)
@@ -109,7 +107,7 @@ void menu_back_no_reset(void)
 	if (menu_depth > 0)
 	{
 		menu_depth--;		
-		menu_goto(menu_stack[menu_depth].menu, menu_stack[menu_depth].position, true, false);
+		menu_goto(menu_stack[menu_depth].menu, menu_stack[menu_depth].position, false);
 	}
 }
 
@@ -134,7 +132,7 @@ void menu_submenu(menu_func_t submenu)
 	{
 		menu_stack[menu_depth].menu = menu_menu;
 		menu_stack[menu_depth++].position = lcd_encoder;
-		menu_goto(submenu, 0, true, true);
+		menu_goto(submenu, 0, true);
 	}
 }
 
@@ -144,7 +142,7 @@ void menu_submenu_no_reset(menu_func_t submenu)
 	{
 		menu_stack[menu_depth].menu = menu_menu;
 		menu_stack[menu_depth++].position = lcd_encoder;
-		menu_goto(submenu, 0, true, false);
+		menu_goto(submenu, 0, false);
 	}
 }
 

--- a/Firmware/menu.cpp
+++ b/Firmware/menu.cpp
@@ -493,7 +493,7 @@ static void _menu_edit_P(void)
 		lcd_set_cursor(0, 1);
 		menu_draw_P<T>(' ', _md->editLabel, (int)lcd_encoder);
 	}
-	if (LCD_CLICKED)
+	if (lcd_clicked())
 	{
 		*((T)(_md->editValue)) = lcd_encoder;
 		menu_back_no_reset();

--- a/Firmware/menu.cpp
+++ b/Firmware/menu.cpp
@@ -399,6 +399,7 @@ uint8_t menu_item_toggle_P(const char* str, const char* toggle, menu_func_t func
 				lcd_update_enabled = 0;
 				if (func) func();
 				lcd_update_enabled = 1;
+				lcd_draw_update = 2;
 			}
 			return 1;
 		}

--- a/Firmware/menu.cpp
+++ b/Firmware/menu.cpp
@@ -73,7 +73,7 @@ void menu_start(void)
     if (lcd_encoder < menu_top)
 		menu_top = lcd_encoder;
     menu_line = menu_top;
-    menu_clicked = LCD_CLICKED;
+    menu_clicked = lcd_clicked(); // Knob click is consumed here
 }
 
 void menu_end(void)
@@ -300,8 +300,6 @@ uint8_t __attribute__((noinline)) menu_item_function_E(const Sheet &sheet, menu_
         if (lcd_draw_update) menu_draw_item_select_sheet_E(' ', sheet);
         if (menu_clicked && (lcd_encoder == menu_item))
         {
-            menu_clicked = false;
-            lcd_consume_click();
             lcd_update_enabled = 0;
             if (func) func();
             lcd_update_enabled = 1;
@@ -339,8 +337,6 @@ uint8_t menu_item_function_P(const char* str, menu_func_t func)
 		if (lcd_draw_update) menu_draw_item_puts_P(' ', str);
 		if (menu_clicked && (lcd_encoder == menu_item))
 		{
-			menu_clicked = false;
-			lcd_consume_click();
 			lcd_update_enabled = 0;
 			if (func) func();
 			lcd_update_enabled = 1;
@@ -368,8 +364,6 @@ uint8_t menu_item_function_P(const char* str, char number, void (*func)(uint8_t)
         if (lcd_draw_update) menu_draw_item_puts_P(' ', str, number);
         if (menu_clicked && (lcd_encoder == menu_item))
         {
-            menu_clicked = false;
-            lcd_consume_click();
             lcd_update_enabled = 0;
             if (func) func(fn_par);
             lcd_update_enabled = 1;
@@ -394,8 +388,6 @@ uint8_t menu_item_toggle_P(const char* str, const char* toggle, menu_func_t func
 			}
 			else // do the actual toggling
 			{
-				menu_clicked = false;
-				lcd_consume_click();
 				lcd_update_enabled = 0;
 				if (func) func();
 				lcd_update_enabled = 1;

--- a/Firmware/menu.cpp
+++ b/Firmware/menu.cpp
@@ -56,6 +56,7 @@ void menu_goto(menu_func_t menu, const uint32_t encoder, bool reset_menu_state)
 		CRITICAL_SECTION_END;
 		if (reset_menu_state)
 			menu_data_reset();
+		lcd_draw_update = 2; // Needed to render new menu
 	}
 	else
 		CRITICAL_SECTION_END;
@@ -135,12 +136,6 @@ void menu_submenu_no_reset(menu_func_t submenu)
 		menu_stack[menu_depth++].position = lcd_encoder;
 		menu_goto(submenu, 0, false);
 	}
-}
-
-uint8_t menu_item_ret(void)
-{
-	lcd_quick_feedback();
-	return 1;
 }
 
 /*
@@ -262,7 +257,7 @@ uint8_t menu_item_text_P(const char* str)
 	{
 		if (lcd_draw_update) menu_draw_item_puts_P(' ', str);
 		if (menu_clicked && (lcd_encoder == menu_item))
-			return menu_item_ret();
+			return 1;
 	}
 	menu_item++;
 	return 0;
@@ -276,7 +271,7 @@ uint8_t menu_item_submenu_P(const char* str, menu_func_t submenu)
 		if (menu_clicked && (lcd_encoder == menu_item))
 		{
 			menu_submenu(submenu);
-			return menu_item_ret();
+			return 1;
 		}
 	}
 	menu_item++;
@@ -291,7 +286,7 @@ uint8_t menu_item_submenu_E(const Sheet &sheet, menu_func_t submenu)
         if (menu_clicked && (lcd_encoder == menu_item))
         {
             menu_submenu(submenu);
-            return menu_item_ret();
+            return 1;
         }
     }
     menu_item++;
@@ -310,7 +305,8 @@ uint8_t __attribute__((noinline)) menu_item_function_E(const Sheet &sheet, menu_
             lcd_update_enabled = 0;
             if (func) func();
             lcd_update_enabled = 1;
-            return menu_item_ret();
+            lcd_draw_update = 2;
+            return 1;
         }
     }
     menu_item++;
@@ -325,7 +321,7 @@ uint8_t menu_item_back_P(const char* str)
 		if (menu_clicked && (lcd_encoder == menu_item))
 		{
 			menu_back();
-			return menu_item_ret();
+			return 1;
 		}
 	}
 	menu_item++;
@@ -348,7 +344,8 @@ uint8_t menu_item_function_P(const char* str, menu_func_t func)
 			lcd_update_enabled = 0;
 			if (func) func();
 			lcd_update_enabled = 1;
-			return menu_item_ret();
+			lcd_draw_update = 2;
+			return 1;
 		}
 	}
 	menu_item++;
@@ -376,7 +373,8 @@ uint8_t menu_item_function_P(const char* str, char number, void (*func)(uint8_t)
             lcd_update_enabled = 0;
             if (func) func(fn_par);
             lcd_update_enabled = 1;
-            return menu_item_ret();
+            lcd_draw_update = 2;
+            return 1;
         }
     }
     menu_item++;
@@ -393,7 +391,6 @@ uint8_t menu_item_toggle_P(const char* str, const char* toggle, menu_func_t func
 			if (toggle == NULL) // print N/A warning message
 			{
 				menu_submenu(func);
-				return menu_item_ret();
 			}
 			else // do the actual toggling
 			{
@@ -402,8 +399,8 @@ uint8_t menu_item_toggle_P(const char* str, const char* toggle, menu_func_t func
 				lcd_update_enabled = 0;
 				if (func) func();
 				lcd_update_enabled = 1;
-				return menu_item_ret();
 			}
+			return 1;
 		}
 	}
 	menu_item++;
@@ -418,7 +415,8 @@ uint8_t menu_item_gcode_P(const char* str, const char* str_gcode)
 		if (menu_clicked && (lcd_encoder == menu_item))
 		{
 			if (str_gcode) enquecommand_P(str_gcode);
-			return menu_item_ret();
+			lcd_draw_update = 2;
+			return 1;
 		}
 	}
 	menu_item++;
@@ -528,7 +526,7 @@ uint8_t menu_item_edit_P(const char* str, T pval, int16_t min_val, int16_t max_v
 			_md->minEditValue = min_val;
 			_md->maxEditValue = max_val;
 			lcd_encoder = *pval;
-			return menu_item_ret();
+			return 1;
 		}
 	}
 	menu_item++;

--- a/Firmware/menu.h
+++ b/Firmware/menu.h
@@ -83,8 +83,6 @@ extern void menu_back_if_clicked(void);
 extern void menu_submenu(menu_func_t submenu);
 extern void menu_submenu_no_reset(menu_func_t submenu);
 
-extern uint8_t menu_item_ret(void);
-
 //extern int menu_draw_item_printf_P(char type_char, const char* format, ...);
 
 

--- a/Firmware/menu.h
+++ b/Firmware/menu.h
@@ -80,8 +80,6 @@ extern void menu_back(uint8_t nLevel);
 
 extern void menu_back_if_clicked(void);
 
-extern void menu_back_if_clicked_fb(void);
-
 extern void menu_submenu(menu_func_t submenu);
 extern void menu_submenu_no_reset(menu_func_t submenu);
 

--- a/Firmware/menu.h
+++ b/Firmware/menu.h
@@ -66,7 +66,7 @@ extern menu_func_t menu_menu;
 
 extern void menu_data_reset(void);
 
-extern void menu_goto(menu_func_t menu, const uint32_t encoder, const bool feedback, bool reset_menu_state);
+extern void menu_goto(menu_func_t menu, const uint32_t encoder, bool reset_menu_state);
 
 #define MENU_BEGIN() menu_start(); for(menu_row = 0; menu_row < LCD_HEIGHT; menu_row++, menu_line++) { menu_item = 0;
 void menu_start(void);

--- a/Firmware/sound.cpp
+++ b/Firmware/sound.cpp
@@ -151,7 +151,6 @@ static void Sound_DoSound_Blind_Alert(void)
 
  static void Sound_DoSound_Encoder_Move(void)
 {
-    backlight_wake();
 uint8_t nI;
 
  for(nI=0;nI<5;nI++)

--- a/Firmware/sound.cpp
+++ b/Firmware/sound.cpp
@@ -164,7 +164,6 @@ uint8_t nI;
 
 static void Sound_DoSound_Echo(void)
 {
-    backlight_wake();
 uint8_t nI;
 
 for(nI=0;nI<10;nI++)

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3747,7 +3747,7 @@ void lcd_first_layer_calibration_reset()
     static_assert(sizeof(menu_data)>= sizeof(MenuData),"_menu_data_t doesn't fit into menu_data");
     MenuData* menuData = (MenuData*)&(menu_data[0]);
 
-    if(LCD_CLICKED || !eeprom_is_sheet_initialized(eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet))) ||
+    if(lcd_clicked() || !eeprom_is_sheet_initialized(eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet))) ||
             (calibration_status() >= CALIBRATION_STATUS_LIVE_ADJUST) ||
             (0 == static_cast<int16_t>(eeprom_read_word(reinterpret_cast<uint16_t*>
             (&EEPROM_Sheets_base->s[(eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet)))].z_offset)))))

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -4979,7 +4979,6 @@ uint8_t choose_menu_P(const char *header, const char *item, const char *last_ite
 
 		if (lcd_clicked())
 		{
-			Sound_MakeSound(e_SOUND_TYPE_ButtonEcho);
 		    KEEPALIVE_STATE(IN_HANDLER);
 			lcd_encoder_diff = 0;
 			return(cursor_pos + first - 1);
@@ -5053,7 +5052,6 @@ char reset_menu() {
 		}
 
 		if (lcd_clicked()) {
-			Sound_MakeSound(e_SOUND_TYPE_ButtonEcho);
 			return(cursor_pos + first);
 		}
 
@@ -5998,7 +5996,6 @@ void lcd_sdcard_stop()
 
 	if (lcd_clicked())
 	{
-		Sound_MakeSound(e_SOUND_TYPE_ButtonEcho);
 		if ((int32_t)lcd_encoder == 1)
 		{
 			lcd_return_to_status();
@@ -7706,6 +7703,7 @@ void menu_lcd_lcdupdate_func(void)
 
 		if (LCD_CLICKED)
 		{
+			Sound_MakeSound(e_SOUND_TYPE_ButtonEcho);
 			lcd_timeoutToStatus.start();
 			backlight_wake();
 		}

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1200,10 +1200,15 @@ static void lcd_menu_fails_stats_mmu_total()
     lcd_home();
     lcd_printf_P(PSTR("%S\n" " %-16.16S%-3d\n"/* " %-16.16S%-3d\n" " %-16.16S%-3d"*/), 
         _T(MSG_TOTAL_FAILURES),
-        _T(MSG_MMU_FAILS), clamp999( eeprom_read_word((uint16_t*)EEPROM_MMU_FAIL_TOT) ),
-        _T(MSG_MMU_LOAD_FAILS), clamp999( eeprom_read_word((uint16_t*)EEPROM_MMU_LOAD_FAIL_TOT) ),
-        _i("MMU power fails"), clamp999( mmu_power_failures )); ////MSG_MMU_POWER_FAILS c=15
-    menu_back_if_clicked();
+        _T(MSG_MMU_FAILS), clamp999( MMU2::mmu2.TotalFailStatistics() ));//,
+        //_T(MSG_MMU_LOAD_FAILS), clamp999( eeprom_read_word((uint16_t*)EEPROM_MMU_LOAD_FAIL_TOT) ),
+        //_i("MMU power fails"), clamp999( mmu_power_failures )); ////MSG_MMU_POWER_FAILS c=15
+    if (lcd_clicked())
+    {
+        first_time_opening_menu = 0;
+        lcd_quick_feedback();
+        menu_back();
+    }
 }
 
 #if defined(TMC2130) && defined(FILAMENT_SENSOR)
@@ -1257,7 +1262,7 @@ static void lcd_menu_fails_stats_print()
         _T(MSG_POWER_FAILURES), power,
         _T(MSG_FIL_RUNOUTS), filam,
         _T(MSG_CRASH), crashX, crashY);
-    menu_back_if_clicked_fb();
+    menu_back_if_clicked();
 }
 
 //! @brief Open fail statistics menu

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -813,7 +813,7 @@ void lcd_status_screen()                          // NOT static due to using ins
 			lcd_commands();
 	}
 
-	bool current_click = LCD_CLICKED;
+	bool current_click = lcd_clicked();
 
 	if (ignore_click)
 	{

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -7579,8 +7579,8 @@ void menu_lcd_longpress_func(void)
     if (menu_menu == lcd_hw_setup_menu)
     {
         // only toggle the experimental menu visibility flag
-        lcd_quick_feedback();
         lcd_experimental_toggle();
+        lcd_draw_update = 2;
         return;
     }
 

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2412,7 +2412,7 @@ static void _lcd_move(const char *name, uint8_t axis, int min, int max)
 		menu_draw_float31(name, current_position[axis]);
 	}
 	if (menu_leaving || LCD_CLICKED) (void)enable_endstops(_md->endstopsEnabledPrevious);
-	if (LCD_CLICKED) menu_back();
+	menu_back_if_clicked();
 }
 
 
@@ -2438,7 +2438,7 @@ void lcd_move_e()
 			// the implementation of menu_draw_float31
 			menu_draw_float31(PSTR("Extruder:"), current_position[E_AXIS]);
 		}
-		if (LCD_CLICKED) menu_back();
+		menu_back_if_clicked();
 	}
 	else
 	{
@@ -2662,7 +2662,7 @@ static void lcd_babystep_z()
 #endif //PINDA_THERMISTOR
 		calibration_status_store(CALIBRATION_STATUS_CALIBRATED);
 	}
-	if (LCD_CLICKED) menu_back();
+	menu_back_if_clicked();
 }
 
 
@@ -3380,7 +3380,7 @@ static void lcd_show_end_stops() {
 #ifndef TMC2130
 static void menu_show_end_stops() {
     lcd_show_end_stops();
-    if (LCD_CLICKED) menu_back();
+    menu_back_if_clicked();
 }
 #endif // not defined TMC2130
 

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -4928,7 +4928,6 @@ uint8_t choose_menu_P(const char *header, const char *item, const char *last_ite
                 cursor_pos++;
             }
             enc_dif = lcd_encoder_diff;
-			Sound_MakeSound(e_SOUND_TYPE_EncoderMove);
 		}
 
 		if (cursor_pos > 3)
@@ -5044,7 +5043,6 @@ char reset_menu() {
 				lcd_puts_at_P(0, 0, PSTR(" \n \n \n "));
 				lcd_set_cursor(0, cursor_pos);
 				lcd_putc('>');
-				Sound_MakeSound(e_SOUND_TYPE_EncoderMove);
 				enc_dif = lcd_encoder_diff;
 				_delay(100);
 			}

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2003,7 +2003,6 @@ void mFilamentItem(uint16_t nTemp, uint16_t nTempBed)
             {
                 setTargetHotend0(0.0);
                 setTargetBed(0.0);
-                menu_back();
             }
             else
             {

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -7573,8 +7573,7 @@ void menu_lcd_longpress_func(void)
 	backlight_wake();
     if (homing_flag || mesh_bed_leveling_flag || menu_menu == lcd_babystep_z || menu_menu == lcd_move_z || menu_block_mask != MENU_BLOCK_NONE)
     {
-        // disable longpress during re-entry, while homing, calibration or if a serious error
-        lcd_quick_feedback();
+        // disable longpress during re-entry, while homing or calibration
         return;
     }
     if (menu_menu == lcd_hw_setup_menu)

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1178,7 +1178,7 @@ static void lcd_menu_fails_stats_mmu_print()
         _T(MSG_LAST_PRINT_FAILURES),
         _T(MSG_MMU_FAILS), clamp999( eeprom_read_byte((uint8_t*)EEPROM_MMU_FAIL) ),
         _T(MSG_MMU_LOAD_FAILS), clamp999( eeprom_read_byte((uint8_t*)EEPROM_MMU_LOAD_FAIL) ));
-    menu_back_if_clicked_fb();
+    menu_back_if_clicked();
 }
 
 //! @brief Show Total Failures Statistics MMU
@@ -1204,15 +1204,10 @@ static void lcd_menu_fails_stats_mmu_total()
     lcd_home();
     lcd_printf_P(PSTR("%S\n" " %-16.16S%-3d\n"/* " %-16.16S%-3d\n" " %-16.16S%-3d"*/), 
         _T(MSG_TOTAL_FAILURES),
-        _T(MSG_MMU_FAILS), clamp999( MMU2::mmu2.TotalFailStatistics() ));//,
-        //_T(MSG_MMU_LOAD_FAILS), clamp999( eeprom_read_word((uint16_t*)EEPROM_MMU_LOAD_FAIL_TOT) ),
-        //_i("MMU power fails"), clamp999( mmu_power_failures )); ////MSG_MMU_POWER_FAILS c=15
-    if (lcd_clicked())
-    {
-        first_time_opening_menu = 0;
-        lcd_quick_feedback();
-        menu_back();
-    }
+        _T(MSG_MMU_FAILS), clamp999( eeprom_read_word((uint16_t*)EEPROM_MMU_FAIL_TOT) ),
+        _T(MSG_MMU_LOAD_FAILS), clamp999( eeprom_read_word((uint16_t*)EEPROM_MMU_LOAD_FAIL_TOT) ),
+        _i("MMU power fails"), clamp999( mmu_power_failures )); ////MSG_MMU_POWER_FAILS c=15
+    menu_back_if_clicked();
 }
 
 #if defined(TMC2130) && defined(FILAMENT_SENSOR)
@@ -1239,7 +1234,7 @@ static void lcd_menu_fails_stats_total()
         _T(MSG_CRASH),
             clamp999( eeprom_read_word((uint16_t*)EEPROM_CRASH_COUNT_X_TOT) ), 
             clamp999( eeprom_read_word((uint16_t*)EEPROM_CRASH_COUNT_Y_TOT) ));
-    menu_back_if_clicked_fb();
+    menu_back_if_clicked();
 }
 
 //! @brief Show Last Print Failures Statistics
@@ -1363,7 +1358,7 @@ static void lcd_menu_debug()
         " heap_end: 0x%04x"), SP_min, __malloc_heap_start, __malloc_heap_end);  ////c=14
 #endif //DEBUG_STACK_MONITOR
 
-	menu_back_if_clicked_fb();
+	menu_back_if_clicked();
 }
 #endif /* DEBUG_BUILD */
 
@@ -2354,7 +2349,7 @@ void lcd_menu_statistics()
 		    ),
             _i("Filament used"), _met,  ////MSG_FILAMENT_USED c=19
             _i("Print time"), _h, _m, _s);  ////MSG_PRINT_TIME c=19
-		menu_back_if_clicked_fb();
+		menu_back_if_clicked();
 	}
 	else
 	{
@@ -2376,7 +2371,7 @@ void lcd_menu_statistics()
             ),
             _i("Total filament"), _filament_m,  ////MSG_TOTAL_FILAMENT c=19
             _i("Total print time"), _days, _hours, _minutes);  ////MSG_TOTAL_PRINT_TIME c=19
-        menu_back_if_clicked_fb();
+        menu_back_if_clicked();
 	}
 }
 

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -341,9 +341,7 @@ uint8_t menu_item_sddir(const char* str_fn, char* str_fnl)
 		}
 		if (menu_clicked && (lcd_encoder == menu_item))
 		{
-			menu_clicked = false;
-			lcd_consume_click();
-			lcd_update_enabled = false;
+			lcd_update_enabled = 0;
 			menu_action_sddirectory(str_fn);
 			lcd_update_enabled = 1;
 			lcd_draw_update = 2;
@@ -364,9 +362,6 @@ static uint8_t menu_item_sdfile(const char* str_fn, char* str_fnl)
 		}
 		if (menu_clicked && (lcd_encoder == menu_item))
 		{
-			menu_clicked = false;
-			lcd_consume_click();
-			lcd_update_enabled = false;
 			menu_action_sdfile(str_fn);
 			lcd_draw_update = 2;
 			return 1;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -345,8 +345,9 @@ uint8_t menu_item_sddir(const char* str_fn, char* str_fnl)
 			lcd_consume_click();
 			lcd_update_enabled = false;
 			menu_action_sddirectory(str_fn);
-			lcd_update_enabled = true;
-			return menu_item_ret();
+			lcd_update_enabled = 1;
+			lcd_draw_update = 2;
+			return 1;
 		}
 	}
 	menu_item++;
@@ -367,8 +368,8 @@ static uint8_t menu_item_sdfile(const char* str_fn, char* str_fnl)
 			lcd_consume_click();
 			lcd_update_enabled = false;
 			menu_action_sdfile(str_fn);
-			lcd_update_enabled = true;
-			return menu_item_ret();
+			lcd_draw_update = 2;
+			return 1;
 		}
 	}
 	menu_item++;
@@ -5671,7 +5672,7 @@ static uint8_t lcd_advance_K()
         {
             menu_submenu_no_reset(lcd_advance_edit_K);
             lcd_encoder = 100. * extruder_advance_K;
-            return menu_item_ret();
+            return 1;
         }
     }
     menu_item++;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1058,7 +1058,7 @@ void lcd_commands()
 void lcd_return_to_status()
 {
 	lcd_refresh(); // to maybe revive the LCD if static electricity killed it.
-	menu_goto(lcd_status_screen, 0, false, true);
+	menu_goto(lcd_status_screen, 0, true);
 	menu_depth = 0;
     eFilamentAction = FilamentAction::None; // i.e. non-autoLoad
 }
@@ -2493,7 +2493,7 @@ static void lcd_menu_xyz_y_min()
 		else lcd_printf_P(_N("%6.2fmm"), distanceMin[i]);
 	}
     if (lcd_clicked())
-        menu_goto(lcd_menu_xyz_skew, 0, true, true);
+        menu_goto(lcd_menu_xyz_skew, 0, true);
 }
 
 //@brief Show measured axis skewness
@@ -2537,7 +2537,7 @@ static void lcd_menu_xyz_skew()
 		lcd_puts_at_P(15,0, _T(MSG_NA));
 	}
     if (lcd_clicked())
-        menu_goto(lcd_menu_xyz_offset, 0, true, true);
+        menu_goto(lcd_menu_xyz_offset, 0, true);
 }
 //! @brief Show measured bed offset from expected position
 //! 
@@ -3612,8 +3612,8 @@ static void crash_mode_switch()
     {
         lcd_crash_detect_enable();
     }
-	if (IS_SD_PRINTING || usb_timer.running() || (lcd_commands_type == LcdCommands::Layer1Cal)) menu_goto(lcd_tune_menu, 9, true, true);
-	else menu_goto(lcd_settings_menu, 9, true, true);
+	if (IS_SD_PRINTING || usb_timer.running() || (lcd_commands_type == LcdCommands::Layer1Cal)) menu_goto(lcd_tune_menu, 9, true);
+	else menu_goto(lcd_settings_menu, 9, true);
 }
 #endif //TMC2130
 
@@ -3627,7 +3627,7 @@ void menu_setlang(unsigned char lang)
 			lang_boot_update_start(lang);
 		lcd_update_enable(true);
 		lcd_clear();
-		menu_goto(lcd_language_menu, 0, true, true);
+		menu_goto(lcd_language_menu, 0, true);
 		lcd_timeoutToStatus.stop(); //infinite timeout
 		lcd_draw_update = 2;
 	}
@@ -3766,7 +3766,7 @@ void lcd_first_layer_calibration_reset()
         {
             eeprom_update_word(reinterpret_cast<uint16_t*>(&EEPROM_Sheets_base->s[(eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet)))].z_offset), 0xffff);
         }
-        menu_goto(lcd_v2_calibration,0,true,true);
+        menu_goto(lcd_v2_calibration,0,true);
     }
 
     if (lcd_encoder > 0)
@@ -3840,7 +3840,7 @@ void lcd_v2_calibration()
 #endif //FILAMENT_SENSOR
 
 	eFilamentAction = FilamentAction::Lay1Cal;
-	menu_goto(lcd_generic_preheat_menu, 0, true, true);
+	menu_goto(lcd_generic_preheat_menu, 0, true);
 }
 
 void lcd_wizard() {
@@ -3864,7 +3864,7 @@ void lcd_language()
 {
 	lcd_update_enable(true);
 	lcd_clear();
-	menu_goto(lcd_language_menu, 0, true, true);
+	menu_goto(lcd_language_menu, 0, true);
 	lcd_timeoutToStatus.stop(); //infinite timeout
 	lcd_draw_update = 2;
 	while ((menu_menu != lcd_status_screen) && (!lang_is_selected()))
@@ -4072,7 +4072,7 @@ void lcd_wizard(WizState state)
 			}
 			break;
 		case S::Preheat:
-		    menu_goto(lcd_preheat_menu,0,false,true);
+		    menu_goto(lcd_preheat_menu,0,true);
 		    lcd_show_fullscreen_message_and_wait_P(_i("Select nozzle preheat temperature which matches your material."));////MSG_SEL_PREHEAT_TEMP c=20 r=6
 		    end = true; // Leave wizard temporarily for lcd_preheat_menu
 		    break;
@@ -4087,7 +4087,7 @@ void lcd_wizard(WizState state)
             break;
 		case S::Lay1CalCold:
             wizard_lay1cal_message(true);
-			menu_goto(lcd_v2_calibration,0,false,true);
+			menu_goto(lcd_v2_calibration,0,true);
 			end = true; // Leave wizard temporarily for lcd_v2_calibration
 			break;
         case S::Lay1CalHot:


### PR DESCRIPTION
Marked as draft: Checkpoint, Need to test more, possibly more ways to optimize.

`menu_lcd_lcdupdate_func()` captures the event when a user:
1. Clicked the knob
2. Rotated the knob 

In this PR I propose we control the "Button Echo" and "Encoder Move" sounds from here. I believe this will be less bug prone and we always ensure that any button click or any knob rotation has sound feedback if that option is turned on.

Current changes save 140 bytes of flash memory.

Before: (01/10/2022)
```
Sketch uses 251302 bytes (98%) of program storage space. Maximum is 253952 bytes.
Global variables use 5684 bytes of dynamic memory.

```

After: (01/10/2022)
```
Sketch uses 251162 bytes (98%) of program storage space. Maximum is 253952 bytes.
Global variables use 5684 bytes of dynamic memory.
```

----

TODO:

- [x] Look into `lcd_quick_feedback()`
- [x] Remove `menu_back_if_clicked_fb()` it is now redundant because any click is guaranteed to have a sound feedback. `menu_back_if_clicked()` should be used instead.
- [x] Bug: (**Fixed by commit** e5ca3d0) When entering the Main Menu (click the knob on the Status Menu screen) then the menu will not render and the Button Echo feedback sound is endlessly beeping.
- [x] Bug: (**Fixed by commit** [4e33864](https://github.com/prusa3d/Prusa-Firmware/pull/3473/commits/4e338640e8effce634769875ec85530a89c8b023)) When folder is selected from "Print from SD" there is a double feedback and the user is returned to the main menu. I suspect we are not properly consuming the knob click here and the firmware thinks we want to back out of the menu until it the knob click is consumed somewhere else in the code. Function to look at: `lcd_sdcard_menu()`
- [x] Bug: (**Fixed by commit** [951dcb4](https://github.com/prusa3d/Prusa-Firmware/pull/3473/commits/951dcb419d7b04c8c9068669a9209e07f7e6c211)) When Toggling Brightness Mode, the LCD display does not update but I can clearly see visually that the firmware is applying the changes.
- [ ] Bug: Sometimes when clicking on folders, there are two beeps. This is due to how `lcd_sdcard_menu()` is written and `menu_lcd_lcdupdate_func()` is called twice until the click event is actually processed. I don't think this is a new issue. Potentially this can be fixed with `lcd_update_enable` flag?
- [x] Bug: (**Fixed by commit** [fd5dab1](https://github.com/prusa3d/Prusa-Firmware/pull/3473/commits/fd5dab17e819202dfb146bd49b366b40ab715e75)) Long-press menus are automatically exited as soon as user enters them.
- [ ] Bug: MMU2S - When I Load to Nozzle, the prompt asking if the extruded color is correct has no sound feedback when scrolling between Yes and No. Also clicking has no feedback.
- [x] Bug: (**Fixed by commit** [f822f91](https://github.com/prusa3d/Prusa-Firmware/pull/3473/commits/f822f9199f9c0f0feb937411fa2903087a37f01e)) Clicking `First layer cal.` -> `Continue` seems to skip a menu
- [ ] Clean up commits and add more description in commit messages.