### PR TITLE
Prevent re-entry in EOF command processing

### DIFF
--- a/Firmware/Dcodes.cpp
+++ b/Firmware/Dcodes.cpp
@@ -44,7 +44,7 @@ void print_hex_word(daddr_t val)
     print_hex_byte(val & 0xFF);
 }
 
-int parse_hex(char* hex, uint8_t* data, int count)
+int parse_hex(const char* hex, uint8_t* data, int count)
 {
 	int parsed = 0;
 	while (*hex)

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -4248,7 +4248,7 @@ void process_commands()
     */
 
     else if (code_seen_P(PSTR("M0")) || code_seen_P(PSTR("M1 "))) {// M0 and M1 - (Un)conditional stop - Wait for user button press on LCD
-        char *src = strchr_pointer + 2;
+        const char *src = strchr_pointer + 2;
         codenum = 0;
         bool hasP = false, hasS = false;
         if (code_seen('P')) {
@@ -5774,7 +5774,7 @@ eeprom_update_word((uint16_t*)EEPROM_NOZZLE_DIAMETER_uM,0xFFFF);
       }
       starpos = (strchr(strchr_pointer + 4,'*'));
 
-      char* namestartpos = (strchr(strchr_pointer + 4,'!'));   //find ! to indicate filename string start.
+      const char* namestartpos = (strchr(strchr_pointer + 4,'!'));   //find ! to indicate filename string start.
       if(namestartpos==NULL)
       {
         namestartpos=strchr_pointer + 4; //default name position, 4 letters after the M

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -5675,6 +5675,7 @@ eeprom_update_word((uint16_t*)EEPROM_NOZZLE_DIAMETER_uM,0xFFFF);
           {
               // A new print has started from scratch, reset stats
               failstats_reset_print();
+              sdpos_atomic = 0;
 #ifndef LA_NOCOMPAT
               la10c_reset();
 #endif
@@ -5802,6 +5803,7 @@ eeprom_update_word((uint16_t*)EEPROM_NOZZLE_DIAMETER_uM,0xFFFF);
             {
                 // A new print has started from scratch, reset stats
                 failstats_reset_print();
+                sdpos_atomic = 0;
 #ifndef LA_NOCOMPAT
                 la10c_reset();
 #endif

--- a/Firmware/cardreader.cpp
+++ b/Firmware/cardreader.cpp
@@ -1008,9 +1008,10 @@ void CardReader::flush_presort() {
 void CardReader::printingHasFinished()
 {
     st_synchronize();
+    file.close();
+
     if(file_subcall_ctr>0) //heading up to a parent file that called current as a procedure.
     {
-      file.close();
       file_subcall_ctr--;
       openFileReadFilteredGcode(filenames[file_subcall_ctr],true);
       setIndex(filespos[file_subcall_ctr]);
@@ -1018,8 +1019,6 @@ void CardReader::printingHasFinished()
     }
     else
     {
-      quickStop();
-      file.close();
       sdprinting = false;
       if(SD_FINISHED_STEPPERRELEASE)
       {

--- a/Firmware/cmdqueue.cpp
+++ b/Firmware/cmdqueue.cpp
@@ -534,7 +534,7 @@ void get_command()
     }
 
   #ifdef SDSUPPORT
-  if(!card.sdprinting || serial_count!=0){
+  if(!card.sdprinting || !card.isFileOpen() || serial_count!=0){
     // If there is a half filled buffer from serial line, wait until return before
     // continuing with the serial line.
      return;
@@ -631,6 +631,10 @@ void get_command()
       // cleared by printingHasFinished after peforming all remaining moves.
       if(!cmdqueue_calc_sd_length())
       {
+          // queue is complete, but before we process EOF commands prevent
+          // re-entry by disabling SD processing from any st_synchronize call
+          card.closefile();
+
           SERIAL_PROTOCOLLNRPGM(_n("Done printing file"));////MSG_FILE_PRINTED
           stoptime=_millis();
           char time[30];

--- a/Firmware/util.cpp
+++ b/Firmware/util.cpp
@@ -431,7 +431,7 @@ lcd_update_enable(true);           // display / status-line recovery
 #define GCODE_DELIMITER '"'
 #define ELLIPSIS "..."
 
-char* code_string(char* pStr,size_t* nLength)
+char* code_string(const char* pStr,size_t* nLength)
 {
 char* pStrBegin;
 char* pStrEnd;
@@ -444,11 +444,10 @@ pStrEnd=strchr(pStrBegin,GCODE_DELIMITER);
 if(!pStrEnd)
      return(NULL);
 *nLength=pStrEnd-pStrBegin;
-pStrBegin[*nLength] = '\0';
 return pStrBegin;
 }
 
-void printer_smodel_check(char* pStrPos)
+void printer_smodel_check(const char* pStrPos)
 {
 char* pResult;
 size_t nLength,nPrinterNameLength;
@@ -458,7 +457,7 @@ pResult = code_string(pStrPos,&nLength);
 
 if(pResult != NULL && nLength == nPrinterNameLength) {
      // Only compare them if the lengths match
-     if (strcmp_P(pResult, sPrinterName) == 0) return;
+     if (strncmp_P(pResult, sPrinterName, nLength) == 0) return;
 }
 
 switch(oCheckModel)

--- a/Firmware/util.h
+++ b/Firmware/util.h
@@ -104,7 +104,7 @@ extern ClCheckGcode oCheckGcode;
 void fCheckModeInit();
 void nozzle_diameter_check(uint16_t nDiameter);
 void printer_model_check(uint16_t nPrinterModel);
-void printer_smodel_check(char* pStrPos);
+void printer_smodel_check(const char* pStrPos);
 void fw_version_check(const char *pVersion);
 void gcode_level_check(uint16_t nGcodeLevel);
 


### PR DESCRIPTION
cmdqueue will run commands when EOF is reached without returning to the
main loop, which is already incorrect.

However, since it needs to ensure the queue is empty, an st_synchronize
call can result in a re-entrant call to get_command, which will
reprocess EOF again. Even if we removed st_synchronize, another command
could be picked by an unsuspecting manage_inactivity() somewhere else.

Short-circuit EOF processing by clearing card.sdprinting immediately.
This is safe to do, since it's already done by printingHasFinished()
called a few lines down. We're just doing this earlier.

This should fix #3549