### PR TITLE
Include missing "re" module for elf_mem_map

### DIFF
--- a/tools/elf_mem_map
+++ b/tools/elf_mem_map
@@ -5,6 +5,7 @@ import elftools.dwarf.descriptions
 from collections import namedtuple
 from struct import unpack
 import os
+import re
 
 from lib.dump import decode_dump
 from lib.avr import *


### PR DESCRIPTION
"re" is required by the --qdirstat flag, and has been incorrectly
removed.