### PR TITLE
Filament loading state fixes

### DIFF
--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -278,7 +278,6 @@ extern uint32_t start_pause_print; // milliseconds
 extern ShortTimer usb_timer;
 extern bool processing_tcode;
 extern bool homing_flag;
-extern bool loading_flag;
 extern uint32_t total_filament_used; // mm/100 or 10um
 
 /// @brief Save print statistics to EEPROM

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -179,7 +179,6 @@ bool mesh_bed_leveling_flag = false;
 
 uint32_t total_filament_used;
 HeatingStatus heating_status;
-bool loading_flag = false;
 int fan_edge_counter[2];
 int fan_speed[2];
 
@@ -3579,13 +3578,12 @@ void gcode_M701(float fastLoadLength, uint8_t mmuSlotIndex){
 
         Sound_MakeCustom(50, 500, false);
 
-        if (!farm_mode && loading_flag) {
+        if (!farm_mode && (eFilamentAction != FilamentAction::None)) {
             lcd_load_filament_color_check();
         }
         lcd_update_enable(true);
         lcd_update(2);
         lcd_setstatuspgm(MSG_WELCOME);
-        loading_flag = false;
         custom_message_type = CustomMsg::Status;
     }
 

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -513,9 +513,8 @@ bool __attribute__((noinline)) printJobOngoing() {
 bool __attribute__((noinline)) printer_active() {
     return printJobOngoing()
         || isPrintPaused
-        || (custom_message_type == CustomMsg::TempCal)
         || saved_printing
-        || (lcd_commands_type == LcdCommands::Layer1Cal)
+        || (lcd_commands_type != LcdCommands::Idle)
         || MMU2::mmu2.MMU_PRINT_SAVED()
         || homing_flag
         || mesh_bed_leveling_flag;

--- a/Firmware/Prusa_farm.cpp
+++ b/Firmware/Prusa_farm.cpp
@@ -242,7 +242,7 @@ void prusa_statistics(uint8_t _message) {
         else if (isPrintPaused) {
             prusa_statistics_case0(14);
         }
-        else if (IS_SD_PRINTING || loading_flag) {
+        else if (IS_SD_PRINTING || (eFilamentAction != FilamentAction::None)) {
             prusa_statistics_case0(4);
         }
         else {
@@ -270,7 +270,7 @@ void prusa_statistics(uint8_t _message) {
         status_number = 3;
         farm_timer = 1;
 
-        if (IS_SD_PRINTING || loading_flag) {
+        if (IS_SD_PRINTING || (eFilamentAction != FilamentAction::None)) {
             SERIAL_ECHO('{');
             prusa_stat_printerstatus(4);
             prusa_stat_farm_number();
@@ -374,7 +374,7 @@ void prusa_statistics_update_from_status_screen() {
         switch (farm_timer) {
         case 8:
             prusa_statistics(21);
-            if(loading_flag)
+            if(eFilamentAction != FilamentAction::None)
                 prusa_statistics(22);
             break;
         case 5:

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5212,7 +5212,7 @@ static void lcd_main_menu()
         }
     }
 
-    if ( ! ( printJobOngoing() || (lcd_commands_type != LcdCommands::Idle) || Stopped) ) {
+    if ( ! ( printJobOngoing() || (lcd_commands_type != LcdCommands::Idle) || loading_flag || Stopped ) ) {
         if (MMU2::mmu2.Enabled()) {
             if(!MMU2::mmu2.FindaDetectsFilament() && !fsensor.getFilamentPresent()) {
                 // The MMU 'Load filament' state machine will reject the command if any 

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -6917,7 +6917,8 @@ static bool check_file(const char* filename) {
 
 static void menu_action_sdfile(const char* filename)
 {
-  loading_flag = false;
+  if(loading_flag) return;
+
   char cmd[30];
   char* c;
   bool result = true;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1867,7 +1867,10 @@ void mFilamentItem(uint16_t nTemp, uint16_t nTempBed)
                     if (eFilamentAction == FilamentAction::AutoLoad) eFilamentAction = FilamentAction::None; // i.e. non-autoLoad
                 }
                 if (eFilamentAction == FilamentAction::UnLoad)
-                enquecommand_P(MSG_M702); // unload filament
+                {
+                    loading_flag = true;
+                    enquecommand_P(MSG_M702); // unload filament
+                }
             }
             break;
         case FilamentAction::MmuLoad:
@@ -4886,6 +4889,7 @@ void unload_filament(float unloadLength)
 	lcd_setstatuspgm(MSG_WELCOME);
 	custom_message_type = CustomMsg::Status;
 	eFilamentAction = FilamentAction::None;
+	loading_flag = false;
 }
 
 /// @brief Set print fan speed

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5179,9 +5179,9 @@ static void lcd_main_menu()
     }
 #endif
 #ifdef SDSUPPORT //!@todo SDSUPPORT undefined creates several issues in source code
-    if (card.cardOK || lcd_commands_type == LcdCommands::Layer1Cal) {
+    if (card.cardOK || lcd_commands_type != LcdCommands::Idle) {
         if (!card.isFileOpen()) {
-            if (!usb_timer.running() && (lcd_commands_type != LcdCommands::Layer1Cal)) {
+            if (!usb_timer.running() && (lcd_commands_type == LcdCommands::Idle)) {
                 bMain=true;               // flag ('fake parameter') for 'lcd_sdcard_menu()' function
                 MENU_ITEM_SUBMENU_P(_T(MSG_CARD_MENU), lcd_sdcard_menu);
             }
@@ -5198,7 +5198,7 @@ static void lcd_main_menu()
     }
 #endif //SDSUPPORT
 
-    if(!isPrintPaused && !printJobOngoing() && (lcd_commands_type != LcdCommands::Layer1Cal)) {
+    if(!isPrintPaused && !printJobOngoing() && (lcd_commands_type == LcdCommands::Idle)) {
         if (!farm_mode) {
             const int8_t sheet = eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet));
             const int8_t nextSheet = eeprom_next_initialized_sheet(sheet);
@@ -5208,7 +5208,7 @@ static void lcd_main_menu()
         }
     }
 
-    if ( ! ( printJobOngoing() || (lcd_commands_type == LcdCommands::Layer1Cal || Stopped) ) ) {
+    if ( ! ( printJobOngoing() || (lcd_commands_type != LcdCommands::Idle) || Stopped) ) {
         if (MMU2::mmu2.Enabled()) {
             if(!MMU2::mmu2.FindaDetectsFilament() && !fsensor.getFilamentPresent()) {
                 // The MMU 'Load filament' state machine will reject the command if any 
@@ -5239,7 +5239,7 @@ static void lcd_main_menu()
     if(!isPrintPaused) MENU_ITEM_SUBMENU_P(_T(MSG_CALIBRATION), lcd_calibration_menu);
     }
 
-    if (!usb_timer.running() && (lcd_commands_type != LcdCommands::Layer1Cal)) {
+    if (!usb_timer.running() && (lcd_commands_type == LcdCommands::Idle)) {
         MENU_ITEM_SUBMENU_P(_i("Statistics"), lcd_menu_statistics);////MSG_STATISTICS c=18
     }
 

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -175,17 +175,17 @@ void lcd_hw_setup_menu(void);                     // NOT static due to using ins
 
 enum class FilamentAction : uint_least8_t
 {
-    None, //!< 'none' state is used as flag for (filament) autoLoad (i.e. opposite for 'autoLoad' state)
+    None, // no filament action is taking place
     Load,
-    AutoLoad,
+    AutoLoad, // triggered by insertion, cancellable until it transitions to Load
     UnLoad,
     MmuLoad,
     MmuUnLoad,
     MmuEject,
     MmuCut,
     MmuLoadingTest,
-    Preheat,
-    Lay1Cal,
+    Preheat, // triggered by preheat (cancellable)
+    Lay1Cal, // triggered by 1st layer calibration (cancellable)
 };
 
 extern FilamentAction eFilamentAction;


### PR DESCRIPTION
There are some issues in the management of "filament autoloading" when the printer is idle. Because the autoloading is performed asynchronously, we need to ensure incompatible actions are disabled while loading is taking place.

With this PR we make impossible to perform another autoload/unload/filament action when one is already taking place (the autoload/load/unload menus are now hidden while autoloading is taking place).

To do so we check for the loading_flag. This was previously done for loading only, but doing so for unload makes the behavior uniform (#2318 performs more than a single move and is also non-blocking - you shouldn't load while the old unload is still pending).

Using bFilamentState flag would have been a little bit cleaner here (removing the need for loading_flag), but it's currently used both as a flag for autoload and also for the autoload state...

We also now prevent to start an SD print while autoload is taking place (fixes https://github.com/prusa3d/Prusa-Firmware/issues/2651). You can still navigate the SD card when waiting, but clicking on the file will just beep (see my comments on b0561a0aa1ba757b6e442c17995f17fc4e969d2c)

As a side note, in the first commit, we change PRINTER_ACTIVE to consider any custom command to be non-idle, which is logical. All custom commands are incompatible with each other, and will return the printer to Idle when complete (LongPause included). Checking for Layer1Cal in the main menu is simply incorrect.

Change in memory (MK3S+ Multilang):
Flash: -8 bytes
SRAM: -1 byte