### PR TITLE
Accept any gcc version to build MK404

### DIFF
--- a/MK404-build.sh
+++ b/MK404-build.sh
@@ -315,7 +315,7 @@ check_packages()
 {
 packages=(
 "libelf-dev"
-"gcc-7"
+"gcc"
 "gcc-avr"
 "libglew-dev"
 "freeglut3-dev"


### PR DESCRIPTION
Restricting the MK404 build to gcc-7 is not a good idea, since gcc-7 is
already not available in several newer distributions.

Just pick the current gcc version.

Current gcc 10 (and newer) versions build MK404 correctly.