### PR TITLE
SD menu fixes

### DIFF
--- a/Firmware/cardreader.cpp
+++ b/Firmware/cardreader.cpp
@@ -984,14 +984,11 @@ void CardReader::presort() {
 		}
 	}
 
-	lcd_update(2);
 	KEEPALIVE_STATE(NOT_BUSY);
 }
 
 void CardReader::flush_presort() {
-	if (sort_count > 0) {
-		sort_count = 0;
-	}
+	sort_count = 0;
 }
 
 #endif // SDCARD_SORT_ALPHA

--- a/Firmware/cardreader.cpp
+++ b/Firmware/cardreader.cpp
@@ -779,7 +779,15 @@ void CardReader::getfilename_sorted(const uint16_t nr, uint8_t sdSort) {
     if (nr < sort_count)
         getfilename_simple(sort_entries[(sdSort == SD_SORT_ALPHA) ? (sort_count - nr - 1) : nr]);
     else
-        getfilename(nr);
+        getfilename_afterMaxSorting(nr);
+}
+
+void CardReader::getfilename_afterMaxSorting(uint16_t entry, const char * const match/*=NULL*/)
+{
+	curDir = &workDir;
+	nrFiles = entry - sort_count + 1;
+	curDir->seekSet(lastSortedFilePosition << 5);
+	lsDive("", *curDir, match, LS_GetFilename);
 }
 
 /**
@@ -830,6 +838,7 @@ void CardReader::presort() {
 			LongTimer sortingSpeedtestTimer;
 			sortingSpeedtestTimer.start();
 #endif //SORTING_SPEEDTEST
+			lastSortedFilePosition = position >> 5;
 
 			// By default re-read the names from SD for every compare
 			// retaining only two filenames at a time. This is very
@@ -989,6 +998,7 @@ void CardReader::presort() {
 
 void CardReader::flush_presort() {
 	sort_count = 0;
+	lastSortedFilePosition = 0;
 }
 
 #endif // SDCARD_SORT_ALPHA

--- a/Firmware/cardreader.h
+++ b/Firmware/cardreader.h
@@ -64,6 +64,7 @@ public:
   #ifdef SDCARD_SORT_ALPHA
      void presort();
      void getfilename_sorted(const uint16_t nr, uint8_t sdSort);
+     void getfilename_afterMaxSorting(uint16_t entry, const char * const match = NULL);
   #endif
 
   FORCE_INLINE bool isFileOpen() { return file.isOpen(); }
@@ -98,8 +99,8 @@ public:
   int lastnr; //last number of the autostart;
 #ifdef SDCARD_SORT_ALPHA
   bool presort_flag;
-  char dir_names[MAX_DIR_DEPTH][9];
 #endif // SDCARD_SORT_ALPHA
+  char dir_names[MAX_DIR_DEPTH][9];
 private:
   SdFile root,*curDir,workDir,workDirParents[MAX_DIR_DEPTH];
   uint16_t workDirDepth;
@@ -108,6 +109,7 @@ private:
 #ifdef SDCARD_SORT_ALPHA
   uint16_t sort_count;        // Count of sorted items in the current directory
   uint16_t sort_entries[SDSORT_LIMIT];
+  uint16_t lastSortedFilePosition;
 
 #endif // SDCARD_SORT_ALPHA
 

--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -702,6 +702,7 @@ void lcd_update(uint8_t lcdDrawUpdateOverride)
 
 void lcd_update_enable(uint8_t enabled)
 {
+	// printf_P(PSTR("lcd_update_enable(%u -> %u)\n"), lcd_update_enabled, enabled);
 	if (lcd_update_enabled != enabled)
 	{
 		lcd_update_enabled = enabled;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -6396,6 +6396,7 @@ void lcd_sdcard_menu()
 			_md->fileCnt = card.getnrfilenames();
 			_md->sdSort = eeprom_read_byte((uint8_t*)EEPROM_SD_SORT);
 			_md->menuState = _standard;
+			_md->row = -1; // assume that no SD file/dir is currently selected. Once they are rendered, it will be changed to the correct row for the _scrolling state.
 		}
 		// FALLTHRU
 		case _standard: //normal menu structure.
@@ -6405,7 +6406,7 @@ void lcd_sdcard_menu()
 				_md->lcd_scrollTimer.start();
 				lcd_draw_update = 1;
 			}
-			if (_md->lcd_scrollTimer.expired(500) && (_md->row != -1)) //switch to the scrolling state on timeout if a file/dir is selected.
+			if ((lcd_draw_update == 0) && _md->lcd_scrollTimer.expired(500) && (_md->row != -1)) //switch to the scrolling state on timeout if a file/dir is selected.
 			{
 				_md->menuState = _scrolling;
 				_md->offset = 0;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -363,9 +363,10 @@ uint8_t menu_item_sddir(const char* str_fn, char* str_fnl)
 		if (menu_clicked && (lcd_encoder == menu_item))
 		{
 			menu_clicked = false;
-			lcd_update_enabled = 0;
+			lcd_consume_click();
+			lcd_update_enabled = false;
 			menu_action_sddirectory(str_fn);
-			lcd_update_enabled = 1;
+			lcd_update_enabled = true;
 			/* return */ menu_item_ret();
 			return 1;
 		}
@@ -384,8 +385,11 @@ static uint8_t menu_item_sdfile(const char* str_fn, char* str_fnl)
 		}
 		if (menu_clicked && (lcd_encoder == menu_item))
 		{
+			menu_clicked = false;
 			lcd_consume_click();
+			lcd_update_enabled = false;
 			menu_action_sdfile(str_fn);
+			lcd_update_enabled = true;
 			/* return */ menu_item_ret();
 			return 1;
 		}
@@ -6387,7 +6391,9 @@ void lcd_sdcard_menu()
 			if (card.presort_flag == true) //used to force resorting if sorting type is changed.
 			{
 				card.presort_flag = false;
+				lcd_update_enabled = false;
 				card.presort();
+				lcd_update_enabled = true;
 			}
 			_md->fileCnt = card.getnrfilenames();
 			_md->sdSort = eeprom_read_byte((uint8_t*)EEPROM_SD_SORT);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -367,8 +367,7 @@ uint8_t menu_item_sddir(const char* str_fn, char* str_fnl)
 			lcd_update_enabled = false;
 			menu_action_sddirectory(str_fn);
 			lcd_update_enabled = true;
-			/* return */ menu_item_ret();
-			return 1;
+			return menu_item_ret();
 		}
 	}
 	menu_item++;
@@ -390,8 +389,7 @@ static uint8_t menu_item_sdfile(const char* str_fn, char* str_fnl)
 			lcd_update_enabled = false;
 			menu_action_sdfile(str_fn);
 			lcd_update_enabled = true;
-			/* return */ menu_item_ret();
-			return 1;
+			return menu_item_ret();
 		}
 	}
 	menu_item++;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3131,8 +3131,6 @@ void lcd_show_fullscreen_message_and_wait_P(const char *msg)
 				if (msg_next == NULL) {
 					KEEPALIVE_STATE(IN_HANDLER);
 					lcd_set_custom_characters();
-					lcd_update_enable(true);
-					lcd_update(2);
 					return;
 				}
 				else {


### PR DESCRIPTION
This PR adds a significant boost to speed to folders where there are more than 100 files.
It also fixes a timing bug with the scrolling that could happen because of the slow rendering of the menu.