### PR TITLE
Improve warning behavior during thermal anomaly

### DIFF
--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -528,6 +528,12 @@ void lcd_print(const char* s)
 	while (*s) lcd_write(*(s++));
 }
 
+void lcd_print_pad(const char* s, uint8_t len)
+{
+    while (len-- && *s) lcd_write(*(s++));
+    lcd_space(len);
+}
+
 void lcd_print(char c, int base)
 {
 	lcd_print((long) c, base);

--- a/Firmware/lcd.h
+++ b/Firmware/lcd.h
@@ -53,6 +53,7 @@ extern void lcd_printNumber(unsigned long n, uint8_t base);
 extern void lcd_printFloat(double number, uint8_t digits);
 
 extern void lcd_print(const char*);
+extern void lcd_print_pad(const char*, uint8_t len);
 extern void lcd_print(char, int = 0);
 extern void lcd_print(unsigned char, int = 0);
 extern void lcd_print(int, int = 10);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -242,9 +242,6 @@ static void lcd_cutter_enabled();
 #endif
 static void lcd_babystep_z();
 
-//! Beware: has side effects - forces lcd_draw_update to 2, which means clear the display
-void lcd_finishstatus();
-
 static void lcd_sdcard_menu();
 static void lcd_sheet_menu();
 
@@ -7422,7 +7419,6 @@ static bool check_file(const char* filename) {
 	card.printingHasFinished();
 
 	lcd_setstatuspgm(MSG_WELCOME);
-	lcd_finishstatus();
 	return result;
 }
 
@@ -7524,11 +7520,6 @@ void lcd_ignore_click(bool b)
   wait_for_unclick = false;
 }
 
-void lcd_finishstatus() {
-  SERIAL_PROTOCOLLNRPGM(MSG_LCD_STATUS_CHANGED);
-  lcd_draw_update = 2;
-}
-
 static bool lcd_message_check(uint8_t priority)
 {
     // regular priority check
@@ -7551,7 +7542,9 @@ static void lcd_updatestatus(const char *message, bool progmem = false)
         strncpy(lcd_status_message, message, LCD_WIDTH);
 
 	lcd_status_message[LCD_WIDTH] = 0;
-	lcd_finishstatus();
+
+	SERIAL_PROTOCOLLNRPGM(MSG_LCD_STATUS_CHANGED);
+
 	// hack lcd_draw_update to 1, i.e. without clear
 	lcd_draw_update = 1;
 }


### PR DESCRIPTION
The current code forces any warning to return the user to the status screen in order to show the message.

Thermal anomaly warnings can repeat at very short intervals, making menu navigation (to pause/tune the print) impossible.

We now check if the message to be displayed is the same and only force a kickback for new messages.

This partially reverts https://github.com/prusa3d/Prusa-Firmware/pull/3600 since we need the string to be null terminated for ease of comparison.

We pad the status line at display time instead using the new lcd_print_pad() function which achieves the same effect.