### PR TITLE
Fix AMBIENT_RAW_*_TEMP define names

### DIFF
--- a/Firmware/temperature.cpp
+++ b/Firmware/temperature.cpp
@@ -1220,7 +1220,7 @@ void tp_init()
 
 #ifdef AMBIENT_MINTEMP
   while(analog2tempAmbient(ambient_minttemp_raw) < AMBIENT_MINTEMP) {
-#if HEATER_AMBIENT_RAW_LO_TEMP < HEATER_AMBIENT_RAW_HI_TEMP
+#if AMBIENT_RAW_LO_TEMP < AMBIENT_RAW_HI_TEMP
     ambient_minttemp_raw += OVERSAMPLENR;
 #else
     ambient_minttemp_raw -= OVERSAMPLENR;
@@ -1229,7 +1229,7 @@ void tp_init()
 #endif //AMBIENT_MINTEMP
 #ifdef AMBIENT_MAXTEMP
   while(analog2tempAmbient(ambient_maxttemp_raw) > AMBIENT_MAXTEMP) {
-#if HEATER_AMBIENT_RAW_LO_TEMP < HEATER_AMBIENT_RAW_HI_TEMP
+#if AMBIENT_RAW_LO_TEMP < AMBIENT_RAW_HI_TEMP
     ambient_maxttemp_raw -= OVERSAMPLENR;
 #else
     ambient_maxttemp_raw += OVERSAMPLENR;


### PR DESCRIPTION
The max/min temperature check were incorrectly using
HEATER_AMBIENT_RAW_*_TEMP (non-existing) instead of the correct
AMBIENT_RAW_*_TEMP (this is not a heater afterall).

This doesn't change the current behavior, since the check defaulted to
the correct path for the MK3+ configuration anyway.