### PR TITLE
Fix long-press LCD inactivity timeout

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -7582,7 +7582,10 @@ uint8_t get_message_level()
 
 void menu_lcd_longpress_func(void)
 {
-	backlight_wake();
+    // Wake up the LCD backlight and,
+    // start LCD inactivity timer
+    lcd_timeoutToStatus.start();
+    backlight_wake();
     if (homing_flag || mesh_bed_leveling_flag || menu_menu == lcd_babystep_z || menu_menu == lcd_move_z || menu_block_mask != MENU_BLOCK_NONE)
     {
         // disable longpress during re-entry, while homing, calibration or if a serious error


### PR DESCRIPTION
Fixes #3715

Issue was likely introduced during 3.12 development here: https://github.com/prusa3d/Prusa-Firmware/pull/3268

When a long-press is triggered, the LCD inactivity timer needs to be restarted. This is done with `lcd_timeoutToStatus.start()`. The function `menu_lcd_lcdupdate_func()` does not reset the timer in this scenario so we need to do it in `menu_lcd_longpress_func()`

This also fixes unpredictable case where a long-press is triggered, and the timer times out immediately (because it was not reset properly)

Change in memory:
Flash: +8 bytes
SRAM: 0 bytes