### PR TITLE
MK3 3.12.0-RC1 pre-release 

### DIFF
--- a/Firmware/Configuration.h
+++ b/Firmware/Configuration.h
@@ -19,7 +19,7 @@ extern PGM_P sPrinterName;
 #define FW_MAJOR 3
 #define FW_MINOR 12
 #define FW_REVISION 0
-#define FW_FLAVOR BETA      //uncomment if DEBUG, DEVEL, ALPHA, BETA or RC
+#define FW_FLAVOR RC      //uncomment if DEBUG, DEVEL, ALPHA, BETA or RC
 #define FW_FLAVERSION 1     //uncomment if FW_FLAVOR is defined and versioning is needed.
 #ifndef FW_FLAVOR
     #define FW_VERSION STR(FW_MAJOR) "." STR(FW_MINOR) "." STR(FW_REVISION)
@@ -27,7 +27,7 @@ extern PGM_P sPrinterName;
     #define FW_VERSION STR(FW_MAJOR) "." STR(FW_MINOR) "." STR(FW_REVISION) "-" STR(FW_FLAVOR) "" STR(FW_FLAVERSION)
 #endif
 
-#define FW_COMMIT_NR 5536
+#define FW_COMMIT_NR 5572
 
 // FW_VERSION_UNKNOWN means this is an unofficial build.
 // The firmware should only be checked into github with this symbol.

--- a/Firmware/eeprom.h
+++ b/Firmware/eeprom.h
@@ -341,8 +341,6 @@ static_assert(sizeof(Sheets) == EEPROM_SHEETS_SIZEOF, "Sizeof(Sheets) is not EEP
 | 0x0CB6 3254 | float   | EEPROM_TEMP_MODEL_Ta_corr             | ???          | ff ff ff ffh          | Temp model ambient temperature correction (K)     | Temp model   | D3 Ax0cb6 C4
 | 0x0CB2 3250 | float   | EEPROM_TEMP_MODEL_W                   | ???          | ff ff ff ffh          | Temp model warning threshold (K/s)                | Temp model   | D3 Ax0cb2 C4
 | 0x0CAE 3246 | float   | EEPROM_TEMP_MODEL_E                   | ???          | ff ff ff ffh          | Temp model error threshold (K/s)                  | Temp model   | D3 Ax0cae C4
-| 0x0CAD 3245 | uint8   | EEPROM_FSENSOR_JAM_DETECTION          | 01h 1        | ff/01                 | fsensor pat9125 jam detection feature             | LCD menu     | D3 Ax0cad C1
-| 0x0CAC 3244 | uint8   | EEPROM_MMU_ENABLED                    | 01h 1        | ff/01                 | MMU enabled                                       | LCD menu     | D3 Ax0cac C1
 
 |Address begin|Bit/Type | Name                                  | Valid values | Default/FactoryReset  | Description                                       |Gcode/Function| Debug code
 | :--:        | :--:    | :--:                                  | :--:         | :--:                  | :--:                                              | :--:         | :--:

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -7638,7 +7638,10 @@ uint8_t get_message_level()
 
 void menu_lcd_longpress_func(void)
 {
-	backlight_wake();
+    // Wake up the LCD backlight and,
+    // start LCD inactivity timer
+    lcd_timeoutToStatus.start();
+    backlight_wake();
     if (homing_flag || mesh_bed_leveling_flag || menu_menu == lcd_babystep_z || menu_menu == lcd_move_z || menu_block_mask != MENU_BLOCK_NONE)
     {
         // disable longpress during re-entry, while homing, calibration or if a serious error

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3321,7 +3321,7 @@ void lcd_bed_calibration_show_result(BedSkewOffsetDetectionResultType result, ui
             msg = _i("XYZ calibration failed. Right front calibration point not reachable.");////MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
         else
             // The left and maybe the center point out of reach.
-            msg = _i("XYZ calibration failed. Left front calibration point not reachable.");////MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_LEFT_FAR c=20 r=8
+            msg = _n("XYZ calibration failed. Left front calibration point not reachable.");////MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_LEFT_FAR c=20 r=8
         lcd_show_fullscreen_message_and_wait_P(msg);
     } else {
         if (point_too_far_mask != 0) {
@@ -3333,7 +3333,7 @@ void lcd_bed_calibration_show_result(BedSkewOffsetDetectionResultType result, ui
                 msg = _i("XYZ calibration compromised. Right front calibration point not reachable.");////MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
             else
                 // The left and maybe the center point out of reach.
-                msg = _i("XYZ calibration compromised. Left front calibration point not reachable.");////MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_LEFT_FAR c=20 r=8
+                msg = _n("XYZ calibration compromised. Left front calibration point not reachable.");////MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_LEFT_FAR c=20 r=8
             lcd_show_fullscreen_message_and_wait_P(msg);
         }
         if (point_too_far_mask == 0 || result > 0) {

--- a/lang/po/Firmware.pot
+++ b/lang/po/Firmware.pot
@@ -17,113 +17,113 @@ msgid " 0.4 or newer"
 msgstr ""
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:7036
+#: ../../Firmware/ultralcd.cpp:7066
 msgid "%s level expected"
 msgstr ""
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1968
-#: ../../Firmware/ultralcd.cpp:3835
+#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1987
+#: ../../Firmware/ultralcd.cpp:3854
 msgid ">Cancel"
 msgstr ""
 
 #. MSG_BABYSTEPPING_Z c=15
 #. Beware: must include the ':' as its last character
-#: ../../Firmware/ultralcd.cpp:2670
+#: ../../Firmware/ultralcd.cpp:2689
 msgid "Adjusting Z:"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:7313
+#: ../../Firmware/ultralcd.cpp:7343
 msgid "All correct"
 msgstr ""
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4180
+#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4190
+#: ../../Firmware/ultralcd.cpp:4199
 msgid "All is done. Happy printing!"
 msgstr ""
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4404
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4423
 msgid "Alphabet"
 msgstr ""
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4308
+#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4327
 msgid "Always"
 msgstr ""
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1405
+#: ../../Firmware/ultralcd.cpp:1424
 msgid "Ambient"
 msgstr ""
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2983
+#: ../../Firmware/ultralcd.cpp:3002
 msgid "Are left and right Z~carriages all up?"
 msgstr ""
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4478
 msgid "Assist"
 msgstr ""
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:5886
 msgid "Auto"
 msgstr ""
 
 #. MSG_AUTO_HOME c=18
 #: ../../Firmware/Marlin_main.cpp:3271 ../../Firmware/messages.cpp:9
-#: ../../Firmware/ultralcd.cpp:4900
+#: ../../Firmware/ultralcd.cpp:4919
 msgid "Auto home"
 msgstr ""
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:4364
-#: ../../Firmware/ultralcd.cpp:5779
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:4383
+#: ../../Firmware/ultralcd.cpp:5801
 msgid "Auto power"
 msgstr ""
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5572
+#: ../../Firmware/ultralcd.cpp:5594
 msgid "AutoLoad filament"
 msgstr ""
 
 #. MSG_AUTOLOADING_ONLY_IF_FSENS_ON c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3549
+#: ../../Firmware/ultralcd.cpp:3568
 msgid ""
 "Autoloading filament available only when filament sensor is turned on..."
 msgstr ""
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2301
+#: ../../Firmware/ultralcd.cpp:2320
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:7015
+#: ../../Firmware/ultralcd.cpp:7045
 msgid "Axis"
 msgstr ""
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:7014
+#: ../../Firmware/ultralcd.cpp:7044
 msgid "Axis length"
 msgstr ""
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:2751
-#: ../../Firmware/ultralcd.cpp:5861 ../../Firmware/ultralcd.cpp:7838
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:2770
+#: ../../Firmware/ultralcd.cpp:5883 ../../Firmware/ultralcd.cpp:7878
 msgid "Back"
 msgstr ""
 
 #. MSG_BED c=13
 #: ../../Firmware/Marlin_main.cpp:2051 ../../Firmware/Marlin_main.cpp:4767
 #: ../../Firmware/Marlin_main.cpp:4819 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:1403 ../../Firmware/ultralcd.cpp:5721
-#: ../../Firmware/ultralcd.cpp:5891
+#: ../../Firmware/ultralcd.cpp:1422 ../../Firmware/ultralcd.cpp:5743
+#: ../../Firmware/ultralcd.cpp:5913
 msgid "Bed"
 msgstr ""
 
@@ -140,7 +140,7 @@ msgid "Bed done"
 msgstr ""
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4912
+#: ../../Firmware/ultralcd.cpp:4931
 msgid "Bed level correct"
 msgstr ""
 
@@ -156,18 +156,18 @@ msgid ""
 msgstr ""
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6972
+#: ../../Firmware/ultralcd.cpp:7002
 msgid "Bed/Heater"
 msgstr ""
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1458
-#: ../../Firmware/ultralcd.cpp:1726
+#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1477
+#: ../../Firmware/ultralcd.cpp:1745
 msgid "Belt status"
 msgstr ""
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4902
+#: ../../Firmware/ultralcd.cpp:4921
 msgid "Belt test"
 msgstr ""
 
@@ -178,28 +178,28 @@ msgid "Blackout occurred. Recover print?"
 msgstr ""
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:5886
 msgid "Bright"
 msgstr ""
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4850
-#: ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4869
+#: ../../Firmware/ultralcd.cpp:5811
 msgid "Brightness"
 msgstr ""
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4906
+#: ../../Firmware/ultralcd.cpp:4925
 msgid "Calibrate XYZ"
 msgstr ""
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4908
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4927
 msgid "Calibrate Z"
 msgstr ""
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2946
+#: ../../Firmware/ultralcd.cpp:2965
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -212,19 +212,19 @@ msgid "Calibrating Z"
 msgstr ""
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2945
+#: ../../Firmware/ultralcd.cpp:2964
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
 msgstr ""
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:7315
+#: ../../Firmware/ultralcd.cpp:7345
 msgid "Calibrating home"
 msgstr ""
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:5581
+#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:5603
 msgid "Calibration"
 msgstr ""
 
@@ -234,115 +234,115 @@ msgid "Calibration done"
 msgstr ""
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7712
+#: ../../Firmware/ultralcd.cpp:7752
 msgid "Card removed"
 msgstr ""
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/ultralcd.cpp:5560
 msgid "Change SD card"
 msgstr ""
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5497
-#: ../../Firmware/ultralcd.cpp:5730
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5519
+#: ../../Firmware/ultralcd.cpp:5752
 msgid "Change filament"
 msgstr ""
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2163
+#: ../../Firmware/ultralcd.cpp:2182
 msgid "Change success!"
 msgstr ""
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2215
+#: ../../Firmware/ultralcd.cpp:2234
 msgid "Changed correctly?"
 msgstr ""
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:6178
-#: ../../Firmware/ultralcd.cpp:7305
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:6208
+#: ../../Firmware/ultralcd.cpp:7335
 msgid "Checking X axis"
 msgstr ""
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:6187
-#: ../../Firmware/ultralcd.cpp:7306
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:6217
+#: ../../Firmware/ultralcd.cpp:7336
 msgid "Checking Y axis"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:7307
+#: ../../Firmware/ultralcd.cpp:7337
 msgid "Checking Z axis"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:7308
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:7338
 msgid "Checking bed"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:7304
+#: ../../Firmware/ultralcd.cpp:7334
 msgid "Checking endstops"
 msgstr ""
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:7403
+#: ../../Firmware/ultralcd.cpp:7433
 msgid "Checking file"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:7310
+#: ../../Firmware/ultralcd.cpp:7340
 msgid "Checking hotend"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:7311
-#: ../../Firmware/ultralcd.cpp:7312
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:7341
+#: ../../Firmware/ultralcd.cpp:7342
 msgid "Checking sensors"
 msgstr ""
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4765
+#: ../../Firmware/ultralcd.cpp:4784
 msgid "Checks"
 msgstr ""
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2218
+#: ../../Firmware/ultralcd.cpp:2237
 msgid "Color not correct"
 msgstr ""
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3725
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3744
 msgid "Community made"
 msgstr ""
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4704
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4723
 msgid "Cont."
 msgstr ""
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2125
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2144
 msgid "Cooldown"
 msgstr ""
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3663
+#: ../../Firmware/ultralcd.cpp:3682
 msgid "Copy selected language?"
 msgstr ""
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1221
-#: ../../Firmware/ultralcd.cpp:1262 ../../Firmware/ultralcd.cpp:1272
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1240
+#: ../../Firmware/ultralcd.cpp:1281 ../../Firmware/ultralcd.cpp:1291
 msgid "Crash"
 msgstr ""
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4341
-#: ../../Firmware/ultralcd.cpp:4342 ../../Firmware/ultralcd.cpp:4344
-#: ../../Firmware/ultralcd.cpp:5765 ../../Firmware/ultralcd.cpp:5767
-#: ../../Firmware/ultralcd.cpp:5771
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4363
+#: ../../Firmware/ultralcd.cpp:5787 ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/ultralcd.cpp:5793
 msgid "Crash det."
 msgstr ""
 
@@ -352,7 +352,7 @@ msgid "Crash detected."
 msgstr ""
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3521
+#: ../../Firmware/ultralcd.cpp:3540
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -360,14 +360,14 @@ msgid ""
 msgstr ""
 
 #. MSG_CUT_FILAMENT c=17
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:5175
-#: ../../Firmware/ultralcd.cpp:5567
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:5197
+#: ../../Firmware/ultralcd.cpp:5589
 msgid "Cut filament"
 msgstr ""
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:4303
-#: ../../Firmware/ultralcd.cpp:4308 ../../Firmware/ultralcd.cpp:4313
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:4322
+#: ../../Firmware/ultralcd.cpp:4327 ../../Firmware/ultralcd.cpp:4332
 msgid "Cutter"
 msgstr ""
 
@@ -377,17 +377,17 @@ msgid "Cutting filament"
 msgstr ""
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1668
+#: ../../Firmware/ultralcd.cpp:1687
 msgid "Date:"
 msgstr ""
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5886
 msgid "Dim"
 msgstr ""
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4802
+#: ../../Firmware/ultralcd.cpp:4821
 msgid "Disable steppers"
 msgstr ""
 
@@ -401,30 +401,30 @@ msgid ""
 msgstr ""
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:4145
+#: ../../Firmware/ultralcd.cpp:4164
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
 msgstr ""
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4214
+#: ../../Firmware/ultralcd.cpp:4233
 msgid "E-correct:"
 msgstr ""
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2279
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2298
 msgid "ERROR:"
 msgstr ""
 
 #. MSG_FSENS_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3562
+#: ../../Firmware/ultralcd.cpp:3581
 msgid "ERROR: Filament sensor is not responding, please check connection."
 msgstr ""
 
 #. MSG_EJECT_FILAMENT c=17
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:5156
-#: ../../Firmware/ultralcd.cpp:5565
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:5178
+#: ../../Firmware/ultralcd.cpp:5587
 msgid "Eject filament"
 msgstr ""
 
@@ -434,47 +434,41 @@ msgid "Ejecting filament"
 msgstr ""
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6985
+#: ../../Firmware/ultralcd.cpp:7015
 msgid "Endstop"
 msgstr ""
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6990
+#: ../../Firmware/ultralcd.cpp:7020
 msgid "Endstop not hit"
 msgstr ""
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6976
+#: ../../Firmware/ultralcd.cpp:7006
 msgid "Endstops"
 msgstr ""
 
 #. MSG_EXTRUDER c=17
 #: ../../Firmware/Marlin_main.cpp:8608 ../../Firmware/messages.cpp:30
-#: ../../Firmware/ultralcd.cpp:3495
+#: ../../Firmware/ultralcd.cpp:3514
 msgid "Extruder"
 msgstr ""
 
-#. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1144
-#: ../../Firmware/ultralcd.cpp:7319
-msgid "Hotend fan:"
-msgstr ""
-
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1722
+#: ../../Firmware/ultralcd.cpp:1741
 msgid "Extruder info"
 msgstr ""
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4229
-#: ../../Firmware/ultralcd.cpp:4237 ../../Firmware/ultralcd.cpp:4248
-#: ../../Firmware/ultralcd.cpp:4250
+#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4248
+#: ../../Firmware/ultralcd.cpp:4256 ../../Firmware/ultralcd.cpp:4267
+#: ../../Firmware/ultralcd.cpp:4269
 msgid "F. autoload"
 msgstr ""
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4704
-#: ../../Firmware/ultralcd.cpp:4707
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4723
+#: ../../Firmware/ultralcd.cpp:4726
 msgid "FS Action"
 msgstr ""
 
@@ -489,102 +483,102 @@ msgid "FS v0.4 or newer"
 msgstr ""
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5589
+#: ../../Firmware/ultralcd.cpp:5611
 msgid "Fail stats"
 msgstr ""
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5592
+#: ../../Firmware/ultralcd.cpp:5614
 msgid "Fail stats MMU"
 msgstr ""
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:7031
+#: ../../Firmware/ultralcd.cpp:7061
 msgid "False triggering"
 msgstr ""
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:5723
-#: ../../Firmware/ultralcd.cpp:5893
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/ultralcd.cpp:5915
 msgid "Fan speed"
 msgstr ""
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:7143
-#: ../../Firmware/ultralcd.cpp:7301 ../../Firmware/ultralcd.cpp:7302
-#: ../../Firmware/ultralcd.cpp:7303
+#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:7173
+#: ../../Firmware/ultralcd.cpp:7331 ../../Firmware/ultralcd.cpp:7332
+#: ../../Firmware/ultralcd.cpp:7333
 msgid "Fan test"
 msgstr ""
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4811
-#: ../../Firmware/ultralcd.cpp:5756
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4830
+#: ../../Firmware/ultralcd.cpp:5778
 msgid "Fans check"
 msgstr ""
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1220
-#: ../../Firmware/ultralcd.cpp:1261 ../../Firmware/ultralcd.cpp:1327
-#: ../../Firmware/ultralcd.cpp:1329
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1239
+#: ../../Firmware/ultralcd.cpp:1280 ../../Firmware/ultralcd.cpp:1346
+#: ../../Firmware/ultralcd.cpp:1348
 msgid "Fil. runouts"
 msgstr ""
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:3451
-#: ../../Firmware/ultralcd.cpp:4228 ../../Firmware/ultralcd.cpp:4234
-#: ../../Firmware/ultralcd.cpp:4244 ../../Firmware/ultralcd.cpp:5737
-#: ../../Firmware/ultralcd.cpp:5741 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:3470
+#: ../../Firmware/ultralcd.cpp:4247 ../../Firmware/ultralcd.cpp:4253
+#: ../../Firmware/ultralcd.cpp:4263 ../../Firmware/ultralcd.cpp:5759
+#: ../../Firmware/ultralcd.cpp:5763 ../../Firmware/ultralcd.cpp:5767
 msgid "Fil. sensor"
 msgstr ""
 
 #. MSG_FILAMENT c=17
 #: ../../Firmware/Marlin_main.cpp:8577 ../../Firmware/Marlin_main.cpp:8604
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3835
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3854
 msgid "Filament"
 msgstr ""
 
 #. MSG_FILAMENT_CLEAN c=20 r=2
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2287
-#: ../../Firmware/ultralcd.cpp:2293
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2306
+#: ../../Firmware/ultralcd.cpp:2312
 msgid "Filament extruding & with correct color?"
 msgstr ""
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2217
+#: ../../Firmware/ultralcd.cpp:2236
 msgid "Filament not loaded"
 msgstr ""
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:7026
-#: ../../Firmware/ultralcd.cpp:7030 ../../Firmware/ultralcd.cpp:7034
-#: ../../Firmware/ultralcd.cpp:7330
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:7056
+#: ../../Firmware/ultralcd.cpp:7060 ../../Firmware/ultralcd.cpp:7064
+#: ../../Firmware/ultralcd.cpp:7360
 msgid "Filament sensor"
 msgstr ""
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2365
+#: ../../Firmware/ultralcd.cpp:2384
 msgid "Filament used"
 msgstr ""
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7461
+#: ../../Firmware/ultralcd.cpp:7491
 msgid "File incomplete. Continue anyway?"
 msgstr ""
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:5314
-#: ../../Firmware/ultralcd.cpp:5630
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:5336
+#: ../../Firmware/ultralcd.cpp:5652
 msgid "Finishing movements"
 msgstr ""
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:4898
-#: ../../Firmware/ultralcd.cpp:5424
+#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:4917
+#: ../../Firmware/ultralcd.cpp:5446
 msgid "First layer cal."
 msgstr ""
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4066
+#: ../../Firmware/ultralcd.cpp:4085
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 
@@ -594,23 +588,23 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr ""
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5724
+#: ../../Firmware/ultralcd.cpp:5746
 msgid "Flow"
 msgstr ""
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:6996
-#: ../../Firmware/ultralcd.cpp:7149 ../../Firmware/ultralcd.cpp:7154
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:7026
+#: ../../Firmware/ultralcd.cpp:7179 ../../Firmware/ultralcd.cpp:7184
 msgid "Front print fan?"
 msgstr ""
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2754
+#: ../../Firmware/ultralcd.cpp:2773
 msgid "Front side[μm]"
 msgstr ""
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:7020
+#: ../../Firmware/ultralcd.cpp:7050
 msgid "Front/left fans"
 msgstr ""
 
@@ -653,20 +647,20 @@ msgid ""
 msgstr ""
 
 #. MSG_GCODE c=8
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:4655
-#: ../../Firmware/ultralcd.cpp:4658 ../../Firmware/ultralcd.cpp:4661
-#: ../../Firmware/ultralcd.cpp:4664
+#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:4674
+#: ../../Firmware/ultralcd.cpp:4677 ../../Firmware/ultralcd.cpp:4680
+#: ../../Firmware/ultralcd.cpp:4683
 msgid "Gcode"
 msgstr ""
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:4672
-#: ../../Firmware/ultralcd.cpp:4726 ../../Firmware/ultralcd.cpp:4818
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:4691
+#: ../../Firmware/ultralcd.cpp:4745 ../../Firmware/ultralcd.cpp:4837
 msgid "HW Setup"
 msgstr ""
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6968
+#: ../../Firmware/ultralcd.cpp:6998
 msgid "Heater/Thermistor"
 msgstr ""
 
@@ -688,7 +682,7 @@ msgid "Heating done."
 msgstr ""
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=16
-#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4042
+#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4061
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -696,31 +690,37 @@ msgid ""
 msgstr ""
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4064
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
 msgstr ""
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:4358
-#: ../../Firmware/ultralcd.cpp:4367 ../../Firmware/ultralcd.cpp:5777
-#: ../../Firmware/ultralcd.cpp:5780
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:4377
+#: ../../Firmware/ultralcd.cpp:4386 ../../Firmware/ultralcd.cpp:5799
+#: ../../Firmware/ultralcd.cpp:5802
 msgid "High power"
 msgstr ""
 
+#. MSG_HOTEND_FAN_SPEED c=15
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1145
+#: ../../Firmware/ultralcd.cpp:7351
+msgid "Hotend fan:"
+msgstr ""
+
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4094
 msgid "I will run xyz calibration now. It will take approx. 12 mins."
 msgstr ""
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/ultralcd.cpp:4102
 msgid "I will run z calibration now."
 msgstr ""
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=9
-#: ../../Firmware/ultralcd.cpp:4153
+#: ../../Firmware/ultralcd.cpp:4172
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -732,36 +732,36 @@ msgid "Improving bed calibration point"
 msgstr ""
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:5478
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:5500
 msgid "Info screen"
 msgstr ""
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5545
+#: ../../Firmware/ultralcd.cpp:5567
 msgid "Init. SD card"
 msgstr ""
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2152
+#: ../../Firmware/ultralcd.cpp:2171
 msgid "Insert filament"
 msgstr ""
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:6223
+#: ../../Firmware/ultralcd.cpp:6253
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
 msgstr ""
 
 #. MSG_FILAMENT_LOADED c=20 r=2
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3855
-#: ../../Firmware/ultralcd.cpp:4108 ../../Firmware/ultralcd.cpp:4111
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3874
+#: ../../Firmware/ultralcd.cpp:4127 ../../Firmware/ultralcd.cpp:4130
 msgid "Is filament loaded?"
 msgstr ""
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=2
 #: ../../Firmware/Marlin_main.cpp:3312 ../../Firmware/Marlin_main.cpp:4886
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:4084
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:4103
 msgid "Is steel sheet on heatbed?"
 msgstr ""
 
@@ -771,74 +771,74 @@ msgid "Iteration"
 msgstr ""
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:1148
-#: ../../Firmware/ultralcd.cpp:1296
+#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:1167
+#: ../../Firmware/ultralcd.cpp:1315
 msgid "Last print"
 msgstr ""
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1169
-#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1269
-#: ../../Firmware/ultralcd.cpp:1326
+#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1188
+#: ../../Firmware/ultralcd.cpp:1278 ../../Firmware/ultralcd.cpp:1288
+#: ../../Firmware/ultralcd.cpp:1345
 msgid "Last print failures"
 msgstr ""
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2496
+#: ../../Firmware/ultralcd.cpp:2515
 msgid "Left"
 msgstr ""
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7001
-#: ../../Firmware/ultralcd.cpp:7147 ../../Firmware/ultralcd.cpp:7152
+#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:7032
+#: ../../Firmware/ultralcd.cpp:7179 ../../Firmware/ultralcd.cpp:7184
 msgid "Left hotend fan?"
 msgstr ""
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2752
+#: ../../Firmware/ultralcd.cpp:2771
 msgid "Left side [μm]"
 msgstr ""
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:5862
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:5884
 msgid "Level Bright"
 msgstr ""
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:5863
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:5885
 msgid "Level Dimmed"
 msgstr ""
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4826
+#: ../../Firmware/ultralcd.cpp:4845
 msgid "Lin. correction"
 msgstr ""
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4838
-#: ../../Firmware/ultralcd.cpp:5493
+#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4857
+#: ../../Firmware/ultralcd.cpp:5515
 msgid "Live adjust Z"
 msgstr ""
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/ultralcd.cpp:5120
+#: ../../Firmware/ultralcd.cpp:5142
 msgid "Load all"
 msgstr ""
 
 #. MSG_LOAD_FILAMENT c=17
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:5122
-#: ../../Firmware/ultralcd.cpp:5133 ../../Firmware/ultralcd.cpp:5562
-#: ../../Firmware/ultralcd.cpp:5576
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:5144
+#: ../../Firmware/ultralcd.cpp:5155 ../../Firmware/ultralcd.cpp:5584
+#: ../../Firmware/ultralcd.cpp:5598
 msgid "Load filament"
 msgstr ""
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5563
+#: ../../Firmware/ultralcd.cpp:5585
 msgid "Load to nozzle"
 msgstr ""
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2185
+#: ../../Firmware/ultralcd.cpp:2204
 msgid "Loading color"
 msgstr ""
 
@@ -846,18 +846,18 @@ msgstr ""
 #: ../../Firmware/Marlin_main.cpp:3641 ../../Firmware/messages.cpp:55
 #: ../../Firmware/mmu.cpp:872 ../../Firmware/mmu.cpp:906
 #: ../../Firmware/mmu.cpp:1014 ../../Firmware/mmu.cpp:1026
-#: ../../Firmware/ultralcd.cpp:2196 ../../Firmware/ultralcd.cpp:3949
+#: ../../Firmware/ultralcd.cpp:2215 ../../Firmware/ultralcd.cpp:3968
 msgid "Loading filament"
 msgstr ""
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:7008
+#: ../../Firmware/ultralcd.cpp:7038
 msgid "Loose pulley"
 msgstr ""
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:4450
-#: ../../Firmware/ultralcd.cpp:4462
+#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/ultralcd.cpp:4481
 msgid "Loud"
 msgstr ""
 
@@ -872,8 +872,8 @@ msgid "MK3S firmware detected on MK3 printer"
 msgstr ""
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4381
-#: ../../Firmware/ultralcd.cpp:4382
+#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4400
+#: ../../Firmware/ultralcd.cpp:4401
 msgid "MMU Mode"
 msgstr ""
 
@@ -893,8 +893,8 @@ msgid "MMU OK. Resuming..."
 msgstr ""
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:64 ../../Firmware/ultralcd.cpp:1170
-#: ../../Firmware/ultralcd.cpp:1193
+#: ../../Firmware/messages.cpp:64 ../../Firmware/ultralcd.cpp:1189
+#: ../../Firmware/ultralcd.cpp:1212
 msgid "MMU fails"
 msgstr ""
 
@@ -904,8 +904,8 @@ msgid "MMU load failed"
 msgstr ""
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:1171
-#: ../../Firmware/ultralcd.cpp:1194
+#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:1190
+#: ../../Firmware/ultralcd.cpp:1213
 msgid "MMU load fails"
 msgstr ""
 
@@ -915,32 +915,32 @@ msgid "MMU needs user attention."
 msgstr ""
 
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/ultralcd.cpp:1195
+#: ../../Firmware/ultralcd.cpp:1214
 msgid "MMU power fails"
 msgstr ""
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1680
+#: ../../Firmware/ultralcd.cpp:1699
 msgid "MMU2 connected"
 msgstr ""
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:5836
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:5858
 msgid "Magnets comp."
 msgstr ""
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1147
-#: ../../Firmware/ultralcd.cpp:1295 ../../Firmware/ultralcd.cpp:1338
-#: ../../Firmware/ultralcd.cpp:1645 ../../Firmware/ultralcd.cpp:4795
-#: ../../Firmware/ultralcd.cpp:4892 ../../Firmware/ultralcd.cpp:5119
-#: ../../Firmware/ultralcd.cpp:5131 ../../Firmware/ultralcd.cpp:5154
-#: ../../Firmware/ultralcd.cpp:5173 ../../Firmware/ultralcd.cpp:5717
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1166
+#: ../../Firmware/ultralcd.cpp:1314 ../../Firmware/ultralcd.cpp:1357
+#: ../../Firmware/ultralcd.cpp:1664 ../../Firmware/ultralcd.cpp:4814
+#: ../../Firmware/ultralcd.cpp:4911 ../../Firmware/ultralcd.cpp:5141
+#: ../../Firmware/ultralcd.cpp:5153 ../../Firmware/ultralcd.cpp:5176
+#: ../../Firmware/ultralcd.cpp:5195 ../../Firmware/ultralcd.cpp:5739
 msgid "Main"
 msgstr ""
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2537
+#: ../../Firmware/ultralcd.cpp:2556
 msgid "Measured skew"
 msgstr ""
 
@@ -951,71 +951,71 @@ msgid "Measuring reference height of calibration point"
 msgstr ""
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:5832
+#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:5854
 msgid "Mesh"
 msgstr ""
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4823
-#: ../../Firmware/ultralcd.cpp:4910
+#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4842
+#: ../../Firmware/ultralcd.cpp:4929
 msgid "Mesh Bed Leveling"
 msgstr ""
 
 #. MSG_MODE c=6
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:4336
-#: ../../Firmware/ultralcd.cpp:4338 ../../Firmware/ultralcd.cpp:4358
-#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4364
-#: ../../Firmware/ultralcd.cpp:4367 ../../Firmware/ultralcd.cpp:5763
-#: ../../Firmware/ultralcd.cpp:5770 ../../Firmware/ultralcd.cpp:5777
-#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5779
-#: ../../Firmware/ultralcd.cpp:5780 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/ultralcd.cpp:4357 ../../Firmware/ultralcd.cpp:4377
+#: ../../Firmware/ultralcd.cpp:4380 ../../Firmware/ultralcd.cpp:4383
+#: ../../Firmware/ultralcd.cpp:4386 ../../Firmware/ultralcd.cpp:5785
+#: ../../Firmware/ultralcd.cpp:5792 ../../Firmware/ultralcd.cpp:5799
+#: ../../Firmware/ultralcd.cpp:5800 ../../Firmware/ultralcd.cpp:5801
+#: ../../Firmware/ultralcd.cpp:5802 ../../Firmware/ultralcd.cpp:5886
 msgid "Mode"
 msgstr ""
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3598
+#: ../../Firmware/ultralcd.cpp:3617
 msgid "Mode change in progress..."
 msgstr ""
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:4575
-#: ../../Firmware/ultralcd.cpp:4578 ../../Firmware/ultralcd.cpp:4581
-#: ../../Firmware/ultralcd.cpp:4584
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:4594
+#: ../../Firmware/ultralcd.cpp:4597 ../../Firmware/ultralcd.cpp:4600
+#: ../../Firmware/ultralcd.cpp:4603
 msgid "Model"
 msgstr ""
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6982
-#: ../../Firmware/ultralcd.cpp:6991 ../../Firmware/ultralcd.cpp:7009
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:7012
+#: ../../Firmware/ultralcd.cpp:7021 ../../Firmware/ultralcd.cpp:7039
 msgid "Motor"
 msgstr ""
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3492
+#: ../../Firmware/ultralcd.cpp:3511
 msgid "Move X"
 msgstr ""
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3493
+#: ../../Firmware/ultralcd.cpp:3512
 msgid "Move Y"
 msgstr ""
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3494
+#: ../../Firmware/ultralcd.cpp:3513
 msgid "Move Z"
 msgstr ""
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4801
+#: ../../Firmware/ultralcd.cpp:4820
 msgid "Move axis"
 msgstr ""
 
 #. MSG_NA c=3
 #: ../../Firmware/menu.cpp:196 ../../Firmware/messages.cpp:124
-#: ../../Firmware/ultralcd.cpp:2502 ../../Firmware/ultralcd.cpp:2547
-#: ../../Firmware/ultralcd.cpp:3411 ../../Firmware/ultralcd.cpp:4228
-#: ../../Firmware/ultralcd.cpp:4276 ../../Firmware/ultralcd.cpp:5737
-#: ../../Firmware/ultralcd.cpp:5836
+#: ../../Firmware/ultralcd.cpp:2521 ../../Firmware/ultralcd.cpp:2566
+#: ../../Firmware/ultralcd.cpp:3430 ../../Firmware/ultralcd.cpp:4247
+#: ../../Firmware/ultralcd.cpp:4295 ../../Firmware/ultralcd.cpp:5759
+#: ../../Firmware/ultralcd.cpp:5858
 msgid "N/A"
 msgstr ""
 
@@ -1025,14 +1025,14 @@ msgid "New firmware version available:"
 msgstr ""
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:2804
-#: ../../Firmware/ultralcd.cpp:3180 ../../Firmware/ultralcd.cpp:4785
-#: ../../Firmware/ultralcd.cpp:5988
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:2823
+#: ../../Firmware/ultralcd.cpp:3199 ../../Firmware/ultralcd.cpp:4804
+#: ../../Firmware/ultralcd.cpp:6018
 msgid "No"
 msgstr ""
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5543
+#: ../../Firmware/ultralcd.cpp:5565
 msgid "No SD card"
 msgstr ""
 
@@ -1042,71 +1042,71 @@ msgid "No move."
 msgstr ""
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4405
-#: ../../Firmware/ultralcd.cpp:4493 ../../Firmware/ultralcd.cpp:4502
-#: ../../Firmware/ultralcd.cpp:4575 ../../Firmware/ultralcd.cpp:4584
-#: ../../Firmware/ultralcd.cpp:4614 ../../Firmware/ultralcd.cpp:4623
-#: ../../Firmware/ultralcd.cpp:4655 ../../Firmware/ultralcd.cpp:4664
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4424
+#: ../../Firmware/ultralcd.cpp:4512 ../../Firmware/ultralcd.cpp:4521
+#: ../../Firmware/ultralcd.cpp:4594 ../../Firmware/ultralcd.cpp:4603
+#: ../../Firmware/ultralcd.cpp:4633 ../../Firmware/ultralcd.cpp:4642
+#: ../../Firmware/ultralcd.cpp:4674 ../../Firmware/ultralcd.cpp:4683
 msgid "None"
 msgstr ""
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:4336
-#: ../../Firmware/ultralcd.cpp:4381 ../../Firmware/ultralcd.cpp:4397
-#: ../../Firmware/ultralcd.cpp:4416 ../../Firmware/ultralcd.cpp:5763
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/ultralcd.cpp:4400 ../../Firmware/ultralcd.cpp:4416
+#: ../../Firmware/ultralcd.cpp:4435 ../../Firmware/ultralcd.cpp:5785
 msgid "Normal"
 msgstr ""
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6969
+#: ../../Firmware/ultralcd.cpp:6999
 msgid "Not connected"
 msgstr ""
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:7168
-#: ../../Firmware/ultralcd.cpp:7183 ../../Firmware/ultralcd.cpp:7191
+#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:7198
+#: ../../Firmware/ultralcd.cpp:7213 ../../Firmware/ultralcd.cpp:7221
 msgid "Not spinning"
 msgstr ""
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3962
+#: ../../Firmware/ultralcd.cpp:3981
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr ""
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:4091
+#: ../../Firmware/ultralcd.cpp:4110
 msgid "Now I will preheat nozzle for PLA."
 msgstr ""
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/ultralcd.cpp:4101
 msgid "Now remove the test print from steel sheet."
 msgstr ""
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:1402
-#: ../../Firmware/ultralcd.cpp:4493 ../../Firmware/ultralcd.cpp:4496
-#: ../../Firmware/ultralcd.cpp:4499 ../../Firmware/ultralcd.cpp:4502
-#: ../../Firmware/ultralcd.cpp:5720 ../../Firmware/ultralcd.cpp:5882
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:1421
+#: ../../Firmware/ultralcd.cpp:4512 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/ultralcd.cpp:4518 ../../Firmware/ultralcd.cpp:4521
+#: ../../Firmware/ultralcd.cpp:5742 ../../Firmware/ultralcd.cpp:5904
 msgid "Nozzle"
 msgstr ""
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4546
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4565
 msgid "Nozzle d."
 msgstr ""
 
 #. MSG_OFF c=3
 #: ../../Firmware/menu.cpp:467 ../../Firmware/messages.cpp:122
-#: ../../Firmware/ultralcd.cpp:4234 ../../Firmware/ultralcd.cpp:4250
-#: ../../Firmware/ultralcd.cpp:4284 ../../Firmware/ultralcd.cpp:4313
-#: ../../Firmware/ultralcd.cpp:4342 ../../Firmware/ultralcd.cpp:4811
-#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4834
-#: ../../Firmware/ultralcd.cpp:5644 ../../Firmware/ultralcd.cpp:5741
-#: ../../Firmware/ultralcd.cpp:5756 ../../Firmware/ultralcd.cpp:5767
-#: ../../Firmware/ultralcd.cpp:5836 ../../Firmware/ultralcd.cpp:7841
-#: ../../Firmware/ultralcd.cpp:7845
+#: ../../Firmware/ultralcd.cpp:4253 ../../Firmware/ultralcd.cpp:4269
+#: ../../Firmware/ultralcd.cpp:4303 ../../Firmware/ultralcd.cpp:4332
+#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4830
+#: ../../Firmware/ultralcd.cpp:4849 ../../Firmware/ultralcd.cpp:4853
+#: ../../Firmware/ultralcd.cpp:5666 ../../Firmware/ultralcd.cpp:5763
+#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/ultralcd.cpp:5858 ../../Firmware/ultralcd.cpp:7881
+#: ../../Firmware/ultralcd.cpp:7885
 msgid "Off"
 msgstr ""
 
@@ -1116,19 +1116,19 @@ msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr ""
 
 #. MSG_ON c=3
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4244
-#: ../../Firmware/ultralcd.cpp:4248 ../../Firmware/ultralcd.cpp:4280
-#: ../../Firmware/ultralcd.cpp:4303 ../../Firmware/ultralcd.cpp:4341
-#: ../../Firmware/ultralcd.cpp:4811 ../../Firmware/ultralcd.cpp:4830
-#: ../../Firmware/ultralcd.cpp:4834 ../../Firmware/ultralcd.cpp:5745
-#: ../../Firmware/ultralcd.cpp:5756 ../../Firmware/ultralcd.cpp:5765
-#: ../../Firmware/ultralcd.cpp:5836 ../../Firmware/ultralcd.cpp:7841
-#: ../../Firmware/ultralcd.cpp:7845
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4263
+#: ../../Firmware/ultralcd.cpp:4267 ../../Firmware/ultralcd.cpp:4299
+#: ../../Firmware/ultralcd.cpp:4322 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4849
+#: ../../Firmware/ultralcd.cpp:4853 ../../Firmware/ultralcd.cpp:5767
+#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5787
+#: ../../Firmware/ultralcd.cpp:5858 ../../Firmware/ultralcd.cpp:7881
+#: ../../Firmware/ultralcd.cpp:7885
 msgid "On"
 msgstr ""
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4453
+#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4472
 msgid "Once"
 msgstr ""
 
@@ -1148,7 +1148,7 @@ msgid "PID cal. finished"
 msgstr ""
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4913
+#: ../../Firmware/ultralcd.cpp:4932
 msgid "PID calibration"
 msgstr ""
 
@@ -1160,31 +1160,31 @@ msgstr ""
 #. MSG_PINDA_CALIBRATION c=13
 #: ../../Firmware/Marlin_main.cpp:4932 ../../Firmware/Marlin_main.cpp:5035
 #: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:654
-#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4920
+#: ../../Firmware/ultralcd.cpp:4849 ../../Firmware/ultralcd.cpp:4939
 msgid "PINDA cal."
 msgstr ""
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3361
+#: ../../Firmware/ultralcd.cpp:3380
 msgid "PINDA calibration failed"
 msgstr ""
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
 #: ../../Firmware/Marlin_main.cpp:5112 ../../Firmware/messages.cpp:110
-#: ../../Firmware/ultralcd.cpp:3355
+#: ../../Firmware/ultralcd.cpp:3374
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
 msgstr ""
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4707
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4726
 msgid "Pause"
 msgstr ""
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:5507
-#: ../../Firmware/ultralcd.cpp:5509
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:5529
+#: ../../Firmware/ultralcd.cpp:5531
 msgid "Pause print"
 msgstr ""
 
@@ -1196,24 +1196,24 @@ msgid ""
 msgstr ""
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:4176
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:4195
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
 msgstr ""
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:6250
+#: ../../Firmware/ultralcd.cpp:6280
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr ""
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6963
+#: ../../Firmware/ultralcd.cpp:6993
 msgid "Please check:"
 msgstr ""
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4148
+#: ../../Firmware/ultralcd.cpp:4167
 msgid "Please clean heatbed and then press the knob."
 msgstr ""
 
@@ -1223,20 +1223,20 @@ msgid "Please clean the nozzle for calibration. Click when done."
 msgstr ""
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3945
+#: ../../Firmware/ultralcd.cpp:3964
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr ""
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3940
+#: ../../Firmware/ultralcd.cpp:3959
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
 msgstr ""
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3863
+#: ../../Firmware/ultralcd.cpp:3882
 msgid "Please load filament first."
 msgstr ""
 
@@ -1247,7 +1247,7 @@ msgstr ""
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=5
 #: ../../Firmware/mesh_bed_calibration.cpp:2799 ../../Firmware/messages.cpp:70
-#: ../../Firmware/ultralcd.cpp:4085
+#: ../../Firmware/ultralcd.cpp:4104
 msgid "Please place steel sheet on heatbed."
 msgstr ""
 
@@ -1258,7 +1258,7 @@ msgid "Please press the knob to unload filament"
 msgstr ""
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:5213
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:5235
 msgid "Please pull out filament immediately"
 msgstr ""
 
@@ -1268,7 +1268,7 @@ msgid "Please remove filament and then press the knob."
 msgstr ""
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:4081
+#: ../../Firmware/ultralcd.cpp:4100
 msgid "Please remove shipping helpers first."
 msgstr ""
 
@@ -1284,7 +1284,7 @@ msgid "Please run XYZ calibration first."
 msgstr ""
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:6247
+#: ../../Firmware/ultralcd.cpp:6277
 msgid "Please unload the filament first, then repeat this action."
 msgstr ""
 
@@ -1301,54 +1301,54 @@ msgstr ""
 #. MSG_PLEASE_WAIT c=20
 #: ../../Firmware/Marlin_main.cpp:3547 ../../Firmware/Marlin_main.cpp:3563
 #: ../../Firmware/Marlin_main.cpp:7931 ../../Firmware/messages.cpp:71
-#: ../../Firmware/ultralcd.cpp:2186 ../../Firmware/ultralcd.cpp:2197
+#: ../../Firmware/ultralcd.cpp:2205 ../../Firmware/ultralcd.cpp:2216
 msgid "Please wait"
 msgstr ""
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1219
-#: ../../Firmware/ultralcd.cpp:1260 ../../Firmware/ultralcd.cpp:1270
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1238
+#: ../../Firmware/ultralcd.cpp:1279 ../../Firmware/ultralcd.cpp:1289
 msgid "Power failures"
 msgstr ""
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5502
+#: ../../Firmware/ultralcd.cpp:5524
 msgid "Preheat"
 msgstr ""
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:2280
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:2299
 msgid "Preheat the nozzle!"
 msgstr ""
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:2900
-#: ../../Firmware/ultralcd.cpp:3924 ../../Firmware/ultralcd.cpp:3926
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:2919
+#: ../../Firmware/ultralcd.cpp:3943 ../../Firmware/ultralcd.cpp:3945
 msgid "Preheating nozzle. Please wait."
 msgstr ""
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1988
+#: ../../Firmware/ultralcd.cpp:2007
 msgid "Preheating to cut"
 msgstr ""
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1985
+#: ../../Firmware/ultralcd.cpp:2004
 msgid "Preheating to eject"
 msgstr ""
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1976
+#: ../../Firmware/ultralcd.cpp:1995
 msgid "Preheating to load"
 msgstr ""
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1981
+#: ../../Firmware/ultralcd.cpp:2000
 msgid "Preheating to unload"
 msgstr ""
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1809
+#: ../../Firmware/ultralcd.cpp:1828
 msgid "Press the knob"
 msgstr ""
 
@@ -1368,13 +1368,13 @@ msgid "Print aborted"
 msgstr ""
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1144
-#: ../../Firmware/ultralcd.cpp:7322
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1145
+#: ../../Firmware/ultralcd.cpp:7354
 msgid "Print fan:"
 msgstr ""
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5535
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5557
 msgid "Print from SD"
 msgstr ""
 
@@ -1384,12 +1384,12 @@ msgid "Print paused"
 msgstr ""
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2366
+#: ../../Firmware/ultralcd.cpp:2385
 msgid "Print time"
 msgstr ""
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1711
+#: ../../Firmware/ultralcd.cpp:1730
 msgid "Printer IP Addr:"
 msgstr ""
 
@@ -1413,12 +1413,12 @@ msgid ""
 msgstr ""
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4834
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4853
 msgid "RPi port"
 msgstr ""
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2755
+#: ../../Firmware/ultralcd.cpp:2774
 msgid "Rear side [μm]"
 msgstr ""
 
@@ -1433,24 +1433,24 @@ msgid "Remove old filament and press the knob to start loading new filament."
 msgstr ""
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5426
+#: ../../Firmware/ultralcd.cpp:5448
 msgid "Rename"
 msgstr ""
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2756
-#: ../../Firmware/ultralcd.cpp:5427
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2775
+#: ../../Firmware/ultralcd.cpp:5449
 msgid "Reset"
 msgstr ""
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4917
+#: ../../Firmware/ultralcd.cpp:4936
 msgid "Reset XYZ calibr."
 msgstr ""
 
 #. MSG_RESUME_PRINT c=18
 #: ../../Firmware/Marlin_main.cpp:655 ../../Firmware/messages.cpp:81
-#: ../../Firmware/ultralcd.cpp:5521 ../../Firmware/ultralcd.cpp:5523
+#: ../../Firmware/ultralcd.cpp:5543 ../../Firmware/ultralcd.cpp:5545
 msgid "Resume print"
 msgstr ""
 
@@ -1460,31 +1460,31 @@ msgid "Resuming print"
 msgstr ""
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2497
+#: ../../Firmware/ultralcd.cpp:2516
 msgid "Right"
 msgstr ""
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2753
+#: ../../Firmware/ultralcd.cpp:2772
 msgid "Right side[μm]"
 msgstr ""
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3884
+#: ../../Firmware/ultralcd.cpp:3903
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
 msgstr ""
 
 #. MSG_RUNOUTS c=7
-#: ../../Firmware/ultralcd.cpp:1271
+#: ../../Firmware/ultralcd.cpp:1290
 msgid "Runouts"
 msgstr ""
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4395
-#: ../../Firmware/ultralcd.cpp:4397 ../../Firmware/ultralcd.cpp:4414
-#: ../../Firmware/ultralcd.cpp:4416
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4414
+#: ../../Firmware/ultralcd.cpp:4416 ../../Firmware/ultralcd.cpp:4433
+#: ../../Firmware/ultralcd.cpp:4435
 msgid "SD card"
 msgstr ""
 
@@ -1500,12 +1500,12 @@ msgid "Searching bed calibration point"
 msgstr ""
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5419
+#: ../../Firmware/ultralcd.cpp:5441
 msgid "Select"
 msgstr ""
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3966
+#: ../../Firmware/ultralcd.cpp:3985
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
@@ -1518,49 +1518,49 @@ msgstr ""
 
 #. MSG_SELECT_FILAMENT c=20
 #: ../../Firmware/Marlin_main.cpp:8577 ../../Firmware/Marlin_main.cpp:8604
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3834
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3853
 msgid "Select filament:"
 msgstr ""
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:3679
-#: ../../Firmware/ultralcd.cpp:4841
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:3698
+#: ../../Firmware/ultralcd.cpp:4860
 msgid "Select language"
 msgstr ""
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:4122
+#: ../../Firmware/ultralcd.cpp:4141
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr ""
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3971
+#: ../../Firmware/ultralcd.cpp:3990
 msgid "Select temperature which matches your material."
 msgstr ""
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6522
+#: ../../Firmware/ultralcd.cpp:6552
 msgid "Self test OK"
 msgstr ""
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:6290
+#: ../../Firmware/ultralcd.cpp:6320
 msgid "Self test start"
 msgstr ""
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4904
+#: ../../Firmware/ultralcd.cpp:4923
 msgid "Selftest"
 msgstr ""
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6962
+#: ../../Firmware/ultralcd.cpp:6992
 msgid "Selftest error!"
 msgstr ""
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:6526
-#: ../../Firmware/ultralcd.cpp:7049 ../../Firmware/ultralcd.cpp:7314
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:6556
+#: ../../Firmware/ultralcd.cpp:7079 ../../Firmware/ultralcd.cpp:7344
 msgid "Selftest failed"
 msgstr ""
 
@@ -1570,30 +1570,30 @@ msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr ""
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1723
+#: ../../Firmware/ultralcd.cpp:1742
 msgid "Sensor info"
 msgstr ""
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:6254
+#: ../../Firmware/ultralcd.cpp:6284
 msgid "Sensor verified, remove the filament now."
 msgstr ""
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2773
+#: ../../Firmware/ultralcd.cpp:2792
 msgid "Set temperature:"
 msgstr ""
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:3491
-#: ../../Firmware/ultralcd.cpp:3696 ../../Firmware/ultralcd.cpp:4206
-#: ../../Firmware/ultralcd.cpp:5580 ../../Firmware/ultralcd.cpp:5827
-#: ../../Firmware/ultralcd.cpp:5880
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:3510
+#: ../../Firmware/ultralcd.cpp:3715 ../../Firmware/ultralcd.cpp:4225
+#: ../../Firmware/ultralcd.cpp:5602 ../../Firmware/ultralcd.cpp:5849
+#: ../../Firmware/ultralcd.cpp:5902
 msgid "Settings"
 msgstr ""
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2540
+#: ../../Firmware/ultralcd.cpp:2559
 msgid "Severe skew"
 msgstr ""
 
@@ -1604,7 +1604,7 @@ msgid "Sheet"
 msgstr ""
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3824
+#: ../../Firmware/ultralcd.cpp:3843
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1613,18 +1613,18 @@ msgid ""
 msgstr ""
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4915
+#: ../../Firmware/ultralcd.cpp:4934
 msgid "Show end stops"
 msgstr ""
 
 #. MSG_SILENT c=7
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4361
-#: ../../Firmware/ultralcd.cpp:4456 ../../Firmware/ultralcd.cpp:5778
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4380
+#: ../../Firmware/ultralcd.cpp:4475 ../../Firmware/ultralcd.cpp:5800
 msgid "Silent"
 msgstr ""
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2539
+#: ../../Firmware/ultralcd.cpp:2558
 msgid "Slight skew"
 msgstr ""
 
@@ -1641,8 +1641,8 @@ msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr ""
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4403
-#: ../../Firmware/ultralcd.cpp:4404 ../../Firmware/ultralcd.cpp:4405
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4422
+#: ../../Firmware/ultralcd.cpp:4423 ../../Firmware/ultralcd.cpp:4424
 msgid "Sort"
 msgstr ""
 
@@ -1653,20 +1653,20 @@ msgid "Sorting files"
 msgstr ""
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4450
-#: ../../Firmware/ultralcd.cpp:4453 ../../Firmware/ultralcd.cpp:4456
-#: ../../Firmware/ultralcd.cpp:4459 ../../Firmware/ultralcd.cpp:4462
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/ultralcd.cpp:4472 ../../Firmware/ultralcd.cpp:4475
+#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4481
 msgid "Sound"
 msgstr ""
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5718
+#: ../../Firmware/ultralcd.cpp:5740
 msgid "Speed"
 msgstr ""
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7166
-#: ../../Firmware/ultralcd.cpp:7181 ../../Firmware/ultralcd.cpp:7189
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7196
+#: ../../Firmware/ultralcd.cpp:7211 ../../Firmware/ultralcd.cpp:7219
 msgid "Spinning"
 msgstr ""
 
@@ -1676,42 +1676,42 @@ msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr ""
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5585
+#: ../../Firmware/ultralcd.cpp:5607
 msgid "Statistics"
 msgstr ""
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4338
-#: ../../Firmware/ultralcd.cpp:4382 ../../Firmware/ultralcd.cpp:5770
+#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4357
+#: ../../Firmware/ultralcd.cpp:4401 ../../Firmware/ultralcd.cpp:5792
 msgid "Stealth"
 msgstr ""
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4763
-#: ../../Firmware/ultralcd.cpp:5416
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4782
+#: ../../Firmware/ultralcd.cpp:5438
 msgid "Steel sheets"
 msgstr ""
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5528
-#: ../../Firmware/ultralcd.cpp:5987
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5550
+#: ../../Firmware/ultralcd.cpp:6017
 msgid "Stop print"
 msgstr ""
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4499
-#: ../../Firmware/ultralcd.cpp:4581 ../../Firmware/ultralcd.cpp:4620
-#: ../../Firmware/ultralcd.cpp:4661
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4518
+#: ../../Firmware/ultralcd.cpp:4600 ../../Firmware/ultralcd.cpp:4639
+#: ../../Firmware/ultralcd.cpp:4680
 msgid "Strict"
 msgstr ""
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/ultralcd.cpp:5616
 msgid "Support"
 msgstr ""
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:7021
+#: ../../Firmware/ultralcd.cpp:7051
 msgid "Swapped"
 msgstr ""
 
@@ -1720,28 +1720,18 @@ msgstr ""
 msgid "THERMAL ANOMALY"
 msgstr ""
 
-#. MSG_TM_AUTOTUNE_FAILED c=20
-#: ../../Firmware/temperature.cpp:2899
-msgid "TM autotune failed"
-msgstr ""
-
-#. MSG_TEMP_MODEL_AUTOTUNE c=20
-#: ../../Firmware/temperature.cpp:2884
-msgid "Temp. model autotune"
-msgstr ""
-
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4797
+#: ../../Firmware/ultralcd.cpp:4816
 msgid "Temperature"
 msgstr ""
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1729
+#: ../../Firmware/ultralcd.cpp:1748
 msgid "Temperatures"
 msgstr ""
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3974
+#: ../../Firmware/ultralcd.cpp:3993
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -1756,66 +1746,66 @@ msgid ""
 msgstr ""
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4403
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4422
 msgid "Time"
 msgstr ""
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:5865
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:5887
 msgid "Timeout"
 msgstr ""
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:1149
-#: ../../Firmware/ultralcd.cpp:1297
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:1168
+#: ../../Firmware/ultralcd.cpp:1316
 msgid "Total"
 msgstr ""
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:1192
-#: ../../Firmware/ultralcd.cpp:1218 ../../Firmware/ultralcd.cpp:1328
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:1211
+#: ../../Firmware/ultralcd.cpp:1237 ../../Firmware/ultralcd.cpp:1347
 msgid "Total failures"
 msgstr ""
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2387
+#: ../../Firmware/ultralcd.cpp:2406
 msgid "Total filament"
 msgstr ""
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2388
+#: ../../Firmware/ultralcd.cpp:2407
 msgid "Total print time"
 msgstr ""
 
 #. MSG_TUNE c=18
-#: ../../Firmware/ultralcd.cpp:5500
+#: ../../Firmware/ultralcd.cpp:5522
 msgid "Tune"
 msgstr ""
 
 #. MSG_UNLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:5564
-#: ../../Firmware/ultralcd.cpp:5578
+#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:5586
+#: ../../Firmware/ultralcd.cpp:5600
 msgid "Unload filament"
 msgstr ""
 
 #. MSG_UNLOADING_FILAMENT c=20
 #: ../../Firmware/messages.cpp:112 ../../Firmware/mmu.cpp:957
-#: ../../Firmware/ultralcd.cpp:5197
+#: ../../Firmware/ultralcd.cpp:5219
 msgid "Unloading filament"
 msgstr ""
 
 #. MSG_FIL_FAILED c=20 r=5
-#: ../../Firmware/ultralcd.cpp:6258
+#: ../../Firmware/ultralcd.cpp:6288
 msgid "Verification failed, remove the filament and try again."
 msgstr ""
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1732
+#: ../../Firmware/ultralcd.cpp:1751
 msgid "Voltages"
 msgstr ""
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3534
+#: ../../Firmware/ultralcd.cpp:3553
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -1829,19 +1819,19 @@ msgid "Wait for user..."
 msgstr ""
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2881
+#: ../../Firmware/ultralcd.cpp:2900
 msgid "Waiting for PINDA probe cooling"
 msgstr ""
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2913
+#: ../../Firmware/ultralcd.cpp:2932
 msgid "Waiting for nozzle and bed cooling"
 msgstr ""
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:4496
-#: ../../Firmware/ultralcd.cpp:4578 ../../Firmware/ultralcd.cpp:4617
-#: ../../Firmware/ultralcd.cpp:4658
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/ultralcd.cpp:4597 ../../Firmware/ultralcd.cpp:4636
+#: ../../Firmware/ultralcd.cpp:4677
 msgid "Warn"
 msgstr ""
 
@@ -1866,144 +1856,133 @@ msgid "Was filament unload successful?"
 msgstr ""
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6973
-#: ../../Firmware/ultralcd.cpp:6977 ../../Firmware/ultralcd.cpp:6997
-#: ../../Firmware/ultralcd.cpp:7003 ../../Firmware/ultralcd.cpp:7027
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:7003
+#: ../../Firmware/ultralcd.cpp:7007 ../../Firmware/ultralcd.cpp:7027
+#: ../../Firmware/ultralcd.cpp:7033 ../../Firmware/ultralcd.cpp:7057
 msgid "Wiring error"
 msgstr ""
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4895
+#: ../../Firmware/ultralcd.cpp:4914
 msgid "Wizard"
 msgstr ""
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4210
+#: ../../Firmware/ultralcd.cpp:4229
 msgid "X-correct:"
 msgstr ""
 
 #. MSG_XFLASH c=18
-#: ../../Firmware/ultralcd.cpp:5596
+#: ../../Firmware/ultralcd.cpp:5618
 msgid "XFLASH init"
 msgstr ""
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1721
+#: ../../Firmware/ultralcd.cpp:1740
 msgid "XYZ cal. details"
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3333
+#: ../../Firmware/ultralcd.cpp:3352
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3330
+#: ../../Firmware/ultralcd.cpp:3349
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3311
+#: ../../Firmware/ultralcd.cpp:3330
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr ""
 
-#. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_LEFT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3317
-msgid ""
-"XYZ calibration compromised. Left front calibration point not reachable."
-msgstr ""
-
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3314
+#: ../../Firmware/ultralcd.cpp:3333
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3293
+#: ../../Firmware/ultralcd.cpp:3312
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3299
+#: ../../Firmware/ultralcd.cpp:3318
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr ""
 
-#. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_LEFT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3305
-msgid "XYZ calibration failed. Left front calibration point not reachable."
-msgstr ""
-
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3296
-#: ../../Firmware/ultralcd.cpp:3324
+#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3315
+#: ../../Firmware/ultralcd.cpp:3343
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3302
+#: ../../Firmware/ultralcd.cpp:3321
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3327
+#: ../../Firmware/ultralcd.cpp:3346
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr ""
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2494
+#: ../../Firmware/ultralcd.cpp:2513
 msgid "Y distance from min"
 msgstr ""
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4211
+#: ../../Firmware/ultralcd.cpp:4230
 msgid "Y-correct:"
 msgstr ""
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:2216
-#: ../../Firmware/ultralcd.cpp:2800 ../../Firmware/ultralcd.cpp:3180
-#: ../../Firmware/ultralcd.cpp:4785 ../../Firmware/ultralcd.cpp:5989
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:2235
+#: ../../Firmware/ultralcd.cpp:2819 ../../Firmware/ultralcd.cpp:3199
+#: ../../Firmware/ultralcd.cpp:4804 ../../Firmware/ultralcd.cpp:6019
 msgid "Yes"
 msgstr ""
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:4187
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:4206
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr ""
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4231
 msgid "Z-correct:"
 msgstr ""
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:5835
+#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:5857
 msgid "Z-probe nr."
 msgstr ""
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2565
+#: ../../Firmware/ultralcd.cpp:2584
 msgid "[0;0] point offset"
 msgstr ""
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2154
+#: ../../Firmware/ultralcd.cpp:2173
 msgid "and press the knob"
 msgstr ""
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1816
+#: ../../Firmware/ultralcd.cpp:1835
 msgid "to load filament"
 msgstr ""
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1820
+#: ../../Firmware/ultralcd.cpp:1839
 msgid "to unload filament"
 msgstr ""
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1688
+#: ../../Firmware/ultralcd.cpp:1707
 msgid "unknown"
 msgstr ""
 
@@ -2013,7 +1992,7 @@ msgid "unknown state"
 msgstr ""
 
 #. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:6077
-#: ../../Firmware/ultralcd.cpp:6080
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:6107
+#: ../../Firmware/ultralcd.cpp:6110
 msgid "🔃Refresh"
 msgstr ""

--- a/lang/po/Firmware_cs.po
+++ b/lang/po/Firmware_cs.po
@@ -26,82 +26,82 @@ msgid " 0.4 or newer"
 msgstr " 0.4 nebo novejsi"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:7036
+#: ../../Firmware/ultralcd.cpp:7066
 msgid "%s level expected"
 msgstr "%s ocekavana verze"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1968
-#: ../../Firmware/ultralcd.cpp:3835
+#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1987
+#: ../../Firmware/ultralcd.cpp:3854
 msgid ">Cancel"
 msgstr ">Zrusit"
 
 #. MSG_BABYSTEPPING_Z c=15
 #. Beware: must include the ':' as its last character
-#: ../../Firmware/ultralcd.cpp:2670
+#: ../../Firmware/ultralcd.cpp:2689
 msgid "Adjusting Z:"
 msgstr "Doladeni Z:"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:7313
+#: ../../Firmware/ultralcd.cpp:7343
 msgid "All correct"
 msgstr "Vse OK"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4180
+#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4190
+#: ../../Firmware/ultralcd.cpp:4199
 msgid "All is done. Happy printing!"
 msgstr "Vse je hotovo. Tisku zdar!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4404
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4423
 msgid "Alphabet"
 msgstr "Abeceda"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4308
+#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4327
 msgid "Always"
 msgstr "Vzdy"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1405
+#: ../../Firmware/ultralcd.cpp:1424
 msgid "Ambient"
 msgstr "Okoli"
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2983
+#: ../../Firmware/ultralcd.cpp:3002
 msgid "Are left and right Z~carriages all up?"
 msgstr "Dojely oba Z voziky k~hornimu dorazu?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4478
 msgid "Assist"
 msgstr "Asist."
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:5886
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
 #: ../../Firmware/Marlin_main.cpp:3271 ../../Firmware/messages.cpp:9
-#: ../../Firmware/ultralcd.cpp:4900
+#: ../../Firmware/ultralcd.cpp:4919
 msgid "Auto home"
 msgstr "Auto home"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:4364
-#: ../../Firmware/ultralcd.cpp:5779
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:4383
+#: ../../Firmware/ultralcd.cpp:5801
 msgid "Auto power"
 msgstr "Automat."
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5572
+#: ../../Firmware/ultralcd.cpp:5594
 msgid "AutoLoad filament"
 msgstr "AutoZavedeni fil."
 
 #. MSG_AUTOLOADING_ONLY_IF_FSENS_ON c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3549
+#: ../../Firmware/ultralcd.cpp:3568
 msgid ""
 "Autoloading filament available only when filament sensor is turned on..."
 msgstr ""
@@ -109,7 +109,7 @@ msgstr ""
 "senzoru..."
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2301
+#: ../../Firmware/ultralcd.cpp:2320
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
@@ -117,26 +117,26 @@ msgstr ""
 "filament..."
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:7015
+#: ../../Firmware/ultralcd.cpp:7045
 msgid "Axis"
 msgstr "Osa"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:7014
+#: ../../Firmware/ultralcd.cpp:7044
 msgid "Axis length"
 msgstr "Delka osy"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:2751
-#: ../../Firmware/ultralcd.cpp:5861 ../../Firmware/ultralcd.cpp:7838
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:2770
+#: ../../Firmware/ultralcd.cpp:5883 ../../Firmware/ultralcd.cpp:7878
 msgid "Back"
 msgstr "Zpet"
 
 #. MSG_BED c=13
 #: ../../Firmware/Marlin_main.cpp:2051 ../../Firmware/Marlin_main.cpp:4767
 #: ../../Firmware/Marlin_main.cpp:4819 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:1403 ../../Firmware/ultralcd.cpp:5721
-#: ../../Firmware/ultralcd.cpp:5891
+#: ../../Firmware/ultralcd.cpp:1422 ../../Firmware/ultralcd.cpp:5743
+#: ../../Firmware/ultralcd.cpp:5913
 msgid "Bed"
 msgstr "Podlozka"
 
@@ -153,7 +153,7 @@ msgid "Bed done"
 msgstr "Bed OK."
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4912
+#: ../../Firmware/ultralcd.cpp:4931
 msgid "Bed level correct"
 msgstr "Korekce podlozky"
 
@@ -170,18 +170,18 @@ msgstr ""
 "Kalibrace Z selhala. Sensor nesepnul. Znecistena tryska? Cekam na reset."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6972
+#: ../../Firmware/ultralcd.cpp:7002
 msgid "Bed/Heater"
 msgstr "Podlozka/Topeni"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1458
-#: ../../Firmware/ultralcd.cpp:1726
+#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1477
+#: ../../Firmware/ultralcd.cpp:1745
 msgid "Belt status"
 msgstr "Stav remenu"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4902
+#: ../../Firmware/ultralcd.cpp:4921
 msgid "Belt test"
 msgstr "Test remenu"
 
@@ -192,28 +192,28 @@ msgid "Blackout occurred. Recover print?"
 msgstr "Detekovan vypadek proudu.Obnovit tisk?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:5886
 msgid "Bright"
 msgstr "Jasny"
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4850
-#: ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4869
+#: ../../Firmware/ultralcd.cpp:5811
 msgid "Brightness"
 msgstr "Podsviceni"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4906
+#: ../../Firmware/ultralcd.cpp:4925
 msgid "Calibrate XYZ"
 msgstr "Kalibrace XYZ"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4908
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4927
 msgid "Calibrate Z"
 msgstr "Kalibrovat Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2946
+#: ../../Firmware/ultralcd.cpp:2965
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -228,7 +228,7 @@ msgid "Calibrating Z"
 msgstr "Kalibruji Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2945
+#: ../../Firmware/ultralcd.cpp:2964
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -237,12 +237,12 @@ msgstr ""
 "tlacitkem."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:7315
+#: ../../Firmware/ultralcd.cpp:7345
 msgid "Calibrating home"
 msgstr "Kalibruji vychozi p."
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:5581
+#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:5603
 msgid "Calibration"
 msgstr "Kalibrace"
 
@@ -252,115 +252,115 @@ msgid "Calibration done"
 msgstr "Kalibrace OK"
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7712
+#: ../../Firmware/ultralcd.cpp:7752
 msgid "Card removed"
 msgstr "Karta vyjmuta"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/ultralcd.cpp:5560
 msgid "Change SD card"
 msgstr "Vymente SD kartu"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5497
-#: ../../Firmware/ultralcd.cpp:5730
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5519
+#: ../../Firmware/ultralcd.cpp:5752
 msgid "Change filament"
 msgstr "Vymenit filament"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2163
+#: ../../Firmware/ultralcd.cpp:2182
 msgid "Change success!"
 msgstr "Zmena uspesna!"
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2215
+#: ../../Firmware/ultralcd.cpp:2234
 msgid "Changed correctly?"
 msgstr "Vymena ok?"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:6178
-#: ../../Firmware/ultralcd.cpp:7305
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:6208
+#: ../../Firmware/ultralcd.cpp:7335
 msgid "Checking X axis"
 msgstr "Kontrola osy X"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:6187
-#: ../../Firmware/ultralcd.cpp:7306
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:6217
+#: ../../Firmware/ultralcd.cpp:7336
 msgid "Checking Y axis"
 msgstr "Kontrola osy Y"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:7307
+#: ../../Firmware/ultralcd.cpp:7337
 msgid "Checking Z axis"
 msgstr "Kontrola osy Z"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:7308
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:7338
 msgid "Checking bed"
 msgstr "Kontrola podlozky"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:7304
+#: ../../Firmware/ultralcd.cpp:7334
 msgid "Checking endstops"
 msgstr "Kontrola endstopu"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:7403
+#: ../../Firmware/ultralcd.cpp:7433
 msgid "Checking file"
 msgstr "Kontroluji soubor"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:7310
+#: ../../Firmware/ultralcd.cpp:7340
 msgid "Checking hotend"
 msgstr "Kontrola hotend"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:7311
-#: ../../Firmware/ultralcd.cpp:7312
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:7341
+#: ../../Firmware/ultralcd.cpp:7342
 msgid "Checking sensors"
 msgstr "Kontrola senzoru"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4765
+#: ../../Firmware/ultralcd.cpp:4784
 msgid "Checks"
 msgstr "Kontrola"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2218
+#: ../../Firmware/ultralcd.cpp:2237
 msgid "Color not correct"
 msgstr "Barva neni cista"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3725
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3744
 msgid "Community made"
 msgstr "Komunitni prekl."
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4704
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4723
 msgid "Cont."
 msgstr "Pokr."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2125
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2144
 msgid "Cooldown"
 msgstr "Zchladit"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3663
+#: ../../Firmware/ultralcd.cpp:3682
 msgid "Copy selected language?"
 msgstr "Kopirovat vybrany jazyk?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1221
-#: ../../Firmware/ultralcd.cpp:1262 ../../Firmware/ultralcd.cpp:1272
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1240
+#: ../../Firmware/ultralcd.cpp:1281 ../../Firmware/ultralcd.cpp:1291
 msgid "Crash"
 msgstr "Naraz"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4341
-#: ../../Firmware/ultralcd.cpp:4342 ../../Firmware/ultralcd.cpp:4344
-#: ../../Firmware/ultralcd.cpp:5765 ../../Firmware/ultralcd.cpp:5767
-#: ../../Firmware/ultralcd.cpp:5771
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4363
+#: ../../Firmware/ultralcd.cpp:5787 ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/ultralcd.cpp:5793
 msgid "Crash det."
 msgstr "Det. narazu"
 
@@ -370,7 +370,7 @@ msgid "Crash detected."
 msgstr "Detekovan naraz."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3521
+#: ../../Firmware/ultralcd.cpp:3540
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -381,14 +381,14 @@ msgstr ""
 "Normal modu"
 
 #. MSG_CUT_FILAMENT c=17
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:5175
-#: ../../Firmware/ultralcd.cpp:5567
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:5197
+#: ../../Firmware/ultralcd.cpp:5589
 msgid "Cut filament"
 msgstr "Ustrihnout"
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:4303
-#: ../../Firmware/ultralcd.cpp:4308 ../../Firmware/ultralcd.cpp:4313
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:4322
+#: ../../Firmware/ultralcd.cpp:4327 ../../Firmware/ultralcd.cpp:4332
 msgid "Cutter"
 msgstr "Strihani"
 
@@ -398,17 +398,17 @@ msgid "Cutting filament"
 msgstr "Strihani filamentu"
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1668
+#: ../../Firmware/ultralcd.cpp:1687
 msgid "Date:"
 msgstr "Datum:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5886
 msgid "Dim"
 msgstr "Temny"
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4802
+#: ../../Firmware/ultralcd.cpp:4821
 msgid "Disable steppers"
 msgstr "Vypnout motory"
 
@@ -424,7 +424,7 @@ msgstr ""
 "podle manualu, kapitola Zaciname, odstavec Nastaveni prvni vrstvy."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:4145
+#: ../../Firmware/ultralcd.cpp:4164
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -432,23 +432,23 @@ msgstr ""
 "Chcete opakovat posledni krok a pozmenit vzdalenost mezi tryskou a podlozkou?"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4214
+#: ../../Firmware/ultralcd.cpp:4233
 msgid "E-correct:"
 msgstr "Korekce E:"
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2279
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2298
 msgid "ERROR:"
 msgstr "CHYBA:"
 
 #. MSG_FSENS_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3562
+#: ../../Firmware/ultralcd.cpp:3581
 msgid "ERROR: Filament sensor is not responding, please check connection."
 msgstr "CHYBA: Filament senzor nereaguje, zkontrolujte prosim zapojeni."
 
 #. MSG_EJECT_FILAMENT c=17
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:5156
-#: ../../Firmware/ultralcd.cpp:5565
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:5178
+#: ../../Firmware/ultralcd.cpp:5587
 msgid "Eject filament"
 msgstr "Vysunout fil."
 
@@ -458,47 +458,41 @@ msgid "Ejecting filament"
 msgstr "Vysouvam filament"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6985
+#: ../../Firmware/ultralcd.cpp:7015
 msgid "Endstop"
 msgstr "Koncovy spinac"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6990
+#: ../../Firmware/ultralcd.cpp:7020
 msgid "Endstop not hit"
 msgstr "Kon. spinac nesepnut"
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6976
+#: ../../Firmware/ultralcd.cpp:7006
 msgid "Endstops"
 msgstr "Konc. spinace"
 
 #. MSG_EXTRUDER c=17
 #: ../../Firmware/Marlin_main.cpp:8608 ../../Firmware/messages.cpp:30
-#: ../../Firmware/ultralcd.cpp:3495
+#: ../../Firmware/ultralcd.cpp:3514
 msgid "Extruder"
 msgstr "Extruder"
 
-#. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1144
-#: ../../Firmware/ultralcd.cpp:7319
-msgid "Hotend fan:"
-msgstr "Vent. hotendu:"
-
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1722
+#: ../../Firmware/ultralcd.cpp:1741
 msgid "Extruder info"
 msgstr "Extruder - info"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4229
-#: ../../Firmware/ultralcd.cpp:4237 ../../Firmware/ultralcd.cpp:4248
-#: ../../Firmware/ultralcd.cpp:4250
+#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4248
+#: ../../Firmware/ultralcd.cpp:4256 ../../Firmware/ultralcd.cpp:4267
+#: ../../Firmware/ultralcd.cpp:4269
 msgid "F. autoload"
 msgstr "F. autozav."
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4704
-#: ../../Firmware/ultralcd.cpp:4707
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4723
+#: ../../Firmware/ultralcd.cpp:4726
 msgid "FS Action"
 msgstr "FS reakce"
 
@@ -513,102 +507,102 @@ msgid "FS v0.4 or newer"
 msgstr "FS 0.4 a novejsi"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5589
+#: ../../Firmware/ultralcd.cpp:5611
 msgid "Fail stats"
 msgstr "Selhani"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5592
+#: ../../Firmware/ultralcd.cpp:5614
 msgid "Fail stats MMU"
 msgstr "Selhani MMU"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:7031
+#: ../../Firmware/ultralcd.cpp:7061
 msgid "False triggering"
 msgstr "Falesne spusteni"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:5723
-#: ../../Firmware/ultralcd.cpp:5893
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/ultralcd.cpp:5915
 msgid "Fan speed"
 msgstr "Rychlost vent."
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:7143
-#: ../../Firmware/ultralcd.cpp:7301 ../../Firmware/ultralcd.cpp:7302
-#: ../../Firmware/ultralcd.cpp:7303
+#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:7173
+#: ../../Firmware/ultralcd.cpp:7331 ../../Firmware/ultralcd.cpp:7332
+#: ../../Firmware/ultralcd.cpp:7333
 msgid "Fan test"
 msgstr "Test ventilatoru"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4811
-#: ../../Firmware/ultralcd.cpp:5756
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4830
+#: ../../Firmware/ultralcd.cpp:5778
 msgid "Fans check"
 msgstr "Kontr. vent."
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1220
-#: ../../Firmware/ultralcd.cpp:1261 ../../Firmware/ultralcd.cpp:1327
-#: ../../Firmware/ultralcd.cpp:1329
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1239
+#: ../../Firmware/ultralcd.cpp:1280 ../../Firmware/ultralcd.cpp:1346
+#: ../../Firmware/ultralcd.cpp:1348
 msgid "Fil. runouts"
 msgstr "Vypadky filam."
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:3451
-#: ../../Firmware/ultralcd.cpp:4228 ../../Firmware/ultralcd.cpp:4234
-#: ../../Firmware/ultralcd.cpp:4244 ../../Firmware/ultralcd.cpp:5737
-#: ../../Firmware/ultralcd.cpp:5741 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:3470
+#: ../../Firmware/ultralcd.cpp:4247 ../../Firmware/ultralcd.cpp:4253
+#: ../../Firmware/ultralcd.cpp:4263 ../../Firmware/ultralcd.cpp:5759
+#: ../../Firmware/ultralcd.cpp:5763 ../../Firmware/ultralcd.cpp:5767
 msgid "Fil. sensor"
 msgstr "Fil. senzor"
 
 #. MSG_FILAMENT c=17
 #: ../../Firmware/Marlin_main.cpp:8577 ../../Firmware/Marlin_main.cpp:8604
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3835
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3854
 msgid "Filament"
 msgstr "Filament"
 
 #. MSG_FILAMENT_CLEAN c=20 r=2
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2287
-#: ../../Firmware/ultralcd.cpp:2293
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2306
+#: ../../Firmware/ultralcd.cpp:2312
 msgid "Filament extruding & with correct color?"
 msgstr "Filament vytlacen a spravne barvy?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2217
+#: ../../Firmware/ultralcd.cpp:2236
 msgid "Filament not loaded"
 msgstr "Filament nezaveden"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:7026
-#: ../../Firmware/ultralcd.cpp:7030 ../../Firmware/ultralcd.cpp:7034
-#: ../../Firmware/ultralcd.cpp:7330
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:7056
+#: ../../Firmware/ultralcd.cpp:7060 ../../Firmware/ultralcd.cpp:7064
+#: ../../Firmware/ultralcd.cpp:7360
 msgid "Filament sensor"
 msgstr "Senzor filamentu"
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2365
+#: ../../Firmware/ultralcd.cpp:2384
 msgid "Filament used"
 msgstr "Spotrebovano filam."
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7461
+#: ../../Firmware/ultralcd.cpp:7491
 msgid "File incomplete. Continue anyway?"
 msgstr "Soubor nekompletni. Pokracovat?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:5314
-#: ../../Firmware/ultralcd.cpp:5630
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:5336
+#: ../../Firmware/ultralcd.cpp:5652
 msgid "Finishing movements"
 msgstr "Dokoncovani pohybu"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:4898
-#: ../../Firmware/ultralcd.cpp:5424
+#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:4917
+#: ../../Firmware/ultralcd.cpp:5446
 msgid "First layer cal."
 msgstr "Kal. prvni vrstvy"
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4066
+#: ../../Firmware/ultralcd.cpp:4085
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Nejdriv pomoci selftestu zkontoluji nejcastejsi chyby vznikajici pri "
@@ -620,23 +614,23 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr "Opravte chybu a pote stisknete tlacitko na jednotce MMU."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5724
+#: ../../Firmware/ultralcd.cpp:5746
 msgid "Flow"
 msgstr "Prutok"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:6996
-#: ../../Firmware/ultralcd.cpp:7149 ../../Firmware/ultralcd.cpp:7154
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:7026
+#: ../../Firmware/ultralcd.cpp:7179 ../../Firmware/ultralcd.cpp:7184
 msgid "Front print fan?"
 msgstr "Predni tiskovy vent?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2754
+#: ../../Firmware/ultralcd.cpp:2773
 msgid "Front side[μm]"
 msgstr "Vpredu [μm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:7020
+#: ../../Firmware/ultralcd.cpp:7050
 msgid "Front/left fans"
 msgstr "Predni/levy vent."
 
@@ -685,20 +679,20 @@ msgstr ""
 "zrusen."
 
 #. MSG_GCODE c=8
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:4655
-#: ../../Firmware/ultralcd.cpp:4658 ../../Firmware/ultralcd.cpp:4661
-#: ../../Firmware/ultralcd.cpp:4664
+#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:4674
+#: ../../Firmware/ultralcd.cpp:4677 ../../Firmware/ultralcd.cpp:4680
+#: ../../Firmware/ultralcd.cpp:4683
 msgid "Gcode"
 msgstr "Gcode"
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:4672
-#: ../../Firmware/ultralcd.cpp:4726 ../../Firmware/ultralcd.cpp:4818
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:4691
+#: ../../Firmware/ultralcd.cpp:4745 ../../Firmware/ultralcd.cpp:4837
 msgid "HW Setup"
 msgstr "HW nastaveni"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6968
+#: ../../Firmware/ultralcd.cpp:6998
 msgid "Heater/Thermistor"
 msgstr "Topeni/Termistor"
 
@@ -720,7 +714,7 @@ msgid "Heating done."
 msgstr "Zahrivani OK."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=16
-#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4042
+#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4061
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -730,7 +724,7 @@ msgstr ""
 "nastaveni, ve kterem zkalibrujeme osu Z. Pak budete moct zacit tisknout."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4064
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -739,24 +733,30 @@ msgstr ""
 "kalibracnim procesem?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:4358
-#: ../../Firmware/ultralcd.cpp:4367 ../../Firmware/ultralcd.cpp:5777
-#: ../../Firmware/ultralcd.cpp:5780
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:4377
+#: ../../Firmware/ultralcd.cpp:4386 ../../Firmware/ultralcd.cpp:5799
+#: ../../Firmware/ultralcd.cpp:5802
 msgid "High power"
 msgstr "Vys. vykon"
 
+#. MSG_HOTEND_FAN_SPEED c=15
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1145
+#: ../../Firmware/ultralcd.cpp:7351
+msgid "Hotend fan:"
+msgstr "Vent. hotendu:"
+
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4094
 msgid "I will run xyz calibration now. It will take approx. 12 mins."
 msgstr "Nyni provedu xyz kalibraci. Zabere to priblizne 12 min."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/ultralcd.cpp:4102
 msgid "I will run z calibration now."
 msgstr "Nyni provedu z kalibraci."
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=9
-#: ../../Firmware/ultralcd.cpp:4153
+#: ../../Firmware/ultralcd.cpp:4172
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -770,36 +770,36 @@ msgid "Improving bed calibration point"
 msgstr "Upresnovani kalibracniho bodu"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:5478
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:5500
 msgid "Info screen"
 msgstr "Informace"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5545
+#: ../../Firmware/ultralcd.cpp:5567
 msgid "Init. SD card"
 msgstr "Zav. SD karty"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2152
+#: ../../Firmware/ultralcd.cpp:2171
 msgid "Insert filament"
 msgstr "Vlozte filament"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:6223
+#: ../../Firmware/ultralcd.cpp:6253
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
 msgstr "Vlozte filament (nezavadejte) do extruderu a stisknete tlacitko"
 
 #. MSG_FILAMENT_LOADED c=20 r=2
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3855
-#: ../../Firmware/ultralcd.cpp:4108 ../../Firmware/ultralcd.cpp:4111
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3874
+#: ../../Firmware/ultralcd.cpp:4127 ../../Firmware/ultralcd.cpp:4130
 msgid "Is filament loaded?"
 msgstr "Je filament zaveden?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=2
 #: ../../Firmware/Marlin_main.cpp:3312 ../../Firmware/Marlin_main.cpp:4886
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:4084
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:4103
 msgid "Is steel sheet on heatbed?"
 msgstr "Je tiskovy plat na podlozce?"
 
@@ -809,74 +809,74 @@ msgid "Iteration"
 msgstr "Opakovani"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:1148
-#: ../../Firmware/ultralcd.cpp:1296
+#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:1167
+#: ../../Firmware/ultralcd.cpp:1315
 msgid "Last print"
 msgstr "Posledni tisk"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1169
-#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1269
-#: ../../Firmware/ultralcd.cpp:1326
+#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1188
+#: ../../Firmware/ultralcd.cpp:1278 ../../Firmware/ultralcd.cpp:1288
+#: ../../Firmware/ultralcd.cpp:1345
 msgid "Last print failures"
 msgstr "Selhani posl. tisku"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2496
+#: ../../Firmware/ultralcd.cpp:2515
 msgid "Left"
 msgstr "Vlevo"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7001
-#: ../../Firmware/ultralcd.cpp:7147 ../../Firmware/ultralcd.cpp:7152
+#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:7032
+#: ../../Firmware/ultralcd.cpp:7179 ../../Firmware/ultralcd.cpp:7184
 msgid "Left hotend fan?"
 msgstr "Levy vent na trysce?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2752
+#: ../../Firmware/ultralcd.cpp:2771
 msgid "Left side [μm]"
 msgstr "Vlevo [μm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:5862
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:5884
 msgid "Level Bright"
 msgstr "Normalni"
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:5863
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:5885
 msgid "Level Dimmed"
 msgstr "Ztlumeny"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4826
+#: ../../Firmware/ultralcd.cpp:4845
 msgid "Lin. correction"
 msgstr "Korekce lin."
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4838
-#: ../../Firmware/ultralcd.cpp:5493
+#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4857
+#: ../../Firmware/ultralcd.cpp:5515
 msgid "Live adjust Z"
 msgstr "Doladeni osy Z"
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/ultralcd.cpp:5120
+#: ../../Firmware/ultralcd.cpp:5142
 msgid "Load all"
 msgstr "Nacist vse"
 
 #. MSG_LOAD_FILAMENT c=17
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:5122
-#: ../../Firmware/ultralcd.cpp:5133 ../../Firmware/ultralcd.cpp:5562
-#: ../../Firmware/ultralcd.cpp:5576
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:5144
+#: ../../Firmware/ultralcd.cpp:5155 ../../Firmware/ultralcd.cpp:5584
+#: ../../Firmware/ultralcd.cpp:5598
 msgid "Load filament"
 msgstr "Zavest filament"
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5563
+#: ../../Firmware/ultralcd.cpp:5585
 msgid "Load to nozzle"
 msgstr "Zavest do trysky"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2185
+#: ../../Firmware/ultralcd.cpp:2204
 msgid "Loading color"
 msgstr "Cisteni barvy"
 
@@ -884,18 +884,18 @@ msgstr "Cisteni barvy"
 #: ../../Firmware/Marlin_main.cpp:3641 ../../Firmware/messages.cpp:55
 #: ../../Firmware/mmu.cpp:872 ../../Firmware/mmu.cpp:906
 #: ../../Firmware/mmu.cpp:1014 ../../Firmware/mmu.cpp:1026
-#: ../../Firmware/ultralcd.cpp:2196 ../../Firmware/ultralcd.cpp:3949
+#: ../../Firmware/ultralcd.cpp:2215 ../../Firmware/ultralcd.cpp:3968
 msgid "Loading filament"
 msgstr "Zavadeni filamentu"
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:7008
+#: ../../Firmware/ultralcd.cpp:7038
 msgid "Loose pulley"
 msgstr "Uvolnena remenicka"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:4450
-#: ../../Firmware/ultralcd.cpp:4462
+#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/ultralcd.cpp:4481
 msgid "Loud"
 msgstr "Hlasity"
 
@@ -910,8 +910,8 @@ msgid "MK3S firmware detected on MK3 printer"
 msgstr "MK3S firmware detekovan na tiskarne MK3"
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4381
-#: ../../Firmware/ultralcd.cpp:4382
+#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4400
+#: ../../Firmware/ultralcd.cpp:4401
 msgid "MMU Mode"
 msgstr "MMU mod"
 
@@ -931,8 +931,8 @@ msgid "MMU OK. Resuming..."
 msgstr "MMU OK. Pokracuji..."
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:64 ../../Firmware/ultralcd.cpp:1170
-#: ../../Firmware/ultralcd.cpp:1193
+#: ../../Firmware/messages.cpp:64 ../../Firmware/ultralcd.cpp:1189
+#: ../../Firmware/ultralcd.cpp:1212
 msgid "MMU fails"
 msgstr "Selhani MMU"
 
@@ -942,8 +942,8 @@ msgid "MMU load failed"
 msgstr "Zavedeni MMU selhalo"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:1171
-#: ../../Firmware/ultralcd.cpp:1194
+#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:1190
+#: ../../Firmware/ultralcd.cpp:1213
 msgid "MMU load fails"
 msgstr "MMU selhani zav"
 
@@ -953,32 +953,32 @@ msgid "MMU needs user attention."
 msgstr "MMU potrebuje zasah uzivatele."
 
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/ultralcd.cpp:1195
+#: ../../Firmware/ultralcd.cpp:1214
 msgid "MMU power fails"
 msgstr "MMU vyp. proudu"
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1680
+#: ../../Firmware/ultralcd.cpp:1699
 msgid "MMU2 connected"
 msgstr "MMU2 pripojeno"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:5836
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:5858
 msgid "Magnets comp."
 msgstr "Komp. magnetu"
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1147
-#: ../../Firmware/ultralcd.cpp:1295 ../../Firmware/ultralcd.cpp:1338
-#: ../../Firmware/ultralcd.cpp:1645 ../../Firmware/ultralcd.cpp:4795
-#: ../../Firmware/ultralcd.cpp:4892 ../../Firmware/ultralcd.cpp:5119
-#: ../../Firmware/ultralcd.cpp:5131 ../../Firmware/ultralcd.cpp:5154
-#: ../../Firmware/ultralcd.cpp:5173 ../../Firmware/ultralcd.cpp:5717
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1166
+#: ../../Firmware/ultralcd.cpp:1314 ../../Firmware/ultralcd.cpp:1357
+#: ../../Firmware/ultralcd.cpp:1664 ../../Firmware/ultralcd.cpp:4814
+#: ../../Firmware/ultralcd.cpp:4911 ../../Firmware/ultralcd.cpp:5141
+#: ../../Firmware/ultralcd.cpp:5153 ../../Firmware/ultralcd.cpp:5176
+#: ../../Firmware/ultralcd.cpp:5195 ../../Firmware/ultralcd.cpp:5739
 msgid "Main"
 msgstr "Hlavni nabidka"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2537
+#: ../../Firmware/ultralcd.cpp:2556
 msgid "Measured skew"
 msgstr "Merene zkos."
 
@@ -989,71 +989,71 @@ msgid "Measuring reference height of calibration point"
 msgstr "Merim referencni vysku kalibracniho bodu"
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:5832
+#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:5854
 msgid "Mesh"
 msgstr "Mesh"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4823
-#: ../../Firmware/ultralcd.cpp:4910
+#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4842
+#: ../../Firmware/ultralcd.cpp:4929
 msgid "Mesh Bed Leveling"
 msgstr "Mesh Bed Leveling"
 
 #. MSG_MODE c=6
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:4336
-#: ../../Firmware/ultralcd.cpp:4338 ../../Firmware/ultralcd.cpp:4358
-#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4364
-#: ../../Firmware/ultralcd.cpp:4367 ../../Firmware/ultralcd.cpp:5763
-#: ../../Firmware/ultralcd.cpp:5770 ../../Firmware/ultralcd.cpp:5777
-#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5779
-#: ../../Firmware/ultralcd.cpp:5780 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/ultralcd.cpp:4357 ../../Firmware/ultralcd.cpp:4377
+#: ../../Firmware/ultralcd.cpp:4380 ../../Firmware/ultralcd.cpp:4383
+#: ../../Firmware/ultralcd.cpp:4386 ../../Firmware/ultralcd.cpp:5785
+#: ../../Firmware/ultralcd.cpp:5792 ../../Firmware/ultralcd.cpp:5799
+#: ../../Firmware/ultralcd.cpp:5800 ../../Firmware/ultralcd.cpp:5801
+#: ../../Firmware/ultralcd.cpp:5802 ../../Firmware/ultralcd.cpp:5886
 msgid "Mode"
 msgstr "Mod"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3598
+#: ../../Firmware/ultralcd.cpp:3617
 msgid "Mode change in progress..."
 msgstr "Probiha zmena modu..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:4575
-#: ../../Firmware/ultralcd.cpp:4578 ../../Firmware/ultralcd.cpp:4581
-#: ../../Firmware/ultralcd.cpp:4584
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:4594
+#: ../../Firmware/ultralcd.cpp:4597 ../../Firmware/ultralcd.cpp:4600
+#: ../../Firmware/ultralcd.cpp:4603
 msgid "Model"
 msgstr "Model"
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6982
-#: ../../Firmware/ultralcd.cpp:6991 ../../Firmware/ultralcd.cpp:7009
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:7012
+#: ../../Firmware/ultralcd.cpp:7021 ../../Firmware/ultralcd.cpp:7039
 msgid "Motor"
 msgstr "Motor"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3492
+#: ../../Firmware/ultralcd.cpp:3511
 msgid "Move X"
 msgstr "Posunout X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3493
+#: ../../Firmware/ultralcd.cpp:3512
 msgid "Move Y"
 msgstr "Posunout Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3494
+#: ../../Firmware/ultralcd.cpp:3513
 msgid "Move Z"
 msgstr "Posunout Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4801
+#: ../../Firmware/ultralcd.cpp:4820
 msgid "Move axis"
 msgstr "Posunout osu"
 
 #. MSG_NA c=3
 #: ../../Firmware/menu.cpp:196 ../../Firmware/messages.cpp:124
-#: ../../Firmware/ultralcd.cpp:2502 ../../Firmware/ultralcd.cpp:2547
-#: ../../Firmware/ultralcd.cpp:3411 ../../Firmware/ultralcd.cpp:4228
-#: ../../Firmware/ultralcd.cpp:4276 ../../Firmware/ultralcd.cpp:5737
-#: ../../Firmware/ultralcd.cpp:5836
+#: ../../Firmware/ultralcd.cpp:2521 ../../Firmware/ultralcd.cpp:2566
+#: ../../Firmware/ultralcd.cpp:3430 ../../Firmware/ultralcd.cpp:4247
+#: ../../Firmware/ultralcd.cpp:4295 ../../Firmware/ultralcd.cpp:5759
+#: ../../Firmware/ultralcd.cpp:5858
 msgid "N/A"
 msgstr "N/A"
 
@@ -1063,14 +1063,14 @@ msgid "New firmware version available:"
 msgstr "Vysla nova verze firmware:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:2804
-#: ../../Firmware/ultralcd.cpp:3180 ../../Firmware/ultralcd.cpp:4785
-#: ../../Firmware/ultralcd.cpp:5988
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:2823
+#: ../../Firmware/ultralcd.cpp:3199 ../../Firmware/ultralcd.cpp:4804
+#: ../../Firmware/ultralcd.cpp:6018
 msgid "No"
 msgstr "Ne"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5543
+#: ../../Firmware/ultralcd.cpp:5565
 msgid "No SD card"
 msgstr "Zadna SD karta"
 
@@ -1080,71 +1080,71 @@ msgid "No move."
 msgstr "Bez pohybu."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4405
-#: ../../Firmware/ultralcd.cpp:4493 ../../Firmware/ultralcd.cpp:4502
-#: ../../Firmware/ultralcd.cpp:4575 ../../Firmware/ultralcd.cpp:4584
-#: ../../Firmware/ultralcd.cpp:4614 ../../Firmware/ultralcd.cpp:4623
-#: ../../Firmware/ultralcd.cpp:4655 ../../Firmware/ultralcd.cpp:4664
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4424
+#: ../../Firmware/ultralcd.cpp:4512 ../../Firmware/ultralcd.cpp:4521
+#: ../../Firmware/ultralcd.cpp:4594 ../../Firmware/ultralcd.cpp:4603
+#: ../../Firmware/ultralcd.cpp:4633 ../../Firmware/ultralcd.cpp:4642
+#: ../../Firmware/ultralcd.cpp:4674 ../../Firmware/ultralcd.cpp:4683
 msgid "None"
 msgstr "Zadne"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:4336
-#: ../../Firmware/ultralcd.cpp:4381 ../../Firmware/ultralcd.cpp:4397
-#: ../../Firmware/ultralcd.cpp:4416 ../../Firmware/ultralcd.cpp:5763
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/ultralcd.cpp:4400 ../../Firmware/ultralcd.cpp:4416
+#: ../../Firmware/ultralcd.cpp:4435 ../../Firmware/ultralcd.cpp:5785
 msgid "Normal"
 msgstr "Normal"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6969
+#: ../../Firmware/ultralcd.cpp:6999
 msgid "Not connected"
 msgstr "Nezapojeno"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:7168
-#: ../../Firmware/ultralcd.cpp:7183 ../../Firmware/ultralcd.cpp:7191
+#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:7198
+#: ../../Firmware/ultralcd.cpp:7213 ../../Firmware/ultralcd.cpp:7221
 msgid "Not spinning"
 msgstr "Netoci se"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3962
+#: ../../Firmware/ultralcd.cpp:3981
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr "Nyni zkalibruji vzdalenost mezi koncem trysky a povrchem podlozky."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:4091
+#: ../../Firmware/ultralcd.cpp:4110
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Nyni predehreji trysku pro PLA."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/ultralcd.cpp:4101
 msgid "Now remove the test print from steel sheet."
 msgstr "Nyni odstrante testovaci vytisk z tiskoveho platu."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:1402
-#: ../../Firmware/ultralcd.cpp:4493 ../../Firmware/ultralcd.cpp:4496
-#: ../../Firmware/ultralcd.cpp:4499 ../../Firmware/ultralcd.cpp:4502
-#: ../../Firmware/ultralcd.cpp:5720 ../../Firmware/ultralcd.cpp:5882
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:1421
+#: ../../Firmware/ultralcd.cpp:4512 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/ultralcd.cpp:4518 ../../Firmware/ultralcd.cpp:4521
+#: ../../Firmware/ultralcd.cpp:5742 ../../Firmware/ultralcd.cpp:5904
 msgid "Nozzle"
 msgstr "Tryska"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4546
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4565
 msgid "Nozzle d."
 msgstr "Tryska"
 
 #. MSG_OFF c=3
 #: ../../Firmware/menu.cpp:467 ../../Firmware/messages.cpp:122
-#: ../../Firmware/ultralcd.cpp:4234 ../../Firmware/ultralcd.cpp:4250
-#: ../../Firmware/ultralcd.cpp:4284 ../../Firmware/ultralcd.cpp:4313
-#: ../../Firmware/ultralcd.cpp:4342 ../../Firmware/ultralcd.cpp:4811
-#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4834
-#: ../../Firmware/ultralcd.cpp:5644 ../../Firmware/ultralcd.cpp:5741
-#: ../../Firmware/ultralcd.cpp:5756 ../../Firmware/ultralcd.cpp:5767
-#: ../../Firmware/ultralcd.cpp:5836 ../../Firmware/ultralcd.cpp:7841
-#: ../../Firmware/ultralcd.cpp:7845
+#: ../../Firmware/ultralcd.cpp:4253 ../../Firmware/ultralcd.cpp:4269
+#: ../../Firmware/ultralcd.cpp:4303 ../../Firmware/ultralcd.cpp:4332
+#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4830
+#: ../../Firmware/ultralcd.cpp:4849 ../../Firmware/ultralcd.cpp:4853
+#: ../../Firmware/ultralcd.cpp:5666 ../../Firmware/ultralcd.cpp:5763
+#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/ultralcd.cpp:5858 ../../Firmware/ultralcd.cpp:7881
+#: ../../Firmware/ultralcd.cpp:7885
 msgid "Off"
 msgstr "Vyp"
 
@@ -1154,19 +1154,19 @@ msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr "Neplatne hodnoty nastaveni. Bude pouzito vychozi PID, Esteps atd."
 
 #. MSG_ON c=3
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4244
-#: ../../Firmware/ultralcd.cpp:4248 ../../Firmware/ultralcd.cpp:4280
-#: ../../Firmware/ultralcd.cpp:4303 ../../Firmware/ultralcd.cpp:4341
-#: ../../Firmware/ultralcd.cpp:4811 ../../Firmware/ultralcd.cpp:4830
-#: ../../Firmware/ultralcd.cpp:4834 ../../Firmware/ultralcd.cpp:5745
-#: ../../Firmware/ultralcd.cpp:5756 ../../Firmware/ultralcd.cpp:5765
-#: ../../Firmware/ultralcd.cpp:5836 ../../Firmware/ultralcd.cpp:7841
-#: ../../Firmware/ultralcd.cpp:7845
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4263
+#: ../../Firmware/ultralcd.cpp:4267 ../../Firmware/ultralcd.cpp:4299
+#: ../../Firmware/ultralcd.cpp:4322 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4849
+#: ../../Firmware/ultralcd.cpp:4853 ../../Firmware/ultralcd.cpp:5767
+#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5787
+#: ../../Firmware/ultralcd.cpp:5858 ../../Firmware/ultralcd.cpp:7881
+#: ../../Firmware/ultralcd.cpp:7885
 msgid "On"
 msgstr "Zap"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4453
+#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4472
 msgid "Once"
 msgstr "Jednou"
 
@@ -1186,7 +1186,7 @@ msgid "PID cal. finished"
 msgstr "PID kal. ukoncena"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4913
+#: ../../Firmware/ultralcd.cpp:4932
 msgid "PID calibration"
 msgstr "PID kalibrace"
 
@@ -1198,18 +1198,18 @@ msgstr "Nahrivani PINDA"
 #. MSG_PINDA_CALIBRATION c=13
 #: ../../Firmware/Marlin_main.cpp:4932 ../../Firmware/Marlin_main.cpp:5035
 #: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:654
-#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4920
+#: ../../Firmware/ultralcd.cpp:4849 ../../Firmware/ultralcd.cpp:4939
 msgid "PINDA cal."
 msgstr "PINDA kal."
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3361
+#: ../../Firmware/ultralcd.cpp:3380
 msgid "PINDA calibration failed"
 msgstr "PINDA kalibrace selhala"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
 #: ../../Firmware/Marlin_main.cpp:5112 ../../Firmware/messages.cpp:110
-#: ../../Firmware/ultralcd.cpp:3355
+#: ../../Firmware/ultralcd.cpp:3374
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1218,13 +1218,13 @@ msgstr ""
 "menu Nastaveni->Tepl. kal."
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4707
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4726
 msgid "Pause"
 msgstr "Pauza"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:5507
-#: ../../Firmware/ultralcd.cpp:5509
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:5529
+#: ../../Firmware/ultralcd.cpp:5531
 msgid "Pause print"
 msgstr "Pozastavit tisk"
 
@@ -1238,7 +1238,7 @@ msgstr ""
 "prvnich 4 bodu. Pokud tryska zachyti papir, okamzite vypnete tiskarnu."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:4176
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:4195
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1247,17 +1247,17 @@ msgstr ""
 "Pruvodce restartovanim tiskarny."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:6250
+#: ../../Firmware/ultralcd.cpp:6280
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "Prosim zkontrolujte zapojeni IR senzoru a vyjmuty filament"
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6963
+#: ../../Firmware/ultralcd.cpp:6993
 msgid "Please check:"
 msgstr "Zkontrolujte:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4148
+#: ../../Firmware/ultralcd.cpp:4167
 msgid "Please clean heatbed and then press the knob."
 msgstr "Prosim ocistete podlozku a stisknete tlacitko."
 
@@ -1268,14 +1268,14 @@ msgstr ""
 "Pro uspesnou kalibraci ocistete prosim tiskovou trysku. Potvrdte tlacitkem."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3945
+#: ../../Firmware/ultralcd.cpp:3964
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr ""
 "Prosim vlozte filament do extruderu a stisknete tlacitko k jeho zavedeni"
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3940
+#: ../../Firmware/ultralcd.cpp:3959
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1284,7 +1284,7 @@ msgstr ""
 "zavedeni"
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3863
+#: ../../Firmware/ultralcd.cpp:3882
 msgid "Please load filament first."
 msgstr "Prosim nejdriv zavedte filament"
 
@@ -1295,7 +1295,7 @@ msgstr "Prosim otevrete idler a manualne odstrante filament."
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=5
 #: ../../Firmware/mesh_bed_calibration.cpp:2799 ../../Firmware/messages.cpp:70
-#: ../../Firmware/ultralcd.cpp:4085
+#: ../../Firmware/ultralcd.cpp:4104
 msgid "Please place steel sheet on heatbed."
 msgstr "Umistete prosim tiskovy plat na podlozku"
 
@@ -1306,7 +1306,7 @@ msgid "Please press the knob to unload filament"
 msgstr "Pro vysunuti filamentu stisknete prosim tlacitko"
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:5213
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:5235
 msgid "Please pull out filament immediately"
 msgstr "Prosim vyjmete urychlene filament"
 
@@ -1316,7 +1316,7 @@ msgid "Please remove filament and then press the knob."
 msgstr "Prosim vyjmete filament a pote stisknete tlacitko."
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:4081
+#: ../../Firmware/ultralcd.cpp:4100
 msgid "Please remove shipping helpers first."
 msgstr "Nejprve prosim sundejte transportni soucastky."
 
@@ -1332,7 +1332,7 @@ msgid "Please run XYZ calibration first."
 msgstr "Nejprve spustte kalibraci XYZ."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:6247
+#: ../../Firmware/ultralcd.cpp:6277
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Prosim vyjmete filament a zopakujte tuto akci"
 
@@ -1349,54 +1349,54 @@ msgstr "Prosim aktualizujte."
 #. MSG_PLEASE_WAIT c=20
 #: ../../Firmware/Marlin_main.cpp:3547 ../../Firmware/Marlin_main.cpp:3563
 #: ../../Firmware/Marlin_main.cpp:7931 ../../Firmware/messages.cpp:71
-#: ../../Firmware/ultralcd.cpp:2186 ../../Firmware/ultralcd.cpp:2197
+#: ../../Firmware/ultralcd.cpp:2205 ../../Firmware/ultralcd.cpp:2216
 msgid "Please wait"
 msgstr "Prosim cekejte"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1219
-#: ../../Firmware/ultralcd.cpp:1260 ../../Firmware/ultralcd.cpp:1270
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1238
+#: ../../Firmware/ultralcd.cpp:1279 ../../Firmware/ultralcd.cpp:1289
 msgid "Power failures"
 msgstr "Vypadky proudu"
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5502
+#: ../../Firmware/ultralcd.cpp:5524
 msgid "Preheat"
 msgstr "Predehrev"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:2280
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:2299
 msgid "Preheat the nozzle!"
 msgstr "Predehrejte trysku!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:2900
-#: ../../Firmware/ultralcd.cpp:3924 ../../Firmware/ultralcd.cpp:3926
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:2919
+#: ../../Firmware/ultralcd.cpp:3943 ../../Firmware/ultralcd.cpp:3945
 msgid "Preheating nozzle. Please wait."
 msgstr "Predehrev trysky. Prosim cekejte."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1988
+#: ../../Firmware/ultralcd.cpp:2007
 msgid "Preheating to cut"
 msgstr "Predehrev ke strihu"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1985
+#: ../../Firmware/ultralcd.cpp:2004
 msgid "Preheating to eject"
 msgstr "Predehrev k vysunuti"
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1976
+#: ../../Firmware/ultralcd.cpp:1995
 msgid "Preheating to load"
 msgstr "Predehrev k zavedeni"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1981
+#: ../../Firmware/ultralcd.cpp:2000
 msgid "Preheating to unload"
 msgstr "Predehrev k vyjmuti"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1809
+#: ../../Firmware/ultralcd.cpp:1828
 msgid "Press the knob"
 msgstr "Stisknete tlacitko"
 
@@ -1416,13 +1416,13 @@ msgid "Print aborted"
 msgstr "Tisk prerusen"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1144
-#: ../../Firmware/ultralcd.cpp:7322
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1145
+#: ../../Firmware/ultralcd.cpp:7354
 msgid "Print fan:"
 msgstr "Tiskovy vent.:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5535
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5557
 msgid "Print from SD"
 msgstr "Tisk z SD"
 
@@ -1432,12 +1432,12 @@ msgid "Print paused"
 msgstr "Tisk pozastaven"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2366
+#: ../../Firmware/ultralcd.cpp:2385
 msgid "Print time"
 msgstr "Cas tisku"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1711
+#: ../../Firmware/ultralcd.cpp:1730
 msgid "Printer IP Addr:"
 msgstr "IP adr. tiskarny:"
 
@@ -1465,12 +1465,12 @@ msgstr ""
 "Tisk zrusen."
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4834
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4853
 msgid "RPi port"
 msgstr "RPi port"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2755
+#: ../../Firmware/ultralcd.cpp:2774
 msgid "Rear side [μm]"
 msgstr "Vzadu [μm]"
 
@@ -1485,24 +1485,24 @@ msgid "Remove old filament and press the knob to start loading new filament."
 msgstr "Vyjmete stary filament a stisknete tlacitko pro zavedeni noveho."
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5426
+#: ../../Firmware/ultralcd.cpp:5448
 msgid "Rename"
 msgstr "Prejmenovat"
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2756
-#: ../../Firmware/ultralcd.cpp:5427
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2775
+#: ../../Firmware/ultralcd.cpp:5449
 msgid "Reset"
 msgstr "Reset"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4917
+#: ../../Firmware/ultralcd.cpp:4936
 msgid "Reset XYZ calibr."
 msgstr "Reset XYZ kalibr."
 
 #. MSG_RESUME_PRINT c=18
 #: ../../Firmware/Marlin_main.cpp:655 ../../Firmware/messages.cpp:81
-#: ../../Firmware/ultralcd.cpp:5521 ../../Firmware/ultralcd.cpp:5523
+#: ../../Firmware/ultralcd.cpp:5543 ../../Firmware/ultralcd.cpp:5545
 msgid "Resume print"
 msgstr "Pokracovat"
 
@@ -1512,17 +1512,17 @@ msgid "Resuming print"
 msgstr "Obnoveni tisku"
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2497
+#: ../../Firmware/ultralcd.cpp:2516
 msgid "Right"
 msgstr "Vpravo"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2753
+#: ../../Firmware/ultralcd.cpp:2772
 msgid "Right side[μm]"
 msgstr "Vpravo [μm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3884
+#: ../../Firmware/ultralcd.cpp:3903
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1531,14 +1531,14 @@ msgstr ""
 "kalibracni proces od zacatku. Pokracovat?"
 
 #. MSG_RUNOUTS c=7
-#: ../../Firmware/ultralcd.cpp:1271
+#: ../../Firmware/ultralcd.cpp:1290
 msgid "Runouts"
 msgstr "Runouts"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4395
-#: ../../Firmware/ultralcd.cpp:4397 ../../Firmware/ultralcd.cpp:4414
-#: ../../Firmware/ultralcd.cpp:4416
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4414
+#: ../../Firmware/ultralcd.cpp:4416 ../../Firmware/ultralcd.cpp:4433
+#: ../../Firmware/ultralcd.cpp:4435
 msgid "SD card"
 msgstr "SD karta"
 
@@ -1554,12 +1554,12 @@ msgid "Searching bed calibration point"
 msgstr "Hledam kalibracni bod podlozky"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5419
+#: ../../Firmware/ultralcd.cpp:5441
 msgid "Select"
 msgstr "Vybrat"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3966
+#: ../../Firmware/ultralcd.cpp:3985
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
@@ -1572,49 +1572,49 @@ msgstr "Vyberte extruder:"
 
 #. MSG_SELECT_FILAMENT c=20
 #: ../../Firmware/Marlin_main.cpp:8577 ../../Firmware/Marlin_main.cpp:8604
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3834
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3853
 msgid "Select filament:"
 msgstr "Zvolte filament:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:3679
-#: ../../Firmware/ultralcd.cpp:4841
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:3698
+#: ../../Firmware/ultralcd.cpp:4860
 msgid "Select language"
 msgstr "Vyber jazyka"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:4122
+#: ../../Firmware/ultralcd.cpp:4141
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr "Vyberte teplotu predehrati trysky ktera odpovida vasemu materialu."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3971
+#: ../../Firmware/ultralcd.cpp:3990
 msgid "Select temperature which matches your material."
 msgstr "Zvolte teplotu, ktera odpovida vasemu materialu."
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6522
+#: ../../Firmware/ultralcd.cpp:6552
 msgid "Self test OK"
 msgstr "Selftest OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:6290
+#: ../../Firmware/ultralcd.cpp:6320
 msgid "Self test start"
 msgstr "Start Selftestu"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4904
+#: ../../Firmware/ultralcd.cpp:4923
 msgid "Selftest"
 msgstr "Selftest"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6962
+#: ../../Firmware/ultralcd.cpp:6992
 msgid "Selftest error!"
 msgstr "Chyba Selftestu!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:6526
-#: ../../Firmware/ultralcd.cpp:7049 ../../Firmware/ultralcd.cpp:7314
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:6556
+#: ../../Firmware/ultralcd.cpp:7079 ../../Firmware/ultralcd.cpp:7344
 msgid "Selftest failed"
 msgstr "Selftest selhal"
 
@@ -1624,30 +1624,30 @@ msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr "Pro kalibraci presneho rehomovani bude nyni spusten selftest."
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1723
+#: ../../Firmware/ultralcd.cpp:1742
 msgid "Sensor info"
 msgstr "Senzor info"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:6254
+#: ../../Firmware/ultralcd.cpp:6284
 msgid "Sensor verified, remove the filament now."
 msgstr "Senzor overen, vyjmete filament."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2773
+#: ../../Firmware/ultralcd.cpp:2792
 msgid "Set temperature:"
 msgstr "Nastavte teplotu:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:3491
-#: ../../Firmware/ultralcd.cpp:3696 ../../Firmware/ultralcd.cpp:4206
-#: ../../Firmware/ultralcd.cpp:5580 ../../Firmware/ultralcd.cpp:5827
-#: ../../Firmware/ultralcd.cpp:5880
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:3510
+#: ../../Firmware/ultralcd.cpp:3715 ../../Firmware/ultralcd.cpp:4225
+#: ../../Firmware/ultralcd.cpp:5602 ../../Firmware/ultralcd.cpp:5849
+#: ../../Firmware/ultralcd.cpp:5902
 msgid "Settings"
 msgstr "Nastaveni"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2540
+#: ../../Firmware/ultralcd.cpp:2559
 msgid "Severe skew"
 msgstr "Tezke zkos."
 
@@ -1658,7 +1658,7 @@ msgid "Sheet"
 msgstr "Plat"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3824
+#: ../../Firmware/ultralcd.cpp:3843
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1671,18 +1671,18 @@ msgstr ""
 "%cReset"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4915
+#: ../../Firmware/ultralcd.cpp:4934
 msgid "Show end stops"
 msgstr "Stav konc. spin."
 
 #. MSG_SILENT c=7
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4361
-#: ../../Firmware/ultralcd.cpp:4456 ../../Firmware/ultralcd.cpp:5778
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4380
+#: ../../Firmware/ultralcd.cpp:4475 ../../Firmware/ultralcd.cpp:5800
 msgid "Silent"
 msgstr "Tichy"
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2539
+#: ../../Firmware/ultralcd.cpp:2558
 msgid "Slight skew"
 msgstr "Lehke zkos."
 
@@ -1701,8 +1701,8 @@ msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Vyskytl se problem, srovnavam osu Z ..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4403
-#: ../../Firmware/ultralcd.cpp:4404 ../../Firmware/ultralcd.cpp:4405
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4422
+#: ../../Firmware/ultralcd.cpp:4423 ../../Firmware/ultralcd.cpp:4424
 msgid "Sort"
 msgstr "Trideni"
 
@@ -1713,20 +1713,20 @@ msgid "Sorting files"
 msgstr "Trideni souboru"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4450
-#: ../../Firmware/ultralcd.cpp:4453 ../../Firmware/ultralcd.cpp:4456
-#: ../../Firmware/ultralcd.cpp:4459 ../../Firmware/ultralcd.cpp:4462
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/ultralcd.cpp:4472 ../../Firmware/ultralcd.cpp:4475
+#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4481
 msgid "Sound"
 msgstr "Zvuk"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5718
+#: ../../Firmware/ultralcd.cpp:5740
 msgid "Speed"
 msgstr "Rychlost"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7166
-#: ../../Firmware/ultralcd.cpp:7181 ../../Firmware/ultralcd.cpp:7189
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7196
+#: ../../Firmware/ultralcd.cpp:7211 ../../Firmware/ultralcd.cpp:7219
 msgid "Spinning"
 msgstr "Toci se"
 
@@ -1736,42 +1736,42 @@ msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr "Je vyzadovana stabilni pokojova teplota 21-26C a pevna podlozka."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5585
+#: ../../Firmware/ultralcd.cpp:5607
 msgid "Statistics"
 msgstr "Statistika"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4338
-#: ../../Firmware/ultralcd.cpp:4382 ../../Firmware/ultralcd.cpp:5770
+#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4357
+#: ../../Firmware/ultralcd.cpp:4401 ../../Firmware/ultralcd.cpp:5792
 msgid "Stealth"
 msgstr "Tichy"
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4763
-#: ../../Firmware/ultralcd.cpp:5416
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4782
+#: ../../Firmware/ultralcd.cpp:5438
 msgid "Steel sheets"
 msgstr "Tiskove platy"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5528
-#: ../../Firmware/ultralcd.cpp:5987
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5550
+#: ../../Firmware/ultralcd.cpp:6017
 msgid "Stop print"
 msgstr "Zastavit tisk"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4499
-#: ../../Firmware/ultralcd.cpp:4581 ../../Firmware/ultralcd.cpp:4620
-#: ../../Firmware/ultralcd.cpp:4661
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4518
+#: ../../Firmware/ultralcd.cpp:4600 ../../Firmware/ultralcd.cpp:4639
+#: ../../Firmware/ultralcd.cpp:4680
 msgid "Strict"
 msgstr "Prisne"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/ultralcd.cpp:5616
 msgid "Support"
 msgstr "Podpora"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:7021
+#: ../../Firmware/ultralcd.cpp:7051
 msgid "Swapped"
 msgstr "Prohozene"
 
@@ -1780,28 +1780,18 @@ msgstr "Prohozene"
 msgid "THERMAL ANOMALY"
 msgstr "TEPLOTNI VYJIMKA"
 
-#. MSG_TM_AUTOTUNE_FAILED c=20
-#: ../../Firmware/temperature.cpp:2899
-msgid "TM autotune failed"
-msgstr "TM ladeni selhalo"
-
-#. MSG_TEMP_MODEL_AUTOTUNE c=20
-#: ../../Firmware/temperature.cpp:2884
-msgid "Temp. model autotune"
-msgstr "Ladeni tepl. modelu"
-
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4797
+#: ../../Firmware/ultralcd.cpp:4816
 msgid "Temperature"
 msgstr "Teplota"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1729
+#: ../../Firmware/ultralcd.cpp:1748
 msgid "Temperatures"
 msgstr "Teploty"
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3974
+#: ../../Firmware/ultralcd.cpp:3993
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -1820,66 +1810,66 @@ msgstr ""
 "Zaciname, sekce Postup kalibrace."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4403
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4422
 msgid "Time"
 msgstr "Cas"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:5865
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:5887
 msgid "Timeout"
 msgstr "Timeout"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:1149
-#: ../../Firmware/ultralcd.cpp:1297
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:1168
+#: ../../Firmware/ultralcd.cpp:1316
 msgid "Total"
 msgstr "Celkem"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:1192
-#: ../../Firmware/ultralcd.cpp:1218 ../../Firmware/ultralcd.cpp:1328
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:1211
+#: ../../Firmware/ultralcd.cpp:1237 ../../Firmware/ultralcd.cpp:1347
 msgid "Total failures"
 msgstr "Celkem selhani"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2387
+#: ../../Firmware/ultralcd.cpp:2406
 msgid "Total filament"
 msgstr "Filament celkem"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2388
+#: ../../Firmware/ultralcd.cpp:2407
 msgid "Total print time"
 msgstr "Celkovy cas tisku"
 
 #. MSG_TUNE c=18
-#: ../../Firmware/ultralcd.cpp:5500
+#: ../../Firmware/ultralcd.cpp:5522
 msgid "Tune"
 msgstr "Ladit"
 
 #. MSG_UNLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:5564
-#: ../../Firmware/ultralcd.cpp:5578
+#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:5586
+#: ../../Firmware/ultralcd.cpp:5600
 msgid "Unload filament"
 msgstr "Vyjmout filament"
 
 #. MSG_UNLOADING_FILAMENT c=20
 #: ../../Firmware/messages.cpp:112 ../../Firmware/mmu.cpp:957
-#: ../../Firmware/ultralcd.cpp:5197
+#: ../../Firmware/ultralcd.cpp:5219
 msgid "Unloading filament"
 msgstr "Vysouvam filament"
 
 #. MSG_FIL_FAILED c=20 r=5
-#: ../../Firmware/ultralcd.cpp:6258
+#: ../../Firmware/ultralcd.cpp:6288
 msgid "Verification failed, remove the filament and try again."
 msgstr "Overeni selhalo, vyjmete filament a zkuste znovu."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1732
+#: ../../Firmware/ultralcd.cpp:1751
 msgid "Voltages"
 msgstr "Napeti"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3534
+#: ../../Firmware/ultralcd.cpp:3553
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -1897,19 +1887,19 @@ msgid "Wait for user..."
 msgstr "Ceka se na uzivatele"
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2881
+#: ../../Firmware/ultralcd.cpp:2900
 msgid "Waiting for PINDA probe cooling"
 msgstr "Cekani na zchladnuti PINDA"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2913
+#: ../../Firmware/ultralcd.cpp:2932
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Cekani na zchladnuti trysky a podlozky."
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:4496
-#: ../../Firmware/ultralcd.cpp:4578 ../../Firmware/ultralcd.cpp:4617
-#: ../../Firmware/ultralcd.cpp:4658
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/ultralcd.cpp:4597 ../../Firmware/ultralcd.cpp:4636
+#: ../../Firmware/ultralcd.cpp:4677
 msgid "Warn"
 msgstr "Varovat"
 
@@ -1934,146 +1924,135 @@ msgid "Was filament unload successful?"
 msgstr "Bylo vysunuti filamentu uspesne?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6973
-#: ../../Firmware/ultralcd.cpp:6977 ../../Firmware/ultralcd.cpp:6997
-#: ../../Firmware/ultralcd.cpp:7003 ../../Firmware/ultralcd.cpp:7027
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:7003
+#: ../../Firmware/ultralcd.cpp:7007 ../../Firmware/ultralcd.cpp:7027
+#: ../../Firmware/ultralcd.cpp:7033 ../../Firmware/ultralcd.cpp:7057
 msgid "Wiring error"
 msgstr "Chyba zapojeni"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4895
+#: ../../Firmware/ultralcd.cpp:4914
 msgid "Wizard"
 msgstr "Pruvodce"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4210
+#: ../../Firmware/ultralcd.cpp:4229
 msgid "X-correct:"
 msgstr "Korekce X:"
 
 #. MSG_XFLASH c=18
-#: ../../Firmware/ultralcd.cpp:5596
+#: ../../Firmware/ultralcd.cpp:5618
 msgid "XFLASH init"
 msgstr "XFLASH init"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1721
+#: ../../Firmware/ultralcd.cpp:1740
 msgid "XYZ cal. details"
 msgstr "Detaily XYZ kal."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3333
+#: ../../Firmware/ultralcd.cpp:3352
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr "Kalibrace XYZ v poradku. Zkoseni bude automaticky vyrovnano pri tisku."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3330
+#: ../../Firmware/ultralcd.cpp:3349
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr "Kalibrace XYZ v poradku. X/Y osy mirne zkosene. Dobra prace!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3311
+#: ../../Firmware/ultralcd.cpp:3330
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr "Kalibrace XYZ nepresna. Predni kalibracni body moc vpredu."
 
-#. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_LEFT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3317
-msgid ""
-"XYZ calibration compromised. Left front calibration point not reachable."
-msgstr ""
-
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3314
+#: ../../Firmware/ultralcd.cpp:3333
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr "Kalibrace XYZ nepresna. Pravy predni bod moc vpredu."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3293
+#: ../../Firmware/ultralcd.cpp:3312
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr "Kalibrace XYZ selhala. Kalibracni bod podlozky nenalezen."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3299
+#: ../../Firmware/ultralcd.cpp:3318
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr ""
 "Kalibrace XYZ selhala. Predni kalibracni body moc vpredu. Srovnejte tiskarnu."
 
-#. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_LEFT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3305
-msgid "XYZ calibration failed. Left front calibration point not reachable."
-msgstr ""
-
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3296
-#: ../../Firmware/ultralcd.cpp:3324
+#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3315
+#: ../../Firmware/ultralcd.cpp:3343
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "Kalibrace XYZ selhala. Nahlednete do manualu."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3302
+#: ../../Firmware/ultralcd.cpp:3321
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr ""
 "Kalibrace XYZ selhala. Pravy predni bod moc vpredu. Srovnejte tiskarnu."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3327
+#: ../../Firmware/ultralcd.cpp:3346
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "Kalibrace XYZ v poradku. X/Y osy jsou kolme. Gratuluji!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2494
+#: ../../Firmware/ultralcd.cpp:2513
 msgid "Y distance from min"
 msgstr "Y vzdalenost od min"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4211
+#: ../../Firmware/ultralcd.cpp:4230
 msgid "Y-correct:"
 msgstr "Korekce Y:"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:2216
-#: ../../Firmware/ultralcd.cpp:2800 ../../Firmware/ultralcd.cpp:3180
-#: ../../Firmware/ultralcd.cpp:4785 ../../Firmware/ultralcd.cpp:5989
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:2235
+#: ../../Firmware/ultralcd.cpp:2819 ../../Firmware/ultralcd.cpp:3199
+#: ../../Firmware/ultralcd.cpp:4804 ../../Firmware/ultralcd.cpp:6019
 msgid "Yes"
 msgstr "Ano"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:4187
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:4206
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr "Pruvodce muzete kdykoliv znovu spustit z menu Kalibrace -> Pruvodce"
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4231
 msgid "Z-correct:"
 msgstr "Korekce Z:"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:5835
+#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:5857
 msgid "Z-probe nr."
 msgstr "Pocet mereni Z"
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2565
+#: ../../Firmware/ultralcd.cpp:2584
 msgid "[0;0] point offset"
 msgstr "[0;0] odsazeni bodu"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2154
+#: ../../Firmware/ultralcd.cpp:2173
 msgid "and press the knob"
 msgstr "a stisknete tlacitko"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1816
+#: ../../Firmware/ultralcd.cpp:1835
 msgid "to load filament"
 msgstr "k zavedeni filamentu"
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1820
+#: ../../Firmware/ultralcd.cpp:1839
 msgid "to unload filament"
 msgstr "k vyjmuti filamentu"
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1688
+#: ../../Firmware/ultralcd.cpp:1707
 msgid "unknown"
 msgstr "neznamy"
 
@@ -2083,8 +2062,8 @@ msgid "unknown state"
 msgstr "neznamy stav"
 
 #. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:6077
-#: ../../Firmware/ultralcd.cpp:6080
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:6107
+#: ../../Firmware/ultralcd.cpp:6110
 msgid "🔃Refresh"
 msgstr "🔃Obnovit"
 
@@ -2093,3 +2072,9 @@ msgstr "🔃Obnovit"
 
 #~ msgid "M117 First layer cal."
 #~ msgstr "M117 Kal. prvni vrstvy"
+
+#~ msgid "TM autotune failed"
+#~ msgstr "TM ladeni selhalo"
+
+#~ msgid "Temp. model autotune"
+#~ msgstr "Ladeni tepl. modelu"

--- a/lang/po/Firmware_da.po
+++ b/lang/po/Firmware_da.po
@@ -26,113 +26,113 @@ msgid " 0.4 or newer"
 msgstr ""
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:7036
+#: ../../Firmware/ultralcd.cpp:7066
 msgid "%s level expected"
 msgstr ""
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1968
-#: ../../Firmware/ultralcd.cpp:3835
+#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1987
+#: ../../Firmware/ultralcd.cpp:3854
 msgid ">Cancel"
 msgstr ""
 
 #. MSG_BABYSTEPPING_Z c=15
 #. Beware: must include the ':' as its last character
-#: ../../Firmware/ultralcd.cpp:2670
+#: ../../Firmware/ultralcd.cpp:2689
 msgid "Adjusting Z:"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:7313
+#: ../../Firmware/ultralcd.cpp:7343
 msgid "All correct"
 msgstr ""
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4180
+#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4190
+#: ../../Firmware/ultralcd.cpp:4199
 msgid "All is done. Happy printing!"
 msgstr ""
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4404
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4423
 msgid "Alphabet"
 msgstr ""
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4308
+#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4327
 msgid "Always"
 msgstr ""
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1405
+#: ../../Firmware/ultralcd.cpp:1424
 msgid "Ambient"
 msgstr ""
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2983
+#: ../../Firmware/ultralcd.cpp:3002
 msgid "Are left and right Z~carriages all up?"
 msgstr ""
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4478
 msgid "Assist"
 msgstr ""
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:5886
 msgid "Auto"
 msgstr ""
 
 #. MSG_AUTO_HOME c=18
 #: ../../Firmware/Marlin_main.cpp:3271 ../../Firmware/messages.cpp:9
-#: ../../Firmware/ultralcd.cpp:4900
+#: ../../Firmware/ultralcd.cpp:4919
 msgid "Auto home"
 msgstr ""
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:4364
-#: ../../Firmware/ultralcd.cpp:5779
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:4383
+#: ../../Firmware/ultralcd.cpp:5801
 msgid "Auto power"
 msgstr ""
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5572
+#: ../../Firmware/ultralcd.cpp:5594
 msgid "AutoLoad filament"
 msgstr ""
 
 #. MSG_AUTOLOADING_ONLY_IF_FSENS_ON c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3549
+#: ../../Firmware/ultralcd.cpp:3568
 msgid ""
 "Autoloading filament available only when filament sensor is turned on..."
 msgstr ""
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2301
+#: ../../Firmware/ultralcd.cpp:2320
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:7015
+#: ../../Firmware/ultralcd.cpp:7045
 msgid "Axis"
 msgstr ""
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:7014
+#: ../../Firmware/ultralcd.cpp:7044
 msgid "Axis length"
 msgstr ""
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:2751
-#: ../../Firmware/ultralcd.cpp:5861 ../../Firmware/ultralcd.cpp:7838
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:2770
+#: ../../Firmware/ultralcd.cpp:5883 ../../Firmware/ultralcd.cpp:7878
 msgid "Back"
 msgstr ""
 
 #. MSG_BED c=13
 #: ../../Firmware/Marlin_main.cpp:2051 ../../Firmware/Marlin_main.cpp:4767
 #: ../../Firmware/Marlin_main.cpp:4819 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:1403 ../../Firmware/ultralcd.cpp:5721
-#: ../../Firmware/ultralcd.cpp:5891
+#: ../../Firmware/ultralcd.cpp:1422 ../../Firmware/ultralcd.cpp:5743
+#: ../../Firmware/ultralcd.cpp:5913
 msgid "Bed"
 msgstr ""
 
@@ -149,7 +149,7 @@ msgid "Bed done"
 msgstr ""
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4912
+#: ../../Firmware/ultralcd.cpp:4931
 msgid "Bed level correct"
 msgstr ""
 
@@ -165,18 +165,18 @@ msgid ""
 msgstr ""
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6972
+#: ../../Firmware/ultralcd.cpp:7002
 msgid "Bed/Heater"
 msgstr ""
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1458
-#: ../../Firmware/ultralcd.cpp:1726
+#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1477
+#: ../../Firmware/ultralcd.cpp:1745
 msgid "Belt status"
 msgstr ""
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4902
+#: ../../Firmware/ultralcd.cpp:4921
 msgid "Belt test"
 msgstr ""
 
@@ -187,28 +187,28 @@ msgid "Blackout occurred. Recover print?"
 msgstr ""
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:5886
 msgid "Bright"
 msgstr ""
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4850
-#: ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4869
+#: ../../Firmware/ultralcd.cpp:5811
 msgid "Brightness"
 msgstr ""
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4906
+#: ../../Firmware/ultralcd.cpp:4925
 msgid "Calibrate XYZ"
 msgstr ""
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4908
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4927
 msgid "Calibrate Z"
 msgstr ""
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2946
+#: ../../Firmware/ultralcd.cpp:2965
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -221,19 +221,19 @@ msgid "Calibrating Z"
 msgstr ""
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2945
+#: ../../Firmware/ultralcd.cpp:2964
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
 msgstr ""
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:7315
+#: ../../Firmware/ultralcd.cpp:7345
 msgid "Calibrating home"
 msgstr ""
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:5581
+#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:5603
 msgid "Calibration"
 msgstr ""
 
@@ -243,115 +243,115 @@ msgid "Calibration done"
 msgstr ""
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7712
+#: ../../Firmware/ultralcd.cpp:7752
 msgid "Card removed"
 msgstr ""
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/ultralcd.cpp:5560
 msgid "Change SD card"
 msgstr ""
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5497
-#: ../../Firmware/ultralcd.cpp:5730
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5519
+#: ../../Firmware/ultralcd.cpp:5752
 msgid "Change filament"
 msgstr ""
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2163
+#: ../../Firmware/ultralcd.cpp:2182
 msgid "Change success!"
 msgstr ""
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2215
+#: ../../Firmware/ultralcd.cpp:2234
 msgid "Changed correctly?"
 msgstr ""
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:6178
-#: ../../Firmware/ultralcd.cpp:7305
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:6208
+#: ../../Firmware/ultralcd.cpp:7335
 msgid "Checking X axis"
 msgstr ""
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:6187
-#: ../../Firmware/ultralcd.cpp:7306
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:6217
+#: ../../Firmware/ultralcd.cpp:7336
 msgid "Checking Y axis"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:7307
+#: ../../Firmware/ultralcd.cpp:7337
 msgid "Checking Z axis"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:7308
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:7338
 msgid "Checking bed"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:7304
+#: ../../Firmware/ultralcd.cpp:7334
 msgid "Checking endstops"
 msgstr ""
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:7403
+#: ../../Firmware/ultralcd.cpp:7433
 msgid "Checking file"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:7310
+#: ../../Firmware/ultralcd.cpp:7340
 msgid "Checking hotend"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:7311
-#: ../../Firmware/ultralcd.cpp:7312
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:7341
+#: ../../Firmware/ultralcd.cpp:7342
 msgid "Checking sensors"
 msgstr ""
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4765
+#: ../../Firmware/ultralcd.cpp:4784
 msgid "Checks"
 msgstr ""
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2218
+#: ../../Firmware/ultralcd.cpp:2237
 msgid "Color not correct"
 msgstr ""
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3725
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3744
 msgid "Community made"
 msgstr ""
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4704
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4723
 msgid "Cont."
 msgstr ""
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2125
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2144
 msgid "Cooldown"
 msgstr ""
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3663
+#: ../../Firmware/ultralcd.cpp:3682
 msgid "Copy selected language?"
 msgstr ""
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1221
-#: ../../Firmware/ultralcd.cpp:1262 ../../Firmware/ultralcd.cpp:1272
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1240
+#: ../../Firmware/ultralcd.cpp:1281 ../../Firmware/ultralcd.cpp:1291
 msgid "Crash"
 msgstr ""
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4341
-#: ../../Firmware/ultralcd.cpp:4342 ../../Firmware/ultralcd.cpp:4344
-#: ../../Firmware/ultralcd.cpp:5765 ../../Firmware/ultralcd.cpp:5767
-#: ../../Firmware/ultralcd.cpp:5771
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4363
+#: ../../Firmware/ultralcd.cpp:5787 ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/ultralcd.cpp:5793
 msgid "Crash det."
 msgstr ""
 
@@ -361,7 +361,7 @@ msgid "Crash detected."
 msgstr ""
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3521
+#: ../../Firmware/ultralcd.cpp:3540
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -369,14 +369,14 @@ msgid ""
 msgstr ""
 
 #. MSG_CUT_FILAMENT c=17
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:5175
-#: ../../Firmware/ultralcd.cpp:5567
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:5197
+#: ../../Firmware/ultralcd.cpp:5589
 msgid "Cut filament"
 msgstr ""
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:4303
-#: ../../Firmware/ultralcd.cpp:4308 ../../Firmware/ultralcd.cpp:4313
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:4322
+#: ../../Firmware/ultralcd.cpp:4327 ../../Firmware/ultralcd.cpp:4332
 msgid "Cutter"
 msgstr ""
 
@@ -386,17 +386,17 @@ msgid "Cutting filament"
 msgstr ""
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1668
+#: ../../Firmware/ultralcd.cpp:1687
 msgid "Date:"
 msgstr ""
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5886
 msgid "Dim"
 msgstr ""
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4802
+#: ../../Firmware/ultralcd.cpp:4821
 msgid "Disable steppers"
 msgstr ""
 
@@ -410,30 +410,30 @@ msgid ""
 msgstr ""
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:4145
+#: ../../Firmware/ultralcd.cpp:4164
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
 msgstr ""
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4214
+#: ../../Firmware/ultralcd.cpp:4233
 msgid "E-correct:"
 msgstr ""
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2279
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2298
 msgid "ERROR:"
 msgstr ""
 
 #. MSG_FSENS_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3562
+#: ../../Firmware/ultralcd.cpp:3581
 msgid "ERROR: Filament sensor is not responding, please check connection."
 msgstr ""
 
 #. MSG_EJECT_FILAMENT c=17
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:5156
-#: ../../Firmware/ultralcd.cpp:5565
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:5178
+#: ../../Firmware/ultralcd.cpp:5587
 msgid "Eject filament"
 msgstr ""
 
@@ -443,47 +443,41 @@ msgid "Ejecting filament"
 msgstr ""
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6985
+#: ../../Firmware/ultralcd.cpp:7015
 msgid "Endstop"
 msgstr ""
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6990
+#: ../../Firmware/ultralcd.cpp:7020
 msgid "Endstop not hit"
 msgstr ""
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6976
+#: ../../Firmware/ultralcd.cpp:7006
 msgid "Endstops"
 msgstr ""
 
 #. MSG_EXTRUDER c=17
 #: ../../Firmware/Marlin_main.cpp:8608 ../../Firmware/messages.cpp:30
-#: ../../Firmware/ultralcd.cpp:3495
+#: ../../Firmware/ultralcd.cpp:3514
 msgid "Extruder"
 msgstr ""
 
-#. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1144
-#: ../../Firmware/ultralcd.cpp:7319
-msgid "Hotend fan:"
-msgstr ""
-
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1722
+#: ../../Firmware/ultralcd.cpp:1741
 msgid "Extruder info"
 msgstr ""
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4229
-#: ../../Firmware/ultralcd.cpp:4237 ../../Firmware/ultralcd.cpp:4248
-#: ../../Firmware/ultralcd.cpp:4250
+#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4248
+#: ../../Firmware/ultralcd.cpp:4256 ../../Firmware/ultralcd.cpp:4267
+#: ../../Firmware/ultralcd.cpp:4269
 msgid "F. autoload"
 msgstr ""
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4704
-#: ../../Firmware/ultralcd.cpp:4707
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4723
+#: ../../Firmware/ultralcd.cpp:4726
 msgid "FS Action"
 msgstr ""
 
@@ -498,102 +492,102 @@ msgid "FS v0.4 or newer"
 msgstr ""
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5589
+#: ../../Firmware/ultralcd.cpp:5611
 msgid "Fail stats"
 msgstr ""
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5592
+#: ../../Firmware/ultralcd.cpp:5614
 msgid "Fail stats MMU"
 msgstr ""
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:7031
+#: ../../Firmware/ultralcd.cpp:7061
 msgid "False triggering"
 msgstr ""
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:5723
-#: ../../Firmware/ultralcd.cpp:5893
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/ultralcd.cpp:5915
 msgid "Fan speed"
 msgstr ""
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:7143
-#: ../../Firmware/ultralcd.cpp:7301 ../../Firmware/ultralcd.cpp:7302
-#: ../../Firmware/ultralcd.cpp:7303
+#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:7173
+#: ../../Firmware/ultralcd.cpp:7331 ../../Firmware/ultralcd.cpp:7332
+#: ../../Firmware/ultralcd.cpp:7333
 msgid "Fan test"
 msgstr ""
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4811
-#: ../../Firmware/ultralcd.cpp:5756
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4830
+#: ../../Firmware/ultralcd.cpp:5778
 msgid "Fans check"
 msgstr ""
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1220
-#: ../../Firmware/ultralcd.cpp:1261 ../../Firmware/ultralcd.cpp:1327
-#: ../../Firmware/ultralcd.cpp:1329
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1239
+#: ../../Firmware/ultralcd.cpp:1280 ../../Firmware/ultralcd.cpp:1346
+#: ../../Firmware/ultralcd.cpp:1348
 msgid "Fil. runouts"
 msgstr ""
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:3451
-#: ../../Firmware/ultralcd.cpp:4228 ../../Firmware/ultralcd.cpp:4234
-#: ../../Firmware/ultralcd.cpp:4244 ../../Firmware/ultralcd.cpp:5737
-#: ../../Firmware/ultralcd.cpp:5741 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:3470
+#: ../../Firmware/ultralcd.cpp:4247 ../../Firmware/ultralcd.cpp:4253
+#: ../../Firmware/ultralcd.cpp:4263 ../../Firmware/ultralcd.cpp:5759
+#: ../../Firmware/ultralcd.cpp:5763 ../../Firmware/ultralcd.cpp:5767
 msgid "Fil. sensor"
 msgstr ""
 
 #. MSG_FILAMENT c=17
 #: ../../Firmware/Marlin_main.cpp:8577 ../../Firmware/Marlin_main.cpp:8604
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3835
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3854
 msgid "Filament"
 msgstr ""
 
 #. MSG_FILAMENT_CLEAN c=20 r=2
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2287
-#: ../../Firmware/ultralcd.cpp:2293
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2306
+#: ../../Firmware/ultralcd.cpp:2312
 msgid "Filament extruding & with correct color?"
 msgstr ""
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2217
+#: ../../Firmware/ultralcd.cpp:2236
 msgid "Filament not loaded"
 msgstr ""
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:7026
-#: ../../Firmware/ultralcd.cpp:7030 ../../Firmware/ultralcd.cpp:7034
-#: ../../Firmware/ultralcd.cpp:7330
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:7056
+#: ../../Firmware/ultralcd.cpp:7060 ../../Firmware/ultralcd.cpp:7064
+#: ../../Firmware/ultralcd.cpp:7360
 msgid "Filament sensor"
 msgstr ""
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2365
+#: ../../Firmware/ultralcd.cpp:2384
 msgid "Filament used"
 msgstr ""
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7461
+#: ../../Firmware/ultralcd.cpp:7491
 msgid "File incomplete. Continue anyway?"
 msgstr ""
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:5314
-#: ../../Firmware/ultralcd.cpp:5630
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:5336
+#: ../../Firmware/ultralcd.cpp:5652
 msgid "Finishing movements"
 msgstr ""
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:4898
-#: ../../Firmware/ultralcd.cpp:5424
+#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:4917
+#: ../../Firmware/ultralcd.cpp:5446
 msgid "First layer cal."
 msgstr ""
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4066
+#: ../../Firmware/ultralcd.cpp:4085
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 
@@ -603,23 +597,23 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr ""
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5724
+#: ../../Firmware/ultralcd.cpp:5746
 msgid "Flow"
 msgstr ""
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:6996
-#: ../../Firmware/ultralcd.cpp:7149 ../../Firmware/ultralcd.cpp:7154
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:7026
+#: ../../Firmware/ultralcd.cpp:7179 ../../Firmware/ultralcd.cpp:7184
 msgid "Front print fan?"
 msgstr ""
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2754
+#: ../../Firmware/ultralcd.cpp:2773
 msgid "Front side[μm]"
 msgstr ""
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:7020
+#: ../../Firmware/ultralcd.cpp:7050
 msgid "Front/left fans"
 msgstr ""
 
@@ -662,20 +656,20 @@ msgid ""
 msgstr ""
 
 #. MSG_GCODE c=8
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:4655
-#: ../../Firmware/ultralcd.cpp:4658 ../../Firmware/ultralcd.cpp:4661
-#: ../../Firmware/ultralcd.cpp:4664
+#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:4674
+#: ../../Firmware/ultralcd.cpp:4677 ../../Firmware/ultralcd.cpp:4680
+#: ../../Firmware/ultralcd.cpp:4683
 msgid "Gcode"
 msgstr ""
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:4672
-#: ../../Firmware/ultralcd.cpp:4726 ../../Firmware/ultralcd.cpp:4818
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:4691
+#: ../../Firmware/ultralcd.cpp:4745 ../../Firmware/ultralcd.cpp:4837
 msgid "HW Setup"
 msgstr ""
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6968
+#: ../../Firmware/ultralcd.cpp:6998
 msgid "Heater/Thermistor"
 msgstr ""
 
@@ -697,7 +691,7 @@ msgid "Heating done."
 msgstr ""
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=16
-#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4042
+#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4061
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -705,7 +699,7 @@ msgid ""
 msgstr ""
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4064
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -714,24 +708,30 @@ msgstr ""
 "dig gennem installationsprocessen?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:4358
-#: ../../Firmware/ultralcd.cpp:4367 ../../Firmware/ultralcd.cpp:5777
-#: ../../Firmware/ultralcd.cpp:5780
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:4377
+#: ../../Firmware/ultralcd.cpp:4386 ../../Firmware/ultralcd.cpp:5799
+#: ../../Firmware/ultralcd.cpp:5802
 msgid "High power"
 msgstr ""
 
+#. MSG_HOTEND_FAN_SPEED c=15
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1145
+#: ../../Firmware/ultralcd.cpp:7351
+msgid "Hotend fan:"
+msgstr ""
+
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4094
 msgid "I will run xyz calibration now. It will take approx. 12 mins."
 msgstr ""
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/ultralcd.cpp:4102
 msgid "I will run z calibration now."
 msgstr ""
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=9
-#: ../../Firmware/ultralcd.cpp:4153
+#: ../../Firmware/ultralcd.cpp:4172
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -743,36 +743,36 @@ msgid "Improving bed calibration point"
 msgstr ""
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:5478
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:5500
 msgid "Info screen"
 msgstr ""
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5545
+#: ../../Firmware/ultralcd.cpp:5567
 msgid "Init. SD card"
 msgstr ""
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2152
+#: ../../Firmware/ultralcd.cpp:2171
 msgid "Insert filament"
 msgstr ""
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:6223
+#: ../../Firmware/ultralcd.cpp:6253
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
 msgstr ""
 
 #. MSG_FILAMENT_LOADED c=20 r=2
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3855
-#: ../../Firmware/ultralcd.cpp:4108 ../../Firmware/ultralcd.cpp:4111
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3874
+#: ../../Firmware/ultralcd.cpp:4127 ../../Firmware/ultralcd.cpp:4130
 msgid "Is filament loaded?"
 msgstr ""
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=2
 #: ../../Firmware/Marlin_main.cpp:3312 ../../Firmware/Marlin_main.cpp:4886
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:4084
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:4103
 msgid "Is steel sheet on heatbed?"
 msgstr ""
 
@@ -782,74 +782,74 @@ msgid "Iteration"
 msgstr ""
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:1148
-#: ../../Firmware/ultralcd.cpp:1296
+#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:1167
+#: ../../Firmware/ultralcd.cpp:1315
 msgid "Last print"
 msgstr ""
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1169
-#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1269
-#: ../../Firmware/ultralcd.cpp:1326
+#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1188
+#: ../../Firmware/ultralcd.cpp:1278 ../../Firmware/ultralcd.cpp:1288
+#: ../../Firmware/ultralcd.cpp:1345
 msgid "Last print failures"
 msgstr ""
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2496
+#: ../../Firmware/ultralcd.cpp:2515
 msgid "Left"
 msgstr ""
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7001
-#: ../../Firmware/ultralcd.cpp:7147 ../../Firmware/ultralcd.cpp:7152
+#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:7032
+#: ../../Firmware/ultralcd.cpp:7179 ../../Firmware/ultralcd.cpp:7184
 msgid "Left hotend fan?"
 msgstr ""
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2752
+#: ../../Firmware/ultralcd.cpp:2771
 msgid "Left side [μm]"
 msgstr ""
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:5862
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:5884
 msgid "Level Bright"
 msgstr ""
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:5863
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:5885
 msgid "Level Dimmed"
 msgstr ""
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4826
+#: ../../Firmware/ultralcd.cpp:4845
 msgid "Lin. correction"
 msgstr ""
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4838
-#: ../../Firmware/ultralcd.cpp:5493
+#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4857
+#: ../../Firmware/ultralcd.cpp:5515
 msgid "Live adjust Z"
 msgstr ""
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/ultralcd.cpp:5120
+#: ../../Firmware/ultralcd.cpp:5142
 msgid "Load all"
 msgstr ""
 
 #. MSG_LOAD_FILAMENT c=17
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:5122
-#: ../../Firmware/ultralcd.cpp:5133 ../../Firmware/ultralcd.cpp:5562
-#: ../../Firmware/ultralcd.cpp:5576
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:5144
+#: ../../Firmware/ultralcd.cpp:5155 ../../Firmware/ultralcd.cpp:5584
+#: ../../Firmware/ultralcd.cpp:5598
 msgid "Load filament"
 msgstr ""
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5563
+#: ../../Firmware/ultralcd.cpp:5585
 msgid "Load to nozzle"
 msgstr ""
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2185
+#: ../../Firmware/ultralcd.cpp:2204
 msgid "Loading color"
 msgstr ""
 
@@ -857,18 +857,18 @@ msgstr ""
 #: ../../Firmware/Marlin_main.cpp:3641 ../../Firmware/messages.cpp:55
 #: ../../Firmware/mmu.cpp:872 ../../Firmware/mmu.cpp:906
 #: ../../Firmware/mmu.cpp:1014 ../../Firmware/mmu.cpp:1026
-#: ../../Firmware/ultralcd.cpp:2196 ../../Firmware/ultralcd.cpp:3949
+#: ../../Firmware/ultralcd.cpp:2215 ../../Firmware/ultralcd.cpp:3968
 msgid "Loading filament"
 msgstr ""
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:7008
+#: ../../Firmware/ultralcd.cpp:7038
 msgid "Loose pulley"
 msgstr ""
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:4450
-#: ../../Firmware/ultralcd.cpp:4462
+#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/ultralcd.cpp:4481
 msgid "Loud"
 msgstr ""
 
@@ -883,8 +883,8 @@ msgid "MK3S firmware detected on MK3 printer"
 msgstr ""
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4381
-#: ../../Firmware/ultralcd.cpp:4382
+#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4400
+#: ../../Firmware/ultralcd.cpp:4401
 msgid "MMU Mode"
 msgstr ""
 
@@ -904,8 +904,8 @@ msgid "MMU OK. Resuming..."
 msgstr ""
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:64 ../../Firmware/ultralcd.cpp:1170
-#: ../../Firmware/ultralcd.cpp:1193
+#: ../../Firmware/messages.cpp:64 ../../Firmware/ultralcd.cpp:1189
+#: ../../Firmware/ultralcd.cpp:1212
 msgid "MMU fails"
 msgstr ""
 
@@ -915,8 +915,8 @@ msgid "MMU load failed"
 msgstr ""
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:1171
-#: ../../Firmware/ultralcd.cpp:1194
+#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:1190
+#: ../../Firmware/ultralcd.cpp:1213
 msgid "MMU load fails"
 msgstr ""
 
@@ -926,32 +926,32 @@ msgid "MMU needs user attention."
 msgstr ""
 
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/ultralcd.cpp:1195
+#: ../../Firmware/ultralcd.cpp:1214
 msgid "MMU power fails"
 msgstr ""
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1680
+#: ../../Firmware/ultralcd.cpp:1699
 msgid "MMU2 connected"
 msgstr ""
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:5836
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:5858
 msgid "Magnets comp."
 msgstr ""
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1147
-#: ../../Firmware/ultralcd.cpp:1295 ../../Firmware/ultralcd.cpp:1338
-#: ../../Firmware/ultralcd.cpp:1645 ../../Firmware/ultralcd.cpp:4795
-#: ../../Firmware/ultralcd.cpp:4892 ../../Firmware/ultralcd.cpp:5119
-#: ../../Firmware/ultralcd.cpp:5131 ../../Firmware/ultralcd.cpp:5154
-#: ../../Firmware/ultralcd.cpp:5173 ../../Firmware/ultralcd.cpp:5717
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1166
+#: ../../Firmware/ultralcd.cpp:1314 ../../Firmware/ultralcd.cpp:1357
+#: ../../Firmware/ultralcd.cpp:1664 ../../Firmware/ultralcd.cpp:4814
+#: ../../Firmware/ultralcd.cpp:4911 ../../Firmware/ultralcd.cpp:5141
+#: ../../Firmware/ultralcd.cpp:5153 ../../Firmware/ultralcd.cpp:5176
+#: ../../Firmware/ultralcd.cpp:5195 ../../Firmware/ultralcd.cpp:5739
 msgid "Main"
 msgstr ""
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2537
+#: ../../Firmware/ultralcd.cpp:2556
 msgid "Measured skew"
 msgstr ""
 
@@ -962,71 +962,71 @@ msgid "Measuring reference height of calibration point"
 msgstr ""
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:5832
+#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:5854
 msgid "Mesh"
 msgstr ""
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4823
-#: ../../Firmware/ultralcd.cpp:4910
+#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4842
+#: ../../Firmware/ultralcd.cpp:4929
 msgid "Mesh Bed Leveling"
 msgstr ""
 
 #. MSG_MODE c=6
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:4336
-#: ../../Firmware/ultralcd.cpp:4338 ../../Firmware/ultralcd.cpp:4358
-#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4364
-#: ../../Firmware/ultralcd.cpp:4367 ../../Firmware/ultralcd.cpp:5763
-#: ../../Firmware/ultralcd.cpp:5770 ../../Firmware/ultralcd.cpp:5777
-#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5779
-#: ../../Firmware/ultralcd.cpp:5780 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/ultralcd.cpp:4357 ../../Firmware/ultralcd.cpp:4377
+#: ../../Firmware/ultralcd.cpp:4380 ../../Firmware/ultralcd.cpp:4383
+#: ../../Firmware/ultralcd.cpp:4386 ../../Firmware/ultralcd.cpp:5785
+#: ../../Firmware/ultralcd.cpp:5792 ../../Firmware/ultralcd.cpp:5799
+#: ../../Firmware/ultralcd.cpp:5800 ../../Firmware/ultralcd.cpp:5801
+#: ../../Firmware/ultralcd.cpp:5802 ../../Firmware/ultralcd.cpp:5886
 msgid "Mode"
 msgstr ""
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3598
+#: ../../Firmware/ultralcd.cpp:3617
 msgid "Mode change in progress..."
 msgstr ""
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:4575
-#: ../../Firmware/ultralcd.cpp:4578 ../../Firmware/ultralcd.cpp:4581
-#: ../../Firmware/ultralcd.cpp:4584
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:4594
+#: ../../Firmware/ultralcd.cpp:4597 ../../Firmware/ultralcd.cpp:4600
+#: ../../Firmware/ultralcd.cpp:4603
 msgid "Model"
 msgstr ""
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6982
-#: ../../Firmware/ultralcd.cpp:6991 ../../Firmware/ultralcd.cpp:7009
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:7012
+#: ../../Firmware/ultralcd.cpp:7021 ../../Firmware/ultralcd.cpp:7039
 msgid "Motor"
 msgstr ""
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3492
+#: ../../Firmware/ultralcd.cpp:3511
 msgid "Move X"
 msgstr ""
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3493
+#: ../../Firmware/ultralcd.cpp:3512
 msgid "Move Y"
 msgstr ""
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3494
+#: ../../Firmware/ultralcd.cpp:3513
 msgid "Move Z"
 msgstr ""
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4801
+#: ../../Firmware/ultralcd.cpp:4820
 msgid "Move axis"
 msgstr ""
 
 #. MSG_NA c=3
 #: ../../Firmware/menu.cpp:196 ../../Firmware/messages.cpp:124
-#: ../../Firmware/ultralcd.cpp:2502 ../../Firmware/ultralcd.cpp:2547
-#: ../../Firmware/ultralcd.cpp:3411 ../../Firmware/ultralcd.cpp:4228
-#: ../../Firmware/ultralcd.cpp:4276 ../../Firmware/ultralcd.cpp:5737
-#: ../../Firmware/ultralcd.cpp:5836
+#: ../../Firmware/ultralcd.cpp:2521 ../../Firmware/ultralcd.cpp:2566
+#: ../../Firmware/ultralcd.cpp:3430 ../../Firmware/ultralcd.cpp:4247
+#: ../../Firmware/ultralcd.cpp:4295 ../../Firmware/ultralcd.cpp:5759
+#: ../../Firmware/ultralcd.cpp:5858
 msgid "N/A"
 msgstr ""
 
@@ -1036,14 +1036,14 @@ msgid "New firmware version available:"
 msgstr ""
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:2804
-#: ../../Firmware/ultralcd.cpp:3180 ../../Firmware/ultralcd.cpp:4785
-#: ../../Firmware/ultralcd.cpp:5988
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:2823
+#: ../../Firmware/ultralcd.cpp:3199 ../../Firmware/ultralcd.cpp:4804
+#: ../../Firmware/ultralcd.cpp:6018
 msgid "No"
 msgstr ""
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5543
+#: ../../Firmware/ultralcd.cpp:5565
 msgid "No SD card"
 msgstr ""
 
@@ -1053,71 +1053,71 @@ msgid "No move."
 msgstr ""
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4405
-#: ../../Firmware/ultralcd.cpp:4493 ../../Firmware/ultralcd.cpp:4502
-#: ../../Firmware/ultralcd.cpp:4575 ../../Firmware/ultralcd.cpp:4584
-#: ../../Firmware/ultralcd.cpp:4614 ../../Firmware/ultralcd.cpp:4623
-#: ../../Firmware/ultralcd.cpp:4655 ../../Firmware/ultralcd.cpp:4664
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4424
+#: ../../Firmware/ultralcd.cpp:4512 ../../Firmware/ultralcd.cpp:4521
+#: ../../Firmware/ultralcd.cpp:4594 ../../Firmware/ultralcd.cpp:4603
+#: ../../Firmware/ultralcd.cpp:4633 ../../Firmware/ultralcd.cpp:4642
+#: ../../Firmware/ultralcd.cpp:4674 ../../Firmware/ultralcd.cpp:4683
 msgid "None"
 msgstr ""
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:4336
-#: ../../Firmware/ultralcd.cpp:4381 ../../Firmware/ultralcd.cpp:4397
-#: ../../Firmware/ultralcd.cpp:4416 ../../Firmware/ultralcd.cpp:5763
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/ultralcd.cpp:4400 ../../Firmware/ultralcd.cpp:4416
+#: ../../Firmware/ultralcd.cpp:4435 ../../Firmware/ultralcd.cpp:5785
 msgid "Normal"
 msgstr ""
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6969
+#: ../../Firmware/ultralcd.cpp:6999
 msgid "Not connected"
 msgstr ""
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:7168
-#: ../../Firmware/ultralcd.cpp:7183 ../../Firmware/ultralcd.cpp:7191
+#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:7198
+#: ../../Firmware/ultralcd.cpp:7213 ../../Firmware/ultralcd.cpp:7221
 msgid "Not spinning"
 msgstr ""
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3962
+#: ../../Firmware/ultralcd.cpp:3981
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr ""
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:4091
+#: ../../Firmware/ultralcd.cpp:4110
 msgid "Now I will preheat nozzle for PLA."
 msgstr ""
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/ultralcd.cpp:4101
 msgid "Now remove the test print from steel sheet."
 msgstr ""
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:1402
-#: ../../Firmware/ultralcd.cpp:4493 ../../Firmware/ultralcd.cpp:4496
-#: ../../Firmware/ultralcd.cpp:4499 ../../Firmware/ultralcd.cpp:4502
-#: ../../Firmware/ultralcd.cpp:5720 ../../Firmware/ultralcd.cpp:5882
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:1421
+#: ../../Firmware/ultralcd.cpp:4512 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/ultralcd.cpp:4518 ../../Firmware/ultralcd.cpp:4521
+#: ../../Firmware/ultralcd.cpp:5742 ../../Firmware/ultralcd.cpp:5904
 msgid "Nozzle"
 msgstr ""
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4546
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4565
 msgid "Nozzle d."
 msgstr ""
 
 #. MSG_OFF c=3
 #: ../../Firmware/menu.cpp:467 ../../Firmware/messages.cpp:122
-#: ../../Firmware/ultralcd.cpp:4234 ../../Firmware/ultralcd.cpp:4250
-#: ../../Firmware/ultralcd.cpp:4284 ../../Firmware/ultralcd.cpp:4313
-#: ../../Firmware/ultralcd.cpp:4342 ../../Firmware/ultralcd.cpp:4811
-#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4834
-#: ../../Firmware/ultralcd.cpp:5644 ../../Firmware/ultralcd.cpp:5741
-#: ../../Firmware/ultralcd.cpp:5756 ../../Firmware/ultralcd.cpp:5767
-#: ../../Firmware/ultralcd.cpp:5836 ../../Firmware/ultralcd.cpp:7841
-#: ../../Firmware/ultralcd.cpp:7845
+#: ../../Firmware/ultralcd.cpp:4253 ../../Firmware/ultralcd.cpp:4269
+#: ../../Firmware/ultralcd.cpp:4303 ../../Firmware/ultralcd.cpp:4332
+#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4830
+#: ../../Firmware/ultralcd.cpp:4849 ../../Firmware/ultralcd.cpp:4853
+#: ../../Firmware/ultralcd.cpp:5666 ../../Firmware/ultralcd.cpp:5763
+#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/ultralcd.cpp:5858 ../../Firmware/ultralcd.cpp:7881
+#: ../../Firmware/ultralcd.cpp:7885
 msgid "Off"
 msgstr ""
 
@@ -1127,19 +1127,19 @@ msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr ""
 
 #. MSG_ON c=3
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4244
-#: ../../Firmware/ultralcd.cpp:4248 ../../Firmware/ultralcd.cpp:4280
-#: ../../Firmware/ultralcd.cpp:4303 ../../Firmware/ultralcd.cpp:4341
-#: ../../Firmware/ultralcd.cpp:4811 ../../Firmware/ultralcd.cpp:4830
-#: ../../Firmware/ultralcd.cpp:4834 ../../Firmware/ultralcd.cpp:5745
-#: ../../Firmware/ultralcd.cpp:5756 ../../Firmware/ultralcd.cpp:5765
-#: ../../Firmware/ultralcd.cpp:5836 ../../Firmware/ultralcd.cpp:7841
-#: ../../Firmware/ultralcd.cpp:7845
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4263
+#: ../../Firmware/ultralcd.cpp:4267 ../../Firmware/ultralcd.cpp:4299
+#: ../../Firmware/ultralcd.cpp:4322 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4849
+#: ../../Firmware/ultralcd.cpp:4853 ../../Firmware/ultralcd.cpp:5767
+#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5787
+#: ../../Firmware/ultralcd.cpp:5858 ../../Firmware/ultralcd.cpp:7881
+#: ../../Firmware/ultralcd.cpp:7885
 msgid "On"
 msgstr ""
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4453
+#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4472
 msgid "Once"
 msgstr ""
 
@@ -1159,7 +1159,7 @@ msgid "PID cal. finished"
 msgstr ""
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4913
+#: ../../Firmware/ultralcd.cpp:4932
 msgid "PID calibration"
 msgstr ""
 
@@ -1171,31 +1171,31 @@ msgstr ""
 #. MSG_PINDA_CALIBRATION c=13
 #: ../../Firmware/Marlin_main.cpp:4932 ../../Firmware/Marlin_main.cpp:5035
 #: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:654
-#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4920
+#: ../../Firmware/ultralcd.cpp:4849 ../../Firmware/ultralcd.cpp:4939
 msgid "PINDA cal."
 msgstr ""
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3361
+#: ../../Firmware/ultralcd.cpp:3380
 msgid "PINDA calibration failed"
 msgstr ""
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
 #: ../../Firmware/Marlin_main.cpp:5112 ../../Firmware/messages.cpp:110
-#: ../../Firmware/ultralcd.cpp:3355
+#: ../../Firmware/ultralcd.cpp:3374
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
 msgstr ""
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4707
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4726
 msgid "Pause"
 msgstr ""
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:5507
-#: ../../Firmware/ultralcd.cpp:5509
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:5529
+#: ../../Firmware/ultralcd.cpp:5531
 msgid "Pause print"
 msgstr ""
 
@@ -1207,24 +1207,24 @@ msgid ""
 msgstr ""
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:4176
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:4195
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
 msgstr ""
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:6250
+#: ../../Firmware/ultralcd.cpp:6280
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr ""
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6963
+#: ../../Firmware/ultralcd.cpp:6993
 msgid "Please check:"
 msgstr ""
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4148
+#: ../../Firmware/ultralcd.cpp:4167
 msgid "Please clean heatbed and then press the knob."
 msgstr ""
 
@@ -1234,20 +1234,20 @@ msgid "Please clean the nozzle for calibration. Click when done."
 msgstr ""
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3945
+#: ../../Firmware/ultralcd.cpp:3964
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr ""
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3940
+#: ../../Firmware/ultralcd.cpp:3959
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
 msgstr ""
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3863
+#: ../../Firmware/ultralcd.cpp:3882
 msgid "Please load filament first."
 msgstr ""
 
@@ -1258,7 +1258,7 @@ msgstr ""
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=5
 #: ../../Firmware/mesh_bed_calibration.cpp:2799 ../../Firmware/messages.cpp:70
-#: ../../Firmware/ultralcd.cpp:4085
+#: ../../Firmware/ultralcd.cpp:4104
 msgid "Please place steel sheet on heatbed."
 msgstr ""
 
@@ -1269,7 +1269,7 @@ msgid "Please press the knob to unload filament"
 msgstr ""
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:5213
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:5235
 msgid "Please pull out filament immediately"
 msgstr ""
 
@@ -1279,7 +1279,7 @@ msgid "Please remove filament and then press the knob."
 msgstr ""
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:4081
+#: ../../Firmware/ultralcd.cpp:4100
 msgid "Please remove shipping helpers first."
 msgstr ""
 
@@ -1295,7 +1295,7 @@ msgid "Please run XYZ calibration first."
 msgstr ""
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:6247
+#: ../../Firmware/ultralcd.cpp:6277
 msgid "Please unload the filament first, then repeat this action."
 msgstr ""
 
@@ -1312,54 +1312,54 @@ msgstr ""
 #. MSG_PLEASE_WAIT c=20
 #: ../../Firmware/Marlin_main.cpp:3547 ../../Firmware/Marlin_main.cpp:3563
 #: ../../Firmware/Marlin_main.cpp:7931 ../../Firmware/messages.cpp:71
-#: ../../Firmware/ultralcd.cpp:2186 ../../Firmware/ultralcd.cpp:2197
+#: ../../Firmware/ultralcd.cpp:2205 ../../Firmware/ultralcd.cpp:2216
 msgid "Please wait"
 msgstr ""
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1219
-#: ../../Firmware/ultralcd.cpp:1260 ../../Firmware/ultralcd.cpp:1270
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1238
+#: ../../Firmware/ultralcd.cpp:1279 ../../Firmware/ultralcd.cpp:1289
 msgid "Power failures"
 msgstr ""
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5502
+#: ../../Firmware/ultralcd.cpp:5524
 msgid "Preheat"
 msgstr ""
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:2280
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:2299
 msgid "Preheat the nozzle!"
 msgstr ""
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:2900
-#: ../../Firmware/ultralcd.cpp:3924 ../../Firmware/ultralcd.cpp:3926
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:2919
+#: ../../Firmware/ultralcd.cpp:3943 ../../Firmware/ultralcd.cpp:3945
 msgid "Preheating nozzle. Please wait."
 msgstr ""
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1988
+#: ../../Firmware/ultralcd.cpp:2007
 msgid "Preheating to cut"
 msgstr ""
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1985
+#: ../../Firmware/ultralcd.cpp:2004
 msgid "Preheating to eject"
 msgstr ""
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1976
+#: ../../Firmware/ultralcd.cpp:1995
 msgid "Preheating to load"
 msgstr ""
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1981
+#: ../../Firmware/ultralcd.cpp:2000
 msgid "Preheating to unload"
 msgstr ""
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1809
+#: ../../Firmware/ultralcd.cpp:1828
 msgid "Press the knob"
 msgstr ""
 
@@ -1379,13 +1379,13 @@ msgid "Print aborted"
 msgstr ""
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1144
-#: ../../Firmware/ultralcd.cpp:7322
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1145
+#: ../../Firmware/ultralcd.cpp:7354
 msgid "Print fan:"
 msgstr ""
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5535
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5557
 msgid "Print from SD"
 msgstr ""
 
@@ -1395,12 +1395,12 @@ msgid "Print paused"
 msgstr ""
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2366
+#: ../../Firmware/ultralcd.cpp:2385
 msgid "Print time"
 msgstr ""
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1711
+#: ../../Firmware/ultralcd.cpp:1730
 msgid "Printer IP Addr:"
 msgstr ""
 
@@ -1424,12 +1424,12 @@ msgid ""
 msgstr ""
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4834
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4853
 msgid "RPi port"
 msgstr ""
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2755
+#: ../../Firmware/ultralcd.cpp:2774
 msgid "Rear side [μm]"
 msgstr ""
 
@@ -1444,24 +1444,24 @@ msgid "Remove old filament and press the knob to start loading new filament."
 msgstr ""
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5426
+#: ../../Firmware/ultralcd.cpp:5448
 msgid "Rename"
 msgstr ""
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2756
-#: ../../Firmware/ultralcd.cpp:5427
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2775
+#: ../../Firmware/ultralcd.cpp:5449
 msgid "Reset"
 msgstr ""
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4917
+#: ../../Firmware/ultralcd.cpp:4936
 msgid "Reset XYZ calibr."
 msgstr ""
 
 #. MSG_RESUME_PRINT c=18
 #: ../../Firmware/Marlin_main.cpp:655 ../../Firmware/messages.cpp:81
-#: ../../Firmware/ultralcd.cpp:5521 ../../Firmware/ultralcd.cpp:5523
+#: ../../Firmware/ultralcd.cpp:5543 ../../Firmware/ultralcd.cpp:5545
 msgid "Resume print"
 msgstr ""
 
@@ -1471,31 +1471,31 @@ msgid "Resuming print"
 msgstr ""
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2497
+#: ../../Firmware/ultralcd.cpp:2516
 msgid "Right"
 msgstr ""
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2753
+#: ../../Firmware/ultralcd.cpp:2772
 msgid "Right side[μm]"
 msgstr ""
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3884
+#: ../../Firmware/ultralcd.cpp:3903
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
 msgstr ""
 
 #. MSG_RUNOUTS c=7
-#: ../../Firmware/ultralcd.cpp:1271
+#: ../../Firmware/ultralcd.cpp:1290
 msgid "Runouts"
 msgstr ""
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4395
-#: ../../Firmware/ultralcd.cpp:4397 ../../Firmware/ultralcd.cpp:4414
-#: ../../Firmware/ultralcd.cpp:4416
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4414
+#: ../../Firmware/ultralcd.cpp:4416 ../../Firmware/ultralcd.cpp:4433
+#: ../../Firmware/ultralcd.cpp:4435
 msgid "SD card"
 msgstr ""
 
@@ -1511,12 +1511,12 @@ msgid "Searching bed calibration point"
 msgstr ""
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5419
+#: ../../Firmware/ultralcd.cpp:5441
 msgid "Select"
 msgstr ""
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3966
+#: ../../Firmware/ultralcd.cpp:3985
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
@@ -1529,49 +1529,49 @@ msgstr ""
 
 #. MSG_SELECT_FILAMENT c=20
 #: ../../Firmware/Marlin_main.cpp:8577 ../../Firmware/Marlin_main.cpp:8604
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3834
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3853
 msgid "Select filament:"
 msgstr ""
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:3679
-#: ../../Firmware/ultralcd.cpp:4841
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:3698
+#: ../../Firmware/ultralcd.cpp:4860
 msgid "Select language"
 msgstr ""
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:4122
+#: ../../Firmware/ultralcd.cpp:4141
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr ""
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3971
+#: ../../Firmware/ultralcd.cpp:3990
 msgid "Select temperature which matches your material."
 msgstr ""
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6522
+#: ../../Firmware/ultralcd.cpp:6552
 msgid "Self test OK"
 msgstr ""
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:6290
+#: ../../Firmware/ultralcd.cpp:6320
 msgid "Self test start"
 msgstr ""
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4904
+#: ../../Firmware/ultralcd.cpp:4923
 msgid "Selftest"
 msgstr ""
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6962
+#: ../../Firmware/ultralcd.cpp:6992
 msgid "Selftest error!"
 msgstr ""
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:6526
-#: ../../Firmware/ultralcd.cpp:7049 ../../Firmware/ultralcd.cpp:7314
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:6556
+#: ../../Firmware/ultralcd.cpp:7079 ../../Firmware/ultralcd.cpp:7344
 msgid "Selftest failed"
 msgstr ""
 
@@ -1581,30 +1581,30 @@ msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr ""
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1723
+#: ../../Firmware/ultralcd.cpp:1742
 msgid "Sensor info"
 msgstr ""
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:6254
+#: ../../Firmware/ultralcd.cpp:6284
 msgid "Sensor verified, remove the filament now."
 msgstr ""
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2773
+#: ../../Firmware/ultralcd.cpp:2792
 msgid "Set temperature:"
 msgstr ""
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:3491
-#: ../../Firmware/ultralcd.cpp:3696 ../../Firmware/ultralcd.cpp:4206
-#: ../../Firmware/ultralcd.cpp:5580 ../../Firmware/ultralcd.cpp:5827
-#: ../../Firmware/ultralcd.cpp:5880
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:3510
+#: ../../Firmware/ultralcd.cpp:3715 ../../Firmware/ultralcd.cpp:4225
+#: ../../Firmware/ultralcd.cpp:5602 ../../Firmware/ultralcd.cpp:5849
+#: ../../Firmware/ultralcd.cpp:5902
 msgid "Settings"
 msgstr ""
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2540
+#: ../../Firmware/ultralcd.cpp:2559
 msgid "Severe skew"
 msgstr ""
 
@@ -1615,7 +1615,7 @@ msgid "Sheet"
 msgstr ""
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3824
+#: ../../Firmware/ultralcd.cpp:3843
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1624,18 +1624,18 @@ msgid ""
 msgstr ""
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4915
+#: ../../Firmware/ultralcd.cpp:4934
 msgid "Show end stops"
 msgstr ""
 
 #. MSG_SILENT c=7
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4361
-#: ../../Firmware/ultralcd.cpp:4456 ../../Firmware/ultralcd.cpp:5778
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4380
+#: ../../Firmware/ultralcd.cpp:4475 ../../Firmware/ultralcd.cpp:5800
 msgid "Silent"
 msgstr ""
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2539
+#: ../../Firmware/ultralcd.cpp:2558
 msgid "Slight skew"
 msgstr ""
 
@@ -1652,8 +1652,8 @@ msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr ""
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4403
-#: ../../Firmware/ultralcd.cpp:4404 ../../Firmware/ultralcd.cpp:4405
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4422
+#: ../../Firmware/ultralcd.cpp:4423 ../../Firmware/ultralcd.cpp:4424
 msgid "Sort"
 msgstr ""
 
@@ -1664,20 +1664,20 @@ msgid "Sorting files"
 msgstr ""
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4450
-#: ../../Firmware/ultralcd.cpp:4453 ../../Firmware/ultralcd.cpp:4456
-#: ../../Firmware/ultralcd.cpp:4459 ../../Firmware/ultralcd.cpp:4462
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/ultralcd.cpp:4472 ../../Firmware/ultralcd.cpp:4475
+#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4481
 msgid "Sound"
 msgstr ""
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5718
+#: ../../Firmware/ultralcd.cpp:5740
 msgid "Speed"
 msgstr ""
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7166
-#: ../../Firmware/ultralcd.cpp:7181 ../../Firmware/ultralcd.cpp:7189
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7196
+#: ../../Firmware/ultralcd.cpp:7211 ../../Firmware/ultralcd.cpp:7219
 msgid "Spinning"
 msgstr ""
 
@@ -1687,42 +1687,42 @@ msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr ""
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5585
+#: ../../Firmware/ultralcd.cpp:5607
 msgid "Statistics"
 msgstr ""
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4338
-#: ../../Firmware/ultralcd.cpp:4382 ../../Firmware/ultralcd.cpp:5770
+#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4357
+#: ../../Firmware/ultralcd.cpp:4401 ../../Firmware/ultralcd.cpp:5792
 msgid "Stealth"
 msgstr ""
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4763
-#: ../../Firmware/ultralcd.cpp:5416
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4782
+#: ../../Firmware/ultralcd.cpp:5438
 msgid "Steel sheets"
 msgstr ""
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5528
-#: ../../Firmware/ultralcd.cpp:5987
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5550
+#: ../../Firmware/ultralcd.cpp:6017
 msgid "Stop print"
 msgstr ""
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4499
-#: ../../Firmware/ultralcd.cpp:4581 ../../Firmware/ultralcd.cpp:4620
-#: ../../Firmware/ultralcd.cpp:4661
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4518
+#: ../../Firmware/ultralcd.cpp:4600 ../../Firmware/ultralcd.cpp:4639
+#: ../../Firmware/ultralcd.cpp:4680
 msgid "Strict"
 msgstr ""
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/ultralcd.cpp:5616
 msgid "Support"
 msgstr ""
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:7021
+#: ../../Firmware/ultralcd.cpp:7051
 msgid "Swapped"
 msgstr ""
 
@@ -1731,28 +1731,18 @@ msgstr ""
 msgid "THERMAL ANOMALY"
 msgstr ""
 
-#. MSG_TM_AUTOTUNE_FAILED c=20
-#: ../../Firmware/temperature.cpp:2899
-msgid "TM autotune failed"
-msgstr ""
-
-#. MSG_TEMP_MODEL_AUTOTUNE c=20
-#: ../../Firmware/temperature.cpp:2884
-msgid "Temp. model autotune"
-msgstr ""
-
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4797
+#: ../../Firmware/ultralcd.cpp:4816
 msgid "Temperature"
 msgstr ""
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1729
+#: ../../Firmware/ultralcd.cpp:1748
 msgid "Temperatures"
 msgstr ""
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3974
+#: ../../Firmware/ultralcd.cpp:3993
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -1767,66 +1757,66 @@ msgid ""
 msgstr ""
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4403
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4422
 msgid "Time"
 msgstr ""
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:5865
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:5887
 msgid "Timeout"
 msgstr ""
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:1149
-#: ../../Firmware/ultralcd.cpp:1297
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:1168
+#: ../../Firmware/ultralcd.cpp:1316
 msgid "Total"
 msgstr ""
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:1192
-#: ../../Firmware/ultralcd.cpp:1218 ../../Firmware/ultralcd.cpp:1328
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:1211
+#: ../../Firmware/ultralcd.cpp:1237 ../../Firmware/ultralcd.cpp:1347
 msgid "Total failures"
 msgstr ""
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2387
+#: ../../Firmware/ultralcd.cpp:2406
 msgid "Total filament"
 msgstr ""
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2388
+#: ../../Firmware/ultralcd.cpp:2407
 msgid "Total print time"
 msgstr ""
 
 #. MSG_TUNE c=18
-#: ../../Firmware/ultralcd.cpp:5500
+#: ../../Firmware/ultralcd.cpp:5522
 msgid "Tune"
 msgstr ""
 
 #. MSG_UNLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:5564
-#: ../../Firmware/ultralcd.cpp:5578
+#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:5586
+#: ../../Firmware/ultralcd.cpp:5600
 msgid "Unload filament"
 msgstr ""
 
 #. MSG_UNLOADING_FILAMENT c=20
 #: ../../Firmware/messages.cpp:112 ../../Firmware/mmu.cpp:957
-#: ../../Firmware/ultralcd.cpp:5197
+#: ../../Firmware/ultralcd.cpp:5219
 msgid "Unloading filament"
 msgstr ""
 
 #. MSG_FIL_FAILED c=20 r=5
-#: ../../Firmware/ultralcd.cpp:6258
+#: ../../Firmware/ultralcd.cpp:6288
 msgid "Verification failed, remove the filament and try again."
 msgstr ""
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1732
+#: ../../Firmware/ultralcd.cpp:1751
 msgid "Voltages"
 msgstr ""
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3534
+#: ../../Firmware/ultralcd.cpp:3553
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -1840,19 +1830,19 @@ msgid "Wait for user..."
 msgstr ""
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2881
+#: ../../Firmware/ultralcd.cpp:2900
 msgid "Waiting for PINDA probe cooling"
 msgstr ""
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2913
+#: ../../Firmware/ultralcd.cpp:2932
 msgid "Waiting for nozzle and bed cooling"
 msgstr ""
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:4496
-#: ../../Firmware/ultralcd.cpp:4578 ../../Firmware/ultralcd.cpp:4617
-#: ../../Firmware/ultralcd.cpp:4658
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/ultralcd.cpp:4597 ../../Firmware/ultralcd.cpp:4636
+#: ../../Firmware/ultralcd.cpp:4677
 msgid "Warn"
 msgstr ""
 
@@ -1877,144 +1867,133 @@ msgid "Was filament unload successful?"
 msgstr ""
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6973
-#: ../../Firmware/ultralcd.cpp:6977 ../../Firmware/ultralcd.cpp:6997
-#: ../../Firmware/ultralcd.cpp:7003 ../../Firmware/ultralcd.cpp:7027
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:7003
+#: ../../Firmware/ultralcd.cpp:7007 ../../Firmware/ultralcd.cpp:7027
+#: ../../Firmware/ultralcd.cpp:7033 ../../Firmware/ultralcd.cpp:7057
 msgid "Wiring error"
 msgstr ""
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4895
+#: ../../Firmware/ultralcd.cpp:4914
 msgid "Wizard"
 msgstr ""
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4210
+#: ../../Firmware/ultralcd.cpp:4229
 msgid "X-correct:"
 msgstr ""
 
 #. MSG_XFLASH c=18
-#: ../../Firmware/ultralcd.cpp:5596
+#: ../../Firmware/ultralcd.cpp:5618
 msgid "XFLASH init"
 msgstr ""
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1721
+#: ../../Firmware/ultralcd.cpp:1740
 msgid "XYZ cal. details"
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3333
+#: ../../Firmware/ultralcd.cpp:3352
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3330
+#: ../../Firmware/ultralcd.cpp:3349
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3311
+#: ../../Firmware/ultralcd.cpp:3330
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr ""
 
-#. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_LEFT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3317
-msgid ""
-"XYZ calibration compromised. Left front calibration point not reachable."
-msgstr ""
-
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3314
+#: ../../Firmware/ultralcd.cpp:3333
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3293
+#: ../../Firmware/ultralcd.cpp:3312
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3299
+#: ../../Firmware/ultralcd.cpp:3318
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr ""
 
-#. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_LEFT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3305
-msgid "XYZ calibration failed. Left front calibration point not reachable."
-msgstr ""
-
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3296
-#: ../../Firmware/ultralcd.cpp:3324
+#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3315
+#: ../../Firmware/ultralcd.cpp:3343
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3302
+#: ../../Firmware/ultralcd.cpp:3321
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3327
+#: ../../Firmware/ultralcd.cpp:3346
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr ""
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2494
+#: ../../Firmware/ultralcd.cpp:2513
 msgid "Y distance from min"
 msgstr ""
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4211
+#: ../../Firmware/ultralcd.cpp:4230
 msgid "Y-correct:"
 msgstr ""
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:2216
-#: ../../Firmware/ultralcd.cpp:2800 ../../Firmware/ultralcd.cpp:3180
-#: ../../Firmware/ultralcd.cpp:4785 ../../Firmware/ultralcd.cpp:5989
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:2235
+#: ../../Firmware/ultralcd.cpp:2819 ../../Firmware/ultralcd.cpp:3199
+#: ../../Firmware/ultralcd.cpp:4804 ../../Firmware/ultralcd.cpp:6019
 msgid "Yes"
 msgstr ""
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:4187
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:4206
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr ""
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4231
 msgid "Z-correct:"
 msgstr ""
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:5835
+#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:5857
 msgid "Z-probe nr."
 msgstr ""
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2565
+#: ../../Firmware/ultralcd.cpp:2584
 msgid "[0;0] point offset"
 msgstr ""
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2154
+#: ../../Firmware/ultralcd.cpp:2173
 msgid "and press the knob"
 msgstr ""
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1816
+#: ../../Firmware/ultralcd.cpp:1835
 msgid "to load filament"
 msgstr ""
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1820
+#: ../../Firmware/ultralcd.cpp:1839
 msgid "to unload filament"
 msgstr ""
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1688
+#: ../../Firmware/ultralcd.cpp:1707
 msgid "unknown"
 msgstr ""
 
@@ -2024,7 +2003,7 @@ msgid "unknown state"
 msgstr ""
 
 #. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:6077
-#: ../../Firmware/ultralcd.cpp:6080
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:6107
+#: ../../Firmware/ultralcd.cpp:6110
 msgid "🔃Refresh"
 msgstr ""

--- a/lang/po/Firmware_de.po
+++ b/lang/po/Firmware_de.po
@@ -26,89 +26,89 @@ msgid " 0.4 or newer"
 msgstr " 0.4 oder neuer"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:7036
+#: ../../Firmware/ultralcd.cpp:7066
 msgid "%s level expected"
 msgstr "%s Level erwartet"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1968
-#: ../../Firmware/ultralcd.cpp:3835
+#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1987
+#: ../../Firmware/ultralcd.cpp:3854
 msgid ">Cancel"
 msgstr ">Abbruch"
 
 #. MSG_BABYSTEPPING_Z c=15
 #. Beware: must include the ':' as its last character
-#: ../../Firmware/ultralcd.cpp:2670
+#: ../../Firmware/ultralcd.cpp:2689
 msgid "Adjusting Z:"
 msgstr "Z Anpassen:"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:7313
+#: ../../Firmware/ultralcd.cpp:7343
 msgid "All correct"
 msgstr "Alles richtig"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4180
+#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4190
+#: ../../Firmware/ultralcd.cpp:4199
 msgid "All is done. Happy printing!"
 msgstr "Alles abgeschlossen. Viel Spaß beim Drucken!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4404
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4423
 msgid "Alphabet"
 msgstr "Alphabet"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4308
+#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4327
 msgid "Always"
 msgstr "Immer"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1405
+#: ../../Firmware/ultralcd.cpp:1424
 msgid "Ambient"
 msgstr "Raumtemp."
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2983
+#: ../../Firmware/ultralcd.cpp:3002
 msgid "Are left and right Z~carriages all up?"
 msgstr "Sind linke+rechte Z- Schlitten ganz oben?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4478
 msgid "Assist"
 msgstr "Assist."
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:5886
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
 #: ../../Firmware/Marlin_main.cpp:3271 ../../Firmware/messages.cpp:9
-#: ../../Firmware/ultralcd.cpp:4900
+#: ../../Firmware/ultralcd.cpp:4919
 msgid "Auto home"
 msgstr "Startposition"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:4364
-#: ../../Firmware/ultralcd.cpp:5779
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:4383
+#: ../../Firmware/ultralcd.cpp:5801
 msgid "Auto power"
 msgstr "Auto Leist"
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5572
+#: ../../Firmware/ultralcd.cpp:5594
 msgid "AutoLoad filament"
 msgstr "AutoLaden Filament"
 
 #. MSG_AUTOLOADING_ONLY_IF_FSENS_ON c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3549
+#: ../../Firmware/ultralcd.cpp:3568
 msgid ""
 "Autoloading filament available only when filament sensor is turned on..."
 msgstr ""
 "Automatisches Laden Filament nur bei eingeschaltetem Fil. sensor verfügbar..."
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2301
+#: ../../Firmware/ultralcd.cpp:2320
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
@@ -116,26 +116,26 @@ msgstr ""
 "einlegen..."
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:7015
+#: ../../Firmware/ultralcd.cpp:7045
 msgid "Axis"
 msgstr "Achse"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:7014
+#: ../../Firmware/ultralcd.cpp:7044
 msgid "Axis length"
 msgstr "Achsenlänge"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:2751
-#: ../../Firmware/ultralcd.cpp:5861 ../../Firmware/ultralcd.cpp:7838
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:2770
+#: ../../Firmware/ultralcd.cpp:5883 ../../Firmware/ultralcd.cpp:7878
 msgid "Back"
 msgstr "Zurück"
 
 #. MSG_BED c=13
 #: ../../Firmware/Marlin_main.cpp:2051 ../../Firmware/Marlin_main.cpp:4767
 #: ../../Firmware/Marlin_main.cpp:4819 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:1403 ../../Firmware/ultralcd.cpp:5721
-#: ../../Firmware/ultralcd.cpp:5891
+#: ../../Firmware/ultralcd.cpp:1422 ../../Firmware/ultralcd.cpp:5743
+#: ../../Firmware/ultralcd.cpp:5913
 msgid "Bed"
 msgstr "Bett"
 
@@ -152,7 +152,7 @@ msgid "Bed done"
 msgstr "Bett OK"
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4912
+#: ../../Firmware/ultralcd.cpp:4931
 msgid "Bed level correct"
 msgstr "Bett Level Korr."
 
@@ -169,18 +169,18 @@ msgstr ""
 "Z-Kal. fehlgeschlg. Sensor nicht ausgelöst. Schmutzige Düse? Warte auf Reset."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6972
+#: ../../Firmware/ultralcd.cpp:7002
 msgid "Bed/Heater"
 msgstr "Bett/Heizung"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1458
-#: ../../Firmware/ultralcd.cpp:1726
+#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1477
+#: ../../Firmware/ultralcd.cpp:1745
 msgid "Belt status"
 msgstr "Gurtstatus"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4902
+#: ../../Firmware/ultralcd.cpp:4921
 msgid "Belt test"
 msgstr "Riementest"
 
@@ -191,28 +191,28 @@ msgid "Blackout occurred. Recover print?"
 msgstr "Stromausfall! Druck wiederherstellen?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:5886
 msgid "Bright"
 msgstr "Hell"
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4850
-#: ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4869
+#: ../../Firmware/ultralcd.cpp:5811
 msgid "Brightness"
 msgstr "Helligkeit"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4906
+#: ../../Firmware/ultralcd.cpp:4925
 msgid "Calibrate XYZ"
 msgstr "Kalibrierung XYZ"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4908
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4927
 msgid "Calibrate Z"
 msgstr "Kalibrierung Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2946
+#: ../../Firmware/ultralcd.cpp:2965
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -227,7 +227,7 @@ msgid "Calibrating Z"
 msgstr "Kalibriere Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2945
+#: ../../Firmware/ultralcd.cpp:2964
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -236,12 +236,12 @@ msgstr ""
 "Anschliessend den Knopf drücken."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:7315
+#: ../../Firmware/ultralcd.cpp:7345
 msgid "Calibrating home"
 msgstr "Kalibriere Start"
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:5581
+#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:5603
 msgid "Calibration"
 msgstr "Kalibrierung"
 
@@ -251,115 +251,115 @@ msgid "Calibration done"
 msgstr "Kalibrierung OK"
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7712
+#: ../../Firmware/ultralcd.cpp:7752
 msgid "Card removed"
 msgstr "SD Karte entfernt"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/ultralcd.cpp:5560
 msgid "Change SD card"
 msgstr "Wechsel SD Karte"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5497
-#: ../../Firmware/ultralcd.cpp:5730
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5519
+#: ../../Firmware/ultralcd.cpp:5752
 msgid "Change filament"
 msgstr "Filament-Wechsel"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2163
+#: ../../Firmware/ultralcd.cpp:2182
 msgid "Change success!"
 msgstr "Wechsel erfolgr.!"
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2215
+#: ../../Firmware/ultralcd.cpp:2234
 msgid "Changed correctly?"
 msgstr "Wechsel ok?"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:6178
-#: ../../Firmware/ultralcd.cpp:7305
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:6208
+#: ../../Firmware/ultralcd.cpp:7335
 msgid "Checking X axis"
 msgstr "Prüfe X Achse"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:6187
-#: ../../Firmware/ultralcd.cpp:7306
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:6217
+#: ../../Firmware/ultralcd.cpp:7336
 msgid "Checking Y axis"
 msgstr "Prüfe Y Achse"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:7307
+#: ../../Firmware/ultralcd.cpp:7337
 msgid "Checking Z axis"
 msgstr "Prüfe Z Achse"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:7308
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:7338
 msgid "Checking bed"
 msgstr "Prüfe Bett"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:7304
+#: ../../Firmware/ultralcd.cpp:7334
 msgid "Checking endstops"
 msgstr "Prüfe Endschalter"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:7403
+#: ../../Firmware/ultralcd.cpp:7433
 msgid "Checking file"
 msgstr "Überprüfe Datei"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:7310
+#: ../../Firmware/ultralcd.cpp:7340
 msgid "Checking hotend"
 msgstr "Prüfe Düse"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:7311
-#: ../../Firmware/ultralcd.cpp:7312
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:7341
+#: ../../Firmware/ultralcd.cpp:7342
 msgid "Checking sensors"
 msgstr "Prüfe Sensoren"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4765
+#: ../../Firmware/ultralcd.cpp:4784
 msgid "Checks"
 msgstr "Kontrolle"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2218
+#: ../../Firmware/ultralcd.cpp:2237
 msgid "Color not correct"
 msgstr "Falsche Farbe"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3725
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3744
 msgid "Community made"
 msgstr "Von der Community"
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4704
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4723
 msgid "Cont."
 msgstr "Weit."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2125
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2144
 msgid "Cooldown"
 msgstr "Abkühlen"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3663
+#: ../../Firmware/ultralcd.cpp:3682
 msgid "Copy selected language?"
 msgstr "Gewählte Sprache kopieren?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1221
-#: ../../Firmware/ultralcd.cpp:1262 ../../Firmware/ultralcd.cpp:1272
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1240
+#: ../../Firmware/ultralcd.cpp:1281 ../../Firmware/ultralcd.cpp:1291
 msgid "Crash"
 msgstr "Crash"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4341
-#: ../../Firmware/ultralcd.cpp:4342 ../../Firmware/ultralcd.cpp:4344
-#: ../../Firmware/ultralcd.cpp:5765 ../../Firmware/ultralcd.cpp:5767
-#: ../../Firmware/ultralcd.cpp:5771
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4363
+#: ../../Firmware/ultralcd.cpp:5787 ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/ultralcd.cpp:5793
 msgid "Crash det."
 msgstr "Crash Erk."
 
@@ -369,7 +369,7 @@ msgid "Crash detected."
 msgstr "Crash erkannt."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3521
+#: ../../Firmware/ultralcd.cpp:3540
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -380,14 +380,14 @@ msgstr ""
 "genutzt werden"
 
 #. MSG_CUT_FILAMENT c=17
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:5175
-#: ../../Firmware/ultralcd.cpp:5567
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:5197
+#: ../../Firmware/ultralcd.cpp:5589
 msgid "Cut filament"
 msgstr "Fil. schneiden"
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:4303
-#: ../../Firmware/ultralcd.cpp:4308 ../../Firmware/ultralcd.cpp:4313
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:4322
+#: ../../Firmware/ultralcd.cpp:4327 ../../Firmware/ultralcd.cpp:4332
 msgid "Cutter"
 msgstr "Messer"
 
@@ -397,17 +397,17 @@ msgid "Cutting filament"
 msgstr "Schneide filament"
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1668
+#: ../../Firmware/ultralcd.cpp:1687
 msgid "Date:"
 msgstr "Datum:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5886
 msgid "Dim"
 msgstr "Dimm"
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4802
+#: ../../Firmware/ultralcd.cpp:4821
 msgid "Disable steppers"
 msgstr "Motoren aus"
 
@@ -424,7 +424,7 @@ msgstr ""
 "Abschnitt Erste Schicht Kalibrierung."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:4145
+#: ../../Firmware/ultralcd.cpp:4164
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -433,23 +433,23 @@ msgstr ""
 "und Druckbett neu einzustellen?"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4214
+#: ../../Firmware/ultralcd.cpp:4233
 msgid "E-correct:"
 msgstr "E-Korrektur:"
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2279
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2298
 msgid "ERROR:"
 msgstr "FEHLER:"
 
 #. MSG_FSENS_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3562
+#: ../../Firmware/ultralcd.cpp:3581
 msgid "ERROR: Filament sensor is not responding, please check connection."
 msgstr "FEHLER: Filament- sensor reagiert nicht, bitte Verbindung prüfen."
 
 #. MSG_EJECT_FILAMENT c=17
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:5156
-#: ../../Firmware/ultralcd.cpp:5565
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:5178
+#: ../../Firmware/ultralcd.cpp:5587
 msgid "Eject filament"
 msgstr "Filamentauswurf"
 
@@ -459,47 +459,41 @@ msgid "Ejecting filament"
 msgstr "werfe Filament aus"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6985
+#: ../../Firmware/ultralcd.cpp:7015
 msgid "Endstop"
 msgstr "Endanschlag"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6990
+#: ../../Firmware/ultralcd.cpp:7020
 msgid "Endstop not hit"
 msgstr "Ende nicht getroffen"
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6976
+#: ../../Firmware/ultralcd.cpp:7006
 msgid "Endstops"
 msgstr "Endschalter"
 
 #. MSG_EXTRUDER c=17
 #: ../../Firmware/Marlin_main.cpp:8608 ../../Firmware/messages.cpp:30
-#: ../../Firmware/ultralcd.cpp:3495
+#: ../../Firmware/ultralcd.cpp:3514
 msgid "Extruder"
 msgstr "Extruder"
 
-#. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1144
-#: ../../Firmware/ultralcd.cpp:7319
-msgid "Hotend fan:"
-msgstr "Hotend-Lüfter:"
-
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1722
+#: ../../Firmware/ultralcd.cpp:1741
 msgid "Extruder info"
 msgstr "Extruder Info"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4229
-#: ../../Firmware/ultralcd.cpp:4237 ../../Firmware/ultralcd.cpp:4248
-#: ../../Firmware/ultralcd.cpp:4250
+#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4248
+#: ../../Firmware/ultralcd.cpp:4256 ../../Firmware/ultralcd.cpp:4267
+#: ../../Firmware/ultralcd.cpp:4269
 msgid "F. autoload"
 msgstr "F. autoladen"
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4704
-#: ../../Firmware/ultralcd.cpp:4707
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4723
+#: ../../Firmware/ultralcd.cpp:4726
 msgid "FS Action"
 msgstr "FS Aktion"
 
@@ -514,102 +508,102 @@ msgid "FS v0.4 or newer"
 msgstr "FS v0.4 oder neuer"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5589
+#: ../../Firmware/ultralcd.cpp:5611
 msgid "Fail stats"
 msgstr "Fehlerstatistik"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5592
+#: ../../Firmware/ultralcd.cpp:5614
 msgid "Fail stats MMU"
 msgstr "MMU-Fehler"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:7031
+#: ../../Firmware/ultralcd.cpp:7061
 msgid "False triggering"
 msgstr "Falschtriggerung"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:5723
-#: ../../Firmware/ultralcd.cpp:5893
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/ultralcd.cpp:5915
 msgid "Fan speed"
 msgstr "Lüfter-Tempo"
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:7143
-#: ../../Firmware/ultralcd.cpp:7301 ../../Firmware/ultralcd.cpp:7302
-#: ../../Firmware/ultralcd.cpp:7303
+#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:7173
+#: ../../Firmware/ultralcd.cpp:7331 ../../Firmware/ultralcd.cpp:7332
+#: ../../Firmware/ultralcd.cpp:7333
 msgid "Fan test"
 msgstr "Lüftertest"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4811
-#: ../../Firmware/ultralcd.cpp:5756
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4830
+#: ../../Firmware/ultralcd.cpp:5778
 msgid "Fans check"
 msgstr "Lüfter Check"
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1220
-#: ../../Firmware/ultralcd.cpp:1261 ../../Firmware/ultralcd.cpp:1327
-#: ../../Firmware/ultralcd.cpp:1329
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1239
+#: ../../Firmware/ultralcd.cpp:1280 ../../Firmware/ultralcd.cpp:1346
+#: ../../Firmware/ultralcd.cpp:1348
 msgid "Fil. runouts"
 msgstr "Fil. Mängel"
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:3451
-#: ../../Firmware/ultralcd.cpp:4228 ../../Firmware/ultralcd.cpp:4234
-#: ../../Firmware/ultralcd.cpp:4244 ../../Firmware/ultralcd.cpp:5737
-#: ../../Firmware/ultralcd.cpp:5741 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:3470
+#: ../../Firmware/ultralcd.cpp:4247 ../../Firmware/ultralcd.cpp:4253
+#: ../../Firmware/ultralcd.cpp:4263 ../../Firmware/ultralcd.cpp:5759
+#: ../../Firmware/ultralcd.cpp:5763 ../../Firmware/ultralcd.cpp:5767
 msgid "Fil. sensor"
 msgstr "Fil. Sensor"
 
 #. MSG_FILAMENT c=17
 #: ../../Firmware/Marlin_main.cpp:8577 ../../Firmware/Marlin_main.cpp:8604
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3835
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3854
 msgid "Filament"
 msgstr "Filament"
 
 #. MSG_FILAMENT_CLEAN c=20 r=2
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2287
-#: ../../Firmware/ultralcd.cpp:2293
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2306
+#: ../../Firmware/ultralcd.cpp:2312
 msgid "Filament extruding & with correct color?"
 msgstr "Filament extrudiert mit richtiger Farbe?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2217
+#: ../../Firmware/ultralcd.cpp:2236
 msgid "Filament not loaded"
 msgstr "Fil. nicht geladen"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:7026
-#: ../../Firmware/ultralcd.cpp:7030 ../../Firmware/ultralcd.cpp:7034
-#: ../../Firmware/ultralcd.cpp:7330
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:7056
+#: ../../Firmware/ultralcd.cpp:7060 ../../Firmware/ultralcd.cpp:7064
+#: ../../Firmware/ultralcd.cpp:7360
 msgid "Filament sensor"
 msgstr "Filamentsensor"
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2365
+#: ../../Firmware/ultralcd.cpp:2384
 msgid "Filament used"
 msgstr "Filament benutzt"
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7461
+#: ../../Firmware/ultralcd.cpp:7491
 msgid "File incomplete. Continue anyway?"
 msgstr "Datei unvollständig Trotzdem fortfahren?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:5314
-#: ../../Firmware/ultralcd.cpp:5630
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:5336
+#: ../../Firmware/ultralcd.cpp:5652
 msgid "Finishing movements"
 msgstr "Bewegung beenden"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:4898
-#: ../../Firmware/ultralcd.cpp:5424
+#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:4917
+#: ../../Firmware/ultralcd.cpp:5446
 msgid "First layer cal."
 msgstr "Erste-Schicht Kal."
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4066
+#: ../../Firmware/ultralcd.cpp:4085
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Zunächst führe ich den Selbsttest durch, um die häufigsten Probleme beim "
@@ -621,23 +615,23 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr "Beseitigen Sie das Problem und drücken Sie dann den Knopf am MMU."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5724
+#: ../../Firmware/ultralcd.cpp:5746
 msgid "Flow"
 msgstr "Durchfluss"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:6996
-#: ../../Firmware/ultralcd.cpp:7149 ../../Firmware/ultralcd.cpp:7154
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:7026
+#: ../../Firmware/ultralcd.cpp:7179 ../../Firmware/ultralcd.cpp:7184
 msgid "Front print fan?"
 msgstr "Drucklüfter?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2754
+#: ../../Firmware/ultralcd.cpp:2773
 msgid "Front side[μm]"
 msgstr "Vorne [μm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:7020
+#: ../../Firmware/ultralcd.cpp:7050
 msgid "Front/left fans"
 msgstr "Druck/Extr. Lüfter"
 
@@ -686,20 +680,20 @@ msgstr ""
 "Druck abgebrochen."
 
 #. MSG_GCODE c=8
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:4655
-#: ../../Firmware/ultralcd.cpp:4658 ../../Firmware/ultralcd.cpp:4661
-#: ../../Firmware/ultralcd.cpp:4664
+#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:4674
+#: ../../Firmware/ultralcd.cpp:4677 ../../Firmware/ultralcd.cpp:4680
+#: ../../Firmware/ultralcd.cpp:4683
 msgid "Gcode"
 msgstr "Gcode"
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:4672
-#: ../../Firmware/ultralcd.cpp:4726 ../../Firmware/ultralcd.cpp:4818
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:4691
+#: ../../Firmware/ultralcd.cpp:4745 ../../Firmware/ultralcd.cpp:4837
 msgid "HW Setup"
 msgstr "HW Einstellungen"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6968
+#: ../../Firmware/ultralcd.cpp:6998
 msgid "Heater/Thermistor"
 msgstr "Heizung/Thermistor"
 
@@ -721,7 +715,7 @@ msgid "Heating done."
 msgstr "Aufwärmen OK."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=16
-#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4042
+#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4061
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -732,7 +726,7 @@ msgstr ""
 "Danach sind Sie bereit für den Druck."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4064
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -741,26 +735,32 @@ msgstr ""
 "durch den Einricht- ungsablauf führe?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:4358
-#: ../../Firmware/ultralcd.cpp:4367 ../../Firmware/ultralcd.cpp:5777
-#: ../../Firmware/ultralcd.cpp:5780
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:4377
+#: ../../Firmware/ultralcd.cpp:4386 ../../Firmware/ultralcd.cpp:5799
+#: ../../Firmware/ultralcd.cpp:5802
 msgid "High power"
 msgstr "Hohe leist"
 
+#. MSG_HOTEND_FAN_SPEED c=15
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1145
+#: ../../Firmware/ultralcd.cpp:7351
+msgid "Hotend fan:"
+msgstr "Hotend-Lüfter:"
+
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4094
 msgid "I will run xyz calibration now. It will take approx. 12 mins."
 msgstr ""
 "Ich werde jetzt die XYZ-Kalibrierung durchführen. Es wird ca. 12 Minuten "
 "dauern."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/ultralcd.cpp:4102
 msgid "I will run z calibration now."
 msgstr "Ich werde jetzt die Z Kalibrierung durchführen."
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=9
-#: ../../Firmware/ultralcd.cpp:4153
+#: ../../Firmware/ultralcd.cpp:4172
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -774,22 +774,22 @@ msgid "Improving bed calibration point"
 msgstr "Verbesserung des Bettkalibrierungspunkts"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:5478
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:5500
 msgid "Info screen"
 msgstr "Infoanzeige"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5545
+#: ../../Firmware/ultralcd.cpp:5567
 msgid "Init. SD card"
 msgstr "Init. SD Karte"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2152
+#: ../../Firmware/ultralcd.cpp:2171
 msgid "Insert filament"
 msgstr "Filament einlegen"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:6223
+#: ../../Firmware/ultralcd.cpp:6253
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
@@ -798,14 +798,14 @@ msgstr ""
 "den Knopf."
 
 #. MSG_FILAMENT_LOADED c=20 r=2
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3855
-#: ../../Firmware/ultralcd.cpp:4108 ../../Firmware/ultralcd.cpp:4111
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3874
+#: ../../Firmware/ultralcd.cpp:4127 ../../Firmware/ultralcd.cpp:4130
 msgid "Is filament loaded?"
 msgstr "Ist das Filament geladen?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=2
 #: ../../Firmware/Marlin_main.cpp:3312 ../../Firmware/Marlin_main.cpp:4886
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:4084
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:4103
 msgid "Is steel sheet on heatbed?"
 msgstr "Liegt das Stahlblech auf dem Heizbett?"
 
@@ -815,74 +815,74 @@ msgid "Iteration"
 msgstr "Wiederholung"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:1148
-#: ../../Firmware/ultralcd.cpp:1296
+#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:1167
+#: ../../Firmware/ultralcd.cpp:1315
 msgid "Last print"
 msgstr "Letzter Druck"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1169
-#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1269
-#: ../../Firmware/ultralcd.cpp:1326
+#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1188
+#: ../../Firmware/ultralcd.cpp:1278 ../../Firmware/ultralcd.cpp:1288
+#: ../../Firmware/ultralcd.cpp:1345
 msgid "Last print failures"
 msgstr "Letzte Druckfehler"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2496
+#: ../../Firmware/ultralcd.cpp:2515
 msgid "Left"
 msgstr "Links"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7001
-#: ../../Firmware/ultralcd.cpp:7147 ../../Firmware/ultralcd.cpp:7152
+#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:7032
+#: ../../Firmware/ultralcd.cpp:7179 ../../Firmware/ultralcd.cpp:7184
 msgid "Left hotend fan?"
 msgstr "Extruderlüfter?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2752
+#: ../../Firmware/ultralcd.cpp:2771
 msgid "Left side [μm]"
 msgstr "Links [μm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:5862
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:5884
 msgid "Level Bright"
 msgstr "Hell.wert"
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:5863
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:5885
 msgid "Level Dimmed"
 msgstr "Dimmwert"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4826
+#: ../../Firmware/ultralcd.cpp:4845
 msgid "Lin. correction"
 msgstr "Lineare Korrektur"
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4838
-#: ../../Firmware/ultralcd.cpp:5493
+#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4857
+#: ../../Firmware/ultralcd.cpp:5515
 msgid "Live adjust Z"
 msgstr "Z einstellen"
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/ultralcd.cpp:5120
+#: ../../Firmware/ultralcd.cpp:5142
 msgid "Load all"
 msgstr "Alle laden"
 
 #. MSG_LOAD_FILAMENT c=17
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:5122
-#: ../../Firmware/ultralcd.cpp:5133 ../../Firmware/ultralcd.cpp:5562
-#: ../../Firmware/ultralcd.cpp:5576
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:5144
+#: ../../Firmware/ultralcd.cpp:5155 ../../Firmware/ultralcd.cpp:5584
+#: ../../Firmware/ultralcd.cpp:5598
 msgid "Load filament"
 msgstr "Filament laden"
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5563
+#: ../../Firmware/ultralcd.cpp:5585
 msgid "Load to nozzle"
 msgstr "In Düse laden"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2185
+#: ../../Firmware/ultralcd.cpp:2204
 msgid "Loading color"
 msgstr "Lade Farbe"
 
@@ -890,18 +890,18 @@ msgstr "Lade Farbe"
 #: ../../Firmware/Marlin_main.cpp:3641 ../../Firmware/messages.cpp:55
 #: ../../Firmware/mmu.cpp:872 ../../Firmware/mmu.cpp:906
 #: ../../Firmware/mmu.cpp:1014 ../../Firmware/mmu.cpp:1026
-#: ../../Firmware/ultralcd.cpp:2196 ../../Firmware/ultralcd.cpp:3949
+#: ../../Firmware/ultralcd.cpp:2215 ../../Firmware/ultralcd.cpp:3968
 msgid "Loading filament"
 msgstr "Filament lädt"
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:7008
+#: ../../Firmware/ultralcd.cpp:7038
 msgid "Loose pulley"
 msgstr "Lose Riemenscheibe"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:4450
-#: ../../Firmware/ultralcd.cpp:4462
+#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/ultralcd.cpp:4481
 msgid "Loud"
 msgstr "Laut"
 
@@ -916,8 +916,8 @@ msgid "MK3S firmware detected on MK3 printer"
 msgstr "MK3S-Firmware auf MK3-Drucker erkannt"
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4381
-#: ../../Firmware/ultralcd.cpp:4382
+#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4400
+#: ../../Firmware/ultralcd.cpp:4401
 msgid "MMU Mode"
 msgstr "MMU Mod."
 
@@ -937,8 +937,8 @@ msgid "MMU OK. Resuming..."
 msgstr "MMU OK. Weiterdrucken..."
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:64 ../../Firmware/ultralcd.cpp:1170
-#: ../../Firmware/ultralcd.cpp:1193
+#: ../../Firmware/messages.cpp:64 ../../Firmware/ultralcd.cpp:1189
+#: ../../Firmware/ultralcd.cpp:1212
 msgid "MMU fails"
 msgstr "MMU Fehler"
 
@@ -948,8 +948,8 @@ msgid "MMU load failed"
 msgstr "MMU Ladefehler"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:1171
-#: ../../Firmware/ultralcd.cpp:1194
+#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:1190
+#: ../../Firmware/ultralcd.cpp:1213
 msgid "MMU load fails"
 msgstr "MMU Ladefehler"
 
@@ -959,32 +959,32 @@ msgid "MMU needs user attention."
 msgstr "MMU erfordert Benutzereingriff."
 
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/ultralcd.cpp:1195
+#: ../../Firmware/ultralcd.cpp:1214
 msgid "MMU power fails"
 msgstr "MMU Netzfehler"
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1680
+#: ../../Firmware/ultralcd.cpp:1699
 msgid "MMU2 connected"
 msgstr "MMU2 verbunden"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:5836
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:5858
 msgid "Magnets comp."
 msgstr "Magnet Komp."
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1147
-#: ../../Firmware/ultralcd.cpp:1295 ../../Firmware/ultralcd.cpp:1338
-#: ../../Firmware/ultralcd.cpp:1645 ../../Firmware/ultralcd.cpp:4795
-#: ../../Firmware/ultralcd.cpp:4892 ../../Firmware/ultralcd.cpp:5119
-#: ../../Firmware/ultralcd.cpp:5131 ../../Firmware/ultralcd.cpp:5154
-#: ../../Firmware/ultralcd.cpp:5173 ../../Firmware/ultralcd.cpp:5717
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1166
+#: ../../Firmware/ultralcd.cpp:1314 ../../Firmware/ultralcd.cpp:1357
+#: ../../Firmware/ultralcd.cpp:1664 ../../Firmware/ultralcd.cpp:4814
+#: ../../Firmware/ultralcd.cpp:4911 ../../Firmware/ultralcd.cpp:5141
+#: ../../Firmware/ultralcd.cpp:5153 ../../Firmware/ultralcd.cpp:5176
+#: ../../Firmware/ultralcd.cpp:5195 ../../Firmware/ultralcd.cpp:5739
 msgid "Main"
 msgstr "Hauptmenü"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2537
+#: ../../Firmware/ultralcd.cpp:2556
 msgid "Measured skew"
 msgstr "Schräglauf"
 
@@ -995,71 +995,71 @@ msgid "Measuring reference height of calibration point"
 msgstr "Messen der Referenzhöhe des Kalibrierpunktes"
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:5832
+#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:5854
 msgid "Mesh"
 msgstr "Gitter"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4823
-#: ../../Firmware/ultralcd.cpp:4910
+#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4842
+#: ../../Firmware/ultralcd.cpp:4929
 msgid "Mesh Bed Leveling"
 msgstr "MeshBett Ausgleich"
 
 #. MSG_MODE c=6
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:4336
-#: ../../Firmware/ultralcd.cpp:4338 ../../Firmware/ultralcd.cpp:4358
-#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4364
-#: ../../Firmware/ultralcd.cpp:4367 ../../Firmware/ultralcd.cpp:5763
-#: ../../Firmware/ultralcd.cpp:5770 ../../Firmware/ultralcd.cpp:5777
-#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5779
-#: ../../Firmware/ultralcd.cpp:5780 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/ultralcd.cpp:4357 ../../Firmware/ultralcd.cpp:4377
+#: ../../Firmware/ultralcd.cpp:4380 ../../Firmware/ultralcd.cpp:4383
+#: ../../Firmware/ultralcd.cpp:4386 ../../Firmware/ultralcd.cpp:5785
+#: ../../Firmware/ultralcd.cpp:5792 ../../Firmware/ultralcd.cpp:5799
+#: ../../Firmware/ultralcd.cpp:5800 ../../Firmware/ultralcd.cpp:5801
+#: ../../Firmware/ultralcd.cpp:5802 ../../Firmware/ultralcd.cpp:5886
 msgid "Mode"
 msgstr "Modus"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3598
+#: ../../Firmware/ultralcd.cpp:3617
 msgid "Mode change in progress..."
 msgstr "Moduswechsel erfolgt..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:4575
-#: ../../Firmware/ultralcd.cpp:4578 ../../Firmware/ultralcd.cpp:4581
-#: ../../Firmware/ultralcd.cpp:4584
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:4594
+#: ../../Firmware/ultralcd.cpp:4597 ../../Firmware/ultralcd.cpp:4600
+#: ../../Firmware/ultralcd.cpp:4603
 msgid "Model"
 msgstr "Modell"
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6982
-#: ../../Firmware/ultralcd.cpp:6991 ../../Firmware/ultralcd.cpp:7009
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:7012
+#: ../../Firmware/ultralcd.cpp:7021 ../../Firmware/ultralcd.cpp:7039
 msgid "Motor"
 msgstr "Motor"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3492
+#: ../../Firmware/ultralcd.cpp:3511
 msgid "Move X"
 msgstr "Bewege X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3493
+#: ../../Firmware/ultralcd.cpp:3512
 msgid "Move Y"
 msgstr "Bewege Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3494
+#: ../../Firmware/ultralcd.cpp:3513
 msgid "Move Z"
 msgstr "Bewege Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4801
+#: ../../Firmware/ultralcd.cpp:4820
 msgid "Move axis"
 msgstr "Achse bewegen"
 
 #. MSG_NA c=3
 #: ../../Firmware/menu.cpp:196 ../../Firmware/messages.cpp:124
-#: ../../Firmware/ultralcd.cpp:2502 ../../Firmware/ultralcd.cpp:2547
-#: ../../Firmware/ultralcd.cpp:3411 ../../Firmware/ultralcd.cpp:4228
-#: ../../Firmware/ultralcd.cpp:4276 ../../Firmware/ultralcd.cpp:5737
-#: ../../Firmware/ultralcd.cpp:5836
+#: ../../Firmware/ultralcd.cpp:2521 ../../Firmware/ultralcd.cpp:2566
+#: ../../Firmware/ultralcd.cpp:3430 ../../Firmware/ultralcd.cpp:4247
+#: ../../Firmware/ultralcd.cpp:4295 ../../Firmware/ultralcd.cpp:5759
+#: ../../Firmware/ultralcd.cpp:5858
 msgid "N/A"
 msgstr "N/V"
 
@@ -1069,14 +1069,14 @@ msgid "New firmware version available:"
 msgstr "Neue Firmware- Version verfügbar:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:2804
-#: ../../Firmware/ultralcd.cpp:3180 ../../Firmware/ultralcd.cpp:4785
-#: ../../Firmware/ultralcd.cpp:5988
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:2823
+#: ../../Firmware/ultralcd.cpp:3199 ../../Firmware/ultralcd.cpp:4804
+#: ../../Firmware/ultralcd.cpp:6018
 msgid "No"
 msgstr "Nein"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5543
+#: ../../Firmware/ultralcd.cpp:5565
 msgid "No SD card"
 msgstr "Keine SD Karte"
 
@@ -1086,72 +1086,72 @@ msgid "No move."
 msgstr "Keine Bewegung."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4405
-#: ../../Firmware/ultralcd.cpp:4493 ../../Firmware/ultralcd.cpp:4502
-#: ../../Firmware/ultralcd.cpp:4575 ../../Firmware/ultralcd.cpp:4584
-#: ../../Firmware/ultralcd.cpp:4614 ../../Firmware/ultralcd.cpp:4623
-#: ../../Firmware/ultralcd.cpp:4655 ../../Firmware/ultralcd.cpp:4664
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4424
+#: ../../Firmware/ultralcd.cpp:4512 ../../Firmware/ultralcd.cpp:4521
+#: ../../Firmware/ultralcd.cpp:4594 ../../Firmware/ultralcd.cpp:4603
+#: ../../Firmware/ultralcd.cpp:4633 ../../Firmware/ultralcd.cpp:4642
+#: ../../Firmware/ultralcd.cpp:4674 ../../Firmware/ultralcd.cpp:4683
 msgid "None"
 msgstr "Ohne"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:4336
-#: ../../Firmware/ultralcd.cpp:4381 ../../Firmware/ultralcd.cpp:4397
-#: ../../Firmware/ultralcd.cpp:4416 ../../Firmware/ultralcd.cpp:5763
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/ultralcd.cpp:4400 ../../Firmware/ultralcd.cpp:4416
+#: ../../Firmware/ultralcd.cpp:4435 ../../Firmware/ultralcd.cpp:5785
 msgid "Normal"
 msgstr "Normal"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6969
+#: ../../Firmware/ultralcd.cpp:6999
 msgid "Not connected"
 msgstr "Nicht angeschlossen"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:7168
-#: ../../Firmware/ultralcd.cpp:7183 ../../Firmware/ultralcd.cpp:7191
+#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:7198
+#: ../../Firmware/ultralcd.cpp:7213 ../../Firmware/ultralcd.cpp:7221
 msgid "Not spinning"
 msgstr "Dreht sich nicht"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3962
+#: ../../Firmware/ultralcd.cpp:3981
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr ""
 "Jetzt werde ich den Abstand zwischen Düsenspitze und Druckbett kalibrieren."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:4091
+#: ../../Firmware/ultralcd.cpp:4110
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Jetzt werde ich die Düse für PLA vorheizen."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/ultralcd.cpp:4101
 msgid "Now remove the test print from steel sheet."
 msgstr "Testdruck jetzt von Stahlblech entfernen."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:1402
-#: ../../Firmware/ultralcd.cpp:4493 ../../Firmware/ultralcd.cpp:4496
-#: ../../Firmware/ultralcd.cpp:4499 ../../Firmware/ultralcd.cpp:4502
-#: ../../Firmware/ultralcd.cpp:5720 ../../Firmware/ultralcd.cpp:5882
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:1421
+#: ../../Firmware/ultralcd.cpp:4512 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/ultralcd.cpp:4518 ../../Firmware/ultralcd.cpp:4521
+#: ../../Firmware/ultralcd.cpp:5742 ../../Firmware/ultralcd.cpp:5904
 msgid "Nozzle"
 msgstr "Düse"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4546
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4565
 msgid "Nozzle d."
 msgstr "Düsen Dia."
 
 #. MSG_OFF c=3
 #: ../../Firmware/menu.cpp:467 ../../Firmware/messages.cpp:122
-#: ../../Firmware/ultralcd.cpp:4234 ../../Firmware/ultralcd.cpp:4250
-#: ../../Firmware/ultralcd.cpp:4284 ../../Firmware/ultralcd.cpp:4313
-#: ../../Firmware/ultralcd.cpp:4342 ../../Firmware/ultralcd.cpp:4811
-#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4834
-#: ../../Firmware/ultralcd.cpp:5644 ../../Firmware/ultralcd.cpp:5741
-#: ../../Firmware/ultralcd.cpp:5756 ../../Firmware/ultralcd.cpp:5767
-#: ../../Firmware/ultralcd.cpp:5836 ../../Firmware/ultralcd.cpp:7841
-#: ../../Firmware/ultralcd.cpp:7845
+#: ../../Firmware/ultralcd.cpp:4253 ../../Firmware/ultralcd.cpp:4269
+#: ../../Firmware/ultralcd.cpp:4303 ../../Firmware/ultralcd.cpp:4332
+#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4830
+#: ../../Firmware/ultralcd.cpp:4849 ../../Firmware/ultralcd.cpp:4853
+#: ../../Firmware/ultralcd.cpp:5666 ../../Firmware/ultralcd.cpp:5763
+#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/ultralcd.cpp:5858 ../../Firmware/ultralcd.cpp:7881
+#: ../../Firmware/ultralcd.cpp:7885
 msgid "Off"
 msgstr "Aus"
 
@@ -1162,19 +1162,19 @@ msgstr ""
 "Alte Einstellungen gefunden. Standard PID, E-Steps u.s.w. werden gesetzt."
 
 #. MSG_ON c=3
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4244
-#: ../../Firmware/ultralcd.cpp:4248 ../../Firmware/ultralcd.cpp:4280
-#: ../../Firmware/ultralcd.cpp:4303 ../../Firmware/ultralcd.cpp:4341
-#: ../../Firmware/ultralcd.cpp:4811 ../../Firmware/ultralcd.cpp:4830
-#: ../../Firmware/ultralcd.cpp:4834 ../../Firmware/ultralcd.cpp:5745
-#: ../../Firmware/ultralcd.cpp:5756 ../../Firmware/ultralcd.cpp:5765
-#: ../../Firmware/ultralcd.cpp:5836 ../../Firmware/ultralcd.cpp:7841
-#: ../../Firmware/ultralcd.cpp:7845
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4263
+#: ../../Firmware/ultralcd.cpp:4267 ../../Firmware/ultralcd.cpp:4299
+#: ../../Firmware/ultralcd.cpp:4322 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4849
+#: ../../Firmware/ultralcd.cpp:4853 ../../Firmware/ultralcd.cpp:5767
+#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5787
+#: ../../Firmware/ultralcd.cpp:5858 ../../Firmware/ultralcd.cpp:7881
+#: ../../Firmware/ultralcd.cpp:7885
 msgid "On"
 msgstr "An"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4453
+#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4472
 msgid "Once"
 msgstr "Einmal"
 
@@ -1194,7 +1194,7 @@ msgid "PID cal. finished"
 msgstr "PID Kalib. fertig"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4913
+#: ../../Firmware/ultralcd.cpp:4932
 msgid "PID calibration"
 msgstr "PID Kalibrierung"
 
@@ -1206,18 +1206,18 @@ msgstr "PINDA erwärmen"
 #. MSG_PINDA_CALIBRATION c=13
 #: ../../Firmware/Marlin_main.cpp:4932 ../../Firmware/Marlin_main.cpp:5035
 #: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:654
-#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4920
+#: ../../Firmware/ultralcd.cpp:4849 ../../Firmware/ultralcd.cpp:4939
 msgid "PINDA cal."
 msgstr "PINDA Kal."
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3361
+#: ../../Firmware/ultralcd.cpp:3380
 msgid "PINDA calibration failed"
 msgstr "PINDA-Kalibrierung fehlgeschlagen"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
 #: ../../Firmware/Marlin_main.cpp:5112 ../../Firmware/messages.cpp:110
-#: ../../Firmware/ultralcd.cpp:3355
+#: ../../Firmware/ultralcd.cpp:3374
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1226,13 +1226,13 @@ msgstr ""
 "Einstellungen -> PINDA kal."
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4707
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4726
 msgid "Pause"
 msgstr "Pause"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:5507
-#: ../../Firmware/ultralcd.cpp:5509
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:5529
+#: ../../Firmware/ultralcd.cpp:5531
 msgid "Pause print"
 msgstr "Druck pausieren"
 
@@ -1247,7 +1247,7 @@ msgstr ""
 "ausschalten."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:4176
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:4195
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1256,17 +1256,17 @@ msgstr ""
 "mit dem Assistenten fort, indem Sie den Drucker neu starten."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:6250
+#: ../../Firmware/ultralcd.cpp:6280
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "Bitte IR Sensor Verbindungen über- prüfen und Filament entladen ist."
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6963
+#: ../../Firmware/ultralcd.cpp:6993
 msgid "Please check:"
 msgstr "Bitte prüfen:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4148
+#: ../../Firmware/ultralcd.cpp:4167
 msgid "Please clean heatbed and then press the knob."
 msgstr "Bitte reinigen Sie das Heizbett und drücken Sie dann den Knopf."
 
@@ -1277,7 +1277,7 @@ msgstr ""
 "Bitte entfernen Sie überstehendes Filament von der Düse. Klicken wenn sauber."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3945
+#: ../../Firmware/ultralcd.cpp:3964
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr ""
@@ -1285,7 +1285,7 @@ msgstr ""
 "Knopf, um es zu laden."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3940
+#: ../../Firmware/ultralcd.cpp:3959
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1294,7 +1294,7 @@ msgstr ""
 "Sie dann den Knopf, um es zu laden."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3863
+#: ../../Firmware/ultralcd.cpp:3882
 msgid "Please load filament first."
 msgstr "Bitte laden Sie zuerst das Filament."
 
@@ -1305,7 +1305,7 @@ msgstr "Bitte Spannrolle öffnen und Filament von Hand entfernen"
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=5
 #: ../../Firmware/mesh_bed_calibration.cpp:2799 ../../Firmware/messages.cpp:70
-#: ../../Firmware/ultralcd.cpp:4085
+#: ../../Firmware/ultralcd.cpp:4104
 msgid "Please place steel sheet on heatbed."
 msgstr "Bitte legen Sie das Stahlblech auf das Heizbett."
 
@@ -1316,7 +1316,7 @@ msgid "Please press the knob to unload filament"
 msgstr "Bitte drücken Sie den Knopf um das Filament zu entladen."
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:5213
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:5235
 msgid "Please pull out filament immediately"
 msgstr "Bitte ziehen Sie das Filament sofort heraus"
 
@@ -1326,7 +1326,7 @@ msgid "Please remove filament and then press the knob."
 msgstr "Bitte Filament entfernen und dann den Knopf drücken"
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:4081
+#: ../../Firmware/ultralcd.cpp:4100
 msgid "Please remove shipping helpers first."
 msgstr "Bitte zuerst Transportsicherungen entfernen."
 
@@ -1342,7 +1342,7 @@ msgid "Please run XYZ calibration first."
 msgstr "Bitte zuerst XYZ Kalibrierung ausführen."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:6247
+#: ../../Firmware/ultralcd.cpp:6277
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Bitte entladen Sie erst das Filament und versuchen Sie es nochmal."
 
@@ -1359,54 +1359,54 @@ msgstr "Bitte aktualisieren."
 #. MSG_PLEASE_WAIT c=20
 #: ../../Firmware/Marlin_main.cpp:3547 ../../Firmware/Marlin_main.cpp:3563
 #: ../../Firmware/Marlin_main.cpp:7931 ../../Firmware/messages.cpp:71
-#: ../../Firmware/ultralcd.cpp:2186 ../../Firmware/ultralcd.cpp:2197
+#: ../../Firmware/ultralcd.cpp:2205 ../../Firmware/ultralcd.cpp:2216
 msgid "Please wait"
 msgstr "Bitte warten"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1219
-#: ../../Firmware/ultralcd.cpp:1260 ../../Firmware/ultralcd.cpp:1270
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1238
+#: ../../Firmware/ultralcd.cpp:1279 ../../Firmware/ultralcd.cpp:1289
 msgid "Power failures"
 msgstr "Netzfehler"
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5502
+#: ../../Firmware/ultralcd.cpp:5524
 msgid "Preheat"
 msgstr "Vorheizen"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:2280
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:2299
 msgid "Preheat the nozzle!"
 msgstr "Düse vorheizen!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:2900
-#: ../../Firmware/ultralcd.cpp:3924 ../../Firmware/ultralcd.cpp:3926
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:2919
+#: ../../Firmware/ultralcd.cpp:3943 ../../Firmware/ultralcd.cpp:3945
 msgid "Preheating nozzle. Please wait."
 msgstr "Vorheizen der Düse. Bitte warten."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1988
+#: ../../Firmware/ultralcd.cpp:2007
 msgid "Preheating to cut"
 msgstr "Heizen zum Schnitt"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1985
+#: ../../Firmware/ultralcd.cpp:2004
 msgid "Preheating to eject"
 msgstr "Heizen zum Auswurf"
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1976
+#: ../../Firmware/ultralcd.cpp:1995
 msgid "Preheating to load"
 msgstr "Heizen zum Laden"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1981
+#: ../../Firmware/ultralcd.cpp:2000
 msgid "Preheating to unload"
 msgstr "Heizen zum Entladen"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1809
+#: ../../Firmware/ultralcd.cpp:1828
 msgid "Press the knob"
 msgstr "Knopf drücken zum"
 
@@ -1426,13 +1426,13 @@ msgid "Print aborted"
 msgstr "Druck abgebrochen"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1144
-#: ../../Firmware/ultralcd.cpp:7322
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1145
+#: ../../Firmware/ultralcd.cpp:7354
 msgid "Print fan:"
 msgstr "Drucklüfter:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5535
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5557
 msgid "Print from SD"
 msgstr "Drucken von SD"
 
@@ -1442,12 +1442,12 @@ msgid "Print paused"
 msgstr "Druck pausiert"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2366
+#: ../../Firmware/ultralcd.cpp:2385
 msgid "Print time"
 msgstr "Druckzeit"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1711
+#: ../../Firmware/ultralcd.cpp:1730
 msgid "Printer IP Addr:"
 msgstr "Drucker IP Adr.:"
 
@@ -1475,12 +1475,12 @@ msgstr ""
 "den Wert in den Einstellungen. Druck abgebrochen."
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4834
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4853
 msgid "RPi port"
 msgstr "RPi port"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2755
+#: ../../Firmware/ultralcd.cpp:2774
 msgid "Rear side [μm]"
 msgstr "Hinten [μm]"
 
@@ -1497,24 +1497,24 @@ msgstr ""
 "laden."
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5426
+#: ../../Firmware/ultralcd.cpp:5448
 msgid "Rename"
 msgstr "Umbenennen"
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2756
-#: ../../Firmware/ultralcd.cpp:5427
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2775
+#: ../../Firmware/ultralcd.cpp:5449
 msgid "Reset"
 msgstr "Reset"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4917
+#: ../../Firmware/ultralcd.cpp:4936
 msgid "Reset XYZ calibr."
 msgstr "Reset XYZ Kalibr."
 
 #. MSG_RESUME_PRINT c=18
 #: ../../Firmware/Marlin_main.cpp:655 ../../Firmware/messages.cpp:81
-#: ../../Firmware/ultralcd.cpp:5521 ../../Firmware/ultralcd.cpp:5523
+#: ../../Firmware/ultralcd.cpp:5543 ../../Firmware/ultralcd.cpp:5545
 msgid "Resume print"
 msgstr "Druck fortsetzen"
 
@@ -1524,17 +1524,17 @@ msgid "Resuming print"
 msgstr "Druck fortgesetzt"
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2497
+#: ../../Firmware/ultralcd.cpp:2516
 msgid "Right"
 msgstr "Rechts"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2753
+#: ../../Firmware/ultralcd.cpp:2772
 msgid "Right side[μm]"
 msgstr "Rechts [μm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3884
+#: ../../Firmware/ultralcd.cpp:3903
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1543,14 +1543,14 @@ msgstr ""
 "beginnen. Fortfahren?"
 
 #. MSG_RUNOUTS c=7
-#: ../../Firmware/ultralcd.cpp:1271
+#: ../../Firmware/ultralcd.cpp:1290
 msgid "Runouts"
 msgstr "Mängel"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4395
-#: ../../Firmware/ultralcd.cpp:4397 ../../Firmware/ultralcd.cpp:4414
-#: ../../Firmware/ultralcd.cpp:4416
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4414
+#: ../../Firmware/ultralcd.cpp:4416 ../../Firmware/ultralcd.cpp:4433
+#: ../../Firmware/ultralcd.cpp:4435
 msgid "SD card"
 msgstr "SD Karte"
 
@@ -1566,12 +1566,12 @@ msgid "Searching bed calibration point"
 msgstr "Suche Bett Kalibrierpunkt"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5419
+#: ../../Firmware/ultralcd.cpp:5441
 msgid "Select"
 msgstr "Auswahl"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3966
+#: ../../Firmware/ultralcd.cpp:3985
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
@@ -1586,49 +1586,49 @@ msgstr "Wähle extruder:"
 
 #. MSG_SELECT_FILAMENT c=20
 #: ../../Firmware/Marlin_main.cpp:8577 ../../Firmware/Marlin_main.cpp:8604
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3834
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3853
 msgid "Select filament:"
 msgstr "Wähle filament:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:3679
-#: ../../Firmware/ultralcd.cpp:4841
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:3698
+#: ../../Firmware/ultralcd.cpp:4860
 msgid "Select language"
 msgstr "Wähle Sprache"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:4122
+#: ../../Firmware/ultralcd.cpp:4141
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr "Bitte Vorheiztemperatur auswählen, die Ihrem Material entspricht."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3971
+#: ../../Firmware/ultralcd.cpp:3990
 msgid "Select temperature which matches your material."
 msgstr "Wählen Sie die Temperatur, die zu Ihrem Material passt."
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6522
+#: ../../Firmware/ultralcd.cpp:6552
 msgid "Self test OK"
 msgstr "Selbsttest OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:6290
+#: ../../Firmware/ultralcd.cpp:6320
 msgid "Self test start"
 msgstr "Selbsttest start"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4904
+#: ../../Firmware/ultralcd.cpp:4923
 msgid "Selftest"
 msgstr "Selbsttest"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6962
+#: ../../Firmware/ultralcd.cpp:6992
 msgid "Selftest error!"
 msgstr "Selbsttest Fehler!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:6526
-#: ../../Firmware/ultralcd.cpp:7049 ../../Firmware/ultralcd.cpp:7314
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:6556
+#: ../../Firmware/ultralcd.cpp:7079 ../../Firmware/ultralcd.cpp:7344
 msgid "Selftest failed"
 msgstr "Selbsttest Error"
 
@@ -1638,30 +1638,30 @@ msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr "Selbsttest wird gestartet, um Startposition zu kalibrieren."
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1723
+#: ../../Firmware/ultralcd.cpp:1742
 msgid "Sensor info"
 msgstr "Sensor Info"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:6254
+#: ../../Firmware/ultralcd.cpp:6284
 msgid "Sensor verified, remove the filament now."
 msgstr "Sensor überprüft, entladen Sie jetzt das Filament."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2773
+#: ../../Firmware/ultralcd.cpp:2792
 msgid "Set temperature:"
 msgstr "Temp. einstellen:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:3491
-#: ../../Firmware/ultralcd.cpp:3696 ../../Firmware/ultralcd.cpp:4206
-#: ../../Firmware/ultralcd.cpp:5580 ../../Firmware/ultralcd.cpp:5827
-#: ../../Firmware/ultralcd.cpp:5880
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:3510
+#: ../../Firmware/ultralcd.cpp:3715 ../../Firmware/ultralcd.cpp:4225
+#: ../../Firmware/ultralcd.cpp:5602 ../../Firmware/ultralcd.cpp:5849
+#: ../../Firmware/ultralcd.cpp:5902
 msgid "Settings"
 msgstr "Einstellungen"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2540
+#: ../../Firmware/ultralcd.cpp:2559
 msgid "Severe skew"
 msgstr "Sehr schräg"
 
@@ -1672,7 +1672,7 @@ msgid "Sheet"
 msgstr "Stahlblech"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3824
+#: ../../Firmware/ultralcd.cpp:3843
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1685,18 +1685,18 @@ msgstr ""
 "%cReset"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4915
+#: ../../Firmware/ultralcd.cpp:4934
 msgid "Show end stops"
 msgstr "Endschalter Status"
 
 #. MSG_SILENT c=7
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4361
-#: ../../Firmware/ultralcd.cpp:4456 ../../Firmware/ultralcd.cpp:5778
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4380
+#: ../../Firmware/ultralcd.cpp:4475 ../../Firmware/ultralcd.cpp:5800
 msgid "Silent"
 msgstr "Leise"
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2539
+#: ../../Firmware/ultralcd.cpp:2558
 msgid "Slight skew"
 msgstr "Leicht schräg"
 
@@ -1714,8 +1714,8 @@ msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Fehler aufgetreten, Z-Kalibrierung erforderlich..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4403
-#: ../../Firmware/ultralcd.cpp:4404 ../../Firmware/ultralcd.cpp:4405
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4422
+#: ../../Firmware/ultralcd.cpp:4423 ../../Firmware/ultralcd.cpp:4424
 msgid "Sort"
 msgstr "Sort."
 
@@ -1726,20 +1726,20 @@ msgid "Sorting files"
 msgstr "Sortiere Dateien"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4450
-#: ../../Firmware/ultralcd.cpp:4453 ../../Firmware/ultralcd.cpp:4456
-#: ../../Firmware/ultralcd.cpp:4459 ../../Firmware/ultralcd.cpp:4462
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/ultralcd.cpp:4472 ../../Firmware/ultralcd.cpp:4475
+#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4481
 msgid "Sound"
 msgstr "Ton"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5718
+#: ../../Firmware/ultralcd.cpp:5740
 msgid "Speed"
 msgstr "Geschwindigkeit"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7166
-#: ../../Firmware/ultralcd.cpp:7181 ../../Firmware/ultralcd.cpp:7189
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7196
+#: ../../Firmware/ultralcd.cpp:7211 ../../Firmware/ultralcd.cpp:7219
 msgid "Spinning"
 msgstr "Dreht sich"
 
@@ -1750,42 +1750,42 @@ msgstr ""
 "Stabile Umgebungs- temperatur 21-26C und feste Stand- fläche erforderlich"
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5585
+#: ../../Firmware/ultralcd.cpp:5607
 msgid "Statistics"
 msgstr "Statistiken"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4338
-#: ../../Firmware/ultralcd.cpp:4382 ../../Firmware/ultralcd.cpp:5770
+#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4357
+#: ../../Firmware/ultralcd.cpp:4401 ../../Firmware/ultralcd.cpp:5792
 msgid "Stealth"
 msgstr "Leise"
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4763
-#: ../../Firmware/ultralcd.cpp:5416
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4782
+#: ../../Firmware/ultralcd.cpp:5438
 msgid "Steel sheets"
 msgstr "Stahlbleche"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5528
-#: ../../Firmware/ultralcd.cpp:5987
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5550
+#: ../../Firmware/ultralcd.cpp:6017
 msgid "Stop print"
 msgstr "Druck abbrechen"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4499
-#: ../../Firmware/ultralcd.cpp:4581 ../../Firmware/ultralcd.cpp:4620
-#: ../../Firmware/ultralcd.cpp:4661
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4518
+#: ../../Firmware/ultralcd.cpp:4600 ../../Firmware/ultralcd.cpp:4639
+#: ../../Firmware/ultralcd.cpp:4680
 msgid "Strict"
 msgstr "Strikt"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/ultralcd.cpp:5616
 msgid "Support"
 msgstr "Support"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:7021
+#: ../../Firmware/ultralcd.cpp:7051
 msgid "Swapped"
 msgstr "Ausgetauscht"
 
@@ -1794,28 +1794,18 @@ msgstr "Ausgetauscht"
 msgid "THERMAL ANOMALY"
 msgstr "THERMISCHE ANOMALIE"
 
-#. MSG_TM_AUTOTUNE_FAILED c=20
-#: ../../Firmware/temperature.cpp:2899
-msgid "TM autotune failed"
-msgstr "TM kal. fehlgeschlg."
-
-#. MSG_TEMP_MODEL_AUTOTUNE c=20
-#: ../../Firmware/temperature.cpp:2884
-msgid "Temp. model autotune"
-msgstr "Temp. Model Autokal."
-
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4797
+#: ../../Firmware/ultralcd.cpp:4816
 msgid "Temperature"
 msgstr "Temperatur"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1729
+#: ../../Firmware/ultralcd.cpp:1748
 msgid "Temperatures"
 msgstr "Temperaturen"
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3974
+#: ../../Firmware/ultralcd.cpp:3993
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -1835,68 +1825,68 @@ msgstr ""
 "Sie das Handbuch, Kapitel Erste Schritte, Abschnitt Kalibrierablauf."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4403
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4422
 msgid "Time"
 msgstr "Zeit"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:5865
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:5887
 msgid "Timeout"
 msgstr "Timeout"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:1149
-#: ../../Firmware/ultralcd.cpp:1297
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:1168
+#: ../../Firmware/ultralcd.cpp:1316
 msgid "Total"
 msgstr "Gesamt"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:1192
-#: ../../Firmware/ultralcd.cpp:1218 ../../Firmware/ultralcd.cpp:1328
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:1211
+#: ../../Firmware/ultralcd.cpp:1237 ../../Firmware/ultralcd.cpp:1347
 msgid "Total failures"
 msgstr "Gesamte Fehler"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2387
+#: ../../Firmware/ultralcd.cpp:2406
 msgid "Total filament"
 msgstr "Gesamtes Filament"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2388
+#: ../../Firmware/ultralcd.cpp:2407
 msgid "Total print time"
 msgstr "Gesamte Druckzeit"
 
 #. MSG_TUNE c=18
-#: ../../Firmware/ultralcd.cpp:5500
+#: ../../Firmware/ultralcd.cpp:5522
 msgid "Tune"
 msgstr "Feineinstellung"
 
 #. MSG_UNLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:5564
-#: ../../Firmware/ultralcd.cpp:5578
+#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:5586
+#: ../../Firmware/ultralcd.cpp:5600
 msgid "Unload filament"
 msgstr "Fil. entladen"
 
 #. MSG_UNLOADING_FILAMENT c=20
 #: ../../Firmware/messages.cpp:112 ../../Firmware/mmu.cpp:957
-#: ../../Firmware/ultralcd.cpp:5197
+#: ../../Firmware/ultralcd.cpp:5219
 msgid "Unloading filament"
 msgstr "Filament auswerfen"
 
 #. MSG_FIL_FAILED c=20 r=5
-#: ../../Firmware/ultralcd.cpp:6258
+#: ../../Firmware/ultralcd.cpp:6288
 msgid "Verification failed, remove the filament and try again."
 msgstr ""
 "Überprüfung fehl- geschlagen, entladen Sie das Filament und versuchen Sie es "
 "erneut."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1732
+#: ../../Firmware/ultralcd.cpp:1751
 msgid "Voltages"
 msgstr "Spannungen"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3534
+#: ../../Firmware/ultralcd.cpp:3553
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -1914,19 +1904,19 @@ msgid "Wait for user..."
 msgstr "Warte auf Benutzer.."
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2881
+#: ../../Firmware/ultralcd.cpp:2900
 msgid "Waiting for PINDA probe cooling"
 msgstr "Warten, bis PINDA- Sonde abgekühlt ist"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2913
+#: ../../Firmware/ultralcd.cpp:2932
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Warten bis Heizung und Bett abgekühlt sind"
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:4496
-#: ../../Firmware/ultralcd.cpp:4578 ../../Firmware/ultralcd.cpp:4617
-#: ../../Firmware/ultralcd.cpp:4658
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/ultralcd.cpp:4597 ../../Firmware/ultralcd.cpp:4636
+#: ../../Firmware/ultralcd.cpp:4677
 msgid "Warn"
 msgstr "Warnen"
 
@@ -1951,57 +1941,51 @@ msgid "Was filament unload successful?"
 msgstr "Konnten Sie das Filament entnehmen?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6973
-#: ../../Firmware/ultralcd.cpp:6977 ../../Firmware/ultralcd.cpp:6997
-#: ../../Firmware/ultralcd.cpp:7003 ../../Firmware/ultralcd.cpp:7027
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:7003
+#: ../../Firmware/ultralcd.cpp:7007 ../../Firmware/ultralcd.cpp:7027
+#: ../../Firmware/ultralcd.cpp:7033 ../../Firmware/ultralcd.cpp:7057
 msgid "Wiring error"
 msgstr "Verdrahtungsfehler"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4895
+#: ../../Firmware/ultralcd.cpp:4914
 msgid "Wizard"
 msgstr "Assistent"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4210
+#: ../../Firmware/ultralcd.cpp:4229
 msgid "X-correct:"
 msgstr "X-Korrektur:"
 
 #. MSG_XFLASH c=18
-#: ../../Firmware/ultralcd.cpp:5596
+#: ../../Firmware/ultralcd.cpp:5618
 msgid "XFLASH init"
 msgstr "XFLASH init"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1721
+#: ../../Firmware/ultralcd.cpp:1740
 msgid "XYZ cal. details"
 msgstr "XYZ Kal. Details"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3333
+#: ../../Firmware/ultralcd.cpp:3352
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr "XYZ Kalibrierung in Ordnung. Schräglauf wird automatisch korrigiert."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3330
+#: ../../Firmware/ultralcd.cpp:3349
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr ""
 "XYZ Kalibrierung in Ordnung. X/Y Achsen sind etwas schräg. Gut gemacht!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3311
+#: ../../Firmware/ultralcd.cpp:3330
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr ""
 "XYZ-Kalibrierung beeinträchtigt. Vordere Kalibrierpunkte nicht erreichbar."
 
-#. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_LEFT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3317
-msgid ""
-"XYZ calibration compromised. Left front calibration point not reachable."
-msgstr ""
-
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3314
+#: ../../Firmware/ultralcd.cpp:3333
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr ""
@@ -2009,95 +1993,90 @@ msgstr ""
 "erreichbar."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3293
+#: ../../Firmware/ultralcd.cpp:3312
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr "XYZ-Kalibrierung fehlgeschlagen. Bett-Kalibrierpunkt nicht gefunden."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3299
+#: ../../Firmware/ultralcd.cpp:3318
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr ""
 "XYZ-Kalibrierung fehlgeschlagen. Vordere Kalibrierpunkte nicht erreichbar."
 
-#. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_LEFT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3305
-msgid "XYZ calibration failed. Left front calibration point not reachable."
-msgstr ""
-
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3296
-#: ../../Firmware/ultralcd.cpp:3324
+#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3315
+#: ../../Firmware/ultralcd.cpp:3343
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "XYZ-Kalibrierung fehlgeschlagen. Bitte schauen Sie in das Handbuch."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3302
+#: ../../Firmware/ultralcd.cpp:3321
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr ""
 "XYZ-Kalibrierung fehlgeschlagen. Rechter vorderer Kalibrierpunkt ist nicht "
 "erreichbar."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3327
+#: ../../Firmware/ultralcd.cpp:3346
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "XYZ-Kalibrierung ok. X/Y-Achsen sind senkrecht zueinander Glückwunsch!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2494
+#: ../../Firmware/ultralcd.cpp:2513
 msgid "Y distance from min"
 msgstr "Y Entfernung vom Min"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4211
+#: ../../Firmware/ultralcd.cpp:4230
 msgid "Y-correct:"
 msgstr "Y-Korrektur:"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:2216
-#: ../../Firmware/ultralcd.cpp:2800 ../../Firmware/ultralcd.cpp:3180
-#: ../../Firmware/ultralcd.cpp:4785 ../../Firmware/ultralcd.cpp:5989
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:2235
+#: ../../Firmware/ultralcd.cpp:2819 ../../Firmware/ultralcd.cpp:3199
+#: ../../Firmware/ultralcd.cpp:4804 ../../Firmware/ultralcd.cpp:6019
 msgid "Yes"
 msgstr "Ja"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:4187
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:4206
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr ""
 "Sie können den Assistenten immer im Menu neu starten: Kalibrierung -> "
 "Assistent"
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4231
 msgid "Z-correct:"
 msgstr "Z-Korrektur:"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:5835
+#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:5857
 msgid "Z-probe nr."
 msgstr "Z-Test Nr."
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2565
+#: ../../Firmware/ultralcd.cpp:2584
 msgid "[0;0] point offset"
 msgstr "[0;0] Punktversatz"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2154
+#: ../../Firmware/ultralcd.cpp:2173
 msgid "and press the knob"
 msgstr "und Knopf drücken"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1816
+#: ../../Firmware/ultralcd.cpp:1835
 msgid "to load filament"
 msgstr "um Filament laden"
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1820
+#: ../../Firmware/ultralcd.cpp:1839
 msgid "to unload filament"
 msgstr "um Filament entladen"
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1688
+#: ../../Firmware/ultralcd.cpp:1707
 msgid "unknown"
 msgstr "unbekannt"
 
@@ -2107,8 +2086,8 @@ msgid "unknown state"
 msgstr "Status unbekannt"
 
 #. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:6077
-#: ../../Firmware/ultralcd.cpp:6080
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:6107
+#: ../../Firmware/ultralcd.cpp:6110
 msgid "🔃Refresh"
 msgstr "🔃Aktualisiere"
 
@@ -2117,3 +2096,9 @@ msgstr "🔃Aktualisiere"
 
 #~ msgid "M117 First layer cal."
 #~ msgstr "M117 Erste-Schicht Kal."
+
+#~ msgid "TM autotune failed"
+#~ msgstr "TM kal. fehlgeschlg."
+
+#~ msgid "Temp. model autotune"
+#~ msgstr "Temp. Model Autokal."

--- a/lang/po/Firmware_es.po
+++ b/lang/po/Firmware_es.po
@@ -26,115 +26,115 @@ msgid " 0.4 or newer"
 msgstr " 0.4 o mas nueva"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:7036
+#: ../../Firmware/ultralcd.cpp:7066
 msgid "%s level expected"
 msgstr "%s nivel esperado"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1968
-#: ../../Firmware/ultralcd.cpp:3835
+#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1987
+#: ../../Firmware/ultralcd.cpp:3854
 msgid ">Cancel"
 msgstr ">Cancelar"
 
 #. MSG_BABYSTEPPING_Z c=15
 #. Beware: must include the ':' as its last character
-#: ../../Firmware/ultralcd.cpp:2670
+#: ../../Firmware/ultralcd.cpp:2689
 msgid "Adjusting Z:"
 msgstr "Ajustar-Z:"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:7313
+#: ../../Firmware/ultralcd.cpp:7343
 msgid "All correct"
 msgstr "Todo bien"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4180
+#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4190
+#: ../../Firmware/ultralcd.cpp:4199
 msgid "All is done. Happy printing!"
 msgstr "Terminado. Felices impresiones!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4404
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4423
 msgid "Alphabet"
 msgstr "Alfabet"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4308
+#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4327
 msgid "Always"
 msgstr "Siemp."
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1405
+#: ../../Firmware/ultralcd.cpp:1424
 msgid "Ambient"
 msgstr "Ambiente"
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2983
+#: ../../Firmware/ultralcd.cpp:3002
 msgid "Are left and right Z~carriages all up?"
 msgstr "Carros Z izq./der. estan arriba maximo?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4478
 msgid "Assist"
 msgstr "Asist."
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:5886
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
 #: ../../Firmware/Marlin_main.cpp:3271 ../../Firmware/messages.cpp:9
-#: ../../Firmware/ultralcd.cpp:4900
+#: ../../Firmware/ultralcd.cpp:4919
 msgid "Auto home"
 msgstr "Llevar al origen"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:4364
-#: ../../Firmware/ultralcd.cpp:5779
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:4383
+#: ../../Firmware/ultralcd.cpp:5801
 msgid "Auto power"
 msgstr "Encendido"
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5572
+#: ../../Firmware/ultralcd.cpp:5594
 msgid "AutoLoad filament"
 msgstr "Carga auto. filam."
 
 #. MSG_AUTOLOADING_ONLY_IF_FSENS_ON c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3549
+#: ../../Firmware/ultralcd.cpp:3568
 msgid ""
 "Autoloading filament available only when filament sensor is turned on..."
 msgstr ""
 "La carga automatica solo funciona si el sensor de filamento esta activado..."
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2301
+#: ../../Firmware/ultralcd.cpp:2320
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
 "La carga automatica esta activada, pulse el dial e inserte el filamento..."
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:7015
+#: ../../Firmware/ultralcd.cpp:7045
 msgid "Axis"
 msgstr "Eje"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:7014
+#: ../../Firmware/ultralcd.cpp:7044
 msgid "Axis length"
 msgstr "Longitud del eje"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:2751
-#: ../../Firmware/ultralcd.cpp:5861 ../../Firmware/ultralcd.cpp:7838
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:2770
+#: ../../Firmware/ultralcd.cpp:5883 ../../Firmware/ultralcd.cpp:7878
 msgid "Back"
 msgstr "atras"
 
 #. MSG_BED c=13
 #: ../../Firmware/Marlin_main.cpp:2051 ../../Firmware/Marlin_main.cpp:4767
 #: ../../Firmware/Marlin_main.cpp:4819 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:1403 ../../Firmware/ultralcd.cpp:5721
-#: ../../Firmware/ultralcd.cpp:5891
+#: ../../Firmware/ultralcd.cpp:1422 ../../Firmware/ultralcd.cpp:5743
+#: ../../Firmware/ultralcd.cpp:5913
 msgid "Bed"
 msgstr "Base"
 
@@ -151,7 +151,7 @@ msgid "Bed done"
 msgstr "Base preparada"
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4912
+#: ../../Firmware/ultralcd.cpp:4931
 msgid "Bed level correct"
 msgstr "Corr. de la cama"
 
@@ -168,18 +168,18 @@ msgstr ""
 "Nivelacion fallada. Sensor no funciona. Restos en boquilla? Esperando reset."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6972
+#: ../../Firmware/ultralcd.cpp:7002
 msgid "Bed/Heater"
 msgstr "Base/Calentador"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1458
-#: ../../Firmware/ultralcd.cpp:1726
+#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1477
+#: ../../Firmware/ultralcd.cpp:1745
 msgid "Belt status"
 msgstr "Estado de correa"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4902
+#: ../../Firmware/ultralcd.cpp:4921
 msgid "Belt test"
 msgstr "Test cinturon"
 
@@ -190,28 +190,28 @@ msgid "Blackout occurred. Recover print?"
 msgstr "Se fue la luz. Re- anudar la impresion?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:5886
 msgid "Bright"
 msgstr "Brill."
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4850
-#: ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4869
+#: ../../Firmware/ultralcd.cpp:5811
 msgid "Brightness"
 msgstr "Brillo"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4906
+#: ../../Firmware/ultralcd.cpp:4925
 msgid "Calibrate XYZ"
 msgstr "Calibrar XYZ"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4908
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4927
 msgid "Calibrate Z"
 msgstr "Calibrar Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2946
+#: ../../Firmware/ultralcd.cpp:2965
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -226,7 +226,7 @@ msgid "Calibrating Z"
 msgstr "Calibrando Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2945
+#: ../../Firmware/ultralcd.cpp:2964
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -235,12 +235,12 @@ msgstr ""
 "superiores. Despues haz clic."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:7315
+#: ../../Firmware/ultralcd.cpp:7345
 msgid "Calibrating home"
 msgstr "Calibrar pos.inicial"
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:5581
+#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:5603
 msgid "Calibration"
 msgstr "Calibracion"
 
@@ -250,115 +250,115 @@ msgid "Calibration done"
 msgstr "Calibracion OK"
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7712
+#: ../../Firmware/ultralcd.cpp:7752
 msgid "Card removed"
 msgstr "Tarjeta retirada"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/ultralcd.cpp:5560
 msgid "Change SD card"
 msgstr "Cambiar Tarj. SD"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5497
-#: ../../Firmware/ultralcd.cpp:5730
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5519
+#: ../../Firmware/ultralcd.cpp:5752
 msgid "Change filament"
 msgstr "Cambiar filamento"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2163
+#: ../../Firmware/ultralcd.cpp:2182
 msgid "Change success!"
 msgstr "Cambio correcto!"
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2215
+#: ../../Firmware/ultralcd.cpp:2234
 msgid "Changed correctly?"
 msgstr "Cambio correcto?"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:6178
-#: ../../Firmware/ultralcd.cpp:7305
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:6208
+#: ../../Firmware/ultralcd.cpp:7335
 msgid "Checking X axis"
 msgstr "Control sensor X"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:6187
-#: ../../Firmware/ultralcd.cpp:7306
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:6217
+#: ../../Firmware/ultralcd.cpp:7336
 msgid "Checking Y axis"
 msgstr "Control sensor Y"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:7307
+#: ../../Firmware/ultralcd.cpp:7337
 msgid "Checking Z axis"
 msgstr "Control sensor Z"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:7308
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:7338
 msgid "Checking bed"
 msgstr "Control base cal."
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:7304
+#: ../../Firmware/ultralcd.cpp:7334
 msgid "Checking endstops"
 msgstr "Control endstops"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:7403
+#: ../../Firmware/ultralcd.cpp:7433
 msgid "Checking file"
 msgstr "Verif. archivo"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:7310
+#: ../../Firmware/ultralcd.cpp:7340
 msgid "Checking hotend"
 msgstr "Control fusor"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:7311
-#: ../../Firmware/ultralcd.cpp:7312
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:7341
+#: ../../Firmware/ultralcd.cpp:7342
 msgid "Checking sensors"
 msgstr "Comprobando sensores"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4765
+#: ../../Firmware/ultralcd.cpp:4784
 msgid "Checks"
 msgstr "Comprobaciones"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2218
+#: ../../Firmware/ultralcd.cpp:2237
 msgid "Color not correct"
 msgstr "Color no homogeneo"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3725
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3744
 msgid "Community made"
 msgstr "Desde la comunidad"
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4704
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4723
 msgid "Cont."
 msgstr "Cont."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2125
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2144
 msgid "Cooldown"
 msgstr "Enfriar"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3663
+#: ../../Firmware/ultralcd.cpp:3682
 msgid "Copy selected language?"
 msgstr "Copiar idioma seleccionado?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1221
-#: ../../Firmware/ultralcd.cpp:1262 ../../Firmware/ultralcd.cpp:1272
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1240
+#: ../../Firmware/ultralcd.cpp:1281 ../../Firmware/ultralcd.cpp:1291
 msgid "Crash"
 msgstr "Choque"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4341
-#: ../../Firmware/ultralcd.cpp:4342 ../../Firmware/ultralcd.cpp:4344
-#: ../../Firmware/ultralcd.cpp:5765 ../../Firmware/ultralcd.cpp:5767
-#: ../../Firmware/ultralcd.cpp:5771
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4363
+#: ../../Firmware/ultralcd.cpp:5787 ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/ultralcd.cpp:5793
 msgid "Crash det."
 msgstr "Det. choque"
 
@@ -368,7 +368,7 @@ msgid "Crash detected."
 msgstr "Choque detectado."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3521
+#: ../../Firmware/ultralcd.cpp:3540
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -379,14 +379,14 @@ msgstr ""
 "Modo normal"
 
 #. MSG_CUT_FILAMENT c=17
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:5175
-#: ../../Firmware/ultralcd.cpp:5567
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:5197
+#: ../../Firmware/ultralcd.cpp:5589
 msgid "Cut filament"
 msgstr "Cortar filament"
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:4303
-#: ../../Firmware/ultralcd.cpp:4308 ../../Firmware/ultralcd.cpp:4313
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:4322
+#: ../../Firmware/ultralcd.cpp:4327 ../../Firmware/ultralcd.cpp:4332
 msgid "Cutter"
 msgstr "Cuchillo"
 
@@ -396,17 +396,17 @@ msgid "Cutting filament"
 msgstr "Corte de filament"
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1668
+#: ../../Firmware/ultralcd.cpp:1687
 msgid "Date:"
 msgstr "Fecha:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5886
 msgid "Dim"
 msgstr "Oscuro"
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4802
+#: ../../Firmware/ultralcd.cpp:4821
 msgid "Disable steppers"
 msgstr "Apagar motores"
 
@@ -423,7 +423,7 @@ msgstr ""
 "primera capa."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:4145
+#: ../../Firmware/ultralcd.cpp:4164
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -431,24 +431,24 @@ msgstr ""
 "Quieres repetir el ultimo paso para reajustar la distancia boquilla-base?"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4214
+#: ../../Firmware/ultralcd.cpp:4233
 msgid "E-correct:"
 msgstr "Corregir-E:"
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2279
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2298
 msgid "ERROR:"
 msgstr "ERROR:"
 
 #. MSG_FSENS_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3562
+#: ../../Firmware/ultralcd.cpp:3581
 msgid "ERROR: Filament sensor is not responding, please check connection."
 msgstr ""
 "ERROR:Sensor de fi- lamento no responde Por favor, comprue- ba la conexion."
 
 #. MSG_EJECT_FILAMENT c=17
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:5156
-#: ../../Firmware/ultralcd.cpp:5565
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:5178
+#: ../../Firmware/ultralcd.cpp:5587
 msgid "Eject filament"
 msgstr "Expulsar fil."
 
@@ -458,47 +458,41 @@ msgid "Ejecting filament"
 msgstr "Expulsando filamento"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6985
+#: ../../Firmware/ultralcd.cpp:7015
 msgid "Endstop"
 msgstr "Final de carrera"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6990
+#: ../../Firmware/ultralcd.cpp:7020
 msgid "Endstop not hit"
 msgstr "Endstop no alcanzado"
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6976
+#: ../../Firmware/ultralcd.cpp:7006
 msgid "Endstops"
 msgstr "Finales de carrera"
 
 #. MSG_EXTRUDER c=17
 #: ../../Firmware/Marlin_main.cpp:8608 ../../Firmware/messages.cpp:30
-#: ../../Firmware/ultralcd.cpp:3495
+#: ../../Firmware/ultralcd.cpp:3514
 msgid "Extruder"
 msgstr "Extruir"
 
-#. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1144
-#: ../../Firmware/ultralcd.cpp:7319
-msgid "Hotend fan:"
-msgstr "Vent. d. fusor:"
-
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1722
+#: ../../Firmware/ultralcd.cpp:1741
 msgid "Extruder info"
 msgstr "Info. del extrusor"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4229
-#: ../../Firmware/ultralcd.cpp:4237 ../../Firmware/ultralcd.cpp:4248
-#: ../../Firmware/ultralcd.cpp:4250
+#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4248
+#: ../../Firmware/ultralcd.cpp:4256 ../../Firmware/ultralcd.cpp:4267
+#: ../../Firmware/ultralcd.cpp:4269
 msgid "F. autoload"
 msgstr "Autocarg.fil."
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4704
-#: ../../Firmware/ultralcd.cpp:4707
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4723
+#: ../../Firmware/ultralcd.cpp:4726
 msgid "FS Action"
 msgstr "FS accion"
 
@@ -513,102 +507,102 @@ msgid "FS v0.4 or newer"
 msgstr "FS 0.4 o mas nueva"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5589
+#: ../../Firmware/ultralcd.cpp:5611
 msgid "Fail stats"
 msgstr "Estadistica Fallos"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5592
+#: ../../Firmware/ultralcd.cpp:5614
 msgid "Fail stats MMU"
 msgstr "Total Fallos MMU"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:7031
+#: ../../Firmware/ultralcd.cpp:7061
 msgid "False triggering"
 msgstr "Falsa activacion"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:5723
-#: ../../Firmware/ultralcd.cpp:5893
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/ultralcd.cpp:5915
 msgid "Fan speed"
 msgstr "Velocidad Vent"
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:7143
-#: ../../Firmware/ultralcd.cpp:7301 ../../Firmware/ultralcd.cpp:7302
-#: ../../Firmware/ultralcd.cpp:7303
+#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:7173
+#: ../../Firmware/ultralcd.cpp:7331 ../../Firmware/ultralcd.cpp:7332
+#: ../../Firmware/ultralcd.cpp:7333
 msgid "Fan test"
 msgstr "Test ventiladores"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4811
-#: ../../Firmware/ultralcd.cpp:5756
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4830
+#: ../../Firmware/ultralcd.cpp:5778
 msgid "Fans check"
 msgstr "Comprob.vent"
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1220
-#: ../../Firmware/ultralcd.cpp:1261 ../../Firmware/ultralcd.cpp:1327
-#: ../../Firmware/ultralcd.cpp:1329
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1239
+#: ../../Firmware/ultralcd.cpp:1280 ../../Firmware/ultralcd.cpp:1346
+#: ../../Firmware/ultralcd.cpp:1348
 msgid "Fil. runouts"
 msgstr "Fil. acabado"
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:3451
-#: ../../Firmware/ultralcd.cpp:4228 ../../Firmware/ultralcd.cpp:4234
-#: ../../Firmware/ultralcd.cpp:4244 ../../Firmware/ultralcd.cpp:5737
-#: ../../Firmware/ultralcd.cpp:5741 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:3470
+#: ../../Firmware/ultralcd.cpp:4247 ../../Firmware/ultralcd.cpp:4253
+#: ../../Firmware/ultralcd.cpp:4263 ../../Firmware/ultralcd.cpp:5759
+#: ../../Firmware/ultralcd.cpp:5763 ../../Firmware/ultralcd.cpp:5767
 msgid "Fil. sensor"
 msgstr "Sensor Fil."
 
 #. MSG_FILAMENT c=17
 #: ../../Firmware/Marlin_main.cpp:8577 ../../Firmware/Marlin_main.cpp:8604
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3835
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3854
 msgid "Filament"
 msgstr "Filamento"
 
 #. MSG_FILAMENT_CLEAN c=20 r=2
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2287
-#: ../../Firmware/ultralcd.cpp:2293
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2306
+#: ../../Firmware/ultralcd.cpp:2312
 msgid "Filament extruding & with correct color?"
 msgstr "Es nitido el color nuevo?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2217
+#: ../../Firmware/ultralcd.cpp:2236
 msgid "Filament not loaded"
 msgstr "Fil. no introducido"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:7026
-#: ../../Firmware/ultralcd.cpp:7030 ../../Firmware/ultralcd.cpp:7034
-#: ../../Firmware/ultralcd.cpp:7330
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:7056
+#: ../../Firmware/ultralcd.cpp:7060 ../../Firmware/ultralcd.cpp:7064
+#: ../../Firmware/ultralcd.cpp:7360
 msgid "Filament sensor"
 msgstr "Sensor de fil."
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2365
+#: ../../Firmware/ultralcd.cpp:2384
 msgid "Filament used"
 msgstr "Filamento usado"
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7461
+#: ../../Firmware/ultralcd.cpp:7491
 msgid "File incomplete. Continue anyway?"
 msgstr "Archivo incompleto. Continuar de todos modos?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:5314
-#: ../../Firmware/ultralcd.cpp:5630
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:5336
+#: ../../Firmware/ultralcd.cpp:5652
 msgid "Finishing movements"
 msgstr "Term. movimientos"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:4898
-#: ../../Firmware/ultralcd.cpp:5424
+#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:4917
+#: ../../Firmware/ultralcd.cpp:5446
 msgid "First layer cal."
 msgstr "Cal. primera cap."
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4066
+#: ../../Firmware/ultralcd.cpp:4085
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Primero, hare el Selftest para comprobar los problemas de montaje mas "
@@ -620,23 +614,23 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr "Corrige el problema y pulsa el boton en la unidad MMU."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5724
+#: ../../Firmware/ultralcd.cpp:5746
 msgid "Flow"
 msgstr "Flujo"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:6996
-#: ../../Firmware/ultralcd.cpp:7149 ../../Firmware/ultralcd.cpp:7154
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:7026
+#: ../../Firmware/ultralcd.cpp:7179 ../../Firmware/ultralcd.cpp:7184
 msgid "Front print fan?"
 msgstr "Vent. frontal?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2754
+#: ../../Firmware/ultralcd.cpp:2773
 msgid "Front side[μm]"
 msgstr "Frontal [μm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:7020
+#: ../../Firmware/ultralcd.cpp:7050
 msgid "Front/left fans"
 msgstr "Vents. front/izqui"
 
@@ -685,20 +679,20 @@ msgstr ""
 "Impresion cancelada."
 
 #. MSG_GCODE c=8
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:4655
-#: ../../Firmware/ultralcd.cpp:4658 ../../Firmware/ultralcd.cpp:4661
-#: ../../Firmware/ultralcd.cpp:4664
+#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:4674
+#: ../../Firmware/ultralcd.cpp:4677 ../../Firmware/ultralcd.cpp:4680
+#: ../../Firmware/ultralcd.cpp:4683
 msgid "Gcode"
 msgstr "Código G"
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:4672
-#: ../../Firmware/ultralcd.cpp:4726 ../../Firmware/ultralcd.cpp:4818
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:4691
+#: ../../Firmware/ultralcd.cpp:4745 ../../Firmware/ultralcd.cpp:4837
 msgid "HW Setup"
 msgstr "Configuracion HW"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6968
+#: ../../Firmware/ultralcd.cpp:6998
 msgid "Heater/Thermistor"
 msgstr "Calentador/Termistor"
 
@@ -720,7 +714,7 @@ msgid "Heating done."
 msgstr "Calentando acabado."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=16
-#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4042
+#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4061
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -731,7 +725,7 @@ msgstr ""
 "listo para imprimir."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4064
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -740,24 +734,30 @@ msgstr ""
 "configuracion?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:4358
-#: ../../Firmware/ultralcd.cpp:4367 ../../Firmware/ultralcd.cpp:5777
-#: ../../Firmware/ultralcd.cpp:5780
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:4377
+#: ../../Firmware/ultralcd.cpp:4386 ../../Firmware/ultralcd.cpp:5799
+#: ../../Firmware/ultralcd.cpp:5802
 msgid "High power"
 msgstr "Rend.pleno"
 
+#. MSG_HOTEND_FAN_SPEED c=15
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1145
+#: ../../Firmware/ultralcd.cpp:7351
+msgid "Hotend fan:"
+msgstr "Vent. d. fusor:"
+
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4094
 msgid "I will run xyz calibration now. It will take approx. 12 mins."
 msgstr "Hare la calibracion XYZ. Tardara 12 min. aproximadamente."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/ultralcd.cpp:4102
 msgid "I will run z calibration now."
 msgstr "Voy a hacer Calibracion Z ahora."
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=9
-#: ../../Firmware/ultralcd.cpp:4153
+#: ../../Firmware/ultralcd.cpp:4172
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -771,22 +771,22 @@ msgid "Improving bed calibration point"
 msgstr "Mejorando punto calibracion base"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:5478
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:5500
 msgid "Info screen"
 msgstr "Monitorizar"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5545
+#: ../../Firmware/ultralcd.cpp:5567
 msgid "Init. SD card"
 msgstr "Init. Tarjeta SD"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2152
+#: ../../Firmware/ultralcd.cpp:2171
 msgid "Insert filament"
 msgstr "Introducir filamento"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:6223
+#: ../../Firmware/ultralcd.cpp:6253
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
@@ -794,14 +794,14 @@ msgstr ""
 "Inserte el filamento (no lo cargue) en el extrusor y luego presione el dial."
 
 #. MSG_FILAMENT_LOADED c=20 r=2
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3855
-#: ../../Firmware/ultralcd.cpp:4108 ../../Firmware/ultralcd.cpp:4111
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3874
+#: ../../Firmware/ultralcd.cpp:4127 ../../Firmware/ultralcd.cpp:4130
 msgid "Is filament loaded?"
 msgstr "Esta el filamento cargado?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=2
 #: ../../Firmware/Marlin_main.cpp:3312 ../../Firmware/Marlin_main.cpp:4886
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:4084
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:4103
 msgid "Is steel sheet on heatbed?"
 msgstr "Esta c. la lamina sobre la base?"
 
@@ -811,74 +811,74 @@ msgid "Iteration"
 msgstr "Iteracion"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:1148
-#: ../../Firmware/ultralcd.cpp:1296
+#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:1167
+#: ../../Firmware/ultralcd.cpp:1315
 msgid "Last print"
 msgstr "Ultima impresion"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1169
-#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1269
-#: ../../Firmware/ultralcd.cpp:1326
+#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1188
+#: ../../Firmware/ultralcd.cpp:1278 ../../Firmware/ultralcd.cpp:1288
+#: ../../Firmware/ultralcd.cpp:1345
 msgid "Last print failures"
 msgstr "Ultimos imp. fallos"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2496
+#: ../../Firmware/ultralcd.cpp:2515
 msgid "Left"
 msgstr "Izquierda"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7001
-#: ../../Firmware/ultralcd.cpp:7147 ../../Firmware/ultralcd.cpp:7152
+#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:7032
+#: ../../Firmware/ultralcd.cpp:7179 ../../Firmware/ultralcd.cpp:7184
 msgid "Left hotend fan?"
 msgstr "Vent. izquierdo?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2752
+#: ../../Firmware/ultralcd.cpp:2771
 msgid "Left side [μm]"
 msgstr "Izquierda [μm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:5862
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:5884
 msgid "Level Bright"
 msgstr "Valor brill."
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:5863
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:5885
 msgid "Level Dimmed"
 msgstr "Valor oscuro"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4826
+#: ../../Firmware/ultralcd.cpp:4845
 msgid "Lin. correction"
 msgstr "Correc. Linealidad"
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4838
-#: ../../Firmware/ultralcd.cpp:5493
+#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4857
+#: ../../Firmware/ultralcd.cpp:5515
 msgid "Live adjust Z"
 msgstr "Micropaso Eje Z"
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/ultralcd.cpp:5120
+#: ../../Firmware/ultralcd.cpp:5142
 msgid "Load all"
 msgstr "Intr. todos fil."
 
 #. MSG_LOAD_FILAMENT c=17
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:5122
-#: ../../Firmware/ultralcd.cpp:5133 ../../Firmware/ultralcd.cpp:5562
-#: ../../Firmware/ultralcd.cpp:5576
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:5144
+#: ../../Firmware/ultralcd.cpp:5155 ../../Firmware/ultralcd.cpp:5584
+#: ../../Firmware/ultralcd.cpp:5598
 msgid "Load filament"
 msgstr "Introducir filam."
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5563
+#: ../../Firmware/ultralcd.cpp:5585
 msgid "Load to nozzle"
 msgstr "Cargar a boquilla"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2185
+#: ../../Firmware/ultralcd.cpp:2204
 msgid "Loading color"
 msgstr "Cambiando color"
 
@@ -886,18 +886,18 @@ msgstr "Cambiando color"
 #: ../../Firmware/Marlin_main.cpp:3641 ../../Firmware/messages.cpp:55
 #: ../../Firmware/mmu.cpp:872 ../../Firmware/mmu.cpp:906
 #: ../../Firmware/mmu.cpp:1014 ../../Firmware/mmu.cpp:1026
-#: ../../Firmware/ultralcd.cpp:2196 ../../Firmware/ultralcd.cpp:3949
+#: ../../Firmware/ultralcd.cpp:2215 ../../Firmware/ultralcd.cpp:3968
 msgid "Loading filament"
 msgstr "Introduciendo filam."
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:7008
+#: ../../Firmware/ultralcd.cpp:7038
 msgid "Loose pulley"
 msgstr "Polea suelta"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:4450
-#: ../../Firmware/ultralcd.cpp:4462
+#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/ultralcd.cpp:4481
 msgid "Loud"
 msgstr "Alto"
 
@@ -912,8 +912,8 @@ msgid "MK3S firmware detected on MK3 printer"
 msgstr "Firmware MK3S detectado en impresora MK3"
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4381
-#: ../../Firmware/ultralcd.cpp:4382
+#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4400
+#: ../../Firmware/ultralcd.cpp:4401
 msgid "MMU Mode"
 msgstr "Modo MMU"
 
@@ -933,8 +933,8 @@ msgid "MMU OK. Resuming..."
 msgstr "MMU OK. Resumiendo..."
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:64 ../../Firmware/ultralcd.cpp:1170
-#: ../../Firmware/ultralcd.cpp:1193
+#: ../../Firmware/messages.cpp:64 ../../Firmware/ultralcd.cpp:1189
+#: ../../Firmware/ultralcd.cpp:1212
 msgid "MMU fails"
 msgstr "Fallos MMU"
 
@@ -944,8 +944,8 @@ msgid "MMU load failed"
 msgstr "Carga MMU fallida"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:1171
-#: ../../Firmware/ultralcd.cpp:1194
+#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:1190
+#: ../../Firmware/ultralcd.cpp:1213
 msgid "MMU load fails"
 msgstr "Carga MMU falla"
 
@@ -955,32 +955,32 @@ msgid "MMU needs user attention."
 msgstr "MMU necesita atencion del usuario."
 
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/ultralcd.cpp:1195
+#: ../../Firmware/ultralcd.cpp:1214
 msgid "MMU power fails"
 msgstr "Fallo red MMU"
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1680
+#: ../../Firmware/ultralcd.cpp:1699
 msgid "MMU2 connected"
 msgstr "MMU2 conectado"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:5836
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:5858
 msgid "Magnets comp."
 msgstr "Comp. imanes"
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1147
-#: ../../Firmware/ultralcd.cpp:1295 ../../Firmware/ultralcd.cpp:1338
-#: ../../Firmware/ultralcd.cpp:1645 ../../Firmware/ultralcd.cpp:4795
-#: ../../Firmware/ultralcd.cpp:4892 ../../Firmware/ultralcd.cpp:5119
-#: ../../Firmware/ultralcd.cpp:5131 ../../Firmware/ultralcd.cpp:5154
-#: ../../Firmware/ultralcd.cpp:5173 ../../Firmware/ultralcd.cpp:5717
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1166
+#: ../../Firmware/ultralcd.cpp:1314 ../../Firmware/ultralcd.cpp:1357
+#: ../../Firmware/ultralcd.cpp:1664 ../../Firmware/ultralcd.cpp:4814
+#: ../../Firmware/ultralcd.cpp:4911 ../../Firmware/ultralcd.cpp:5141
+#: ../../Firmware/ultralcd.cpp:5153 ../../Firmware/ultralcd.cpp:5176
+#: ../../Firmware/ultralcd.cpp:5195 ../../Firmware/ultralcd.cpp:5739
 msgid "Main"
 msgstr "Menu principal"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2537
+#: ../../Firmware/ultralcd.cpp:2556
 msgid "Measured skew"
 msgstr "Desv. medida"
 
@@ -991,71 +991,71 @@ msgid "Measuring reference height of calibration point"
 msgstr "Midiendo altura del punto de calibracion"
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:5832
+#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:5854
 msgid "Mesh"
 msgstr "Malla"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4823
-#: ../../Firmware/ultralcd.cpp:4910
+#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4842
+#: ../../Firmware/ultralcd.cpp:4929
 msgid "Mesh Bed Leveling"
 msgstr "Nivela. Malla Base"
 
 #. MSG_MODE c=6
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:4336
-#: ../../Firmware/ultralcd.cpp:4338 ../../Firmware/ultralcd.cpp:4358
-#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4364
-#: ../../Firmware/ultralcd.cpp:4367 ../../Firmware/ultralcd.cpp:5763
-#: ../../Firmware/ultralcd.cpp:5770 ../../Firmware/ultralcd.cpp:5777
-#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5779
-#: ../../Firmware/ultralcd.cpp:5780 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/ultralcd.cpp:4357 ../../Firmware/ultralcd.cpp:4377
+#: ../../Firmware/ultralcd.cpp:4380 ../../Firmware/ultralcd.cpp:4383
+#: ../../Firmware/ultralcd.cpp:4386 ../../Firmware/ultralcd.cpp:5785
+#: ../../Firmware/ultralcd.cpp:5792 ../../Firmware/ultralcd.cpp:5799
+#: ../../Firmware/ultralcd.cpp:5800 ../../Firmware/ultralcd.cpp:5801
+#: ../../Firmware/ultralcd.cpp:5802 ../../Firmware/ultralcd.cpp:5886
 msgid "Mode"
 msgstr "Modo"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3598
+#: ../../Firmware/ultralcd.cpp:3617
 msgid "Mode change in progress..."
 msgstr "Cambio de modo progresando ..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:4575
-#: ../../Firmware/ultralcd.cpp:4578 ../../Firmware/ultralcd.cpp:4581
-#: ../../Firmware/ultralcd.cpp:4584
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:4594
+#: ../../Firmware/ultralcd.cpp:4597 ../../Firmware/ultralcd.cpp:4600
+#: ../../Firmware/ultralcd.cpp:4603
 msgid "Model"
 msgstr "Modelo"
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6982
-#: ../../Firmware/ultralcd.cpp:6991 ../../Firmware/ultralcd.cpp:7009
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:7012
+#: ../../Firmware/ultralcd.cpp:7021 ../../Firmware/ultralcd.cpp:7039
 msgid "Motor"
 msgstr "Motor"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3492
+#: ../../Firmware/ultralcd.cpp:3511
 msgid "Move X"
 msgstr "Mover X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3493
+#: ../../Firmware/ultralcd.cpp:3512
 msgid "Move Y"
 msgstr "Mover Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3494
+#: ../../Firmware/ultralcd.cpp:3513
 msgid "Move Z"
 msgstr "Mover Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4801
+#: ../../Firmware/ultralcd.cpp:4820
 msgid "Move axis"
 msgstr "Mover ejes"
 
 #. MSG_NA c=3
 #: ../../Firmware/menu.cpp:196 ../../Firmware/messages.cpp:124
-#: ../../Firmware/ultralcd.cpp:2502 ../../Firmware/ultralcd.cpp:2547
-#: ../../Firmware/ultralcd.cpp:3411 ../../Firmware/ultralcd.cpp:4228
-#: ../../Firmware/ultralcd.cpp:4276 ../../Firmware/ultralcd.cpp:5737
-#: ../../Firmware/ultralcd.cpp:5836
+#: ../../Firmware/ultralcd.cpp:2521 ../../Firmware/ultralcd.cpp:2566
+#: ../../Firmware/ultralcd.cpp:3430 ../../Firmware/ultralcd.cpp:4247
+#: ../../Firmware/ultralcd.cpp:4295 ../../Firmware/ultralcd.cpp:5759
+#: ../../Firmware/ultralcd.cpp:5858
 msgid "N/A"
 msgstr "N/D"
 
@@ -1065,14 +1065,14 @@ msgid "New firmware version available:"
 msgstr "Nuevo firmware disponible:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:2804
-#: ../../Firmware/ultralcd.cpp:3180 ../../Firmware/ultralcd.cpp:4785
-#: ../../Firmware/ultralcd.cpp:5988
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:2823
+#: ../../Firmware/ultralcd.cpp:3199 ../../Firmware/ultralcd.cpp:4804
+#: ../../Firmware/ultralcd.cpp:6018
 msgid "No"
 msgstr "No"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5543
+#: ../../Firmware/ultralcd.cpp:5565
 msgid "No SD card"
 msgstr "No hay tarjeta SD"
 
@@ -1082,34 +1082,34 @@ msgid "No move."
 msgstr "Sin movimiento"
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4405
-#: ../../Firmware/ultralcd.cpp:4493 ../../Firmware/ultralcd.cpp:4502
-#: ../../Firmware/ultralcd.cpp:4575 ../../Firmware/ultralcd.cpp:4584
-#: ../../Firmware/ultralcd.cpp:4614 ../../Firmware/ultralcd.cpp:4623
-#: ../../Firmware/ultralcd.cpp:4655 ../../Firmware/ultralcd.cpp:4664
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4424
+#: ../../Firmware/ultralcd.cpp:4512 ../../Firmware/ultralcd.cpp:4521
+#: ../../Firmware/ultralcd.cpp:4594 ../../Firmware/ultralcd.cpp:4603
+#: ../../Firmware/ultralcd.cpp:4633 ../../Firmware/ultralcd.cpp:4642
+#: ../../Firmware/ultralcd.cpp:4674 ../../Firmware/ultralcd.cpp:4683
 msgid "None"
 msgstr "Ninguno"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:4336
-#: ../../Firmware/ultralcd.cpp:4381 ../../Firmware/ultralcd.cpp:4397
-#: ../../Firmware/ultralcd.cpp:4416 ../../Firmware/ultralcd.cpp:5763
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/ultralcd.cpp:4400 ../../Firmware/ultralcd.cpp:4416
+#: ../../Firmware/ultralcd.cpp:4435 ../../Firmware/ultralcd.cpp:5785
 msgid "Normal"
 msgstr "Normal"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6969
+#: ../../Firmware/ultralcd.cpp:6999
 msgid "Not connected"
 msgstr "No hay conexion"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:7168
-#: ../../Firmware/ultralcd.cpp:7183 ../../Firmware/ultralcd.cpp:7191
+#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:7198
+#: ../../Firmware/ultralcd.cpp:7213 ../../Firmware/ultralcd.cpp:7221
 msgid "Not spinning"
 msgstr "Ventilador no gira"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3962
+#: ../../Firmware/ultralcd.cpp:3981
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr ""
@@ -1117,38 +1117,38 @@ msgstr ""
 "la base."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:4091
+#: ../../Firmware/ultralcd.cpp:4110
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Ahora precalentare la boquilla para PLA."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/ultralcd.cpp:4101
 msgid "Now remove the test print from steel sheet."
 msgstr "Ahora retira la prueba de la lamina de acero."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:1402
-#: ../../Firmware/ultralcd.cpp:4493 ../../Firmware/ultralcd.cpp:4496
-#: ../../Firmware/ultralcd.cpp:4499 ../../Firmware/ultralcd.cpp:4502
-#: ../../Firmware/ultralcd.cpp:5720 ../../Firmware/ultralcd.cpp:5882
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:1421
+#: ../../Firmware/ultralcd.cpp:4512 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/ultralcd.cpp:4518 ../../Firmware/ultralcd.cpp:4521
+#: ../../Firmware/ultralcd.cpp:5742 ../../Firmware/ultralcd.cpp:5904
 msgid "Nozzle"
 msgstr "Boquilla"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4546
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4565
 msgid "Nozzle d."
 msgstr "D boquilla"
 
 #. MSG_OFF c=3
 #: ../../Firmware/menu.cpp:467 ../../Firmware/messages.cpp:122
-#: ../../Firmware/ultralcd.cpp:4234 ../../Firmware/ultralcd.cpp:4250
-#: ../../Firmware/ultralcd.cpp:4284 ../../Firmware/ultralcd.cpp:4313
-#: ../../Firmware/ultralcd.cpp:4342 ../../Firmware/ultralcd.cpp:4811
-#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4834
-#: ../../Firmware/ultralcd.cpp:5644 ../../Firmware/ultralcd.cpp:5741
-#: ../../Firmware/ultralcd.cpp:5756 ../../Firmware/ultralcd.cpp:5767
-#: ../../Firmware/ultralcd.cpp:5836 ../../Firmware/ultralcd.cpp:7841
-#: ../../Firmware/ultralcd.cpp:7845
+#: ../../Firmware/ultralcd.cpp:4253 ../../Firmware/ultralcd.cpp:4269
+#: ../../Firmware/ultralcd.cpp:4303 ../../Firmware/ultralcd.cpp:4332
+#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4830
+#: ../../Firmware/ultralcd.cpp:4849 ../../Firmware/ultralcd.cpp:4853
+#: ../../Firmware/ultralcd.cpp:5666 ../../Firmware/ultralcd.cpp:5763
+#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/ultralcd.cpp:5858 ../../Firmware/ultralcd.cpp:7881
+#: ../../Firmware/ultralcd.cpp:7885
 msgid "Off"
 msgstr "Ina"
 
@@ -1160,19 +1160,19 @@ msgstr ""
 "extrusor, etc"
 
 #. MSG_ON c=3
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4244
-#: ../../Firmware/ultralcd.cpp:4248 ../../Firmware/ultralcd.cpp:4280
-#: ../../Firmware/ultralcd.cpp:4303 ../../Firmware/ultralcd.cpp:4341
-#: ../../Firmware/ultralcd.cpp:4811 ../../Firmware/ultralcd.cpp:4830
-#: ../../Firmware/ultralcd.cpp:4834 ../../Firmware/ultralcd.cpp:5745
-#: ../../Firmware/ultralcd.cpp:5756 ../../Firmware/ultralcd.cpp:5765
-#: ../../Firmware/ultralcd.cpp:5836 ../../Firmware/ultralcd.cpp:7841
-#: ../../Firmware/ultralcd.cpp:7845
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4263
+#: ../../Firmware/ultralcd.cpp:4267 ../../Firmware/ultralcd.cpp:4299
+#: ../../Firmware/ultralcd.cpp:4322 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4849
+#: ../../Firmware/ultralcd.cpp:4853 ../../Firmware/ultralcd.cpp:5767
+#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5787
+#: ../../Firmware/ultralcd.cpp:5858 ../../Firmware/ultralcd.cpp:7881
+#: ../../Firmware/ultralcd.cpp:7885
 msgid "On"
 msgstr "Act"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4453
+#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4472
 msgid "Once"
 msgstr "Una vez"
 
@@ -1192,7 +1192,7 @@ msgid "PID cal. finished"
 msgstr "Cal. PID terminada"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4913
+#: ../../Firmware/ultralcd.cpp:4932
 msgid "PID calibration"
 msgstr "Calibracion PID"
 
@@ -1204,18 +1204,18 @@ msgstr "Calentando PINDA"
 #. MSG_PINDA_CALIBRATION c=13
 #: ../../Firmware/Marlin_main.cpp:4932 ../../Firmware/Marlin_main.cpp:5035
 #: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:654
-#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4920
+#: ../../Firmware/ultralcd.cpp:4849 ../../Firmware/ultralcd.cpp:4939
 msgid "PINDA cal."
 msgstr "Cal. PINDA"
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3361
+#: ../../Firmware/ultralcd.cpp:3380
 msgid "PINDA calibration failed"
 msgstr "Fallo de la calibracion de PINDA"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
 #: ../../Firmware/Marlin_main.cpp:5112 ../../Firmware/messages.cpp:110
-#: ../../Firmware/ultralcd.cpp:3355
+#: ../../Firmware/ultralcd.cpp:3374
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1224,13 +1224,13 @@ msgstr ""
 "menu Configuracion -> Cal. PINDA"
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4707
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4726
 msgid "Pause"
 msgstr "Pausa"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:5507
-#: ../../Firmware/ultralcd.cpp:5509
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:5529
+#: ../../Firmware/ultralcd.cpp:5531
 msgid "Pause print"
 msgstr "Pausar impresion"
 
@@ -1245,7 +1245,7 @@ msgstr ""
 "impresora inmediatamente."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:4176
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:4195
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1254,18 +1254,18 @@ msgstr ""
 "continua con el Asistente"
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:6250
+#: ../../Firmware/ultralcd.cpp:6280
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr ""
 "Por favor comprueba la conexion del IR sensor y filamento esta descargado."
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6963
+#: ../../Firmware/ultralcd.cpp:6993
 msgid "Please check:"
 msgstr "Controla:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4148
+#: ../../Firmware/ultralcd.cpp:4167
 msgid "Please clean heatbed and then press the knob."
 msgstr "Limpia la superficie de la base, por favor, y luego presiona el dial."
 
@@ -1275,7 +1275,7 @@ msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Limpia boquilla para calibracion. Clic cuando acabes."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3945
+#: ../../Firmware/ultralcd.cpp:3964
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr ""
@@ -1283,7 +1283,7 @@ msgstr ""
 "cargarlo."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3940
+#: ../../Firmware/ultralcd.cpp:3959
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1292,7 +1292,7 @@ msgstr ""
 "dial para cargarlo."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3863
+#: ../../Firmware/ultralcd.cpp:3882
 msgid "Please load filament first."
 msgstr "Por favor, carga primero el filamento."
 
@@ -1303,7 +1303,7 @@ msgstr "Por favor abre el tensor y retira el filamento manualmente."
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=5
 #: ../../Firmware/mesh_bed_calibration.cpp:2799 ../../Firmware/messages.cpp:70
-#: ../../Firmware/ultralcd.cpp:4085
+#: ../../Firmware/ultralcd.cpp:4104
 msgid "Please place steel sheet on heatbed."
 msgstr "Por favor coloca la lam. de acero en la base calefactable."
 
@@ -1314,7 +1314,7 @@ msgid "Please press the knob to unload filament"
 msgstr "Por favor, pulsa el dial para descargar el filamento"
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:5213
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:5235
 msgid "Please pull out filament immediately"
 msgstr "Por favor retira el filamento de inmediato"
 
@@ -1324,7 +1324,7 @@ msgid "Please remove filament and then press the knob."
 msgstr "Por favor quite el filamento y luego presione el dial."
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:4081
+#: ../../Firmware/ultralcd.cpp:4100
 msgid "Please remove shipping helpers first."
 msgstr "Por favor retira los soportes de envio primero."
 
@@ -1340,7 +1340,7 @@ msgid "Please run XYZ calibration first."
 msgstr "Por favor realiza la calibracion XYZ primero."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:6247
+#: ../../Firmware/ultralcd.cpp:6277
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Primero descarga el filamento, luego repite esta accion."
 
@@ -1357,54 +1357,54 @@ msgstr "Actualiza por favor."
 #. MSG_PLEASE_WAIT c=20
 #: ../../Firmware/Marlin_main.cpp:3547 ../../Firmware/Marlin_main.cpp:3563
 #: ../../Firmware/Marlin_main.cpp:7931 ../../Firmware/messages.cpp:71
-#: ../../Firmware/ultralcd.cpp:2186 ../../Firmware/ultralcd.cpp:2197
+#: ../../Firmware/ultralcd.cpp:2205 ../../Firmware/ultralcd.cpp:2216
 msgid "Please wait"
 msgstr "Por favor espere"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1219
-#: ../../Firmware/ultralcd.cpp:1260 ../../Firmware/ultralcd.cpp:1270
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1238
+#: ../../Firmware/ultralcd.cpp:1279 ../../Firmware/ultralcd.cpp:1289
 msgid "Power failures"
 msgstr "Fallos energia"
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5502
+#: ../../Firmware/ultralcd.cpp:5524
 msgid "Preheat"
 msgstr "Precalentar"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:2280
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:2299
 msgid "Preheat the nozzle!"
 msgstr "Precalienta extrusor"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:2900
-#: ../../Firmware/ultralcd.cpp:3924 ../../Firmware/ultralcd.cpp:3926
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:2919
+#: ../../Firmware/ultralcd.cpp:3943 ../../Firmware/ultralcd.cpp:3945
 msgid "Preheating nozzle. Please wait."
 msgstr "Precalentando nozzle. Espera por favor."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1988
+#: ../../Firmware/ultralcd.cpp:2007
 msgid "Preheating to cut"
 msgstr "Precalent. laminar"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1985
+#: ../../Firmware/ultralcd.cpp:2004
 msgid "Preheating to eject"
 msgstr "Precalent. expulsar"
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1976
+#: ../../Firmware/ultralcd.cpp:1995
 msgid "Preheating to load"
 msgstr "Precalent. cargar"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1981
+#: ../../Firmware/ultralcd.cpp:2000
 msgid "Preheating to unload"
 msgstr "Precalent. descargar"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1809
+#: ../../Firmware/ultralcd.cpp:1828
 msgid "Press the knob"
 msgstr "Pulsa el dial"
 
@@ -1424,13 +1424,13 @@ msgid "Print aborted"
 msgstr "Impresion cancelada"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1144
-#: ../../Firmware/ultralcd.cpp:7322
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1145
+#: ../../Firmware/ultralcd.cpp:7354
 msgid "Print fan:"
 msgstr "Vent.fusor:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5535
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5557
 msgid "Print from SD"
 msgstr "Menu tarjeta SD"
 
@@ -1440,12 +1440,12 @@ msgid "Print paused"
 msgstr "Impresion en pausa"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2366
+#: ../../Firmware/ultralcd.cpp:2385
 msgid "Print time"
 msgstr "Tiempo de imp."
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1711
+#: ../../Firmware/ultralcd.cpp:1730
 msgid "Printer IP Addr:"
 msgstr "Dir. IP impresora:"
 
@@ -1473,12 +1473,12 @@ msgstr ""
 "ajustes. Impresion cancelada."
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4834
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4853
 msgid "RPi port"
 msgstr "Puerto RPi"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2755
+#: ../../Firmware/ultralcd.cpp:2774
 msgid "Rear side [μm]"
 msgstr "Trasera [μm]"
 
@@ -1495,24 +1495,24 @@ msgstr ""
 "filamento."
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5426
+#: ../../Firmware/ultralcd.cpp:5448
 msgid "Rename"
 msgstr "Renombrar"
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2756
-#: ../../Firmware/ultralcd.cpp:5427
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2775
+#: ../../Firmware/ultralcd.cpp:5449
 msgid "Reset"
 msgstr "Reset"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4917
+#: ../../Firmware/ultralcd.cpp:4936
 msgid "Reset XYZ calibr."
 msgstr "Reset calibr. XYZ"
 
 #. MSG_RESUME_PRINT c=18
 #: ../../Firmware/Marlin_main.cpp:655 ../../Firmware/messages.cpp:81
-#: ../../Firmware/ultralcd.cpp:5521 ../../Firmware/ultralcd.cpp:5523
+#: ../../Firmware/ultralcd.cpp:5543 ../../Firmware/ultralcd.cpp:5545
 msgid "Resume print"
 msgstr "Reanudar impres."
 
@@ -1522,17 +1522,17 @@ msgid "Resuming print"
 msgstr "Continuan. impresion"
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2497
+#: ../../Firmware/ultralcd.cpp:2516
 msgid "Right"
 msgstr "Derecha"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2753
+#: ../../Firmware/ultralcd.cpp:2772
 msgid "Right side[μm]"
 msgstr "Derecha [μm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3884
+#: ../../Firmware/ultralcd.cpp:3903
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1541,14 +1541,14 @@ msgstr ""
 "comenzara de nuevo. Continuar?"
 
 #. MSG_RUNOUTS c=7
-#: ../../Firmware/ultralcd.cpp:1271
+#: ../../Firmware/ultralcd.cpp:1290
 msgid "Runouts"
 msgstr "Falla"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4395
-#: ../../Firmware/ultralcd.cpp:4397 ../../Firmware/ultralcd.cpp:4414
-#: ../../Firmware/ultralcd.cpp:4416
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4414
+#: ../../Firmware/ultralcd.cpp:4416 ../../Firmware/ultralcd.cpp:4433
+#: ../../Firmware/ultralcd.cpp:4435
 msgid "SD card"
 msgstr "Tarj. SD"
 
@@ -1564,12 +1564,12 @@ msgid "Searching bed calibration point"
 msgstr "Buscando punto de calibracion base"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5419
+#: ../../Firmware/ultralcd.cpp:5441
 msgid "Select"
 msgstr "Seleccionar"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3966
+#: ../../Firmware/ultralcd.cpp:3985
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
@@ -1584,51 +1584,51 @@ msgstr "Elegir extrusor:"
 
 #. MSG_SELECT_FILAMENT c=20
 #: ../../Firmware/Marlin_main.cpp:8577 ../../Firmware/Marlin_main.cpp:8604
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3834
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3853
 msgid "Select filament:"
 msgstr "Selecciona filam.:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:3679
-#: ../../Firmware/ultralcd.cpp:4841
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:3698
+#: ../../Firmware/ultralcd.cpp:4860
 msgid "Select language"
 msgstr "Cambiar el idioma"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:4122
+#: ../../Firmware/ultralcd.cpp:4141
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr ""
 "Selecciona la temperatura para precalentar la boquilla que se ajuste a tu "
 "material."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3971
+#: ../../Firmware/ultralcd.cpp:3990
 msgid "Select temperature which matches your material."
 msgstr "Selecciona la temperatura adecuada a tu material."
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6522
+#: ../../Firmware/ultralcd.cpp:6552
 msgid "Self test OK"
 msgstr "Self test OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:6290
+#: ../../Firmware/ultralcd.cpp:6320
 msgid "Self test start"
 msgstr "Iniciar Selftest"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4904
+#: ../../Firmware/ultralcd.cpp:4923
 msgid "Selftest"
 msgstr "Selftest"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6962
+#: ../../Firmware/ultralcd.cpp:6992
 msgid "Selftest error!"
 msgstr "Error Selftest!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:6526
-#: ../../Firmware/ultralcd.cpp:7049 ../../Firmware/ultralcd.cpp:7314
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:6556
+#: ../../Firmware/ultralcd.cpp:7079 ../../Firmware/ultralcd.cpp:7344
 msgid "Selftest failed"
 msgstr "Fallo Selftest"
 
@@ -1640,30 +1640,30 @@ msgstr ""
 "posicion inicial sin sensores."
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1723
+#: ../../Firmware/ultralcd.cpp:1742
 msgid "Sensor info"
 msgstr "Info sensor"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:6254
+#: ../../Firmware/ultralcd.cpp:6284
 msgid "Sensor verified, remove the filament now."
 msgstr "Sensor verificado, retira el filamento ahora."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2773
+#: ../../Firmware/ultralcd.cpp:2792
 msgid "Set temperature:"
 msgstr "Establecer temp.:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:3491
-#: ../../Firmware/ultralcd.cpp:3696 ../../Firmware/ultralcd.cpp:4206
-#: ../../Firmware/ultralcd.cpp:5580 ../../Firmware/ultralcd.cpp:5827
-#: ../../Firmware/ultralcd.cpp:5880
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:3510
+#: ../../Firmware/ultralcd.cpp:3715 ../../Firmware/ultralcd.cpp:4225
+#: ../../Firmware/ultralcd.cpp:5602 ../../Firmware/ultralcd.cpp:5849
+#: ../../Firmware/ultralcd.cpp:5902
 msgid "Settings"
 msgstr "Configuracion"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2540
+#: ../../Firmware/ultralcd.cpp:2559
 msgid "Severe skew"
 msgstr "Desv. severa"
 
@@ -1674,7 +1674,7 @@ msgid "Sheet"
 msgstr "Lamina"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3824
+#: ../../Firmware/ultralcd.cpp:3843
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1687,18 +1687,18 @@ msgstr ""
 "%cReset"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4915
+#: ../../Firmware/ultralcd.cpp:4934
 msgid "Show end stops"
 msgstr "Mostrar endstops"
 
 #. MSG_SILENT c=7
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4361
-#: ../../Firmware/ultralcd.cpp:4456 ../../Firmware/ultralcd.cpp:5778
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4380
+#: ../../Firmware/ultralcd.cpp:4475 ../../Firmware/ultralcd.cpp:5800
 msgid "Silent"
 msgstr "Acallar"
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2539
+#: ../../Firmware/ultralcd.cpp:2558
 msgid "Slight skew"
 msgstr "Desv. ligera"
 
@@ -1717,8 +1717,8 @@ msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Problema encontrado, nivelacion Z forzosa ..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4403
-#: ../../Firmware/ultralcd.cpp:4404 ../../Firmware/ultralcd.cpp:4405
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4422
+#: ../../Firmware/ultralcd.cpp:4423 ../../Firmware/ultralcd.cpp:4424
 msgid "Sort"
 msgstr "Ordenar"
 
@@ -1729,20 +1729,20 @@ msgid "Sorting files"
 msgstr "Ordenando archivos"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4450
-#: ../../Firmware/ultralcd.cpp:4453 ../../Firmware/ultralcd.cpp:4456
-#: ../../Firmware/ultralcd.cpp:4459 ../../Firmware/ultralcd.cpp:4462
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/ultralcd.cpp:4472 ../../Firmware/ultralcd.cpp:4475
+#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4481
 msgid "Sound"
 msgstr "Sonido"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5718
+#: ../../Firmware/ultralcd.cpp:5740
 msgid "Speed"
 msgstr "Velocidad"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7166
-#: ../../Firmware/ultralcd.cpp:7181 ../../Firmware/ultralcd.cpp:7189
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7196
+#: ../../Firmware/ultralcd.cpp:7211 ../../Firmware/ultralcd.cpp:7219
 msgid "Spinning"
 msgstr "Ventilador girando"
 
@@ -1753,42 +1753,42 @@ msgstr ""
 "Se necesita una temperatura ambiente ente 21 y 26C y un soporte rigido."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5585
+#: ../../Firmware/ultralcd.cpp:5607
 msgid "Statistics"
 msgstr "Estadisticas"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4338
-#: ../../Firmware/ultralcd.cpp:4382 ../../Firmware/ultralcd.cpp:5770
+#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4357
+#: ../../Firmware/ultralcd.cpp:4401 ../../Firmware/ultralcd.cpp:5792
 msgid "Stealth"
 msgstr "Sigilo"
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4763
-#: ../../Firmware/ultralcd.cpp:5416
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4782
+#: ../../Firmware/ultralcd.cpp:5438
 msgid "Steel sheets"
 msgstr "Lamina de acero"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5528
-#: ../../Firmware/ultralcd.cpp:5987
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5550
+#: ../../Firmware/ultralcd.cpp:6017
 msgid "Stop print"
 msgstr "Detener impresion"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4499
-#: ../../Firmware/ultralcd.cpp:4581 ../../Firmware/ultralcd.cpp:4620
-#: ../../Firmware/ultralcd.cpp:4661
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4518
+#: ../../Firmware/ultralcd.cpp:4600 ../../Firmware/ultralcd.cpp:4639
+#: ../../Firmware/ultralcd.cpp:4680
 msgid "Strict"
 msgstr "Estrict"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/ultralcd.cpp:5616
 msgid "Support"
 msgstr "Soporte"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:7021
+#: ../../Firmware/ultralcd.cpp:7051
 msgid "Swapped"
 msgstr "Intercambiado"
 
@@ -1797,28 +1797,18 @@ msgstr "Intercambiado"
 msgid "THERMAL ANOMALY"
 msgstr "ANOMALIA TERMICA"
 
-#. MSG_TM_AUTOTUNE_FAILED c=20
-#: ../../Firmware/temperature.cpp:2899
-msgid "TM autotune failed"
-msgstr "Fallo autotune TM"
-
-#. MSG_TEMP_MODEL_AUTOTUNE c=20
-#: ../../Firmware/temperature.cpp:2884
-msgid "Temp. model autotune"
-msgstr "Autotune model temp."
-
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4797
+#: ../../Firmware/ultralcd.cpp:4816
 msgid "Temperature"
 msgstr "Temperatura"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1729
+#: ../../Firmware/ultralcd.cpp:1748
 msgid "Temperatures"
 msgstr "Temperaturas"
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3974
+#: ../../Firmware/ultralcd.cpp:3993
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -1838,66 +1828,66 @@ msgstr ""
 "capitulo Primeros pasos, seccion Calibracion del flujo."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4403
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4422
 msgid "Time"
 msgstr "Fecha"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:5865
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:5887
 msgid "Timeout"
 msgstr "Expirar"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:1149
-#: ../../Firmware/ultralcd.cpp:1297
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:1168
+#: ../../Firmware/ultralcd.cpp:1316
 msgid "Total"
 msgstr "Total"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:1192
-#: ../../Firmware/ultralcd.cpp:1218 ../../Firmware/ultralcd.cpp:1328
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:1211
+#: ../../Firmware/ultralcd.cpp:1237 ../../Firmware/ultralcd.cpp:1347
 msgid "Total failures"
 msgstr "Fallos totales"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2387
+#: ../../Firmware/ultralcd.cpp:2406
 msgid "Total filament"
 msgstr "Filamento total"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2388
+#: ../../Firmware/ultralcd.cpp:2407
 msgid "Total print time"
 msgstr "Tiempo total imp."
 
 #. MSG_TUNE c=18
-#: ../../Firmware/ultralcd.cpp:5500
+#: ../../Firmware/ultralcd.cpp:5522
 msgid "Tune"
 msgstr "Ajustar"
 
 #. MSG_UNLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:5564
-#: ../../Firmware/ultralcd.cpp:5578
+#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:5586
+#: ../../Firmware/ultralcd.cpp:5600
 msgid "Unload filament"
 msgstr "Descargar fil."
 
 #. MSG_UNLOADING_FILAMENT c=20
 #: ../../Firmware/messages.cpp:112 ../../Firmware/mmu.cpp:957
-#: ../../Firmware/ultralcd.cpp:5197
+#: ../../Firmware/ultralcd.cpp:5219
 msgid "Unloading filament"
 msgstr "Descargando fil."
 
 #. MSG_FIL_FAILED c=20 r=5
-#: ../../Firmware/ultralcd.cpp:6258
+#: ../../Firmware/ultralcd.cpp:6288
 msgid "Verification failed, remove the filament and try again."
 msgstr "La verificacion fallo, retira el filamento e intenta nuevamente."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1732
+#: ../../Firmware/ultralcd.cpp:1751
 msgid "Voltages"
 msgstr "Voltajes"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3534
+#: ../../Firmware/ultralcd.cpp:3553
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -1915,19 +1905,19 @@ msgid "Wait for user..."
 msgstr "Esperando ordenes..."
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2881
+#: ../../Firmware/ultralcd.cpp:2900
 msgid "Waiting for PINDA probe cooling"
 msgstr "Esperando a que se enfrie la sonda PINDA"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2913
+#: ../../Firmware/ultralcd.cpp:2932
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Esperando enfriamiento de la base y extrusor."
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:4496
-#: ../../Firmware/ultralcd.cpp:4578 ../../Firmware/ultralcd.cpp:4617
-#: ../../Firmware/ultralcd.cpp:4658
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/ultralcd.cpp:4597 ../../Firmware/ultralcd.cpp:4636
+#: ../../Firmware/ultralcd.cpp:4677
 msgid "Warn"
 msgstr "Aviso"
 
@@ -1953,147 +1943,136 @@ msgid "Was filament unload successful?"
 msgstr "Se descargo con exito el filamento?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6973
-#: ../../Firmware/ultralcd.cpp:6977 ../../Firmware/ultralcd.cpp:6997
-#: ../../Firmware/ultralcd.cpp:7003 ../../Firmware/ultralcd.cpp:7027
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:7003
+#: ../../Firmware/ultralcd.cpp:7007 ../../Firmware/ultralcd.cpp:7027
+#: ../../Firmware/ultralcd.cpp:7033 ../../Firmware/ultralcd.cpp:7057
 msgid "Wiring error"
 msgstr "Error de conexion"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4895
+#: ../../Firmware/ultralcd.cpp:4914
 msgid "Wizard"
 msgstr "Asistente"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4210
+#: ../../Firmware/ultralcd.cpp:4229
 msgid "X-correct:"
 msgstr "Corregir-X:"
 
 #. MSG_XFLASH c=18
-#: ../../Firmware/ultralcd.cpp:5596
+#: ../../Firmware/ultralcd.cpp:5618
 msgid "XFLASH init"
 msgstr "XFLASH init"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1721
+#: ../../Firmware/ultralcd.cpp:1740
 msgid "XYZ cal. details"
 msgstr "Detalles cal. XYZ"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3333
+#: ../../Firmware/ultralcd.cpp:3352
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr "Calibracion XYZ correcta. La desviacion se corregira automaticamente."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3330
+#: ../../Firmware/ultralcd.cpp:3349
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr ""
 "Calibracion XYZ correcta. Los ejes X/Y estan ligeramente desviados. Buen "
 "trabajo!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3311
+#: ../../Firmware/ultralcd.cpp:3330
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr "Calibrazion XYZ comprometida. Puntos frontales no alcanzables."
 
-#. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_LEFT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3317
-msgid ""
-"XYZ calibration compromised. Left front calibration point not reachable."
-msgstr ""
-
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3314
+#: ../../Firmware/ultralcd.cpp:3333
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr "Calibrazion XYZ comprometida. Punto frontal derecho no alcanzable."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3293
+#: ../../Firmware/ultralcd.cpp:3312
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr ""
 "Calibracion XYZ fallada. Puntos de calibracion en la base no encontrados."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3299
+#: ../../Firmware/ultralcd.cpp:3318
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr "Calibracion XYZ fallada. Puntos frontales no alcanzables."
 
-#. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_LEFT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3305
-msgid "XYZ calibration failed. Left front calibration point not reachable."
-msgstr ""
-
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3296
-#: ../../Firmware/ultralcd.cpp:3324
+#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3315
+#: ../../Firmware/ultralcd.cpp:3343
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "Calibracion XYZ fallada. Consulta el manual por favor."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3302
+#: ../../Firmware/ultralcd.cpp:3321
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr "Calibracion XYZ fallad. Punto frontal derecho no alcanzable."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3327
+#: ../../Firmware/ultralcd.cpp:3346
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "Calibracion XYZ ok. Ejes X/Y perpendiculares. Enhorabuena!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2494
+#: ../../Firmware/ultralcd.cpp:2513
 msgid "Y distance from min"
 msgstr "Dist. en Y desde min"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4211
+#: ../../Firmware/ultralcd.cpp:4230
 msgid "Y-correct:"
 msgstr "Corregir-Y:"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:2216
-#: ../../Firmware/ultralcd.cpp:2800 ../../Firmware/ultralcd.cpp:3180
-#: ../../Firmware/ultralcd.cpp:4785 ../../Firmware/ultralcd.cpp:5989
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:2235
+#: ../../Firmware/ultralcd.cpp:2819 ../../Firmware/ultralcd.cpp:3199
+#: ../../Firmware/ultralcd.cpp:4804 ../../Firmware/ultralcd.cpp:6019
 msgid "Yes"
 msgstr "Si"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:4187
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:4206
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr "Siempre puedes acceder al asistente desde Calibracion -> Asistente"
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4231
 msgid "Z-correct:"
 msgstr "Corregir-Z:"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:5835
+#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:5857
 msgid "Z-probe nr."
 msgstr "Z-sensor nr."
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2565
+#: ../../Firmware/ultralcd.cpp:2584
 msgid "[0;0] point offset"
 msgstr "[0;0] punto offset"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2154
+#: ../../Firmware/ultralcd.cpp:2173
 msgid "and press the knob"
 msgstr "y presione el dial"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1816
+#: ../../Firmware/ultralcd.cpp:1835
 msgid "to load filament"
 msgstr "para cargar el fil."
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1820
+#: ../../Firmware/ultralcd.cpp:1839
 msgid "to unload filament"
 msgstr "para descargar fil."
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1688
+#: ../../Firmware/ultralcd.cpp:1707
 msgid "unknown"
 msgstr "desconocido"
 
@@ -2103,8 +2082,8 @@ msgid "unknown state"
 msgstr "estado desconocido"
 
 #. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:6077
-#: ../../Firmware/ultralcd.cpp:6080
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:6107
+#: ../../Firmware/ultralcd.cpp:6110
 msgid "🔃Refresh"
 msgstr "🔃Actualizar"
 
@@ -2113,3 +2092,9 @@ msgstr "🔃Actualizar"
 
 #~ msgid "M117 First layer cal."
 #~ msgstr "M117 Cal. primera cap."
+
+#~ msgid "TM autotune failed"
+#~ msgstr "Fallo autotune TM"
+
+#~ msgid "Temp. model autotune"
+#~ msgstr "Autotune model temp."

--- a/lang/po/Firmware_fr.po
+++ b/lang/po/Firmware_fr.po
@@ -26,115 +26,115 @@ msgid " 0.4 or newer"
 msgstr " 0.4 ou +recent"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:7036
+#: ../../Firmware/ultralcd.cpp:7066
 msgid "%s level expected"
 msgstr "niveau %s attendu"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1968
-#: ../../Firmware/ultralcd.cpp:3835
+#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1987
+#: ../../Firmware/ultralcd.cpp:3854
 msgid ">Cancel"
 msgstr ">Annuler"
 
 #. MSG_BABYSTEPPING_Z c=15
 #. Beware: must include the ':' as its last character
-#: ../../Firmware/ultralcd.cpp:2670
+#: ../../Firmware/ultralcd.cpp:2689
 msgid "Adjusting Z:"
 msgstr "Ajuster Z:"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:7313
+#: ../../Firmware/ultralcd.cpp:7343
 msgid "All correct"
 msgstr "Tout est correct"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4180
+#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4190
+#: ../../Firmware/ultralcd.cpp:4199
 msgid "All is done. Happy printing!"
 msgstr "Tout est pret. Bonne impression!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4404
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4423
 msgid "Alphabet"
 msgstr "Alphabet"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4308
+#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4327
 msgid "Always"
 msgstr "Tjrs"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1405
+#: ../../Firmware/ultralcd.cpp:1424
 msgid "Ambient"
 msgstr "Ambiant"
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2983
+#: ../../Firmware/ultralcd.cpp:3002
 msgid "Are left and right Z~carriages all up?"
 msgstr "Z~carriages gauche + droite tout en haut?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4478
 msgid "Assist"
 msgstr "Assist"
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:5886
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
 #: ../../Firmware/Marlin_main.cpp:3271 ../../Firmware/messages.cpp:9
-#: ../../Firmware/ultralcd.cpp:4900
+#: ../../Firmware/ultralcd.cpp:4919
 msgid "Auto home"
 msgstr "Mise a 0 des axes"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:4364
-#: ../../Firmware/ultralcd.cpp:5779
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:4383
+#: ../../Firmware/ultralcd.cpp:5801
 msgid "Auto power"
 msgstr "Puiss.auto"
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5572
+#: ../../Firmware/ultralcd.cpp:5594
 msgid "AutoLoad filament"
 msgstr "Autocharge du fil."
 
 #. MSG_AUTOLOADING_ONLY_IF_FSENS_ON c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3549
+#: ../../Firmware/ultralcd.cpp:3568
 msgid ""
 "Autoloading filament available only when filament sensor is turned on..."
 msgstr ""
 "Chargement auto du filament uniquement si le capteur de filament est active."
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2301
+#: ../../Firmware/ultralcd.cpp:2320
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
 "Chargement auto. du fil. active, appuyez sur le bouton et inserez le fil."
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:7015
+#: ../../Firmware/ultralcd.cpp:7045
 msgid "Axis"
 msgstr "Axe"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:7014
+#: ../../Firmware/ultralcd.cpp:7044
 msgid "Axis length"
 msgstr "Longueur de l'axe"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:2751
-#: ../../Firmware/ultralcd.cpp:5861 ../../Firmware/ultralcd.cpp:7838
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:2770
+#: ../../Firmware/ultralcd.cpp:5883 ../../Firmware/ultralcd.cpp:7878
 msgid "Back"
 msgstr "Retour"
 
 #. MSG_BED c=13
 #: ../../Firmware/Marlin_main.cpp:2051 ../../Firmware/Marlin_main.cpp:4767
 #: ../../Firmware/Marlin_main.cpp:4819 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:1403 ../../Firmware/ultralcd.cpp:5721
-#: ../../Firmware/ultralcd.cpp:5891
+#: ../../Firmware/ultralcd.cpp:1422 ../../Firmware/ultralcd.cpp:5743
+#: ../../Firmware/ultralcd.cpp:5913
 msgid "Bed"
 msgstr "Lit"
 
@@ -151,7 +151,7 @@ msgid "Bed done"
 msgstr "Plateau termine"
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4912
+#: ../../Firmware/ultralcd.cpp:4931
 msgid "Bed level correct"
 msgstr "Reglage plateau"
 
@@ -169,18 +169,18 @@ msgstr ""
 "attente d'un reset."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6972
+#: ../../Firmware/ultralcd.cpp:7002
 msgid "Bed/Heater"
 msgstr "Lit/Chauffage"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1458
-#: ../../Firmware/ultralcd.cpp:1726
+#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1477
+#: ../../Firmware/ultralcd.cpp:1745
 msgid "Belt status"
 msgstr "Statut courroie"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4902
+#: ../../Firmware/ultralcd.cpp:4921
 msgid "Belt test"
 msgstr "Test de courroie"
 
@@ -191,28 +191,28 @@ msgid "Blackout occurred. Recover print?"
 msgstr "Coupure detectee. Reprendre impres.?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:5886
 msgid "Bright"
 msgstr "Brill."
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4850
-#: ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4869
+#: ../../Firmware/ultralcd.cpp:5811
 msgid "Brightness"
 msgstr "Luminosite"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4906
+#: ../../Firmware/ultralcd.cpp:4925
 msgid "Calibrate XYZ"
 msgstr "Calibrer XYZ"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4908
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4927
 msgid "Calibrate Z"
 msgstr "Calibrer Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2946
+#: ../../Firmware/ultralcd.cpp:2965
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -227,7 +227,7 @@ msgid "Calibrating Z"
 msgstr "Calibration Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2945
+#: ../../Firmware/ultralcd.cpp:2964
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -236,12 +236,12 @@ msgstr ""
 "Z jusqu'aux butees. Cliquez une fois fait."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:7315
+#: ../../Firmware/ultralcd.cpp:7345
 msgid "Calibrating home"
 msgstr "Calib. mise a 0"
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:5581
+#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:5603
 msgid "Calibration"
 msgstr "Calibration"
 
@@ -251,115 +251,115 @@ msgid "Calibration done"
 msgstr "Calibration terminee"
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7712
+#: ../../Firmware/ultralcd.cpp:7752
 msgid "Card removed"
 msgstr "Carte retiree"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/ultralcd.cpp:5560
 msgid "Change SD card"
 msgstr "Changez carte SD"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5497
-#: ../../Firmware/ultralcd.cpp:5730
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5519
+#: ../../Firmware/ultralcd.cpp:5752
 msgid "Change filament"
 msgstr "Changer filament"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2163
+#: ../../Firmware/ultralcd.cpp:2182
 msgid "Change success!"
 msgstr "Changement reussi!"
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2215
+#: ../../Firmware/ultralcd.cpp:2234
 msgid "Changed correctly?"
 msgstr "Change correctement?"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:6178
-#: ../../Firmware/ultralcd.cpp:7305
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:6208
+#: ../../Firmware/ultralcd.cpp:7335
 msgid "Checking X axis"
 msgstr "Verification axe X"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:6187
-#: ../../Firmware/ultralcd.cpp:7306
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:6217
+#: ../../Firmware/ultralcd.cpp:7336
 msgid "Checking Y axis"
 msgstr "Verification axe Y"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:7307
+#: ../../Firmware/ultralcd.cpp:7337
 msgid "Checking Z axis"
 msgstr "Verification axe Z"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:7308
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:7338
 msgid "Checking bed"
 msgstr "Verif. plateau chauf"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:7304
+#: ../../Firmware/ultralcd.cpp:7334
 msgid "Checking endstops"
 msgstr "Verification butees"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:7403
+#: ../../Firmware/ultralcd.cpp:7433
 msgid "Checking file"
 msgstr "Verific. fichier"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:7310
+#: ../../Firmware/ultralcd.cpp:7340
 msgid "Checking hotend"
 msgstr "Verif. du hotend"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:7311
-#: ../../Firmware/ultralcd.cpp:7312
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:7341
+#: ../../Firmware/ultralcd.cpp:7342
 msgid "Checking sensors"
 msgstr "Verif. des capteurs"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4765
+#: ../../Firmware/ultralcd.cpp:4784
 msgid "Checks"
 msgstr "Verifications"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2218
+#: ../../Firmware/ultralcd.cpp:2237
 msgid "Color not correct"
 msgstr "Couleur incorrecte"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3725
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3744
 msgid "Community made"
 msgstr "Fait de community"
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4704
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4723
 msgid "Cont."
 msgstr "Cont."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2125
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2144
 msgid "Cooldown"
 msgstr "Refroidissement"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3663
+#: ../../Firmware/ultralcd.cpp:3682
 msgid "Copy selected language?"
 msgstr "Copier la langue choisie?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1221
-#: ../../Firmware/ultralcd.cpp:1262 ../../Firmware/ultralcd.cpp:1272
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1240
+#: ../../Firmware/ultralcd.cpp:1281 ../../Firmware/ultralcd.cpp:1291
 msgid "Crash"
 msgstr "Crash"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4341
-#: ../../Firmware/ultralcd.cpp:4342 ../../Firmware/ultralcd.cpp:4344
-#: ../../Firmware/ultralcd.cpp:5765 ../../Firmware/ultralcd.cpp:5767
-#: ../../Firmware/ultralcd.cpp:5771
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4363
+#: ../../Firmware/ultralcd.cpp:5787 ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/ultralcd.cpp:5793
 msgid "Crash det."
 msgstr "Detect.crash"
 
@@ -369,7 +369,7 @@ msgid "Crash detected."
 msgstr "Crash detecte."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3521
+#: ../../Firmware/ultralcd.cpp:3540
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -381,14 +381,14 @@ msgstr ""
 "mode Normal"
 
 #. MSG_CUT_FILAMENT c=17
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:5175
-#: ../../Firmware/ultralcd.cpp:5567
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:5197
+#: ../../Firmware/ultralcd.cpp:5589
 msgid "Cut filament"
 msgstr "Coupe filament"
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:4303
-#: ../../Firmware/ultralcd.cpp:4308 ../../Firmware/ultralcd.cpp:4313
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:4322
+#: ../../Firmware/ultralcd.cpp:4327 ../../Firmware/ultralcd.cpp:4332
 msgid "Cutter"
 msgstr "Coupeur"
 
@@ -398,17 +398,17 @@ msgid "Cutting filament"
 msgstr "Je coupe filament"
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1668
+#: ../../Firmware/ultralcd.cpp:1687
 msgid "Date:"
 msgstr "Date:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5886
 msgid "Dim"
 msgstr "Sombre"
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4802
+#: ../../Firmware/ultralcd.cpp:4821
 msgid "Disable steppers"
 msgstr "Desactiver moteurs"
 
@@ -425,7 +425,7 @@ msgstr ""
 "Calibration de la premiere couche."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:4145
+#: ../../Firmware/ultralcd.cpp:4164
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -434,23 +434,23 @@ msgstr ""
 "plateau chauffant?"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4214
+#: ../../Firmware/ultralcd.cpp:4233
 msgid "E-correct:"
 msgstr "Correct-E:"
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2279
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2298
 msgid "ERROR:"
 msgstr "ERREUR:"
 
 #. MSG_FSENS_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3562
+#: ../../Firmware/ultralcd.cpp:3581
 msgid "ERROR: Filament sensor is not responding, please check connection."
 msgstr "ERREUR: Le capteur de filament ne repond pas, verifiez le branchement."
 
 #. MSG_EJECT_FILAMENT c=17
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:5156
-#: ../../Firmware/ultralcd.cpp:5565
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:5178
+#: ../../Firmware/ultralcd.cpp:5587
 msgid "Eject filament"
 msgstr "Remonter le fil."
 
@@ -460,47 +460,41 @@ msgid "Ejecting filament"
 msgstr "Le fil. remonte"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6985
+#: ../../Firmware/ultralcd.cpp:7015
 msgid "Endstop"
 msgstr "Butee"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6990
+#: ../../Firmware/ultralcd.cpp:7020
 msgid "Endstop not hit"
 msgstr "Butee non atteinte"
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6976
+#: ../../Firmware/ultralcd.cpp:7006
 msgid "Endstops"
 msgstr "Butees"
 
 #. MSG_EXTRUDER c=17
 #: ../../Firmware/Marlin_main.cpp:8608 ../../Firmware/messages.cpp:30
-#: ../../Firmware/ultralcd.cpp:3495
+#: ../../Firmware/ultralcd.cpp:3514
 msgid "Extruder"
 msgstr "Extrudeur"
 
-#. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1144
-#: ../../Firmware/ultralcd.cpp:7319
-msgid "Hotend fan:"
-msgstr "Vent. hotend:"
-
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1722
+#: ../../Firmware/ultralcd.cpp:1741
 msgid "Extruder info"
 msgstr "Infos extrudeur"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4229
-#: ../../Firmware/ultralcd.cpp:4237 ../../Firmware/ultralcd.cpp:4248
-#: ../../Firmware/ultralcd.cpp:4250
+#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4248
+#: ../../Firmware/ultralcd.cpp:4256 ../../Firmware/ultralcd.cpp:4267
+#: ../../Firmware/ultralcd.cpp:4269
 msgid "F. autoload"
 msgstr "F. autocharg."
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4704
-#: ../../Firmware/ultralcd.cpp:4707
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4723
+#: ../../Firmware/ultralcd.cpp:4726
 msgid "FS Action"
 msgstr "Action FS"
 
@@ -515,102 +509,102 @@ msgid "FS v0.4 or newer"
 msgstr "FS v0.4 ou +recent"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5589
+#: ../../Firmware/ultralcd.cpp:5611
 msgid "Fail stats"
 msgstr "Stat. d'echec"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5592
+#: ../../Firmware/ultralcd.cpp:5614
 msgid "Fail stats MMU"
 msgstr "Stat. d'echec MMU"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:7031
+#: ../../Firmware/ultralcd.cpp:7061
 msgid "False triggering"
 msgstr "Faux declenchement"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:5723
-#: ../../Firmware/ultralcd.cpp:5893
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/ultralcd.cpp:5915
 msgid "Fan speed"
 msgstr "Vitesse vent."
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:7143
-#: ../../Firmware/ultralcd.cpp:7301 ../../Firmware/ultralcd.cpp:7302
-#: ../../Firmware/ultralcd.cpp:7303
+#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:7173
+#: ../../Firmware/ultralcd.cpp:7331 ../../Firmware/ultralcd.cpp:7332
+#: ../../Firmware/ultralcd.cpp:7333
 msgid "Fan test"
 msgstr "Test du ventilateur"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4811
-#: ../../Firmware/ultralcd.cpp:5756
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4830
+#: ../../Firmware/ultralcd.cpp:5778
 msgid "Fans check"
 msgstr "Verif vent."
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1220
-#: ../../Firmware/ultralcd.cpp:1261 ../../Firmware/ultralcd.cpp:1327
-#: ../../Firmware/ultralcd.cpp:1329
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1239
+#: ../../Firmware/ultralcd.cpp:1280 ../../Firmware/ultralcd.cpp:1346
+#: ../../Firmware/ultralcd.cpp:1348
 msgid "Fil. runouts"
 msgstr "Fins filament"
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:3451
-#: ../../Firmware/ultralcd.cpp:4228 ../../Firmware/ultralcd.cpp:4234
-#: ../../Firmware/ultralcd.cpp:4244 ../../Firmware/ultralcd.cpp:5737
-#: ../../Firmware/ultralcd.cpp:5741 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:3470
+#: ../../Firmware/ultralcd.cpp:4247 ../../Firmware/ultralcd.cpp:4253
+#: ../../Firmware/ultralcd.cpp:4263 ../../Firmware/ultralcd.cpp:5759
+#: ../../Firmware/ultralcd.cpp:5763 ../../Firmware/ultralcd.cpp:5767
 msgid "Fil. sensor"
 msgstr "Capteur Fil."
 
 #. MSG_FILAMENT c=17
 #: ../../Firmware/Marlin_main.cpp:8577 ../../Firmware/Marlin_main.cpp:8604
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3835
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3854
 msgid "Filament"
 msgstr "Filament"
 
 #. MSG_FILAMENT_CLEAN c=20 r=2
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2287
-#: ../../Firmware/ultralcd.cpp:2293
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2306
+#: ../../Firmware/ultralcd.cpp:2312
 msgid "Filament extruding & with correct color?"
 msgstr "Filament extrude et avec bonne couleur?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2217
+#: ../../Firmware/ultralcd.cpp:2236
 msgid "Filament not loaded"
 msgstr "Filament non charge"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:7026
-#: ../../Firmware/ultralcd.cpp:7030 ../../Firmware/ultralcd.cpp:7034
-#: ../../Firmware/ultralcd.cpp:7330
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:7056
+#: ../../Firmware/ultralcd.cpp:7060 ../../Firmware/ultralcd.cpp:7064
+#: ../../Firmware/ultralcd.cpp:7360
 msgid "Filament sensor"
 msgstr "Capteur de fil."
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2365
+#: ../../Firmware/ultralcd.cpp:2384
 msgid "Filament used"
 msgstr "Filament utilise"
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7461
+#: ../../Firmware/ultralcd.cpp:7491
 msgid "File incomplete. Continue anyway?"
 msgstr "Fichier incomplet. Continuer qd meme?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:5314
-#: ../../Firmware/ultralcd.cpp:5630
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:5336
+#: ../../Firmware/ultralcd.cpp:5652
 msgid "Finishing movements"
 msgstr "Mouvement final"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:4898
-#: ../../Firmware/ultralcd.cpp:5424
+#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:4917
+#: ../../Firmware/ultralcd.cpp:5446
 msgid "First layer cal."
 msgstr "Cal. 1ere couche"
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4066
+#: ../../Firmware/ultralcd.cpp:4085
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "D'abord, je vais lancer le Auto-test pour verifier les problemes "
@@ -622,23 +616,23 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr "Corrigez le probleme et appuyez sur le bouton sur la MMU."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5724
+#: ../../Firmware/ultralcd.cpp:5746
 msgid "Flow"
 msgstr "Flux"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:6996
-#: ../../Firmware/ultralcd.cpp:7149 ../../Firmware/ultralcd.cpp:7154
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:7026
+#: ../../Firmware/ultralcd.cpp:7179 ../../Firmware/ultralcd.cpp:7184
 msgid "Front print fan?"
 msgstr "Ventilo impr avant?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2754
+#: ../../Firmware/ultralcd.cpp:2773
 msgid "Front side[μm]"
 msgstr "Avant [μm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:7020
+#: ../../Firmware/ultralcd.cpp:7050
 msgid "Front/left fans"
 msgstr "Ventilos avt/gauche"
 
@@ -689,20 +683,20 @@ msgstr ""
 "mettre a jour le firmware. L'impression annulee."
 
 #. MSG_GCODE c=8
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:4655
-#: ../../Firmware/ultralcd.cpp:4658 ../../Firmware/ultralcd.cpp:4661
-#: ../../Firmware/ultralcd.cpp:4664
+#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:4674
+#: ../../Firmware/ultralcd.cpp:4677 ../../Firmware/ultralcd.cpp:4680
+#: ../../Firmware/ultralcd.cpp:4683
 msgid "Gcode"
 msgstr "Gcode"
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:4672
-#: ../../Firmware/ultralcd.cpp:4726 ../../Firmware/ultralcd.cpp:4818
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:4691
+#: ../../Firmware/ultralcd.cpp:4745 ../../Firmware/ultralcd.cpp:4837
 msgid "HW Setup"
 msgstr "Config HW"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6968
+#: ../../Firmware/ultralcd.cpp:6998
 msgid "Heater/Thermistor"
 msgstr "Chauffage/Thermistor"
 
@@ -724,7 +718,7 @@ msgid "Heating done."
 msgstr "Chauffe terminee."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=16
-#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4042
+#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4061
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -735,7 +729,7 @@ msgstr ""
 "calibrer le Z-axis. Apres cela, tout sera pret pour imprimer."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4064
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -744,25 +738,31 @@ msgstr ""
 "guide a travers le processus d'installation?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:4358
-#: ../../Firmware/ultralcd.cpp:4367 ../../Firmware/ultralcd.cpp:5777
-#: ../../Firmware/ultralcd.cpp:5780
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:4377
+#: ../../Firmware/ultralcd.cpp:4386 ../../Firmware/ultralcd.cpp:5799
+#: ../../Firmware/ultralcd.cpp:5802
 msgid "High power"
 msgstr "Haut.puiss"
 
+#. MSG_HOTEND_FAN_SPEED c=15
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1145
+#: ../../Firmware/ultralcd.cpp:7351
+msgid "Hotend fan:"
+msgstr "Vent. hotend:"
+
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4094
 msgid "I will run xyz calibration now. It will take approx. 12 mins."
 msgstr ""
 "Je vais maintenant lancer la calibration XYZ. Cela prendra 12 min environ."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/ultralcd.cpp:4102
 msgid "I will run z calibration now."
 msgstr "Je vais maintenant lancer la calibration Z."
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=9
-#: ../../Firmware/ultralcd.cpp:4153
+#: ../../Firmware/ultralcd.cpp:4172
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -776,22 +776,22 @@ msgid "Improving bed calibration point"
 msgstr "Amelioration du point de calibration du plateau"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:5478
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:5500
 msgid "Info screen"
 msgstr "Ecran d'info"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5545
+#: ../../Firmware/ultralcd.cpp:5567
 msgid "Init. SD card"
 msgstr "Init. carte SD"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2152
+#: ../../Firmware/ultralcd.cpp:2171
 msgid "Insert filament"
 msgstr "Inserez le filament"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:6223
+#: ../../Firmware/ultralcd.cpp:6253
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
@@ -800,14 +800,14 @@ msgstr ""
 "appuyez sur le bouton."
 
 #. MSG_FILAMENT_LOADED c=20 r=2
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3855
-#: ../../Firmware/ultralcd.cpp:4108 ../../Firmware/ultralcd.cpp:4111
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3874
+#: ../../Firmware/ultralcd.cpp:4127 ../../Firmware/ultralcd.cpp:4130
 msgid "Is filament loaded?"
 msgstr "Fil. est-il charge?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=2
 #: ../../Firmware/Marlin_main.cpp:3312 ../../Firmware/Marlin_main.cpp:4886
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:4084
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:4103
 msgid "Is steel sheet on heatbed?"
 msgstr "Est la plaque sur le plat. chauffant?"
 
@@ -817,74 +817,74 @@ msgid "Iteration"
 msgstr "Iteration"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:1148
-#: ../../Firmware/ultralcd.cpp:1296
+#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:1167
+#: ../../Firmware/ultralcd.cpp:1315
 msgid "Last print"
 msgstr "Derniere impres."
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1169
-#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1269
-#: ../../Firmware/ultralcd.cpp:1326
+#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1188
+#: ../../Firmware/ultralcd.cpp:1278 ../../Firmware/ultralcd.cpp:1288
+#: ../../Firmware/ultralcd.cpp:1345
 msgid "Last print failures"
 msgstr "Echecs derniere imp."
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2496
+#: ../../Firmware/ultralcd.cpp:2515
 msgid "Left"
 msgstr "Gauche"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7001
-#: ../../Firmware/ultralcd.cpp:7147 ../../Firmware/ultralcd.cpp:7152
+#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:7032
+#: ../../Firmware/ultralcd.cpp:7179 ../../Firmware/ultralcd.cpp:7184
 msgid "Left hotend fan?"
 msgstr "Ventilo gauche?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2752
+#: ../../Firmware/ultralcd.cpp:2771
 msgid "Left side [μm]"
 msgstr "Gauche [μm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:5862
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:5884
 msgid "Level Bright"
 msgstr "Niveau brill"
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:5863
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:5885
 msgid "Level Dimmed"
 msgstr "Niv. sombre"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4826
+#: ../../Firmware/ultralcd.cpp:4845
 msgid "Lin. correction"
 msgstr "Correction lin."
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4838
-#: ../../Firmware/ultralcd.cpp:5493
+#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4857
+#: ../../Firmware/ultralcd.cpp:5515
 msgid "Live adjust Z"
 msgstr "Ajuster Z en dir."
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/ultralcd.cpp:5120
+#: ../../Firmware/ultralcd.cpp:5142
 msgid "Load all"
 msgstr "Tout Charge"
 
 #. MSG_LOAD_FILAMENT c=17
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:5122
-#: ../../Firmware/ultralcd.cpp:5133 ../../Firmware/ultralcd.cpp:5562
-#: ../../Firmware/ultralcd.cpp:5576
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:5144
+#: ../../Firmware/ultralcd.cpp:5155 ../../Firmware/ultralcd.cpp:5584
+#: ../../Firmware/ultralcd.cpp:5598
 msgid "Load filament"
 msgstr "Charger filament"
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5563
+#: ../../Firmware/ultralcd.cpp:5585
 msgid "Load to nozzle"
 msgstr "Charger la buse"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2185
+#: ../../Firmware/ultralcd.cpp:2204
 msgid "Loading color"
 msgstr "Charg. de la couleur"
 
@@ -892,18 +892,18 @@ msgstr "Charg. de la couleur"
 #: ../../Firmware/Marlin_main.cpp:3641 ../../Firmware/messages.cpp:55
 #: ../../Firmware/mmu.cpp:872 ../../Firmware/mmu.cpp:906
 #: ../../Firmware/mmu.cpp:1014 ../../Firmware/mmu.cpp:1026
-#: ../../Firmware/ultralcd.cpp:2196 ../../Firmware/ultralcd.cpp:3949
+#: ../../Firmware/ultralcd.cpp:2215 ../../Firmware/ultralcd.cpp:3968
 msgid "Loading filament"
 msgstr "Chargement du fil."
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:7008
+#: ../../Firmware/ultralcd.cpp:7038
 msgid "Loose pulley"
 msgstr "Poulie lache"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:4450
-#: ../../Firmware/ultralcd.cpp:4462
+#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/ultralcd.cpp:4481
 msgid "Loud"
 msgstr "Fort"
 
@@ -918,8 +918,8 @@ msgid "MK3S firmware detected on MK3 printer"
 msgstr "Firmware MK3S detecte sur imprimante MK3"
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4381
-#: ../../Firmware/ultralcd.cpp:4382
+#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4400
+#: ../../Firmware/ultralcd.cpp:4401
 msgid "MMU Mode"
 msgstr "Mode MMU"
 
@@ -939,8 +939,8 @@ msgid "MMU OK. Resuming..."
 msgstr "MMU OK. Reprise ..."
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:64 ../../Firmware/ultralcd.cpp:1170
-#: ../../Firmware/ultralcd.cpp:1193
+#: ../../Firmware/messages.cpp:64 ../../Firmware/ultralcd.cpp:1189
+#: ../../Firmware/ultralcd.cpp:1212
 msgid "MMU fails"
 msgstr "Echecs MMU"
 
@@ -950,8 +950,8 @@ msgid "MMU load failed"
 msgstr "Def. charg. MMU"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:1171
-#: ../../Firmware/ultralcd.cpp:1194
+#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:1190
+#: ../../Firmware/ultralcd.cpp:1213
 msgid "MMU load fails"
 msgstr "Def. charg. MMU"
 
@@ -961,32 +961,32 @@ msgid "MMU needs user attention."
 msgstr "Le MMU necessite l'attention de l'utilisateur."
 
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/ultralcd.cpp:1195
+#: ../../Firmware/ultralcd.cpp:1214
 msgid "MMU power fails"
 msgstr "Def. alim. MMU"
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1680
+#: ../../Firmware/ultralcd.cpp:1699
 msgid "MMU2 connected"
 msgstr "MMU2 connecte"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:5836
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:5858
 msgid "Magnets comp."
 msgstr "Compens. aim."
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1147
-#: ../../Firmware/ultralcd.cpp:1295 ../../Firmware/ultralcd.cpp:1338
-#: ../../Firmware/ultralcd.cpp:1645 ../../Firmware/ultralcd.cpp:4795
-#: ../../Firmware/ultralcd.cpp:4892 ../../Firmware/ultralcd.cpp:5119
-#: ../../Firmware/ultralcd.cpp:5131 ../../Firmware/ultralcd.cpp:5154
-#: ../../Firmware/ultralcd.cpp:5173 ../../Firmware/ultralcd.cpp:5717
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1166
+#: ../../Firmware/ultralcd.cpp:1314 ../../Firmware/ultralcd.cpp:1357
+#: ../../Firmware/ultralcd.cpp:1664 ../../Firmware/ultralcd.cpp:4814
+#: ../../Firmware/ultralcd.cpp:4911 ../../Firmware/ultralcd.cpp:5141
+#: ../../Firmware/ultralcd.cpp:5153 ../../Firmware/ultralcd.cpp:5176
+#: ../../Firmware/ultralcd.cpp:5195 ../../Firmware/ultralcd.cpp:5739
 msgid "Main"
 msgstr "Menu principal"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2537
+#: ../../Firmware/ultralcd.cpp:2556
 msgid "Measured skew"
 msgstr "Var. mesuree"
 
@@ -997,71 +997,71 @@ msgid "Measuring reference height of calibration point"
 msgstr "Je mesure la hauteur de reference du point de calibrage"
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:5832
+#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:5854
 msgid "Mesh"
 msgstr "Mesh"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4823
-#: ../../Firmware/ultralcd.cpp:4910
+#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4842
+#: ../../Firmware/ultralcd.cpp:4929
 msgid "Mesh Bed Leveling"
 msgstr "Mesh Bed Leveling"
 
 #. MSG_MODE c=6
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:4336
-#: ../../Firmware/ultralcd.cpp:4338 ../../Firmware/ultralcd.cpp:4358
-#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4364
-#: ../../Firmware/ultralcd.cpp:4367 ../../Firmware/ultralcd.cpp:5763
-#: ../../Firmware/ultralcd.cpp:5770 ../../Firmware/ultralcd.cpp:5777
-#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5779
-#: ../../Firmware/ultralcd.cpp:5780 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/ultralcd.cpp:4357 ../../Firmware/ultralcd.cpp:4377
+#: ../../Firmware/ultralcd.cpp:4380 ../../Firmware/ultralcd.cpp:4383
+#: ../../Firmware/ultralcd.cpp:4386 ../../Firmware/ultralcd.cpp:5785
+#: ../../Firmware/ultralcd.cpp:5792 ../../Firmware/ultralcd.cpp:5799
+#: ../../Firmware/ultralcd.cpp:5800 ../../Firmware/ultralcd.cpp:5801
+#: ../../Firmware/ultralcd.cpp:5802 ../../Firmware/ultralcd.cpp:5886
 msgid "Mode"
 msgstr "Mode"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3598
+#: ../../Firmware/ultralcd.cpp:3617
 msgid "Mode change in progress..."
 msgstr "Changement de mode en cours..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:4575
-#: ../../Firmware/ultralcd.cpp:4578 ../../Firmware/ultralcd.cpp:4581
-#: ../../Firmware/ultralcd.cpp:4584
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:4594
+#: ../../Firmware/ultralcd.cpp:4597 ../../Firmware/ultralcd.cpp:4600
+#: ../../Firmware/ultralcd.cpp:4603
 msgid "Model"
 msgstr "Modele"
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6982
-#: ../../Firmware/ultralcd.cpp:6991 ../../Firmware/ultralcd.cpp:7009
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:7012
+#: ../../Firmware/ultralcd.cpp:7021 ../../Firmware/ultralcd.cpp:7039
 msgid "Motor"
 msgstr "Moteur"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3492
+#: ../../Firmware/ultralcd.cpp:3511
 msgid "Move X"
 msgstr "Deplacer X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3493
+#: ../../Firmware/ultralcd.cpp:3512
 msgid "Move Y"
 msgstr "Deplacer Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3494
+#: ../../Firmware/ultralcd.cpp:3513
 msgid "Move Z"
 msgstr "Deplacer Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4801
+#: ../../Firmware/ultralcd.cpp:4820
 msgid "Move axis"
 msgstr "Deplacer l'axe"
 
 #. MSG_NA c=3
 #: ../../Firmware/menu.cpp:196 ../../Firmware/messages.cpp:124
-#: ../../Firmware/ultralcd.cpp:2502 ../../Firmware/ultralcd.cpp:2547
-#: ../../Firmware/ultralcd.cpp:3411 ../../Firmware/ultralcd.cpp:4228
-#: ../../Firmware/ultralcd.cpp:4276 ../../Firmware/ultralcd.cpp:5737
-#: ../../Firmware/ultralcd.cpp:5836
+#: ../../Firmware/ultralcd.cpp:2521 ../../Firmware/ultralcd.cpp:2566
+#: ../../Firmware/ultralcd.cpp:3430 ../../Firmware/ultralcd.cpp:4247
+#: ../../Firmware/ultralcd.cpp:4295 ../../Firmware/ultralcd.cpp:5759
+#: ../../Firmware/ultralcd.cpp:5858
 msgid "N/A"
 msgstr "I/D"
 
@@ -1071,14 +1071,14 @@ msgid "New firmware version available:"
 msgstr "Nouvelle version de firmware disponible:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:2804
-#: ../../Firmware/ultralcd.cpp:3180 ../../Firmware/ultralcd.cpp:4785
-#: ../../Firmware/ultralcd.cpp:5988
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:2823
+#: ../../Firmware/ultralcd.cpp:3199 ../../Firmware/ultralcd.cpp:4804
+#: ../../Firmware/ultralcd.cpp:6018
 msgid "No"
 msgstr "Non"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5543
+#: ../../Firmware/ultralcd.cpp:5565
 msgid "No SD card"
 msgstr "Pas de carte SD"
 
@@ -1088,34 +1088,34 @@ msgid "No move."
 msgstr "Pas de mouvement."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4405
-#: ../../Firmware/ultralcd.cpp:4493 ../../Firmware/ultralcd.cpp:4502
-#: ../../Firmware/ultralcd.cpp:4575 ../../Firmware/ultralcd.cpp:4584
-#: ../../Firmware/ultralcd.cpp:4614 ../../Firmware/ultralcd.cpp:4623
-#: ../../Firmware/ultralcd.cpp:4655 ../../Firmware/ultralcd.cpp:4664
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4424
+#: ../../Firmware/ultralcd.cpp:4512 ../../Firmware/ultralcd.cpp:4521
+#: ../../Firmware/ultralcd.cpp:4594 ../../Firmware/ultralcd.cpp:4603
+#: ../../Firmware/ultralcd.cpp:4633 ../../Firmware/ultralcd.cpp:4642
+#: ../../Firmware/ultralcd.cpp:4674 ../../Firmware/ultralcd.cpp:4683
 msgid "None"
 msgstr "Aucun"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:4336
-#: ../../Firmware/ultralcd.cpp:4381 ../../Firmware/ultralcd.cpp:4397
-#: ../../Firmware/ultralcd.cpp:4416 ../../Firmware/ultralcd.cpp:5763
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/ultralcd.cpp:4400 ../../Firmware/ultralcd.cpp:4416
+#: ../../Firmware/ultralcd.cpp:4435 ../../Firmware/ultralcd.cpp:5785
 msgid "Normal"
 msgstr "Normal"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6969
+#: ../../Firmware/ultralcd.cpp:6999
 msgid "Not connected"
 msgstr "Non connecte"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:7168
-#: ../../Firmware/ultralcd.cpp:7183 ../../Firmware/ultralcd.cpp:7191
+#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:7198
+#: ../../Firmware/ultralcd.cpp:7213 ../../Firmware/ultralcd.cpp:7221
 msgid "Not spinning"
 msgstr "Ne tourne pas"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3962
+#: ../../Firmware/ultralcd.cpp:3981
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr ""
@@ -1123,38 +1123,38 @@ msgstr ""
 "surface du plateau chauffant."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:4091
+#: ../../Firmware/ultralcd.cpp:4110
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Maintenant je vais prechauffer la buse pour du PLA."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/ultralcd.cpp:4101
 msgid "Now remove the test print from steel sheet."
 msgstr "Retirez maintenant l'impression de test de la plaque en acier."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:1402
-#: ../../Firmware/ultralcd.cpp:4493 ../../Firmware/ultralcd.cpp:4496
-#: ../../Firmware/ultralcd.cpp:4499 ../../Firmware/ultralcd.cpp:4502
-#: ../../Firmware/ultralcd.cpp:5720 ../../Firmware/ultralcd.cpp:5882
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:1421
+#: ../../Firmware/ultralcd.cpp:4512 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/ultralcd.cpp:4518 ../../Firmware/ultralcd.cpp:4521
+#: ../../Firmware/ultralcd.cpp:5742 ../../Firmware/ultralcd.cpp:5904
 msgid "Nozzle"
 msgstr "Buse"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4546
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4565
 msgid "Nozzle d."
 msgstr "Diam. buse"
 
 #. MSG_OFF c=3
 #: ../../Firmware/menu.cpp:467 ../../Firmware/messages.cpp:122
-#: ../../Firmware/ultralcd.cpp:4234 ../../Firmware/ultralcd.cpp:4250
-#: ../../Firmware/ultralcd.cpp:4284 ../../Firmware/ultralcd.cpp:4313
-#: ../../Firmware/ultralcd.cpp:4342 ../../Firmware/ultralcd.cpp:4811
-#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4834
-#: ../../Firmware/ultralcd.cpp:5644 ../../Firmware/ultralcd.cpp:5741
-#: ../../Firmware/ultralcd.cpp:5756 ../../Firmware/ultralcd.cpp:5767
-#: ../../Firmware/ultralcd.cpp:5836 ../../Firmware/ultralcd.cpp:7841
-#: ../../Firmware/ultralcd.cpp:7845
+#: ../../Firmware/ultralcd.cpp:4253 ../../Firmware/ultralcd.cpp:4269
+#: ../../Firmware/ultralcd.cpp:4303 ../../Firmware/ultralcd.cpp:4332
+#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4830
+#: ../../Firmware/ultralcd.cpp:4849 ../../Firmware/ultralcd.cpp:4853
+#: ../../Firmware/ultralcd.cpp:5666 ../../Firmware/ultralcd.cpp:5763
+#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/ultralcd.cpp:5858 ../../Firmware/ultralcd.cpp:7881
+#: ../../Firmware/ultralcd.cpp:7885
 msgid "Off"
 msgstr "Off"
 
@@ -1165,19 +1165,19 @@ msgstr ""
 "Anciens reglages trouves. Le PID, les Esteps etc. par defaut seront regles"
 
 #. MSG_ON c=3
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4244
-#: ../../Firmware/ultralcd.cpp:4248 ../../Firmware/ultralcd.cpp:4280
-#: ../../Firmware/ultralcd.cpp:4303 ../../Firmware/ultralcd.cpp:4341
-#: ../../Firmware/ultralcd.cpp:4811 ../../Firmware/ultralcd.cpp:4830
-#: ../../Firmware/ultralcd.cpp:4834 ../../Firmware/ultralcd.cpp:5745
-#: ../../Firmware/ultralcd.cpp:5756 ../../Firmware/ultralcd.cpp:5765
-#: ../../Firmware/ultralcd.cpp:5836 ../../Firmware/ultralcd.cpp:7841
-#: ../../Firmware/ultralcd.cpp:7845
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4263
+#: ../../Firmware/ultralcd.cpp:4267 ../../Firmware/ultralcd.cpp:4299
+#: ../../Firmware/ultralcd.cpp:4322 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4849
+#: ../../Firmware/ultralcd.cpp:4853 ../../Firmware/ultralcd.cpp:5767
+#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5787
+#: ../../Firmware/ultralcd.cpp:5858 ../../Firmware/ultralcd.cpp:7881
+#: ../../Firmware/ultralcd.cpp:7885
 msgid "On"
 msgstr "On"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4453
+#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4472
 msgid "Once"
 msgstr "1 fois"
 
@@ -1197,7 +1197,7 @@ msgid "PID cal. finished"
 msgstr "Calib. PID terminee"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4913
+#: ../../Firmware/ultralcd.cpp:4932
 msgid "PID calibration"
 msgstr "Calibration PID"
 
@@ -1209,18 +1209,18 @@ msgstr "Chauffe de la PINDA"
 #. MSG_PINDA_CALIBRATION c=13
 #: ../../Firmware/Marlin_main.cpp:4932 ../../Firmware/Marlin_main.cpp:5035
 #: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:654
-#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4920
+#: ../../Firmware/ultralcd.cpp:4849 ../../Firmware/ultralcd.cpp:4939
 msgid "PINDA cal."
 msgstr "Calib. PINDA"
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3361
+#: ../../Firmware/ultralcd.cpp:3380
 msgid "PINDA calibration failed"
 msgstr "Echec de la calibration en PINDA"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
 #: ../../Firmware/Marlin_main.cpp:5112 ../../Firmware/messages.cpp:110
-#: ../../Firmware/ultralcd.cpp:3355
+#: ../../Firmware/ultralcd.cpp:3374
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1229,13 +1229,13 @@ msgstr ""
 "dans le menu Reglages-> Calib. PINDA"
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4707
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4726
 msgid "Pause"
 msgstr "Pause"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:5507
-#: ../../Firmware/ultralcd.cpp:5509
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:5529
+#: ../../Firmware/ultralcd.cpp:5531
 msgid "Pause print"
 msgstr "Pause de l'impr."
 
@@ -1249,7 +1249,7 @@ msgstr ""
 "premiers points. Si la buse accroche le papier, eteignez vite l'imprimante."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:4176
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:4195
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1258,17 +1258,17 @@ msgstr ""
 "l'assistant en redemarrant l'imprimante."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:6250
+#: ../../Firmware/ultralcd.cpp:6280
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "SVP, verifiez la connexion du capteur IR et decharge le filament."
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6963
+#: ../../Firmware/ultralcd.cpp:6993
 msgid "Please check:"
 msgstr "Verifiez:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4148
+#: ../../Firmware/ultralcd.cpp:4167
 msgid "Please clean heatbed and then press the knob."
 msgstr "Nettoyez plateau chauffant en acier et appuyez sur le bouton."
 
@@ -1278,7 +1278,7 @@ msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Nettoyez la buse pour la calibration. Cliquez une fois fait."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3945
+#: ../../Firmware/ultralcd.cpp:3964
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr ""
@@ -1286,7 +1286,7 @@ msgstr ""
 "pour le charger."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3940
+#: ../../Firmware/ultralcd.cpp:3959
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1295,7 +1295,7 @@ msgstr ""
 "le bouton pour le charger."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3863
+#: ../../Firmware/ultralcd.cpp:3882
 msgid "Please load filament first."
 msgstr "Veuillez d'abord charger un filament."
 
@@ -1306,7 +1306,7 @@ msgstr "Ouvrez l'idler et retirez le filament manuellement."
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=5
 #: ../../Firmware/mesh_bed_calibration.cpp:2799 ../../Firmware/messages.cpp:70
-#: ../../Firmware/ultralcd.cpp:4085
+#: ../../Firmware/ultralcd.cpp:4104
 msgid "Please place steel sheet on heatbed."
 msgstr "Placez la plaque en acier sur le plateau chauffant."
 
@@ -1317,7 +1317,7 @@ msgid "Please press the knob to unload filament"
 msgstr "Appuyez sur le bouton pour decharger le filament"
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:5213
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:5235
 msgid "Please pull out filament immediately"
 msgstr "Retirez immediatement le filament"
 
@@ -1327,7 +1327,7 @@ msgid "Please remove filament and then press the knob."
 msgstr "Veuillez retirer le filament puis appuyez sur le bouton."
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:4081
+#: ../../Firmware/ultralcd.cpp:4100
 msgid "Please remove shipping helpers first."
 msgstr "Retirez d'abord les protections de transport."
 
@@ -1343,7 +1343,7 @@ msgid "Please run XYZ calibration first."
 msgstr "Veuillez d'abord lancer la calibration XYZ."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:6247
+#: ../../Firmware/ultralcd.cpp:6277
 msgid "Please unload the filament first, then repeat this action."
 msgstr "SVP, dechargez le filament et reessayez."
 
@@ -1361,54 +1361,54 @@ msgstr "Mettez a jour le FW."
 #. MSG_PLEASE_WAIT c=20
 #: ../../Firmware/Marlin_main.cpp:3547 ../../Firmware/Marlin_main.cpp:3563
 #: ../../Firmware/Marlin_main.cpp:7931 ../../Firmware/messages.cpp:71
-#: ../../Firmware/ultralcd.cpp:2186 ../../Firmware/ultralcd.cpp:2197
+#: ../../Firmware/ultralcd.cpp:2205 ../../Firmware/ultralcd.cpp:2216
 msgid "Please wait"
 msgstr "Merci de patienter"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1219
-#: ../../Firmware/ultralcd.cpp:1260 ../../Firmware/ultralcd.cpp:1270
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1238
+#: ../../Firmware/ultralcd.cpp:1279 ../../Firmware/ultralcd.cpp:1289
 msgid "Power failures"
 msgstr "Coup.de courant"
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5502
+#: ../../Firmware/ultralcd.cpp:5524
 msgid "Preheat"
 msgstr "Prechauffage"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:2280
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:2299
 msgid "Preheat the nozzle!"
 msgstr "Prechauffez la buse!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:2900
-#: ../../Firmware/ultralcd.cpp:3924 ../../Firmware/ultralcd.cpp:3926
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:2919
+#: ../../Firmware/ultralcd.cpp:3943 ../../Firmware/ultralcd.cpp:3945
 msgid "Preheating nozzle. Please wait."
 msgstr "Prechauffage de la buse. Merci de patienter."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1988
+#: ../../Firmware/ultralcd.cpp:2007
 msgid "Preheating to cut"
 msgstr "Chauffe pour couper"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1985
+#: ../../Firmware/ultralcd.cpp:2004
 msgid "Preheating to eject"
 msgstr "Chauf. pour remonter"
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1976
+#: ../../Firmware/ultralcd.cpp:1995
 msgid "Preheating to load"
 msgstr "Chauffe pour charger"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1981
+#: ../../Firmware/ultralcd.cpp:2000
 msgid "Preheating to unload"
 msgstr "Chauf.pour decharger"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1809
+#: ../../Firmware/ultralcd.cpp:1828
 msgid "Press the knob"
 msgstr "App. sur sur bouton"
 
@@ -1428,13 +1428,13 @@ msgid "Print aborted"
 msgstr "Impression annulee"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1144
-#: ../../Firmware/ultralcd.cpp:7322
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1145
+#: ../../Firmware/ultralcd.cpp:7354
 msgid "Print fan:"
 msgstr "Vent. impr:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5535
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5557
 msgid "Print from SD"
 msgstr "Impr. depuis la SD"
 
@@ -1444,12 +1444,12 @@ msgid "Print paused"
 msgstr "Impression en pause"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2366
+#: ../../Firmware/ultralcd.cpp:2385
 msgid "Print time"
 msgstr "Temps d'impression"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1711
+#: ../../Firmware/ultralcd.cpp:1730
 msgid "Printer IP Addr:"
 msgstr "Adr.IP imprimante:"
 
@@ -1479,12 +1479,12 @@ msgstr ""
 "Code. Merci de verifier le parametre dans les reglages. Impression annulee."
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4834
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4853
 msgid "RPi port"
 msgstr "Port RPi"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2755
+#: ../../Firmware/ultralcd.cpp:2774
 msgid "Rear side [μm]"
 msgstr "Arriere [μm]"
 
@@ -1500,24 +1500,24 @@ msgstr ""
 "Retirez l'ancien filament puis appuyez sur le bouton pour charger le nouveau."
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5426
+#: ../../Firmware/ultralcd.cpp:5448
 msgid "Rename"
 msgstr "Renommer"
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2756
-#: ../../Firmware/ultralcd.cpp:5427
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2775
+#: ../../Firmware/ultralcd.cpp:5449
 msgid "Reset"
 msgstr "Reinitialiser"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4917
+#: ../../Firmware/ultralcd.cpp:4936
 msgid "Reset XYZ calibr."
 msgstr "Reinit. calib. XYZ"
 
 #. MSG_RESUME_PRINT c=18
 #: ../../Firmware/Marlin_main.cpp:655 ../../Firmware/messages.cpp:81
-#: ../../Firmware/ultralcd.cpp:5521 ../../Firmware/ultralcd.cpp:5523
+#: ../../Firmware/ultralcd.cpp:5543 ../../Firmware/ultralcd.cpp:5545
 msgid "Resume print"
 msgstr "Reprise impression"
 
@@ -1527,17 +1527,17 @@ msgid "Resuming print"
 msgstr "Reprise de l'impr."
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2497
+#: ../../Firmware/ultralcd.cpp:2516
 msgid "Right"
 msgstr "Droite"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2753
+#: ../../Firmware/ultralcd.cpp:2772
 msgid "Right side[μm]"
 msgstr "Droite [μm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3884
+#: ../../Firmware/ultralcd.cpp:3903
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1546,14 +1546,14 @@ msgstr ""
 "commencera du debut. Continuer?"
 
 #. MSG_RUNOUTS c=7
-#: ../../Firmware/ultralcd.cpp:1271
+#: ../../Firmware/ultralcd.cpp:1290
 msgid "Runouts"
 msgstr "Fins"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4395
-#: ../../Firmware/ultralcd.cpp:4397 ../../Firmware/ultralcd.cpp:4414
-#: ../../Firmware/ultralcd.cpp:4416
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4414
+#: ../../Firmware/ultralcd.cpp:4416 ../../Firmware/ultralcd.cpp:4433
+#: ../../Firmware/ultralcd.cpp:4435
 msgid "SD card"
 msgstr "Carte SD"
 
@@ -1569,12 +1569,12 @@ msgid "Searching bed calibration point"
 msgstr "Recherche point calibration du plateau"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5419
+#: ../../Firmware/ultralcd.cpp:5441
 msgid "Select"
 msgstr "Selectionner"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3966
+#: ../../Firmware/ultralcd.cpp:3985
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
@@ -1589,51 +1589,51 @@ msgstr "Choisir extrudeur:"
 
 #. MSG_SELECT_FILAMENT c=20
 #: ../../Firmware/Marlin_main.cpp:8577 ../../Firmware/Marlin_main.cpp:8604
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3834
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3853
 msgid "Select filament:"
 msgstr "Choix du filament:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:3679
-#: ../../Firmware/ultralcd.cpp:4841
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:3698
+#: ../../Firmware/ultralcd.cpp:4860
 msgid "Select language"
 msgstr "Choisir langue"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:4122
+#: ../../Firmware/ultralcd.cpp:4141
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr ""
 "Selectionnez la temperature de prechauffage de la buse qui correspond a "
 "votre materiau."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3971
+#: ../../Firmware/ultralcd.cpp:3990
 msgid "Select temperature which matches your material."
 msgstr "Selectionnez la temperature qui correspond a votre materiau."
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6522
+#: ../../Firmware/ultralcd.cpp:6552
 msgid "Self test OK"
 msgstr "Auto-test OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:6290
+#: ../../Firmware/ultralcd.cpp:6320
 msgid "Self test start"
 msgstr "Debut auto-test"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4904
+#: ../../Firmware/ultralcd.cpp:4923
 msgid "Selftest"
 msgstr "Auto-test"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6962
+#: ../../Firmware/ultralcd.cpp:6992
 msgid "Selftest error!"
 msgstr "Erreur auto-test!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:6526
-#: ../../Firmware/ultralcd.cpp:7049 ../../Firmware/ultralcd.cpp:7314
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:6556
+#: ../../Firmware/ultralcd.cpp:7079 ../../Firmware/ultralcd.cpp:7344
 msgid "Selftest failed"
 msgstr "Echec de l'auto-test"
 
@@ -1644,30 +1644,30 @@ msgstr ""
 "Le Selftest sera lance pour calibrer la remise a zero precise sans capteur"
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1723
+#: ../../Firmware/ultralcd.cpp:1742
 msgid "Sensor info"
 msgstr "Info capteur"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:6254
+#: ../../Firmware/ultralcd.cpp:6284
 msgid "Sensor verified, remove the filament now."
 msgstr "Capteur verifie, retirez le filament maintenant."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2773
+#: ../../Firmware/ultralcd.cpp:2792
 msgid "Set temperature:"
 msgstr "Regler temp.:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:3491
-#: ../../Firmware/ultralcd.cpp:3696 ../../Firmware/ultralcd.cpp:4206
-#: ../../Firmware/ultralcd.cpp:5580 ../../Firmware/ultralcd.cpp:5827
-#: ../../Firmware/ultralcd.cpp:5880
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:3510
+#: ../../Firmware/ultralcd.cpp:3715 ../../Firmware/ultralcd.cpp:4225
+#: ../../Firmware/ultralcd.cpp:5602 ../../Firmware/ultralcd.cpp:5849
+#: ../../Firmware/ultralcd.cpp:5902
 msgid "Settings"
 msgstr "Reglages"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2540
+#: ../../Firmware/ultralcd.cpp:2559
 msgid "Severe skew"
 msgstr "Deviat.sev."
 
@@ -1678,7 +1678,7 @@ msgid "Sheet"
 msgstr "Plaque"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3824
+#: ../../Firmware/ultralcd.cpp:3843
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1691,18 +1691,18 @@ msgstr ""
 "%cReinitialiser"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4915
+#: ../../Firmware/ultralcd.cpp:4934
 msgid "Show end stops"
 msgstr "Afficher butees"
 
 #. MSG_SILENT c=7
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4361
-#: ../../Firmware/ultralcd.cpp:4456 ../../Firmware/ultralcd.cpp:5778
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4380
+#: ../../Firmware/ultralcd.cpp:4475 ../../Firmware/ultralcd.cpp:5800
 msgid "Silent"
 msgstr "Furtif"
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2539
+#: ../../Firmware/ultralcd.cpp:2558
 msgid "Slight skew"
 msgstr "Deviat.leg."
 
@@ -1720,8 +1720,8 @@ msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Probleme rencontre, cliquez sur le bouton pour niveller l'axe Z..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4403
-#: ../../Firmware/ultralcd.cpp:4404 ../../Firmware/ultralcd.cpp:4405
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4422
+#: ../../Firmware/ultralcd.cpp:4423 ../../Firmware/ultralcd.cpp:4424
 msgid "Sort"
 msgstr "Tri"
 
@@ -1732,20 +1732,20 @@ msgid "Sorting files"
 msgstr "Tri des fichiers"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4450
-#: ../../Firmware/ultralcd.cpp:4453 ../../Firmware/ultralcd.cpp:4456
-#: ../../Firmware/ultralcd.cpp:4459 ../../Firmware/ultralcd.cpp:4462
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/ultralcd.cpp:4472 ../../Firmware/ultralcd.cpp:4475
+#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4481
 msgid "Sound"
 msgstr "Son"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5718
+#: ../../Firmware/ultralcd.cpp:5740
 msgid "Speed"
 msgstr "Vitesse"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7166
-#: ../../Firmware/ultralcd.cpp:7181 ../../Firmware/ultralcd.cpp:7189
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7196
+#: ../../Firmware/ultralcd.cpp:7211 ../../Firmware/ultralcd.cpp:7219
 msgid "Spinning"
 msgstr "Tourne"
 
@@ -1756,42 +1756,42 @@ msgstr ""
 "Une temperature ambiante stable de 21-26C et un support stable sont requis."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5585
+#: ../../Firmware/ultralcd.cpp:5607
 msgid "Statistics"
 msgstr "Statistiques"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4338
-#: ../../Firmware/ultralcd.cpp:4382 ../../Firmware/ultralcd.cpp:5770
+#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4357
+#: ../../Firmware/ultralcd.cpp:4401 ../../Firmware/ultralcd.cpp:5792
 msgid "Stealth"
 msgstr "Furtif"
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4763
-#: ../../Firmware/ultralcd.cpp:5416
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4782
+#: ../../Firmware/ultralcd.cpp:5438
 msgid "Steel sheets"
 msgstr "Plaques en acier"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5528
-#: ../../Firmware/ultralcd.cpp:5987
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5550
+#: ../../Firmware/ultralcd.cpp:6017
 msgid "Stop print"
 msgstr "Arreter impression"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4499
-#: ../../Firmware/ultralcd.cpp:4581 ../../Firmware/ultralcd.cpp:4620
-#: ../../Firmware/ultralcd.cpp:4661
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4518
+#: ../../Firmware/ultralcd.cpp:4600 ../../Firmware/ultralcd.cpp:4639
+#: ../../Firmware/ultralcd.cpp:4680
 msgid "Strict"
 msgstr "Stricte"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/ultralcd.cpp:5616
 msgid "Support"
 msgstr "Support"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:7021
+#: ../../Firmware/ultralcd.cpp:7051
 msgid "Swapped"
 msgstr "Echange"
 
@@ -1800,28 +1800,18 @@ msgstr "Echange"
 msgid "THERMAL ANOMALY"
 msgstr "ANOMALIE THERMIQUE"
 
-#. MSG_TM_AUTOTUNE_FAILED c=20
-#: ../../Firmware/temperature.cpp:2899
-msgid "TM autotune failed"
-msgstr "Echec regl. auto MT"
-
-#. MSG_TEMP_MODEL_AUTOTUNE c=20
-#: ../../Firmware/temperature.cpp:2884
-msgid "Temp. model autotune"
-msgstr "Regl. auto mod temp."
-
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4797
+#: ../../Firmware/ultralcd.cpp:4816
 msgid "Temperature"
 msgstr "Temperature"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1729
+#: ../../Firmware/ultralcd.cpp:1748
 msgid "Temperatures"
 msgstr "Temperatures"
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3974
+#: ../../Firmware/ultralcd.cpp:3993
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -1841,66 +1831,66 @@ msgstr ""
 "chapitre Premiers pas, section Processus de calibration."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4403
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4422
 msgid "Time"
 msgstr "Heure"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:5865
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:5887
 msgid "Timeout"
 msgstr "Delai ecoule"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:1149
-#: ../../Firmware/ultralcd.cpp:1297
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:1168
+#: ../../Firmware/ultralcd.cpp:1316
 msgid "Total"
 msgstr "Totale"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:1192
-#: ../../Firmware/ultralcd.cpp:1218 ../../Firmware/ultralcd.cpp:1328
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:1211
+#: ../../Firmware/ultralcd.cpp:1237 ../../Firmware/ultralcd.cpp:1347
 msgid "Total failures"
 msgstr "Total des echecs"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2387
+#: ../../Firmware/ultralcd.cpp:2406
 msgid "Total filament"
 msgstr "Filament total"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2388
+#: ../../Firmware/ultralcd.cpp:2407
 msgid "Total print time"
 msgstr "Temps total impr."
 
 #. MSG_TUNE c=18
-#: ../../Firmware/ultralcd.cpp:5500
+#: ../../Firmware/ultralcd.cpp:5522
 msgid "Tune"
 msgstr "Regler"
 
 #. MSG_UNLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:5564
-#: ../../Firmware/ultralcd.cpp:5578
+#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:5586
+#: ../../Firmware/ultralcd.cpp:5600
 msgid "Unload filament"
 msgstr "Decharger fil."
 
 #. MSG_UNLOADING_FILAMENT c=20
 #: ../../Firmware/messages.cpp:112 ../../Firmware/mmu.cpp:957
-#: ../../Firmware/ultralcd.cpp:5197
+#: ../../Firmware/ultralcd.cpp:5219
 msgid "Unloading filament"
 msgstr "Dechargement fil."
 
 #. MSG_FIL_FAILED c=20 r=5
-#: ../../Firmware/ultralcd.cpp:6258
+#: ../../Firmware/ultralcd.cpp:6288
 msgid "Verification failed, remove the filament and try again."
 msgstr "Verification en echec, retirez le filament et reessayez."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1732
+#: ../../Firmware/ultralcd.cpp:1751
 msgid "Voltages"
 msgstr "Tensions"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3534
+#: ../../Firmware/ultralcd.cpp:3553
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -1918,19 +1908,19 @@ msgid "Wait for user..."
 msgstr "Attente utilisateur."
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2881
+#: ../../Firmware/ultralcd.cpp:2900
 msgid "Waiting for PINDA probe cooling"
 msgstr "Attente du refroidissement de la sonde PINDA"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2913
+#: ../../Firmware/ultralcd.cpp:2932
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Attente du refroidissement des buse et plateau chauffant"
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:4496
-#: ../../Firmware/ultralcd.cpp:4578 ../../Firmware/ultralcd.cpp:4617
-#: ../../Firmware/ultralcd.cpp:4658
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/ultralcd.cpp:4597 ../../Firmware/ultralcd.cpp:4636
+#: ../../Firmware/ultralcd.cpp:4677
 msgid "Warn"
 msgstr "Avert"
 
@@ -1955,59 +1945,53 @@ msgid "Was filament unload successful?"
 msgstr "Dechargement du filament reussi?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6973
-#: ../../Firmware/ultralcd.cpp:6977 ../../Firmware/ultralcd.cpp:6997
-#: ../../Firmware/ultralcd.cpp:7003 ../../Firmware/ultralcd.cpp:7027
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:7003
+#: ../../Firmware/ultralcd.cpp:7007 ../../Firmware/ultralcd.cpp:7027
+#: ../../Firmware/ultralcd.cpp:7033 ../../Firmware/ultralcd.cpp:7057
 msgid "Wiring error"
 msgstr "Erreur de cablage"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4895
+#: ../../Firmware/ultralcd.cpp:4914
 msgid "Wizard"
 msgstr "Assistant"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4210
+#: ../../Firmware/ultralcd.cpp:4229
 msgid "X-correct:"
 msgstr "Correct-X:"
 
 #. MSG_XFLASH c=18
-#: ../../Firmware/ultralcd.cpp:5596
+#: ../../Firmware/ultralcd.cpp:5618
 msgid "XFLASH init"
 msgstr "Init XFLASH"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1721
+#: ../../Firmware/ultralcd.cpp:1740
 msgid "XYZ cal. details"
 msgstr "Details calib. XYZ"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3333
+#: ../../Firmware/ultralcd.cpp:3352
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr "Calibration XYZ OK. L'ecart sera corrige automatiquement."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3330
+#: ../../Firmware/ultralcd.cpp:3349
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr ""
 "Calibration XYZ OK. Les axes X/Y sont legerement non perpendiculaires. Bon "
 "boulot!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3311
+#: ../../Firmware/ultralcd.cpp:3330
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr ""
 "Calibration XYZ compromise. Les points de calibration en avant ne sont pas "
 "atteignables."
 
-#. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_LEFT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3317
-msgid ""
-"XYZ calibration compromised. Left front calibration point not reachable."
-msgstr ""
-
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3314
+#: ../../Firmware/ultralcd.cpp:3333
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr ""
@@ -2015,96 +1999,91 @@ msgstr ""
 "atteignable."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3293
+#: ../../Firmware/ultralcd.cpp:3312
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr ""
 "Echec calibration XYZ. Le point de calibration du plateau n'a pas ete trouve."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3299
+#: ../../Firmware/ultralcd.cpp:3318
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr ""
 "Echec calibration XYZ. Les points de calibration en avant ne sont pas "
 "atteignables."
 
-#. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_LEFT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3305
-msgid "XYZ calibration failed. Left front calibration point not reachable."
-msgstr ""
-
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3296
-#: ../../Firmware/ultralcd.cpp:3324
+#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3315
+#: ../../Firmware/ultralcd.cpp:3343
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "Echec calibration XYZ. Consultez le manuel."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3302
+#: ../../Firmware/ultralcd.cpp:3321
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr ""
 "Echec calibration XYZ. Le point de calibration avant droit n'est pas "
 "atteignable."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3327
+#: ../../Firmware/ultralcd.cpp:3346
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "Calibration XYZ OK. Les axes X/Y sont perpendiculaires. Felicitations!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2494
+#: ../../Firmware/ultralcd.cpp:2513
 msgid "Y distance from min"
 msgstr "Distance Y du min"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4211
+#: ../../Firmware/ultralcd.cpp:4230
 msgid "Y-correct:"
 msgstr "Correct-Y:"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:2216
-#: ../../Firmware/ultralcd.cpp:2800 ../../Firmware/ultralcd.cpp:3180
-#: ../../Firmware/ultralcd.cpp:4785 ../../Firmware/ultralcd.cpp:5989
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:2235
+#: ../../Firmware/ultralcd.cpp:2819 ../../Firmware/ultralcd.cpp:3199
+#: ../../Firmware/ultralcd.cpp:4804 ../../Firmware/ultralcd.cpp:6019
 msgid "Yes"
 msgstr "Oui"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:4187
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:4206
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr ""
 "Vous pouvez toujours relancer l'Assistant dans Calibration > Assistant."
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4231
 msgid "Z-correct:"
 msgstr "Correct-Z:"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:5835
+#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:5857
 msgid "Z-probe nr."
 msgstr "Mesurer x-fois"
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2565
+#: ../../Firmware/ultralcd.cpp:2584
 msgid "[0;0] point offset"
 msgstr "Offset point [0;0]"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2154
+#: ../../Firmware/ultralcd.cpp:2173
 msgid "and press the knob"
 msgstr "et appuyez sur le bouton"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1816
+#: ../../Firmware/ultralcd.cpp:1835
 msgid "to load filament"
 msgstr "pour charger le fil."
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1820
+#: ../../Firmware/ultralcd.cpp:1839
 msgid "to unload filament"
 msgstr "pour decharger fil."
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1688
+#: ../../Firmware/ultralcd.cpp:1707
 msgid "unknown"
 msgstr "inconnu"
 
@@ -2114,8 +2093,8 @@ msgid "unknown state"
 msgstr "Etat inconnu"
 
 #. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:6077
-#: ../../Firmware/ultralcd.cpp:6080
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:6107
+#: ../../Firmware/ultralcd.cpp:6110
 msgid "🔃Refresh"
 msgstr "🔃Rafraichir"
 
@@ -2124,3 +2103,9 @@ msgstr "🔃Rafraichir"
 
 #~ msgid "M117 First layer cal."
 #~ msgstr "M117 Cal. 1ere couche"
+
+#~ msgid "TM autotune failed"
+#~ msgstr "Echec regl. auto MT"
+
+#~ msgid "Temp. model autotune"
+#~ msgstr "Regl. auto mod temp."

--- a/lang/po/Firmware_hr.po
+++ b/lang/po/Firmware_hr.po
@@ -26,82 +26,82 @@ msgid " 0.4 or newer"
 msgstr " 0.4 ili noviji"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:7036
+#: ../../Firmware/ultralcd.cpp:7066
 msgid "%s level expected"
 msgstr "%s level ocekivan"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1968
-#: ../../Firmware/ultralcd.cpp:3835
+#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1987
+#: ../../Firmware/ultralcd.cpp:3854
 msgid ">Cancel"
 msgstr ">Otkazati"
 
 #. MSG_BABYSTEPPING_Z c=15
 #. Beware: must include the ':' as its last character
-#: ../../Firmware/ultralcd.cpp:2670
+#: ../../Firmware/ultralcd.cpp:2689
 msgid "Adjusting Z:"
 msgstr "Podesavanje Z:"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:7313
+#: ../../Firmware/ultralcd.cpp:7343
 msgid "All correct"
 msgstr "Sve je u redu"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4180
+#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4190
+#: ../../Firmware/ultralcd.cpp:4199
 msgid "All is done. Happy printing!"
 msgstr "Sve je gotovo. Sretno printanje!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4404
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4423
 msgid "Alphabet"
 msgstr "Abeceda"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4308
+#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4327
 msgid "Always"
 msgstr "Uvijek"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1405
+#: ../../Firmware/ultralcd.cpp:1424
 msgid "Ambient"
 msgstr "Ambijent"
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2983
+#: ../../Firmware/ultralcd.cpp:3002
 msgid "Are left and right Z~carriages all up?"
 msgstr "Jesu lijevi i desni Z~nosaci podignuti?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4478
 msgid "Assist"
 msgstr "Pomoc"
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:5886
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
 #: ../../Firmware/Marlin_main.cpp:3271 ../../Firmware/messages.cpp:9
-#: ../../Firmware/ultralcd.cpp:4900
+#: ../../Firmware/ultralcd.cpp:4919
 msgid "Auto home"
 msgstr "Pocetna tocka"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:4364
-#: ../../Firmware/ultralcd.cpp:5779
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:4383
+#: ../../Firmware/ultralcd.cpp:5801
 msgid "Auto power"
 msgstr "Auto napaj"
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5572
+#: ../../Firmware/ultralcd.cpp:5594
 msgid "AutoLoad filament"
 msgstr "Autopunj filamenta"
 
 #. MSG_AUTOLOADING_ONLY_IF_FSENS_ON c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3549
+#: ../../Firmware/ultralcd.cpp:3568
 msgid ""
 "Autoloading filament available only when filament sensor is turned on..."
 msgstr ""
@@ -109,32 +109,32 @@ msgstr ""
 "ukljucen.."
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2301
+#: ../../Firmware/ultralcd.cpp:2320
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr "Auto punjenje fil. je aktivno, pritisnite gumb i umetnite fil.."
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:7015
+#: ../../Firmware/ultralcd.cpp:7045
 msgid "Axis"
 msgstr "Os"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:7014
+#: ../../Firmware/ultralcd.cpp:7044
 msgid "Axis length"
 msgstr "Duljina osi"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:2751
-#: ../../Firmware/ultralcd.cpp:5861 ../../Firmware/ultralcd.cpp:7838
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:2770
+#: ../../Firmware/ultralcd.cpp:5883 ../../Firmware/ultralcd.cpp:7878
 msgid "Back"
 msgstr "Natrag"
 
 #. MSG_BED c=13
 #: ../../Firmware/Marlin_main.cpp:2051 ../../Firmware/Marlin_main.cpp:4767
 #: ../../Firmware/Marlin_main.cpp:4819 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:1403 ../../Firmware/ultralcd.cpp:5721
-#: ../../Firmware/ultralcd.cpp:5891
+#: ../../Firmware/ultralcd.cpp:1422 ../../Firmware/ultralcd.cpp:5743
+#: ../../Firmware/ultralcd.cpp:5913
 msgid "Bed"
 msgstr "Podloga"
 
@@ -151,7 +151,7 @@ msgid "Bed done"
 msgstr "Podloga zagrijana"
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4912
+#: ../../Firmware/ultralcd.cpp:4931
 msgid "Bed level correct"
 msgstr "Podloga ispravna"
 
@@ -169,18 +169,18 @@ msgstr ""
 "mlaznici? Ceka se resetiranje."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6972
+#: ../../Firmware/ultralcd.cpp:7002
 msgid "Bed/Heater"
 msgstr "Grijac/Podloga"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1458
-#: ../../Firmware/ultralcd.cpp:1726
+#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1477
+#: ../../Firmware/ultralcd.cpp:1745
 msgid "Belt status"
 msgstr "Status remena"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4902
+#: ../../Firmware/ultralcd.cpp:4921
 msgid "Belt test"
 msgstr "Testiranje remena"
 
@@ -191,28 +191,28 @@ msgid "Blackout occurred. Recover print?"
 msgstr "Doslo je do gasenja. Oporaviti print?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:5886
 msgid "Bright"
 msgstr "Svijet"
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4850
-#: ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4869
+#: ../../Firmware/ultralcd.cpp:5811
 msgid "Brightness"
 msgstr "Svjetlina"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4906
+#: ../../Firmware/ultralcd.cpp:4925
 msgid "Calibrate XYZ"
 msgstr "Kalibrirajte XYZ"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4908
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4927
 msgid "Calibrate Z"
 msgstr "Kalibrirajte Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2946
+#: ../../Firmware/ultralcd.cpp:2965
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -227,7 +227,7 @@ msgid "Calibrating Z"
 msgstr "Kalibriracija Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2945
+#: ../../Firmware/ultralcd.cpp:2964
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -236,12 +236,12 @@ msgstr ""
 "Kliknite kada je zavrseno."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:7315
+#: ../../Firmware/ultralcd.cpp:7345
 msgid "Calibrating home"
 msgstr "Kalibracija nultocke"
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:5581
+#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:5603
 msgid "Calibration"
 msgstr "Kalibriranje"
 
@@ -251,115 +251,115 @@ msgid "Calibration done"
 msgstr "Kalibracija gotova"
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7712
+#: ../../Firmware/ultralcd.cpp:7752
 msgid "Card removed"
 msgstr "Kartica je uklonjena"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/ultralcd.cpp:5560
 msgid "Change SD card"
 msgstr "Promjeni SD karti."
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5497
-#: ../../Firmware/ultralcd.cpp:5730
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5519
+#: ../../Firmware/ultralcd.cpp:5752
 msgid "Change filament"
 msgstr "Promijeni filament"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2163
+#: ../../Firmware/ultralcd.cpp:2182
 msgid "Change success!"
 msgstr "Promijena uspjesna!"
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2215
+#: ../../Firmware/ultralcd.cpp:2234
 msgid "Changed correctly?"
 msgstr "Ispravno izmjenjeno?"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:6178
-#: ../../Firmware/ultralcd.cpp:7305
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:6208
+#: ../../Firmware/ultralcd.cpp:7335
 msgid "Checking X axis"
 msgstr "Provjera X osi"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:6187
-#: ../../Firmware/ultralcd.cpp:7306
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:6217
+#: ../../Firmware/ultralcd.cpp:7336
 msgid "Checking Y axis"
 msgstr "Provjera Y osi"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:7307
+#: ../../Firmware/ultralcd.cpp:7337
 msgid "Checking Z axis"
 msgstr "Provjera Z osi"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:7308
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:7338
 msgid "Checking bed"
 msgstr "Provjera podloge"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:7304
+#: ../../Firmware/ultralcd.cpp:7334
 msgid "Checking endstops"
 msgstr "Provjera granicnika"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:7403
+#: ../../Firmware/ultralcd.cpp:7433
 msgid "Checking file"
 msgstr "Provjera datoteke"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:7310
+#: ../../Firmware/ultralcd.cpp:7340
 msgid "Checking hotend"
 msgstr "Provjera hotenda"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:7311
-#: ../../Firmware/ultralcd.cpp:7312
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:7341
+#: ../../Firmware/ultralcd.cpp:7342
 msgid "Checking sensors"
 msgstr "Provjera senzora"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4765
+#: ../../Firmware/ultralcd.cpp:4784
 msgid "Checks"
 msgstr "Provjere"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2218
+#: ../../Firmware/ultralcd.cpp:2237
 msgid "Color not correct"
 msgstr "Boja nije ispravna"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3725
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3744
 msgid "Community made"
 msgstr "Napravilo zajedno"
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4704
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4723
 msgid "Cont."
 msgstr "Nast."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2125
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2144
 msgid "Cooldown"
 msgstr "Ohladi"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3663
+#: ../../Firmware/ultralcd.cpp:3682
 msgid "Copy selected language?"
 msgstr "Kopirati odabrani jezik?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1221
-#: ../../Firmware/ultralcd.cpp:1262 ../../Firmware/ultralcd.cpp:1272
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1240
+#: ../../Firmware/ultralcd.cpp:1281 ../../Firmware/ultralcd.cpp:1291
 msgid "Crash"
 msgstr "Udar"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4341
-#: ../../Firmware/ultralcd.cpp:4342 ../../Firmware/ultralcd.cpp:4344
-#: ../../Firmware/ultralcd.cpp:5765 ../../Firmware/ultralcd.cpp:5767
-#: ../../Firmware/ultralcd.cpp:5771
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4363
+#: ../../Firmware/ultralcd.cpp:5787 ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/ultralcd.cpp:5793
 msgid "Crash det."
 msgstr "Udar detekti."
 
@@ -369,7 +369,7 @@ msgid "Crash detected."
 msgstr "Udar otkriven."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3521
+#: ../../Firmware/ultralcd.cpp:3540
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -377,14 +377,14 @@ msgid ""
 msgstr "Detekcija udarca moze biti ukljuceno samo u Normalnom nacinu rada"
 
 #. MSG_CUT_FILAMENT c=17
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:5175
-#: ../../Firmware/ultralcd.cpp:5567
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:5197
+#: ../../Firmware/ultralcd.cpp:5589
 msgid "Cut filament"
 msgstr "Odrezite fil."
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:4303
-#: ../../Firmware/ultralcd.cpp:4308 ../../Firmware/ultralcd.cpp:4313
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:4322
+#: ../../Firmware/ultralcd.cpp:4327 ../../Firmware/ultralcd.cpp:4332
 msgid "Cutter"
 msgstr "Rezac"
 
@@ -394,17 +394,17 @@ msgid "Cutting filament"
 msgstr "Rezanje filamenta"
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1668
+#: ../../Firmware/ultralcd.cpp:1687
 msgid "Date:"
 msgstr "Datum:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5886
 msgid "Dim"
 msgstr "Tamno"
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4802
+#: ../../Firmware/ultralcd.cpp:4821
 msgid "Disable steppers"
 msgstr "Onemoguci stepere"
 
@@ -421,7 +421,7 @@ msgstr ""
 "prvog sloja."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:4145
+#: ../../Firmware/ultralcd.cpp:4164
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -430,23 +430,23 @@ msgstr ""
 "mlaznice i grijace podloge?"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4214
+#: ../../Firmware/ultralcd.cpp:4233
 msgid "E-correct:"
 msgstr "E-ispravan:"
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2279
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2298
 msgid "ERROR:"
 msgstr "POGRESKA:"
 
 #. MSG_FSENS_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3562
+#: ../../Firmware/ultralcd.cpp:3581
 msgid "ERROR: Filament sensor is not responding, please check connection."
 msgstr "POGRESKA: Senzor filamenta ne reagira, provjerite vezu."
 
 #. MSG_EJECT_FILAMENT c=17
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:5156
-#: ../../Firmware/ultralcd.cpp:5565
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:5178
+#: ../../Firmware/ultralcd.cpp:5587
 msgid "Eject filament"
 msgstr "Izbaci filament"
 
@@ -456,47 +456,41 @@ msgid "Ejecting filament"
 msgstr "Izbacivanje fil."
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6985
+#: ../../Firmware/ultralcd.cpp:7015
 msgid "Endstop"
 msgstr "Granicnik"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6990
+#: ../../Firmware/ultralcd.cpp:7020
 msgid "Endstop not hit"
 msgstr "Granicnik nije aktiv"
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6976
+#: ../../Firmware/ultralcd.cpp:7006
 msgid "Endstops"
 msgstr "Granicnici"
 
 #. MSG_EXTRUDER c=17
 #: ../../Firmware/Marlin_main.cpp:8608 ../../Firmware/messages.cpp:30
-#: ../../Firmware/ultralcd.cpp:3495
+#: ../../Firmware/ultralcd.cpp:3514
 msgid "Extruder"
 msgstr "Ekstruder"
 
-#. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1144
-#: ../../Firmware/ultralcd.cpp:7319
-msgid "Hotend fan:"
-msgstr "Hotend vent:"
-
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1722
+#: ../../Firmware/ultralcd.cpp:1741
 msgid "Extruder info"
 msgstr "Info o ekstruderu"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4229
-#: ../../Firmware/ultralcd.cpp:4237 ../../Firmware/ultralcd.cpp:4248
-#: ../../Firmware/ultralcd.cpp:4250
+#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4248
+#: ../../Firmware/ultralcd.cpp:4256 ../../Firmware/ultralcd.cpp:4267
+#: ../../Firmware/ultralcd.cpp:4269
 msgid "F. autoload"
 msgstr "F. auto.punj"
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4704
-#: ../../Firmware/ultralcd.cpp:4707
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4723
+#: ../../Firmware/ultralcd.cpp:4726
 msgid "FS Action"
 msgstr "FS Akcija"
 
@@ -511,102 +505,102 @@ msgid "FS v0.4 or newer"
 msgstr "FS v0.4 ili noviji"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5589
+#: ../../Firmware/ultralcd.cpp:5611
 msgid "Fail stats"
 msgstr "Neuspjesna stat"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5592
+#: ../../Firmware/ultralcd.cpp:5614
 msgid "Fail stats MMU"
 msgstr "Neuspjes. MMU stat"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:7031
+#: ../../Firmware/ultralcd.cpp:7061
 msgid "False triggering"
 msgstr "Lazno aktiviranje"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:5723
-#: ../../Firmware/ultralcd.cpp:5893
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/ultralcd.cpp:5915
 msgid "Fan speed"
 msgstr "Brzina vent"
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:7143
-#: ../../Firmware/ultralcd.cpp:7301 ../../Firmware/ultralcd.cpp:7302
-#: ../../Firmware/ultralcd.cpp:7303
+#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:7173
+#: ../../Firmware/ultralcd.cpp:7331 ../../Firmware/ultralcd.cpp:7332
+#: ../../Firmware/ultralcd.cpp:7333
 msgid "Fan test"
 msgstr "Test ventilatora"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4811
-#: ../../Firmware/ultralcd.cpp:5756
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4830
+#: ../../Firmware/ultralcd.cpp:5778
 msgid "Fans check"
 msgstr "Provjera vent"
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1220
-#: ../../Firmware/ultralcd.cpp:1261 ../../Firmware/ultralcd.cpp:1327
-#: ../../Firmware/ultralcd.cpp:1329
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1239
+#: ../../Firmware/ultralcd.cpp:1280 ../../Firmware/ultralcd.cpp:1346
+#: ../../Firmware/ultralcd.cpp:1348
 msgid "Fil. runouts"
 msgstr "Bez filmaneta"
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:3451
-#: ../../Firmware/ultralcd.cpp:4228 ../../Firmware/ultralcd.cpp:4234
-#: ../../Firmware/ultralcd.cpp:4244 ../../Firmware/ultralcd.cpp:5737
-#: ../../Firmware/ultralcd.cpp:5741 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:3470
+#: ../../Firmware/ultralcd.cpp:4247 ../../Firmware/ultralcd.cpp:4253
+#: ../../Firmware/ultralcd.cpp:4263 ../../Firmware/ultralcd.cpp:5759
+#: ../../Firmware/ultralcd.cpp:5763 ../../Firmware/ultralcd.cpp:5767
 msgid "Fil. sensor"
 msgstr "Fil. senzor"
 
 #. MSG_FILAMENT c=17
 #: ../../Firmware/Marlin_main.cpp:8577 ../../Firmware/Marlin_main.cpp:8604
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3835
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3854
 msgid "Filament"
 msgstr "Filament"
 
 #. MSG_FILAMENT_CLEAN c=20 r=2
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2287
-#: ../../Firmware/ultralcd.cpp:2293
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2306
+#: ../../Firmware/ultralcd.cpp:2312
 msgid "Filament extruding & with correct color?"
 msgstr "Ekstrudiranje fil.s sa ispravnom bojom?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2217
+#: ../../Firmware/ultralcd.cpp:2236
 msgid "Filament not loaded"
 msgstr "Fil. nije napunjen"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:7026
-#: ../../Firmware/ultralcd.cpp:7030 ../../Firmware/ultralcd.cpp:7034
-#: ../../Firmware/ultralcd.cpp:7330
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:7056
+#: ../../Firmware/ultralcd.cpp:7060 ../../Firmware/ultralcd.cpp:7064
+#: ../../Firmware/ultralcd.cpp:7360
 msgid "Filament sensor"
 msgstr "Senzor filamenta"
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2365
+#: ../../Firmware/ultralcd.cpp:2384
 msgid "Filament used"
 msgstr "Iskoristeni fil."
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7461
+#: ../../Firmware/ultralcd.cpp:7491
 msgid "File incomplete. Continue anyway?"
 msgstr "Datoteka je nepotpuna. Svejedno nastaviti?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:5314
-#: ../../Firmware/ultralcd.cpp:5630
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:5336
+#: ../../Firmware/ultralcd.cpp:5652
 msgid "Finishing movements"
 msgstr "Zavrsni pokreti"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:4898
-#: ../../Firmware/ultralcd.cpp:5424
+#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:4917
+#: ../../Firmware/ultralcd.cpp:5446
 msgid "First layer cal."
 msgstr "Prvi sloj kalib."
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4066
+#: ../../Firmware/ultralcd.cpp:4085
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Prvo cu pokrenuti samotestiranje kako bih provjerio najcesce probleme sa "
@@ -618,23 +612,23 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr "Rijesite problem, a zatim pritisnite gumb na MMU jedinici."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5724
+#: ../../Firmware/ultralcd.cpp:5746
 msgid "Flow"
 msgstr "Protok"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:6996
-#: ../../Firmware/ultralcd.cpp:7149 ../../Firmware/ultralcd.cpp:7154
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:7026
+#: ../../Firmware/ultralcd.cpp:7179 ../../Firmware/ultralcd.cpp:7184
 msgid "Front print fan?"
 msgstr "Prednji print vent?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2754
+#: ../../Firmware/ultralcd.cpp:2773
 msgid "Front side[μm]"
 msgstr "Prednj str[μm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:7020
+#: ../../Firmware/ultralcd.cpp:7050
 msgid "Front/left fans"
 msgstr "Prednji/lijevi vent"
 
@@ -683,20 +677,20 @@ msgstr ""
 "otkazan."
 
 #. MSG_GCODE c=8
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:4655
-#: ../../Firmware/ultralcd.cpp:4658 ../../Firmware/ultralcd.cpp:4661
-#: ../../Firmware/ultralcd.cpp:4664
+#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:4674
+#: ../../Firmware/ultralcd.cpp:4677 ../../Firmware/ultralcd.cpp:4680
+#: ../../Firmware/ultralcd.cpp:4683
 msgid "Gcode"
 msgstr "Gkod"
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:4672
-#: ../../Firmware/ultralcd.cpp:4726 ../../Firmware/ultralcd.cpp:4818
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:4691
+#: ../../Firmware/ultralcd.cpp:4745 ../../Firmware/ultralcd.cpp:4837
 msgid "HW Setup"
 msgstr "HW podesavanje"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6968
+#: ../../Firmware/ultralcd.cpp:6998
 msgid "Heater/Thermistor"
 msgstr "Grijac/Termostat"
 
@@ -718,7 +712,7 @@ msgid "Heating done."
 msgstr "Grijanje obavljeno."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=16
-#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4042
+#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4061
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -729,7 +723,7 @@ msgstr ""
 "printanje."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4064
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -738,24 +732,30 @@ msgstr ""
 "postupak postavljanja?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:4358
-#: ../../Firmware/ultralcd.cpp:4367 ../../Firmware/ultralcd.cpp:5777
-#: ../../Firmware/ultralcd.cpp:5780
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:4377
+#: ../../Firmware/ultralcd.cpp:4386 ../../Firmware/ultralcd.cpp:5799
+#: ../../Firmware/ultralcd.cpp:5802
 msgid "High power"
 msgstr "Visoka sna"
 
+#. MSG_HOTEND_FAN_SPEED c=15
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1145
+#: ../../Firmware/ultralcd.cpp:7351
+msgid "Hotend fan:"
+msgstr "Hotend vent:"
+
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4094
 msgid "I will run xyz calibration now. It will take approx. 12 mins."
 msgstr "Sada cu pokrenuti xyz kalibraciju. Trebat ce cca. 12 min."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/ultralcd.cpp:4102
 msgid "I will run z calibration now."
 msgstr "Sada cu pokrenuti z kalibraciju."
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=9
-#: ../../Firmware/ultralcd.cpp:4153
+#: ../../Firmware/ultralcd.cpp:4172
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -769,22 +769,22 @@ msgid "Improving bed calibration point"
 msgstr "Poboljšanje točke kalibracije podloge"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:5478
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:5500
 msgid "Info screen"
 msgstr "Info zaslon"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5545
+#: ../../Firmware/ultralcd.cpp:5567
 msgid "Init. SD card"
 msgstr "Obrada SD kartice"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2152
+#: ../../Firmware/ultralcd.cpp:2171
 msgid "Insert filament"
 msgstr "Umetnite filament"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:6223
+#: ../../Firmware/ultralcd.cpp:6253
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
@@ -792,14 +792,14 @@ msgstr ""
 "Umetnite filament (nemojte ga puniti) u ekstruder i zatim pritisnite gumb."
 
 #. MSG_FILAMENT_LOADED c=20 r=2
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3855
-#: ../../Firmware/ultralcd.cpp:4108 ../../Firmware/ultralcd.cpp:4111
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3874
+#: ../../Firmware/ultralcd.cpp:4127 ../../Firmware/ultralcd.cpp:4130
 msgid "Is filament loaded?"
 msgstr "Je li filament napunjen?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=2
 #: ../../Firmware/Marlin_main.cpp:3312 ../../Firmware/Marlin_main.cpp:4886
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:4084
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:4103
 msgid "Is steel sheet on heatbed?"
 msgstr "Je li celicna ploca na grijanoj podlozi?"
 
@@ -809,74 +809,74 @@ msgid "Iteration"
 msgstr "Ponavljanje"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:1148
-#: ../../Firmware/ultralcd.cpp:1296
+#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:1167
+#: ../../Firmware/ultralcd.cpp:1315
 msgid "Last print"
 msgstr "Zadnji print"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1169
-#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1269
-#: ../../Firmware/ultralcd.cpp:1326
+#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1188
+#: ../../Firmware/ultralcd.cpp:1278 ../../Firmware/ultralcd.cpp:1288
+#: ../../Firmware/ultralcd.cpp:1345
 msgid "Last print failures"
 msgstr "Zadnji neusp. print"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2496
+#: ../../Firmware/ultralcd.cpp:2515
 msgid "Left"
 msgstr "Lijevo"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7001
-#: ../../Firmware/ultralcd.cpp:7147 ../../Firmware/ultralcd.cpp:7152
+#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:7032
+#: ../../Firmware/ultralcd.cpp:7179 ../../Firmware/ultralcd.cpp:7184
 msgid "Left hotend fan?"
 msgstr "Lijevi hotend vent?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2752
+#: ../../Firmware/ultralcd.cpp:2771
 msgid "Left side [μm]"
 msgstr "Lijeva str[μm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:5862
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:5884
 msgid "Level Bright"
 msgstr "Razina svjet"
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:5863
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:5885
 msgid "Level Dimmed"
 msgstr "Razina zatam"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4826
+#: ../../Firmware/ultralcd.cpp:4845
 msgid "Lin. correction"
 msgstr "Lin. ispravak"
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4838
-#: ../../Firmware/ultralcd.cpp:5493
+#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4857
+#: ../../Firmware/ultralcd.cpp:5515
 msgid "Live adjust Z"
 msgstr "Live podesavanje Z"
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/ultralcd.cpp:5120
+#: ../../Firmware/ultralcd.cpp:5142
 msgid "Load all"
 msgstr "Puni sve"
 
 #. MSG_LOAD_FILAMENT c=17
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:5122
-#: ../../Firmware/ultralcd.cpp:5133 ../../Firmware/ultralcd.cpp:5562
-#: ../../Firmware/ultralcd.cpp:5576
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:5144
+#: ../../Firmware/ultralcd.cpp:5155 ../../Firmware/ultralcd.cpp:5584
+#: ../../Firmware/ultralcd.cpp:5598
 msgid "Load filament"
 msgstr "Napunite filament"
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5563
+#: ../../Firmware/ultralcd.cpp:5585
 msgid "Load to nozzle"
 msgstr "Punjenje u mlazn"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2185
+#: ../../Firmware/ultralcd.cpp:2204
 msgid "Loading color"
 msgstr "Ucitavanje boje"
 
@@ -884,18 +884,18 @@ msgstr "Ucitavanje boje"
 #: ../../Firmware/Marlin_main.cpp:3641 ../../Firmware/messages.cpp:55
 #: ../../Firmware/mmu.cpp:872 ../../Firmware/mmu.cpp:906
 #: ../../Firmware/mmu.cpp:1014 ../../Firmware/mmu.cpp:1026
-#: ../../Firmware/ultralcd.cpp:2196 ../../Firmware/ultralcd.cpp:3949
+#: ../../Firmware/ultralcd.cpp:2215 ../../Firmware/ultralcd.cpp:3968
 msgid "Loading filament"
 msgstr "Punjenje filamenta"
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:7008
+#: ../../Firmware/ultralcd.cpp:7038
 msgid "Loose pulley"
 msgstr "Labava remenica"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:4450
-#: ../../Firmware/ultralcd.cpp:4462
+#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/ultralcd.cpp:4481
 msgid "Loud"
 msgstr "Glasno"
 
@@ -910,8 +910,8 @@ msgid "MK3S firmware detected on MK3 printer"
 msgstr "MK3S firmware detektiran na MK3 printeru"
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4381
-#: ../../Firmware/ultralcd.cpp:4382
+#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4400
+#: ../../Firmware/ultralcd.cpp:4401
 msgid "MMU Mode"
 msgstr "MMU Mod"
 
@@ -931,8 +931,8 @@ msgid "MMU OK. Resuming..."
 msgstr "MMU OK. Nastavak..."
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:64 ../../Firmware/ultralcd.cpp:1170
-#: ../../Firmware/ultralcd.cpp:1193
+#: ../../Firmware/messages.cpp:64 ../../Firmware/ultralcd.cpp:1189
+#: ../../Firmware/ultralcd.cpp:1212
 msgid "MMU fails"
 msgstr "MMU ne uspijeva"
 
@@ -942,8 +942,8 @@ msgid "MMU load failed"
 msgstr "Neusp. MMU punjenje"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:1171
-#: ../../Firmware/ultralcd.cpp:1194
+#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:1190
+#: ../../Firmware/ultralcd.cpp:1213
 msgid "MMU load fails"
 msgstr "Neusp. MMU punj"
 
@@ -953,32 +953,32 @@ msgid "MMU needs user attention."
 msgstr "MMU treba paznju korisnika."
 
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/ultralcd.cpp:1195
+#: ../../Firmware/ultralcd.cpp:1214
 msgid "MMU power fails"
 msgstr "Neusp. MMU nap"
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1680
+#: ../../Firmware/ultralcd.cpp:1699
 msgid "MMU2 connected"
 msgstr "MMU2 spojen"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:5836
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:5858
 msgid "Magnets comp."
 msgstr "Magnet. komp."
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1147
-#: ../../Firmware/ultralcd.cpp:1295 ../../Firmware/ultralcd.cpp:1338
-#: ../../Firmware/ultralcd.cpp:1645 ../../Firmware/ultralcd.cpp:4795
-#: ../../Firmware/ultralcd.cpp:4892 ../../Firmware/ultralcd.cpp:5119
-#: ../../Firmware/ultralcd.cpp:5131 ../../Firmware/ultralcd.cpp:5154
-#: ../../Firmware/ultralcd.cpp:5173 ../../Firmware/ultralcd.cpp:5717
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1166
+#: ../../Firmware/ultralcd.cpp:1314 ../../Firmware/ultralcd.cpp:1357
+#: ../../Firmware/ultralcd.cpp:1664 ../../Firmware/ultralcd.cpp:4814
+#: ../../Firmware/ultralcd.cpp:4911 ../../Firmware/ultralcd.cpp:5141
+#: ../../Firmware/ultralcd.cpp:5153 ../../Firmware/ultralcd.cpp:5176
+#: ../../Firmware/ultralcd.cpp:5195 ../../Firmware/ultralcd.cpp:5739
 msgid "Main"
 msgstr "Nazad"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2537
+#: ../../Firmware/ultralcd.cpp:2556
 msgid "Measured skew"
 msgstr "Mjereni nagib"
 
@@ -989,71 +989,71 @@ msgid "Measuring reference height of calibration point"
 msgstr "Mjerenje referentne visine kalibracijske tocke"
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:5832
+#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:5854
 msgid "Mesh"
 msgstr "Mreza"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4823
-#: ../../Firmware/ultralcd.cpp:4910
+#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4842
+#: ../../Firmware/ultralcd.cpp:4929
 msgid "Mesh Bed Leveling"
 msgstr "Izrav. mrez. podl"
 
 #. MSG_MODE c=6
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:4336
-#: ../../Firmware/ultralcd.cpp:4338 ../../Firmware/ultralcd.cpp:4358
-#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4364
-#: ../../Firmware/ultralcd.cpp:4367 ../../Firmware/ultralcd.cpp:5763
-#: ../../Firmware/ultralcd.cpp:5770 ../../Firmware/ultralcd.cpp:5777
-#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5779
-#: ../../Firmware/ultralcd.cpp:5780 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/ultralcd.cpp:4357 ../../Firmware/ultralcd.cpp:4377
+#: ../../Firmware/ultralcd.cpp:4380 ../../Firmware/ultralcd.cpp:4383
+#: ../../Firmware/ultralcd.cpp:4386 ../../Firmware/ultralcd.cpp:5785
+#: ../../Firmware/ultralcd.cpp:5792 ../../Firmware/ultralcd.cpp:5799
+#: ../../Firmware/ultralcd.cpp:5800 ../../Firmware/ultralcd.cpp:5801
+#: ../../Firmware/ultralcd.cpp:5802 ../../Firmware/ultralcd.cpp:5886
 msgid "Mode"
 msgstr "Mod"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3598
+#: ../../Firmware/ultralcd.cpp:3617
 msgid "Mode change in progress..."
 msgstr "Promjena moda u tijeku..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:4575
-#: ../../Firmware/ultralcd.cpp:4578 ../../Firmware/ultralcd.cpp:4581
-#: ../../Firmware/ultralcd.cpp:4584
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:4594
+#: ../../Firmware/ultralcd.cpp:4597 ../../Firmware/ultralcd.cpp:4600
+#: ../../Firmware/ultralcd.cpp:4603
 msgid "Model"
 msgstr "Model"
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6982
-#: ../../Firmware/ultralcd.cpp:6991 ../../Firmware/ultralcd.cpp:7009
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:7012
+#: ../../Firmware/ultralcd.cpp:7021 ../../Firmware/ultralcd.cpp:7039
 msgid "Motor"
 msgstr "Motor"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3492
+#: ../../Firmware/ultralcd.cpp:3511
 msgid "Move X"
 msgstr "Pomaknite X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3493
+#: ../../Firmware/ultralcd.cpp:3512
 msgid "Move Y"
 msgstr "Pomaknite Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3494
+#: ../../Firmware/ultralcd.cpp:3513
 msgid "Move Z"
 msgstr "Pomaknite Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4801
+#: ../../Firmware/ultralcd.cpp:4820
 msgid "Move axis"
 msgstr "Pomaknite os"
 
 #. MSG_NA c=3
 #: ../../Firmware/menu.cpp:196 ../../Firmware/messages.cpp:124
-#: ../../Firmware/ultralcd.cpp:2502 ../../Firmware/ultralcd.cpp:2547
-#: ../../Firmware/ultralcd.cpp:3411 ../../Firmware/ultralcd.cpp:4228
-#: ../../Firmware/ultralcd.cpp:4276 ../../Firmware/ultralcd.cpp:5737
-#: ../../Firmware/ultralcd.cpp:5836
+#: ../../Firmware/ultralcd.cpp:2521 ../../Firmware/ultralcd.cpp:2566
+#: ../../Firmware/ultralcd.cpp:3430 ../../Firmware/ultralcd.cpp:4247
+#: ../../Firmware/ultralcd.cpp:4295 ../../Firmware/ultralcd.cpp:5759
+#: ../../Firmware/ultralcd.cpp:5858
 msgid "N/A"
 msgstr "N/A"
 
@@ -1063,14 +1063,14 @@ msgid "New firmware version available:"
 msgstr "Dostupna nova verzija firmwera:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:2804
-#: ../../Firmware/ultralcd.cpp:3180 ../../Firmware/ultralcd.cpp:4785
-#: ../../Firmware/ultralcd.cpp:5988
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:2823
+#: ../../Firmware/ultralcd.cpp:3199 ../../Firmware/ultralcd.cpp:4804
+#: ../../Firmware/ultralcd.cpp:6018
 msgid "No"
 msgstr "Ne"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5543
+#: ../../Firmware/ultralcd.cpp:5565
 msgid "No SD card"
 msgstr "Nema SD kartice"
 
@@ -1080,34 +1080,34 @@ msgid "No move."
 msgstr "Bez pomaka."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4405
-#: ../../Firmware/ultralcd.cpp:4493 ../../Firmware/ultralcd.cpp:4502
-#: ../../Firmware/ultralcd.cpp:4575 ../../Firmware/ultralcd.cpp:4584
-#: ../../Firmware/ultralcd.cpp:4614 ../../Firmware/ultralcd.cpp:4623
-#: ../../Firmware/ultralcd.cpp:4655 ../../Firmware/ultralcd.cpp:4664
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4424
+#: ../../Firmware/ultralcd.cpp:4512 ../../Firmware/ultralcd.cpp:4521
+#: ../../Firmware/ultralcd.cpp:4594 ../../Firmware/ultralcd.cpp:4603
+#: ../../Firmware/ultralcd.cpp:4633 ../../Firmware/ultralcd.cpp:4642
+#: ../../Firmware/ultralcd.cpp:4674 ../../Firmware/ultralcd.cpp:4683
 msgid "None"
 msgstr "Nema"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:4336
-#: ../../Firmware/ultralcd.cpp:4381 ../../Firmware/ultralcd.cpp:4397
-#: ../../Firmware/ultralcd.cpp:4416 ../../Firmware/ultralcd.cpp:5763
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/ultralcd.cpp:4400 ../../Firmware/ultralcd.cpp:4416
+#: ../../Firmware/ultralcd.cpp:4435 ../../Firmware/ultralcd.cpp:5785
 msgid "Normal"
 msgstr "Normal"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6969
+#: ../../Firmware/ultralcd.cpp:6999
 msgid "Not connected"
 msgstr "Nije povezano"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:7168
-#: ../../Firmware/ultralcd.cpp:7183 ../../Firmware/ultralcd.cpp:7191
+#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:7198
+#: ../../Firmware/ultralcd.cpp:7213 ../../Firmware/ultralcd.cpp:7221
 msgid "Not spinning"
 msgstr "Ne okrece se"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3962
+#: ../../Firmware/ultralcd.cpp:3981
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr ""
@@ -1115,38 +1115,38 @@ msgstr ""
 "podloge."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:4091
+#: ../../Firmware/ultralcd.cpp:4110
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Sada cu zagrijati mlaznicu za PLA."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/ultralcd.cpp:4101
 msgid "Now remove the test print from steel sheet."
 msgstr "Sada uklonite probni print sa celicne ploce."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:1402
-#: ../../Firmware/ultralcd.cpp:4493 ../../Firmware/ultralcd.cpp:4496
-#: ../../Firmware/ultralcd.cpp:4499 ../../Firmware/ultralcd.cpp:4502
-#: ../../Firmware/ultralcd.cpp:5720 ../../Firmware/ultralcd.cpp:5882
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:1421
+#: ../../Firmware/ultralcd.cpp:4512 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/ultralcd.cpp:4518 ../../Firmware/ultralcd.cpp:4521
+#: ../../Firmware/ultralcd.cpp:5742 ../../Firmware/ultralcd.cpp:5904
 msgid "Nozzle"
 msgstr "Mlaznica"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4546
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4565
 msgid "Nozzle d."
 msgstr "Mlaznica."
 
 #. MSG_OFF c=3
 #: ../../Firmware/menu.cpp:467 ../../Firmware/messages.cpp:122
-#: ../../Firmware/ultralcd.cpp:4234 ../../Firmware/ultralcd.cpp:4250
-#: ../../Firmware/ultralcd.cpp:4284 ../../Firmware/ultralcd.cpp:4313
-#: ../../Firmware/ultralcd.cpp:4342 ../../Firmware/ultralcd.cpp:4811
-#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4834
-#: ../../Firmware/ultralcd.cpp:5644 ../../Firmware/ultralcd.cpp:5741
-#: ../../Firmware/ultralcd.cpp:5756 ../../Firmware/ultralcd.cpp:5767
-#: ../../Firmware/ultralcd.cpp:5836 ../../Firmware/ultralcd.cpp:7841
-#: ../../Firmware/ultralcd.cpp:7845
+#: ../../Firmware/ultralcd.cpp:4253 ../../Firmware/ultralcd.cpp:4269
+#: ../../Firmware/ultralcd.cpp:4303 ../../Firmware/ultralcd.cpp:4332
+#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4830
+#: ../../Firmware/ultralcd.cpp:4849 ../../Firmware/ultralcd.cpp:4853
+#: ../../Firmware/ultralcd.cpp:5666 ../../Firmware/ultralcd.cpp:5763
+#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/ultralcd.cpp:5858 ../../Firmware/ultralcd.cpp:7881
+#: ../../Firmware/ultralcd.cpp:7885
 msgid "Off"
 msgstr "Off"
 
@@ -1156,19 +1156,19 @@ msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr "Pronadene stare postavke. Postavit ce se zadani PID, Esteps itd."
 
 #. MSG_ON c=3
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4244
-#: ../../Firmware/ultralcd.cpp:4248 ../../Firmware/ultralcd.cpp:4280
-#: ../../Firmware/ultralcd.cpp:4303 ../../Firmware/ultralcd.cpp:4341
-#: ../../Firmware/ultralcd.cpp:4811 ../../Firmware/ultralcd.cpp:4830
-#: ../../Firmware/ultralcd.cpp:4834 ../../Firmware/ultralcd.cpp:5745
-#: ../../Firmware/ultralcd.cpp:5756 ../../Firmware/ultralcd.cpp:5765
-#: ../../Firmware/ultralcd.cpp:5836 ../../Firmware/ultralcd.cpp:7841
-#: ../../Firmware/ultralcd.cpp:7845
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4263
+#: ../../Firmware/ultralcd.cpp:4267 ../../Firmware/ultralcd.cpp:4299
+#: ../../Firmware/ultralcd.cpp:4322 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4849
+#: ../../Firmware/ultralcd.cpp:4853 ../../Firmware/ultralcd.cpp:5767
+#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5787
+#: ../../Firmware/ultralcd.cpp:5858 ../../Firmware/ultralcd.cpp:7881
+#: ../../Firmware/ultralcd.cpp:7885
 msgid "On"
 msgstr "On"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4453
+#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4472
 msgid "Once"
 msgstr "Jednom"
 
@@ -1188,7 +1188,7 @@ msgid "PID cal. finished"
 msgstr "PID kal. zavrsena"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4913
+#: ../../Firmware/ultralcd.cpp:4932
 msgid "PID calibration"
 msgstr "PID kalibracija"
 
@@ -1200,18 +1200,18 @@ msgstr "PINDA se Zagrijava"
 #. MSG_PINDA_CALIBRATION c=13
 #: ../../Firmware/Marlin_main.cpp:4932 ../../Firmware/Marlin_main.cpp:5035
 #: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:654
-#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4920
+#: ../../Firmware/ultralcd.cpp:4849 ../../Firmware/ultralcd.cpp:4939
 msgid "PINDA cal."
 msgstr "PINDA kal."
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3361
+#: ../../Firmware/ultralcd.cpp:3380
 msgid "PINDA calibration failed"
 msgstr "Kalibracija PINDA nije uspjela"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
 #: ../../Firmware/Marlin_main.cpp:5112 ../../Firmware/messages.cpp:110
-#: ../../Firmware/ultralcd.cpp:3355
+#: ../../Firmware/ultralcd.cpp:3374
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1220,13 +1220,13 @@ msgstr ""
 "Postavke->PINDA. kal."
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4707
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4726
 msgid "Pause"
 msgstr "Pauza"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:5507
-#: ../../Firmware/ultralcd.cpp:5509
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:5529
+#: ../../Firmware/ultralcd.cpp:5531
 msgid "Pause print"
 msgstr "Pauzirajte print"
 
@@ -1240,7 +1240,7 @@ msgstr ""
 "mlaznica uhvati papir, odmah iskljucite printer."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:4176
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:4195
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1249,17 +1249,17 @@ msgstr ""
 "ponovnim pokretanjem printera."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:6250
+#: ../../Firmware/ultralcd.cpp:6280
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "Provjerite IR prikljucak senzora, izvadite filament ako postoji."
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6963
+#: ../../Firmware/ultralcd.cpp:6993
 msgid "Please check:"
 msgstr "Molimo provjerite:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4148
+#: ../../Firmware/ultralcd.cpp:4167
 msgid "Please clean heatbed and then press the knob."
 msgstr "Ocistite grijacu podlogu, a zatim pritisnite gumb."
 
@@ -1269,13 +1269,13 @@ msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Molimo ocistite mlaznicu radi kalibracije. Kliknite kada ste gotovi."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3945
+#: ../../Firmware/ultralcd.cpp:3964
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr "Umetnite filament u ekstruder, a zatim pritisnite gumb za punjenje."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3940
+#: ../../Firmware/ultralcd.cpp:3959
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1283,7 +1283,7 @@ msgstr ""
 "Umetnite filament u prvu cijev MMU-a, a zatim pritisnite gumb za punjenje."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3863
+#: ../../Firmware/ultralcd.cpp:3882
 msgid "Please load filament first."
 msgstr "Molimo prvo ubacite filament."
 
@@ -1294,7 +1294,7 @@ msgstr "Molimo otvorite klizac i rucno uklonite filament."
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=5
 #: ../../Firmware/mesh_bed_calibration.cpp:2799 ../../Firmware/messages.cpp:70
-#: ../../Firmware/ultralcd.cpp:4085
+#: ../../Firmware/ultralcd.cpp:4104
 msgid "Please place steel sheet on heatbed."
 msgstr "Stavite celicnu plocu na grijacu podlogu."
 
@@ -1305,7 +1305,7 @@ msgid "Please press the knob to unload filament"
 msgstr "Pritisnite gumb za praznjenje filamenta"
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:5213
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:5235
 msgid "Please pull out filament immediately"
 msgstr "Molimo odmah izvucite filament"
 
@@ -1315,7 +1315,7 @@ msgid "Please remove filament and then press the knob."
 msgstr "Molimo uklonite filament i zatim pritisnite gumb."
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:4081
+#: ../../Firmware/ultralcd.cpp:4100
 msgid "Please remove shipping helpers first."
 msgstr "Najprije uklonite prijevozne osloce."
 
@@ -1331,7 +1331,7 @@ msgid "Please run XYZ calibration first."
 msgstr "Prvo pokrenite XYZ kalibraciju."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:6247
+#: ../../Firmware/ultralcd.cpp:6277
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Prvo izvadite filament, a zatim ponovite ovu radnju."
 
@@ -1348,54 +1348,54 @@ msgstr "Molimo nadogradite."
 #. MSG_PLEASE_WAIT c=20
 #: ../../Firmware/Marlin_main.cpp:3547 ../../Firmware/Marlin_main.cpp:3563
 #: ../../Firmware/Marlin_main.cpp:7931 ../../Firmware/messages.cpp:71
-#: ../../Firmware/ultralcd.cpp:2186 ../../Firmware/ultralcd.cpp:2197
+#: ../../Firmware/ultralcd.cpp:2205 ../../Firmware/ultralcd.cpp:2216
 msgid "Please wait"
 msgstr "Molimo pricekajte"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1219
-#: ../../Firmware/ultralcd.cpp:1260 ../../Firmware/ultralcd.cpp:1270
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1238
+#: ../../Firmware/ultralcd.cpp:1279 ../../Firmware/ultralcd.cpp:1289
 msgid "Power failures"
 msgstr "Prekidi struje"
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5502
+#: ../../Firmware/ultralcd.cpp:5524
 msgid "Preheat"
 msgstr "Predgrijavanje"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:2280
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:2299
 msgid "Preheat the nozzle!"
 msgstr "Predgr. mlaznicu!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:2900
-#: ../../Firmware/ultralcd.cpp:3924 ../../Firmware/ultralcd.cpp:3926
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:2919
+#: ../../Firmware/ultralcd.cpp:3943 ../../Firmware/ultralcd.cpp:3945
 msgid "Preheating nozzle. Please wait."
 msgstr "Predgrijavanje mlaznice. Molim vas pricekajte."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1988
+#: ../../Firmware/ultralcd.cpp:2007
 msgid "Preheating to cut"
 msgstr "Predgr. za rezanje"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1985
+#: ../../Firmware/ultralcd.cpp:2004
 msgid "Preheating to eject"
 msgstr "Predgr. za izbaci."
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1976
+#: ../../Firmware/ultralcd.cpp:1995
 msgid "Preheating to load"
 msgstr "Predgr. za punjenje"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1981
+#: ../../Firmware/ultralcd.cpp:2000
 msgid "Preheating to unload"
 msgstr "Predgr. za praznj."
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1809
+#: ../../Firmware/ultralcd.cpp:1828
 msgid "Press the knob"
 msgstr "Pritisnite gumb"
 
@@ -1415,13 +1415,13 @@ msgid "Print aborted"
 msgstr "Print je prekinut"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1144
-#: ../../Firmware/ultralcd.cpp:7322
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1145
+#: ../../Firmware/ultralcd.cpp:7354
 msgid "Print fan:"
 msgstr "Vent printa:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5535
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5557
 msgid "Print from SD"
 msgstr "Printaj sa SD"
 
@@ -1431,12 +1431,12 @@ msgid "Print paused"
 msgstr "Print pauziran"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2366
+#: ../../Firmware/ultralcd.cpp:2385
 msgid "Print time"
 msgstr "Vrijeme printanja"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1711
+#: ../../Firmware/ultralcd.cpp:1730
 msgid "Printer IP Addr:"
 msgstr "Printer IP Adr:"
 
@@ -1464,12 +1464,12 @@ msgstr ""
 "vrijednost u postavkama. Print je otkazan."
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4834
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4853
 msgid "RPi port"
 msgstr "RPi utor"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2755
+#: ../../Firmware/ultralcd.cpp:2774
 msgid "Rear side [μm]"
 msgstr "Zad. str.[μm]"
 
@@ -1486,24 +1486,24 @@ msgstr ""
 "filamenta."
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5426
+#: ../../Firmware/ultralcd.cpp:5448
 msgid "Rename"
 msgstr "Preimenuj"
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2756
-#: ../../Firmware/ultralcd.cpp:5427
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2775
+#: ../../Firmware/ultralcd.cpp:5449
 msgid "Reset"
 msgstr "Resetiraj"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4917
+#: ../../Firmware/ultralcd.cpp:4936
 msgid "Reset XYZ calibr."
 msgstr "Reset XYZ kalibr."
 
 #. MSG_RESUME_PRINT c=18
 #: ../../Firmware/Marlin_main.cpp:655 ../../Firmware/messages.cpp:81
-#: ../../Firmware/ultralcd.cpp:5521 ../../Firmware/ultralcd.cpp:5523
+#: ../../Firmware/ultralcd.cpp:5543 ../../Firmware/ultralcd.cpp:5545
 msgid "Resume print"
 msgstr "Nastavite print"
 
@@ -1513,17 +1513,17 @@ msgid "Resuming print"
 msgstr "Nastavak printa"
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2497
+#: ../../Firmware/ultralcd.cpp:2516
 msgid "Right"
 msgstr "Tocno"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2753
+#: ../../Firmware/ultralcd.cpp:2772
 msgid "Right side[μm]"
 msgstr "Desna str.[μm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3884
+#: ../../Firmware/ultralcd.cpp:3903
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1532,14 +1532,14 @@ msgstr ""
 "ispocetka. Nastavite?"
 
 #. MSG_RUNOUTS c=7
-#: ../../Firmware/ultralcd.cpp:1271
+#: ../../Firmware/ultralcd.cpp:1290
 msgid "Runouts"
 msgstr "Nestalo"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4395
-#: ../../Firmware/ultralcd.cpp:4397 ../../Firmware/ultralcd.cpp:4414
-#: ../../Firmware/ultralcd.cpp:4416
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4414
+#: ../../Firmware/ultralcd.cpp:4416 ../../Firmware/ultralcd.cpp:4433
+#: ../../Firmware/ultralcd.cpp:4435
 msgid "SD card"
 msgstr "SD karti"
 
@@ -1555,12 +1555,12 @@ msgid "Searching bed calibration point"
 msgstr "Trazenje tocke kalibracije podloge"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5419
+#: ../../Firmware/ultralcd.cpp:5441
 msgid "Select"
 msgstr "Odaberi"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3966
+#: ../../Firmware/ultralcd.cpp:3985
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
@@ -1575,50 +1575,50 @@ msgstr "Odaberite ekstruder:"
 
 #. MSG_SELECT_FILAMENT c=20
 #: ../../Firmware/Marlin_main.cpp:8577 ../../Firmware/Marlin_main.cpp:8604
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3834
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3853
 msgid "Select filament:"
 msgstr "Odaberi filament:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:3679
-#: ../../Firmware/ultralcd.cpp:4841
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:3698
+#: ../../Firmware/ultralcd.cpp:4860
 msgid "Select language"
 msgstr "Izaberi jezik"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:4122
+#: ../../Firmware/ultralcd.cpp:4141
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr ""
 "Odaberite temperaturu predgrijavanja mlaznice koja odgovara vasem materijalu."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3971
+#: ../../Firmware/ultralcd.cpp:3990
 msgid "Select temperature which matches your material."
 msgstr "Odaberite temperaturu koja odgovara vasem materijalu."
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6522
+#: ../../Firmware/ultralcd.cpp:6552
 msgid "Self test OK"
 msgstr "Samotestiranje OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:6290
+#: ../../Firmware/ultralcd.cpp:6320
 msgid "Self test start"
 msgstr "Pocetak selftesta"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4904
+#: ../../Firmware/ultralcd.cpp:4923
 msgid "Selftest"
 msgstr "Selftest"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6962
+#: ../../Firmware/ultralcd.cpp:6992
 msgid "Selftest error!"
 msgstr "Selftest error!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:6526
-#: ../../Firmware/ultralcd.cpp:7049 ../../Firmware/ultralcd.cpp:7314
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:6556
+#: ../../Firmware/ultralcd.cpp:7079 ../../Firmware/ultralcd.cpp:7344
 msgid "Selftest failed"
 msgstr "Selftest nije uspio"
 
@@ -1630,30 +1630,30 @@ msgstr ""
 "senzora."
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1723
+#: ../../Firmware/ultralcd.cpp:1742
 msgid "Sensor info"
 msgstr "Info senzora"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:6254
+#: ../../Firmware/ultralcd.cpp:6284
 msgid "Sensor verified, remove the filament now."
 msgstr "Senzor je provjeren, odmah uklonite filament."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2773
+#: ../../Firmware/ultralcd.cpp:2792
 msgid "Set temperature:"
 msgstr "Postavi temperaturu:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:3491
-#: ../../Firmware/ultralcd.cpp:3696 ../../Firmware/ultralcd.cpp:4206
-#: ../../Firmware/ultralcd.cpp:5580 ../../Firmware/ultralcd.cpp:5827
-#: ../../Firmware/ultralcd.cpp:5880
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:3510
+#: ../../Firmware/ultralcd.cpp:3715 ../../Firmware/ultralcd.cpp:4225
+#: ../../Firmware/ultralcd.cpp:5602 ../../Firmware/ultralcd.cpp:5849
+#: ../../Firmware/ultralcd.cpp:5902
 msgid "Settings"
 msgstr "Postavke"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2540
+#: ../../Firmware/ultralcd.cpp:2559
 msgid "Severe skew"
 msgstr "Veliki nagib"
 
@@ -1664,7 +1664,7 @@ msgid "Sheet"
 msgstr "Ploca"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3824
+#: ../../Firmware/ultralcd.cpp:3843
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1677,18 +1677,18 @@ msgstr ""
 "%cResetiraj"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4915
+#: ../../Firmware/ultralcd.cpp:4934
 msgid "Show end stops"
 msgstr "Pokazi granicnike"
 
 #. MSG_SILENT c=7
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4361
-#: ../../Firmware/ultralcd.cpp:4456 ../../Firmware/ultralcd.cpp:5778
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4380
+#: ../../Firmware/ultralcd.cpp:4475 ../../Firmware/ultralcd.cpp:5800
 msgid "Silent"
 msgstr "Tih"
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2539
+#: ../../Firmware/ultralcd.cpp:2558
 msgid "Slight skew"
 msgstr "Lagani nagib"
 
@@ -1707,8 +1707,8 @@ msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Naisao je neki problem, nametnuto Z-niveliranje..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4403
-#: ../../Firmware/ultralcd.cpp:4404 ../../Firmware/ultralcd.cpp:4405
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4422
+#: ../../Firmware/ultralcd.cpp:4423 ../../Firmware/ultralcd.cpp:4424
 msgid "Sort"
 msgstr "Vrsta"
 
@@ -1719,20 +1719,20 @@ msgid "Sorting files"
 msgstr "Sortiranje datoteka"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4450
-#: ../../Firmware/ultralcd.cpp:4453 ../../Firmware/ultralcd.cpp:4456
-#: ../../Firmware/ultralcd.cpp:4459 ../../Firmware/ultralcd.cpp:4462
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/ultralcd.cpp:4472 ../../Firmware/ultralcd.cpp:4475
+#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4481
 msgid "Sound"
 msgstr "Zvuk"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5718
+#: ../../Firmware/ultralcd.cpp:5740
 msgid "Speed"
 msgstr "Brzina"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7166
-#: ../../Firmware/ultralcd.cpp:7181 ../../Firmware/ultralcd.cpp:7189
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7196
+#: ../../Firmware/ultralcd.cpp:7211 ../../Firmware/ultralcd.cpp:7219
 msgid "Spinning"
 msgstr "Okrece se"
 
@@ -1743,42 +1743,42 @@ msgstr ""
 "Potrebna je stabilna temperatura okoline 21-26C, potrebno je cvrsto postolje."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5585
+#: ../../Firmware/ultralcd.cpp:5607
 msgid "Statistics"
 msgstr "Statistika"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4338
-#: ../../Firmware/ultralcd.cpp:4382 ../../Firmware/ultralcd.cpp:5770
+#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4357
+#: ../../Firmware/ultralcd.cpp:4401 ../../Firmware/ultralcd.cpp:5792
 msgid "Stealth"
 msgstr "Tiho"
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4763
-#: ../../Firmware/ultralcd.cpp:5416
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4782
+#: ../../Firmware/ultralcd.cpp:5438
 msgid "Steel sheets"
 msgstr "Celicna ploca"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5528
-#: ../../Firmware/ultralcd.cpp:5987
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5550
+#: ../../Firmware/ultralcd.cpp:6017
 msgid "Stop print"
 msgstr "Zaustavi print"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4499
-#: ../../Firmware/ultralcd.cpp:4581 ../../Firmware/ultralcd.cpp:4620
-#: ../../Firmware/ultralcd.cpp:4661
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4518
+#: ../../Firmware/ultralcd.cpp:4600 ../../Firmware/ultralcd.cpp:4639
+#: ../../Firmware/ultralcd.cpp:4680
 msgid "Strict"
 msgstr "Strogo"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/ultralcd.cpp:5616
 msgid "Support"
 msgstr "Podrska"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:7021
+#: ../../Firmware/ultralcd.cpp:7051
 msgid "Swapped"
 msgstr "Zamjenjeno"
 
@@ -1787,28 +1787,18 @@ msgstr "Zamjenjeno"
 msgid "THERMAL ANOMALY"
 msgstr "TERMALNA ANOMALIJA"
 
-#. MSG_TM_AUTOTUNE_FAILED c=20
-#: ../../Firmware/temperature.cpp:2899
-msgid "TM autotune failed"
-msgstr "TM autotune nije usp"
-
-#. MSG_TEMP_MODEL_AUTOTUNE c=20
-#: ../../Firmware/temperature.cpp:2884
-msgid "Temp. model autotune"
-msgstr "Temp. autptune model"
-
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4797
+#: ../../Firmware/ultralcd.cpp:4816
 msgid "Temperature"
 msgstr "Temperatura"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1729
+#: ../../Firmware/ultralcd.cpp:1748
 msgid "Temperatures"
 msgstr "Temperature"
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3974
+#: ../../Firmware/ultralcd.cpp:3993
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -1827,66 +1817,66 @@ msgstr ""
 "poglavlje Prvi koraci, odjeljak Tijek kalibracije."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4403
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4422
 msgid "Time"
 msgstr "Vrijeme"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:5865
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:5887
 msgid "Timeout"
 msgstr "Pauza"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:1149
-#: ../../Firmware/ultralcd.cpp:1297
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:1168
+#: ../../Firmware/ultralcd.cpp:1316
 msgid "Total"
 msgstr "Ukupno"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:1192
-#: ../../Firmware/ultralcd.cpp:1218 ../../Firmware/ultralcd.cpp:1328
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:1211
+#: ../../Firmware/ultralcd.cpp:1237 ../../Firmware/ultralcd.cpp:1347
 msgid "Total failures"
 msgstr "Totalne pogreske"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2387
+#: ../../Firmware/ultralcd.cpp:2406
 msgid "Total filament"
 msgstr "Totalno filamenta"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2388
+#: ../../Firmware/ultralcd.cpp:2407
 msgid "Total print time"
 msgstr "Vrijeme printanja"
 
 #. MSG_TUNE c=18
-#: ../../Firmware/ultralcd.cpp:5500
+#: ../../Firmware/ultralcd.cpp:5522
 msgid "Tune"
 msgstr "Ugodi"
 
 #. MSG_UNLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:5564
-#: ../../Firmware/ultralcd.cpp:5578
+#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:5586
+#: ../../Firmware/ultralcd.cpp:5600
 msgid "Unload filament"
 msgstr "Ispraznite fil."
 
 #. MSG_UNLOADING_FILAMENT c=20
 #: ../../Firmware/messages.cpp:112 ../../Firmware/mmu.cpp:957
-#: ../../Firmware/ultralcd.cpp:5197
+#: ../../Firmware/ultralcd.cpp:5219
 msgid "Unloading filament"
 msgstr "Praznjenje filamenta"
 
 #. MSG_FIL_FAILED c=20 r=5
-#: ../../Firmware/ultralcd.cpp:6258
+#: ../../Firmware/ultralcd.cpp:6288
 msgid "Verification failed, remove the filament and try again."
 msgstr "Provjera nije uspjela, uklonite filament i pokusajte ponovno."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1732
+#: ../../Firmware/ultralcd.cpp:1751
 msgid "Voltages"
 msgstr "Voltaza"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3534
+#: ../../Firmware/ultralcd.cpp:3553
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -1903,19 +1893,19 @@ msgid "Wait for user..."
 msgstr "Ceka se korisnik..."
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2881
+#: ../../Firmware/ultralcd.cpp:2900
 msgid "Waiting for PINDA probe cooling"
 msgstr "Ceka se hladenje PINDA sonde"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2913
+#: ../../Firmware/ultralcd.cpp:2932
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Ceka se hladjenje mlaznice i podloge"
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:4496
-#: ../../Firmware/ultralcd.cpp:4578 ../../Firmware/ultralcd.cpp:4617
-#: ../../Firmware/ultralcd.cpp:4658
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/ultralcd.cpp:4597 ../../Firmware/ultralcd.cpp:4636
+#: ../../Firmware/ultralcd.cpp:4677
 msgid "Warn"
 msgstr "Upozore"
 
@@ -1940,151 +1930,138 @@ msgid "Was filament unload successful?"
 msgstr "Je li praznjenje fil. bilo uspjesno?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6973
-#: ../../Firmware/ultralcd.cpp:6977 ../../Firmware/ultralcd.cpp:6997
-#: ../../Firmware/ultralcd.cpp:7003 ../../Firmware/ultralcd.cpp:7027
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:7003
+#: ../../Firmware/ultralcd.cpp:7007 ../../Firmware/ultralcd.cpp:7027
+#: ../../Firmware/ultralcd.cpp:7033 ../../Firmware/ultralcd.cpp:7057
 msgid "Wiring error"
 msgstr "Greska u ozicenju"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4895
+#: ../../Firmware/ultralcd.cpp:4914
 msgid "Wizard"
 msgstr "Carobnjak"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4210
+#: ../../Firmware/ultralcd.cpp:4229
 msgid "X-correct:"
 msgstr "X-ispravan:"
 
 #. MSG_XFLASH c=18
-#: ../../Firmware/ultralcd.cpp:5596
+#: ../../Firmware/ultralcd.cpp:5618
 msgid "XFLASH init"
 msgstr "XFLASH  validacija"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1721
+#: ../../Firmware/ultralcd.cpp:1740
 msgid "XYZ cal. details"
 msgstr "XYZ detalji kal"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3333
+#: ../../Firmware/ultralcd.cpp:3352
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr "XYZ kalibracija u redu. Iskrivljenost ce se automatski ispraviti."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3330
+#: ../../Firmware/ultralcd.cpp:3349
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr "XYZ kalibracija je u redu. Osi X/Y su malo nagnute. Bravo!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3311
+#: ../../Firmware/ultralcd.cpp:3330
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr ""
 "XYZ kalibracija je ugrozena. Prednje kalibracijske tocke nisu dostupne."
 
-#. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_LEFT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3317
-msgid ""
-"XYZ calibration compromised. Left front calibration point not reachable."
-msgstr ""
-"XYZ kalibracija je ugrozena. Lijeva prednja tocka kalibracije nije dostupna."
-
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3314
+#: ../../Firmware/ultralcd.cpp:3333
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr ""
 "XYZ kalibracija je ugrozena. Desna prednja tocka kalibracije nije dostupna."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3293
+#: ../../Firmware/ultralcd.cpp:3312
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr ""
 "XYZ kalibracija nije uspjela. Tocka kalibracije podloga nije pronadena."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3299
+#: ../../Firmware/ultralcd.cpp:3318
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr ""
 "XYZ kalibracija nije uspjela. Prednje kalibracijske tocke nisu dostupne."
 
-#. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_LEFT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3305
-msgid "XYZ calibration failed. Left front calibration point not reachable."
-msgstr ""
-"XYZ kalibracija nije uspjela. Lijeva prednja tocka kalibracije nije dostupna."
-
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3296
-#: ../../Firmware/ultralcd.cpp:3324
+#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3315
+#: ../../Firmware/ultralcd.cpp:3343
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "XYZ kalibracija nije uspjela. Molimo pogledajte prirucnik."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3302
+#: ../../Firmware/ultralcd.cpp:3321
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr ""
 "XYZ kalibracija nije uspjela. Desna prednja tocka kalibracije nije dostupna."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3327
+#: ../../Firmware/ultralcd.cpp:3346
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "XYZ kalibracija u redu. Osi X/Y su okomite. Cestitamo!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2494
+#: ../../Firmware/ultralcd.cpp:2513
 msgid "Y distance from min"
 msgstr "Y distanca od min"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4211
+#: ../../Firmware/ultralcd.cpp:4230
 msgid "Y-correct:"
 msgstr "Y-ispravan:"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:2216
-#: ../../Firmware/ultralcd.cpp:2800 ../../Firmware/ultralcd.cpp:3180
-#: ../../Firmware/ultralcd.cpp:4785 ../../Firmware/ultralcd.cpp:5989
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:2235
+#: ../../Firmware/ultralcd.cpp:2819 ../../Firmware/ultralcd.cpp:3199
+#: ../../Firmware/ultralcd.cpp:4804 ../../Firmware/ultralcd.cpp:6019
 msgid "Yes"
 msgstr "Da"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:4187
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:4206
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr "Carobnjak uvijek mozete nastaviti iz Kalibracija -> Carobnjak."
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4231
 msgid "Z-correct:"
 msgstr "Z-ispravan:"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:5835
+#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:5857
 msgid "Z-probe nr."
 msgstr "Z-sonda br."
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2565
+#: ../../Firmware/ultralcd.cpp:2584
 msgid "[0;0] point offset"
 msgstr "[0;0] razmak tocke"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2154
+#: ../../Firmware/ultralcd.cpp:2173
 msgid "and press the knob"
 msgstr "i pritisnite gumb"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1816
+#: ../../Firmware/ultralcd.cpp:1835
 msgid "to load filament"
 msgstr "da napuni filament"
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1820
+#: ../../Firmware/ultralcd.cpp:1839
 msgid "to unload filament"
 msgstr "da isprazni filament"
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1688
+#: ../../Firmware/ultralcd.cpp:1707
 msgid "unknown"
 msgstr "nepoznato"
 
@@ -2094,8 +2071,8 @@ msgid "unknown state"
 msgstr "nepoznato stanje"
 
 #. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:6077
-#: ../../Firmware/ultralcd.cpp:6080
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:6107
+#: ../../Firmware/ultralcd.cpp:6110
 msgid "🔃Refresh"
 msgstr "🔃Osvjeziti"
 
@@ -2104,3 +2081,20 @@ msgstr "🔃Osvjeziti"
 
 #~ msgid "M117 First layer cal."
 #~ msgstr "M117 Prvi sloj kal."
+
+#~ msgid "TM autotune failed"
+#~ msgstr "TM autotune nije usp"
+
+#~ msgid "Temp. model autotune"
+#~ msgstr "Temp. autptune model"
+
+#~ msgid ""
+#~ "XYZ calibration compromised. Left front calibration point not reachable."
+#~ msgstr ""
+#~ "XYZ kalibracija je ugrozena. Lijeva prednja tocka kalibracije nije "
+#~ "dostupna."
+
+#~ msgid "XYZ calibration failed. Left front calibration point not reachable."
+#~ msgstr ""
+#~ "XYZ kalibracija nije uspjela. Lijeva prednja tocka kalibracije nije "
+#~ "dostupna."

--- a/lang/po/Firmware_hu.po
+++ b/lang/po/Firmware_hu.po
@@ -26,113 +26,113 @@ msgid " 0.4 or newer"
 msgstr " 0.4 v. ujabb"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:7036
+#: ../../Firmware/ultralcd.cpp:7066
 msgid "%s level expected"
 msgstr "Vart szint: %s"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1968
-#: ../../Firmware/ultralcd.cpp:3835
+#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1987
+#: ../../Firmware/ultralcd.cpp:3854
 msgid ">Cancel"
 msgstr ">Megsem"
 
 #. MSG_BABYSTEPPING_Z c=15
 #. Beware: must include the ':' as its last character
-#: ../../Firmware/ultralcd.cpp:2670
+#: ../../Firmware/ultralcd.cpp:2689
 msgid "Adjusting Z:"
 msgstr "Z allitasa:"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:7313
+#: ../../Firmware/ultralcd.cpp:7343
 msgid "All correct"
 msgstr "Minden rendben"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4180
+#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4190
+#: ../../Firmware/ultralcd.cpp:4199
 msgid "All is done. Happy printing!"
 msgstr "Keszen vagyunk. Jo nyomtatast!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4404
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4423
 msgid "Alphabet"
 msgstr "Abece"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4308
+#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4327
 msgid "Always"
 msgstr "Mindig"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1405
+#: ../../Firmware/ultralcd.cpp:1424
 msgid "Ambient"
 msgstr "Kornyezet"
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2983
+#: ../../Firmware/ultralcd.cpp:3002
 msgid "Are left and right Z~carriages all up?"
 msgstr "A Z tengely a felso vegponton van?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4478
 msgid "Assist"
 msgstr "Seged"
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:5886
 msgid "Auto"
 msgstr "Autom."
 
 #. MSG_AUTO_HOME c=18
 #: ../../Firmware/Marlin_main.cpp:3271 ../../Firmware/messages.cpp:9
-#: ../../Firmware/ultralcd.cpp:4900
+#: ../../Firmware/ultralcd.cpp:4919
 msgid "Auto home"
 msgstr "Auto homeolas"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:4364
-#: ../../Firmware/ultralcd.cpp:5779
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:4383
+#: ../../Firmware/ultralcd.cpp:5801
 msgid "Auto power"
 msgstr "Auto ero"
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5572
+#: ../../Firmware/ultralcd.cpp:5594
 msgid "AutoLoad filament"
 msgstr "Fil. auto.betolt."
 
 #. MSG_AUTOLOADING_ONLY_IF_FSENS_ON c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3549
+#: ../../Firmware/ultralcd.cpp:3568
 msgid ""
 "Autoloading filament available only when filament sensor is turned on..."
 msgstr "Filament autom. betolteste csak bekapcs. fil. szenzorral mukodik."
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2301
+#: ../../Firmware/ultralcd.cpp:2320
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr "Autom. betoltes be, nyomd meg a gombot es helyzed be a filamentet."
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:7015
+#: ../../Firmware/ultralcd.cpp:7045
 msgid "Axis"
 msgstr "Tengely"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:7014
+#: ../../Firmware/ultralcd.cpp:7044
 msgid "Axis length"
 msgstr "Tengely hossz"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:2751
-#: ../../Firmware/ultralcd.cpp:5861 ../../Firmware/ultralcd.cpp:7838
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:2770
+#: ../../Firmware/ultralcd.cpp:5883 ../../Firmware/ultralcd.cpp:7878
 msgid "Back"
 msgstr "Vissza"
 
 #. MSG_BED c=13
 #: ../../Firmware/Marlin_main.cpp:2051 ../../Firmware/Marlin_main.cpp:4767
 #: ../../Firmware/Marlin_main.cpp:4819 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:1403 ../../Firmware/ultralcd.cpp:5721
-#: ../../Firmware/ultralcd.cpp:5891
+#: ../../Firmware/ultralcd.cpp:1422 ../../Firmware/ultralcd.cpp:5743
+#: ../../Firmware/ultralcd.cpp:5913
 msgid "Bed"
 msgstr "Asztal"
 
@@ -149,7 +149,7 @@ msgid "Bed done"
 msgstr "Asztal kesz"
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4912
+#: ../../Firmware/ultralcd.cpp:4931
 msgid "Bed level correct"
 msgstr "Szint. korrekcio"
 
@@ -167,18 +167,18 @@ msgstr ""
 "az ujrainditast."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6972
+#: ../../Firmware/ultralcd.cpp:7002
 msgid "Bed/Heater"
 msgstr "Asztal/Fej futes"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1458
-#: ../../Firmware/ultralcd.cpp:1726
+#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1477
+#: ../../Firmware/ultralcd.cpp:1745
 msgid "Belt status"
 msgstr "Szij allapot"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4902
+#: ../../Firmware/ultralcd.cpp:4921
 msgid "Belt test"
 msgstr "Szij teszt"
 
@@ -189,28 +189,28 @@ msgid "Blackout occurred. Recover print?"
 msgstr "Aramkieses volt, nyomt. folytatasa?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:5886
 msgid "Bright"
 msgstr "Fenyes"
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4850
-#: ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4869
+#: ../../Firmware/ultralcd.cpp:5811
 msgid "Brightness"
 msgstr "Fenyero"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4906
+#: ../../Firmware/ultralcd.cpp:4925
 msgid "Calibrate XYZ"
 msgstr "XYZ kalibracio"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4908
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4927
 msgid "Calibrate Z"
 msgstr "Z kalibracio"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2946
+#: ../../Firmware/ultralcd.cpp:2965
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -225,7 +225,7 @@ msgid "Calibrating Z"
 msgstr "Z kalibralasa"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2945
+#: ../../Firmware/ultralcd.cpp:2964
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -234,12 +234,12 @@ msgstr ""
 "er, majd nyomd meg ha keszen vagy."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:7315
+#: ../../Firmware/ultralcd.cpp:7345
 msgid "Calibrating home"
 msgstr "Home poz. kalibralas"
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:5581
+#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:5603
 msgid "Calibration"
 msgstr "Kalibracio"
 
@@ -249,115 +249,115 @@ msgid "Calibration done"
 msgstr "Kalibracio kesz"
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7712
+#: ../../Firmware/ultralcd.cpp:7752
 msgid "Card removed"
 msgstr "Kartya eltavolitva"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/ultralcd.cpp:5560
 msgid "Change SD card"
 msgstr "Cserelj SD kartyat"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5497
-#: ../../Firmware/ultralcd.cpp:5730
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5519
+#: ../../Firmware/ultralcd.cpp:5752
 msgid "Change filament"
 msgstr "Filament csere"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2163
+#: ../../Firmware/ultralcd.cpp:2182
 msgid "Change success!"
 msgstr "Csere sikerult!"
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2215
+#: ../../Firmware/ultralcd.cpp:2234
 msgid "Changed correctly?"
 msgstr "Sikerult a csere?"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:6178
-#: ../../Firmware/ultralcd.cpp:7305
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:6208
+#: ../../Firmware/ultralcd.cpp:7335
 msgid "Checking X axis"
 msgstr "X tengely ellenorzes"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:6187
-#: ../../Firmware/ultralcd.cpp:7306
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:6217
+#: ../../Firmware/ultralcd.cpp:7336
 msgid "Checking Y axis"
 msgstr "Y tengely ellenorzes"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:7307
+#: ../../Firmware/ultralcd.cpp:7337
 msgid "Checking Z axis"
 msgstr "Z tengely ellenorzes"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:7308
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:7338
 msgid "Checking bed"
 msgstr "Asztal ellenorzese"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:7304
+#: ../../Firmware/ultralcd.cpp:7334
 msgid "Checking endstops"
 msgstr "Vegallaskapcs. ellen"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:7403
+#: ../../Firmware/ultralcd.cpp:7433
 msgid "Checking file"
 msgstr "Fajl ellenorzese"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:7310
+#: ../../Firmware/ultralcd.cpp:7340
 msgid "Checking hotend"
 msgstr "Hotend ellenorzese"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:7311
-#: ../../Firmware/ultralcd.cpp:7312
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:7341
+#: ../../Firmware/ultralcd.cpp:7342
 msgid "Checking sensors"
 msgstr "Szenz. ellenorzese"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4765
+#: ../../Firmware/ultralcd.cpp:4784
 msgid "Checks"
 msgstr "Ellenorzesek"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2218
+#: ../../Firmware/ultralcd.cpp:2237
 msgid "Color not correct"
 msgstr "Szin nem jo"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3725
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3744
 msgid "Community made"
 msgstr "Kozossegi"
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4704
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4723
 msgid "Cont."
 msgstr "Folyt"
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2125
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2144
 msgid "Cooldown"
 msgstr "Lehutes"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3663
+#: ../../Firmware/ultralcd.cpp:3682
 msgid "Copy selected language?"
 msgstr "Kivalasztott nyelv masolasa?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1221
-#: ../../Firmware/ultralcd.cpp:1262 ../../Firmware/ultralcd.cpp:1272
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1240
+#: ../../Firmware/ultralcd.cpp:1281 ../../Firmware/ultralcd.cpp:1291
 msgid "Crash"
 msgstr "Utkozes"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4341
-#: ../../Firmware/ultralcd.cpp:4342 ../../Firmware/ultralcd.cpp:4344
-#: ../../Firmware/ultralcd.cpp:5765 ../../Firmware/ultralcd.cpp:5767
-#: ../../Firmware/ultralcd.cpp:5771
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4363
+#: ../../Firmware/ultralcd.cpp:5787 ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/ultralcd.cpp:5793
 msgid "Crash det."
 msgstr "Utkozes erz."
 
@@ -367,7 +367,7 @@ msgid "Crash detected."
 msgstr "Utkozes erzekelve."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3521
+#: ../../Firmware/ultralcd.cpp:3540
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -378,14 +378,14 @@ msgstr ""
 "kapcsolhato be"
 
 #. MSG_CUT_FILAMENT c=17
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:5175
-#: ../../Firmware/ultralcd.cpp:5567
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:5197
+#: ../../Firmware/ultralcd.cpp:5589
 msgid "Cut filament"
 msgstr "Filament vagasa"
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:4303
-#: ../../Firmware/ultralcd.cpp:4308 ../../Firmware/ultralcd.cpp:4313
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:4322
+#: ../../Firmware/ultralcd.cpp:4327 ../../Firmware/ultralcd.cpp:4332
 msgid "Cutter"
 msgstr "Vago"
 
@@ -395,17 +395,17 @@ msgid "Cutting filament"
 msgstr "Filament vagasa"
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1668
+#: ../../Firmware/ultralcd.cpp:1687
 msgid "Date:"
 msgstr "Datum:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5886
 msgid "Dim"
 msgstr "Sotet"
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4802
+#: ../../Firmware/ultralcd.cpp:4821
 msgid "Disable steppers"
 msgstr "Motorok kikapcsol."
 
@@ -422,7 +422,7 @@ msgstr ""
 "bekezdest."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:4145
+#: ../../Firmware/ultralcd.cpp:4164
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -431,23 +431,23 @@ msgstr ""
 "asztal kozotti tavolsagot?"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4214
+#: ../../Firmware/ultralcd.cpp:4233
 msgid "E-correct:"
 msgstr "E-korrekcio:"
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2279
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2298
 msgid "ERROR:"
 msgstr "HIBA:"
 
 #. MSG_FSENS_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3562
+#: ../../Firmware/ultralcd.cpp:3581
 msgid "ERROR: Filament sensor is not responding, please check connection."
 msgstr "HIBA: A fil. szenzor nem valaszol, ellenorizd a csatlakozast."
 
 #. MSG_EJECT_FILAMENT c=17
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:5156
-#: ../../Firmware/ultralcd.cpp:5565
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:5178
+#: ../../Firmware/ultralcd.cpp:5587
 msgid "Eject filament"
 msgstr "Filament kiadasa"
 
@@ -457,47 +457,41 @@ msgid "Ejecting filament"
 msgstr "Filament kiadasa"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6985
+#: ../../Firmware/ultralcd.cpp:7015
 msgid "Endstop"
 msgstr "Vegallaskapcsolo"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6990
+#: ../../Firmware/ultralcd.cpp:7020
 msgid "Endstop not hit"
 msgstr "Vegallask. nem kapcs"
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6976
+#: ../../Firmware/ultralcd.cpp:7006
 msgid "Endstops"
 msgstr "Vegallaskapcsolok"
 
 #. MSG_EXTRUDER c=17
 #: ../../Firmware/Marlin_main.cpp:8608 ../../Firmware/messages.cpp:30
-#: ../../Firmware/ultralcd.cpp:3495
+#: ../../Firmware/ultralcd.cpp:3514
 msgid "Extruder"
 msgstr "Extruder"
 
-#. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1144
-#: ../../Firmware/ultralcd.cpp:7319
-msgid "Hotend fan:"
-msgstr "Hotend vent.:"
-
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1722
+#: ../../Firmware/ultralcd.cpp:1741
 msgid "Extruder info"
 msgstr "Extruder info"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4229
-#: ../../Firmware/ultralcd.cpp:4237 ../../Firmware/ultralcd.cpp:4248
-#: ../../Firmware/ultralcd.cpp:4250
+#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4248
+#: ../../Firmware/ultralcd.cpp:4256 ../../Firmware/ultralcd.cpp:4267
+#: ../../Firmware/ultralcd.cpp:4269
 msgid "F. autoload"
 msgstr "F. autobetolt"
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4704
-#: ../../Firmware/ultralcd.cpp:4707
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4723
+#: ../../Firmware/ultralcd.cpp:4726
 msgid "FS Action"
 msgstr "FSz akcio"
 
@@ -512,102 +506,102 @@ msgid "FS v0.4 or newer"
 msgstr "FS v0.4 vagy ujabb"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5589
+#: ../../Firmware/ultralcd.cpp:5611
 msgid "Fail stats"
 msgstr "Hiba statisztika"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5592
+#: ../../Firmware/ultralcd.cpp:5614
 msgid "Fail stats MMU"
 msgstr "MMU hiba stat."
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:7031
+#: ../../Firmware/ultralcd.cpp:7061
 msgid "False triggering"
 msgstr "Hamis kivalto ok"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:5723
-#: ../../Firmware/ultralcd.cpp:5893
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/ultralcd.cpp:5915
 msgid "Fan speed"
 msgstr "Vent. sebesseg"
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:7143
-#: ../../Firmware/ultralcd.cpp:7301 ../../Firmware/ultralcd.cpp:7302
-#: ../../Firmware/ultralcd.cpp:7303
+#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:7173
+#: ../../Firmware/ultralcd.cpp:7331 ../../Firmware/ultralcd.cpp:7332
+#: ../../Firmware/ultralcd.cpp:7333
 msgid "Fan test"
 msgstr "Ventillator teszt"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4811
-#: ../../Firmware/ultralcd.cpp:5756
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4830
+#: ../../Firmware/ultralcd.cpp:5778
 msgid "Fans check"
 msgstr "Vent.proba"
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1220
-#: ../../Firmware/ultralcd.cpp:1261 ../../Firmware/ultralcd.cpp:1327
-#: ../../Firmware/ultralcd.cpp:1329
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1239
+#: ../../Firmware/ultralcd.cpp:1280 ../../Firmware/ultralcd.cpp:1346
+#: ../../Firmware/ultralcd.cpp:1348
 msgid "Fil. runouts"
 msgstr "Fil. kifutasok"
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:3451
-#: ../../Firmware/ultralcd.cpp:4228 ../../Firmware/ultralcd.cpp:4234
-#: ../../Firmware/ultralcd.cpp:4244 ../../Firmware/ultralcd.cpp:5737
-#: ../../Firmware/ultralcd.cpp:5741 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:3470
+#: ../../Firmware/ultralcd.cpp:4247 ../../Firmware/ultralcd.cpp:4253
+#: ../../Firmware/ultralcd.cpp:4263 ../../Firmware/ultralcd.cpp:5759
+#: ../../Firmware/ultralcd.cpp:5763 ../../Firmware/ultralcd.cpp:5767
 msgid "Fil. sensor"
 msgstr "Fil. szenzor"
 
 #. MSG_FILAMENT c=17
 #: ../../Firmware/Marlin_main.cpp:8577 ../../Firmware/Marlin_main.cpp:8604
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3835
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3854
 msgid "Filament"
 msgstr "Filament"
 
 #. MSG_FILAMENT_CLEAN c=20 r=2
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2287
-#: ../../Firmware/ultralcd.cpp:2293
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2306
+#: ../../Firmware/ultralcd.cpp:2312
 msgid "Filament extruding & with correct color?"
 msgstr "Filament es a szine rendben?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2217
+#: ../../Firmware/ultralcd.cpp:2236
 msgid "Filament not loaded"
 msgstr "Fil. nincs betoltve"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:7026
-#: ../../Firmware/ultralcd.cpp:7030 ../../Firmware/ultralcd.cpp:7034
-#: ../../Firmware/ultralcd.cpp:7330
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:7056
+#: ../../Firmware/ultralcd.cpp:7060 ../../Firmware/ultralcd.cpp:7064
+#: ../../Firmware/ultralcd.cpp:7360
 msgid "Filament sensor"
 msgstr "Filament szenzor"
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2365
+#: ../../Firmware/ultralcd.cpp:2384
 msgid "Filament used"
 msgstr "Felhasznalt filam."
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7461
+#: ../../Firmware/ultralcd.cpp:7491
 msgid "File incomplete. Continue anyway?"
 msgstr "A fajl vege hianyzik. Folytatod igy is?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:5314
-#: ../../Firmware/ultralcd.cpp:5630
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:5336
+#: ../../Firmware/ultralcd.cpp:5652
 msgid "Finishing movements"
 msgstr "Mozdulat befejezese"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:4898
-#: ../../Firmware/ultralcd.cpp:5424
+#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:4917
+#: ../../Firmware/ultralcd.cpp:5446
 msgid "First layer cal."
 msgstr "Elso reteg kal."
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4066
+#: ../../Firmware/ultralcd.cpp:4085
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Elsokent lefuttatom az onellenorzest, hogy megnezzem a leggyakoribb "
@@ -619,23 +613,23 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr "Hozd helyre a hibat, majd nyomd meg a gombot az MMU egysegen."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5724
+#: ../../Firmware/ultralcd.cpp:5746
 msgid "Flow"
 msgstr "Flow"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:6996
-#: ../../Firmware/ultralcd.cpp:7149 ../../Firmware/ultralcd.cpp:7154
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:7026
+#: ../../Firmware/ultralcd.cpp:7179 ../../Firmware/ultralcd.cpp:7184
 msgid "Front print fan?"
 msgstr "Elso targyhuto vent?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2754
+#: ../../Firmware/ultralcd.cpp:2773
 msgid "Front side[μm]"
 msgstr "Elulso old[μm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:7020
+#: ../../Firmware/ultralcd.cpp:7050
 msgid "Front/left fans"
 msgstr "Elso/bal ventillator"
 
@@ -684,20 +678,20 @@ msgstr ""
 "Nyomtatas megallitva."
 
 #. MSG_GCODE c=8
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:4655
-#: ../../Firmware/ultralcd.cpp:4658 ../../Firmware/ultralcd.cpp:4661
-#: ../../Firmware/ultralcd.cpp:4664
+#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:4674
+#: ../../Firmware/ultralcd.cpp:4677 ../../Firmware/ultralcd.cpp:4680
+#: ../../Firmware/ultralcd.cpp:4683
 msgid "Gcode"
 msgstr "Gcode"
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:4672
-#: ../../Firmware/ultralcd.cpp:4726 ../../Firmware/ultralcd.cpp:4818
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:4691
+#: ../../Firmware/ultralcd.cpp:4745 ../../Firmware/ultralcd.cpp:4837
 msgid "HW Setup"
 msgstr "HW beallitas"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6968
+#: ../../Firmware/ultralcd.cpp:6998
 msgid "Heater/Thermistor"
 msgstr "Futotest/Termisztor"
 
@@ -719,7 +713,7 @@ msgid "Heating done."
 msgstr "Futes kesz."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=16
-#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4042
+#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4061
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -730,7 +724,7 @@ msgstr ""
 "nyomtathatsz is."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4064
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -739,24 +733,30 @@ msgstr ""
 "a beallitasi folyamaton?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:4358
-#: ../../Firmware/ultralcd.cpp:4367 ../../Firmware/ultralcd.cpp:5777
-#: ../../Firmware/ultralcd.cpp:5780
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:4377
+#: ../../Firmware/ultralcd.cpp:4386 ../../Firmware/ultralcd.cpp:5799
+#: ../../Firmware/ultralcd.cpp:5802
 msgid "High power"
 msgstr "Magas ero"
 
+#. MSG_HOTEND_FAN_SPEED c=15
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1145
+#: ../../Firmware/ultralcd.cpp:7351
+msgid "Hotend fan:"
+msgstr "Hotend vent.:"
+
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4094
 msgid "I will run xyz calibration now. It will take approx. 12 mins."
 msgstr "Lefuttatom az XYZ kalibraciot. Ez kb. 12 percet vesz igenybe."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/ultralcd.cpp:4102
 msgid "I will run z calibration now."
 msgstr "Lefuttatom a Z kalibraciot."
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=9
-#: ../../Firmware/ultralcd.cpp:4153
+#: ../../Firmware/ultralcd.cpp:4172
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -770,22 +770,22 @@ msgid "Improving bed calibration point"
 msgstr "Bed kalibracio pontositasa"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:5478
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:5500
 msgid "Info screen"
 msgstr "Info kepernyo"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5545
+#: ../../Firmware/ultralcd.cpp:5567
 msgid "Init. SD card"
 msgstr "SD kartya inic."
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2152
+#: ../../Firmware/ultralcd.cpp:2171
 msgid "Insert filament"
 msgstr "Helyezd be a filam."
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:6223
+#: ../../Firmware/ultralcd.cpp:6253
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
@@ -794,14 +794,14 @@ msgstr ""
 "gombot."
 
 #. MSG_FILAMENT_LOADED c=20 r=2
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3855
-#: ../../Firmware/ultralcd.cpp:4108 ../../Firmware/ultralcd.cpp:4111
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3874
+#: ../../Firmware/ultralcd.cpp:4127 ../../Firmware/ultralcd.cpp:4130
 msgid "Is filament loaded?"
 msgstr "Filament behelyezve?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=2
 #: ../../Firmware/Marlin_main.cpp:3312 ../../Firmware/Marlin_main.cpp:4886
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:4084
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:4103
 msgid "Is steel sheet on heatbed?"
 msgstr "Rajta van az acellap a targyasztalon?"
 
@@ -811,74 +811,74 @@ msgid "Iteration"
 msgstr "Iteracio"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:1148
-#: ../../Firmware/ultralcd.cpp:1296
+#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:1167
+#: ../../Firmware/ultralcd.cpp:1315
 msgid "Last print"
 msgstr "Utolso nyomtatas"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1169
-#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1269
-#: ../../Firmware/ultralcd.cpp:1326
+#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1188
+#: ../../Firmware/ultralcd.cpp:1278 ../../Firmware/ultralcd.cpp:1288
+#: ../../Firmware/ultralcd.cpp:1345
 msgid "Last print failures"
 msgstr "Utolso nyomt. hibak"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2496
+#: ../../Firmware/ultralcd.cpp:2515
 msgid "Left"
 msgstr "Bal"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7001
-#: ../../Firmware/ultralcd.cpp:7147 ../../Firmware/ultralcd.cpp:7152
+#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:7032
+#: ../../Firmware/ultralcd.cpp:7179 ../../Firmware/ultralcd.cpp:7184
 msgid "Left hotend fan?"
 msgstr "Bal hotend vent.?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2752
+#: ../../Firmware/ultralcd.cpp:2771
 msgid "Left side [μm]"
 msgstr "Bal [μm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:5862
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:5884
 msgid "Level Bright"
 msgstr "Fenyes szint"
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:5863
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:5885
 msgid "Level Dimmed"
 msgstr "Sotet szint"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4826
+#: ../../Firmware/ultralcd.cpp:4845
 msgid "Lin. correction"
 msgstr "Lin. korrekcio"
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4838
-#: ../../Firmware/ultralcd.cpp:5493
+#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4857
+#: ../../Firmware/ultralcd.cpp:5515
 msgid "Live adjust Z"
 msgstr "Z magassag beall."
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/ultralcd.cpp:5120
+#: ../../Firmware/ultralcd.cpp:5142
 msgid "Load all"
 msgstr "Osszes betolt."
 
 #. MSG_LOAD_FILAMENT c=17
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:5122
-#: ../../Firmware/ultralcd.cpp:5133 ../../Firmware/ultralcd.cpp:5562
-#: ../../Firmware/ultralcd.cpp:5576
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:5144
+#: ../../Firmware/ultralcd.cpp:5155 ../../Firmware/ultralcd.cpp:5584
+#: ../../Firmware/ultralcd.cpp:5598
 msgid "Load filament"
 msgstr "Filament betolt."
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5563
+#: ../../Firmware/ultralcd.cpp:5585
 msgid "Load to nozzle"
 msgstr "Betolt. fuvokahoz"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2185
+#: ../../Firmware/ultralcd.cpp:2204
 msgid "Loading color"
 msgstr "Szin tisztitasa"
 
@@ -886,18 +886,18 @@ msgstr "Szin tisztitasa"
 #: ../../Firmware/Marlin_main.cpp:3641 ../../Firmware/messages.cpp:55
 #: ../../Firmware/mmu.cpp:872 ../../Firmware/mmu.cpp:906
 #: ../../Firmware/mmu.cpp:1014 ../../Firmware/mmu.cpp:1026
-#: ../../Firmware/ultralcd.cpp:2196 ../../Firmware/ultralcd.cpp:3949
+#: ../../Firmware/ultralcd.cpp:2215 ../../Firmware/ultralcd.cpp:3968
 msgid "Loading filament"
 msgstr "Filament betoltese"
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:7008
+#: ../../Firmware/ultralcd.cpp:7038
 msgid "Loose pulley"
 msgstr "Laza szijtarcsa"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:4450
-#: ../../Firmware/ultralcd.cpp:4462
+#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/ultralcd.cpp:4481
 msgid "Loud"
 msgstr "Hangos"
 
@@ -912,8 +912,8 @@ msgid "MK3S firmware detected on MK3 printer"
 msgstr "MK3S firmver eszlelve MK3 nyomtaton"
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4381
-#: ../../Firmware/ultralcd.cpp:4382
+#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4400
+#: ../../Firmware/ultralcd.cpp:4401
 msgid "MMU Mode"
 msgstr "MMU Mod"
 
@@ -933,8 +933,8 @@ msgid "MMU OK. Resuming..."
 msgstr "MMU OK. Folytatom..."
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:64 ../../Firmware/ultralcd.cpp:1170
-#: ../../Firmware/ultralcd.cpp:1193
+#: ../../Firmware/messages.cpp:64 ../../Firmware/ultralcd.cpp:1189
+#: ../../Firmware/ultralcd.cpp:1212
 msgid "MMU fails"
 msgstr "MMU hibak"
 
@@ -944,8 +944,8 @@ msgid "MMU load failed"
 msgstr "MMU betolt.hiba"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:1171
-#: ../../Firmware/ultralcd.cpp:1194
+#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:1190
+#: ../../Firmware/ultralcd.cpp:1213
 msgid "MMU load fails"
 msgstr "MMU bet. hibak"
 
@@ -955,32 +955,32 @@ msgid "MMU needs user attention."
 msgstr "Az MMU felhasznaloi figyelmet igenyel."
 
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/ultralcd.cpp:1195
+#: ../../Firmware/ultralcd.cpp:1214
 msgid "MMU power fails"
 msgstr "MMU tap hibak"
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1680
+#: ../../Firmware/ultralcd.cpp:1699
 msgid "MMU2 connected"
 msgstr "MMU2 csatlakozott"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:5836
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:5858
 msgid "Magnets comp."
 msgstr "Magnes komp."
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1147
-#: ../../Firmware/ultralcd.cpp:1295 ../../Firmware/ultralcd.cpp:1338
-#: ../../Firmware/ultralcd.cpp:1645 ../../Firmware/ultralcd.cpp:4795
-#: ../../Firmware/ultralcd.cpp:4892 ../../Firmware/ultralcd.cpp:5119
-#: ../../Firmware/ultralcd.cpp:5131 ../../Firmware/ultralcd.cpp:5154
-#: ../../Firmware/ultralcd.cpp:5173 ../../Firmware/ultralcd.cpp:5717
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1166
+#: ../../Firmware/ultralcd.cpp:1314 ../../Firmware/ultralcd.cpp:1357
+#: ../../Firmware/ultralcd.cpp:1664 ../../Firmware/ultralcd.cpp:4814
+#: ../../Firmware/ultralcd.cpp:4911 ../../Firmware/ultralcd.cpp:5141
+#: ../../Firmware/ultralcd.cpp:5153 ../../Firmware/ultralcd.cpp:5176
+#: ../../Firmware/ultralcd.cpp:5195 ../../Firmware/ultralcd.cpp:5739
 msgid "Main"
 msgstr "Fomenu"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2537
+#: ../../Firmware/ultralcd.cpp:2556
 msgid "Measured skew"
 msgstr "Meroleg. hiba"
 
@@ -991,71 +991,71 @@ msgid "Measuring reference height of calibration point"
 msgstr "Kalibracios pont magassaganak merese"
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:5832
+#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:5854
 msgid "Mesh"
 msgstr "Halo"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4823
-#: ../../Firmware/ultralcd.cpp:4910
+#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4842
+#: ../../Firmware/ultralcd.cpp:4929
 msgid "Mesh Bed Leveling"
 msgstr "Asztal szintezes"
 
 #. MSG_MODE c=6
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:4336
-#: ../../Firmware/ultralcd.cpp:4338 ../../Firmware/ultralcd.cpp:4358
-#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4364
-#: ../../Firmware/ultralcd.cpp:4367 ../../Firmware/ultralcd.cpp:5763
-#: ../../Firmware/ultralcd.cpp:5770 ../../Firmware/ultralcd.cpp:5777
-#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5779
-#: ../../Firmware/ultralcd.cpp:5780 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/ultralcd.cpp:4357 ../../Firmware/ultralcd.cpp:4377
+#: ../../Firmware/ultralcd.cpp:4380 ../../Firmware/ultralcd.cpp:4383
+#: ../../Firmware/ultralcd.cpp:4386 ../../Firmware/ultralcd.cpp:5785
+#: ../../Firmware/ultralcd.cpp:5792 ../../Firmware/ultralcd.cpp:5799
+#: ../../Firmware/ultralcd.cpp:5800 ../../Firmware/ultralcd.cpp:5801
+#: ../../Firmware/ultralcd.cpp:5802 ../../Firmware/ultralcd.cpp:5886
 msgid "Mode"
 msgstr "Mod"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3598
+#: ../../Firmware/ultralcd.cpp:3617
 msgid "Mode change in progress..."
 msgstr "Modvaltas folyamatban..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:4575
-#: ../../Firmware/ultralcd.cpp:4578 ../../Firmware/ultralcd.cpp:4581
-#: ../../Firmware/ultralcd.cpp:4584
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:4594
+#: ../../Firmware/ultralcd.cpp:4597 ../../Firmware/ultralcd.cpp:4600
+#: ../../Firmware/ultralcd.cpp:4603
 msgid "Model"
 msgstr "Modell"
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6982
-#: ../../Firmware/ultralcd.cpp:6991 ../../Firmware/ultralcd.cpp:7009
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:7012
+#: ../../Firmware/ultralcd.cpp:7021 ../../Firmware/ultralcd.cpp:7039
 msgid "Motor"
 msgstr "Motor"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3492
+#: ../../Firmware/ultralcd.cpp:3511
 msgid "Move X"
 msgstr "X mozgatasa"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3493
+#: ../../Firmware/ultralcd.cpp:3512
 msgid "Move Y"
 msgstr "Y mozgatasa"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3494
+#: ../../Firmware/ultralcd.cpp:3513
 msgid "Move Z"
 msgstr "Z mozgatasa"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4801
+#: ../../Firmware/ultralcd.cpp:4820
 msgid "Move axis"
 msgstr "Tengely mozgatasa"
 
 #. MSG_NA c=3
 #: ../../Firmware/menu.cpp:196 ../../Firmware/messages.cpp:124
-#: ../../Firmware/ultralcd.cpp:2502 ../../Firmware/ultralcd.cpp:2547
-#: ../../Firmware/ultralcd.cpp:3411 ../../Firmware/ultralcd.cpp:4228
-#: ../../Firmware/ultralcd.cpp:4276 ../../Firmware/ultralcd.cpp:5737
-#: ../../Firmware/ultralcd.cpp:5836
+#: ../../Firmware/ultralcd.cpp:2521 ../../Firmware/ultralcd.cpp:2566
+#: ../../Firmware/ultralcd.cpp:3430 ../../Firmware/ultralcd.cpp:4247
+#: ../../Firmware/ultralcd.cpp:4295 ../../Firmware/ultralcd.cpp:5759
+#: ../../Firmware/ultralcd.cpp:5858
 msgid "N/A"
 msgstr "N/A"
 
@@ -1065,14 +1065,14 @@ msgid "New firmware version available:"
 msgstr "Uj firmver verzio erheto el:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:2804
-#: ../../Firmware/ultralcd.cpp:3180 ../../Firmware/ultralcd.cpp:4785
-#: ../../Firmware/ultralcd.cpp:5988
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:2823
+#: ../../Firmware/ultralcd.cpp:3199 ../../Firmware/ultralcd.cpp:4804
+#: ../../Firmware/ultralcd.cpp:6018
 msgid "No"
 msgstr "Nem"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5543
+#: ../../Firmware/ultralcd.cpp:5565
 msgid "No SD card"
 msgstr "Nincs SD kartya"
 
@@ -1082,72 +1082,72 @@ msgid "No move."
 msgstr "Nincs mozgas."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4405
-#: ../../Firmware/ultralcd.cpp:4493 ../../Firmware/ultralcd.cpp:4502
-#: ../../Firmware/ultralcd.cpp:4575 ../../Firmware/ultralcd.cpp:4584
-#: ../../Firmware/ultralcd.cpp:4614 ../../Firmware/ultralcd.cpp:4623
-#: ../../Firmware/ultralcd.cpp:4655 ../../Firmware/ultralcd.cpp:4664
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4424
+#: ../../Firmware/ultralcd.cpp:4512 ../../Firmware/ultralcd.cpp:4521
+#: ../../Firmware/ultralcd.cpp:4594 ../../Firmware/ultralcd.cpp:4603
+#: ../../Firmware/ultralcd.cpp:4633 ../../Firmware/ultralcd.cpp:4642
+#: ../../Firmware/ultralcd.cpp:4674 ../../Firmware/ultralcd.cpp:4683
 msgid "None"
 msgstr "Nincs"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:4336
-#: ../../Firmware/ultralcd.cpp:4381 ../../Firmware/ultralcd.cpp:4397
-#: ../../Firmware/ultralcd.cpp:4416 ../../Firmware/ultralcd.cpp:5763
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/ultralcd.cpp:4400 ../../Firmware/ultralcd.cpp:4416
+#: ../../Firmware/ultralcd.cpp:4435 ../../Firmware/ultralcd.cpp:5785
 msgid "Normal"
 msgstr "Normal"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6969
+#: ../../Firmware/ultralcd.cpp:6999
 msgid "Not connected"
 msgstr "Nincs csatlakoztatva"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:7168
-#: ../../Firmware/ultralcd.cpp:7183 ../../Firmware/ultralcd.cpp:7191
+#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:7198
+#: ../../Firmware/ultralcd.cpp:7213 ../../Firmware/ultralcd.cpp:7221
 msgid "Not spinning"
 msgstr "Nem forog"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3962
+#: ../../Firmware/ultralcd.cpp:3981
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr ""
 "Most beallitjuk a fuvoka hegye es a targyasztal felulete kozotti tavolsagot."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:4091
+#: ../../Firmware/ultralcd.cpp:4110
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Felfutom a fuvokat PLA-hoz."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/ultralcd.cpp:4101
 msgid "Now remove the test print from steel sheet."
 msgstr "Vedd le a tesztnyomatot az acellaprol."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:1402
-#: ../../Firmware/ultralcd.cpp:4493 ../../Firmware/ultralcd.cpp:4496
-#: ../../Firmware/ultralcd.cpp:4499 ../../Firmware/ultralcd.cpp:4502
-#: ../../Firmware/ultralcd.cpp:5720 ../../Firmware/ultralcd.cpp:5882
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:1421
+#: ../../Firmware/ultralcd.cpp:4512 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/ultralcd.cpp:4518 ../../Firmware/ultralcd.cpp:4521
+#: ../../Firmware/ultralcd.cpp:5742 ../../Firmware/ultralcd.cpp:5904
 msgid "Nozzle"
 msgstr "Fuvoka"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4546
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4565
 msgid "Nozzle d."
 msgstr "Fuv. atm."
 
 #. MSG_OFF c=3
 #: ../../Firmware/menu.cpp:467 ../../Firmware/messages.cpp:122
-#: ../../Firmware/ultralcd.cpp:4234 ../../Firmware/ultralcd.cpp:4250
-#: ../../Firmware/ultralcd.cpp:4284 ../../Firmware/ultralcd.cpp:4313
-#: ../../Firmware/ultralcd.cpp:4342 ../../Firmware/ultralcd.cpp:4811
-#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4834
-#: ../../Firmware/ultralcd.cpp:5644 ../../Firmware/ultralcd.cpp:5741
-#: ../../Firmware/ultralcd.cpp:5756 ../../Firmware/ultralcd.cpp:5767
-#: ../../Firmware/ultralcd.cpp:5836 ../../Firmware/ultralcd.cpp:7841
-#: ../../Firmware/ultralcd.cpp:7845
+#: ../../Firmware/ultralcd.cpp:4253 ../../Firmware/ultralcd.cpp:4269
+#: ../../Firmware/ultralcd.cpp:4303 ../../Firmware/ultralcd.cpp:4332
+#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4830
+#: ../../Firmware/ultralcd.cpp:4849 ../../Firmware/ultralcd.cpp:4853
+#: ../../Firmware/ultralcd.cpp:5666 ../../Firmware/ultralcd.cpp:5763
+#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/ultralcd.cpp:5858 ../../Firmware/ultralcd.cpp:7881
+#: ../../Firmware/ultralcd.cpp:7885
 msgid "Off"
 msgstr "Ki"
 
@@ -1157,19 +1157,19 @@ msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr "Regi beallitasokat talaltam. Az alap PID, Esteps, stb. lesz beallitva."
 
 #. MSG_ON c=3
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4244
-#: ../../Firmware/ultralcd.cpp:4248 ../../Firmware/ultralcd.cpp:4280
-#: ../../Firmware/ultralcd.cpp:4303 ../../Firmware/ultralcd.cpp:4341
-#: ../../Firmware/ultralcd.cpp:4811 ../../Firmware/ultralcd.cpp:4830
-#: ../../Firmware/ultralcd.cpp:4834 ../../Firmware/ultralcd.cpp:5745
-#: ../../Firmware/ultralcd.cpp:5756 ../../Firmware/ultralcd.cpp:5765
-#: ../../Firmware/ultralcd.cpp:5836 ../../Firmware/ultralcd.cpp:7841
-#: ../../Firmware/ultralcd.cpp:7845
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4263
+#: ../../Firmware/ultralcd.cpp:4267 ../../Firmware/ultralcd.cpp:4299
+#: ../../Firmware/ultralcd.cpp:4322 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4849
+#: ../../Firmware/ultralcd.cpp:4853 ../../Firmware/ultralcd.cpp:5767
+#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5787
+#: ../../Firmware/ultralcd.cpp:5858 ../../Firmware/ultralcd.cpp:7881
+#: ../../Firmware/ultralcd.cpp:7885
 msgid "On"
 msgstr "Be"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4453
+#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4472
 msgid "Once"
 msgstr "Egyszer"
 
@@ -1189,7 +1189,7 @@ msgid "PID cal. finished"
 msgstr "PID kal. kesz"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4913
+#: ../../Firmware/ultralcd.cpp:4932
 msgid "PID calibration"
 msgstr "PID kalibracio"
 
@@ -1201,31 +1201,31 @@ msgstr "PINDA Futes"
 #. MSG_PINDA_CALIBRATION c=13
 #: ../../Firmware/Marlin_main.cpp:4932 ../../Firmware/Marlin_main.cpp:5035
 #: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:654
-#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4920
+#: ../../Firmware/ultralcd.cpp:4849 ../../Firmware/ultralcd.cpp:4939
 msgid "PINDA cal."
 msgstr "PINDA kal."
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3361
+#: ../../Firmware/ultralcd.cpp:3380
 msgid "PINDA calibration failed"
 msgstr "PINDA kalibracio sikertelen."
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
 #: ../../Firmware/Marlin_main.cpp:5112 ../../Firmware/messages.cpp:110
-#: ../../Firmware/ultralcd.cpp:3355
+#: ../../Firmware/ultralcd.cpp:3374
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
 msgstr "PINDA kalibracio sikeres es aktiv. A Beallitasok ->PINDA kal."
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4707
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4726
 msgid "Pause"
 msgstr "Szun."
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:5507
-#: ../../Firmware/ultralcd.cpp:5509
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:5529
+#: ../../Firmware/ultralcd.cpp:5531
 msgid "Pause print"
 msgstr "Nyomtatas szunet"
 
@@ -1239,7 +1239,7 @@ msgstr ""
 "fuvoka hozzaer a papirlaphoz, azonnal kapcsold ki a nyomtatot."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:4176
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:4195
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1248,17 +1248,17 @@ msgstr ""
 "folytathatod az uzembe helyezest a nyomtato ujrainditasaval."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:6250
+#: ../../Firmware/ultralcd.cpp:6280
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "Nezd meg az IR szenzor csatlakoz., vedd ki a filam., ha bent van."
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6963
+#: ../../Firmware/ultralcd.cpp:6993
 msgid "Please check:"
 msgstr "Kerlek ellenorizd:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4148
+#: ../../Firmware/ultralcd.cpp:4167
 msgid "Please clean heatbed and then press the knob."
 msgstr "Kerlek, tisztisd le a targyasztalt, majd nyomd meg a gombot."
 
@@ -1270,7 +1270,7 @@ msgstr ""
 "keszen vagy."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3945
+#: ../../Firmware/ultralcd.cpp:3964
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr ""
@@ -1278,7 +1278,7 @@ msgstr ""
 "betolteshez."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3940
+#: ../../Firmware/ultralcd.cpp:3959
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1287,7 +1287,7 @@ msgstr ""
 "a betolteshez."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3863
+#: ../../Firmware/ultralcd.cpp:3882
 msgid "Please load filament first."
 msgstr "Kerlek eloszor toltsd be a filamentet."
 
@@ -1299,7 +1299,7 @@ msgstr ""
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=5
 #: ../../Firmware/mesh_bed_calibration.cpp:2799 ../../Firmware/messages.cpp:70
-#: ../../Firmware/ultralcd.cpp:4085
+#: ../../Firmware/ultralcd.cpp:4104
 msgid "Please place steel sheet on heatbed."
 msgstr "Kerlek, helyzed az acellapot a targyasztalra."
 
@@ -1310,7 +1310,7 @@ msgid "Please press the knob to unload filament"
 msgstr "Kerlek, nyomd meg a gombot a filament kiadasahoz"
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:5213
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:5235
 msgid "Please pull out filament immediately"
 msgstr "Kerlek, huzd ki a filamentet most"
 
@@ -1320,7 +1320,7 @@ msgid "Please remove filament and then press the knob."
 msgstr "Kerlek, tavolitsd el a filamentet, majd nyomd meg a gombot."
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:4081
+#: ../../Firmware/ultralcd.cpp:4100
 msgid "Please remove shipping helpers first."
 msgstr "Tavolitsd el a szallitasi segedanyagokat."
 
@@ -1336,7 +1336,7 @@ msgid "Please run XYZ calibration first."
 msgstr "Kerlek, elobb futtasd le az XYZ kalibraciot."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:6247
+#: ../../Firmware/ultralcd.cpp:6277
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Kerlek eloszor vedd ki a filamentet, majd probalkozz ujra."
 
@@ -1353,54 +1353,54 @@ msgstr "Kerlek frissits."
 #. MSG_PLEASE_WAIT c=20
 #: ../../Firmware/Marlin_main.cpp:3547 ../../Firmware/Marlin_main.cpp:3563
 #: ../../Firmware/Marlin_main.cpp:7931 ../../Firmware/messages.cpp:71
-#: ../../Firmware/ultralcd.cpp:2186 ../../Firmware/ultralcd.cpp:2197
+#: ../../Firmware/ultralcd.cpp:2205 ../../Firmware/ultralcd.cpp:2216
 msgid "Please wait"
 msgstr "Kerlek varj"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1219
-#: ../../Firmware/ultralcd.cpp:1260 ../../Firmware/ultralcd.cpp:1270
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1238
+#: ../../Firmware/ultralcd.cpp:1279 ../../Firmware/ultralcd.cpp:1289
 msgid "Power failures"
 msgstr "Aramkimaradasok"
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5502
+#: ../../Firmware/ultralcd.cpp:5524
 msgid "Preheat"
 msgstr "Elofutes"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:2280
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:2299
 msgid "Preheat the nozzle!"
 msgstr "Futsd fel a fuvokat!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:2900
-#: ../../Firmware/ultralcd.cpp:3924 ../../Firmware/ultralcd.cpp:3926
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:2919
+#: ../../Firmware/ultralcd.cpp:3943 ../../Firmware/ultralcd.cpp:3945
 msgid "Preheating nozzle. Please wait."
 msgstr "Fuvoka futese folyamatban. Kerlek, varj."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1988
+#: ../../Firmware/ultralcd.cpp:2007
 msgid "Preheating to cut"
 msgstr "Melegites vagashoz"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1985
+#: ../../Firmware/ultralcd.cpp:2004
 msgid "Preheating to eject"
 msgstr "Melegites kiadashoz"
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1976
+#: ../../Firmware/ultralcd.cpp:1995
 msgid "Preheating to load"
 msgstr "Felfutes betolteshez"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1981
+#: ../../Firmware/ultralcd.cpp:2000
 msgid "Preheating to unload"
 msgstr "Felfutes kiadashoz"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1809
+#: ../../Firmware/ultralcd.cpp:1828
 msgid "Press the knob"
 msgstr "Nyomd meg a gombot"
 
@@ -1420,13 +1420,13 @@ msgid "Print aborted"
 msgstr "Nyomt. megszakitva"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1144
-#: ../../Firmware/ultralcd.cpp:7322
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1145
+#: ../../Firmware/ultralcd.cpp:7354
 msgid "Print fan:"
 msgstr "Targyhuto:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5535
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5557
 msgid "Print from SD"
 msgstr "Nyomtatas SD-rol"
 
@@ -1436,12 +1436,12 @@ msgid "Print paused"
 msgstr "Nyomt. szuneteltetve"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2366
+#: ../../Firmware/ultralcd.cpp:2385
 msgid "Print time"
 msgstr "Nyomtatasi ido"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1711
+#: ../../Firmware/ultralcd.cpp:1730
 msgid "Printer IP Addr:"
 msgstr "Nyomtato IP cime:"
 
@@ -1469,12 +1469,12 @@ msgstr ""
 "beallitasokban. Nyomtatas megallitva."
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4834
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4853
 msgid "RPi port"
 msgstr "RPi port"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2755
+#: ../../Firmware/ultralcd.cpp:2774
 msgid "Rear side [μm]"
 msgstr "Hatso old.[μm]"
 
@@ -1491,24 +1491,24 @@ msgstr ""
 "betoltesehez."
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5426
+#: ../../Firmware/ultralcd.cpp:5448
 msgid "Rename"
 msgstr "Atnevezes"
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2756
-#: ../../Firmware/ultralcd.cpp:5427
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2775
+#: ../../Firmware/ultralcd.cpp:5449
 msgid "Reset"
 msgstr "Ujrainditas"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4917
+#: ../../Firmware/ultralcd.cpp:4936
 msgid "Reset XYZ calibr."
 msgstr "XYZ kal. nullazas"
 
 #. MSG_RESUME_PRINT c=18
 #: ../../Firmware/Marlin_main.cpp:655 ../../Firmware/messages.cpp:81
-#: ../../Firmware/ultralcd.cpp:5521 ../../Firmware/ultralcd.cpp:5523
+#: ../../Firmware/ultralcd.cpp:5543 ../../Firmware/ultralcd.cpp:5545
 msgid "Resume print"
 msgstr "Nyomt. folytatasa"
 
@@ -1518,17 +1518,17 @@ msgid "Resuming print"
 msgstr "Nyomtatas folytatasa"
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2497
+#: ../../Firmware/ultralcd.cpp:2516
 msgid "Right"
 msgstr "Jobb"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2753
+#: ../../Firmware/ultralcd.cpp:2772
 msgid "Right side[μm]"
 msgstr "Jobb old.[μm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3884
+#: ../../Firmware/ultralcd.cpp:3903
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1537,14 +1537,14 @@ msgstr ""
 "fog mindent kezdeni. Folytatod?"
 
 #. MSG_RUNOUTS c=7
-#: ../../Firmware/ultralcd.cpp:1271
+#: ../../Firmware/ultralcd.cpp:1290
 msgid "Runouts"
 msgstr "Kifutas"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4395
-#: ../../Firmware/ultralcd.cpp:4397 ../../Firmware/ultralcd.cpp:4414
-#: ../../Firmware/ultralcd.cpp:4416
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4414
+#: ../../Firmware/ultralcd.cpp:4416 ../../Firmware/ultralcd.cpp:4433
+#: ../../Firmware/ultralcd.cpp:4435
 msgid "SD card"
 msgstr "SDkartya"
 
@@ -1560,12 +1560,12 @@ msgid "Searching bed calibration point"
 msgstr "Kalibracios pont keresese az asztalon"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5419
+#: ../../Firmware/ultralcd.cpp:5441
 msgid "Select"
 msgstr "Kivalasztas"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3966
+#: ../../Firmware/ultralcd.cpp:3985
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
@@ -1578,51 +1578,51 @@ msgstr "Extruder valasztas:"
 
 #. MSG_SELECT_FILAMENT c=20
 #: ../../Firmware/Marlin_main.cpp:8577 ../../Firmware/Marlin_main.cpp:8604
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3834
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3853
 msgid "Select filament:"
 msgstr "Valassz filamentet:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:3679
-#: ../../Firmware/ultralcd.cpp:4841
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:3698
+#: ../../Firmware/ultralcd.cpp:4860
 msgid "Select language"
 msgstr "Valassz nyelvet"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:4122
+#: ../../Firmware/ultralcd.cpp:4141
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr ""
 "Valaszd ki a fuvoka homersekletet, amelyik megfelel az altalad hasznalt "
 "anyaghoz ajanlott homersekletnek."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3971
+#: ../../Firmware/ultralcd.cpp:3990
 msgid "Select temperature which matches your material."
 msgstr "Valassz homersekletet, ami megfelel a filamenthez."
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6522
+#: ../../Firmware/ultralcd.cpp:6552
 msgid "Self test OK"
 msgstr "Ondiagnosztika OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:6290
+#: ../../Firmware/ultralcd.cpp:6320
 msgid "Self test start"
 msgstr "Ondiagnosztika indul"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4904
+#: ../../Firmware/ultralcd.cpp:4923
 msgid "Selftest"
 msgstr "Ondiagnosztika"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6962
+#: ../../Firmware/ultralcd.cpp:6992
 msgid "Selftest error!"
 msgstr "Ondiagnosztika hiba!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:6526
-#: ../../Firmware/ultralcd.cpp:7049 ../../Firmware/ultralcd.cpp:7314
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:6556
+#: ../../Firmware/ultralcd.cpp:7079 ../../Firmware/ultralcd.cpp:7344
 msgid "Selftest failed"
 msgstr "Ondiag. sikertelen"
 
@@ -1633,30 +1633,30 @@ msgstr ""
 "A pontos szenzor nelkuli homing erdekeben lefuttatom az ondiagnosztikat."
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1723
+#: ../../Firmware/ultralcd.cpp:1742
 msgid "Sensor info"
 msgstr "Szenzor info"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:6254
+#: ../../Firmware/ultralcd.cpp:6284
 msgid "Sensor verified, remove the filament now."
 msgstr "Szenzor OK, vedd ki a filamentet most."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2773
+#: ../../Firmware/ultralcd.cpp:2792
 msgid "Set temperature:"
 msgstr "Homerseklet beall.:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:3491
-#: ../../Firmware/ultralcd.cpp:3696 ../../Firmware/ultralcd.cpp:4206
-#: ../../Firmware/ultralcd.cpp:5580 ../../Firmware/ultralcd.cpp:5827
-#: ../../Firmware/ultralcd.cpp:5880
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:3510
+#: ../../Firmware/ultralcd.cpp:3715 ../../Firmware/ultralcd.cpp:4225
+#: ../../Firmware/ultralcd.cpp:5602 ../../Firmware/ultralcd.cpp:5849
+#: ../../Firmware/ultralcd.cpp:5902
 msgid "Settings"
 msgstr "Beallitasok"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2540
+#: ../../Firmware/ultralcd.cpp:2559
 msgid "Severe skew"
 msgstr "NagyMerol.hiba"
 
@@ -1667,7 +1667,7 @@ msgid "Sheet"
 msgstr "Acellap"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3824
+#: ../../Firmware/ultralcd.cpp:3843
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1680,18 +1680,18 @@ msgstr ""
 "%cUjrainditas"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4915
+#: ../../Firmware/ultralcd.cpp:4934
 msgid "Show end stops"
 msgstr "Vegallaskapcsolok"
 
 #. MSG_SILENT c=7
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4361
-#: ../../Firmware/ultralcd.cpp:4456 ../../Firmware/ultralcd.cpp:5778
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4380
+#: ../../Firmware/ultralcd.cpp:4475 ../../Firmware/ultralcd.cpp:5800
 msgid "Silent"
 msgstr "Halk"
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2539
+#: ../../Firmware/ultralcd.cpp:2558
 msgid "Slight skew"
 msgstr "Kis merol.hiba"
 
@@ -1710,8 +1710,8 @@ msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Hiba tortent, Z szintezes indul..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4403
-#: ../../Firmware/ultralcd.cpp:4404 ../../Firmware/ultralcd.cpp:4405
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4422
+#: ../../Firmware/ultralcd.cpp:4423 ../../Firmware/ultralcd.cpp:4424
 msgid "Sort"
 msgstr "Rendez"
 
@@ -1722,20 +1722,20 @@ msgid "Sorting files"
 msgstr "Fajlok rendezese"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4450
-#: ../../Firmware/ultralcd.cpp:4453 ../../Firmware/ultralcd.cpp:4456
-#: ../../Firmware/ultralcd.cpp:4459 ../../Firmware/ultralcd.cpp:4462
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/ultralcd.cpp:4472 ../../Firmware/ultralcd.cpp:4475
+#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4481
 msgid "Sound"
 msgstr "Hang"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5718
+#: ../../Firmware/ultralcd.cpp:5740
 msgid "Speed"
 msgstr "Sebesseg"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7166
-#: ../../Firmware/ultralcd.cpp:7181 ../../Firmware/ultralcd.cpp:7189
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7196
+#: ../../Firmware/ultralcd.cpp:7211 ../../Firmware/ultralcd.cpp:7219
 msgid "Spinning"
 msgstr "Forog"
 
@@ -1745,42 +1745,42 @@ msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr "Stabil 21-26C homerseklet es egy merev allvany (asztal) szukseges."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5585
+#: ../../Firmware/ultralcd.cpp:5607
 msgid "Statistics"
 msgstr "Statisztika"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4338
-#: ../../Firmware/ultralcd.cpp:4382 ../../Firmware/ultralcd.cpp:5770
+#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4357
+#: ../../Firmware/ultralcd.cpp:4401 ../../Firmware/ultralcd.cpp:5792
 msgid "Stealth"
 msgstr "Halk"
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4763
-#: ../../Firmware/ultralcd.cpp:5416
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4782
+#: ../../Firmware/ultralcd.cpp:5438
 msgid "Steel sheets"
 msgstr "Acellapok"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5528
-#: ../../Firmware/ultralcd.cpp:5987
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5550
+#: ../../Firmware/ultralcd.cpp:6017
 msgid "Stop print"
 msgstr "Nyomt. megallitasa"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4499
-#: ../../Firmware/ultralcd.cpp:4581 ../../Firmware/ultralcd.cpp:4620
-#: ../../Firmware/ultralcd.cpp:4661
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4518
+#: ../../Firmware/ultralcd.cpp:4600 ../../Firmware/ultralcd.cpp:4639
+#: ../../Firmware/ultralcd.cpp:4680
 msgid "Strict"
 msgstr "Szigoru"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/ultralcd.cpp:5616
 msgid "Support"
 msgstr "Tamogatas"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:7021
+#: ../../Firmware/ultralcd.cpp:7051
 msgid "Swapped"
 msgstr "Felcserelve"
 
@@ -1789,28 +1789,18 @@ msgstr "Felcserelve"
 msgid "THERMAL ANOMALY"
 msgstr "Homersekl. anomalia"
 
-#. MSG_TM_AUTOTUNE_FAILED c=20
-#: ../../Firmware/temperature.cpp:2899
-msgid "TM autotune failed"
-msgstr "HM kalib. sikertelen"
-
-#. MSG_TEMP_MODEL_AUTOTUNE c=20
-#: ../../Firmware/temperature.cpp:2884
-msgid "Temp. model autotune"
-msgstr "Homers. modell kalib"
-
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4797
+#: ../../Firmware/ultralcd.cpp:4816
 msgid "Temperature"
 msgstr "Homerseklet"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1729
+#: ../../Firmware/ultralcd.cpp:1748
 msgid "Temperatures"
 msgstr "Homersekletek"
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3974
+#: ../../Firmware/ultralcd.cpp:3993
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -1830,66 +1820,66 @@ msgstr ""
 "fejezetenek Kalibracio menete bekezdeset."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4403
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4422
 msgid "Time"
 msgstr "Ido"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:5865
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:5887
 msgid "Timeout"
 msgstr "Idotullepes"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:1149
-#: ../../Firmware/ultralcd.cpp:1297
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:1168
+#: ../../Firmware/ultralcd.cpp:1316
 msgid "Total"
 msgstr "Ossz."
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:1192
-#: ../../Firmware/ultralcd.cpp:1218 ../../Firmware/ultralcd.cpp:1328
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:1211
+#: ../../Firmware/ultralcd.cpp:1237 ../../Firmware/ultralcd.cpp:1347
 msgid "Total failures"
 msgstr "Ossz. hiba"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2387
+#: ../../Firmware/ultralcd.cpp:2406
 msgid "Total filament"
 msgstr "Osszes filament"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2388
+#: ../../Firmware/ultralcd.cpp:2407
 msgid "Total print time"
 msgstr "Ossz. nyomt. ido"
 
 #. MSG_TUNE c=18
-#: ../../Firmware/ultralcd.cpp:5500
+#: ../../Firmware/ultralcd.cpp:5522
 msgid "Tune"
 msgstr "Finomhangolas"
 
 #. MSG_UNLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:5564
-#: ../../Firmware/ultralcd.cpp:5578
+#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:5586
+#: ../../Firmware/ultralcd.cpp:5600
 msgid "Unload filament"
 msgstr "Filament kiadasa"
 
 #. MSG_UNLOADING_FILAMENT c=20
 #: ../../Firmware/messages.cpp:112 ../../Firmware/mmu.cpp:957
-#: ../../Firmware/ultralcd.cpp:5197
+#: ../../Firmware/ultralcd.cpp:5219
 msgid "Unloading filament"
 msgstr "Filament kiadasa"
 
 #. MSG_FIL_FAILED c=20 r=5
-#: ../../Firmware/ultralcd.cpp:6258
+#: ../../Firmware/ultralcd.cpp:6288
 msgid "Verification failed, remove the filament and try again."
 msgstr "Ellenorzes sikertelen, vedd ki a filamentet es probald ujra."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1732
+#: ../../Firmware/ultralcd.cpp:1751
 msgid "Voltages"
 msgstr "Feszultsegek"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3534
+#: ../../Firmware/ultralcd.cpp:3553
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -1907,19 +1897,19 @@ msgid "Wait for user..."
 msgstr "Var. a felhasznalora"
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2881
+#: ../../Firmware/ultralcd.cpp:2900
 msgid "Waiting for PINDA probe cooling"
 msgstr "A PINDA szenzor kihuleset varom."
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2913
+#: ../../Firmware/ultralcd.cpp:2932
 msgid "Waiting for nozzle and bed cooling"
 msgstr "A fuvoka es az asztal kihuleset varom."
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:4496
-#: ../../Firmware/ultralcd.cpp:4578 ../../Firmware/ultralcd.cpp:4617
-#: ../../Firmware/ultralcd.cpp:4658
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/ultralcd.cpp:4597 ../../Firmware/ultralcd.cpp:4636
+#: ../../Firmware/ultralcd.cpp:4677
 msgid "Warn"
 msgstr "Figylem."
 
@@ -1944,152 +1934,141 @@ msgid "Was filament unload successful?"
 msgstr "Sikerult kivenni a filamentet?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6973
-#: ../../Firmware/ultralcd.cpp:6977 ../../Firmware/ultralcd.cpp:6997
-#: ../../Firmware/ultralcd.cpp:7003 ../../Firmware/ultralcd.cpp:7027
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:7003
+#: ../../Firmware/ultralcd.cpp:7007 ../../Firmware/ultralcd.cpp:7027
+#: ../../Firmware/ultralcd.cpp:7033 ../../Firmware/ultralcd.cpp:7057
 msgid "Wiring error"
 msgstr "Kabelezesi hiba"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4895
+#: ../../Firmware/ultralcd.cpp:4914
 msgid "Wizard"
 msgstr "Varazslo"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4210
+#: ../../Firmware/ultralcd.cpp:4229
 msgid "X-correct:"
 msgstr "X-korrekcio:"
 
 #. MSG_XFLASH c=18
-#: ../../Firmware/ultralcd.cpp:5596
+#: ../../Firmware/ultralcd.cpp:5618
 msgid "XFLASH init"
 msgstr "XFLASH inicializal"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1721
+#: ../../Firmware/ultralcd.cpp:1740
 msgid "XYZ cal. details"
 msgstr "XYZ kal. reszlet"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3333
+#: ../../Firmware/ultralcd.cpp:3352
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr ""
 "XYZ kalibracio OK. Az esetleges X/Y merolegessegi hiba automatikusan "
 "korrigalva lesz."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3330
+#: ../../Firmware/ultralcd.cpp:3349
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr ""
 "XYZ kalibracio sikerult. Az X/Y tengelyeken enyhe merolegessegi hiba van."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3311
+#: ../../Firmware/ultralcd.cpp:3330
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr ""
 "Az XYZ kalibracio sikertelen. Az elulso kalibracios pontok nem erhetoek el."
 
-#. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_LEFT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3317
-msgid ""
-"XYZ calibration compromised. Left front calibration point not reachable."
-msgstr "XYZ kalibracio nem jo. Bal elso kal. pont nem elerheto."
-
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3314
+#: ../../Firmware/ultralcd.cpp:3333
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr ""
 "Az XYZ kalibracio sikertelen. A jobb kalibracios pontok nem erhetoek el."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3293
+#: ../../Firmware/ultralcd.cpp:3312
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr ""
 "Az XYZ kalibracio sikertelen. Az asztal kalibracios pontja nem erheto el."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3299
+#: ../../Firmware/ultralcd.cpp:3318
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr ""
 "Az XYZ kalibracio sikertelen. Az elulso kalibracios pontok nem erhetoek el."
 
-#. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_LEFT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3305
-msgid "XYZ calibration failed. Left front calibration point not reachable."
-msgstr "XYZ kalibracio sikertelen. Bal elso kal. pont nem elerheto."
-
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3296
-#: ../../Firmware/ultralcd.cpp:3324
+#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3315
+#: ../../Firmware/ultralcd.cpp:3343
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "XYZ kalibracio sikertelen. Kerlek, nezz bele a kezikonyvbe."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3302
+#: ../../Firmware/ultralcd.cpp:3321
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr ""
 "Az XYZ kalibracio sikertelen. A jobb kalibracios pontok nem erhetoek el."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3327
+#: ../../Firmware/ultralcd.cpp:3346
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "XYZ kalibracio OK. Az X/Y tengelyek merolegesek. Gratulalok!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2494
+#: ../../Firmware/ultralcd.cpp:2513
 msgid "Y distance from min"
 msgstr "Y-minimum tavolsag"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4211
+#: ../../Firmware/ultralcd.cpp:4230
 msgid "Y-correct:"
 msgstr "Y-korrekcio:"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:2216
-#: ../../Firmware/ultralcd.cpp:2800 ../../Firmware/ultralcd.cpp:3180
-#: ../../Firmware/ultralcd.cpp:4785 ../../Firmware/ultralcd.cpp:5989
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:2235
+#: ../../Firmware/ultralcd.cpp:2819 ../../Firmware/ultralcd.cpp:3199
+#: ../../Firmware/ultralcd.cpp:4804 ../../Firmware/ultralcd.cpp:6019
 msgid "Yes"
 msgstr "Igen"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:4187
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:4206
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr "A Varazsolt barmikor elered a Kalibracio -> Varazslo menubol."
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4231
 msgid "Z-correct:"
 msgstr "Z-korrekcio:"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:5835
+#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:5857
 msgid "Z-probe nr."
 msgstr "Z meres szama"
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2565
+#: ../../Firmware/ultralcd.cpp:2584
 msgid "[0;0] point offset"
 msgstr "[0;0] pont offszet"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2154
+#: ../../Firmware/ultralcd.cpp:2173
 msgid "and press the knob"
 msgstr "es nyomd meg a gombot"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1816
+#: ../../Firmware/ultralcd.cpp:1835
 msgid "to load filament"
 msgstr "filam. betoltesehez"
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1820
+#: ../../Firmware/ultralcd.cpp:1839
 msgid "to unload filament"
 msgstr "filament kiadasahoz"
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1688
+#: ../../Firmware/ultralcd.cpp:1707
 msgid "unknown"
 msgstr "ismeretlen"
 
@@ -2099,8 +2078,8 @@ msgid "unknown state"
 msgstr "ismeretlen allapot"
 
 #. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:6077
-#: ../../Firmware/ultralcd.cpp:6080
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:6107
+#: ../../Firmware/ultralcd.cpp:6110
 msgid "🔃Refresh"
 msgstr "🔃Frissites"
 
@@ -2109,3 +2088,16 @@ msgstr "🔃Frissites"
 
 #~ msgid "M117 First layer cal."
 #~ msgstr "M117. Elso reteg kalibr."
+
+#~ msgid "TM autotune failed"
+#~ msgstr "HM kalib. sikertelen"
+
+#~ msgid "Temp. model autotune"
+#~ msgstr "Homers. modell kalib"
+
+#~ msgid ""
+#~ "XYZ calibration compromised. Left front calibration point not reachable."
+#~ msgstr "XYZ kalibracio nem jo. Bal elso kal. pont nem elerheto."
+
+#~ msgid "XYZ calibration failed. Left front calibration point not reachable."
+#~ msgstr "XYZ kalibracio sikertelen. Bal elso kal. pont nem elerheto."

--- a/lang/po/Firmware_it.po
+++ b/lang/po/Firmware_it.po
@@ -26,114 +26,114 @@ msgid " 0.4 or newer"
 msgstr " 0.4 o superiore"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:7036
+#: ../../Firmware/ultralcd.cpp:7066
 msgid "%s level expected"
 msgstr "atteso livello %s"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1968
-#: ../../Firmware/ultralcd.cpp:3835
+#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1987
+#: ../../Firmware/ultralcd.cpp:3854
 msgid ">Cancel"
 msgstr ">Annulla"
 
 #. MSG_BABYSTEPPING_Z c=15
 #. Beware: must include the ':' as its last character
-#: ../../Firmware/ultralcd.cpp:2670
+#: ../../Firmware/ultralcd.cpp:2689
 msgid "Adjusting Z:"
 msgstr "Compensaz. Z:"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:7313
+#: ../../Firmware/ultralcd.cpp:7343
 msgid "All correct"
 msgstr "Nessun errore"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4180
+#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4190
+#: ../../Firmware/ultralcd.cpp:4199
 msgid "All is done. Happy printing!"
 msgstr "Tutto fatto. Buona stampa!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4404
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4423
 msgid "Alphabet"
 msgstr "Alfabeti"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4308
+#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4327
 msgid "Always"
 msgstr "Sempre"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1405
+#: ../../Firmware/ultralcd.cpp:1424
 msgid "Ambient"
 msgstr "Ambiente"
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2983
+#: ../../Firmware/ultralcd.cpp:3002
 msgid "Are left and right Z~carriages all up?"
 msgstr "I carrelli Z sin/des sono altezza max?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4478
 msgid "Assist"
 msgstr "Assist."
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:5886
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
 #: ../../Firmware/Marlin_main.cpp:3271 ../../Firmware/messages.cpp:9
-#: ../../Firmware/ultralcd.cpp:4900
+#: ../../Firmware/ultralcd.cpp:4919
 msgid "Auto home"
 msgstr "Trova origine"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:4364
-#: ../../Firmware/ultralcd.cpp:5779
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:4383
+#: ../../Firmware/ultralcd.cpp:5801
 msgid "Auto power"
 msgstr "Automatico"
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5572
+#: ../../Firmware/ultralcd.cpp:5594
 msgid "AutoLoad filament"
 msgstr "Autocaric. filam."
 
 #. MSG_AUTOLOADING_ONLY_IF_FSENS_ON c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3549
+#: ../../Firmware/ultralcd.cpp:3568
 msgid ""
 "Autoloading filament available only when filament sensor is turned on..."
 msgstr ""
 "Caricamento automatico filamento disponibile solo con il sensore attivo..."
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2301
+#: ../../Firmware/ultralcd.cpp:2320
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr "Caricamento automatico attivo, premi la manopola e inserisci il filam."
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:7015
+#: ../../Firmware/ultralcd.cpp:7045
 msgid "Axis"
 msgstr "Assi"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:7014
+#: ../../Firmware/ultralcd.cpp:7044
 msgid "Axis length"
 msgstr "Lunghezza dell'asse"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:2751
-#: ../../Firmware/ultralcd.cpp:5861 ../../Firmware/ultralcd.cpp:7838
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:2770
+#: ../../Firmware/ultralcd.cpp:5883 ../../Firmware/ultralcd.cpp:7878
 msgid "Back"
 msgstr "Indietro"
 
 #. MSG_BED c=13
 #: ../../Firmware/Marlin_main.cpp:2051 ../../Firmware/Marlin_main.cpp:4767
 #: ../../Firmware/Marlin_main.cpp:4819 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:1403 ../../Firmware/ultralcd.cpp:5721
-#: ../../Firmware/ultralcd.cpp:5891
+#: ../../Firmware/ultralcd.cpp:1422 ../../Firmware/ultralcd.cpp:5743
+#: ../../Firmware/ultralcd.cpp:5913
 msgid "Bed"
 msgstr "Piano"
 
@@ -150,7 +150,7 @@ msgid "Bed done"
 msgstr "Piano fatto."
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4912
+#: ../../Firmware/ultralcd.cpp:4931
 msgid "Bed level correct"
 msgstr "Correz. liv.piano"
 
@@ -168,18 +168,18 @@ msgstr ""
 "reset."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6972
+#: ../../Firmware/ultralcd.cpp:7002
 msgid "Bed/Heater"
 msgstr "Piano/Riscald."
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1458
-#: ../../Firmware/ultralcd.cpp:1726
+#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1477
+#: ../../Firmware/ultralcd.cpp:1745
 msgid "Belt status"
 msgstr "Stato cinghie"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4902
+#: ../../Firmware/ultralcd.cpp:4921
 msgid "Belt test"
 msgstr "Test cinghie"
 
@@ -190,28 +190,28 @@ msgid "Blackout occurred. Recover print?"
 msgstr "Blackout rilevato. Recuperare stampa?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:5886
 msgid "Bright"
 msgstr "Chiaro"
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4850
-#: ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4869
+#: ../../Firmware/ultralcd.cpp:5811
 msgid "Brightness"
 msgstr "Luminosita'"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4906
+#: ../../Firmware/ultralcd.cpp:4925
 msgid "Calibrate XYZ"
 msgstr "Calibra XYZ"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4908
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4927
 msgid "Calibrate Z"
 msgstr "Calibra Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2946
+#: ../../Firmware/ultralcd.cpp:2965
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -226,7 +226,7 @@ msgid "Calibrating Z"
 msgstr "Calibrando Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2945
+#: ../../Firmware/ultralcd.cpp:2964
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -235,12 +235,12 @@ msgstr ""
 "all'altezza massima. Click per terminare."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:7315
+#: ../../Firmware/ultralcd.cpp:7345
 msgid "Calibrating home"
 msgstr "Calibrazione Home"
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:5581
+#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:5603
 msgid "Calibration"
 msgstr "Calibrazione"
 
@@ -250,115 +250,115 @@ msgid "Calibration done"
 msgstr "Calibr. completa"
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7712
+#: ../../Firmware/ultralcd.cpp:7752
 msgid "Card removed"
 msgstr "SD rimossa"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/ultralcd.cpp:5560
 msgid "Change SD card"
 msgstr "Cambia scheda SD"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5497
-#: ../../Firmware/ultralcd.cpp:5730
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5519
+#: ../../Firmware/ultralcd.cpp:5752
 msgid "Change filament"
 msgstr "Cambia filamento"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2163
+#: ../../Firmware/ultralcd.cpp:2182
 msgid "Change success!"
 msgstr "Cambio riuscito!"
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2215
+#: ../../Firmware/ultralcd.cpp:2234
 msgid "Changed correctly?"
 msgstr "Cambio corretto?"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:6178
-#: ../../Firmware/ultralcd.cpp:7305
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:6208
+#: ../../Firmware/ultralcd.cpp:7335
 msgid "Checking X axis"
 msgstr "Verifica asse X"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:6187
-#: ../../Firmware/ultralcd.cpp:7306
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:6217
+#: ../../Firmware/ultralcd.cpp:7336
 msgid "Checking Y axis"
 msgstr "Verifica asse Y"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:7307
+#: ../../Firmware/ultralcd.cpp:7337
 msgid "Checking Z axis"
 msgstr "Verifica asse Z"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:7308
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:7338
 msgid "Checking bed"
 msgstr "Verifica piano"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:7304
+#: ../../Firmware/ultralcd.cpp:7334
 msgid "Checking endstops"
 msgstr "Verifica finecorsa"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:7403
+#: ../../Firmware/ultralcd.cpp:7433
 msgid "Checking file"
 msgstr "Verifica file"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:7310
+#: ../../Firmware/ultralcd.cpp:7340
 msgid "Checking hotend"
 msgstr "Verifica ugello"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:7311
-#: ../../Firmware/ultralcd.cpp:7312
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:7341
+#: ../../Firmware/ultralcd.cpp:7342
 msgid "Checking sensors"
 msgstr "Controllo sensori"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4765
+#: ../../Firmware/ultralcd.cpp:4784
 msgid "Checks"
 msgstr "Controlli"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2218
+#: ../../Firmware/ultralcd.cpp:2237
 msgid "Color not correct"
 msgstr "Colore non puro"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3725
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3744
 msgid "Community made"
 msgstr "Contribuiti"
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4704
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4723
 msgid "Cont."
 msgstr "Cont."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2125
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2144
 msgid "Cooldown"
 msgstr "Raffredda"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3663
+#: ../../Firmware/ultralcd.cpp:3682
 msgid "Copy selected language?"
 msgstr "Copiare la lingua selezionata?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1221
-#: ../../Firmware/ultralcd.cpp:1262 ../../Firmware/ultralcd.cpp:1272
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1240
+#: ../../Firmware/ultralcd.cpp:1281 ../../Firmware/ultralcd.cpp:1291
 msgid "Crash"
 msgstr "Impatto"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4341
-#: ../../Firmware/ultralcd.cpp:4342 ../../Firmware/ultralcd.cpp:4344
-#: ../../Firmware/ultralcd.cpp:5765 ../../Firmware/ultralcd.cpp:5767
-#: ../../Firmware/ultralcd.cpp:5771
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4363
+#: ../../Firmware/ultralcd.cpp:5787 ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/ultralcd.cpp:5793
 msgid "Crash det."
 msgstr "Rileva.crash"
 
@@ -368,7 +368,7 @@ msgid "Crash detected."
 msgstr "Rilevato impatto."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3521
+#: ../../Firmware/ultralcd.cpp:3540
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -379,14 +379,14 @@ msgstr ""
 "in Modalita normale"
 
 #. MSG_CUT_FILAMENT c=17
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:5175
-#: ../../Firmware/ultralcd.cpp:5567
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:5197
+#: ../../Firmware/ultralcd.cpp:5589
 msgid "Cut filament"
 msgstr "Taglia filamento"
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:4303
-#: ../../Firmware/ultralcd.cpp:4308 ../../Firmware/ultralcd.cpp:4313
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:4322
+#: ../../Firmware/ultralcd.cpp:4327 ../../Firmware/ultralcd.cpp:4332
 msgid "Cutter"
 msgstr "Tagliatr."
 
@@ -396,17 +396,17 @@ msgid "Cutting filament"
 msgstr "Tagliando filam."
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1668
+#: ../../Firmware/ultralcd.cpp:1687
 msgid "Date:"
 msgstr "Data:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5886
 msgid "Dim"
 msgstr "Scuro"
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4802
+#: ../../Firmware/ultralcd.cpp:4821
 msgid "Disable steppers"
 msgstr "Disattiva motori"
 
@@ -423,7 +423,7 @@ msgstr ""
 "Calibrazione primo strato."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:4145
+#: ../../Firmware/ultralcd.cpp:4164
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -432,23 +432,23 @@ msgstr ""
 "piatto?"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4214
+#: ../../Firmware/ultralcd.cpp:4233
 msgid "E-correct:"
 msgstr "Correzione-E:"
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2279
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2298
 msgid "ERROR:"
 msgstr "ERRORE:"
 
 #. MSG_FSENS_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3562
+#: ../../Firmware/ultralcd.cpp:3581
 msgid "ERROR: Filament sensor is not responding, please check connection."
 msgstr "ERRORE: il sensore filam. non risponde,Controllare conness."
 
 #. MSG_EJECT_FILAMENT c=17
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:5156
-#: ../../Firmware/ultralcd.cpp:5565
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:5178
+#: ../../Firmware/ultralcd.cpp:5587
 msgid "Eject filament"
 msgstr "Espelli fil."
 
@@ -458,47 +458,41 @@ msgid "Ejecting filament"
 msgstr "Espellendo filamento"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6985
+#: ../../Firmware/ultralcd.cpp:7015
 msgid "Endstop"
 msgstr "Finecorsa"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6990
+#: ../../Firmware/ultralcd.cpp:7020
 msgid "Endstop not hit"
 msgstr "Finec. fuori portata"
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6976
+#: ../../Firmware/ultralcd.cpp:7006
 msgid "Endstops"
 msgstr "Finecorsa"
 
 #. MSG_EXTRUDER c=17
 #: ../../Firmware/Marlin_main.cpp:8608 ../../Firmware/messages.cpp:30
-#: ../../Firmware/ultralcd.cpp:3495
+#: ../../Firmware/ultralcd.cpp:3514
 msgid "Extruder"
 msgstr "Estrusore"
 
-#. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1131
-#: ../../Firmware/ultralcd.cpp:7302
-msgid "Hotend fan:"
-msgstr "Ventola hotend:"
-
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1722
+#: ../../Firmware/ultralcd.cpp:1741
 msgid "Extruder info"
 msgstr "Info estrusore"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4229
-#: ../../Firmware/ultralcd.cpp:4237 ../../Firmware/ultralcd.cpp:4248
-#: ../../Firmware/ultralcd.cpp:4250
+#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4248
+#: ../../Firmware/ultralcd.cpp:4256 ../../Firmware/ultralcd.cpp:4267
+#: ../../Firmware/ultralcd.cpp:4269
 msgid "F. autoload"
 msgstr "Autocar.fil."
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4704
-#: ../../Firmware/ultralcd.cpp:4707
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4723
+#: ../../Firmware/ultralcd.cpp:4726
 msgid "FS Action"
 msgstr "Azione FS"
 
@@ -513,102 +507,102 @@ msgid "FS v0.4 or newer"
 msgstr "FS 0.4 o superiore"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5589
+#: ../../Firmware/ultralcd.cpp:5611
 msgid "Fail stats"
 msgstr "Stat. fallimenti"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5592
+#: ../../Firmware/ultralcd.cpp:5614
 msgid "Fail stats MMU"
 msgstr "Stat.fall. MMU"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:7031
+#: ../../Firmware/ultralcd.cpp:7061
 msgid "False triggering"
 msgstr "Falso innesco"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:5723
-#: ../../Firmware/ultralcd.cpp:5893
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/ultralcd.cpp:5915
 msgid "Fan speed"
 msgstr "Velocita vent."
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:7143
-#: ../../Firmware/ultralcd.cpp:7301 ../../Firmware/ultralcd.cpp:7302
-#: ../../Firmware/ultralcd.cpp:7303
+#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:7173
+#: ../../Firmware/ultralcd.cpp:7331 ../../Firmware/ultralcd.cpp:7332
+#: ../../Firmware/ultralcd.cpp:7333
 msgid "Fan test"
 msgstr "Test ventola"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4811
-#: ../../Firmware/ultralcd.cpp:5756
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4830
+#: ../../Firmware/ultralcd.cpp:5778
 msgid "Fans check"
 msgstr "Control.vent"
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1220
-#: ../../Firmware/ultralcd.cpp:1261 ../../Firmware/ultralcd.cpp:1327
-#: ../../Firmware/ultralcd.cpp:1329
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1239
+#: ../../Firmware/ultralcd.cpp:1280 ../../Firmware/ultralcd.cpp:1346
+#: ../../Firmware/ultralcd.cpp:1348
 msgid "Fil. runouts"
 msgstr "Fil. esauriti"
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:3451
-#: ../../Firmware/ultralcd.cpp:4228 ../../Firmware/ultralcd.cpp:4234
-#: ../../Firmware/ultralcd.cpp:4244 ../../Firmware/ultralcd.cpp:5737
-#: ../../Firmware/ultralcd.cpp:5741 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:3470
+#: ../../Firmware/ultralcd.cpp:4247 ../../Firmware/ultralcd.cpp:4253
+#: ../../Firmware/ultralcd.cpp:4263 ../../Firmware/ultralcd.cpp:5759
+#: ../../Firmware/ultralcd.cpp:5763 ../../Firmware/ultralcd.cpp:5767
 msgid "Fil. sensor"
 msgstr "Sensore fil."
 
 #. MSG_FILAMENT c=17
 #: ../../Firmware/Marlin_main.cpp:8577 ../../Firmware/Marlin_main.cpp:8604
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3835
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3854
 msgid "Filament"
 msgstr "Filamento"
 
 #. MSG_FILAMENT_CLEAN c=20 r=2
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2287
-#: ../../Firmware/ultralcd.cpp:2293
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2306
+#: ../../Firmware/ultralcd.cpp:2312
 msgid "Filament extruding & with correct color?"
 msgstr "Filamento estruso e con colore corretto?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2217
+#: ../../Firmware/ultralcd.cpp:2236
 msgid "Filament not loaded"
 msgstr "Fil. non caricato"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:7026
-#: ../../Firmware/ultralcd.cpp:7030 ../../Firmware/ultralcd.cpp:7034
-#: ../../Firmware/ultralcd.cpp:7330
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:7056
+#: ../../Firmware/ultralcd.cpp:7060 ../../Firmware/ultralcd.cpp:7064
+#: ../../Firmware/ultralcd.cpp:7360
 msgid "Filament sensor"
 msgstr "Sensore filam."
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2365
+#: ../../Firmware/ultralcd.cpp:2384
 msgid "Filament used"
 msgstr "Fil. utilizzato"
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7461
+#: ../../Firmware/ultralcd.cpp:7491
 msgid "File incomplete. Continue anyway?"
 msgstr "File incompleto. Continuare comunque?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:5314
-#: ../../Firmware/ultralcd.cpp:5630
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:5336
+#: ../../Firmware/ultralcd.cpp:5652
 msgid "Finishing movements"
 msgstr "Finaliz. spostamenti"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:4898
-#: ../../Firmware/ultralcd.cpp:5424
+#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:4917
+#: ../../Firmware/ultralcd.cpp:5446
 msgid "First layer cal."
 msgstr "Cal. primo strato"
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4066
+#: ../../Firmware/ultralcd.cpp:4085
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Per primo avviero l'autotest per controllare gli errori di assemblaggio piu "
@@ -620,23 +614,23 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr "Risolvere il problema e premere il bottone sull'unita MMU."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5724
+#: ../../Firmware/ultralcd.cpp:5746
 msgid "Flow"
 msgstr "Flusso"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:6996
-#: ../../Firmware/ultralcd.cpp:7149 ../../Firmware/ultralcd.cpp:7154
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:7026
+#: ../../Firmware/ultralcd.cpp:7179 ../../Firmware/ultralcd.cpp:7184
 msgid "Front print fan?"
 msgstr "Ventola frontale?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2754
+#: ../../Firmware/ultralcd.cpp:2773
 msgid "Front side[μm]"
 msgstr "Fronte [μm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:7020
+#: ../../Firmware/ultralcd.cpp:7050
 msgid "Front/left fans"
 msgstr "Ventola frontale/sin"
 
@@ -685,20 +679,20 @@ msgstr ""
 "firmware. Stampa annullata."
 
 #. MSG_GCODE c=8
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:4655
-#: ../../Firmware/ultralcd.cpp:4658 ../../Firmware/ultralcd.cpp:4661
-#: ../../Firmware/ultralcd.cpp:4664
+#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:4674
+#: ../../Firmware/ultralcd.cpp:4677 ../../Firmware/ultralcd.cpp:4680
+#: ../../Firmware/ultralcd.cpp:4683
 msgid "Gcode"
 msgstr "Gcode"
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:4672
-#: ../../Firmware/ultralcd.cpp:4726 ../../Firmware/ultralcd.cpp:4818
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:4691
+#: ../../Firmware/ultralcd.cpp:4745 ../../Firmware/ultralcd.cpp:4837
 msgid "HW Setup"
 msgstr "Impostazioni HW"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6968
+#: ../../Firmware/ultralcd.cpp:6998
 msgid "Heater/Thermistor"
 msgstr "Riscald./Termist."
 
@@ -720,7 +714,7 @@ msgid "Heating done."
 msgstr "Riscald. completo"
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=16
-#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4042
+#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4061
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -731,7 +725,7 @@ msgstr ""
 "stampare."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4064
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -740,24 +734,30 @@ msgstr ""
 "processo di configurazione?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:4358
-#: ../../Firmware/ultralcd.cpp:4367 ../../Firmware/ultralcd.cpp:5777
-#: ../../Firmware/ultralcd.cpp:5780
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:4377
+#: ../../Firmware/ultralcd.cpp:4386 ../../Firmware/ultralcd.cpp:5799
+#: ../../Firmware/ultralcd.cpp:5802
 msgid "High power"
 msgstr "Forte"
 
+#. MSG_HOTEND_FAN_SPEED c=15
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1145
+#: ../../Firmware/ultralcd.cpp:7351
+msgid "Hotend fan:"
+msgstr "Ventola hotend:"
+
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4094
 msgid "I will run xyz calibration now. It will take approx. 12 mins."
 msgstr "Adesso avviero una Calibrazione XYZ. Puo durare circa 12 min."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/ultralcd.cpp:4102
 msgid "I will run z calibration now."
 msgstr "Adesso avviero la Calibrazione Z."
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=9
-#: ../../Firmware/ultralcd.cpp:4153
+#: ../../Firmware/ultralcd.cpp:4172
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -771,22 +771,22 @@ msgid "Improving bed calibration point"
 msgstr "Miglioramento punto di calibrazione del piatto"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:5478
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:5500
 msgid "Info screen"
 msgstr "Schermata info"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5545
+#: ../../Firmware/ultralcd.cpp:5567
 msgid "Init. SD card"
 msgstr "Inizial. scheda SD"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2152
+#: ../../Firmware/ultralcd.cpp:2171
 msgid "Insert filament"
 msgstr "Inserire filamento"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:6223
+#: ../../Firmware/ultralcd.cpp:6253
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
@@ -794,14 +794,14 @@ msgstr ""
 "Inserire filamento (senza caricarlo) nell'estrusore e premere la manopola."
 
 #. MSG_FILAMENT_LOADED c=20 r=2
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3855
-#: ../../Firmware/ultralcd.cpp:4108 ../../Firmware/ultralcd.cpp:4111
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3874
+#: ../../Firmware/ultralcd.cpp:4127 ../../Firmware/ultralcd.cpp:4130
 msgid "Is filament loaded?"
 msgstr "Il filamento e' stato caricato?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=2
 #: ../../Firmware/Marlin_main.cpp:3312 ../../Firmware/Marlin_main.cpp:4886
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:4084
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:4103
 msgid "Is steel sheet on heatbed?"
 msgstr "Piastra d'acciaio su piano riscaldato?"
 
@@ -811,74 +811,74 @@ msgid "Iteration"
 msgstr "Iterazione"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:1148
-#: ../../Firmware/ultralcd.cpp:1296
+#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:1167
+#: ../../Firmware/ultralcd.cpp:1315
 msgid "Last print"
 msgstr "Ultima stampa"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1169
-#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1269
-#: ../../Firmware/ultralcd.cpp:1326
+#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1188
+#: ../../Firmware/ultralcd.cpp:1278 ../../Firmware/ultralcd.cpp:1288
+#: ../../Firmware/ultralcd.cpp:1345
 msgid "Last print failures"
 msgstr "Errori ultima stampa"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2496
+#: ../../Firmware/ultralcd.cpp:2515
 msgid "Left"
 msgstr "Sinistra"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:6984
-#: ../../Firmware/ultralcd.cpp:7130 ../../Firmware/ultralcd.cpp:7135
+#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:7032
+#: ../../Firmware/ultralcd.cpp:7179 ../../Firmware/ultralcd.cpp:7184
 msgid "Left hotend fan?"
 msgstr "Vent SX hotend?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2752
+#: ../../Firmware/ultralcd.cpp:2771
 msgid "Left side [μm]"
 msgstr "Sinistra [μm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:5862
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:5884
 msgid "Level Bright"
 msgstr "Liv. Chiaro"
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:5863
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:5885
 msgid "Level Dimmed"
 msgstr "Liv. Scuro"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4826
+#: ../../Firmware/ultralcd.cpp:4845
 msgid "Lin. correction"
 msgstr "Correzione lineare"
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4838
-#: ../../Firmware/ultralcd.cpp:5493
+#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4857
+#: ../../Firmware/ultralcd.cpp:5515
 msgid "Live adjust Z"
 msgstr "Compensazione Z"
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/ultralcd.cpp:5120
+#: ../../Firmware/ultralcd.cpp:5142
 msgid "Load all"
 msgstr "Carica tutti"
 
 #. MSG_LOAD_FILAMENT c=17
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:5122
-#: ../../Firmware/ultralcd.cpp:5133 ../../Firmware/ultralcd.cpp:5562
-#: ../../Firmware/ultralcd.cpp:5576
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:5144
+#: ../../Firmware/ultralcd.cpp:5155 ../../Firmware/ultralcd.cpp:5584
+#: ../../Firmware/ultralcd.cpp:5598
 msgid "Load filament"
 msgstr "Carica filamento"
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5563
+#: ../../Firmware/ultralcd.cpp:5585
 msgid "Load to nozzle"
 msgstr "Carica ugello"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2185
+#: ../../Firmware/ultralcd.cpp:2204
 msgid "Loading color"
 msgstr "Caricando colore"
 
@@ -886,18 +886,18 @@ msgstr "Caricando colore"
 #: ../../Firmware/Marlin_main.cpp:3641 ../../Firmware/messages.cpp:55
 #: ../../Firmware/mmu.cpp:872 ../../Firmware/mmu.cpp:906
 #: ../../Firmware/mmu.cpp:1014 ../../Firmware/mmu.cpp:1026
-#: ../../Firmware/ultralcd.cpp:2196 ../../Firmware/ultralcd.cpp:3949
+#: ../../Firmware/ultralcd.cpp:2215 ../../Firmware/ultralcd.cpp:3968
 msgid "Loading filament"
 msgstr "Caricando filamento"
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:7008
+#: ../../Firmware/ultralcd.cpp:7038
 msgid "Loose pulley"
 msgstr "Puleggia lenta"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:4450
-#: ../../Firmware/ultralcd.cpp:4462
+#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/ultralcd.cpp:4481
 msgid "Loud"
 msgstr "Forte"
 
@@ -912,8 +912,8 @@ msgid "MK3S firmware detected on MK3 printer"
 msgstr "Firmware MK3S rilevato su stampante MK3"
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4381
-#: ../../Firmware/ultralcd.cpp:4382
+#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4400
+#: ../../Firmware/ultralcd.cpp:4401
 msgid "MMU Mode"
 msgstr "Mod. MMU"
 
@@ -933,8 +933,8 @@ msgid "MMU OK. Resuming..."
 msgstr "MMU OK. Riprendendo..."
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:64 ../../Firmware/ultralcd.cpp:1170
-#: ../../Firmware/ultralcd.cpp:1193
+#: ../../Firmware/messages.cpp:64 ../../Firmware/ultralcd.cpp:1189
+#: ../../Firmware/ultralcd.cpp:1212
 msgid "MMU fails"
 msgstr "Fallimenti MMU"
 
@@ -944,8 +944,8 @@ msgid "MMU load failed"
 msgstr "Caricam. MMU fallito"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:1171
-#: ../../Firmware/ultralcd.cpp:1194
+#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:1190
+#: ../../Firmware/ultralcd.cpp:1213
 msgid "MMU load fails"
 msgstr "Car MMU falliti"
 
@@ -955,32 +955,32 @@ msgid "MMU needs user attention."
 msgstr "Il MMU richiede attenzione dall'utente."
 
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/ultralcd.cpp:1195
+#: ../../Firmware/ultralcd.cpp:1214
 msgid "MMU power fails"
 msgstr "Manc. corr. MMU"
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1680
+#: ../../Firmware/ultralcd.cpp:1699
 msgid "MMU2 connected"
 msgstr "MMU2 connessa"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:5836
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:5858
 msgid "Magnets comp."
 msgstr "Comp. Magneti"
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1147
-#: ../../Firmware/ultralcd.cpp:1295 ../../Firmware/ultralcd.cpp:1338
-#: ../../Firmware/ultralcd.cpp:1645 ../../Firmware/ultralcd.cpp:4795
-#: ../../Firmware/ultralcd.cpp:4892 ../../Firmware/ultralcd.cpp:5119
-#: ../../Firmware/ultralcd.cpp:5131 ../../Firmware/ultralcd.cpp:5154
-#: ../../Firmware/ultralcd.cpp:5173 ../../Firmware/ultralcd.cpp:5717
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1166
+#: ../../Firmware/ultralcd.cpp:1314 ../../Firmware/ultralcd.cpp:1357
+#: ../../Firmware/ultralcd.cpp:1664 ../../Firmware/ultralcd.cpp:4814
+#: ../../Firmware/ultralcd.cpp:4911 ../../Firmware/ultralcd.cpp:5141
+#: ../../Firmware/ultralcd.cpp:5153 ../../Firmware/ultralcd.cpp:5176
+#: ../../Firmware/ultralcd.cpp:5195 ../../Firmware/ultralcd.cpp:5739
 msgid "Main"
 msgstr "Menu principale"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2537
+#: ../../Firmware/ultralcd.cpp:2556
 msgid "Measured skew"
 msgstr "Dev. misurata"
 
@@ -991,71 +991,71 @@ msgid "Measuring reference height of calibration point"
 msgstr "Misura altezza di rif. del punto di calib."
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:5832
+#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:5854
 msgid "Mesh"
 msgstr "Griglia"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4823
-#: ../../Firmware/ultralcd.cpp:4910
+#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4842
+#: ../../Firmware/ultralcd.cpp:4929
 msgid "Mesh Bed Leveling"
 msgstr "Liv. griglia piano"
 
 #. MSG_MODE c=6
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:4336
-#: ../../Firmware/ultralcd.cpp:4338 ../../Firmware/ultralcd.cpp:4358
-#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4364
-#: ../../Firmware/ultralcd.cpp:4367 ../../Firmware/ultralcd.cpp:5763
-#: ../../Firmware/ultralcd.cpp:5770 ../../Firmware/ultralcd.cpp:5777
-#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5779
-#: ../../Firmware/ultralcd.cpp:5780 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/ultralcd.cpp:4357 ../../Firmware/ultralcd.cpp:4377
+#: ../../Firmware/ultralcd.cpp:4380 ../../Firmware/ultralcd.cpp:4383
+#: ../../Firmware/ultralcd.cpp:4386 ../../Firmware/ultralcd.cpp:5785
+#: ../../Firmware/ultralcd.cpp:5792 ../../Firmware/ultralcd.cpp:5799
+#: ../../Firmware/ultralcd.cpp:5800 ../../Firmware/ultralcd.cpp:5801
+#: ../../Firmware/ultralcd.cpp:5802 ../../Firmware/ultralcd.cpp:5886
 msgid "Mode"
 msgstr "Mod."
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3598
+#: ../../Firmware/ultralcd.cpp:3617
 msgid "Mode change in progress..."
 msgstr "Cambio modalita in corso..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:4575
-#: ../../Firmware/ultralcd.cpp:4578 ../../Firmware/ultralcd.cpp:4581
-#: ../../Firmware/ultralcd.cpp:4584
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:4594
+#: ../../Firmware/ultralcd.cpp:4597 ../../Firmware/ultralcd.cpp:4600
+#: ../../Firmware/ultralcd.cpp:4603
 msgid "Model"
 msgstr "Modello"
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6982
-#: ../../Firmware/ultralcd.cpp:6991 ../../Firmware/ultralcd.cpp:7009
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:7012
+#: ../../Firmware/ultralcd.cpp:7021 ../../Firmware/ultralcd.cpp:7039
 msgid "Motor"
 msgstr "Motore"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3492
+#: ../../Firmware/ultralcd.cpp:3511
 msgid "Move X"
 msgstr "Sposta X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3493
+#: ../../Firmware/ultralcd.cpp:3512
 msgid "Move Y"
 msgstr "Sposta Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3494
+#: ../../Firmware/ultralcd.cpp:3513
 msgid "Move Z"
 msgstr "Sposta Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4801
+#: ../../Firmware/ultralcd.cpp:4820
 msgid "Move axis"
 msgstr "Muovi asse"
 
 #. MSG_NA c=3
 #: ../../Firmware/menu.cpp:196 ../../Firmware/messages.cpp:124
-#: ../../Firmware/ultralcd.cpp:2502 ../../Firmware/ultralcd.cpp:2547
-#: ../../Firmware/ultralcd.cpp:3411 ../../Firmware/ultralcd.cpp:4228
-#: ../../Firmware/ultralcd.cpp:4276 ../../Firmware/ultralcd.cpp:5737
-#: ../../Firmware/ultralcd.cpp:5836
+#: ../../Firmware/ultralcd.cpp:2521 ../../Firmware/ultralcd.cpp:2566
+#: ../../Firmware/ultralcd.cpp:3430 ../../Firmware/ultralcd.cpp:4247
+#: ../../Firmware/ultralcd.cpp:4295 ../../Firmware/ultralcd.cpp:5759
+#: ../../Firmware/ultralcd.cpp:5858
 msgid "N/A"
 msgstr "N/D"
 
@@ -1065,14 +1065,14 @@ msgid "New firmware version available:"
 msgstr "Nuova vers. firmware disponibile:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:2804
-#: ../../Firmware/ultralcd.cpp:3180 ../../Firmware/ultralcd.cpp:4785
-#: ../../Firmware/ultralcd.cpp:5988
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:2823
+#: ../../Firmware/ultralcd.cpp:3199 ../../Firmware/ultralcd.cpp:4804
+#: ../../Firmware/ultralcd.cpp:6018
 msgid "No"
 msgstr "No"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5543
+#: ../../Firmware/ultralcd.cpp:5565
 msgid "No SD card"
 msgstr "Nessuna SD"
 
@@ -1082,71 +1082,71 @@ msgid "No move."
 msgstr "Nessun movimento."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4405
-#: ../../Firmware/ultralcd.cpp:4493 ../../Firmware/ultralcd.cpp:4502
-#: ../../Firmware/ultralcd.cpp:4575 ../../Firmware/ultralcd.cpp:4584
-#: ../../Firmware/ultralcd.cpp:4614 ../../Firmware/ultralcd.cpp:4623
-#: ../../Firmware/ultralcd.cpp:4655 ../../Firmware/ultralcd.cpp:4664
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4424
+#: ../../Firmware/ultralcd.cpp:4512 ../../Firmware/ultralcd.cpp:4521
+#: ../../Firmware/ultralcd.cpp:4594 ../../Firmware/ultralcd.cpp:4603
+#: ../../Firmware/ultralcd.cpp:4633 ../../Firmware/ultralcd.cpp:4642
+#: ../../Firmware/ultralcd.cpp:4674 ../../Firmware/ultralcd.cpp:4683
 msgid "None"
 msgstr "Nessuno"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:4336
-#: ../../Firmware/ultralcd.cpp:4381 ../../Firmware/ultralcd.cpp:4397
-#: ../../Firmware/ultralcd.cpp:4416 ../../Firmware/ultralcd.cpp:5763
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/ultralcd.cpp:4400 ../../Firmware/ultralcd.cpp:4416
+#: ../../Firmware/ultralcd.cpp:4435 ../../Firmware/ultralcd.cpp:5785
 msgid "Normal"
 msgstr "Normale"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6969
+#: ../../Firmware/ultralcd.cpp:6999
 msgid "Not connected"
 msgstr "Non connesso"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:7168
-#: ../../Firmware/ultralcd.cpp:7183 ../../Firmware/ultralcd.cpp:7191
+#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:7198
+#: ../../Firmware/ultralcd.cpp:7213 ../../Firmware/ultralcd.cpp:7221
 msgid "Not spinning"
 msgstr "Non gira"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3962
+#: ../../Firmware/ultralcd.cpp:3981
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr "Adesso calibro la distanza fra ugello e superfice del piatto."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:4091
+#: ../../Firmware/ultralcd.cpp:4110
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Adesso preriscaldero l'ugello per PLA."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/ultralcd.cpp:4101
 msgid "Now remove the test print from steel sheet."
 msgstr "Ora rimuovete la stampa di prova dalla piastra in acciaio."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:1402
-#: ../../Firmware/ultralcd.cpp:4493 ../../Firmware/ultralcd.cpp:4496
-#: ../../Firmware/ultralcd.cpp:4499 ../../Firmware/ultralcd.cpp:4502
-#: ../../Firmware/ultralcd.cpp:5720 ../../Firmware/ultralcd.cpp:5882
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:1421
+#: ../../Firmware/ultralcd.cpp:4512 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/ultralcd.cpp:4518 ../../Firmware/ultralcd.cpp:4521
+#: ../../Firmware/ultralcd.cpp:5742 ../../Firmware/ultralcd.cpp:5904
 msgid "Nozzle"
 msgstr "Ugello"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4546
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4565
 msgid "Nozzle d."
 msgstr "Dia.Ugello"
 
 #. MSG_OFF c=3
 #: ../../Firmware/menu.cpp:467 ../../Firmware/messages.cpp:122
-#: ../../Firmware/ultralcd.cpp:4234 ../../Firmware/ultralcd.cpp:4250
-#: ../../Firmware/ultralcd.cpp:4284 ../../Firmware/ultralcd.cpp:4313
-#: ../../Firmware/ultralcd.cpp:4342 ../../Firmware/ultralcd.cpp:4811
-#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4834
-#: ../../Firmware/ultralcd.cpp:5644 ../../Firmware/ultralcd.cpp:5741
-#: ../../Firmware/ultralcd.cpp:5756 ../../Firmware/ultralcd.cpp:5767
-#: ../../Firmware/ultralcd.cpp:5836 ../../Firmware/ultralcd.cpp:7841
-#: ../../Firmware/ultralcd.cpp:7845
+#: ../../Firmware/ultralcd.cpp:4253 ../../Firmware/ultralcd.cpp:4269
+#: ../../Firmware/ultralcd.cpp:4303 ../../Firmware/ultralcd.cpp:4332
+#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4830
+#: ../../Firmware/ultralcd.cpp:4849 ../../Firmware/ultralcd.cpp:4853
+#: ../../Firmware/ultralcd.cpp:5666 ../../Firmware/ultralcd.cpp:5763
+#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/ultralcd.cpp:5858 ../../Firmware/ultralcd.cpp:7881
+#: ../../Firmware/ultralcd.cpp:7885
 msgid "Off"
 msgstr "Off"
 
@@ -1158,19 +1158,19 @@ msgstr ""
 "predefiniti di PID, Esteps etc."
 
 #. MSG_ON c=3
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4244
-#: ../../Firmware/ultralcd.cpp:4248 ../../Firmware/ultralcd.cpp:4280
-#: ../../Firmware/ultralcd.cpp:4303 ../../Firmware/ultralcd.cpp:4341
-#: ../../Firmware/ultralcd.cpp:4811 ../../Firmware/ultralcd.cpp:4830
-#: ../../Firmware/ultralcd.cpp:4834 ../../Firmware/ultralcd.cpp:5745
-#: ../../Firmware/ultralcd.cpp:5756 ../../Firmware/ultralcd.cpp:5765
-#: ../../Firmware/ultralcd.cpp:5836 ../../Firmware/ultralcd.cpp:7841
-#: ../../Firmware/ultralcd.cpp:7845
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4263
+#: ../../Firmware/ultralcd.cpp:4267 ../../Firmware/ultralcd.cpp:4299
+#: ../../Firmware/ultralcd.cpp:4322 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4849
+#: ../../Firmware/ultralcd.cpp:4853 ../../Firmware/ultralcd.cpp:5767
+#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5787
+#: ../../Firmware/ultralcd.cpp:5858 ../../Firmware/ultralcd.cpp:7881
+#: ../../Firmware/ultralcd.cpp:7885
 msgid "On"
 msgstr "On"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4453
+#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4472
 msgid "Once"
 msgstr "Singolo"
 
@@ -1190,7 +1190,7 @@ msgid "PID cal. finished"
 msgstr "Calib. PID completa"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4913
+#: ../../Firmware/ultralcd.cpp:4932
 msgid "PID calibration"
 msgstr "Calibrazione PID"
 
@@ -1202,18 +1202,18 @@ msgstr "Riscaldamento PINDA"
 #. MSG_PINDA_CALIBRATION c=13
 #: ../../Firmware/Marlin_main.cpp:4932 ../../Firmware/Marlin_main.cpp:5035
 #: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:654
-#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4920
+#: ../../Firmware/ultralcd.cpp:4849 ../../Firmware/ultralcd.cpp:4939
 msgid "PINDA cal."
 msgstr "Calib. PINDA"
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3361
+#: ../../Firmware/ultralcd.cpp:3380
 msgid "PINDA calibration failed"
 msgstr "Calibrazione temperatura fallita"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
 #: ../../Firmware/Marlin_main.cpp:5112 ../../Firmware/messages.cpp:110
-#: ../../Firmware/ultralcd.cpp:3355
+#: ../../Firmware/ultralcd.cpp:3374
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1222,13 +1222,13 @@ msgstr ""
 "Impostazioni ->Calib. PINDA"
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4707
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4726
 msgid "Pause"
 msgstr "Pausa"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:5507
-#: ../../Firmware/ultralcd.cpp:5509
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:5529
+#: ../../Firmware/ultralcd.cpp:5531
 msgid "Pause print"
 msgstr "Metti in pausa"
 
@@ -1242,7 +1242,7 @@ msgstr ""
 "punti. In caso l'ugello muova il foglio spegnere subito la stampante."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:4176
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:4195
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1251,17 +1251,17 @@ msgstr ""
 "riprendi il Wizard dopo aver riavviato la stampante."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:6250
+#: ../../Firmware/ultralcd.cpp:6280
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "Controllare il collegamento al sensore e rimuovere il filamento."
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6963
+#: ../../Firmware/ultralcd.cpp:6993
 msgid "Please check:"
 msgstr "Verifica:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4148
+#: ../../Firmware/ultralcd.cpp:4167
 msgid "Please clean heatbed and then press the knob."
 msgstr "Per favore pulisci il piatto, poi premi la manopola."
 
@@ -1271,14 +1271,14 @@ msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Pulire l'ugello per la calibrazione, poi fare click."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3945
+#: ../../Firmware/ultralcd.cpp:3964
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr ""
 "Inserisci il filamento nell'estrusore, poi premi la manopola per caricarlo."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3940
+#: ../../Firmware/ultralcd.cpp:3959
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1287,7 +1287,7 @@ msgstr ""
 "manopola per caricarlo."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3863
+#: ../../Firmware/ultralcd.cpp:3882
 msgid "Please load filament first."
 msgstr "Per favore prima carica il filamento."
 
@@ -1298,7 +1298,7 @@ msgstr "Aprire la guida filam. e rimuovere il filam. a mano"
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=5
 #: ../../Firmware/mesh_bed_calibration.cpp:2799 ../../Firmware/messages.cpp:70
-#: ../../Firmware/ultralcd.cpp:4085
+#: ../../Firmware/ultralcd.cpp:4104
 msgid "Please place steel sheet on heatbed."
 msgstr "Per favore posizionate la piastra d'acciaio sul piano riscaldato."
 
@@ -1309,7 +1309,7 @@ msgid "Please press the knob to unload filament"
 msgstr "Premete la manopola per scaricare il filamento"
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:5213
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:5235
 msgid "Please pull out filament immediately"
 msgstr "Estrarre il filamento immediatamente"
 
@@ -1319,7 +1319,7 @@ msgid "Please remove filament and then press the knob."
 msgstr "Rimuovi il filamento e quindi premi la manopola."
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:4081
+#: ../../Firmware/ultralcd.cpp:4100
 msgid "Please remove shipping helpers first."
 msgstr "Per favore rimuovete i materiali da spedizione"
 
@@ -1335,7 +1335,7 @@ msgid "Please run XYZ calibration first."
 msgstr "Esegui la calibrazione XYZ prima."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:6247
+#: ../../Firmware/ultralcd.cpp:6277
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Scaricare prima il filamento, poi ripetere l'operazione."
 
@@ -1352,54 +1352,54 @@ msgstr "Prego aggiornare."
 #. MSG_PLEASE_WAIT c=20
 #: ../../Firmware/Marlin_main.cpp:3547 ../../Firmware/Marlin_main.cpp:3563
 #: ../../Firmware/Marlin_main.cpp:7931 ../../Firmware/messages.cpp:71
-#: ../../Firmware/ultralcd.cpp:2186 ../../Firmware/ultralcd.cpp:2197
+#: ../../Firmware/ultralcd.cpp:2205 ../../Firmware/ultralcd.cpp:2216
 msgid "Please wait"
 msgstr "Attendere"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1219
-#: ../../Firmware/ultralcd.cpp:1260 ../../Firmware/ultralcd.cpp:1270
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1238
+#: ../../Firmware/ultralcd.cpp:1279 ../../Firmware/ultralcd.cpp:1289
 msgid "Power failures"
 msgstr "Interr. corr."
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5502
+#: ../../Firmware/ultralcd.cpp:5524
 msgid "Preheat"
 msgstr "Preriscalda"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:2280
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:2299
 msgid "Preheat the nozzle!"
 msgstr "Prerisc. ugello!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:2900
-#: ../../Firmware/ultralcd.cpp:3924 ../../Firmware/ultralcd.cpp:3926
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:2919
+#: ../../Firmware/ultralcd.cpp:3943 ../../Firmware/ultralcd.cpp:3945
 msgid "Preheating nozzle. Please wait."
 msgstr "Preriscaldando l'ugello. Attendere prego."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1988
+#: ../../Firmware/ultralcd.cpp:2007
 msgid "Preheating to cut"
 msgstr "Preriscalda. taglio"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1985
+#: ../../Firmware/ultralcd.cpp:2004
 msgid "Preheating to eject"
 msgstr "Preriscalda. espuls."
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1976
+#: ../../Firmware/ultralcd.cpp:1995
 msgid "Preheating to load"
 msgstr "Preriscald. carico"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1981
+#: ../../Firmware/ultralcd.cpp:2000
 msgid "Preheating to unload"
 msgstr "Preriscald. scarico"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1809
+#: ../../Firmware/ultralcd.cpp:1828
 msgid "Press the knob"
 msgstr "Premere la manopola"
 
@@ -1419,13 +1419,13 @@ msgid "Print aborted"
 msgstr "Stampa interrotta"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1131
-#: ../../Firmware/ultralcd.cpp:7305
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1145
+#: ../../Firmware/ultralcd.cpp:7354
 msgid "Print fan:"
 msgstr "Vent.stam:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5535
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5557
 msgid "Print from SD"
 msgstr "Stampa da SD"
 
@@ -1435,12 +1435,12 @@ msgid "Print paused"
 msgstr "Stampa in pausa"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2366
+#: ../../Firmware/ultralcd.cpp:2385
 msgid "Print time"
 msgstr "Tempo di stampa"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1711
+#: ../../Firmware/ultralcd.cpp:1730
 msgid "Printer IP Addr:"
 msgstr "Ind. IP stampante:"
 
@@ -1468,12 +1468,12 @@ msgstr ""
 "Stampa annullata."
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4834
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4853
 msgid "RPi port"
 msgstr "Porta RPi"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2755
+#: ../../Firmware/ultralcd.cpp:2774
 msgid "Rear side [μm]"
 msgstr "Retro [μm]"
 
@@ -1490,24 +1490,24 @@ msgstr ""
 "filamento."
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5426
+#: ../../Firmware/ultralcd.cpp:5448
 msgid "Rename"
 msgstr "Rinomina"
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2756
-#: ../../Firmware/ultralcd.cpp:5427
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2775
+#: ../../Firmware/ultralcd.cpp:5449
 msgid "Reset"
 msgstr "Reset"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4917
+#: ../../Firmware/ultralcd.cpp:4936
 msgid "Reset XYZ calibr."
 msgstr "Reset calibr. XYZ."
 
 #. MSG_RESUME_PRINT c=18
 #: ../../Firmware/Marlin_main.cpp:655 ../../Firmware/messages.cpp:81
-#: ../../Firmware/ultralcd.cpp:5521 ../../Firmware/ultralcd.cpp:5523
+#: ../../Firmware/ultralcd.cpp:5543 ../../Firmware/ultralcd.cpp:5545
 msgid "Resume print"
 msgstr "Riprendi stampa"
 
@@ -1517,17 +1517,17 @@ msgid "Resuming print"
 msgstr "Riprendi stampa"
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2497
+#: ../../Firmware/ultralcd.cpp:2516
 msgid "Right"
 msgstr "Destra"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2753
+#: ../../Firmware/ultralcd.cpp:2772
 msgid "Right side[μm]"
 msgstr "Destra [μm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3884
+#: ../../Firmware/ultralcd.cpp:3903
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1536,14 +1536,14 @@ msgstr ""
 "ricominciare dall'inizio. Continuare?"
 
 #. MSG_RUNOUTS c=7
-#: ../../Firmware/ultralcd.cpp:1271
+#: ../../Firmware/ultralcd.cpp:1290
 msgid "Runouts"
 msgstr "Esaurim"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4395
-#: ../../Firmware/ultralcd.cpp:4397 ../../Firmware/ultralcd.cpp:4414
-#: ../../Firmware/ultralcd.cpp:4416
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4414
+#: ../../Firmware/ultralcd.cpp:4416 ../../Firmware/ultralcd.cpp:4433
+#: ../../Firmware/ultralcd.cpp:4435
 msgid "SD card"
 msgstr "Mem. SD"
 
@@ -1559,12 +1559,12 @@ msgid "Searching bed calibration point"
 msgstr "Ricerca punti calibrazione piano"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5419
+#: ../../Firmware/ultralcd.cpp:5441
 msgid "Select"
 msgstr "Seleziona"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3966
+#: ../../Firmware/ultralcd.cpp:3985
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
@@ -1579,51 +1579,51 @@ msgstr "Seleziona estrusore:"
 
 #. MSG_SELECT_FILAMENT c=20
 #: ../../Firmware/Marlin_main.cpp:8577 ../../Firmware/Marlin_main.cpp:8604
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3834
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3853
 msgid "Select filament:"
 msgstr "Seleziona il filam.:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:3679
-#: ../../Firmware/ultralcd.cpp:4841
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:3698
+#: ../../Firmware/ultralcd.cpp:4860
 msgid "Select language"
 msgstr "Seleziona lingua"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:4122
+#: ../../Firmware/ultralcd.cpp:4141
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr ""
 "Selezionate la temperatura per il preriscaldamento dell'ugello adatta al "
 "vostro materiale."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3971
+#: ../../Firmware/ultralcd.cpp:3990
 msgid "Select temperature which matches your material."
 msgstr "Seleziona la temperatura appropriata per il tuo materiale."
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6522
+#: ../../Firmware/ultralcd.cpp:6552
 msgid "Self test OK"
 msgstr "Autotest OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:6290
+#: ../../Firmware/ultralcd.cpp:6320
 msgid "Self test start"
 msgstr "Avvia autotest"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4904
+#: ../../Firmware/ultralcd.cpp:4923
 msgid "Selftest"
 msgstr "Autotest"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6962
+#: ../../Firmware/ultralcd.cpp:6992
 msgid "Selftest error!"
 msgstr "Errore Autotest!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:6526
-#: ../../Firmware/ultralcd.cpp:7049 ../../Firmware/ultralcd.cpp:7314
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:6556
+#: ../../Firmware/ultralcd.cpp:7079 ../../Firmware/ultralcd.cpp:7344
 msgid "Selftest failed"
 msgstr "Autotest fallito"
 
@@ -1633,30 +1633,30 @@ msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr "Verra effettuato un self test per calibrare l'homing senza sensori"
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1723
+#: ../../Firmware/ultralcd.cpp:1742
 msgid "Sensor info"
 msgstr "Info Sensore"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:6254
+#: ../../Firmware/ultralcd.cpp:6284
 msgid "Sensor verified, remove the filament now."
 msgstr "Sensore verificato, rimuovere il filamento."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2773
+#: ../../Firmware/ultralcd.cpp:2792
 msgid "Set temperature:"
 msgstr "Imposta temperatura:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:3491
-#: ../../Firmware/ultralcd.cpp:3696 ../../Firmware/ultralcd.cpp:4206
-#: ../../Firmware/ultralcd.cpp:5580 ../../Firmware/ultralcd.cpp:5827
-#: ../../Firmware/ultralcd.cpp:5880
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:3510
+#: ../../Firmware/ultralcd.cpp:3715 ../../Firmware/ultralcd.cpp:4225
+#: ../../Firmware/ultralcd.cpp:5602 ../../Firmware/ultralcd.cpp:5849
+#: ../../Firmware/ultralcd.cpp:5902
 msgid "Settings"
 msgstr "Impostazioni"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2540
+#: ../../Firmware/ultralcd.cpp:2559
 msgid "Severe skew"
 msgstr "Deviaz. forte"
 
@@ -1667,7 +1667,7 @@ msgid "Sheet"
 msgstr "Piano"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3824
+#: ../../Firmware/ultralcd.cpp:3843
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1680,18 +1680,18 @@ msgstr ""
 "%cReset"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4915
+#: ../../Firmware/ultralcd.cpp:4934
 msgid "Show end stops"
 msgstr "Stato finecorsa"
 
 #. MSG_SILENT c=7
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4361
-#: ../../Firmware/ultralcd.cpp:4456 ../../Firmware/ultralcd.cpp:5778
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4380
+#: ../../Firmware/ultralcd.cpp:4475 ../../Firmware/ultralcd.cpp:5800
 msgid "Silent"
 msgstr "Silenz."
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2539
+#: ../../Firmware/ultralcd.cpp:2558
 msgid "Slight skew"
 msgstr "Deviaz. lieve"
 
@@ -1710,8 +1710,8 @@ msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Sono stati rilevati problemi, avviato livellamento Z ..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4403
-#: ../../Firmware/ultralcd.cpp:4404 ../../Firmware/ultralcd.cpp:4405
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4422
+#: ../../Firmware/ultralcd.cpp:4423 ../../Firmware/ultralcd.cpp:4424
 msgid "Sort"
 msgstr "Ordina"
 
@@ -1722,20 +1722,20 @@ msgid "Sorting files"
 msgstr "Ordinando i file"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4450
-#: ../../Firmware/ultralcd.cpp:4453 ../../Firmware/ultralcd.cpp:4456
-#: ../../Firmware/ultralcd.cpp:4459 ../../Firmware/ultralcd.cpp:4462
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/ultralcd.cpp:4472 ../../Firmware/ultralcd.cpp:4475
+#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4481
 msgid "Sound"
 msgstr "Suono"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5718
+#: ../../Firmware/ultralcd.cpp:5740
 msgid "Speed"
 msgstr "Velocita"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7166
-#: ../../Firmware/ultralcd.cpp:7181 ../../Firmware/ultralcd.cpp:7189
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7196
+#: ../../Firmware/ultralcd.cpp:7211 ../../Firmware/ultralcd.cpp:7219
 msgid "Spinning"
 msgstr "Gira"
 
@@ -1746,42 +1746,42 @@ msgstr ""
 "Sono necessari una temperatura ambiente di 21-26C e una superficie rigida."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5585
+#: ../../Firmware/ultralcd.cpp:5607
 msgid "Statistics"
 msgstr "Statistiche"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4338
-#: ../../Firmware/ultralcd.cpp:4382 ../../Firmware/ultralcd.cpp:5770
+#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4357
+#: ../../Firmware/ultralcd.cpp:4401 ../../Firmware/ultralcd.cpp:5792
 msgid "Stealth"
 msgstr "Silenz."
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4763
-#: ../../Firmware/ultralcd.cpp:5416
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4782
+#: ../../Firmware/ultralcd.cpp:5438
 msgid "Steel sheets"
 msgstr "Piani d'acciaio"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5528
-#: ../../Firmware/ultralcd.cpp:5987
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5550
+#: ../../Firmware/ultralcd.cpp:6017
 msgid "Stop print"
 msgstr "Arresta stampa"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4499
-#: ../../Firmware/ultralcd.cpp:4581 ../../Firmware/ultralcd.cpp:4620
-#: ../../Firmware/ultralcd.cpp:4661
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4518
+#: ../../Firmware/ultralcd.cpp:4600 ../../Firmware/ultralcd.cpp:4639
+#: ../../Firmware/ultralcd.cpp:4680
 msgid "Strict"
 msgstr "Esatto"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/ultralcd.cpp:5616
 msgid "Support"
 msgstr "Supporto"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:7021
+#: ../../Firmware/ultralcd.cpp:7051
 msgid "Swapped"
 msgstr "Scambiato"
 
@@ -1790,28 +1790,18 @@ msgstr "Scambiato"
 msgid "THERMAL ANOMALY"
 msgstr "ANOMALIA TERMICA"
 
-#. MSG_TM_AUTOTUNE_FAILED c=20
-#: ../../Firmware/temperature.cpp:2899
-msgid "TM autotune failed"
-msgstr "Autocal. MT fallita"
-
-#. MSG_TEMP_MODEL_AUTOTUNE c=20
-#: ../../Firmware/temperature.cpp:2884
-msgid "Temp. model autotune"
-msgstr "Cal. modello termico"
-
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4797
+#: ../../Firmware/ultralcd.cpp:4816
 msgid "Temperature"
 msgstr "Temperatura"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1729
+#: ../../Firmware/ultralcd.cpp:1748
 msgid "Temperatures"
 msgstr "Temperature"
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3974
+#: ../../Firmware/ultralcd.cpp:3993
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -1831,66 +1821,66 @@ msgstr ""
 "Primi Passi, sezione Sequenza di Calibrazione."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4403
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4422
 msgid "Time"
 msgstr "Cron."
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:5865
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:5887
 msgid "Timeout"
 msgstr "Timeout"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:1149
-#: ../../Firmware/ultralcd.cpp:1297
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:1168
+#: ../../Firmware/ultralcd.cpp:1316
 msgid "Total"
 msgstr "Totale"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:1192
-#: ../../Firmware/ultralcd.cpp:1218 ../../Firmware/ultralcd.cpp:1328
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:1211
+#: ../../Firmware/ultralcd.cpp:1237 ../../Firmware/ultralcd.cpp:1347
 msgid "Total failures"
 msgstr "Totale fallimenti"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2387
+#: ../../Firmware/ultralcd.cpp:2406
 msgid "Total filament"
 msgstr "Filamento totale"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2388
+#: ../../Firmware/ultralcd.cpp:2407
 msgid "Total print time"
 msgstr "Tempo stampa totale"
 
 #. MSG_TUNE c=18
-#: ../../Firmware/ultralcd.cpp:5500
+#: ../../Firmware/ultralcd.cpp:5522
 msgid "Tune"
 msgstr "Regola"
 
 #. MSG_UNLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:5564
-#: ../../Firmware/ultralcd.cpp:5578
+#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:5586
+#: ../../Firmware/ultralcd.cpp:5600
 msgid "Unload filament"
 msgstr "Scarica filam."
 
 #. MSG_UNLOADING_FILAMENT c=20
 #: ../../Firmware/messages.cpp:112 ../../Firmware/mmu.cpp:957
-#: ../../Firmware/ultralcd.cpp:5197
+#: ../../Firmware/ultralcd.cpp:5219
 msgid "Unloading filament"
 msgstr "Scaricando filamento"
 
 #. MSG_FIL_FAILED c=20 r=5
-#: ../../Firmware/ultralcd.cpp:6258
+#: ../../Firmware/ultralcd.cpp:6288
 msgid "Verification failed, remove the filament and try again."
 msgstr "Verifica fallita, rimuovere il filamento e riprovare."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1732
+#: ../../Firmware/ultralcd.cpp:1751
 msgid "Voltages"
 msgstr "Voltaggi"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3534
+#: ../../Firmware/ultralcd.cpp:3553
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -1908,19 +1898,19 @@ msgid "Wait for user..."
 msgstr "Attendendo utente..."
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2881
+#: ../../Firmware/ultralcd.cpp:2900
 msgid "Waiting for PINDA probe cooling"
 msgstr "In attesa del raffreddamento della sonda PINDA"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2913
+#: ../../Firmware/ultralcd.cpp:2932
 msgid "Waiting for nozzle and bed cooling"
 msgstr "In attesa del raffreddamento dell'ugello e del piano"
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:4496
-#: ../../Firmware/ultralcd.cpp:4578 ../../Firmware/ultralcd.cpp:4617
-#: ../../Firmware/ultralcd.cpp:4658
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/ultralcd.cpp:4597 ../../Firmware/ultralcd.cpp:4636
+#: ../../Firmware/ultralcd.cpp:4677
 msgid "Warn"
 msgstr "Avviso"
 
@@ -1945,150 +1935,139 @@ msgid "Was filament unload successful?"
 msgstr "Filamento scaricato con successo?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6973
-#: ../../Firmware/ultralcd.cpp:6977 ../../Firmware/ultralcd.cpp:6997
-#: ../../Firmware/ultralcd.cpp:7003 ../../Firmware/ultralcd.cpp:7027
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:7003
+#: ../../Firmware/ultralcd.cpp:7007 ../../Firmware/ultralcd.cpp:7027
+#: ../../Firmware/ultralcd.cpp:7033 ../../Firmware/ultralcd.cpp:7057
 msgid "Wiring error"
 msgstr "Errore cablaggio"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4895
+#: ../../Firmware/ultralcd.cpp:4914
 msgid "Wizard"
 msgstr "Wizard"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4210
+#: ../../Firmware/ultralcd.cpp:4229
 msgid "X-correct:"
 msgstr "Correzione-X:"
 
 #. MSG_XFLASH c=18
-#: ../../Firmware/ultralcd.cpp:5596
+#: ../../Firmware/ultralcd.cpp:5618
 msgid "XFLASH init"
 msgstr "Inizializza XFLASH"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1721
+#: ../../Firmware/ultralcd.cpp:1740
 msgid "XYZ cal. details"
 msgstr "XYZ Cal. dettagli"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3333
+#: ../../Firmware/ultralcd.cpp:3352
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr ""
 "Calibrazione XYZ corretta. La distorsione verra compensata automaticamente."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3330
+#: ../../Firmware/ultralcd.cpp:3349
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr "Calibrazion XYZ corretta. Assi X/Y leggermente storti. Ben fatto!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3311
+#: ../../Firmware/ultralcd.cpp:3330
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr "Calibrazione XYZ compromessa. Punti anteriori non raggiungibili."
 
-#. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_LEFT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3317
-msgid ""
-"XYZ calibration compromised. Left front calibration point not reachable."
-msgstr ""
-
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3314
+#: ../../Firmware/ultralcd.cpp:3333
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr ""
 "Calibrazione XYZ compromessa. Punto anteriore destro non raggiungibile."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3293
+#: ../../Firmware/ultralcd.cpp:3312
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr ""
 "Calibrazione XYZ fallita. Il punto di calibrazione sul piano non e' stato "
 "trovato."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3299
+#: ../../Firmware/ultralcd.cpp:3318
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr "Calibrazione XYZ fallita. Punti anteriori non raggiungibili."
 
-#. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_LEFT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3305
-msgid "XYZ calibration failed. Left front calibration point not reachable."
-msgstr "Calibrazione XYZ fallita. Punto anteriore sinistro non raggiungibile."
-
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3296
-#: ../../Firmware/ultralcd.cpp:3324
+#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3315
+#: ../../Firmware/ultralcd.cpp:3343
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "Calibrazione XYZ fallita. Si prega di consultare il manuale."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3302
+#: ../../Firmware/ultralcd.cpp:3321
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr "Calibrazione XYZ fallita. Punto anteriore destro non raggiungibile."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3327
+#: ../../Firmware/ultralcd.cpp:3346
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "Calibrazione XYZ OK. Gli assi X/Y sono perpendicolari. Complimenti!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2494
+#: ../../Firmware/ultralcd.cpp:2513
 msgid "Y distance from min"
 msgstr "Distanza Y dal min"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4211
+#: ../../Firmware/ultralcd.cpp:4230
 msgid "Y-correct:"
 msgstr "Correzione-Y:"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:2216
-#: ../../Firmware/ultralcd.cpp:2800 ../../Firmware/ultralcd.cpp:3180
-#: ../../Firmware/ultralcd.cpp:4785 ../../Firmware/ultralcd.cpp:5989
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:2235
+#: ../../Firmware/ultralcd.cpp:2819 ../../Firmware/ultralcd.cpp:3199
+#: ../../Firmware/ultralcd.cpp:4804 ../../Firmware/ultralcd.cpp:6019
 msgid "Yes"
 msgstr "Si"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:4187
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:4206
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr ""
 "E possibile riprendere il Wizard in qualsiasi momento attraverso "
 "Calibrazione -> Wizard."
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4231
 msgid "Z-correct:"
 msgstr "Correzione-Z:"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:5835
+#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:5857
 msgid "Z-probe nr."
 msgstr "Nr. Z-test"
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2565
+#: ../../Firmware/ultralcd.cpp:2584
 msgid "[0;0] point offset"
 msgstr "[0;0] punto offset"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2154
+#: ../../Firmware/ultralcd.cpp:2173
 msgid "and press the knob"
 msgstr "e cliccare manopola"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1816
+#: ../../Firmware/ultralcd.cpp:1835
 msgid "to load filament"
 msgstr "per caricare il fil."
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1820
+#: ../../Firmware/ultralcd.cpp:1839
 msgid "to unload filament"
 msgstr "per scaricare fil."
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1688
+#: ../../Firmware/ultralcd.cpp:1707
 msgid "unknown"
 msgstr "sconosciuto"
 
@@ -2098,8 +2077,8 @@ msgid "unknown state"
 msgstr "stato sconosciuto"
 
 #. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:6077
-#: ../../Firmware/ultralcd.cpp:6080
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:6107
+#: ../../Firmware/ultralcd.cpp:6110
 msgid "🔃Refresh"
 msgstr "🔃Ricaricare"
 
@@ -2108,3 +2087,13 @@ msgstr "🔃Ricaricare"
 
 #~ msgid "M117 First layer cal."
 #~ msgstr "M117 Calibr. primo strato"
+
+#~ msgid "TM autotune failed"
+#~ msgstr "Autocal. MT fallita"
+
+#~ msgid "Temp. model autotune"
+#~ msgstr "Cal. modello termico"
+
+#~ msgid "XYZ calibration failed. Left front calibration point not reachable."
+#~ msgstr ""
+#~ "Calibrazione XYZ fallita. Punto anteriore sinistro non raggiungibile."

--- a/lang/po/Firmware_lb.po
+++ b/lang/po/Firmware_lb.po
@@ -26,113 +26,113 @@ msgid " 0.4 or newer"
 msgstr ""
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:7036
+#: ../../Firmware/ultralcd.cpp:7066
 msgid "%s level expected"
 msgstr ""
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1968
-#: ../../Firmware/ultralcd.cpp:3835
+#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1987
+#: ../../Firmware/ultralcd.cpp:3854
 msgid ">Cancel"
 msgstr ""
 
 #. MSG_BABYSTEPPING_Z c=15
 #. Beware: must include the ':' as its last character
-#: ../../Firmware/ultralcd.cpp:2670
+#: ../../Firmware/ultralcd.cpp:2689
 msgid "Adjusting Z:"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:7313
+#: ../../Firmware/ultralcd.cpp:7343
 msgid "All correct"
 msgstr ""
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4180
+#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4190
+#: ../../Firmware/ultralcd.cpp:4199
 msgid "All is done. Happy printing!"
 msgstr ""
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4404
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4423
 msgid "Alphabet"
 msgstr ""
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4308
+#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4327
 msgid "Always"
 msgstr ""
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1405
+#: ../../Firmware/ultralcd.cpp:1424
 msgid "Ambient"
 msgstr ""
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2983
+#: ../../Firmware/ultralcd.cpp:3002
 msgid "Are left and right Z~carriages all up?"
 msgstr ""
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4478
 msgid "Assist"
 msgstr ""
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:5886
 msgid "Auto"
 msgstr ""
 
 #. MSG_AUTO_HOME c=18
 #: ../../Firmware/Marlin_main.cpp:3271 ../../Firmware/messages.cpp:9
-#: ../../Firmware/ultralcd.cpp:4900
+#: ../../Firmware/ultralcd.cpp:4919
 msgid "Auto home"
 msgstr ""
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:4364
-#: ../../Firmware/ultralcd.cpp:5779
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:4383
+#: ../../Firmware/ultralcd.cpp:5801
 msgid "Auto power"
 msgstr ""
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5572
+#: ../../Firmware/ultralcd.cpp:5594
 msgid "AutoLoad filament"
 msgstr ""
 
 #. MSG_AUTOLOADING_ONLY_IF_FSENS_ON c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3549
+#: ../../Firmware/ultralcd.cpp:3568
 msgid ""
 "Autoloading filament available only when filament sensor is turned on..."
 msgstr ""
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2301
+#: ../../Firmware/ultralcd.cpp:2320
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:7015
+#: ../../Firmware/ultralcd.cpp:7045
 msgid "Axis"
 msgstr ""
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:7014
+#: ../../Firmware/ultralcd.cpp:7044
 msgid "Axis length"
 msgstr ""
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:2751
-#: ../../Firmware/ultralcd.cpp:5861 ../../Firmware/ultralcd.cpp:7838
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:2770
+#: ../../Firmware/ultralcd.cpp:5883 ../../Firmware/ultralcd.cpp:7878
 msgid "Back"
 msgstr ""
 
 #. MSG_BED c=13
 #: ../../Firmware/Marlin_main.cpp:2051 ../../Firmware/Marlin_main.cpp:4767
 #: ../../Firmware/Marlin_main.cpp:4819 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:1403 ../../Firmware/ultralcd.cpp:5721
-#: ../../Firmware/ultralcd.cpp:5891
+#: ../../Firmware/ultralcd.cpp:1422 ../../Firmware/ultralcd.cpp:5743
+#: ../../Firmware/ultralcd.cpp:5913
 msgid "Bed"
 msgstr ""
 
@@ -149,7 +149,7 @@ msgid "Bed done"
 msgstr ""
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4912
+#: ../../Firmware/ultralcd.cpp:4931
 msgid "Bed level correct"
 msgstr ""
 
@@ -165,18 +165,18 @@ msgid ""
 msgstr ""
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6972
+#: ../../Firmware/ultralcd.cpp:7002
 msgid "Bed/Heater"
 msgstr ""
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1458
-#: ../../Firmware/ultralcd.cpp:1726
+#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1477
+#: ../../Firmware/ultralcd.cpp:1745
 msgid "Belt status"
 msgstr ""
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4902
+#: ../../Firmware/ultralcd.cpp:4921
 msgid "Belt test"
 msgstr ""
 
@@ -187,28 +187,28 @@ msgid "Blackout occurred. Recover print?"
 msgstr ""
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:5886
 msgid "Bright"
 msgstr ""
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4850
-#: ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4869
+#: ../../Firmware/ultralcd.cpp:5811
 msgid "Brightness"
 msgstr ""
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4906
+#: ../../Firmware/ultralcd.cpp:4925
 msgid "Calibrate XYZ"
 msgstr ""
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4908
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4927
 msgid "Calibrate Z"
 msgstr ""
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2946
+#: ../../Firmware/ultralcd.cpp:2965
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -221,19 +221,19 @@ msgid "Calibrating Z"
 msgstr ""
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2945
+#: ../../Firmware/ultralcd.cpp:2964
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
 msgstr ""
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:7315
+#: ../../Firmware/ultralcd.cpp:7345
 msgid "Calibrating home"
 msgstr ""
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:5581
+#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:5603
 msgid "Calibration"
 msgstr ""
 
@@ -243,115 +243,115 @@ msgid "Calibration done"
 msgstr ""
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7712
+#: ../../Firmware/ultralcd.cpp:7752
 msgid "Card removed"
 msgstr ""
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/ultralcd.cpp:5560
 msgid "Change SD card"
 msgstr ""
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5497
-#: ../../Firmware/ultralcd.cpp:5730
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5519
+#: ../../Firmware/ultralcd.cpp:5752
 msgid "Change filament"
 msgstr ""
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2163
+#: ../../Firmware/ultralcd.cpp:2182
 msgid "Change success!"
 msgstr ""
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2215
+#: ../../Firmware/ultralcd.cpp:2234
 msgid "Changed correctly?"
 msgstr ""
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:6178
-#: ../../Firmware/ultralcd.cpp:7305
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:6208
+#: ../../Firmware/ultralcd.cpp:7335
 msgid "Checking X axis"
 msgstr ""
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:6187
-#: ../../Firmware/ultralcd.cpp:7306
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:6217
+#: ../../Firmware/ultralcd.cpp:7336
 msgid "Checking Y axis"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:7307
+#: ../../Firmware/ultralcd.cpp:7337
 msgid "Checking Z axis"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:7308
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:7338
 msgid "Checking bed"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:7304
+#: ../../Firmware/ultralcd.cpp:7334
 msgid "Checking endstops"
 msgstr ""
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:7403
+#: ../../Firmware/ultralcd.cpp:7433
 msgid "Checking file"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:7310
+#: ../../Firmware/ultralcd.cpp:7340
 msgid "Checking hotend"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:7311
-#: ../../Firmware/ultralcd.cpp:7312
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:7341
+#: ../../Firmware/ultralcd.cpp:7342
 msgid "Checking sensors"
 msgstr ""
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4765
+#: ../../Firmware/ultralcd.cpp:4784
 msgid "Checks"
 msgstr ""
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2218
+#: ../../Firmware/ultralcd.cpp:2237
 msgid "Color not correct"
 msgstr ""
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3725
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3744
 msgid "Community made"
 msgstr ""
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4704
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4723
 msgid "Cont."
 msgstr ""
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2125
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2144
 msgid "Cooldown"
 msgstr ""
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3663
+#: ../../Firmware/ultralcd.cpp:3682
 msgid "Copy selected language?"
 msgstr ""
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1221
-#: ../../Firmware/ultralcd.cpp:1262 ../../Firmware/ultralcd.cpp:1272
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1240
+#: ../../Firmware/ultralcd.cpp:1281 ../../Firmware/ultralcd.cpp:1291
 msgid "Crash"
 msgstr ""
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4341
-#: ../../Firmware/ultralcd.cpp:4342 ../../Firmware/ultralcd.cpp:4344
-#: ../../Firmware/ultralcd.cpp:5765 ../../Firmware/ultralcd.cpp:5767
-#: ../../Firmware/ultralcd.cpp:5771
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4363
+#: ../../Firmware/ultralcd.cpp:5787 ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/ultralcd.cpp:5793
 msgid "Crash det."
 msgstr ""
 
@@ -361,7 +361,7 @@ msgid "Crash detected."
 msgstr ""
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3521
+#: ../../Firmware/ultralcd.cpp:3540
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -369,14 +369,14 @@ msgid ""
 msgstr ""
 
 #. MSG_CUT_FILAMENT c=17
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:5175
-#: ../../Firmware/ultralcd.cpp:5567
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:5197
+#: ../../Firmware/ultralcd.cpp:5589
 msgid "Cut filament"
 msgstr ""
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:4303
-#: ../../Firmware/ultralcd.cpp:4308 ../../Firmware/ultralcd.cpp:4313
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:4322
+#: ../../Firmware/ultralcd.cpp:4327 ../../Firmware/ultralcd.cpp:4332
 msgid "Cutter"
 msgstr ""
 
@@ -386,17 +386,17 @@ msgid "Cutting filament"
 msgstr ""
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1668
+#: ../../Firmware/ultralcd.cpp:1687
 msgid "Date:"
 msgstr ""
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5886
 msgid "Dim"
 msgstr ""
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4802
+#: ../../Firmware/ultralcd.cpp:4821
 msgid "Disable steppers"
 msgstr ""
 
@@ -410,30 +410,30 @@ msgid ""
 msgstr ""
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:4145
+#: ../../Firmware/ultralcd.cpp:4164
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
 msgstr ""
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4214
+#: ../../Firmware/ultralcd.cpp:4233
 msgid "E-correct:"
 msgstr ""
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2279
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2298
 msgid "ERROR:"
 msgstr ""
 
 #. MSG_FSENS_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3562
+#: ../../Firmware/ultralcd.cpp:3581
 msgid "ERROR: Filament sensor is not responding, please check connection."
 msgstr ""
 
 #. MSG_EJECT_FILAMENT c=17
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:5156
-#: ../../Firmware/ultralcd.cpp:5565
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:5178
+#: ../../Firmware/ultralcd.cpp:5587
 msgid "Eject filament"
 msgstr ""
 
@@ -443,47 +443,41 @@ msgid "Ejecting filament"
 msgstr ""
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6985
+#: ../../Firmware/ultralcd.cpp:7015
 msgid "Endstop"
 msgstr ""
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6990
+#: ../../Firmware/ultralcd.cpp:7020
 msgid "Endstop not hit"
 msgstr ""
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6976
+#: ../../Firmware/ultralcd.cpp:7006
 msgid "Endstops"
 msgstr ""
 
 #. MSG_EXTRUDER c=17
 #: ../../Firmware/Marlin_main.cpp:8608 ../../Firmware/messages.cpp:30
-#: ../../Firmware/ultralcd.cpp:3495
+#: ../../Firmware/ultralcd.cpp:3514
 msgid "Extruder"
 msgstr ""
 
-#. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1144
-#: ../../Firmware/ultralcd.cpp:7319
-msgid "Hotend fan:"
-msgstr ""
-
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1722
+#: ../../Firmware/ultralcd.cpp:1741
 msgid "Extruder info"
 msgstr ""
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4229
-#: ../../Firmware/ultralcd.cpp:4237 ../../Firmware/ultralcd.cpp:4248
-#: ../../Firmware/ultralcd.cpp:4250
+#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4248
+#: ../../Firmware/ultralcd.cpp:4256 ../../Firmware/ultralcd.cpp:4267
+#: ../../Firmware/ultralcd.cpp:4269
 msgid "F. autoload"
 msgstr ""
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4704
-#: ../../Firmware/ultralcd.cpp:4707
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4723
+#: ../../Firmware/ultralcd.cpp:4726
 msgid "FS Action"
 msgstr ""
 
@@ -498,102 +492,102 @@ msgid "FS v0.4 or newer"
 msgstr ""
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5589
+#: ../../Firmware/ultralcd.cpp:5611
 msgid "Fail stats"
 msgstr ""
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5592
+#: ../../Firmware/ultralcd.cpp:5614
 msgid "Fail stats MMU"
 msgstr ""
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:7031
+#: ../../Firmware/ultralcd.cpp:7061
 msgid "False triggering"
 msgstr ""
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:5723
-#: ../../Firmware/ultralcd.cpp:5893
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/ultralcd.cpp:5915
 msgid "Fan speed"
 msgstr ""
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:7143
-#: ../../Firmware/ultralcd.cpp:7301 ../../Firmware/ultralcd.cpp:7302
-#: ../../Firmware/ultralcd.cpp:7303
+#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:7173
+#: ../../Firmware/ultralcd.cpp:7331 ../../Firmware/ultralcd.cpp:7332
+#: ../../Firmware/ultralcd.cpp:7333
 msgid "Fan test"
 msgstr ""
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4811
-#: ../../Firmware/ultralcd.cpp:5756
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4830
+#: ../../Firmware/ultralcd.cpp:5778
 msgid "Fans check"
 msgstr ""
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1220
-#: ../../Firmware/ultralcd.cpp:1261 ../../Firmware/ultralcd.cpp:1327
-#: ../../Firmware/ultralcd.cpp:1329
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1239
+#: ../../Firmware/ultralcd.cpp:1280 ../../Firmware/ultralcd.cpp:1346
+#: ../../Firmware/ultralcd.cpp:1348
 msgid "Fil. runouts"
 msgstr ""
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:3451
-#: ../../Firmware/ultralcd.cpp:4228 ../../Firmware/ultralcd.cpp:4234
-#: ../../Firmware/ultralcd.cpp:4244 ../../Firmware/ultralcd.cpp:5737
-#: ../../Firmware/ultralcd.cpp:5741 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:3470
+#: ../../Firmware/ultralcd.cpp:4247 ../../Firmware/ultralcd.cpp:4253
+#: ../../Firmware/ultralcd.cpp:4263 ../../Firmware/ultralcd.cpp:5759
+#: ../../Firmware/ultralcd.cpp:5763 ../../Firmware/ultralcd.cpp:5767
 msgid "Fil. sensor"
 msgstr ""
 
 #. MSG_FILAMENT c=17
 #: ../../Firmware/Marlin_main.cpp:8577 ../../Firmware/Marlin_main.cpp:8604
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3835
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3854
 msgid "Filament"
 msgstr ""
 
 #. MSG_FILAMENT_CLEAN c=20 r=2
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2287
-#: ../../Firmware/ultralcd.cpp:2293
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2306
+#: ../../Firmware/ultralcd.cpp:2312
 msgid "Filament extruding & with correct color?"
 msgstr ""
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2217
+#: ../../Firmware/ultralcd.cpp:2236
 msgid "Filament not loaded"
 msgstr ""
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:7026
-#: ../../Firmware/ultralcd.cpp:7030 ../../Firmware/ultralcd.cpp:7034
-#: ../../Firmware/ultralcd.cpp:7330
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:7056
+#: ../../Firmware/ultralcd.cpp:7060 ../../Firmware/ultralcd.cpp:7064
+#: ../../Firmware/ultralcd.cpp:7360
 msgid "Filament sensor"
 msgstr ""
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2365
+#: ../../Firmware/ultralcd.cpp:2384
 msgid "Filament used"
 msgstr ""
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7461
+#: ../../Firmware/ultralcd.cpp:7491
 msgid "File incomplete. Continue anyway?"
 msgstr ""
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:5314
-#: ../../Firmware/ultralcd.cpp:5630
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:5336
+#: ../../Firmware/ultralcd.cpp:5652
 msgid "Finishing movements"
 msgstr ""
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:4898
-#: ../../Firmware/ultralcd.cpp:5424
+#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:4917
+#: ../../Firmware/ultralcd.cpp:5446
 msgid "First layer cal."
 msgstr ""
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4066
+#: ../../Firmware/ultralcd.cpp:4085
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 
@@ -603,23 +597,23 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr ""
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5724
+#: ../../Firmware/ultralcd.cpp:5746
 msgid "Flow"
 msgstr ""
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:6996
-#: ../../Firmware/ultralcd.cpp:7149 ../../Firmware/ultralcd.cpp:7154
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:7026
+#: ../../Firmware/ultralcd.cpp:7179 ../../Firmware/ultralcd.cpp:7184
 msgid "Front print fan?"
 msgstr ""
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2754
+#: ../../Firmware/ultralcd.cpp:2773
 msgid "Front side[μm]"
 msgstr ""
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:7020
+#: ../../Firmware/ultralcd.cpp:7050
 msgid "Front/left fans"
 msgstr ""
 
@@ -662,20 +656,20 @@ msgid ""
 msgstr ""
 
 #. MSG_GCODE c=8
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:4655
-#: ../../Firmware/ultralcd.cpp:4658 ../../Firmware/ultralcd.cpp:4661
-#: ../../Firmware/ultralcd.cpp:4664
+#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:4674
+#: ../../Firmware/ultralcd.cpp:4677 ../../Firmware/ultralcd.cpp:4680
+#: ../../Firmware/ultralcd.cpp:4683
 msgid "Gcode"
 msgstr ""
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:4672
-#: ../../Firmware/ultralcd.cpp:4726 ../../Firmware/ultralcd.cpp:4818
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:4691
+#: ../../Firmware/ultralcd.cpp:4745 ../../Firmware/ultralcd.cpp:4837
 msgid "HW Setup"
 msgstr ""
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6968
+#: ../../Firmware/ultralcd.cpp:6998
 msgid "Heater/Thermistor"
 msgstr ""
 
@@ -697,7 +691,7 @@ msgid "Heating done."
 msgstr ""
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=16
-#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4042
+#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4061
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -705,7 +699,7 @@ msgid ""
 msgstr ""
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4064
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -714,24 +708,30 @@ msgstr ""
 "duerch de Setupprozess guideieren?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:4358
-#: ../../Firmware/ultralcd.cpp:4367 ../../Firmware/ultralcd.cpp:5777
-#: ../../Firmware/ultralcd.cpp:5780
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:4377
+#: ../../Firmware/ultralcd.cpp:4386 ../../Firmware/ultralcd.cpp:5799
+#: ../../Firmware/ultralcd.cpp:5802
 msgid "High power"
 msgstr ""
 
+#. MSG_HOTEND_FAN_SPEED c=15
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1145
+#: ../../Firmware/ultralcd.cpp:7351
+msgid "Hotend fan:"
+msgstr ""
+
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4094
 msgid "I will run xyz calibration now. It will take approx. 12 mins."
 msgstr ""
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/ultralcd.cpp:4102
 msgid "I will run z calibration now."
 msgstr ""
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=9
-#: ../../Firmware/ultralcd.cpp:4153
+#: ../../Firmware/ultralcd.cpp:4172
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -743,36 +743,36 @@ msgid "Improving bed calibration point"
 msgstr ""
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:5478
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:5500
 msgid "Info screen"
 msgstr ""
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5545
+#: ../../Firmware/ultralcd.cpp:5567
 msgid "Init. SD card"
 msgstr ""
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2152
+#: ../../Firmware/ultralcd.cpp:2171
 msgid "Insert filament"
 msgstr ""
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:6223
+#: ../../Firmware/ultralcd.cpp:6253
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
 msgstr ""
 
 #. MSG_FILAMENT_LOADED c=20 r=2
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3855
-#: ../../Firmware/ultralcd.cpp:4108 ../../Firmware/ultralcd.cpp:4111
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3874
+#: ../../Firmware/ultralcd.cpp:4127 ../../Firmware/ultralcd.cpp:4130
 msgid "Is filament loaded?"
 msgstr ""
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=2
 #: ../../Firmware/Marlin_main.cpp:3312 ../../Firmware/Marlin_main.cpp:4886
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:4084
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:4103
 msgid "Is steel sheet on heatbed?"
 msgstr ""
 
@@ -782,74 +782,74 @@ msgid "Iteration"
 msgstr ""
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:1148
-#: ../../Firmware/ultralcd.cpp:1296
+#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:1167
+#: ../../Firmware/ultralcd.cpp:1315
 msgid "Last print"
 msgstr ""
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1169
-#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1269
-#: ../../Firmware/ultralcd.cpp:1326
+#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1188
+#: ../../Firmware/ultralcd.cpp:1278 ../../Firmware/ultralcd.cpp:1288
+#: ../../Firmware/ultralcd.cpp:1345
 msgid "Last print failures"
 msgstr ""
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2496
+#: ../../Firmware/ultralcd.cpp:2515
 msgid "Left"
 msgstr ""
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7001
-#: ../../Firmware/ultralcd.cpp:7147 ../../Firmware/ultralcd.cpp:7152
+#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:7032
+#: ../../Firmware/ultralcd.cpp:7179 ../../Firmware/ultralcd.cpp:7184
 msgid "Left hotend fan?"
 msgstr ""
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2752
+#: ../../Firmware/ultralcd.cpp:2771
 msgid "Left side [μm]"
 msgstr ""
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:5862
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:5884
 msgid "Level Bright"
 msgstr ""
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:5863
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:5885
 msgid "Level Dimmed"
 msgstr ""
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4826
+#: ../../Firmware/ultralcd.cpp:4845
 msgid "Lin. correction"
 msgstr ""
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4838
-#: ../../Firmware/ultralcd.cpp:5493
+#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4857
+#: ../../Firmware/ultralcd.cpp:5515
 msgid "Live adjust Z"
 msgstr ""
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/ultralcd.cpp:5120
+#: ../../Firmware/ultralcd.cpp:5142
 msgid "Load all"
 msgstr ""
 
 #. MSG_LOAD_FILAMENT c=17
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:5122
-#: ../../Firmware/ultralcd.cpp:5133 ../../Firmware/ultralcd.cpp:5562
-#: ../../Firmware/ultralcd.cpp:5576
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:5144
+#: ../../Firmware/ultralcd.cpp:5155 ../../Firmware/ultralcd.cpp:5584
+#: ../../Firmware/ultralcd.cpp:5598
 msgid "Load filament"
 msgstr ""
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5563
+#: ../../Firmware/ultralcd.cpp:5585
 msgid "Load to nozzle"
 msgstr ""
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2185
+#: ../../Firmware/ultralcd.cpp:2204
 msgid "Loading color"
 msgstr ""
 
@@ -857,18 +857,18 @@ msgstr ""
 #: ../../Firmware/Marlin_main.cpp:3641 ../../Firmware/messages.cpp:55
 #: ../../Firmware/mmu.cpp:872 ../../Firmware/mmu.cpp:906
 #: ../../Firmware/mmu.cpp:1014 ../../Firmware/mmu.cpp:1026
-#: ../../Firmware/ultralcd.cpp:2196 ../../Firmware/ultralcd.cpp:3949
+#: ../../Firmware/ultralcd.cpp:2215 ../../Firmware/ultralcd.cpp:3968
 msgid "Loading filament"
 msgstr ""
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:7008
+#: ../../Firmware/ultralcd.cpp:7038
 msgid "Loose pulley"
 msgstr ""
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:4450
-#: ../../Firmware/ultralcd.cpp:4462
+#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/ultralcd.cpp:4481
 msgid "Loud"
 msgstr ""
 
@@ -883,8 +883,8 @@ msgid "MK3S firmware detected on MK3 printer"
 msgstr ""
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4381
-#: ../../Firmware/ultralcd.cpp:4382
+#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4400
+#: ../../Firmware/ultralcd.cpp:4401
 msgid "MMU Mode"
 msgstr ""
 
@@ -904,8 +904,8 @@ msgid "MMU OK. Resuming..."
 msgstr ""
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:64 ../../Firmware/ultralcd.cpp:1170
-#: ../../Firmware/ultralcd.cpp:1193
+#: ../../Firmware/messages.cpp:64 ../../Firmware/ultralcd.cpp:1189
+#: ../../Firmware/ultralcd.cpp:1212
 msgid "MMU fails"
 msgstr ""
 
@@ -915,8 +915,8 @@ msgid "MMU load failed"
 msgstr ""
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:1171
-#: ../../Firmware/ultralcd.cpp:1194
+#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:1190
+#: ../../Firmware/ultralcd.cpp:1213
 msgid "MMU load fails"
 msgstr ""
 
@@ -926,32 +926,32 @@ msgid "MMU needs user attention."
 msgstr ""
 
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/ultralcd.cpp:1195
+#: ../../Firmware/ultralcd.cpp:1214
 msgid "MMU power fails"
 msgstr ""
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1680
+#: ../../Firmware/ultralcd.cpp:1699
 msgid "MMU2 connected"
 msgstr ""
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:5836
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:5858
 msgid "Magnets comp."
 msgstr ""
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1147
-#: ../../Firmware/ultralcd.cpp:1295 ../../Firmware/ultralcd.cpp:1338
-#: ../../Firmware/ultralcd.cpp:1645 ../../Firmware/ultralcd.cpp:4795
-#: ../../Firmware/ultralcd.cpp:4892 ../../Firmware/ultralcd.cpp:5119
-#: ../../Firmware/ultralcd.cpp:5131 ../../Firmware/ultralcd.cpp:5154
-#: ../../Firmware/ultralcd.cpp:5173 ../../Firmware/ultralcd.cpp:5717
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1166
+#: ../../Firmware/ultralcd.cpp:1314 ../../Firmware/ultralcd.cpp:1357
+#: ../../Firmware/ultralcd.cpp:1664 ../../Firmware/ultralcd.cpp:4814
+#: ../../Firmware/ultralcd.cpp:4911 ../../Firmware/ultralcd.cpp:5141
+#: ../../Firmware/ultralcd.cpp:5153 ../../Firmware/ultralcd.cpp:5176
+#: ../../Firmware/ultralcd.cpp:5195 ../../Firmware/ultralcd.cpp:5739
 msgid "Main"
 msgstr ""
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2537
+#: ../../Firmware/ultralcd.cpp:2556
 msgid "Measured skew"
 msgstr ""
 
@@ -962,71 +962,71 @@ msgid "Measuring reference height of calibration point"
 msgstr ""
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:5832
+#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:5854
 msgid "Mesh"
 msgstr ""
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4823
-#: ../../Firmware/ultralcd.cpp:4910
+#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4842
+#: ../../Firmware/ultralcd.cpp:4929
 msgid "Mesh Bed Leveling"
 msgstr ""
 
 #. MSG_MODE c=6
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:4336
-#: ../../Firmware/ultralcd.cpp:4338 ../../Firmware/ultralcd.cpp:4358
-#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4364
-#: ../../Firmware/ultralcd.cpp:4367 ../../Firmware/ultralcd.cpp:5763
-#: ../../Firmware/ultralcd.cpp:5770 ../../Firmware/ultralcd.cpp:5777
-#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5779
-#: ../../Firmware/ultralcd.cpp:5780 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/ultralcd.cpp:4357 ../../Firmware/ultralcd.cpp:4377
+#: ../../Firmware/ultralcd.cpp:4380 ../../Firmware/ultralcd.cpp:4383
+#: ../../Firmware/ultralcd.cpp:4386 ../../Firmware/ultralcd.cpp:5785
+#: ../../Firmware/ultralcd.cpp:5792 ../../Firmware/ultralcd.cpp:5799
+#: ../../Firmware/ultralcd.cpp:5800 ../../Firmware/ultralcd.cpp:5801
+#: ../../Firmware/ultralcd.cpp:5802 ../../Firmware/ultralcd.cpp:5886
 msgid "Mode"
 msgstr ""
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3598
+#: ../../Firmware/ultralcd.cpp:3617
 msgid "Mode change in progress..."
 msgstr ""
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:4575
-#: ../../Firmware/ultralcd.cpp:4578 ../../Firmware/ultralcd.cpp:4581
-#: ../../Firmware/ultralcd.cpp:4584
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:4594
+#: ../../Firmware/ultralcd.cpp:4597 ../../Firmware/ultralcd.cpp:4600
+#: ../../Firmware/ultralcd.cpp:4603
 msgid "Model"
 msgstr ""
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6982
-#: ../../Firmware/ultralcd.cpp:6991 ../../Firmware/ultralcd.cpp:7009
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:7012
+#: ../../Firmware/ultralcd.cpp:7021 ../../Firmware/ultralcd.cpp:7039
 msgid "Motor"
 msgstr ""
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3492
+#: ../../Firmware/ultralcd.cpp:3511
 msgid "Move X"
 msgstr ""
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3493
+#: ../../Firmware/ultralcd.cpp:3512
 msgid "Move Y"
 msgstr ""
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3494
+#: ../../Firmware/ultralcd.cpp:3513
 msgid "Move Z"
 msgstr ""
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4801
+#: ../../Firmware/ultralcd.cpp:4820
 msgid "Move axis"
 msgstr ""
 
 #. MSG_NA c=3
 #: ../../Firmware/menu.cpp:196 ../../Firmware/messages.cpp:124
-#: ../../Firmware/ultralcd.cpp:2502 ../../Firmware/ultralcd.cpp:2547
-#: ../../Firmware/ultralcd.cpp:3411 ../../Firmware/ultralcd.cpp:4228
-#: ../../Firmware/ultralcd.cpp:4276 ../../Firmware/ultralcd.cpp:5737
-#: ../../Firmware/ultralcd.cpp:5836
+#: ../../Firmware/ultralcd.cpp:2521 ../../Firmware/ultralcd.cpp:2566
+#: ../../Firmware/ultralcd.cpp:3430 ../../Firmware/ultralcd.cpp:4247
+#: ../../Firmware/ultralcd.cpp:4295 ../../Firmware/ultralcd.cpp:5759
+#: ../../Firmware/ultralcd.cpp:5858
 msgid "N/A"
 msgstr ""
 
@@ -1036,14 +1036,14 @@ msgid "New firmware version available:"
 msgstr ""
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:2804
-#: ../../Firmware/ultralcd.cpp:3180 ../../Firmware/ultralcd.cpp:4785
-#: ../../Firmware/ultralcd.cpp:5988
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:2823
+#: ../../Firmware/ultralcd.cpp:3199 ../../Firmware/ultralcd.cpp:4804
+#: ../../Firmware/ultralcd.cpp:6018
 msgid "No"
 msgstr ""
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5543
+#: ../../Firmware/ultralcd.cpp:5565
 msgid "No SD card"
 msgstr ""
 
@@ -1053,71 +1053,71 @@ msgid "No move."
 msgstr ""
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4405
-#: ../../Firmware/ultralcd.cpp:4493 ../../Firmware/ultralcd.cpp:4502
-#: ../../Firmware/ultralcd.cpp:4575 ../../Firmware/ultralcd.cpp:4584
-#: ../../Firmware/ultralcd.cpp:4614 ../../Firmware/ultralcd.cpp:4623
-#: ../../Firmware/ultralcd.cpp:4655 ../../Firmware/ultralcd.cpp:4664
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4424
+#: ../../Firmware/ultralcd.cpp:4512 ../../Firmware/ultralcd.cpp:4521
+#: ../../Firmware/ultralcd.cpp:4594 ../../Firmware/ultralcd.cpp:4603
+#: ../../Firmware/ultralcd.cpp:4633 ../../Firmware/ultralcd.cpp:4642
+#: ../../Firmware/ultralcd.cpp:4674 ../../Firmware/ultralcd.cpp:4683
 msgid "None"
 msgstr ""
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:4336
-#: ../../Firmware/ultralcd.cpp:4381 ../../Firmware/ultralcd.cpp:4397
-#: ../../Firmware/ultralcd.cpp:4416 ../../Firmware/ultralcd.cpp:5763
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/ultralcd.cpp:4400 ../../Firmware/ultralcd.cpp:4416
+#: ../../Firmware/ultralcd.cpp:4435 ../../Firmware/ultralcd.cpp:5785
 msgid "Normal"
 msgstr ""
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6969
+#: ../../Firmware/ultralcd.cpp:6999
 msgid "Not connected"
 msgstr ""
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:7168
-#: ../../Firmware/ultralcd.cpp:7183 ../../Firmware/ultralcd.cpp:7191
+#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:7198
+#: ../../Firmware/ultralcd.cpp:7213 ../../Firmware/ultralcd.cpp:7221
 msgid "Not spinning"
 msgstr ""
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3962
+#: ../../Firmware/ultralcd.cpp:3981
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr ""
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:4091
+#: ../../Firmware/ultralcd.cpp:4110
 msgid "Now I will preheat nozzle for PLA."
 msgstr ""
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/ultralcd.cpp:4101
 msgid "Now remove the test print from steel sheet."
 msgstr ""
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:1402
-#: ../../Firmware/ultralcd.cpp:4493 ../../Firmware/ultralcd.cpp:4496
-#: ../../Firmware/ultralcd.cpp:4499 ../../Firmware/ultralcd.cpp:4502
-#: ../../Firmware/ultralcd.cpp:5720 ../../Firmware/ultralcd.cpp:5882
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:1421
+#: ../../Firmware/ultralcd.cpp:4512 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/ultralcd.cpp:4518 ../../Firmware/ultralcd.cpp:4521
+#: ../../Firmware/ultralcd.cpp:5742 ../../Firmware/ultralcd.cpp:5904
 msgid "Nozzle"
 msgstr ""
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4546
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4565
 msgid "Nozzle d."
 msgstr ""
 
 #. MSG_OFF c=3
 #: ../../Firmware/menu.cpp:467 ../../Firmware/messages.cpp:122
-#: ../../Firmware/ultralcd.cpp:4234 ../../Firmware/ultralcd.cpp:4250
-#: ../../Firmware/ultralcd.cpp:4284 ../../Firmware/ultralcd.cpp:4313
-#: ../../Firmware/ultralcd.cpp:4342 ../../Firmware/ultralcd.cpp:4811
-#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4834
-#: ../../Firmware/ultralcd.cpp:5644 ../../Firmware/ultralcd.cpp:5741
-#: ../../Firmware/ultralcd.cpp:5756 ../../Firmware/ultralcd.cpp:5767
-#: ../../Firmware/ultralcd.cpp:5836 ../../Firmware/ultralcd.cpp:7841
-#: ../../Firmware/ultralcd.cpp:7845
+#: ../../Firmware/ultralcd.cpp:4253 ../../Firmware/ultralcd.cpp:4269
+#: ../../Firmware/ultralcd.cpp:4303 ../../Firmware/ultralcd.cpp:4332
+#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4830
+#: ../../Firmware/ultralcd.cpp:4849 ../../Firmware/ultralcd.cpp:4853
+#: ../../Firmware/ultralcd.cpp:5666 ../../Firmware/ultralcd.cpp:5763
+#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/ultralcd.cpp:5858 ../../Firmware/ultralcd.cpp:7881
+#: ../../Firmware/ultralcd.cpp:7885
 msgid "Off"
 msgstr ""
 
@@ -1127,19 +1127,19 @@ msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr ""
 
 #. MSG_ON c=3
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4244
-#: ../../Firmware/ultralcd.cpp:4248 ../../Firmware/ultralcd.cpp:4280
-#: ../../Firmware/ultralcd.cpp:4303 ../../Firmware/ultralcd.cpp:4341
-#: ../../Firmware/ultralcd.cpp:4811 ../../Firmware/ultralcd.cpp:4830
-#: ../../Firmware/ultralcd.cpp:4834 ../../Firmware/ultralcd.cpp:5745
-#: ../../Firmware/ultralcd.cpp:5756 ../../Firmware/ultralcd.cpp:5765
-#: ../../Firmware/ultralcd.cpp:5836 ../../Firmware/ultralcd.cpp:7841
-#: ../../Firmware/ultralcd.cpp:7845
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4263
+#: ../../Firmware/ultralcd.cpp:4267 ../../Firmware/ultralcd.cpp:4299
+#: ../../Firmware/ultralcd.cpp:4322 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4849
+#: ../../Firmware/ultralcd.cpp:4853 ../../Firmware/ultralcd.cpp:5767
+#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5787
+#: ../../Firmware/ultralcd.cpp:5858 ../../Firmware/ultralcd.cpp:7881
+#: ../../Firmware/ultralcd.cpp:7885
 msgid "On"
 msgstr ""
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4453
+#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4472
 msgid "Once"
 msgstr ""
 
@@ -1159,7 +1159,7 @@ msgid "PID cal. finished"
 msgstr ""
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4913
+#: ../../Firmware/ultralcd.cpp:4932
 msgid "PID calibration"
 msgstr ""
 
@@ -1171,31 +1171,31 @@ msgstr ""
 #. MSG_PINDA_CALIBRATION c=13
 #: ../../Firmware/Marlin_main.cpp:4932 ../../Firmware/Marlin_main.cpp:5035
 #: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:654
-#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4920
+#: ../../Firmware/ultralcd.cpp:4849 ../../Firmware/ultralcd.cpp:4939
 msgid "PINDA cal."
 msgstr ""
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3361
+#: ../../Firmware/ultralcd.cpp:3380
 msgid "PINDA calibration failed"
 msgstr ""
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
 #: ../../Firmware/Marlin_main.cpp:5112 ../../Firmware/messages.cpp:110
-#: ../../Firmware/ultralcd.cpp:3355
+#: ../../Firmware/ultralcd.cpp:3374
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
 msgstr ""
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4707
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4726
 msgid "Pause"
 msgstr ""
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:5507
-#: ../../Firmware/ultralcd.cpp:5509
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:5529
+#: ../../Firmware/ultralcd.cpp:5531
 msgid "Pause print"
 msgstr ""
 
@@ -1207,24 +1207,24 @@ msgid ""
 msgstr ""
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:4176
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:4195
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
 msgstr ""
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:6250
+#: ../../Firmware/ultralcd.cpp:6280
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr ""
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6963
+#: ../../Firmware/ultralcd.cpp:6993
 msgid "Please check:"
 msgstr ""
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4148
+#: ../../Firmware/ultralcd.cpp:4167
 msgid "Please clean heatbed and then press the knob."
 msgstr ""
 
@@ -1234,20 +1234,20 @@ msgid "Please clean the nozzle for calibration. Click when done."
 msgstr ""
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3945
+#: ../../Firmware/ultralcd.cpp:3964
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr ""
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3940
+#: ../../Firmware/ultralcd.cpp:3959
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
 msgstr ""
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3863
+#: ../../Firmware/ultralcd.cpp:3882
 msgid "Please load filament first."
 msgstr ""
 
@@ -1258,7 +1258,7 @@ msgstr ""
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=5
 #: ../../Firmware/mesh_bed_calibration.cpp:2799 ../../Firmware/messages.cpp:70
-#: ../../Firmware/ultralcd.cpp:4085
+#: ../../Firmware/ultralcd.cpp:4104
 msgid "Please place steel sheet on heatbed."
 msgstr ""
 
@@ -1269,7 +1269,7 @@ msgid "Please press the knob to unload filament"
 msgstr ""
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:5213
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:5235
 msgid "Please pull out filament immediately"
 msgstr ""
 
@@ -1279,7 +1279,7 @@ msgid "Please remove filament and then press the knob."
 msgstr ""
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:4081
+#: ../../Firmware/ultralcd.cpp:4100
 msgid "Please remove shipping helpers first."
 msgstr ""
 
@@ -1295,7 +1295,7 @@ msgid "Please run XYZ calibration first."
 msgstr ""
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:6247
+#: ../../Firmware/ultralcd.cpp:6277
 msgid "Please unload the filament first, then repeat this action."
 msgstr ""
 
@@ -1312,54 +1312,54 @@ msgstr ""
 #. MSG_PLEASE_WAIT c=20
 #: ../../Firmware/Marlin_main.cpp:3547 ../../Firmware/Marlin_main.cpp:3563
 #: ../../Firmware/Marlin_main.cpp:7931 ../../Firmware/messages.cpp:71
-#: ../../Firmware/ultralcd.cpp:2186 ../../Firmware/ultralcd.cpp:2197
+#: ../../Firmware/ultralcd.cpp:2205 ../../Firmware/ultralcd.cpp:2216
 msgid "Please wait"
 msgstr ""
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1219
-#: ../../Firmware/ultralcd.cpp:1260 ../../Firmware/ultralcd.cpp:1270
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1238
+#: ../../Firmware/ultralcd.cpp:1279 ../../Firmware/ultralcd.cpp:1289
 msgid "Power failures"
 msgstr ""
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5502
+#: ../../Firmware/ultralcd.cpp:5524
 msgid "Preheat"
 msgstr ""
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:2280
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:2299
 msgid "Preheat the nozzle!"
 msgstr ""
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:2900
-#: ../../Firmware/ultralcd.cpp:3924 ../../Firmware/ultralcd.cpp:3926
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:2919
+#: ../../Firmware/ultralcd.cpp:3943 ../../Firmware/ultralcd.cpp:3945
 msgid "Preheating nozzle. Please wait."
 msgstr ""
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1988
+#: ../../Firmware/ultralcd.cpp:2007
 msgid "Preheating to cut"
 msgstr ""
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1985
+#: ../../Firmware/ultralcd.cpp:2004
 msgid "Preheating to eject"
 msgstr ""
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1976
+#: ../../Firmware/ultralcd.cpp:1995
 msgid "Preheating to load"
 msgstr ""
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1981
+#: ../../Firmware/ultralcd.cpp:2000
 msgid "Preheating to unload"
 msgstr ""
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1809
+#: ../../Firmware/ultralcd.cpp:1828
 msgid "Press the knob"
 msgstr ""
 
@@ -1379,13 +1379,13 @@ msgid "Print aborted"
 msgstr ""
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1144
-#: ../../Firmware/ultralcd.cpp:7322
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1145
+#: ../../Firmware/ultralcd.cpp:7354
 msgid "Print fan:"
 msgstr ""
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5535
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5557
 msgid "Print from SD"
 msgstr ""
 
@@ -1395,12 +1395,12 @@ msgid "Print paused"
 msgstr ""
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2366
+#: ../../Firmware/ultralcd.cpp:2385
 msgid "Print time"
 msgstr ""
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1711
+#: ../../Firmware/ultralcd.cpp:1730
 msgid "Printer IP Addr:"
 msgstr ""
 
@@ -1424,12 +1424,12 @@ msgid ""
 msgstr ""
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4834
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4853
 msgid "RPi port"
 msgstr ""
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2755
+#: ../../Firmware/ultralcd.cpp:2774
 msgid "Rear side [μm]"
 msgstr ""
 
@@ -1444,24 +1444,24 @@ msgid "Remove old filament and press the knob to start loading new filament."
 msgstr ""
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5426
+#: ../../Firmware/ultralcd.cpp:5448
 msgid "Rename"
 msgstr ""
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2756
-#: ../../Firmware/ultralcd.cpp:5427
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2775
+#: ../../Firmware/ultralcd.cpp:5449
 msgid "Reset"
 msgstr ""
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4917
+#: ../../Firmware/ultralcd.cpp:4936
 msgid "Reset XYZ calibr."
 msgstr ""
 
 #. MSG_RESUME_PRINT c=18
 #: ../../Firmware/Marlin_main.cpp:655 ../../Firmware/messages.cpp:81
-#: ../../Firmware/ultralcd.cpp:5521 ../../Firmware/ultralcd.cpp:5523
+#: ../../Firmware/ultralcd.cpp:5543 ../../Firmware/ultralcd.cpp:5545
 msgid "Resume print"
 msgstr ""
 
@@ -1471,31 +1471,31 @@ msgid "Resuming print"
 msgstr ""
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2497
+#: ../../Firmware/ultralcd.cpp:2516
 msgid "Right"
 msgstr ""
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2753
+#: ../../Firmware/ultralcd.cpp:2772
 msgid "Right side[μm]"
 msgstr ""
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3884
+#: ../../Firmware/ultralcd.cpp:3903
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
 msgstr ""
 
 #. MSG_RUNOUTS c=7
-#: ../../Firmware/ultralcd.cpp:1271
+#: ../../Firmware/ultralcd.cpp:1290
 msgid "Runouts"
 msgstr ""
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4395
-#: ../../Firmware/ultralcd.cpp:4397 ../../Firmware/ultralcd.cpp:4414
-#: ../../Firmware/ultralcd.cpp:4416
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4414
+#: ../../Firmware/ultralcd.cpp:4416 ../../Firmware/ultralcd.cpp:4433
+#: ../../Firmware/ultralcd.cpp:4435
 msgid "SD card"
 msgstr ""
 
@@ -1511,12 +1511,12 @@ msgid "Searching bed calibration point"
 msgstr ""
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5419
+#: ../../Firmware/ultralcd.cpp:5441
 msgid "Select"
 msgstr ""
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3966
+#: ../../Firmware/ultralcd.cpp:3985
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
@@ -1529,49 +1529,49 @@ msgstr ""
 
 #. MSG_SELECT_FILAMENT c=20
 #: ../../Firmware/Marlin_main.cpp:8577 ../../Firmware/Marlin_main.cpp:8604
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3834
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3853
 msgid "Select filament:"
 msgstr ""
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:3679
-#: ../../Firmware/ultralcd.cpp:4841
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:3698
+#: ../../Firmware/ultralcd.cpp:4860
 msgid "Select language"
 msgstr ""
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:4122
+#: ../../Firmware/ultralcd.cpp:4141
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr ""
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3971
+#: ../../Firmware/ultralcd.cpp:3990
 msgid "Select temperature which matches your material."
 msgstr ""
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6522
+#: ../../Firmware/ultralcd.cpp:6552
 msgid "Self test OK"
 msgstr ""
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:6290
+#: ../../Firmware/ultralcd.cpp:6320
 msgid "Self test start"
 msgstr ""
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4904
+#: ../../Firmware/ultralcd.cpp:4923
 msgid "Selftest"
 msgstr ""
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6962
+#: ../../Firmware/ultralcd.cpp:6992
 msgid "Selftest error!"
 msgstr ""
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:6526
-#: ../../Firmware/ultralcd.cpp:7049 ../../Firmware/ultralcd.cpp:7314
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:6556
+#: ../../Firmware/ultralcd.cpp:7079 ../../Firmware/ultralcd.cpp:7344
 msgid "Selftest failed"
 msgstr ""
 
@@ -1581,30 +1581,30 @@ msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr ""
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1723
+#: ../../Firmware/ultralcd.cpp:1742
 msgid "Sensor info"
 msgstr ""
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:6254
+#: ../../Firmware/ultralcd.cpp:6284
 msgid "Sensor verified, remove the filament now."
 msgstr ""
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2773
+#: ../../Firmware/ultralcd.cpp:2792
 msgid "Set temperature:"
 msgstr ""
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:3491
-#: ../../Firmware/ultralcd.cpp:3696 ../../Firmware/ultralcd.cpp:4206
-#: ../../Firmware/ultralcd.cpp:5580 ../../Firmware/ultralcd.cpp:5827
-#: ../../Firmware/ultralcd.cpp:5880
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:3510
+#: ../../Firmware/ultralcd.cpp:3715 ../../Firmware/ultralcd.cpp:4225
+#: ../../Firmware/ultralcd.cpp:5602 ../../Firmware/ultralcd.cpp:5849
+#: ../../Firmware/ultralcd.cpp:5902
 msgid "Settings"
 msgstr ""
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2540
+#: ../../Firmware/ultralcd.cpp:2559
 msgid "Severe skew"
 msgstr ""
 
@@ -1615,7 +1615,7 @@ msgid "Sheet"
 msgstr ""
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3824
+#: ../../Firmware/ultralcd.cpp:3843
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1624,18 +1624,18 @@ msgid ""
 msgstr ""
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4915
+#: ../../Firmware/ultralcd.cpp:4934
 msgid "Show end stops"
 msgstr ""
 
 #. MSG_SILENT c=7
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4361
-#: ../../Firmware/ultralcd.cpp:4456 ../../Firmware/ultralcd.cpp:5778
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4380
+#: ../../Firmware/ultralcd.cpp:4475 ../../Firmware/ultralcd.cpp:5800
 msgid "Silent"
 msgstr ""
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2539
+#: ../../Firmware/ultralcd.cpp:2558
 msgid "Slight skew"
 msgstr ""
 
@@ -1652,8 +1652,8 @@ msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr ""
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4403
-#: ../../Firmware/ultralcd.cpp:4404 ../../Firmware/ultralcd.cpp:4405
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4422
+#: ../../Firmware/ultralcd.cpp:4423 ../../Firmware/ultralcd.cpp:4424
 msgid "Sort"
 msgstr ""
 
@@ -1664,20 +1664,20 @@ msgid "Sorting files"
 msgstr ""
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4450
-#: ../../Firmware/ultralcd.cpp:4453 ../../Firmware/ultralcd.cpp:4456
-#: ../../Firmware/ultralcd.cpp:4459 ../../Firmware/ultralcd.cpp:4462
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/ultralcd.cpp:4472 ../../Firmware/ultralcd.cpp:4475
+#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4481
 msgid "Sound"
 msgstr ""
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5718
+#: ../../Firmware/ultralcd.cpp:5740
 msgid "Speed"
 msgstr ""
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7166
-#: ../../Firmware/ultralcd.cpp:7181 ../../Firmware/ultralcd.cpp:7189
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7196
+#: ../../Firmware/ultralcd.cpp:7211 ../../Firmware/ultralcd.cpp:7219
 msgid "Spinning"
 msgstr ""
 
@@ -1687,42 +1687,42 @@ msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr ""
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5585
+#: ../../Firmware/ultralcd.cpp:5607
 msgid "Statistics"
 msgstr ""
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4338
-#: ../../Firmware/ultralcd.cpp:4382 ../../Firmware/ultralcd.cpp:5770
+#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4357
+#: ../../Firmware/ultralcd.cpp:4401 ../../Firmware/ultralcd.cpp:5792
 msgid "Stealth"
 msgstr ""
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4763
-#: ../../Firmware/ultralcd.cpp:5416
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4782
+#: ../../Firmware/ultralcd.cpp:5438
 msgid "Steel sheets"
 msgstr ""
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5528
-#: ../../Firmware/ultralcd.cpp:5987
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5550
+#: ../../Firmware/ultralcd.cpp:6017
 msgid "Stop print"
 msgstr ""
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4499
-#: ../../Firmware/ultralcd.cpp:4581 ../../Firmware/ultralcd.cpp:4620
-#: ../../Firmware/ultralcd.cpp:4661
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4518
+#: ../../Firmware/ultralcd.cpp:4600 ../../Firmware/ultralcd.cpp:4639
+#: ../../Firmware/ultralcd.cpp:4680
 msgid "Strict"
 msgstr ""
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/ultralcd.cpp:5616
 msgid "Support"
 msgstr ""
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:7021
+#: ../../Firmware/ultralcd.cpp:7051
 msgid "Swapped"
 msgstr ""
 
@@ -1731,28 +1731,18 @@ msgstr ""
 msgid "THERMAL ANOMALY"
 msgstr ""
 
-#. MSG_TM_AUTOTUNE_FAILED c=20
-#: ../../Firmware/temperature.cpp:2899
-msgid "TM autotune failed"
-msgstr ""
-
-#. MSG_TEMP_MODEL_AUTOTUNE c=20
-#: ../../Firmware/temperature.cpp:2884
-msgid "Temp. model autotune"
-msgstr ""
-
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4797
+#: ../../Firmware/ultralcd.cpp:4816
 msgid "Temperature"
 msgstr ""
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1729
+#: ../../Firmware/ultralcd.cpp:1748
 msgid "Temperatures"
 msgstr ""
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3974
+#: ../../Firmware/ultralcd.cpp:3993
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -1767,66 +1757,66 @@ msgid ""
 msgstr ""
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4403
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4422
 msgid "Time"
 msgstr ""
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:5865
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:5887
 msgid "Timeout"
 msgstr ""
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:1149
-#: ../../Firmware/ultralcd.cpp:1297
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:1168
+#: ../../Firmware/ultralcd.cpp:1316
 msgid "Total"
 msgstr ""
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:1192
-#: ../../Firmware/ultralcd.cpp:1218 ../../Firmware/ultralcd.cpp:1328
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:1211
+#: ../../Firmware/ultralcd.cpp:1237 ../../Firmware/ultralcd.cpp:1347
 msgid "Total failures"
 msgstr ""
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2387
+#: ../../Firmware/ultralcd.cpp:2406
 msgid "Total filament"
 msgstr ""
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2388
+#: ../../Firmware/ultralcd.cpp:2407
 msgid "Total print time"
 msgstr ""
 
 #. MSG_TUNE c=18
-#: ../../Firmware/ultralcd.cpp:5500
+#: ../../Firmware/ultralcd.cpp:5522
 msgid "Tune"
 msgstr ""
 
 #. MSG_UNLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:5564
-#: ../../Firmware/ultralcd.cpp:5578
+#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:5586
+#: ../../Firmware/ultralcd.cpp:5600
 msgid "Unload filament"
 msgstr ""
 
 #. MSG_UNLOADING_FILAMENT c=20
 #: ../../Firmware/messages.cpp:112 ../../Firmware/mmu.cpp:957
-#: ../../Firmware/ultralcd.cpp:5197
+#: ../../Firmware/ultralcd.cpp:5219
 msgid "Unloading filament"
 msgstr ""
 
 #. MSG_FIL_FAILED c=20 r=5
-#: ../../Firmware/ultralcd.cpp:6258
+#: ../../Firmware/ultralcd.cpp:6288
 msgid "Verification failed, remove the filament and try again."
 msgstr ""
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1732
+#: ../../Firmware/ultralcd.cpp:1751
 msgid "Voltages"
 msgstr ""
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3534
+#: ../../Firmware/ultralcd.cpp:3553
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -1840,19 +1830,19 @@ msgid "Wait for user..."
 msgstr ""
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2881
+#: ../../Firmware/ultralcd.cpp:2900
 msgid "Waiting for PINDA probe cooling"
 msgstr ""
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2913
+#: ../../Firmware/ultralcd.cpp:2932
 msgid "Waiting for nozzle and bed cooling"
 msgstr ""
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:4496
-#: ../../Firmware/ultralcd.cpp:4578 ../../Firmware/ultralcd.cpp:4617
-#: ../../Firmware/ultralcd.cpp:4658
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/ultralcd.cpp:4597 ../../Firmware/ultralcd.cpp:4636
+#: ../../Firmware/ultralcd.cpp:4677
 msgid "Warn"
 msgstr ""
 
@@ -1877,144 +1867,133 @@ msgid "Was filament unload successful?"
 msgstr ""
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6973
-#: ../../Firmware/ultralcd.cpp:6977 ../../Firmware/ultralcd.cpp:6997
-#: ../../Firmware/ultralcd.cpp:7003 ../../Firmware/ultralcd.cpp:7027
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:7003
+#: ../../Firmware/ultralcd.cpp:7007 ../../Firmware/ultralcd.cpp:7027
+#: ../../Firmware/ultralcd.cpp:7033 ../../Firmware/ultralcd.cpp:7057
 msgid "Wiring error"
 msgstr ""
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4895
+#: ../../Firmware/ultralcd.cpp:4914
 msgid "Wizard"
 msgstr ""
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4210
+#: ../../Firmware/ultralcd.cpp:4229
 msgid "X-correct:"
 msgstr ""
 
 #. MSG_XFLASH c=18
-#: ../../Firmware/ultralcd.cpp:5596
+#: ../../Firmware/ultralcd.cpp:5618
 msgid "XFLASH init"
 msgstr ""
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1721
+#: ../../Firmware/ultralcd.cpp:1740
 msgid "XYZ cal. details"
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3333
+#: ../../Firmware/ultralcd.cpp:3352
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3330
+#: ../../Firmware/ultralcd.cpp:3349
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3311
+#: ../../Firmware/ultralcd.cpp:3330
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr ""
 
-#. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_LEFT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3317
-msgid ""
-"XYZ calibration compromised. Left front calibration point not reachable."
-msgstr ""
-
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3314
+#: ../../Firmware/ultralcd.cpp:3333
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3293
+#: ../../Firmware/ultralcd.cpp:3312
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3299
+#: ../../Firmware/ultralcd.cpp:3318
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr ""
 
-#. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_LEFT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3305
-msgid "XYZ calibration failed. Left front calibration point not reachable."
-msgstr ""
-
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3296
-#: ../../Firmware/ultralcd.cpp:3324
+#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3315
+#: ../../Firmware/ultralcd.cpp:3343
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3302
+#: ../../Firmware/ultralcd.cpp:3321
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3327
+#: ../../Firmware/ultralcd.cpp:3346
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr ""
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2494
+#: ../../Firmware/ultralcd.cpp:2513
 msgid "Y distance from min"
 msgstr ""
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4211
+#: ../../Firmware/ultralcd.cpp:4230
 msgid "Y-correct:"
 msgstr ""
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:2216
-#: ../../Firmware/ultralcd.cpp:2800 ../../Firmware/ultralcd.cpp:3180
-#: ../../Firmware/ultralcd.cpp:4785 ../../Firmware/ultralcd.cpp:5989
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:2235
+#: ../../Firmware/ultralcd.cpp:2819 ../../Firmware/ultralcd.cpp:3199
+#: ../../Firmware/ultralcd.cpp:4804 ../../Firmware/ultralcd.cpp:6019
 msgid "Yes"
 msgstr ""
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:4187
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:4206
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr ""
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4231
 msgid "Z-correct:"
 msgstr ""
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:5835
+#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:5857
 msgid "Z-probe nr."
 msgstr ""
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2565
+#: ../../Firmware/ultralcd.cpp:2584
 msgid "[0;0] point offset"
 msgstr ""
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2154
+#: ../../Firmware/ultralcd.cpp:2173
 msgid "and press the knob"
 msgstr ""
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1816
+#: ../../Firmware/ultralcd.cpp:1835
 msgid "to load filament"
 msgstr ""
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1820
+#: ../../Firmware/ultralcd.cpp:1839
 msgid "to unload filament"
 msgstr ""
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1688
+#: ../../Firmware/ultralcd.cpp:1707
 msgid "unknown"
 msgstr ""
 
@@ -2024,7 +2003,7 @@ msgid "unknown state"
 msgstr ""
 
 #. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:6077
-#: ../../Firmware/ultralcd.cpp:6080
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:6107
+#: ../../Firmware/ultralcd.cpp:6110
 msgid "🔃Refresh"
 msgstr ""

--- a/lang/po/Firmware_lt.po
+++ b/lang/po/Firmware_lt.po
@@ -26,113 +26,113 @@ msgid " 0.4 or newer"
 msgstr ""
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:7036
+#: ../../Firmware/ultralcd.cpp:7066
 msgid "%s level expected"
 msgstr ""
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1968
-#: ../../Firmware/ultralcd.cpp:3835
+#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1987
+#: ../../Firmware/ultralcd.cpp:3854
 msgid ">Cancel"
 msgstr ""
 
 #. MSG_BABYSTEPPING_Z c=15
 #. Beware: must include the ':' as its last character
-#: ../../Firmware/ultralcd.cpp:2670
+#: ../../Firmware/ultralcd.cpp:2689
 msgid "Adjusting Z:"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:7313
+#: ../../Firmware/ultralcd.cpp:7343
 msgid "All correct"
 msgstr ""
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4180
+#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4190
+#: ../../Firmware/ultralcd.cpp:4199
 msgid "All is done. Happy printing!"
 msgstr ""
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4404
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4423
 msgid "Alphabet"
 msgstr ""
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4308
+#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4327
 msgid "Always"
 msgstr ""
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1405
+#: ../../Firmware/ultralcd.cpp:1424
 msgid "Ambient"
 msgstr ""
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2983
+#: ../../Firmware/ultralcd.cpp:3002
 msgid "Are left and right Z~carriages all up?"
 msgstr ""
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4478
 msgid "Assist"
 msgstr ""
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:5886
 msgid "Auto"
 msgstr ""
 
 #. MSG_AUTO_HOME c=18
 #: ../../Firmware/Marlin_main.cpp:3271 ../../Firmware/messages.cpp:9
-#: ../../Firmware/ultralcd.cpp:4900
+#: ../../Firmware/ultralcd.cpp:4919
 msgid "Auto home"
 msgstr ""
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:4364
-#: ../../Firmware/ultralcd.cpp:5779
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:4383
+#: ../../Firmware/ultralcd.cpp:5801
 msgid "Auto power"
 msgstr ""
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5572
+#: ../../Firmware/ultralcd.cpp:5594
 msgid "AutoLoad filament"
 msgstr ""
 
 #. MSG_AUTOLOADING_ONLY_IF_FSENS_ON c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3549
+#: ../../Firmware/ultralcd.cpp:3568
 msgid ""
 "Autoloading filament available only when filament sensor is turned on..."
 msgstr ""
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2301
+#: ../../Firmware/ultralcd.cpp:2320
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:7015
+#: ../../Firmware/ultralcd.cpp:7045
 msgid "Axis"
 msgstr ""
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:7014
+#: ../../Firmware/ultralcd.cpp:7044
 msgid "Axis length"
 msgstr ""
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:2751
-#: ../../Firmware/ultralcd.cpp:5861 ../../Firmware/ultralcd.cpp:7838
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:2770
+#: ../../Firmware/ultralcd.cpp:5883 ../../Firmware/ultralcd.cpp:7878
 msgid "Back"
 msgstr ""
 
 #. MSG_BED c=13
 #: ../../Firmware/Marlin_main.cpp:2051 ../../Firmware/Marlin_main.cpp:4767
 #: ../../Firmware/Marlin_main.cpp:4819 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:1403 ../../Firmware/ultralcd.cpp:5721
-#: ../../Firmware/ultralcd.cpp:5891
+#: ../../Firmware/ultralcd.cpp:1422 ../../Firmware/ultralcd.cpp:5743
+#: ../../Firmware/ultralcd.cpp:5913
 msgid "Bed"
 msgstr ""
 
@@ -149,7 +149,7 @@ msgid "Bed done"
 msgstr ""
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4912
+#: ../../Firmware/ultralcd.cpp:4931
 msgid "Bed level correct"
 msgstr ""
 
@@ -165,18 +165,18 @@ msgid ""
 msgstr ""
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6972
+#: ../../Firmware/ultralcd.cpp:7002
 msgid "Bed/Heater"
 msgstr ""
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1458
-#: ../../Firmware/ultralcd.cpp:1726
+#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1477
+#: ../../Firmware/ultralcd.cpp:1745
 msgid "Belt status"
 msgstr ""
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4902
+#: ../../Firmware/ultralcd.cpp:4921
 msgid "Belt test"
 msgstr ""
 
@@ -187,28 +187,28 @@ msgid "Blackout occurred. Recover print?"
 msgstr ""
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:5886
 msgid "Bright"
 msgstr ""
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4850
-#: ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4869
+#: ../../Firmware/ultralcd.cpp:5811
 msgid "Brightness"
 msgstr ""
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4906
+#: ../../Firmware/ultralcd.cpp:4925
 msgid "Calibrate XYZ"
 msgstr ""
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4908
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4927
 msgid "Calibrate Z"
 msgstr ""
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2946
+#: ../../Firmware/ultralcd.cpp:2965
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -221,19 +221,19 @@ msgid "Calibrating Z"
 msgstr ""
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2945
+#: ../../Firmware/ultralcd.cpp:2964
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
 msgstr ""
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:7315
+#: ../../Firmware/ultralcd.cpp:7345
 msgid "Calibrating home"
 msgstr ""
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:5581
+#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:5603
 msgid "Calibration"
 msgstr ""
 
@@ -243,115 +243,115 @@ msgid "Calibration done"
 msgstr ""
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7712
+#: ../../Firmware/ultralcd.cpp:7752
 msgid "Card removed"
 msgstr ""
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/ultralcd.cpp:5560
 msgid "Change SD card"
 msgstr ""
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5497
-#: ../../Firmware/ultralcd.cpp:5730
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5519
+#: ../../Firmware/ultralcd.cpp:5752
 msgid "Change filament"
 msgstr ""
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2163
+#: ../../Firmware/ultralcd.cpp:2182
 msgid "Change success!"
 msgstr ""
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2215
+#: ../../Firmware/ultralcd.cpp:2234
 msgid "Changed correctly?"
 msgstr ""
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:6178
-#: ../../Firmware/ultralcd.cpp:7305
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:6208
+#: ../../Firmware/ultralcd.cpp:7335
 msgid "Checking X axis"
 msgstr ""
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:6187
-#: ../../Firmware/ultralcd.cpp:7306
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:6217
+#: ../../Firmware/ultralcd.cpp:7336
 msgid "Checking Y axis"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:7307
+#: ../../Firmware/ultralcd.cpp:7337
 msgid "Checking Z axis"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:7308
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:7338
 msgid "Checking bed"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:7304
+#: ../../Firmware/ultralcd.cpp:7334
 msgid "Checking endstops"
 msgstr ""
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:7403
+#: ../../Firmware/ultralcd.cpp:7433
 msgid "Checking file"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:7310
+#: ../../Firmware/ultralcd.cpp:7340
 msgid "Checking hotend"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:7311
-#: ../../Firmware/ultralcd.cpp:7312
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:7341
+#: ../../Firmware/ultralcd.cpp:7342
 msgid "Checking sensors"
 msgstr ""
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4765
+#: ../../Firmware/ultralcd.cpp:4784
 msgid "Checks"
 msgstr ""
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2218
+#: ../../Firmware/ultralcd.cpp:2237
 msgid "Color not correct"
 msgstr ""
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3725
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3744
 msgid "Community made"
 msgstr ""
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4704
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4723
 msgid "Cont."
 msgstr ""
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2125
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2144
 msgid "Cooldown"
 msgstr ""
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3663
+#: ../../Firmware/ultralcd.cpp:3682
 msgid "Copy selected language?"
 msgstr ""
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1221
-#: ../../Firmware/ultralcd.cpp:1262 ../../Firmware/ultralcd.cpp:1272
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1240
+#: ../../Firmware/ultralcd.cpp:1281 ../../Firmware/ultralcd.cpp:1291
 msgid "Crash"
 msgstr ""
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4341
-#: ../../Firmware/ultralcd.cpp:4342 ../../Firmware/ultralcd.cpp:4344
-#: ../../Firmware/ultralcd.cpp:5765 ../../Firmware/ultralcd.cpp:5767
-#: ../../Firmware/ultralcd.cpp:5771
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4363
+#: ../../Firmware/ultralcd.cpp:5787 ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/ultralcd.cpp:5793
 msgid "Crash det."
 msgstr ""
 
@@ -361,7 +361,7 @@ msgid "Crash detected."
 msgstr ""
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3521
+#: ../../Firmware/ultralcd.cpp:3540
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -369,14 +369,14 @@ msgid ""
 msgstr ""
 
 #. MSG_CUT_FILAMENT c=17
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:5175
-#: ../../Firmware/ultralcd.cpp:5567
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:5197
+#: ../../Firmware/ultralcd.cpp:5589
 msgid "Cut filament"
 msgstr ""
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:4303
-#: ../../Firmware/ultralcd.cpp:4308 ../../Firmware/ultralcd.cpp:4313
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:4322
+#: ../../Firmware/ultralcd.cpp:4327 ../../Firmware/ultralcd.cpp:4332
 msgid "Cutter"
 msgstr ""
 
@@ -386,17 +386,17 @@ msgid "Cutting filament"
 msgstr ""
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1668
+#: ../../Firmware/ultralcd.cpp:1687
 msgid "Date:"
 msgstr ""
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5886
 msgid "Dim"
 msgstr ""
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4802
+#: ../../Firmware/ultralcd.cpp:4821
 msgid "Disable steppers"
 msgstr ""
 
@@ -410,30 +410,30 @@ msgid ""
 msgstr ""
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:4145
+#: ../../Firmware/ultralcd.cpp:4164
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
 msgstr ""
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4214
+#: ../../Firmware/ultralcd.cpp:4233
 msgid "E-correct:"
 msgstr ""
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2279
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2298
 msgid "ERROR:"
 msgstr ""
 
 #. MSG_FSENS_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3562
+#: ../../Firmware/ultralcd.cpp:3581
 msgid "ERROR: Filament sensor is not responding, please check connection."
 msgstr ""
 
 #. MSG_EJECT_FILAMENT c=17
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:5156
-#: ../../Firmware/ultralcd.cpp:5565
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:5178
+#: ../../Firmware/ultralcd.cpp:5587
 msgid "Eject filament"
 msgstr ""
 
@@ -443,47 +443,41 @@ msgid "Ejecting filament"
 msgstr ""
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6985
+#: ../../Firmware/ultralcd.cpp:7015
 msgid "Endstop"
 msgstr ""
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6990
+#: ../../Firmware/ultralcd.cpp:7020
 msgid "Endstop not hit"
 msgstr ""
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6976
+#: ../../Firmware/ultralcd.cpp:7006
 msgid "Endstops"
 msgstr ""
 
 #. MSG_EXTRUDER c=17
 #: ../../Firmware/Marlin_main.cpp:8608 ../../Firmware/messages.cpp:30
-#: ../../Firmware/ultralcd.cpp:3495
+#: ../../Firmware/ultralcd.cpp:3514
 msgid "Extruder"
 msgstr ""
 
-#. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1144
-#: ../../Firmware/ultralcd.cpp:7319
-msgid "Hotend fan:"
-msgstr ""
-
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1722
+#: ../../Firmware/ultralcd.cpp:1741
 msgid "Extruder info"
 msgstr ""
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4229
-#: ../../Firmware/ultralcd.cpp:4237 ../../Firmware/ultralcd.cpp:4248
-#: ../../Firmware/ultralcd.cpp:4250
+#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4248
+#: ../../Firmware/ultralcd.cpp:4256 ../../Firmware/ultralcd.cpp:4267
+#: ../../Firmware/ultralcd.cpp:4269
 msgid "F. autoload"
 msgstr ""
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4704
-#: ../../Firmware/ultralcd.cpp:4707
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4723
+#: ../../Firmware/ultralcd.cpp:4726
 msgid "FS Action"
 msgstr ""
 
@@ -498,102 +492,102 @@ msgid "FS v0.4 or newer"
 msgstr ""
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5589
+#: ../../Firmware/ultralcd.cpp:5611
 msgid "Fail stats"
 msgstr ""
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5592
+#: ../../Firmware/ultralcd.cpp:5614
 msgid "Fail stats MMU"
 msgstr ""
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:7031
+#: ../../Firmware/ultralcd.cpp:7061
 msgid "False triggering"
 msgstr ""
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:5723
-#: ../../Firmware/ultralcd.cpp:5893
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/ultralcd.cpp:5915
 msgid "Fan speed"
 msgstr ""
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:7143
-#: ../../Firmware/ultralcd.cpp:7301 ../../Firmware/ultralcd.cpp:7302
-#: ../../Firmware/ultralcd.cpp:7303
+#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:7173
+#: ../../Firmware/ultralcd.cpp:7331 ../../Firmware/ultralcd.cpp:7332
+#: ../../Firmware/ultralcd.cpp:7333
 msgid "Fan test"
 msgstr ""
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4811
-#: ../../Firmware/ultralcd.cpp:5756
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4830
+#: ../../Firmware/ultralcd.cpp:5778
 msgid "Fans check"
 msgstr ""
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1220
-#: ../../Firmware/ultralcd.cpp:1261 ../../Firmware/ultralcd.cpp:1327
-#: ../../Firmware/ultralcd.cpp:1329
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1239
+#: ../../Firmware/ultralcd.cpp:1280 ../../Firmware/ultralcd.cpp:1346
+#: ../../Firmware/ultralcd.cpp:1348
 msgid "Fil. runouts"
 msgstr ""
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:3451
-#: ../../Firmware/ultralcd.cpp:4228 ../../Firmware/ultralcd.cpp:4234
-#: ../../Firmware/ultralcd.cpp:4244 ../../Firmware/ultralcd.cpp:5737
-#: ../../Firmware/ultralcd.cpp:5741 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:3470
+#: ../../Firmware/ultralcd.cpp:4247 ../../Firmware/ultralcd.cpp:4253
+#: ../../Firmware/ultralcd.cpp:4263 ../../Firmware/ultralcd.cpp:5759
+#: ../../Firmware/ultralcd.cpp:5763 ../../Firmware/ultralcd.cpp:5767
 msgid "Fil. sensor"
 msgstr ""
 
 #. MSG_FILAMENT c=17
 #: ../../Firmware/Marlin_main.cpp:8577 ../../Firmware/Marlin_main.cpp:8604
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3835
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3854
 msgid "Filament"
 msgstr ""
 
 #. MSG_FILAMENT_CLEAN c=20 r=2
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2287
-#: ../../Firmware/ultralcd.cpp:2293
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2306
+#: ../../Firmware/ultralcd.cpp:2312
 msgid "Filament extruding & with correct color?"
 msgstr ""
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2217
+#: ../../Firmware/ultralcd.cpp:2236
 msgid "Filament not loaded"
 msgstr ""
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:7026
-#: ../../Firmware/ultralcd.cpp:7030 ../../Firmware/ultralcd.cpp:7034
-#: ../../Firmware/ultralcd.cpp:7330
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:7056
+#: ../../Firmware/ultralcd.cpp:7060 ../../Firmware/ultralcd.cpp:7064
+#: ../../Firmware/ultralcd.cpp:7360
 msgid "Filament sensor"
 msgstr ""
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2365
+#: ../../Firmware/ultralcd.cpp:2384
 msgid "Filament used"
 msgstr ""
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7461
+#: ../../Firmware/ultralcd.cpp:7491
 msgid "File incomplete. Continue anyway?"
 msgstr ""
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:5314
-#: ../../Firmware/ultralcd.cpp:5630
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:5336
+#: ../../Firmware/ultralcd.cpp:5652
 msgid "Finishing movements"
 msgstr ""
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:4898
-#: ../../Firmware/ultralcd.cpp:5424
+#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:4917
+#: ../../Firmware/ultralcd.cpp:5446
 msgid "First layer cal."
 msgstr ""
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4066
+#: ../../Firmware/ultralcd.cpp:4085
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 
@@ -603,23 +597,23 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr ""
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5724
+#: ../../Firmware/ultralcd.cpp:5746
 msgid "Flow"
 msgstr ""
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:6996
-#: ../../Firmware/ultralcd.cpp:7149 ../../Firmware/ultralcd.cpp:7154
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:7026
+#: ../../Firmware/ultralcd.cpp:7179 ../../Firmware/ultralcd.cpp:7184
 msgid "Front print fan?"
 msgstr ""
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2754
+#: ../../Firmware/ultralcd.cpp:2773
 msgid "Front side[μm]"
 msgstr ""
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:7020
+#: ../../Firmware/ultralcd.cpp:7050
 msgid "Front/left fans"
 msgstr ""
 
@@ -662,20 +656,20 @@ msgid ""
 msgstr ""
 
 #. MSG_GCODE c=8
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:4655
-#: ../../Firmware/ultralcd.cpp:4658 ../../Firmware/ultralcd.cpp:4661
-#: ../../Firmware/ultralcd.cpp:4664
+#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:4674
+#: ../../Firmware/ultralcd.cpp:4677 ../../Firmware/ultralcd.cpp:4680
+#: ../../Firmware/ultralcd.cpp:4683
 msgid "Gcode"
 msgstr ""
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:4672
-#: ../../Firmware/ultralcd.cpp:4726 ../../Firmware/ultralcd.cpp:4818
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:4691
+#: ../../Firmware/ultralcd.cpp:4745 ../../Firmware/ultralcd.cpp:4837
 msgid "HW Setup"
 msgstr ""
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6968
+#: ../../Firmware/ultralcd.cpp:6998
 msgid "Heater/Thermistor"
 msgstr ""
 
@@ -697,7 +691,7 @@ msgid "Heating done."
 msgstr ""
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=16
-#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4042
+#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4061
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -705,7 +699,7 @@ msgid ""
 msgstr ""
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4064
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -714,24 +708,30 @@ msgstr ""
 "padetu jums atlikti sarankos procesa?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:4358
-#: ../../Firmware/ultralcd.cpp:4367 ../../Firmware/ultralcd.cpp:5777
-#: ../../Firmware/ultralcd.cpp:5780
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:4377
+#: ../../Firmware/ultralcd.cpp:4386 ../../Firmware/ultralcd.cpp:5799
+#: ../../Firmware/ultralcd.cpp:5802
 msgid "High power"
 msgstr ""
 
+#. MSG_HOTEND_FAN_SPEED c=15
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1145
+#: ../../Firmware/ultralcd.cpp:7351
+msgid "Hotend fan:"
+msgstr ""
+
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4094
 msgid "I will run xyz calibration now. It will take approx. 12 mins."
 msgstr ""
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/ultralcd.cpp:4102
 msgid "I will run z calibration now."
 msgstr ""
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=9
-#: ../../Firmware/ultralcd.cpp:4153
+#: ../../Firmware/ultralcd.cpp:4172
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -743,36 +743,36 @@ msgid "Improving bed calibration point"
 msgstr ""
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:5478
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:5500
 msgid "Info screen"
 msgstr ""
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5545
+#: ../../Firmware/ultralcd.cpp:5567
 msgid "Init. SD card"
 msgstr ""
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2152
+#: ../../Firmware/ultralcd.cpp:2171
 msgid "Insert filament"
 msgstr ""
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:6223
+#: ../../Firmware/ultralcd.cpp:6253
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
 msgstr ""
 
 #. MSG_FILAMENT_LOADED c=20 r=2
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3855
-#: ../../Firmware/ultralcd.cpp:4108 ../../Firmware/ultralcd.cpp:4111
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3874
+#: ../../Firmware/ultralcd.cpp:4127 ../../Firmware/ultralcd.cpp:4130
 msgid "Is filament loaded?"
 msgstr ""
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=2
 #: ../../Firmware/Marlin_main.cpp:3312 ../../Firmware/Marlin_main.cpp:4886
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:4084
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:4103
 msgid "Is steel sheet on heatbed?"
 msgstr ""
 
@@ -782,74 +782,74 @@ msgid "Iteration"
 msgstr ""
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:1148
-#: ../../Firmware/ultralcd.cpp:1296
+#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:1167
+#: ../../Firmware/ultralcd.cpp:1315
 msgid "Last print"
 msgstr ""
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1169
-#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1269
-#: ../../Firmware/ultralcd.cpp:1326
+#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1188
+#: ../../Firmware/ultralcd.cpp:1278 ../../Firmware/ultralcd.cpp:1288
+#: ../../Firmware/ultralcd.cpp:1345
 msgid "Last print failures"
 msgstr ""
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2496
+#: ../../Firmware/ultralcd.cpp:2515
 msgid "Left"
 msgstr ""
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7001
-#: ../../Firmware/ultralcd.cpp:7147 ../../Firmware/ultralcd.cpp:7152
+#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:7032
+#: ../../Firmware/ultralcd.cpp:7179 ../../Firmware/ultralcd.cpp:7184
 msgid "Left hotend fan?"
 msgstr ""
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2752
+#: ../../Firmware/ultralcd.cpp:2771
 msgid "Left side [μm]"
 msgstr ""
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:5862
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:5884
 msgid "Level Bright"
 msgstr ""
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:5863
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:5885
 msgid "Level Dimmed"
 msgstr ""
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4826
+#: ../../Firmware/ultralcd.cpp:4845
 msgid "Lin. correction"
 msgstr ""
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4838
-#: ../../Firmware/ultralcd.cpp:5493
+#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4857
+#: ../../Firmware/ultralcd.cpp:5515
 msgid "Live adjust Z"
 msgstr ""
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/ultralcd.cpp:5120
+#: ../../Firmware/ultralcd.cpp:5142
 msgid "Load all"
 msgstr ""
 
 #. MSG_LOAD_FILAMENT c=17
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:5122
-#: ../../Firmware/ultralcd.cpp:5133 ../../Firmware/ultralcd.cpp:5562
-#: ../../Firmware/ultralcd.cpp:5576
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:5144
+#: ../../Firmware/ultralcd.cpp:5155 ../../Firmware/ultralcd.cpp:5584
+#: ../../Firmware/ultralcd.cpp:5598
 msgid "Load filament"
 msgstr ""
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5563
+#: ../../Firmware/ultralcd.cpp:5585
 msgid "Load to nozzle"
 msgstr ""
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2185
+#: ../../Firmware/ultralcd.cpp:2204
 msgid "Loading color"
 msgstr ""
 
@@ -857,18 +857,18 @@ msgstr ""
 #: ../../Firmware/Marlin_main.cpp:3641 ../../Firmware/messages.cpp:55
 #: ../../Firmware/mmu.cpp:872 ../../Firmware/mmu.cpp:906
 #: ../../Firmware/mmu.cpp:1014 ../../Firmware/mmu.cpp:1026
-#: ../../Firmware/ultralcd.cpp:2196 ../../Firmware/ultralcd.cpp:3949
+#: ../../Firmware/ultralcd.cpp:2215 ../../Firmware/ultralcd.cpp:3968
 msgid "Loading filament"
 msgstr ""
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:7008
+#: ../../Firmware/ultralcd.cpp:7038
 msgid "Loose pulley"
 msgstr ""
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:4450
-#: ../../Firmware/ultralcd.cpp:4462
+#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/ultralcd.cpp:4481
 msgid "Loud"
 msgstr ""
 
@@ -883,8 +883,8 @@ msgid "MK3S firmware detected on MK3 printer"
 msgstr ""
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4381
-#: ../../Firmware/ultralcd.cpp:4382
+#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4400
+#: ../../Firmware/ultralcd.cpp:4401
 msgid "MMU Mode"
 msgstr ""
 
@@ -904,8 +904,8 @@ msgid "MMU OK. Resuming..."
 msgstr ""
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:64 ../../Firmware/ultralcd.cpp:1170
-#: ../../Firmware/ultralcd.cpp:1193
+#: ../../Firmware/messages.cpp:64 ../../Firmware/ultralcd.cpp:1189
+#: ../../Firmware/ultralcd.cpp:1212
 msgid "MMU fails"
 msgstr ""
 
@@ -915,8 +915,8 @@ msgid "MMU load failed"
 msgstr ""
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:1171
-#: ../../Firmware/ultralcd.cpp:1194
+#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:1190
+#: ../../Firmware/ultralcd.cpp:1213
 msgid "MMU load fails"
 msgstr ""
 
@@ -926,32 +926,32 @@ msgid "MMU needs user attention."
 msgstr ""
 
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/ultralcd.cpp:1195
+#: ../../Firmware/ultralcd.cpp:1214
 msgid "MMU power fails"
 msgstr ""
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1680
+#: ../../Firmware/ultralcd.cpp:1699
 msgid "MMU2 connected"
 msgstr ""
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:5836
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:5858
 msgid "Magnets comp."
 msgstr ""
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1147
-#: ../../Firmware/ultralcd.cpp:1295 ../../Firmware/ultralcd.cpp:1338
-#: ../../Firmware/ultralcd.cpp:1645 ../../Firmware/ultralcd.cpp:4795
-#: ../../Firmware/ultralcd.cpp:4892 ../../Firmware/ultralcd.cpp:5119
-#: ../../Firmware/ultralcd.cpp:5131 ../../Firmware/ultralcd.cpp:5154
-#: ../../Firmware/ultralcd.cpp:5173 ../../Firmware/ultralcd.cpp:5717
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1166
+#: ../../Firmware/ultralcd.cpp:1314 ../../Firmware/ultralcd.cpp:1357
+#: ../../Firmware/ultralcd.cpp:1664 ../../Firmware/ultralcd.cpp:4814
+#: ../../Firmware/ultralcd.cpp:4911 ../../Firmware/ultralcd.cpp:5141
+#: ../../Firmware/ultralcd.cpp:5153 ../../Firmware/ultralcd.cpp:5176
+#: ../../Firmware/ultralcd.cpp:5195 ../../Firmware/ultralcd.cpp:5739
 msgid "Main"
 msgstr ""
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2537
+#: ../../Firmware/ultralcd.cpp:2556
 msgid "Measured skew"
 msgstr ""
 
@@ -962,71 +962,71 @@ msgid "Measuring reference height of calibration point"
 msgstr ""
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:5832
+#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:5854
 msgid "Mesh"
 msgstr ""
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4823
-#: ../../Firmware/ultralcd.cpp:4910
+#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4842
+#: ../../Firmware/ultralcd.cpp:4929
 msgid "Mesh Bed Leveling"
 msgstr ""
 
 #. MSG_MODE c=6
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:4336
-#: ../../Firmware/ultralcd.cpp:4338 ../../Firmware/ultralcd.cpp:4358
-#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4364
-#: ../../Firmware/ultralcd.cpp:4367 ../../Firmware/ultralcd.cpp:5763
-#: ../../Firmware/ultralcd.cpp:5770 ../../Firmware/ultralcd.cpp:5777
-#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5779
-#: ../../Firmware/ultralcd.cpp:5780 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/ultralcd.cpp:4357 ../../Firmware/ultralcd.cpp:4377
+#: ../../Firmware/ultralcd.cpp:4380 ../../Firmware/ultralcd.cpp:4383
+#: ../../Firmware/ultralcd.cpp:4386 ../../Firmware/ultralcd.cpp:5785
+#: ../../Firmware/ultralcd.cpp:5792 ../../Firmware/ultralcd.cpp:5799
+#: ../../Firmware/ultralcd.cpp:5800 ../../Firmware/ultralcd.cpp:5801
+#: ../../Firmware/ultralcd.cpp:5802 ../../Firmware/ultralcd.cpp:5886
 msgid "Mode"
 msgstr ""
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3598
+#: ../../Firmware/ultralcd.cpp:3617
 msgid "Mode change in progress..."
 msgstr ""
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:4575
-#: ../../Firmware/ultralcd.cpp:4578 ../../Firmware/ultralcd.cpp:4581
-#: ../../Firmware/ultralcd.cpp:4584
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:4594
+#: ../../Firmware/ultralcd.cpp:4597 ../../Firmware/ultralcd.cpp:4600
+#: ../../Firmware/ultralcd.cpp:4603
 msgid "Model"
 msgstr ""
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6982
-#: ../../Firmware/ultralcd.cpp:6991 ../../Firmware/ultralcd.cpp:7009
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:7012
+#: ../../Firmware/ultralcd.cpp:7021 ../../Firmware/ultralcd.cpp:7039
 msgid "Motor"
 msgstr ""
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3492
+#: ../../Firmware/ultralcd.cpp:3511
 msgid "Move X"
 msgstr ""
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3493
+#: ../../Firmware/ultralcd.cpp:3512
 msgid "Move Y"
 msgstr ""
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3494
+#: ../../Firmware/ultralcd.cpp:3513
 msgid "Move Z"
 msgstr ""
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4801
+#: ../../Firmware/ultralcd.cpp:4820
 msgid "Move axis"
 msgstr ""
 
 #. MSG_NA c=3
 #: ../../Firmware/menu.cpp:196 ../../Firmware/messages.cpp:124
-#: ../../Firmware/ultralcd.cpp:2502 ../../Firmware/ultralcd.cpp:2547
-#: ../../Firmware/ultralcd.cpp:3411 ../../Firmware/ultralcd.cpp:4228
-#: ../../Firmware/ultralcd.cpp:4276 ../../Firmware/ultralcd.cpp:5737
-#: ../../Firmware/ultralcd.cpp:5836
+#: ../../Firmware/ultralcd.cpp:2521 ../../Firmware/ultralcd.cpp:2566
+#: ../../Firmware/ultralcd.cpp:3430 ../../Firmware/ultralcd.cpp:4247
+#: ../../Firmware/ultralcd.cpp:4295 ../../Firmware/ultralcd.cpp:5759
+#: ../../Firmware/ultralcd.cpp:5858
 msgid "N/A"
 msgstr ""
 
@@ -1036,14 +1036,14 @@ msgid "New firmware version available:"
 msgstr ""
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:2804
-#: ../../Firmware/ultralcd.cpp:3180 ../../Firmware/ultralcd.cpp:4785
-#: ../../Firmware/ultralcd.cpp:5988
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:2823
+#: ../../Firmware/ultralcd.cpp:3199 ../../Firmware/ultralcd.cpp:4804
+#: ../../Firmware/ultralcd.cpp:6018
 msgid "No"
 msgstr ""
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5543
+#: ../../Firmware/ultralcd.cpp:5565
 msgid "No SD card"
 msgstr ""
 
@@ -1053,71 +1053,71 @@ msgid "No move."
 msgstr ""
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4405
-#: ../../Firmware/ultralcd.cpp:4493 ../../Firmware/ultralcd.cpp:4502
-#: ../../Firmware/ultralcd.cpp:4575 ../../Firmware/ultralcd.cpp:4584
-#: ../../Firmware/ultralcd.cpp:4614 ../../Firmware/ultralcd.cpp:4623
-#: ../../Firmware/ultralcd.cpp:4655 ../../Firmware/ultralcd.cpp:4664
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4424
+#: ../../Firmware/ultralcd.cpp:4512 ../../Firmware/ultralcd.cpp:4521
+#: ../../Firmware/ultralcd.cpp:4594 ../../Firmware/ultralcd.cpp:4603
+#: ../../Firmware/ultralcd.cpp:4633 ../../Firmware/ultralcd.cpp:4642
+#: ../../Firmware/ultralcd.cpp:4674 ../../Firmware/ultralcd.cpp:4683
 msgid "None"
 msgstr ""
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:4336
-#: ../../Firmware/ultralcd.cpp:4381 ../../Firmware/ultralcd.cpp:4397
-#: ../../Firmware/ultralcd.cpp:4416 ../../Firmware/ultralcd.cpp:5763
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/ultralcd.cpp:4400 ../../Firmware/ultralcd.cpp:4416
+#: ../../Firmware/ultralcd.cpp:4435 ../../Firmware/ultralcd.cpp:5785
 msgid "Normal"
 msgstr ""
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6969
+#: ../../Firmware/ultralcd.cpp:6999
 msgid "Not connected"
 msgstr ""
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:7168
-#: ../../Firmware/ultralcd.cpp:7183 ../../Firmware/ultralcd.cpp:7191
+#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:7198
+#: ../../Firmware/ultralcd.cpp:7213 ../../Firmware/ultralcd.cpp:7221
 msgid "Not spinning"
 msgstr ""
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3962
+#: ../../Firmware/ultralcd.cpp:3981
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr ""
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:4091
+#: ../../Firmware/ultralcd.cpp:4110
 msgid "Now I will preheat nozzle for PLA."
 msgstr ""
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/ultralcd.cpp:4101
 msgid "Now remove the test print from steel sheet."
 msgstr ""
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:1402
-#: ../../Firmware/ultralcd.cpp:4493 ../../Firmware/ultralcd.cpp:4496
-#: ../../Firmware/ultralcd.cpp:4499 ../../Firmware/ultralcd.cpp:4502
-#: ../../Firmware/ultralcd.cpp:5720 ../../Firmware/ultralcd.cpp:5882
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:1421
+#: ../../Firmware/ultralcd.cpp:4512 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/ultralcd.cpp:4518 ../../Firmware/ultralcd.cpp:4521
+#: ../../Firmware/ultralcd.cpp:5742 ../../Firmware/ultralcd.cpp:5904
 msgid "Nozzle"
 msgstr ""
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4546
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4565
 msgid "Nozzle d."
 msgstr ""
 
 #. MSG_OFF c=3
 #: ../../Firmware/menu.cpp:467 ../../Firmware/messages.cpp:122
-#: ../../Firmware/ultralcd.cpp:4234 ../../Firmware/ultralcd.cpp:4250
-#: ../../Firmware/ultralcd.cpp:4284 ../../Firmware/ultralcd.cpp:4313
-#: ../../Firmware/ultralcd.cpp:4342 ../../Firmware/ultralcd.cpp:4811
-#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4834
-#: ../../Firmware/ultralcd.cpp:5644 ../../Firmware/ultralcd.cpp:5741
-#: ../../Firmware/ultralcd.cpp:5756 ../../Firmware/ultralcd.cpp:5767
-#: ../../Firmware/ultralcd.cpp:5836 ../../Firmware/ultralcd.cpp:7841
-#: ../../Firmware/ultralcd.cpp:7845
+#: ../../Firmware/ultralcd.cpp:4253 ../../Firmware/ultralcd.cpp:4269
+#: ../../Firmware/ultralcd.cpp:4303 ../../Firmware/ultralcd.cpp:4332
+#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4830
+#: ../../Firmware/ultralcd.cpp:4849 ../../Firmware/ultralcd.cpp:4853
+#: ../../Firmware/ultralcd.cpp:5666 ../../Firmware/ultralcd.cpp:5763
+#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/ultralcd.cpp:5858 ../../Firmware/ultralcd.cpp:7881
+#: ../../Firmware/ultralcd.cpp:7885
 msgid "Off"
 msgstr ""
 
@@ -1127,19 +1127,19 @@ msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr ""
 
 #. MSG_ON c=3
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4244
-#: ../../Firmware/ultralcd.cpp:4248 ../../Firmware/ultralcd.cpp:4280
-#: ../../Firmware/ultralcd.cpp:4303 ../../Firmware/ultralcd.cpp:4341
-#: ../../Firmware/ultralcd.cpp:4811 ../../Firmware/ultralcd.cpp:4830
-#: ../../Firmware/ultralcd.cpp:4834 ../../Firmware/ultralcd.cpp:5745
-#: ../../Firmware/ultralcd.cpp:5756 ../../Firmware/ultralcd.cpp:5765
-#: ../../Firmware/ultralcd.cpp:5836 ../../Firmware/ultralcd.cpp:7841
-#: ../../Firmware/ultralcd.cpp:7845
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4263
+#: ../../Firmware/ultralcd.cpp:4267 ../../Firmware/ultralcd.cpp:4299
+#: ../../Firmware/ultralcd.cpp:4322 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4849
+#: ../../Firmware/ultralcd.cpp:4853 ../../Firmware/ultralcd.cpp:5767
+#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5787
+#: ../../Firmware/ultralcd.cpp:5858 ../../Firmware/ultralcd.cpp:7881
+#: ../../Firmware/ultralcd.cpp:7885
 msgid "On"
 msgstr ""
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4453
+#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4472
 msgid "Once"
 msgstr ""
 
@@ -1159,7 +1159,7 @@ msgid "PID cal. finished"
 msgstr ""
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4913
+#: ../../Firmware/ultralcd.cpp:4932
 msgid "PID calibration"
 msgstr ""
 
@@ -1171,31 +1171,31 @@ msgstr ""
 #. MSG_PINDA_CALIBRATION c=13
 #: ../../Firmware/Marlin_main.cpp:4932 ../../Firmware/Marlin_main.cpp:5035
 #: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:654
-#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4920
+#: ../../Firmware/ultralcd.cpp:4849 ../../Firmware/ultralcd.cpp:4939
 msgid "PINDA cal."
 msgstr ""
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3361
+#: ../../Firmware/ultralcd.cpp:3380
 msgid "PINDA calibration failed"
 msgstr ""
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
 #: ../../Firmware/Marlin_main.cpp:5112 ../../Firmware/messages.cpp:110
-#: ../../Firmware/ultralcd.cpp:3355
+#: ../../Firmware/ultralcd.cpp:3374
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
 msgstr ""
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4707
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4726
 msgid "Pause"
 msgstr ""
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:5507
-#: ../../Firmware/ultralcd.cpp:5509
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:5529
+#: ../../Firmware/ultralcd.cpp:5531
 msgid "Pause print"
 msgstr ""
 
@@ -1207,24 +1207,24 @@ msgid ""
 msgstr ""
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:4176
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:4195
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
 msgstr ""
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:6250
+#: ../../Firmware/ultralcd.cpp:6280
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr ""
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6963
+#: ../../Firmware/ultralcd.cpp:6993
 msgid "Please check:"
 msgstr ""
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4148
+#: ../../Firmware/ultralcd.cpp:4167
 msgid "Please clean heatbed and then press the knob."
 msgstr ""
 
@@ -1234,20 +1234,20 @@ msgid "Please clean the nozzle for calibration. Click when done."
 msgstr ""
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3945
+#: ../../Firmware/ultralcd.cpp:3964
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr ""
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3940
+#: ../../Firmware/ultralcd.cpp:3959
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
 msgstr ""
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3863
+#: ../../Firmware/ultralcd.cpp:3882
 msgid "Please load filament first."
 msgstr ""
 
@@ -1258,7 +1258,7 @@ msgstr ""
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=5
 #: ../../Firmware/mesh_bed_calibration.cpp:2799 ../../Firmware/messages.cpp:70
-#: ../../Firmware/ultralcd.cpp:4085
+#: ../../Firmware/ultralcd.cpp:4104
 msgid "Please place steel sheet on heatbed."
 msgstr ""
 
@@ -1269,7 +1269,7 @@ msgid "Please press the knob to unload filament"
 msgstr ""
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:5213
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:5235
 msgid "Please pull out filament immediately"
 msgstr ""
 
@@ -1279,7 +1279,7 @@ msgid "Please remove filament and then press the knob."
 msgstr ""
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:4081
+#: ../../Firmware/ultralcd.cpp:4100
 msgid "Please remove shipping helpers first."
 msgstr ""
 
@@ -1295,7 +1295,7 @@ msgid "Please run XYZ calibration first."
 msgstr ""
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:6247
+#: ../../Firmware/ultralcd.cpp:6277
 msgid "Please unload the filament first, then repeat this action."
 msgstr ""
 
@@ -1312,54 +1312,54 @@ msgstr ""
 #. MSG_PLEASE_WAIT c=20
 #: ../../Firmware/Marlin_main.cpp:3547 ../../Firmware/Marlin_main.cpp:3563
 #: ../../Firmware/Marlin_main.cpp:7931 ../../Firmware/messages.cpp:71
-#: ../../Firmware/ultralcd.cpp:2186 ../../Firmware/ultralcd.cpp:2197
+#: ../../Firmware/ultralcd.cpp:2205 ../../Firmware/ultralcd.cpp:2216
 msgid "Please wait"
 msgstr ""
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1219
-#: ../../Firmware/ultralcd.cpp:1260 ../../Firmware/ultralcd.cpp:1270
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1238
+#: ../../Firmware/ultralcd.cpp:1279 ../../Firmware/ultralcd.cpp:1289
 msgid "Power failures"
 msgstr ""
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5502
+#: ../../Firmware/ultralcd.cpp:5524
 msgid "Preheat"
 msgstr ""
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:2280
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:2299
 msgid "Preheat the nozzle!"
 msgstr ""
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:2900
-#: ../../Firmware/ultralcd.cpp:3924 ../../Firmware/ultralcd.cpp:3926
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:2919
+#: ../../Firmware/ultralcd.cpp:3943 ../../Firmware/ultralcd.cpp:3945
 msgid "Preheating nozzle. Please wait."
 msgstr ""
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1988
+#: ../../Firmware/ultralcd.cpp:2007
 msgid "Preheating to cut"
 msgstr ""
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1985
+#: ../../Firmware/ultralcd.cpp:2004
 msgid "Preheating to eject"
 msgstr ""
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1976
+#: ../../Firmware/ultralcd.cpp:1995
 msgid "Preheating to load"
 msgstr ""
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1981
+#: ../../Firmware/ultralcd.cpp:2000
 msgid "Preheating to unload"
 msgstr ""
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1809
+#: ../../Firmware/ultralcd.cpp:1828
 msgid "Press the knob"
 msgstr ""
 
@@ -1379,13 +1379,13 @@ msgid "Print aborted"
 msgstr ""
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1144
-#: ../../Firmware/ultralcd.cpp:7322
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1145
+#: ../../Firmware/ultralcd.cpp:7354
 msgid "Print fan:"
 msgstr ""
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5535
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5557
 msgid "Print from SD"
 msgstr ""
 
@@ -1395,12 +1395,12 @@ msgid "Print paused"
 msgstr ""
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2366
+#: ../../Firmware/ultralcd.cpp:2385
 msgid "Print time"
 msgstr ""
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1711
+#: ../../Firmware/ultralcd.cpp:1730
 msgid "Printer IP Addr:"
 msgstr ""
 
@@ -1424,12 +1424,12 @@ msgid ""
 msgstr ""
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4834
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4853
 msgid "RPi port"
 msgstr ""
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2755
+#: ../../Firmware/ultralcd.cpp:2774
 msgid "Rear side [μm]"
 msgstr ""
 
@@ -1444,24 +1444,24 @@ msgid "Remove old filament and press the knob to start loading new filament."
 msgstr ""
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5426
+#: ../../Firmware/ultralcd.cpp:5448
 msgid "Rename"
 msgstr ""
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2756
-#: ../../Firmware/ultralcd.cpp:5427
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2775
+#: ../../Firmware/ultralcd.cpp:5449
 msgid "Reset"
 msgstr ""
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4917
+#: ../../Firmware/ultralcd.cpp:4936
 msgid "Reset XYZ calibr."
 msgstr ""
 
 #. MSG_RESUME_PRINT c=18
 #: ../../Firmware/Marlin_main.cpp:655 ../../Firmware/messages.cpp:81
-#: ../../Firmware/ultralcd.cpp:5521 ../../Firmware/ultralcd.cpp:5523
+#: ../../Firmware/ultralcd.cpp:5543 ../../Firmware/ultralcd.cpp:5545
 msgid "Resume print"
 msgstr ""
 
@@ -1471,31 +1471,31 @@ msgid "Resuming print"
 msgstr ""
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2497
+#: ../../Firmware/ultralcd.cpp:2516
 msgid "Right"
 msgstr ""
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2753
+#: ../../Firmware/ultralcd.cpp:2772
 msgid "Right side[μm]"
 msgstr ""
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3884
+#: ../../Firmware/ultralcd.cpp:3903
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
 msgstr ""
 
 #. MSG_RUNOUTS c=7
-#: ../../Firmware/ultralcd.cpp:1271
+#: ../../Firmware/ultralcd.cpp:1290
 msgid "Runouts"
 msgstr ""
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4395
-#: ../../Firmware/ultralcd.cpp:4397 ../../Firmware/ultralcd.cpp:4414
-#: ../../Firmware/ultralcd.cpp:4416
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4414
+#: ../../Firmware/ultralcd.cpp:4416 ../../Firmware/ultralcd.cpp:4433
+#: ../../Firmware/ultralcd.cpp:4435
 msgid "SD card"
 msgstr ""
 
@@ -1511,12 +1511,12 @@ msgid "Searching bed calibration point"
 msgstr ""
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5419
+#: ../../Firmware/ultralcd.cpp:5441
 msgid "Select"
 msgstr ""
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3966
+#: ../../Firmware/ultralcd.cpp:3985
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
@@ -1529,49 +1529,49 @@ msgstr ""
 
 #. MSG_SELECT_FILAMENT c=20
 #: ../../Firmware/Marlin_main.cpp:8577 ../../Firmware/Marlin_main.cpp:8604
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3834
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3853
 msgid "Select filament:"
 msgstr ""
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:3679
-#: ../../Firmware/ultralcd.cpp:4841
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:3698
+#: ../../Firmware/ultralcd.cpp:4860
 msgid "Select language"
 msgstr ""
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:4122
+#: ../../Firmware/ultralcd.cpp:4141
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr ""
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3971
+#: ../../Firmware/ultralcd.cpp:3990
 msgid "Select temperature which matches your material."
 msgstr ""
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6522
+#: ../../Firmware/ultralcd.cpp:6552
 msgid "Self test OK"
 msgstr ""
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:6290
+#: ../../Firmware/ultralcd.cpp:6320
 msgid "Self test start"
 msgstr ""
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4904
+#: ../../Firmware/ultralcd.cpp:4923
 msgid "Selftest"
 msgstr ""
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6962
+#: ../../Firmware/ultralcd.cpp:6992
 msgid "Selftest error!"
 msgstr ""
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:6526
-#: ../../Firmware/ultralcd.cpp:7049 ../../Firmware/ultralcd.cpp:7314
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:6556
+#: ../../Firmware/ultralcd.cpp:7079 ../../Firmware/ultralcd.cpp:7344
 msgid "Selftest failed"
 msgstr ""
 
@@ -1581,30 +1581,30 @@ msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr ""
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1723
+#: ../../Firmware/ultralcd.cpp:1742
 msgid "Sensor info"
 msgstr ""
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:6254
+#: ../../Firmware/ultralcd.cpp:6284
 msgid "Sensor verified, remove the filament now."
 msgstr ""
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2773
+#: ../../Firmware/ultralcd.cpp:2792
 msgid "Set temperature:"
 msgstr ""
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:3491
-#: ../../Firmware/ultralcd.cpp:3696 ../../Firmware/ultralcd.cpp:4206
-#: ../../Firmware/ultralcd.cpp:5580 ../../Firmware/ultralcd.cpp:5827
-#: ../../Firmware/ultralcd.cpp:5880
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:3510
+#: ../../Firmware/ultralcd.cpp:3715 ../../Firmware/ultralcd.cpp:4225
+#: ../../Firmware/ultralcd.cpp:5602 ../../Firmware/ultralcd.cpp:5849
+#: ../../Firmware/ultralcd.cpp:5902
 msgid "Settings"
 msgstr ""
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2540
+#: ../../Firmware/ultralcd.cpp:2559
 msgid "Severe skew"
 msgstr ""
 
@@ -1615,7 +1615,7 @@ msgid "Sheet"
 msgstr ""
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3824
+#: ../../Firmware/ultralcd.cpp:3843
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1624,18 +1624,18 @@ msgid ""
 msgstr ""
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4915
+#: ../../Firmware/ultralcd.cpp:4934
 msgid "Show end stops"
 msgstr ""
 
 #. MSG_SILENT c=7
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4361
-#: ../../Firmware/ultralcd.cpp:4456 ../../Firmware/ultralcd.cpp:5778
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4380
+#: ../../Firmware/ultralcd.cpp:4475 ../../Firmware/ultralcd.cpp:5800
 msgid "Silent"
 msgstr ""
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2539
+#: ../../Firmware/ultralcd.cpp:2558
 msgid "Slight skew"
 msgstr ""
 
@@ -1652,8 +1652,8 @@ msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr ""
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4403
-#: ../../Firmware/ultralcd.cpp:4404 ../../Firmware/ultralcd.cpp:4405
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4422
+#: ../../Firmware/ultralcd.cpp:4423 ../../Firmware/ultralcd.cpp:4424
 msgid "Sort"
 msgstr ""
 
@@ -1664,20 +1664,20 @@ msgid "Sorting files"
 msgstr ""
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4450
-#: ../../Firmware/ultralcd.cpp:4453 ../../Firmware/ultralcd.cpp:4456
-#: ../../Firmware/ultralcd.cpp:4459 ../../Firmware/ultralcd.cpp:4462
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/ultralcd.cpp:4472 ../../Firmware/ultralcd.cpp:4475
+#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4481
 msgid "Sound"
 msgstr ""
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5718
+#: ../../Firmware/ultralcd.cpp:5740
 msgid "Speed"
 msgstr ""
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7166
-#: ../../Firmware/ultralcd.cpp:7181 ../../Firmware/ultralcd.cpp:7189
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7196
+#: ../../Firmware/ultralcd.cpp:7211 ../../Firmware/ultralcd.cpp:7219
 msgid "Spinning"
 msgstr ""
 
@@ -1687,42 +1687,42 @@ msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr ""
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5585
+#: ../../Firmware/ultralcd.cpp:5607
 msgid "Statistics"
 msgstr ""
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4338
-#: ../../Firmware/ultralcd.cpp:4382 ../../Firmware/ultralcd.cpp:5770
+#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4357
+#: ../../Firmware/ultralcd.cpp:4401 ../../Firmware/ultralcd.cpp:5792
 msgid "Stealth"
 msgstr ""
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4763
-#: ../../Firmware/ultralcd.cpp:5416
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4782
+#: ../../Firmware/ultralcd.cpp:5438
 msgid "Steel sheets"
 msgstr ""
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5528
-#: ../../Firmware/ultralcd.cpp:5987
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5550
+#: ../../Firmware/ultralcd.cpp:6017
 msgid "Stop print"
 msgstr ""
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4499
-#: ../../Firmware/ultralcd.cpp:4581 ../../Firmware/ultralcd.cpp:4620
-#: ../../Firmware/ultralcd.cpp:4661
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4518
+#: ../../Firmware/ultralcd.cpp:4600 ../../Firmware/ultralcd.cpp:4639
+#: ../../Firmware/ultralcd.cpp:4680
 msgid "Strict"
 msgstr ""
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/ultralcd.cpp:5616
 msgid "Support"
 msgstr ""
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:7021
+#: ../../Firmware/ultralcd.cpp:7051
 msgid "Swapped"
 msgstr ""
 
@@ -1731,28 +1731,18 @@ msgstr ""
 msgid "THERMAL ANOMALY"
 msgstr ""
 
-#. MSG_TM_AUTOTUNE_FAILED c=20
-#: ../../Firmware/temperature.cpp:2899
-msgid "TM autotune failed"
-msgstr ""
-
-#. MSG_TEMP_MODEL_AUTOTUNE c=20
-#: ../../Firmware/temperature.cpp:2884
-msgid "Temp. model autotune"
-msgstr ""
-
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4797
+#: ../../Firmware/ultralcd.cpp:4816
 msgid "Temperature"
 msgstr ""
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1729
+#: ../../Firmware/ultralcd.cpp:1748
 msgid "Temperatures"
 msgstr ""
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3974
+#: ../../Firmware/ultralcd.cpp:3993
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -1767,66 +1757,66 @@ msgid ""
 msgstr ""
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4403
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4422
 msgid "Time"
 msgstr ""
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:5865
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:5887
 msgid "Timeout"
 msgstr ""
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:1149
-#: ../../Firmware/ultralcd.cpp:1297
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:1168
+#: ../../Firmware/ultralcd.cpp:1316
 msgid "Total"
 msgstr ""
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:1192
-#: ../../Firmware/ultralcd.cpp:1218 ../../Firmware/ultralcd.cpp:1328
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:1211
+#: ../../Firmware/ultralcd.cpp:1237 ../../Firmware/ultralcd.cpp:1347
 msgid "Total failures"
 msgstr ""
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2387
+#: ../../Firmware/ultralcd.cpp:2406
 msgid "Total filament"
 msgstr ""
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2388
+#: ../../Firmware/ultralcd.cpp:2407
 msgid "Total print time"
 msgstr ""
 
 #. MSG_TUNE c=18
-#: ../../Firmware/ultralcd.cpp:5500
+#: ../../Firmware/ultralcd.cpp:5522
 msgid "Tune"
 msgstr ""
 
 #. MSG_UNLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:5564
-#: ../../Firmware/ultralcd.cpp:5578
+#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:5586
+#: ../../Firmware/ultralcd.cpp:5600
 msgid "Unload filament"
 msgstr ""
 
 #. MSG_UNLOADING_FILAMENT c=20
 #: ../../Firmware/messages.cpp:112 ../../Firmware/mmu.cpp:957
-#: ../../Firmware/ultralcd.cpp:5197
+#: ../../Firmware/ultralcd.cpp:5219
 msgid "Unloading filament"
 msgstr ""
 
 #. MSG_FIL_FAILED c=20 r=5
-#: ../../Firmware/ultralcd.cpp:6258
+#: ../../Firmware/ultralcd.cpp:6288
 msgid "Verification failed, remove the filament and try again."
 msgstr ""
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1732
+#: ../../Firmware/ultralcd.cpp:1751
 msgid "Voltages"
 msgstr ""
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3534
+#: ../../Firmware/ultralcd.cpp:3553
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -1840,19 +1830,19 @@ msgid "Wait for user..."
 msgstr ""
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2881
+#: ../../Firmware/ultralcd.cpp:2900
 msgid "Waiting for PINDA probe cooling"
 msgstr ""
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2913
+#: ../../Firmware/ultralcd.cpp:2932
 msgid "Waiting for nozzle and bed cooling"
 msgstr ""
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:4496
-#: ../../Firmware/ultralcd.cpp:4578 ../../Firmware/ultralcd.cpp:4617
-#: ../../Firmware/ultralcd.cpp:4658
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/ultralcd.cpp:4597 ../../Firmware/ultralcd.cpp:4636
+#: ../../Firmware/ultralcd.cpp:4677
 msgid "Warn"
 msgstr ""
 
@@ -1877,144 +1867,133 @@ msgid "Was filament unload successful?"
 msgstr ""
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6973
-#: ../../Firmware/ultralcd.cpp:6977 ../../Firmware/ultralcd.cpp:6997
-#: ../../Firmware/ultralcd.cpp:7003 ../../Firmware/ultralcd.cpp:7027
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:7003
+#: ../../Firmware/ultralcd.cpp:7007 ../../Firmware/ultralcd.cpp:7027
+#: ../../Firmware/ultralcd.cpp:7033 ../../Firmware/ultralcd.cpp:7057
 msgid "Wiring error"
 msgstr ""
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4895
+#: ../../Firmware/ultralcd.cpp:4914
 msgid "Wizard"
 msgstr ""
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4210
+#: ../../Firmware/ultralcd.cpp:4229
 msgid "X-correct:"
 msgstr ""
 
 #. MSG_XFLASH c=18
-#: ../../Firmware/ultralcd.cpp:5596
+#: ../../Firmware/ultralcd.cpp:5618
 msgid "XFLASH init"
 msgstr ""
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1721
+#: ../../Firmware/ultralcd.cpp:1740
 msgid "XYZ cal. details"
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3333
+#: ../../Firmware/ultralcd.cpp:3352
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3330
+#: ../../Firmware/ultralcd.cpp:3349
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3311
+#: ../../Firmware/ultralcd.cpp:3330
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr ""
 
-#. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_LEFT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3317
-msgid ""
-"XYZ calibration compromised. Left front calibration point not reachable."
-msgstr ""
-
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3314
+#: ../../Firmware/ultralcd.cpp:3333
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3293
+#: ../../Firmware/ultralcd.cpp:3312
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3299
+#: ../../Firmware/ultralcd.cpp:3318
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr ""
 
-#. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_LEFT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3305
-msgid "XYZ calibration failed. Left front calibration point not reachable."
-msgstr ""
-
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3296
-#: ../../Firmware/ultralcd.cpp:3324
+#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3315
+#: ../../Firmware/ultralcd.cpp:3343
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3302
+#: ../../Firmware/ultralcd.cpp:3321
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3327
+#: ../../Firmware/ultralcd.cpp:3346
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr ""
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2494
+#: ../../Firmware/ultralcd.cpp:2513
 msgid "Y distance from min"
 msgstr ""
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4211
+#: ../../Firmware/ultralcd.cpp:4230
 msgid "Y-correct:"
 msgstr ""
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:2216
-#: ../../Firmware/ultralcd.cpp:2800 ../../Firmware/ultralcd.cpp:3180
-#: ../../Firmware/ultralcd.cpp:4785 ../../Firmware/ultralcd.cpp:5989
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:2235
+#: ../../Firmware/ultralcd.cpp:2819 ../../Firmware/ultralcd.cpp:3199
+#: ../../Firmware/ultralcd.cpp:4804 ../../Firmware/ultralcd.cpp:6019
 msgid "Yes"
 msgstr ""
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:4187
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:4206
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr ""
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4231
 msgid "Z-correct:"
 msgstr ""
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:5835
+#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:5857
 msgid "Z-probe nr."
 msgstr ""
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2565
+#: ../../Firmware/ultralcd.cpp:2584
 msgid "[0;0] point offset"
 msgstr ""
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2154
+#: ../../Firmware/ultralcd.cpp:2173
 msgid "and press the knob"
 msgstr ""
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1816
+#: ../../Firmware/ultralcd.cpp:1835
 msgid "to load filament"
 msgstr ""
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1820
+#: ../../Firmware/ultralcd.cpp:1839
 msgid "to unload filament"
 msgstr ""
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1688
+#: ../../Firmware/ultralcd.cpp:1707
 msgid "unknown"
 msgstr ""
 
@@ -2024,7 +2003,7 @@ msgid "unknown state"
 msgstr ""
 
 #. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:6077
-#: ../../Firmware/ultralcd.cpp:6080
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:6107
+#: ../../Firmware/ultralcd.cpp:6110
 msgid "🔃Refresh"
 msgstr ""

--- a/lang/po/Firmware_nl.po
+++ b/lang/po/Firmware_nl.po
@@ -26,82 +26,82 @@ msgid " 0.4 or newer"
 msgstr " 0.4 of nieuwer"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:7036
+#: ../../Firmware/ultralcd.cpp:7066
 msgid "%s level expected"
 msgstr "%s niveau verwacht"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1968
-#: ../../Firmware/ultralcd.cpp:3835
+#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1987
+#: ../../Firmware/ultralcd.cpp:3854
 msgid ">Cancel"
 msgstr ">Annuleren"
 
 #. MSG_BABYSTEPPING_Z c=15
 #. Beware: must include the ':' as its last character
-#: ../../Firmware/ultralcd.cpp:2670
+#: ../../Firmware/ultralcd.cpp:2689
 msgid "Adjusting Z:"
 msgstr "Z is ingesteld:"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:7313
+#: ../../Firmware/ultralcd.cpp:7343
 msgid "All correct"
 msgstr "Allemaal goed"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4180
+#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4190
+#: ../../Firmware/ultralcd.cpp:4199
 msgid "All is done. Happy printing!"
 msgstr "Klaar. Happy printing!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4404
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4423
 msgid "Alphabet"
 msgstr "Alfabet"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4308
+#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4327
 msgid "Always"
 msgstr "Altijd"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1405
+#: ../../Firmware/ultralcd.cpp:1424
 msgid "Ambient"
 msgstr "Kamertemp."
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2983
+#: ../../Firmware/ultralcd.cpp:3002
 msgid "Are left and right Z~carriages all up?"
 msgstr "Zijn beide Z wagen heelemaal boven?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4478
 msgid "Assist"
 msgstr "Assist."
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:5886
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
 #: ../../Firmware/Marlin_main.cpp:3271 ../../Firmware/messages.cpp:9
-#: ../../Firmware/ultralcd.cpp:4900
+#: ../../Firmware/ultralcd.cpp:4919
 msgid "Auto home"
 msgstr "Startpositie"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:4364
-#: ../../Firmware/ultralcd.cpp:5779
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:4383
+#: ../../Firmware/ultralcd.cpp:5801
 msgid "Auto power"
 msgstr "Auto power"
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5572
+#: ../../Firmware/ultralcd.cpp:5594
 msgid "AutoLoad filament"
 msgstr "Autoladen filament"
 
 #. MSG_AUTOLOADING_ONLY_IF_FSENS_ON c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3549
+#: ../../Firmware/ultralcd.cpp:3568
 msgid ""
 "Autoloading filament available only when filament sensor is turned on..."
 msgstr ""
@@ -109,33 +109,33 @@ msgstr ""
 "ingeschakeld..."
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2301
+#: ../../Firmware/ultralcd.cpp:2320
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
 "Automatisch laden van flament is actief, druk de knop en laad filament..."
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:7015
+#: ../../Firmware/ultralcd.cpp:7045
 msgid "Axis"
 msgstr "As"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:7014
+#: ../../Firmware/ultralcd.cpp:7044
 msgid "Axis length"
 msgstr "Aslengte"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:2751
-#: ../../Firmware/ultralcd.cpp:5861 ../../Firmware/ultralcd.cpp:7838
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:2770
+#: ../../Firmware/ultralcd.cpp:5883 ../../Firmware/ultralcd.cpp:7878
 msgid "Back"
 msgstr "terug"
 
 #. MSG_BED c=13
 #: ../../Firmware/Marlin_main.cpp:2051 ../../Firmware/Marlin_main.cpp:4767
 #: ../../Firmware/Marlin_main.cpp:4819 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:1403 ../../Firmware/ultralcd.cpp:5721
-#: ../../Firmware/ultralcd.cpp:5891
+#: ../../Firmware/ultralcd.cpp:1422 ../../Firmware/ultralcd.cpp:5743
+#: ../../Firmware/ultralcd.cpp:5913
 msgid "Bed"
 msgstr "Bed"
 
@@ -152,7 +152,7 @@ msgid "Bed done"
 msgstr "Bed klaar"
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4912
+#: ../../Firmware/ultralcd.cpp:4931
 msgid "Bed level correct"
 msgstr "Bed niveau correct"
 
@@ -170,18 +170,18 @@ msgstr ""
 "reset."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6972
+#: ../../Firmware/ultralcd.cpp:7002
 msgid "Bed/Heater"
 msgstr "Bed/Verwarming"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1458
-#: ../../Firmware/ultralcd.cpp:1726
+#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1477
+#: ../../Firmware/ultralcd.cpp:1745
 msgid "Belt status"
 msgstr "Riem status"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4902
+#: ../../Firmware/ultralcd.cpp:4921
 msgid "Belt test"
 msgstr "Riemtest"
 
@@ -192,28 +192,28 @@ msgid "Blackout occurred. Recover print?"
 msgstr "Stroomstoring. Print herstellen?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:5886
 msgid "Bright"
 msgstr "Helder"
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4850
-#: ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4869
+#: ../../Firmware/ultralcd.cpp:5811
 msgid "Brightness"
 msgstr "Helderheid"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4906
+#: ../../Firmware/ultralcd.cpp:4925
 msgid "Calibrate XYZ"
 msgstr "Kalibratie XYZ"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4908
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4927
 msgid "Calibrate Z"
 msgstr "Kalibratie Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2946
+#: ../../Firmware/ultralcd.cpp:2965
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -228,7 +228,7 @@ msgid "Calibrating Z"
 msgstr "Kalibrere Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2945
+#: ../../Firmware/ultralcd.cpp:2964
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -237,12 +237,12 @@ msgstr ""
 "stoppers. Druk knop als klaar."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:7315
+#: ../../Firmware/ultralcd.cpp:7345
 msgid "Calibrating home"
 msgstr "Kalibreren start"
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:5581
+#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:5603
 msgid "Calibration"
 msgstr "Kalibratie"
 
@@ -252,115 +252,115 @@ msgid "Calibration done"
 msgstr "Kalibratie klaar"
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7712
+#: ../../Firmware/ultralcd.cpp:7752
 msgid "Card removed"
 msgstr "SD verwijderd"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/ultralcd.cpp:5560
 msgid "Change SD card"
 msgstr "Wissel SD kaart"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5497
-#: ../../Firmware/ultralcd.cpp:5730
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5519
+#: ../../Firmware/ultralcd.cpp:5752
 msgid "Change filament"
 msgstr "Wissel filament"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2163
+#: ../../Firmware/ultralcd.cpp:2182
 msgid "Change success!"
 msgstr "Wissel geslaagd!"
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2215
+#: ../../Firmware/ultralcd.cpp:2234
 msgid "Changed correctly?"
 msgstr "Wissel ok?"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:6178
-#: ../../Firmware/ultralcd.cpp:7305
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:6208
+#: ../../Firmware/ultralcd.cpp:7335
 msgid "Checking X axis"
 msgstr "Controleer X as"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:6187
-#: ../../Firmware/ultralcd.cpp:7306
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:6217
+#: ../../Firmware/ultralcd.cpp:7336
 msgid "Checking Y axis"
 msgstr "Controleer Y as"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:7307
+#: ../../Firmware/ultralcd.cpp:7337
 msgid "Checking Z axis"
 msgstr "Controleer Z as"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:7308
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:7338
 msgid "Checking bed"
 msgstr "Controleer bed"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:7304
+#: ../../Firmware/ultralcd.cpp:7334
 msgid "Checking endstops"
 msgstr "Controleer endstops"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:7403
+#: ../../Firmware/ultralcd.cpp:7433
 msgid "Checking file"
 msgstr "Bestand controle"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:7310
+#: ../../Firmware/ultralcd.cpp:7340
 msgid "Checking hotend"
 msgstr "Controleer hotend"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:7311
-#: ../../Firmware/ultralcd.cpp:7312
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:7341
+#: ../../Firmware/ultralcd.cpp:7342
 msgid "Checking sensors"
 msgstr "Controleer sensors"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4765
+#: ../../Firmware/ultralcd.cpp:4784
 msgid "Checks"
 msgstr "Checks"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2218
+#: ../../Firmware/ultralcd.cpp:2237
 msgid "Color not correct"
 msgstr "Kleur niet juist"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3725
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3744
 msgid "Community made"
 msgstr "Van de community"
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4704
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4723
 msgid "Cont."
 msgstr "Door."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2125
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2144
 msgid "Cooldown"
 msgstr "Afkoelen"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3663
+#: ../../Firmware/ultralcd.cpp:3682
 msgid "Copy selected language?"
 msgstr "Geselecteerde taal kopieren?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1221
-#: ../../Firmware/ultralcd.cpp:1262 ../../Firmware/ultralcd.cpp:1272
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1240
+#: ../../Firmware/ultralcd.cpp:1281 ../../Firmware/ultralcd.cpp:1291
 msgid "Crash"
 msgstr "Crash"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4341
-#: ../../Firmware/ultralcd.cpp:4342 ../../Firmware/ultralcd.cpp:4344
-#: ../../Firmware/ultralcd.cpp:5765 ../../Firmware/ultralcd.cpp:5767
-#: ../../Firmware/ultralcd.cpp:5771
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4363
+#: ../../Firmware/ultralcd.cpp:5787 ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/ultralcd.cpp:5793
 msgid "Crash det."
 msgstr "Crashdet."
 
@@ -370,7 +370,7 @@ msgid "Crash detected."
 msgstr "Crash gedetecteerd."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3521
+#: ../../Firmware/ultralcd.cpp:3540
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -381,14 +381,14 @@ msgstr ""
 "gebruikt worden"
 
 #. MSG_CUT_FILAMENT c=17
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:5175
-#: ../../Firmware/ultralcd.cpp:5567
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:5197
+#: ../../Firmware/ultralcd.cpp:5589
 msgid "Cut filament"
 msgstr "Fil. knippen"
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:4303
-#: ../../Firmware/ultralcd.cpp:4308 ../../Firmware/ultralcd.cpp:4313
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:4322
+#: ../../Firmware/ultralcd.cpp:4327 ../../Firmware/ultralcd.cpp:4332
 msgid "Cutter"
 msgstr "Mes"
 
@@ -398,17 +398,17 @@ msgid "Cutting filament"
 msgstr "Knippe filament"
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1668
+#: ../../Firmware/ultralcd.cpp:1687
 msgid "Date:"
 msgstr "Datum:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5886
 msgid "Dim"
 msgstr "Dim"
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4802
+#: ../../Firmware/ultralcd.cpp:4821
 msgid "Disable steppers"
 msgstr "Motoren uit"
 
@@ -425,7 +425,7 @@ msgstr ""
 "calibration."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:4145
+#: ../../Firmware/ultralcd.cpp:4164
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -434,23 +434,23 @@ msgstr ""
 "opnieuw in te stellen?"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4214
+#: ../../Firmware/ultralcd.cpp:4233
 msgid "E-correct:"
 msgstr "E-correctie:"
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2279
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2298
 msgid "ERROR:"
 msgstr "FOUT:"
 
 #. MSG_FSENS_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3562
+#: ../../Firmware/ultralcd.cpp:3581
 msgid "ERROR: Filament sensor is not responding, please check connection."
 msgstr "FOUT: Filamentsensor reageert niet, controleer de verbinding."
 
 #. MSG_EJECT_FILAMENT c=17
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:5156
-#: ../../Firmware/ultralcd.cpp:5565
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:5178
+#: ../../Firmware/ultralcd.cpp:5587
 msgid "Eject filament"
 msgstr "Fil. uitwerpen"
 
@@ -460,47 +460,41 @@ msgid "Ejecting filament"
 msgstr "Fil. word ontladen"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6985
+#: ../../Firmware/ultralcd.cpp:7015
 msgid "Endstop"
 msgstr "Eindstop"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6990
+#: ../../Firmware/ultralcd.cpp:7020
 msgid "Endstop not hit"
 msgstr "Endstop niet geraakt"
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6976
+#: ../../Firmware/ultralcd.cpp:7006
 msgid "Endstops"
 msgstr "Eindstops"
 
 #. MSG_EXTRUDER c=17
 #: ../../Firmware/Marlin_main.cpp:8608 ../../Firmware/messages.cpp:30
-#: ../../Firmware/ultralcd.cpp:3495
+#: ../../Firmware/ultralcd.cpp:3514
 msgid "Extruder"
 msgstr "Extruder"
 
-#. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1144
-#: ../../Firmware/ultralcd.cpp:7319
-msgid "Hotend fan:"
-msgstr "Hotend fan:"
-
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1722
+#: ../../Firmware/ultralcd.cpp:1741
 msgid "Extruder info"
 msgstr "Extruder info"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4229
-#: ../../Firmware/ultralcd.cpp:4237 ../../Firmware/ultralcd.cpp:4248
-#: ../../Firmware/ultralcd.cpp:4250
+#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4248
+#: ../../Firmware/ultralcd.cpp:4256 ../../Firmware/ultralcd.cpp:4267
+#: ../../Firmware/ultralcd.cpp:4269
 msgid "F. autoload"
 msgstr "F. autoladen"
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4704
-#: ../../Firmware/ultralcd.cpp:4707
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4723
+#: ../../Firmware/ultralcd.cpp:4726
 msgid "FS Action"
 msgstr "FS actie"
 
@@ -515,102 +509,102 @@ msgid "FS v0.4 or newer"
 msgstr "FS 0.4 of nieuwer"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5589
+#: ../../Firmware/ultralcd.cpp:5611
 msgid "Fail stats"
 msgstr "Foutstatistieken"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5592
+#: ../../Firmware/ultralcd.cpp:5614
 msgid "Fail stats MMU"
 msgstr "MMU-Fouten"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:7031
+#: ../../Firmware/ultralcd.cpp:7061
 msgid "False triggering"
 msgstr "Valse triggering"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:5723
-#: ../../Firmware/ultralcd.cpp:5893
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/ultralcd.cpp:5915
 msgid "Fan speed"
 msgstr "Fan snelh."
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:7143
-#: ../../Firmware/ultralcd.cpp:7301 ../../Firmware/ultralcd.cpp:7302
-#: ../../Firmware/ultralcd.cpp:7303
+#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:7173
+#: ../../Firmware/ultralcd.cpp:7331 ../../Firmware/ultralcd.cpp:7332
+#: ../../Firmware/ultralcd.cpp:7333
 msgid "Fan test"
 msgstr "Fan test"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4811
-#: ../../Firmware/ultralcd.cpp:5756
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4830
+#: ../../Firmware/ultralcd.cpp:5778
 msgid "Fans check"
 msgstr "Fans check"
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1220
-#: ../../Firmware/ultralcd.cpp:1261 ../../Firmware/ultralcd.cpp:1327
-#: ../../Firmware/ultralcd.cpp:1329
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1239
+#: ../../Firmware/ultralcd.cpp:1280 ../../Firmware/ultralcd.cpp:1346
+#: ../../Firmware/ultralcd.cpp:1348
 msgid "Fil. runouts"
 msgstr "Fil. fouten"
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:3451
-#: ../../Firmware/ultralcd.cpp:4228 ../../Firmware/ultralcd.cpp:4234
-#: ../../Firmware/ultralcd.cpp:4244 ../../Firmware/ultralcd.cpp:5737
-#: ../../Firmware/ultralcd.cpp:5741 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:3470
+#: ../../Firmware/ultralcd.cpp:4247 ../../Firmware/ultralcd.cpp:4253
+#: ../../Firmware/ultralcd.cpp:4263 ../../Firmware/ultralcd.cpp:5759
+#: ../../Firmware/ultralcd.cpp:5763 ../../Firmware/ultralcd.cpp:5767
 msgid "Fil. sensor"
 msgstr "Fil. sensor"
 
 #. MSG_FILAMENT c=17
 #: ../../Firmware/Marlin_main.cpp:8577 ../../Firmware/Marlin_main.cpp:8604
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3835
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3854
 msgid "Filament"
 msgstr "Filament"
 
 #. MSG_FILAMENT_CLEAN c=20 r=2
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2287
-#: ../../Firmware/ultralcd.cpp:2293
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2306
+#: ../../Firmware/ultralcd.cpp:2312
 msgid "Filament extruding & with correct color?"
 msgstr "Filament extrudeert met de juiste kleur?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2217
+#: ../../Firmware/ultralcd.cpp:2236
 msgid "Filament not loaded"
 msgstr "Fil. niet geladen"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:7026
-#: ../../Firmware/ultralcd.cpp:7030 ../../Firmware/ultralcd.cpp:7034
-#: ../../Firmware/ultralcd.cpp:7330
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:7056
+#: ../../Firmware/ultralcd.cpp:7060 ../../Firmware/ultralcd.cpp:7064
+#: ../../Firmware/ultralcd.cpp:7360
 msgid "Filament sensor"
 msgstr "Filamentsensor"
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2365
+#: ../../Firmware/ultralcd.cpp:2384
 msgid "Filament used"
 msgstr "Gebruikte filament"
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7461
+#: ../../Firmware/ultralcd.cpp:7491
 msgid "File incomplete. Continue anyway?"
 msgstr "Bestand onvolledig. Toch doorgaan?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:5314
-#: ../../Firmware/ultralcd.cpp:5630
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:5336
+#: ../../Firmware/ultralcd.cpp:5652
 msgid "Finishing movements"
 msgstr "Voortgang afwerken"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:4898
-#: ../../Firmware/ultralcd.cpp:5424
+#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:4917
+#: ../../Firmware/ultralcd.cpp:5446
 msgid "First layer cal."
 msgstr "Eerste laag kal."
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4066
+#: ../../Firmware/ultralcd.cpp:4085
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Ten eerste zullen we de zelftest uitvoeren om de meest voorkomende "
@@ -622,23 +616,23 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr "Los het probleem op en druk vervolgens op de knop op de MMU-eenheid."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5724
+#: ../../Firmware/ultralcd.cpp:5746
 msgid "Flow"
 msgstr "Stromen"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:6996
-#: ../../Firmware/ultralcd.cpp:7149 ../../Firmware/ultralcd.cpp:7154
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:7026
+#: ../../Firmware/ultralcd.cpp:7179 ../../Firmware/ultralcd.cpp:7184
 msgid "Front print fan?"
 msgstr "Voorzijde fan?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2754
+#: ../../Firmware/ultralcd.cpp:2773
 msgid "Front side[μm]"
 msgstr "Voorkant [μm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:7020
+#: ../../Firmware/ultralcd.cpp:7050
 msgid "Front/left fans"
 msgstr "Fans voor/links"
 
@@ -687,20 +681,20 @@ msgstr ""
 "alsjeblieft. Druk geannuleerd."
 
 #. MSG_GCODE c=8
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:4655
-#: ../../Firmware/ultralcd.cpp:4658 ../../Firmware/ultralcd.cpp:4661
-#: ../../Firmware/ultralcd.cpp:4664
+#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:4674
+#: ../../Firmware/ultralcd.cpp:4677 ../../Firmware/ultralcd.cpp:4680
+#: ../../Firmware/ultralcd.cpp:4683
 msgid "Gcode"
 msgstr "Gcode"
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:4672
-#: ../../Firmware/ultralcd.cpp:4726 ../../Firmware/ultralcd.cpp:4818
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:4691
+#: ../../Firmware/ultralcd.cpp:4745 ../../Firmware/ultralcd.cpp:4837
 msgid "HW Setup"
 msgstr "HW Configuratie"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6968
+#: ../../Firmware/ultralcd.cpp:6998
 msgid "Heater/Thermistor"
 msgstr "Verwarmer/Therm."
 
@@ -722,7 +716,7 @@ msgid "Heating done."
 msgstr "Opwarmen klaar."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=16
-#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4042
+#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4061
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -733,7 +727,7 @@ msgstr ""
 "printen."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4064
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -742,24 +736,30 @@ msgstr ""
 "installatieproces?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:4358
-#: ../../Firmware/ultralcd.cpp:4367 ../../Firmware/ultralcd.cpp:5777
-#: ../../Firmware/ultralcd.cpp:5780
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:4377
+#: ../../Firmware/ultralcd.cpp:4386 ../../Firmware/ultralcd.cpp:5799
+#: ../../Firmware/ultralcd.cpp:5802
 msgid "High power"
 msgstr "Hoog verm."
 
+#. MSG_HOTEND_FAN_SPEED c=15
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1145
+#: ../../Firmware/ultralcd.cpp:7351
+msgid "Hotend fan:"
+msgstr "Hotend fan:"
+
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4094
 msgid "I will run xyz calibration now. It will take approx. 12 mins."
 msgstr "Begin nu met xyz-kalibratie. Het duurt ongeveer 12 min."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/ultralcd.cpp:4102
 msgid "I will run z calibration now."
 msgstr "Begin nu met z-kalibratie."
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=9
-#: ../../Firmware/ultralcd.cpp:4153
+#: ../../Firmware/ultralcd.cpp:4172
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -773,22 +773,22 @@ msgid "Improving bed calibration point"
 msgstr "Verbetering van het bedijkingspunt"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:5478
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:5500
 msgid "Info screen"
 msgstr "Info scherm"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5545
+#: ../../Firmware/ultralcd.cpp:5567
 msgid "Init. SD card"
 msgstr "Init. SD kaart"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2152
+#: ../../Firmware/ultralcd.cpp:2171
 msgid "Insert filament"
 msgstr "Voer filament in"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:6223
+#: ../../Firmware/ultralcd.cpp:6253
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
@@ -796,14 +796,14 @@ msgstr ""
 "Steek a.u.b. filament (maar niet laden) in de extruder en druk op knop."
 
 #. MSG_FILAMENT_LOADED c=20 r=2
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3855
-#: ../../Firmware/ultralcd.cpp:4108 ../../Firmware/ultralcd.cpp:4111
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3874
+#: ../../Firmware/ultralcd.cpp:4127 ../../Firmware/ultralcd.cpp:4130
 msgid "Is filament loaded?"
 msgstr "Is filament geladen?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=2
 #: ../../Firmware/Marlin_main.cpp:3312 ../../Firmware/Marlin_main.cpp:4886
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:4084
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:4103
 msgid "Is steel sheet on heatbed?"
 msgstr "Ligt de staalplaat op het bed?"
 
@@ -813,74 +813,74 @@ msgid "Iteration"
 msgstr "Iteratie"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:1148
-#: ../../Firmware/ultralcd.cpp:1296
+#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:1167
+#: ../../Firmware/ultralcd.cpp:1315
 msgid "Last print"
 msgstr "Laatste print"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1169
-#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1269
-#: ../../Firmware/ultralcd.cpp:1326
+#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1188
+#: ../../Firmware/ultralcd.cpp:1278 ../../Firmware/ultralcd.cpp:1288
+#: ../../Firmware/ultralcd.cpp:1345
 msgid "Last print failures"
 msgstr "Laatste printfouten"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2496
+#: ../../Firmware/ultralcd.cpp:2515
 msgid "Left"
 msgstr "Links"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7001
-#: ../../Firmware/ultralcd.cpp:7147 ../../Firmware/ultralcd.cpp:7152
+#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:7032
+#: ../../Firmware/ultralcd.cpp:7179 ../../Firmware/ultralcd.cpp:7184
 msgid "Left hotend fan?"
 msgstr "Linker hotend fan?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2752
+#: ../../Firmware/ultralcd.cpp:2771
 msgid "Left side [μm]"
 msgstr "Linkerkant[μm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:5862
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:5884
 msgid "Level Bright"
 msgstr "Helder waard"
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:5863
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:5885
 msgid "Level Dimmed"
 msgstr "Dim waarde"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4826
+#: ../../Firmware/ultralcd.cpp:4845
 msgid "Lin. correction"
 msgstr "Lineaire correctie"
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4838
-#: ../../Firmware/ultralcd.cpp:5493
+#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4857
+#: ../../Firmware/ultralcd.cpp:5515
 msgid "Live adjust Z"
 msgstr "Live Z aanpassen"
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/ultralcd.cpp:5120
+#: ../../Firmware/ultralcd.cpp:5142
 msgid "Load all"
 msgstr "Laad alle"
 
 #. MSG_LOAD_FILAMENT c=17
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:5122
-#: ../../Firmware/ultralcd.cpp:5133 ../../Firmware/ultralcd.cpp:5562
-#: ../../Firmware/ultralcd.cpp:5576
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:5144
+#: ../../Firmware/ultralcd.cpp:5155 ../../Firmware/ultralcd.cpp:5584
+#: ../../Firmware/ultralcd.cpp:5598
 msgid "Load filament"
 msgstr "Filament laden"
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5563
+#: ../../Firmware/ultralcd.cpp:5585
 msgid "Load to nozzle"
 msgstr "Tot tuit laden"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2185
+#: ../../Firmware/ultralcd.cpp:2204
 msgid "Loading color"
 msgstr "Laden kleur"
 
@@ -888,18 +888,18 @@ msgstr "Laden kleur"
 #: ../../Firmware/Marlin_main.cpp:3641 ../../Firmware/messages.cpp:55
 #: ../../Firmware/mmu.cpp:872 ../../Firmware/mmu.cpp:906
 #: ../../Firmware/mmu.cpp:1014 ../../Firmware/mmu.cpp:1026
-#: ../../Firmware/ultralcd.cpp:2196 ../../Firmware/ultralcd.cpp:3949
+#: ../../Firmware/ultralcd.cpp:2215 ../../Firmware/ultralcd.cpp:3968
 msgid "Loading filament"
 msgstr "Laden filament"
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:7008
+#: ../../Firmware/ultralcd.cpp:7038
 msgid "Loose pulley"
 msgstr "Losse riemschijf"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:4450
-#: ../../Firmware/ultralcd.cpp:4462
+#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/ultralcd.cpp:4481
 msgid "Loud"
 msgstr "Hard"
 
@@ -914,8 +914,8 @@ msgid "MK3S firmware detected on MK3 printer"
 msgstr "MK3S-firmware op MK3-printer ontdekt"
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4381
-#: ../../Firmware/ultralcd.cpp:4382
+#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4400
+#: ../../Firmware/ultralcd.cpp:4401
 msgid "MMU Mode"
 msgstr "MMU Mod"
 
@@ -935,8 +935,8 @@ msgid "MMU OK. Resuming..."
 msgstr "MMU OK. Hervatten..."
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:64 ../../Firmware/ultralcd.cpp:1170
-#: ../../Firmware/ultralcd.cpp:1193
+#: ../../Firmware/messages.cpp:64 ../../Firmware/ultralcd.cpp:1189
+#: ../../Firmware/ultralcd.cpp:1212
 msgid "MMU fails"
 msgstr "MMU fout"
 
@@ -946,8 +946,8 @@ msgid "MMU load failed"
 msgstr "MMU laden mislukt"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:1171
-#: ../../Firmware/ultralcd.cpp:1194
+#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:1190
+#: ../../Firmware/ultralcd.cpp:1213
 msgid "MMU load fails"
 msgstr "MMU laadfout"
 
@@ -957,32 +957,32 @@ msgid "MMU needs user attention."
 msgstr "MMU heeft gebruikersaandacht nodig."
 
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/ultralcd.cpp:1195
+#: ../../Firmware/ultralcd.cpp:1214
 msgid "MMU power fails"
 msgstr "MMU stroomstor."
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1680
+#: ../../Firmware/ultralcd.cpp:1699
 msgid "MMU2 connected"
 msgstr "MMU2 verbonden"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:5836
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:5858
 msgid "Magnets comp."
 msgstr "Magnet. comp."
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1147
-#: ../../Firmware/ultralcd.cpp:1295 ../../Firmware/ultralcd.cpp:1338
-#: ../../Firmware/ultralcd.cpp:1645 ../../Firmware/ultralcd.cpp:4795
-#: ../../Firmware/ultralcd.cpp:4892 ../../Firmware/ultralcd.cpp:5119
-#: ../../Firmware/ultralcd.cpp:5131 ../../Firmware/ultralcd.cpp:5154
-#: ../../Firmware/ultralcd.cpp:5173 ../../Firmware/ultralcd.cpp:5717
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1166
+#: ../../Firmware/ultralcd.cpp:1314 ../../Firmware/ultralcd.cpp:1357
+#: ../../Firmware/ultralcd.cpp:1664 ../../Firmware/ultralcd.cpp:4814
+#: ../../Firmware/ultralcd.cpp:4911 ../../Firmware/ultralcd.cpp:5141
+#: ../../Firmware/ultralcd.cpp:5153 ../../Firmware/ultralcd.cpp:5176
+#: ../../Firmware/ultralcd.cpp:5195 ../../Firmware/ultralcd.cpp:5739
 msgid "Main"
 msgstr "Hoofdmenu"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2537
+#: ../../Firmware/ultralcd.cpp:2556
 msgid "Measured skew"
 msgstr "Scheefheid"
 
@@ -993,71 +993,71 @@ msgid "Measuring reference height of calibration point"
 msgstr "Referentie hoogte van het kalibratiepunt meten"
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:5832
+#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:5854
 msgid "Mesh"
 msgstr "Mesh"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4823
-#: ../../Firmware/ultralcd.cpp:4910
+#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4842
+#: ../../Firmware/ultralcd.cpp:4929
 msgid "Mesh Bed Leveling"
 msgstr "Mesh bed Leveling"
 
 #. MSG_MODE c=6
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:4336
-#: ../../Firmware/ultralcd.cpp:4338 ../../Firmware/ultralcd.cpp:4358
-#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4364
-#: ../../Firmware/ultralcd.cpp:4367 ../../Firmware/ultralcd.cpp:5763
-#: ../../Firmware/ultralcd.cpp:5770 ../../Firmware/ultralcd.cpp:5777
-#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5779
-#: ../../Firmware/ultralcd.cpp:5780 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/ultralcd.cpp:4357 ../../Firmware/ultralcd.cpp:4377
+#: ../../Firmware/ultralcd.cpp:4380 ../../Firmware/ultralcd.cpp:4383
+#: ../../Firmware/ultralcd.cpp:4386 ../../Firmware/ultralcd.cpp:5785
+#: ../../Firmware/ultralcd.cpp:5792 ../../Firmware/ultralcd.cpp:5799
+#: ../../Firmware/ultralcd.cpp:5800 ../../Firmware/ultralcd.cpp:5801
+#: ../../Firmware/ultralcd.cpp:5802 ../../Firmware/ultralcd.cpp:5886
 msgid "Mode"
 msgstr "Stand"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3598
+#: ../../Firmware/ultralcd.cpp:3617
 msgid "Mode change in progress..."
 msgstr "Moduswijziging bezig..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:4575
-#: ../../Firmware/ultralcd.cpp:4578 ../../Firmware/ultralcd.cpp:4581
-#: ../../Firmware/ultralcd.cpp:4584
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:4594
+#: ../../Firmware/ultralcd.cpp:4597 ../../Firmware/ultralcd.cpp:4600
+#: ../../Firmware/ultralcd.cpp:4603
 msgid "Model"
 msgstr "Model"
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6982
-#: ../../Firmware/ultralcd.cpp:6991 ../../Firmware/ultralcd.cpp:7009
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:7012
+#: ../../Firmware/ultralcd.cpp:7021 ../../Firmware/ultralcd.cpp:7039
 msgid "Motor"
 msgstr "Motor"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3492
+#: ../../Firmware/ultralcd.cpp:3511
 msgid "Move X"
 msgstr "Verplaats X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3493
+#: ../../Firmware/ultralcd.cpp:3512
 msgid "Move Y"
 msgstr "Verplaats Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3494
+#: ../../Firmware/ultralcd.cpp:3513
 msgid "Move Z"
 msgstr "Verplaats Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4801
+#: ../../Firmware/ultralcd.cpp:4820
 msgid "Move axis"
 msgstr "As verplaatsen"
 
 #. MSG_NA c=3
 #: ../../Firmware/menu.cpp:196 ../../Firmware/messages.cpp:124
-#: ../../Firmware/ultralcd.cpp:2502 ../../Firmware/ultralcd.cpp:2547
-#: ../../Firmware/ultralcd.cpp:3411 ../../Firmware/ultralcd.cpp:4228
-#: ../../Firmware/ultralcd.cpp:4276 ../../Firmware/ultralcd.cpp:5737
-#: ../../Firmware/ultralcd.cpp:5836
+#: ../../Firmware/ultralcd.cpp:2521 ../../Firmware/ultralcd.cpp:2566
+#: ../../Firmware/ultralcd.cpp:3430 ../../Firmware/ultralcd.cpp:4247
+#: ../../Firmware/ultralcd.cpp:4295 ../../Firmware/ultralcd.cpp:5759
+#: ../../Firmware/ultralcd.cpp:5858
 msgid "N/A"
 msgstr "N/V"
 
@@ -1067,14 +1067,14 @@ msgid "New firmware version available:"
 msgstr "Nieuwe firmware versie beschikbaar:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:2804
-#: ../../Firmware/ultralcd.cpp:3180 ../../Firmware/ultralcd.cpp:4785
-#: ../../Firmware/ultralcd.cpp:5988
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:2823
+#: ../../Firmware/ultralcd.cpp:3199 ../../Firmware/ultralcd.cpp:4804
+#: ../../Firmware/ultralcd.cpp:6018
 msgid "No"
 msgstr "Nee"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5543
+#: ../../Firmware/ultralcd.cpp:5565
 msgid "No SD card"
 msgstr "Geen SD kaart"
 
@@ -1084,71 +1084,71 @@ msgid "No move."
 msgstr "Geen beweging."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4405
-#: ../../Firmware/ultralcd.cpp:4493 ../../Firmware/ultralcd.cpp:4502
-#: ../../Firmware/ultralcd.cpp:4575 ../../Firmware/ultralcd.cpp:4584
-#: ../../Firmware/ultralcd.cpp:4614 ../../Firmware/ultralcd.cpp:4623
-#: ../../Firmware/ultralcd.cpp:4655 ../../Firmware/ultralcd.cpp:4664
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4424
+#: ../../Firmware/ultralcd.cpp:4512 ../../Firmware/ultralcd.cpp:4521
+#: ../../Firmware/ultralcd.cpp:4594 ../../Firmware/ultralcd.cpp:4603
+#: ../../Firmware/ultralcd.cpp:4633 ../../Firmware/ultralcd.cpp:4642
+#: ../../Firmware/ultralcd.cpp:4674 ../../Firmware/ultralcd.cpp:4683
 msgid "None"
 msgstr "Geen"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:4336
-#: ../../Firmware/ultralcd.cpp:4381 ../../Firmware/ultralcd.cpp:4397
-#: ../../Firmware/ultralcd.cpp:4416 ../../Firmware/ultralcd.cpp:5763
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/ultralcd.cpp:4400 ../../Firmware/ultralcd.cpp:4416
+#: ../../Firmware/ultralcd.cpp:4435 ../../Firmware/ultralcd.cpp:5785
 msgid "Normal"
 msgstr "Normaal"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6969
+#: ../../Firmware/ultralcd.cpp:6999
 msgid "Not connected"
 msgstr "Niet verbonden"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:7168
-#: ../../Firmware/ultralcd.cpp:7183 ../../Firmware/ultralcd.cpp:7191
+#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:7198
+#: ../../Firmware/ultralcd.cpp:7213 ../../Firmware/ultralcd.cpp:7221
 msgid "Not spinning"
 msgstr "Draait niet"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3962
+#: ../../Firmware/ultralcd.cpp:3981
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr "Begin met kalibratie tussen de tuit en het bed."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:4091
+#: ../../Firmware/ultralcd.cpp:4110
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Opwarmen van de tuit voor PLA voor."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/ultralcd.cpp:4101
 msgid "Now remove the test print from steel sheet."
 msgstr "Verwijder nu de testprint van staalplaat."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:1402
-#: ../../Firmware/ultralcd.cpp:4493 ../../Firmware/ultralcd.cpp:4496
-#: ../../Firmware/ultralcd.cpp:4499 ../../Firmware/ultralcd.cpp:4502
-#: ../../Firmware/ultralcd.cpp:5720 ../../Firmware/ultralcd.cpp:5882
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:1421
+#: ../../Firmware/ultralcd.cpp:4512 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/ultralcd.cpp:4518 ../../Firmware/ultralcd.cpp:4521
+#: ../../Firmware/ultralcd.cpp:5742 ../../Firmware/ultralcd.cpp:5904
 msgid "Nozzle"
 msgstr "Tuit"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4546
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4565
 msgid "Nozzle d."
 msgstr "Tuit d."
 
 #. MSG_OFF c=3
 #: ../../Firmware/menu.cpp:467 ../../Firmware/messages.cpp:122
-#: ../../Firmware/ultralcd.cpp:4234 ../../Firmware/ultralcd.cpp:4250
-#: ../../Firmware/ultralcd.cpp:4284 ../../Firmware/ultralcd.cpp:4313
-#: ../../Firmware/ultralcd.cpp:4342 ../../Firmware/ultralcd.cpp:4811
-#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4834
-#: ../../Firmware/ultralcd.cpp:5644 ../../Firmware/ultralcd.cpp:5741
-#: ../../Firmware/ultralcd.cpp:5756 ../../Firmware/ultralcd.cpp:5767
-#: ../../Firmware/ultralcd.cpp:5836 ../../Firmware/ultralcd.cpp:7841
-#: ../../Firmware/ultralcd.cpp:7845
+#: ../../Firmware/ultralcd.cpp:4253 ../../Firmware/ultralcd.cpp:4269
+#: ../../Firmware/ultralcd.cpp:4303 ../../Firmware/ultralcd.cpp:4332
+#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4830
+#: ../../Firmware/ultralcd.cpp:4849 ../../Firmware/ultralcd.cpp:4853
+#: ../../Firmware/ultralcd.cpp:5666 ../../Firmware/ultralcd.cpp:5763
+#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/ultralcd.cpp:5858 ../../Firmware/ultralcd.cpp:7881
+#: ../../Firmware/ultralcd.cpp:7885
 msgid "Off"
 msgstr "Uit"
 
@@ -1160,19 +1160,19 @@ msgstr ""
 "geladen."
 
 #. MSG_ON c=3
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4244
-#: ../../Firmware/ultralcd.cpp:4248 ../../Firmware/ultralcd.cpp:4280
-#: ../../Firmware/ultralcd.cpp:4303 ../../Firmware/ultralcd.cpp:4341
-#: ../../Firmware/ultralcd.cpp:4811 ../../Firmware/ultralcd.cpp:4830
-#: ../../Firmware/ultralcd.cpp:4834 ../../Firmware/ultralcd.cpp:5745
-#: ../../Firmware/ultralcd.cpp:5756 ../../Firmware/ultralcd.cpp:5765
-#: ../../Firmware/ultralcd.cpp:5836 ../../Firmware/ultralcd.cpp:7841
-#: ../../Firmware/ultralcd.cpp:7845
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4263
+#: ../../Firmware/ultralcd.cpp:4267 ../../Firmware/ultralcd.cpp:4299
+#: ../../Firmware/ultralcd.cpp:4322 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4849
+#: ../../Firmware/ultralcd.cpp:4853 ../../Firmware/ultralcd.cpp:5767
+#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5787
+#: ../../Firmware/ultralcd.cpp:5858 ../../Firmware/ultralcd.cpp:7881
+#: ../../Firmware/ultralcd.cpp:7885
 msgid "On"
 msgstr "Aan"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4453
+#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4472
 msgid "Once"
 msgstr "Eenmaal"
 
@@ -1192,7 +1192,7 @@ msgid "PID cal. finished"
 msgstr "PID kalibratie klaar"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4913
+#: ../../Firmware/ultralcd.cpp:4932
 msgid "PID calibration"
 msgstr "PID kalibratie"
 
@@ -1204,18 +1204,18 @@ msgstr "PINDA opwarmen"
 #. MSG_PINDA_CALIBRATION c=13
 #: ../../Firmware/Marlin_main.cpp:4932 ../../Firmware/Marlin_main.cpp:5035
 #: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:654
-#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4920
+#: ../../Firmware/ultralcd.cpp:4849 ../../Firmware/ultralcd.cpp:4939
 msgid "PINDA cal."
 msgstr "PINDA kalib."
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3361
+#: ../../Firmware/ultralcd.cpp:3380
 msgid "PINDA calibration failed"
 msgstr "PINDA-kalibratie mislukt"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
 #: ../../Firmware/Marlin_main.cpp:5112 ../../Firmware/messages.cpp:110
-#: ../../Firmware/ultralcd.cpp:3355
+#: ../../Firmware/ultralcd.cpp:3374
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1224,13 +1224,13 @@ msgstr ""
 "menu Instellingen-> PINDA kalib."
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4707
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4726
 msgid "Pause"
 msgstr "Pauze"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:5507
-#: ../../Firmware/ultralcd.cpp:5509
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:5529
+#: ../../Firmware/ultralcd.cpp:5531
 msgid "Pause print"
 msgstr "Print pauzeren"
 
@@ -1244,7 +1244,7 @@ msgstr ""
 "punten. Als de tuit het papier beweegt, de printer onmiddellijk uitschakelen."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:4176
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:4195
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1253,18 +1253,18 @@ msgstr ""
 "wizard door de printer opnieuw te starten."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:6250
+#: ../../Firmware/ultralcd.cpp:6280
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr ""
 "AUB IR sensor ver- binding kontrolleren , verwijder filament indien aanwezig."
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6963
+#: ../../Firmware/ultralcd.cpp:6993
 msgid "Please check:"
 msgstr "Controleer aub:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4148
+#: ../../Firmware/ultralcd.cpp:4167
 msgid "Please clean heatbed and then press the knob."
 msgstr "Maak het bed schoon en druk op de knop."
 
@@ -1274,14 +1274,14 @@ msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Reinig de tuit voor de kalibratie. Druk op de knop wanneer gereed."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3945
+#: ../../Firmware/ultralcd.cpp:3964
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr ""
 "Steek a.u.b. filament in de extruder en druk op de knop om het te laden."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3940
+#: ../../Firmware/ultralcd.cpp:3959
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1290,7 +1290,7 @@ msgstr ""
 "te laden."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3863
+#: ../../Firmware/ultralcd.cpp:3882
 msgid "Please load filament first."
 msgstr "Laad a.u.b. eerst filament."
 
@@ -1301,7 +1301,7 @@ msgstr "Open rondsel en verwijder filament handmatig."
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=5
 #: ../../Firmware/mesh_bed_calibration.cpp:2799 ../../Firmware/messages.cpp:70
-#: ../../Firmware/ultralcd.cpp:4085
+#: ../../Firmware/ultralcd.cpp:4104
 msgid "Please place steel sheet on heatbed."
 msgstr "Leg staalplaat op bed."
 
@@ -1312,7 +1312,7 @@ msgid "Please press the knob to unload filament"
 msgstr "Druk op de knop om filament te verwijderen"
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:5213
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:5235
 msgid "Please pull out filament immediately"
 msgstr "Trek onmiddellijk de filament eruit"
 
@@ -1322,7 +1322,7 @@ msgid "Please remove filament and then press the knob."
 msgstr "Trek onmiddellijk filament eruit en druk vervolgens op de knop."
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:4081
+#: ../../Firmware/ultralcd.cpp:4100
 msgid "Please remove shipping helpers first."
 msgstr "Verwijder eerst de transport beschermers."
 
@@ -1338,7 +1338,7 @@ msgid "Please run XYZ calibration first."
 msgstr "Voer eerst de XYZ-kalibratie uit."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:6247
+#: ../../Firmware/ultralcd.cpp:6277
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Verwijder eerst het filament en probeer het opnieuw."
 
@@ -1355,54 +1355,54 @@ msgstr "Voer een upgrade uit"
 #. MSG_PLEASE_WAIT c=20
 #: ../../Firmware/Marlin_main.cpp:3547 ../../Firmware/Marlin_main.cpp:3563
 #: ../../Firmware/Marlin_main.cpp:7931 ../../Firmware/messages.cpp:71
-#: ../../Firmware/ultralcd.cpp:2186 ../../Firmware/ultralcd.cpp:2197
+#: ../../Firmware/ultralcd.cpp:2205 ../../Firmware/ultralcd.cpp:2216
 msgid "Please wait"
 msgstr "Even geduld aub"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1219
-#: ../../Firmware/ultralcd.cpp:1260 ../../Firmware/ultralcd.cpp:1270
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1238
+#: ../../Firmware/ultralcd.cpp:1279 ../../Firmware/ultralcd.cpp:1289
 msgid "Power failures"
 msgstr "Stroomstoringen"
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5502
+#: ../../Firmware/ultralcd.cpp:5524
 msgid "Preheat"
 msgstr "Voorverwarmen"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:2280
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:2299
 msgid "Preheat the nozzle!"
 msgstr "Tuit voorverwarmen!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:2900
-#: ../../Firmware/ultralcd.cpp:3924 ../../Firmware/ultralcd.cpp:3926
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:2919
+#: ../../Firmware/ultralcd.cpp:3943 ../../Firmware/ultralcd.cpp:3945
 msgid "Preheating nozzle. Please wait."
 msgstr "Opwarmen van de tuit. Wacht aub."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1988
+#: ../../Firmware/ultralcd.cpp:2007
 msgid "Preheating to cut"
 msgstr "Opwarm. te snijden"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1985
+#: ../../Firmware/ultralcd.cpp:2004
 msgid "Preheating to eject"
 msgstr "Opwarm.te uitwerpen"
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1976
+#: ../../Firmware/ultralcd.cpp:1995
 msgid "Preheating to load"
 msgstr "Opwarmen invoeren"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1981
+#: ../../Firmware/ultralcd.cpp:2000
 msgid "Preheating to unload"
 msgstr "Opwarmen uitwerpen"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1809
+#: ../../Firmware/ultralcd.cpp:1828
 msgid "Press the knob"
 msgstr "Druk op knop"
 
@@ -1422,13 +1422,13 @@ msgid "Print aborted"
 msgstr "Print afgebroken"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1144
-#: ../../Firmware/ultralcd.cpp:7322
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1145
+#: ../../Firmware/ultralcd.cpp:7354
 msgid "Print fan:"
 msgstr "Print fan:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5535
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5557
 msgid "Print from SD"
 msgstr "Print van SD"
 
@@ -1438,12 +1438,12 @@ msgid "Print paused"
 msgstr "Print pauzeren"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2366
+#: ../../Firmware/ultralcd.cpp:2385
 msgid "Print time"
 msgstr "Print tijd"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1711
+#: ../../Firmware/ultralcd.cpp:1730
 msgid "Printer IP Addr:"
 msgstr "Printer IP-adres:"
 
@@ -1472,12 +1472,12 @@ msgstr ""
 "de waarde in de instellingen. Afdrukken geannuleerd."
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4834
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4853
 msgid "RPi port"
 msgstr "RPi port"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2755
+#: ../../Firmware/ultralcd.cpp:2774
 msgid "Rear side [μm]"
 msgstr "Achterkant[μm]"
 
@@ -1493,24 +1493,24 @@ msgstr ""
 "Verwijder de oude filament en druk op de knop om nieuwe filament te laden."
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5426
+#: ../../Firmware/ultralcd.cpp:5448
 msgid "Rename"
 msgstr "Hernoem"
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2756
-#: ../../Firmware/ultralcd.cpp:5427
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2775
+#: ../../Firmware/ultralcd.cpp:5449
 msgid "Reset"
 msgstr "Reset"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4917
+#: ../../Firmware/ultralcd.cpp:4936
 msgid "Reset XYZ calibr."
 msgstr "Reset XYZ kalibr."
 
 #. MSG_RESUME_PRINT c=18
 #: ../../Firmware/Marlin_main.cpp:655 ../../Firmware/messages.cpp:81
-#: ../../Firmware/ultralcd.cpp:5521 ../../Firmware/ultralcd.cpp:5523
+#: ../../Firmware/ultralcd.cpp:5543 ../../Firmware/ultralcd.cpp:5545
 msgid "Resume print"
 msgstr "Print hervatten"
 
@@ -1520,17 +1520,17 @@ msgid "Resuming print"
 msgstr "Hervatten print"
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2497
+#: ../../Firmware/ultralcd.cpp:2516
 msgid "Right"
 msgstr "Rechts"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2753
+#: ../../Firmware/ultralcd.cpp:2772
 msgid "Right side[μm]"
 msgstr "Recht.kant[μm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3884
+#: ../../Firmware/ultralcd.cpp:3903
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1539,14 +1539,14 @@ msgstr ""
 "vanaf het begin. Doorgaan?"
 
 #. MSG_RUNOUTS c=7
-#: ../../Firmware/ultralcd.cpp:1271
+#: ../../Firmware/ultralcd.cpp:1290
 msgid "Runouts"
 msgstr "Fouten"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4395
-#: ../../Firmware/ultralcd.cpp:4397 ../../Firmware/ultralcd.cpp:4414
-#: ../../Firmware/ultralcd.cpp:4416
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4414
+#: ../../Firmware/ultralcd.cpp:4416 ../../Firmware/ultralcd.cpp:4433
+#: ../../Firmware/ultralcd.cpp:4435
 msgid "SD card"
 msgstr "SD kaart"
 
@@ -1562,12 +1562,12 @@ msgid "Searching bed calibration point"
 msgstr "Zoeken bed kalibratiepunt"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5419
+#: ../../Firmware/ultralcd.cpp:5441
 msgid "Select"
 msgstr "Selecteer"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3966
+#: ../../Firmware/ultralcd.cpp:3985
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
@@ -1582,51 +1582,51 @@ msgstr "Kies extruder:"
 
 #. MSG_SELECT_FILAMENT c=20
 #: ../../Firmware/Marlin_main.cpp:8577 ../../Firmware/Marlin_main.cpp:8604
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3834
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3853
 msgid "Select filament:"
 msgstr "Kies filament:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:3679
-#: ../../Firmware/ultralcd.cpp:4841
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:3698
+#: ../../Firmware/ultralcd.cpp:4860
 msgid "Select language"
 msgstr "Kies taal"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:4122
+#: ../../Firmware/ultralcd.cpp:4141
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr ""
 "Selecteer de voorverwarmingstemperatuur van de tuit die overeenkomt met uw "
 "materiaal."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3971
+#: ../../Firmware/ultralcd.cpp:3990
 msgid "Select temperature which matches your material."
 msgstr "Selecteer de temperatuur die overeenkomt met uw materiaal."
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6522
+#: ../../Firmware/ultralcd.cpp:6552
 msgid "Self test OK"
 msgstr "Zelftest OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:6290
+#: ../../Firmware/ultralcd.cpp:6320
 msgid "Self test start"
 msgstr "Zelftest start"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4904
+#: ../../Firmware/ultralcd.cpp:4923
 msgid "Selftest"
 msgstr "Zelftest"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6962
+#: ../../Firmware/ultralcd.cpp:6992
 msgid "Selftest error!"
 msgstr "Zelftest fout!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:6526
-#: ../../Firmware/ultralcd.cpp:7049 ../../Firmware/ultralcd.cpp:7314
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:6556
+#: ../../Firmware/ultralcd.cpp:7079 ../../Firmware/ultralcd.cpp:7344
 msgid "Selftest failed"
 msgstr "Zelftest mislukt"
 
@@ -1638,30 +1638,30 @@ msgstr ""
 "kalibreren."
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1723
+#: ../../Firmware/ultralcd.cpp:1742
 msgid "Sensor info"
 msgstr "Sensor info"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:6254
+#: ../../Firmware/ultralcd.cpp:6284
 msgid "Sensor verified, remove the filament now."
 msgstr "Sensor geverifieerd, verwijder nu het filament."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2773
+#: ../../Firmware/ultralcd.cpp:2792
 msgid "Set temperature:"
 msgstr "Temp. instellen:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:3491
-#: ../../Firmware/ultralcd.cpp:3696 ../../Firmware/ultralcd.cpp:4206
-#: ../../Firmware/ultralcd.cpp:5580 ../../Firmware/ultralcd.cpp:5827
-#: ../../Firmware/ultralcd.cpp:5880
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:3510
+#: ../../Firmware/ultralcd.cpp:3715 ../../Firmware/ultralcd.cpp:4225
+#: ../../Firmware/ultralcd.cpp:5602 ../../Firmware/ultralcd.cpp:5849
+#: ../../Firmware/ultralcd.cpp:5902
 msgid "Settings"
 msgstr "Instellingen"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2540
+#: ../../Firmware/ultralcd.cpp:2559
 msgid "Severe skew"
 msgstr "Erg scheef"
 
@@ -1672,7 +1672,7 @@ msgid "Sheet"
 msgstr "Staalplaat"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3824
+#: ../../Firmware/ultralcd.cpp:3843
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1685,18 +1685,18 @@ msgstr ""
 "%cReset"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4915
+#: ../../Firmware/ultralcd.cpp:4934
 msgid "Show end stops"
 msgstr "Toon endstops"
 
 #. MSG_SILENT c=7
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4361
-#: ../../Firmware/ultralcd.cpp:4456 ../../Firmware/ultralcd.cpp:5778
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4380
+#: ../../Firmware/ultralcd.cpp:4475 ../../Firmware/ultralcd.cpp:5800
 msgid "Silent"
 msgstr "Stil"
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2539
+#: ../../Firmware/ultralcd.cpp:2558
 msgid "Slight skew"
 msgstr "Beetje scheef"
 
@@ -1715,8 +1715,8 @@ msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Er is een probleem opgetreden, Z-kalibratie afgedwongen ..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4403
-#: ../../Firmware/ultralcd.cpp:4404 ../../Firmware/ultralcd.cpp:4405
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4422
+#: ../../Firmware/ultralcd.cpp:4423 ../../Firmware/ultralcd.cpp:4424
 msgid "Sort"
 msgstr "Sort."
 
@@ -1727,20 +1727,20 @@ msgid "Sorting files"
 msgstr "Bestanden sorteren"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4450
-#: ../../Firmware/ultralcd.cpp:4453 ../../Firmware/ultralcd.cpp:4456
-#: ../../Firmware/ultralcd.cpp:4459 ../../Firmware/ultralcd.cpp:4462
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/ultralcd.cpp:4472 ../../Firmware/ultralcd.cpp:4475
+#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4481
 msgid "Sound"
 msgstr "Geluid"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5718
+#: ../../Firmware/ultralcd.cpp:5740
 msgid "Speed"
 msgstr "Snelheid"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7166
-#: ../../Firmware/ultralcd.cpp:7181 ../../Firmware/ultralcd.cpp:7189
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7196
+#: ../../Firmware/ultralcd.cpp:7211 ../../Firmware/ultralcd.cpp:7219
 msgid "Spinning"
 msgstr "Draait"
 
@@ -1752,42 +1752,42 @@ msgstr ""
 "vereist."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5585
+#: ../../Firmware/ultralcd.cpp:5607
 msgid "Statistics"
 msgstr "Statistieken"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4338
-#: ../../Firmware/ultralcd.cpp:4382 ../../Firmware/ultralcd.cpp:5770
+#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4357
+#: ../../Firmware/ultralcd.cpp:4401 ../../Firmware/ultralcd.cpp:5792
 msgid "Stealth"
 msgstr "Stil"
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4763
-#: ../../Firmware/ultralcd.cpp:5416
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4782
+#: ../../Firmware/ultralcd.cpp:5438
 msgid "Steel sheets"
 msgstr "Staalplaten"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5528
-#: ../../Firmware/ultralcd.cpp:5987
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5550
+#: ../../Firmware/ultralcd.cpp:6017
 msgid "Stop print"
 msgstr "Print stoppen"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4499
-#: ../../Firmware/ultralcd.cpp:4581 ../../Firmware/ultralcd.cpp:4620
-#: ../../Firmware/ultralcd.cpp:4661
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4518
+#: ../../Firmware/ultralcd.cpp:4600 ../../Firmware/ultralcd.cpp:4639
+#: ../../Firmware/ultralcd.cpp:4680
 msgid "Strict"
 msgstr "Strikt"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/ultralcd.cpp:5616
 msgid "Support"
 msgstr "Support"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:7021
+#: ../../Firmware/ultralcd.cpp:7051
 msgid "Swapped"
 msgstr "Gewisseld"
 
@@ -1796,28 +1796,18 @@ msgstr "Gewisseld"
 msgid "THERMAL ANOMALY"
 msgstr "THERMISCHE ANOMALIE"
 
-#. MSG_TM_AUTOTUNE_FAILED c=20
-#: ../../Firmware/temperature.cpp:2899
-msgid "TM autotune failed"
-msgstr "TM autotune mislukt"
-
-#. MSG_TEMP_MODEL_AUTOTUNE c=20
-#: ../../Firmware/temperature.cpp:2884
-msgid "Temp. model autotune"
-msgstr "Temp. model autotune"
-
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4797
+#: ../../Firmware/ultralcd.cpp:4816
 msgid "Temperature"
 msgstr "Temperatuur"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1729
+#: ../../Firmware/ultralcd.cpp:1748
 msgid "Temperatures"
 msgstr "Temperaturen"
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3974
+#: ../../Firmware/ultralcd.cpp:3993
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -1837,66 +1827,66 @@ msgstr ""
 "handleiding, hoofdstuk First steps, section Calibration flow."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4403
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4422
 msgid "Time"
 msgstr "Tijd"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:5865
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:5887
 msgid "Timeout"
 msgstr "Time-out"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:1149
-#: ../../Firmware/ultralcd.cpp:1297
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:1168
+#: ../../Firmware/ultralcd.cpp:1316
 msgid "Total"
 msgstr "Totaal"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:1192
-#: ../../Firmware/ultralcd.cpp:1218 ../../Firmware/ultralcd.cpp:1328
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:1211
+#: ../../Firmware/ultralcd.cpp:1237 ../../Firmware/ultralcd.cpp:1347
 msgid "Total failures"
 msgstr "Totaal fouten"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2387
+#: ../../Firmware/ultralcd.cpp:2406
 msgid "Total filament"
 msgstr "Totaal fil."
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2388
+#: ../../Firmware/ultralcd.cpp:2407
 msgid "Total print time"
 msgstr "Totaal printtijd"
 
 #. MSG_TUNE c=18
-#: ../../Firmware/ultralcd.cpp:5500
+#: ../../Firmware/ultralcd.cpp:5522
 msgid "Tune"
 msgstr "Fijnafstemming"
 
 #. MSG_UNLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:5564
-#: ../../Firmware/ultralcd.cpp:5578
+#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:5586
+#: ../../Firmware/ultralcd.cpp:5600
 msgid "Unload filament"
 msgstr "Fil. uitwerpen"
 
 #. MSG_UNLOADING_FILAMENT c=20
 #: ../../Firmware/messages.cpp:112 ../../Firmware/mmu.cpp:957
-#: ../../Firmware/ultralcd.cpp:5197
+#: ../../Firmware/ultralcd.cpp:5219
 msgid "Unloading filament"
 msgstr "Uitwerpen filament"
 
 #. MSG_FIL_FAILED c=20 r=5
-#: ../../Firmware/ultralcd.cpp:6258
+#: ../../Firmware/ultralcd.cpp:6288
 msgid "Verification failed, remove the filament and try again."
 msgstr "Verificatie mislukt, verwijder het filament en probeer het opnieuw."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1732
+#: ../../Firmware/ultralcd.cpp:1751
 msgid "Voltages"
 msgstr "Spanning"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3534
+#: ../../Firmware/ultralcd.cpp:3553
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -1914,19 +1904,19 @@ msgid "Wait for user..."
 msgstr "Wacht op gebruiker.."
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2881
+#: ../../Firmware/ultralcd.cpp:2900
 msgid "Waiting for PINDA probe cooling"
 msgstr "Wachten op afkoelen van PINDA"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2913
+#: ../../Firmware/ultralcd.cpp:2932
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Wachten op afkoelen van tuit en bed"
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:4496
-#: ../../Firmware/ultralcd.cpp:4578 ../../Firmware/ultralcd.cpp:4617
-#: ../../Firmware/ultralcd.cpp:4658
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/ultralcd.cpp:4597 ../../Firmware/ultralcd.cpp:4636
+#: ../../Firmware/ultralcd.cpp:4677
 msgid "Warn"
 msgstr "Waarsch."
 
@@ -1952,146 +1942,135 @@ msgid "Was filament unload successful?"
 msgstr "Is filament succes- vol verwijderd?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6973
-#: ../../Firmware/ultralcd.cpp:6977 ../../Firmware/ultralcd.cpp:6997
-#: ../../Firmware/ultralcd.cpp:7003 ../../Firmware/ultralcd.cpp:7027
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:7003
+#: ../../Firmware/ultralcd.cpp:7007 ../../Firmware/ultralcd.cpp:7027
+#: ../../Firmware/ultralcd.cpp:7033 ../../Firmware/ultralcd.cpp:7057
 msgid "Wiring error"
 msgstr "Aansluitingsfout"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4895
+#: ../../Firmware/ultralcd.cpp:4914
 msgid "Wizard"
 msgstr "Wizard"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4210
+#: ../../Firmware/ultralcd.cpp:4229
 msgid "X-correct:"
 msgstr "X-correctie:"
 
 #. MSG_XFLASH c=18
-#: ../../Firmware/ultralcd.cpp:5596
+#: ../../Firmware/ultralcd.cpp:5618
 msgid "XFLASH init"
 msgstr "XFLASH init"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1721
+#: ../../Firmware/ultralcd.cpp:1740
 msgid "XYZ cal. details"
 msgstr "XYZ kal. details"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3333
+#: ../../Firmware/ultralcd.cpp:3352
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr ""
 "XYZ-kalibratie in orde. Scheefheid zal automatisch worden gecorrigeerd."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3330
+#: ../../Firmware/ultralcd.cpp:3349
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr "XYZ-kalibratie in orde. X / Y-assen zijn licht scheef. Goed gedaan!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3311
+#: ../../Firmware/ultralcd.cpp:3330
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr "XYZ-kalibratie niet gelukt. Voorste kalibratiepunten niet bereikbaar."
 
-#. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_LEFT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3317
-msgid ""
-"XYZ calibration compromised. Left front calibration point not reachable."
-msgstr ""
-
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3314
+#: ../../Firmware/ultralcd.cpp:3333
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr ""
 "XYZ-kalibratie niet gelukt. Rechter voor kalibratiepunt niet bereikbaar."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3293
+#: ../../Firmware/ultralcd.cpp:3312
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr "XYZ-kalibratie mislukt. Bed ijkpunt niet gevonden."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3299
+#: ../../Firmware/ultralcd.cpp:3318
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr "XYZ-kalibratie mislukt. Voorste kalibratiepunten niet bereikbaar."
 
-#. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_LEFT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3305
-msgid "XYZ calibration failed. Left front calibration point not reachable."
-msgstr "XYZ-kalibratie mislukt. Kalibratiepunt linksvoor niet bereikbaar."
-
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3296
-#: ../../Firmware/ultralcd.cpp:3324
+#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3315
+#: ../../Firmware/ultralcd.cpp:3343
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "XYZ-kalibratie mislukt. Raadpleeg de handleiding aub."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3302
+#: ../../Firmware/ultralcd.cpp:3321
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr "XYZ-kalibratie mislukt. Rechter voor kalibratiepunt niet bereikbaar."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3327
+#: ../../Firmware/ultralcd.cpp:3346
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "XYZ-kalibratie ok. X / Y-assen staan loodrecht. Gefeliciteerd!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2494
+#: ../../Firmware/ultralcd.cpp:2513
 msgid "Y distance from min"
 msgstr "Y afstand van min"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4211
+#: ../../Firmware/ultralcd.cpp:4230
 msgid "Y-correct:"
 msgstr "Y-correctie:"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:2216
-#: ../../Firmware/ultralcd.cpp:2800 ../../Firmware/ultralcd.cpp:3180
-#: ../../Firmware/ultralcd.cpp:4785 ../../Firmware/ultralcd.cpp:5989
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:2235
+#: ../../Firmware/ultralcd.cpp:2819 ../../Firmware/ultralcd.cpp:3199
+#: ../../Firmware/ultralcd.cpp:4804 ../../Firmware/ultralcd.cpp:6019
 msgid "Yes"
 msgstr "Ja"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:4187
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:4206
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr "U kunt de wizard altijd hervatten via Kalibratie -> Wizard."
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4231
 msgid "Z-correct:"
 msgstr "Z-correctie:"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:5835
+#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:5857
 msgid "Z-probe nr."
 msgstr "Z-test nr."
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2565
+#: ../../Firmware/ultralcd.cpp:2584
 msgid "[0;0] point offset"
 msgstr "[0;0] punt offset"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2154
+#: ../../Firmware/ultralcd.cpp:2173
 msgid "and press the knob"
 msgstr "en druk op knop"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1816
+#: ../../Firmware/ultralcd.cpp:1835
 msgid "to load filament"
 msgstr "om filament te laden"
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1820
+#: ../../Firmware/ultralcd.cpp:1839
 msgid "to unload filament"
 msgstr "om fil. uitwerpen"
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1688
+#: ../../Firmware/ultralcd.cpp:1707
 msgid "unknown"
 msgstr "onbekend"
 
@@ -2101,8 +2080,8 @@ msgid "unknown state"
 msgstr "Status onbekend"
 
 #. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:6077
-#: ../../Firmware/ultralcd.cpp:6080
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:6107
+#: ../../Firmware/ultralcd.cpp:6110
 msgid "🔃Refresh"
 msgstr "🔃Refresh"
 
@@ -2111,3 +2090,12 @@ msgstr "🔃Refresh"
 
 #~ msgid "M117 First layer cal."
 #~ msgstr "M117 Eerste laag kal."
+
+#~ msgid "TM autotune failed"
+#~ msgstr "TM autotune mislukt"
+
+#~ msgid "Temp. model autotune"
+#~ msgstr "Temp. model autotune"
+
+#~ msgid "XYZ calibration failed. Left front calibration point not reachable."
+#~ msgstr "XYZ-kalibratie mislukt. Kalibratiepunt linksvoor niet bereikbaar."

--- a/lang/po/Firmware_no.po
+++ b/lang/po/Firmware_no.po
@@ -26,115 +26,115 @@ msgid " 0.4 or newer"
 msgstr " 0.4 eller nyere"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:7036
+#: ../../Firmware/ultralcd.cpp:7066
 msgid "%s level expected"
 msgstr "%s nivå ventet"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1968
-#: ../../Firmware/ultralcd.cpp:3835
+#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1987
+#: ../../Firmware/ultralcd.cpp:3854
 msgid ">Cancel"
 msgstr ">Avbryt"
 
 #. MSG_BABYSTEPPING_Z c=15
 #. Beware: must include the ':' as its last character
-#: ../../Firmware/ultralcd.cpp:2670
+#: ../../Firmware/ultralcd.cpp:2689
 msgid "Adjusting Z:"
 msgstr "Justerer Z:"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:7313
+#: ../../Firmware/ultralcd.cpp:7343
 msgid "All correct"
 msgstr "Alt korrekt"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4180
+#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4190
+#: ../../Firmware/ultralcd.cpp:4199
 msgid "All is done. Happy printing!"
 msgstr "Alt klart. God printing!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4404
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4423
 msgid "Alphabet"
 msgstr "Alfabet"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4308
+#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4327
 msgid "Always"
 msgstr "Alltid"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1405
+#: ../../Firmware/ultralcd.cpp:1424
 msgid "Ambient"
 msgstr "Omgivelse"
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2983
+#: ../../Firmware/ultralcd.cpp:3002
 msgid "Are left and right Z~carriages all up?"
 msgstr "Er venstre og høyre Z-vogn helt oppe?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4478
 msgid "Assist"
 msgstr "Hjelp"
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:5886
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
 #: ../../Firmware/Marlin_main.cpp:3271 ../../Firmware/messages.cpp:9
-#: ../../Firmware/ultralcd.cpp:4900
+#: ../../Firmware/ultralcd.cpp:4919
 msgid "Auto home"
 msgstr "Auto hjem"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:4364
-#: ../../Firmware/ultralcd.cpp:5779
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:4383
+#: ../../Firmware/ultralcd.cpp:5801
 msgid "Auto power"
 msgstr "Autostyrke"
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5572
+#: ../../Firmware/ultralcd.cpp:5594
 msgid "AutoLoad filament"
 msgstr "AutoLast filament"
 
 #. MSG_AUTOLOADING_ONLY_IF_FSENS_ON c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3549
+#: ../../Firmware/ultralcd.cpp:3568
 msgid ""
 "Autoloading filament available only when filament sensor is turned on..."
 msgstr ""
 "Autolasting av fil. er kun tilgjengelig når fil.- sensoren er skrudd på..."
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2301
+#: ../../Firmware/ultralcd.cpp:2320
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
 "Autolasting av fil. er aktivert. Trykk på knappen og sett inn filament..."
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:7015
+#: ../../Firmware/ultralcd.cpp:7045
 msgid "Axis"
 msgstr "Akse"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:7014
+#: ../../Firmware/ultralcd.cpp:7044
 msgid "Axis length"
 msgstr "Akselengde"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:2751
-#: ../../Firmware/ultralcd.cpp:5861 ../../Firmware/ultralcd.cpp:7838
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:2770
+#: ../../Firmware/ultralcd.cpp:5883 ../../Firmware/ultralcd.cpp:7878
 msgid "Back"
 msgstr "Tilbake"
 
 #. MSG_BED c=13
 #: ../../Firmware/Marlin_main.cpp:2051 ../../Firmware/Marlin_main.cpp:4767
 #: ../../Firmware/Marlin_main.cpp:4819 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:1403 ../../Firmware/ultralcd.cpp:5721
-#: ../../Firmware/ultralcd.cpp:5891
+#: ../../Firmware/ultralcd.cpp:1422 ../../Firmware/ultralcd.cpp:5743
+#: ../../Firmware/ultralcd.cpp:5913
 msgid "Bed"
 msgstr "Seng"
 
@@ -151,7 +151,7 @@ msgid "Bed done"
 msgstr "Seng ferdig"
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4912
+#: ../../Firmware/ultralcd.cpp:4931
 msgid "Bed level correct"
 msgstr "Plankorrekt seng"
 
@@ -169,18 +169,18 @@ msgstr ""
 "omstart."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6972
+#: ../../Firmware/ultralcd.cpp:7002
 msgid "Bed/Heater"
 msgstr "Seng/Varmer"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1458
-#: ../../Firmware/ultralcd.cpp:1726
+#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1477
+#: ../../Firmware/ultralcd.cpp:1745
 msgid "Belt status"
 msgstr "Beltestatus"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4902
+#: ../../Firmware/ultralcd.cpp:4921
 msgid "Belt test"
 msgstr "Belte test"
 
@@ -191,28 +191,28 @@ msgid "Blackout occurred. Recover print?"
 msgstr "Oppdaget Strømbrudd! Gjenoppta print?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:5886
 msgid "Bright"
 msgstr "Lys"
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4850
-#: ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4869
+#: ../../Firmware/ultralcd.cpp:5811
 msgid "Brightness"
 msgstr "Lysstyrke"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4906
+#: ../../Firmware/ultralcd.cpp:4925
 msgid "Calibrate XYZ"
 msgstr "Kalibrer XYZ"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4908
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4927
 msgid "Calibrate Z"
 msgstr "Kalibrer Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2946
+#: ../../Firmware/ultralcd.cpp:2965
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -227,7 +227,7 @@ msgid "Calibrating Z"
 msgstr "Kalibrer Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2945
+#: ../../Firmware/ultralcd.cpp:2964
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -236,12 +236,12 @@ msgstr ""
 "trykk."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:7315
+#: ../../Firmware/ultralcd.cpp:7345
 msgid "Calibrating home"
 msgstr "Kalibrerer hjem"
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:5581
+#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:5603
 msgid "Calibration"
 msgstr "Kalibrering"
 
@@ -251,115 +251,115 @@ msgid "Calibration done"
 msgstr "Kalibrering ferdig"
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7712
+#: ../../Firmware/ultralcd.cpp:7752
 msgid "Card removed"
 msgstr "Kort fjernet"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/ultralcd.cpp:5560
 msgid "Change SD card"
 msgstr "Bytt SD kort"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5497
-#: ../../Firmware/ultralcd.cpp:5730
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5519
+#: ../../Firmware/ultralcd.cpp:5752
 msgid "Change filament"
 msgstr "Bytt filament"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2163
+#: ../../Firmware/ultralcd.cpp:2182
 msgid "Change success!"
 msgstr "Bytte vellykket!"
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2215
+#: ../../Firmware/ultralcd.cpp:2234
 msgid "Changed correctly?"
 msgstr "Byttet riktig?"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:6178
-#: ../../Firmware/ultralcd.cpp:7305
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:6208
+#: ../../Firmware/ultralcd.cpp:7335
 msgid "Checking X axis"
 msgstr "Sjekker X aksen"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:6187
-#: ../../Firmware/ultralcd.cpp:7306
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:6217
+#: ../../Firmware/ultralcd.cpp:7336
 msgid "Checking Y axis"
 msgstr "Sjekker Y aksen"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:7307
+#: ../../Firmware/ultralcd.cpp:7337
 msgid "Checking Z axis"
 msgstr "Sjekker Z aksen"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:7308
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:7338
 msgid "Checking bed"
 msgstr "Sjekker seng"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:7304
+#: ../../Firmware/ultralcd.cpp:7334
 msgid "Checking endstops"
 msgstr "Sjekker endesensorer"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:7403
+#: ../../Firmware/ultralcd.cpp:7433
 msgid "Checking file"
 msgstr "Sjekker fil"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:7310
+#: ../../Firmware/ultralcd.cpp:7340
 msgid "Checking hotend"
 msgstr "Sjekker hotend"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:7311
-#: ../../Firmware/ultralcd.cpp:7312
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:7341
+#: ../../Firmware/ultralcd.cpp:7342
 msgid "Checking sensors"
 msgstr "Sjekker sensorer"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4765
+#: ../../Firmware/ultralcd.cpp:4784
 msgid "Checks"
 msgstr "G-code sjekk"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2218
+#: ../../Firmware/ultralcd.cpp:2237
 msgid "Color not correct"
 msgstr "Farge ikke riktig"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3725
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3744
 msgid "Community made"
 msgstr "Community laget"
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4704
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4723
 msgid "Cont."
 msgstr "Fort."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2125
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2144
 msgid "Cooldown"
 msgstr "Nedkjøling"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3663
+#: ../../Firmware/ultralcd.cpp:3682
 msgid "Copy selected language?"
 msgstr "Kopiere det valgte språket?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1221
-#: ../../Firmware/ultralcd.cpp:1262 ../../Firmware/ultralcd.cpp:1272
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1240
+#: ../../Firmware/ultralcd.cpp:1281 ../../Firmware/ultralcd.cpp:1291
 msgid "Crash"
 msgstr "Krasj"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4341
-#: ../../Firmware/ultralcd.cpp:4342 ../../Firmware/ultralcd.cpp:4344
-#: ../../Firmware/ultralcd.cpp:5765 ../../Firmware/ultralcd.cpp:5767
-#: ../../Firmware/ultralcd.cpp:5771
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4363
+#: ../../Firmware/ultralcd.cpp:5787 ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/ultralcd.cpp:5793
 msgid "Crash det."
 msgstr "Krasjdetek."
 
@@ -369,7 +369,7 @@ msgid "Crash detected."
 msgstr "Krasj oppdaget."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3521
+#: ../../Firmware/ultralcd.cpp:3540
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -380,14 +380,14 @@ msgstr ""
 "Normal modus"
 
 #. MSG_CUT_FILAMENT c=17
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:5175
-#: ../../Firmware/ultralcd.cpp:5567
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:5197
+#: ../../Firmware/ultralcd.cpp:5589
 msgid "Cut filament"
 msgstr "Kutt filament"
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:4303
-#: ../../Firmware/ultralcd.cpp:4308 ../../Firmware/ultralcd.cpp:4313
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:4322
+#: ../../Firmware/ultralcd.cpp:4327 ../../Firmware/ultralcd.cpp:4332
 msgid "Cutter"
 msgstr "Kutter"
 
@@ -397,17 +397,17 @@ msgid "Cutting filament"
 msgstr "Kutter filament"
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1668
+#: ../../Firmware/ultralcd.cpp:1687
 msgid "Date:"
 msgstr "Dato:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5886
 msgid "Dim"
 msgstr "Svak"
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4802
+#: ../../Firmware/ultralcd.cpp:4821
 msgid "Disable steppers"
 msgstr "Frigjør motorer"
 
@@ -423,7 +423,7 @@ msgstr ""
 "manualen, under First Steps, for hvordan det første laget skal kalibreres."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:4145
+#: ../../Firmware/ultralcd.cpp:4164
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -432,23 +432,23 @@ msgstr ""
 "platen?"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4214
+#: ../../Firmware/ultralcd.cpp:4233
 msgid "E-correct:"
 msgstr "E-korreksjon:"
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2279
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2298
 msgid "ERROR:"
 msgstr "FEIL:"
 
 #. MSG_FSENS_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3562
+#: ../../Firmware/ultralcd.cpp:3581
 msgid "ERROR: Filament sensor is not responding, please check connection."
 msgstr "ERROR: Filament- sensor svarer ikke. Vennligst sjekk koblingen."
 
 #. MSG_EJECT_FILAMENT c=17
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:5156
-#: ../../Firmware/ultralcd.cpp:5565
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:5178
+#: ../../Firmware/ultralcd.cpp:5587
 msgid "Eject filament"
 msgstr "Mat ut filament"
 
@@ -458,47 +458,41 @@ msgid "Ejecting filament"
 msgstr "Mater ut filament"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6985
+#: ../../Firmware/ultralcd.cpp:7015
 msgid "Endstop"
 msgstr "Endesensor"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6990
+#: ../../Firmware/ultralcd.cpp:7020
 msgid "Endstop not hit"
 msgstr "Traff ikke endesens."
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6976
+#: ../../Firmware/ultralcd.cpp:7006
 msgid "Endstops"
 msgstr "Endesensorer"
 
 #. MSG_EXTRUDER c=17
 #: ../../Firmware/Marlin_main.cpp:8608 ../../Firmware/messages.cpp:30
-#: ../../Firmware/ultralcd.cpp:3495
+#: ../../Firmware/ultralcd.cpp:3514
 msgid "Extruder"
 msgstr "Ekstruder"
 
-#. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1144
-#: ../../Firmware/ultralcd.cpp:7319
-msgid "Hotend fan:"
-msgstr "Hotend-vifte:"
-
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1722
+#: ../../Firmware/ultralcd.cpp:1741
 msgid "Extruder info"
 msgstr "Ekstruderinfo"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4229
-#: ../../Firmware/ultralcd.cpp:4237 ../../Firmware/ultralcd.cpp:4248
-#: ../../Firmware/ultralcd.cpp:4250
+#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4248
+#: ../../Firmware/ultralcd.cpp:4256 ../../Firmware/ultralcd.cpp:4267
+#: ../../Firmware/ultralcd.cpp:4269
 msgid "F. autoload"
 msgstr "F. autolast"
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4704
-#: ../../Firmware/ultralcd.cpp:4707
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4723
+#: ../../Firmware/ultralcd.cpp:4726
 msgid "FS Action"
 msgstr "FS aksjon"
 
@@ -513,102 +507,102 @@ msgid "FS v0.4 or newer"
 msgstr "FS 0.4 eller nyere"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5589
+#: ../../Firmware/ultralcd.cpp:5611
 msgid "Fail stats"
 msgstr "Feilstatistikk"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5592
+#: ../../Firmware/ultralcd.cpp:5614
 msgid "Fail stats MMU"
 msgstr "Feil stat. MMU"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:7031
+#: ../../Firmware/ultralcd.cpp:7061
 msgid "False triggering"
 msgstr "Falskt utløsning"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:5723
-#: ../../Firmware/ultralcd.cpp:5893
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/ultralcd.cpp:5915
 msgid "Fan speed"
 msgstr "Viftehastighet"
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:7143
-#: ../../Firmware/ultralcd.cpp:7301 ../../Firmware/ultralcd.cpp:7302
-#: ../../Firmware/ultralcd.cpp:7303
+#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:7173
+#: ../../Firmware/ultralcd.cpp:7331 ../../Firmware/ultralcd.cpp:7332
+#: ../../Firmware/ultralcd.cpp:7333
 msgid "Fan test"
 msgstr "Viftetest"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4811
-#: ../../Firmware/ultralcd.cpp:5756
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4830
+#: ../../Firmware/ultralcd.cpp:5778
 msgid "Fans check"
 msgstr "Viftesjekk"
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1220
-#: ../../Firmware/ultralcd.cpp:1261 ../../Firmware/ultralcd.cpp:1327
-#: ../../Firmware/ultralcd.cpp:1329
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1239
+#: ../../Firmware/ultralcd.cpp:1280 ../../Firmware/ultralcd.cpp:1346
+#: ../../Firmware/ultralcd.cpp:1348
 msgid "Fil. runouts"
 msgstr "Tomt filament"
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:3451
-#: ../../Firmware/ultralcd.cpp:4228 ../../Firmware/ultralcd.cpp:4234
-#: ../../Firmware/ultralcd.cpp:4244 ../../Firmware/ultralcd.cpp:5737
-#: ../../Firmware/ultralcd.cpp:5741 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:3470
+#: ../../Firmware/ultralcd.cpp:4247 ../../Firmware/ultralcd.cpp:4253
+#: ../../Firmware/ultralcd.cpp:4263 ../../Firmware/ultralcd.cpp:5759
+#: ../../Firmware/ultralcd.cpp:5763 ../../Firmware/ultralcd.cpp:5767
 msgid "Fil. sensor"
 msgstr "Fil. Sensor"
 
 #. MSG_FILAMENT c=17
 #: ../../Firmware/Marlin_main.cpp:8577 ../../Firmware/Marlin_main.cpp:8604
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3835
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3854
 msgid "Filament"
 msgstr "Filament"
 
 #. MSG_FILAMENT_CLEAN c=20 r=2
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2287
-#: ../../Firmware/ultralcd.cpp:2293
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2306
+#: ../../Firmware/ultralcd.cpp:2312
 msgid "Filament extruding & with correct color?"
 msgstr "Kommer Filament ut og har riktig farge?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2217
+#: ../../Firmware/ultralcd.cpp:2236
 msgid "Filament not loaded"
 msgstr "Fil. ikke lastet"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:7026
-#: ../../Firmware/ultralcd.cpp:7030 ../../Firmware/ultralcd.cpp:7034
-#: ../../Firmware/ultralcd.cpp:7330
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:7056
+#: ../../Firmware/ultralcd.cpp:7060 ../../Firmware/ultralcd.cpp:7064
+#: ../../Firmware/ultralcd.cpp:7360
 msgid "Filament sensor"
 msgstr "Filamentsensor"
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2365
+#: ../../Firmware/ultralcd.cpp:2384
 msgid "Filament used"
 msgstr "Brukt filament"
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7461
+#: ../../Firmware/ultralcd.cpp:7491
 msgid "File incomplete. Continue anyway?"
 msgstr "Fil er ukomplett. Fortsette allikevel?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:5314
-#: ../../Firmware/ultralcd.cpp:5630
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:5336
+#: ../../Firmware/ultralcd.cpp:5652
 msgid "Finishing movements"
 msgstr "Avslutter bevegelser"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:4898
-#: ../../Firmware/ultralcd.cpp:5424
+#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:4917
+#: ../../Firmware/ultralcd.cpp:5446
 msgid "First layer cal."
 msgstr "Førstelagskal."
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4066
+#: ../../Firmware/ultralcd.cpp:4085
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr "Først skal jeg kjøre en selvtest for å sjekke vanlige byggefeil."
 
@@ -618,23 +612,23 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr "Løs problemet og trykk på MM-enhetens knapp."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5724
+#: ../../Firmware/ultralcd.cpp:5746
 msgid "Flow"
 msgstr "Flyt"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:6996
-#: ../../Firmware/ultralcd.cpp:7149 ../../Firmware/ultralcd.cpp:7154
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:7026
+#: ../../Firmware/ultralcd.cpp:7179 ../../Firmware/ultralcd.cpp:7184
 msgid "Front print fan?"
 msgstr "Fremre printvifte?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2754
+#: ../../Firmware/ultralcd.cpp:2773
 msgid "Front side[μm]"
 msgstr "Fremsiden [μm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:7020
+#: ../../Firmware/ultralcd.cpp:7050
 msgid "Front/left fans"
 msgstr "Fremre/venstre vifte"
 
@@ -677,24 +671,23 @@ msgid ""
 "G-code sliced for a newer firmware. Please update the firmware. Print "
 "cancelled."
 msgstr ""
-"G-code sliced for nyere fastvare. Vennligst oppdater systemet. Print "
-"avbrutt."
+"G-code sliced for nyere fastvare. Vennligst oppdater systemet. Print avbrutt."
 
 #. MSG_GCODE c=8
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:4655
-#: ../../Firmware/ultralcd.cpp:4658 ../../Firmware/ultralcd.cpp:4661
-#: ../../Firmware/ultralcd.cpp:4664
+#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:4674
+#: ../../Firmware/ultralcd.cpp:4677 ../../Firmware/ultralcd.cpp:4680
+#: ../../Firmware/ultralcd.cpp:4683
 msgid "Gcode"
 msgstr "Gcode"
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:4672
-#: ../../Firmware/ultralcd.cpp:4726 ../../Firmware/ultralcd.cpp:4818
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:4691
+#: ../../Firmware/ultralcd.cpp:4745 ../../Firmware/ultralcd.cpp:4837
 msgid "HW Setup"
 msgstr "GW oppsett"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6968
+#: ../../Firmware/ultralcd.cpp:6998
 msgid "Heater/Thermistor"
 msgstr "Varmer/Termistor"
 
@@ -716,7 +709,7 @@ msgid "Heating done."
 msgstr "Oppvarming ferdig."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=16
-#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4042
+#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4061
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -726,7 +719,7 @@ msgstr ""
 "oppsett, hvor Z aksen blir kalibrert. Du er da klar til å printe."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4064
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -735,24 +728,30 @@ msgstr ""
 "gjennom oppsettprosessen?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:4358
-#: ../../Firmware/ultralcd.cpp:4367 ../../Firmware/ultralcd.cpp:5777
-#: ../../Firmware/ultralcd.cpp:5780
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:4377
+#: ../../Firmware/ultralcd.cpp:4386 ../../Firmware/ultralcd.cpp:5799
+#: ../../Firmware/ultralcd.cpp:5802
 msgid "High power"
 msgstr "Høy styrke"
 
+#. MSG_HOTEND_FAN_SPEED c=15
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1145
+#: ../../Firmware/ultralcd.cpp:7351
+msgid "Hotend fan:"
+msgstr "Hotend-vifte:"
+
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4094
 msgid "I will run xyz calibration now. It will take approx. 12 mins."
 msgstr "Nå skal jeg kjøre kalibreringen. Det tar ca. 12 min."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/ultralcd.cpp:4102
 msgid "I will run z calibration now."
 msgstr "Nå kjører jeg Z-kalibreringen."
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=9
-#: ../../Firmware/ultralcd.cpp:4153
+#: ../../Firmware/ultralcd.cpp:4172
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -766,36 +765,36 @@ msgid "Improving bed calibration point"
 msgstr "Forbedrer seng kalibreringspunkt"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:5478
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:5500
 msgid "Info screen"
 msgstr "Infoskjerm"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5545
+#: ../../Firmware/ultralcd.cpp:5567
 msgid "Init. SD card"
 msgstr "Init. SD kort"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2152
+#: ../../Firmware/ultralcd.cpp:2171
 msgid "Insert filament"
 msgstr "Sett inn filament"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:6223
+#: ../../Firmware/ultralcd.cpp:6253
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
 msgstr "Sett inn filamentet i ekstruderen og deretter trykk inn valghjulet."
 
 #. MSG_FILAMENT_LOADED c=20 r=2
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3855
-#: ../../Firmware/ultralcd.cpp:4108 ../../Firmware/ultralcd.cpp:4111
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3874
+#: ../../Firmware/ultralcd.cpp:4127 ../../Firmware/ultralcd.cpp:4130
 msgid "Is filament loaded?"
 msgstr "Er filament lastet?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=2
 #: ../../Firmware/Marlin_main.cpp:3312 ../../Firmware/Marlin_main.cpp:4886
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:4084
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:4103
 msgid "Is steel sheet on heatbed?"
 msgstr "Er stålplaten på varmesenga?"
 
@@ -805,74 +804,74 @@ msgid "Iteration"
 msgstr "Iterasjon"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:1148
-#: ../../Firmware/ultralcd.cpp:1296
+#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:1167
+#: ../../Firmware/ultralcd.cpp:1315
 msgid "Last print"
 msgstr "Siste print"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1169
-#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1269
-#: ../../Firmware/ultralcd.cpp:1326
+#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1188
+#: ../../Firmware/ultralcd.cpp:1278 ../../Firmware/ultralcd.cpp:1288
+#: ../../Firmware/ultralcd.cpp:1345
 msgid "Last print failures"
 msgstr "Siste printfeil"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2496
+#: ../../Firmware/ultralcd.cpp:2515
 msgid "Left"
 msgstr "Venstre"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7001
-#: ../../Firmware/ultralcd.cpp:7147 ../../Firmware/ultralcd.cpp:7152
+#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:7032
+#: ../../Firmware/ultralcd.cpp:7179 ../../Firmware/ultralcd.cpp:7184
 msgid "Left hotend fan?"
 msgstr "Venst. hotendvifte?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2752
+#: ../../Firmware/ultralcd.cpp:2771
 msgid "Left side [μm]"
 msgstr "Vens. side[μm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:5862
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:5884
 msgid "Level Bright"
 msgstr "Nivå Lyst"
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:5863
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:5885
 msgid "Level Dimmed"
 msgstr "Nivå Dimmet"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4826
+#: ../../Firmware/ultralcd.cpp:4845
 msgid "Lin. correction"
 msgstr "Lin. korreksjon"
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4838
-#: ../../Firmware/ultralcd.cpp:5493
+#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4857
+#: ../../Firmware/ultralcd.cpp:5515
 msgid "Live adjust Z"
 msgstr "Juster Live-Z"
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/ultralcd.cpp:5120
+#: ../../Firmware/ultralcd.cpp:5142
 msgid "Load all"
 msgstr "Last alle"
 
 #. MSG_LOAD_FILAMENT c=17
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:5122
-#: ../../Firmware/ultralcd.cpp:5133 ../../Firmware/ultralcd.cpp:5562
-#: ../../Firmware/ultralcd.cpp:5576
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:5144
+#: ../../Firmware/ultralcd.cpp:5155 ../../Firmware/ultralcd.cpp:5584
+#: ../../Firmware/ultralcd.cpp:5598
 msgid "Load filament"
 msgstr "Last inn filament"
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5563
+#: ../../Firmware/ultralcd.cpp:5585
 msgid "Load to nozzle"
 msgstr "Last til dysen"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2185
+#: ../../Firmware/ultralcd.cpp:2204
 msgid "Loading color"
 msgstr "Laster farge"
 
@@ -880,18 +879,18 @@ msgstr "Laster farge"
 #: ../../Firmware/Marlin_main.cpp:3641 ../../Firmware/messages.cpp:55
 #: ../../Firmware/mmu.cpp:872 ../../Firmware/mmu.cpp:906
 #: ../../Firmware/mmu.cpp:1014 ../../Firmware/mmu.cpp:1026
-#: ../../Firmware/ultralcd.cpp:2196 ../../Firmware/ultralcd.cpp:3949
+#: ../../Firmware/ultralcd.cpp:2215 ../../Firmware/ultralcd.cpp:3968
 msgid "Loading filament"
 msgstr "Laster filament"
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:7008
+#: ../../Firmware/ultralcd.cpp:7038
 msgid "Loose pulley"
 msgstr "Løs reim"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:4450
-#: ../../Firmware/ultralcd.cpp:4462
+#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/ultralcd.cpp:4481
 msgid "Loud"
 msgstr "Høyt"
 
@@ -906,8 +905,8 @@ msgid "MK3S firmware detected on MK3 printer"
 msgstr "MK3S systemvare funnet på MK3 printer"
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4381
-#: ../../Firmware/ultralcd.cpp:4382
+#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4400
+#: ../../Firmware/ultralcd.cpp:4401
 msgid "MMU Mode"
 msgstr "MMU Mod."
 
@@ -927,8 +926,8 @@ msgid "MMU OK. Resuming..."
 msgstr "MMU OK. Gjenopptar..."
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:64 ../../Firmware/ultralcd.cpp:1170
-#: ../../Firmware/ultralcd.cpp:1193
+#: ../../Firmware/messages.cpp:64 ../../Firmware/ultralcd.cpp:1189
+#: ../../Firmware/ultralcd.cpp:1212
 msgid "MMU fails"
 msgstr "MMU feil"
 
@@ -938,8 +937,8 @@ msgid "MMU load failed"
 msgstr "MMU last feilet"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:1171
-#: ../../Firmware/ultralcd.cpp:1194
+#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:1190
+#: ../../Firmware/ultralcd.cpp:1213
 msgid "MMU load fails"
 msgstr "MMU lastefeil"
 
@@ -949,32 +948,32 @@ msgid "MMU needs user attention."
 msgstr "MMU trenger brukerinnvending."
 
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/ultralcd.cpp:1195
+#: ../../Firmware/ultralcd.cpp:1214
 msgid "MMU power fails"
 msgstr "MMU strøm feil"
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1680
+#: ../../Firmware/ultralcd.cpp:1699
 msgid "MMU2 connected"
 msgstr "MMU2 tilkoblet"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:5836
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:5858
 msgid "Magnets comp."
 msgstr "Magnet komp."
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1147
-#: ../../Firmware/ultralcd.cpp:1295 ../../Firmware/ultralcd.cpp:1338
-#: ../../Firmware/ultralcd.cpp:1645 ../../Firmware/ultralcd.cpp:4795
-#: ../../Firmware/ultralcd.cpp:4892 ../../Firmware/ultralcd.cpp:5119
-#: ../../Firmware/ultralcd.cpp:5131 ../../Firmware/ultralcd.cpp:5154
-#: ../../Firmware/ultralcd.cpp:5173 ../../Firmware/ultralcd.cpp:5717
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1166
+#: ../../Firmware/ultralcd.cpp:1314 ../../Firmware/ultralcd.cpp:1357
+#: ../../Firmware/ultralcd.cpp:1664 ../../Firmware/ultralcd.cpp:4814
+#: ../../Firmware/ultralcd.cpp:4911 ../../Firmware/ultralcd.cpp:5141
+#: ../../Firmware/ultralcd.cpp:5153 ../../Firmware/ultralcd.cpp:5176
+#: ../../Firmware/ultralcd.cpp:5195 ../../Firmware/ultralcd.cpp:5739
 msgid "Main"
 msgstr "Hovedmeny"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2537
+#: ../../Firmware/ultralcd.cpp:2556
 msgid "Measured skew"
 msgstr "Målt skjevhet"
 
@@ -985,71 +984,71 @@ msgid "Measuring reference height of calibration point"
 msgstr "Måler referansehøyde for kalibreringspunkt"
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:5832
+#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:5854
 msgid "Mesh"
 msgstr "Plan-nett"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4823
-#: ../../Firmware/ultralcd.cpp:4910
+#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4842
+#: ../../Firmware/ultralcd.cpp:4929
 msgid "Mesh Bed Leveling"
 msgstr "Sengeplanering"
 
 #. MSG_MODE c=6
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:4336
-#: ../../Firmware/ultralcd.cpp:4338 ../../Firmware/ultralcd.cpp:4358
-#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4364
-#: ../../Firmware/ultralcd.cpp:4367 ../../Firmware/ultralcd.cpp:5763
-#: ../../Firmware/ultralcd.cpp:5770 ../../Firmware/ultralcd.cpp:5777
-#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5779
-#: ../../Firmware/ultralcd.cpp:5780 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/ultralcd.cpp:4357 ../../Firmware/ultralcd.cpp:4377
+#: ../../Firmware/ultralcd.cpp:4380 ../../Firmware/ultralcd.cpp:4383
+#: ../../Firmware/ultralcd.cpp:4386 ../../Firmware/ultralcd.cpp:5785
+#: ../../Firmware/ultralcd.cpp:5792 ../../Firmware/ultralcd.cpp:5799
+#: ../../Firmware/ultralcd.cpp:5800 ../../Firmware/ultralcd.cpp:5801
+#: ../../Firmware/ultralcd.cpp:5802 ../../Firmware/ultralcd.cpp:5886
 msgid "Mode"
 msgstr "Modus"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3598
+#: ../../Firmware/ultralcd.cpp:3617
 msgid "Mode change in progress..."
 msgstr "Modus endres..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:4575
-#: ../../Firmware/ultralcd.cpp:4578 ../../Firmware/ultralcd.cpp:4581
-#: ../../Firmware/ultralcd.cpp:4584
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:4594
+#: ../../Firmware/ultralcd.cpp:4597 ../../Firmware/ultralcd.cpp:4600
+#: ../../Firmware/ultralcd.cpp:4603
 msgid "Model"
 msgstr "Modell"
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6982
-#: ../../Firmware/ultralcd.cpp:6991 ../../Firmware/ultralcd.cpp:7009
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:7012
+#: ../../Firmware/ultralcd.cpp:7021 ../../Firmware/ultralcd.cpp:7039
 msgid "Motor"
 msgstr "Motor"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3492
+#: ../../Firmware/ultralcd.cpp:3511
 msgid "Move X"
 msgstr "Beveg X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3493
+#: ../../Firmware/ultralcd.cpp:3512
 msgid "Move Y"
 msgstr "Beveg Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3494
+#: ../../Firmware/ultralcd.cpp:3513
 msgid "Move Z"
 msgstr "Beveg Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4801
+#: ../../Firmware/ultralcd.cpp:4820
 msgid "Move axis"
 msgstr "Beveg akse"
 
 #. MSG_NA c=3
 #: ../../Firmware/menu.cpp:196 ../../Firmware/messages.cpp:124
-#: ../../Firmware/ultralcd.cpp:2502 ../../Firmware/ultralcd.cpp:2547
-#: ../../Firmware/ultralcd.cpp:3411 ../../Firmware/ultralcd.cpp:4228
-#: ../../Firmware/ultralcd.cpp:4276 ../../Firmware/ultralcd.cpp:5737
-#: ../../Firmware/ultralcd.cpp:5836
+#: ../../Firmware/ultralcd.cpp:2521 ../../Firmware/ultralcd.cpp:2566
+#: ../../Firmware/ultralcd.cpp:3430 ../../Firmware/ultralcd.cpp:4247
+#: ../../Firmware/ultralcd.cpp:4295 ../../Firmware/ultralcd.cpp:5759
+#: ../../Firmware/ultralcd.cpp:5858
 msgid "N/A"
 msgstr " -"
 
@@ -1059,14 +1058,14 @@ msgid "New firmware version available:"
 msgstr "Ny fastvare tilgjengelig:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:2804
-#: ../../Firmware/ultralcd.cpp:3180 ../../Firmware/ultralcd.cpp:4785
-#: ../../Firmware/ultralcd.cpp:5988
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:2823
+#: ../../Firmware/ultralcd.cpp:3199 ../../Firmware/ultralcd.cpp:4804
+#: ../../Firmware/ultralcd.cpp:6018
 msgid "No"
 msgstr "Nei"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5543
+#: ../../Firmware/ultralcd.cpp:5565
 msgid "No SD card"
 msgstr "SD-kort mangler"
 
@@ -1076,71 +1075,71 @@ msgid "No move."
 msgstr "Ingen bevegelse."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4405
-#: ../../Firmware/ultralcd.cpp:4493 ../../Firmware/ultralcd.cpp:4502
-#: ../../Firmware/ultralcd.cpp:4575 ../../Firmware/ultralcd.cpp:4584
-#: ../../Firmware/ultralcd.cpp:4614 ../../Firmware/ultralcd.cpp:4623
-#: ../../Firmware/ultralcd.cpp:4655 ../../Firmware/ultralcd.cpp:4664
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4424
+#: ../../Firmware/ultralcd.cpp:4512 ../../Firmware/ultralcd.cpp:4521
+#: ../../Firmware/ultralcd.cpp:4594 ../../Firmware/ultralcd.cpp:4603
+#: ../../Firmware/ultralcd.cpp:4633 ../../Firmware/ultralcd.cpp:4642
+#: ../../Firmware/ultralcd.cpp:4674 ../../Firmware/ultralcd.cpp:4683
 msgid "None"
 msgstr "Ingen"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:4336
-#: ../../Firmware/ultralcd.cpp:4381 ../../Firmware/ultralcd.cpp:4397
-#: ../../Firmware/ultralcd.cpp:4416 ../../Firmware/ultralcd.cpp:5763
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/ultralcd.cpp:4400 ../../Firmware/ultralcd.cpp:4416
+#: ../../Firmware/ultralcd.cpp:4435 ../../Firmware/ultralcd.cpp:5785
 msgid "Normal"
 msgstr "Normal"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6969
+#: ../../Firmware/ultralcd.cpp:6999
 msgid "Not connected"
 msgstr "Ikke tilkoblet"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:7168
-#: ../../Firmware/ultralcd.cpp:7183 ../../Firmware/ultralcd.cpp:7191
+#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:7198
+#: ../../Firmware/ultralcd.cpp:7213 ../../Firmware/ultralcd.cpp:7221
 msgid "Not spinning"
 msgstr "Spinner ikke"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3962
+#: ../../Firmware/ultralcd.cpp:3981
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr "Jeg vil nå kalibrere avstanden mellom tuppen av dysen og varmeplaten."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:4091
+#: ../../Firmware/ultralcd.cpp:4110
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Jeg vil nå forvarme dysen for PLA."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/ultralcd.cpp:4101
 msgid "Now remove the test print from steel sheet."
 msgstr "Fjern nå testprintet fra stålplaten."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:1402
-#: ../../Firmware/ultralcd.cpp:4493 ../../Firmware/ultralcd.cpp:4496
-#: ../../Firmware/ultralcd.cpp:4499 ../../Firmware/ultralcd.cpp:4502
-#: ../../Firmware/ultralcd.cpp:5720 ../../Firmware/ultralcd.cpp:5882
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:1421
+#: ../../Firmware/ultralcd.cpp:4512 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/ultralcd.cpp:4518 ../../Firmware/ultralcd.cpp:4521
+#: ../../Firmware/ultralcd.cpp:5742 ../../Firmware/ultralcd.cpp:5904
 msgid "Nozzle"
 msgstr "Dyse"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4546
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4565
 msgid "Nozzle d."
 msgstr "Dyse diam."
 
 #. MSG_OFF c=3
 #: ../../Firmware/menu.cpp:467 ../../Firmware/messages.cpp:122
-#: ../../Firmware/ultralcd.cpp:4234 ../../Firmware/ultralcd.cpp:4250
-#: ../../Firmware/ultralcd.cpp:4284 ../../Firmware/ultralcd.cpp:4313
-#: ../../Firmware/ultralcd.cpp:4342 ../../Firmware/ultralcd.cpp:4811
-#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4834
-#: ../../Firmware/ultralcd.cpp:5644 ../../Firmware/ultralcd.cpp:5741
-#: ../../Firmware/ultralcd.cpp:5756 ../../Firmware/ultralcd.cpp:5767
-#: ../../Firmware/ultralcd.cpp:5836 ../../Firmware/ultralcd.cpp:7841
-#: ../../Firmware/ultralcd.cpp:7845
+#: ../../Firmware/ultralcd.cpp:4253 ../../Firmware/ultralcd.cpp:4269
+#: ../../Firmware/ultralcd.cpp:4303 ../../Firmware/ultralcd.cpp:4332
+#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4830
+#: ../../Firmware/ultralcd.cpp:4849 ../../Firmware/ultralcd.cpp:4853
+#: ../../Firmware/ultralcd.cpp:5666 ../../Firmware/ultralcd.cpp:5763
+#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/ultralcd.cpp:5858 ../../Firmware/ultralcd.cpp:7881
+#: ../../Firmware/ultralcd.cpp:7885
 msgid "Off"
 msgstr "Av"
 
@@ -1151,19 +1150,19 @@ msgstr ""
 "Gamle verdier funnet Standarinnstillinger for PID, Esteg etc. blir satt."
 
 #. MSG_ON c=3
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4244
-#: ../../Firmware/ultralcd.cpp:4248 ../../Firmware/ultralcd.cpp:4280
-#: ../../Firmware/ultralcd.cpp:4303 ../../Firmware/ultralcd.cpp:4341
-#: ../../Firmware/ultralcd.cpp:4811 ../../Firmware/ultralcd.cpp:4830
-#: ../../Firmware/ultralcd.cpp:4834 ../../Firmware/ultralcd.cpp:5745
-#: ../../Firmware/ultralcd.cpp:5756 ../../Firmware/ultralcd.cpp:5765
-#: ../../Firmware/ultralcd.cpp:5836 ../../Firmware/ultralcd.cpp:7841
-#: ../../Firmware/ultralcd.cpp:7845
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4263
+#: ../../Firmware/ultralcd.cpp:4267 ../../Firmware/ultralcd.cpp:4299
+#: ../../Firmware/ultralcd.cpp:4322 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4849
+#: ../../Firmware/ultralcd.cpp:4853 ../../Firmware/ultralcd.cpp:5767
+#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5787
+#: ../../Firmware/ultralcd.cpp:5858 ../../Firmware/ultralcd.cpp:7881
+#: ../../Firmware/ultralcd.cpp:7885
 msgid "On"
 msgstr "På"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4453
+#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4472
 msgid "Once"
 msgstr "En gang"
 
@@ -1183,7 +1182,7 @@ msgid "PID cal. finished"
 msgstr "PID kal. ferdig"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4913
+#: ../../Firmware/ultralcd.cpp:4932
 msgid "PID calibration"
 msgstr "PID kalibrering"
 
@@ -1195,18 +1194,18 @@ msgstr "PINDA varmes"
 #. MSG_PINDA_CALIBRATION c=13
 #: ../../Firmware/Marlin_main.cpp:4932 ../../Firmware/Marlin_main.cpp:5035
 #: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:654
-#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4920
+#: ../../Firmware/ultralcd.cpp:4849 ../../Firmware/ultralcd.cpp:4939
 msgid "PINDA cal."
 msgstr "PINDA kal."
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3361
+#: ../../Firmware/ultralcd.cpp:3380
 msgid "PINDA calibration failed"
 msgstr "PINDA kalibrering mislyktes"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
 #: ../../Firmware/Marlin_main.cpp:5112 ../../Firmware/messages.cpp:110
-#: ../../Firmware/ultralcd.cpp:3355
+#: ../../Firmware/ultralcd.cpp:3374
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1215,13 +1214,13 @@ msgstr ""
 "under Innstillinger -> PINDA kal."
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4707
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4726
 msgid "Pause"
 msgstr "Pause"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:5507
-#: ../../Firmware/ultralcd.cpp:5509
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:5529
+#: ../../Firmware/ultralcd.cpp:5531
 msgid "Pause print"
 msgstr "Pause printjobben"
 
@@ -1235,7 +1234,7 @@ msgstr ""
 "dysen tar papiret, skru umiddelbart av printeren."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:4176
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:4195
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1244,17 +1243,17 @@ msgstr ""
 "omstarte printeren."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:6250
+#: ../../Firmware/ultralcd.cpp:6280
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "Vennligst sjekk koblingen til IR sensorer. Last ut filament om lastet."
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6963
+#: ../../Firmware/ultralcd.cpp:6993
 msgid "Please check:"
 msgstr "Venligst sjekk:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4148
+#: ../../Firmware/ultralcd.cpp:4167
 msgid "Please clean heatbed and then press the knob."
 msgstr "Rengjør stålplaten og trykk valghjulet."
 
@@ -1264,13 +1263,13 @@ msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Rengjør dysen og trykk valghjulet."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3945
+#: ../../Firmware/ultralcd.cpp:3964
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr "Sett inn filament I ekstruderen og trykk valghjulet for å laste."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3940
+#: ../../Firmware/ultralcd.cpp:3959
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1279,7 +1278,7 @@ msgstr ""
 "å laste."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3863
+#: ../../Firmware/ultralcd.cpp:3882
 msgid "Please load filament first."
 msgstr "Vennligst sett inn filament først."
 
@@ -1290,7 +1289,7 @@ msgstr "Åpne taljedøren og fjern filamentet for hånd."
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=5
 #: ../../Firmware/mesh_bed_calibration.cpp:2799 ../../Firmware/messages.cpp:70
-#: ../../Firmware/ultralcd.cpp:4085
+#: ../../Firmware/ultralcd.cpp:4104
 msgid "Please place steel sheet on heatbed."
 msgstr "Plasser stålplaten på varmesenga."
 
@@ -1301,7 +1300,7 @@ msgid "Please press the knob to unload filament"
 msgstr "Trykk valghjulet for å ta ut filamentet"
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:5213
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:5235
 msgid "Please pull out filament immediately"
 msgstr "Trekk ut filamented med en gang"
 
@@ -1311,7 +1310,7 @@ msgid "Please remove filament and then press the knob."
 msgstr "Fjern filamentet og trykk valghjulet."
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:4081
+#: ../../Firmware/ultralcd.cpp:4100
 msgid "Please remove shipping helpers first."
 msgstr "Vennligst fjern sendingsbeskyttelsen først."
 
@@ -1327,7 +1326,7 @@ msgid "Please run XYZ calibration first."
 msgstr "Vennligst fullfør XYZ kalibreringen først."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:6247
+#: ../../Firmware/ultralcd.cpp:6277
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Vennligst last ut filamentet først, deretter repeter denne handlingen."
 
@@ -1344,54 +1343,54 @@ msgstr "Vennligst oppdater."
 #. MSG_PLEASE_WAIT c=20
 #: ../../Firmware/Marlin_main.cpp:3547 ../../Firmware/Marlin_main.cpp:3563
 #: ../../Firmware/Marlin_main.cpp:7931 ../../Firmware/messages.cpp:71
-#: ../../Firmware/ultralcd.cpp:2186 ../../Firmware/ultralcd.cpp:2197
+#: ../../Firmware/ultralcd.cpp:2205 ../../Firmware/ultralcd.cpp:2216
 msgid "Please wait"
 msgstr "Vennligst vent"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1219
-#: ../../Firmware/ultralcd.cpp:1260 ../../Firmware/ultralcd.cpp:1270
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1238
+#: ../../Firmware/ultralcd.cpp:1279 ../../Firmware/ultralcd.cpp:1289
 msgid "Power failures"
 msgstr "Strømfeil"
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5502
+#: ../../Firmware/ultralcd.cpp:5524
 msgid "Preheat"
 msgstr "Forvarming"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:2280
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:2299
 msgid "Preheat the nozzle!"
 msgstr "Forvarm dysen!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:2900
-#: ../../Firmware/ultralcd.cpp:3924 ../../Firmware/ultralcd.cpp:3926
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:2919
+#: ../../Firmware/ultralcd.cpp:3943 ../../Firmware/ultralcd.cpp:3945
 msgid "Preheating nozzle. Please wait."
 msgstr "Forvarmer dysen. Vennligst vent..."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1988
+#: ../../Firmware/ultralcd.cpp:2007
 msgid "Preheating to cut"
 msgstr "Forvarmer for kutt"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1985
+#: ../../Firmware/ultralcd.cpp:2004
 msgid "Preheating to eject"
 msgstr "Forvarmer for utmat."
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1976
+#: ../../Firmware/ultralcd.cpp:1995
 msgid "Preheating to load"
 msgstr "Forvarmer for last"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1981
+#: ../../Firmware/ultralcd.cpp:2000
 msgid "Preheating to unload"
 msgstr "Forvarmer for fil."
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1809
+#: ../../Firmware/ultralcd.cpp:1828
 msgid "Press the knob"
 msgstr "Trykk valghjulet"
 
@@ -1411,13 +1410,13 @@ msgid "Print aborted"
 msgstr "Print avbrutt"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1144
-#: ../../Firmware/ultralcd.cpp:7322
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1145
+#: ../../Firmware/ultralcd.cpp:7354
 msgid "Print fan:"
 msgstr "Printvifte:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5535
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5557
 msgid "Print from SD"
 msgstr "Print fra SD-kort"
 
@@ -1427,12 +1426,12 @@ msgid "Print paused"
 msgstr "Print satt på pause"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2366
+#: ../../Firmware/ultralcd.cpp:2385
 msgid "Print time"
 msgstr "Printetid"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1711
+#: ../../Firmware/ultralcd.cpp:1730
 msgid "Printer IP Addr:"
 msgstr "Printer IP adr.:"
 
@@ -1458,12 +1457,12 @@ msgstr ""
 "hva som er satt. Print avbrutt."
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4834
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4853
 msgid "RPi port"
 msgstr "RPi port"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2755
+#: ../../Firmware/ultralcd.cpp:2774
 msgid "Rear side [μm]"
 msgstr "Baksiden [μm]"
 
@@ -1478,24 +1477,24 @@ msgid "Remove old filament and press the knob to start loading new filament."
 msgstr "Ta bort det gamle filamentet og trykk valghjulet for å laste et nytt."
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5426
+#: ../../Firmware/ultralcd.cpp:5448
 msgid "Rename"
 msgstr "Gi nytt navn"
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2756
-#: ../../Firmware/ultralcd.cpp:5427
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2775
+#: ../../Firmware/ultralcd.cpp:5449
 msgid "Reset"
 msgstr "Nullstill"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4917
+#: ../../Firmware/ultralcd.cpp:4936
 msgid "Reset XYZ calibr."
 msgstr "Nullstill XYZ kal."
 
 #. MSG_RESUME_PRINT c=18
 #: ../../Firmware/Marlin_main.cpp:655 ../../Firmware/messages.cpp:81
-#: ../../Firmware/ultralcd.cpp:5521 ../../Firmware/ultralcd.cpp:5523
+#: ../../Firmware/ultralcd.cpp:5543 ../../Firmware/ultralcd.cpp:5545
 msgid "Resume print"
 msgstr "Gjenoppta print"
 
@@ -1505,17 +1504,17 @@ msgid "Resuming print"
 msgstr "Gjenopptar print"
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2497
+#: ../../Firmware/ultralcd.cpp:2516
 msgid "Right"
 msgstr "Høyre"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2753
+#: ../../Firmware/ultralcd.cpp:2772
 msgid "Right side[μm]"
 msgstr "Høyre side[μm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3884
+#: ../../Firmware/ultralcd.cpp:3903
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1524,14 +1523,14 @@ msgstr ""
 "begynne på nytt. Fortsette?"
 
 #. MSG_RUNOUTS c=7
-#: ../../Firmware/ultralcd.cpp:1271
+#: ../../Firmware/ultralcd.cpp:1290
 msgid "Runouts"
 msgstr "F. tomt"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4395
-#: ../../Firmware/ultralcd.cpp:4397 ../../Firmware/ultralcd.cpp:4414
-#: ../../Firmware/ultralcd.cpp:4416
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4414
+#: ../../Firmware/ultralcd.cpp:4416 ../../Firmware/ultralcd.cpp:4433
+#: ../../Firmware/ultralcd.cpp:4435
 msgid "SD card"
 msgstr "SD-kort"
 
@@ -1547,12 +1546,12 @@ msgid "Searching bed calibration point"
 msgstr "Søker etter kalibreringspunkt"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5419
+#: ../../Firmware/ultralcd.cpp:5441
 msgid "Select"
 msgstr "Velg"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3966
+#: ../../Firmware/ultralcd.cpp:3985
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
@@ -1565,49 +1564,49 @@ msgstr "Velg ekstruder:"
 
 #. MSG_SELECT_FILAMENT c=20
 #: ../../Firmware/Marlin_main.cpp:8577 ../../Firmware/Marlin_main.cpp:8604
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3834
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3853
 msgid "Select filament:"
 msgstr "Velg filament:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:3679
-#: ../../Firmware/ultralcd.cpp:4841
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:3698
+#: ../../Firmware/ultralcd.cpp:4860
 msgid "Select language"
 msgstr "Velg språk"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:4122
+#: ../../Firmware/ultralcd.cpp:4141
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr "Velg dysetemperatur som passer ditt materiale."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3971
+#: ../../Firmware/ultralcd.cpp:3990
 msgid "Select temperature which matches your material."
 msgstr "Velg temperaturen som passer ditt materiale."
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6522
+#: ../../Firmware/ultralcd.cpp:6552
 msgid "Self test OK"
 msgstr "Selvtest OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:6290
+#: ../../Firmware/ultralcd.cpp:6320
 msgid "Self test start"
 msgstr "Selvtest starter"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4904
+#: ../../Firmware/ultralcd.cpp:4923
 msgid "Selftest"
 msgstr "Selvtest"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6962
+#: ../../Firmware/ultralcd.cpp:6992
 msgid "Selftest error!"
 msgstr "Selvtest feil!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:6526
-#: ../../Firmware/ultralcd.cpp:7049 ../../Firmware/ultralcd.cpp:7314
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:6556
+#: ../../Firmware/ultralcd.cpp:7079 ../../Firmware/ultralcd.cpp:7344
 msgid "Selftest failed"
 msgstr "Selvtest feilet"
 
@@ -1618,30 +1617,30 @@ msgstr ""
 "Selvtest vil bli kjørt for å kalibrere nøyaktig sensorløs hjemposisjon."
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1723
+#: ../../Firmware/ultralcd.cpp:1742
 msgid "Sensor info"
 msgstr "Sensorinformasjon"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:6254
+#: ../../Firmware/ultralcd.cpp:6284
 msgid "Sensor verified, remove the filament now."
 msgstr "Sensor verifiserte, fjern filamentet nå."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2773
+#: ../../Firmware/ultralcd.cpp:2792
 msgid "Set temperature:"
 msgstr "Satt temperatur:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:3491
-#: ../../Firmware/ultralcd.cpp:3696 ../../Firmware/ultralcd.cpp:4206
-#: ../../Firmware/ultralcd.cpp:5580 ../../Firmware/ultralcd.cpp:5827
-#: ../../Firmware/ultralcd.cpp:5880
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:3510
+#: ../../Firmware/ultralcd.cpp:3715 ../../Firmware/ultralcd.cpp:4225
+#: ../../Firmware/ultralcd.cpp:5602 ../../Firmware/ultralcd.cpp:5849
+#: ../../Firmware/ultralcd.cpp:5902
 msgid "Settings"
 msgstr "Innstillinger"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2540
+#: ../../Firmware/ultralcd.cpp:2559
 msgid "Severe skew"
 msgstr "Stor skjevhet"
 
@@ -1652,7 +1651,7 @@ msgid "Sheet"
 msgstr "Plate"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3824
+#: ../../Firmware/ultralcd.cpp:3843
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1665,18 +1664,18 @@ msgstr ""
 "%cNullstill"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4915
+#: ../../Firmware/ultralcd.cpp:4934
 msgid "Show end stops"
 msgstr "Vis endesensorer"
 
 #. MSG_SILENT c=7
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4361
-#: ../../Firmware/ultralcd.cpp:4456 ../../Firmware/ultralcd.cpp:5778
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4380
+#: ../../Firmware/ultralcd.cpp:4475 ../../Firmware/ultralcd.cpp:5800
 msgid "Silent"
 msgstr "Lydløs"
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2539
+#: ../../Firmware/ultralcd.cpp:2558
 msgid "Slight skew"
 msgstr "Lett skjevhet"
 
@@ -1693,8 +1692,8 @@ msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Problem møtt. Z aksjeplanering tvunget ..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4403
-#: ../../Firmware/ultralcd.cpp:4404 ../../Firmware/ultralcd.cpp:4405
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4422
+#: ../../Firmware/ultralcd.cpp:4423 ../../Firmware/ultralcd.cpp:4424
 msgid "Sort"
 msgstr "Sorter"
 
@@ -1705,20 +1704,20 @@ msgid "Sorting files"
 msgstr "Sorter filer"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4450
-#: ../../Firmware/ultralcd.cpp:4453 ../../Firmware/ultralcd.cpp:4456
-#: ../../Firmware/ultralcd.cpp:4459 ../../Firmware/ultralcd.cpp:4462
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/ultralcd.cpp:4472 ../../Firmware/ultralcd.cpp:4475
+#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4481
 msgid "Sound"
 msgstr "Lyd"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5718
+#: ../../Firmware/ultralcd.cpp:5740
 msgid "Speed"
 msgstr "Hastighet"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7166
-#: ../../Firmware/ultralcd.cpp:7181 ../../Firmware/ultralcd.cpp:7189
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7196
+#: ../../Firmware/ultralcd.cpp:7211 ../../Firmware/ultralcd.cpp:7219
 msgid "Spinning"
 msgstr "Spinner"
 
@@ -1728,42 +1727,42 @@ msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr "En stabil rom- temperatur på 21-26C og et solid underlag er nødvendig."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5585
+#: ../../Firmware/ultralcd.cpp:5607
 msgid "Statistics"
 msgstr "Statistikk"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4338
-#: ../../Firmware/ultralcd.cpp:4382 ../../Firmware/ultralcd.cpp:5770
+#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4357
+#: ../../Firmware/ultralcd.cpp:4401 ../../Firmware/ultralcd.cpp:5792
 msgid "Stealth"
 msgstr "Stille"
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4763
-#: ../../Firmware/ultralcd.cpp:5416
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4782
+#: ../../Firmware/ultralcd.cpp:5438
 msgid "Steel sheets"
 msgstr "Stål plate"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5528
-#: ../../Firmware/ultralcd.cpp:5987
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5550
+#: ../../Firmware/ultralcd.cpp:6017
 msgid "Stop print"
 msgstr "Stopp printjobb"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4499
-#: ../../Firmware/ultralcd.cpp:4581 ../../Firmware/ultralcd.cpp:4620
-#: ../../Firmware/ultralcd.cpp:4661
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4518
+#: ../../Firmware/ultralcd.cpp:4600 ../../Firmware/ultralcd.cpp:4639
+#: ../../Firmware/ultralcd.cpp:4680
 msgid "Strict"
 msgstr "Streng"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/ultralcd.cpp:5616
 msgid "Support"
 msgstr "System info"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:7021
+#: ../../Firmware/ultralcd.cpp:7051
 msgid "Swapped"
 msgstr "Byttet"
 
@@ -1772,28 +1771,18 @@ msgstr "Byttet"
 msgid "THERMAL ANOMALY"
 msgstr "THERMISK ANOMALI"
 
-#. MSG_TM_AUTOTUNE_FAILED c=20
-#: ../../Firmware/temperature.cpp:2899
-msgid "TM autotune failed"
-msgstr "TM autotune feilet"
-
-#. MSG_TEMP_MODEL_AUTOTUNE c=20
-#: ../../Firmware/temperature.cpp:2884
-msgid "Temp. model autotune"
-msgstr "Temp. model autotune"
-
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4797
+#: ../../Firmware/ultralcd.cpp:4816
 msgid "Temperature"
 msgstr "Temperatur"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1729
+#: ../../Firmware/ultralcd.cpp:1748
 msgid "Temperatures"
 msgstr "Temperaturer"
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3974
+#: ../../Firmware/ultralcd.cpp:3993
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -1813,66 +1802,66 @@ msgstr ""
 "hovedmenyen og følg Veilederen."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4403
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4422
 msgid "Time"
 msgstr "Dato"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:5865
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:5887
 msgid "Timeout"
 msgstr "Tidsavbrudd"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:1149
-#: ../../Firmware/ultralcd.cpp:1297
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:1168
+#: ../../Firmware/ultralcd.cpp:1316
 msgid "Total"
 msgstr "Totalt"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:1192
-#: ../../Firmware/ultralcd.cpp:1218 ../../Firmware/ultralcd.cpp:1328
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:1211
+#: ../../Firmware/ultralcd.cpp:1237 ../../Firmware/ultralcd.cpp:1347
 msgid "Total failures"
 msgstr "Feil totalt"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2387
+#: ../../Firmware/ultralcd.cpp:2406
 msgid "Total filament"
 msgstr "Filament totalt"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2388
+#: ../../Firmware/ultralcd.cpp:2407
 msgid "Total print time"
 msgstr "Printetid totalt"
 
 #. MSG_TUNE c=18
-#: ../../Firmware/ultralcd.cpp:5500
+#: ../../Firmware/ultralcd.cpp:5522
 msgid "Tune"
 msgstr "Juster"
 
 #. MSG_UNLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:5564
-#: ../../Firmware/ultralcd.cpp:5578
+#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:5586
+#: ../../Firmware/ultralcd.cpp:5600
 msgid "Unload filament"
 msgstr "Last ut filament"
 
 #. MSG_UNLOADING_FILAMENT c=20
 #: ../../Firmware/messages.cpp:112 ../../Firmware/mmu.cpp:957
-#: ../../Firmware/ultralcd.cpp:5197
+#: ../../Firmware/ultralcd.cpp:5219
 msgid "Unloading filament"
 msgstr "Laster ut filament"
 
 #. MSG_FIL_FAILED c=20 r=5
-#: ../../Firmware/ultralcd.cpp:6258
+#: ../../Firmware/ultralcd.cpp:6288
 msgid "Verification failed, remove the filament and try again."
 msgstr "Verifisering feilet. Fjern filamentet og prøv igjen."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1732
+#: ../../Firmware/ultralcd.cpp:1751
 msgid "Voltages"
 msgstr "Strøm/Volt"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3534
+#: ../../Firmware/ultralcd.cpp:3553
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -1890,19 +1879,19 @@ msgid "Wait for user..."
 msgstr "Venter på bruker..."
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2881
+#: ../../Firmware/ultralcd.cpp:2900
 msgid "Waiting for PINDA probe cooling"
 msgstr "Venter på PINDA nedkjøling"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2913
+#: ../../Firmware/ultralcd.cpp:2932
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Venter på dyse- og platenedkjøling"
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:4496
-#: ../../Firmware/ultralcd.cpp:4578 ../../Firmware/ultralcd.cpp:4617
-#: ../../Firmware/ultralcd.cpp:4658
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/ultralcd.cpp:4597 ../../Firmware/ultralcd.cpp:4636
+#: ../../Firmware/ultralcd.cpp:4677
 msgid "Warn"
 msgstr "Advarsel"
 
@@ -1927,146 +1916,135 @@ msgid "Was filament unload successful?"
 msgstr "Ble filamentet lastet helt ut?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6973
-#: ../../Firmware/ultralcd.cpp:6977 ../../Firmware/ultralcd.cpp:6997
-#: ../../Firmware/ultralcd.cpp:7003 ../../Firmware/ultralcd.cpp:7027
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:7003
+#: ../../Firmware/ultralcd.cpp:7007 ../../Firmware/ultralcd.cpp:7027
+#: ../../Firmware/ultralcd.cpp:7033 ../../Firmware/ultralcd.cpp:7057
 msgid "Wiring error"
 msgstr "Koblingsfeil"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4895
+#: ../../Firmware/ultralcd.cpp:4914
 msgid "Wizard"
 msgstr "Veileder"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4210
+#: ../../Firmware/ultralcd.cpp:4229
 msgid "X-correct:"
 msgstr "X-korreksjon:"
 
 #. MSG_XFLASH c=18
-#: ../../Firmware/ultralcd.cpp:5596
+#: ../../Firmware/ultralcd.cpp:5618
 msgid "XFLASH init"
 msgstr "XFLASH init"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1721
+#: ../../Firmware/ultralcd.cpp:1740
 msgid "XYZ cal. details"
 msgstr "XYZ cal. detaljer"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3333
+#: ../../Firmware/ultralcd.cpp:3352
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr "XYZ kalibreringen er grei. Skjevhet blir justert automatisk."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3330
+#: ../../Firmware/ultralcd.cpp:3349
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr "XYZ kalibreringen er god. Godt jobba!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3311
+#: ../../Firmware/ultralcd.cpp:3330
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr "XYZ kalibreringen feilet. Front kalibreringspunkt ikke nådd."
 
-#. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_LEFT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3317
-msgid ""
-"XYZ calibration compromised. Left front calibration point not reachable."
-msgstr "XYZ kalibrasjon feilet. Fremre venstre kalibrerings kan ikke nås."
-
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3314
+#: ../../Firmware/ultralcd.cpp:3333
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr "XYZ kalibreringen feilet. Høyre front kalibreringspunkt ikke nådd."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3293
+#: ../../Firmware/ultralcd.cpp:3312
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr "XYZ kalibreringen feilet. Kalibreringspunkt ikke funnet."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3299
+#: ../../Firmware/ultralcd.cpp:3318
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr "XYZ kalibreringen feilet. Front kalibreringspunkt ikke nådd."
 
-#. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_LEFT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3305
-msgid "XYZ calibration failed. Left front calibration point not reachable."
-msgstr "XYZ kalibreringen feilet. Fremre venstre kalibreringspunkt kan ikke nås"
-
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3296
-#: ../../Firmware/ultralcd.cpp:3324
+#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3315
+#: ../../Firmware/ultralcd.cpp:3343
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "XYZ kal. mislyktes. Vennligst rådfør med håndboken."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3302
+#: ../../Firmware/ultralcd.cpp:3321
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr "XYZ kalibreringen feilet. Høyre front kalibreringspunkt ikke nådd."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3327
+#: ../../Firmware/ultralcd.cpp:3346
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr ""
 "XYZ kalibrering OK.\n"
 "X og Y aksen er perpendikulær. Gratulerer!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2494
+#: ../../Firmware/ultralcd.cpp:2513
 msgid "Y distance from min"
 msgstr "Y distanse fra min."
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4211
+#: ../../Firmware/ultralcd.cpp:4230
 msgid "Y-correct:"
 msgstr "Y-korreksjon:"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:2216
-#: ../../Firmware/ultralcd.cpp:2800 ../../Firmware/ultralcd.cpp:3180
-#: ../../Firmware/ultralcd.cpp:4785 ../../Firmware/ultralcd.cpp:5989
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:2235
+#: ../../Firmware/ultralcd.cpp:2819 ../../Firmware/ultralcd.cpp:3199
+#: ../../Firmware/ultralcd.cpp:4804 ../../Firmware/ultralcd.cpp:6019
 msgid "Yes"
 msgstr "Ja"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:4187
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:4206
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr "Du kan alltid starte Veilederen fra Kalibrering -> Veileder."
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4231
 msgid "Z-correct:"
 msgstr "Z-korreksjon:"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:5835
+#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:5857
 msgid "Z-probe nr."
 msgstr "Z-sensor nr."
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2565
+#: ../../Firmware/ultralcd.cpp:2584
 msgid "[0;0] point offset"
 msgstr "[0;0] punktforskyv."
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2154
+#: ../../Firmware/ultralcd.cpp:2173
 msgid "and press the knob"
 msgstr "og trykk på knappen"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1816
+#: ../../Firmware/ultralcd.cpp:1835
 msgid "to load filament"
 msgstr "for filamentlast"
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1820
+#: ../../Firmware/ultralcd.cpp:1839
 msgid "to unload filament"
 msgstr "for filament ut"
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1688
+#: ../../Firmware/ultralcd.cpp:1707
 msgid "unknown"
 msgstr "ukjent"
 
@@ -2076,8 +2054,8 @@ msgid "unknown state"
 msgstr "ukjent tilstand"
 
 #. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:6077
-#: ../../Firmware/ultralcd.cpp:6080
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:6107
+#: ../../Firmware/ultralcd.cpp:6110
 msgid "🔃Refresh"
 msgstr "🔃Forfriske"
 
@@ -2086,3 +2064,17 @@ msgstr "🔃Forfriske"
 
 #~ msgid "M117 First layer cal."
 #~ msgstr "M117 Førstelagskal."
+
+#~ msgid "TM autotune failed"
+#~ msgstr "TM autotune feilet"
+
+#~ msgid "Temp. model autotune"
+#~ msgstr "Temp. model autotune"
+
+#~ msgid ""
+#~ "XYZ calibration compromised. Left front calibration point not reachable."
+#~ msgstr "XYZ kalibrasjon feilet. Fremre venstre kalibrerings kan ikke nås."
+
+#~ msgid "XYZ calibration failed. Left front calibration point not reachable."
+#~ msgstr ""
+#~ "XYZ kalibreringen feilet. Fremre venstre kalibreringspunkt kan ikke nås"

--- a/lang/po/Firmware_pl.po
+++ b/lang/po/Firmware_pl.po
@@ -26,114 +26,114 @@ msgid " 0.4 or newer"
 msgstr " 0.4 lub nowszy"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:7036
+#: ../../Firmware/ultralcd.cpp:7066
 msgid "%s level expected"
 msgstr "Oczekiwano wersji %s"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1968
-#: ../../Firmware/ultralcd.cpp:3835
+#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1987
+#: ../../Firmware/ultralcd.cpp:3854
 msgid ">Cancel"
 msgstr ">Anuluj"
 
 #. MSG_BABYSTEPPING_Z c=15
 #. Beware: must include the ':' as its last character
-#: ../../Firmware/ultralcd.cpp:2670
+#: ../../Firmware/ultralcd.cpp:2689
 msgid "Adjusting Z:"
 msgstr "Ustawianie Z:"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:7313
+#: ../../Firmware/ultralcd.cpp:7343
 msgid "All correct"
 msgstr "Wszystko OK"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4180
+#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4190
+#: ../../Firmware/ultralcd.cpp:4199
 msgid "All is done. Happy printing!"
 msgstr "Gotowe. Udanego drukowania!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4404
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4423
 msgid "Alphabet"
 msgstr "Alfab"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4308
+#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4327
 msgid "Always"
 msgstr "Zawsze"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1405
+#: ../../Firmware/ultralcd.cpp:1424
 msgid "Ambient"
 msgstr "Otoczenie"
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2983
+#: ../../Firmware/ultralcd.cpp:3002
 msgid "Are left and right Z~carriages all up?"
 msgstr "Obydwa konce osi sa na szczycie?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4478
 msgid "Assist"
 msgstr "Asyst."
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:5886
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
 #: ../../Firmware/Marlin_main.cpp:3271 ../../Firmware/messages.cpp:9
-#: ../../Firmware/ultralcd.cpp:4900
+#: ../../Firmware/ultralcd.cpp:4919
 msgid "Auto home"
 msgstr "Auto zerowanie"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:4364
-#: ../../Firmware/ultralcd.cpp:5779
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:4383
+#: ../../Firmware/ultralcd.cpp:5801
 msgid "Auto power"
 msgstr "Automatycz"
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5572
+#: ../../Firmware/ultralcd.cpp:5594
 msgid "AutoLoad filament"
 msgstr "Autoladowanie fil."
 
 #. MSG_AUTOLOADING_ONLY_IF_FSENS_ON c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3549
+#: ../../Firmware/ultralcd.cpp:3568
 msgid ""
 "Autoloading filament available only when filament sensor is turned on..."
 msgstr ""
 "Autoladowanie fil. dostepne tylko gdy czujnik filamentu jest wlaczony..."
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2301
+#: ../../Firmware/ultralcd.cpp:2320
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr "Autoladowanie filamentu wlaczone, nacisnij pokretlo i wsun filament..."
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:7015
+#: ../../Firmware/ultralcd.cpp:7045
 msgid "Axis"
 msgstr "Os"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:7014
+#: ../../Firmware/ultralcd.cpp:7044
 msgid "Axis length"
 msgstr "Dlugosc osi"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:2751
-#: ../../Firmware/ultralcd.cpp:5861 ../../Firmware/ultralcd.cpp:7838
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:2770
+#: ../../Firmware/ultralcd.cpp:5883 ../../Firmware/ultralcd.cpp:7878
 msgid "Back"
 msgstr "Wstecz"
 
 #. MSG_BED c=13
 #: ../../Firmware/Marlin_main.cpp:2051 ../../Firmware/Marlin_main.cpp:4767
 #: ../../Firmware/Marlin_main.cpp:4819 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:1403 ../../Firmware/ultralcd.cpp:5721
-#: ../../Firmware/ultralcd.cpp:5891
+#: ../../Firmware/ultralcd.cpp:1422 ../../Firmware/ultralcd.cpp:5743
+#: ../../Firmware/ultralcd.cpp:5913
 msgid "Bed"
 msgstr "Stol"
 
@@ -150,7 +150,7 @@ msgid "Bed done"
 msgstr "Stol OK"
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4912
+#: ../../Firmware/ultralcd.cpp:4931
 msgid "Bed level correct"
 msgstr "Korekta stolu"
 
@@ -168,18 +168,18 @@ msgstr ""
 "reset."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6972
+#: ../../Firmware/ultralcd.cpp:7002
 msgid "Bed/Heater"
 msgstr "Stol/Grzanie"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1458
-#: ../../Firmware/ultralcd.cpp:1726
+#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1477
+#: ../../Firmware/ultralcd.cpp:1745
 msgid "Belt status"
 msgstr "Stan paskow"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4902
+#: ../../Firmware/ultralcd.cpp:4921
 msgid "Belt test"
 msgstr "Test paskow"
 
@@ -190,28 +190,28 @@ msgid "Blackout occurred. Recover print?"
 msgstr "Wykryto zanik napiecia.Kontynowac?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:5886
 msgid "Bright"
 msgstr "Jasny"
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4850
-#: ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4869
+#: ../../Firmware/ultralcd.cpp:5811
 msgid "Brightness"
 msgstr "Jasnosc"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4906
+#: ../../Firmware/ultralcd.cpp:4925
 msgid "Calibrate XYZ"
 msgstr "Kalibracja XYZ"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4908
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4927
 msgid "Calibrate Z"
 msgstr "Kalibruj Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2946
+#: ../../Firmware/ultralcd.cpp:2965
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -226,7 +226,7 @@ msgid "Calibrating Z"
 msgstr "Kalibruje Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2945
+#: ../../Firmware/ultralcd.cpp:2964
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -235,12 +235,12 @@ msgstr ""
 "ogranicznikow. Nacisnij, by potwierdzic."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:7315
+#: ../../Firmware/ultralcd.cpp:7345
 msgid "Calibrating home"
 msgstr "Zerowanie osi"
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:5581
+#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:5603
 msgid "Calibration"
 msgstr "Kalibracja"
 
@@ -250,115 +250,115 @@ msgid "Calibration done"
 msgstr "Kalibracja OK"
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7712
+#: ../../Firmware/ultralcd.cpp:7752
 msgid "Card removed"
 msgstr "Karta wyjeta"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/ultralcd.cpp:5560
 msgid "Change SD card"
 msgstr "Zmiana karty SD"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5497
-#: ../../Firmware/ultralcd.cpp:5730
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5519
+#: ../../Firmware/ultralcd.cpp:5752
 msgid "Change filament"
 msgstr "Wymiana filamentu"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2163
+#: ../../Firmware/ultralcd.cpp:2182
 msgid "Change success!"
 msgstr "Wymiana ok!"
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2215
+#: ../../Firmware/ultralcd.cpp:2234
 msgid "Changed correctly?"
 msgstr "Wymiana ok?"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:6178
-#: ../../Firmware/ultralcd.cpp:7305
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:6208
+#: ../../Firmware/ultralcd.cpp:7335
 msgid "Checking X axis"
 msgstr "Kontrola osi X"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:6187
-#: ../../Firmware/ultralcd.cpp:7306
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:6217
+#: ../../Firmware/ultralcd.cpp:7336
 msgid "Checking Y axis"
 msgstr "Kontrola osi Y"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:7307
+#: ../../Firmware/ultralcd.cpp:7337
 msgid "Checking Z axis"
 msgstr "Kontrola osi Z"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:7308
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:7338
 msgid "Checking bed"
 msgstr "Kontrola stolu"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:7304
+#: ../../Firmware/ultralcd.cpp:7334
 msgid "Checking endstops"
 msgstr "Kontrola krancowek"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:7403
+#: ../../Firmware/ultralcd.cpp:7433
 msgid "Checking file"
 msgstr "Sprawdzanie pliku"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:7310
+#: ../../Firmware/ultralcd.cpp:7340
 msgid "Checking hotend"
 msgstr "Kontrola hotendu"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:7311
-#: ../../Firmware/ultralcd.cpp:7312
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:7341
+#: ../../Firmware/ultralcd.cpp:7342
 msgid "Checking sensors"
 msgstr "Kontrola czujnikow"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4765
+#: ../../Firmware/ultralcd.cpp:4784
 msgid "Checks"
 msgstr "Testy"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2218
+#: ../../Firmware/ultralcd.cpp:2237
 msgid "Color not correct"
 msgstr "Kolor zanieczysz."
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3725
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3744
 msgid "Community made"
 msgstr "Od spolecznosci"
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4704
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4723
 msgid "Cont."
 msgstr "Kont."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2125
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2144
 msgid "Cooldown"
 msgstr "Chlodzenie"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3663
+#: ../../Firmware/ultralcd.cpp:3682
 msgid "Copy selected language?"
 msgstr "Skopiowac wybrany jezyk?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1221
-#: ../../Firmware/ultralcd.cpp:1262 ../../Firmware/ultralcd.cpp:1272
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1240
+#: ../../Firmware/ultralcd.cpp:1281 ../../Firmware/ultralcd.cpp:1291
 msgid "Crash"
 msgstr "Zderzen"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4341
-#: ../../Firmware/ultralcd.cpp:4342 ../../Firmware/ultralcd.cpp:4344
-#: ../../Firmware/ultralcd.cpp:5765 ../../Firmware/ultralcd.cpp:5767
-#: ../../Firmware/ultralcd.cpp:5771
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4363
+#: ../../Firmware/ultralcd.cpp:5787 ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/ultralcd.cpp:5793
 msgid "Crash det."
 msgstr "Wykr.zderzen"
 
@@ -368,7 +368,7 @@ msgid "Crash detected."
 msgstr "Zderzenie wykryte"
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3521
+#: ../../Firmware/ultralcd.cpp:3540
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -380,14 +380,14 @@ msgstr ""
 "trybie Normalnym"
 
 #. MSG_CUT_FILAMENT c=17
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:5175
-#: ../../Firmware/ultralcd.cpp:5567
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:5197
+#: ../../Firmware/ultralcd.cpp:5589
 msgid "Cut filament"
 msgstr "Ciecie filamentu"
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:4303
-#: ../../Firmware/ultralcd.cpp:4308 ../../Firmware/ultralcd.cpp:4313
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:4322
+#: ../../Firmware/ultralcd.cpp:4327 ../../Firmware/ultralcd.cpp:4332
 msgid "Cutter"
 msgstr "Nozyk"
 
@@ -397,17 +397,17 @@ msgid "Cutting filament"
 msgstr "Obcinanie fil."
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1668
+#: ../../Firmware/ultralcd.cpp:1687
 msgid "Date:"
 msgstr "Data:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5886
 msgid "Dim"
 msgstr "Sciemn"
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4802
+#: ../../Firmware/ultralcd.cpp:4821
 msgid "Disable steppers"
 msgstr "Wylacz silniki"
 
@@ -423,7 +423,7 @@ msgstr ""
 "z instrukcja: rozdzial Wprowadzenie - Kalibracja pierwszej warstwy."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:4145
+#: ../../Firmware/ultralcd.cpp:4164
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -432,23 +432,23 @@ msgstr ""
 "stolikiem?"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4214
+#: ../../Firmware/ultralcd.cpp:4233
 msgid "E-correct:"
 msgstr "Korekcja-E:"
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2279
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2298
 msgid "ERROR:"
 msgstr "BLAD:"
 
 #. MSG_FSENS_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3562
+#: ../../Firmware/ultralcd.cpp:3581
 msgid "ERROR: Filament sensor is not responding, please check connection."
 msgstr "BLAD: Czujnik filamentu nie odpowiada, sprawdz polaczenie."
 
 #. MSG_EJECT_FILAMENT c=17
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:5156
-#: ../../Firmware/ultralcd.cpp:5565
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:5178
+#: ../../Firmware/ultralcd.cpp:5587
 msgid "Eject filament"
 msgstr "Wysun filament"
 
@@ -458,47 +458,41 @@ msgid "Ejecting filament"
 msgstr "Wysuwanie filamentu"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6985
+#: ../../Firmware/ultralcd.cpp:7015
 msgid "Endstop"
 msgstr "Krancowka"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6990
+#: ../../Firmware/ultralcd.cpp:7020
 msgid "Endstop not hit"
 msgstr "Krancowka nie aktyw."
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6976
+#: ../../Firmware/ultralcd.cpp:7006
 msgid "Endstops"
 msgstr "Krancowki"
 
 #. MSG_EXTRUDER c=17
 #: ../../Firmware/Marlin_main.cpp:8608 ../../Firmware/messages.cpp:30
-#: ../../Firmware/ultralcd.cpp:3495
+#: ../../Firmware/ultralcd.cpp:3514
 msgid "Extruder"
 msgstr "Ekstruder"
 
-#. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1144
-#: ../../Firmware/ultralcd.cpp:7319
-msgid "Hotend fan:"
-msgstr "Went. hotend:"
-
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1722
+#: ../../Firmware/ultralcd.cpp:1741
 msgid "Extruder info"
 msgstr "Ekstruder - info"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4229
-#: ../../Firmware/ultralcd.cpp:4237 ../../Firmware/ultralcd.cpp:4248
-#: ../../Firmware/ultralcd.cpp:4250
+#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4248
+#: ../../Firmware/ultralcd.cpp:4256 ../../Firmware/ultralcd.cpp:4267
+#: ../../Firmware/ultralcd.cpp:4269
 msgid "F. autoload"
 msgstr "Autolad. fil."
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4704
-#: ../../Firmware/ultralcd.cpp:4707
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4723
+#: ../../Firmware/ultralcd.cpp:4726
 msgid "FS Action"
 msgstr "Akcja FS"
 
@@ -513,102 +507,102 @@ msgid "FS v0.4 or newer"
 msgstr "FS 0.4 lub nowszy"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5589
+#: ../../Firmware/ultralcd.cpp:5611
 msgid "Fail stats"
 msgstr "Statystyki bledow"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5592
+#: ../../Firmware/ultralcd.cpp:5614
 msgid "Fail stats MMU"
 msgstr "Bledy MMU"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:7031
+#: ../../Firmware/ultralcd.cpp:7061
 msgid "False triggering"
 msgstr "Falszywy alarm"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:5723
-#: ../../Firmware/ultralcd.cpp:5893
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/ultralcd.cpp:5915
 msgid "Fan speed"
 msgstr "Predkosc went."
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:7143
-#: ../../Firmware/ultralcd.cpp:7301 ../../Firmware/ultralcd.cpp:7302
-#: ../../Firmware/ultralcd.cpp:7303
+#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:7173
+#: ../../Firmware/ultralcd.cpp:7331 ../../Firmware/ultralcd.cpp:7332
+#: ../../Firmware/ultralcd.cpp:7333
 msgid "Fan test"
 msgstr "Test wentylatora"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4811
-#: ../../Firmware/ultralcd.cpp:5756
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4830
+#: ../../Firmware/ultralcd.cpp:5778
 msgid "Fans check"
 msgstr "Sprawd.went."
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1220
-#: ../../Firmware/ultralcd.cpp:1261 ../../Firmware/ultralcd.cpp:1327
-#: ../../Firmware/ultralcd.cpp:1329
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1239
+#: ../../Firmware/ultralcd.cpp:1280 ../../Firmware/ultralcd.cpp:1346
+#: ../../Firmware/ultralcd.cpp:1348
 msgid "Fil. runouts"
 msgstr "Konc.filamentu"
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:3451
-#: ../../Firmware/ultralcd.cpp:4228 ../../Firmware/ultralcd.cpp:4234
-#: ../../Firmware/ultralcd.cpp:4244 ../../Firmware/ultralcd.cpp:5737
-#: ../../Firmware/ultralcd.cpp:5741 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:3470
+#: ../../Firmware/ultralcd.cpp:4247 ../../Firmware/ultralcd.cpp:4253
+#: ../../Firmware/ultralcd.cpp:4263 ../../Firmware/ultralcd.cpp:5759
+#: ../../Firmware/ultralcd.cpp:5763 ../../Firmware/ultralcd.cpp:5767
 msgid "Fil. sensor"
 msgstr "Czuj. filam."
 
 #. MSG_FILAMENT c=17
 #: ../../Firmware/Marlin_main.cpp:8577 ../../Firmware/Marlin_main.cpp:8604
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3835
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3854
 msgid "Filament"
 msgstr "Filament"
 
 #. MSG_FILAMENT_CLEAN c=20 r=2
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2287
-#: ../../Firmware/ultralcd.cpp:2293
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2306
+#: ../../Firmware/ultralcd.cpp:2312
 msgid "Filament extruding & with correct color?"
 msgstr "Filament wychodzi z dyszy,kolor jest ok?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2217
+#: ../../Firmware/ultralcd.cpp:2236
 msgid "Filament not loaded"
 msgstr "Fil. nie zaladowany"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:7026
-#: ../../Firmware/ultralcd.cpp:7030 ../../Firmware/ultralcd.cpp:7034
-#: ../../Firmware/ultralcd.cpp:7330
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:7056
+#: ../../Firmware/ultralcd.cpp:7060 ../../Firmware/ultralcd.cpp:7064
+#: ../../Firmware/ultralcd.cpp:7360
 msgid "Filament sensor"
 msgstr "Czujnik filamentu"
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2365
+#: ../../Firmware/ultralcd.cpp:2384
 msgid "Filament used"
 msgstr "Uzyty filament"
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7461
+#: ../../Firmware/ultralcd.cpp:7491
 msgid "File incomplete. Continue anyway?"
 msgstr "Plik niekompletny. Kontynowac?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:5314
-#: ../../Firmware/ultralcd.cpp:5630
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:5336
+#: ../../Firmware/ultralcd.cpp:5652
 msgid "Finishing movements"
 msgstr "Konczenie druku"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:4898
-#: ../../Firmware/ultralcd.cpp:5424
+#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:4917
+#: ../../Firmware/ultralcd.cpp:5446
 msgid "First layer cal."
 msgstr "Kal. 1. warstwy"
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4066
+#: ../../Firmware/ultralcd.cpp:4085
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Najpierw wlacze selftest w celu sprawdzenia najczestszych problemow podczas "
@@ -620,23 +614,23 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr "Rozwiaz problem i wcisnij przycisk na MMU."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5724
+#: ../../Firmware/ultralcd.cpp:5746
 msgid "Flow"
 msgstr "Przeplyw"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:6996
-#: ../../Firmware/ultralcd.cpp:7149 ../../Firmware/ultralcd.cpp:7154
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:7026
+#: ../../Firmware/ultralcd.cpp:7179 ../../Firmware/ultralcd.cpp:7184
 msgid "Front print fan?"
 msgstr "Przedni went. druku?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2754
+#: ../../Firmware/ultralcd.cpp:2773
 msgid "Front side[μm]"
 msgstr "Przod [μm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:7020
+#: ../../Firmware/ultralcd.cpp:7050
 msgid "Front/left fans"
 msgstr "Przedni/lewy wentyl."
 
@@ -683,20 +677,20 @@ msgstr ""
 "G-code pociety dla nowszego firmware. Zaktualizuj firmware. Druk anulowany."
 
 #. MSG_GCODE c=8
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:4655
-#: ../../Firmware/ultralcd.cpp:4658 ../../Firmware/ultralcd.cpp:4661
-#: ../../Firmware/ultralcd.cpp:4664
+#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:4674
+#: ../../Firmware/ultralcd.cpp:4677 ../../Firmware/ultralcd.cpp:4680
+#: ../../Firmware/ultralcd.cpp:4683
 msgid "Gcode"
 msgstr "Gcode"
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:4672
-#: ../../Firmware/ultralcd.cpp:4726 ../../Firmware/ultralcd.cpp:4818
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:4691
+#: ../../Firmware/ultralcd.cpp:4745 ../../Firmware/ultralcd.cpp:4837
 msgid "HW Setup"
 msgstr "Ustawienia HW"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6968
+#: ../../Firmware/ultralcd.cpp:6998
 msgid "Heater/Thermistor"
 msgstr "Grzalka/Termistor"
 
@@ -718,7 +712,7 @@ msgid "Heating done."
 msgstr "Grzanie zakonczone"
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=16
-#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4042
+#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4061
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -728,7 +722,7 @@ msgstr ""
 "krotka kalibracje osi Z, po ktorej mozesz rozpoczac drukowanie."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4064
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -737,24 +731,30 @@ msgstr ""
 "ustawieniem?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:4358
-#: ../../Firmware/ultralcd.cpp:4367 ../../Firmware/ultralcd.cpp:5777
-#: ../../Firmware/ultralcd.cpp:5780
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:4377
+#: ../../Firmware/ultralcd.cpp:4386 ../../Firmware/ultralcd.cpp:5799
+#: ../../Firmware/ultralcd.cpp:5802
 msgid "High power"
 msgstr "Wysoka wyd"
 
+#. MSG_HOTEND_FAN_SPEED c=15
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1145
+#: ../../Firmware/ultralcd.cpp:7351
+msgid "Hotend fan:"
+msgstr "Went. hotend:"
+
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4094
 msgid "I will run xyz calibration now. It will take approx. 12 mins."
 msgstr "Przeprowadze teraz kalibracje XYZ. Zajmie ok. 12 min."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/ultralcd.cpp:4102
 msgid "I will run z calibration now."
 msgstr "Przeprowadze kalibracje Z."
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=9
-#: ../../Firmware/ultralcd.cpp:4153
+#: ../../Firmware/ultralcd.cpp:4172
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -768,22 +768,22 @@ msgid "Improving bed calibration point"
 msgstr "Poprawa punktu kalibracji stolu"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:5478
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:5500
 msgid "Info screen"
 msgstr "Ekran informacyjny"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5545
+#: ../../Firmware/ultralcd.cpp:5567
 msgid "Init. SD card"
 msgstr "Inic. karty SD"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2152
+#: ../../Firmware/ultralcd.cpp:2171
 msgid "Insert filament"
 msgstr "Wprowadz filament"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:6223
+#: ../../Firmware/ultralcd.cpp:6253
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
@@ -792,14 +792,14 @@ msgstr ""
 "pokretlo."
 
 #. MSG_FILAMENT_LOADED c=20 r=2
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3855
-#: ../../Firmware/ultralcd.cpp:4108 ../../Firmware/ultralcd.cpp:4111
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3874
+#: ../../Firmware/ultralcd.cpp:4127 ../../Firmware/ultralcd.cpp:4130
 msgid "Is filament loaded?"
 msgstr "Filament jest zaladowany?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=2
 #: ../../Firmware/Marlin_main.cpp:3312 ../../Firmware/Marlin_main.cpp:4886
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:4084
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:4103
 msgid "Is steel sheet on heatbed?"
 msgstr "Czy plyta stal. jest na podgrzew. stole?"
 
@@ -809,74 +809,74 @@ msgid "Iteration"
 msgstr "Iteracja"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:1148
-#: ../../Firmware/ultralcd.cpp:1296
+#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:1167
+#: ../../Firmware/ultralcd.cpp:1315
 msgid "Last print"
 msgstr "Ost. wydruk"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1169
-#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1269
-#: ../../Firmware/ultralcd.cpp:1326
+#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1188
+#: ../../Firmware/ultralcd.cpp:1278 ../../Firmware/ultralcd.cpp:1288
+#: ../../Firmware/ultralcd.cpp:1345
 msgid "Last print failures"
 msgstr "Ostatnie bledy druku"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2496
+#: ../../Firmware/ultralcd.cpp:2515
 msgid "Left"
 msgstr "Lewa"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7001
-#: ../../Firmware/ultralcd.cpp:7147 ../../Firmware/ultralcd.cpp:7152
+#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:7032
+#: ../../Firmware/ultralcd.cpp:7179 ../../Firmware/ultralcd.cpp:7184
 msgid "Left hotend fan?"
 msgstr "Lewy went hotendu?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2752
+#: ../../Firmware/ultralcd.cpp:2771
 msgid "Left side [μm]"
 msgstr "Lewo [μm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:5862
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:5884
 msgid "Level Bright"
 msgstr "Poziom jasn."
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:5863
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:5885
 msgid "Level Dimmed"
 msgstr "Poziom ciem."
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4826
+#: ../../Firmware/ultralcd.cpp:4845
 msgid "Lin. correction"
 msgstr "Korekcja liniowa"
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4838
-#: ../../Firmware/ultralcd.cpp:5493
+#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4857
+#: ../../Firmware/ultralcd.cpp:5515
 msgid "Live adjust Z"
 msgstr "Ustaw. Live Z"
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/ultralcd.cpp:5120
+#: ../../Firmware/ultralcd.cpp:5142
 msgid "Load all"
 msgstr "Zalad. wszystkie"
 
 #. MSG_LOAD_FILAMENT c=17
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:5122
-#: ../../Firmware/ultralcd.cpp:5133 ../../Firmware/ultralcd.cpp:5562
-#: ../../Firmware/ultralcd.cpp:5576
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:5144
+#: ../../Firmware/ultralcd.cpp:5155 ../../Firmware/ultralcd.cpp:5584
+#: ../../Firmware/ultralcd.cpp:5598
 msgid "Load filament"
 msgstr "Ladowanie fil."
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5563
+#: ../../Firmware/ultralcd.cpp:5585
 msgid "Load to nozzle"
 msgstr "Zaladuj do dyszy"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2185
+#: ../../Firmware/ultralcd.cpp:2204
 msgid "Loading color"
 msgstr "Czyszcz. koloru"
 
@@ -884,18 +884,18 @@ msgstr "Czyszcz. koloru"
 #: ../../Firmware/Marlin_main.cpp:3641 ../../Firmware/messages.cpp:55
 #: ../../Firmware/mmu.cpp:872 ../../Firmware/mmu.cpp:906
 #: ../../Firmware/mmu.cpp:1014 ../../Firmware/mmu.cpp:1026
-#: ../../Firmware/ultralcd.cpp:2196 ../../Firmware/ultralcd.cpp:3949
+#: ../../Firmware/ultralcd.cpp:2215 ../../Firmware/ultralcd.cpp:3968
 msgid "Loading filament"
 msgstr "Laduje filament"
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:7008
+#: ../../Firmware/ultralcd.cpp:7038
 msgid "Loose pulley"
 msgstr "Luzne kolo pasowe"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:4450
-#: ../../Firmware/ultralcd.cpp:4462
+#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/ultralcd.cpp:4481
 msgid "Loud"
 msgstr "Glosny"
 
@@ -910,8 +910,8 @@ msgid "MK3S firmware detected on MK3 printer"
 msgstr "Wykryto firmware MK3S w drukarce MK3"
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4381
-#: ../../Firmware/ultralcd.cpp:4382
+#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4400
+#: ../../Firmware/ultralcd.cpp:4401
 msgid "MMU Mode"
 msgstr "Tryb MMU"
 
@@ -931,8 +931,8 @@ msgid "MMU OK. Resuming..."
 msgstr "MMU OK. Wznawianie..."
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:64 ../../Firmware/ultralcd.cpp:1170
-#: ../../Firmware/ultralcd.cpp:1193
+#: ../../Firmware/messages.cpp:64 ../../Firmware/ultralcd.cpp:1189
+#: ../../Firmware/ultralcd.cpp:1212
 msgid "MMU fails"
 msgstr "Bledy MMU"
 
@@ -942,8 +942,8 @@ msgid "MMU load failed"
 msgstr "Blad ladowania MMU"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:1171
-#: ../../Firmware/ultralcd.cpp:1194
+#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:1190
+#: ../../Firmware/ultralcd.cpp:1213
 msgid "MMU load fails"
 msgstr "Bledy lad. MMU"
 
@@ -953,32 +953,32 @@ msgid "MMU needs user attention."
 msgstr "MMU wymaga uwagi uzytkownika."
 
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/ultralcd.cpp:1195
+#: ../../Firmware/ultralcd.cpp:1214
 msgid "MMU power fails"
 msgstr "Zaniki zas. MMU"
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1680
+#: ../../Firmware/ultralcd.cpp:1699
 msgid "MMU2 connected"
 msgstr "MMU podlaczone"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:5836
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:5858
 msgid "Magnets comp."
 msgstr "Kor. magnesow"
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1147
-#: ../../Firmware/ultralcd.cpp:1295 ../../Firmware/ultralcd.cpp:1338
-#: ../../Firmware/ultralcd.cpp:1645 ../../Firmware/ultralcd.cpp:4795
-#: ../../Firmware/ultralcd.cpp:4892 ../../Firmware/ultralcd.cpp:5119
-#: ../../Firmware/ultralcd.cpp:5131 ../../Firmware/ultralcd.cpp:5154
-#: ../../Firmware/ultralcd.cpp:5173 ../../Firmware/ultralcd.cpp:5717
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1166
+#: ../../Firmware/ultralcd.cpp:1314 ../../Firmware/ultralcd.cpp:1357
+#: ../../Firmware/ultralcd.cpp:1664 ../../Firmware/ultralcd.cpp:4814
+#: ../../Firmware/ultralcd.cpp:4911 ../../Firmware/ultralcd.cpp:5141
+#: ../../Firmware/ultralcd.cpp:5153 ../../Firmware/ultralcd.cpp:5176
+#: ../../Firmware/ultralcd.cpp:5195 ../../Firmware/ultralcd.cpp:5739
 msgid "Main"
 msgstr "Menu glowne"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2537
+#: ../../Firmware/ultralcd.cpp:2556
 msgid "Measured skew"
 msgstr "Zmierz. skos"
 
@@ -989,71 +989,71 @@ msgid "Measuring reference height of calibration point"
 msgstr "Okreslam wysokosc odniesienia punktu kalibracyjnego"
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:5832
+#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:5854
 msgid "Mesh"
 msgstr "Siatka"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4823
-#: ../../Firmware/ultralcd.cpp:4910
+#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4842
+#: ../../Firmware/ultralcd.cpp:4929
 msgid "Mesh Bed Leveling"
 msgstr "Poziomowanie stolu"
 
 #. MSG_MODE c=6
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:4336
-#: ../../Firmware/ultralcd.cpp:4338 ../../Firmware/ultralcd.cpp:4358
-#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4364
-#: ../../Firmware/ultralcd.cpp:4367 ../../Firmware/ultralcd.cpp:5763
-#: ../../Firmware/ultralcd.cpp:5770 ../../Firmware/ultralcd.cpp:5777
-#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5779
-#: ../../Firmware/ultralcd.cpp:5780 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/ultralcd.cpp:4357 ../../Firmware/ultralcd.cpp:4377
+#: ../../Firmware/ultralcd.cpp:4380 ../../Firmware/ultralcd.cpp:4383
+#: ../../Firmware/ultralcd.cpp:4386 ../../Firmware/ultralcd.cpp:5785
+#: ../../Firmware/ultralcd.cpp:5792 ../../Firmware/ultralcd.cpp:5799
+#: ../../Firmware/ultralcd.cpp:5800 ../../Firmware/ultralcd.cpp:5801
+#: ../../Firmware/ultralcd.cpp:5802 ../../Firmware/ultralcd.cpp:5886
 msgid "Mode"
 msgstr "Tryb"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3598
+#: ../../Firmware/ultralcd.cpp:3617
 msgid "Mode change in progress..."
 msgstr "Trwa zmiana trybu..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:4575
-#: ../../Firmware/ultralcd.cpp:4578 ../../Firmware/ultralcd.cpp:4581
-#: ../../Firmware/ultralcd.cpp:4584
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:4594
+#: ../../Firmware/ultralcd.cpp:4597 ../../Firmware/ultralcd.cpp:4600
+#: ../../Firmware/ultralcd.cpp:4603
 msgid "Model"
 msgstr "Model"
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6982
-#: ../../Firmware/ultralcd.cpp:6991 ../../Firmware/ultralcd.cpp:7009
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:7012
+#: ../../Firmware/ultralcd.cpp:7021 ../../Firmware/ultralcd.cpp:7039
 msgid "Motor"
 msgstr "Silnik"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3492
+#: ../../Firmware/ultralcd.cpp:3511
 msgid "Move X"
 msgstr "Ruch osi X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3493
+#: ../../Firmware/ultralcd.cpp:3512
 msgid "Move Y"
 msgstr "Ruch osi Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3494
+#: ../../Firmware/ultralcd.cpp:3513
 msgid "Move Z"
 msgstr "Ruch osi Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4801
+#: ../../Firmware/ultralcd.cpp:4820
 msgid "Move axis"
 msgstr "Ruch osi"
 
 #. MSG_NA c=3
 #: ../../Firmware/menu.cpp:196 ../../Firmware/messages.cpp:124
-#: ../../Firmware/ultralcd.cpp:2502 ../../Firmware/ultralcd.cpp:2547
-#: ../../Firmware/ultralcd.cpp:3411 ../../Firmware/ultralcd.cpp:4228
-#: ../../Firmware/ultralcd.cpp:4276 ../../Firmware/ultralcd.cpp:5737
-#: ../../Firmware/ultralcd.cpp:5836
+#: ../../Firmware/ultralcd.cpp:2521 ../../Firmware/ultralcd.cpp:2566
+#: ../../Firmware/ultralcd.cpp:3430 ../../Firmware/ultralcd.cpp:4247
+#: ../../Firmware/ultralcd.cpp:4295 ../../Firmware/ultralcd.cpp:5759
+#: ../../Firmware/ultralcd.cpp:5858
 msgid "N/A"
 msgstr "N/D"
 
@@ -1063,14 +1063,14 @@ msgid "New firmware version available:"
 msgstr "Dostepna nowa wersja firmware:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:2804
-#: ../../Firmware/ultralcd.cpp:3180 ../../Firmware/ultralcd.cpp:4785
-#: ../../Firmware/ultralcd.cpp:5988
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:2823
+#: ../../Firmware/ultralcd.cpp:3199 ../../Firmware/ultralcd.cpp:4804
+#: ../../Firmware/ultralcd.cpp:6018
 msgid "No"
 msgstr "Nie"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5543
+#: ../../Firmware/ultralcd.cpp:5565
 msgid "No SD card"
 msgstr "Brak karty SD"
 
@@ -1080,71 +1080,71 @@ msgid "No move."
 msgstr "Brak ruchu."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4405
-#: ../../Firmware/ultralcd.cpp:4493 ../../Firmware/ultralcd.cpp:4502
-#: ../../Firmware/ultralcd.cpp:4575 ../../Firmware/ultralcd.cpp:4584
-#: ../../Firmware/ultralcd.cpp:4614 ../../Firmware/ultralcd.cpp:4623
-#: ../../Firmware/ultralcd.cpp:4655 ../../Firmware/ultralcd.cpp:4664
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4424
+#: ../../Firmware/ultralcd.cpp:4512 ../../Firmware/ultralcd.cpp:4521
+#: ../../Firmware/ultralcd.cpp:4594 ../../Firmware/ultralcd.cpp:4603
+#: ../../Firmware/ultralcd.cpp:4633 ../../Firmware/ultralcd.cpp:4642
+#: ../../Firmware/ultralcd.cpp:4674 ../../Firmware/ultralcd.cpp:4683
 msgid "None"
 msgstr "Brak"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:4336
-#: ../../Firmware/ultralcd.cpp:4381 ../../Firmware/ultralcd.cpp:4397
-#: ../../Firmware/ultralcd.cpp:4416 ../../Firmware/ultralcd.cpp:5763
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/ultralcd.cpp:4400 ../../Firmware/ultralcd.cpp:4416
+#: ../../Firmware/ultralcd.cpp:4435 ../../Firmware/ultralcd.cpp:5785
 msgid "Normal"
 msgstr "Normal"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6969
+#: ../../Firmware/ultralcd.cpp:6999
 msgid "Not connected"
 msgstr "Nie podlaczono"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:7168
-#: ../../Firmware/ultralcd.cpp:7183 ../../Firmware/ultralcd.cpp:7191
+#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:7198
+#: ../../Firmware/ultralcd.cpp:7213 ../../Firmware/ultralcd.cpp:7221
 msgid "Not spinning"
 msgstr "Nie kreci sie"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3962
+#: ../../Firmware/ultralcd.cpp:3981
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr "Kalibruje odleglosc miedzy koncowka dyszy a powierzchnia druku."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:4091
+#: ../../Firmware/ultralcd.cpp:4110
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Nagrzewam dysze dla PLA."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/ultralcd.cpp:4101
 msgid "Now remove the test print from steel sheet."
 msgstr "Teraz zdejmij wydruk testowy ze stolu."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:1402
-#: ../../Firmware/ultralcd.cpp:4493 ../../Firmware/ultralcd.cpp:4496
-#: ../../Firmware/ultralcd.cpp:4499 ../../Firmware/ultralcd.cpp:4502
-#: ../../Firmware/ultralcd.cpp:5720 ../../Firmware/ultralcd.cpp:5882
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:1421
+#: ../../Firmware/ultralcd.cpp:4512 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/ultralcd.cpp:4518 ../../Firmware/ultralcd.cpp:4521
+#: ../../Firmware/ultralcd.cpp:5742 ../../Firmware/ultralcd.cpp:5904
 msgid "Nozzle"
 msgstr "Dysza"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4546
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4565
 msgid "Nozzle d."
 msgstr "Sr. dyszy"
 
 #. MSG_OFF c=3
 #: ../../Firmware/menu.cpp:467 ../../Firmware/messages.cpp:122
-#: ../../Firmware/ultralcd.cpp:4234 ../../Firmware/ultralcd.cpp:4250
-#: ../../Firmware/ultralcd.cpp:4284 ../../Firmware/ultralcd.cpp:4313
-#: ../../Firmware/ultralcd.cpp:4342 ../../Firmware/ultralcd.cpp:4811
-#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4834
-#: ../../Firmware/ultralcd.cpp:5644 ../../Firmware/ultralcd.cpp:5741
-#: ../../Firmware/ultralcd.cpp:5756 ../../Firmware/ultralcd.cpp:5767
-#: ../../Firmware/ultralcd.cpp:5836 ../../Firmware/ultralcd.cpp:7841
-#: ../../Firmware/ultralcd.cpp:7845
+#: ../../Firmware/ultralcd.cpp:4253 ../../Firmware/ultralcd.cpp:4269
+#: ../../Firmware/ultralcd.cpp:4303 ../../Firmware/ultralcd.cpp:4332
+#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4830
+#: ../../Firmware/ultralcd.cpp:4849 ../../Firmware/ultralcd.cpp:4853
+#: ../../Firmware/ultralcd.cpp:5666 ../../Firmware/ultralcd.cpp:5763
+#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/ultralcd.cpp:5858 ../../Firmware/ultralcd.cpp:7881
+#: ../../Firmware/ultralcd.cpp:7885
 msgid "Off"
 msgstr "Wyl"
 
@@ -1156,19 +1156,19 @@ msgstr ""
 "itp."
 
 #. MSG_ON c=3
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4244
-#: ../../Firmware/ultralcd.cpp:4248 ../../Firmware/ultralcd.cpp:4280
-#: ../../Firmware/ultralcd.cpp:4303 ../../Firmware/ultralcd.cpp:4341
-#: ../../Firmware/ultralcd.cpp:4811 ../../Firmware/ultralcd.cpp:4830
-#: ../../Firmware/ultralcd.cpp:4834 ../../Firmware/ultralcd.cpp:5745
-#: ../../Firmware/ultralcd.cpp:5756 ../../Firmware/ultralcd.cpp:5765
-#: ../../Firmware/ultralcd.cpp:5836 ../../Firmware/ultralcd.cpp:7841
-#: ../../Firmware/ultralcd.cpp:7845
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4263
+#: ../../Firmware/ultralcd.cpp:4267 ../../Firmware/ultralcd.cpp:4299
+#: ../../Firmware/ultralcd.cpp:4322 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4849
+#: ../../Firmware/ultralcd.cpp:4853 ../../Firmware/ultralcd.cpp:5767
+#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5787
+#: ../../Firmware/ultralcd.cpp:5858 ../../Firmware/ultralcd.cpp:7881
+#: ../../Firmware/ultralcd.cpp:7885
 msgid "On"
 msgstr "Wl"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4453
+#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4472
 msgid "Once"
 msgstr "1-raz"
 
@@ -1188,7 +1188,7 @@ msgid "PID cal. finished"
 msgstr "Kal. PID zakonczona"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4913
+#: ../../Firmware/ultralcd.cpp:4932
 msgid "PID calibration"
 msgstr "Kalibracja PID"
 
@@ -1200,18 +1200,18 @@ msgstr "Grzanie sondy PINDA"
 #. MSG_PINDA_CALIBRATION c=13
 #: ../../Firmware/Marlin_main.cpp:4932 ../../Firmware/Marlin_main.cpp:5035
 #: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:654
-#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4920
+#: ../../Firmware/ultralcd.cpp:4849 ../../Firmware/ultralcd.cpp:4939
 msgid "PINDA cal."
 msgstr "Kalib. PINDA"
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3361
+#: ../../Firmware/ultralcd.cpp:3380
 msgid "PINDA calibration failed"
 msgstr "Kalibracja temperaturowa nieudana"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
 #: ../../Firmware/Marlin_main.cpp:5112 ../../Firmware/messages.cpp:110
-#: ../../Firmware/ultralcd.cpp:3355
+#: ../../Firmware/ultralcd.cpp:3374
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1220,13 +1220,13 @@ msgstr ""
 "-> Kalib. PINDA"
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4707
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4726
 msgid "Pause"
 msgstr "Pauza"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:5507
-#: ../../Firmware/ultralcd.cpp:5509
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:5529
+#: ../../Firmware/ultralcd.cpp:5531
 msgid "Pause print"
 msgstr "Wstrzym. wydruku"
 
@@ -1240,7 +1240,7 @@ msgstr ""
 "punktow. Jesli dysza zahaczy o papier, natychmiast wylacz drukarke."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:4176
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:4195
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1249,17 +1249,17 @@ msgstr ""
 "Asystenta przez restart drukarki."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:6250
+#: ../../Firmware/ultralcd.cpp:6280
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "Sprawdz polaczenie czujnika IR, rozladuj filament, jesli zaladowany."
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6963
+#: ../../Firmware/ultralcd.cpp:6993
 msgid "Please check:"
 msgstr "Sprawdz:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4148
+#: ../../Firmware/ultralcd.cpp:4167
 msgid "Please clean heatbed and then press the knob."
 msgstr "Oczysc powierzchnie druku i nacisnij pokretlo."
 
@@ -1269,13 +1269,13 @@ msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Dla prawidlowej kalibracji nalezy oczyscic dysze. Potwierdz guzikiem."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3945
+#: ../../Firmware/ultralcd.cpp:3964
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr "Wsun filament do ekstrudera i nacisnij pokretlo, aby go zaladowac."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3940
+#: ../../Firmware/ultralcd.cpp:3959
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1284,7 +1284,7 @@ msgstr ""
 "zaladowac."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3863
+#: ../../Firmware/ultralcd.cpp:3882
 msgid "Please load filament first."
 msgstr "Najpierw zaladuj filament."
 
@@ -1296,7 +1296,7 @@ msgstr ""
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=5
 #: ../../Firmware/mesh_bed_calibration.cpp:2799 ../../Firmware/messages.cpp:70
-#: ../../Firmware/ultralcd.cpp:4085
+#: ../../Firmware/ultralcd.cpp:4104
 msgid "Please place steel sheet on heatbed."
 msgstr "Prosze umiescic plyte stalowa na stole podgrzewanym."
 
@@ -1307,7 +1307,7 @@ msgid "Please press the knob to unload filament"
 msgstr "Nacisnij pokretlo aby rozladowac filament"
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:5213
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:5235
 msgid "Please pull out filament immediately"
 msgstr "Wyciagnij filament teraz"
 
@@ -1317,7 +1317,7 @@ msgid "Please remove filament and then press the knob."
 msgstr "Wyciagnij filament i wcisnij pokretlo."
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:4081
+#: ../../Firmware/ultralcd.cpp:4100
 msgid "Please remove shipping helpers first."
 msgstr "Najpierw usun zabezpieczenia transportowe"
 
@@ -1333,7 +1333,7 @@ msgid "Please run XYZ calibration first."
 msgstr "Prosze najpierw uruchomic kalibracje XYZ"
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:6247
+#: ../../Firmware/ultralcd.cpp:6277
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Najpierw rozladuj filament, nastepnie powtorz czynnosc."
 
@@ -1350,54 +1350,54 @@ msgstr "Prosze zaktualizowac"
 #. MSG_PLEASE_WAIT c=20
 #: ../../Firmware/Marlin_main.cpp:3547 ../../Firmware/Marlin_main.cpp:3563
 #: ../../Firmware/Marlin_main.cpp:7931 ../../Firmware/messages.cpp:71
-#: ../../Firmware/ultralcd.cpp:2186 ../../Firmware/ultralcd.cpp:2197
+#: ../../Firmware/ultralcd.cpp:2205 ../../Firmware/ultralcd.cpp:2216
 msgid "Please wait"
 msgstr "Prosze czekac"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1219
-#: ../../Firmware/ultralcd.cpp:1260 ../../Firmware/ultralcd.cpp:1270
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1238
+#: ../../Firmware/ultralcd.cpp:1279 ../../Firmware/ultralcd.cpp:1289
 msgid "Power failures"
 msgstr "Zaniki zasil."
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5502
+#: ../../Firmware/ultralcd.cpp:5524
 msgid "Preheat"
 msgstr "Grzanie"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:2280
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:2299
 msgid "Preheat the nozzle!"
 msgstr "Nagrzej dysze!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:2900
-#: ../../Firmware/ultralcd.cpp:3924 ../../Firmware/ultralcd.cpp:3926
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:2919
+#: ../../Firmware/ultralcd.cpp:3943 ../../Firmware/ultralcd.cpp:3945
 msgid "Preheating nozzle. Please wait."
 msgstr "Nagrzewanie dyszy. Prosze czekac."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1988
+#: ../../Firmware/ultralcd.cpp:2007
 msgid "Preheating to cut"
 msgstr "Nagrzew. obciecia"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1985
+#: ../../Firmware/ultralcd.cpp:2004
 msgid "Preheating to eject"
 msgstr "Nagrzew. wysuniecia"
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1976
+#: ../../Firmware/ultralcd.cpp:1995
 msgid "Preheating to load"
 msgstr "Nagrzew.do ladowania"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1981
+#: ../../Firmware/ultralcd.cpp:2000
 msgid "Preheating to unload"
 msgstr "Nagrzew. do rozlad."
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1809
+#: ../../Firmware/ultralcd.cpp:1828
 msgid "Press the knob"
 msgstr "Wcisnij pokretlo"
 
@@ -1417,13 +1417,13 @@ msgid "Print aborted"
 msgstr "Druk przerwany"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1144
-#: ../../Firmware/ultralcd.cpp:7322
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1145
+#: ../../Firmware/ultralcd.cpp:7354
 msgid "Print fan:"
 msgstr "WentWydruk:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5535
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5557
 msgid "Print from SD"
 msgstr "Druk z karty SD"
 
@@ -1433,12 +1433,12 @@ msgid "Print paused"
 msgstr "Druk wstrzymany"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2366
+#: ../../Firmware/ultralcd.cpp:2385
 msgid "Print time"
 msgstr "Czas druku"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1711
+#: ../../Firmware/ultralcd.cpp:1730
 msgid "Printer IP Addr:"
 msgstr "Adr. IP drukarki:"
 
@@ -1465,12 +1465,12 @@ msgstr ""
 "Srednica dyszy rozni sie od tej w G-code. Sprawdz ustawienia. Druk anulowany."
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4834
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4853
 msgid "RPi port"
 msgstr "Port RPi"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2755
+#: ../../Firmware/ultralcd.cpp:2774
 msgid "Rear side [μm]"
 msgstr "Tyl [μm]"
 
@@ -1485,24 +1485,24 @@ msgid "Remove old filament and press the knob to start loading new filament."
 msgstr "Wyciagnij poprzedni filament i nacisnij pokretlo aby zaladowac nowy."
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5426
+#: ../../Firmware/ultralcd.cpp:5448
 msgid "Rename"
 msgstr "Zmien nazwe"
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2756
-#: ../../Firmware/ultralcd.cpp:5427
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2775
+#: ../../Firmware/ultralcd.cpp:5449
 msgid "Reset"
 msgstr "Reset"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4917
+#: ../../Firmware/ultralcd.cpp:4936
 msgid "Reset XYZ calibr."
 msgstr "Reset kalibr. XYZ"
 
 #. MSG_RESUME_PRINT c=18
 #: ../../Firmware/Marlin_main.cpp:655 ../../Firmware/messages.cpp:81
-#: ../../Firmware/ultralcd.cpp:5521 ../../Firmware/ultralcd.cpp:5523
+#: ../../Firmware/ultralcd.cpp:5543 ../../Firmware/ultralcd.cpp:5545
 msgid "Resume print"
 msgstr "Wznowic wydruk"
 
@@ -1512,17 +1512,17 @@ msgid "Resuming print"
 msgstr "Wznawianie druku"
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2497
+#: ../../Firmware/ultralcd.cpp:2516
 msgid "Right"
 msgstr "Prawa"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2753
+#: ../../Firmware/ultralcd.cpp:2772
 msgid "Right side[μm]"
 msgstr "Prawo [μm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3884
+#: ../../Firmware/ultralcd.cpp:3903
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1531,14 +1531,14 @@ msgstr ""
 "Kontynuowac?"
 
 #. MSG_RUNOUTS c=7
-#: ../../Firmware/ultralcd.cpp:1271
+#: ../../Firmware/ultralcd.cpp:1290
 msgid "Runouts"
 msgstr "Konce f"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4395
-#: ../../Firmware/ultralcd.cpp:4397 ../../Firmware/ultralcd.cpp:4414
-#: ../../Firmware/ultralcd.cpp:4416
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4414
+#: ../../Firmware/ultralcd.cpp:4416 ../../Firmware/ultralcd.cpp:4433
+#: ../../Firmware/ultralcd.cpp:4435
 msgid "SD card"
 msgstr "Karta SD"
 
@@ -1554,12 +1554,12 @@ msgid "Searching bed calibration point"
 msgstr "Szukam punktu kalib. na stole"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5419
+#: ../../Firmware/ultralcd.cpp:5441
 msgid "Select"
 msgstr "Wybierz"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3966
+#: ../../Firmware/ultralcd.cpp:3985
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
@@ -1574,49 +1574,49 @@ msgstr "Wybierz ekstruder:"
 
 #. MSG_SELECT_FILAMENT c=20
 #: ../../Firmware/Marlin_main.cpp:8577 ../../Firmware/Marlin_main.cpp:8604
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3834
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3853
 msgid "Select filament:"
 msgstr "Wybierz filament:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:3679
-#: ../../Firmware/ultralcd.cpp:4841
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:3698
+#: ../../Firmware/ultralcd.cpp:4860
 msgid "Select language"
 msgstr "Wybor jezyka"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:4122
+#: ../../Firmware/ultralcd.cpp:4141
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr "Wybierz temperature grzania dyszy odpowiednia dla materialu."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3971
+#: ../../Firmware/ultralcd.cpp:3990
 msgid "Select temperature which matches your material."
 msgstr "Wybierz temperature, ktora odpowiada Twojemu filamentowi."
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6522
+#: ../../Firmware/ultralcd.cpp:6552
 msgid "Self test OK"
 msgstr "Selftest OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:6290
+#: ../../Firmware/ultralcd.cpp:6320
 msgid "Self test start"
 msgstr "Selftest startuje"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4904
+#: ../../Firmware/ultralcd.cpp:4923
 msgid "Selftest"
 msgstr "Selftest"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6962
+#: ../../Firmware/ultralcd.cpp:6992
 msgid "Selftest error!"
 msgstr "Blad selftest!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:6526
-#: ../../Firmware/ultralcd.cpp:7049 ../../Firmware/ultralcd.cpp:7314
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:6556
+#: ../../Firmware/ultralcd.cpp:7079 ../../Firmware/ultralcd.cpp:7344
 msgid "Selftest failed"
 msgstr "Selftest nieudany"
 
@@ -1628,30 +1628,30 @@ msgstr ""
 "krancowek"
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1723
+#: ../../Firmware/ultralcd.cpp:1742
 msgid "Sensor info"
 msgstr "Info o sensorach"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:6254
+#: ../../Firmware/ultralcd.cpp:6284
 msgid "Sensor verified, remove the filament now."
 msgstr "Czujnik sprawdzony, wyciagnij filament."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2773
+#: ../../Firmware/ultralcd.cpp:2792
 msgid "Set temperature:"
 msgstr "Ustaw temperature:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:3491
-#: ../../Firmware/ultralcd.cpp:3696 ../../Firmware/ultralcd.cpp:4206
-#: ../../Firmware/ultralcd.cpp:5580 ../../Firmware/ultralcd.cpp:5827
-#: ../../Firmware/ultralcd.cpp:5880
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:3510
+#: ../../Firmware/ultralcd.cpp:3715 ../../Firmware/ultralcd.cpp:4225
+#: ../../Firmware/ultralcd.cpp:5602 ../../Firmware/ultralcd.cpp:5849
+#: ../../Firmware/ultralcd.cpp:5902
 msgid "Settings"
 msgstr "Ustawienia"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2540
+#: ../../Firmware/ultralcd.cpp:2559
 msgid "Severe skew"
 msgstr "Znaczny skos"
 
@@ -1662,7 +1662,7 @@ msgid "Sheet"
 msgstr "Plyta"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3824
+#: ../../Firmware/ultralcd.cpp:3843
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1675,18 +1675,18 @@ msgstr ""
 "%cReset"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4915
+#: ../../Firmware/ultralcd.cpp:4934
 msgid "Show end stops"
 msgstr "Pokaz krancowki"
 
 #. MSG_SILENT c=7
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4361
-#: ../../Firmware/ultralcd.cpp:4456 ../../Firmware/ultralcd.cpp:5778
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4380
+#: ../../Firmware/ultralcd.cpp:4475 ../../Firmware/ultralcd.cpp:5800
 msgid "Silent"
 msgstr "Cichy"
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2539
+#: ../../Firmware/ultralcd.cpp:2558
 msgid "Slight skew"
 msgstr "Lekki skos"
 
@@ -1705,8 +1705,8 @@ msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Wykryto problem, wymuszono poziomowanie osi Z."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4403
-#: ../../Firmware/ultralcd.cpp:4404 ../../Firmware/ultralcd.cpp:4405
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4422
+#: ../../Firmware/ultralcd.cpp:4423 ../../Firmware/ultralcd.cpp:4424
 msgid "Sort"
 msgstr "Sort."
 
@@ -1717,20 +1717,20 @@ msgid "Sorting files"
 msgstr "Sortowanie plikow"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4450
-#: ../../Firmware/ultralcd.cpp:4453 ../../Firmware/ultralcd.cpp:4456
-#: ../../Firmware/ultralcd.cpp:4459 ../../Firmware/ultralcd.cpp:4462
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/ultralcd.cpp:4472 ../../Firmware/ultralcd.cpp:4475
+#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4481
 msgid "Sound"
 msgstr "Dzwiek"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5718
+#: ../../Firmware/ultralcd.cpp:5740
 msgid "Speed"
 msgstr "Predkosc"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7166
-#: ../../Firmware/ultralcd.cpp:7181 ../../Firmware/ultralcd.cpp:7189
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7196
+#: ../../Firmware/ultralcd.cpp:7211 ../../Firmware/ultralcd.cpp:7219
 msgid "Spinning"
 msgstr "Kreci sie"
 
@@ -1741,42 +1741,42 @@ msgstr ""
 "Potrzebna jest stabilna temperatura otoczenia 21-26C i stabilne podloze."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5585
+#: ../../Firmware/ultralcd.cpp:5607
 msgid "Statistics"
 msgstr "Statystyki"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4338
-#: ../../Firmware/ultralcd.cpp:4382 ../../Firmware/ultralcd.cpp:5770
+#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4357
+#: ../../Firmware/ultralcd.cpp:4401 ../../Firmware/ultralcd.cpp:5792
 msgid "Stealth"
 msgstr "Cichy"
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4763
-#: ../../Firmware/ultralcd.cpp:5416
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4782
+#: ../../Firmware/ultralcd.cpp:5438
 msgid "Steel sheets"
 msgstr "Plyty stalowe"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5528
-#: ../../Firmware/ultralcd.cpp:5987
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5550
+#: ../../Firmware/ultralcd.cpp:6017
 msgid "Stop print"
 msgstr "Przerwanie druku"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4499
-#: ../../Firmware/ultralcd.cpp:4581 ../../Firmware/ultralcd.cpp:4620
-#: ../../Firmware/ultralcd.cpp:4661
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4518
+#: ../../Firmware/ultralcd.cpp:4600 ../../Firmware/ultralcd.cpp:4639
+#: ../../Firmware/ultralcd.cpp:4680
 msgid "Strict"
 msgstr "Restr."
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/ultralcd.cpp:5616
 msgid "Support"
 msgstr "Wsparcie"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:7021
+#: ../../Firmware/ultralcd.cpp:7051
 msgid "Swapped"
 msgstr "Zamieniono"
 
@@ -1785,28 +1785,18 @@ msgstr "Zamieniono"
 msgid "THERMAL ANOMALY"
 msgstr "THERMAL ANOMALY"
 
-#. MSG_TM_AUTOTUNE_FAILED c=20
-#: ../../Firmware/temperature.cpp:2899
-msgid "TM autotune failed"
-msgstr "Blad TM autotune"
-
-#. MSG_TEMP_MODEL_AUTOTUNE c=20
-#: ../../Firmware/temperature.cpp:2884
-msgid "Temp. model autotune"
-msgstr "Autotune modelu temp"
-
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4797
+#: ../../Firmware/ultralcd.cpp:4816
 msgid "Temperature"
 msgstr "Temperatura"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1729
+#: ../../Firmware/ultralcd.cpp:1748
 msgid "Temperatures"
 msgstr "Temperatury"
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3974
+#: ../../Firmware/ultralcd.cpp:3993
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -1826,66 +1816,66 @@ msgstr ""
 "Kroki, sekcja Kalibracja."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4403
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4422
 msgid "Time"
 msgstr "Czas"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:5865
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:5887
 msgid "Timeout"
 msgstr "Wyl. czas."
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:1149
-#: ../../Firmware/ultralcd.cpp:1297
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:1168
+#: ../../Firmware/ultralcd.cpp:1316
 msgid "Total"
 msgstr "Suma"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:1192
-#: ../../Firmware/ultralcd.cpp:1218 ../../Firmware/ultralcd.cpp:1328
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:1211
+#: ../../Firmware/ultralcd.cpp:1237 ../../Firmware/ultralcd.cpp:1347
 msgid "Total failures"
 msgstr "Suma bledow"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2387
+#: ../../Firmware/ultralcd.cpp:2406
 msgid "Total filament"
 msgstr "Zuzycie filamentu"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2388
+#: ../../Firmware/ultralcd.cpp:2407
 msgid "Total print time"
 msgstr "Laczny czas druku"
 
 #. MSG_TUNE c=18
-#: ../../Firmware/ultralcd.cpp:5500
+#: ../../Firmware/ultralcd.cpp:5522
 msgid "Tune"
 msgstr "Strojenie"
 
 #. MSG_UNLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:5564
-#: ../../Firmware/ultralcd.cpp:5578
+#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:5586
+#: ../../Firmware/ultralcd.cpp:5600
 msgid "Unload filament"
 msgstr "Rozladowanie fil"
 
 #. MSG_UNLOADING_FILAMENT c=20
 #: ../../Firmware/messages.cpp:112 ../../Firmware/mmu.cpp:957
-#: ../../Firmware/ultralcd.cpp:5197
+#: ../../Firmware/ultralcd.cpp:5219
 msgid "Unloading filament"
 msgstr "Rozladowuje filament"
 
 #. MSG_FIL_FAILED c=20 r=5
-#: ../../Firmware/ultralcd.cpp:6258
+#: ../../Firmware/ultralcd.cpp:6288
 msgid "Verification failed, remove the filament and try again."
 msgstr "Niepowodzenie sprawdzenia, wyciagnij filament i sprobuj ponownie."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1732
+#: ../../Firmware/ultralcd.cpp:1751
 msgid "Voltages"
 msgstr "Napiecia"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3534
+#: ../../Firmware/ultralcd.cpp:3553
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -1903,19 +1893,19 @@ msgid "Wait for user..."
 msgstr "Czekam na uzytk. ..."
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2881
+#: ../../Firmware/ultralcd.cpp:2900
 msgid "Waiting for PINDA probe cooling"
 msgstr "Czekam az spadnie temp. sondy PINDA"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2913
+#: ../../Firmware/ultralcd.cpp:2932
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Oczekiwanie na wychlodzenie dyszy i stolu"
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:4496
-#: ../../Firmware/ultralcd.cpp:4578 ../../Firmware/ultralcd.cpp:4617
-#: ../../Firmware/ultralcd.cpp:4658
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/ultralcd.cpp:4597 ../../Firmware/ultralcd.cpp:4636
+#: ../../Firmware/ultralcd.cpp:4677
 msgid "Warn"
 msgstr "Ostrzez"
 
@@ -1940,149 +1930,138 @@ msgid "Was filament unload successful?"
 msgstr "Rozladowanie fil. ok?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6973
-#: ../../Firmware/ultralcd.cpp:6977 ../../Firmware/ultralcd.cpp:6997
-#: ../../Firmware/ultralcd.cpp:7003 ../../Firmware/ultralcd.cpp:7027
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:7003
+#: ../../Firmware/ultralcd.cpp:7007 ../../Firmware/ultralcd.cpp:7027
+#: ../../Firmware/ultralcd.cpp:7033 ../../Firmware/ultralcd.cpp:7057
 msgid "Wiring error"
 msgstr "Blad polaczenia"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4895
+#: ../../Firmware/ultralcd.cpp:4914
 msgid "Wizard"
 msgstr "Asystent"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4210
+#: ../../Firmware/ultralcd.cpp:4229
 msgid "X-correct:"
 msgstr "Korekcja-X:"
 
 #. MSG_XFLASH c=18
-#: ../../Firmware/ultralcd.cpp:5596
+#: ../../Firmware/ultralcd.cpp:5618
 msgid "XFLASH init"
 msgstr "XFLASH init"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1721
+#: ../../Firmware/ultralcd.cpp:1740
 msgid "XYZ cal. details"
 msgstr "Szczegoly kal. XYZ"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3333
+#: ../../Firmware/ultralcd.cpp:3352
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr "Kalibracja XYZ pomyslna. Skos bedzie automatycznie korygowany."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3330
+#: ../../Firmware/ultralcd.cpp:3349
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr "Kalibracja XYZ prawidlowa. Osie X/Y lekko skosne. Dobra robota!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3311
+#: ../../Firmware/ultralcd.cpp:3330
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr "Kalibr. XYZ niedokladna. Przednie punkty kalibr. nieosiagalne."
 
-#. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_LEFT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3317
-msgid ""
-"XYZ calibration compromised. Left front calibration point not reachable."
-msgstr ""
-
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3314
+#: ../../Firmware/ultralcd.cpp:3333
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr "Kalibracja XYZ niedokladna. Prawy przedni punkt nieosiagalny."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3293
+#: ../../Firmware/ultralcd.cpp:3312
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr "Kalibracja XYZ nieudana. Nie znaleziono punktow kalibracyjnych."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3299
+#: ../../Firmware/ultralcd.cpp:3318
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr ""
 "Kalibr. XYZ nieudana. Przednie punkty kalibr. nieosiagalne. Nalezy poprawic "
 "montaz drukarki."
 
-#. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_LEFT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3305
-msgid "XYZ calibration failed. Left front calibration point not reachable."
-msgstr ""
-
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3296
-#: ../../Firmware/ultralcd.cpp:3324
+#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3315
+#: ../../Firmware/ultralcd.cpp:3343
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "Kalibracja XYZ nieudana. Sprawdz przyczyny i rozwiazania w instrukcji."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3302
+#: ../../Firmware/ultralcd.cpp:3321
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr ""
 "Kalibr. XYZ nieudana. Prawy przedni punkt nieosiagalny. Nalezy poprawic "
 "montaz drukarki."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3327
+#: ../../Firmware/ultralcd.cpp:3346
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "Kalibracja XYZ ok. Osie X/Y sa prostopadle. Gratulacje!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2494
+#: ../../Firmware/ultralcd.cpp:2513
 msgid "Y distance from min"
 msgstr "Dystans od 0 w osi Y"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4211
+#: ../../Firmware/ultralcd.cpp:4230
 msgid "Y-correct:"
 msgstr "Korekcja-Y:"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:2216
-#: ../../Firmware/ultralcd.cpp:2800 ../../Firmware/ultralcd.cpp:3180
-#: ../../Firmware/ultralcd.cpp:4785 ../../Firmware/ultralcd.cpp:5989
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:2235
+#: ../../Firmware/ultralcd.cpp:2819 ../../Firmware/ultralcd.cpp:3199
+#: ../../Firmware/ultralcd.cpp:4804 ../../Firmware/ultralcd.cpp:6019
 msgid "Yes"
 msgstr "Tak"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:4187
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:4206
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr ""
 "Zawsze mozesz uruchomic Asystenta ponownie przez Kalibracja -> Asystent."
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4231
 msgid "Z-correct:"
 msgstr "Korekcja-Z:"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:5835
+#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:5857
 msgid "Z-probe nr."
 msgstr "Ilosc Pomiarow"
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2565
+#: ../../Firmware/ultralcd.cpp:2584
 msgid "[0;0] point offset"
 msgstr "[0;0] przesun.punktu"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2154
+#: ../../Firmware/ultralcd.cpp:2173
 msgid "and press the knob"
 msgstr "i nacisnij pokretlo"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1816
+#: ../../Firmware/ultralcd.cpp:1835
 msgid "to load filament"
 msgstr "aby zaladow. fil."
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1820
+#: ../../Firmware/ultralcd.cpp:1839
 msgid "to unload filament"
 msgstr "aby rozlad. filament"
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1688
+#: ../../Firmware/ultralcd.cpp:1707
 msgid "unknown"
 msgstr "nieznane"
 
@@ -2092,8 +2071,8 @@ msgid "unknown state"
 msgstr "Stan nieznany"
 
 #. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:6077
-#: ../../Firmware/ultralcd.cpp:6080
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:6107
+#: ../../Firmware/ultralcd.cpp:6110
 msgid "🔃Refresh"
 msgstr "🔃Odswiezac"
 
@@ -2102,3 +2081,9 @@ msgstr "🔃Odswiezac"
 
 #~ msgid "M117 First layer cal."
 #~ msgstr "M117 Kal. 1. warstwy"
+
+#~ msgid "TM autotune failed"
+#~ msgstr "Blad TM autotune"
+
+#~ msgid "Temp. model autotune"
+#~ msgstr "Autotune modelu temp"

--- a/lang/po/Firmware_ro.po
+++ b/lang/po/Firmware_ro.po
@@ -26,89 +26,89 @@ msgid " 0.4 or newer"
 msgstr " 0.4 / mai nou"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:7036
+#: ../../Firmware/ultralcd.cpp:7066
 msgid "%s level expected"
 msgstr "nivel %s asteptat"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1968
-#: ../../Firmware/ultralcd.cpp:3835
+#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1987
+#: ../../Firmware/ultralcd.cpp:3854
 msgid ">Cancel"
 msgstr ">Anuleaza"
 
 #. MSG_BABYSTEPPING_Z c=15
 #. Beware: must include the ':' as its last character
-#: ../../Firmware/ultralcd.cpp:2670
+#: ../../Firmware/ultralcd.cpp:2689
 msgid "Adjusting Z:"
 msgstr "Ajustare Z:"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:7313
+#: ../../Firmware/ultralcd.cpp:7343
 msgid "All correct"
 msgstr "Totul OK"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4180
+#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4190
+#: ../../Firmware/ultralcd.cpp:4199
 msgid "All is done. Happy printing!"
 msgstr "Totul este OK. Distractie placuta!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4404
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4423
 msgid "Alphabet"
 msgstr "Alfabet"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4308
+#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4327
 msgid "Always"
 msgstr "Mereu"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1405
+#: ../../Firmware/ultralcd.cpp:1424
 msgid "Ambient"
 msgstr "Ambiental"
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2983
+#: ../../Firmware/ultralcd.cpp:3002
 msgid "Are left and right Z~carriages all up?"
 msgstr "Este axa Z aliniata sus?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4478
 msgid "Assist"
 msgstr "Asist."
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:5886
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
 #: ../../Firmware/Marlin_main.cpp:3271 ../../Firmware/messages.cpp:9
-#: ../../Firmware/ultralcd.cpp:4900
+#: ../../Firmware/ultralcd.cpp:4919
 msgid "Auto home"
 msgstr "Auto home"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:4364
-#: ../../Firmware/ultralcd.cpp:5779
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:4383
+#: ../../Firmware/ultralcd.cpp:5801
 msgid "Auto power"
 msgstr "Put. auto"
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5572
+#: ../../Firmware/ultralcd.cpp:5594
 msgid "AutoLoad filament"
 msgstr "Inc.auto Filament"
 
 #. MSG_AUTOLOADING_ONLY_IF_FSENS_ON c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3549
+#: ../../Firmware/ultralcd.cpp:3568
 msgid ""
 "Autoloading filament available only when filament sensor is turned on..."
 msgstr ""
 "Incarcarea automata de fil. e valabila doar cand senzorul este pornit..."
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2301
+#: ../../Firmware/ultralcd.cpp:2320
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
@@ -116,26 +116,26 @@ msgstr ""
 "filamentul"
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:7015
+#: ../../Firmware/ultralcd.cpp:7045
 msgid "Axis"
 msgstr "Axa"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:7014
+#: ../../Firmware/ultralcd.cpp:7044
 msgid "Axis length"
 msgstr "Lungime axa"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:2751
-#: ../../Firmware/ultralcd.cpp:5861 ../../Firmware/ultralcd.cpp:7838
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:2770
+#: ../../Firmware/ultralcd.cpp:5883 ../../Firmware/ultralcd.cpp:7878
 msgid "Back"
 msgstr "Inapoi"
 
 #. MSG_BED c=13
 #: ../../Firmware/Marlin_main.cpp:2051 ../../Firmware/Marlin_main.cpp:4767
 #: ../../Firmware/Marlin_main.cpp:4819 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:1403 ../../Firmware/ultralcd.cpp:5721
-#: ../../Firmware/ultralcd.cpp:5891
+#: ../../Firmware/ultralcd.cpp:1422 ../../Firmware/ultralcd.cpp:5743
+#: ../../Firmware/ultralcd.cpp:5913
 msgid "Bed"
 msgstr "Pat"
 
@@ -152,7 +152,7 @@ msgid "Bed done"
 msgstr "Pat incalzit"
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4912
+#: ../../Firmware/ultralcd.cpp:4931
 msgid "Bed level correct"
 msgstr "Nivelare pat"
 
@@ -170,18 +170,18 @@ msgstr ""
 "reset."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6972
+#: ../../Firmware/ultralcd.cpp:7002
 msgid "Bed/Heater"
 msgstr "Incalzitor/Pat"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1458
-#: ../../Firmware/ultralcd.cpp:1726
+#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1477
+#: ../../Firmware/ultralcd.cpp:1745
 msgid "Belt status"
 msgstr "Status curele"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4902
+#: ../../Firmware/ultralcd.cpp:4921
 msgid "Belt test"
 msgstr "Test curele"
 
@@ -192,28 +192,28 @@ msgid "Blackout occurred. Recover print?"
 msgstr "Pana de curent. Continuati printul?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:5886
 msgid "Bright"
 msgstr "Maxim"
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4850
-#: ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4869
+#: ../../Firmware/ultralcd.cpp:5811
 msgid "Brightness"
 msgstr "Luminozitate ecran"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4906
+#: ../../Firmware/ultralcd.cpp:4925
 msgid "Calibrate XYZ"
 msgstr "Calibrare XYZ"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4908
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4927
 msgid "Calibrate Z"
 msgstr "Calibrare Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2946
+#: ../../Firmware/ultralcd.cpp:2965
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -228,7 +228,7 @@ msgid "Calibrating Z"
 msgstr "Calibrare Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2945
+#: ../../Firmware/ultralcd.cpp:2964
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -237,12 +237,12 @@ msgstr ""
 "butonul cand este gata."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:7315
+#: ../../Firmware/ultralcd.cpp:7345
 msgid "Calibrating home"
 msgstr "Calibrare home"
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:5581
+#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:5603
 msgid "Calibration"
 msgstr "Calibrare"
 
@@ -252,115 +252,115 @@ msgid "Calibration done"
 msgstr "Calibrare gata"
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7712
+#: ../../Firmware/ultralcd.cpp:7752
 msgid "Card removed"
 msgstr "Card scos"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/ultralcd.cpp:5560
 msgid "Change SD card"
 msgstr "Schimba card SD"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5497
-#: ../../Firmware/ultralcd.cpp:5730
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5519
+#: ../../Firmware/ultralcd.cpp:5752
 msgid "Change filament"
 msgstr "Schimba filamentul"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2163
+#: ../../Firmware/ultralcd.cpp:2182
 msgid "Change success!"
 msgstr "Schimbare cu succes!"
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2215
+#: ../../Firmware/ultralcd.cpp:2234
 msgid "Changed correctly?"
 msgstr "Schimbat corect?"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:6178
-#: ../../Firmware/ultralcd.cpp:7305
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:6208
+#: ../../Firmware/ultralcd.cpp:7335
 msgid "Checking X axis"
 msgstr "Verificare axa X"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:6187
-#: ../../Firmware/ultralcd.cpp:7306
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:6217
+#: ../../Firmware/ultralcd.cpp:7336
 msgid "Checking Y axis"
 msgstr "Verificare axa Y"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:7307
+#: ../../Firmware/ultralcd.cpp:7337
 msgid "Checking Z axis"
 msgstr "Verificare axa Z"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:7308
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:7338
 msgid "Checking bed"
 msgstr "Verificare pat"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:7304
+#: ../../Firmware/ultralcd.cpp:7334
 msgid "Checking endstops"
 msgstr "Verif. endstop-uri"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:7403
+#: ../../Firmware/ultralcd.cpp:7433
 msgid "Checking file"
 msgstr "Verif. fisier"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:7310
+#: ../../Firmware/ultralcd.cpp:7340
 msgid "Checking hotend"
 msgstr "Verificare hotend"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:7311
-#: ../../Firmware/ultralcd.cpp:7312
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:7341
+#: ../../Firmware/ultralcd.cpp:7342
 msgid "Checking sensors"
 msgstr "Verificare senzori"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4765
+#: ../../Firmware/ultralcd.cpp:4784
 msgid "Checks"
 msgstr "Verificari"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2218
+#: ../../Firmware/ultralcd.cpp:2237
 msgid "Color not correct"
 msgstr "Culoare gresita"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3725
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3744
 msgid "Community made"
 msgstr "Comunitate"
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4704
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4723
 msgid "Cont."
 msgstr "Cont."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2125
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2144
 msgid "Cooldown"
 msgstr "Racire"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3663
+#: ../../Firmware/ultralcd.cpp:3682
 msgid "Copy selected language?"
 msgstr "Copiaza limba selectata?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1221
-#: ../../Firmware/ultralcd.cpp:1262 ../../Firmware/ultralcd.cpp:1272
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1240
+#: ../../Firmware/ultralcd.cpp:1281 ../../Firmware/ultralcd.cpp:1291
 msgid "Crash"
 msgstr "Coliz."
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4341
-#: ../../Firmware/ultralcd.cpp:4342 ../../Firmware/ultralcd.cpp:4344
-#: ../../Firmware/ultralcd.cpp:5765 ../../Firmware/ultralcd.cpp:5767
-#: ../../Firmware/ultralcd.cpp:5771
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4363
+#: ../../Firmware/ultralcd.cpp:5787 ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/ultralcd.cpp:5793
 msgid "Crash det."
 msgstr "Det.coliziune"
 
@@ -370,7 +370,7 @@ msgid "Crash detected."
 msgstr "Coliziune detectata."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3521
+#: ../../Firmware/ultralcd.cpp:3540
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -381,14 +381,14 @@ msgstr ""
 "doar in modul normal"
 
 #. MSG_CUT_FILAMENT c=17
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:5175
-#: ../../Firmware/ultralcd.cpp:5567
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:5197
+#: ../../Firmware/ultralcd.cpp:5589
 msgid "Cut filament"
 msgstr "Taie filamentul"
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:4303
-#: ../../Firmware/ultralcd.cpp:4308 ../../Firmware/ultralcd.cpp:4313
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:4322
+#: ../../Firmware/ultralcd.cpp:4327 ../../Firmware/ultralcd.cpp:4332
 msgid "Cutter"
 msgstr "Cutter"
 
@@ -398,17 +398,17 @@ msgid "Cutting filament"
 msgstr "Filamentul se taie"
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1668
+#: ../../Firmware/ultralcd.cpp:1687
 msgid "Date:"
 msgstr "Data:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5886
 msgid "Dim"
 msgstr "Minim"
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4802
+#: ../../Firmware/ultralcd.cpp:4821
 msgid "Disable steppers"
 msgstr "Oprire steppere"
 
@@ -424,7 +424,7 @@ msgstr ""
 "manual, capitolul First steps, sectiunea First layer calibration."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:4145
+#: ../../Firmware/ultralcd.cpp:4164
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -433,23 +433,23 @@ msgstr ""
 "suprafata de print?"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4214
+#: ../../Firmware/ultralcd.cpp:4233
 msgid "E-correct:"
 msgstr "E-correctie:"
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2279
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2298
 msgid "ERROR:"
 msgstr "EROARE:"
 
 #. MSG_FSENS_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3562
+#: ../../Firmware/ultralcd.cpp:3581
 msgid "ERROR: Filament sensor is not responding, please check connection."
 msgstr "EROARE: Senzorul de filament nu merge, verificati conexiunea."
 
 #. MSG_EJECT_FILAMENT c=17
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:5156
-#: ../../Firmware/ultralcd.cpp:5565
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:5178
+#: ../../Firmware/ultralcd.cpp:5587
 msgid "Eject filament"
 msgstr "Scoate filament"
 
@@ -459,47 +459,41 @@ msgid "Ejecting filament"
 msgstr "Se scoate filamentul"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6985
+#: ../../Firmware/ultralcd.cpp:7015
 msgid "Endstop"
 msgstr "Endstop"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6990
+#: ../../Firmware/ultralcd.cpp:7020
 msgid "Endstop not hit"
 msgstr "Endstop neatins"
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6976
+#: ../../Firmware/ultralcd.cpp:7006
 msgid "Endstops"
 msgstr "Endstop-uri"
 
 #. MSG_EXTRUDER c=17
 #: ../../Firmware/Marlin_main.cpp:8608 ../../Firmware/messages.cpp:30
-#: ../../Firmware/ultralcd.cpp:3495
+#: ../../Firmware/ultralcd.cpp:3514
 msgid "Extruder"
 msgstr "Extruder"
 
-#. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1144
-#: ../../Firmware/ultralcd.cpp:7319
-msgid "Hotend fan:"
-msgstr "Vent. hotend:"
-
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1722
+#: ../../Firmware/ultralcd.cpp:1741
 msgid "Extruder info"
 msgstr "Info. extruder"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4229
-#: ../../Firmware/ultralcd.cpp:4237 ../../Firmware/ultralcd.cpp:4248
-#: ../../Firmware/ultralcd.cpp:4250
+#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4248
+#: ../../Firmware/ultralcd.cpp:4256 ../../Firmware/ultralcd.cpp:4267
+#: ../../Firmware/ultralcd.cpp:4269
 msgid "F. autoload"
 msgstr "Autoload fil."
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4704
-#: ../../Firmware/ultralcd.cpp:4707
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4723
+#: ../../Firmware/ultralcd.cpp:4726
 msgid "FS Action"
 msgstr "Actiune FS"
 
@@ -514,102 +508,102 @@ msgid "FS v0.4 or newer"
 msgstr "FS 0.4 / mai nou"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5589
+#: ../../Firmware/ultralcd.cpp:5611
 msgid "Fail stats"
 msgstr "Statistici erori"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5592
+#: ../../Firmware/ultralcd.cpp:5614
 msgid "Fail stats MMU"
 msgstr "Stat. erori MMU"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:7031
+#: ../../Firmware/ultralcd.cpp:7061
 msgid "False triggering"
 msgstr "nu detect. schimbare"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:5723
-#: ../../Firmware/ultralcd.cpp:5893
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/ultralcd.cpp:5915
 msgid "Fan speed"
 msgstr "Viteza vent."
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:7143
-#: ../../Firmware/ultralcd.cpp:7301 ../../Firmware/ultralcd.cpp:7302
-#: ../../Firmware/ultralcd.cpp:7303
+#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:7173
+#: ../../Firmware/ultralcd.cpp:7331 ../../Firmware/ultralcd.cpp:7332
+#: ../../Firmware/ultralcd.cpp:7333
 msgid "Fan test"
 msgstr "Test ventilator"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4811
-#: ../../Firmware/ultralcd.cpp:5756
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4830
+#: ../../Firmware/ultralcd.cpp:5778
 msgid "Fans check"
 msgstr "Verif. vent."
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1220
-#: ../../Firmware/ultralcd.cpp:1261 ../../Firmware/ultralcd.cpp:1327
-#: ../../Firmware/ultralcd.cpp:1329
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1239
+#: ../../Firmware/ultralcd.cpp:1280 ../../Firmware/ultralcd.cpp:1346
+#: ../../Firmware/ultralcd.cpp:1348
 msgid "Fil. runouts"
 msgstr "Epuizari fil."
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:3451
-#: ../../Firmware/ultralcd.cpp:4228 ../../Firmware/ultralcd.cpp:4234
-#: ../../Firmware/ultralcd.cpp:4244 ../../Firmware/ultralcd.cpp:5737
-#: ../../Firmware/ultralcd.cpp:5741 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:3470
+#: ../../Firmware/ultralcd.cpp:4247 ../../Firmware/ultralcd.cpp:4253
+#: ../../Firmware/ultralcd.cpp:4263 ../../Firmware/ultralcd.cpp:5759
+#: ../../Firmware/ultralcd.cpp:5763 ../../Firmware/ultralcd.cpp:5767
 msgid "Fil. sensor"
 msgstr "Senzor Fil."
 
 #. MSG_FILAMENT c=17
 #: ../../Firmware/Marlin_main.cpp:8577 ../../Firmware/Marlin_main.cpp:8604
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3835
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3854
 msgid "Filament"
 msgstr "Filament"
 
 #. MSG_FILAMENT_CLEAN c=20 r=2
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2287
-#: ../../Firmware/ultralcd.cpp:2293
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2306
+#: ../../Firmware/ultralcd.cpp:2312
 msgid "Filament extruding & with correct color?"
 msgstr "Fil. curge si are culoarea corecta?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2217
+#: ../../Firmware/ultralcd.cpp:2236
 msgid "Filament not loaded"
 msgstr "Fil. nu e incarcat"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:7026
-#: ../../Firmware/ultralcd.cpp:7030 ../../Firmware/ultralcd.cpp:7034
-#: ../../Firmware/ultralcd.cpp:7330
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:7056
+#: ../../Firmware/ultralcd.cpp:7060 ../../Firmware/ultralcd.cpp:7064
+#: ../../Firmware/ultralcd.cpp:7360
 msgid "Filament sensor"
 msgstr "Senz. de filament"
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2365
+#: ../../Firmware/ultralcd.cpp:2384
 msgid "Filament used"
 msgstr "Filament folosit"
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7461
+#: ../../Firmware/ultralcd.cpp:7491
 msgid "File incomplete. Continue anyway?"
 msgstr "Fisier incomplet. Continua oricum?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:5314
-#: ../../Firmware/ultralcd.cpp:5630
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:5336
+#: ../../Firmware/ultralcd.cpp:5652
 msgid "Finishing movements"
 msgstr "Finalizare miscari"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:4898
-#: ../../Firmware/ultralcd.cpp:5424
+#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:4917
+#: ../../Firmware/ultralcd.cpp:5446
 msgid "First layer cal."
 msgstr "Cal. first layer"
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4066
+#: ../../Firmware/ultralcd.cpp:4085
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Mai intai, voi rula testele automate pentru a verifica cele mai intalnite "
@@ -621,23 +615,23 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr "Rezolvati problema si apasati butonul pe unitatea MMU."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5724
+#: ../../Firmware/ultralcd.cpp:5746
 msgid "Flow"
 msgstr "Flow"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:6996
-#: ../../Firmware/ultralcd.cpp:7149 ../../Firmware/ultralcd.cpp:7154
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:7026
+#: ../../Firmware/ultralcd.cpp:7179 ../../Firmware/ultralcd.cpp:7184
 msgid "Front print fan?"
 msgstr "Vent. print?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2754
+#: ../../Firmware/ultralcd.cpp:2773
 msgid "Front side[μm]"
 msgstr "Fata [μm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:7020
+#: ../../Firmware/ultralcd.cpp:7050
 msgid "Front/left fans"
 msgstr "Ventilatoarele sunt"
 
@@ -686,20 +680,20 @@ msgstr ""
 "Print anulat."
 
 #. MSG_GCODE c=8
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:4655
-#: ../../Firmware/ultralcd.cpp:4658 ../../Firmware/ultralcd.cpp:4661
-#: ../../Firmware/ultralcd.cpp:4664
+#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:4674
+#: ../../Firmware/ultralcd.cpp:4677 ../../Firmware/ultralcd.cpp:4680
+#: ../../Firmware/ultralcd.cpp:4683
 msgid "Gcode"
 msgstr "Gcode"
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:4672
-#: ../../Firmware/ultralcd.cpp:4726 ../../Firmware/ultralcd.cpp:4818
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:4691
+#: ../../Firmware/ultralcd.cpp:4745 ../../Firmware/ultralcd.cpp:4837
 msgid "HW Setup"
 msgstr "Setup HW"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6968
+#: ../../Firmware/ultralcd.cpp:6998
 msgid "Heater/Thermistor"
 msgstr "Incalzitor/Termistor"
 
@@ -721,7 +715,7 @@ msgid "Heating done."
 msgstr "Incalzirea gata."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=16
-#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4042
+#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4061
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -731,7 +725,7 @@ msgstr ""
 "proces de setup in care axa Z va fi calibrata. Apoi, vei fi gata sa printezi."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4064
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -740,24 +734,30 @@ msgstr ""
 "automate si calibrarile?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:4358
-#: ../../Firmware/ultralcd.cpp:4367 ../../Firmware/ultralcd.cpp:5777
-#: ../../Firmware/ultralcd.cpp:5780
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:4377
+#: ../../Firmware/ultralcd.cpp:4386 ../../Firmware/ultralcd.cpp:5799
+#: ../../Firmware/ultralcd.cpp:5802
 msgid "High power"
 msgstr "Put. max"
 
+#. MSG_HOTEND_FAN_SPEED c=15
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1145
+#: ../../Firmware/ultralcd.cpp:7351
+msgid "Hotend fan:"
+msgstr "Vent. hotend:"
+
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4094
 msgid "I will run xyz calibration now. It will take approx. 12 mins."
 msgstr "Voi rula calibrarea XYZ acum. Va dura aprox. 12 minute."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/ultralcd.cpp:4102
 msgid "I will run z calibration now."
 msgstr "Voi rula calibrarea Z acum."
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=9
-#: ../../Firmware/ultralcd.cpp:4153
+#: ../../Firmware/ultralcd.cpp:4172
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -771,36 +771,36 @@ msgid "Improving bed calibration point"
 msgstr "Imbunatatirea punctului de calibrare al patului"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:5478
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:5500
 msgid "Info screen"
 msgstr "Ecran informatii"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5545
+#: ../../Firmware/ultralcd.cpp:5567
 msgid "Init. SD card"
 msgstr "Init. card SD"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2152
+#: ../../Firmware/ultralcd.cpp:2171
 msgid "Insert filament"
 msgstr "Incarca filament"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:6223
+#: ../../Firmware/ultralcd.cpp:6253
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
 msgstr "Infige filamentul (nu-l incarca) in extruder si apasa butonul."
 
 #. MSG_FILAMENT_LOADED c=20 r=2
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3855
-#: ../../Firmware/ultralcd.cpp:4108 ../../Firmware/ultralcd.cpp:4111
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3874
+#: ../../Firmware/ultralcd.cpp:4127 ../../Firmware/ultralcd.cpp:4130
 msgid "Is filament loaded?"
 msgstr "Este filamentul incarcat?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=2
 #: ../../Firmware/Marlin_main.cpp:3312 ../../Firmware/Marlin_main.cpp:4886
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:4084
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:4103
 msgid "Is steel sheet on heatbed?"
 msgstr "Este suprafata de print pe pat?"
 
@@ -810,74 +810,74 @@ msgid "Iteration"
 msgstr "Iteratie"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:1148
-#: ../../Firmware/ultralcd.cpp:1296
+#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:1167
+#: ../../Firmware/ultralcd.cpp:1315
 msgid "Last print"
 msgstr "Ultimul print"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1169
-#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1269
-#: ../../Firmware/ultralcd.cpp:1326
+#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1188
+#: ../../Firmware/ultralcd.cpp:1278 ../../Firmware/ultralcd.cpp:1288
+#: ../../Firmware/ultralcd.cpp:1345
 msgid "Last print failures"
 msgstr "Err. ultimului print"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2496
+#: ../../Firmware/ultralcd.cpp:2515
 msgid "Left"
 msgstr "Stanga"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7001
-#: ../../Firmware/ultralcd.cpp:7147 ../../Firmware/ultralcd.cpp:7152
+#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:7032
+#: ../../Firmware/ultralcd.cpp:7179 ../../Firmware/ultralcd.cpp:7184
 msgid "Left hotend fan?"
 msgstr "Vent. hotend?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2752
+#: ../../Firmware/ultralcd.cpp:2771
 msgid "Left side [μm]"
 msgstr "Stanga [μm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:5862
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:5884
 msgid "Level Bright"
 msgstr "Lum. maxim"
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:5863
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:5885
 msgid "Level Dimmed"
 msgstr "Lum. minim"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4826
+#: ../../Firmware/ultralcd.cpp:4845
 msgid "Lin. correction"
 msgstr "Corectie lin."
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4838
-#: ../../Firmware/ultralcd.cpp:5493
+#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4857
+#: ../../Firmware/ultralcd.cpp:5515
 msgid "Live adjust Z"
 msgstr "Reglare Z live"
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/ultralcd.cpp:5120
+#: ../../Firmware/ultralcd.cpp:5142
 msgid "Load all"
 msgstr "Incarca toate"
 
 #. MSG_LOAD_FILAMENT c=17
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:5122
-#: ../../Firmware/ultralcd.cpp:5133 ../../Firmware/ultralcd.cpp:5562
-#: ../../Firmware/ultralcd.cpp:5576
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:5144
+#: ../../Firmware/ultralcd.cpp:5155 ../../Firmware/ultralcd.cpp:5584
+#: ../../Firmware/ultralcd.cpp:5598
 msgid "Load filament"
 msgstr "Incarca filament"
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5563
+#: ../../Firmware/ultralcd.cpp:5585
 msgid "Load to nozzle"
 msgstr "Incarca la varf"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2185
+#: ../../Firmware/ultralcd.cpp:2204
 msgid "Loading color"
 msgstr "Incarcare culoare"
 
@@ -885,18 +885,18 @@ msgstr "Incarcare culoare"
 #: ../../Firmware/Marlin_main.cpp:3641 ../../Firmware/messages.cpp:55
 #: ../../Firmware/mmu.cpp:872 ../../Firmware/mmu.cpp:906
 #: ../../Firmware/mmu.cpp:1014 ../../Firmware/mmu.cpp:1026
-#: ../../Firmware/ultralcd.cpp:2196 ../../Firmware/ultralcd.cpp:3949
+#: ../../Firmware/ultralcd.cpp:2215 ../../Firmware/ultralcd.cpp:3968
 msgid "Loading filament"
 msgstr "Incarcare filament"
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:7008
+#: ../../Firmware/ultralcd.cpp:7038
 msgid "Loose pulley"
 msgstr "Fulie slabita"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:4450
-#: ../../Firmware/ultralcd.cpp:4462
+#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/ultralcd.cpp:4481
 msgid "Loud"
 msgstr "Tare"
 
@@ -911,8 +911,8 @@ msgid "MK3S firmware detected on MK3 printer"
 msgstr "Firmware MK3S detectat pe imprimanta MK3"
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4381
-#: ../../Firmware/ultralcd.cpp:4382
+#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4400
+#: ../../Firmware/ultralcd.cpp:4401
 msgid "MMU Mode"
 msgstr "Mod MMU"
 
@@ -932,8 +932,8 @@ msgid "MMU OK. Resuming..."
 msgstr "MMU OK. Reluare..."
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:64 ../../Firmware/ultralcd.cpp:1170
-#: ../../Firmware/ultralcd.cpp:1193
+#: ../../Firmware/messages.cpp:64 ../../Firmware/ultralcd.cpp:1189
+#: ../../Firmware/ultralcd.cpp:1212
 msgid "MMU fails"
 msgstr "Erori MMU"
 
@@ -943,8 +943,8 @@ msgid "MMU load failed"
 msgstr "Eroare incarcare MMU"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:1171
-#: ../../Firmware/ultralcd.cpp:1194
+#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:1190
+#: ../../Firmware/ultralcd.cpp:1213
 msgid "MMU load fails"
 msgstr "Err. incarc MMU"
 
@@ -954,32 +954,32 @@ msgid "MMU needs user attention."
 msgstr "MMU necesita atentia utilizatorului."
 
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/ultralcd.cpp:1195
+#: ../../Firmware/ultralcd.cpp:1214
 msgid "MMU power fails"
 msgstr "Err. MMU curent"
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1680
+#: ../../Firmware/ultralcd.cpp:1699
 msgid "MMU2 connected"
 msgstr "MMU2 conectat"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:5836
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:5858
 msgid "Magnets comp."
 msgstr "Comp. magneti"
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1147
-#: ../../Firmware/ultralcd.cpp:1295 ../../Firmware/ultralcd.cpp:1338
-#: ../../Firmware/ultralcd.cpp:1645 ../../Firmware/ultralcd.cpp:4795
-#: ../../Firmware/ultralcd.cpp:4892 ../../Firmware/ultralcd.cpp:5119
-#: ../../Firmware/ultralcd.cpp:5131 ../../Firmware/ultralcd.cpp:5154
-#: ../../Firmware/ultralcd.cpp:5173 ../../Firmware/ultralcd.cpp:5717
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1166
+#: ../../Firmware/ultralcd.cpp:1314 ../../Firmware/ultralcd.cpp:1357
+#: ../../Firmware/ultralcd.cpp:1664 ../../Firmware/ultralcd.cpp:4814
+#: ../../Firmware/ultralcd.cpp:4911 ../../Firmware/ultralcd.cpp:5141
+#: ../../Firmware/ultralcd.cpp:5153 ../../Firmware/ultralcd.cpp:5176
+#: ../../Firmware/ultralcd.cpp:5195 ../../Firmware/ultralcd.cpp:5739
 msgid "Main"
 msgstr "Meniu principal"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2537
+#: ../../Firmware/ultralcd.cpp:2556
 msgid "Measured skew"
 msgstr "Distorsiune"
 
@@ -990,71 +990,71 @@ msgid "Measuring reference height of calibration point"
 msgstr "Masurare distanta de referinta pentru punctul de calib."
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:5832
+#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:5854
 msgid "Mesh"
 msgstr "Mesh"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4823
-#: ../../Firmware/ultralcd.cpp:4910
+#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4842
+#: ../../Firmware/ultralcd.cpp:4929
 msgid "Mesh Bed Leveling"
 msgstr "Calibrare mesh"
 
 #. MSG_MODE c=6
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:4336
-#: ../../Firmware/ultralcd.cpp:4338 ../../Firmware/ultralcd.cpp:4358
-#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4364
-#: ../../Firmware/ultralcd.cpp:4367 ../../Firmware/ultralcd.cpp:5763
-#: ../../Firmware/ultralcd.cpp:5770 ../../Firmware/ultralcd.cpp:5777
-#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5779
-#: ../../Firmware/ultralcd.cpp:5780 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/ultralcd.cpp:4357 ../../Firmware/ultralcd.cpp:4377
+#: ../../Firmware/ultralcd.cpp:4380 ../../Firmware/ultralcd.cpp:4383
+#: ../../Firmware/ultralcd.cpp:4386 ../../Firmware/ultralcd.cpp:5785
+#: ../../Firmware/ultralcd.cpp:5792 ../../Firmware/ultralcd.cpp:5799
+#: ../../Firmware/ultralcd.cpp:5800 ../../Firmware/ultralcd.cpp:5801
+#: ../../Firmware/ultralcd.cpp:5802 ../../Firmware/ultralcd.cpp:5886
 msgid "Mode"
 msgstr "Mod"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3598
+#: ../../Firmware/ultralcd.cpp:3617
 msgid "Mode change in progress..."
 msgstr "Schimbare mod in progres..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:4575
-#: ../../Firmware/ultralcd.cpp:4578 ../../Firmware/ultralcd.cpp:4581
-#: ../../Firmware/ultralcd.cpp:4584
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:4594
+#: ../../Firmware/ultralcd.cpp:4597 ../../Firmware/ultralcd.cpp:4600
+#: ../../Firmware/ultralcd.cpp:4603
 msgid "Model"
 msgstr "Model"
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6982
-#: ../../Firmware/ultralcd.cpp:6991 ../../Firmware/ultralcd.cpp:7009
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:7012
+#: ../../Firmware/ultralcd.cpp:7021 ../../Firmware/ultralcd.cpp:7039
 msgid "Motor"
 msgstr "Motor"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3492
+#: ../../Firmware/ultralcd.cpp:3511
 msgid "Move X"
 msgstr "Miscare X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3493
+#: ../../Firmware/ultralcd.cpp:3512
 msgid "Move Y"
 msgstr "Miscare Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3494
+#: ../../Firmware/ultralcd.cpp:3513
 msgid "Move Z"
 msgstr "Miscare Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4801
+#: ../../Firmware/ultralcd.cpp:4820
 msgid "Move axis"
 msgstr "Miscare axe"
 
 #. MSG_NA c=3
 #: ../../Firmware/menu.cpp:196 ../../Firmware/messages.cpp:124
-#: ../../Firmware/ultralcd.cpp:2502 ../../Firmware/ultralcd.cpp:2547
-#: ../../Firmware/ultralcd.cpp:3411 ../../Firmware/ultralcd.cpp:4228
-#: ../../Firmware/ultralcd.cpp:4276 ../../Firmware/ultralcd.cpp:5737
-#: ../../Firmware/ultralcd.cpp:5836
+#: ../../Firmware/ultralcd.cpp:2521 ../../Firmware/ultralcd.cpp:2566
+#: ../../Firmware/ultralcd.cpp:3430 ../../Firmware/ultralcd.cpp:4247
+#: ../../Firmware/ultralcd.cpp:4295 ../../Firmware/ultralcd.cpp:5759
+#: ../../Firmware/ultralcd.cpp:5858
 msgid "N/A"
 msgstr "N/A"
 
@@ -1064,14 +1064,14 @@ msgid "New firmware version available:"
 msgstr "Vers. de firmware noua disponibila:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:2804
-#: ../../Firmware/ultralcd.cpp:3180 ../../Firmware/ultralcd.cpp:4785
-#: ../../Firmware/ultralcd.cpp:5988
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:2823
+#: ../../Firmware/ultralcd.cpp:3199 ../../Firmware/ultralcd.cpp:4804
+#: ../../Firmware/ultralcd.cpp:6018
 msgid "No"
 msgstr "Nu"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5543
+#: ../../Firmware/ultralcd.cpp:5565
 msgid "No SD card"
 msgstr "Fara card SD"
 
@@ -1081,71 +1081,71 @@ msgid "No move."
 msgstr "Fara miscare."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4405
-#: ../../Firmware/ultralcd.cpp:4493 ../../Firmware/ultralcd.cpp:4502
-#: ../../Firmware/ultralcd.cpp:4575 ../../Firmware/ultralcd.cpp:4584
-#: ../../Firmware/ultralcd.cpp:4614 ../../Firmware/ultralcd.cpp:4623
-#: ../../Firmware/ultralcd.cpp:4655 ../../Firmware/ultralcd.cpp:4664
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4424
+#: ../../Firmware/ultralcd.cpp:4512 ../../Firmware/ultralcd.cpp:4521
+#: ../../Firmware/ultralcd.cpp:4594 ../../Firmware/ultralcd.cpp:4603
+#: ../../Firmware/ultralcd.cpp:4633 ../../Firmware/ultralcd.cpp:4642
+#: ../../Firmware/ultralcd.cpp:4674 ../../Firmware/ultralcd.cpp:4683
 msgid "None"
 msgstr "N/A"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:4336
-#: ../../Firmware/ultralcd.cpp:4381 ../../Firmware/ultralcd.cpp:4397
-#: ../../Firmware/ultralcd.cpp:4416 ../../Firmware/ultralcd.cpp:5763
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/ultralcd.cpp:4400 ../../Firmware/ultralcd.cpp:4416
+#: ../../Firmware/ultralcd.cpp:4435 ../../Firmware/ultralcd.cpp:5785
 msgid "Normal"
 msgstr "Normal"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6969
+#: ../../Firmware/ultralcd.cpp:6999
 msgid "Not connected"
 msgstr "Nu este conectat"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:7168
-#: ../../Firmware/ultralcd.cpp:7183 ../../Firmware/ultralcd.cpp:7191
+#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:7198
+#: ../../Firmware/ultralcd.cpp:7213 ../../Firmware/ultralcd.cpp:7221
 msgid "Not spinning"
 msgstr "Nu se roteste"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3962
+#: ../../Firmware/ultralcd.cpp:3981
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr "Acum voi calibra distanta dintre varf si suprafata patului."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:4091
+#: ../../Firmware/ultralcd.cpp:4110
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Acum voi preincalzi extruder-ul pentru PLA."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/ultralcd.cpp:4101
 msgid "Now remove the test print from steel sheet."
 msgstr "Acum inlaturati printul de test de pe suprafata de print."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:1402
-#: ../../Firmware/ultralcd.cpp:4493 ../../Firmware/ultralcd.cpp:4496
-#: ../../Firmware/ultralcd.cpp:4499 ../../Firmware/ultralcd.cpp:4502
-#: ../../Firmware/ultralcd.cpp:5720 ../../Firmware/ultralcd.cpp:5882
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:1421
+#: ../../Firmware/ultralcd.cpp:4512 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/ultralcd.cpp:4518 ../../Firmware/ultralcd.cpp:4521
+#: ../../Firmware/ultralcd.cpp:5742 ../../Firmware/ultralcd.cpp:5904
 msgid "Nozzle"
 msgstr "Varf"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4546
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4565
 msgid "Nozzle d."
 msgstr "Diam. varf"
 
 #. MSG_OFF c=3
 #: ../../Firmware/menu.cpp:467 ../../Firmware/messages.cpp:122
-#: ../../Firmware/ultralcd.cpp:4234 ../../Firmware/ultralcd.cpp:4250
-#: ../../Firmware/ultralcd.cpp:4284 ../../Firmware/ultralcd.cpp:4313
-#: ../../Firmware/ultralcd.cpp:4342 ../../Firmware/ultralcd.cpp:4811
-#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4834
-#: ../../Firmware/ultralcd.cpp:5644 ../../Firmware/ultralcd.cpp:5741
-#: ../../Firmware/ultralcd.cpp:5756 ../../Firmware/ultralcd.cpp:5767
-#: ../../Firmware/ultralcd.cpp:5836 ../../Firmware/ultralcd.cpp:7841
-#: ../../Firmware/ultralcd.cpp:7845
+#: ../../Firmware/ultralcd.cpp:4253 ../../Firmware/ultralcd.cpp:4269
+#: ../../Firmware/ultralcd.cpp:4303 ../../Firmware/ultralcd.cpp:4332
+#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4830
+#: ../../Firmware/ultralcd.cpp:4849 ../../Firmware/ultralcd.cpp:4853
+#: ../../Firmware/ultralcd.cpp:5666 ../../Firmware/ultralcd.cpp:5763
+#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/ultralcd.cpp:5858 ../../Firmware/ultralcd.cpp:7881
+#: ../../Firmware/ultralcd.cpp:7885
 msgid "Off"
 msgstr "Off"
 
@@ -1155,19 +1155,19 @@ msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr "Setari vechi detectate. PID, Esteps etc. de baza vor fi setate."
 
 #. MSG_ON c=3
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4244
-#: ../../Firmware/ultralcd.cpp:4248 ../../Firmware/ultralcd.cpp:4280
-#: ../../Firmware/ultralcd.cpp:4303 ../../Firmware/ultralcd.cpp:4341
-#: ../../Firmware/ultralcd.cpp:4811 ../../Firmware/ultralcd.cpp:4830
-#: ../../Firmware/ultralcd.cpp:4834 ../../Firmware/ultralcd.cpp:5745
-#: ../../Firmware/ultralcd.cpp:5756 ../../Firmware/ultralcd.cpp:5765
-#: ../../Firmware/ultralcd.cpp:5836 ../../Firmware/ultralcd.cpp:7841
-#: ../../Firmware/ultralcd.cpp:7845
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4263
+#: ../../Firmware/ultralcd.cpp:4267 ../../Firmware/ultralcd.cpp:4299
+#: ../../Firmware/ultralcd.cpp:4322 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4849
+#: ../../Firmware/ultralcd.cpp:4853 ../../Firmware/ultralcd.cpp:5767
+#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5787
+#: ../../Firmware/ultralcd.cpp:5858 ../../Firmware/ultralcd.cpp:7881
+#: ../../Firmware/ultralcd.cpp:7885
 msgid "On"
 msgstr "On"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4453
+#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4472
 msgid "Once"
 msgstr "O data"
 
@@ -1187,7 +1187,7 @@ msgid "PID cal. finished"
 msgstr "Calibrare PID gata"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4913
+#: ../../Firmware/ultralcd.cpp:4932
 msgid "PID calibration"
 msgstr "Calibrare PID"
 
@@ -1199,18 +1199,18 @@ msgstr "Incalzire PINDA"
 #. MSG_PINDA_CALIBRATION c=13
 #: ../../Firmware/Marlin_main.cpp:4932 ../../Firmware/Marlin_main.cpp:5035
 #: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:654
-#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4920
+#: ../../Firmware/ultralcd.cpp:4849 ../../Firmware/ultralcd.cpp:4939
 msgid "PINDA cal."
 msgstr "Cal. PINDA"
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3361
+#: ../../Firmware/ultralcd.cpp:3380
 msgid "PINDA calibration failed"
 msgstr "Calibrarea temperaturii a esuat"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
 #: ../../Firmware/Marlin_main.cpp:5112 ../../Firmware/messages.cpp:110
-#: ../../Firmware/ultralcd.cpp:3355
+#: ../../Firmware/ultralcd.cpp:3374
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1219,13 +1219,13 @@ msgstr ""
 "meniul Setari->Cal. PINDA"
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4707
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4726
 msgid "Pause"
 msgstr "Pauza"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:5507
-#: ../../Firmware/ultralcd.cpp:5509
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:5529
+#: ../../Firmware/ultralcd.cpp:5531
 msgid "Pause print"
 msgstr "Pauza print"
 
@@ -1239,7 +1239,7 @@ msgstr ""
 "Daca varful prinde hartia, opriti imediat imprimanta."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:4176
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:4195
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1248,17 +1248,17 @@ msgstr ""
 "ul repornind imprimanta."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:6250
+#: ../../Firmware/ultralcd.cpp:6280
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "Verificati senzorul IR, scoateti filamentul daca exista."
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6963
+#: ../../Firmware/ultralcd.cpp:6993
 msgid "Please check:"
 msgstr "Verificati:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4148
+#: ../../Firmware/ultralcd.cpp:4167
 msgid "Please clean heatbed and then press the knob."
 msgstr "Curatati patul si apoi apasati butonul pentru a continua."
 
@@ -1268,7 +1268,7 @@ msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Curatati varful pentru calibrare. Apasati butonul cand terminati."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3945
+#: ../../Firmware/ultralcd.cpp:3964
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr ""
@@ -1276,7 +1276,7 @@ msgstr ""
 "incarca."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3940
+#: ../../Firmware/ultralcd.cpp:3959
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1285,7 +1285,7 @@ msgstr ""
 "pentru a-l incarca."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3863
+#: ../../Firmware/ultralcd.cpp:3882
 msgid "Please load filament first."
 msgstr "Va rugam incarcati filamentul mai intai."
 
@@ -1296,7 +1296,7 @@ msgstr "Deschideti idler-ul si scoateti filamentul manual."
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=5
 #: ../../Firmware/mesh_bed_calibration.cpp:2799 ../../Firmware/messages.cpp:70
-#: ../../Firmware/ultralcd.cpp:4085
+#: ../../Firmware/ultralcd.cpp:4104
 msgid "Please place steel sheet on heatbed."
 msgstr "Asezati suprafata de print pe pat."
 
@@ -1307,7 +1307,7 @@ msgid "Please press the knob to unload filament"
 msgstr "Apasati butonul pentru a scoate filamentul."
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:5213
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:5235
 msgid "Please pull out filament immediately"
 msgstr "Va rugam scoateti filamentul imediat"
 
@@ -1317,7 +1317,7 @@ msgid "Please remove filament and then press the knob."
 msgstr "Va rugam scoateti filamentul, iar apoi apasati butonul."
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:4081
+#: ../../Firmware/ultralcd.cpp:4100
 msgid "Please remove shipping helpers first."
 msgstr "Va rugam scoateti protectiile de transport mai intai."
 
@@ -1333,7 +1333,7 @@ msgid "Please run XYZ calibration first."
 msgstr "Va rugam rulati calibrarea XYZ mai intai."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:6247
+#: ../../Firmware/ultralcd.cpp:6277
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Va rugam mai intai sa scoateti filamentul, apoi incercati din nou."
 
@@ -1350,54 +1350,54 @@ msgstr "Va rugam actualizati"
 #. MSG_PLEASE_WAIT c=20
 #: ../../Firmware/Marlin_main.cpp:3547 ../../Firmware/Marlin_main.cpp:3563
 #: ../../Firmware/Marlin_main.cpp:7931 ../../Firmware/messages.cpp:71
-#: ../../Firmware/ultralcd.cpp:2186 ../../Firmware/ultralcd.cpp:2197
+#: ../../Firmware/ultralcd.cpp:2205 ../../Firmware/ultralcd.cpp:2216
 msgid "Please wait"
 msgstr "Va rog asteptati"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1219
-#: ../../Firmware/ultralcd.cpp:1260 ../../Firmware/ultralcd.cpp:1270
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1238
+#: ../../Firmware/ultralcd.cpp:1279 ../../Firmware/ultralcd.cpp:1289
 msgid "Power failures"
 msgstr "Err. alimentare"
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5502
+#: ../../Firmware/ultralcd.cpp:5524
 msgid "Preheat"
 msgstr "Preincalzire"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:2280
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:2299
 msgid "Preheat the nozzle!"
 msgstr "Preincalziti varful!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:2900
-#: ../../Firmware/ultralcd.cpp:3924 ../../Firmware/ultralcd.cpp:3926
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:2919
+#: ../../Firmware/ultralcd.cpp:3943 ../../Firmware/ultralcd.cpp:3945
 msgid "Preheating nozzle. Please wait."
 msgstr "Preincalzire extruder. Asteptati, va rugam."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1988
+#: ../../Firmware/ultralcd.cpp:2007
 msgid "Preheating to cut"
 msgstr "Preincalzire..."
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1985
+#: ../../Firmware/ultralcd.cpp:2004
 msgid "Preheating to eject"
 msgstr "Preincalzire..."
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1976
+#: ../../Firmware/ultralcd.cpp:1995
 msgid "Preheating to load"
 msgstr "Preincalzire load"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1981
+#: ../../Firmware/ultralcd.cpp:2000
 msgid "Preheating to unload"
 msgstr "Preincalzire unload"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1809
+#: ../../Firmware/ultralcd.cpp:1828
 msgid "Press the knob"
 msgstr "Apasati butonul"
 
@@ -1417,13 +1417,13 @@ msgid "Print aborted"
 msgstr "Print anulat"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1144
-#: ../../Firmware/ultralcd.cpp:7322
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1145
+#: ../../Firmware/ultralcd.cpp:7354
 msgid "Print fan:"
 msgstr "Vent. print:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5535
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5557
 msgid "Print from SD"
 msgstr "Printare de pe SD"
 
@@ -1433,12 +1433,12 @@ msgid "Print paused"
 msgstr "Print oprit"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2366
+#: ../../Firmware/ultralcd.cpp:2385
 msgid "Print time"
 msgstr "Durata print"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1711
+#: ../../Firmware/ultralcd.cpp:1730
 msgid "Printer IP Addr:"
 msgstr "IP imprimanta:"
 
@@ -1466,12 +1466,12 @@ msgstr ""
 "valoarea in setari. Print anulat."
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4834
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4853
 msgid "RPi port"
 msgstr "Port RPi"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2755
+#: ../../Firmware/ultralcd.cpp:2774
 msgid "Rear side [μm]"
 msgstr "Spate [μm]"
 
@@ -1487,24 +1487,24 @@ msgstr ""
 "Scoateti filamentul vechi si apasati butonul pentru a incarca filamentul nou."
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5426
+#: ../../Firmware/ultralcd.cpp:5448
 msgid "Rename"
 msgstr "Redenumeste"
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2756
-#: ../../Firmware/ultralcd.cpp:5427
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2775
+#: ../../Firmware/ultralcd.cpp:5449
 msgid "Reset"
 msgstr "Reset."
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4917
+#: ../../Firmware/ultralcd.cpp:4936
 msgid "Reset XYZ calibr."
 msgstr "Reset. calibr. XYZ"
 
 #. MSG_RESUME_PRINT c=18
 #: ../../Firmware/Marlin_main.cpp:655 ../../Firmware/messages.cpp:81
-#: ../../Firmware/ultralcd.cpp:5521 ../../Firmware/ultralcd.cpp:5523
+#: ../../Firmware/ultralcd.cpp:5543 ../../Firmware/ultralcd.cpp:5545
 msgid "Resume print"
 msgstr "Continua print"
 
@@ -1514,17 +1514,17 @@ msgid "Resuming print"
 msgstr "Reluare print..."
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2497
+#: ../../Firmware/ultralcd.cpp:2516
 msgid "Right"
 msgstr "Dreapta"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2753
+#: ../../Firmware/ultralcd.cpp:2772
 msgid "Right side[μm]"
 msgstr "Dreapta [μm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3884
+#: ../../Firmware/ultralcd.cpp:3903
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1533,14 +1533,14 @@ msgstr ""
 "de la inceput. Continuati?"
 
 #. MSG_RUNOUTS c=7
-#: ../../Firmware/ultralcd.cpp:1271
+#: ../../Firmware/ultralcd.cpp:1290
 msgid "Runouts"
 msgstr "Rulaje"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4395
-#: ../../Firmware/ultralcd.cpp:4397 ../../Firmware/ultralcd.cpp:4414
-#: ../../Firmware/ultralcd.cpp:4416
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4414
+#: ../../Firmware/ultralcd.cpp:4416 ../../Firmware/ultralcd.cpp:4433
+#: ../../Firmware/ultralcd.cpp:4435
 msgid "SD card"
 msgstr "Card SD"
 
@@ -1556,12 +1556,12 @@ msgid "Searching bed calibration point"
 msgstr "Se cauta punctele de calibrare"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5419
+#: ../../Firmware/ultralcd.cpp:5441
 msgid "Select"
 msgstr "Selecteaza"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3966
+#: ../../Firmware/ultralcd.cpp:3985
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
@@ -1576,50 +1576,50 @@ msgstr "Alege extruderul:"
 
 #. MSG_SELECT_FILAMENT c=20
 #: ../../Firmware/Marlin_main.cpp:8577 ../../Firmware/Marlin_main.cpp:8604
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3834
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3853
 msgid "Select filament:"
 msgstr "Select. filamentul:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:3679
-#: ../../Firmware/ultralcd.cpp:4841
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:3698
+#: ../../Firmware/ultralcd.cpp:4860
 msgid "Select language"
 msgstr "Selectati limba"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:4122
+#: ../../Firmware/ultralcd.cpp:4141
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr ""
 "Selectati temperatura de preheat a extruder-ului pentru materialul ales."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3971
+#: ../../Firmware/ultralcd.cpp:3990
 msgid "Select temperature which matches your material."
 msgstr "Selectati temp. potrivita pentru materialul curent."
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6522
+#: ../../Firmware/ultralcd.cpp:6552
 msgid "Self test OK"
 msgstr "Testare automata OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:6290
+#: ../../Firmware/ultralcd.cpp:6320
 msgid "Self test start"
 msgstr "Start Autotestare"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4904
+#: ../../Firmware/ultralcd.cpp:4923
 msgid "Selftest"
 msgstr "Testare automata"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6962
+#: ../../Firmware/ultralcd.cpp:6992
 msgid "Selftest error!"
 msgstr "Err. test. automata!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:6526
-#: ../../Firmware/ultralcd.cpp:7049 ../../Firmware/ultralcd.cpp:7314
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:6556
+#: ../../Firmware/ultralcd.cpp:7079 ../../Firmware/ultralcd.cpp:7344
 msgid "Selftest failed"
 msgstr "Autotestare esuata"
 
@@ -1630,30 +1630,30 @@ msgstr ""
 "Testarea automata va fi rulata pentru a calibra sensorless rehoming-ul."
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1723
+#: ../../Firmware/ultralcd.cpp:1742
 msgid "Sensor info"
 msgstr "Info. senzori"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:6254
+#: ../../Firmware/ultralcd.cpp:6284
 msgid "Sensor verified, remove the filament now."
 msgstr "Senzorul a fost verificat, scoate filamentul."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2773
+#: ../../Firmware/ultralcd.cpp:2792
 msgid "Set temperature:"
 msgstr "Setati temperatura:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:3491
-#: ../../Firmware/ultralcd.cpp:3696 ../../Firmware/ultralcd.cpp:4206
-#: ../../Firmware/ultralcd.cpp:5580 ../../Firmware/ultralcd.cpp:5827
-#: ../../Firmware/ultralcd.cpp:5880
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:3510
+#: ../../Firmware/ultralcd.cpp:3715 ../../Firmware/ultralcd.cpp:4225
+#: ../../Firmware/ultralcd.cpp:5602 ../../Firmware/ultralcd.cpp:5849
+#: ../../Firmware/ultralcd.cpp:5902
 msgid "Settings"
 msgstr "Setari"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2540
+#: ../../Firmware/ultralcd.cpp:2559
 msgid "Severe skew"
 msgstr "Dist. severa"
 
@@ -1664,7 +1664,7 @@ msgid "Sheet"
 msgstr "Suprafata"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3824
+#: ../../Firmware/ultralcd.cpp:3843
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1677,18 +1677,18 @@ msgstr ""
 "%cReset."
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4915
+#: ../../Firmware/ultralcd.cpp:4934
 msgid "Show end stops"
 msgstr "Stare endstop-uri"
 
 #. MSG_SILENT c=7
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4361
-#: ../../Firmware/ultralcd.cpp:4456 ../../Firmware/ultralcd.cpp:5778
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4380
+#: ../../Firmware/ultralcd.cpp:4475 ../../Firmware/ultralcd.cpp:5800
 msgid "Silent"
 msgstr "Silent."
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2539
+#: ../../Firmware/ultralcd.cpp:2558
 msgid "Slight skew"
 msgstr "Dist. usoara"
 
@@ -1707,8 +1707,8 @@ msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "A fost intalnita o problema, calibrarea Z a fost initiata..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4403
-#: ../../Firmware/ultralcd.cpp:4404 ../../Firmware/ultralcd.cpp:4405
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4422
+#: ../../Firmware/ultralcd.cpp:4423 ../../Firmware/ultralcd.cpp:4424
 msgid "Sort"
 msgstr "Sortare"
 
@@ -1719,20 +1719,20 @@ msgid "Sorting files"
 msgstr "Sortare fisiere..."
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4450
-#: ../../Firmware/ultralcd.cpp:4453 ../../Firmware/ultralcd.cpp:4456
-#: ../../Firmware/ultralcd.cpp:4459 ../../Firmware/ultralcd.cpp:4462
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/ultralcd.cpp:4472 ../../Firmware/ultralcd.cpp:4475
+#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4481
 msgid "Sound"
 msgstr "Sunet"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5718
+#: ../../Firmware/ultralcd.cpp:5740
 msgid "Speed"
 msgstr "Viteza"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7166
-#: ../../Firmware/ultralcd.cpp:7181 ../../Firmware/ultralcd.cpp:7189
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7196
+#: ../../Firmware/ultralcd.cpp:7211 ../../Firmware/ultralcd.cpp:7219
 msgid "Spinning"
 msgstr "Se roteste"
 
@@ -1743,42 +1743,42 @@ msgstr ""
 "Temp. ambient. stabila (21-26C) si o suprafata de lucru rigida necesare."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5585
+#: ../../Firmware/ultralcd.cpp:5607
 msgid "Statistics"
 msgstr "Statistici"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4338
-#: ../../Firmware/ultralcd.cpp:4382 ../../Firmware/ultralcd.cpp:5770
+#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4357
+#: ../../Firmware/ultralcd.cpp:4401 ../../Firmware/ultralcd.cpp:5792
 msgid "Stealth"
 msgstr "Silent."
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4763
-#: ../../Firmware/ultralcd.cpp:5416
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4782
+#: ../../Firmware/ultralcd.cpp:5438
 msgid "Steel sheets"
 msgstr "Suprafete print"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5528
-#: ../../Firmware/ultralcd.cpp:5987
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5550
+#: ../../Firmware/ultralcd.cpp:6017
 msgid "Stop print"
 msgstr "Oprire print"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4499
-#: ../../Firmware/ultralcd.cpp:4581 ../../Firmware/ultralcd.cpp:4620
-#: ../../Firmware/ultralcd.cpp:4661
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4518
+#: ../../Firmware/ultralcd.cpp:4600 ../../Firmware/ultralcd.cpp:4639
+#: ../../Firmware/ultralcd.cpp:4680
 msgid "Strict"
 msgstr "Strict"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/ultralcd.cpp:5616
 msgid "Support"
 msgstr "Informatii"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:7021
+#: ../../Firmware/ultralcd.cpp:7051
 msgid "Swapped"
 msgstr "inversate"
 
@@ -1787,28 +1787,18 @@ msgstr "inversate"
 msgid "THERMAL ANOMALY"
 msgstr "ANOMALIE TERMICA"
 
-#. MSG_TM_AUTOTUNE_FAILED c=20
-#: ../../Firmware/temperature.cpp:2899
-msgid "TM autotune failed"
-msgstr "Autotune TM esuat"
-
-#. MSG_TEMP_MODEL_AUTOTUNE c=20
-#: ../../Firmware/temperature.cpp:2884
-msgid "Temp. model autotune"
-msgstr "Temp. model autotune"
-
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4797
+#: ../../Firmware/ultralcd.cpp:4816
 msgid "Temperature"
 msgstr "Temperatura"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1729
+#: ../../Firmware/ultralcd.cpp:1748
 msgid "Temperatures"
 msgstr "Temperaturi"
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3974
+#: ../../Firmware/ultralcd.cpp:3993
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -1827,66 +1817,66 @@ msgstr ""
 "First steps, sectiunea Calibration flow."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4403
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4422
 msgid "Time"
 msgstr "Data"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:5865
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:5887
 msgid "Timeout"
 msgstr "Timeout"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:1149
-#: ../../Firmware/ultralcd.cpp:1297
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:1168
+#: ../../Firmware/ultralcd.cpp:1316
 msgid "Total"
 msgstr "Total"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:1192
-#: ../../Firmware/ultralcd.cpp:1218 ../../Firmware/ultralcd.cpp:1328
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:1211
+#: ../../Firmware/ultralcd.cpp:1237 ../../Firmware/ultralcd.cpp:1347
 msgid "Total failures"
 msgstr "Total erori"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2387
+#: ../../Firmware/ultralcd.cpp:2406
 msgid "Total filament"
 msgstr "Filament total"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2388
+#: ../../Firmware/ultralcd.cpp:2407
 msgid "Total print time"
 msgstr "Durata totala print"
 
 #. MSG_TUNE c=18
-#: ../../Firmware/ultralcd.cpp:5500
+#: ../../Firmware/ultralcd.cpp:5522
 msgid "Tune"
 msgstr "Optiuni"
 
 #. MSG_UNLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:5564
-#: ../../Firmware/ultralcd.cpp:5578
+#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:5586
+#: ../../Firmware/ultralcd.cpp:5600
 msgid "Unload filament"
 msgstr "Descarca filam."
 
 #. MSG_UNLOADING_FILAMENT c=20
 #: ../../Firmware/messages.cpp:112 ../../Firmware/mmu.cpp:957
-#: ../../Firmware/ultralcd.cpp:5197
+#: ../../Firmware/ultralcd.cpp:5219
 msgid "Unloading filament"
 msgstr "Scoatere filament"
 
 #. MSG_FIL_FAILED c=20 r=5
-#: ../../Firmware/ultralcd.cpp:6258
+#: ../../Firmware/ultralcd.cpp:6288
 msgid "Verification failed, remove the filament and try again."
 msgstr "Verificarea a esuat, scoateti filamentul si incercati din nou."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1732
+#: ../../Firmware/ultralcd.cpp:1751
 msgid "Voltages"
 msgstr "Voltaje"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3534
+#: ../../Firmware/ultralcd.cpp:3553
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -1904,19 +1894,19 @@ msgid "Wait for user..."
 msgstr "Se asteapta..."
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2881
+#: ../../Firmware/ultralcd.cpp:2900
 msgid "Waiting for PINDA probe cooling"
 msgstr "Se asteapta racirea probei PINDA"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2913
+#: ../../Firmware/ultralcd.cpp:2932
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Se ateapta racirea extruder-ului si a patului"
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:4496
-#: ../../Firmware/ultralcd.cpp:4578 ../../Firmware/ultralcd.cpp:4617
-#: ../../Firmware/ultralcd.cpp:4658
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/ultralcd.cpp:4597 ../../Firmware/ultralcd.cpp:4636
+#: ../../Firmware/ultralcd.cpp:4677
 msgid "Warn"
 msgstr "Avert."
 
@@ -1941,59 +1931,51 @@ msgid "Was filament unload successful?"
 msgstr "Filamentul a fost scos cu succes?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6973
-#: ../../Firmware/ultralcd.cpp:6977 ../../Firmware/ultralcd.cpp:6997
-#: ../../Firmware/ultralcd.cpp:7003 ../../Firmware/ultralcd.cpp:7027
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:7003
+#: ../../Firmware/ultralcd.cpp:7007 ../../Firmware/ultralcd.cpp:7027
+#: ../../Firmware/ultralcd.cpp:7033 ../../Firmware/ultralcd.cpp:7057
 msgid "Wiring error"
 msgstr "Eroare de cablare"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4895
+#: ../../Firmware/ultralcd.cpp:4914
 msgid "Wizard"
 msgstr "Wizard"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4210
+#: ../../Firmware/ultralcd.cpp:4229
 msgid "X-correct:"
 msgstr "Corect. X:"
 
 #. MSG_XFLASH c=18
-#: ../../Firmware/ultralcd.cpp:5596
+#: ../../Firmware/ultralcd.cpp:5618
 msgid "XFLASH init"
 msgstr "Init XFLASH"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1721
+#: ../../Firmware/ultralcd.cpp:1740
 msgid "XYZ cal. details"
 msgstr "Detalii cal. XYZ"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3333
+#: ../../Firmware/ultralcd.cpp:3352
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr "Calibrarea XYZ in regula. Distorsiunea va fi corectata automat."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3330
+#: ../../Firmware/ultralcd.cpp:3349
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr ""
 "Calibrarea XYZ in regula. Axele X/Y sunt distorsionate putin. Felicitari!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3311
+#: ../../Firmware/ultralcd.cpp:3330
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr ""
 "Calibrarea XYZ compromisa. Punctele de calibrare din fata nu pot fi atinse."
 
-#. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_LEFT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3317
-msgid ""
-"XYZ calibration compromised. Left front calibration point not reachable."
-msgstr ""
-"Calibrarea XYZ compromisa. Punctele de calibrare din fata stanga nu pot fi "
-"atinse."
-
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3314
+#: ../../Firmware/ultralcd.cpp:3333
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr ""
@@ -2001,94 +1983,89 @@ msgstr ""
 "atinse."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3293
+#: ../../Firmware/ultralcd.cpp:3312
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr ""
 "Calibrarea XYZ a esuat. Un punct de calibrare a patului nu a fost gasit."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3299
+#: ../../Firmware/ultralcd.cpp:3318
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr ""
 "Calibrarea XYZ a esuat. Punctele de calibrare din fata nu pot fi atinse."
 
-#. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_LEFT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3305
-msgid "XYZ calibration failed. Left front calibration point not reachable."
-msgstr ""
-
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3296
-#: ../../Firmware/ultralcd.cpp:3324
+#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3315
+#: ../../Firmware/ultralcd.cpp:3343
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "Calibrarea XYZ a esuat. Va rugam consultati manualul."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3302
+#: ../../Firmware/ultralcd.cpp:3321
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr ""
 "Calibrarea XYZ a esuat. Punctele de calibrare din fata dreapta nu pot fi "
 "atinse."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3327
+#: ../../Firmware/ultralcd.cpp:3346
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "Calibrarea XYZ ok. Axele X/Y sunt perpendiculare. Felicitari!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2494
+#: ../../Firmware/ultralcd.cpp:2513
 msgid "Y distance from min"
 msgstr "Distanta Y de la min"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4211
+#: ../../Firmware/ultralcd.cpp:4230
 msgid "Y-correct:"
 msgstr "Corect. Y:"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:2216
-#: ../../Firmware/ultralcd.cpp:2800 ../../Firmware/ultralcd.cpp:3180
-#: ../../Firmware/ultralcd.cpp:4785 ../../Firmware/ultralcd.cpp:5989
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:2235
+#: ../../Firmware/ultralcd.cpp:2819 ../../Firmware/ultralcd.cpp:3199
+#: ../../Firmware/ultralcd.cpp:4804 ../../Firmware/ultralcd.cpp:6019
 msgid "Yes"
 msgstr "Da"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:4187
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:4206
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr "Puteti oricand sa reluati Wizard-ul din Calibrare -> Wizard."
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4231
 msgid "Z-correct:"
 msgstr "Corect. Z:"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:5835
+#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:5857
 msgid "Z-probe nr."
 msgstr "Nr. Z-probe"
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2565
+#: ../../Firmware/ultralcd.cpp:2584
 msgid "[0;0] point offset"
 msgstr "[0;0] offset origine"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2154
+#: ../../Firmware/ultralcd.cpp:2173
 msgid "and press the knob"
 msgstr "si apasa butonul"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1816
+#: ../../Firmware/ultralcd.cpp:1835
 msgid "to load filament"
 msgstr "a incarca filament"
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1820
+#: ../../Firmware/ultralcd.cpp:1839
 msgid "to unload filament"
 msgstr "a scoate filament"
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1688
+#: ../../Firmware/ultralcd.cpp:1707
 msgid "unknown"
 msgstr "necunoscut"
 
@@ -2098,8 +2075,8 @@ msgid "unknown state"
 msgstr "vers. necunoscuta"
 
 #. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:6077
-#: ../../Firmware/ultralcd.cpp:6080
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:6107
+#: ../../Firmware/ultralcd.cpp:6110
 msgid "🔃Refresh"
 msgstr "🔃Reimprospata"
 
@@ -2108,3 +2085,15 @@ msgstr "🔃Reimprospata"
 
 #~ msgid "M117 First layer cal."
 #~ msgstr "M117 Cal. first layer"
+
+#~ msgid "TM autotune failed"
+#~ msgstr "Autotune TM esuat"
+
+#~ msgid "Temp. model autotune"
+#~ msgstr "Temp. model autotune"
+
+#~ msgid ""
+#~ "XYZ calibration compromised. Left front calibration point not reachable."
+#~ msgstr ""
+#~ "Calibrarea XYZ compromisa. Punctele de calibrare din fata stanga nu pot "
+#~ "fi atinse."

--- a/lang/po/Firmware_sk.po
+++ b/lang/po/Firmware_sk.po
@@ -26,115 +26,115 @@ msgid " 0.4 or newer"
 msgstr " 0.4 a novsie"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:7036
+#: ../../Firmware/ultralcd.cpp:7066
 msgid "%s level expected"
 msgstr "Ocakavana verzia %s"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1968
-#: ../../Firmware/ultralcd.cpp:3835
+#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1987
+#: ../../Firmware/ultralcd.cpp:3854
 msgid ">Cancel"
 msgstr ">Zrusit"
 
 #. MSG_BABYSTEPPING_Z c=15
 #. Beware: must include the ':' as its last character
-#: ../../Firmware/ultralcd.cpp:2670
+#: ../../Firmware/ultralcd.cpp:2689
 msgid "Adjusting Z:"
 msgstr "Doladenie Z:"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:7313
+#: ../../Firmware/ultralcd.cpp:7343
 msgid "All correct"
 msgstr "Vsetko OK"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4180
+#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4190
+#: ../../Firmware/ultralcd.cpp:4199
 msgid "All is done. Happy printing!"
 msgstr "Vsetko je hotove!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4404
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4423
 msgid "Alphabet"
 msgstr "Abeceda"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4308
+#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4327
 msgid "Always"
 msgstr "Vzdy"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1405
+#: ../../Firmware/ultralcd.cpp:1424
 msgid "Ambient"
 msgstr "Okolie"
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2983
+#: ../../Firmware/ultralcd.cpp:3002
 msgid "Are left and right Z~carriages all up?"
 msgstr "Dosli oba Z voziky k hornemu dorazu?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4478
 msgid "Assist"
 msgstr "Asist."
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:5886
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
 #: ../../Firmware/Marlin_main.cpp:3271 ../../Firmware/messages.cpp:9
-#: ../../Firmware/ultralcd.cpp:4900
+#: ../../Firmware/ultralcd.cpp:4919
 msgid "Auto home"
 msgstr "Auto home"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:4364
-#: ../../Firmware/ultralcd.cpp:5779
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:4383
+#: ../../Firmware/ultralcd.cpp:5801
 msgid "Auto power"
 msgstr "Automat."
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5572
+#: ../../Firmware/ultralcd.cpp:5594
 msgid "AutoLoad filament"
 msgstr "Autozav. filamentu"
 
 #. MSG_AUTOLOADING_ONLY_IF_FSENS_ON c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3549
+#: ../../Firmware/ultralcd.cpp:3568
 msgid ""
 "Autoloading filament available only when filament sensor is turned on..."
 msgstr ""
 "Autom. zavedenie filamentu je mozne len pri zapnutom senzore filamentu..."
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2301
+#: ../../Firmware/ultralcd.cpp:2320
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
 "Autom. zavedenie filamentu aktivne, stlacte tlacidlo a vlozte filament..."
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:7015
+#: ../../Firmware/ultralcd.cpp:7045
 msgid "Axis"
 msgstr "Os"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:7014
+#: ../../Firmware/ultralcd.cpp:7044
 msgid "Axis length"
 msgstr "Dlzka osi"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:2751
-#: ../../Firmware/ultralcd.cpp:5861 ../../Firmware/ultralcd.cpp:7838
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:2770
+#: ../../Firmware/ultralcd.cpp:5883 ../../Firmware/ultralcd.cpp:7878
 msgid "Back"
 msgstr "Spat"
 
 #. MSG_BED c=13
 #: ../../Firmware/Marlin_main.cpp:2051 ../../Firmware/Marlin_main.cpp:4767
 #: ../../Firmware/Marlin_main.cpp:4819 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:1403 ../../Firmware/ultralcd.cpp:5721
-#: ../../Firmware/ultralcd.cpp:5891
+#: ../../Firmware/ultralcd.cpp:1422 ../../Firmware/ultralcd.cpp:5743
+#: ../../Firmware/ultralcd.cpp:5913
 msgid "Bed"
 msgstr "Podlozka"
 
@@ -151,7 +151,7 @@ msgid "Bed done"
 msgstr "Podlozka OK."
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4912
+#: ../../Firmware/ultralcd.cpp:4931
 msgid "Bed level correct"
 msgstr "Korekcia podlozky"
 
@@ -168,18 +168,18 @@ msgstr ""
 "Kalibracia Z zlyhala. Sensor nezopol. Znecistena tryska? Cakam na reset."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6972
+#: ../../Firmware/ultralcd.cpp:7002
 msgid "Bed/Heater"
 msgstr "Podlozka/Zohrievanie"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1458
-#: ../../Firmware/ultralcd.cpp:1726
+#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1477
+#: ../../Firmware/ultralcd.cpp:1745
 msgid "Belt status"
 msgstr "Stav remena"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4902
+#: ../../Firmware/ultralcd.cpp:4921
 msgid "Belt test"
 msgstr "Test remena"
 
@@ -190,28 +190,28 @@ msgid "Blackout occurred. Recover print?"
 msgstr "Nastal vypadok prudu. Obnovit tlac?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:5886
 msgid "Bright"
 msgstr "Jasne"
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4850
-#: ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4869
+#: ../../Firmware/ultralcd.cpp:5811
 msgid "Brightness"
 msgstr "Podsvietenie"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4906
+#: ../../Firmware/ultralcd.cpp:4925
 msgid "Calibrate XYZ"
 msgstr "Kalibracia XYZ"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4908
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4927
 msgid "Calibrate Z"
 msgstr "Kalibrovat Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2946
+#: ../../Firmware/ultralcd.cpp:2965
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -226,7 +226,7 @@ msgid "Calibrating Z"
 msgstr "Kalibrujem Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2945
+#: ../../Firmware/ultralcd.cpp:2964
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -235,12 +235,12 @@ msgstr ""
 "tlacidlom."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:7315
+#: ../../Firmware/ultralcd.cpp:7345
 msgid "Calibrating home"
 msgstr "Kalibr. vychodziu p."
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:5581
+#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:5603
 msgid "Calibration"
 msgstr "Kalibracia"
 
@@ -250,115 +250,115 @@ msgid "Calibration done"
 msgstr "Kalibracia OK"
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7712
+#: ../../Firmware/ultralcd.cpp:7752
 msgid "Card removed"
 msgstr "Karta vysunuta"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/ultralcd.cpp:5560
 msgid "Change SD card"
 msgstr "Zmenit SD kartu"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5497
-#: ../../Firmware/ultralcd.cpp:5730
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5519
+#: ../../Firmware/ultralcd.cpp:5752
 msgid "Change filament"
 msgstr "Vymenit filament"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2163
+#: ../../Firmware/ultralcd.cpp:2182
 msgid "Change success!"
 msgstr "Vymena uspesna!"
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2215
+#: ../../Firmware/ultralcd.cpp:2234
 msgid "Changed correctly?"
 msgstr "Vymena ok?"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:6178
-#: ../../Firmware/ultralcd.cpp:7305
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:6208
+#: ../../Firmware/ultralcd.cpp:7335
 msgid "Checking X axis"
 msgstr "Kontrola osi X"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:6187
-#: ../../Firmware/ultralcd.cpp:7306
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:6217
+#: ../../Firmware/ultralcd.cpp:7336
 msgid "Checking Y axis"
 msgstr "Kontrola osi Y"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:7307
+#: ../../Firmware/ultralcd.cpp:7337
 msgid "Checking Z axis"
 msgstr "Kontrola osi Z"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:7308
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:7338
 msgid "Checking bed"
 msgstr "Kontrola podlozky"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:7304
+#: ../../Firmware/ultralcd.cpp:7334
 msgid "Checking endstops"
 msgstr "Kontrola endstopu"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:7403
+#: ../../Firmware/ultralcd.cpp:7433
 msgid "Checking file"
 msgstr "Kontrolujem subor"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:7310
+#: ../../Firmware/ultralcd.cpp:7340
 msgid "Checking hotend"
 msgstr "Kontrola hotend"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:7311
-#: ../../Firmware/ultralcd.cpp:7312
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:7341
+#: ../../Firmware/ultralcd.cpp:7342
 msgid "Checking sensors"
 msgstr "Kontrola senzorov"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4765
+#: ../../Firmware/ultralcd.cpp:4784
 msgid "Checks"
 msgstr "Kontroly"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2218
+#: ../../Firmware/ultralcd.cpp:2237
 msgid "Color not correct"
 msgstr "Nespravna farba"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3725
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3744
 msgid "Community made"
 msgstr "Komunitny prekl."
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4704
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4723
 msgid "Cont."
 msgstr "Pokr."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2125
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2144
 msgid "Cooldown"
 msgstr "Schladit"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3663
+#: ../../Firmware/ultralcd.cpp:3682
 msgid "Copy selected language?"
 msgstr "Kopirovat vybrany jazyk?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1221
-#: ../../Firmware/ultralcd.cpp:1262 ../../Firmware/ultralcd.cpp:1272
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1240
+#: ../../Firmware/ultralcd.cpp:1281 ../../Firmware/ultralcd.cpp:1291
 msgid "Crash"
 msgstr "Naraz"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4341
-#: ../../Firmware/ultralcd.cpp:4342 ../../Firmware/ultralcd.cpp:4344
-#: ../../Firmware/ultralcd.cpp:5765 ../../Firmware/ultralcd.cpp:5767
-#: ../../Firmware/ultralcd.cpp:5771
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4363
+#: ../../Firmware/ultralcd.cpp:5787 ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/ultralcd.cpp:5793
 msgid "Crash det."
 msgstr "Det. narazu"
 
@@ -368,7 +368,7 @@ msgid "Crash detected."
 msgstr "Zisteny naraz."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3521
+#: ../../Firmware/ultralcd.cpp:3540
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -379,14 +379,14 @@ msgstr ""
 "Normalnom rezime"
 
 #. MSG_CUT_FILAMENT c=17
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:5175
-#: ../../Firmware/ultralcd.cpp:5567
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:5197
+#: ../../Firmware/ultralcd.cpp:5589
 msgid "Cut filament"
 msgstr "Odstrihnut filam."
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:4303
-#: ../../Firmware/ultralcd.cpp:4308 ../../Firmware/ultralcd.cpp:4313
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:4322
+#: ../../Firmware/ultralcd.cpp:4327 ../../Firmware/ultralcd.cpp:4332
 msgid "Cutter"
 msgstr "Strihanie"
 
@@ -396,17 +396,17 @@ msgid "Cutting filament"
 msgstr "Strihanie filam."
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1668
+#: ../../Firmware/ultralcd.cpp:1687
 msgid "Date:"
 msgstr "Datum:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5886
 msgid "Dim"
 msgstr "Tmavy"
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4802
+#: ../../Firmware/ultralcd.cpp:4821
 msgid "Disable steppers"
 msgstr "Vypnut motory"
 
@@ -422,7 +422,7 @@ msgstr ""
 "manualu, kapitola Zaciname, odstavec Nastavenie prvej vrstvy."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:4145
+#: ../../Firmware/ultralcd.cpp:4164
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -431,23 +431,23 @@ msgstr ""
 "podlozkou?"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4214
+#: ../../Firmware/ultralcd.cpp:4233
 msgid "E-correct:"
 msgstr "Korekcia E:"
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2279
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2298
 msgid "ERROR:"
 msgstr "ERROR:"
 
 #. MSG_FSENS_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3562
+#: ../../Firmware/ultralcd.cpp:3581
 msgid "ERROR: Filament sensor is not responding, please check connection."
 msgstr "CHYBA: Filament senzor nereaguje, skontrolujte prosim zapojenie."
 
 #. MSG_EJECT_FILAMENT c=17
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:5156
-#: ../../Firmware/ultralcd.cpp:5565
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:5178
+#: ../../Firmware/ultralcd.cpp:5587
 msgid "Eject filament"
 msgstr "Vysunut fil."
 
@@ -457,92 +457,41 @@ msgid "Ejecting filament"
 msgstr "Vysunutie filamentu"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6985
+#: ../../Firmware/ultralcd.cpp:7015
 msgid "Endstop"
 msgstr "Koncovy spinac"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6990
+#: ../../Firmware/ultralcd.cpp:7020
 msgid "Endstop not hit"
 msgstr "Kon. spinac nezopol"
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6976
+#: ../../Firmware/ultralcd.cpp:7006
 msgid "Endstops"
 msgstr "Konc. spinace"
 
 #. MSG_EXTRUDER c=17
 #: ../../Firmware/Marlin_main.cpp:8608 ../../Firmware/messages.cpp:30
-#: ../../Firmware/ultralcd.cpp:3495
+#: ../../Firmware/ultralcd.cpp:3514
 msgid "Extruder"
 msgstr "Extruder"
 
-#. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1144
-#: ../../Firmware/ultralcd.cpp:7319
-msgid "Hotend fan:"
-msgstr "Hotend vent.:"
-
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1722
+#: ../../Firmware/ultralcd.cpp:1741
 msgid "Extruder info"
 msgstr "Extruder info"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4229
-#: ../../Firmware/ultralcd.cpp:4237 ../../Firmware/ultralcd.cpp:4248
-#: ../../Firmware/ultralcd.cpp:4250
+#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4248
+#: ../../Firmware/ultralcd.cpp:4256 ../../Firmware/ultralcd.cpp:4267
+#: ../../Firmware/ultralcd.cpp:4269
 msgid "F. autoload"
 msgstr "F. autozav."
 
-#. MSG_FSENSOR_JAM_DETECTION c=13
-#: ../../Firmware/messages.cpp:46 ../../Firmware/ultralcd.cpp:4232
-#: ../../Firmware/ultralcd.cpp:4239
-msgid "F. jam detect"
-msgstr "F. zasek"
-
-#. MSG_FSENSOR_RUNOUT c=13
-#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4229
-#: ../../Firmware/ultralcd.cpp:4236
-msgid "F. runout"
-msgstr "F. vypadok"
-
-#. MSG_TITLE_FIL_ALREADY_LOADED c=20
-#: ../../Firmware/mmu2/errors_list.h:148 ../../Firmware/mmu2/errors_list.h:186
-msgid "FILAMENT ALREADY LOA"
-msgstr "FILAMENT ALREADY LOA"
-
-#. MSG_TITLE_FINDA_DIDNT_TRIGGER c=20
-#: ../../Firmware/mmu2/errors_list.h:118 ../../Firmware/mmu2/errors_list.h:156
-msgid "FINDA DIDNT TRIGGER"
-msgstr "FINDA DIDNT TRIGGER"
-
-#. MSG_DESC_FINDA_DIDNT_GO_OFF c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:197 ../../Firmware/mmu2/errors_list.h:237
-msgid ""
-"FINDA didn't switch off while unloading filament. Try unloading manually. "
-"Ensure filament can move and FINDA works."
-msgstr ""
-"FINDA sa nevypol pocas vyberania filamentu. Skuste to manualne. Uistite sa, "
-"ze filament sa moze hybat a FINDA funguje."
-
-#. MSG_DESC_FINDA_DIDNT_TRIGGER c=20 r=8
-#: ../../Firmware/mmu2/errors_list.h:196 ../../Firmware/mmu2/errors_list.h:236
-msgid ""
-"FINDA didn't trigger while loading the filament. Ensure the filament can "
-"move and FINDA works."
-msgstr ""
-"FINDA sa nezopol pocas zavedenia filamentu. Uiste sa, ze FINDA funguje "
-"spravne."
-
-#. MSG_TITLE_FINDA_DIDNT_GO_OFF c=20
-#: ../../Firmware/mmu2/errors_list.h:119 ../../Firmware/mmu2/errors_list.h:157
-msgid "FINDA: FILAM. STUCK"
-msgstr "FINDA: FILAM. STUCK"
-
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4704
-#: ../../Firmware/ultralcd.cpp:4707
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4723
+#: ../../Firmware/ultralcd.cpp:4726
 msgid "FS Action"
 msgstr "FS Akcia"
 
@@ -557,102 +506,102 @@ msgid "FS v0.4 or newer"
 msgstr "FS 0.4 a novsie"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5589
+#: ../../Firmware/ultralcd.cpp:5611
 msgid "Fail stats"
 msgstr "Statistiky zlyhani"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5592
+#: ../../Firmware/ultralcd.cpp:5614
 msgid "Fail stats MMU"
 msgstr "Zlyhania MMU"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:7031
+#: ../../Firmware/ultralcd.cpp:7061
 msgid "False triggering"
 msgstr "Falosne spustenie"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:5723
-#: ../../Firmware/ultralcd.cpp:5893
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/ultralcd.cpp:5915
 msgid "Fan speed"
 msgstr "Rychlost vent."
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:7143
-#: ../../Firmware/ultralcd.cpp:7301 ../../Firmware/ultralcd.cpp:7302
-#: ../../Firmware/ultralcd.cpp:7303
+#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:7173
+#: ../../Firmware/ultralcd.cpp:7331 ../../Firmware/ultralcd.cpp:7332
+#: ../../Firmware/ultralcd.cpp:7333
 msgid "Fan test"
 msgstr "Test ventilatora"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4811
-#: ../../Firmware/ultralcd.cpp:5756
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4830
+#: ../../Firmware/ultralcd.cpp:5778
 msgid "Fans check"
 msgstr "Kontr. vent."
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1220
-#: ../../Firmware/ultralcd.cpp:1261 ../../Firmware/ultralcd.cpp:1327
-#: ../../Firmware/ultralcd.cpp:1329
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1239
+#: ../../Firmware/ultralcd.cpp:1280 ../../Firmware/ultralcd.cpp:1346
+#: ../../Firmware/ultralcd.cpp:1348
 msgid "Fil. runouts"
 msgstr "Vypadky filam."
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:3451
-#: ../../Firmware/ultralcd.cpp:4228 ../../Firmware/ultralcd.cpp:4234
-#: ../../Firmware/ultralcd.cpp:4244 ../../Firmware/ultralcd.cpp:5737
-#: ../../Firmware/ultralcd.cpp:5741 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:3470
+#: ../../Firmware/ultralcd.cpp:4247 ../../Firmware/ultralcd.cpp:4253
+#: ../../Firmware/ultralcd.cpp:4263 ../../Firmware/ultralcd.cpp:5759
+#: ../../Firmware/ultralcd.cpp:5763 ../../Firmware/ultralcd.cpp:5767
 msgid "Fil. sensor"
 msgstr "Fil. senzor"
 
 #. MSG_FILAMENT c=17
 #: ../../Firmware/Marlin_main.cpp:8577 ../../Firmware/Marlin_main.cpp:8604
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3835
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3854
 msgid "Filament"
 msgstr "Filament"
 
 #. MSG_FILAMENT_CLEAN c=20 r=2
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2287
-#: ../../Firmware/ultralcd.cpp:2293
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2306
+#: ../../Firmware/ultralcd.cpp:2312
 msgid "Filament extruding & with correct color?"
 msgstr "Filament vytlaceny a spravnej farby?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2217
+#: ../../Firmware/ultralcd.cpp:2236
 msgid "Filament not loaded"
 msgstr "Filament nezavedeny"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:7026
-#: ../../Firmware/ultralcd.cpp:7030 ../../Firmware/ultralcd.cpp:7034
-#: ../../Firmware/ultralcd.cpp:7330
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:7056
+#: ../../Firmware/ultralcd.cpp:7060 ../../Firmware/ultralcd.cpp:7064
+#: ../../Firmware/ultralcd.cpp:7360
 msgid "Filament sensor"
 msgstr "Senzor filamentu"
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2365
+#: ../../Firmware/ultralcd.cpp:2384
 msgid "Filament used"
 msgstr "Spotrebovany filam."
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7461
+#: ../../Firmware/ultralcd.cpp:7491
 msgid "File incomplete. Continue anyway?"
 msgstr "Subor nekompletny. Pokracovat?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:5314
-#: ../../Firmware/ultralcd.cpp:5630
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:5336
+#: ../../Firmware/ultralcd.cpp:5652
 msgid "Finishing movements"
 msgstr "Dokoncovanie pohybu"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:4898
-#: ../../Firmware/ultralcd.cpp:5424
+#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:4917
+#: ../../Firmware/ultralcd.cpp:5446
 msgid "First layer cal."
 msgstr "Kal. prvej vrstvy"
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4066
+#: ../../Firmware/ultralcd.cpp:4085
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Najskor pomocou selftestu skontrolujem nejcastejsie chyby vznikajuce pri "
@@ -664,23 +613,23 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr "Opravte chybu a potom stlacte tlacidlo na jednotke MMU."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5724
+#: ../../Firmware/ultralcd.cpp:5746
 msgid "Flow"
 msgstr "Prietok"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:6996
-#: ../../Firmware/ultralcd.cpp:7149 ../../Firmware/ultralcd.cpp:7154
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:7026
+#: ../../Firmware/ultralcd.cpp:7179 ../../Firmware/ultralcd.cpp:7184
 msgid "Front print fan?"
 msgstr "Predny tlacovy vent?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2754
+#: ../../Firmware/ultralcd.cpp:2773
 msgid "Front side[μm]"
 msgstr "Predna st.[μm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:7020
+#: ../../Firmware/ultralcd.cpp:7050
 msgid "Front/left fans"
 msgstr "Predny/lavy vent."
 
@@ -728,20 +677,20 @@ msgstr ""
 "zrusena."
 
 #. MSG_GCODE c=8
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:4655
-#: ../../Firmware/ultralcd.cpp:4658 ../../Firmware/ultralcd.cpp:4661
-#: ../../Firmware/ultralcd.cpp:4664
+#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:4674
+#: ../../Firmware/ultralcd.cpp:4677 ../../Firmware/ultralcd.cpp:4680
+#: ../../Firmware/ultralcd.cpp:4683
 msgid "Gcode"
 msgstr "G-code"
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:4672
-#: ../../Firmware/ultralcd.cpp:4726 ../../Firmware/ultralcd.cpp:4818
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:4691
+#: ../../Firmware/ultralcd.cpp:4745 ../../Firmware/ultralcd.cpp:4837
 msgid "HW Setup"
 msgstr "HW nastavenie"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6968
+#: ../../Firmware/ultralcd.cpp:6998
 msgid "Heater/Thermistor"
 msgstr "Zohr./Termistor"
 
@@ -763,7 +712,7 @@ msgid "Heating done."
 msgstr "Zahrievanie OK."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=16
-#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4042
+#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4061
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -773,7 +722,7 @@ msgstr ""
 "nastavenia, v ktorom skalibrujem os Z. Potom budete moct zacat tlacit."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4064
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -782,24 +731,30 @@ msgstr ""
 "previedla kalibracnym procesom?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:4358
-#: ../../Firmware/ultralcd.cpp:4367 ../../Firmware/ultralcd.cpp:5777
-#: ../../Firmware/ultralcd.cpp:5780
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:4377
+#: ../../Firmware/ultralcd.cpp:4386 ../../Firmware/ultralcd.cpp:5799
+#: ../../Firmware/ultralcd.cpp:5802
 msgid "High power"
 msgstr "Vys. vykon"
 
+#. MSG_HOTEND_FAN_SPEED c=15
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1145
+#: ../../Firmware/ultralcd.cpp:7351
+msgid "Hotend fan:"
+msgstr "Hotend vent.:"
+
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4094
 msgid "I will run xyz calibration now. It will take approx. 12 mins."
 msgstr "Teraz urobim XYZ kalibraciu. Zaberie to priblizne 12 min."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/ultralcd.cpp:4102
 msgid "I will run z calibration now."
 msgstr "Teraz urobim kalibraciu Z."
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=9
-#: ../../Firmware/ultralcd.cpp:4153
+#: ../../Firmware/ultralcd.cpp:4172
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -813,36 +768,36 @@ msgid "Improving bed calibration point"
 msgstr "Zlepsenie bodu kalibracie podlozky"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:5478
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:5500
 msgid "Info screen"
 msgstr "Informacie"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5545
+#: ../../Firmware/ultralcd.cpp:5567
 msgid "Init. SD card"
 msgstr "Nacitanie SD karty"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2152
+#: ../../Firmware/ultralcd.cpp:2171
 msgid "Insert filament"
 msgstr "Vlozte filament"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:6223
+#: ../../Firmware/ultralcd.cpp:6253
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
 msgstr "Vlozte filament (nezavadzajte) do extruderu a stlacte tlacidlo"
 
 #. MSG_FILAMENT_LOADED c=20 r=2
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3855
-#: ../../Firmware/ultralcd.cpp:4108 ../../Firmware/ultralcd.cpp:4111
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3874
+#: ../../Firmware/ultralcd.cpp:4127 ../../Firmware/ultralcd.cpp:4130
 msgid "Is filament loaded?"
 msgstr "Je filament zavedeny?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=2
 #: ../../Firmware/Marlin_main.cpp:3312 ../../Firmware/Marlin_main.cpp:4886
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:4084
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:4103
 msgid "Is steel sheet on heatbed?"
 msgstr "Je platna na podlozke?"
 
@@ -852,75 +807,74 @@ msgid "Iteration"
 msgstr "Opakovanie"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:1148
-#: ../../Firmware/ultralcd.cpp:1296
+#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:1167
+#: ../../Firmware/ultralcd.cpp:1315
 msgid "Last print"
 msgstr "Posledna tlac"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1169
-#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1269
-#: ../../Firmware/ultralcd.cpp:1326
+#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1188
+#: ../../Firmware/ultralcd.cpp:1278 ../../Firmware/ultralcd.cpp:1288
+#: ../../Firmware/ultralcd.cpp:1345
 msgid "Last print failures"
 msgstr "Zlyhanie posl. tlace"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2496
+#: ../../Firmware/ultralcd.cpp:2515
 msgid "Left"
 msgstr "Vlavo"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7001
-#: ../../Firmware/ultralcd.cpp:7147 ../../Firmware/ultralcd.cpp:7152
+#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:7032
+#: ../../Firmware/ultralcd.cpp:7179 ../../Firmware/ultralcd.cpp:7184
 msgid "Left hotend fan?"
 msgstr "Lavy vent na tryske?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2752
+#: ../../Firmware/ultralcd.cpp:2771
 msgid "Left side [μm]"
 msgstr "Lava str.[μm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:5862
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:5884
 msgid "Level Bright"
 msgstr "Normalne"
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:5863
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:5885
 msgid "Level Dimmed"
 msgstr "Stlmene"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4826
+#: ../../Firmware/ultralcd.cpp:4845
 msgid "Lin. correction"
 msgstr "Korekcia lin."
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4838
-#: ../../Firmware/ultralcd.cpp:5493
+#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4857
+#: ../../Firmware/ultralcd.cpp:5515
 msgid "Live adjust Z"
 msgstr "Doladenie osi Z"
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:5098
-#: ../../Firmware/ultralcd.cpp:5178
+#: ../../Firmware/ultralcd.cpp:5142
 msgid "Load all"
 msgstr "Zaviest vsetko"
 
 #. MSG_LOAD_FILAMENT c=17
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:5122
-#: ../../Firmware/ultralcd.cpp:5133 ../../Firmware/ultralcd.cpp:5562
-#: ../../Firmware/ultralcd.cpp:5576
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:5144
+#: ../../Firmware/ultralcd.cpp:5155 ../../Firmware/ultralcd.cpp:5584
+#: ../../Firmware/ultralcd.cpp:5598
 msgid "Load filament"
 msgstr "Zaviest filament"
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5563
+#: ../../Firmware/ultralcd.cpp:5585
 msgid "Load to nozzle"
 msgstr "Zaved. do trysky"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2185
+#: ../../Firmware/ultralcd.cpp:2204
 msgid "Loading color"
 msgstr "Cistenie farby"
 
@@ -928,18 +882,18 @@ msgstr "Cistenie farby"
 #: ../../Firmware/Marlin_main.cpp:3641 ../../Firmware/messages.cpp:55
 #: ../../Firmware/mmu.cpp:872 ../../Firmware/mmu.cpp:906
 #: ../../Firmware/mmu.cpp:1014 ../../Firmware/mmu.cpp:1026
-#: ../../Firmware/ultralcd.cpp:2196 ../../Firmware/ultralcd.cpp:3949
+#: ../../Firmware/ultralcd.cpp:2215 ../../Firmware/ultralcd.cpp:3968
 msgid "Loading filament"
 msgstr "Zavedenie filamentu"
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:7008
+#: ../../Firmware/ultralcd.cpp:7038
 msgid "Loose pulley"
 msgstr "Uvolnena remenica"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:4450
-#: ../../Firmware/ultralcd.cpp:4462
+#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/ultralcd.cpp:4481
 msgid "Loud"
 msgstr "Hlasny"
 
@@ -954,8 +908,8 @@ msgid "MK3S firmware detected on MK3 printer"
 msgstr "MK3S firmware na MK3 tlaciarni"
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4381
-#: ../../Firmware/ultralcd.cpp:4382
+#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4400
+#: ../../Firmware/ultralcd.cpp:4401
 msgid "MMU Mode"
 msgstr "MMU mod"
 
@@ -975,8 +929,8 @@ msgid "MMU OK. Resuming..."
 msgstr "MMU OK. Pokracujem..."
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:64 ../../Firmware/ultralcd.cpp:1170
-#: ../../Firmware/ultralcd.cpp:1193
+#: ../../Firmware/messages.cpp:64 ../../Firmware/ultralcd.cpp:1189
+#: ../../Firmware/ultralcd.cpp:1212
 msgid "MMU fails"
 msgstr "Zlyhanie MMU"
 
@@ -986,8 +940,8 @@ msgid "MMU load failed"
 msgstr "MMU zaved. zlyhalo"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:1171
-#: ../../Firmware/ultralcd.cpp:1194
+#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:1190
+#: ../../Firmware/ultralcd.cpp:1213
 msgid "MMU load fails"
 msgstr "MMU zlyhalo"
 
@@ -997,32 +951,32 @@ msgid "MMU needs user attention."
 msgstr "MMU potrebuje zasah uzivatela."
 
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/ultralcd.cpp:1195
+#: ../../Firmware/ultralcd.cpp:1214
 msgid "MMU power fails"
 msgstr "MMU vyp. prudu"
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1680
+#: ../../Firmware/ultralcd.cpp:1699
 msgid "MMU2 connected"
 msgstr "MMU2 pripojene"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:5836
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:5858
 msgid "Magnets comp."
 msgstr "Komp. magnetu"
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1147
-#: ../../Firmware/ultralcd.cpp:1295 ../../Firmware/ultralcd.cpp:1338
-#: ../../Firmware/ultralcd.cpp:1645 ../../Firmware/ultralcd.cpp:4795
-#: ../../Firmware/ultralcd.cpp:4892 ../../Firmware/ultralcd.cpp:5119
-#: ../../Firmware/ultralcd.cpp:5131 ../../Firmware/ultralcd.cpp:5154
-#: ../../Firmware/ultralcd.cpp:5173 ../../Firmware/ultralcd.cpp:5717
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1166
+#: ../../Firmware/ultralcd.cpp:1314 ../../Firmware/ultralcd.cpp:1357
+#: ../../Firmware/ultralcd.cpp:1664 ../../Firmware/ultralcd.cpp:4814
+#: ../../Firmware/ultralcd.cpp:4911 ../../Firmware/ultralcd.cpp:5141
+#: ../../Firmware/ultralcd.cpp:5153 ../../Firmware/ultralcd.cpp:5176
+#: ../../Firmware/ultralcd.cpp:5195 ../../Firmware/ultralcd.cpp:5739
 msgid "Main"
 msgstr "Hlavna ponuka"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2537
+#: ../../Firmware/ultralcd.cpp:2556
 msgid "Measured skew"
 msgstr "Merane skos."
 
@@ -1033,71 +987,71 @@ msgid "Measuring reference height of calibration point"
 msgstr "Meriam referencnu vysku kalibracneho bodu"
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:5832
+#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:5854
 msgid "Mesh"
 msgstr "Mriezka"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4823
-#: ../../Firmware/ultralcd.cpp:4910
+#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4842
+#: ../../Firmware/ultralcd.cpp:4929
 msgid "Mesh Bed Leveling"
 msgstr "Vyrovnanie podl."
 
 #. MSG_MODE c=6
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:4336
-#: ../../Firmware/ultralcd.cpp:4338 ../../Firmware/ultralcd.cpp:4358
-#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4364
-#: ../../Firmware/ultralcd.cpp:4367 ../../Firmware/ultralcd.cpp:5763
-#: ../../Firmware/ultralcd.cpp:5770 ../../Firmware/ultralcd.cpp:5777
-#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5779
-#: ../../Firmware/ultralcd.cpp:5780 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/ultralcd.cpp:4357 ../../Firmware/ultralcd.cpp:4377
+#: ../../Firmware/ultralcd.cpp:4380 ../../Firmware/ultralcd.cpp:4383
+#: ../../Firmware/ultralcd.cpp:4386 ../../Firmware/ultralcd.cpp:5785
+#: ../../Firmware/ultralcd.cpp:5792 ../../Firmware/ultralcd.cpp:5799
+#: ../../Firmware/ultralcd.cpp:5800 ../../Firmware/ultralcd.cpp:5801
+#: ../../Firmware/ultralcd.cpp:5802 ../../Firmware/ultralcd.cpp:5886
 msgid "Mode"
 msgstr "Mod"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3598
+#: ../../Firmware/ultralcd.cpp:3617
 msgid "Mode change in progress..."
 msgstr "Prebieha zmena modu..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:4575
-#: ../../Firmware/ultralcd.cpp:4578 ../../Firmware/ultralcd.cpp:4581
-#: ../../Firmware/ultralcd.cpp:4584
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:4594
+#: ../../Firmware/ultralcd.cpp:4597 ../../Firmware/ultralcd.cpp:4600
+#: ../../Firmware/ultralcd.cpp:4603
 msgid "Model"
 msgstr "Model"
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6982
-#: ../../Firmware/ultralcd.cpp:6991 ../../Firmware/ultralcd.cpp:7009
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:7012
+#: ../../Firmware/ultralcd.cpp:7021 ../../Firmware/ultralcd.cpp:7039
 msgid "Motor"
 msgstr "Motor"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3492
+#: ../../Firmware/ultralcd.cpp:3511
 msgid "Move X"
 msgstr "Posunut X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3493
+#: ../../Firmware/ultralcd.cpp:3512
 msgid "Move Y"
 msgstr "Posunut Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3494
+#: ../../Firmware/ultralcd.cpp:3513
 msgid "Move Z"
 msgstr "Posunut Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4801
+#: ../../Firmware/ultralcd.cpp:4820
 msgid "Move axis"
 msgstr "Posunut os"
 
 #. MSG_NA c=3
 #: ../../Firmware/menu.cpp:196 ../../Firmware/messages.cpp:124
-#: ../../Firmware/ultralcd.cpp:2502 ../../Firmware/ultralcd.cpp:2547
-#: ../../Firmware/ultralcd.cpp:3411 ../../Firmware/ultralcd.cpp:4228
-#: ../../Firmware/ultralcd.cpp:4276 ../../Firmware/ultralcd.cpp:5737
-#: ../../Firmware/ultralcd.cpp:5836
+#: ../../Firmware/ultralcd.cpp:2521 ../../Firmware/ultralcd.cpp:2566
+#: ../../Firmware/ultralcd.cpp:3430 ../../Firmware/ultralcd.cpp:4247
+#: ../../Firmware/ultralcd.cpp:4295 ../../Firmware/ultralcd.cpp:5759
+#: ../../Firmware/ultralcd.cpp:5858
 msgid "N/A"
 msgstr "N/A"
 
@@ -1107,14 +1061,14 @@ msgid "New firmware version available:"
 msgstr "Vysla nova verzia firmware:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:2804
-#: ../../Firmware/ultralcd.cpp:3180 ../../Firmware/ultralcd.cpp:4785
-#: ../../Firmware/ultralcd.cpp:5988
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:2823
+#: ../../Firmware/ultralcd.cpp:3199 ../../Firmware/ultralcd.cpp:4804
+#: ../../Firmware/ultralcd.cpp:6018
 msgid "No"
 msgstr "Nie"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5543
+#: ../../Firmware/ultralcd.cpp:5565
 msgid "No SD card"
 msgstr "Ziadna SD karta"
 
@@ -1124,71 +1078,71 @@ msgid "No move."
 msgstr "Bez pohybu."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4405
-#: ../../Firmware/ultralcd.cpp:4493 ../../Firmware/ultralcd.cpp:4502
-#: ../../Firmware/ultralcd.cpp:4575 ../../Firmware/ultralcd.cpp:4584
-#: ../../Firmware/ultralcd.cpp:4614 ../../Firmware/ultralcd.cpp:4623
-#: ../../Firmware/ultralcd.cpp:4655 ../../Firmware/ultralcd.cpp:4664
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4424
+#: ../../Firmware/ultralcd.cpp:4512 ../../Firmware/ultralcd.cpp:4521
+#: ../../Firmware/ultralcd.cpp:4594 ../../Firmware/ultralcd.cpp:4603
+#: ../../Firmware/ultralcd.cpp:4633 ../../Firmware/ultralcd.cpp:4642
+#: ../../Firmware/ultralcd.cpp:4674 ../../Firmware/ultralcd.cpp:4683
 msgid "None"
 msgstr "Ziadne"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:4336
-#: ../../Firmware/ultralcd.cpp:4381 ../../Firmware/ultralcd.cpp:4397
-#: ../../Firmware/ultralcd.cpp:4416 ../../Firmware/ultralcd.cpp:5763
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/ultralcd.cpp:4400 ../../Firmware/ultralcd.cpp:4416
+#: ../../Firmware/ultralcd.cpp:4435 ../../Firmware/ultralcd.cpp:5785
 msgid "Normal"
 msgstr "Normal"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6969
+#: ../../Firmware/ultralcd.cpp:6999
 msgid "Not connected"
 msgstr "Nezapojene"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:7168
-#: ../../Firmware/ultralcd.cpp:7183 ../../Firmware/ultralcd.cpp:7191
+#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:7198
+#: ../../Firmware/ultralcd.cpp:7213 ../../Firmware/ultralcd.cpp:7221
 msgid "Not spinning"
 msgstr "Netoci sa"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3962
+#: ../../Firmware/ultralcd.cpp:3981
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr "Teraz skalibrujem vzdialenost medzi koncom trysky a povrchom podlozky."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:4091
+#: ../../Firmware/ultralcd.cpp:4110
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Teraz predohrejem trysku pre PLA."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/ultralcd.cpp:4101
 msgid "Now remove the test print from steel sheet."
 msgstr "Teraz odstrante testovaci vytlacok z platne."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:1402
-#: ../../Firmware/ultralcd.cpp:4493 ../../Firmware/ultralcd.cpp:4496
-#: ../../Firmware/ultralcd.cpp:4499 ../../Firmware/ultralcd.cpp:4502
-#: ../../Firmware/ultralcd.cpp:5720 ../../Firmware/ultralcd.cpp:5882
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:1421
+#: ../../Firmware/ultralcd.cpp:4512 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/ultralcd.cpp:4518 ../../Firmware/ultralcd.cpp:4521
+#: ../../Firmware/ultralcd.cpp:5742 ../../Firmware/ultralcd.cpp:5904
 msgid "Nozzle"
 msgstr "Tryska"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4546
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4565
 msgid "Nozzle d."
 msgstr "Tryska"
 
 #. MSG_OFF c=3
 #: ../../Firmware/menu.cpp:467 ../../Firmware/messages.cpp:122
-#: ../../Firmware/ultralcd.cpp:4234 ../../Firmware/ultralcd.cpp:4250
-#: ../../Firmware/ultralcd.cpp:4284 ../../Firmware/ultralcd.cpp:4313
-#: ../../Firmware/ultralcd.cpp:4342 ../../Firmware/ultralcd.cpp:4811
-#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4834
-#: ../../Firmware/ultralcd.cpp:5644 ../../Firmware/ultralcd.cpp:5741
-#: ../../Firmware/ultralcd.cpp:5756 ../../Firmware/ultralcd.cpp:5767
-#: ../../Firmware/ultralcd.cpp:5836 ../../Firmware/ultralcd.cpp:7841
-#: ../../Firmware/ultralcd.cpp:7845
+#: ../../Firmware/ultralcd.cpp:4253 ../../Firmware/ultralcd.cpp:4269
+#: ../../Firmware/ultralcd.cpp:4303 ../../Firmware/ultralcd.cpp:4332
+#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4830
+#: ../../Firmware/ultralcd.cpp:4849 ../../Firmware/ultralcd.cpp:4853
+#: ../../Firmware/ultralcd.cpp:5666 ../../Firmware/ultralcd.cpp:5763
+#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/ultralcd.cpp:5858 ../../Firmware/ultralcd.cpp:7881
+#: ../../Firmware/ultralcd.cpp:7885
 msgid "Off"
 msgstr "Vyp"
 
@@ -1198,19 +1152,19 @@ msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr "Neplatne hodnoty nastavenia. Bude pouzite predvolene PID, Esteps atd."
 
 #. MSG_ON c=3
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4244
-#: ../../Firmware/ultralcd.cpp:4248 ../../Firmware/ultralcd.cpp:4280
-#: ../../Firmware/ultralcd.cpp:4303 ../../Firmware/ultralcd.cpp:4341
-#: ../../Firmware/ultralcd.cpp:4811 ../../Firmware/ultralcd.cpp:4830
-#: ../../Firmware/ultralcd.cpp:4834 ../../Firmware/ultralcd.cpp:5745
-#: ../../Firmware/ultralcd.cpp:5756 ../../Firmware/ultralcd.cpp:5765
-#: ../../Firmware/ultralcd.cpp:5836 ../../Firmware/ultralcd.cpp:7841
-#: ../../Firmware/ultralcd.cpp:7845
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4263
+#: ../../Firmware/ultralcd.cpp:4267 ../../Firmware/ultralcd.cpp:4299
+#: ../../Firmware/ultralcd.cpp:4322 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4849
+#: ../../Firmware/ultralcd.cpp:4853 ../../Firmware/ultralcd.cpp:5767
+#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5787
+#: ../../Firmware/ultralcd.cpp:5858 ../../Firmware/ultralcd.cpp:7881
+#: ../../Firmware/ultralcd.cpp:7885
 msgid "On"
 msgstr "Zap"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4453
+#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4472
 msgid "Once"
 msgstr "Raz"
 
@@ -1230,7 +1184,7 @@ msgid "PID cal. finished"
 msgstr "PID kal. ukoncena"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4913
+#: ../../Firmware/ultralcd.cpp:4932
 msgid "PID calibration"
 msgstr "PID kalibracia"
 
@@ -1242,18 +1196,18 @@ msgstr "Nahrievanie PINDA"
 #. MSG_PINDA_CALIBRATION c=13
 #: ../../Firmware/Marlin_main.cpp:4932 ../../Firmware/Marlin_main.cpp:5035
 #: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:654
-#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4920
+#: ../../Firmware/ultralcd.cpp:4849 ../../Firmware/ultralcd.cpp:4939
 msgid "PINDA cal."
 msgstr "PINDA kal."
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3361
+#: ../../Firmware/ultralcd.cpp:3380
 msgid "PINDA calibration failed"
 msgstr "Kalibracia PINDA zlyhala"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
 #: ../../Firmware/Marlin_main.cpp:5112 ../../Firmware/messages.cpp:110
-#: ../../Firmware/ultralcd.cpp:3355
+#: ../../Firmware/ultralcd.cpp:3374
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1262,13 +1216,13 @@ msgstr ""
 "menu Nastavenia->PINDA kal."
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4707
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4726
 msgid "Pause"
 msgstr "Pauza"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:5507
-#: ../../Firmware/ultralcd.cpp:5509
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:5529
+#: ../../Firmware/ultralcd.cpp:5531
 msgid "Pause print"
 msgstr "Pozastavit tlac"
 
@@ -1283,7 +1237,7 @@ msgstr ""
 "tlacidlom X."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:4176
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:4195
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1292,17 +1246,17 @@ msgstr ""
 "restartovanim tlaciarne."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:6250
+#: ../../Firmware/ultralcd.cpp:6280
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "Prosim skontrolujte zapojenie IR senzoru a vyberte filament"
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6963
+#: ../../Firmware/ultralcd.cpp:6993
 msgid "Please check:"
 msgstr "Skontrolujte:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4148
+#: ../../Firmware/ultralcd.cpp:4167
 msgid "Please clean heatbed and then press the knob."
 msgstr "Prosim ocistite podlozku a stlacte tlacidlo."
 
@@ -1313,14 +1267,14 @@ msgstr ""
 "Pre uspesnu kalibraciu ocistite prosim tlacovu trysku. Potvrdte tlacidlom."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3945
+#: ../../Firmware/ultralcd.cpp:3964
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr ""
 "Prosim vlozte filament do extruderu a stlacte tlacidlo k jeho zavedeniu"
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3940
+#: ../../Firmware/ultralcd.cpp:3959
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1329,7 +1283,7 @@ msgstr ""
 "zavedeniu"
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3863
+#: ../../Firmware/ultralcd.cpp:3882
 msgid "Please load filament first."
 msgstr "Prosim najskor zavedte filament"
 
@@ -1340,7 +1294,7 @@ msgstr "Prosim otvorte idler a manualne odstrante filament."
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=5
 #: ../../Firmware/mesh_bed_calibration.cpp:2799 ../../Firmware/messages.cpp:70
-#: ../../Firmware/ultralcd.cpp:4085
+#: ../../Firmware/ultralcd.cpp:4104
 msgid "Please place steel sheet on heatbed."
 msgstr "Umiestnite prosim platnu na podlozku"
 
@@ -1351,7 +1305,7 @@ msgid "Please press the knob to unload filament"
 msgstr "Pre vysunutie filamentu stlacte tlacidlo"
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:5213
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:5235
 msgid "Please pull out filament immediately"
 msgstr "Prosim vyberte urychlene filament"
 
@@ -1361,7 +1315,7 @@ msgid "Please remove filament and then press the knob."
 msgstr "Prosim vyberte filament a potom stlacte tlacidlo."
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:4081
+#: ../../Firmware/ultralcd.cpp:4100
 msgid "Please remove shipping helpers first."
 msgstr "Najskor prosim odstrante prevozne pomocky."
 
@@ -1377,7 +1331,7 @@ msgid "Please run XYZ calibration first."
 msgstr "Najskor spustite kalibraciu XYZ."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:6247
+#: ../../Firmware/ultralcd.cpp:6277
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Prosim vyberte filament a zopakujte tuto akciu"
 
@@ -1394,54 +1348,54 @@ msgstr "Aktualizujte prosim."
 #. MSG_PLEASE_WAIT c=20
 #: ../../Firmware/Marlin_main.cpp:3547 ../../Firmware/Marlin_main.cpp:3563
 #: ../../Firmware/Marlin_main.cpp:7931 ../../Firmware/messages.cpp:71
-#: ../../Firmware/ultralcd.cpp:2186 ../../Firmware/ultralcd.cpp:2197
+#: ../../Firmware/ultralcd.cpp:2205 ../../Firmware/ultralcd.cpp:2216
 msgid "Please wait"
 msgstr "Cakajte prosim"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1219
-#: ../../Firmware/ultralcd.cpp:1260 ../../Firmware/ultralcd.cpp:1270
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1238
+#: ../../Firmware/ultralcd.cpp:1279 ../../Firmware/ultralcd.cpp:1289
 msgid "Power failures"
 msgstr "Vypadky prudu"
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5502
+#: ../../Firmware/ultralcd.cpp:5524
 msgid "Preheat"
 msgstr "Predohrev"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:2280
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:2299
 msgid "Preheat the nozzle!"
 msgstr "Predohrejte trysku!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:2900
-#: ../../Firmware/ultralcd.cpp:3924 ../../Firmware/ultralcd.cpp:3926
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:2919
+#: ../../Firmware/ultralcd.cpp:3943 ../../Firmware/ultralcd.cpp:3945
 msgid "Preheating nozzle. Please wait."
 msgstr "Predhrev trysky. Prosim cakajte."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1988
+#: ../../Firmware/ultralcd.cpp:2007
 msgid "Preheating to cut"
 msgstr "Predohrev k strihu"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1985
+#: ../../Firmware/ultralcd.cpp:2004
 msgid "Preheating to eject"
 msgstr "Predhrev k vysunutiu"
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1976
+#: ../../Firmware/ultralcd.cpp:1995
 msgid "Preheating to load"
 msgstr "Predhrev k zavedeniu"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1981
+#: ../../Firmware/ultralcd.cpp:2000
 msgid "Preheating to unload"
 msgstr "Predohrev k vybratiu"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1809
+#: ../../Firmware/ultralcd.cpp:1828
 msgid "Press the knob"
 msgstr "Stlacte tlacidlo"
 
@@ -1461,13 +1415,13 @@ msgid "Print aborted"
 msgstr "Tlac prerusena"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1144
-#: ../../Firmware/ultralcd.cpp:7322
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1145
+#: ../../Firmware/ultralcd.cpp:7354
 msgid "Print fan:"
 msgstr "Tlacovy vent.:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5535
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5557
 msgid "Print from SD"
 msgstr "Tlac z SD"
 
@@ -1477,12 +1431,12 @@ msgid "Print paused"
 msgstr "Tlac pozastavena"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2366
+#: ../../Firmware/ultralcd.cpp:2385
 msgid "Print time"
 msgstr "Cas tlace"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1711
+#: ../../Firmware/ultralcd.cpp:1730
 msgid "Printer IP Addr:"
 msgstr "IP adr. tlaciarne:"
 
@@ -1510,12 +1464,12 @@ msgstr ""
 "Tlac zrusena."
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4834
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4853
 msgid "RPi port"
 msgstr "RPi port"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2755
+#: ../../Firmware/ultralcd.cpp:2774
 msgid "Rear side [μm]"
 msgstr "Zadna str.[μm]"
 
@@ -1530,24 +1484,24 @@ msgid "Remove old filament and press the knob to start loading new filament."
 msgstr "Vyberte stary filament a stlacte tlacidlo pre zavedenie noveho."
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5426
+#: ../../Firmware/ultralcd.cpp:5448
 msgid "Rename"
 msgstr "Premenovat"
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2756
-#: ../../Firmware/ultralcd.cpp:5427
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2775
+#: ../../Firmware/ultralcd.cpp:5449
 msgid "Reset"
 msgstr "Reset"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4917
+#: ../../Firmware/ultralcd.cpp:4936
 msgid "Reset XYZ calibr."
 msgstr "Reset XYZ kalibr."
 
 #. MSG_RESUME_PRINT c=18
 #: ../../Firmware/Marlin_main.cpp:655 ../../Firmware/messages.cpp:81
-#: ../../Firmware/ultralcd.cpp:5521 ../../Firmware/ultralcd.cpp:5523
+#: ../../Firmware/ultralcd.cpp:5543 ../../Firmware/ultralcd.cpp:5545
 msgid "Resume print"
 msgstr "Pokracovat"
 
@@ -1557,17 +1511,17 @@ msgid "Resuming print"
 msgstr "Obnovenie tlace"
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2497
+#: ../../Firmware/ultralcd.cpp:2516
 msgid "Right"
 msgstr "Vpravo"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2753
+#: ../../Firmware/ultralcd.cpp:2772
 msgid "Right side[μm]"
 msgstr "Prava str.[μm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3884
+#: ../../Firmware/ultralcd.cpp:3903
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1576,14 +1530,14 @@ msgstr ""
 "kalibracny proces od zaciatku. Pokracovat?"
 
 #. MSG_RUNOUTS c=7
-#: ../../Firmware/ultralcd.cpp:1271
+#: ../../Firmware/ultralcd.cpp:1290
 msgid "Runouts"
 msgstr "Výbehy"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4395
-#: ../../Firmware/ultralcd.cpp:4397 ../../Firmware/ultralcd.cpp:4414
-#: ../../Firmware/ultralcd.cpp:4416
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4414
+#: ../../Firmware/ultralcd.cpp:4416 ../../Firmware/ultralcd.cpp:4433
+#: ../../Firmware/ultralcd.cpp:4435
 msgid "SD card"
 msgstr "SD karta"
 
@@ -1599,12 +1553,12 @@ msgid "Searching bed calibration point"
 msgstr "Hladam kalibracny bod podlozky"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5419
+#: ../../Firmware/ultralcd.cpp:5441
 msgid "Select"
 msgstr "Vybrat"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3966
+#: ../../Firmware/ultralcd.cpp:3985
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
@@ -1617,49 +1571,49 @@ msgstr "Zvolte extruder:"
 
 #. MSG_SELECT_FILAMENT c=20
 #: ../../Firmware/Marlin_main.cpp:8577 ../../Firmware/Marlin_main.cpp:8604
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3834
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3853
 msgid "Select filament:"
 msgstr "Zvolte filament:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:3679
-#: ../../Firmware/ultralcd.cpp:4841
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:3698
+#: ../../Firmware/ultralcd.cpp:4860
 msgid "Select language"
 msgstr "Vyber jazyka"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:4122
+#: ../../Firmware/ultralcd.cpp:4141
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr "Vyberte teplotu predohrevu trysky ktora zodpoveda vasmu materialu."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3971
+#: ../../Firmware/ultralcd.cpp:3990
 msgid "Select temperature which matches your material."
 msgstr "Zvolte teplotu, ktora odpoveda vasmu materialu."
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6522
+#: ../../Firmware/ultralcd.cpp:6552
 msgid "Self test OK"
 msgstr "Samotest OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:6290
+#: ../../Firmware/ultralcd.cpp:6320
 msgid "Self test start"
 msgstr "Zaciatok testu"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4904
+#: ../../Firmware/ultralcd.cpp:4923
 msgid "Selftest"
 msgstr "Samotest"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6962
+#: ../../Firmware/ultralcd.cpp:6992
 msgid "Selftest error!"
 msgstr "Chyba samotestu!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:6526
-#: ../../Firmware/ultralcd.cpp:7049 ../../Firmware/ultralcd.cpp:7314
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:6556
+#: ../../Firmware/ultralcd.cpp:7079 ../../Firmware/ultralcd.cpp:7344
 msgid "Selftest failed"
 msgstr "Samotest zlyhal"
 
@@ -1669,30 +1623,30 @@ msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr "Bude spusteny test pre kalibraciu presneho navratu."
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1723
+#: ../../Firmware/ultralcd.cpp:1742
 msgid "Sensor info"
 msgstr "Senzor info"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:6254
+#: ../../Firmware/ultralcd.cpp:6284
 msgid "Sensor verified, remove the filament now."
 msgstr "Senzor overeny, vyberte filament."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2773
+#: ../../Firmware/ultralcd.cpp:2792
 msgid "Set temperature:"
 msgstr "Nastavte teplotu:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:3491
-#: ../../Firmware/ultralcd.cpp:3696 ../../Firmware/ultralcd.cpp:4206
-#: ../../Firmware/ultralcd.cpp:5580 ../../Firmware/ultralcd.cpp:5827
-#: ../../Firmware/ultralcd.cpp:5880
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:3510
+#: ../../Firmware/ultralcd.cpp:3715 ../../Firmware/ultralcd.cpp:4225
+#: ../../Firmware/ultralcd.cpp:5602 ../../Firmware/ultralcd.cpp:5849
+#: ../../Firmware/ultralcd.cpp:5902
 msgid "Settings"
 msgstr "Nastavenia"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2540
+#: ../../Firmware/ultralcd.cpp:2559
 msgid "Severe skew"
 msgstr "Tazke skos."
 
@@ -1703,7 +1657,7 @@ msgid "Sheet"
 msgstr "Platna"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3824
+#: ../../Firmware/ultralcd.cpp:3843
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1716,18 +1670,18 @@ msgstr ""
 "%cReset"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4915
+#: ../../Firmware/ultralcd.cpp:4934
 msgid "Show end stops"
 msgstr "Stav konc. spin."
 
 #. MSG_SILENT c=7
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4361
-#: ../../Firmware/ultralcd.cpp:4456 ../../Firmware/ultralcd.cpp:5778
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4380
+#: ../../Firmware/ultralcd.cpp:4475 ../../Firmware/ultralcd.cpp:5800
 msgid "Silent"
 msgstr "Tichy"
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2539
+#: ../../Firmware/ultralcd.cpp:2558
 msgid "Slight skew"
 msgstr "Lahke skos."
 
@@ -1746,8 +1700,8 @@ msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Vyskytol sa problem, zarovnam os Z ..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4403
-#: ../../Firmware/ultralcd.cpp:4404 ../../Firmware/ultralcd.cpp:4405
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4422
+#: ../../Firmware/ultralcd.cpp:4423 ../../Firmware/ultralcd.cpp:4424
 msgid "Sort"
 msgstr "Triedit"
 
@@ -1758,20 +1712,20 @@ msgid "Sorting files"
 msgstr "Triedenie suborov"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4450
-#: ../../Firmware/ultralcd.cpp:4453 ../../Firmware/ultralcd.cpp:4456
-#: ../../Firmware/ultralcd.cpp:4459 ../../Firmware/ultralcd.cpp:4462
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/ultralcd.cpp:4472 ../../Firmware/ultralcd.cpp:4475
+#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4481
 msgid "Sound"
 msgstr "Zvuk"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5718
+#: ../../Firmware/ultralcd.cpp:5740
 msgid "Speed"
 msgstr "Rychlost"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7166
-#: ../../Firmware/ultralcd.cpp:7181 ../../Firmware/ultralcd.cpp:7189
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7196
+#: ../../Firmware/ultralcd.cpp:7211 ../../Firmware/ultralcd.cpp:7219
 msgid "Spinning"
 msgstr "Toci sa"
 
@@ -1781,42 +1735,42 @@ msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr "Je vyzadovana stabilna izbova teplota 21-26C a pevna podlozka."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5585
+#: ../../Firmware/ultralcd.cpp:5607
 msgid "Statistics"
 msgstr "Statistika"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4338
-#: ../../Firmware/ultralcd.cpp:4382 ../../Firmware/ultralcd.cpp:5770
+#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4357
+#: ../../Firmware/ultralcd.cpp:4401 ../../Firmware/ultralcd.cpp:5792
 msgid "Stealth"
 msgstr "Tichy"
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4763
-#: ../../Firmware/ultralcd.cpp:5416
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4782
+#: ../../Firmware/ultralcd.cpp:5438
 msgid "Steel sheets"
 msgstr "Platne"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5528
-#: ../../Firmware/ultralcd.cpp:5987
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5550
+#: ../../Firmware/ultralcd.cpp:6017
 msgid "Stop print"
 msgstr "Zastavit tlac"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4499
-#: ../../Firmware/ultralcd.cpp:4581 ../../Firmware/ultralcd.cpp:4620
-#: ../../Firmware/ultralcd.cpp:4661
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4518
+#: ../../Firmware/ultralcd.cpp:4600 ../../Firmware/ultralcd.cpp:4639
+#: ../../Firmware/ultralcd.cpp:4680
 msgid "Strict"
 msgstr "Prisne"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/ultralcd.cpp:5616
 msgid "Support"
 msgstr "Podpora"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:7021
+#: ../../Firmware/ultralcd.cpp:7051
 msgid "Swapped"
 msgstr "Prehodene"
 
@@ -1825,28 +1779,18 @@ msgstr "Prehodene"
 msgid "THERMAL ANOMALY"
 msgstr "THERMAL ANOMALY"
 
-#. MSG_TM_AUTOTUNE_FAILED c=20
-#: ../../Firmware/temperature.cpp:2899
-msgid "TM autotune failed"
-msgstr "TM autotune failed"
-
-#. MSG_TEMP_MODEL_AUTOTUNE c=20
-#: ../../Firmware/temperature.cpp:2884
-msgid "Temp. model autotune"
-msgstr "Autom. nast. teploty"
-
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4797
+#: ../../Firmware/ultralcd.cpp:4816
 msgid "Temperature"
 msgstr "Teplota"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1729
+#: ../../Firmware/ultralcd.cpp:1748
 msgid "Temperatures"
 msgstr "Teploty"
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3974
+#: ../../Firmware/ultralcd.cpp:3993
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -1865,66 +1809,66 @@ msgstr ""
 "Zaciname, sekcia Postup kalibracie."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4403
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4422
 msgid "Time"
 msgstr "Cas"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:5865
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:5887
 msgid "Timeout"
 msgstr "Casovac"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:1149
-#: ../../Firmware/ultralcd.cpp:1297
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:1168
+#: ../../Firmware/ultralcd.cpp:1316
 msgid "Total"
 msgstr "Celkom"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:1192
-#: ../../Firmware/ultralcd.cpp:1218 ../../Firmware/ultralcd.cpp:1328
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:1211
+#: ../../Firmware/ultralcd.cpp:1237 ../../Firmware/ultralcd.cpp:1347
 msgid "Total failures"
 msgstr "Celkom zlyhani"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2387
+#: ../../Firmware/ultralcd.cpp:2406
 msgid "Total filament"
 msgstr "Filament celkom"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2388
+#: ../../Firmware/ultralcd.cpp:2407
 msgid "Total print time"
 msgstr "Celkovy cas tlace"
 
 #. MSG_TUNE c=18
-#: ../../Firmware/ultralcd.cpp:5500
+#: ../../Firmware/ultralcd.cpp:5522
 msgid "Tune"
 msgstr "Ladit"
 
 #. MSG_UNLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:5564
-#: ../../Firmware/ultralcd.cpp:5578
+#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:5586
+#: ../../Firmware/ultralcd.cpp:5600
 msgid "Unload filament"
 msgstr "Vybrat filament"
 
 #. MSG_UNLOADING_FILAMENT c=20
 #: ../../Firmware/messages.cpp:112 ../../Firmware/mmu.cpp:957
-#: ../../Firmware/ultralcd.cpp:5197
+#: ../../Firmware/ultralcd.cpp:5219
 msgid "Unloading filament"
 msgstr "Vysuvanie filamentu"
 
 #. MSG_FIL_FAILED c=20 r=5
-#: ../../Firmware/ultralcd.cpp:6258
+#: ../../Firmware/ultralcd.cpp:6288
 msgid "Verification failed, remove the filament and try again."
 msgstr "Overenie zlyhalo, vyberte filament a skuste znovu."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1732
+#: ../../Firmware/ultralcd.cpp:1751
 msgid "Voltages"
 msgstr "Napatie"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3534
+#: ../../Firmware/ultralcd.cpp:3553
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -1942,19 +1886,19 @@ msgid "Wait for user..."
 msgstr "Caka sa na uzivatela"
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2881
+#: ../../Firmware/ultralcd.cpp:2900
 msgid "Waiting for PINDA probe cooling"
 msgstr "Caka sa na ochladenie PINDA"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2913
+#: ../../Firmware/ultralcd.cpp:2932
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Cakanie na schladenie trysky a podlozky."
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:4496
-#: ../../Firmware/ultralcd.cpp:4578 ../../Firmware/ultralcd.cpp:4617
-#: ../../Firmware/ultralcd.cpp:4658
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/ultralcd.cpp:4597 ../../Firmware/ultralcd.cpp:4636
+#: ../../Firmware/ultralcd.cpp:4677
 msgid "Warn"
 msgstr "Varovat"
 
@@ -1979,146 +1923,135 @@ msgid "Was filament unload successful?"
 msgstr "Bolo vysunutie filamentu uspesne?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6973
-#: ../../Firmware/ultralcd.cpp:6977 ../../Firmware/ultralcd.cpp:6997
-#: ../../Firmware/ultralcd.cpp:7003 ../../Firmware/ultralcd.cpp:7027
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:7003
+#: ../../Firmware/ultralcd.cpp:7007 ../../Firmware/ultralcd.cpp:7027
+#: ../../Firmware/ultralcd.cpp:7033 ../../Firmware/ultralcd.cpp:7057
 msgid "Wiring error"
 msgstr "Chyba zapojenia"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4895
+#: ../../Firmware/ultralcd.cpp:4914
 msgid "Wizard"
 msgstr "Sprievodca"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4210
+#: ../../Firmware/ultralcd.cpp:4229
 msgid "X-correct:"
 msgstr "Korekcia X:"
 
 #. MSG_XFLASH c=18
-#: ../../Firmware/ultralcd.cpp:5596
+#: ../../Firmware/ultralcd.cpp:5618
 msgid "XFLASH init"
 msgstr "XFLASH init"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1721
+#: ../../Firmware/ultralcd.cpp:1740
 msgid "XYZ cal. details"
 msgstr "Detaily XYZ kal."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3333
+#: ../../Firmware/ultralcd.cpp:3352
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr ""
 "Kalibracia XYZ v poriadku. Skosenie bude automaticky vyrovnane pri tlaci."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3330
+#: ../../Firmware/ultralcd.cpp:3349
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr "Kalibracia XYZ v poriadku. X/Y osi mierne skosene. Dobra praca!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3311
+#: ../../Firmware/ultralcd.cpp:3330
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr "Kalibracia XYZ je nepresna. Predne kalibracne body su nedostupne."
 
-#. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_LEFT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3317
-msgid ""
-"XYZ calibration compromised. Left front calibration point not reachable."
-msgstr "Kalibracia XYZ je nepresna. Lavy predny bod je nedostupny."
-
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3314
+#: ../../Firmware/ultralcd.cpp:3333
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr "Kalibracia XYZ je nepresna. Pravy predny bod je nedostupny."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3293
+#: ../../Firmware/ultralcd.cpp:3312
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr "Kalibracia XYZ zlyhala. Kalibracny bod podlozky nenajdeny."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3299
+#: ../../Firmware/ultralcd.cpp:3318
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr "Kalibracia XYZ zlyhala. Predne kalibracne body su nedostupne."
 
-#. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_LEFT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3305
-msgid "XYZ calibration failed. Left front calibration point not reachable."
-msgstr "Kalibracia XYZ zlyhala. Lavy predny bod je nedostupny"
-
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3296
-#: ../../Firmware/ultralcd.cpp:3324
+#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3315
+#: ../../Firmware/ultralcd.cpp:3343
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "Kalibracia XYZ zlyhala. Nahliadnite do manualu."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3302
+#: ../../Firmware/ultralcd.cpp:3321
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr "Kalibracia XYZ zlyhala. Pravy predny bod je nedostupny."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3327
+#: ../../Firmware/ultralcd.cpp:3346
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "Kalibracia XYZ v poradku. X/Y osi su kolme. Gratulujeme!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2494
+#: ../../Firmware/ultralcd.cpp:2513
 msgid "Y distance from min"
 msgstr "Y vzdialenost od min"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4211
+#: ../../Firmware/ultralcd.cpp:4230
 msgid "Y-correct:"
 msgstr "Korekcia Y:"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:2216
-#: ../../Firmware/ultralcd.cpp:2800 ../../Firmware/ultralcd.cpp:3180
-#: ../../Firmware/ultralcd.cpp:4785 ../../Firmware/ultralcd.cpp:5989
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:2235
+#: ../../Firmware/ultralcd.cpp:2819 ../../Firmware/ultralcd.cpp:3199
+#: ../../Firmware/ultralcd.cpp:4804 ../../Firmware/ultralcd.cpp:6019
 msgid "Yes"
 msgstr "Ano"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:4187
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:4206
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr ""
 "Sprievodcu mozete kedykolvek znovu spustit z menu Kalibracia -> Sprievodca"
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4231
 msgid "Z-correct:"
 msgstr "Korekcia Z:"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:5835
+#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:5857
 msgid "Z-probe nr."
 msgstr "Pocet merani Z"
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2565
+#: ../../Firmware/ultralcd.cpp:2584
 msgid "[0;0] point offset"
 msgstr "[0;0] odsadenie bodu"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2154
+#: ../../Firmware/ultralcd.cpp:2173
 msgid "and press the knob"
 msgstr "a stlacte tlacidlo"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1816
+#: ../../Firmware/ultralcd.cpp:1835
 msgid "to load filament"
 msgstr "k zavedeniu filam."
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1820
+#: ../../Firmware/ultralcd.cpp:1839
 msgid "to unload filament"
 msgstr "k vybraniu filamentu"
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1688
+#: ../../Firmware/ultralcd.cpp:1707
 msgid "unknown"
 msgstr "neznamy"
 
@@ -2128,13 +2061,55 @@ msgid "unknown state"
 msgstr "neznamy stav"
 
 #. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:6077
-#: ../../Firmware/ultralcd.cpp:6080
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:6107
+#: ../../Firmware/ultralcd.cpp:6110
 msgid "🔃Refresh"
 msgstr "🔃Obnovit"
 
 #~ msgid "Crash detected. Resume print?"
 #~ msgstr "Zisteny naraz. Obnovit tlac?"
 
+#~ msgid "F. jam detect"
+#~ msgstr "F. zasek"
+
+#~ msgid "F. runout"
+#~ msgstr "F. vypadok"
+
+#~ msgid "FILAMENT ALREADY LOA"
+#~ msgstr "FILAMENT ALREADY LOA"
+
+#~ msgid "FINDA DIDNT TRIGGER"
+#~ msgstr "FINDA DIDNT TRIGGER"
+
+#~ msgid ""
+#~ "FINDA didn't switch off while unloading filament. Try unloading manually. "
+#~ "Ensure filament can move and FINDA works."
+#~ msgstr ""
+#~ "FINDA sa nevypol pocas vyberania filamentu. Skuste to manualne. Uistite "
+#~ "sa, ze filament sa moze hybat a FINDA funguje."
+
+#~ msgid ""
+#~ "FINDA didn't trigger while loading the filament. Ensure the filament can "
+#~ "move and FINDA works."
+#~ msgstr ""
+#~ "FINDA sa nezopol pocas zavedenia filamentu. Uiste sa, ze FINDA funguje "
+#~ "spravne."
+
+#~ msgid "FINDA: FILAM. STUCK"
+#~ msgstr "FINDA: FILAM. STUCK"
+
 #~ msgid "M117 First layer cal."
 #~ msgstr "M117 Kal. prvej vrstvy"
+
+#~ msgid "TM autotune failed"
+#~ msgstr "TM autotune failed"
+
+#~ msgid "Temp. model autotune"
+#~ msgstr "Autom. nast. teploty"
+
+#~ msgid ""
+#~ "XYZ calibration compromised. Left front calibration point not reachable."
+#~ msgstr "Kalibracia XYZ je nepresna. Lavy predny bod je nedostupny."
+
+#~ msgid "XYZ calibration failed. Left front calibration point not reachable."
+#~ msgstr "Kalibracia XYZ zlyhala. Lavy predny bod je nedostupny"

--- a/lang/po/Firmware_sl.po
+++ b/lang/po/Firmware_sl.po
@@ -26,113 +26,113 @@ msgid " 0.4 or newer"
 msgstr ""
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:7036
+#: ../../Firmware/ultralcd.cpp:7066
 msgid "%s level expected"
 msgstr ""
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1968
-#: ../../Firmware/ultralcd.cpp:3835
+#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1987
+#: ../../Firmware/ultralcd.cpp:3854
 msgid ">Cancel"
 msgstr ""
 
 #. MSG_BABYSTEPPING_Z c=15
 #. Beware: must include the ':' as its last character
-#: ../../Firmware/ultralcd.cpp:2670
+#: ../../Firmware/ultralcd.cpp:2689
 msgid "Adjusting Z:"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:7313
+#: ../../Firmware/ultralcd.cpp:7343
 msgid "All correct"
 msgstr ""
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4180
+#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4190
+#: ../../Firmware/ultralcd.cpp:4199
 msgid "All is done. Happy printing!"
 msgstr ""
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4404
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4423
 msgid "Alphabet"
 msgstr ""
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4308
+#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4327
 msgid "Always"
 msgstr ""
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1405
+#: ../../Firmware/ultralcd.cpp:1424
 msgid "Ambient"
 msgstr ""
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2983
+#: ../../Firmware/ultralcd.cpp:3002
 msgid "Are left and right Z~carriages all up?"
 msgstr ""
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4478
 msgid "Assist"
 msgstr ""
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:5886
 msgid "Auto"
 msgstr ""
 
 #. MSG_AUTO_HOME c=18
 #: ../../Firmware/Marlin_main.cpp:3271 ../../Firmware/messages.cpp:9
-#: ../../Firmware/ultralcd.cpp:4900
+#: ../../Firmware/ultralcd.cpp:4919
 msgid "Auto home"
 msgstr ""
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:4364
-#: ../../Firmware/ultralcd.cpp:5779
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:4383
+#: ../../Firmware/ultralcd.cpp:5801
 msgid "Auto power"
 msgstr ""
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5572
+#: ../../Firmware/ultralcd.cpp:5594
 msgid "AutoLoad filament"
 msgstr ""
 
 #. MSG_AUTOLOADING_ONLY_IF_FSENS_ON c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3549
+#: ../../Firmware/ultralcd.cpp:3568
 msgid ""
 "Autoloading filament available only when filament sensor is turned on..."
 msgstr ""
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2301
+#: ../../Firmware/ultralcd.cpp:2320
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:7015
+#: ../../Firmware/ultralcd.cpp:7045
 msgid "Axis"
 msgstr ""
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:7014
+#: ../../Firmware/ultralcd.cpp:7044
 msgid "Axis length"
 msgstr ""
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:2751
-#: ../../Firmware/ultralcd.cpp:5861 ../../Firmware/ultralcd.cpp:7838
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:2770
+#: ../../Firmware/ultralcd.cpp:5883 ../../Firmware/ultralcd.cpp:7878
 msgid "Back"
 msgstr ""
 
 #. MSG_BED c=13
 #: ../../Firmware/Marlin_main.cpp:2051 ../../Firmware/Marlin_main.cpp:4767
 #: ../../Firmware/Marlin_main.cpp:4819 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:1403 ../../Firmware/ultralcd.cpp:5721
-#: ../../Firmware/ultralcd.cpp:5891
+#: ../../Firmware/ultralcd.cpp:1422 ../../Firmware/ultralcd.cpp:5743
+#: ../../Firmware/ultralcd.cpp:5913
 msgid "Bed"
 msgstr ""
 
@@ -149,7 +149,7 @@ msgid "Bed done"
 msgstr ""
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4912
+#: ../../Firmware/ultralcd.cpp:4931
 msgid "Bed level correct"
 msgstr ""
 
@@ -165,18 +165,18 @@ msgid ""
 msgstr ""
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6972
+#: ../../Firmware/ultralcd.cpp:7002
 msgid "Bed/Heater"
 msgstr ""
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1458
-#: ../../Firmware/ultralcd.cpp:1726
+#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1477
+#: ../../Firmware/ultralcd.cpp:1745
 msgid "Belt status"
 msgstr ""
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4902
+#: ../../Firmware/ultralcd.cpp:4921
 msgid "Belt test"
 msgstr ""
 
@@ -187,28 +187,28 @@ msgid "Blackout occurred. Recover print?"
 msgstr ""
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:5886
 msgid "Bright"
 msgstr ""
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4850
-#: ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4869
+#: ../../Firmware/ultralcd.cpp:5811
 msgid "Brightness"
 msgstr ""
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4906
+#: ../../Firmware/ultralcd.cpp:4925
 msgid "Calibrate XYZ"
 msgstr ""
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4908
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4927
 msgid "Calibrate Z"
 msgstr ""
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2946
+#: ../../Firmware/ultralcd.cpp:2965
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -221,19 +221,19 @@ msgid "Calibrating Z"
 msgstr ""
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2945
+#: ../../Firmware/ultralcd.cpp:2964
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
 msgstr ""
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:7315
+#: ../../Firmware/ultralcd.cpp:7345
 msgid "Calibrating home"
 msgstr ""
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:5581
+#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:5603
 msgid "Calibration"
 msgstr ""
 
@@ -243,115 +243,115 @@ msgid "Calibration done"
 msgstr ""
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7712
+#: ../../Firmware/ultralcd.cpp:7752
 msgid "Card removed"
 msgstr ""
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/ultralcd.cpp:5560
 msgid "Change SD card"
 msgstr ""
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5497
-#: ../../Firmware/ultralcd.cpp:5730
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5519
+#: ../../Firmware/ultralcd.cpp:5752
 msgid "Change filament"
 msgstr ""
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2163
+#: ../../Firmware/ultralcd.cpp:2182
 msgid "Change success!"
 msgstr ""
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2215
+#: ../../Firmware/ultralcd.cpp:2234
 msgid "Changed correctly?"
 msgstr ""
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:6178
-#: ../../Firmware/ultralcd.cpp:7305
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:6208
+#: ../../Firmware/ultralcd.cpp:7335
 msgid "Checking X axis"
 msgstr ""
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:6187
-#: ../../Firmware/ultralcd.cpp:7306
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:6217
+#: ../../Firmware/ultralcd.cpp:7336
 msgid "Checking Y axis"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:7307
+#: ../../Firmware/ultralcd.cpp:7337
 msgid "Checking Z axis"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:7308
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:7338
 msgid "Checking bed"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:7304
+#: ../../Firmware/ultralcd.cpp:7334
 msgid "Checking endstops"
 msgstr ""
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:7403
+#: ../../Firmware/ultralcd.cpp:7433
 msgid "Checking file"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:7310
+#: ../../Firmware/ultralcd.cpp:7340
 msgid "Checking hotend"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:7311
-#: ../../Firmware/ultralcd.cpp:7312
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:7341
+#: ../../Firmware/ultralcd.cpp:7342
 msgid "Checking sensors"
 msgstr ""
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4765
+#: ../../Firmware/ultralcd.cpp:4784
 msgid "Checks"
 msgstr ""
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2218
+#: ../../Firmware/ultralcd.cpp:2237
 msgid "Color not correct"
 msgstr ""
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3725
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3744
 msgid "Community made"
 msgstr ""
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4704
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4723
 msgid "Cont."
 msgstr ""
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2125
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2144
 msgid "Cooldown"
 msgstr ""
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3663
+#: ../../Firmware/ultralcd.cpp:3682
 msgid "Copy selected language?"
 msgstr ""
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1221
-#: ../../Firmware/ultralcd.cpp:1262 ../../Firmware/ultralcd.cpp:1272
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1240
+#: ../../Firmware/ultralcd.cpp:1281 ../../Firmware/ultralcd.cpp:1291
 msgid "Crash"
 msgstr ""
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4341
-#: ../../Firmware/ultralcd.cpp:4342 ../../Firmware/ultralcd.cpp:4344
-#: ../../Firmware/ultralcd.cpp:5765 ../../Firmware/ultralcd.cpp:5767
-#: ../../Firmware/ultralcd.cpp:5771
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4363
+#: ../../Firmware/ultralcd.cpp:5787 ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/ultralcd.cpp:5793
 msgid "Crash det."
 msgstr ""
 
@@ -361,7 +361,7 @@ msgid "Crash detected."
 msgstr ""
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3521
+#: ../../Firmware/ultralcd.cpp:3540
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -369,14 +369,14 @@ msgid ""
 msgstr ""
 
 #. MSG_CUT_FILAMENT c=17
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:5175
-#: ../../Firmware/ultralcd.cpp:5567
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:5197
+#: ../../Firmware/ultralcd.cpp:5589
 msgid "Cut filament"
 msgstr ""
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:4303
-#: ../../Firmware/ultralcd.cpp:4308 ../../Firmware/ultralcd.cpp:4313
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:4322
+#: ../../Firmware/ultralcd.cpp:4327 ../../Firmware/ultralcd.cpp:4332
 msgid "Cutter"
 msgstr ""
 
@@ -386,17 +386,17 @@ msgid "Cutting filament"
 msgstr ""
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1668
+#: ../../Firmware/ultralcd.cpp:1687
 msgid "Date:"
 msgstr ""
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5886
 msgid "Dim"
 msgstr ""
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4802
+#: ../../Firmware/ultralcd.cpp:4821
 msgid "Disable steppers"
 msgstr ""
 
@@ -410,30 +410,30 @@ msgid ""
 msgstr ""
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:4145
+#: ../../Firmware/ultralcd.cpp:4164
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
 msgstr ""
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4214
+#: ../../Firmware/ultralcd.cpp:4233
 msgid "E-correct:"
 msgstr ""
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2279
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2298
 msgid "ERROR:"
 msgstr ""
 
 #. MSG_FSENS_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3562
+#: ../../Firmware/ultralcd.cpp:3581
 msgid "ERROR: Filament sensor is not responding, please check connection."
 msgstr ""
 
 #. MSG_EJECT_FILAMENT c=17
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:5156
-#: ../../Firmware/ultralcd.cpp:5565
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:5178
+#: ../../Firmware/ultralcd.cpp:5587
 msgid "Eject filament"
 msgstr ""
 
@@ -443,47 +443,41 @@ msgid "Ejecting filament"
 msgstr ""
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6985
+#: ../../Firmware/ultralcd.cpp:7015
 msgid "Endstop"
 msgstr ""
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6990
+#: ../../Firmware/ultralcd.cpp:7020
 msgid "Endstop not hit"
 msgstr ""
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6976
+#: ../../Firmware/ultralcd.cpp:7006
 msgid "Endstops"
 msgstr ""
 
 #. MSG_EXTRUDER c=17
 #: ../../Firmware/Marlin_main.cpp:8608 ../../Firmware/messages.cpp:30
-#: ../../Firmware/ultralcd.cpp:3495
+#: ../../Firmware/ultralcd.cpp:3514
 msgid "Extruder"
 msgstr ""
 
-#. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1144
-#: ../../Firmware/ultralcd.cpp:7319
-msgid "Hotend fan:"
-msgstr ""
-
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1722
+#: ../../Firmware/ultralcd.cpp:1741
 msgid "Extruder info"
 msgstr ""
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4229
-#: ../../Firmware/ultralcd.cpp:4237 ../../Firmware/ultralcd.cpp:4248
-#: ../../Firmware/ultralcd.cpp:4250
+#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4248
+#: ../../Firmware/ultralcd.cpp:4256 ../../Firmware/ultralcd.cpp:4267
+#: ../../Firmware/ultralcd.cpp:4269
 msgid "F. autoload"
 msgstr ""
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4704
-#: ../../Firmware/ultralcd.cpp:4707
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4723
+#: ../../Firmware/ultralcd.cpp:4726
 msgid "FS Action"
 msgstr ""
 
@@ -498,102 +492,102 @@ msgid "FS v0.4 or newer"
 msgstr ""
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5589
+#: ../../Firmware/ultralcd.cpp:5611
 msgid "Fail stats"
 msgstr ""
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5592
+#: ../../Firmware/ultralcd.cpp:5614
 msgid "Fail stats MMU"
 msgstr ""
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:7031
+#: ../../Firmware/ultralcd.cpp:7061
 msgid "False triggering"
 msgstr ""
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:5723
-#: ../../Firmware/ultralcd.cpp:5893
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/ultralcd.cpp:5915
 msgid "Fan speed"
 msgstr ""
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:7143
-#: ../../Firmware/ultralcd.cpp:7301 ../../Firmware/ultralcd.cpp:7302
-#: ../../Firmware/ultralcd.cpp:7303
+#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:7173
+#: ../../Firmware/ultralcd.cpp:7331 ../../Firmware/ultralcd.cpp:7332
+#: ../../Firmware/ultralcd.cpp:7333
 msgid "Fan test"
 msgstr ""
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4811
-#: ../../Firmware/ultralcd.cpp:5756
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4830
+#: ../../Firmware/ultralcd.cpp:5778
 msgid "Fans check"
 msgstr ""
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1220
-#: ../../Firmware/ultralcd.cpp:1261 ../../Firmware/ultralcd.cpp:1327
-#: ../../Firmware/ultralcd.cpp:1329
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1239
+#: ../../Firmware/ultralcd.cpp:1280 ../../Firmware/ultralcd.cpp:1346
+#: ../../Firmware/ultralcd.cpp:1348
 msgid "Fil. runouts"
 msgstr ""
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:3451
-#: ../../Firmware/ultralcd.cpp:4228 ../../Firmware/ultralcd.cpp:4234
-#: ../../Firmware/ultralcd.cpp:4244 ../../Firmware/ultralcd.cpp:5737
-#: ../../Firmware/ultralcd.cpp:5741 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:3470
+#: ../../Firmware/ultralcd.cpp:4247 ../../Firmware/ultralcd.cpp:4253
+#: ../../Firmware/ultralcd.cpp:4263 ../../Firmware/ultralcd.cpp:5759
+#: ../../Firmware/ultralcd.cpp:5763 ../../Firmware/ultralcd.cpp:5767
 msgid "Fil. sensor"
 msgstr ""
 
 #. MSG_FILAMENT c=17
 #: ../../Firmware/Marlin_main.cpp:8577 ../../Firmware/Marlin_main.cpp:8604
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3835
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3854
 msgid "Filament"
 msgstr ""
 
 #. MSG_FILAMENT_CLEAN c=20 r=2
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2287
-#: ../../Firmware/ultralcd.cpp:2293
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2306
+#: ../../Firmware/ultralcd.cpp:2312
 msgid "Filament extruding & with correct color?"
 msgstr ""
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2217
+#: ../../Firmware/ultralcd.cpp:2236
 msgid "Filament not loaded"
 msgstr ""
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:7026
-#: ../../Firmware/ultralcd.cpp:7030 ../../Firmware/ultralcd.cpp:7034
-#: ../../Firmware/ultralcd.cpp:7330
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:7056
+#: ../../Firmware/ultralcd.cpp:7060 ../../Firmware/ultralcd.cpp:7064
+#: ../../Firmware/ultralcd.cpp:7360
 msgid "Filament sensor"
 msgstr ""
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2365
+#: ../../Firmware/ultralcd.cpp:2384
 msgid "Filament used"
 msgstr ""
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7461
+#: ../../Firmware/ultralcd.cpp:7491
 msgid "File incomplete. Continue anyway?"
 msgstr ""
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:5314
-#: ../../Firmware/ultralcd.cpp:5630
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:5336
+#: ../../Firmware/ultralcd.cpp:5652
 msgid "Finishing movements"
 msgstr ""
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:4898
-#: ../../Firmware/ultralcd.cpp:5424
+#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:4917
+#: ../../Firmware/ultralcd.cpp:5446
 msgid "First layer cal."
 msgstr ""
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4066
+#: ../../Firmware/ultralcd.cpp:4085
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 
@@ -603,23 +597,23 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr ""
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5724
+#: ../../Firmware/ultralcd.cpp:5746
 msgid "Flow"
 msgstr ""
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:6996
-#: ../../Firmware/ultralcd.cpp:7149 ../../Firmware/ultralcd.cpp:7154
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:7026
+#: ../../Firmware/ultralcd.cpp:7179 ../../Firmware/ultralcd.cpp:7184
 msgid "Front print fan?"
 msgstr ""
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2754
+#: ../../Firmware/ultralcd.cpp:2773
 msgid "Front side[μm]"
 msgstr ""
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:7020
+#: ../../Firmware/ultralcd.cpp:7050
 msgid "Front/left fans"
 msgstr ""
 
@@ -662,20 +656,20 @@ msgid ""
 msgstr ""
 
 #. MSG_GCODE c=8
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:4655
-#: ../../Firmware/ultralcd.cpp:4658 ../../Firmware/ultralcd.cpp:4661
-#: ../../Firmware/ultralcd.cpp:4664
+#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:4674
+#: ../../Firmware/ultralcd.cpp:4677 ../../Firmware/ultralcd.cpp:4680
+#: ../../Firmware/ultralcd.cpp:4683
 msgid "Gcode"
 msgstr ""
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:4672
-#: ../../Firmware/ultralcd.cpp:4726 ../../Firmware/ultralcd.cpp:4818
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:4691
+#: ../../Firmware/ultralcd.cpp:4745 ../../Firmware/ultralcd.cpp:4837
 msgid "HW Setup"
 msgstr ""
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6968
+#: ../../Firmware/ultralcd.cpp:6998
 msgid "Heater/Thermistor"
 msgstr ""
 
@@ -697,7 +691,7 @@ msgid "Heating done."
 msgstr ""
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=16
-#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4042
+#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4061
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -705,7 +699,7 @@ msgid ""
 msgstr ""
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4064
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -714,24 +708,30 @@ msgstr ""
 "skozi postopek nastavitve?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:4358
-#: ../../Firmware/ultralcd.cpp:4367 ../../Firmware/ultralcd.cpp:5777
-#: ../../Firmware/ultralcd.cpp:5780
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:4377
+#: ../../Firmware/ultralcd.cpp:4386 ../../Firmware/ultralcd.cpp:5799
+#: ../../Firmware/ultralcd.cpp:5802
 msgid "High power"
 msgstr ""
 
+#. MSG_HOTEND_FAN_SPEED c=15
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1145
+#: ../../Firmware/ultralcd.cpp:7351
+msgid "Hotend fan:"
+msgstr ""
+
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4094
 msgid "I will run xyz calibration now. It will take approx. 12 mins."
 msgstr ""
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/ultralcd.cpp:4102
 msgid "I will run z calibration now."
 msgstr ""
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=9
-#: ../../Firmware/ultralcd.cpp:4153
+#: ../../Firmware/ultralcd.cpp:4172
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -743,36 +743,36 @@ msgid "Improving bed calibration point"
 msgstr ""
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:5478
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:5500
 msgid "Info screen"
 msgstr ""
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5545
+#: ../../Firmware/ultralcd.cpp:5567
 msgid "Init. SD card"
 msgstr ""
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2152
+#: ../../Firmware/ultralcd.cpp:2171
 msgid "Insert filament"
 msgstr ""
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:6223
+#: ../../Firmware/ultralcd.cpp:6253
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
 msgstr ""
 
 #. MSG_FILAMENT_LOADED c=20 r=2
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3855
-#: ../../Firmware/ultralcd.cpp:4108 ../../Firmware/ultralcd.cpp:4111
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3874
+#: ../../Firmware/ultralcd.cpp:4127 ../../Firmware/ultralcd.cpp:4130
 msgid "Is filament loaded?"
 msgstr ""
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=2
 #: ../../Firmware/Marlin_main.cpp:3312 ../../Firmware/Marlin_main.cpp:4886
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:4084
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:4103
 msgid "Is steel sheet on heatbed?"
 msgstr ""
 
@@ -782,74 +782,74 @@ msgid "Iteration"
 msgstr ""
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:1148
-#: ../../Firmware/ultralcd.cpp:1296
+#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:1167
+#: ../../Firmware/ultralcd.cpp:1315
 msgid "Last print"
 msgstr ""
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1169
-#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1269
-#: ../../Firmware/ultralcd.cpp:1326
+#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1188
+#: ../../Firmware/ultralcd.cpp:1278 ../../Firmware/ultralcd.cpp:1288
+#: ../../Firmware/ultralcd.cpp:1345
 msgid "Last print failures"
 msgstr ""
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2496
+#: ../../Firmware/ultralcd.cpp:2515
 msgid "Left"
 msgstr ""
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7001
-#: ../../Firmware/ultralcd.cpp:7147 ../../Firmware/ultralcd.cpp:7152
+#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:7032
+#: ../../Firmware/ultralcd.cpp:7179 ../../Firmware/ultralcd.cpp:7184
 msgid "Left hotend fan?"
 msgstr ""
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2752
+#: ../../Firmware/ultralcd.cpp:2771
 msgid "Left side [μm]"
 msgstr ""
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:5862
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:5884
 msgid "Level Bright"
 msgstr ""
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:5863
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:5885
 msgid "Level Dimmed"
 msgstr ""
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4826
+#: ../../Firmware/ultralcd.cpp:4845
 msgid "Lin. correction"
 msgstr ""
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4838
-#: ../../Firmware/ultralcd.cpp:5493
+#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4857
+#: ../../Firmware/ultralcd.cpp:5515
 msgid "Live adjust Z"
 msgstr ""
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/ultralcd.cpp:5120
+#: ../../Firmware/ultralcd.cpp:5142
 msgid "Load all"
 msgstr ""
 
 #. MSG_LOAD_FILAMENT c=17
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:5122
-#: ../../Firmware/ultralcd.cpp:5133 ../../Firmware/ultralcd.cpp:5562
-#: ../../Firmware/ultralcd.cpp:5576
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:5144
+#: ../../Firmware/ultralcd.cpp:5155 ../../Firmware/ultralcd.cpp:5584
+#: ../../Firmware/ultralcd.cpp:5598
 msgid "Load filament"
 msgstr ""
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5563
+#: ../../Firmware/ultralcd.cpp:5585
 msgid "Load to nozzle"
 msgstr ""
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2185
+#: ../../Firmware/ultralcd.cpp:2204
 msgid "Loading color"
 msgstr ""
 
@@ -857,18 +857,18 @@ msgstr ""
 #: ../../Firmware/Marlin_main.cpp:3641 ../../Firmware/messages.cpp:55
 #: ../../Firmware/mmu.cpp:872 ../../Firmware/mmu.cpp:906
 #: ../../Firmware/mmu.cpp:1014 ../../Firmware/mmu.cpp:1026
-#: ../../Firmware/ultralcd.cpp:2196 ../../Firmware/ultralcd.cpp:3949
+#: ../../Firmware/ultralcd.cpp:2215 ../../Firmware/ultralcd.cpp:3968
 msgid "Loading filament"
 msgstr ""
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:7008
+#: ../../Firmware/ultralcd.cpp:7038
 msgid "Loose pulley"
 msgstr ""
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:4450
-#: ../../Firmware/ultralcd.cpp:4462
+#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/ultralcd.cpp:4481
 msgid "Loud"
 msgstr ""
 
@@ -883,8 +883,8 @@ msgid "MK3S firmware detected on MK3 printer"
 msgstr ""
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4381
-#: ../../Firmware/ultralcd.cpp:4382
+#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4400
+#: ../../Firmware/ultralcd.cpp:4401
 msgid "MMU Mode"
 msgstr ""
 
@@ -904,8 +904,8 @@ msgid "MMU OK. Resuming..."
 msgstr ""
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:64 ../../Firmware/ultralcd.cpp:1170
-#: ../../Firmware/ultralcd.cpp:1193
+#: ../../Firmware/messages.cpp:64 ../../Firmware/ultralcd.cpp:1189
+#: ../../Firmware/ultralcd.cpp:1212
 msgid "MMU fails"
 msgstr ""
 
@@ -915,8 +915,8 @@ msgid "MMU load failed"
 msgstr ""
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:1171
-#: ../../Firmware/ultralcd.cpp:1194
+#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:1190
+#: ../../Firmware/ultralcd.cpp:1213
 msgid "MMU load fails"
 msgstr ""
 
@@ -926,32 +926,32 @@ msgid "MMU needs user attention."
 msgstr ""
 
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/ultralcd.cpp:1195
+#: ../../Firmware/ultralcd.cpp:1214
 msgid "MMU power fails"
 msgstr ""
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1680
+#: ../../Firmware/ultralcd.cpp:1699
 msgid "MMU2 connected"
 msgstr ""
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:5836
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:5858
 msgid "Magnets comp."
 msgstr ""
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1147
-#: ../../Firmware/ultralcd.cpp:1295 ../../Firmware/ultralcd.cpp:1338
-#: ../../Firmware/ultralcd.cpp:1645 ../../Firmware/ultralcd.cpp:4795
-#: ../../Firmware/ultralcd.cpp:4892 ../../Firmware/ultralcd.cpp:5119
-#: ../../Firmware/ultralcd.cpp:5131 ../../Firmware/ultralcd.cpp:5154
-#: ../../Firmware/ultralcd.cpp:5173 ../../Firmware/ultralcd.cpp:5717
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1166
+#: ../../Firmware/ultralcd.cpp:1314 ../../Firmware/ultralcd.cpp:1357
+#: ../../Firmware/ultralcd.cpp:1664 ../../Firmware/ultralcd.cpp:4814
+#: ../../Firmware/ultralcd.cpp:4911 ../../Firmware/ultralcd.cpp:5141
+#: ../../Firmware/ultralcd.cpp:5153 ../../Firmware/ultralcd.cpp:5176
+#: ../../Firmware/ultralcd.cpp:5195 ../../Firmware/ultralcd.cpp:5739
 msgid "Main"
 msgstr ""
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2537
+#: ../../Firmware/ultralcd.cpp:2556
 msgid "Measured skew"
 msgstr ""
 
@@ -962,71 +962,71 @@ msgid "Measuring reference height of calibration point"
 msgstr ""
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:5832
+#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:5854
 msgid "Mesh"
 msgstr ""
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4823
-#: ../../Firmware/ultralcd.cpp:4910
+#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4842
+#: ../../Firmware/ultralcd.cpp:4929
 msgid "Mesh Bed Leveling"
 msgstr ""
 
 #. MSG_MODE c=6
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:4336
-#: ../../Firmware/ultralcd.cpp:4338 ../../Firmware/ultralcd.cpp:4358
-#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4364
-#: ../../Firmware/ultralcd.cpp:4367 ../../Firmware/ultralcd.cpp:5763
-#: ../../Firmware/ultralcd.cpp:5770 ../../Firmware/ultralcd.cpp:5777
-#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5779
-#: ../../Firmware/ultralcd.cpp:5780 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/ultralcd.cpp:4357 ../../Firmware/ultralcd.cpp:4377
+#: ../../Firmware/ultralcd.cpp:4380 ../../Firmware/ultralcd.cpp:4383
+#: ../../Firmware/ultralcd.cpp:4386 ../../Firmware/ultralcd.cpp:5785
+#: ../../Firmware/ultralcd.cpp:5792 ../../Firmware/ultralcd.cpp:5799
+#: ../../Firmware/ultralcd.cpp:5800 ../../Firmware/ultralcd.cpp:5801
+#: ../../Firmware/ultralcd.cpp:5802 ../../Firmware/ultralcd.cpp:5886
 msgid "Mode"
 msgstr ""
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3598
+#: ../../Firmware/ultralcd.cpp:3617
 msgid "Mode change in progress..."
 msgstr ""
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:4575
-#: ../../Firmware/ultralcd.cpp:4578 ../../Firmware/ultralcd.cpp:4581
-#: ../../Firmware/ultralcd.cpp:4584
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:4594
+#: ../../Firmware/ultralcd.cpp:4597 ../../Firmware/ultralcd.cpp:4600
+#: ../../Firmware/ultralcd.cpp:4603
 msgid "Model"
 msgstr ""
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6982
-#: ../../Firmware/ultralcd.cpp:6991 ../../Firmware/ultralcd.cpp:7009
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:7012
+#: ../../Firmware/ultralcd.cpp:7021 ../../Firmware/ultralcd.cpp:7039
 msgid "Motor"
 msgstr ""
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3492
+#: ../../Firmware/ultralcd.cpp:3511
 msgid "Move X"
 msgstr ""
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3493
+#: ../../Firmware/ultralcd.cpp:3512
 msgid "Move Y"
 msgstr ""
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3494
+#: ../../Firmware/ultralcd.cpp:3513
 msgid "Move Z"
 msgstr ""
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4801
+#: ../../Firmware/ultralcd.cpp:4820
 msgid "Move axis"
 msgstr ""
 
 #. MSG_NA c=3
 #: ../../Firmware/menu.cpp:196 ../../Firmware/messages.cpp:124
-#: ../../Firmware/ultralcd.cpp:2502 ../../Firmware/ultralcd.cpp:2547
-#: ../../Firmware/ultralcd.cpp:3411 ../../Firmware/ultralcd.cpp:4228
-#: ../../Firmware/ultralcd.cpp:4276 ../../Firmware/ultralcd.cpp:5737
-#: ../../Firmware/ultralcd.cpp:5836
+#: ../../Firmware/ultralcd.cpp:2521 ../../Firmware/ultralcd.cpp:2566
+#: ../../Firmware/ultralcd.cpp:3430 ../../Firmware/ultralcd.cpp:4247
+#: ../../Firmware/ultralcd.cpp:4295 ../../Firmware/ultralcd.cpp:5759
+#: ../../Firmware/ultralcd.cpp:5858
 msgid "N/A"
 msgstr ""
 
@@ -1036,14 +1036,14 @@ msgid "New firmware version available:"
 msgstr ""
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:2804
-#: ../../Firmware/ultralcd.cpp:3180 ../../Firmware/ultralcd.cpp:4785
-#: ../../Firmware/ultralcd.cpp:5988
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:2823
+#: ../../Firmware/ultralcd.cpp:3199 ../../Firmware/ultralcd.cpp:4804
+#: ../../Firmware/ultralcd.cpp:6018
 msgid "No"
 msgstr ""
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5543
+#: ../../Firmware/ultralcd.cpp:5565
 msgid "No SD card"
 msgstr ""
 
@@ -1053,71 +1053,71 @@ msgid "No move."
 msgstr ""
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4405
-#: ../../Firmware/ultralcd.cpp:4493 ../../Firmware/ultralcd.cpp:4502
-#: ../../Firmware/ultralcd.cpp:4575 ../../Firmware/ultralcd.cpp:4584
-#: ../../Firmware/ultralcd.cpp:4614 ../../Firmware/ultralcd.cpp:4623
-#: ../../Firmware/ultralcd.cpp:4655 ../../Firmware/ultralcd.cpp:4664
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4424
+#: ../../Firmware/ultralcd.cpp:4512 ../../Firmware/ultralcd.cpp:4521
+#: ../../Firmware/ultralcd.cpp:4594 ../../Firmware/ultralcd.cpp:4603
+#: ../../Firmware/ultralcd.cpp:4633 ../../Firmware/ultralcd.cpp:4642
+#: ../../Firmware/ultralcd.cpp:4674 ../../Firmware/ultralcd.cpp:4683
 msgid "None"
 msgstr ""
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:4336
-#: ../../Firmware/ultralcd.cpp:4381 ../../Firmware/ultralcd.cpp:4397
-#: ../../Firmware/ultralcd.cpp:4416 ../../Firmware/ultralcd.cpp:5763
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/ultralcd.cpp:4400 ../../Firmware/ultralcd.cpp:4416
+#: ../../Firmware/ultralcd.cpp:4435 ../../Firmware/ultralcd.cpp:5785
 msgid "Normal"
 msgstr ""
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6969
+#: ../../Firmware/ultralcd.cpp:6999
 msgid "Not connected"
 msgstr ""
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:7168
-#: ../../Firmware/ultralcd.cpp:7183 ../../Firmware/ultralcd.cpp:7191
+#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:7198
+#: ../../Firmware/ultralcd.cpp:7213 ../../Firmware/ultralcd.cpp:7221
 msgid "Not spinning"
 msgstr ""
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3962
+#: ../../Firmware/ultralcd.cpp:3981
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr ""
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:4091
+#: ../../Firmware/ultralcd.cpp:4110
 msgid "Now I will preheat nozzle for PLA."
 msgstr ""
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/ultralcd.cpp:4101
 msgid "Now remove the test print from steel sheet."
 msgstr ""
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:1402
-#: ../../Firmware/ultralcd.cpp:4493 ../../Firmware/ultralcd.cpp:4496
-#: ../../Firmware/ultralcd.cpp:4499 ../../Firmware/ultralcd.cpp:4502
-#: ../../Firmware/ultralcd.cpp:5720 ../../Firmware/ultralcd.cpp:5882
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:1421
+#: ../../Firmware/ultralcd.cpp:4512 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/ultralcd.cpp:4518 ../../Firmware/ultralcd.cpp:4521
+#: ../../Firmware/ultralcd.cpp:5742 ../../Firmware/ultralcd.cpp:5904
 msgid "Nozzle"
 msgstr ""
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4546
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4565
 msgid "Nozzle d."
 msgstr ""
 
 #. MSG_OFF c=3
 #: ../../Firmware/menu.cpp:467 ../../Firmware/messages.cpp:122
-#: ../../Firmware/ultralcd.cpp:4234 ../../Firmware/ultralcd.cpp:4250
-#: ../../Firmware/ultralcd.cpp:4284 ../../Firmware/ultralcd.cpp:4313
-#: ../../Firmware/ultralcd.cpp:4342 ../../Firmware/ultralcd.cpp:4811
-#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4834
-#: ../../Firmware/ultralcd.cpp:5644 ../../Firmware/ultralcd.cpp:5741
-#: ../../Firmware/ultralcd.cpp:5756 ../../Firmware/ultralcd.cpp:5767
-#: ../../Firmware/ultralcd.cpp:5836 ../../Firmware/ultralcd.cpp:7841
-#: ../../Firmware/ultralcd.cpp:7845
+#: ../../Firmware/ultralcd.cpp:4253 ../../Firmware/ultralcd.cpp:4269
+#: ../../Firmware/ultralcd.cpp:4303 ../../Firmware/ultralcd.cpp:4332
+#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4830
+#: ../../Firmware/ultralcd.cpp:4849 ../../Firmware/ultralcd.cpp:4853
+#: ../../Firmware/ultralcd.cpp:5666 ../../Firmware/ultralcd.cpp:5763
+#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/ultralcd.cpp:5858 ../../Firmware/ultralcd.cpp:7881
+#: ../../Firmware/ultralcd.cpp:7885
 msgid "Off"
 msgstr ""
 
@@ -1127,19 +1127,19 @@ msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr ""
 
 #. MSG_ON c=3
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4244
-#: ../../Firmware/ultralcd.cpp:4248 ../../Firmware/ultralcd.cpp:4280
-#: ../../Firmware/ultralcd.cpp:4303 ../../Firmware/ultralcd.cpp:4341
-#: ../../Firmware/ultralcd.cpp:4811 ../../Firmware/ultralcd.cpp:4830
-#: ../../Firmware/ultralcd.cpp:4834 ../../Firmware/ultralcd.cpp:5745
-#: ../../Firmware/ultralcd.cpp:5756 ../../Firmware/ultralcd.cpp:5765
-#: ../../Firmware/ultralcd.cpp:5836 ../../Firmware/ultralcd.cpp:7841
-#: ../../Firmware/ultralcd.cpp:7845
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4263
+#: ../../Firmware/ultralcd.cpp:4267 ../../Firmware/ultralcd.cpp:4299
+#: ../../Firmware/ultralcd.cpp:4322 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4849
+#: ../../Firmware/ultralcd.cpp:4853 ../../Firmware/ultralcd.cpp:5767
+#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5787
+#: ../../Firmware/ultralcd.cpp:5858 ../../Firmware/ultralcd.cpp:7881
+#: ../../Firmware/ultralcd.cpp:7885
 msgid "On"
 msgstr ""
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4453
+#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4472
 msgid "Once"
 msgstr ""
 
@@ -1159,7 +1159,7 @@ msgid "PID cal. finished"
 msgstr ""
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4913
+#: ../../Firmware/ultralcd.cpp:4932
 msgid "PID calibration"
 msgstr ""
 
@@ -1171,31 +1171,31 @@ msgstr ""
 #. MSG_PINDA_CALIBRATION c=13
 #: ../../Firmware/Marlin_main.cpp:4932 ../../Firmware/Marlin_main.cpp:5035
 #: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:654
-#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4920
+#: ../../Firmware/ultralcd.cpp:4849 ../../Firmware/ultralcd.cpp:4939
 msgid "PINDA cal."
 msgstr ""
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3361
+#: ../../Firmware/ultralcd.cpp:3380
 msgid "PINDA calibration failed"
 msgstr ""
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
 #: ../../Firmware/Marlin_main.cpp:5112 ../../Firmware/messages.cpp:110
-#: ../../Firmware/ultralcd.cpp:3355
+#: ../../Firmware/ultralcd.cpp:3374
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
 msgstr ""
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4707
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4726
 msgid "Pause"
 msgstr ""
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:5507
-#: ../../Firmware/ultralcd.cpp:5509
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:5529
+#: ../../Firmware/ultralcd.cpp:5531
 msgid "Pause print"
 msgstr ""
 
@@ -1207,24 +1207,24 @@ msgid ""
 msgstr ""
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:4176
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:4195
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
 msgstr ""
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:6250
+#: ../../Firmware/ultralcd.cpp:6280
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr ""
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6963
+#: ../../Firmware/ultralcd.cpp:6993
 msgid "Please check:"
 msgstr ""
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4148
+#: ../../Firmware/ultralcd.cpp:4167
 msgid "Please clean heatbed and then press the knob."
 msgstr ""
 
@@ -1234,20 +1234,20 @@ msgid "Please clean the nozzle for calibration. Click when done."
 msgstr ""
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3945
+#: ../../Firmware/ultralcd.cpp:3964
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr ""
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3940
+#: ../../Firmware/ultralcd.cpp:3959
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
 msgstr ""
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3863
+#: ../../Firmware/ultralcd.cpp:3882
 msgid "Please load filament first."
 msgstr ""
 
@@ -1258,7 +1258,7 @@ msgstr ""
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=5
 #: ../../Firmware/mesh_bed_calibration.cpp:2799 ../../Firmware/messages.cpp:70
-#: ../../Firmware/ultralcd.cpp:4085
+#: ../../Firmware/ultralcd.cpp:4104
 msgid "Please place steel sheet on heatbed."
 msgstr ""
 
@@ -1269,7 +1269,7 @@ msgid "Please press the knob to unload filament"
 msgstr ""
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:5213
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:5235
 msgid "Please pull out filament immediately"
 msgstr ""
 
@@ -1279,7 +1279,7 @@ msgid "Please remove filament and then press the knob."
 msgstr ""
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:4081
+#: ../../Firmware/ultralcd.cpp:4100
 msgid "Please remove shipping helpers first."
 msgstr ""
 
@@ -1295,7 +1295,7 @@ msgid "Please run XYZ calibration first."
 msgstr ""
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:6247
+#: ../../Firmware/ultralcd.cpp:6277
 msgid "Please unload the filament first, then repeat this action."
 msgstr ""
 
@@ -1312,54 +1312,54 @@ msgstr ""
 #. MSG_PLEASE_WAIT c=20
 #: ../../Firmware/Marlin_main.cpp:3547 ../../Firmware/Marlin_main.cpp:3563
 #: ../../Firmware/Marlin_main.cpp:7931 ../../Firmware/messages.cpp:71
-#: ../../Firmware/ultralcd.cpp:2186 ../../Firmware/ultralcd.cpp:2197
+#: ../../Firmware/ultralcd.cpp:2205 ../../Firmware/ultralcd.cpp:2216
 msgid "Please wait"
 msgstr ""
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1219
-#: ../../Firmware/ultralcd.cpp:1260 ../../Firmware/ultralcd.cpp:1270
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1238
+#: ../../Firmware/ultralcd.cpp:1279 ../../Firmware/ultralcd.cpp:1289
 msgid "Power failures"
 msgstr ""
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5502
+#: ../../Firmware/ultralcd.cpp:5524
 msgid "Preheat"
 msgstr ""
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:2280
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:2299
 msgid "Preheat the nozzle!"
 msgstr ""
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:2900
-#: ../../Firmware/ultralcd.cpp:3924 ../../Firmware/ultralcd.cpp:3926
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:2919
+#: ../../Firmware/ultralcd.cpp:3943 ../../Firmware/ultralcd.cpp:3945
 msgid "Preheating nozzle. Please wait."
 msgstr ""
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1988
+#: ../../Firmware/ultralcd.cpp:2007
 msgid "Preheating to cut"
 msgstr ""
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1985
+#: ../../Firmware/ultralcd.cpp:2004
 msgid "Preheating to eject"
 msgstr ""
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1976
+#: ../../Firmware/ultralcd.cpp:1995
 msgid "Preheating to load"
 msgstr ""
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1981
+#: ../../Firmware/ultralcd.cpp:2000
 msgid "Preheating to unload"
 msgstr ""
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1809
+#: ../../Firmware/ultralcd.cpp:1828
 msgid "Press the knob"
 msgstr ""
 
@@ -1379,13 +1379,13 @@ msgid "Print aborted"
 msgstr ""
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1144
-#: ../../Firmware/ultralcd.cpp:7322
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1145
+#: ../../Firmware/ultralcd.cpp:7354
 msgid "Print fan:"
 msgstr ""
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5535
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5557
 msgid "Print from SD"
 msgstr ""
 
@@ -1395,12 +1395,12 @@ msgid "Print paused"
 msgstr ""
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2366
+#: ../../Firmware/ultralcd.cpp:2385
 msgid "Print time"
 msgstr ""
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1711
+#: ../../Firmware/ultralcd.cpp:1730
 msgid "Printer IP Addr:"
 msgstr ""
 
@@ -1424,12 +1424,12 @@ msgid ""
 msgstr ""
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4834
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4853
 msgid "RPi port"
 msgstr ""
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2755
+#: ../../Firmware/ultralcd.cpp:2774
 msgid "Rear side [μm]"
 msgstr ""
 
@@ -1444,24 +1444,24 @@ msgid "Remove old filament and press the knob to start loading new filament."
 msgstr ""
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5426
+#: ../../Firmware/ultralcd.cpp:5448
 msgid "Rename"
 msgstr ""
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2756
-#: ../../Firmware/ultralcd.cpp:5427
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2775
+#: ../../Firmware/ultralcd.cpp:5449
 msgid "Reset"
 msgstr ""
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4917
+#: ../../Firmware/ultralcd.cpp:4936
 msgid "Reset XYZ calibr."
 msgstr ""
 
 #. MSG_RESUME_PRINT c=18
 #: ../../Firmware/Marlin_main.cpp:655 ../../Firmware/messages.cpp:81
-#: ../../Firmware/ultralcd.cpp:5521 ../../Firmware/ultralcd.cpp:5523
+#: ../../Firmware/ultralcd.cpp:5543 ../../Firmware/ultralcd.cpp:5545
 msgid "Resume print"
 msgstr ""
 
@@ -1471,31 +1471,31 @@ msgid "Resuming print"
 msgstr ""
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2497
+#: ../../Firmware/ultralcd.cpp:2516
 msgid "Right"
 msgstr ""
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2753
+#: ../../Firmware/ultralcd.cpp:2772
 msgid "Right side[μm]"
 msgstr ""
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3884
+#: ../../Firmware/ultralcd.cpp:3903
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
 msgstr ""
 
 #. MSG_RUNOUTS c=7
-#: ../../Firmware/ultralcd.cpp:1271
+#: ../../Firmware/ultralcd.cpp:1290
 msgid "Runouts"
 msgstr ""
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4395
-#: ../../Firmware/ultralcd.cpp:4397 ../../Firmware/ultralcd.cpp:4414
-#: ../../Firmware/ultralcd.cpp:4416
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4414
+#: ../../Firmware/ultralcd.cpp:4416 ../../Firmware/ultralcd.cpp:4433
+#: ../../Firmware/ultralcd.cpp:4435
 msgid "SD card"
 msgstr ""
 
@@ -1511,12 +1511,12 @@ msgid "Searching bed calibration point"
 msgstr ""
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5419
+#: ../../Firmware/ultralcd.cpp:5441
 msgid "Select"
 msgstr ""
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3966
+#: ../../Firmware/ultralcd.cpp:3985
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
@@ -1529,49 +1529,49 @@ msgstr ""
 
 #. MSG_SELECT_FILAMENT c=20
 #: ../../Firmware/Marlin_main.cpp:8577 ../../Firmware/Marlin_main.cpp:8604
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3834
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3853
 msgid "Select filament:"
 msgstr ""
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:3679
-#: ../../Firmware/ultralcd.cpp:4841
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:3698
+#: ../../Firmware/ultralcd.cpp:4860
 msgid "Select language"
 msgstr ""
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:4122
+#: ../../Firmware/ultralcd.cpp:4141
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr ""
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3971
+#: ../../Firmware/ultralcd.cpp:3990
 msgid "Select temperature which matches your material."
 msgstr ""
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6522
+#: ../../Firmware/ultralcd.cpp:6552
 msgid "Self test OK"
 msgstr ""
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:6290
+#: ../../Firmware/ultralcd.cpp:6320
 msgid "Self test start"
 msgstr ""
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4904
+#: ../../Firmware/ultralcd.cpp:4923
 msgid "Selftest"
 msgstr ""
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6962
+#: ../../Firmware/ultralcd.cpp:6992
 msgid "Selftest error!"
 msgstr ""
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:6526
-#: ../../Firmware/ultralcd.cpp:7049 ../../Firmware/ultralcd.cpp:7314
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:6556
+#: ../../Firmware/ultralcd.cpp:7079 ../../Firmware/ultralcd.cpp:7344
 msgid "Selftest failed"
 msgstr ""
 
@@ -1581,30 +1581,30 @@ msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr ""
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1723
+#: ../../Firmware/ultralcd.cpp:1742
 msgid "Sensor info"
 msgstr ""
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:6254
+#: ../../Firmware/ultralcd.cpp:6284
 msgid "Sensor verified, remove the filament now."
 msgstr ""
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2773
+#: ../../Firmware/ultralcd.cpp:2792
 msgid "Set temperature:"
 msgstr ""
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:3491
-#: ../../Firmware/ultralcd.cpp:3696 ../../Firmware/ultralcd.cpp:4206
-#: ../../Firmware/ultralcd.cpp:5580 ../../Firmware/ultralcd.cpp:5827
-#: ../../Firmware/ultralcd.cpp:5880
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:3510
+#: ../../Firmware/ultralcd.cpp:3715 ../../Firmware/ultralcd.cpp:4225
+#: ../../Firmware/ultralcd.cpp:5602 ../../Firmware/ultralcd.cpp:5849
+#: ../../Firmware/ultralcd.cpp:5902
 msgid "Settings"
 msgstr ""
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2540
+#: ../../Firmware/ultralcd.cpp:2559
 msgid "Severe skew"
 msgstr ""
 
@@ -1615,7 +1615,7 @@ msgid "Sheet"
 msgstr ""
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3824
+#: ../../Firmware/ultralcd.cpp:3843
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1624,18 +1624,18 @@ msgid ""
 msgstr ""
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4915
+#: ../../Firmware/ultralcd.cpp:4934
 msgid "Show end stops"
 msgstr ""
 
 #. MSG_SILENT c=7
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4361
-#: ../../Firmware/ultralcd.cpp:4456 ../../Firmware/ultralcd.cpp:5778
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4380
+#: ../../Firmware/ultralcd.cpp:4475 ../../Firmware/ultralcd.cpp:5800
 msgid "Silent"
 msgstr ""
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2539
+#: ../../Firmware/ultralcd.cpp:2558
 msgid "Slight skew"
 msgstr ""
 
@@ -1652,8 +1652,8 @@ msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr ""
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4403
-#: ../../Firmware/ultralcd.cpp:4404 ../../Firmware/ultralcd.cpp:4405
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4422
+#: ../../Firmware/ultralcd.cpp:4423 ../../Firmware/ultralcd.cpp:4424
 msgid "Sort"
 msgstr ""
 
@@ -1664,20 +1664,20 @@ msgid "Sorting files"
 msgstr ""
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4450
-#: ../../Firmware/ultralcd.cpp:4453 ../../Firmware/ultralcd.cpp:4456
-#: ../../Firmware/ultralcd.cpp:4459 ../../Firmware/ultralcd.cpp:4462
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/ultralcd.cpp:4472 ../../Firmware/ultralcd.cpp:4475
+#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4481
 msgid "Sound"
 msgstr ""
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5718
+#: ../../Firmware/ultralcd.cpp:5740
 msgid "Speed"
 msgstr ""
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7166
-#: ../../Firmware/ultralcd.cpp:7181 ../../Firmware/ultralcd.cpp:7189
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7196
+#: ../../Firmware/ultralcd.cpp:7211 ../../Firmware/ultralcd.cpp:7219
 msgid "Spinning"
 msgstr ""
 
@@ -1687,42 +1687,42 @@ msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr ""
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5585
+#: ../../Firmware/ultralcd.cpp:5607
 msgid "Statistics"
 msgstr ""
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4338
-#: ../../Firmware/ultralcd.cpp:4382 ../../Firmware/ultralcd.cpp:5770
+#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4357
+#: ../../Firmware/ultralcd.cpp:4401 ../../Firmware/ultralcd.cpp:5792
 msgid "Stealth"
 msgstr ""
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4763
-#: ../../Firmware/ultralcd.cpp:5416
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4782
+#: ../../Firmware/ultralcd.cpp:5438
 msgid "Steel sheets"
 msgstr ""
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5528
-#: ../../Firmware/ultralcd.cpp:5987
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5550
+#: ../../Firmware/ultralcd.cpp:6017
 msgid "Stop print"
 msgstr ""
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4499
-#: ../../Firmware/ultralcd.cpp:4581 ../../Firmware/ultralcd.cpp:4620
-#: ../../Firmware/ultralcd.cpp:4661
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4518
+#: ../../Firmware/ultralcd.cpp:4600 ../../Firmware/ultralcd.cpp:4639
+#: ../../Firmware/ultralcd.cpp:4680
 msgid "Strict"
 msgstr ""
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/ultralcd.cpp:5616
 msgid "Support"
 msgstr ""
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:7021
+#: ../../Firmware/ultralcd.cpp:7051
 msgid "Swapped"
 msgstr ""
 
@@ -1731,28 +1731,18 @@ msgstr ""
 msgid "THERMAL ANOMALY"
 msgstr ""
 
-#. MSG_TM_AUTOTUNE_FAILED c=20
-#: ../../Firmware/temperature.cpp:2899
-msgid "TM autotune failed"
-msgstr ""
-
-#. MSG_TEMP_MODEL_AUTOTUNE c=20
-#: ../../Firmware/temperature.cpp:2884
-msgid "Temp. model autotune"
-msgstr ""
-
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4797
+#: ../../Firmware/ultralcd.cpp:4816
 msgid "Temperature"
 msgstr ""
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1729
+#: ../../Firmware/ultralcd.cpp:1748
 msgid "Temperatures"
 msgstr ""
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3974
+#: ../../Firmware/ultralcd.cpp:3993
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -1767,66 +1757,66 @@ msgid ""
 msgstr ""
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4403
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4422
 msgid "Time"
 msgstr ""
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:5865
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:5887
 msgid "Timeout"
 msgstr ""
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:1149
-#: ../../Firmware/ultralcd.cpp:1297
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:1168
+#: ../../Firmware/ultralcd.cpp:1316
 msgid "Total"
 msgstr ""
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:1192
-#: ../../Firmware/ultralcd.cpp:1218 ../../Firmware/ultralcd.cpp:1328
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:1211
+#: ../../Firmware/ultralcd.cpp:1237 ../../Firmware/ultralcd.cpp:1347
 msgid "Total failures"
 msgstr ""
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2387
+#: ../../Firmware/ultralcd.cpp:2406
 msgid "Total filament"
 msgstr ""
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2388
+#: ../../Firmware/ultralcd.cpp:2407
 msgid "Total print time"
 msgstr ""
 
 #. MSG_TUNE c=18
-#: ../../Firmware/ultralcd.cpp:5500
+#: ../../Firmware/ultralcd.cpp:5522
 msgid "Tune"
 msgstr ""
 
 #. MSG_UNLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:5564
-#: ../../Firmware/ultralcd.cpp:5578
+#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:5586
+#: ../../Firmware/ultralcd.cpp:5600
 msgid "Unload filament"
 msgstr ""
 
 #. MSG_UNLOADING_FILAMENT c=20
 #: ../../Firmware/messages.cpp:112 ../../Firmware/mmu.cpp:957
-#: ../../Firmware/ultralcd.cpp:5197
+#: ../../Firmware/ultralcd.cpp:5219
 msgid "Unloading filament"
 msgstr ""
 
 #. MSG_FIL_FAILED c=20 r=5
-#: ../../Firmware/ultralcd.cpp:6258
+#: ../../Firmware/ultralcd.cpp:6288
 msgid "Verification failed, remove the filament and try again."
 msgstr ""
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1732
+#: ../../Firmware/ultralcd.cpp:1751
 msgid "Voltages"
 msgstr ""
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3534
+#: ../../Firmware/ultralcd.cpp:3553
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -1840,19 +1830,19 @@ msgid "Wait for user..."
 msgstr ""
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2881
+#: ../../Firmware/ultralcd.cpp:2900
 msgid "Waiting for PINDA probe cooling"
 msgstr ""
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2913
+#: ../../Firmware/ultralcd.cpp:2932
 msgid "Waiting for nozzle and bed cooling"
 msgstr ""
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:4496
-#: ../../Firmware/ultralcd.cpp:4578 ../../Firmware/ultralcd.cpp:4617
-#: ../../Firmware/ultralcd.cpp:4658
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/ultralcd.cpp:4597 ../../Firmware/ultralcd.cpp:4636
+#: ../../Firmware/ultralcd.cpp:4677
 msgid "Warn"
 msgstr ""
 
@@ -1877,144 +1867,133 @@ msgid "Was filament unload successful?"
 msgstr ""
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6973
-#: ../../Firmware/ultralcd.cpp:6977 ../../Firmware/ultralcd.cpp:6997
-#: ../../Firmware/ultralcd.cpp:7003 ../../Firmware/ultralcd.cpp:7027
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:7003
+#: ../../Firmware/ultralcd.cpp:7007 ../../Firmware/ultralcd.cpp:7027
+#: ../../Firmware/ultralcd.cpp:7033 ../../Firmware/ultralcd.cpp:7057
 msgid "Wiring error"
 msgstr ""
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4895
+#: ../../Firmware/ultralcd.cpp:4914
 msgid "Wizard"
 msgstr ""
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4210
+#: ../../Firmware/ultralcd.cpp:4229
 msgid "X-correct:"
 msgstr ""
 
 #. MSG_XFLASH c=18
-#: ../../Firmware/ultralcd.cpp:5596
+#: ../../Firmware/ultralcd.cpp:5618
 msgid "XFLASH init"
 msgstr ""
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1721
+#: ../../Firmware/ultralcd.cpp:1740
 msgid "XYZ cal. details"
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3333
+#: ../../Firmware/ultralcd.cpp:3352
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3330
+#: ../../Firmware/ultralcd.cpp:3349
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3311
+#: ../../Firmware/ultralcd.cpp:3330
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr ""
 
-#. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_LEFT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3317
-msgid ""
-"XYZ calibration compromised. Left front calibration point not reachable."
-msgstr ""
-
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3314
+#: ../../Firmware/ultralcd.cpp:3333
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3293
+#: ../../Firmware/ultralcd.cpp:3312
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3299
+#: ../../Firmware/ultralcd.cpp:3318
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr ""
 
-#. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_LEFT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3305
-msgid "XYZ calibration failed. Left front calibration point not reachable."
-msgstr ""
-
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3296
-#: ../../Firmware/ultralcd.cpp:3324
+#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3315
+#: ../../Firmware/ultralcd.cpp:3343
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3302
+#: ../../Firmware/ultralcd.cpp:3321
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3327
+#: ../../Firmware/ultralcd.cpp:3346
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr ""
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2494
+#: ../../Firmware/ultralcd.cpp:2513
 msgid "Y distance from min"
 msgstr ""
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4211
+#: ../../Firmware/ultralcd.cpp:4230
 msgid "Y-correct:"
 msgstr ""
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:2216
-#: ../../Firmware/ultralcd.cpp:2800 ../../Firmware/ultralcd.cpp:3180
-#: ../../Firmware/ultralcd.cpp:4785 ../../Firmware/ultralcd.cpp:5989
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:2235
+#: ../../Firmware/ultralcd.cpp:2819 ../../Firmware/ultralcd.cpp:3199
+#: ../../Firmware/ultralcd.cpp:4804 ../../Firmware/ultralcd.cpp:6019
 msgid "Yes"
 msgstr ""
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:4187
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:4206
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr ""
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4231
 msgid "Z-correct:"
 msgstr ""
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:5835
+#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:5857
 msgid "Z-probe nr."
 msgstr ""
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2565
+#: ../../Firmware/ultralcd.cpp:2584
 msgid "[0;0] point offset"
 msgstr ""
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2154
+#: ../../Firmware/ultralcd.cpp:2173
 msgid "and press the knob"
 msgstr ""
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1816
+#: ../../Firmware/ultralcd.cpp:1835
 msgid "to load filament"
 msgstr ""
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1820
+#: ../../Firmware/ultralcd.cpp:1839
 msgid "to unload filament"
 msgstr ""
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1688
+#: ../../Firmware/ultralcd.cpp:1707
 msgid "unknown"
 msgstr ""
 
@@ -2024,7 +2003,7 @@ msgid "unknown state"
 msgstr ""
 
 #. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:6077
-#: ../../Firmware/ultralcd.cpp:6080
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:6107
+#: ../../Firmware/ultralcd.cpp:6110
 msgid "🔃Refresh"
 msgstr ""

--- a/lang/po/Firmware_sv.po
+++ b/lang/po/Firmware_sv.po
@@ -26,114 +26,114 @@ msgid " 0.4 or newer"
 msgstr " 0.4 el nyare"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/ultralcd.cpp:7036
+#: ../../Firmware/ultralcd.cpp:7066
 msgid "%s level expected"
 msgstr "%s nivå förväntad"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1968
-#: ../../Firmware/ultralcd.cpp:3835
+#: ../../Firmware/messages.cpp:18 ../../Firmware/ultralcd.cpp:1987
+#: ../../Firmware/ultralcd.cpp:3854
 msgid ">Cancel"
 msgstr ">Avbryt"
 
 #. MSG_BABYSTEPPING_Z c=15
 #. Beware: must include the ':' as its last character
-#: ../../Firmware/ultralcd.cpp:2670
+#: ../../Firmware/ultralcd.cpp:2689
 msgid "Adjusting Z:"
 msgstr "Justerar Z:"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/ultralcd.cpp:7313
+#: ../../Firmware/ultralcd.cpp:7343
 msgid "All correct"
 msgstr "Allt korrekt"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4171
-#: ../../Firmware/ultralcd.cpp:4180
+#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4190
+#: ../../Firmware/ultralcd.cpp:4199
 msgid "All is done. Happy printing!"
 msgstr "Allt är klart. God utskrift!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4404
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4423
 msgid "Alphabet"
 msgstr "Alfabet"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4308
+#: ../../Firmware/messages.cpp:8 ../../Firmware/ultralcd.cpp:4327
 msgid "Always"
 msgstr "Alltid"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/ultralcd.cpp:1405
+#: ../../Firmware/ultralcd.cpp:1424
 msgid "Ambient"
 msgstr "Omgivande"
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2983
+#: ../../Firmware/ultralcd.cpp:3002
 msgid "Are left and right Z~carriages all up?"
 msgstr "Är båda Z-vagnarna helt uppe?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4478
 msgid "Assist"
 msgstr "Assist"
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:5886
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
 #: ../../Firmware/Marlin_main.cpp:3271 ../../Firmware/messages.cpp:9
-#: ../../Firmware/ultralcd.cpp:4900
+#: ../../Firmware/ultralcd.cpp:4919
 msgid "Auto home"
 msgstr "Auto hem"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:4364
-#: ../../Firmware/ultralcd.cpp:5779
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:4383
+#: ../../Firmware/ultralcd.cpp:5801
 msgid "Auto power"
 msgstr "Auto kraft"
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/ultralcd.cpp:5572
+#: ../../Firmware/ultralcd.cpp:5594
 msgid "AutoLoad filament"
 msgstr "Autoladda filament"
 
 #. MSG_AUTOLOADING_ONLY_IF_FSENS_ON c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3549
+#: ../../Firmware/ultralcd.cpp:3568
 msgid ""
 "Autoloading filament available only when filament sensor is turned on..."
 msgstr "Autoladdning av fil. är endast möjligt när fil. sensorn är aktiv..."
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2301
+#: ../../Firmware/ultralcd.cpp:2320
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
 "Autoladdning filament är aktiv, tryck på knappen och sätt i filament..."
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/ultralcd.cpp:7015
+#: ../../Firmware/ultralcd.cpp:7045
 msgid "Axis"
 msgstr "Axel"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/ultralcd.cpp:7014
+#: ../../Firmware/ultralcd.cpp:7044
 msgid "Axis length"
 msgstr "Axellängd"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:2751
-#: ../../Firmware/ultralcd.cpp:5861 ../../Firmware/ultralcd.cpp:7838
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:2770
+#: ../../Firmware/ultralcd.cpp:5883 ../../Firmware/ultralcd.cpp:7878
 msgid "Back"
 msgstr "Tillbaka"
 
 #. MSG_BED c=13
 #: ../../Firmware/Marlin_main.cpp:2051 ../../Firmware/Marlin_main.cpp:4767
 #: ../../Firmware/Marlin_main.cpp:4819 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:1403 ../../Firmware/ultralcd.cpp:5721
-#: ../../Firmware/ultralcd.cpp:5891
+#: ../../Firmware/ultralcd.cpp:1422 ../../Firmware/ultralcd.cpp:5743
+#: ../../Firmware/ultralcd.cpp:5913
 msgid "Bed"
 msgstr "Bädd"
 
@@ -150,7 +150,7 @@ msgid "Bed done"
 msgstr "Bädd klar"
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/ultralcd.cpp:4912
+#: ../../Firmware/ultralcd.cpp:4931
 msgid "Bed level correct"
 msgstr "Bäddnivå korrekt"
 
@@ -168,18 +168,18 @@ msgstr ""
 "på återställning."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/ultralcd.cpp:6972
+#: ../../Firmware/ultralcd.cpp:7002
 msgid "Bed/Heater"
 msgstr "Bädd/Värmare"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1458
-#: ../../Firmware/ultralcd.cpp:1726
+#: ../../Firmware/messages.cpp:17 ../../Firmware/ultralcd.cpp:1477
+#: ../../Firmware/ultralcd.cpp:1745
 msgid "Belt status"
 msgstr "Bält status"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/ultralcd.cpp:4902
+#: ../../Firmware/ultralcd.cpp:4921
 msgid "Belt test"
 msgstr "Bält test"
 
@@ -190,28 +190,28 @@ msgid "Blackout occurred. Recover print?"
 msgstr "Blackout inträffat. Återställa utskr?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:5886
 msgid "Bright"
 msgstr "Ljus"
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4850
-#: ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4869
+#: ../../Firmware/ultralcd.cpp:5811
 msgid "Brightness"
 msgstr "Ljusstyrka"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/ultralcd.cpp:4906
+#: ../../Firmware/ultralcd.cpp:4925
 msgid "Calibrate XYZ"
 msgstr "Kalibrera XYZ"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4908
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4927
 msgid "Calibrate Z"
 msgstr "Kalibrera Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2946
+#: ../../Firmware/ultralcd.cpp:2965
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -226,7 +226,7 @@ msgid "Calibrating Z"
 msgstr "Kalibrerar Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/ultralcd.cpp:2945
+#: ../../Firmware/ultralcd.cpp:2964
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -235,12 +235,12 @@ msgstr ""
 "Klicka när du är klar."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/ultralcd.cpp:7315
+#: ../../Firmware/ultralcd.cpp:7345
 msgid "Calibrating home"
 msgstr "Kalibrerar hem"
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:5581
+#: ../../Firmware/messages.cpp:63 ../../Firmware/ultralcd.cpp:5603
 msgid "Calibration"
 msgstr "Kalibrering"
 
@@ -250,115 +250,115 @@ msgid "Calibration done"
 msgstr "Kalibraring utförd"
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/ultralcd.cpp:7712
+#: ../../Firmware/ultralcd.cpp:7752
 msgid "Card removed"
 msgstr "Kort borttaget"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5538
+#: ../../Firmware/ultralcd.cpp:5560
 msgid "Change SD card"
 msgstr "Byt ut SD-kort"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5497
-#: ../../Firmware/ultralcd.cpp:5730
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:5519
+#: ../../Firmware/ultralcd.cpp:5752
 msgid "Change filament"
 msgstr "Ändra filament"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/ultralcd.cpp:2163
+#: ../../Firmware/ultralcd.cpp:2182
 msgid "Change success!"
 msgstr "Ändring utförd!"
 
 #. MSG_CORRECTLY c=20
-#: ../../Firmware/ultralcd.cpp:2215
+#: ../../Firmware/ultralcd.cpp:2234
 msgid "Changed correctly?"
 msgstr "Ändring korrekt?"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:6178
-#: ../../Firmware/ultralcd.cpp:7305
+#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:6208
+#: ../../Firmware/ultralcd.cpp:7335
 msgid "Checking X axis"
 msgstr "Kontroll X-axel"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:6187
-#: ../../Firmware/ultralcd.cpp:7306
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:6217
+#: ../../Firmware/ultralcd.cpp:7336
 msgid "Checking Y axis"
 msgstr "Kontroll Y-axel"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/ultralcd.cpp:7307
+#: ../../Firmware/ultralcd.cpp:7337
 msgid "Checking Z axis"
 msgstr "Kontroll Z-axel"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:7308
+#: ../../Firmware/messages.cpp:89 ../../Firmware/ultralcd.cpp:7338
 msgid "Checking bed"
 msgstr "Kontroll bädd"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:7304
+#: ../../Firmware/ultralcd.cpp:7334
 msgid "Checking endstops"
 msgstr "Kontroll ändlägen"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/ultralcd.cpp:7403
+#: ../../Firmware/ultralcd.cpp:7433
 msgid "Checking file"
 msgstr "Kontrollerar fil"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/ultralcd.cpp:7310
+#: ../../Firmware/ultralcd.cpp:7340
 msgid "Checking hotend"
 msgstr "Kontroll hotend"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:7311
-#: ../../Firmware/ultralcd.cpp:7312
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:7341
+#: ../../Firmware/ultralcd.cpp:7342
 msgid "Checking sensors"
 msgstr "Kontroll sensorer"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/ultralcd.cpp:4765
+#: ../../Firmware/ultralcd.cpp:4784
 msgid "Checks"
 msgstr "Kontroller"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/ultralcd.cpp:2218
+#: ../../Firmware/ultralcd.cpp:2237
 msgid "Color not correct"
 msgstr "Färg ej korrekt"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3725
+#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:3744
 msgid "Community made"
 msgstr "Allmänhetsgjord"
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4704
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4723
 msgid "Cont."
 msgstr "Frts."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2125
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:2144
 msgid "Cooldown"
 msgstr "Kyla ner"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3663
+#: ../../Firmware/ultralcd.cpp:3682
 msgid "Copy selected language?"
 msgstr "Kopiera det valda språket?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1221
-#: ../../Firmware/ultralcd.cpp:1262 ../../Firmware/ultralcd.cpp:1272
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:1240
+#: ../../Firmware/ultralcd.cpp:1281 ../../Firmware/ultralcd.cpp:1291
 msgid "Crash"
 msgstr "Krock"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4341
-#: ../../Firmware/ultralcd.cpp:4342 ../../Firmware/ultralcd.cpp:4344
-#: ../../Firmware/ultralcd.cpp:5765 ../../Firmware/ultralcd.cpp:5767
-#: ../../Firmware/ultralcd.cpp:5771
+#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4363
+#: ../../Firmware/ultralcd.cpp:5787 ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/ultralcd.cpp:5793
 msgid "Crash det."
 msgstr "Krockdetekt."
 
@@ -368,7 +368,7 @@ msgid "Crash detected."
 msgstr "Krock upptäckt."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3521
+#: ../../Firmware/ultralcd.cpp:3540
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -379,14 +379,14 @@ msgstr ""
 "normalt läge"
 
 #. MSG_CUT_FILAMENT c=17
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:5175
-#: ../../Firmware/ultralcd.cpp:5567
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:5197
+#: ../../Firmware/ultralcd.cpp:5589
 msgid "Cut filament"
 msgstr "Skär filament"
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:4303
-#: ../../Firmware/ultralcd.cpp:4308 ../../Firmware/ultralcd.cpp:4313
+#: ../../Firmware/messages.cpp:125 ../../Firmware/ultralcd.cpp:4322
+#: ../../Firmware/ultralcd.cpp:4327 ../../Firmware/ultralcd.cpp:4332
 msgid "Cutter"
 msgstr "Skärare"
 
@@ -396,17 +396,17 @@ msgid "Cutting filament"
 msgstr "Skär filament"
 
 #. MSG_DATE c=17
-#: ../../Firmware/ultralcd.cpp:1668
+#: ../../Firmware/ultralcd.cpp:1687
 msgid "Date:"
 msgstr "Datum:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5886
 msgid "Dim"
 msgstr "Dim"
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/ultralcd.cpp:4802
+#: ../../Firmware/ultralcd.cpp:4821
 msgid "Disable steppers"
 msgstr "Inaktivera stepper"
 
@@ -422,7 +422,7 @@ msgstr ""
 "Vänligen följ manualen Första lagrets kalibrering."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:4145
+#: ../../Firmware/ultralcd.cpp:4164
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -431,23 +431,23 @@ msgstr ""
 "bädden?"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4214
+#: ../../Firmware/ultralcd.cpp:4233
 msgid "E-correct:"
 msgstr "E-korrektion:"
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2279
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2298
 msgid "ERROR:"
 msgstr "FEL:"
 
 #. MSG_FSENS_NOT_RESPONDING c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3562
+#: ../../Firmware/ultralcd.cpp:3581
 msgid "ERROR: Filament sensor is not responding, please check connection."
 msgstr "FEL: Filamentsensorn svarar inte, kontrollera anslutningen."
 
 #. MSG_EJECT_FILAMENT c=17
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:5156
-#: ../../Firmware/ultralcd.cpp:5565
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:5178
+#: ../../Firmware/ultralcd.cpp:5587
 msgid "Eject filament"
 msgstr "Mata ut filament"
 
@@ -457,47 +457,41 @@ msgid "Ejecting filament"
 msgstr "Matar ut filament"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/ultralcd.cpp:6985
+#: ../../Firmware/ultralcd.cpp:7015
 msgid "Endstop"
 msgstr "Ändläge"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/ultralcd.cpp:6990
+#: ../../Firmware/ultralcd.cpp:7020
 msgid "Endstop not hit"
 msgstr "Ändlage inte nått"
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/ultralcd.cpp:6976
+#: ../../Firmware/ultralcd.cpp:7006
 msgid "Endstops"
 msgstr "Ändlägen"
 
 #. MSG_EXTRUDER c=17
 #: ../../Firmware/Marlin_main.cpp:8608 ../../Firmware/messages.cpp:30
-#: ../../Firmware/ultralcd.cpp:3495
+#: ../../Firmware/ultralcd.cpp:3514
 msgid "Extruder"
 msgstr "Extruder"
 
-#. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1144
-#: ../../Firmware/ultralcd.cpp:7319
-msgid "Hotend fan:"
-msgstr "Hotend-fläkt:"
-
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/ultralcd.cpp:1722
+#: ../../Firmware/ultralcd.cpp:1741
 msgid "Extruder info"
 msgstr "Extruder info"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4229
-#: ../../Firmware/ultralcd.cpp:4237 ../../Firmware/ultralcd.cpp:4248
-#: ../../Firmware/ultralcd.cpp:4250
+#: ../../Firmware/messages.cpp:44 ../../Firmware/ultralcd.cpp:4248
+#: ../../Firmware/ultralcd.cpp:4256 ../../Firmware/ultralcd.cpp:4267
+#: ../../Firmware/ultralcd.cpp:4269
 msgid "F. autoload"
 msgstr "F. autoladdn"
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4704
-#: ../../Firmware/ultralcd.cpp:4707
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4723
+#: ../../Firmware/ultralcd.cpp:4726
 msgid "FS Action"
 msgstr "FS aktion"
 
@@ -512,102 +506,102 @@ msgid "FS v0.4 or newer"
 msgstr "FS v0.4 el nyare"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5589
+#: ../../Firmware/ultralcd.cpp:5611
 msgid "Fail stats"
 msgstr "Felstatistik"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/ultralcd.cpp:5592
+#: ../../Firmware/ultralcd.cpp:5614
 msgid "Fail stats MMU"
 msgstr "Felstatistik MMU"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/ultralcd.cpp:7031
+#: ../../Firmware/ultralcd.cpp:7061
 msgid "False triggering"
 msgstr "Felaktig triggning"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:5723
-#: ../../Firmware/ultralcd.cpp:5893
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/ultralcd.cpp:5915
 msgid "Fan speed"
 msgstr "Fläktfart"
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:7143
-#: ../../Firmware/ultralcd.cpp:7301 ../../Firmware/ultralcd.cpp:7302
-#: ../../Firmware/ultralcd.cpp:7303
+#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:7173
+#: ../../Firmware/ultralcd.cpp:7331 ../../Firmware/ultralcd.cpp:7332
+#: ../../Firmware/ultralcd.cpp:7333
 msgid "Fan test"
 msgstr "Fläkttest"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4811
-#: ../../Firmware/ultralcd.cpp:5756
+#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4830
+#: ../../Firmware/ultralcd.cpp:5778
 msgid "Fans check"
 msgstr "Fläktcheck"
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1220
-#: ../../Firmware/ultralcd.cpp:1261 ../../Firmware/ultralcd.cpp:1327
-#: ../../Firmware/ultralcd.cpp:1329
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:1239
+#: ../../Firmware/ultralcd.cpp:1280 ../../Firmware/ultralcd.cpp:1346
+#: ../../Firmware/ultralcd.cpp:1348
 msgid "Fil. runouts"
 msgstr "Fil. avbrott"
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:3451
-#: ../../Firmware/ultralcd.cpp:4228 ../../Firmware/ultralcd.cpp:4234
-#: ../../Firmware/ultralcd.cpp:4244 ../../Firmware/ultralcd.cpp:5737
-#: ../../Firmware/ultralcd.cpp:5741 ../../Firmware/ultralcd.cpp:5745
+#: ../../Firmware/messages.cpp:45 ../../Firmware/ultralcd.cpp:3470
+#: ../../Firmware/ultralcd.cpp:4247 ../../Firmware/ultralcd.cpp:4253
+#: ../../Firmware/ultralcd.cpp:4263 ../../Firmware/ultralcd.cpp:5759
+#: ../../Firmware/ultralcd.cpp:5763 ../../Firmware/ultralcd.cpp:5767
 msgid "Fil. sensor"
 msgstr "Fil. sensor"
 
 #. MSG_FILAMENT c=17
 #: ../../Firmware/Marlin_main.cpp:8577 ../../Firmware/Marlin_main.cpp:8604
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3835
+#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:3854
 msgid "Filament"
 msgstr "Filament"
 
 #. MSG_FILAMENT_CLEAN c=20 r=2
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2287
-#: ../../Firmware/ultralcd.cpp:2293
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:2306
+#: ../../Firmware/ultralcd.cpp:2312
 msgid "Filament extruding & with correct color?"
 msgstr "Extruderas filament med rätt färg?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/ultralcd.cpp:2217
+#: ../../Firmware/ultralcd.cpp:2236
 msgid "Filament not loaded"
 msgstr "Filament ej laddat"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:7026
-#: ../../Firmware/ultralcd.cpp:7030 ../../Firmware/ultralcd.cpp:7034
-#: ../../Firmware/ultralcd.cpp:7330
+#: ../../Firmware/messages.cpp:92 ../../Firmware/ultralcd.cpp:7056
+#: ../../Firmware/ultralcd.cpp:7060 ../../Firmware/ultralcd.cpp:7064
+#: ../../Firmware/ultralcd.cpp:7360
 msgid "Filament sensor"
 msgstr "Filament sensor"
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/ultralcd.cpp:2365
+#: ../../Firmware/ultralcd.cpp:2384
 msgid "Filament used"
 msgstr "Använt filament"
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/ultralcd.cpp:7461
+#: ../../Firmware/ultralcd.cpp:7491
 msgid "File incomplete. Continue anyway?"
 msgstr "Filen är ofullständig. Fortsätta ändå?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:5314
-#: ../../Firmware/ultralcd.cpp:5630
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:5336
+#: ../../Firmware/ultralcd.cpp:5652
 msgid "Finishing movements"
 msgstr "Avslutar flyttning"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:4898
-#: ../../Firmware/ultralcd.cpp:5424
+#: ../../Firmware/messages.cpp:121 ../../Firmware/ultralcd.cpp:4917
+#: ../../Firmware/ultralcd.cpp:5446
 msgid "First layer cal."
 msgstr "Förstalager kalib."
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4066
+#: ../../Firmware/ultralcd.cpp:4085
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Först kommer jag att utföra självtestet för att kontrollera de vanligaste "
@@ -619,23 +613,23 @@ msgid "Fix the issue and then press button on MMU unit."
 msgstr "Åtgärda problemet och tryck sedan på knappen på MMU-enheten."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/ultralcd.cpp:5724
+#: ../../Firmware/ultralcd.cpp:5746
 msgid "Flow"
 msgstr "Flöde"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:6996
-#: ../../Firmware/ultralcd.cpp:7149 ../../Firmware/ultralcd.cpp:7154
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:7026
+#: ../../Firmware/ultralcd.cpp:7179 ../../Firmware/ultralcd.cpp:7184
 msgid "Front print fan?"
 msgstr "Frontfläkt?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/ultralcd.cpp:2754
+#: ../../Firmware/ultralcd.cpp:2773
 msgid "Front side[μm]"
 msgstr "Frontsida[μm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/ultralcd.cpp:7020
+#: ../../Firmware/ultralcd.cpp:7050
 msgid "Front/left fans"
 msgstr "Front/vänster fläkt"
 
@@ -650,8 +644,8 @@ msgid ""
 "G-code sliced for a different level. Please re-slice the model again. Print "
 "cancelled."
 msgstr ""
-"G-code genererad för en annan nivå. Vänligen re-generera modellen igen. Utskriften "
-"avbröts."
+"G-code genererad för en annan nivå. Vänligen re-generera modellen igen. "
+"Utskriften avbröts."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=5
 #: ../../Firmware/messages.cpp:131 ../../Firmware/util.cpp:335
@@ -666,8 +660,8 @@ msgid ""
 "G-code sliced for a different printer type. Please re-slice the model again. "
 "Print cancelled."
 msgstr ""
-"G-code genererad för en annan skrivartyp. Vänligen re-generera modellen igen. "
-"Utskriften avbröts."
+"G-code genererad för en annan skrivartyp. Vänligen re-generera modellen "
+"igen. Utskriften avbröts."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=5
 #: ../../Firmware/util.cpp:385
@@ -684,20 +678,20 @@ msgstr ""
 "Utskriften avbröts."
 
 #. MSG_GCODE c=8
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:4655
-#: ../../Firmware/ultralcd.cpp:4658 ../../Firmware/ultralcd.cpp:4661
-#: ../../Firmware/ultralcd.cpp:4664
+#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:4674
+#: ../../Firmware/ultralcd.cpp:4677 ../../Firmware/ultralcd.cpp:4680
+#: ../../Firmware/ultralcd.cpp:4683
 msgid "Gcode"
 msgstr "Gcode"
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:4672
-#: ../../Firmware/ultralcd.cpp:4726 ../../Firmware/ultralcd.cpp:4818
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:4691
+#: ../../Firmware/ultralcd.cpp:4745 ../../Firmware/ultralcd.cpp:4837
 msgid "HW Setup"
 msgstr "HW inställning"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/ultralcd.cpp:6968
+#: ../../Firmware/ultralcd.cpp:6998
 msgid "Heater/Thermistor"
 msgstr "Värmare/Termistor"
 
@@ -719,7 +713,7 @@ msgid "Heating done."
 msgstr "Uppvärmning klar."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=16
-#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4042
+#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4061
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -730,7 +724,7 @@ msgstr ""
 "att skriva ut."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4045
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4064
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -739,25 +733,31 @@ msgstr ""
 "installationsprocessen?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:4358
-#: ../../Firmware/ultralcd.cpp:4367 ../../Firmware/ultralcd.cpp:5777
-#: ../../Firmware/ultralcd.cpp:5780
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:4377
+#: ../../Firmware/ultralcd.cpp:4386 ../../Firmware/ultralcd.cpp:5799
+#: ../../Firmware/ultralcd.cpp:5802
 msgid "High power"
 msgstr "Hög kraft"
 
+#. MSG_HOTEND_FAN_SPEED c=15
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1145
+#: ../../Firmware/ultralcd.cpp:7351
+msgid "Hotend fan:"
+msgstr "Hotend-fläkt:"
+
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4094
 msgid "I will run xyz calibration now. It will take approx. 12 mins."
 msgstr ""
 "Jag kommer att utföra en xyz-kalibrering nu. Det kommer att ta ca. 12 min."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/ultralcd.cpp:4102
 msgid "I will run z calibration now."
 msgstr "Jag kommer att utföra z-kalibrering nu."
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=9
-#: ../../Firmware/ultralcd.cpp:4153
+#: ../../Firmware/ultralcd.cpp:4172
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -771,22 +771,22 @@ msgid "Improving bed calibration point"
 msgstr "Förbättrar bäddens kalibreringspunkt"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:5478
+#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:5500
 msgid "Info screen"
 msgstr "Infoskärm"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/ultralcd.cpp:5545
+#: ../../Firmware/ultralcd.cpp:5567
 msgid "Init. SD card"
 msgstr "Init. SD-kort"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/ultralcd.cpp:2152
+#: ../../Firmware/ultralcd.cpp:2171
 msgid "Insert filament"
 msgstr "Sätt i filament"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/ultralcd.cpp:6223
+#: ../../Firmware/ultralcd.cpp:6253
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
@@ -794,14 +794,14 @@ msgstr ""
 "Infoga filamentet (ladda inte in det) i extrudern och tryck sedan på knappen."
 
 #. MSG_FILAMENT_LOADED c=20 r=2
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3855
-#: ../../Firmware/ultralcd.cpp:4108 ../../Firmware/ultralcd.cpp:4111
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3874
+#: ../../Firmware/ultralcd.cpp:4127 ../../Firmware/ultralcd.cpp:4130
 msgid "Is filament loaded?"
 msgstr "Är filament laddat?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=2
 #: ../../Firmware/Marlin_main.cpp:3312 ../../Firmware/Marlin_main.cpp:4886
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:4084
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:4103
 msgid "Is steel sheet on heatbed?"
 msgstr "Ligger metallskiva på värmebädden?"
 
@@ -811,74 +811,74 @@ msgid "Iteration"
 msgstr "Iteration"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:1148
-#: ../../Firmware/ultralcd.cpp:1296
+#: ../../Firmware/messages.cpp:52 ../../Firmware/ultralcd.cpp:1167
+#: ../../Firmware/ultralcd.cpp:1315
 msgid "Last print"
 msgstr "Senaste utskrift"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1169
-#: ../../Firmware/ultralcd.cpp:1259 ../../Firmware/ultralcd.cpp:1269
-#: ../../Firmware/ultralcd.cpp:1326
+#: ../../Firmware/messages.cpp:53 ../../Firmware/ultralcd.cpp:1188
+#: ../../Firmware/ultralcd.cpp:1278 ../../Firmware/ultralcd.cpp:1288
+#: ../../Firmware/ultralcd.cpp:1345
 msgid "Last print failures"
 msgstr "Senaste utskriftsfel"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/ultralcd.cpp:2496
+#: ../../Firmware/ultralcd.cpp:2515
 msgid "Left"
 msgstr "Vänster"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7001
-#: ../../Firmware/ultralcd.cpp:7147 ../../Firmware/ultralcd.cpp:7152
+#: ../../Firmware/messages.cpp:84 ../../Firmware/ultralcd.cpp:7032
+#: ../../Firmware/ultralcd.cpp:7179 ../../Firmware/ultralcd.cpp:7184
 msgid "Left hotend fan?"
 msgstr "Vänst hotend fläkt?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/ultralcd.cpp:2752
+#: ../../Firmware/ultralcd.cpp:2771
 msgid "Left side [μm]"
 msgstr "Vänstsida [μm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:5862
+#: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:5884
 msgid "Level Bright"
 msgstr "Ljusnivå"
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:5863
+#: ../../Firmware/messages.cpp:153 ../../Firmware/ultralcd.cpp:5885
 msgid "Level Dimmed"
 msgstr "Nivå dämpad"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/ultralcd.cpp:4826
+#: ../../Firmware/ultralcd.cpp:4845
 msgid "Lin. correction"
 msgstr "Linjär korrektion"
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4838
-#: ../../Firmware/ultralcd.cpp:5493
+#: ../../Firmware/messages.cpp:10 ../../Firmware/ultralcd.cpp:4857
+#: ../../Firmware/ultralcd.cpp:5515
 msgid "Live adjust Z"
 msgstr "Live justera Z"
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/ultralcd.cpp:5120
+#: ../../Firmware/ultralcd.cpp:5142
 msgid "Load all"
 msgstr "Ladda alla"
 
 #. MSG_LOAD_FILAMENT c=17
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:5122
-#: ../../Firmware/ultralcd.cpp:5133 ../../Firmware/ultralcd.cpp:5562
-#: ../../Firmware/ultralcd.cpp:5576
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:5144
+#: ../../Firmware/ultralcd.cpp:5155 ../../Firmware/ultralcd.cpp:5584
+#: ../../Firmware/ultralcd.cpp:5598
 msgid "Load filament"
 msgstr "Ladda filament"
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/ultralcd.cpp:5563
+#: ../../Firmware/ultralcd.cpp:5585
 msgid "Load to nozzle"
 msgstr "Ladd till munstyck"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/ultralcd.cpp:2185
+#: ../../Firmware/ultralcd.cpp:2204
 msgid "Loading color"
 msgstr "Laddar färg"
 
@@ -886,18 +886,18 @@ msgstr "Laddar färg"
 #: ../../Firmware/Marlin_main.cpp:3641 ../../Firmware/messages.cpp:55
 #: ../../Firmware/mmu.cpp:872 ../../Firmware/mmu.cpp:906
 #: ../../Firmware/mmu.cpp:1014 ../../Firmware/mmu.cpp:1026
-#: ../../Firmware/ultralcd.cpp:2196 ../../Firmware/ultralcd.cpp:3949
+#: ../../Firmware/ultralcd.cpp:2215 ../../Firmware/ultralcd.cpp:3968
 msgid "Loading filament"
 msgstr "Laddar filament"
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/ultralcd.cpp:7008
+#: ../../Firmware/ultralcd.cpp:7038
 msgid "Loose pulley"
 msgstr "Lös pulley"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:4450
-#: ../../Firmware/ultralcd.cpp:4462
+#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/ultralcd.cpp:4481
 msgid "Loud"
 msgstr "Högt"
 
@@ -912,8 +912,8 @@ msgid "MK3S firmware detected on MK3 printer"
 msgstr "MK3S-firmware upptäckt på MK3-skrivare"
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4381
-#: ../../Firmware/ultralcd.cpp:4382
+#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4400
+#: ../../Firmware/ultralcd.cpp:4401
 msgid "MMU Mode"
 msgstr "MMU-läge"
 
@@ -933,8 +933,8 @@ msgid "MMU OK. Resuming..."
 msgstr "MMU OK. Återupptar..."
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:64 ../../Firmware/ultralcd.cpp:1170
-#: ../../Firmware/ultralcd.cpp:1193
+#: ../../Firmware/messages.cpp:64 ../../Firmware/ultralcd.cpp:1189
+#: ../../Firmware/ultralcd.cpp:1212
 msgid "MMU fails"
 msgstr "MMU felar"
 
@@ -944,8 +944,8 @@ msgid "MMU load failed"
 msgstr "MMU-laddning felade"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:1171
-#: ../../Firmware/ultralcd.cpp:1194
+#: ../../Firmware/messages.cpp:65 ../../Firmware/ultralcd.cpp:1190
+#: ../../Firmware/ultralcd.cpp:1213
 msgid "MMU load fails"
 msgstr "MMU-laddn felar"
 
@@ -955,32 +955,32 @@ msgid "MMU needs user attention."
 msgstr "MMU fordrar användarens uppmärksamhet.."
 
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/ultralcd.cpp:1195
+#: ../../Firmware/ultralcd.cpp:1214
 msgid "MMU power fails"
 msgstr "MMU strömavbr."
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/ultralcd.cpp:1680
+#: ../../Firmware/ultralcd.cpp:1699
 msgid "MMU2 connected"
 msgstr "MMU2 ansluten"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:5836
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:5858
 msgid "Magnets comp."
 msgstr "Magnets komp."
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1147
-#: ../../Firmware/ultralcd.cpp:1295 ../../Firmware/ultralcd.cpp:1338
-#: ../../Firmware/ultralcd.cpp:1645 ../../Firmware/ultralcd.cpp:4795
-#: ../../Firmware/ultralcd.cpp:4892 ../../Firmware/ultralcd.cpp:5119
-#: ../../Firmware/ultralcd.cpp:5131 ../../Firmware/ultralcd.cpp:5154
-#: ../../Firmware/ultralcd.cpp:5173 ../../Firmware/ultralcd.cpp:5717
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1166
+#: ../../Firmware/ultralcd.cpp:1314 ../../Firmware/ultralcd.cpp:1357
+#: ../../Firmware/ultralcd.cpp:1664 ../../Firmware/ultralcd.cpp:4814
+#: ../../Firmware/ultralcd.cpp:4911 ../../Firmware/ultralcd.cpp:5141
+#: ../../Firmware/ultralcd.cpp:5153 ../../Firmware/ultralcd.cpp:5176
+#: ../../Firmware/ultralcd.cpp:5195 ../../Firmware/ultralcd.cpp:5739
 msgid "Main"
 msgstr "Huvudmeny"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2537
+#: ../../Firmware/ultralcd.cpp:2556
 msgid "Measured skew"
 msgstr "Mätt skevhet"
 
@@ -991,71 +991,71 @@ msgid "Measuring reference height of calibration point"
 msgstr "Mätning av referenshöjd för kalibreringspunkt"
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:5832
+#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:5854
 msgid "Mesh"
 msgstr "Nätverk"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4823
-#: ../../Firmware/ultralcd.cpp:4910
+#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4842
+#: ../../Firmware/ultralcd.cpp:4929
 msgid "Mesh Bed Leveling"
 msgstr "Bäddytsjustering"
 
 #. MSG_MODE c=6
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:4336
-#: ../../Firmware/ultralcd.cpp:4338 ../../Firmware/ultralcd.cpp:4358
-#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4364
-#: ../../Firmware/ultralcd.cpp:4367 ../../Firmware/ultralcd.cpp:5763
-#: ../../Firmware/ultralcd.cpp:5770 ../../Firmware/ultralcd.cpp:5777
-#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5779
-#: ../../Firmware/ultralcd.cpp:5780 ../../Firmware/ultralcd.cpp:5864
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/ultralcd.cpp:4357 ../../Firmware/ultralcd.cpp:4377
+#: ../../Firmware/ultralcd.cpp:4380 ../../Firmware/ultralcd.cpp:4383
+#: ../../Firmware/ultralcd.cpp:4386 ../../Firmware/ultralcd.cpp:5785
+#: ../../Firmware/ultralcd.cpp:5792 ../../Firmware/ultralcd.cpp:5799
+#: ../../Firmware/ultralcd.cpp:5800 ../../Firmware/ultralcd.cpp:5801
+#: ../../Firmware/ultralcd.cpp:5802 ../../Firmware/ultralcd.cpp:5886
 msgid "Mode"
 msgstr "Mode"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:3598
+#: ../../Firmware/ultralcd.cpp:3617
 msgid "Mode change in progress..."
 msgstr "Lägesändring pågår..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:4575
-#: ../../Firmware/ultralcd.cpp:4578 ../../Firmware/ultralcd.cpp:4581
-#: ../../Firmware/ultralcd.cpp:4584
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:4594
+#: ../../Firmware/ultralcd.cpp:4597 ../../Firmware/ultralcd.cpp:4600
+#: ../../Firmware/ultralcd.cpp:4603
 msgid "Model"
 msgstr "Modell"
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:6982
-#: ../../Firmware/ultralcd.cpp:6991 ../../Firmware/ultralcd.cpp:7009
+#: ../../Firmware/messages.cpp:91 ../../Firmware/ultralcd.cpp:7012
+#: ../../Firmware/ultralcd.cpp:7021 ../../Firmware/ultralcd.cpp:7039
 msgid "Motor"
 msgstr "Motor"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/ultralcd.cpp:3492
+#: ../../Firmware/ultralcd.cpp:3511
 msgid "Move X"
 msgstr "Flytta X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/ultralcd.cpp:3493
+#: ../../Firmware/ultralcd.cpp:3512
 msgid "Move Y"
 msgstr "Flytta Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/ultralcd.cpp:3494
+#: ../../Firmware/ultralcd.cpp:3513
 msgid "Move Z"
 msgstr "Flytta Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/ultralcd.cpp:4801
+#: ../../Firmware/ultralcd.cpp:4820
 msgid "Move axis"
 msgstr "Flytta axlar"
 
 #. MSG_NA c=3
 #: ../../Firmware/menu.cpp:196 ../../Firmware/messages.cpp:124
-#: ../../Firmware/ultralcd.cpp:2502 ../../Firmware/ultralcd.cpp:2547
-#: ../../Firmware/ultralcd.cpp:3411 ../../Firmware/ultralcd.cpp:4228
-#: ../../Firmware/ultralcd.cpp:4276 ../../Firmware/ultralcd.cpp:5737
-#: ../../Firmware/ultralcd.cpp:5836
+#: ../../Firmware/ultralcd.cpp:2521 ../../Firmware/ultralcd.cpp:2566
+#: ../../Firmware/ultralcd.cpp:3430 ../../Firmware/ultralcd.cpp:4247
+#: ../../Firmware/ultralcd.cpp:4295 ../../Firmware/ultralcd.cpp:5759
+#: ../../Firmware/ultralcd.cpp:5858
 msgid "N/A"
 msgstr "N/A"
 
@@ -1065,14 +1065,14 @@ msgid "New firmware version available:"
 msgstr "Ny firmware vers tillgänglig:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:2804
-#: ../../Firmware/ultralcd.cpp:3180 ../../Firmware/ultralcd.cpp:4785
-#: ../../Firmware/ultralcd.cpp:5988
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:2823
+#: ../../Firmware/ultralcd.cpp:3199 ../../Firmware/ultralcd.cpp:4804
+#: ../../Firmware/ultralcd.cpp:6018
 msgid "No"
 msgstr "Nej"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/ultralcd.cpp:5543
+#: ../../Firmware/ultralcd.cpp:5565
 msgid "No SD card"
 msgstr "Inget SD-kort"
 
@@ -1082,95 +1082,95 @@ msgid "No move."
 msgstr "Ingen rörelse."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4405
-#: ../../Firmware/ultralcd.cpp:4493 ../../Firmware/ultralcd.cpp:4502
-#: ../../Firmware/ultralcd.cpp:4575 ../../Firmware/ultralcd.cpp:4584
-#: ../../Firmware/ultralcd.cpp:4614 ../../Firmware/ultralcd.cpp:4623
-#: ../../Firmware/ultralcd.cpp:4655 ../../Firmware/ultralcd.cpp:4664
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4424
+#: ../../Firmware/ultralcd.cpp:4512 ../../Firmware/ultralcd.cpp:4521
+#: ../../Firmware/ultralcd.cpp:4594 ../../Firmware/ultralcd.cpp:4603
+#: ../../Firmware/ultralcd.cpp:4633 ../../Firmware/ultralcd.cpp:4642
+#: ../../Firmware/ultralcd.cpp:4674 ../../Firmware/ultralcd.cpp:4683
 msgid "None"
 msgstr "Ingen"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:4336
-#: ../../Firmware/ultralcd.cpp:4381 ../../Firmware/ultralcd.cpp:4397
-#: ../../Firmware/ultralcd.cpp:4416 ../../Firmware/ultralcd.cpp:5763
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/ultralcd.cpp:4400 ../../Firmware/ultralcd.cpp:4416
+#: ../../Firmware/ultralcd.cpp:4435 ../../Firmware/ultralcd.cpp:5785
 msgid "Normal"
 msgstr "Normal"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/ultralcd.cpp:6969
+#: ../../Firmware/ultralcd.cpp:6999
 msgid "Not connected"
 msgstr "Inte ansluten"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:7168
-#: ../../Firmware/ultralcd.cpp:7183 ../../Firmware/ultralcd.cpp:7191
+#: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:7198
+#: ../../Firmware/ultralcd.cpp:7213 ../../Firmware/ultralcd.cpp:7221
 msgid "Not spinning"
 msgstr "Roterar inte"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3962
+#: ../../Firmware/ultralcd.cpp:3981
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr ""
 "Nu ska jag kalibrera avståndet mellan munstyckets spets och värmebäddsytan."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:4091
+#: ../../Firmware/ultralcd.cpp:4110
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Nu ska jag förvärma munstycket för PLA."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:4082
+#: ../../Firmware/ultralcd.cpp:4101
 msgid "Now remove the test print from steel sheet."
 msgstr "Ta nu bort testutskriften från metallskivan."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:1402
-#: ../../Firmware/ultralcd.cpp:4493 ../../Firmware/ultralcd.cpp:4496
-#: ../../Firmware/ultralcd.cpp:4499 ../../Firmware/ultralcd.cpp:4502
-#: ../../Firmware/ultralcd.cpp:5720 ../../Firmware/ultralcd.cpp:5882
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:1421
+#: ../../Firmware/ultralcd.cpp:4512 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/ultralcd.cpp:4518 ../../Firmware/ultralcd.cpp:4521
+#: ../../Firmware/ultralcd.cpp:5742 ../../Firmware/ultralcd.cpp:5904
 msgid "Nozzle"
 msgstr "Munstycke"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4546
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:4565
 msgid "Nozzle d."
 msgstr "Munst dia."
 
 #. MSG_OFF c=3
 #: ../../Firmware/menu.cpp:467 ../../Firmware/messages.cpp:122
-#: ../../Firmware/ultralcd.cpp:4234 ../../Firmware/ultralcd.cpp:4250
-#: ../../Firmware/ultralcd.cpp:4284 ../../Firmware/ultralcd.cpp:4313
-#: ../../Firmware/ultralcd.cpp:4342 ../../Firmware/ultralcd.cpp:4811
-#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4834
-#: ../../Firmware/ultralcd.cpp:5644 ../../Firmware/ultralcd.cpp:5741
-#: ../../Firmware/ultralcd.cpp:5756 ../../Firmware/ultralcd.cpp:5767
-#: ../../Firmware/ultralcd.cpp:5836 ../../Firmware/ultralcd.cpp:7841
-#: ../../Firmware/ultralcd.cpp:7845
+#: ../../Firmware/ultralcd.cpp:4253 ../../Firmware/ultralcd.cpp:4269
+#: ../../Firmware/ultralcd.cpp:4303 ../../Firmware/ultralcd.cpp:4332
+#: ../../Firmware/ultralcd.cpp:4361 ../../Firmware/ultralcd.cpp:4830
+#: ../../Firmware/ultralcd.cpp:4849 ../../Firmware/ultralcd.cpp:4853
+#: ../../Firmware/ultralcd.cpp:5666 ../../Firmware/ultralcd.cpp:5763
+#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/ultralcd.cpp:5858 ../../Firmware/ultralcd.cpp:7881
+#: ../../Firmware/ultralcd.cpp:7885
 msgid "Off"
 msgstr "Av"
 
 #. MSG_DEFAULT_SETTINGS_LOADED c=20 r=6
 #: ../../Firmware/Marlin_main.cpp:1535
 msgid "Old settings found. Default PID, Esteps etc. will be set."
-msgstr "Gamla inställningar funna. Standard PID, Esteps etc. kommer att ställas in."
-
+msgstr ""
+"Gamla inställningar funna. Standard PID, Esteps etc. kommer att ställas in."
 
 #. MSG_ON c=3
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4244
-#: ../../Firmware/ultralcd.cpp:4248 ../../Firmware/ultralcd.cpp:4280
-#: ../../Firmware/ultralcd.cpp:4303 ../../Firmware/ultralcd.cpp:4341
-#: ../../Firmware/ultralcd.cpp:4811 ../../Firmware/ultralcd.cpp:4830
-#: ../../Firmware/ultralcd.cpp:4834 ../../Firmware/ultralcd.cpp:5745
-#: ../../Firmware/ultralcd.cpp:5756 ../../Firmware/ultralcd.cpp:5765
-#: ../../Firmware/ultralcd.cpp:5836 ../../Firmware/ultralcd.cpp:7841
-#: ../../Firmware/ultralcd.cpp:7845
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4263
+#: ../../Firmware/ultralcd.cpp:4267 ../../Firmware/ultralcd.cpp:4299
+#: ../../Firmware/ultralcd.cpp:4322 ../../Firmware/ultralcd.cpp:4360
+#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4849
+#: ../../Firmware/ultralcd.cpp:4853 ../../Firmware/ultralcd.cpp:5767
+#: ../../Firmware/ultralcd.cpp:5778 ../../Firmware/ultralcd.cpp:5787
+#: ../../Firmware/ultralcd.cpp:5858 ../../Firmware/ultralcd.cpp:7881
+#: ../../Firmware/ultralcd.cpp:7885
 msgid "On"
 msgstr "På"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4453
+#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4472
 msgid "Once"
 msgstr "En gång"
 
@@ -1190,7 +1190,7 @@ msgid "PID cal. finished"
 msgstr "PID kalibrering klar"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/ultralcd.cpp:4913
+#: ../../Firmware/ultralcd.cpp:4932
 msgid "PID calibration"
 msgstr "PID kalibrering"
 
@@ -1202,18 +1202,18 @@ msgstr "PINDA uppvärmning"
 #. MSG_PINDA_CALIBRATION c=13
 #: ../../Firmware/Marlin_main.cpp:4932 ../../Firmware/Marlin_main.cpp:5035
 #: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:654
-#: ../../Firmware/ultralcd.cpp:4830 ../../Firmware/ultralcd.cpp:4920
+#: ../../Firmware/ultralcd.cpp:4849 ../../Firmware/ultralcd.cpp:4939
 msgid "PINDA cal."
 msgstr "PINDA kal."
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3361
+#: ../../Firmware/ultralcd.cpp:3380
 msgid "PINDA calibration failed"
 msgstr "PINDA-kalibrering misslyckades"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
 #: ../../Firmware/Marlin_main.cpp:5112 ../../Firmware/messages.cpp:110
-#: ../../Firmware/ultralcd.cpp:3355
+#: ../../Firmware/ultralcd.cpp:3374
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1222,13 +1222,13 @@ msgstr ""
 "menyn Inställningar->PINDA kal."
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4707
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4726
 msgid "Pause"
 msgstr "Paus"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:5507
-#: ../../Firmware/ultralcd.cpp:5509
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:5529
+#: ../../Firmware/ultralcd.cpp:5531
 msgid "Pause print"
 msgstr "Pausa utskrift"
 
@@ -1242,7 +1242,7 @@ msgstr ""
 "punkterna. Stäng av skrivaren omedelbart om munstycket rör vid pappret.."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:4176
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:4195
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1251,17 +1251,17 @@ msgstr ""
 "starta om skrivaren."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/ultralcd.cpp:6250
+#: ../../Firmware/ultralcd.cpp:6280
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "Kontrollera IR-sensorns anslutning, mata ut eventuellt filament."
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/ultralcd.cpp:6963
+#: ../../Firmware/ultralcd.cpp:6993
 msgid "Please check:"
 msgstr "Kontrollera:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/ultralcd.cpp:4148
+#: ../../Firmware/ultralcd.cpp:4167
 msgid "Please clean heatbed and then press the knob."
 msgstr "Rengör bädden och tryck sedan på knappen."
 
@@ -1271,7 +1271,7 @@ msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Rengör munstycket för kalibrering. Klicka när du är klar."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3945
+#: ../../Firmware/ultralcd.cpp:3964
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr ""
@@ -1279,7 +1279,7 @@ msgstr ""
 "inladdning.."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3940
+#: ../../Firmware/ultralcd.cpp:3959
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1288,7 +1288,7 @@ msgstr ""
 "knappen för inladdning."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3863
+#: ../../Firmware/ultralcd.cpp:3882
 msgid "Please load filament first."
 msgstr "Vänligen ladda filament först."
 
@@ -1299,7 +1299,7 @@ msgstr "Öppna idler och ta bort filamentet manuellt."
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=5
 #: ../../Firmware/mesh_bed_calibration.cpp:2799 ../../Firmware/messages.cpp:70
-#: ../../Firmware/ultralcd.cpp:4085
+#: ../../Firmware/ultralcd.cpp:4104
 msgid "Please place steel sheet on heatbed."
 msgstr "Placera metallskiva på värmebädden."
 
@@ -1310,7 +1310,7 @@ msgid "Please press the knob to unload filament"
 msgstr "Vänligen tryck på knappen för att mata ut filament"
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:5213
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:5235
 msgid "Please pull out filament immediately"
 msgstr "Vänligen ta ut filamentet omedelbart"
 
@@ -1320,7 +1320,7 @@ msgid "Please remove filament and then press the knob."
 msgstr "Ta bort filamentet och tryck sedan på knappen."
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/ultralcd.cpp:4081
+#: ../../Firmware/ultralcd.cpp:4100
 msgid "Please remove shipping helpers first."
 msgstr "Vänligen ta bort fraktinsatserna först."
 
@@ -1336,7 +1336,7 @@ msgid "Please run XYZ calibration first."
 msgstr "Utför XYZ-kalibrering först."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/ultralcd.cpp:6247
+#: ../../Firmware/ultralcd.cpp:6277
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Vänligen mata ut filamentet först och upprepa sedan denna åtgärd."
 
@@ -1353,54 +1353,54 @@ msgstr "Vänligen uppgradera."
 #. MSG_PLEASE_WAIT c=20
 #: ../../Firmware/Marlin_main.cpp:3547 ../../Firmware/Marlin_main.cpp:3563
 #: ../../Firmware/Marlin_main.cpp:7931 ../../Firmware/messages.cpp:71
-#: ../../Firmware/ultralcd.cpp:2186 ../../Firmware/ultralcd.cpp:2197
+#: ../../Firmware/ultralcd.cpp:2205 ../../Firmware/ultralcd.cpp:2216
 msgid "Please wait"
 msgstr "Vänligen vänta"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1219
-#: ../../Firmware/ultralcd.cpp:1260 ../../Firmware/ultralcd.cpp:1270
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1238
+#: ../../Firmware/ultralcd.cpp:1279 ../../Firmware/ultralcd.cpp:1289
 msgid "Power failures"
 msgstr "Strömavbrott"
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/ultralcd.cpp:5502
+#: ../../Firmware/ultralcd.cpp:5524
 msgid "Preheat"
 msgstr "Förvärm"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:2280
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:2299
 msgid "Preheat the nozzle!"
 msgstr "Förvärm munstycket!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:2900
-#: ../../Firmware/ultralcd.cpp:3924 ../../Firmware/ultralcd.cpp:3926
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:2919
+#: ../../Firmware/ultralcd.cpp:3943 ../../Firmware/ultralcd.cpp:3945
 msgid "Preheating nozzle. Please wait."
 msgstr "Förvärmer munstycke. Vänta."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/ultralcd.cpp:1988
+#: ../../Firmware/ultralcd.cpp:2007
 msgid "Preheating to cut"
 msgstr "Förvärmer för skära"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/ultralcd.cpp:1985
+#: ../../Firmware/ultralcd.cpp:2004
 msgid "Preheating to eject"
 msgstr "Förvämer för utmatn"
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/ultralcd.cpp:1976
+#: ../../Firmware/ultralcd.cpp:1995
 msgid "Preheating to load"
 msgstr "Förvärmer för laddn"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/ultralcd.cpp:1981
+#: ../../Firmware/ultralcd.cpp:2000
 msgid "Preheating to unload"
 msgstr "Förvärmer for utmatn"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/ultralcd.cpp:1809
+#: ../../Firmware/ultralcd.cpp:1828
 msgid "Press the knob"
 msgstr "Tryck på knappen"
 
@@ -1420,13 +1420,13 @@ msgid "Print aborted"
 msgstr "Utskriften avbröts"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1144
-#: ../../Firmware/ultralcd.cpp:7322
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1145
+#: ../../Firmware/ultralcd.cpp:7354
 msgid "Print fan:"
 msgstr "Utskriftsfläkt:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5535
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:5557
 msgid "Print from SD"
 msgstr "Skriv ut från SD"
 
@@ -1436,12 +1436,12 @@ msgid "Print paused"
 msgstr "Utskriften pausad"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2366
+#: ../../Firmware/ultralcd.cpp:2385
 msgid "Print time"
 msgstr "Utskriftstid"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/ultralcd.cpp:1711
+#: ../../Firmware/ultralcd.cpp:1730
 msgid "Printer IP Addr:"
 msgstr "Skrivarens IP adr:"
 
@@ -1469,12 +1469,12 @@ msgstr ""
 "inställningarna. Utskriften avbröts."
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4834
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:4853
 msgid "RPi port"
 msgstr "RPi port"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/ultralcd.cpp:2755
+#: ../../Firmware/ultralcd.cpp:2774
 msgid "Rear side [μm]"
 msgstr "Baksida [μm]"
 
@@ -1491,24 +1491,24 @@ msgstr ""
 "filament."
 
 #. MSG_RENAME c=18
-#: ../../Firmware/ultralcd.cpp:5426
+#: ../../Firmware/ultralcd.cpp:5448
 msgid "Rename"
 msgstr "Döp om"
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2756
-#: ../../Firmware/ultralcd.cpp:5427
+#: ../../Firmware/messages.cpp:80 ../../Firmware/ultralcd.cpp:2775
+#: ../../Firmware/ultralcd.cpp:5449
 msgid "Reset"
 msgstr "Återställ"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/ultralcd.cpp:4917
+#: ../../Firmware/ultralcd.cpp:4936
 msgid "Reset XYZ calibr."
 msgstr "Återställ XYZ-kal."
 
 #. MSG_RESUME_PRINT c=18
 #: ../../Firmware/Marlin_main.cpp:655 ../../Firmware/messages.cpp:81
-#: ../../Firmware/ultralcd.cpp:5521 ../../Firmware/ultralcd.cpp:5523
+#: ../../Firmware/ultralcd.cpp:5543 ../../Firmware/ultralcd.cpp:5545
 msgid "Resume print"
 msgstr "Återuppta utskrift"
 
@@ -1518,17 +1518,17 @@ msgid "Resuming print"
 msgstr "Återupptar utskrift"
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/ultralcd.cpp:2497
+#: ../../Firmware/ultralcd.cpp:2516
 msgid "Right"
 msgstr "Höger"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/ultralcd.cpp:2753
+#: ../../Firmware/ultralcd.cpp:2772
 msgid "Right side[μm]"
 msgstr "Höger sida[μm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3884
+#: ../../Firmware/ultralcd.cpp:3903
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1537,14 +1537,14 @@ msgstr ""
 "börja om från början. Fortsätta?"
 
 #. MSG_RUNOUTS c=7
-#: ../../Firmware/ultralcd.cpp:1271
+#: ../../Firmware/ultralcd.cpp:1290
 msgid "Runouts"
 msgstr "Avbrott"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4395
-#: ../../Firmware/ultralcd.cpp:4397 ../../Firmware/ultralcd.cpp:4414
-#: ../../Firmware/ultralcd.cpp:4416
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:4414
+#: ../../Firmware/ultralcd.cpp:4416 ../../Firmware/ultralcd.cpp:4433
+#: ../../Firmware/ultralcd.cpp:4435
 msgid "SD card"
 msgstr "SD-kort"
 
@@ -1560,12 +1560,12 @@ msgid "Searching bed calibration point"
 msgstr "Söker efter kalibreringspunkt för bädden"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/ultralcd.cpp:5419
+#: ../../Firmware/ultralcd.cpp:5441
 msgid "Select"
 msgstr "Välj"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/ultralcd.cpp:3966
+#: ../../Firmware/ultralcd.cpp:3985
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
@@ -1579,49 +1579,49 @@ msgstr "Välj extruder:"
 
 #. MSG_SELECT_FILAMENT c=20
 #: ../../Firmware/Marlin_main.cpp:8577 ../../Firmware/Marlin_main.cpp:8604
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3834
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3853
 msgid "Select filament:"
 msgstr "Välj filament:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:3679
-#: ../../Firmware/ultralcd.cpp:4841
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:3698
+#: ../../Firmware/ultralcd.cpp:4860
 msgid "Select language"
 msgstr "Välj språk"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/ultralcd.cpp:4122
+#: ../../Firmware/ultralcd.cpp:4141
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr "Välj munstycksförvärmningstemperatur som passar ditt material."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3971
+#: ../../Firmware/ultralcd.cpp:3990
 msgid "Select temperature which matches your material."
 msgstr "Välj temperatur som passar ditt material."
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/ultralcd.cpp:6522
+#: ../../Firmware/ultralcd.cpp:6552
 msgid "Self test OK"
 msgstr "Självtest OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/ultralcd.cpp:6290
+#: ../../Firmware/ultralcd.cpp:6320
 msgid "Self test start"
 msgstr "Självteststart"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/ultralcd.cpp:4904
+#: ../../Firmware/ultralcd.cpp:4923
 msgid "Selftest"
 msgstr "Självtest"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/ultralcd.cpp:6962
+#: ../../Firmware/ultralcd.cpp:6992
 msgid "Selftest error!"
 msgstr "Självtestfel!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:6526
-#: ../../Firmware/ultralcd.cpp:7049 ../../Firmware/ultralcd.cpp:7314
+#: ../../Firmware/messages.cpp:85 ../../Firmware/ultralcd.cpp:6556
+#: ../../Firmware/ultralcd.cpp:7079 ../../Firmware/ultralcd.cpp:7344
 msgid "Selftest failed"
 msgstr "Självtestet felade"
 
@@ -1632,30 +1632,30 @@ msgstr ""
 "Självtest kommer att utföras för att kalibrera exakt sensorlös hemposition."
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/ultralcd.cpp:1723
+#: ../../Firmware/ultralcd.cpp:1742
 msgid "Sensor info"
 msgstr "Sensorinfo"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/ultralcd.cpp:6254
+#: ../../Firmware/ultralcd.cpp:6284
 msgid "Sensor verified, remove the filament now."
 msgstr "Sensor verifierad, ta bort filamentet nu."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/ultralcd.cpp:2773
+#: ../../Firmware/ultralcd.cpp:2792
 msgid "Set temperature:"
 msgstr "Sätt temperatur:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:3491
-#: ../../Firmware/ultralcd.cpp:3696 ../../Firmware/ultralcd.cpp:4206
-#: ../../Firmware/ultralcd.cpp:5580 ../../Firmware/ultralcd.cpp:5827
-#: ../../Firmware/ultralcd.cpp:5880
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:3510
+#: ../../Firmware/ultralcd.cpp:3715 ../../Firmware/ultralcd.cpp:4225
+#: ../../Firmware/ultralcd.cpp:5602 ../../Firmware/ultralcd.cpp:5849
+#: ../../Firmware/ultralcd.cpp:5902
 msgid "Settings"
 msgstr "Inställningar"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2540
+#: ../../Firmware/ultralcd.cpp:2559
 msgid "Severe skew"
 msgstr "Hög skevhet"
 
@@ -1666,7 +1666,7 @@ msgid "Sheet"
 msgstr "Skiva"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3824
+#: ../../Firmware/ultralcd.cpp:3843
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1679,18 +1679,18 @@ msgstr ""
 "%cÅterställ"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/ultralcd.cpp:4915
+#: ../../Firmware/ultralcd.cpp:4934
 msgid "Show end stops"
 msgstr "Visa ändlägen"
 
 #. MSG_SILENT c=7
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4361
-#: ../../Firmware/ultralcd.cpp:4456 ../../Firmware/ultralcd.cpp:5778
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4380
+#: ../../Firmware/ultralcd.cpp:4475 ../../Firmware/ultralcd.cpp:5800
 msgid "Silent"
 msgstr "Tyst"
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/ultralcd.cpp:2539
+#: ../../Firmware/ultralcd.cpp:2558
 msgid "Slight skew"
 msgstr "Låg skevhet"
 
@@ -1709,8 +1709,8 @@ msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Ett problem har uppstått, Z-nivellering utförs..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4403
-#: ../../Firmware/ultralcd.cpp:4404 ../../Firmware/ultralcd.cpp:4405
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:4422
+#: ../../Firmware/ultralcd.cpp:4423 ../../Firmware/ultralcd.cpp:4424
 msgid "Sort"
 msgstr "Sortera"
 
@@ -1721,20 +1721,20 @@ msgid "Sorting files"
 msgstr "Sorterar filer"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4450
-#: ../../Firmware/ultralcd.cpp:4453 ../../Firmware/ultralcd.cpp:4456
-#: ../../Firmware/ultralcd.cpp:4459 ../../Firmware/ultralcd.cpp:4462
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:4469
+#: ../../Firmware/ultralcd.cpp:4472 ../../Firmware/ultralcd.cpp:4475
+#: ../../Firmware/ultralcd.cpp:4478 ../../Firmware/ultralcd.cpp:4481
 msgid "Sound"
 msgstr "Ljud"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/ultralcd.cpp:5718
+#: ../../Firmware/ultralcd.cpp:5740
 msgid "Speed"
 msgstr "Fart"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7166
-#: ../../Firmware/ultralcd.cpp:7181 ../../Firmware/ultralcd.cpp:7189
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:7196
+#: ../../Firmware/ultralcd.cpp:7211 ../../Firmware/ultralcd.cpp:7219
 msgid "Spinning"
 msgstr "Rotation"
 
@@ -1744,42 +1744,42 @@ msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr "Stabil omgivningstemperatur 21-26C krävs samt ett styvt stativ."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/ultralcd.cpp:5585
+#: ../../Firmware/ultralcd.cpp:5607
 msgid "Statistics"
 msgstr "Statistik"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4338
-#: ../../Firmware/ultralcd.cpp:4382 ../../Firmware/ultralcd.cpp:5770
+#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4357
+#: ../../Firmware/ultralcd.cpp:4401 ../../Firmware/ultralcd.cpp:5792
 msgid "Stealth"
 msgstr "Tyst"
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4763
-#: ../../Firmware/ultralcd.cpp:5416
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4782
+#: ../../Firmware/ultralcd.cpp:5438
 msgid "Steel sheets"
 msgstr "Metallskivor"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5528
-#: ../../Firmware/ultralcd.cpp:5987
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5550
+#: ../../Firmware/ultralcd.cpp:6017
 msgid "Stop print"
 msgstr "Stoppa utskriften"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4499
-#: ../../Firmware/ultralcd.cpp:4581 ../../Firmware/ultralcd.cpp:4620
-#: ../../Firmware/ultralcd.cpp:4661
+#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:4518
+#: ../../Firmware/ultralcd.cpp:4600 ../../Firmware/ultralcd.cpp:4639
+#: ../../Firmware/ultralcd.cpp:4680
 msgid "Strict"
 msgstr "Strikt"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/ultralcd.cpp:5616
 msgid "Support"
 msgstr "Support"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/ultralcd.cpp:7021
+#: ../../Firmware/ultralcd.cpp:7051
 msgid "Swapped"
 msgstr "Utbytt"
 
@@ -1788,28 +1788,18 @@ msgstr "Utbytt"
 msgid "THERMAL ANOMALY"
 msgstr "TERMISK ANOMALI"
 
-#. MSG_TM_AUTOTUNE_FAILED c=20
-#: ../../Firmware/temperature.cpp:2899
-msgid "TM autotune failed"
-msgstr "TM autoinst fallerad"
-
-#. MSG_TEMP_MODEL_AUTOTUNE c=20
-#: ../../Firmware/temperature.cpp:2884
-msgid "Temp. model autotune"
-msgstr "Temp modell autoinst"
-
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/ultralcd.cpp:4797
+#: ../../Firmware/ultralcd.cpp:4816
 msgid "Temperature"
 msgstr "Temperatur"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/ultralcd.cpp:1729
+#: ../../Firmware/ultralcd.cpp:1748
 msgid "Temperatures"
 msgstr "Temperaturer"
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/ultralcd.cpp:3974
+#: ../../Firmware/ultralcd.cpp:3993
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -1828,66 +1818,66 @@ msgstr ""
 "kap Första stegen, avs Kalibreringsflöde."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4403
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4422
 msgid "Time"
 msgstr "Tid"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:5865
+#: ../../Firmware/messages.cpp:154 ../../Firmware/ultralcd.cpp:5887
 msgid "Timeout"
 msgstr "Timeout"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:1149
-#: ../../Firmware/ultralcd.cpp:1297
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:1168
+#: ../../Firmware/ultralcd.cpp:1316
 msgid "Total"
 msgstr "Total"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:1192
-#: ../../Firmware/ultralcd.cpp:1218 ../../Firmware/ultralcd.cpp:1328
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:1211
+#: ../../Firmware/ultralcd.cpp:1237 ../../Firmware/ultralcd.cpp:1347
 msgid "Total failures"
 msgstr "Totala fel"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/ultralcd.cpp:2387
+#: ../../Firmware/ultralcd.cpp:2406
 msgid "Total filament"
 msgstr "Total filament"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/ultralcd.cpp:2388
+#: ../../Firmware/ultralcd.cpp:2407
 msgid "Total print time"
 msgstr "Tot utskriftstid"
 
 #. MSG_TUNE c=18
-#: ../../Firmware/ultralcd.cpp:5500
+#: ../../Firmware/ultralcd.cpp:5522
 msgid "Tune"
 msgstr "Ställ in"
 
 #. MSG_UNLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:5564
-#: ../../Firmware/ultralcd.cpp:5578
+#: ../../Firmware/messages.cpp:111 ../../Firmware/ultralcd.cpp:5586
+#: ../../Firmware/ultralcd.cpp:5600
 msgid "Unload filament"
 msgstr "Ta bort filament"
 
 #. MSG_UNLOADING_FILAMENT c=20
 #: ../../Firmware/messages.cpp:112 ../../Firmware/mmu.cpp:957
-#: ../../Firmware/ultralcd.cpp:5197
+#: ../../Firmware/ultralcd.cpp:5219
 msgid "Unloading filament"
 msgstr "Tar bort filament"
 
 #. MSG_FIL_FAILED c=20 r=5
-#: ../../Firmware/ultralcd.cpp:6258
+#: ../../Firmware/ultralcd.cpp:6288
 msgid "Verification failed, remove the filament and try again."
 msgstr "Verifieringen felade, ta bort filamentet, försök igen."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/ultralcd.cpp:1732
+#: ../../Firmware/ultralcd.cpp:1751
 msgid "Voltages"
 msgstr "Spänning"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/ultralcd.cpp:3534
+#: ../../Firmware/ultralcd.cpp:3553
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -1905,19 +1895,19 @@ msgid "Wait for user..."
 msgstr "Väntar på användare."
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/ultralcd.cpp:2881
+#: ../../Firmware/ultralcd.cpp:2900
 msgid "Waiting for PINDA probe cooling"
 msgstr "Väntar på PINDA-sondens kylning"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/ultralcd.cpp:2913
+#: ../../Firmware/ultralcd.cpp:2932
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Väntar på munstycks- och bäddkylning"
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:4496
-#: ../../Firmware/ultralcd.cpp:4578 ../../Firmware/ultralcd.cpp:4617
-#: ../../Firmware/ultralcd.cpp:4658
+#: ../../Firmware/messages.cpp:127 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/ultralcd.cpp:4597 ../../Firmware/ultralcd.cpp:4636
+#: ../../Firmware/ultralcd.cpp:4677
 msgid "Warn"
 msgstr "Varna"
 
@@ -1942,145 +1932,134 @@ msgid "Was filament unload successful?"
 msgstr "Lyckades filamentutmatningen?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6973
-#: ../../Firmware/ultralcd.cpp:6977 ../../Firmware/ultralcd.cpp:6997
-#: ../../Firmware/ultralcd.cpp:7003 ../../Firmware/ultralcd.cpp:7027
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:7003
+#: ../../Firmware/ultralcd.cpp:7007 ../../Firmware/ultralcd.cpp:7027
+#: ../../Firmware/ultralcd.cpp:7033 ../../Firmware/ultralcd.cpp:7057
 msgid "Wiring error"
 msgstr "Kabelfel"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/ultralcd.cpp:4895
+#: ../../Firmware/ultralcd.cpp:4914
 msgid "Wizard"
 msgstr "Guide"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4210
+#: ../../Firmware/ultralcd.cpp:4229
 msgid "X-correct:"
 msgstr "X-korrektion:"
 
 #. MSG_XFLASH c=18
-#: ../../Firmware/ultralcd.cpp:5596
+#: ../../Firmware/ultralcd.cpp:5618
 msgid "XFLASH init"
 msgstr "XFLASH init"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/ultralcd.cpp:1721
+#: ../../Firmware/ultralcd.cpp:1740
 msgid "XYZ cal. details"
 msgstr "XYZ kal. detaljer"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3333
+#: ../../Firmware/ultralcd.cpp:3352
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr "XYZ-kalibrering ok. Skevhet kommer att korrigeras automatiskt."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3330
+#: ../../Firmware/ultralcd.cpp:3349
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr "XYZ-kalibrering ok. X/Y-axlarna är mycket lite skeva. Bra jobbat!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3311
+#: ../../Firmware/ultralcd.cpp:3330
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr "XYZ-kalibrering komprometterad. Främre kalibreringspunkt kan ej nås."
 
-#. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_LEFT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3317
-msgid ""
-"XYZ calibration compromised. Left front calibration point not reachable."
-msgstr "XYZ-kalibrering komprometterad. Främre vä kalibreringspunkt kan ej nås."
-
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3314
+#: ../../Firmware/ultralcd.cpp:3333
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr ""
 "XYZ-kalibrering komprometterad. Främre hö kalibreringspunkter kan ej nås."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3293
+#: ../../Firmware/ultralcd.cpp:3312
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr "XYZ-kalibrering felade. Kalibreringspunkter ej funna."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3299
+#: ../../Firmware/ultralcd.cpp:3318
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr "XYZ-kalibrering felade. Främre kalibreringspunkt kan ej nås."
 
-#. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_LEFT_FAR c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3305
-msgid "XYZ calibration failed. Left front calibration point not reachable."
-msgstr "XYZ-kalibrering felade. Främre vä kalibreringspunkt kan ej nås."
-
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3296
-#: ../../Firmware/ultralcd.cpp:3324
+#: ../../Firmware/messages.cpp:16 ../../Firmware/ultralcd.cpp:3315
+#: ../../Firmware/ultralcd.cpp:3343
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "XYZ-kalibrering felade. Se bruksanvisningen."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/ultralcd.cpp:3302
+#: ../../Firmware/ultralcd.cpp:3321
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr "XYZ-kalibrering felade. Höger främre kalibreringspunkt kan ej nås."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/ultralcd.cpp:3327
+#: ../../Firmware/ultralcd.cpp:3346
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "XYZ-kalibrering ok. X/Y-axlarna ar vinkelräta. Grattis!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/ultralcd.cpp:2494
+#: ../../Firmware/ultralcd.cpp:2513
 msgid "Y distance from min"
 msgstr "Y avstånd från min"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4211
+#: ../../Firmware/ultralcd.cpp:4230
 msgid "Y-correct:"
 msgstr "Y-korrekt:"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:2216
-#: ../../Firmware/ultralcd.cpp:2800 ../../Firmware/ultralcd.cpp:3180
-#: ../../Firmware/ultralcd.cpp:4785 ../../Firmware/ultralcd.cpp:5989
+#: ../../Firmware/messages.cpp:120 ../../Firmware/ultralcd.cpp:2235
+#: ../../Firmware/ultralcd.cpp:2819 ../../Firmware/ultralcd.cpp:3199
+#: ../../Firmware/ultralcd.cpp:4804 ../../Firmware/ultralcd.cpp:6019
 msgid "Yes"
 msgstr "Ja"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:4187
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:4206
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr "Du kan alltid återuppta guiden från Kalibrering -> Guide."
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4231
 msgid "Z-correct:"
 msgstr "Z-korrekt:"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:5835
+#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:5857
 msgid "Z-probe nr."
 msgstr "Z-sond nr."
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/ultralcd.cpp:2565
+#: ../../Firmware/ultralcd.cpp:2584
 msgid "[0;0] point offset"
 msgstr "[0;0] punktförskjutn"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/ultralcd.cpp:2154
+#: ../../Firmware/ultralcd.cpp:2173
 msgid "and press the knob"
 msgstr "och tryck på knapp"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1816
+#: ../../Firmware/ultralcd.cpp:1835
 msgid "to load filament"
 msgstr "att ladda filament"
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/ultralcd.cpp:1820
+#: ../../Firmware/ultralcd.cpp:1839
 msgid "to unload filament"
 msgstr "att ta bort filament"
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/ultralcd.cpp:1688
+#: ../../Firmware/ultralcd.cpp:1707
 msgid "unknown"
 msgstr "okänd"
 
@@ -2090,8 +2069,8 @@ msgid "unknown state"
 msgstr "okänt stat"
 
 #. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:6077
-#: ../../Firmware/ultralcd.cpp:6080
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:6107
+#: ../../Firmware/ultralcd.cpp:6110
 msgid "🔃Refresh"
 msgstr "🔃Uppdatera"
 
@@ -2100,3 +2079,17 @@ msgstr "🔃Uppdatera"
 
 #~ msgid "M117 First layer cal."
 #~ msgstr "M117 Först lager kalibr."
+
+#~ msgid "TM autotune failed"
+#~ msgstr "TM autoinst fallerad"
+
+#~ msgid "Temp. model autotune"
+#~ msgstr "Temp modell autoinst"
+
+#~ msgid ""
+#~ "XYZ calibration compromised. Left front calibration point not reachable."
+#~ msgstr ""
+#~ "XYZ-kalibrering komprometterad. Främre vä kalibreringspunkt kan ej nås."
+
+#~ msgid "XYZ calibration failed. Left front calibration point not reachable."
+#~ msgstr "XYZ-kalibrering felade. Främre vä kalibreringspunkt kan ej nås."


### PR DESCRIPTION
[Fix Long-press cherry-pick from](https://github.com/prusa3d/Prusa-Firmware/commit/de562800ca462c7b08e2d196d27ec4669d58bf69) https://github.com/prusa3d/Prusa-Firmware/pull/3737

Fix eeprom documentation
Update pot and po files as pre-release task
Bump up to FW 3.12.0-RC1 and build number +2 (+1 commit + 1 merge)

- [ ] create tag t3.12.0-RC1 after merge  