### PR TITLE
Disable `Error:` messages for MMU2 errors

### DIFF
--- a/Firmware/mmu2_log.cpp
+++ b/Firmware/mmu2_log.cpp
@@ -3,7 +3,7 @@
 namespace MMU2 {
 
 void LogErrorEvent_P(const char *msg){
-    SERIAL_ERROR_START;
+    SERIAL_ECHO_START; //!@todo Decide MMU2 errors  on serial line
     SERIAL_MMU2();
     SERIAL_ECHOLNRPGM(msg);
 }

--- a/Firmware/mmu2_log.h
+++ b/Firmware/mmu2_log.h
@@ -23,9 +23,9 @@ void LogEchoEvent_P(const char *msg);
 #define SERIAL_MMU2() { serialprintPGM(mmu2Magic); }
 
 #define MMU2_ECHO_MSG(S) do{ SERIAL_ECHO_START; SERIAL_MMU2(); SERIAL_ECHO(S); }while(0)
-#define MMU2_ERROR_MSG(S) do{ SERIAL_ERROR_START; SERIAL_MMU2(); SERIAL_ECHO(S); }while(0)
+#define MMU2_ERROR_MSG(S) MMU2_ECHO_MSG(S) //!@todo Decide MMU2 errors  on serial line
 #define MMU2_ECHO_MSGRPGM(S) do{ SERIAL_ECHO_START; SERIAL_MMU2(); SERIAL_ECHORPGM(S); }while(0)
-#define MMU2_ERROR_MSGRPGM(S) do{ SERIAL_ERROR_START; SERIAL_MMU2(); SERIAL_ECHORPGM(S); }while(0)
+#define MMU2_ERROR_MSGRPGM(S) MMU2_ECHO_MSGRPGM(S) //!@todo Decide MMU2 errors  on serial line
 
 #else // #ifndef UNITTEST
 


### PR DESCRIPTION
OctoPrint and maybe other host system by default reacts with emergency stop on `Error:` and `!!` on serial line.

Short serial log output which still shows the `MMU2:Command Error` but doesn't force a emergency stop in OctoPrint
```
2022-10-26 21:03:16,702 - Recv: echo:MMU2:<R1a Affa7*c1.
2022-10-26 21:03:17,123 - Recv: echo:MMU2:>Q0*ea.
2022-10-26 21:03:17,126 - Recv: echo:MMU2:<L1 E8002*16.
2022-10-26 21:03:17,127 - Recv: echo:MMU2:>f0*21.
2022-10-26 21:03:17,133 - Recv: echo:MMU2:Command Error, last bytes: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 4c
2022-10-26 21:03:17,138 - Recv: echo:MMU2:Saving and parking
2022-10-26 21:03:17,139 - Recv: echo:MMU2:<f0 A*c5.
2022-10-26 21:03:17,140 - Recv: echo:MMU2:>R8*81.
```
[this build](https://app.travis-ci.com/github/prusa3d/Prusa-Firmware/jobs/586829281#L625) - [previous build](https://app.travis-ci.com/github/prusa3d/Prusa-Firmware/jobs/586414833#L625)
Flash: 256939 - 256965 = -26
RAM: 5395 - 5395 = 0