### PR TITLE
Merge #3628 into 3.12

### DIFF
--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -530,7 +530,10 @@ void lcd_print(const char* s)
 
 void lcd_print_pad(const char* s, uint8_t len)
 {
-    while (len-- && *s) lcd_write(*(s++));
+    while (len && *s) {
+        lcd_write(*(s++));
+        --len;
+    }
     lcd_space(len);
 }
 


### PR DESCRIPTION
lcd_print_pad: do not overflow len when truncating the string