### PR TITLE
TM: Consume LCD click after calibration for MK3_3.12

### DIFF
--- a/Firmware/lcd.h
+++ b/Firmware/lcd.h
@@ -204,11 +204,12 @@ private:
 extern void lcd_set_custom_characters(void);
 extern void lcd_set_custom_characters_nextpage(void);
 
-//! @brief Consume click event
+//! @brief Consume click and longpress event
 inline void lcd_consume_click()
 {
     lcd_button_pressed = 0;
     lcd_buttons &= 0xff^EN_C;
+    lcd_longpress_trigger = 0;
 }
 
 

--- a/Firmware/temperature.cpp
+++ b/Firmware/temperature.cpp
@@ -2906,6 +2906,7 @@ void temp_model_autotune(int16_t temp, bool selftest)
         temp_model_report_settings();
     }
 
+    lcd_consume_click();
     menu_unset_block(MENU_BLOCK_TEMP_MODEL_AUTOTUNE);
 }
 


### PR DESCRIPTION
Cherry-pick from https://github.com/prusa3d/Prusa-Firmware/pull/3638