### PR TITLE
Flash optimizations in loop() and status screen menu

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1940,7 +1940,7 @@ void loop()
 }
   //check heater every n milliseconds
   manage_heater();
-  isPrintPaused ? manage_inactivity(true) : manage_inactivity(false);
+  manage_inactivity(isPrintPaused);
   checkHitEndstops();
   lcd_update(0);
 #ifdef TMC2130

--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -638,7 +638,6 @@ uint8_t lcd_button_pressed = 0;
 uint8_t lcd_update_enabled = 1;
 
 uint32_t lcd_next_update_millis = 0;
-uint8_t lcd_status_update_delay = 0;
 
 
 

--- a/Firmware/lcd.h
+++ b/Firmware/lcd.h
@@ -107,8 +107,6 @@ extern LongTimer lcd_timeoutToStatus;
 
 extern uint32_t lcd_next_update_millis;
 
-extern uint8_t lcd_status_update_delay;
-
 extern lcd_longpress_func_t lcd_longpress_func;
 extern bool lcd_longpress_trigger;
 

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -789,6 +789,11 @@ void lcd_status_screen()                          // NOT static due to using ins
 	else if (feedmultiply > 999)
 		feedmultiply = 999;
 
+	if (lcd_draw_update) {
+		// Update the status screen immediately
+		lcd_status_update_delay = 0;
+	}
+
 	if (lcd_status_update_delay)
 		lcd_status_update_delay--;
 	else

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -758,6 +758,7 @@ void lcdui_print_status_screen(void)
 // Main status screen. It's up to the implementation specific part to show what is needed. As this is very display dependent
 void lcd_status_screen()                          // NOT static due to using inside "Marlin_main" module ("manage_inactivity()")
 {
+	static uint8_t lcd_status_update_delay = 0;
 #ifdef ULTIPANEL_FEEDMULTIPLY
 	// Dead zone at 100% feedrate
 	if ((feedmultiply < 100 && (feedmultiply + int(lcd_encoder)) > 100) ||
@@ -791,11 +792,9 @@ void lcd_status_screen()                          // NOT static due to using ins
 	if (lcd_status_update_delay)
 		lcd_status_update_delay--;
 	else
-		lcd_draw_update = 1;
-
-
-	if (lcd_draw_update)
-	{
+	{	// Redraw the main screen every second (see LCD_UPDATE_INTERVAL).
+		// This is easier then trying keep track of all things that change on the screen
+		lcd_status_update_delay = 10;
 		ReInitLCD++;
 		if (ReInitLCD == 30)
 		{
@@ -832,10 +831,9 @@ void lcd_status_screen()                          // NOT static due to using ins
 			}
 		} // end of farm_mode
 
-		lcd_status_update_delay = 10;   /* redraw the main screen every second. This is easier then trying keep track of all things that change on the screen */
 		if (lcd_commands_type != LcdCommands::Idle)
 			lcd_commands();
-	} // end of lcd_draw_update
+	}
 
 	bool current_click = LCD_CLICKED;
 


### PR DESCRIPTION
These are just small optimizations I have noticed. Thought I should commit them in case I see more or forget them.

The 2 commits save 22 bytes of flash. Removes one global variable