### PR TITLE
Add notices about Sheet::bed_temp and Sheet::pinda_temp being unused

### DIFF
--- a/Firmware/eeprom.h
+++ b/Firmware/eeprom.h
@@ -20,8 +20,8 @@ typedef struct
 {
     char name[MAX_SHEET_NAME_LENGTH]; //!< Can be null terminated, doesn't need to be null terminated
     int16_t z_offset; //!< Z_BABYSTEP_MIN .. Z_BABYSTEP_MAX = Z_BABYSTEP_MIN*2/1000 [mm] .. Z_BABYSTEP_MAX*2/1000 [mm]
-    uint8_t bed_temp; //!< 0 .. 254 [°C]
-    uint8_t pinda_temp; //!< 0 .. 254 [°C]
+    uint8_t bed_temp; //!< 0 .. 254 [°C] NOTE: currently only written-to and never used
+    uint8_t pinda_temp; //!< 0 .. 254 [°C] NOTE: currently only written-to and never used
 } Sheet;
 
 typedef struct

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2685,6 +2685,8 @@ static void lcd_babystep_z()
 		// Only update the EEPROM when leaving the menu.
           uint8_t active_sheet=eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet));
 		eeprom_update_word(reinterpret_cast<uint16_t *>(&(EEPROM_Sheets_base->s[active_sheet].z_offset)),_md->babystepMemZ);
+
+        // NOTE: bed_temp and pinda_temp are not currently read/used anywhere.
 		eeprom_update_byte(&(EEPROM_Sheets_base->s[active_sheet].bed_temp),target_temperature_bed);
 #ifdef PINDA_THERMISTOR        
 		eeprom_update_byte(&(EEPROM_Sheets_base->s[active_sheet].pinda_temp),current_temperature_pinda);


### PR DESCRIPTION
Using the bed temp to compensate for different material expansion is a nice idea, but it's not currently done.

There is a potential for 2*8 bytes of extra sparse eeprom space, plus a
few bytes saved if we remove the update calls, so add a notice that
these values are currently only written-to, but never actually used.