### PR TITLE
Add ability to stop print *fast* remotely, just like via LCD.

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -8133,6 +8133,7 @@ Sigma_Exit:
 
     /*!
     ### M603 - Stop print <a href="https://reprap.org/wiki/G-code#M603:_Stop_print">M603: Stop print</a>
+    It is processed much earlier as to bypass the cmdqueue.
     */
     case 603: {
         lcd_print_stop();

--- a/Firmware/cmdqueue.cpp
+++ b/Firmware/cmdqueue.cpp
@@ -476,10 +476,10 @@ void get_command()
             return;
         }
         // Handle KILL early, even when Stopped
-        if(strcmp(cmdbuffer+bufindw+CMDHDRSIZE, "M112") == 0)
+        if(strcmp_P(cmdbuffer+bufindw+CMDHDRSIZE, PSTR("M112")) == 0)
           kill(MSG_M112_KILL, 2);
         // Stop print
-        if (strcmp(cmdbuffer+bufindw+CMDHDRSIZE, "M603") == 0)
+        else if (strcmp_P(cmdbuffer+bufindw+CMDHDRSIZE, PSTR("M603")) == 0)
           lcd_print_stop();
         // Handle the USB timer
         if ((strchr_pointer = strchr(cmdbuffer+bufindw+CMDHDRSIZE, 'G')) != NULL) {

--- a/Firmware/cmdqueue.cpp
+++ b/Firmware/cmdqueue.cpp
@@ -478,6 +478,9 @@ void get_command()
         // Handle KILL early, even when Stopped
         if(strcmp(cmdbuffer+bufindw+CMDHDRSIZE, "M112") == 0)
           kill(MSG_M112_KILL, 2);
+        // Stop print
+        if (strcmp(cmdbuffer+bufindw+CMDHDRSIZE, "M603") == 0)
+          lcd_print_stop();
         // Handle the USB timer
         if ((strchr_pointer = strchr(cmdbuffer+bufindw+CMDHDRSIZE, 'G')) != NULL) {
             if (!IS_SD_PRINTING) {


### PR DESCRIPTION
Add ability to stop print fast remotely, just like via LCD.
Currently when sitting next to printer it is possible
to stop print immediately by choosing "Stop print"
option on LCD.

When monitoring printer remotely and having a need to stop
print immediately there is no such possibility at all.
M603 which stops the print is pushed into planner and executed
way too late to be useful.

So far the only methods to stop print were 1) to disconnect
from serial and reconnect causing reset, 2) reset via command
;C2560_RES, 3) issue emergency M112 (which is processed early)

**This change adds M603 (stop the print) command to be processed
early, too.**

For this to be useful with OctoPrint (without hacks) EMERGENCY_PARSER
capability needs to be implemented which is also done.
