### PR TITLE
Replace EXTRUDE_MINTEMP with the configurable extrude_min_temp

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3421,7 +3421,7 @@ static void gcode_G80()
     go_home_with_z_lift();
     //		SERIAL_ECHOLNPGM("Go home finished");
     //unretract (after PINDA preheat retraction)
-    if ((degHotend(active_extruder) > EXTRUDE_MINTEMP) && eeprom_read_byte((unsigned char *)EEPROM_TEMP_CAL_ACTIVE) && calibration_status_pinda() && (target_temperature_bed >= 50)) {
+    if ((degHotend(active_extruder) > extrude_min_temp) && eeprom_read_byte((unsigned char *)EEPROM_TEMP_CAL_ACTIVE) && calibration_status_pinda() && (target_temperature_bed >= 50)) {
         current_position[E_AXIS] += default_retraction;
         plan_buffer_line_curposXYZE(400);
     }
@@ -7916,8 +7916,8 @@ Sigma_Exit:
     */
     case 302:
     {
-	  float temp = .0;
-	  if (code_seen('S')) temp=code_value();
+	  int temp = 0;
+	  if (code_seen('S')) temp=code_value_short();
       set_extrude_min_temp(temp);
     }
     break;
@@ -9860,7 +9860,7 @@ static uint16_t nFSCheckCount=0;
 #ifdef PAT9125
 					fsensor_autoload_check_stop();
 #endif //PAT9125
-//-//					if (degHotend0() > EXTRUDE_MINTEMP)
+//-//					if (degHotend0() > extrude_min_temp)
 if(0)
 					{
 						Sound_MakeCustom(50,1000,false);
@@ -9876,7 +9876,7 @@ if(0)
 */
 						eFilamentAction=FilamentAction::AutoLoad;
 						bFilamentFirstRun=false;
-						if(target_temperature[0]>=EXTRUDE_MINTEMP){
+						if(target_temperature[0] >= extrude_min_temp){
 							bFilamentPreheatState=true;
 //							mFilamentItem(target_temperature[0],target_temperature_bed);
 							menu_submenu(mFilamentItemForce);
@@ -10801,7 +10801,7 @@ static void temp_compensation_start() {
 	custom_message_type = CustomMsg::TempCompPreheat;
 	custom_message_state = PINDA_HEAT_T + 1;
 	lcd_update(2);
-	if (degHotend(active_extruder) > EXTRUDE_MINTEMP) {
+	if (degHotend(active_extruder) > extrude_min_temp) {
 		current_position[E_AXIS] -= default_retraction;
 	}
 	plan_buffer_line_curposXYZE(400, active_extruder);

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3421,7 +3421,7 @@ static void gcode_G80()
     go_home_with_z_lift();
     //		SERIAL_ECHOLNPGM("Go home finished");
     //unretract (after PINDA preheat retraction)
-    if ((degHotend(active_extruder) > extrude_min_temp) && eeprom_read_byte((unsigned char *)EEPROM_TEMP_CAL_ACTIVE) && calibration_status_pinda() && (target_temperature_bed >= 50)) {
+    if (((int)degHotend(active_extruder) > extrude_min_temp) && eeprom_read_byte((unsigned char *)EEPROM_TEMP_CAL_ACTIVE) && calibration_status_pinda() && (target_temperature_bed >= 50)) {
         current_position[E_AXIS] += default_retraction;
         plan_buffer_line_curposXYZE(400);
     }
@@ -9860,7 +9860,7 @@ static uint16_t nFSCheckCount=0;
 #ifdef PAT9125
 					fsensor_autoload_check_stop();
 #endif //PAT9125
-//-//					if (degHotend0() > extrude_min_temp)
+//-//					if ((int)degHotend0() > extrude_min_temp)
 if(0)
 					{
 						Sound_MakeCustom(50,1000,false);
@@ -10801,7 +10801,7 @@ static void temp_compensation_start() {
 	custom_message_type = CustomMsg::TempCompPreheat;
 	custom_message_state = PINDA_HEAT_T + 1;
 	lcd_update(2);
-	if (degHotend(active_extruder) > extrude_min_temp) {
+	if ((int)degHotend(active_extruder) > extrude_min_temp) {
 		current_position[E_AXIS] -= default_retraction;
 	}
 	plan_buffer_line_curposXYZE(400, active_extruder);

--- a/Firmware/planner.cpp
+++ b/Firmware/planner.cpp
@@ -833,7 +833,7 @@ void plan_buffer_line(float x, float y, float z, const float &e, float feed_rate
   #ifdef PREVENT_DANGEROUS_EXTRUDE
   if(target[E_AXIS]!=position[E_AXIS])
   {
-    if(degHotend(active_extruder)<extrude_min_temp)
+    if((int)degHotend(active_extruder)<extrude_min_temp)
     {
       position[E_AXIS]=target[E_AXIS]; //behave as if the move really took place, but ignore E part
       #ifdef LIN_ADVANCE

--- a/Firmware/planner.cpp
+++ b/Firmware/planner.cpp
@@ -122,7 +122,7 @@ static uint8_t g_cntr_planner_queue_min = 0;
 //=============================private variables ============================
 //===========================================================================
 #ifdef PREVENT_DANGEROUS_EXTRUDE
-float extrude_min_temp=EXTRUDE_MINTEMP;
+int extrude_min_temp = EXTRUDE_MINTEMP;
 #endif
 
 #ifdef LIN_ADVANCE
@@ -1434,9 +1434,9 @@ void plan_reset_next_e()
 }
 
 #ifdef PREVENT_DANGEROUS_EXTRUDE
-void set_extrude_min_temp(float temp)
+void set_extrude_min_temp(int temp)
 {
-  extrude_min_temp=temp;
+  extrude_min_temp = temp;
 }
 #endif
 

--- a/Firmware/planner.h
+++ b/Firmware/planner.h
@@ -262,7 +262,8 @@ extern void planner_abort_hard();
 extern bool waiting_inside_plan_buffer_line_print_aborted;
 
 #ifdef PREVENT_DANGEROUS_EXTRUDE
-void set_extrude_min_temp(float temp);
+extern int extrude_min_temp;
+void set_extrude_min_temp(int temp);
 #endif
 
 void reset_acceleration_rates();

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2314,7 +2314,7 @@ static void lcd_menu_AutoLoadFilament()
 static void preheat_or_continue()
 {
     bFilamentFirstRun = false;
-    if (target_temperature[0] >= EXTRUDE_MINTEMP)
+    if (target_temperature[0] >= extrude_min_temp)
     {
         bFilamentPreheatState = true;
         mFilamentItem(target_temperature[0], target_temperature_bed);
@@ -2447,7 +2447,7 @@ static void _lcd_move(const char *name, uint8_t axis, int min, int max)
 
 void lcd_move_e()
 {
-	if (degHotend0() > EXTRUDE_MINTEMP)
+	if (degHotend0() > extrude_min_temp)
 	{
 		if (lcd_encoder != 0)
 		{
@@ -5561,7 +5561,7 @@ static void mmu_cut_filament_menu()
     {
         eFilamentAction=FilamentAction::MmuCut;
         bFilamentFirstRun=false;
-        if(target_temperature[0]>=EXTRUDE_MINTEMP)
+        if(target_temperature[0] >= extrude_min_temp)
         {
             bFilamentPreheatState=true;
             mFilamentItem(target_temperature[0],target_temperature_bed);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2447,7 +2447,7 @@ static void _lcd_move(const char *name, uint8_t axis, int min, int max)
 
 void lcd_move_e()
 {
-	if (degHotend0() > extrude_min_temp)
+	if ((int)degHotend0() > extrude_min_temp)
 	{
 		if (lcd_encoder != 0)
 		{


### PR DESCRIPTION
Everywhere MINTEMP is checked, use the configurable value set
by M302, not an hardcoded value. As mentioned in #2577, I hit this a couple of times.

EXTRUDE_MINTEMP is now used only as the initial default value.

Reduce the precision of extrude_min_temp to an integer to reduce the
generated code size (constant folding did in fact do the same previously
anyway). Having tenths of degrees is not necessary for this feature.

This is based on the previous version by @leptun in https://github.com/leptun/Prusa-Firmware/tree/MK3-cold_extrude (and the above is the reason why  it generated significantly larger code).

The new code though is still 83 bytes larger. I didn't check if this is due to the extra reads and/or some extra manual casts could help us get down further.

This fixes #2577
