### PR TITLE
Optimisation: `workDirDepth` can be one byte

### DIFF
--- a/Firmware/cardreader.cpp
+++ b/Firmware/cardreader.cpp
@@ -290,7 +290,7 @@ void CardReader::getDirName(char* name, uint8_t level)
 		workDirParents[level].getFilename(name);
 }
 
-uint16_t CardReader::getWorkDirDepth() {
+uint8_t CardReader::getWorkDirDepth() {
 	return workDirDepth;
 }
 
@@ -738,7 +738,7 @@ bool CardReader::chdir(const char * relpath, bool doPresort)
     puts(relpath);
 
     if (workDirDepth < MAX_DIR_DEPTH) {
-      for (int d = ++workDirDepth; d--;)
+      for (uint8_t d = ++workDirDepth; d--;)
         workDirParents[d+1] = workDirParents[d];
       workDirParents[0]=*parent;
     }
@@ -760,7 +760,7 @@ void CardReader::updir()
   {
     --workDirDepth;
     workDir = workDirParents[0];
-    for (unsigned int d = 0; d < workDirDepth; d++)
+    for (uint8_t d = 0; d < workDirDepth; d++)
     {
         workDirParents[d] = workDirParents[d+1];
     }

--- a/Firmware/cardreader.h
+++ b/Firmware/cardreader.h
@@ -53,7 +53,7 @@ public:
   void getAbsFilename(char *t);
   void printAbsFilenameFast();
   void getDirName(char* name, uint8_t level);
-  uint16_t getWorkDirDepth();
+  uint8_t getWorkDirDepth();
   
 
   void ls(ls_param params);
@@ -103,7 +103,7 @@ public:
   char dir_names[MAX_DIR_DEPTH][9];
 private:
   SdFile root,*curDir,workDir,workDirParents[MAX_DIR_DEPTH];
-  uint16_t workDirDepth;
+  uint8_t workDirDepth;
 
   // Sort files and folders alphabetically.
 #ifdef SDCARD_SORT_ALPHA

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -7857,7 +7857,7 @@ static void menu_action_sdfile(const char* filename)
 	  }
   }
 
-  uint8_t depth = (uint8_t)card.getWorkDirDepth();
+  uint8_t depth = card.getWorkDirDepth();
   eeprom_write_byte((uint8_t*)EEPROM_DIR_DEPTH, depth);
 
   for (uint_least8_t i = 0; i < depth; i++) {


### PR DESCRIPTION
We set the max working directory depth to 6 (see `MAX_DIR_DEPTH`)

Changes save 1 byte of SRAM and 50 bytes of flash