### PR TITLE
Don't include M851 in build if Auto Bed Leveling is not enabled

### DIFF
--- a/Firmware/Configuration.h
+++ b/Firmware/Configuration.h
@@ -444,10 +444,12 @@ your extruder heater takes 2 minutes to hit the target on heating.
 // Custom M code points
 #define CUSTOM_M_CODES
 #ifdef CUSTOM_M_CODES
+#ifdef ENABLE_AUTO_BED_LEVELING
   #define CUSTOM_M_CODE_SET_Z_PROBE_OFFSET 851
   #define Z_PROBE_OFFSET_RANGE_MIN -15
   #define Z_PROBE_OFFSET_RANGE_MAX -5
-#endif
+#endif // ENABLE_AUTO_BED_LEVELING
+#endif // CUSTOM_M_CODES
 
 
 // EEPROM

--- a/Firmware/ConfigurationStore.h
+++ b/Firmware/ConfigurationStore.h
@@ -19,7 +19,7 @@ typedef struct
     unsigned long minsegmenttime;
     float max_jerk[4]; //!< Jerk is a maximum immediate velocity change.
     float add_homing[3];
-    float zprobe_zoffset;
+    float zprobe_zoffset; //!< Only used with define ENABLE_AUTO_BED_LEVELING
     float Kp;
     float Ki;
     float Kd;

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -7930,6 +7930,7 @@ Sigma_Exit:
     break;
     #endif
 
+#ifdef ENABLE_AUTO_BED_LEVELING
 	/*!
 	### M851 - Set Z-Probe Offset <a href="https://reprap.org/wiki/G-code#M851:_Set_Z-Probe_Offset">M851: Set Z-Probe Offset"</a>
     Sets the Z-probe Z offset. This offset is used to determine the actual Z position of the nozzle when using a probe to home Z with G28. This value may also be used by G81 (Prusa) / G29 (Marlin) to apply correction to the Z position.
@@ -7976,6 +7977,7 @@ Sigma_Exit:
       break;
     }
     #endif // CUSTOM_M_CODE_SET_Z_PROBE_OFFSET
+#endif // ENABLE_AUTO_BED_LEVELING
 
 	/*!
 	### M552 - Set IP address <a href="https://reprap.org/wiki/G-code#M552:_Set_IP_address.2C_enable.2Fdisable_network_interface">M552: Set IP address, enable/disable network interface"</a>

--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -181,7 +181,9 @@ const char MSG_WATCHDOG_RESET[] PROGMEM_N1 = " Watchdog Reset"; ////
 const char MSG_Z_MAX[] PROGMEM_N1 = "z_max: "; ////
 const char MSG_Z_MIN[] PROGMEM_N1 = "z_min: "; ////
 const char MSG_ZPROBE_OUT[] PROGMEM_N1 = "Z probe out. bed"; ////
+#ifdef ENABLE_AUTO_BED_LEVELING
 const char MSG_ZPROBE_ZOFFSET[] PROGMEM_N1 = "Z Offset"; ////
+#endif
 const char MSG_TMC_OVERTEMP[] PROGMEM_N1 = "TMC DRIVER OVERTEMP"; ////
 const char MSG_Enqueing[] PROGMEM_N1 = "enqueing \""; ////
 const char MSG_ENDSTOPS_HIT[] PROGMEM_N1 = "endstops hit: "; ////

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -184,7 +184,9 @@ extern const char MSG_WATCHDOG_RESET[];
 extern const char MSG_Z_MAX[];
 extern const char MSG_Z_MIN[];
 extern const char MSG_ZPROBE_OUT[];
+#ifdef ENABLE_AUTO_BED_LEVELING
 extern const char MSG_ZPROBE_ZOFFSET[];
+#endif
 extern const char MSG_TMC_OVERTEMP[];
 extern const char MSG_Enqueing[];
 extern const char MSG_ENDSTOPS_HIT[];


### PR DESCRIPTION
The variable `cs.zprobe_zoffset` is not used unless
auto bed leveling is enabled

This reduces flash usage by 270 bytes. No change in SRAM.