### PR TITLE
[BUGFIX] Debug code D9 could induce undefined behaviour when left shifting a negative value

### DIFF
--- a/Firmware/Dcodes.cpp
+++ b/Firmware/Dcodes.cpp
@@ -584,7 +584,7 @@ void dcode_9()
 			if (code_seen('V')) // value to be written as simulated
 			{
 				adc_sim_mask |= (1 << index);
-				adc_values[index] = (((int)code_value()) << 4);
+				adc_values[index] = ((uint16_t)code_value_short() << 4);
 				printf_P(PSTR("ADC%d=%4d\n"), index, adc_values[index] >> 4);
 			}
 		}


### PR DESCRIPTION
This might not be the most severe bug, but it seems like for some C++ compilers, left shifting a negative value is not well-defined as stated [here](https://stackoverflow.com/questions/8415895/is-left-and-right-shifting-negative-integers-defined-behavior). I fixed this bug by simply casting the parsed value into an unsigned 16bit integer first before left shifting it by 4 bits. As adc_values is an array of uint16_t anyway this should not be a problem here.