### PR TITLE
mmu: move RetryIfPossible outside the error screen

### DIFF
--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -839,7 +839,12 @@ void MMU2::ReportError(ErrorCode ec, ErrorSource res) {
         LogErrorEvent_P( _O(PrusaErrorTitle(PrusaErrorCodeIndex((uint16_t)ec))) );
     }
 
-    ReportErrorHook((uint16_t)ec);
+    if( !mmu2.RetryIfPossible((uint16_t)ec) ) {
+        // If retry attempts are all used up
+        // or if 'Retry' operation is not available
+        // raise the MMU error sceen and wait for user input
+        ReportErrorHook((uint16_t)ec);
+    }
 
     static_assert(mmu2Magic[0] == 'M' 
         && mmu2Magic[1] == 'M' 

--- a/Firmware/mmu2.h
+++ b/Firmware/mmu2.h
@@ -185,6 +185,8 @@ public:
     bool MMU_PRINT_SAVED() const { return mmu_print_saved != SavedState::None; }
 
     /// Automagically "press" a Retry button if we have any retry attempts left
+    /// @param ec ErrorCode enum value
+    /// @returns true if auto-retry is ongoing, false when retry is unavailable or retry attempts are all used up
     bool RetryIfPossible(uint16_t ec);
 
     /// Decrement the retry attempts, if in a retry. 

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -224,13 +224,6 @@ void ReportErrorHook(uint16_t ec) {
         // a button was pushed on the MMU and the LCD should
         // dismiss the error screen until MMU raises a new error
         ReportErrorHookState = ReportErrorHookStates::DISMISS_ERROR_SCREEN;
-    } else {
-        // attempt an automatic Retry button
-        if( ReportErrorHookState == ReportErrorHookStates::MONITOR_SELECTION ){
-            if( mmu2.RetryIfPossible(ec) ){
-                ReportErrorHookState = ReportErrorHookStates::DISMISS_ERROR_SCREEN;
-            }
-        }
     }
 
     const uint8_t ei = PrusaErrorCodeIndex(ec);


### PR DESCRIPTION
* Fixes issue where `retryAttempts=3` may be spammed in the logs when the Retry button is not available
* Fixes UI issue where if anything is shown on the LCD (For example "Loading Filament X") and current MMU operations fails, now the message stays on the screen until the MMU error screen appears (until all retry attempts are used up). Previous behavior allowed the static characters to be drawn just before the retry attempt and the error screen is dismissed. 

Change in memory:
Flash: 0 bytes
SRAM: 0 bytes