### PR TITLE
Fix lost changes during rebase

### DIFF
--- a/Firmware/util.cpp
+++ b/Firmware/util.cpp
@@ -420,7 +420,7 @@ void gcode_level_check(uint16_t nGcodeLevel) {
 #define GCODE_DELIMITER '"'
 #define ELLIPSIS "..."
 
-char *code_string(char *pStr, size_t *nLength) {
+char *code_string(const char *pStr, size_t *nLength) {
 char* pStrBegin;
 char* pStrEnd;
 
@@ -432,11 +432,10 @@ pStrEnd=strchr(pStrBegin,GCODE_DELIMITER);
 if(!pStrEnd)
      return(NULL);
 *nLength=pStrEnd-pStrBegin;
-pStrBegin[*nLength] = '\0';
 return pStrBegin;
 }
 
-void printer_smodel_check(char *pStrPos) {
+void printer_smodel_check(const char *pStrPos) {
 char* pResult;
 size_t nLength,nPrinterNameLength;
 

--- a/Firmware/util.h
+++ b/Firmware/util.h
@@ -104,7 +104,7 @@ extern ClCheckGcode oCheckGcode;
 void fCheckModeInit();
 void nozzle_diameter_check(uint16_t nDiameter);
 void printer_model_check(uint16_t nPrinterModel);
-void printer_smodel_check(char* pStrPos);
+void printer_smodel_check(const char* pStrPos);
 void fw_version_check(const char *pVersion);
 void gcode_level_check(uint16_t nGcodeLevel);
 


### PR DESCRIPTION
See changes already merged into 3.12 here: https://github.com/prusa3d/Prusa-Firmware/pull/3551/files
This fixes an issue where the cmdbuffer can be corrupted