### PR TITLE
Farm mode: cache filenames in the presort function

### DIFF
--- a/Firmware/cardreader.cpp
+++ b/Firmware/cardreader.cpp
@@ -803,7 +803,7 @@ void CardReader::presort() {
 	// Throw away old sort index
 	flush_presort();
 	
-	if (farm_mode || IS_SD_INSERTED == false) return; //sorting is not used in farm mode
+	if (IS_SD_INSERTED == false) return; //sorting is not used in farm mode
 	uint8_t sdSort = eeprom_read_byte((uint8_t*)EEPROM_SD_SORT);
 
 	KEEPALIVE_STATE(IN_HANDLER);
@@ -814,7 +814,7 @@ void CardReader::presort() {
 		// Never sort more than the max allowed
 		// If you use folders to organize, 20 may be enough
 		if (fileCnt > SDSORT_LIMIT) {
-			if (sdSort != SD_SORT_NONE) {
+			if ((sdSort != SD_SORT_NONE) && !farm_mode) {
 				lcd_show_fullscreen_message_and_wait_P(_i("Some files will not be sorted. Max. No. of files in 1 folder for sorting is 100."));////MSG_FILE_CNT c=20 r=6
 			}
 			fileCnt = SDSORT_LIMIT;
@@ -833,7 +833,7 @@ void CardReader::presort() {
 			sort_entries[i] = position >> 5;
 		}
 
-		if ((fileCnt > 1) && (sdSort != SD_SORT_NONE)) {
+		if ((fileCnt > 1) && (sdSort != SD_SORT_NONE) && !farm_mode) {
 
 #ifdef SORTING_SPEEDTEST
 			LongTimer sortingSpeedtestTimer;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -6001,7 +6001,7 @@ void lcd_sdcard_menu()
 				lcd_update_enabled = true;
 			}
 			_md->fileCnt = card.getnrfilenames();
-			_md->sdSort = eeprom_read_byte((uint8_t*)EEPROM_SD_SORT);
+			_md->sdSort = farm_mode ? SD_SORT_NONE : eeprom_read_byte((uint8_t*)EEPROM_SD_SORT);
 			_md->menuState = _standard;
 			_md->row = -1; // assume that no SD file/dir is currently selected. Once they are rendered, it will be changed to the correct row for the _scrolling state.
 		}

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -4355,37 +4355,6 @@ while (0)
 #define SETTINGS_MMU_MODE
 #endif //MMU_FORCE_STEALTH_MODE
 
-#ifdef SDCARD_SORT_ALPHA
-#define SETTINGS_SD \
-do\
-{\
-    if (card.ToshibaFlashAir_isEnabled())\
-        MENU_ITEM_TOGGLE_P(_T(MSG_SD_CARD), MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY, lcd_toshiba_flash_air_compatibility_toggle);\
-    else\
-        MENU_ITEM_TOGGLE_P(_T(MSG_SD_CARD), _T(MSG_NORMAL), lcd_toshiba_flash_air_compatibility_toggle);\
-\
-    uint8_t sdSort;\
-    sdSort = eeprom_read_byte((uint8_t*) EEPROM_SD_SORT);\
-    switch (sdSort)\
-    {\
-      case SD_SORT_TIME: MENU_ITEM_TOGGLE_P(_T(MSG_SORT), _T(MSG_SORT_TIME), lcd_sort_type_set); break;\
-      case SD_SORT_ALPHA: MENU_ITEM_TOGGLE_P(_T(MSG_SORT), _T(MSG_SORT_ALPHA), lcd_sort_type_set); break;\
-      default: MENU_ITEM_TOGGLE_P(_T(MSG_SORT), _T(MSG_NONE), lcd_sort_type_set);\
-    }\
-}\
-while (0)
-#else // SDCARD_SORT_ALPHA
-#define SETTINGS_SD \
-do\
-{\
-    if (card.ToshibaFlashAir_isEnabled())\
-        MENU_ITEM_TOGGLE_P(_T(MSG_SD_CARD), MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY, lcd_toshiba_flash_air_compatibility_toggle);\
-    else\
-        MENU_ITEM_TOGGLE_P(_T(MSG_SD_CARD), _T(MSG_NORMAL), lcd_toshiba_flash_air_compatibility_toggle);\
-}\
-while (0)
-#endif // SDCARD_SORT_ALPHA
-
 /*
 #define SETTINGS_MBL_MODE \
 do\
@@ -4782,7 +4751,20 @@ static void lcd_settings_menu()
 	MENU_ITEM_SUBMENU_P(_T(MSG_SELECT_LANGUAGE), lcd_language_menu);
 #endif //(LANG_MODE != 0)
 
-	SETTINGS_SD;
+    if (!farm_mode) { //SD related settings are not available in farm mode
+        if (card.ToshibaFlashAir_isEnabled())
+            MENU_ITEM_TOGGLE_P(_T(MSG_SD_CARD), MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY, lcd_toshiba_flash_air_compatibility_toggle);
+        else
+            MENU_ITEM_TOGGLE_P(_T(MSG_SD_CARD), _T(MSG_NORMAL), lcd_toshiba_flash_air_compatibility_toggle);
+#ifdef SDCARD_SORT_ALPHA
+        switch (eeprom_read_byte((uint8_t*) EEPROM_SD_SORT)) {
+            case SD_SORT_TIME: MENU_ITEM_TOGGLE_P(_T(MSG_SORT), _T(MSG_SORT_TIME), lcd_sort_type_set); break;
+            case SD_SORT_ALPHA: MENU_ITEM_TOGGLE_P(_T(MSG_SORT), _T(MSG_SORT_ALPHA), lcd_sort_type_set); break;
+            default: MENU_ITEM_TOGGLE_P(_T(MSG_SORT), _T(MSG_NONE), lcd_sort_type_set);
+        }
+    }
+#endif //SDCARD_SORT_ALPHA
+
 	SETTINGS_SOUND;
 
 #ifdef LCD_BL_PIN


### PR DESCRIPTION
This should fix the first filename in the SD menu with farm mode enabled.
Even though we are not sorting, we still want to benefit from the speedup of filename caching, so we allow presort() to cache the file positions in the FAT.

PFW-1414