### PR TITLE
Cleanup: remove `automatic` parameter from `unload_filament()`

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3544,7 +3544,7 @@ static void gcode_M600(bool automatic, float x_position, float y_position, float
     if (MMU2::mmu2.Enabled())
         mmu_M600_unload_filament();
     else
-        unload_filament(FILAMENTCHANGE_FINALRETRACT, true); // unload filament for single material (used also in M702)
+        unload_filament(FILAMENTCHANGE_FINALRETRACT);
     st_synchronize();          // finish moves
     {
         FSensorBlockRunout fsBlockRunout;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -4030,13 +4030,14 @@ void lcd_wizard(WizState state)
 			}
 			wizard_event = gcode_M45(true, 0);
 			if (wizard_event) {
+				raise_z_above(MIN_Z_FOR_SWAP);
 				//current filament needs to be unloaded and then new filament should be loaded
 				//start to preheat nozzle for unloading remaining PLA filament
 				setTargetHotend(PLA_PREHEAT_HOTEND_TEMP, 0);
 				lcd_display_message_fullscreen_P(_i("Now I will preheat nozzle for PLA.")); ////MSG_WIZARD_WILL_PREHEAT c=20 r=4
 				wait_preheat();
 				//unload current filament
-				unload_filament(FILAMENTCHANGE_FINALRETRACT, true);
+				unload_filament(FILAMENTCHANGE_FINALRETRACT);
 				//load filament
 				lcd_wizard_load();
 				setTargetHotend(0, 0); //we are finished, cooldown nozzle
@@ -5124,20 +5125,14 @@ static void mmu_loading_test_menu() {
     }
 }
 
-// unload filament for single material printer (used in M702 gcode)
-// @param automatic: If true, unload_filament is part of a unload+load sequence (M600)
-void unload_filament(float unloadLength, bool automatic)
+/// @brief unload filament for single material printer (used in M600 and M702)
+/// @param unloadLength Retract distance for removal (manual reload)
+void unload_filament(float unloadLength)
 {
 	custom_message_type = CustomMsg::FilamentLoading;
 	lcd_setstatuspgm(_T(MSG_UNLOADING_FILAMENT));
 
     FSensorBlockRunout fsBlockRunout;
-
-    if (automatic)
-    {
-        // M600
-        raise_z_above(MIN_Z_FOR_SWAP);
-    }
 
     // Retract filament
     current_position[E_AXIS] += -FILAMENT_UNLOAD_PURGE_RETRACT;

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -197,7 +197,7 @@ extern bool bFilamentAction;
 void mFilamentItem(uint16_t nTemp,uint16_t nTempBed);
 void mFilamentItemForce();
 void lcd_generic_preheat_menu();
-void unload_filament(float unloadLength, bool automatic = false);
+void unload_filament(float unloadLength);
 
 
 void lcd_wait_for_heater();


### PR DESCRIPTION
In M600 and M702, the Z-lift is taken care of outside this function (via gcode) so it makes no sense to have a Z-lift within `unload_filament()`

Only exception to this is in the wizard, there I moved the Z-lift to happen before we start heating the nozzle.

Change in memory:
Flash: -12 bytes
SRAM: 0 bytes