### PR TITLE
Make M117 message persistent on LCD when used with M601 or G4

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -4272,7 +4272,7 @@ void process_commands()
         if (starpos != NULL)
             *(starpos) = '\0';
         lcd_setstatus(strchr_pointer + 5);
-        custom_message_type = CustomMsg::MsgUpdate;
+        custom_message_type = CustomMsg::M117;
     }
 
     /*!

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -4939,7 +4939,13 @@ if(eSoundMode!=e_SOUND_MODE_SILENT)
       codenum = 0;
       if(code_seen('P')) codenum = code_value(); // milliseconds to wait
       if(code_seen('S')) codenum = code_value() * 1000; // seconds to wait
-	  if(codenum != 0) LCD_MESSAGERPGM(_n("Sleep..."));////MSG_DWELL
+      if(codenum != 0)
+      {
+        if(custom_message_type != CustomMsg::M117)
+        {
+          LCD_MESSAGERPGM(_n("Sleep..."));////MSG_DWELL
+        }
+      }
       st_synchronize();
       codenum += _millis();  // keep track of when we started waiting
       previous_millis_cmd.start();

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -618,7 +618,7 @@ void lcdui_print_status_line(void)
         }
     } else { // Otherwise check for other special events
         switch (custom_message_type) {
-        case CustomMsg::MsgUpdate: //Short message even while printing from SD
+        case CustomMsg::M117:   // M117 Set the status line message on the LCD
         case CustomMsg::Status: // Nothing special, print status message normally
         case CustomMsg::M0Wait: // M0/M1 Wait command working even from SD
             lcd_print(lcd_status_message);
@@ -675,9 +675,6 @@ void lcdui_print_status_line(void)
             break;
         case CustomMsg::Resuming: //Resuming
             lcd_puts_at_P(0, 3, _T(MSG_RESUMING_PRINT));
-            break;
-        case CustomMsg::M117:
-            lcd_print(lcd_status_message);
             break;
         }
     }

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -676,6 +676,9 @@ void lcdui_print_status_line(void)
         case CustomMsg::Resuming: //Resuming
             lcd_puts_at_P(0, 3, _T(MSG_RESUMING_PRINT));
             break;
+        case CustomMsg::M117:
+            lcd_print(lcd_status_message);
+            break;
         }
     }
 
@@ -875,10 +878,13 @@ void lcd_commands()
 	{
 		if (!blocks_queued() && !homing_flag)
 		{
-			lcd_setstatuspgm(_i("Print paused"));////MSG_PRINT_PAUSED c=20
-            lcd_commands_type = LcdCommands::Idle;
-            lcd_commands_step = 0;
-            long_pause();
+			if (custom_message_type != CustomMsg::M117)
+			{
+				lcd_setstatuspgm(_i("Print paused"));////MSG_PRINT_PAUSED c=20
+			}
+			lcd_commands_type = LcdCommands::Idle;
+			lcd_commands_step = 0;
+			long_pause();
 		}
 	}
 

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -121,9 +121,8 @@ enum class CustomMsg : uint_least8_t
     TempCal,         //!< PINDA temperature calibration
     TempCompPreheat, //!< Temperature compensation preheat
     M0Wait,          //!< M0/M1 Wait command working even from SD
-    MsgUpdate,       //!< Short message even while printing from SD
+    M117,            //!< M117 Set the status line message on the LCD
     Resuming,        //!< Resuming message
-    M117,            //!< M117 Custom Message to be displayed
 };
 
 extern CustomMsg custom_message_type;

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -122,7 +122,8 @@ enum class CustomMsg : uint_least8_t
     TempCompPreheat, //!< Temperature compensation preheat
     M0Wait,          //!< M0/M1 Wait command working even from SD
     MsgUpdate,       //!< Short message even while printing from SD
-    Resuming,       //!< Resuming message
+    Resuming,        //!< Resuming message
+    M117,            //!< M117 Custom Message to be displayed
 };
 
 extern CustomMsg custom_message_type;


### PR DESCRIPTION
If M117 is called before M601 or G4 then we would like the custom message to
be visible on the LCD screen until the print is resumed.

Change in memory: +16 bytes of flash

Fixes #3316 (M601)
Fixes #1443 (G4)
Fixes #2970 (G4)

Video demonstration (with M601):

* Before (current Master branch): https://www.youtube.com/watch?v=8Mr-1lYwjsk
* After (this PR): https://www.youtube.com/watch?v=A7_uLBHg0qE