### PR TITLE
M300: do not set a default frequency if S is not set

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -7598,6 +7598,7 @@ Sigma_Exit:
       uint16_t beepS = code_seen('S') ? code_value() : 0;
       uint16_t beepP = code_seen('P') ? code_value() : 1000;
       #if BEEPER > 0
+      if (beepP > 0)
         Sound_MakeCustom(beepP,beepS,false);
       #endif
     }

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -7595,18 +7595,11 @@ Sigma_Exit:
     */
     case 300: // M300
     {
-      uint16_t beepS = code_seen('S') ? code_value() : 110;
+      uint16_t beepS = code_seen('S') ? code_value() : 0;
       uint16_t beepP = code_seen('P') ? code_value() : 1000;
-      if (beepS > 0)
-      {
-        #if BEEPER > 0
-          Sound_MakeCustom(beepP,beepS,false);
-        #endif
-      }
-      else
-      {
-        _delay(beepP);
-      }
+      #if BEEPER > 0
+        Sound_MakeCustom(beepP,beepS,false);
+      #endif
     }
     break;
     #endif // M300


### PR DESCRIPTION
Fallback to use the default HIGH value if a frequency has not been
specified.

This makes the tone of "M300" and "M300 P<x>" identical as a result.

Supersedes #3339