### PR TITLE
Do not prompt on M115 if FW version check has been disabled

### DIFF
--- a/Firmware/util.cpp
+++ b/Firmware/util.cpp
@@ -187,6 +187,9 @@ bool force_selftest_if_fw_version()
 
 bool show_upgrade_dialog_if_version_newer(const char *version_string)
 {
+    if(oCheckVersion == ClCheckVersion::_None)
+        return false;
+
     int8_t upgrade = is_provided_version_newer(version_string);
     if (upgrade < 0)
         return false;


### PR DESCRIPTION
As done for M862.4, do now show an upgrade prompt if FW version check as
been disabled in the Settings -> HW Setup -> Checks menu.