### PR TITLE
Display Welcome message after MMU progress report ends

### DIFF
--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -20,6 +20,7 @@ void BeginReport(CommandInProgress /*cip*/, uint16_t ec) {
 
 void EndReport(CommandInProgress /*cip*/, uint16_t /*ec*/) {
     // clear the status msg line - let the printed filename get visible again
+    lcd_setstatuspgm(MSG_WELCOME); // should be seen only when the printer is not printing a file
     custom_message_type = CustomMsg::Status;
 }
 


### PR DESCRIPTION
Should make the status line look cleaner when the printer is not printing.

PFW-1426