### PR TITLE
PFW-1403 Fix issue where physical MMU buttons do not dismiss error screen

### DIFF
--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -216,7 +216,7 @@ void MMU2::mmu_loop() {
     if (is_mmu_error_monitor_active){
         // Call this every iteration to keep the knob rotation responsive
         // This includes when mmu_loop is called within manage_response
-        ReportErrorHook((uint16_t)lastErrorCode, mmu2.MMUCurrentErrorCode() == ErrorCode::OK ? ErrorSourcePrinter : ErrorSourceMMU);
+        ReportErrorHook((uint16_t)lastErrorCode);
     }
 
     avoidRecursion = false;
@@ -795,7 +795,7 @@ void MMU2::execute_extruder_sequence(const E_Step *sequence, uint8_t steps) {
     }
 }
 
-void MMU2::ReportError(ErrorCode ec, uint8_t res) {
+void MMU2::ReportError(ErrorCode ec, ReportErrorSource res) {
     // Due to a potential lossy error reporting layers linked to this hook
     // we'd better report everything to make sure especially the error states
     // do not get lost. 
@@ -821,12 +821,13 @@ void MMU2::ReportError(ErrorCode ec, uint8_t res) {
         break;
     }
 
-    ReportErrorHook((uint16_t)ec, res);
-
     if( ec != lastErrorCode ){ // deduplicate: only report changes in error codes into the log
         lastErrorCode = ec;
+        lastErrorSource = res;
         LogErrorEvent_P( _O(PrusaErrorTitle(PrusaErrorCodeIndex((uint16_t)ec))) );
     }
+
+    ReportErrorHook((uint16_t)ec);
 
     static_assert(mmu2Magic[0] == 'M' 
         && mmu2Magic[1] == 'M' 

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -795,7 +795,7 @@ void MMU2::execute_extruder_sequence(const E_Step *sequence, uint8_t steps) {
     }
 }
 
-void MMU2::ReportError(ErrorCode ec, ReportErrorSource res) {
+void MMU2::ReportError(ErrorCode ec, ErrorSource res) {
     // Due to a potential lossy error reporting layers linked to this hook
     // we'd better report everything to make sure especially the error states
     // do not get lost. 

--- a/Firmware/mmu2.h
+++ b/Firmware/mmu2.h
@@ -70,7 +70,7 @@ public:
     };
 
     /// Source of operation error
-    enum ReportErrorSource: uint8_t {
+    enum ErrorSource: uint8_t {
         ErrorSourcePrinter = 0,
         ErrorSourceMMU = 1,
         ErrorSourceNone = 0xFF,
@@ -166,7 +166,7 @@ public:
     inline ErrorCode MMUCurrentErrorCode() const { return logic.Error(); }
 
     /// @returns Last error source
-    inline ReportErrorSource MMULastErrorSource() const { return lastErrorSource; }
+    inline ErrorSource MMULastErrorSource() const { return lastErrorSource; }
 
     /// @returns the version of the connected MMU FW.
     /// In the future we'll return the trully detected FW version
@@ -222,7 +222,7 @@ private:
     /// Reports an error into attached ExtUIs
     /// @param ec error code, see ErrorCode
     /// @param res reporter error source, is either Printer (0) or MMU (1)
-    void ReportError(ErrorCode ec, ReportErrorSource res);
+    void ReportError(ErrorCode ec, ErrorSource res);
 
     /// Reports progress of operations into attached ExtUIs
     /// @param pc progress code, see ProgressCode
@@ -268,7 +268,7 @@ private:
     
     ProgressCode lastProgressCode = ProgressCode::OK;
     ErrorCode lastErrorCode = ErrorCode::MMU_NOT_RESPONDING;
-    ReportErrorSource lastErrorSource = ReportErrorSource::ErrorSourceNone;
+    ErrorSource lastErrorSource = ErrorSource::ErrorSourceNone;
     Buttons lastButton = Buttons::NoButton;
 
     StepStatus logicStepLastStatus;

--- a/Firmware/mmu2.h
+++ b/Firmware/mmu2.h
@@ -73,6 +73,7 @@ public:
     enum ReportErrorSource: uint8_t {
         ErrorSourcePrinter = 0,
         ErrorSourceMMU = 1,
+        ErrorSourceNone = 0xFF,
     };
 
     /// Perform a reset of the MMU
@@ -164,6 +165,9 @@ public:
     /// @returns Current error code
     inline ErrorCode MMUCurrentErrorCode() const { return logic.Error(); }
 
+    /// @returns Last error source
+    inline ReportErrorSource MMULastErrorSource() const { return lastErrorSource; }
+
     /// @returns the version of the connected MMU FW.
     /// In the future we'll return the trully detected FW version
     Version GetMMUFWVersion()const {
@@ -218,7 +222,7 @@ private:
     /// Reports an error into attached ExtUIs
     /// @param ec error code, see ErrorCode
     /// @param res reporter error source, is either Printer (0) or MMU (1)
-    void ReportError(ErrorCode ec, uint8_t res);
+    void ReportError(ErrorCode ec, ReportErrorSource res);
 
     /// Reports progress of operations into attached ExtUIs
     /// @param pc progress code, see ProgressCode
@@ -264,6 +268,7 @@ private:
     
     ProgressCode lastProgressCode = ProgressCode::OK;
     ErrorCode lastErrorCode = ErrorCode::MMU_NOT_RESPONDING;
+    ReportErrorSource lastErrorSource = ReportErrorSource::ErrorSourceNone;
     Buttons lastButton = Buttons::NoButton;
 
     StepStatus logicStepLastStatus;

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -216,8 +216,8 @@ enum class ReportErrorHookStates : uint8_t {
 
 enum ReportErrorHookStates ReportErrorHookState = ReportErrorHookStates::RENDER_ERROR_SCREEN;
 
-void ReportErrorHook(uint16_t ec, uint8_t res) {
-    if (mmu2.MMUCurrentErrorCode() == ErrorCode::OK && res == MMU2::ErrorSourceMMU)
+void ReportErrorHook(uint16_t ec) {
+    if (mmu2.MMUCurrentErrorCode() == ErrorCode::OK && mmu2.MMULastErrorSource() == MMU2::ErrorSourceMMU)
     {
         // If the error code suddenly changes to OK, that means
         // a button was pushed on the MMU and the LCD should

--- a/Firmware/mmu2_reporting.h
+++ b/Firmware/mmu2_reporting.h
@@ -27,9 +27,8 @@ void EndReport(CommandInProgress cip, uint16_t ec);
  * Render MMU error screen on the LCD. This must be non-blocking
  * and allow the MMU and printer to communicate with each other.
  * @param[in] ec error code
- * @param[in] res reporter error source, is either Printer (0) or MMU (1)
  */
-void ReportErrorHook(uint16_t ec, uint8_t res);
+void ReportErrorHook(uint16_t ec);
 
 /// Called when the MMU sends operation progress update
 void ReportProgressHook(CommandInProgress cip, uint16_t ec);


### PR DESCRIPTION
When the physical MMU buttons are used instead of the LCD buttons to resolve error screen, the screen will not be dismissed. Even if the error itself is resolved by pressing the button, the error screen will stay indefinitely on the LCD.

**Steps to reproduce issue:**

1. Boot up printer
2. Send T0 over serial
3. Wait for MMU to raise an error screen
4. Try clicking any of the physical MMU buttons
5. Observe that the error screen is not dismissed.

----
Solution here is to write down the error source into SRAM as soon as the error is reported (and only once). Then there can not be any confusion whether the error originated from the Printer or the MMU.