### PR TITLE
MK3_3.12: Add Menu Calibration -> Temp Model cal. 

### DIFF
--- a/Firmware/temp_model.h
+++ b/Firmware/temp_model.h
@@ -59,6 +59,7 @@ struct model_data
 };
 
 static bool enabled;          // model check enabled
+static bool valid = false;    // model is valid
 static bool warn_beep = true; // beep on warning threshold
 static model_data data;       // default heater data
 

--- a/Firmware/temperature.cpp
+++ b/Firmware/temperature.cpp
@@ -2506,6 +2506,7 @@ static void temp_model_reset_enabled(bool enabled)
 {
     TempMgrGuard temp_mgr_guard;
     temp_model::enabled = enabled;
+    temp_model::valid = enabled;
     temp_model::data.flag_bits.uninitialized = true;
 }
 
@@ -2516,11 +2517,19 @@ void temp_model_set_enabled(bool enabled)
         TempMgrGuard temp_mgr_guard;
         temp_model::enabled = enabled;
         temp_model::setup();
+        temp_model::valid = true;
     }
 
     // verify that the model has been enabled
-    if(enabled && !temp_model::enabled)
+    if(enabled && !temp_model::enabled) {
         SERIAL_ECHOLNPGM("TM: invalid parameters, cannot enable");
+        temp_model::valid = false;
+    }
+}
+
+bool temp_model_valid()
+{
+  return temp_model::valid;
 }
 
 void temp_model_set_warn_beep(bool enabled)
@@ -2582,6 +2591,7 @@ void temp_model_reset_settings()
     temp_model::data.err = TEMP_MODEL_E;
     temp_model::warn_beep = true;
     temp_model::enabled = false;
+    temp_model::valid = false;
 }
 
 void temp_model_load_settings()
@@ -2779,21 +2789,24 @@ static bool autotune(int16_t cal_temp)
 {
     uint16_t samples;
     float e;
-
+    char tm_message[20];
     // bootstrap C/R values without fan
     set_fan_speed(0);
 
     for(uint8_t i = 0; i != 2; ++i) {
-        const char* PROGMEM verb = (i == 0? PSTR("initial"): PSTR("refining"));
-
+        const char* PROGMEM verb = (i == 0? PSTR("inital"): PSTR("refine"));
         target_temperature[0] = 0;
         if(current_temperature[0] >= TEMP_MODEL_CAL_Tl) {
-            printf_P(PSTR("TM: cooling down to %dC\n"), TEMP_MODEL_CAL_Tl);
+            sprintf_P(tm_message, PSTR("TM: cool down <%dC"), TEMP_MODEL_CAL_Tl);
+            SERIAL_ECHOLN(tm_message);
+            lcd_setstatus(tm_message);
             cooldown(TEMP_MODEL_CAL_Tl);
             wait(10000);
         }
 
-        printf_P(PSTR("TM: %S C estimation\n"), verb);
+        sprintf_P(tm_message, PSTR("TM: %S C est."), verb);
+        SERIAL_ECHOLN(tm_message);
+        lcd_setstatus(tm_message);
         target_temperature[0] = cal_temp;
         samples = record();
         if(temp_error_state.v || !samples)
@@ -2813,7 +2826,9 @@ static bool autotune(int16_t cal_temp)
         if(i) break; // we don't need to refine R
         wait(30000); // settle PID regulation
 
-        printf_P(PSTR("TM: %S R estimation @ %dC\n"), verb, cal_temp);
+        sprintf_P(tm_message, PSTR("TM: %S R %dC"), verb, cal_temp);
+        SERIAL_ECHOLN(tm_message);
+        lcd_setstatus(tm_message);
         samples = record();
         if(temp_error_state.v || !samples)
             return true;
@@ -2837,7 +2852,9 @@ static bool autotune(int16_t cal_temp)
         set_fan_speed(speed);
         wait(10000);
 
-        printf_P(PSTR("TM: R[%u] estimation\n"), (unsigned)i);
+        sprintf_P(tm_message, PSTR("TM: R[%u] estimat."), (unsigned)i);
+        SERIAL_ECHOLN(tm_message);
+        lcd_setstatus(tm_message);
         samples = record();
         if(temp_error_state.v || !samples)
             return true;
@@ -2873,30 +2890,33 @@ static bool autotune(int16_t cal_temp)
 
 void temp_model_autotune(int16_t temp, bool selftest)
 {
+    char tm_message[20];
     if(moves_planned() || printer_active()) {
-        SERIAL_ECHOLNPGM("TM: printer needs to be idle for calibration");
+        sprintf_P(tm_message, PSTR("TM: Cal. NOT IDLE"));
+        SERIAL_ECHOLN(tm_message);
+        lcd_setstatuspgm(tm_message);
         return;
     }
 
     // lockout the printer during calibration
     KEEPALIVE_STATE(IN_PROCESS);
     menu_set_block(MENU_BLOCK_TEMP_MODEL_AUTOTUNE);
-    lcd_setstatuspgm(_i("Temp. model autotune")); ////MSG_TEMP_MODEL_AUTOTUNE c=20
     lcd_return_to_status();
 
     // set the model checking state during self-calibration
     bool was_enabled = temp_model::enabled;
     temp_model_reset_enabled(selftest);
 
-    SERIAL_ECHOLNPGM("TM: autotune start");
+    SERIAL_ECHOLNPGM("TM: calibration start");
     bool err = temp_model_cal::autotune(temp > 0 ? temp : TEMP_MODEL_CAL_Th);
 
     // always reset temperature
     disable_heater();
 
     if(err) {
-        SERIAL_ECHOLNPGM("TM: autotune failed");
-        lcd_setstatuspgm(_i("TM autotune failed")); ////MSG_TM_AUTOTUNE_FAILED c=20
+        sprintf_P(tm_message, PSTR("TM: calibr. failed!"));
+        SERIAL_ECHOLN(tm_message);
+        lcd_setstatuspgm(tm_message); ////MSG_TM_AUTOTUNE_FAILED c=20
         if(temp_error_state.v)
             temp_model_cal::set_fan_speed(255);
     } else {

--- a/Firmware/temperature.cpp
+++ b/Firmware/temperature.cpp
@@ -2794,19 +2794,21 @@ static bool autotune(int16_t cal_temp)
     set_fan_speed(0);
 
     for(uint8_t i = 0; i != 2; ++i) {
-        const char* PROGMEM verb = (i == 0? PSTR("inital"): PSTR("refine"));
+        const char* PROGMEM verb = (i == 0? PSTR("initial"): PSTR("refine"));
         target_temperature[0] = 0;
         if(current_temperature[0] >= TEMP_MODEL_CAL_Tl) {
+//!01234567890123456789|
+//!TM: cool down <50C  |
             sprintf_P(tm_message, PSTR("TM: cool down <%dC"), TEMP_MODEL_CAL_Tl);
-            SERIAL_ECHOLN(tm_message);
-            lcd_setstatus(tm_message);
+            lcd_setstatus_serial(tm_message);
             cooldown(TEMP_MODEL_CAL_Tl);
             wait(10000);
         }
-
+//!01234567890123456789|
+//!TM: initial R est.  |
+//!TM: refine R est.   |
         sprintf_P(tm_message, PSTR("TM: %S C est."), verb);
-        SERIAL_ECHOLN(tm_message);
-        lcd_setstatus(tm_message);
+        lcd_setstatus_serial(tm_message);
         target_temperature[0] = cal_temp;
         samples = record();
         if(temp_error_state.v || !samples)
@@ -2825,10 +2827,11 @@ static bool autotune(int16_t cal_temp)
         wait_temp();
         if(i) break; // we don't need to refine R
         wait(30000); // settle PID regulation
-
+//!01234567890123456789|
+//!TM: initial R 230C  |
+//!TM: refine R 230C   |
         sprintf_P(tm_message, PSTR("TM: %S R %dC"), verb, cal_temp);
-        SERIAL_ECHOLN(tm_message);
-        lcd_setstatus(tm_message);
+        lcd_setstatus_serial(tm_message);
         samples = record();
         if(temp_error_state.v || !samples)
             return true;
@@ -2851,10 +2854,10 @@ static bool autotune(int16_t cal_temp)
         uint8_t speed = 256 / TEMP_MODEL_R_SIZE * (i + 1) - 1;
         set_fan_speed(speed);
         wait(10000);
-
+//!01234567890123456789|
+//!TM: R[15] estimat.  |
         sprintf_P(tm_message, PSTR("TM: R[%u] estimat."), (unsigned)i);
-        SERIAL_ECHOLN(tm_message);
-        lcd_setstatus(tm_message);
+        lcd_setstatus_serial(tm_message);
         samples = record();
         if(temp_error_state.v || !samples)
             return true;
@@ -2892,9 +2895,10 @@ void temp_model_autotune(int16_t temp, bool selftest)
 {
     char tm_message[20];
     if(moves_planned() || printer_active()) {
+//!01234567890123456789|
+//!TM: Cal. NOT ILDE   |
         sprintf_P(tm_message, PSTR("TM: Cal. NOT IDLE"));
-        SERIAL_ECHOLN(tm_message);
-        lcd_setstatuspgm(tm_message);
+        lcd_setstatus_serial(tm_message);
         return;
     }
 
@@ -2906,7 +2910,6 @@ void temp_model_autotune(int16_t temp, bool selftest)
     // set the model checking state during self-calibration
     bool was_enabled = temp_model::enabled;
     temp_model_reset_enabled(selftest);
-
     SERIAL_ECHOLNPGM("TM: calibration start");
     bool err = temp_model_cal::autotune(temp > 0 ? temp : TEMP_MODEL_CAL_Th);
 
@@ -2914,9 +2917,10 @@ void temp_model_autotune(int16_t temp, bool selftest)
     disable_heater();
 
     if(err) {
+//!01234567890123456789|
+//!TM: calibr. failed! |
         sprintf_P(tm_message, PSTR("TM: calibr. failed!"));
-        SERIAL_ECHOLN(tm_message);
-        lcd_setstatuspgm(tm_message); ////MSG_TM_AUTOTUNE_FAILED c=20
+        lcd_setstatus_serial(tm_message);
         if(temp_error_state.v)
             temp_model_cal::set_fan_speed(255);
     } else {

--- a/Firmware/temperature.h
+++ b/Firmware/temperature.h
@@ -218,6 +218,7 @@ void PID_autotune(float temp, int extruder, int ncycles);
 
 #ifdef TEMP_MODEL
 void temp_model_set_enabled(bool enabled);
+bool temp_model_valid();
 void temp_model_set_warn_beep(bool enabled);
 void temp_model_set_params(float C = NAN, float P = NAN, float Ta_corr = NAN, float warn = NAN, float err = NAN);
 void temp_model_set_resistance(uint8_t index, float R);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1041,6 +1041,25 @@ void lcd_commands()
 		}
 	}
 
+    if (lcd_commands_type == LcdCommands::TempModel) {
+        if (lcd_commands_step == 0) {
+            lcd_commands_step = 3;
+        }
+        if (lcd_commands_step == 3) {
+            enquecommand_P(PSTR("M310 A F0"));
+            lcd_commands_step = 2;
+        }
+        if (lcd_commands_step ==2 && temp_model_valid()) {
+            enquecommand_P(PSTR("M310 S1"));
+            lcd_commands_step = 1;
+        }
+        //if (lcd_commands_step == 1 && calibrated()) {
+        if (lcd_commands_step == 1 && temp_model_valid()) {
+            enquecommand_P(PSTR("M500"));
+            lcd_commands_step = 0;
+            lcd_commands_type = LcdCommands::Idle;
+        }
+    }
 
 }
 
@@ -4920,6 +4939,9 @@ static void lcd_calibration_menu()
 	    MENU_ITEM_FUNCTION_P(_T(MSG_PINDA_CALIBRATION), lcd_calibrate_pinda);
     }
   }
+#ifdef TEMP_MODEL
+    MENU_ITEM_SUBMENU_P(_n("Temp Model cal."), lcd_temp_model_cal);
+#endif //TEMP_MODEL
   
   MENU_END();
 }
@@ -5980,6 +6002,14 @@ void lcd_print_stop()
     lcd_commands_type = LcdCommands::StopPrint;
     lcd_return_to_status();
 }
+
+#ifdef TEMP_MODEL
+void lcd_temp_model_cal()
+{
+    lcd_commands_type = LcdCommands::TempModel;
+    lcd_return_to_status();
+}
+#endif //TEMP_MODEL
 
 void lcd_sdcard_stop()
 {

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1040,7 +1040,7 @@ void lcd_commands()
 			lcd_commands_type = LcdCommands::Idle;
 		}
 	}
-
+#ifdef TEMP_MODEL
     if (lcd_commands_type == LcdCommands::TempModel) {
         if (lcd_commands_step == 0) {
             lcd_commands_step = 3;
@@ -1060,7 +1060,7 @@ void lcd_commands()
             lcd_commands_type = LcdCommands::Idle;
         }
     }
-
+#endif //TEMP_MODEL
 }
 
 void lcd_return_to_status()

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -7591,6 +7591,13 @@ void lcd_setstatuspgm(const char* message)
         lcd_updatestatus(message, true);
 }
 
+void lcd_setstatus_serial(const char* message)
+{
+    if (lcd_message_check(LCD_STATUS_NONE))
+        lcd_updatestatus(message);
+    SERIAL_ECHOLN(message);
+}
+
 void lcd_setalertstatus_(const char* message, uint8_t severity, bool progmem)
 {
     if (lcd_message_check(severity)) {

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -47,6 +47,9 @@ void lcd_pause_print();
 void lcd_pause_usb_print();
 void lcd_resume_print();
 void lcd_print_stop();
+#ifdef TEMP_MODEL
+void lcd_temp_model_cal();
+#endif //TEMP_MODEL
 void lcd_load_filament_color_check();
 
 extern void lcd_belttest();
@@ -107,6 +110,9 @@ enum class LcdCommands : uint_least8_t
 	LongPause,
 	PidExtruder,
 	Layer1Cal,
+#ifdef TEMP_MODEL
+    TempModel,
+#endif //TEMP_MODEL
 };
 
 extern LcdCommands lcd_commands_type;

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -21,6 +21,7 @@ void ultralcd_init();
 // Set the current status message (equivalent to LCD_STATUS_NONE)
 void lcd_setstatus(const char* message);
 void lcd_setstatuspgm(const char* message);
+void lcd_setstatus_serial(const char* message);
 
 //! return to the main status screen and display the alert message
 //! Beware - it has sideeffects:


### PR DESCRIPTION
Runs M310 A F0
Enables with M310 S1
Saves settings M500

Tested on MK404 with Octoprint serial logging.