### PR TITLE
M600: Fix bug where fan is not turned off

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3538,6 +3538,9 @@ static void gcode_M600(bool automatic, float x_position, float y_position, float
 
     memcpy(lastpos, current_position, sizeof(lastpos));
 
+    // Turn off the fan
+    fanSpeed = 0;
+
     // Retract E
     current_position[E_AXIS] += e_shift;
     plan_buffer_line_curposXYZE(FILAMENTCHANGE_RFEED);


### PR DESCRIPTION
The firmware saves the current fanspeed before parking, and the fanspeed is restored after unparking. The problem is the fan was never actually paused.

Turning the fan off just before the retraction is consistent with Marlin 2.

Fixes #3670