### PR TITLE
Fix crash due to recursion when printing a file is done

### DIFF
--- a/Firmware/cardreader.cpp
+++ b/Firmware/cardreader.cpp
@@ -1007,7 +1007,6 @@ void CardReader::flush_presort() {
 
 void CardReader::printingHasFinished()
 {
-    st_synchronize();
     if(file_subcall_ctr>0) //heading up to a parent file that called current as a procedure.
     {
       file.close();


### PR DESCRIPTION
The recursion could cause a crash

`manage_inactivity()` --> `get_command()` --> `card.printingHasFinished()` --> `st_synchronize()` --> `manage_inactivity()` (repeat)

Fixes #3549