### PR TITLE
pat9125 deinit

### DIFF
--- a/Firmware/Filament_sensor.h
+++ b/Firmware/Filament_sensor.h
@@ -243,7 +243,9 @@ public:
     
 #ifdef FSENSOR_PROBING
     bool probeOtherType() {
-        return pat9125_probe();
+        bool fsensorDetected = pat9125_probe();
+        pat9125_deinit();
+        return fsensorDetected;
     }
 #endif
     
@@ -484,7 +486,7 @@ public:
     
     void deinit() {
         puts_P(PSTR("fsensor::deinit()"));
-        ;//
+        pat9125_deinit();
         state = State::disabled;
         filter = 0;
     }

--- a/Firmware/pat9125.cpp
+++ b/Firmware/pat9125.cpp
@@ -186,6 +186,17 @@ uint8_t pat9125_init(void)
 	return 1;
 }
 
+void pat9125_deinit(void)
+{
+#if defined(PAT9125_SWSPI)
+	#error not implemented
+#elif defined(PAT9125_SWI2C)
+	swi2c_disable();
+#elif defined(PAT9125_I2C)
+	twi_disable();
+#endif
+}
+
 uint8_t pat9125_update(void)
 {
 	if ((pat9125_PID1 == 0x31) && (pat9125_PID2 == 0x91))

--- a/Firmware/pat9125.h
+++ b/Firmware/pat9125.h
@@ -9,6 +9,7 @@ extern uint8_t pat9125_s;
 
 extern uint8_t pat9125_probe(void);     // Return non-zero if PAT9125 can be trivially detected
 extern uint8_t pat9125_init(void);
+extern void pat9125_deinit(void);
 extern uint8_t pat9125_update(void);    // update all sensor data
 extern uint8_t pat9125_update_y(void);  // update _y only
 extern uint8_t pat9125_update_bs(void); // update _b/_s only


### PR DESCRIPTION
Deinitialize the i2c bus after probing for the pat9125 sensor and also when disabling the filament sensor on printer variants with pat9125