### PR TITLE
cleanup: Fix more spourious missing return warnings

### DIFF
--- a/Firmware/Filament_sensor.cpp
+++ b/Firmware/Filament_sensor.cpp
@@ -466,7 +466,9 @@ void PAT9125_sensor::settings_init() {
 }
 
 int16_t PAT9125_sensor::getStepCount() {
-    ATOMIC_BLOCK(ATOMIC_RESTORESTATE) { return stepCount; }
+    int16_t ret;
+    ATOMIC_BLOCK(ATOMIC_RESTORESTATE) { ret = stepCount; }
+    return ret;
 }
 
 void PAT9125_sensor::resetStepCount() {


### PR DESCRIPTION
Rewrite to use a temporary and get rid of the warning. The generated asm is *unchanged*.