### PR TITLE
Jump to PLA temps in LCD temperature settings when starting from zero

### DIFF
--- a/Firmware/menu.cpp
+++ b/Firmware/menu.cpp
@@ -467,6 +467,16 @@ static void _menu_edit_P(void)
 	menu_data_edit_t* _md = (menu_data_edit_t*)&(menu_data[0]);
 	if (lcd_draw_update)
 	{
+        // handle initial value jumping
+        if (_md->minJumpValue && lcd_encoder) {
+            if (lcd_encoder > 0 && _md->currentValue == _md->minEditValue) {
+                _md->currentValue = _md->minJumpValue;
+                lcd_encoder = 0;
+            }
+            // disable after first use and/or if the initial value is not minEditValue
+            _md->minJumpValue = 0;
+        }
+
 		_md->currentValue += lcd_encoder;
 		lcd_encoder = 0; // Consume knob rotation event
 
@@ -483,7 +493,7 @@ static void _menu_edit_P(void)
 }
 
 template <typename T>
-void menu_item_edit_P(const char* str, T pval, int16_t min_val, int16_t max_val)
+void menu_item_edit_P(const char* str, T pval, int16_t min_val, int16_t max_val, int16_t jmp_val)
 {
 	menu_data_edit_t* _md = (menu_data_edit_t*)&(menu_data[0]);
 	if (menu_item == menu_line)
@@ -501,6 +511,7 @@ void menu_item_edit_P(const char* str, T pval, int16_t min_val, int16_t max_val)
 			_md->currentValue = *pval;
 			_md->minEditValue = min_val;
 			_md->maxEditValue = max_val;
+			_md->minJumpValue = jmp_val;
 			menu_item_ret();
 			return;
 		}
@@ -508,8 +519,8 @@ void menu_item_edit_P(const char* str, T pval, int16_t min_val, int16_t max_val)
 	menu_item++;
 }
 
-template void menu_item_edit_P<int16_t*>(const char* str, int16_t *pval, int16_t min_val, int16_t max_val);
-template void menu_item_edit_P<uint8_t*>(const char* str, uint8_t *pval, int16_t min_val, int16_t max_val);
+template void menu_item_edit_P<int16_t*>(const char* str, int16_t *pval, int16_t min_val, int16_t max_val, int16_t jmp_val);
+template void menu_item_edit_P<uint8_t*>(const char* str, uint8_t *pval, int16_t min_val, int16_t max_val, int16_t jmp_val);
 
 static uint8_t progressbar_block_count = 0;
 static uint16_t progressbar_total = 0;

--- a/Firmware/menu.cpp
+++ b/Firmware/menu.cpp
@@ -461,8 +461,7 @@ void menu_draw_float13(const char* str, float val)
 	lcd_printf_P(menu_fmt_float13, ' ', str, val);
 }
 
-template <typename T>
-static void _menu_edit_P(void)
+static void _menu_edit_P()
 {
 	menu_data_edit_t* _md = (menu_data_edit_t*)&(menu_data[0]);
 	if (lcd_draw_update)
@@ -487,28 +486,33 @@ static void _menu_edit_P(void)
 	}
 	if (lcd_clicked())
 	{
-		*((T)(_md->editValue)) = _md->currentValue;
+        if (_md->editValueBits == 8)
+            *((uint8_t*)(_md->editValuePtr)) = _md->currentValue;
+        else
+            *((int16_t*)(_md->editValuePtr)) = _md->currentValue;
 		menu_back_no_reset();
 	}
 }
 
-template <typename T>
-void menu_item_edit_P(const char* str, T pval, int16_t min_val, int16_t max_val, int16_t jmp_val)
+void menu_item_edit_P(const char* str, void* pval, uint8_t pbits, int16_t min_val, int16_t max_val, int16_t jmp_val)
 {
 	menu_data_edit_t* _md = (menu_data_edit_t*)&(menu_data[0]);
 	if (menu_item == menu_line)
 	{
+        int16_t cur_val = (pbits == 8 ? *((uint8_t*)pval) : *((int16_t*)pval));
+
 		if (lcd_draw_update) 
 		{
 			lcd_set_cursor(0, menu_row);
-			menu_draw_P(menu_selection_mark(), str, *pval);
+			menu_draw_P(menu_selection_mark(), str, cur_val);
 		}
 		if (menu_clicked && (lcd_encoder == menu_item))
 		{
-			menu_submenu_no_reset(_menu_edit_P<T>);
+			menu_submenu_no_reset(_menu_edit_P);
 			_md->editLabel = str;
-			_md->editValue = pval;
-			_md->currentValue = *pval;
+			_md->editValuePtr = pval;
+			_md->editValueBits = pbits;
+			_md->currentValue = cur_val;
 			_md->minEditValue = min_val;
 			_md->maxEditValue = max_val;
 			_md->minJumpValue = jmp_val;
@@ -518,9 +522,6 @@ void menu_item_edit_P(const char* str, T pval, int16_t min_val, int16_t max_val,
 	}
 	menu_item++;
 }
-
-template void menu_item_edit_P<int16_t*>(const char* str, int16_t *pval, int16_t min_val, int16_t max_val, int16_t jmp_val);
-template void menu_item_edit_P<uint8_t*>(const char* str, uint8_t *pval, int16_t min_val, int16_t max_val, int16_t jmp_val);
 
 static uint8_t progressbar_block_count = 0;
 static uint16_t progressbar_total = 0;

--- a/Firmware/menu.h
+++ b/Firmware/menu.h
@@ -20,7 +20,8 @@ typedef struct
 {
     //Variables used when editing values.
     const char* editLabel;
-    void* editValue;
+    uint8_t editValueBits; // 8 or 16
+    void* editValuePtr;
     int16_t currentValue;
     int16_t minEditValue;
     int16_t maxEditValue;
@@ -144,11 +145,9 @@ struct SheetFormatBuffer
 
 extern void menu_format_sheet_E(const Sheet &sheet_E, SheetFormatBuffer &buffer);
 
-
-#define MENU_ITEM_EDIT_int3_P(str, pval, minval, maxval) do { menu_item_edit_P(str, pval, minval, maxval, 0); } while (0)
-#define MENU_ITEM_EDIT_int3_jmp_P(str, pval, minval, maxval, jmpval) do { menu_item_edit_P(str, pval, minval, maxval, jmpval); } while (0)
-template <typename T>
-extern void menu_item_edit_P(const char* str, T pval, int16_t min_val, int16_t max_val, int16_t jmp_val);
+#define MENU_ITEM_EDIT_int3_P(str, pval, minval, maxval) do { menu_item_edit_P(str, pval, sizeof(*pval)*8, minval, maxval, 0); } while (0)
+#define MENU_ITEM_EDIT_int3_jmp_P(str, pval, minval, maxval, jmpval) do { menu_item_edit_P(str, pval, sizeof(*pval)*8, minval, maxval, jmpval); } while (0)
+extern void menu_item_edit_P(const char* str, void* pval, uint8_t pbits, int16_t min_val, int16_t max_val, int16_t jmp_val);
 
 extern void menu_progressbar_init(uint16_t total, const char* title);
 extern void menu_progressbar_update(uint16_t newVal);

--- a/Firmware/menu.h
+++ b/Firmware/menu.h
@@ -24,6 +24,7 @@ typedef struct
     int16_t currentValue;
     int16_t minEditValue;
     int16_t maxEditValue;
+    int16_t minJumpValue;
 } menu_data_edit_t;
 
 extern uint8_t menu_data[MENU_DATA_SIZE];
@@ -144,10 +145,10 @@ struct SheetFormatBuffer
 extern void menu_format_sheet_E(const Sheet &sheet_E, SheetFormatBuffer &buffer);
 
 
-#define MENU_ITEM_EDIT_int3_P(str, pval, minval, maxval) do { menu_item_edit_P(str, pval, minval, maxval); } while (0)
-//#define MENU_ITEM_EDIT_int3_P(str, pval, minval, maxval) MENU_ITEM_EDIT(int3, str, pval, minval, maxval)
+#define MENU_ITEM_EDIT_int3_P(str, pval, minval, maxval) do { menu_item_edit_P(str, pval, minval, maxval, 0); } while (0)
+#define MENU_ITEM_EDIT_int3_jmp_P(str, pval, minval, maxval, jmpval) do { menu_item_edit_P(str, pval, minval, maxval, jmpval); } while (0)
 template <typename T>
-extern void menu_item_edit_P(const char* str, T pval, int16_t min_val, int16_t max_val);
+extern void menu_item_edit_P(const char* str, T pval, int16_t min_val, int16_t max_val, int16_t jmp_val);
 
 extern void menu_progressbar_init(uint16_t total, const char* title);
 extern void menu_progressbar_update(uint16_t newVal);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -4139,12 +4139,12 @@ static void SETTINGS_SILENT_MODE()
 
 static void menuitems_temperature_common() {
 #if TEMP_SENSOR_0 != 0
-    MENU_ITEM_EDIT_int3_P(_T(MSG_NOZZLE), &target_temperature[0], 0, HEATER_0_MAXTEMP - 10);
+    MENU_ITEM_EDIT_int3_jmp_P(_T(MSG_NOZZLE), &target_temperature[0], 0, HEATER_0_MAXTEMP - 10, LCD_JUMP_HOTEND_TEMP);
 #endif
 #if TEMP_SENSOR_BED != 0
-    MENU_ITEM_EDIT_int3_P(_T(MSG_BED), &target_temperature_bed, 0, BED_MAXTEMP - 5);
+    MENU_ITEM_EDIT_int3_jmp_P(_T(MSG_BED), &target_temperature_bed, 0, BED_MAXTEMP - 5, LCD_JUMP_BED_TEMP);
 #endif
-    MENU_ITEM_EDIT_int3_P(_T(MSG_FAN_SPEED), &fanSpeed, 0, 255);
+    MENU_ITEM_EDIT_int3_jmp_P(_T(MSG_FAN_SPEED), &fanSpeed, 0, 255, LCD_JUMP_FAN_SPEED);
 }
 
 void SETTINGS_FANS_CHECK() {

--- a/Firmware/variants/MK25-RAMBo10a.h
+++ b/Firmware/variants/MK25-RAMBo10a.h
@@ -381,6 +381,10 @@
 #define FLEX_PREHEAT_HOTEND_TEMP 240
 #define FLEX_PREHEAT_HPB_TEMP 50
 
+#define LCD_JUMP_HOTEND_TEMP 200
+#define LCD_JUMP_BED_TEMP 50
+#define LCD_JUMP_FAN_SPEED 127
+
 /*------------------------------------
  THERMISTORS SETTINGS
  *------------------------------------*/

--- a/Firmware/variants/MK25-RAMBo13a.h
+++ b/Firmware/variants/MK25-RAMBo13a.h
@@ -382,6 +382,10 @@
 #define FLEX_PREHEAT_HOTEND_TEMP 240
 #define FLEX_PREHEAT_HPB_TEMP 50
 
+#define LCD_JUMP_HOTEND_TEMP 200
+#define LCD_JUMP_BED_TEMP 50
+#define LCD_JUMP_FAN_SPEED 127
+
 /*------------------------------------
  THERMISTORS SETTINGS
  *------------------------------------*/

--- a/Firmware/variants/MK25S-RAMBo10a.h
+++ b/Firmware/variants/MK25S-RAMBo10a.h
@@ -381,6 +381,10 @@
 #define FLEX_PREHEAT_HOTEND_TEMP 240
 #define FLEX_PREHEAT_HPB_TEMP 50
 
+#define LCD_JUMP_HOTEND_TEMP 200
+#define LCD_JUMP_BED_TEMP 50
+#define LCD_JUMP_FAN_SPEED 127
+
 /*------------------------------------
  THERMISTORS SETTINGS
  *------------------------------------*/

--- a/Firmware/variants/MK25S-RAMBo13a.h
+++ b/Firmware/variants/MK25S-RAMBo13a.h
@@ -382,6 +382,10 @@
 #define FLEX_PREHEAT_HOTEND_TEMP 240
 #define FLEX_PREHEAT_HPB_TEMP 50
 
+#define LCD_JUMP_HOTEND_TEMP 200
+#define LCD_JUMP_BED_TEMP 50
+#define LCD_JUMP_FAN_SPEED 127
+
 /*------------------------------------
  THERMISTORS SETTINGS
  *------------------------------------*/

--- a/Firmware/variants/MK3-E3DREVO.h
+++ b/Firmware/variants/MK3-E3DREVO.h
@@ -527,6 +527,10 @@
 #define FLEX_PREHEAT_HOTEND_TEMP 240
 #define FLEX_PREHEAT_HPB_TEMP 50
 
+#define LCD_JUMP_HOTEND_TEMP 200
+#define LCD_JUMP_BED_TEMP 50
+#define LCD_JUMP_FAN_SPEED 127
+
 /*------------------------------------
  THERMISTORS SETTINGS
  *------------------------------------*/

--- a/Firmware/variants/MK3-E3DREVO_HF_60W.h
+++ b/Firmware/variants/MK3-E3DREVO_HF_60W.h
@@ -528,6 +528,10 @@
 #define FLEX_PREHEAT_HOTEND_TEMP 240
 #define FLEX_PREHEAT_HPB_TEMP 50
 
+#define LCD_JUMP_HOTEND_TEMP 200
+#define LCD_JUMP_BED_TEMP 50
+#define LCD_JUMP_FAN_SPEED 127
+
 /*------------------------------------
  THERMISTORS SETTINGS
  *------------------------------------*/

--- a/Firmware/variants/MK3.h
+++ b/Firmware/variants/MK3.h
@@ -530,6 +530,10 @@
 #define FLEX_PREHEAT_HOTEND_TEMP 240
 #define FLEX_PREHEAT_HPB_TEMP 50
 
+#define LCD_JUMP_HOTEND_TEMP 200
+#define LCD_JUMP_BED_TEMP 50
+#define LCD_JUMP_FAN_SPEED 127
+
 /*------------------------------------
  THERMISTORS SETTINGS
  *------------------------------------*/

--- a/Firmware/variants/MK3S-E3DREVO.h
+++ b/Firmware/variants/MK3S-E3DREVO.h
@@ -531,6 +531,10 @@
 #define FLEX_PREHEAT_HOTEND_TEMP 240
 #define FLEX_PREHEAT_HPB_TEMP 50
 
+#define LCD_JUMP_HOTEND_TEMP 200
+#define LCD_JUMP_BED_TEMP 50
+#define LCD_JUMP_FAN_SPEED 127
+
 /*------------------------------------
  THERMISTORS SETTINGS
  *------------------------------------*/

--- a/Firmware/variants/MK3S-E3DREVO_HF_60W.h
+++ b/Firmware/variants/MK3S-E3DREVO_HF_60W.h
@@ -532,6 +532,10 @@
 #define FLEX_PREHEAT_HOTEND_TEMP 240
 #define FLEX_PREHEAT_HPB_TEMP 50
 
+#define LCD_JUMP_HOTEND_TEMP 200
+#define LCD_JUMP_BED_TEMP 50
+#define LCD_JUMP_FAN_SPEED 127
+
 /*------------------------------------
  THERMISTORS SETTINGS
  *------------------------------------*/

--- a/Firmware/variants/MK3S.h
+++ b/Firmware/variants/MK3S.h
@@ -534,6 +534,10 @@
 #define FLEX_PREHEAT_HOTEND_TEMP 240
 #define FLEX_PREHEAT_HPB_TEMP 50
 
+#define LCD_JUMP_HOTEND_TEMP 200
+#define LCD_JUMP_BED_TEMP 50
+#define LCD_JUMP_FAN_SPEED 127
+
 /*------------------------------------
  THERMISTORS SETTINGS
  *------------------------------------*/


### PR DESCRIPTION
When turning on one heater manually through the Settings -> Temperature menu, it's painfully slow to turn encoder to reach _any_ useful temperature (usually, a minimum of 180C is required).

This PR allows to set an initial "jump" value when starting from zero. It's used in the Settings -> Temperature menus for both the Nozzle and Bed, setting the jump point to 215/60C respectively.

That is, when the nozzle temp is zero, and the user is trying to increase the value, immediately set the value to 215 for further editing. The jump works only once after entering the menu, and the user is still allowed to decrease the value after the jump, so there's no functional restriction. For this reason, 215/60C seem a pretty good all-around value, since most other materials require higher temperatures.

This fixes #3085

It is somewhat expensive in terms of code size, increasing flash usage by 248 bytes (sadly, most of which is due to the ugly menu call interface).