### PR TITLE
PFW-1358 More button utilizes text and an empty character on the right

### DIFF
--- a/Firmware/mmu2/errors_list.h
+++ b/Firmware/mmu2/errors_list.h
@@ -284,7 +284,7 @@ static const char MSG_BTN_RESTART_MMU[] PROGMEM_I1 = ISTR("Reset MMU"); ////MSG_
 static const char MSG_BTN_UNLOAD[] PROGMEM_I1 = ISTR("Unload"); ////MSG_BTN_UNLOAD c=6
 static const char MSG_BTN_STOP[] PROGMEM_I1 = ISTR("Stop"); ////MSG_BTN_STOP c=5
 static const char MSG_BTN_DISABLE_MMU[] PROGMEM_I1 = ISTR("Disable"); ////MSG_BTN_DISABLE_MMU c=9
-static const char MSG_BTN_MORE[] PROGMEM_I1 = ISTR("\x06"); ////MSG_BTN_MORE c=5
+static const char MSG_BTN_MORE[] PROGMEM_N1 = ISTR("\x06"); ////MSG_BTN_MORE c=5
 
 // Used to parse the buttons from Btns().
 static const char * const btnOperation[] PROGMEM = {

--- a/Firmware/mmu2/errors_list.h
+++ b/Firmware/mmu2/errors_list.h
@@ -284,7 +284,7 @@ static const char MSG_BTN_RESTART_MMU[] PROGMEM_I1 = ISTR("Reset MMU"); ////MSG_
 static const char MSG_BTN_UNLOAD[] PROGMEM_I1 = ISTR("Unload"); ////MSG_BTN_UNLOAD c=6
 static const char MSG_BTN_STOP[] PROGMEM_I1 = ISTR("Stop"); ////MSG_BTN_STOP c=5
 static const char MSG_BTN_DISABLE_MMU[] PROGMEM_I1 = ISTR("Disable"); ////MSG_BTN_DISABLE_MMU c=9
-static const char MSG_BTN_MORE[] PROGMEM_I1 = ISTR("More\x06"); ////MSG_BTN_MORE c=5
+static const char MSG_BTN_MORE[] PROGMEM_I1 = ISTR("\x06"); ////MSG_BTN_MORE c=5
 
 // Used to parse the buttons from Btns().
 static const char * const btnOperation[] PROGMEM = {

--- a/Firmware/mmu2/errors_list.h
+++ b/Firmware/mmu2/errors_list.h
@@ -273,18 +273,19 @@ static const char * const errorDescs[] PROGMEM = {
 
 // we have max 3 buttons/operations to select from
 // one of them is "More" to show the explanation text normally hidden in the next screens.
+// It is displayed with W (Double down arrow, special character from CGRAM)
 // 01234567890123456789
-// >bttxt >bttxt>MoreW
-// Therefore at least some of the buttons, which can occur on the screen together, need to be 5-chars long max @@TODO.
+// >bttxt   >bttxt   >W
+// Therefore at least some of the buttons, which can occur on the screen together, can only be 8-chars long max @@TODO.
 // Beware - we only have space for 2 buttons on the LCD while the MMU has 3 buttons
 // -> the left button on the MMU is not used/rendered on the LCD (it is also almost unused on the MMU side)
-static const char MSG_BTN_RETRY[] PROGMEM_I1 = ISTR("Retry"); ////MSG_BTN_RETRY c=5
-static const char MSG_BTN_CONTINUE[] PROGMEM_I1 = ISTR("Done"); ////MSG_BTN_CONTINUE c=5
+static const char MSG_BTN_RETRY[] PROGMEM_I1 = ISTR("Retry"); ////MSG_BTN_RETRY c=8
+static const char MSG_BTN_CONTINUE[] PROGMEM_I1 = ISTR("Done"); ////MSG_BTN_CONTINUE c=8
 static const char MSG_BTN_RESTART_MMU[] PROGMEM_I1 = ISTR("Reset MMU"); ////MSG_BTN_RESTART_MMU c=9
-static const char MSG_BTN_UNLOAD[] PROGMEM_I1 = ISTR("Unload"); ////MSG_BTN_UNLOAD c=6
-static const char MSG_BTN_STOP[] PROGMEM_I1 = ISTR("Stop"); ////MSG_BTN_STOP c=5
+static const char MSG_BTN_UNLOAD[] PROGMEM_I1 = ISTR("Unload"); ////MSG_BTN_UNLOAD c=8
+static const char MSG_BTN_STOP[] PROGMEM_I1 = ISTR("Stop"); ////MSG_BTN_STOP c=8
 static const char MSG_BTN_DISABLE_MMU[] PROGMEM_I1 = ISTR("Disable"); ////MSG_BTN_DISABLE_MMU c=9
-static const char MSG_BTN_MORE[] PROGMEM_N1 = ISTR("\x06"); ////MSG_BTN_MORE c=5
+static const char MSG_BTN_MORE[] PROGMEM_N1 = ISTR("\x06"); ////MSG_BTN_MORE c=8
 
 // Used to parse the buttons from Btns().
 static const char * const btnOperation[] PROGMEM = {

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -74,9 +74,9 @@ static void ReportErrorHookStaticRender(uint8_t ei) {
     lcd_printf_P(PSTR("%.20S\nprusa3d.com/ERR04%hu"), _T(PrusaErrorTitle(ei)), PrusaErrorCode(ei) );
 
     ReportErrorHookSensorLineRender();
-    
+
     // Render the choices
-    lcd_show_choices_prompt_P(two_choices ? LCD_LEFT_BUTTON_CHOICE : LCD_MIDDLE_BUTTON_CHOICE, _T(PrusaErrorButtonTitle(button_op_middle)), _T(two_choices ? PrusaErrorButtonMore() : PrusaErrorButtonTitle(button_op_right)), 9, two_choices ? nullptr : _T(PrusaErrorButtonMore()));
+    lcd_show_choices_prompt_P(two_choices ? LCD_LEFT_BUTTON_CHOICE : LCD_MIDDLE_BUTTON_CHOICE, _T(PrusaErrorButtonTitle(button_op_middle)), _T(two_choices ? PrusaErrorButtonMore() : PrusaErrorButtonTitle(button_op_right)), two_choices ? 18 : 9, two_choices ? nullptr : _T(PrusaErrorButtonMore()));
 }
 
 extern void ReportErrorHookSensorLineRender()
@@ -164,12 +164,16 @@ static uint8_t ReportErrorHookMonitor(uint8_t ei) {
         //
         lcd_set_cursor(0, 3);
         lcd_print(current_selection == LCD_LEFT_BUTTON_CHOICE ? '>': ' ');
-        lcd_set_cursor(9, 3);
-        lcd_print(current_selection == LCD_MIDDLE_BUTTON_CHOICE ? '>': ' ');
         if (two_choices == false)
         {
+            lcd_set_cursor(9, 3);
+            lcd_print(current_selection == LCD_MIDDLE_BUTTON_CHOICE ? '>': ' ');
             lcd_set_cursor(18, 3);
             lcd_print(current_selection == LCD_RIGHT_BUTTON_CHOICE ? '>': ' ');
+        } else {
+            // More button for two button screen
+            lcd_set_cursor(18, 3);
+            lcd_print(current_selection == LCD_MIDDLE_BUTTON_CHOICE ? '>': ' ');
         }
         // Consume rotation event and make feedback sound
         enc_dif = lcd_encoder_diff;

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -52,7 +52,7 @@ static void ReportErrorHookStaticRender(uint8_t ei) {
     //! |MMU FW update needed|     <- title/header of the error: max 20 characters
     //! |prusa3d.com/ERR04504|     <- URL 20 characters
     //! |FI:1 FS:1  5>3 t201°|     <- status line, t is thermometer symbol
-    //! |>Retry >Done >MoreW |     <- buttons
+    //! |>Retry   >Done    >W|     <- buttons
     bool two_choices = false;
 
     // Read and determine what operations should be shown on the menu
@@ -76,7 +76,7 @@ static void ReportErrorHookStaticRender(uint8_t ei) {
     ReportErrorHookSensorLineRender();
     
     // Render the choices
-    lcd_show_choices_prompt_P(two_choices ? LCD_LEFT_BUTTON_CHOICE : LCD_MIDDLE_BUTTON_CHOICE, _T(PrusaErrorButtonTitle(button_op_middle)), _T(two_choices ? PrusaErrorButtonMore() : PrusaErrorButtonTitle(button_op_right)), two_choices ? 10 : 7, two_choices ? nullptr : _T(PrusaErrorButtonMore()));
+    lcd_show_choices_prompt_P(two_choices ? LCD_LEFT_BUTTON_CHOICE : LCD_MIDDLE_BUTTON_CHOICE, _T(PrusaErrorButtonTitle(button_op_middle)), _T(two_choices ? PrusaErrorButtonMore() : PrusaErrorButtonTitle(button_op_right)), 10, two_choices ? nullptr : _T(PrusaErrorButtonMore()));
 }
 
 extern void ReportErrorHookSensorLineRender()
@@ -166,9 +166,9 @@ static uint8_t ReportErrorHookMonitor(uint8_t ei) {
         lcd_print(current_selection == LCD_LEFT_BUTTON_CHOICE ? '>': ' ');
         if (two_choices == false)
         {
-            lcd_set_cursor(7, 3);
+            lcd_set_cursor(9, 3);
             lcd_print(current_selection == LCD_MIDDLE_BUTTON_CHOICE ? '>': ' ');
-            lcd_set_cursor(13, 3);
+            lcd_set_cursor(18, 3);
             lcd_print(current_selection == LCD_RIGHT_BUTTON_CHOICE ? '>': ' ');
         } else {
             lcd_set_cursor(10, 3);

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -76,7 +76,7 @@ static void ReportErrorHookStaticRender(uint8_t ei) {
     ReportErrorHookSensorLineRender();
     
     // Render the choices
-    lcd_show_choices_prompt_P(two_choices ? LCD_LEFT_BUTTON_CHOICE : LCD_MIDDLE_BUTTON_CHOICE, _T(PrusaErrorButtonTitle(button_op_middle)), _T(two_choices ? PrusaErrorButtonMore() : PrusaErrorButtonTitle(button_op_right)), 10, two_choices ? nullptr : _T(PrusaErrorButtonMore()));
+    lcd_show_choices_prompt_P(two_choices ? LCD_LEFT_BUTTON_CHOICE : LCD_MIDDLE_BUTTON_CHOICE, _T(PrusaErrorButtonTitle(button_op_middle)), _T(two_choices ? PrusaErrorButtonMore() : PrusaErrorButtonTitle(button_op_right)), 9, two_choices ? nullptr : _T(PrusaErrorButtonMore()));
 }
 
 extern void ReportErrorHookSensorLineRender()
@@ -164,15 +164,12 @@ static uint8_t ReportErrorHookMonitor(uint8_t ei) {
         //
         lcd_set_cursor(0, 3);
         lcd_print(current_selection == LCD_LEFT_BUTTON_CHOICE ? '>': ' ');
+        lcd_set_cursor(9, 3);
+        lcd_print(current_selection == LCD_MIDDLE_BUTTON_CHOICE ? '>': ' ');
         if (two_choices == false)
         {
-            lcd_set_cursor(9, 3);
-            lcd_print(current_selection == LCD_MIDDLE_BUTTON_CHOICE ? '>': ' ');
             lcd_set_cursor(18, 3);
             lcd_print(current_selection == LCD_RIGHT_BUTTON_CHOICE ? '>': ' ');
-        } else {
-            lcd_set_cursor(10, 3);
-            lcd_print(current_selection == LCD_MIDDLE_BUTTON_CHOICE ? '>': ' ');
         }
         // Consume rotation event and make feedback sound
         enc_dif = lcd_encoder_diff;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3172,18 +3172,14 @@ void lcd_show_choices_prompt_P(uint8_t selected, const char *first_choice, const
     lcd_set_cursor(0, 3);
     lcd_print(selected == LCD_LEFT_BUTTON_CHOICE ? '>': ' ');
     lcd_puts_P(first_choice);
+    lcd_set_cursor(second_col, 3);
+    lcd_print(selected == LCD_MIDDLE_BUTTON_CHOICE ? '>': ' ');
+    lcd_puts_P(second_choice);
     if (third_choice)
     {
-        lcd_set_cursor(9, 3);
-        lcd_print(selected == LCD_MIDDLE_BUTTON_CHOICE ? '>': ' ');
-        lcd_puts_P(second_choice);
         lcd_set_cursor(18, 3);
         lcd_print(selected == LCD_RIGHT_BUTTON_CHOICE ? '>': ' ');
         lcd_puts_P(third_choice);
-    } else {
-        lcd_set_cursor(second_col, 3);
-        lcd_print(selected == LCD_MIDDLE_BUTTON_CHOICE ? '>': ' ');
-        lcd_puts_P(second_choice);
     }
 }
 

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3165,7 +3165,7 @@ uint8_t lcd_show_multiscreen_message_yes_no_and_wait_P(const char *msg, bool all
 //! @param selected Show first choice as selected if true, the second otherwise
 //! @param first_choice text caption of first possible choice
 //! @param second_choice text caption of second possible choice
-//! @param second_col column on LCD where second choice is rendered. If third choice is set, this value is hardcoded to 7
+//! @param second_col column on LCD where second choice is rendered.
 //! @param third_choice text caption of third, optional, choice.
 void lcd_show_choices_prompt_P(uint8_t selected, const char *first_choice, const char *second_choice, uint8_t second_col, const char *third_choice)
 {

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3174,10 +3174,10 @@ void lcd_show_choices_prompt_P(uint8_t selected, const char *first_choice, const
     lcd_puts_P(first_choice);
     if (third_choice)
     {
-        lcd_set_cursor(7, 3);
+        lcd_set_cursor(9, 3);
         lcd_print(selected == LCD_MIDDLE_BUTTON_CHOICE ? '>': ' ');
         lcd_puts_P(second_choice);
-        lcd_set_cursor(13, 3);
+        lcd_set_cursor(18, 3);
         lcd_print(selected == LCD_RIGHT_BUTTON_CHOICE ? '>': ' ');
         lcd_puts_P(third_choice);
     } else {

--- a/lang/po/Firmware.pot
+++ b/lang/po/Firmware.pot
@@ -434,7 +434,7 @@ msgid ""
 "heatbed?"
 msgstr ""
 
-#. MSG_BTN_CONTINUE c=5
+#. MSG_BTN_CONTINUE c=8
 #: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:292
 msgid "Done"
 msgstr ""
@@ -1707,7 +1707,7 @@ msgstr ""
 msgid "Retract from FINDA"
 msgstr ""
 
-#. MSG_BTN_RETRY c=5
+#. MSG_BTN_RETRY c=8
 #: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:291
 msgid "Retry"
 msgstr ""
@@ -1963,7 +1963,7 @@ msgstr ""
 msgid "Steel sheets"
 msgstr ""
 
-#. MSG_BTN_STOP c=5
+#. MSG_BTN_STOP c=8
 #: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:295
 msgid "Stop"
 msgstr ""
@@ -2134,7 +2134,7 @@ msgid ""
 " is free. Check FINDA connection."
 msgstr ""
 
-#. MSG_BTN_UNLOAD c=6
+#. MSG_BTN_UNLOAD c=8
 #: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:294
 msgid "Unload"
 msgstr ""

--- a/lang/po/Firmware.pot
+++ b/lang/po/Firmware.pot
@@ -1176,12 +1176,6 @@ msgstr ""
 msgid "More details online."
 msgstr ""
 
-#. MSG_BTN_MORE c=5
-#: ../../Firmware/mmu2/errors_list.h:287
-#: ../../Firmware/mmu2_error_converter.cpp:153
-msgid "More⏬"
-msgstr ""
-
 #. MSG_SELFTEST_MOTOR c=18
 #: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6981
 #: ../../Firmware/ultralcd.cpp:6990 ../../Firmware/ultralcd.cpp:7008

--- a/lang/po/Firmware_cs.po
+++ b/lang/po/Firmware_cs.po
@@ -1210,12 +1210,6 @@ msgstr ""
 msgid "More details online."
 msgstr ""
 
-#. MSG_BTN_MORE c=5
-#: ../../Firmware/mmu2/errors_list.h:287
-#: ../../Firmware/mmu2_error_converter.cpp:153
-msgid "More⏬"
-msgstr ""
-
 #. MSG_SELFTEST_MOTOR c=18
 #: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6981
 #: ../../Firmware/ultralcd.cpp:6990 ../../Firmware/ultralcd.cpp:7008

--- a/lang/po/Firmware_cs.po
+++ b/lang/po/Firmware_cs.po
@@ -455,7 +455,7 @@ msgid ""
 msgstr ""
 "Chcete opakovat posledni krok a pozmenit vzdalenost mezi tryskou a podlozkou?"
 
-#. MSG_BTN_CONTINUE c=5
+#. MSG_BTN_CONTINUE c=8
 #: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:292
 msgid "Done"
 msgstr ""
@@ -1755,7 +1755,7 @@ msgstr "Obnoveni tisku"
 msgid "Retract from FINDA"
 msgstr ""
 
-#. MSG_BTN_RETRY c=5
+#. MSG_BTN_RETRY c=8
 #: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:291
 msgid "Retry"
 msgstr ""
@@ -2019,7 +2019,7 @@ msgstr "Tichy"
 msgid "Steel sheets"
 msgstr "Tiskove platy"
 
-#. MSG_BTN_STOP c=5
+#. MSG_BTN_STOP c=8
 #: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:295
 msgid "Stop"
 msgstr ""
@@ -2194,7 +2194,7 @@ msgid ""
 "is free. Check FINDA connection."
 msgstr ""
 
-#. MSG_BTN_UNLOAD c=6
+#. MSG_BTN_UNLOAD c=8
 #: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:294
 msgid "Unload"
 msgstr ""

--- a/lang/po/Firmware_da.po
+++ b/lang/po/Firmware_da.po
@@ -1185,12 +1185,6 @@ msgstr ""
 msgid "More details online."
 msgstr ""
 
-#. MSG_BTN_MORE c=5
-#: ../../Firmware/mmu2/errors_list.h:287
-#: ../../Firmware/mmu2_error_converter.cpp:153
-msgid "More⏬"
-msgstr ""
-
 #. MSG_SELFTEST_MOTOR c=18
 #: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6981
 #: ../../Firmware/ultralcd.cpp:6990 ../../Firmware/ultralcd.cpp:7008

--- a/lang/po/Firmware_da.po
+++ b/lang/po/Firmware_da.po
@@ -442,7 +442,7 @@ msgid ""
 "heatbed?"
 msgstr ""
 
-#. MSG_BTN_CONTINUE c=5
+#. MSG_BTN_CONTINUE c=8
 #: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:292
 msgid "Done"
 msgstr ""
@@ -1716,7 +1716,7 @@ msgstr ""
 msgid "Retract from FINDA"
 msgstr ""
 
-#. MSG_BTN_RETRY c=5
+#. MSG_BTN_RETRY c=8
 #: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:291
 msgid "Retry"
 msgstr ""
@@ -1972,7 +1972,7 @@ msgstr ""
 msgid "Steel sheets"
 msgstr ""
 
-#. MSG_BTN_STOP c=5
+#. MSG_BTN_STOP c=8
 #: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:295
 msgid "Stop"
 msgstr ""
@@ -2143,7 +2143,7 @@ msgid ""
 "is free. Check FINDA connection."
 msgstr ""
 
-#. MSG_BTN_UNLOAD c=6
+#. MSG_BTN_UNLOAD c=8
 #: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:294
 msgid "Unload"
 msgstr ""

--- a/lang/po/Firmware_de.po
+++ b/lang/po/Firmware_de.po
@@ -459,7 +459,7 @@ msgstr ""
 "Möchten Sie den letzten Schritt wiederholen, um den Abstand zwischen Düse "
 "und Druckbett neu einzustellen?"
 
-#. MSG_BTN_CONTINUE c=5
+#. MSG_BTN_CONTINUE c=8
 #: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:292
 msgid "Done"
 msgstr "Klar"
@@ -1795,7 +1795,7 @@ msgstr "Druck fortgesetzt"
 msgid "Retract from FINDA"
 msgstr "Einziehen von FINDA"
 
-#. MSG_BTN_RETRY c=5
+#. MSG_BTN_RETRY c=8
 #: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:291
 msgid "Retry"
 msgstr "Wdh."
@@ -2061,7 +2061,7 @@ msgstr "Leise"
 msgid "Steel sheets"
 msgstr "Stahlbleche"
 
-#. MSG_BTN_STOP c=5
+#. MSG_BTN_STOP c=8
 #: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:295
 msgid "Stop"
 msgstr "Stop"
@@ -2246,7 +2246,7 @@ msgstr ""
 "Unerwarteter FINDA-Wert. Stellen Sie sicher, dass sich kein Filament unter "
 "FINDA befindet und der Selektor frei ist. Prüfen Sie die FINDA-Verbindung."
 
-#. MSG_BTN_UNLOAD c=6
+#. MSG_BTN_UNLOAD c=8
 #: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:294
 msgid "Unload"
 msgstr "Entla."

--- a/lang/po/Firmware_de.po
+++ b/lang/po/Firmware_de.po
@@ -1240,12 +1240,6 @@ msgstr "Modell"
 msgid "More details online."
 msgstr "Weiter Details online."
 
-#. MSG_BTN_MORE c=5
-#: ../../Firmware/mmu2/errors_list.h:287
-#: ../../Firmware/mmu2_error_converter.cpp:153
-msgid "More⏬"
-msgstr "Mehr⏬"
-
 #. MSG_SELFTEST_MOTOR c=18
 #: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6981
 #: ../../Firmware/ultralcd.cpp:6990 ../../Firmware/ultralcd.cpp:7008

--- a/lang/po/Firmware_es.po
+++ b/lang/po/Firmware_es.po
@@ -455,7 +455,7 @@ msgid ""
 msgstr ""
 "Quieres repetir el ultimo paso para reajustar la distancia boquilla-base?"
 
-#. MSG_BTN_CONTINUE c=5
+#. MSG_BTN_CONTINUE c=8
 #: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:292
 msgid "Done"
 msgstr ""
@@ -1767,7 +1767,7 @@ msgstr "Continuan. impresion"
 msgid "Retract from FINDA"
 msgstr ""
 
-#. MSG_BTN_RETRY c=5
+#. MSG_BTN_RETRY c=8
 #: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:291
 msgid "Retry"
 msgstr ""
@@ -2038,7 +2038,7 @@ msgstr "Sigilo"
 msgid "Steel sheets"
 msgstr "Lamina de acero"
 
-#. MSG_BTN_STOP c=5
+#. MSG_BTN_STOP c=8
 #: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:295
 msgid "Stop"
 msgstr ""
@@ -2214,7 +2214,7 @@ msgid ""
 "is free. Check FINDA connection."
 msgstr ""
 
-#. MSG_BTN_UNLOAD c=6
+#. MSG_BTN_UNLOAD c=8
 #: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:294
 msgid "Unload"
 msgstr ""

--- a/lang/po/Firmware_es.po
+++ b/lang/po/Firmware_es.po
@@ -1212,12 +1212,6 @@ msgstr "Modelo"
 msgid "More details online."
 msgstr ""
 
-#. MSG_BTN_MORE c=5
-#: ../../Firmware/mmu2/errors_list.h:287
-#: ../../Firmware/mmu2_error_converter.cpp:153
-msgid "More⏬"
-msgstr ""
-
 #. MSG_SELFTEST_MOTOR c=18
 #: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6981
 #: ../../Firmware/ultralcd.cpp:6990 ../../Firmware/ultralcd.cpp:7008

--- a/lang/po/Firmware_fr.po
+++ b/lang/po/Firmware_fr.po
@@ -1219,12 +1219,6 @@ msgstr "Modele"
 msgid "More details online."
 msgstr ""
 
-#. MSG_BTN_MORE c=5
-#: ../../Firmware/mmu2/errors_list.h:287
-#: ../../Firmware/mmu2_error_converter.cpp:153
-msgid "More⏬"
-msgstr ""
-
 #. MSG_SELFTEST_MOTOR c=18
 #: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6981
 #: ../../Firmware/ultralcd.cpp:6990 ../../Firmware/ultralcd.cpp:7008

--- a/lang/po/Firmware_fr.po
+++ b/lang/po/Firmware_fr.po
@@ -458,7 +458,7 @@ msgstr ""
 "Voulez-vous refaire l'etape pour reajuster la hauteur entre la buse et le "
 "plateau chauffant?"
 
-#. MSG_BTN_CONTINUE c=5
+#. MSG_BTN_CONTINUE c=8
 #: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:292
 msgid "Done"
 msgstr ""
@@ -1770,7 +1770,7 @@ msgstr "Reprise de l'impr."
 msgid "Retract from FINDA"
 msgstr ""
 
-#. MSG_BTN_RETRY c=5
+#. MSG_BTN_RETRY c=8
 #: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:291
 msgid "Retry"
 msgstr ""
@@ -2039,7 +2039,7 @@ msgstr "Furtif"
 msgid "Steel sheets"
 msgstr "Plaques en acier"
 
-#. MSG_BTN_STOP c=5
+#. MSG_BTN_STOP c=8
 #: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:295
 msgid "Stop"
 msgstr ""
@@ -2215,7 +2215,7 @@ msgid ""
 "is free. Check FINDA connection."
 msgstr ""
 
-#. MSG_BTN_UNLOAD c=6
+#. MSG_BTN_UNLOAD c=8
 #: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:294
 msgid "Unload"
 msgstr ""

--- a/lang/po/Firmware_hr.po
+++ b/lang/po/Firmware_hr.po
@@ -453,7 +453,7 @@ msgstr ""
 "Zelite li ponoviti zadnji korak za ponovno podesavanje udaljenosti izmedu "
 "mlaznice i grijace podloge?"
 
-#. MSG_BTN_CONTINUE c=5
+#. MSG_BTN_CONTINUE c=8
 #: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:292
 msgid "Done"
 msgstr ""
@@ -1756,7 +1756,7 @@ msgstr "Nastavak printa"
 msgid "Retract from FINDA"
 msgstr ""
 
-#. MSG_BTN_RETRY c=5
+#. MSG_BTN_RETRY c=8
 #: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:291
 msgid "Retry"
 msgstr ""
@@ -2026,7 +2026,7 @@ msgstr "Tiho"
 msgid "Steel sheets"
 msgstr "Celicna ploca"
 
-#. MSG_BTN_STOP c=5
+#. MSG_BTN_STOP c=8
 #: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:295
 msgid "Stop"
 msgstr ""
@@ -2201,7 +2201,7 @@ msgid ""
 "is free. Check FINDA connection."
 msgstr ""
 
-#. MSG_BTN_UNLOAD c=6
+#. MSG_BTN_UNLOAD c=8
 #: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:294
 msgid "Unload"
 msgstr ""

--- a/lang/po/Firmware_hr.po
+++ b/lang/po/Firmware_hr.po
@@ -1210,12 +1210,6 @@ msgstr ""
 msgid "More details online."
 msgstr ""
 
-#. MSG_BTN_MORE c=5
-#: ../../Firmware/mmu2/errors_list.h:287
-#: ../../Firmware/mmu2_error_converter.cpp:153
-msgid "More⏬"
-msgstr ""
-
 #. MSG_SELFTEST_MOTOR c=18
 #: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6981
 #: ../../Firmware/ultralcd.cpp:6990 ../../Firmware/ultralcd.cpp:7008

--- a/lang/po/Firmware_hu.po
+++ b/lang/po/Firmware_hu.po
@@ -456,7 +456,7 @@ msgstr ""
 "Meg szeretned ismetelni az utolso lepest, hogy finomhangold a fuvoka es az "
 "asztal kozotti tavolsagot?"
 
-#. MSG_BTN_CONTINUE c=5
+#. MSG_BTN_CONTINUE c=8
 #: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:292
 msgid "Done"
 msgstr ""
@@ -1763,7 +1763,7 @@ msgstr "Nyomtatas folytatasa"
 msgid "Retract from FINDA"
 msgstr ""
 
-#. MSG_BTN_RETRY c=5
+#. MSG_BTN_RETRY c=8
 #: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:291
 msgid "Retry"
 msgstr ""
@@ -2030,7 +2030,7 @@ msgstr "Halk"
 msgid "Steel sheets"
 msgstr "Acellapok"
 
-#. MSG_BTN_STOP c=5
+#. MSG_BTN_STOP c=8
 #: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:295
 msgid "Stop"
 msgstr ""
@@ -2206,7 +2206,7 @@ msgid ""
 "is free. Check FINDA connection."
 msgstr ""
 
-#. MSG_BTN_UNLOAD c=6
+#. MSG_BTN_UNLOAD c=8
 #: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:294
 msgid "Unload"
 msgstr ""

--- a/lang/po/Firmware_hu.po
+++ b/lang/po/Firmware_hu.po
@@ -1214,12 +1214,6 @@ msgstr "Modell"
 msgid "More details online."
 msgstr ""
 
-#. MSG_BTN_MORE c=5
-#: ../../Firmware/mmu2/errors_list.h:287
-#: ../../Firmware/mmu2_error_converter.cpp:153
-msgid "More⏬"
-msgstr ""
-
 #. MSG_SELFTEST_MOTOR c=18
 #: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6981
 #: ../../Firmware/ultralcd.cpp:6990 ../../Firmware/ultralcd.cpp:7008

--- a/lang/po/Firmware_it.po
+++ b/lang/po/Firmware_it.po
@@ -456,7 +456,7 @@ msgstr ""
 "Desideri ripetere l'ultimo passaggio per migliorare la distanza fra ugello e "
 "piatto?"
 
-#. MSG_BTN_CONTINUE c=5
+#. MSG_BTN_CONTINUE c=8
 #: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:292
 msgid "Done"
 msgstr ""
@@ -1761,7 +1761,7 @@ msgstr "Riprendi stampa"
 msgid "Retract from FINDA"
 msgstr ""
 
-#. MSG_BTN_RETRY c=5
+#. MSG_BTN_RETRY c=8
 #: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:291
 msgid "Retry"
 msgstr ""
@@ -2030,7 +2030,7 @@ msgstr "Silenz."
 msgid "Steel sheets"
 msgstr "Piani d'acciaio"
 
-#. MSG_BTN_STOP c=5
+#. MSG_BTN_STOP c=8
 #: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:295
 msgid "Stop"
 msgstr ""
@@ -2206,7 +2206,7 @@ msgid ""
 "is free. Check FINDA connection."
 msgstr ""
 
-#. MSG_BTN_UNLOAD c=6
+#. MSG_BTN_UNLOAD c=8
 #: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:294
 msgid "Unload"
 msgstr ""

--- a/lang/po/Firmware_it.po
+++ b/lang/po/Firmware_it.po
@@ -1213,12 +1213,6 @@ msgstr "Modello"
 msgid "More details online."
 msgstr ""
 
-#. MSG_BTN_MORE c=5
-#: ../../Firmware/mmu2/errors_list.h:287
-#: ../../Firmware/mmu2_error_converter.cpp:153
-msgid "More⏬"
-msgstr ""
-
 #. MSG_SELFTEST_MOTOR c=18
 #: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6981
 #: ../../Firmware/ultralcd.cpp:6990 ../../Firmware/ultralcd.cpp:7008

--- a/lang/po/Firmware_lb.po
+++ b/lang/po/Firmware_lb.po
@@ -1185,12 +1185,6 @@ msgstr ""
 msgid "More details online."
 msgstr ""
 
-#. MSG_BTN_MORE c=5
-#: ../../Firmware/mmu2/errors_list.h:287
-#: ../../Firmware/mmu2_error_converter.cpp:153
-msgid "More⏬"
-msgstr ""
-
 #. MSG_SELFTEST_MOTOR c=18
 #: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6981
 #: ../../Firmware/ultralcd.cpp:6990 ../../Firmware/ultralcd.cpp:7008

--- a/lang/po/Firmware_lb.po
+++ b/lang/po/Firmware_lb.po
@@ -442,7 +442,7 @@ msgid ""
 "heatbed?"
 msgstr ""
 
-#. MSG_BTN_CONTINUE c=5
+#. MSG_BTN_CONTINUE c=8
 #: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:292
 msgid "Done"
 msgstr ""
@@ -1716,7 +1716,7 @@ msgstr ""
 msgid "Retract from FINDA"
 msgstr ""
 
-#. MSG_BTN_RETRY c=5
+#. MSG_BTN_RETRY c=8
 #: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:291
 msgid "Retry"
 msgstr ""
@@ -1972,7 +1972,7 @@ msgstr ""
 msgid "Steel sheets"
 msgstr ""
 
-#. MSG_BTN_STOP c=5
+#. MSG_BTN_STOP c=8
 #: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:295
 msgid "Stop"
 msgstr ""
@@ -2143,7 +2143,7 @@ msgid ""
 "is free. Check FINDA connection."
 msgstr ""
 
-#. MSG_BTN_UNLOAD c=6
+#. MSG_BTN_UNLOAD c=8
 #: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:294
 msgid "Unload"
 msgstr ""

--- a/lang/po/Firmware_lt.po
+++ b/lang/po/Firmware_lt.po
@@ -1185,12 +1185,6 @@ msgstr ""
 msgid "More details online."
 msgstr ""
 
-#. MSG_BTN_MORE c=5
-#: ../../Firmware/mmu2/errors_list.h:287
-#: ../../Firmware/mmu2_error_converter.cpp:153
-msgid "More⏬"
-msgstr ""
-
 #. MSG_SELFTEST_MOTOR c=18
 #: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6981
 #: ../../Firmware/ultralcd.cpp:6990 ../../Firmware/ultralcd.cpp:7008

--- a/lang/po/Firmware_lt.po
+++ b/lang/po/Firmware_lt.po
@@ -442,7 +442,7 @@ msgid ""
 "heatbed?"
 msgstr ""
 
-#. MSG_BTN_CONTINUE c=5
+#. MSG_BTN_CONTINUE c=8
 #: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:292
 msgid "Done"
 msgstr ""
@@ -1716,7 +1716,7 @@ msgstr ""
 msgid "Retract from FINDA"
 msgstr ""
 
-#. MSG_BTN_RETRY c=5
+#. MSG_BTN_RETRY c=8
 #: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:291
 msgid "Retry"
 msgstr ""
@@ -1972,7 +1972,7 @@ msgstr ""
 msgid "Steel sheets"
 msgstr ""
 
-#. MSG_BTN_STOP c=5
+#. MSG_BTN_STOP c=8
 #: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:295
 msgid "Stop"
 msgstr ""
@@ -2143,7 +2143,7 @@ msgid ""
 "is free. Check FINDA connection."
 msgstr ""
 
-#. MSG_BTN_UNLOAD c=6
+#. MSG_BTN_UNLOAD c=8
 #: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:294
 msgid "Unload"
 msgstr ""

--- a/lang/po/Firmware_nl.po
+++ b/lang/po/Firmware_nl.po
@@ -1232,12 +1232,6 @@ msgstr "Model"
 msgid "More details online."
 msgstr "Meer details online."
 
-#. MSG_BTN_MORE c=5
-#: ../../Firmware/mmu2/errors_list.h:287
-#: ../../Firmware/mmu2_error_converter.cpp:153
-msgid "More⏬"
-msgstr "Meer⏬"
-
 #. MSG_SELFTEST_MOTOR c=18
 #: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6981
 #: ../../Firmware/ultralcd.cpp:6990 ../../Firmware/ultralcd.cpp:7008

--- a/lang/po/Firmware_nl.po
+++ b/lang/po/Firmware_nl.po
@@ -459,7 +459,7 @@ msgstr ""
 "Wilt u de laatste stap herhalen om de afstand tussen de tuit en de bed "
 "opnieuw in te stellen?"
 
-#. MSG_BTN_CONTINUE c=5
+#. MSG_BTN_CONTINUE c=8
 #: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:292
 msgid "Done"
 msgstr "Klaar"
@@ -1784,7 +1784,7 @@ msgstr "Hervatten print"
 msgid "Retract from FINDA"
 msgstr "Intrekken van FINDA"
 
-#. MSG_BTN_RETRY c=5
+#. MSG_BTN_RETRY c=8
 #: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:291
 msgid "Retry"
 msgstr "Retry"
@@ -2056,7 +2056,7 @@ msgstr "Stil"
 msgid "Steel sheets"
 msgstr "Staalplaten"
 
-#. MSG_BTN_STOP c=5
+#. MSG_BTN_STOP c=8
 #: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:295
 msgid "Stop"
 msgstr "Stop"
@@ -2238,7 +2238,7 @@ msgstr ""
 "Onverwachte FINDA-aflezing. Zorg ervoor dat er geen filament onder FINDA zit"
 " en dat de selecteur vrij is. Controleer de FINDA-verbinding."
 
-#. MSG_BTN_UNLOAD c=6
+#. MSG_BTN_UNLOAD c=8
 #: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:294
 msgid "Unload"
 msgstr "Ontla."

--- a/lang/po/Firmware_no.po
+++ b/lang/po/Firmware_no.po
@@ -1207,12 +1207,6 @@ msgstr "Modell"
 msgid "More details online."
 msgstr ""
 
-#. MSG_BTN_MORE c=5
-#: ../../Firmware/mmu2/errors_list.h:287
-#: ../../Firmware/mmu2_error_converter.cpp:153
-msgid "More⏬"
-msgstr ""
-
 #. MSG_SELFTEST_MOTOR c=18
 #: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6981
 #: ../../Firmware/ultralcd.cpp:6990 ../../Firmware/ultralcd.cpp:7008

--- a/lang/po/Firmware_no.po
+++ b/lang/po/Firmware_no.po
@@ -456,7 +456,7 @@ msgstr ""
 "Vil du repetere det siste trinnet for å omjustere avstanden mellom dysen og "
 "platen?"
 
-#. MSG_BTN_CONTINUE c=5
+#. MSG_BTN_CONTINUE c=8
 #: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:292
 msgid "Done"
 msgstr ""
@@ -1749,7 +1749,7 @@ msgstr "Gjenopptar print"
 msgid "Retract from FINDA"
 msgstr ""
 
-#. MSG_BTN_RETRY c=5
+#. MSG_BTN_RETRY c=8
 #: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:291
 msgid "Retry"
 msgstr ""
@@ -2012,7 +2012,7 @@ msgstr "Stille"
 msgid "Steel sheets"
 msgstr "Stål plate"
 
-#. MSG_BTN_STOP c=5
+#. MSG_BTN_STOP c=8
 #: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:295
 msgid "Stop"
 msgstr ""
@@ -2188,7 +2188,7 @@ msgid ""
 "is free. Check FINDA connection."
 msgstr ""
 
-#. MSG_BTN_UNLOAD c=6
+#. MSG_BTN_UNLOAD c=8
 #: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:294
 msgid "Unload"
 msgstr ""

--- a/lang/po/Firmware_pl.po
+++ b/lang/po/Firmware_pl.po
@@ -1211,12 +1211,6 @@ msgstr ""
 msgid "More details online."
 msgstr ""
 
-#. MSG_BTN_MORE c=5
-#: ../../Firmware/mmu2/errors_list.h:287
-#: ../../Firmware/mmu2_error_converter.cpp:153
-msgid "More⏬"
-msgstr ""
-
 #. MSG_SELFTEST_MOTOR c=18
 #: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6981
 #: ../../Firmware/ultralcd.cpp:6990 ../../Firmware/ultralcd.cpp:7008

--- a/lang/po/Firmware_pl.po
+++ b/lang/po/Firmware_pl.po
@@ -456,7 +456,7 @@ msgstr ""
 "Chcesz powtorzyc ostatni krok i ponownie ustawic odleglosc miedzy dysza a "
 "stolikiem?"
 
-#. MSG_BTN_CONTINUE c=5
+#. MSG_BTN_CONTINUE c=8
 #: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:292
 msgid "Done"
 msgstr ""
@@ -1756,7 +1756,7 @@ msgstr "Wznawianie druku"
 msgid "Retract from FINDA"
 msgstr ""
 
-#. MSG_BTN_RETRY c=5
+#. MSG_BTN_RETRY c=8
 #: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:291
 msgid "Retry"
 msgstr ""
@@ -2025,7 +2025,7 @@ msgstr "Cichy"
 msgid "Steel sheets"
 msgstr "Plyty stalowe"
 
-#. MSG_BTN_STOP c=5
+#. MSG_BTN_STOP c=8
 #: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:295
 msgid "Stop"
 msgstr ""
@@ -2201,7 +2201,7 @@ msgid ""
 "is free. Check FINDA connection."
 msgstr ""
 
-#. MSG_BTN_UNLOAD c=6
+#. MSG_BTN_UNLOAD c=8
 #: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:294
 msgid "Unload"
 msgstr ""

--- a/lang/po/Firmware_ro.po
+++ b/lang/po/Firmware_ro.po
@@ -1227,12 +1227,6 @@ msgstr "Model"
 msgid "More details online."
 msgstr "Mai multe detalii online"
 
-#. MSG_BTN_MORE c=5
-#: ../../Firmware/mmu2/errors_list.h:287
-#: ../../Firmware/mmu2_error_converter.cpp:153
-msgid "More⏬"
-msgstr "More⏬"
-
 #. MSG_SELFTEST_MOTOR c=18
 #: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6981
 #: ../../Firmware/ultralcd.cpp:6990 ../../Firmware/ultralcd.cpp:7008

--- a/lang/po/Firmware_ro.po
+++ b/lang/po/Firmware_ro.po
@@ -457,7 +457,7 @@ msgstr ""
 "Vreti sa repetati ultimul pas pentru a reajusta distanta dintre varf si "
 "suprafata de print?"
 
-#. MSG_BTN_CONTINUE c=5
+#. MSG_BTN_CONTINUE c=8
 #: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:292
 msgid "Done"
 msgstr "Gata"
@@ -1775,7 +1775,7 @@ msgstr "Reluare print..."
 msgid "Retract from FINDA"
 msgstr "Retract de la FINDA"
 
-#. MSG_BTN_RETRY c=5
+#. MSG_BTN_RETRY c=8
 #: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:291
 msgid "Retry"
 msgstr "Retry"
@@ -2044,7 +2044,7 @@ msgstr "Silent."
 msgid "Steel sheets"
 msgstr "Suprafete print"
 
-#. MSG_BTN_STOP c=5
+#. MSG_BTN_STOP c=8
 #: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:295
 msgid "Stop"
 msgstr "Stop"
@@ -2224,7 +2224,7 @@ msgstr ""
 "Citire FINDA neasteptata.Asig. ca nu este Fil. sub FINDA si SELECTOR"
 "Verifica conexiune FINDA"
 
-#. MSG_BTN_UNLOAD c=6
+#. MSG_BTN_UNLOAD c=8
 #: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:294
 msgid "Unload"
 msgstr "Unload"

--- a/lang/po/Firmware_sk.po
+++ b/lang/po/Firmware_sk.po
@@ -1226,12 +1226,6 @@ msgstr "Model"
 msgid "More details online."
 msgstr "Viac podrobnosti online."
 
-#. MSG_BTN_MORE c=5
-#: ../../Firmware/mmu2/errors_list.h:287
-#: ../../Firmware/mmu2_error_converter.cpp:153
-msgid "More⏬"
-msgstr "Viac⏬"
-
 #. MSG_SELFTEST_MOTOR c=18
 #: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6981
 #: ../../Firmware/ultralcd.cpp:6990 ../../Firmware/ultralcd.cpp:7008

--- a/lang/po/Firmware_sk.po
+++ b/lang/po/Firmware_sk.po
@@ -456,7 +456,7 @@ msgstr ""
 "Chcete opakovat posledny krok a pozmenit vzdialenost medzi tryskou a "
 "podlozkou?"
 
-#. MSG_BTN_CONTINUE c=5
+#. MSG_BTN_CONTINUE c=8
 #: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:292
 msgid "Done"
 msgstr "Hotov"
@@ -1776,7 +1776,7 @@ msgstr "Obnovenie tlace"
 msgid "Retract from FINDA"
 msgstr "Vybrat z FINDA"
 
-#. MSG_BTN_RETRY c=5
+#. MSG_BTN_RETRY c=8
 #: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:291
 msgid "Retry"
 msgstr "Znova"
@@ -2040,7 +2040,7 @@ msgstr "Tichy"
 msgid "Steel sheets"
 msgstr "Platne"
 
-#. MSG_BTN_STOP c=5
+#. MSG_BTN_STOP c=8
 #: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:295
 msgid "Stop"
 msgstr "Zast."
@@ -2222,7 +2222,7 @@ msgstr ""
 "Neocakavane nacitanie FINDA. Skontrolujte, ze filament nie je pod FINDA a "
 "selektor je volny. Skontrolujte pripojenie FINDA."
 
-#. MSG_BTN_UNLOAD c=6
+#. MSG_BTN_UNLOAD c=8
 #: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:294
 msgid "Unload"
 msgstr "Vysuv"

--- a/lang/po/Firmware_sl.po
+++ b/lang/po/Firmware_sl.po
@@ -1185,12 +1185,6 @@ msgstr ""
 msgid "More details online."
 msgstr ""
 
-#. MSG_BTN_MORE c=5
-#: ../../Firmware/mmu2/errors_list.h:287
-#: ../../Firmware/mmu2_error_converter.cpp:153
-msgid "More⏬"
-msgstr ""
-
 #. MSG_SELFTEST_MOTOR c=18
 #: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6981
 #: ../../Firmware/ultralcd.cpp:6990 ../../Firmware/ultralcd.cpp:7008

--- a/lang/po/Firmware_sl.po
+++ b/lang/po/Firmware_sl.po
@@ -442,7 +442,7 @@ msgid ""
 "heatbed?"
 msgstr ""
 
-#. MSG_BTN_CONTINUE c=5
+#. MSG_BTN_CONTINUE c=8
 #: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:292
 msgid "Done"
 msgstr ""
@@ -1716,7 +1716,7 @@ msgstr ""
 msgid "Retract from FINDA"
 msgstr ""
 
-#. MSG_BTN_RETRY c=5
+#. MSG_BTN_RETRY c=8
 #: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:291
 msgid "Retry"
 msgstr ""
@@ -1972,7 +1972,7 @@ msgstr ""
 msgid "Steel sheets"
 msgstr ""
 
-#. MSG_BTN_STOP c=5
+#. MSG_BTN_STOP c=8
 #: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:295
 msgid "Stop"
 msgstr ""
@@ -2143,7 +2143,7 @@ msgid ""
 "is free. Check FINDA connection."
 msgstr ""
 
-#. MSG_BTN_UNLOAD c=6
+#. MSG_BTN_UNLOAD c=8
 #: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:294
 msgid "Unload"
 msgstr ""

--- a/lang/po/Firmware_sv.po
+++ b/lang/po/Firmware_sv.po
@@ -456,7 +456,7 @@ msgstr ""
 "Vill du upprepa det sista steget för att justera avståndet mellan munstycket "
 "och värmebädden?"
 
-#. MSG_BTN_CONTINUE c=5
+#. MSG_BTN_CONTINUE c=8
 #: ../../Firmware/mmu2/errors_list.h:282 ../../Firmware/mmu2/errors_list.h:292
 msgid "Done"
 msgstr ""
@@ -1764,7 +1764,7 @@ msgstr "Återupptar utskrift"
 msgid "Retract from FINDA"
 msgstr ""
 
-#. MSG_BTN_RETRY c=5
+#. MSG_BTN_RETRY c=8
 #: ../../Firmware/mmu2/errors_list.h:281 ../../Firmware/mmu2/errors_list.h:291
 msgid "Retry"
 msgstr ""
@@ -2030,7 +2030,7 @@ msgstr "Tyst"
 msgid "Steel sheets"
 msgstr "Metallskivor"
 
-#. MSG_BTN_STOP c=5
+#. MSG_BTN_STOP c=8
 #: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:295
 msgid "Stop"
 msgstr ""
@@ -2205,7 +2205,7 @@ msgid ""
 "is free. Check FINDA connection."
 msgstr ""
 
-#. MSG_BTN_UNLOAD c=6
+#. MSG_BTN_UNLOAD c=8
 #: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:294
 msgid "Unload"
 msgstr ""

--- a/lang/po/Firmware_sv.po
+++ b/lang/po/Firmware_sv.po
@@ -1214,12 +1214,6 @@ msgstr "Modell"
 msgid "More details online."
 msgstr ""
 
-#. MSG_BTN_MORE c=5
-#: ../../Firmware/mmu2/errors_list.h:287
-#: ../../Firmware/mmu2_error_converter.cpp:153
-msgid "More⏬"
-msgstr ""
-
 #. MSG_SELFTEST_MOTOR c=18
 #: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6981
 #: ../../Firmware/ultralcd.cpp:6990 ../../Firmware/ultralcd.cpp:7008


### PR DESCRIPTION
The main change is when there are 3 buttons present on the MMU error screen, now the first two choices can have 8 characters.

This is what the error screen looks like after the changes:

Two button screen:
---

| MK3 branch| AFTER [58464cd](https://github.com/prusa3d/Prusa-Firmware/pull/3643/commits/58464cd74409330a645b2a02f487ff33c41006c1) | AFTER [b74d293](https://github.com/prusa3d/Prusa-Firmware/pull/3643/commits/b74d29371270942ffe2cde0f8f23617694df70bb) |
| ------------- | ------------- | ------------- |
| ![IMG_2431](https://user-images.githubusercontent.com/8218499/193403639-6447b4a6-73a9-4be7-93cc-27effa0a2e2e.jpg) | ![IMG_2430](https://user-images.githubusercontent.com/8218499/193403222-caf212e6-db2a-4504-a5bb-e012cd4e892f.jpg) | ![IMG_2436](https://user-images.githubusercontent.com/8218499/193414075-8d333f46-f3ad-4322-865a-376b0cee575d.jpg) |

Three button screen:
---




| MK3 branch| AFTER [58464cd](https://github.com/prusa3d/Prusa-Firmware/pull/3643/commits/58464cd74409330a645b2a02f487ff33c41006c1) | AFTER [b74d293](https://github.com/prusa3d/Prusa-Firmware/pull/3643/commits/b74d29371270942ffe2cde0f8f23617694df70bb) |
| ------------- | ------------- | ------------- |
| ![IMG_2433](https://user-images.githubusercontent.com/8218499/193403635-9f2a997d-94ad-4416-8fab-b0e7d6dd07c4.jpg)   | ![IMG_2429](https://user-images.githubusercontent.com/8218499/193403214-cff5f3b1-36f8-44b1-b39e-4390a8cdce26.jpg) |![IMG_2435](https://user-images.githubusercontent.com/8218499/193414097-3871ae54-d0a5-4375-b095-7a8089c06479.jpg)|


Change in memory:
Flash: -8 bytes
SRAM: 0 bytes