### PR TITLE
Allow to keep model checking enabled during autotuning

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -7764,7 +7764,7 @@ Sigma_Exit:
     #### Usage
 
         M310                                           ; report values
-        M310 [ A ]                                     ; autotune
+        M310 [ A ] [ F ]                               ; autotune
         M310 [ S ]                                     ; set 0=disable 1=enable
         M310 [ I ] [ R ]                               ; set resistance at index
         M310 [ P | C ]                                 ; set power, capacitance
@@ -7782,12 +7782,13 @@ Sigma_Exit:
     - `W` - warning threshold (K/s; default in variant)
     - `T` - ambient temperature correction (K; default in variant)
     - `A` - autotune C+R values
+    - `F` - force model self-test state (0=off 1=on) during autotune using current values
     */
     case 310:
     {
         // parse all parameters
         float P = NAN, C = NAN, R = NAN, E = NAN, W = NAN, T = NAN;
-        int8_t I = -1, S = -1, B = -1, A = -1;
+        int8_t I = -1, S = -1, B = -1, A = -1, F = -1;
         if(code_seen('C')) C = code_value();
         if(code_seen('P')) P = code_value();
         if(code_seen('I')) I = code_value_short();
@@ -7798,6 +7799,7 @@ Sigma_Exit:
         if(code_seen('W')) W = code_value();
         if(code_seen('T')) T = code_value();
         if(code_seen('A')) A = code_value_short();
+        if(code_seen('F')) F = code_value_short();
 
         // report values if nothing has been requested
         if(isnan(C) && isnan(P) && isnan(R) && isnan(E) && isnan(W) && isnan(T) && I < 0 && S < 0 && B < 0 && A < 0) {
@@ -7814,7 +7816,7 @@ Sigma_Exit:
         if(S >= 0) temp_model_set_enabled(S);
 
         // run autotune
-        if(A >= 0) temp_model_autotune(A);
+        if(A >= 0) temp_model_autotune(A, F > 0);
     }
     break;
 #endif

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -9201,13 +9201,13 @@ Sigma_Exit:
     ## D70 - Enable low-level temperature model logging for offline simulation
     #### Usage
 
-        D70 [ I ]
+        D70 [ S ]
 
     #### Parameters
-    - `I` - Enable 0-1 (default 0)
+    - `S` - Enable 0-1 (default 0)
     */
     case 70: {
-        if(code_seen('I'))
+        if(code_seen('S'))
             temp_model_log_enable(code_value_short());
         break;
     }

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -9955,6 +9955,8 @@ void ThermalStop(bool allow_pause)
         Stopped = true;
         if(allow_pause && (IS_SD_PRINTING || usb_timer.running())) {
             if (!isPrintPaused) {
+                lcd_setalertstatuspgm(_T(MSG_PAUSED_THERMAL_ERROR), LCD_STATUS_CRITICAL);
+
                 // we cannot make a distinction for the host here, the pause must be instantaneous
                 // so we call the lcd_pause_print to save the print state internally. Thermal errors
                 // disable heaters and save the original temperatures to saved_*, which will get

--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -159,9 +159,9 @@ const char MSG_IR_04_OR_NEWER[] PROGMEM_I1 = ISTR(" 0.4 or newer");////MSG_IR_04
 const char MSG_IR_03_OR_OLDER[] PROGMEM_I1 = ISTR(" 0.3 or older");////MSG_IR_03_OR_OLDER c=18
 const char MSG_IR_UNKNOWN[] PROGMEM_I1 = ISTR("unknown state");////MSG_IR_UNKNOWN c=18
 #endif
+extern const char MSG_PAUSED_THERMAL_ERROR[] PROGMEM_I1 = ISTR("PAUSED THERMAL ERROR");////c=20
 #ifdef TEMP_MODEL
 extern const char MSG_THERMAL_ANOMALY[] PROGMEM_I1 = ISTR("THERMAL ANOMALY");////c=20
-extern const char MSG_PAUSED_THERMAL_ERROR[] PROGMEM_I1 = ISTR("PAUSED THERMAL ERROR");////c=20
 #endif
 
 //not internationalized messages

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -168,9 +168,9 @@ extern const char MSG_IR_04_OR_NEWER[];
 extern const char MSG_IR_03_OR_OLDER[];
 extern const char MSG_IR_UNKNOWN[];
 #endif
+extern const char MSG_PAUSED_THERMAL_ERROR[];
 #ifdef TEMP_MODEL
 extern const char MSG_THERMAL_ANOMALY[];
-extern const char MSG_PAUSED_THERMAL_ERROR[];
 #endif
 
 //not internationalized messages

--- a/Firmware/temperature.cpp
+++ b/Firmware/temperature.cpp
@@ -2486,7 +2486,7 @@ void log_isr()
     if(!log_buf.enabled) return;
 
     uint32_t stamp = _millis();
-    uint8_t delta_ms = stamp - log_buf.entry.stamp - (TEMP_MGR_INTV * 1000);
+    uint8_t delta_ms = stamp - log_buf.entry.stamp - (uint32_t)(TEMP_MGR_INTV * 1000);
     log_buf.entry.stamp = stamp;
 
     ++log_buf.entry.counter;

--- a/Firmware/temperature.cpp
+++ b/Firmware/temperature.cpp
@@ -2315,7 +2315,8 @@ static void check_temp_raw()
 #ifdef TEMP_MODEL
 namespace temp_model {
 
-void model_data::reset(uint8_t heater_pwm, uint8_t fan_pwm, float heater_temp, float ambient_temp)
+void model_data::reset(uint8_t heater_pwm _UNUSED, uint8_t fan_pwm _UNUSED,
+    float heater_temp _UNUSED, float ambient_temp _UNUSED)
 {
     // pre-compute invariant values
     C_i = (TEMP_MGR_INTV / C);
@@ -2323,16 +2324,20 @@ void model_data::reset(uint8_t heater_pwm, uint8_t fan_pwm, float heater_temp, f
     err_s = err * TEMP_MGR_INTV;
 
     // initial values
-    memset(dT_lag_buf, 0, sizeof(dT_lag_buf));
+    for(uint8_t i = 0; i != TEMP_MODEL_LAG_SIZE; ++i)
+        dT_lag_buf[i] = NAN;
     dT_lag_idx = 0;
     dT_err_prev = 0;
-    T_prev = heater_temp;
-
-    // perform one step to initialize the first delta
-    step(heater_pwm, fan_pwm, heater_temp, ambient_temp);
+    T_prev = NAN;
 
     // clear the initialization flag
     flag_bits.uninitialized = false;
+}
+
+static constexpr float iir_mul(const float a, const float b, const float f, const float nanv)
+{
+    const float a_ = !isnan(a) ? a : nanv;
+    return (a_ * (1.f - f)) + (b * f);
 }
 
 void model_data::step(uint8_t heater_pwm, uint8_t fan_pwm, float heater_temp, float ambient_temp)
@@ -2353,13 +2358,13 @@ void model_data::step(uint8_t heater_pwm, uint8_t fan_pwm, float heater_temp, fl
     uint8_t dT_next_idx = (dT_lag_idx == (TEMP_MODEL_LAG_SIZE - 1) ? 0: dT_lag_idx + 1);
     float dT_lag = dT_lag_buf[dT_next_idx];
     float dT_lag_prev = dT_lag_buf[dT_lag_idx];
-    float dT_f = (dT_lag_prev * (1.f - TEMP_MODEL_fS)) + (dT * TEMP_MODEL_fS);
+    float dT_f = iir_mul(dT_lag_prev, dT, TEMP_MODEL_fS, dT);
     dT_lag_buf[dT_next_idx] = dT_f;
     dT_lag_idx = dT_next_idx;
 
     // calculate and filter dT_err
     float dT_err = (cur_heater_temp - T_prev) - dT_lag;
-    float dT_err_f = (dT_err_prev * (1.f - TEMP_MODEL_fE)) + (dT_err * TEMP_MODEL_fE);
+    float dT_err_f = iir_mul(dT_err_prev, dT_err, TEMP_MODEL_fE, 0.);
     T_prev = cur_heater_temp;
     dT_err_prev = dT_err_f;
 
@@ -2698,11 +2703,17 @@ static float cost_fn(uint16_t samples, float* const var, float v, uint8_t fan_pw
     *var = v;
     temp_model::data.reset(rec_buffer[0].pwm, fan_pwm, rec_buffer[0].temp, ambient);
     float err = 0;
+    uint16_t cnt = 0;
     for(uint16_t i = 1; i < samples; ++i) {
         temp_model::data.step(rec_buffer[i].pwm, fan_pwm, rec_buffer[i].temp, ambient);
-        err += fabsf(temp_model::data.dT_err_prev);
+        float err_v = temp_model::data.dT_err_prev;
+        if(!isnan(err_v)) {
+            err_v = fabsf(err_v);
+            err += err_v * err_v;
+            ++cnt;
+        }
     }
-    return (err / (samples - 1));
+    return cnt ? (err / cnt) : NAN;
 }
 
 constexpr float GOLDEN_RATIO = 0.6180339887498949;

--- a/Firmware/temperature.cpp
+++ b/Firmware/temperature.cpp
@@ -2716,7 +2716,6 @@ static float cost_fn(uint16_t samples, float* const var, float v, uint8_t fan_pw
         temp_model::data.step(rec_buffer[i].pwm, fan_pwm, rec_buffer[i].temp, ambient);
         float err_v = temp_model::data.dT_err_prev;
         if(!isnan(err_v)) {
-            err_v = fabsf(err_v);
             err += err_v * err_v;
             ++cnt;
         }

--- a/Firmware/temperature.cpp
+++ b/Firmware/temperature.cpp
@@ -1760,7 +1760,6 @@ void handle_temp_error()
     case TempErrorType::model:
         if(temp_error_state.assert) {
             if(IsStopped() == false) {
-                lcd_setalertstatuspgm(MSG_PAUSED_THERMAL_ERROR, LCD_STATUS_CRITICAL);
                 SERIAL_ECHOLNPGM("TM: error triggered!");
             }
             ThermalStop(true);
@@ -2436,7 +2435,7 @@ void handle_warning()
     if(warning_state.assert) {
         if (first) {
             if(warn_beep) {
-                lcd_setalertstatuspgm(MSG_THERMAL_ANOMALY, LCD_STATUS_INFO);
+                lcd_setalertstatuspgm(_T(MSG_THERMAL_ANOMALY), LCD_STATUS_INFO);
                 WRITE(BEEPER, HIGH);
             }
         } else {

--- a/Firmware/temperature.cpp
+++ b/Firmware/temperature.cpp
@@ -2769,15 +2769,15 @@ static bool autotune(int16_t cal_temp)
             wait(10000);
         }
 
-        // we need a valid R value for the initial C guess
-        if(isnan(temp_model::data.R[0]))
-            temp_model::data.R[0] = TEMP_MODEL_Rh;
-
         printf_P(PSTR("TM: %S C estimation\n"), verb);
         target_temperature[0] = cal_temp;
         samples = record();
         if(temp_error_state.v || !samples)
             return true;
+
+        // we need a high R value for the initial C guess
+        if(isnan(temp_model::data.R[0]))
+            temp_model::data.R[0] = TEMP_MODEL_Rh;
 
         e = estimate(samples, &temp_model::data.C,
             TEMP_MODEL_Cl, TEMP_MODEL_Ch, TEMP_MODEL_C_thr, TEMP_MODEL_C_itr,

--- a/Firmware/temperature.h
+++ b/Firmware/temperature.h
@@ -227,7 +227,7 @@ void temp_model_reset_settings();
 void temp_model_load_settings();
 void temp_model_save_settings();
 
-void temp_model_autotune(int16_t temp = 0);
+void temp_model_autotune(int16_t temp = 0, bool selftest = false);
 
 #ifdef TEMP_MODEL_DEBUG
 void temp_model_log_enable(bool enable);

--- a/Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h
@@ -419,13 +419,13 @@
 
 #define TEMP_MODEL_P 38.      // heater power (W)
 
-#define TEMP_MODEL_C 11.      // initial guess for heatblock capacitance (J/K)
+#define TEMP_MODEL_C 12.1     // initial guess for heatblock capacitance (J/K)
 #define TEMP_MODEL_Cl 5       // C estimation lower limit
 #define TEMP_MODEL_Ch 20      // C estimation upper limit
 #define TEMP_MODEL_C_thr 0.01 // C estimation iteration threshold
 #define TEMP_MODEL_C_itr 30   // C estimation iteration limit
 
-#define TEMP_MODEL_R 25       // initial guess for heatblock resistance (K/W)
+#define TEMP_MODEL_R 29.7     // initial guess for heatblock resistance (K/W)
 #define TEMP_MODEL_Rl 5       // R estimation lower limit
 #define TEMP_MODEL_Rh 50      // R estimation upper limit
 #define TEMP_MODEL_R_thr 0.01 // R estimation iteration threshold

--- a/Firmware/variants/1_75mm_MK3S-EINSy10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK3S-EINSy10a-E3Dv6full.h
@@ -423,13 +423,13 @@
 
 #define TEMP_MODEL_P 38.      // heater power (W)
 
-#define TEMP_MODEL_C 11.      // initial guess for heatblock capacitance (J/K)
+#define TEMP_MODEL_C 12.1     // initial guess for heatblock capacitance (J/K)
 #define TEMP_MODEL_Cl 5       // C estimation lower limit
 #define TEMP_MODEL_Ch 20      // C estimation upper limit
 #define TEMP_MODEL_C_thr 0.01 // C estimation iteration threshold
 #define TEMP_MODEL_C_itr 30   // C estimation iteration limit
 
-#define TEMP_MODEL_R 25       // initial guess for heatblock resistance (K/W)
+#define TEMP_MODEL_R 29.7     // initial guess for heatblock resistance (K/W)
 #define TEMP_MODEL_Rl 5       // R estimation lower limit
 #define TEMP_MODEL_Rh 50      // R estimation upper limit
 #define TEMP_MODEL_R_thr 0.01 // R estimation iteration threshold


### PR DESCRIPTION
Allow running the model checking while doing model autotune. The C/R0 values should be stable enough to provide a further safety mechanism for printers of the same variant right from the factory.

This updates the default C/R0 estimates for MK3/MK3S variants, as well as a new parameter `M310 A F1` to force self-check during autotune.

With this PR, the following:

```
M502
M310 A F1
```

will autotune the model while still checking the hotend during the heating steps, aborting if the hotend is too far from the factory defaults. The warning threshold still generate beeps during autotune, although short beeps during autotune are considered to be expected in this scenario.