### PR TITLE
PSU_DELTA alternative

### DIFF
--- a/Firmware/tmc2130.cpp
+++ b/Firmware/tmc2130.cpp
@@ -12,6 +12,7 @@
 
 #define TMC2130_GCONF_NORMAL 0x00000000 // spreadCycle
 #define TMC2130_GCONF_SGSENS 0x00000180 // spreadCycle with stallguard (stall activates DIAG0 and DIAG1 [open collector])
+#define TMC2130_GCONF_DYNAMIC_SGSENS 0x00000184 // stealthChop/spreadCycle (dynamic) with stallguard (stall activates DIAG0 and DIAG1 [open collector])
 #define TMC2130_GCONF_SILENT 0x00000004 // stealthChop
 
 
@@ -182,9 +183,9 @@ void tmc2130_init(TMCInitParams params)
 #else //TMC2130_STEALTH_Z
 		tmc2130_wr(axis, TMC2130_REG_COOLCONF, (((uint32_t)tmc2130_sg_thr[axis]) << 16) | ((uint32_t)1 << 24));
 		tmc2130_wr(axis, TMC2130_REG_TCOOLTHRS, (tmc2130_mode == TMC2130_MODE_SILENT)?0:__tcoolthrs(axis));
-		tmc2130_wr(axis, TMC2130_REG_GCONF, (tmc2130_mode == TMC2130_MODE_SILENT)?TMC2130_GCONF_SILENT:TMC2130_GCONF_SGSENS);
+		tmc2130_wr(axis, TMC2130_REG_GCONF, (tmc2130_mode == TMC2130_MODE_SILENT)?TMC2130_GCONF_SILENT:TMC2130_GCONF_DYNAMIC_SGSENS);
 		tmc2130_wr_PWMCONF(axis, tmc2130_pwm_ampl[axis], tmc2130_pwm_grad[axis], tmc2130_pwm_freq[axis], tmc2130_pwm_auto[axis], 0, 0);
-		tmc2130_wr_TPWMTHRS(axis, TMC2130_TPWMTHRS);
+		tmc2130_wr_TPWMTHRS(axis, (tmc2130_mode == TMC2130_MODE_SILENT)?0:0xFFFF0);
 #endif //TMC2130_STEALTH_Z
 	}
 	for (uint_least8_t axis = 3; axis < 4; axis++) // E axis

--- a/Firmware/variants/1_75mm_MK3S-EINSy10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK3S-EINSy10a-E3Dv6full.h
@@ -28,7 +28,7 @@
 #define HAS_SECOND_SERIAL_PORT
 
 // PSU
-#define PSU_Delta                                 // uncomment if DeltaElectronics PSU installed
+// #define PSU_Delta                                 // uncomment if DeltaElectronics PSU installed
 
 
 // Uncomment the below for the E3D PT100 temperature sensor (with or without PT100 Amplifier)


### PR DESCRIPTION
This PR is an alternative proposal to the infamous PSU_DELTA code.

The idea behind PSU_DELTA was to automatically switch the Z motors to stealthchop when these motors were supposedly unused. This was because the PSU_DELTA has more noise on the 24V rail, causing any active stepper to create high pitched noise.

In practice, that had quite a few issues:
- not only the Z motor got switched to stealthchop when idle/"disabled", but also all the other steppers. As a result, the conservative motion profile got applied automatically to all steppers as soon as the Z went silent. Even more annoyingly, the only way to get the other steppers to the correct mode was to move the Z motor by any distance (effectively "enabling" the stepper, switching all the other ones to the correct mode as well).
- As you might have noticed in my point above, I put quotation marks around enabled and disabled. That's because the PSU_DELTA code would hijack the enable and disable macros in marlin to do the mode switching. This was a poor choice in my opinion since these sometimes get called from stupid places such as the babystepping in the temperature isr (if that is still there). @wavexx knows what I'm talking about (from the mystery crashing printer). The problem is that these functions access the SPI bus without regarding that the bus could be busy from the main context.
- The PSU_DELTA code is a mess. Trying to read it made my head hurt.

My approach:
Instead of manually toggling the mode (in stupid ways), why not just let the Z driver do that on it's own? This is what I attempt to do in this PR. In stealth mode, the Z motor is always in stealthchop mode. However, in normal mode the driver is configured so that if the velocity is above standstill, it switches to spreadcycle, otherwise stay in stealthchop.

flash: -202
RAM: -1

PFW-1455