### PR TITLE
Fix Unload Manually MMU error being impossible to resolve

### DIFF
--- a/Firmware/mmu2_error_converter.cpp
+++ b/Firmware/mmu2_error_converter.cpp
@@ -179,9 +179,6 @@ Buttons ButtonAvailable(uint16_t ec) {
     switch ( PrusaErrorCode(ei) ) {
     case ERR_MECHANICAL_FINDA_DIDNT_TRIGGER:
     case ERR_MECHANICAL_FINDA_DIDNT_GO_OFF:
-    case ERR_MECHANICAL_FSENSOR_DIDNT_TRIGGER:
-    case ERR_MECHANICAL_FSENSOR_DIDNT_GO_OFF:
-    case ERR_MECHANICAL_FSENSOR_TOO_EARLY:
         switch (buttonSelectedOperation) {
         case ButtonOperations::Retry: // "Repeat action"
             return Middle;
@@ -191,6 +188,9 @@ Buttons ButtonAvailable(uint16_t ec) {
             break;
         }
         break;
+    case ERR_MECHANICAL_FSENSOR_DIDNT_TRIGGER:
+    case ERR_MECHANICAL_FSENSOR_DIDNT_GO_OFF:
+    case ERR_MECHANICAL_FSENSOR_TOO_EARLY:
     case ERR_MECHANICAL_SELECTOR_CANNOT_HOME:
     case ERR_MECHANICAL_SELECTOR_CANNOT_MOVE:
     case ERR_MECHANICAL_IDLER_CANNOT_HOME:

--- a/Firmware/mmu2_error_converter.cpp
+++ b/Firmware/mmu2_error_converter.cpp
@@ -196,6 +196,7 @@ Buttons ButtonAvailable(uint16_t ec) {
     case ERR_MECHANICAL_IDLER_CANNOT_HOME:
     case ERR_MECHANICAL_IDLER_CANNOT_MOVE:
     case ERR_MECHANICAL_PULLEY_CANNOT_MOVE:
+    case ERR_SYSTEM_UNLOAD_MANUALLY:
         switch (buttonSelectedOperation) {
         // may be allow move selector right and left in the future
         case ButtonOperations::Retry: // "Repeat action"

--- a/Firmware/mmu2_error_converter.cpp
+++ b/Firmware/mmu2_error_converter.cpp
@@ -265,8 +265,6 @@ Buttons ButtonAvailable(uint16_t ec) {
             return Left;
         case ButtonOperations::Continue: // "Proceed/Continue"
             return Right;
-        case ButtonOperations::RestartMMU: // "Restart MMU"
-            return RestartMMU;
         default:
             break;
         }


### PR DESCRIPTION
- Unload Manually error did not send any buttons to the MMU (even though it does have an error screen, so clicking the button may seem like the MK3S does nothing or the MMU does nothing)
- Fsensor errors only have the Retry button. The Done button was removed several weeks ago.
- Filament Already Loaded error only has two buttons defined. I removed the one which does not appear on the error screen.

Changes save 2 bytes of flash.

PFW-1356