### PR TITLE
Add targets for language checking

### DIFF
--- a/.github/travis/cmake-lang.sh
+++ b/.github/travis/cmake-lang.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -xe
+rm -rf build
+mkdir build
+cd build
+cmake .. \
+    -DCMAKE_TOOLCHAIN_FILE="../cmake/AvrGcc.cmake" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -G Ninja
+ninja check_lang

--- a/.github/travis/cmake-lang.sh
+++ b/.github/travis/cmake-lang.sh
@@ -7,4 +7,6 @@ cmake .. \
     -DCMAKE_TOOLCHAIN_FILE="../cmake/AvrGcc.cmake" \
     -DCMAKE_BUILD_TYPE=Release \
     -G Ninja
-ninja check_lang
+
+# ignore all failures in order to show as much output as possible
+ninja -k0 check_lang || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,12 @@ jobs:
     - stage: tests
       script: ./.github/travis/cmake-test.sh
 
+    # language checks
+    - stage: lang
+      script: ./.github/travis/cmake-lang.sh
+
 stages:
   - cmake
+  - lang
   - legacy
   - tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -381,12 +381,11 @@ function(fw_add_variant variant_name)
 
     add_custom_command(
       OUTPUT ${LANG_BIN}
-      #[[
-      # Check po file:
-      #COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/lang/lang-check.py --no-warning --map ${LANG_MAP} ${PO_FILE}
-      #]]
+      # Check po file for errors _only_
+      COMMAND ${CMAKE_SOURCE_DIR}/lang/lang-check.py --errors-only --map ${LANG_MAP} ${PO_FILE}
+      # Build the catalog
       COMMAND ${CMAKE_SOURCE_DIR}/lang/lang-build.py ${LANG_MAP} ${PO_FILE} ${LANG_BIN}
-      # Check bin size:
+      # Check bin size
       COMMAND ${CMAKE_COMMAND} -DLANG_MAX_SIZE=${LANG_MAX_SIZE} -DLANG_FILE=${LANG_BIN} -P
               ${PROJECT_CMAKE_DIR}/Check_lang_size.cmake
       DEPENDS ${LANG_MAP} ${PO_FILE}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,8 +294,7 @@ function(add_base_binary variant_name)
   target_include_directories(
     ${variant_name}
     PRIVATE ${PRUSA_BOARDS_DIR}/cores/prusa_einsy_rambo/
-            ${PRUSA_BOARDS_DIR}/variants/prusa_einsy_rambo/
-            ${CMAKE_SOURCE_DIR}/Firmware
+            ${PRUSA_BOARDS_DIR}/variants/prusa_einsy_rambo/ ${CMAKE_SOURCE_DIR}/Firmware
     )
 
   target_link_libraries(${variant_name} avr_core)
@@ -373,11 +372,26 @@ function(fw_add_variant variant_name)
     COMMENT "Generating ${variant_name} language map"
     )
 
+  # Base targets for language checks
+  add_custom_target(check_lang_${variant_name})
+  add_dependencies(check_lang check_lang_${variant_name})
+
   # Build language catalogs
   set(LANG_BINS "")
   foreach(LANG IN LISTS SELECTED_LANGUAGES)
     set(LANG_BIN ${LANG_TMP_DIR}/${variant_name}_${LANG}.bin)
     set(PO_FILE "${CMAKE_SOURCE_DIR}/lang/po/Firmware_${LANG}.po")
+
+    # Full language checks
+    add_custom_target(
+      check_lang_${variant_name}_${LANG}
+      COMMENT "Checking ${variant_name} language ${LANG}"
+      COMMAND ${CMAKE_SOURCE_DIR}/lang/lang-check.py --map ${LANG_MAP} ${PO_FILE}
+      DEPENDS ${LANG_MAP} ${PO_FILE}
+      USES_TERMINAL
+      )
+    add_dependencies(check_lang_${variant_name} check_lang_${variant_name}_${LANG})
+    add_dependencies(check_lang_${LANG} check_lang_${variant_name}_${LANG})
 
     add_custom_command(
       OUTPUT ${LANG_BIN}
@@ -469,6 +483,13 @@ function(fw_add_variant variant_name)
 endfunction()
 
 if(CMAKE_CROSSCOMPILING)
+
+  # Main target for language checks
+  add_custom_target(check_lang)
+  foreach(LANG IN LISTS SELECTED_LANGUAGES)
+    add_custom_target(check_lang_${LANG})
+    add_dependencies(check_lang check_lang_${LANG})
+  endforeach()
 
   # build a list of all supported variants
   file(

--- a/lang/lang-check.py
+++ b/lang/lang-check.py
@@ -211,7 +211,7 @@ def check_translation(entry, msgids, is_pot, no_warning, no_suggest, warn_empty,
         return (errors == 0)
 
     # Missing translation
-    if len(translation) == 0 and (known_msgid or warn_empty):
+    if len(translation) == 0 and (warn_empty or (not no_warning and known_msgid)):
         errors += 1
         if rows == 1:
             print(yellow("[W]: Empty translation for \"%s\" on line %d" % (source, line)))

--- a/lang/lang-check.py
+++ b/lang/lang-check.py
@@ -308,6 +308,9 @@ def main():
         "--no-suggest", action="store_true",
         help="Disable suggestions")
     parser.add_argument(
+        "--errors-only", action="store_true",
+        help="Only check errors")
+    parser.add_argument(
         "--pot", action="store_true",
         help="Do not check translations")
     parser.add_argument(
@@ -330,6 +333,10 @@ def main():
     if not os.path.isfile(args.po):
         print("{}: file does not exist or is not a regular file".format(args.po), file=stderr)
         return 1
+
+    if args.errors_only:
+        args.no_warning = True
+        args.no_suggest = True
 
     # load the symbol map to supress empty (but unused) translation warnings
     msgids = None


### PR DESCRIPTION
Add the following macro targets to check translations:

- check_lang: check all languages for all variants
- check_lang_[variant]: check all languages for [variant]
- check_lang_[lang]: check all variants against [lang]
- check_lang_[variant]_[lang]: check a single variant/language

For example:

- ninja check_lang: check *everything*
- ninja check_lang_de: check German in all variants
- ninja check_lang_MK3S-EINSy10a: check all languages in the MK3S
- ninja check_lang_MK3S-EINSy10a_de: check German in the MK3S

The build now also checks for language *errors*. The old output is now split into a new travis stage due to the amount of output it produces.  See "Show all checks" -> Details -> "Stage 2: lang"