### PR TITLE
PFW-1397 Add Toolchange counter

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -9849,6 +9849,10 @@ void save_statistics(unsigned long _total_filament_used, unsigned long _total_pr
 
 	total_filament_used = 0;
 
+  if (MMU2::mmu2.Enabled())
+  {
+    MMU2::mmu2.update_tool_change_counter_eeprom();
+  }
 }
 
 float calculate_extruder_multiplier(float diameter) {

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -711,6 +711,7 @@ static void factory_reset_stats(){
 
     eeprom_update_word((uint16_t *)EEPROM_MMU_FAIL_TOT, 0);
     eeprom_update_word((uint16_t *)EEPROM_MMU_LOAD_FAIL_TOT, 0);
+    eeprom_update_dword((uint32_t *)EEPROM_TOTAL_TOOLCHANGE_COUNT, 0);
 }
 
 // Factory reset function

--- a/Firmware/eeprom.cpp
+++ b/Firmware/eeprom.cpp
@@ -62,6 +62,7 @@ void eeprom_init()
     if (eeprom_read_word((uint16_t*)EEPROM_MMU_LOAD_FAIL_TOT) == 0xffff) eeprom_update_word((uint16_t *)EEPROM_MMU_LOAD_FAIL_TOT, 0);
     if (eeprom_read_byte((uint8_t*)EEPROM_MMU_FAIL) == 0xff) eeprom_update_byte((uint8_t *)EEPROM_MMU_FAIL, 0);
     if (eeprom_read_byte((uint8_t*)EEPROM_MMU_LOAD_FAIL) == 0xff) eeprom_update_byte((uint8_t *)EEPROM_MMU_LOAD_FAIL, 0);
+    if (eeprom_read_dword((uint32_t*)EEPROM_TOTAL_TOOLCHANGE_COUNT) == 0xffffffff) eeprom_update_dword((uint32_t *)EEPROM_TOTAL_TOOLCHANGE_COUNT, 0);
     if (eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet)) == EEPROM_EMPTY_VALUE)
     {
         eeprom_update_byte(&(EEPROM_Sheets_base->active_sheet), 0);

--- a/Firmware/eeprom.h
+++ b/Firmware/eeprom.h
@@ -343,6 +343,7 @@ static_assert(sizeof(Sheets) == EEPROM_SHEETS_SIZEOF, "Sizeof(Sheets) is not EEP
 | 0x0CAE 3246 | float   | EEPROM_TEMP_MODEL_E                   | ???          | ff ff ff ffh          | Temp model error threshold (K/s)                  | Temp model   | D3 Ax0cae C4
 | 0x0CAD 3245 | uint8   | EEPROM_FSENSOR_JAM_DETECTION          | 01h 1        | ff/01                 | fsensor pat9125 jam detection feature             | LCD menu     | D3 Ax0cad C1
 | 0x0CAC 3244 | uint8   | EEPROM_MMU_ENABLED                    | 01h 1        | ff/01                 | MMU enabled                                       | LCD menu     | D3 Ax0cac C1
+| 0x0CA8 3240 | uint32  | EEPROM_TOTAL_TOOLCHANGE_COUNT         | ???          | ff ff ff ffh          | MMU toolchange counter over printers lifetime     | LCD statistic| D3 Ax0ca8 C4
 
 |Address begin|Bit/Type | Name                                  | Valid values | Default/FactoryReset  | Description                                       |Gcode/Function| Debug code
 | :--:        | :--:    | :--:                                  | :--:         | :--:                  | :--:                                              | :--:         | :--:
@@ -568,8 +569,9 @@ static Sheets * const EEPROM_Sheets_base = (Sheets*)(EEPROM_SHEETS_BASE);
 
 #define EEPROM_FSENSOR_JAM_DETECTION (EEPROM_TEMP_MODEL_E-1) // uint8_t
 #define EEPROM_MMU_ENABLED (EEPROM_FSENSOR_JAM_DETECTION-1) // uint8_t
+#define EEPROM_TOTAL_TOOLCHANGE_COUNT (EEPROM_MMU_ENABLED-4)
 //This is supposed to point to last item to allow EEPROM overrun check. Please update when adding new items.
-#define EEPROM_LAST_ITEM EEPROM_MMU_ENABLED
+#define EEPROM_LAST_ITEM EEPROM_TOTAL_TOOLCHANGE_COUNT
 // !!!!!
 // !!!!! this is end of EEPROM section ... all updates MUST BE inserted before this mark !!!!!
 // !!!!!

--- a/Firmware/menu.cpp
+++ b/Firmware/menu.cpp
@@ -29,7 +29,7 @@ uint8_t menu_line = 0;
 uint8_t menu_item = 0;
 uint8_t menu_row = 0;
 uint8_t menu_top = 0;
-static bool menu_changed; // flag to indicate a new menu was entered
+bool menu_changed; // flag to indicate a new menu was entered
 
 uint8_t menu_clicked = 0;
 
@@ -347,11 +347,6 @@ uint8_t menu_item_back_P(const char* str)
 
 bool __attribute__((noinline)) menu_item_leave(){
     return ((menu_item == menu_line) && menu_clicked && (lcd_encoder == menu_item)) || menu_leaving;
-}
-
-bool menu_item_enter() {
-    menu_changed = false;
-    return !menu_changed;
 }
 
 uint8_t menu_item_function_P(const char* str, menu_func_t func)

--- a/Firmware/menu.cpp
+++ b/Firmware/menu.cpp
@@ -29,6 +29,7 @@ uint8_t menu_line = 0;
 uint8_t menu_item = 0;
 uint8_t menu_row = 0;
 uint8_t menu_top = 0;
+static bool menu_changed; // flag to indicate a new menu was entered
 
 uint8_t menu_clicked = 0;
 
@@ -53,6 +54,7 @@ void menu_goto(menu_func_t menu, const uint32_t encoder, const bool feedback, bo
 		menu_menu = menu;
 		lcd_encoder = encoder;
 		menu_top = 0; //reset menu view. Needed if menu_back() is called from deep inside a menu, such as Support
+		menu_changed = true;
 		CRITICAL_SECTION_END;
 		if (reset_menu_state)
 			menu_data_reset();
@@ -345,6 +347,11 @@ uint8_t menu_item_back_P(const char* str)
 
 bool __attribute__((noinline)) menu_item_leave(){
     return ((menu_item == menu_line) && menu_clicked && (lcd_encoder == menu_item)) || menu_leaving;
+}
+
+bool menu_item_enter() {
+    menu_changed = false;
+    return !menu_changed;
 }
 
 uint8_t menu_item_function_P(const char* str, menu_func_t func)

--- a/Firmware/menu.cpp
+++ b/Firmware/menu.cpp
@@ -29,7 +29,6 @@ uint8_t menu_line = 0;
 uint8_t menu_item = 0;
 uint8_t menu_row = 0;
 uint8_t menu_top = 0;
-bool menu_changed; // flag to indicate a new menu was entered
 
 uint8_t menu_clicked = 0;
 
@@ -54,7 +53,6 @@ void menu_goto(menu_func_t menu, const uint32_t encoder, const bool feedback, bo
 		menu_menu = menu;
 		lcd_encoder = encoder;
 		menu_top = 0; //reset menu view. Needed if menu_back() is called from deep inside a menu, such as Support
-		menu_changed = true;
 		CRITICAL_SECTION_END;
 		if (reset_menu_state)
 			menu_data_reset();

--- a/Firmware/menu.h
+++ b/Firmware/menu.h
@@ -58,7 +58,6 @@ extern uint8_t menu_row;
 extern uint8_t menu_top;
 extern uint8_t menu_clicked;
 extern uint8_t menu_leaving;
-extern bool menu_changed;
 
 //function pointer to the currently active menu
 extern menu_func_t menu_menu;
@@ -115,7 +114,6 @@ extern bool menu_item_leave();
 
 /// Entering a new menu
 /// @param func lines of code to run once upon enter a menu or submenu
-#define ON_MENU_ENTER(func) do { if (menu_changed){ menu_changed = false; func } } while (0)
 
 #define MENU_ITEM_FUNCTION_P(str, func) do { if (menu_item_function_P(str, func)) return; } while (0)
 extern uint8_t menu_item_function_P(const char* str, menu_func_t func);

--- a/Firmware/menu.h
+++ b/Firmware/menu.h
@@ -114,6 +114,11 @@ extern uint8_t menu_item_back_P(const char* str);
 #define ON_MENU_LEAVE(func) do { if (menu_item_leave()){ func } } while (0)
 extern bool menu_item_leave();
 
+/// Entering a new menu
+/// @param func lines of code to run once upon enter a menu or submenu
+#define ON_MENU_ENTER(func) do { if (menu_item_enter()){ func } } while (0)
+extern bool menu_item_enter();
+
 #define MENU_ITEM_FUNCTION_P(str, func) do { if (menu_item_function_P(str, func)) return; } while (0)
 extern uint8_t menu_item_function_P(const char* str, menu_func_t func);
 

--- a/Firmware/menu.h
+++ b/Firmware/menu.h
@@ -112,9 +112,6 @@ extern uint8_t menu_item_back_P(const char* str);
 #define ON_MENU_LEAVE(func) do { if (menu_item_leave()){ func } } while (0)
 extern bool menu_item_leave();
 
-/// Entering a new menu
-/// @param func lines of code to run once upon enter a menu or submenu
-
 #define MENU_ITEM_FUNCTION_P(str, func) do { if (menu_item_function_P(str, func)) return; } while (0)
 extern uint8_t menu_item_function_P(const char* str, menu_func_t func);
 

--- a/Firmware/menu.h
+++ b/Firmware/menu.h
@@ -56,10 +56,9 @@ extern uint8_t menu_row;
 
 //scroll offset in the current menu
 extern uint8_t menu_top;
-
 extern uint8_t menu_clicked;
-
 extern uint8_t menu_leaving;
+extern bool menu_changed;
 
 //function pointer to the currently active menu
 extern menu_func_t menu_menu;
@@ -116,8 +115,7 @@ extern bool menu_item_leave();
 
 /// Entering a new menu
 /// @param func lines of code to run once upon enter a menu or submenu
-#define ON_MENU_ENTER(func) do { if (menu_item_enter()){ func } } while (0)
-extern bool menu_item_enter();
+#define ON_MENU_ENTER(func) do { if (menu_changed){ menu_changed = false; func } } while (0)
 
 #define MENU_ITEM_FUNCTION_P(str, func) do { if (menu_item_function_P(str, func)) return; } while (0)
 extern uint8_t menu_item_function_P(const char* str, menu_func_t func);

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -301,6 +301,12 @@ void MMU2::DecrementRetryAttempts(){
     }
 }
 
+void MMU2::increment_tool_change_counter()
+{
+    uint32_t toolchanges = eeprom_read_dword((uint32_t*)EEPROM_TOTAL_TOOLCHANGE_COUNT);
+    eeprom_write_dword((uint32_t *)EEPROM_TOTAL_TOOLCHANGE_COUNT, ++toolchanges);
+}
+
 bool MMU2::tool_change(uint8_t index) {
     if( ! WaitForMMUReady())
         return false;
@@ -331,10 +337,7 @@ bool MMU2::tool_change(uint8_t index) {
         // @@TODO really report onto the serial? May be for the Octoprint? Not important now
         //        SERIAL_ECHO_START();
         //        SERIAL_ECHOLNPAIR(MSG_ACTIVE_EXTRUDER, int(extruder));
-        
-        // Update toolchange counter
-        uint32_t toolchanges = eeprom_read_dword((uint32_t*)EEPROM_TOTAL_TOOLCHANGE_COUNT);
-        eeprom_write_dword((uint32_t *)EEPROM_TOTAL_TOOLCHANGE_COUNT, ++toolchanges);
+        increment_tool_change_counter();
     }
     return true;
 }
@@ -365,9 +368,7 @@ bool MMU2::tool_change(char code, uint8_t slot) {
         extruder = slot;
         SpoolJoin::spooljoin.setSlot(slot);
         set_extrude_min_temp(EXTRUDE_MINTEMP);
-        // Update toolchange counter
-        uint32_t toolchanges = eeprom_read_dword((uint32_t*)EEPROM_TOTAL_TOOLCHANGE_COUNT);
-        eeprom_write_dword((uint32_t *)EEPROM_TOTAL_TOOLCHANGE_COUNT, ++toolchanges);
+        increment_tool_change_counter();
     } break;
 
     case 'c': {
@@ -518,10 +519,7 @@ bool MMU2::load_filament_to_nozzle(uint8_t index) {
         SpoolJoin::spooljoin.setSlot(index);
 
         Sound_MakeSound(e_SOUND_TYPE_StandardConfirm);
-
-        // Update toolchange count
-        uint32_t toolchanges = eeprom_read_dword((uint32_t*)EEPROM_TOTAL_TOOLCHANGE_COUNT);
-        eeprom_write_dword((uint32_t *)EEPROM_TOTAL_TOOLCHANGE_COUNT, ++toolchanges);
+        increment_tool_change_counter();
     }
     lcd_update_enable(true);
     return true;

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -331,6 +331,10 @@ bool MMU2::tool_change(uint8_t index) {
         // @@TODO really report onto the serial? May be for the Octoprint? Not important now
         //        SERIAL_ECHO_START();
         //        SERIAL_ECHOLNPAIR(MSG_ACTIVE_EXTRUDER, int(extruder));
+        
+        // Update toolchange counter
+        uint32_t toolchanges = eeprom_read_dword((uint32_t*)EEPROM_TOTAL_TOOLCHANGE_COUNT);
+        eeprom_write_dword((uint32_t *)EEPROM_TOTAL_TOOLCHANGE_COUNT, ++toolchanges);
     }
     return true;
 }
@@ -361,6 +365,9 @@ bool MMU2::tool_change(char code, uint8_t slot) {
         extruder = slot;
         SpoolJoin::spooljoin.setSlot(slot);
         set_extrude_min_temp(EXTRUDE_MINTEMP);
+        // Update toolchange counter
+        uint32_t toolchanges = eeprom_read_dword((uint32_t*)EEPROM_TOTAL_TOOLCHANGE_COUNT);
+        eeprom_write_dword((uint32_t *)EEPROM_TOTAL_TOOLCHANGE_COUNT, ++toolchanges);
     } break;
 
     case 'c': {
@@ -511,6 +518,10 @@ bool MMU2::load_filament_to_nozzle(uint8_t index) {
         SpoolJoin::spooljoin.setSlot(index);
 
         Sound_MakeSound(e_SOUND_TYPE_StandardConfirm);
+
+        // Update toolchange count
+        uint32_t toolchanges = eeprom_read_dword((uint32_t*)EEPROM_TOTAL_TOOLCHANGE_COUNT);
+        eeprom_write_dword((uint32_t *)EEPROM_TOTAL_TOOLCHANGE_COUNT, ++toolchanges);
     }
     lcd_update_enable(true);
     return true;

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -118,6 +118,7 @@ MMU2::MMU2()
     , loadingToNozzle(false)
     , inAutoRetry(false)
     , retryAttempts(MAX_RETRIES)
+    , toolchange_counter(0)
 {
 }
 
@@ -301,10 +302,11 @@ void MMU2::DecrementRetryAttempts(){
     }
 }
 
-void MMU2::increment_tool_change_counter()
+void MMU2::update_tool_change_counter_eeprom()
 {
     uint32_t toolchanges = eeprom_read_dword((uint32_t*)EEPROM_TOTAL_TOOLCHANGE_COUNT);
-    eeprom_write_dword((uint32_t *)EEPROM_TOTAL_TOOLCHANGE_COUNT, ++toolchanges);
+    eeprom_update_dword((uint32_t *)EEPROM_TOTAL_TOOLCHANGE_COUNT, toolchanges + (uint32_t)read_toolchange_counter());
+    reset_toolchange_counter();
 }
 
 bool MMU2::tool_change(uint8_t index) {

--- a/Firmware/mmu2.h
+++ b/Firmware/mmu2.h
@@ -192,6 +192,9 @@ public:
     void DecrementRetryAttempts();
 
 private:
+    /// increments tool change counter in EEPROM
+    void increment_tool_change_counter();
+
     /// Reset the retryAttempts back to the default value
     void ResetRetryAttempts();
     /// Perform software self-reset of the MMU (sends an X0 command)

--- a/Firmware/mmu2.h
+++ b/Firmware/mmu2.h
@@ -182,7 +182,7 @@ public:
     bool is_mmu_error_monitor_active;
 
     /// Method to read-only mmu_print_saved
-    bool MMU_PRINT_SAVED() const { return mmu_print_saved != SavedState::None; }
+    inline bool MMU_PRINT_SAVED() const { return mmu_print_saved != SavedState::None; }
 
     /// Automagically "press" a Retry button if we have any retry attempts left
     bool RetryIfPossible(uint16_t ec);
@@ -191,9 +191,19 @@ public:
     // Called by the MMU protocol when a sent button is acknowledged.
     void DecrementRetryAttempts();
 
-private:
     /// increments tool change counter in EEPROM
-    void increment_tool_change_counter();
+    /// ATmega2560 EEPROM has only 100'000 write/erase cycles
+    /// so we can't call this function on every tool change.
+    void update_tool_change_counter_eeprom();
+
+    /// @return count for toolchange in current print
+    inline uint16_t read_toolchange_counter() const { return toolchange_counter; };
+
+    inline void reset_toolchange_counter() { toolchange_counter = 0; };
+
+private:
+    // Increment the toolchange counter via SRAM to reserve EEPROM write cycles
+    inline void increment_tool_change_counter() { ++toolchange_counter; };
 
     /// Reset the retryAttempts back to the default value
     void ResetRetryAttempts();
@@ -289,6 +299,7 @@ private:
     
     bool inAutoRetry;
     uint8_t retryAttempts;
+    uint16_t toolchange_counter;
 };
 
 /// following Marlin's way of doing stuff - one and only instance of MMU implementation in the code base

--- a/Firmware/mmu2.h
+++ b/Firmware/mmu2.h
@@ -191,7 +191,7 @@ public:
     // Called by the MMU protocol when a sent button is acknowledged.
     void DecrementRetryAttempts();
 
-    /// increments tool change counter in EEPROM
+    /// Updates toolchange counter in EEPROM
     /// ATmega2560 EEPROM has only 100'000 write/erase cycles
     /// so we can't call this function on every tool change.
     void update_tool_change_counter_eeprom();
@@ -199,6 +199,7 @@ public:
     /// @return count for toolchange in current print
     inline uint16_t read_toolchange_counter() const { return toolchange_counter; };
 
+    /// Set toolchange counter to zero
     inline void reset_toolchange_counter() { toolchange_counter = 0; };
 
 private:

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1211,12 +1211,13 @@ static void lcd_menu_fails_stats_mmu_total()
 //! @endcode
 static void lcd_menu_toolchange_stats_mmu_total()
 {
-    lcd_clear();
-    uint32_t toolchanges = eeprom_read_dword((uint32_t*)EEPROM_TOTAL_TOOLCHANGE_COUNT);
-    lcd_set_cursor(0, 0);
-	lcd_puts_P(PSTR("Toolchange count:"));
-    lcd_set_cursor(10, 1);
-    lcd_print(toolchanges);
+    ON_MENU_ENTER(
+        lcd_set_cursor(0, 0);
+        lcd_puts_P(PSTR("Toolchange count:"));
+        lcd_set_cursor(10, 1);
+        lcd_print(eeprom_read_dword((uint32_t*)EEPROM_TOTAL_TOOLCHANGE_COUNT));
+    );
+
     menu_back_if_clicked_fb();
 }
 

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -116,6 +116,7 @@ static void lcd_menu_xyz_offset();
 static void lcd_menu_fails_stats_mmu();
 static void lcd_menu_fails_stats_mmu_print();
 static void lcd_menu_fails_stats_mmu_total();
+static void lcd_menu_toolchange_stats_mmu_total();
 static void mmu_unload_filament();
 static void lcd_v2_calibration();
 //static void lcd_menu_show_sensors_state();      // NOT static due to using inside "Marlin_main" module ("manage_inactivity()")
@@ -1139,6 +1140,7 @@ static void lcd_menu_fails_stats_mmu()
 	MENU_ITEM_BACK_P(_T(MSG_MAIN));
 	MENU_ITEM_SUBMENU_P(_T(MSG_LAST_PRINT), lcd_menu_fails_stats_mmu_print);
 	MENU_ITEM_SUBMENU_P(_T(MSG_TOTAL), lcd_menu_fails_stats_mmu_total);
+    MENU_ITEM_SUBMENU_P(_O(PSTR("Toolchange count")), lcd_menu_toolchange_stats_mmu_total);
 	MENU_END();
 }
 
@@ -1195,6 +1197,27 @@ static void lcd_menu_fails_stats_mmu_total()
         lcd_quick_feedback();
         menu_back();
     }
+}
+
+//! @brief Show Total Failures Statistics MMU
+//!
+//! @code{.unparsed}
+//! |01234567890123456789|
+//! |Toolchange count:   |
+//! |          4294967295|
+//! |                    |
+//! |                    |
+//! ----------------------
+//! @endcode
+static void lcd_menu_toolchange_stats_mmu_total()
+{
+    lcd_clear();
+    uint32_t toolchanges = eeprom_read_dword((uint32_t*)EEPROM_TOTAL_TOOLCHANGE_COUNT);
+    lcd_set_cursor(0, 0);
+	lcd_puts_P(PSTR("Toolchange count:"));
+    lcd_set_cursor(10, 1);
+    lcd_print(toolchanges);
+    menu_back_if_clicked_fb();
 }
 
 #if defined(TMC2130) && defined(FILAMENT_SENSOR)

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1178,13 +1178,10 @@ static void lcd_menu_fails_stats_mmu_print()
 //! @todo Positioning of the messages and values on LCD aren't fixed to their exact place. This causes issues with translations.
 static void lcd_menu_fails_stats_mmu_total()
 {
-    static uint8_t first_time_opening_menu = 0;
-    if (!first_time_opening_menu) {
-        // Send S3 Query; MMU responds with "S3 A%u" where %u is the number of drive errors
+    ON_MENU_ENTER(
         MMU2::mmu2.get_statistics();
-        first_time_opening_menu = 1;
-    }
-    lcd_timeoutToStatus.stop(); //infinite timeout
+        lcd_timeoutToStatus.stop(); //infinite timeout
+    );
     lcd_home();
     lcd_printf_P(PSTR("%S\n" " %-16.16S%-3d\n"/* " %-16.16S%-3d\n" " %-16.16S%-3d"*/), 
         _T(MSG_TOTAL_FAILURES),
@@ -1193,7 +1190,6 @@ static void lcd_menu_fails_stats_mmu_total()
         //_i("MMU power fails"), clamp999( mmu_power_failures )); ////MSG_MMU_POWER_FAILS c=15
     if (lcd_clicked())
     {
-        first_time_opening_menu = 0;
         lcd_quick_feedback();
         menu_back();
     }

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1178,10 +1178,17 @@ static void lcd_menu_fails_stats_mmu_print()
 //! @todo Positioning of the messages and values on LCD aren't fixed to their exact place. This causes issues with translations.
 static void lcd_menu_fails_stats_mmu_total()
 {
-    ON_MENU_ENTER(
+    typedef struct
+    {
+        bool initialized;              // 1byte
+    } _menu_data_t;
+    static_assert(sizeof(menu_data)>= sizeof(_menu_data_t),"_menu_data_t doesn't fit into menu_data");
+    _menu_data_t* _md = (_menu_data_t*)&(menu_data[0]);
+    if(_md->initialized) {
         MMU2::mmu2.get_statistics();
         lcd_timeoutToStatus.stop(); //infinite timeout
-    );
+        _md->initialized = false;
+    }
     lcd_home();
     lcd_printf_P(PSTR("%S\n" " %-16.16S%-3d\n"/* " %-16.16S%-3d\n" " %-16.16S%-3d"*/), 
         _T(MSG_TOTAL_FAILURES),
@@ -1207,12 +1214,19 @@ static void lcd_menu_fails_stats_mmu_total()
 //! @endcode
 static void lcd_menu_toolchange_stats_mmu_total()
 {
-    ON_MENU_ENTER(
+    typedef struct
+    {
+        bool initialized;              // 1byte
+    } _menu_data_t;
+    static_assert(sizeof(menu_data)>= sizeof(_menu_data_t),"_menu_data_t doesn't fit into menu_data");
+    _menu_data_t* _md = (_menu_data_t*)&(menu_data[0]);
+    if(_md->initialized) {
         lcd_set_cursor(0, 0);
         lcd_puts_P(PSTR("Toolchange count:"));
         lcd_set_cursor(10, 1);
         lcd_print(eeprom_read_dword((uint32_t*)EEPROM_TOTAL_TOOLCHANGE_COUNT));
-    );
+        _md->initialized = false;
+    }
 
     menu_back_if_clicked_fb();
 }


### PR DESCRIPTION
This PR implements a new statistic for MMU2S users. Every tool change is now counted over the printer's lifetime. This statistic can be useful to determine when it is time to replace the "small" PTFE tube which is inside the extruder. 

The following will increment the counter:
1.  Toolchanges via T-code: `T0`, `T1`, `T2`, `T3`, `T4`, `T5`
2. Single material toolchange via T-code: `Tx` 
    - **NOTE:** `Tc` does not increment the counter. Because `Tx` and `Tc` are always used together, only `Tx` increments the counter to prevent double counts.
4. Any calls to `MMU2::load_filament_to_nozzle()`, this includes:
    - T-code `T?`
    - Loading to the nozzle via LCD menu
    - G-codes: `M600` and `M701` 

⚠️ **NOTE:**
> Currently it has not been decided how to show this statistic to users, so for the time being I've placed it inside the **Fail stats MMU** menu for convenience only. It had one unused menu item row.

----

Change in memory:
Flash: +262 bytes
SRAM: +1 bytes

NOTE: The EEPROM code is eating up a lot of this.