### PR TITLE
Optimisation: reduce code size in showing file name being printed

### DIFF
--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -528,13 +528,14 @@ void lcd_print(const char* s)
 	while (*s) lcd_write(*(s++));
 }
 
-void lcd_print_pad(const char* s, uint8_t len)
+char lcd_print_pad(const char* s, uint8_t len)
 {
     while (len && *s) {
         lcd_write(*(s++));
         --len;
     }
     lcd_space(len);
+    return *s;
 }
 
 void lcd_print(char c, int base)

--- a/Firmware/lcd.h
+++ b/Firmware/lcd.h
@@ -53,7 +53,7 @@ extern void lcd_printNumber(unsigned long n, uint8_t base);
 extern void lcd_printFloat(double number, uint8_t digits);
 
 extern void lcd_print(const char*);
-extern void lcd_print_pad(const char*, uint8_t len);
+extern char lcd_print_pad(const char* s, uint8_t len);
 extern void lcd_print(char, int = 0);
 extern void lcd_print(unsigned char, int = 0);
 extern void lcd_print(int, int = 10);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -585,20 +585,11 @@ void lcdui_print_status_line(void) {
     {
         // If printing from SD, show what we are printing
         const char* longFilenameOLD = (card.longFilename[0] ? card.longFilename : card.filename);
-        if(strlen(longFilenameOLD) > LCD_WIDTH) {
-            uint8_t gh = scrollstuff;
-            while (((gh - scrollstuff) < LCD_WIDTH)) {
-                lcd_putc_at(gh - scrollstuff, 3, longFilenameOLD[gh - 1]);
-                if (longFilenameOLD[gh] == '\0') {
-                    scrollstuff = 0;
-                    break; // Exit while loop
-                } else {
-                    gh++;
-                }
-            }
+        if( lcd_print_pad(&longFilenameOLD[scrollstuff], LCD_WIDTH) )
+        {
             scrollstuff++;
         } else {
-            lcd_print_pad(longFilenameOLD, LCD_WIDTH);
+            scrollstuff = 0;
         }
     } else { // Otherwise check for other special events
         switch (custom_message_type) {

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -6140,28 +6140,20 @@ void lcd_sdcard_menu()
 				_md->offset = 0; //redraw once again from the beginning.
 			if (_md->lcd_scrollTimer.expired(300) || rewindFlag)
 			{
-				uint8_t i = LCD_WIDTH - ((_md->isDir)?2:1);
+				uint8_t len = LCD_WIDTH - ((_md->isDir)? 2 : 1);
 				lcd_set_cursor(0, _md->row);
 				lcd_print('>');
 				if (_md->isDir)
 					lcd_print(LCD_STR_FOLDER[0]);
-				for (; i != 0; i--)
+
+				if( lcd_print_pad(&_md->scrollPointer[_md->offset], len) )
 				{
-					const char* c = (_md->scrollPointer + _md->offset + ((LCD_WIDTH - ((_md->isDir)?2:1)) - i));
-					lcd_print(c[0]);
-					if (c[1])
-						_md->lcd_scrollTimer.start();
-					else
-					{
-						_md->lcd_scrollTimer.stop();
-						break; //stop at the end of the string
-					}
+					_md->lcd_scrollTimer.start();
+					_md->offset++;
+				} else {
+					// stop at the end of the string
+					_md->lcd_scrollTimer.stop();
 				}
-				if (i != 0) //adds spaces if string is incomplete or at the end (instead of null).
-				{
-					lcd_space(i);
-				}
-				_md->offset++;
 			}
 			if (rewindFlag) //go back to sd_menu.
 			{

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -584,25 +584,21 @@ void lcdui_print_status_line(void) {
         lcd_status_message_timeout.expired_cont(LCD_STATUS_INFO_TIMEOUT))
     {
         // If printing from SD, show what we are printing
-		const char* longFilenameOLD = (card.longFilename[0] ? card.longFilename : card.filename);
+        const char* longFilenameOLD = (card.longFilename[0] ? card.longFilename : card.filename);
         if(strlen(longFilenameOLD) > LCD_WIDTH) {
             uint8_t gh = scrollstuff;
             while (((gh - scrollstuff) < LCD_WIDTH)) {
+                lcd_putc_at(gh - scrollstuff, 3, longFilenameOLD[gh - 1]);
                 if (longFilenameOLD[gh] == '\0') {
-                    lcd_set_cursor(gh - scrollstuff, 3);
-                    lcd_print(longFilenameOLD[gh - 1]);
                     scrollstuff = 0;
-                    gh = scrollstuff;
-                    break;
+                    break; // Exit while loop
                 } else {
-                    lcd_set_cursor(gh - scrollstuff, 3);
-                    lcd_print(longFilenameOLD[gh - 1]);
                     gh++;
                 }
             }
             scrollstuff++;
         } else {
-            lcd_printf_P(PSTR("%-20s"), longFilenameOLD);
+            lcd_print_pad(longFilenameOLD, LCD_WIDTH);
         }
     } else { // Otherwise check for other special events
         switch (custom_message_type) {


### PR DESCRIPTION
The PR optimizes how the SD card file name is printed on the screen.

`lcd_print_pad()` now returns the last character it's pointer pointed to which is `'\0'` (NULL) when the end of the string was reached, or a non-zero value which indicates the opposite. We can use this directly to make the file name scroll to the left on the LCD by shifting the starting pointer by one index each time `lcd_print_pad()` didn't reach the end of the string.

Affected UI:
* SD card filename on the status screen
* SD card filenames in the "Print from SD" menu.

Change in memory:
Flash: -140 bytes
SRAM: 0 bytes