### PR TITLE
PFW-1429: Fix Z-leveling

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -2173,6 +2173,7 @@ bool calibrate_z_auto()
 	//	current_position[axis] = 0;
 	//	plan_set_position_curposXYZE();
 	tmc2130_home_exit();
+	enable_endstops(false);
 	current_position[Z_AXIS] = 0;
 	plan_set_position_curposXYZE();
 	set_destination_to_current();


### PR DESCRIPTION
Not sure which PR removed it see [here](https://github.com/prusa3d/Prusa-Firmware/compare/v3.12.0-BETA1...prusa3d:Prusa-Firmware:MK3?expand=1#diff-a2e2d6e9dab1e37ea9a2882433e2b8f70af751b3c3445d5e997d11a93d4b28b3L2181)

Test before fix:
- power off printer
- manually rise only right z
- run `M155 S1 C4` to get serial xyze positions 
- run `G28 W` to home at first point
- run `M45 Z` to level Z

Bad result is that the right is hitting the right z-top part while the left is still lower and no motor skipping.

Test after fix:
Same steps but this time the motors skip and both sides left + right are hitting the z-top parts.