### PR TITLE
Extract PRINTER_ACTIVE into a noinline function

### DIFF
--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -355,7 +355,6 @@ extern uint16_t gcode_in_progress;
 extern LongTimer safetyTimer;
 
 #define PRINT_PERCENT_DONE_INIT 0xff
-#define PRINTER_ACTIVE (IS_SD_PRINTING || usb_timer.running() || isPrintPaused || (custom_message_type == CustomMsg::TempCal) || saved_printing || (lcd_commands_type == LcdCommands::Layer1Cal) || mmu_print_saved || homing_flag || mesh_bed_leveling_flag)
 
 extern bool printer_active();
 

--- a/Firmware/fancheck.cpp
+++ b/Firmware/fancheck.cpp
@@ -137,7 +137,7 @@ void checkFanSpeed()
         // we may even send some info to the LCD from here
         fan_check_error = EFCE_FIXED;
     }
-    if ((fan_check_error == EFCE_FIXED) && !PRINTER_ACTIVE){
+    if ((fan_check_error == EFCE_FIXED) && !printer_active()){
         fan_check_error = EFCE_OK; //if the issue is fixed while the printer is doing nothing, reenable processing immediately.
         lcd_reset_alert_level(); //for another fan speed error
     }

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -436,7 +436,7 @@ void lcdui_print_percent_done(void)
 {
 	const char* src = usb_timer.running()?_N("USB"):(IS_SD_PRINTING?_N(" SD"):_N("   "));
 	char per[4];
-	bool num = IS_SD_PRINTING || (PRINTER_ACTIVE && (print_percent_done_normal != PRINT_PERCENT_DONE_INIT));
+	bool num = IS_SD_PRINTING || (printer_active() && (print_percent_done_normal != PRINT_PERCENT_DONE_INIT));
 	if (!num || heating_status != HeatingStatus::NO_HEATING) // either not printing or heating
 	{
 		const int8_t sheetNR = eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet));
@@ -492,7 +492,7 @@ void lcdui_print_time(void)
 {
     //if remaining print time estimation is available print it else print elapsed time
     int chars = 0;
-    if (PRINTER_ACTIVE) {
+    if (printer_active()) {
         uint16_t print_t = PRINT_TIME_REMAINING_INIT;
         uint16_t print_tr = PRINT_TIME_REMAINING_INIT;
         uint16_t print_tc = PRINT_TIME_REMAINING_INIT;
@@ -4850,7 +4850,7 @@ static void lcd_settings_menu()
 
 	MENU_ITEM_SUBMENU_P(_i("Temperature"), lcd_control_temperature_menu);////MSG_TEMPERATURE c=18
 
-	if (!PRINTER_ACTIVE || isPrintPaused)
+	if (!printer_active() || isPrintPaused)
     {
 	    MENU_ITEM_SUBMENU_P(_i("Move axis"), lcd_move_menu_axis);////MSG_MOVE_AXIS c=18
 	    MENU_ITEM_GCODE_P(_i("Disable steppers"), PSTR("M84"));////MSG_DISABLE_STEPPERS c=18
@@ -5550,7 +5550,7 @@ static void lcd_main_menu()
     if (farm_mode)
         MENU_ITEM_FUNCTION_P(_T(MSG_FILAMENTCHANGE), lcd_colorprint_change);//8
 
-    if ( moves_planned() || PRINTER_ACTIVE ) {
+    if ( moves_planned() || printer_active() ) {
         MENU_ITEM_SUBMENU_P(_i("Tune"), lcd_tune_menu);////MSG_TUNE c=18
     } else {
         MENU_ITEM_SUBMENU_P(_i("Preheat"), lcd_preheat_menu);////MSG_PREHEAT c=18


### PR DESCRIPTION
Having the original PRINTER_ACTIVE macro copied at multiple spots doesn't make sense. Refactoring it into a non-inline function saved ~400 bytes of code. It should be safe in terms of performance, all occurrences are at non-time critical spots.

Cherry picked from #3592