### PR TITLE
Set CMake build type to Release when using kit

### DIFF
--- a/.vscode/cmake-kits.json
+++ b/.vscode/cmake-kits.json
@@ -3,7 +3,8 @@
         "name": "Local_avr-gcc-none-eabi",
         "toolchainFile": "${workspaceFolder}/cmake/LocalAvrGcc.cmake",
         "cmakeSettings": {
-            "CMAKE_MAKE_PROGRAM": "${workspaceFolder}/.dependencies/ninja-1.10.2/ninja"
+            "CMAKE_MAKE_PROGRAM": "${workspaceFolder}/.dependencies/ninja-1.10.2/ninja",
+            "CMAKE_BUILD_TYPE": "Release"
         }
     }
 ]


### PR DESCRIPTION
This ensures Release build type is used when one is using the CMake kit with the Vscode CMake Tools plugin.