### PR TITLE
XFlash upload message

### DIFF
--- a/Firmware/optiboot_xflash.cpp
+++ b/Firmware/optiboot_xflash.cpp
@@ -8,6 +8,7 @@
 #include "stk500.h"
 #include "bootapp.h"
 #include <avr/wdt.h>
+#include "lcd.h"
 
 #define OPTIBOOT_MAJVER 6
 #define OPTIBOOT_CUSTOMVER 0
@@ -158,6 +159,9 @@ uint8_t optiboot_xflash_enter()
   spi_init();
   xflash_init();
   wdt_disable();
+
+  lcd_clear();
+  lcd_puts_at_P(0, 1, PSTR(" Upgrading xflash\n Do not disconnect!"));
 
   /* Forever loop: exits by causing WDT reset */
   for (;;) {


### PR DESCRIPTION
Print a message during xflash firmware upload similar to the one in the bootloader. The code is simple (no animations/progress bar). Just a message telling you not to disconnect the cable instead of the startup screen while writing/reading the xflash. The old behavior is misleading since the user gets no feedback that the firmware is still uploading, so sometimes users disconnect the cable while the xflash is still uploading thinking the upload was done as soon as the flash section was uploaded resulting in broken languages.
https://photos.app.goo.gl/moHjQmnbQWLn3KLYA