### PR TITLE
Show firmware version on splash screen

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -798,7 +798,7 @@ int uart_putchar(char c, FILE *)
 void lcd_splash()
 {
 	lcd_clear(); // clears display and homes screen
-	lcd_puts_P(PSTR("\n Original Prusa i3\n   Prusa Research"));
+	lcd_printf_P(PSTR("\n Original Prusa i3\n   Prusa Research\n%20.20S"), PSTR(FW_VERSION));
 }
 
 


### PR DESCRIPTION
Closes #3553 

The message is right aligned on the last line of the splash screen. It's the shorter variant where only the flavor is included (eg: "3.11.1-RC", so no commit number here)

https://photos.app.goo.gl/JKVee4jkvd5BFtxY7