### PR TITLE
PFW-1427 If MMU is reset in error state, wait for re-connection with printer

### DIFF
--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -666,6 +666,8 @@ void MMU2::CheckUserInput(){
     case RestartMMU:
         Reset(ResetPin); // we cannot do power cycle on the MK3
         // ... but mmu2_power.cpp knows this and triggers a soft-reset instead.
+        state = xState::Connecting;
+        logic.Start();  // Wait for the MMU to be ready
         break;
     case DisableMMU:
         Stop(); // Poweroff handles updating the EEPROM shutoff.


### PR DESCRIPTION
When the MMU is reset to recover from an error, the MK3S sees the error code change to OK and will continue printing immediately. This is not ok as we may need to unload or load a filament to fully recover. To start fixing this issue we should at minimum wait for the MMU to be reconnected to the printer to allow us to do more operations before continuing with the print.

An example is TMC DRIVER ERROR. The filament may be half way into the PTFE tube. This PR does not fix that issue, but waiting for the MMU to be connected to the printer via UART will allow us to improve this later.