### PR TITLE
MMU: Improve purge line during first layer calibration

### DIFF
--- a/Firmware/first_lay_cal.cpp
+++ b/Firmware/first_lay_cal.cpp
@@ -48,8 +48,8 @@ void lay1cal_load_filament(char *cmd_buffer, uint8_t filament)
 //! @brief Print intro line
 void lay1cal_intro_line()
 {
-    static const char cmd_intro_mmu_3[] PROGMEM = "G1 X55.0 E32.0 F1073.0";
-    static const char cmd_intro_mmu_4[] PROGMEM = "G1 X5.0 E32.0 F1800.0";
+    static const char cmd_intro_mmu_3[] PROGMEM = "G1 X55.0 E29.0 F1073.0";
+    static const char cmd_intro_mmu_4[] PROGMEM = "G1 X5.0 E29.0 F1800.0";
     static const char cmd_intro_mmu_5[] PROGMEM = "G1 X55.0 E8.0 F2000.0";
     static const char cmd_intro_mmu_6[] PROGMEM = "G1 Z0.3 F1000.0";
     static const char cmd_intro_mmu_7[] PROGMEM = "G92 E0.0";


### PR DESCRIPTION
Sync the purge line gcode with PrusaSlicer output when using Tcodes.

These 2 lines:
```
G1 X55.0 E32.0 F1073.0
G1 X5.0 E32.0 F1800.0
```

Should be like this
```
G1 X55.0 E29.0 F1073.0
G1 X5.0 E29.0 F1800.0
```

Change in memory:
Flash: 0 bytes
SRAM: 0 bytes