### PR TITLE
Fix a crash during file check when `CMDBUFFER_DEBUG` is defined

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -7784,6 +7784,11 @@ static bool check_file(const char* filename) {
 		card.sdprinting = true;
 		get_command();
 		result = check_commands();
+#ifdef CMDBUFFER_DEBUG
+		// Kick watchdog because the file check is very slow
+		// with the CMDBUFFER_DEBUG enabled
+		manage_heater();
+#endif // CMDBUFFER_DEBUG
 	}
 	
 	menu_progressbar_finish();


### PR DESCRIPTION
There is so much serial output during the file check that it can slow the file check enough to timeout the watchdog. But this is only an issue if `CMDBUFFER_DEBUG` is defined