### PR TITLE
cmake: Toolchain tweaks

### DIFF
--- a/.github/travis/cmake-build.sh
+++ b/.github/travis/cmake-build.sh
@@ -4,7 +4,7 @@ rm -rf build
 mkdir build
 cd build
 cmake .. \
-    -DCMAKE_TOOLCHAIN_FILE="../cmake/LocalAvrGcc.cmake" \
+    -DCMAKE_TOOLCHAIN_FILE="../cmake/AvrGcc.cmake" \
     -DCMAKE_BUILD_TYPE=Release \
     -G Ninja
 ninja ALL_FIRMWARE

--- a/.vscode/cmake-kits.json
+++ b/.vscode/cmake-kits.json
@@ -1,7 +1,7 @@
 [
     {
-        "name": "Local_avr-gcc-none-eabi",
-        "toolchainFile": "${workspaceFolder}/cmake/LocalAvrGcc.cmake",
+        "name": "avr-gcc",
+        "toolchainFile": "${workspaceFolder}/cmake/AvrGcc.cmake",
         "cmakeSettings": {
             "CMAKE_MAKE_PROGRAM": "${workspaceFolder}/.dependencies/ninja-1.10.2/ninja",
             "CMAKE_BUILD_TYPE": "Release"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,7 @@ message("Language maximum size (from config.h): ${LANG_MAX_SIZE} bytes")
 # Ditto, this in xflash_layout.h but needs invocation of the preprocessor... :-/
 set(LANG_BIN_MAX 249856)
 
+# Check GCC Version
 get_recommended_gcc_version(RECOMMENDED_TOOLCHAIN_VERSION)
 if(CMAKE_CROSSCOMPILING AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL
                             ${RECOMMENDED_TOOLCHAIN_VERSION}

--- a/cmake/AnyAvrGcc.cmake
+++ b/cmake/AnyAvrGcc.cmake
@@ -2,9 +2,7 @@ get_filename_component(PROJECT_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" DIRECTORY)
 include("${PROJECT_CMAKE_DIR}/Utilities.cmake")
 set(CMAKE_SYSTEM_NAME Generic)
 set(CMAKE_SYSTEM_PROCESSOR avr)
-set(CMAKE_CROSSCOMPILING 1)
-get_dependency_directory("avr-gcc" AVR_TOOLCHAIN_DIR)
-message( "tc dir is ${AVR_TOOLCHAIN_DIR}")
+
 #
 # Utilities
 
@@ -27,6 +25,7 @@ set(TOOLCHAIN_PREFIX avr-)
 
 if(AVR_TOOLCHAIN_DIR)
   # using toolchain set by AvrGcc.cmake (locked version)
+  message("ToolChain dir is ${AVR_TOOLCHAIN_DIR}")
   set(BINUTILS_PATH "${AVR_TOOLCHAIN_DIR}/bin")
 else()
   # search for ANY avr-gcc toolchain

--- a/cmake/AvrGcc.cmake
+++ b/cmake/AvrGcc.cmake
@@ -1,0 +1,4 @@
+get_filename_component(PROJECT_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" DIRECTORY)
+include("${PROJECT_CMAKE_DIR}/Utilities.cmake")
+get_dependency_directory("avr-gcc" AVR_TOOLCHAIN_DIR)
+include("${PROJECT_CMAKE_DIR}/AnyAvrGcc.cmake")

--- a/utils/bootstrap.py
+++ b/utils/bootstrap.py
@@ -47,9 +47,9 @@ dependencies = {
     'avr-gcc': {
         'version': '7.3.0',
         'url': {
-            'Linux': 'http://downloads.arduino.cc/tools/avr-gcc-7.3.0-atmel3.6.1-arduino7-x86_64-pc-linux-gnu.tar.bz2',
-            'Windows': 'http://downloads.arduino.cc/tools/avr-gcc-7.3.0-atmel3.6.1-arduino7-i686-w64-mingw32.zip',
-            'Darwin': 'http://downloads.arduino.cc/tools/avr-gcc-7.3.0-atmel3.6.1-arduino7-x86_64-apple-darwin14.tar.bz2',
+            'Linux': 'https://ww1.microchip.com/downloads/aemDocuments/documents/DEV/ProductDocuments/SoftwareTools/avr8-gnu-toolchain-3.7.0.1796-linux.any.x86_64.tar.gz',
+            'Windows': 'https://ww1.microchip.com/downloads/aemDocuments/documents/DEV/ProductDocuments/SoftwareTools/avr8-gnu-toolchain-3.7.0.1796-win32.any.x86_64.zip',
+            'Darwin': 'https://ww1.microchip.com/downloads/aemDocuments/documents/DEV/ProductDocuments/SoftwareTools/avr8-gnu-toolchain-osx-3.7.0.518-darwin.any.x86_64.tar.gz',
         },
     },
     'prusa3dboards': {

--- a/utils/bootstrap.py
+++ b/utils/bootstrap.py
@@ -141,6 +141,15 @@ def install_dependency(dependency):
     fix_executable_permissions(dependency, installation_directory)
 
 
+def get_dependency_version(dependency):
+    return dependencies[dependency]['version']
+
+
+def get_dependency_directory(dependency) -> Path:
+    version = dependencies[dependency]['version']
+    return Path(directory_for_dependency(dependency, version))
+
+
 def main() -> int:
     parser = ArgumentParser()
     # yapf: disable
@@ -155,8 +164,7 @@ def main() -> int:
 
     if args.print_dependency_version:
         try:
-            version = dependencies[args.print_dependency_version]['version']
-            print(version)
+            print(get_dependency_version(args.print_dependency_version))
             return 0
         except KeyError:
             print('Unknown dependency "%s"' % args.print_dependency_version)
@@ -164,10 +172,7 @@ def main() -> int:
 
     if args.print_dependency_directory:
         try:
-            dependency = args.print_dependency_directory
-            version = dependencies[dependency]['version']
-            install_dir = directory_for_dependency(dependency, version)
-            print(install_dir)
+            print(get_dependency_directory(args.print_dependency_directory))
             return 0
         except KeyError:
             print('Unknown dependency "%s"' % args.print_dependency_directory)


### PR DESCRIPTION
Allow two toolchains to be used:

- AvrGcc: use avr-gcc from dependencies
- AnyAvrGcc: use system's avr-gcc for testing

Switch avr-gcc to Microchip's version, which has less overhead.

Update travis and vscode to use AvrGcc.