### PR TITLE
Fix "Card removed" on startup

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -7863,6 +7863,7 @@ void ultralcd_init()
 #if defined (SDSUPPORT) && defined(SDCARDDETECT) && (SDCARDDETECT > 0)
   SET_INPUT(SDCARDDETECT);
   WRITE(SDCARDDETECT, HIGH);
+  _delay_ms(1); //wait for the pullups to raise the line
   lcd_oldcardstatus = IS_SD_INSERTED;
 #endif//(SDCARDDETECT > 0)
   lcd_encoder_diff = 0;


### PR DESCRIPTION
Allow the SDCARDDETECT line to be raised by the pullups before sampling it for the first time. The chosen delay is arbitrary and worked on a problematic printer I had around.