### PR TITLE
Enable MISO pullup during SD CMD0

### DIFF
--- a/Firmware/Sd2Card.cpp
+++ b/Firmware/Sd2Card.cpp
@@ -311,13 +311,16 @@ bool Sd2Card::init(uint8_t sckRateID) {
   // must supply min of 74 clock cycles with CS high.
   for (uint8_t i = 0; i < 10; i++) spiSend(0XFF);
 
+  WRITE(MISO, 1); // temporarily enable the MISO line pullup
   // command to go idle in SPI mode
   while ((status_ = cardCommand(CMD0, 0)) != R1_IDLE_STATE) {
     if (((uint16_t)_millis() - t0) > SD_INIT_TIMEOUT) {
+      WRITE(MISO, 0); // disable the MISO line pullup
       error(SD_CARD_ERROR_CMD0);
       goto fail;
     }
   }
+  WRITE(MISO, 0); // disable the MISO line pullup
 
   // send 0xFF until 0xFF received to give card some clock cycles
   t0 = (uint16_t)_millis();


### PR DESCRIPTION
This fixes the SD card initilaization on the miniRambo for some SD cards which don't pull the MISO line high while the SD card operates in open collector mode. This issue has been observed on miniRambo only while using the new (as of writing) Verbatim SD cards that are sent out with printers.

Because there is no pull-up on the MISO line, it never gets pulled high while waiting for idle, so the init sequence times out. To counter this, the internal pullup of the atmega2560 is enabled briefly while sending the CMD0 command, ensuring that the card (which operates in open collector mode before CMD0) can talk to the atmega2560. Most cards have pullups also on the data lines, so they are not affected by this issue. This Verbatim card seems to be an exception, but it somehow works with the EinsyRambo.