### PR TITLE
Add support for datamatrix ID

### DIFF
--- a/Firmware/eeprom.h
+++ b/Firmware/eeprom.h
@@ -334,6 +334,7 @@ static_assert(sizeof(Sheets) == EEPROM_SHEETS_SIZEOF, "Sizeof(Sheets) is not EEP
 | ^					| ^			| ^										| 03h 3			| ^						| bad_isr											| ^				| ^
 | ^					| ^			| ^										| 04h 4			| ^						| bad_pullup_temp_isr								| ^				| ^
 | ^					| ^			| ^										| 05h 5			| ^						| bad_pullup_step_isr								| ^				| ^
+| 0x0CEA 3307		| char[25]	| EEPROM_PRUSA_DM						| DM[24] == 0	| ffffffffffffffff...	| PRUSA Datamatrix ID string						| PRUSA DM		| D3 Ax0cea C1
 
 | Address begin		| Bit/Type 	| Name 									| Valid values	| Default/FactoryReset	| Description 										| Gcode/Function| Debug code
 | :--:				| :--: 		| :--: 									| :--:			| :--:					| :--:												| :--:			| :--:
@@ -550,8 +551,11 @@ static Sheets * const EEPROM_Sheets_base = (Sheets*)(EEPROM_SHEETS_BASE);
 #define EEPROM_ECOOL_ENABLE (EEPROM_JOB_ID-1) // uint8_t
 #define EEPROM_FW_CRASH_FLAG (EEPROM_ECOOL_ENABLE-1) // uint8_t
 
+#define EEPROM_PRUSA_DM (EEPROM_FW_CRASH_FLAG-25) // char[25]
+
+
 //This is supposed to point to last item to allow EEPROM overrun check. Please update when adding new items.
-#define EEPROM_LAST_ITEM EEPROM_FW_CRASH_FLAG
+#define EEPROM_LAST_ITEM EEPROM_PRUSA_DM
 // !!!!!
 // !!!!! this is end of EEPROM section ... all updates MUST BE inserted before this mark !!!!!
 // !!!!!

--- a/Firmware/pins_Einsy_1_0.h
+++ b/Firmware/pins_Einsy_1_0.h
@@ -15,7 +15,7 @@
 #define AMBIENT_THERMISTOR
 #define PINDA_THERMISTOR
 
-#define PRUSA_SN_SUPPORT //enables the "PRUSA SN" command and 32u2 enhanced firmware support
+#define PRUSA_32u2_ENHANCED_FW //enables the 32u2 enhanced firmware support ("PRUSA SN" and "PRUSA DM" commands)
 
 #define XFLASH                 // external 256kB flash
 #define BOOTAPP                  // bootloader support

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -8232,14 +8232,19 @@ bool FarmOrUserECool(){
     return farm_mode || UserECoolEnabled();
 }
 
-#ifdef PRUSA_SN_SUPPORT
-void WorkaroundPrusaSN() {
+#ifdef PRUSA_32u2_ENHANCED_FW
+void WorkaroundPrusa32u2() {
     const char *SN = PSTR("CZPXInvalidSerialNr");
     for (uint8_t i = 0; i < 20; i++) {
         eeprom_update_byte((uint8_t*)EEPROM_PRUSA_SN + i, pgm_read_byte(SN++));
     }
+    
+    const char *DM = PSTR("AAAA-invalidDatamatrixID");
+    for (uint8_t i = 0; i < 25; i++) {
+        eeprom_update_byte((uint8_t*)EEPROM_PRUSA_DM + i, pgm_read_byte(DM++));
+    }
 }
-#endif //PRUSA_SN_SUPPORT
+#endif //PRUSA_32u2_ENHANCED_FW
 
 void lcd_experimental_menu()
 {
@@ -8258,9 +8263,9 @@ void lcd_experimental_menu()
     MENU_ITEM_FUNCTION_P(_N("Test Pullup Crash"), TestPullupCrash);
 #endif // DEBUG_PULLUP_CRASH
     
-#ifdef PRUSA_SN_SUPPORT
-    MENU_ITEM_FUNCTION_P(_N("Fake serial number"), WorkaroundPrusaSN);////MSG_WORKAROUND_PRUSA_SN c=18
-#endif //PRUSA_SN_SUPPORT
+#ifdef PRUSA_32u2_ENHANCED_FW
+    MENU_ITEM_FUNCTION_P(_N("Set invalid SN/DM"), WorkaroundPrusa32u2);////MSG_WORKAROUND_PRUSA_SN c=18
+#endif //PRUSA_32u2_ENHANCED_FW
     MENU_END();
 }
 


### PR DESCRIPTION
Datamatrix ID – 24 characters + NULL is save in eeprom at address 0x0CEA až 0x0D02