### PR TITLE
MMU: Sync first layer purge line with PrusaSlicer generated output

### DIFF
--- a/Firmware/first_lay_cal.cpp
+++ b/Firmware/first_lay_cal.cpp
@@ -48,8 +48,8 @@ void lay1cal_load_filament(char *cmd_buffer, uint8_t filament)
 //! @brief Print intro line
 void lay1cal_intro_line()
 {
-    static const char cmd_intro_mmu_3[] PROGMEM = "G1 X55.0 E32.0 F1073.0";
-    static const char cmd_intro_mmu_4[] PROGMEM = "G1 X5.0 E32.0 F1800.0";
+    static const char cmd_intro_mmu_3[] PROGMEM = "G1 X55.0 E29.0 F1073.0";
+    static const char cmd_intro_mmu_4[] PROGMEM = "G1 X5.0 E29.0 F1800.0";
     static const char cmd_intro_mmu_5[] PROGMEM = "G1 X55.0 E8.0 F2000.0";
     static const char cmd_intro_mmu_6[] PROGMEM = "G1 Z0.3 F1000.0";
     static const char cmd_intro_mmu_7[] PROGMEM = "G92 E0.0";


### PR DESCRIPTION
If one generates a multicolor gcode file with PrusaSlicer, the purge line gcode will look like this.

This reduces clicking sounds from the extruder, filament extrusion is reduced by 6mm.