### PR TITLE
Optimisation: Remove duplicate code in `cmdqueue_could_enqueue_back()`

### DIFF
--- a/Firmware/cmdqueue.cpp
+++ b/Firmware/cmdqueue.cpp
@@ -156,7 +156,7 @@ static bool cmdqueue_could_enqueue_front(size_t len_asked)
 // len_asked does not contain the zero terminator size.
 // This function may update bufindw, therefore for the power panic to work, this function must be called
 // with the interrupts disabled!
-static bool cmdqueue_could_enqueue_back(size_t len_asked)
+static bool __attribute__((noinline)) cmdqueue_could_enqueue_back(size_t len_asked)
 {
     // MAX_CMD_SIZE has to accommodate the zero terminator.
     if (len_asked >= MAX_CMD_SIZE)


### PR DESCRIPTION
PR removes duplicated code in `cmdqueue_could_enqueue_back()`. The code under `if (serial_count > 0)` and its respective `else` is exactly the same. Removing the if statement saves both flash memory and about ~8 clock cycles.

Code is 28 lines shorter :)

Change in memory:
Flash: -64 bytes
SRAM: 0 bytes