### PR TITLE
Fix PFW-1364 & possible comms timeout during reheat

### DIFF
--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -635,9 +635,9 @@ void MMU2::ResumeHotendTemp() {
         lcd_display_message_fullscreen_P(_i("MMU Retry: Restoring temperature...")); ////MSG_MMU_RESTORE_TEMP c=20 r=4
         //@todo better report the event and let the GUI do its work somewhere else
         ReportErrorHookSensorLineRender();
-        waitForHotendTargetTemp(100, [this]{
+        waitForHotendTargetTemp(100, []{
             manage_inactivity(true);
-            this->mmu_loop_inner(); // This keeps the comms alive, the call in manage_inactivity is blocked by recursion guard.
+            mmu2.mmu_loop_inner();
             ReportErrorHookDynamicRender();
         });
         lcd_update_enable(true); // temporary hack to stop this locking the printer...

--- a/Firmware/mmu2.h
+++ b/Firmware/mmu2.h
@@ -226,8 +226,12 @@ private:
     /// Along with the mmu_loop method, this loops until a response from the MMU is received and acts upon.
     /// In case of an error, it parks the print head and turns off nozzle heating
     void manage_response(const bool move_axes, const bool turn_off_nozzle);
-    
-    /// Performs one step of the protocol logic state machine 
+
+    /// The inner private implementation of mmu_loop()
+    /// which is NOT (!!!) recursion-guarded. Use caution - but we do need it during waiting for hotend resume to keep comms alive!
+    void mmu_loop_inner();
+
+    /// Performs one step of the protocol logic state machine
     /// and reports progress and errors if needed to attached ExtUIs.
     /// Updates the global state of MMU (Active/Connecting/Stopped) at runtime, see @ref State
     StepStatus LogicStep();

--- a/Firmware/mmu2.h
+++ b/Firmware/mmu2.h
@@ -229,12 +229,14 @@ private:
 
     /// The inner private implementation of mmu_loop()
     /// which is NOT (!!!) recursion-guarded. Use caution - but we do need it during waiting for hotend resume to keep comms alive!
-    void mmu_loop_inner();
+    /// @param reportErrors true if Errors should raise MMU Error screen, false otherwise
+    void mmu_loop_inner(bool reportErrors);
 
     /// Performs one step of the protocol logic state machine
     /// and reports progress and errors if needed to attached ExtUIs.
     /// Updates the global state of MMU (Active/Connecting/Stopped) at runtime, see @ref State
-    StepStatus LogicStep();
+    /// @param reportErrors true if Errors should raise MMU Error screen, false otherwise
+    StepStatus LogicStep(bool reportErrors);
     
     void filament_ramming();
     void execute_extruder_sequence(const E_Step *sequence, uint8_t steps);


### PR DESCRIPTION
Per title. 

Underlying issue was recursion guarding preventing the MMU protocol from continuing to query while in the reheat wait loop. 

This should also fix issues with MMU communications timing out after a reheat if it took too long. 