### PR TITLE
Optimize EEPROM usage/functions

### DIFF
--- a/Firmware/Configuration.h
+++ b/Firmware/Configuration.h
@@ -457,17 +457,6 @@ your extruder heater takes 2 minutes to hit the target on heating.
 #endif // CUSTOM_M_CODES
 
 
-// EEPROM
-// The microcontroller can store settings in the EEPROM, e.g. max velocity...
-// M500 - stores parameters in EEPROM
-// M501 - reads parameters from EEPROM (if you need reset them after you changed them temporarily).
-// M502 - reverts to the default "factory settings".  You still need to store them in EEPROM afterwards if you want to.
-//define this to enable EEPROM support
-//#define EEPROM_SETTINGS
-//to disable EEPROM Serial responses and decrease program space by ~1700 byte: comment this out:
-// please keep turned on if you can.
-//#define EEPROM_CHITCHAT
-
 // Host Keepalive
 //
 // When enabled Marlin will send a busy status message to the host

--- a/Firmware/ConfigurationStore.cpp
+++ b/Firmware/ConfigurationStore.cpp
@@ -292,9 +292,6 @@ bool Config_RetrieveSettings()
       previous_settings_retrieved = false;
     }
     }
-    #ifdef EEPROM_CHITCHAT
-      Config_PrintSettings();
-    #endif
   return previous_settings_retrieved;
 }
 #endif

--- a/Firmware/ConfigurationStore.cpp
+++ b/Firmware/ConfigurationStore.cpp
@@ -215,10 +215,10 @@ static bool is_uninitialized(void* addr, uint8_t len)
 bool Config_RetrieveSettings()
 {
   bool previous_settings_retrieved = true;
-    char ver[4]=EEPROM_VERSION;
+    static const char ver[4] PROGMEM = EEPROM_VERSION;
     eeprom_read_block(reinterpret_cast<uint8_t*>(cs.version), reinterpret_cast<uint8_t*>(EEPROM_M500_base->version), sizeof(cs.version));
     //  SERIAL_ECHOLN("Version: [" << ver << "] Stored version: [" << cs.version << "]");
-    if (strncmp(ver,cs.version,3) == 0)  // version number match
+    if (strncmp_P(ver, cs.version, sizeof(EEPROM_VERSION)) == 0)  // version number match
     {
         eeprom_read_block(reinterpret_cast<uint8_t*>(&cs), reinterpret_cast<uint8_t*>(EEPROM_M500_base), sizeof(cs));
         calculate_extruder_multipliers();

--- a/Firmware/ConfigurationStore.h
+++ b/Firmware/ConfigurationStore.h
@@ -42,9 +42,9 @@ typedef struct
     // Arc Interpolation Settings, configurable via M214
     float mm_per_arc_segment;
     float min_mm_per_arc_segment;
-    unsigned char n_arc_correction; // If equal to zero, this is disabled
-    unsigned short min_arc_segments; // If equal to zero, this is disabled
-    unsigned short arc_segments_per_sec; // If equal to zero, this is disabled
+    uint8_t n_arc_correction; // If equal to zero, this is disabled
+    uint16_t min_arc_segments; // If equal to zero, this is disabled
+    uint16_t arc_segments_per_sec; // If equal to zero, this is disabled
 } M500_conf;
 
 extern M500_conf cs;

--- a/Firmware/Filament_sensor.cpp
+++ b/Firmware/Filament_sensor.cpp
@@ -481,8 +481,8 @@ void PAT9125_sensor::filJam() {
     jamDetection = false;
     stop_and_save_print_to_ram(0, 0);
     restore_print_from_ram_and_continue(0);
-    eeprom_update_byte((uint8_t *)EEPROM_FERROR_COUNT, eeprom_read_byte((uint8_t *)EEPROM_FERROR_COUNT) + 1);
-    eeprom_update_word((uint16_t *)EEPROM_FERROR_COUNT_TOT, eeprom_read_word((uint16_t *)EEPROM_FERROR_COUNT_TOT) + 1);
+    eeprom_increment_byte((uint8_t *)EEPROM_FERROR_COUNT);
+    eeprom_increment_word((uint16_t *)EEPROM_FERROR_COUNT_TOT);
     enquecommand_front_P((PSTR("M600")));
 }
 

--- a/Firmware/Filament_sensor.cpp
+++ b/Firmware/Filament_sensor.cpp
@@ -161,8 +161,8 @@ void Filament_sensor::filRunout() {
     autoLoadEnabled = false;
     stop_and_save_print_to_ram(0, 0);
     restore_print_from_ram_and_continue(0);
-    eeprom_increment_byte((uint8_t *)EEPROM_FERROR_COUNT, 1);
-    eeprom_increment_word((uint16_t *)EEPROM_FERROR_COUNT_TOT, 1);
+    eeprom_increment_byte((uint8_t *)EEPROM_FERROR_COUNT);
+    eeprom_increment_word((uint16_t *)EEPROM_FERROR_COUNT_TOT);
     enquecommand_front_P((PSTR("M600")));
 }
 

--- a/Firmware/Filament_sensor.cpp
+++ b/Firmware/Filament_sensor.cpp
@@ -161,8 +161,8 @@ void Filament_sensor::filRunout() {
     autoLoadEnabled = false;
     stop_and_save_print_to_ram(0, 0);
     restore_print_from_ram_and_continue(0);
-    eeprom_update_byte((uint8_t *)EEPROM_FERROR_COUNT, eeprom_read_byte((uint8_t *)EEPROM_FERROR_COUNT) + 1);
-    eeprom_update_word((uint16_t *)EEPROM_FERROR_COUNT_TOT, eeprom_read_word((uint16_t *)EEPROM_FERROR_COUNT_TOT) + 1);
+    eeprom_increment_byte((uint8_t *)EEPROM_FERROR_COUNT, 1);
+    eeprom_increment_word((uint16_t *)EEPROM_FERROR_COUNT_TOT, 1);
     enquecommand_front_P((PSTR("M600")));
 }
 

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -609,13 +609,13 @@ void crashdet_detected(uint8_t mask)
 
 	if (mask & X_AXIS_MASK)
 	{
-		eeprom_increment_byte((uint8_t*)EEPROM_CRASH_COUNT_X, 1);
-		eeprom_increment_word((uint16_t*)EEPROM_CRASH_COUNT_X_TOT, 1);
+		eeprom_increment_byte((uint8_t*)EEPROM_CRASH_COUNT_X);
+		eeprom_increment_word((uint16_t*)EEPROM_CRASH_COUNT_X_TOT);
 	}
 	if (mask & Y_AXIS_MASK)
 	{
-		eeprom_increment_byte((uint8_t*)EEPROM_CRASH_COUNT_Y, 1);
-		eeprom_increment_word((uint16_t*)EEPROM_CRASH_COUNT_Y_TOT, 1);
+		eeprom_increment_byte((uint8_t*)EEPROM_CRASH_COUNT_Y);
+		eeprom_increment_word((uint16_t*)EEPROM_CRASH_COUNT_Y_TOT);
 	}
 
 	lcd_update_enable(true);
@@ -10678,8 +10678,8 @@ void uvlo_()
 	if(sd_print) eeprom_update_byte((uint8_t*)EEPROM_UVLO, 1);
 
     // Increment power failure counter
-	eeprom_increment_byte((uint8_t*)EEPROM_POWER_COUNT, 1);
-	eeprom_increment_word((uint16_t*)EEPROM_POWER_COUNT_TOT, 1);
+	eeprom_increment_byte((uint8_t*)EEPROM_POWER_COUNT);
+	eeprom_increment_word((uint16_t*)EEPROM_POWER_COUNT_TOT);
 
     printf_P(_N("UVLO - end %d\n"), _millis() - time_start);
     WRITE(BEEPER,HIGH);

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -9753,8 +9753,8 @@ bool setTargetedHotend(int code, uint8_t &extruder)
 
 void save_statistics(unsigned long _total_filament_used, unsigned long _total_print_time) //_total_filament_used unit: mm/100; print time in s
 {
-	unsigned long _previous_filament = eeprom_init_default_dword((uint32_t *)EEPROM_FILAMENTUSED, 0); //_previous_filament unit: cm
-	unsigned long _previous_time = eeprom_init_default_dword((uint32_t *)EEPROM_TOTALTIME, 0); //_previous_time unit: min
+	uint32_t _previous_filament = eeprom_init_default_dword((uint32_t *)EEPROM_FILAMENTUSED, 0); //_previous_filament unit: cm
+	uint32_t _previous_time = eeprom_init_default_dword((uint32_t *)EEPROM_TOTALTIME, 0); //_previous_time unit: min
 
 	eeprom_update_dword((uint32_t *)EEPROM_TOTALTIME, _previous_time + (_total_print_time/60)); //EEPROM_TOTALTIME unit: min
 	eeprom_update_dword((uint32_t *)EEPROM_FILAMENTUSED, _previous_filament + (_total_filament_used / 1000));

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -609,13 +609,13 @@ void crashdet_detected(uint8_t mask)
 
 	if (mask & X_AXIS_MASK)
 	{
-		eeprom_update_byte((uint8_t*)EEPROM_CRASH_COUNT_X, eeprom_read_byte((uint8_t*)EEPROM_CRASH_COUNT_X) + 1);
-		eeprom_update_word((uint16_t*)EEPROM_CRASH_COUNT_X_TOT, eeprom_read_word((uint16_t*)EEPROM_CRASH_COUNT_X_TOT) + 1);
+		eeprom_increment_byte((uint8_t*)EEPROM_CRASH_COUNT_X, 1);
+		eeprom_increment_word((uint16_t*)EEPROM_CRASH_COUNT_X_TOT, 1);
 	}
 	if (mask & Y_AXIS_MASK)
 	{
-		eeprom_update_byte((uint8_t*)EEPROM_CRASH_COUNT_Y, eeprom_read_byte((uint8_t*)EEPROM_CRASH_COUNT_Y) + 1);
-		eeprom_update_word((uint16_t*)EEPROM_CRASH_COUNT_Y_TOT, eeprom_read_word((uint16_t*)EEPROM_CRASH_COUNT_Y_TOT) + 1);
+		eeprom_increment_byte((uint8_t*)EEPROM_CRASH_COUNT_Y, 1);
+		eeprom_increment_word((uint16_t*)EEPROM_CRASH_COUNT_Y_TOT, 1);
 	}
 
 	lcd_update_enable(true);
@@ -1444,9 +1444,7 @@ void setup()
 
 #endif //(LANG_MODE != 0)
 
-	if (eeprom_read_byte((uint8_t*)EEPROM_TEMP_CAL_ACTIVE) == 255) {
-		eeprom_write_byte((uint8_t*)EEPROM_TEMP_CAL_ACTIVE, 0);
-	}
+	eeprom_init_default_byte((uint8_t*)EEPROM_TEMP_CAL_ACTIVE, 0);
 
 	if (eeprom_read_byte((uint8_t*)EEPROM_CALIBRATION_STATUS_PINDA) == 255) {
 		//eeprom_write_byte((uint8_t*)EEPROM_CALIBRATION_STATUS_PINDA, 0);
@@ -1457,12 +1455,9 @@ void setup()
 		}
 		eeprom_write_byte((uint8_t*)EEPROM_TEMP_CAL_ACTIVE, 0);
 	}
-	if (eeprom_read_byte((uint8_t*)EEPROM_UVLO) == 255) {
-		eeprom_write_byte((uint8_t*)EEPROM_UVLO, 0);
-	}
-	if (eeprom_read_byte((uint8_t*)EEPROM_SD_SORT) == 255) {
-		eeprom_write_byte((uint8_t*)EEPROM_SD_SORT, 0);
-	}
+	eeprom_init_default_byte((uint8_t*)EEPROM_UVLO, 0);
+	eeprom_init_default_byte((uint8_t*)EEPROM_SD_SORT, 0);
+
 	//mbl_mode_init();
 	mbl_settings_init();
 	SilentModeMenu_MMU = eeprom_read_byte((uint8_t*)EEPROM_MMU_STEALTH);
@@ -10683,8 +10678,8 @@ void uvlo_()
 	if(sd_print) eeprom_update_byte((uint8_t*)EEPROM_UVLO, 1);
 
     // Increment power failure counter
-	eeprom_update_byte((uint8_t*)EEPROM_POWER_COUNT, eeprom_read_byte((uint8_t*)EEPROM_POWER_COUNT) + 1);
-	eeprom_update_word((uint16_t*)EEPROM_POWER_COUNT_TOT, eeprom_read_word((uint16_t*)EEPROM_POWER_COUNT_TOT) + 1);
+	eeprom_increment_byte((uint8_t*)EEPROM_POWER_COUNT, 1);
+	eeprom_increment_word((uint16_t*)EEPROM_POWER_COUNT_TOT, 1);
 
     printf_P(_N("UVLO - end %d\n"), _millis() - time_start);
     WRITE(BEEPER,HIGH);

--- a/Firmware/Prusa_farm.cpp
+++ b/Firmware/Prusa_farm.cpp
@@ -390,12 +390,8 @@ void prusa_statistics_update_from_lcd_update() {
 }
 
 void farm_mode_init() {
-    farm_mode = eeprom_read_byte((uint8_t*)EEPROM_FARM_MODE); 
-    if (farm_mode == 0xFF) {
-        farm_mode = false; //if farm_mode has not been stored to eeprom yet and farm number is set to zero or EEPROM is fresh, deactivate farm mode
-        eeprom_update_byte((uint8_t*)EEPROM_FARM_MODE, farm_mode);
-    }
-    else if (farm_mode) {
+    farm_mode = eeprom_init_default_byte((uint8_t*)EEPROM_FARM_MODE, 0); 
+    if (farm_mode) {
         no_response = true; //we need confirmation by recieving PRUSA thx
         prusa_statistics(8);
 #ifdef HAS_SECOND_SERIAL_PORT

--- a/Firmware/eeprom.cpp
+++ b/Firmware/eeprom.cpp
@@ -49,19 +49,19 @@ bool eeprom_is_sheet_initialized(uint8_t sheet_num)
 
 void eeprom_init()
 {
-    if (eeprom_read_byte((uint8_t*)EEPROM_POWER_COUNT) == 0xff) eeprom_write_byte((uint8_t*)EEPROM_POWER_COUNT, 0);
-    if (eeprom_read_byte((uint8_t*)EEPROM_CRASH_COUNT_X) == 0xff) eeprom_write_byte((uint8_t*)EEPROM_CRASH_COUNT_X, 0);
-    if (eeprom_read_byte((uint8_t*)EEPROM_CRASH_COUNT_Y) == 0xff) eeprom_write_byte((uint8_t*)EEPROM_CRASH_COUNT_Y, 0);
-    if (eeprom_read_byte((uint8_t*)EEPROM_FERROR_COUNT) == 0xff) eeprom_write_byte((uint8_t*)EEPROM_FERROR_COUNT, 0);
-    if (eeprom_read_word((uint16_t*)EEPROM_POWER_COUNT_TOT) == 0xffff) eeprom_write_word((uint16_t*)EEPROM_POWER_COUNT_TOT, 0);
-    if (eeprom_read_word((uint16_t*)EEPROM_CRASH_COUNT_X_TOT) == 0xffff) eeprom_write_word((uint16_t*)EEPROM_CRASH_COUNT_X_TOT, 0);
-    if (eeprom_read_word((uint16_t*)EEPROM_CRASH_COUNT_Y_TOT) == 0xffff) eeprom_write_word((uint16_t*)EEPROM_CRASH_COUNT_Y_TOT, 0);
-    if (eeprom_read_word((uint16_t*)EEPROM_FERROR_COUNT_TOT) == 0xffff) eeprom_write_word((uint16_t*)EEPROM_FERROR_COUNT_TOT, 0);
+    eeprom_init_default_byte((uint8_t*)EEPROM_POWER_COUNT, 0);
+    eeprom_init_default_byte((uint8_t*)EEPROM_CRASH_COUNT_X, 0);
+    eeprom_init_default_byte((uint8_t*)EEPROM_CRASH_COUNT_Y, 0);
+    eeprom_init_default_byte((uint8_t*)EEPROM_FERROR_COUNT, 0);
+    eeprom_init_default_word((uint16_t*)EEPROM_POWER_COUNT_TOT, 0);
+    eeprom_init_default_word((uint16_t*)EEPROM_CRASH_COUNT_X_TOT, 0);
+    eeprom_init_default_word((uint16_t*)EEPROM_CRASH_COUNT_Y_TOT, 0);
+    eeprom_init_default_word((uint16_t*)EEPROM_FERROR_COUNT_TOT, 0);
 
-    if (eeprom_read_word((uint16_t*)EEPROM_MMU_FAIL_TOT) == 0xffff) eeprom_update_word((uint16_t *)EEPROM_MMU_FAIL_TOT, 0);
-    if (eeprom_read_word((uint16_t*)EEPROM_MMU_LOAD_FAIL_TOT) == 0xffff) eeprom_update_word((uint16_t *)EEPROM_MMU_LOAD_FAIL_TOT, 0);
-    if (eeprom_read_byte((uint8_t*)EEPROM_MMU_FAIL) == 0xff) eeprom_update_byte((uint8_t *)EEPROM_MMU_FAIL, 0);
-    if (eeprom_read_byte((uint8_t*)EEPROM_MMU_LOAD_FAIL) == 0xff) eeprom_update_byte((uint8_t *)EEPROM_MMU_LOAD_FAIL, 0);
+    eeprom_init_default_word((uint16_t*)EEPROM_MMU_FAIL_TOT, 0);
+    eeprom_init_default_word((uint16_t*)EEPROM_MMU_LOAD_FAIL_TOT, 0);
+    eeprom_init_default_byte((uint8_t*)EEPROM_MMU_FAIL, 0);
+    eeprom_init_default_byte((uint8_t*)EEPROM_MMU_LOAD_FAIL, 0);
     if (eeprom_read_dword((uint32_t*)EEPROM_TOTAL_TOOLCHANGE_COUNT) == 0xffffffff) eeprom_update_dword((uint32_t *)EEPROM_TOTAL_TOOLCHANGE_COUNT, 0);
     if (eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet)) == EEPROM_EMPTY_VALUE)
     {
@@ -102,12 +102,12 @@ if (eeprom_read_byte((uint8_t*)EEPROM_PINDA_TEMP_COMPENSATION) == 0xff) eeprom_u
 	if (eeprom_read_dword((uint32_t*)EEPROM_JOB_ID) == EEPROM_EMPTY_VALUE32)
 		eeprom_update_dword((uint32_t*)EEPROM_JOB_ID, 0);
 
-    if (eeprom_read_byte((uint8_t *)EEPROM_TOTALTIME) == 255 && eeprom_read_byte((uint8_t *)EEPROM_TOTALTIME + 1) == 255 && eeprom_read_byte((uint8_t *)EEPROM_TOTALTIME + 2) == 255 && eeprom_read_byte((uint8_t *)EEPROM_TOTALTIME + 3) == 255) {
+    if (eeprom_read_dword((uint32_t *)EEPROM_TOTALTIME) == 0xffffffff) {
         eeprom_update_dword((uint32_t *)EEPROM_TOTALTIME, 0);
         eeprom_update_dword((uint32_t *)EEPROM_FILAMENTUSED, 0);
     }
 //Set Cutter OFF if 0xff
-    if (eeprom_read_byte((uint8_t*)EEPROM_MMU_CUTTER_ENABLED) == 0xff) eeprom_update_byte((uint8_t *)EEPROM_MMU_CUTTER_ENABLED, 0);
+    eeprom_init_default_byte((uint8_t*)EEPROM_MMU_CUTTER_ENABLED, 0);
 }
 
 //! @brief Get default sheet name for index
@@ -180,4 +180,22 @@ void eeprom_switch_to_next_sheet()
 
     sheet = eeprom_next_initialized_sheet(sheet);
     if (sheet >= 0) eeprom_update_byte(&(EEPROM_Sheets_base->active_sheet), sheet);
+}
+
+void __attribute__((noinline)) eeprom_increment_byte(uint8_t *__p, uint8_t inc){
+    eeprom_update_byte(__p, eeprom_read_byte(__p) + inc);
+}
+
+void __attribute__((noinline)) eeprom_increment_word(uint16_t *__p, uint8_t inc){
+    eeprom_update_word(__p, eeprom_read_word(__p) + inc);
+}
+
+void __attribute__((noinline)) eeprom_init_default_byte(uint8_t *__p, uint8_t def){
+    if (eeprom_read_byte(__p) == 0xff)
+        eeprom_write_byte(__p, def);
+}
+
+void __attribute__((noinline)) eeprom_init_default_word(uint16_t *__p, uint16_t def){
+    if (eeprom_read_word(__p) == 0xffff)
+        eeprom_write_word(__p, def);
 }

--- a/Firmware/eeprom.cpp
+++ b/Firmware/eeprom.cpp
@@ -182,20 +182,28 @@ void eeprom_switch_to_next_sheet()
     if (sheet >= 0) eeprom_update_byte(&(EEPROM_Sheets_base->active_sheet), sheet);
 }
 
-void __attribute__((noinline)) eeprom_increment_byte(uint8_t *__p, uint8_t inc){
-    eeprom_update_byte(__p, eeprom_read_byte(__p) + inc);
+void __attribute__((noinline)) eeprom_increment_byte(uint8_t *__p) {
+    eeprom_write_byte(__p, eeprom_read_byte(__p) + 1);
 }
 
-void __attribute__((noinline)) eeprom_increment_word(uint16_t *__p, uint8_t inc){
-    eeprom_update_word(__p, eeprom_read_word(__p) + inc);
+void __attribute__((noinline)) eeprom_increment_word(uint16_t *__p) {
+    eeprom_write_word(__p, eeprom_read_word(__p) + 1);
 }
 
-void __attribute__((noinline)) eeprom_init_default_byte(uint8_t *__p, uint8_t def){
+void __attribute__((noinline)) eeprom_add_byte(uint8_t *__p, uint8_t add) {
+    eeprom_write_byte(__p, eeprom_read_byte(__p) + add);
+}
+
+void __attribute__((noinline)) eeprom_add_word(uint16_t *__p, uint16_t add) {
+    eeprom_write_word(__p, eeprom_read_word(__p) + add);
+}
+
+void __attribute__((noinline)) eeprom_init_default_byte(uint8_t *__p, uint8_t def) {
     if (eeprom_read_byte(__p) == 0xff)
         eeprom_write_byte(__p, def);
 }
 
-void __attribute__((noinline)) eeprom_init_default_word(uint16_t *__p, uint16_t def){
+void __attribute__((noinline)) eeprom_init_default_word(uint16_t *__p, uint16_t def) {
     if (eeprom_read_word(__p) == 0xffff)
         eeprom_write_word(__p, def);
 }

--- a/Firmware/eeprom.cpp
+++ b/Firmware/eeprom.cpp
@@ -190,12 +190,20 @@ void __attribute__((noinline)) eeprom_increment_word(uint16_t *__p) {
     eeprom_write_word(__p, eeprom_read_word(__p) + 1);
 }
 
+void __attribute__((noinline)) eeprom_increment_dword(uint32_t *__p) {
+    eeprom_write_dword(__p, eeprom_read_dword(__p) + 1);
+}
+
 void __attribute__((noinline)) eeprom_add_byte(uint8_t *__p, uint8_t add) {
     eeprom_write_byte(__p, eeprom_read_byte(__p) + add);
 }
 
 void __attribute__((noinline)) eeprom_add_word(uint16_t *__p, uint16_t add) {
     eeprom_write_word(__p, eeprom_read_word(__p) + add);
+}
+
+void __attribute__((noinline)) eeprom_add_dword(uint32_t *__p, uint32_t add) {
+    eeprom_write_dword(__p, eeprom_read_dword(__p) + add);
 }
 
 void __attribute__((noinline)) eeprom_init_default_byte(uint8_t *__p, uint8_t def) {
@@ -206,4 +214,9 @@ void __attribute__((noinline)) eeprom_init_default_byte(uint8_t *__p, uint8_t de
 void __attribute__((noinline)) eeprom_init_default_word(uint16_t *__p, uint16_t def) {
     if (eeprom_read_word(__p) == 0xffff)
         eeprom_write_word(__p, def);
+}
+
+void __attribute__((noinline)) eeprom_init_default_dword(uint32_t *__p, uint32_t def) {
+    if (eeprom_read_dword(__p) == 0xffffffff)
+        eeprom_write_dword(__p, def);
 }

--- a/Firmware/eeprom.cpp
+++ b/Firmware/eeprom.cpp
@@ -26,7 +26,7 @@ void eeprom_init()
     eeprom_init_default_word((uint16_t*)EEPROM_MMU_LOAD_FAIL_TOT, 0);
     eeprom_init_default_byte((uint8_t*)EEPROM_MMU_FAIL, 0);
     eeprom_init_default_byte((uint8_t*)EEPROM_MMU_LOAD_FAIL, 0);
-    if (eeprom_read_dword((uint32_t*)EEPROM_TOTAL_TOOLCHANGE_COUNT) == 0xffffffff) eeprom_update_dword((uint32_t *)EEPROM_TOTAL_TOOLCHANGE_COUNT, 0);
+    eeprom_init_default_dword((uint32_t*)EEPROM_TOTAL_TOOLCHANGE_COUNT, 0);
     if (eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet)) == EEPROM_EMPTY_VALUE)
     {
         eeprom_update_byte(&(EEPROM_Sheets_base->active_sheet), 0);
@@ -50,17 +50,12 @@ void eeprom_init()
     check_babystep();
 
 #ifdef PINDA_TEMP_COMP
-if (eeprom_read_byte((uint8_t*)EEPROM_PINDA_TEMP_COMPENSATION) == 0xff) eeprom_update_byte((uint8_t *)EEPROM_PINDA_TEMP_COMPENSATION, 0);
+    eeprom_init_default_byte((uint8_t*)EEPROM_PINDA_TEMP_COMPENSATION, 0);
 #endif //PINDA_TEMP_COMP
 
-	if (eeprom_read_dword((uint32_t*)EEPROM_JOB_ID) == EEPROM_EMPTY_VALUE32)
-		eeprom_update_dword((uint32_t*)EEPROM_JOB_ID, 0);
-
-    if (eeprom_read_dword((uint32_t *)EEPROM_TOTALTIME) == 0xffffffff) {
-        eeprom_update_dword((uint32_t *)EEPROM_TOTALTIME, 0);
-        eeprom_update_dword((uint32_t *)EEPROM_FILAMENTUSED, 0);
-    }
-//Set Cutter OFF if 0xff
+    eeprom_init_default_dword((uint32_t*)EEPROM_JOB_ID, 0);
+    eeprom_init_default_dword((uint32_t*)EEPROM_TOTALTIME, 0);
+    eeprom_init_default_dword((uint32_t*)EEPROM_FILAMENTUSED, 0);
     eeprom_init_default_byte((uint8_t*)EEPROM_MMU_CUTTER_ENABLED, 0);
 }
 
@@ -184,19 +179,31 @@ void __attribute__((noinline)) eeprom_add_dword(uint32_t *__p, uint32_t add) {
 }
 
 
-void __attribute__((noinline)) eeprom_init_default_byte(uint8_t *__p, uint8_t def) {
-    if (eeprom_read_byte(__p) == EEPROM_EMPTY_VALUE)
+uint8_t __attribute__((noinline)) eeprom_init_default_byte(uint8_t *__p, uint8_t def) {
+    uint8_t val = eeprom_read_byte(__p);
+    if (val == EEPROM_EMPTY_VALUE) {
         eeprom_write_byte(__p, def);
+        return def;
+    }
+    return val;
 }
 
-void __attribute__((noinline)) eeprom_init_default_word(uint16_t *__p, uint16_t def) {
-    if (eeprom_read_word(__p) == EEPROM_EMPTY_VALUE16)
+uint16_t __attribute__((noinline)) eeprom_init_default_word(uint16_t *__p, uint16_t def) {
+    uint16_t val = eeprom_read_word(__p);
+    if (val == EEPROM_EMPTY_VALUE16) {
         eeprom_write_word(__p, def);
+        return def;
+    }
+    return val;
 }
 
-void __attribute__((noinline)) eeprom_init_default_dword(uint32_t *__p, uint32_t def) {
-    if (eeprom_read_dword(__p) == EEPROM_EMPTY_VALUE32)
+uint32_t __attribute__((noinline)) eeprom_init_default_dword(uint32_t *__p, uint32_t def) {
+    uint32_t val = eeprom_read_dword(__p);
+    if (val == EEPROM_EMPTY_VALUE32) {
         eeprom_write_dword(__p, def);
+        return def;
+    }
+    return val;
 }
 
 void __attribute__((noinline)) eeprom_init_default_float(float *__p, float def) {

--- a/Firmware/eeprom.cpp
+++ b/Firmware/eeprom.cpp
@@ -153,6 +153,10 @@ void eeprom_update_block_P(const void *__src, void *__dst, size_t __n) {
     }
 }
 
+void eeprom_toggle(uint8_t *__p) {
+    eeprom_write_byte(__p, !eeprom_read_byte(__p));
+}
+
 void __attribute__((noinline)) eeprom_increment_byte(uint8_t *__p) {
     eeprom_write_byte(__p, eeprom_read_byte(__p) + 1);
 }

--- a/Firmware/eeprom.h
+++ b/Firmware/eeprom.h
@@ -615,12 +615,15 @@ void eeprom_switch_to_next_sheet();
 
 void eeprom_increment_byte(uint8_t *__p);
 void eeprom_increment_word(uint16_t *__p);
+void eeprom_increment_dword(uint32_t *__p);
 
 void eeprom_add_byte(uint8_t *__p, uint8_t add);
 void eeprom_add_word(uint16_t *__p, uint16_t add);
+void eeprom_add_dword(uint32_t *__p, uint32_t add);
 
 void eeprom_init_default_byte(uint8_t *__p, uint8_t def);
 void eeprom_init_default_word(uint16_t *__p, uint16_t def);
+void eeprom_init_default_dword(uint32_t *__p, uint32_t def);
 #endif
 
 #endif // EEPROM_H

--- a/Firmware/eeprom.h
+++ b/Firmware/eeprom.h
@@ -615,6 +615,7 @@ bool eeprom_is_sheet_initialized(uint8_t sheet_num);
 
 bool eeprom_is_initialized_block(const void *__p, size_t __n);
 void eeprom_update_block_P(const void *__src, void *__dst, size_t __n);
+void eeprom_toggle(uint8_t *__p);
 
 void eeprom_increment_byte(uint8_t *__p);
 void eeprom_increment_word(uint16_t *__p);

--- a/Firmware/eeprom.h
+++ b/Firmware/eeprom.h
@@ -614,6 +614,7 @@ void eeprom_switch_to_next_sheet();
 bool eeprom_is_sheet_initialized(uint8_t sheet_num);
 
 bool eeprom_is_initialized_block(const void *__p, size_t __n);
+void eeprom_update_block_P(const void *__src, void *__dst, size_t __n);
 
 void eeprom_increment_byte(uint8_t *__p);
 void eeprom_increment_word(uint16_t *__p);
@@ -626,7 +627,9 @@ void eeprom_add_dword(uint32_t *__p, uint32_t add);
 void eeprom_init_default_byte(uint8_t *__p, uint8_t def);
 void eeprom_init_default_word(uint16_t *__p, uint16_t def);
 void eeprom_init_default_dword(uint32_t *__p, uint32_t def);
+void eeprom_init_default_float(float *__p, float def);
 void eeprom_init_default_block(void *__p, size_t __n, const void *def);
+void eeprom_init_default_block_P(void *__p, size_t __n, const void *def);
 #endif
 
 #endif // EEPROM_H

--- a/Firmware/eeprom.h
+++ b/Firmware/eeprom.h
@@ -604,7 +604,6 @@ enum
 
 #ifdef __cplusplus
 void eeprom_init();
-bool eeprom_is_sheet_initialized(uint8_t sheet_num);
 struct SheetName
 {
     char c[sizeof(Sheet::name) + 1];
@@ -612,6 +611,9 @@ struct SheetName
 void eeprom_default_sheet_name(uint8_t index, SheetName &sheetName);
 int8_t eeprom_next_initialized_sheet(int8_t sheet);
 void eeprom_switch_to_next_sheet();
+bool eeprom_is_sheet_initialized(uint8_t sheet_num);
+
+bool eeprom_is_initialized_block(const void *__p, size_t __n);
 
 void eeprom_increment_byte(uint8_t *__p);
 void eeprom_increment_word(uint16_t *__p);
@@ -624,6 +626,7 @@ void eeprom_add_dword(uint32_t *__p, uint32_t add);
 void eeprom_init_default_byte(uint8_t *__p, uint8_t def);
 void eeprom_init_default_word(uint16_t *__p, uint16_t def);
 void eeprom_init_default_dword(uint32_t *__p, uint32_t def);
+void eeprom_init_default_block(void *__p, size_t __n, const void *def);
 #endif
 
 #endif // EEPROM_H

--- a/Firmware/eeprom.h
+++ b/Firmware/eeprom.h
@@ -613,8 +613,11 @@ void eeprom_default_sheet_name(uint8_t index, SheetName &sheetName);
 int8_t eeprom_next_initialized_sheet(int8_t sheet);
 void eeprom_switch_to_next_sheet();
 
-void eeprom_increment_byte(uint8_t *__p, uint8_t inc);
-void eeprom_increment_word(uint16_t *__p, uint8_t inc);
+void eeprom_increment_byte(uint8_t *__p);
+void eeprom_increment_word(uint16_t *__p);
+
+void eeprom_add_byte(uint8_t *__p, uint8_t add);
+void eeprom_add_word(uint16_t *__p, uint16_t add);
 
 void eeprom_init_default_byte(uint8_t *__p, uint8_t def);
 void eeprom_init_default_word(uint16_t *__p, uint16_t def);

--- a/Firmware/eeprom.h
+++ b/Firmware/eeprom.h
@@ -624,9 +624,9 @@ void eeprom_add_byte(uint8_t *__p, uint8_t add);
 void eeprom_add_word(uint16_t *__p, uint16_t add);
 void eeprom_add_dword(uint32_t *__p, uint32_t add);
 
-void eeprom_init_default_byte(uint8_t *__p, uint8_t def);
-void eeprom_init_default_word(uint16_t *__p, uint16_t def);
-void eeprom_init_default_dword(uint32_t *__p, uint32_t def);
+uint8_t eeprom_init_default_byte(uint8_t *__p, uint8_t def);
+uint16_t eeprom_init_default_word(uint16_t *__p, uint16_t def);
+uint32_t eeprom_init_default_dword(uint32_t *__p, uint32_t def);
 void eeprom_init_default_float(float *__p, float def);
 void eeprom_init_default_block(void *__p, size_t __n, const void *def);
 void eeprom_init_default_block_P(void *__p, size_t __n, const void *def);

--- a/Firmware/eeprom.h
+++ b/Firmware/eeprom.h
@@ -612,6 +612,12 @@ struct SheetName
 void eeprom_default_sheet_name(uint8_t index, SheetName &sheetName);
 int8_t eeprom_next_initialized_sheet(int8_t sheet);
 void eeprom_switch_to_next_sheet();
+
+void eeprom_increment_byte(uint8_t *__p, uint8_t inc);
+void eeprom_increment_word(uint16_t *__p, uint8_t inc);
+
+void eeprom_init_default_byte(uint8_t *__p, uint8_t def);
+void eeprom_init_default_word(uint16_t *__p, uint16_t def);
 #endif
 
 #endif // EEPROM_H

--- a/Firmware/mesh_bed_calibration.cpp
+++ b/Firmware/mesh_bed_calibration.cpp
@@ -3123,12 +3123,8 @@ void mbl_mode_init() {
 void mbl_settings_init() {
 //3x3 mesh; 3 Z-probes on each point, magnet elimination on
 //magnet elimination: use aaproximate Z-coordinate instead of measured values for points which are near magnets
-	if (eeprom_read_byte((uint8_t*)EEPROM_MBL_MAGNET_ELIMINATION) == 0xFF) {
-		eeprom_update_byte((uint8_t*)EEPROM_MBL_MAGNET_ELIMINATION, 1);
-	}
-	if (eeprom_read_byte((uint8_t*)EEPROM_MBL_POINTS_NR) == 0xFF) {
-		eeprom_update_byte((uint8_t*)EEPROM_MBL_POINTS_NR, 3);
-	}
+	eeprom_init_default_byte((uint8_t*)EEPROM_MBL_MAGNET_ELIMINATION, 1);
+	eeprom_init_default_byte((uint8_t*)EEPROM_MBL_POINTS_NR, 3);
 	mbl_z_probe_nr = eeprom_read_byte((uint8_t*)EEPROM_MBL_PROBE_NR);
 	if (mbl_z_probe_nr == 0xFF) {
 		mbl_z_probe_nr = 3;

--- a/Firmware/mesh_bed_calibration.cpp
+++ b/Firmware/mesh_bed_calibration.cpp
@@ -3125,11 +3125,7 @@ void mbl_settings_init() {
 //magnet elimination: use aaproximate Z-coordinate instead of measured values for points which are near magnets
 	eeprom_init_default_byte((uint8_t*)EEPROM_MBL_MAGNET_ELIMINATION, 1);
 	eeprom_init_default_byte((uint8_t*)EEPROM_MBL_POINTS_NR, 3);
-	mbl_z_probe_nr = eeprom_read_byte((uint8_t*)EEPROM_MBL_PROBE_NR);
-	if (mbl_z_probe_nr == 0xFF) {
-		mbl_z_probe_nr = 3;
-		eeprom_update_byte((uint8_t*)EEPROM_MBL_PROBE_NR, mbl_z_probe_nr);
-	}
+	mbl_z_probe_nr = eeprom_init_default_byte((uint8_t*)EEPROM_MBL_PROBE_NR, 3);
 }
 
 //parameter ix: index of mesh bed leveling point in X-axis (for meas_points == 7 is valid range from 0 to 6; for meas_points == 3 is valid range from 0 to 2 )  

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -4605,12 +4605,7 @@ void lcd_hw_setup_menu(void)                      // can not be "static"
     if (_md->status == 0 || lcd_draw_update)
     {
         _md->status = 1;
-        _md->experimental_menu_visibility = eeprom_read_byte((uint8_t *)EEPROM_EXPERIMENTAL_VISIBILITY);
-        if (_md->experimental_menu_visibility == EEPROM_EMPTY_VALUE)
-        {
-            _md->experimental_menu_visibility = 0;
-            eeprom_update_byte((uint8_t *)EEPROM_EXPERIMENTAL_VISIBILITY, _md->experimental_menu_visibility);
-        }
+        _md->experimental_menu_visibility = eeprom_init_default_byte((uint8_t *)EEPROM_EXPERIMENTAL_VISIBILITY, 0);
     }
 
 
@@ -7527,7 +7522,7 @@ void menu_lcd_longpress_func(void)
     {
         // only toggle the experimental menu visibility flag
         lcd_quick_feedback();
-        lcd_experimental_toggle();
+        eeprom_toggle((uint8_t *)EEPROM_EXPERIMENTAL_VISIBILITY);
         return;
     }
 
@@ -7689,16 +7684,6 @@ void lcd_crash_detect_disable()
     eeprom_update_byte((uint8_t*)EEPROM_CRASH_DET, 0x00);
 }
 #endif
-
-void lcd_experimental_toggle()
-{
-    uint8_t oldVal = eeprom_read_byte((uint8_t *)EEPROM_EXPERIMENTAL_VISIBILITY);
-    if (oldVal == EEPROM_EMPTY_VALUE)
-        oldVal = 0;
-    else
-        oldVal = !oldVal;
-    eeprom_update_byte((uint8_t *)EEPROM_EXPERIMENTAL_VISIBILITY, oldVal);
-}
 
 #ifdef TMC2130
 void UserECool_toggle(){

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2698,27 +2698,23 @@ void lcd_adjust_bed(void)
     if (_md->status == 0)
 	{
         // Menu was entered.
-		_md->left  = 0;
-		_md->right = 0;
-		_md->front = 0;
-		_md->rear  = 0;
         if (eeprom_read_byte((unsigned char*)EEPROM_BED_CORRECTION_VALID) == 1)
 		{
-			_md->left  = eeprom_read_int8((unsigned char*)EEPROM_BED_CORRECTION_LEFT);
-			_md->right = eeprom_read_int8((unsigned char*)EEPROM_BED_CORRECTION_RIGHT);
-			_md->front = eeprom_read_int8((unsigned char*)EEPROM_BED_CORRECTION_FRONT);
-			_md->rear  = eeprom_read_int8((unsigned char*)EEPROM_BED_CORRECTION_REAR);
+			_md->left = (int8_t)eeprom_read_byte((uint8_t*)EEPROM_BED_CORRECTION_LEFT);
+			_md->right = (int8_t)eeprom_read_byte((uint8_t*)EEPROM_BED_CORRECTION_RIGHT);
+			_md->front = (int8_t)eeprom_read_byte((uint8_t*)EEPROM_BED_CORRECTION_FRONT);
+			_md->rear = (int8_t)eeprom_read_byte((uint8_t*)EEPROM_BED_CORRECTION_REAR);
 		}
         _md->status = 1;
     }
     MENU_BEGIN();
 	// leaving menu - this condition must be immediately before MENU_ITEM_BACK_P
     ON_MENU_LEAVE(
-        eeprom_update_int8((unsigned char*)EEPROM_BED_CORRECTION_LEFT,  _md->left);
-        eeprom_update_int8((unsigned char*)EEPROM_BED_CORRECTION_RIGHT, _md->right);
-        eeprom_update_int8((unsigned char*)EEPROM_BED_CORRECTION_FRONT, _md->front);
-        eeprom_update_int8((unsigned char*)EEPROM_BED_CORRECTION_REAR,  _md->rear);
-        eeprom_update_byte((unsigned char*)EEPROM_BED_CORRECTION_VALID, 1);
+        eeprom_update_byte((uint8_t*)EEPROM_BED_CORRECTION_LEFT, (uint8_t)_md->left);
+        eeprom_update_byte((uint8_t*)EEPROM_BED_CORRECTION_FRONT, (uint8_t)_md->front);
+        eeprom_update_byte((uint8_t*)EEPROM_BED_CORRECTION_REAR, (uint8_t)_md->rear);
+        eeprom_update_byte((uint8_t*)EEPROM_BED_CORRECTION_RIGHT, (uint8_t)_md->right);
+        eeprom_update_byte((uint8_t*)EEPROM_BED_CORRECTION_VALID, 1);
     );
     MENU_ITEM_BACK_P(_T(MSG_BACK));
 	MENU_ITEM_EDIT_int3_P(_i("Left side [\xe4m]"),  &_md->left,  -BED_ADJUSTMENT_UM_MAX, BED_ADJUSTMENT_UM_MAX);////MSG_BED_CORRECTION_LEFT c=14

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -244,7 +244,6 @@ enum class WizState : uint8_t
 
 void lcd_wizard(WizState state);
 
-extern void lcd_experimental_toggle();
 extern void lcd_experimental_menu();
 
 uint8_t lcdui_print_extruder(void);

--- a/Firmware/util.cpp
+++ b/Firmware/util.cpp
@@ -243,8 +243,7 @@ void fCheckModeInit() {
     }
     if (farm_mode) {
         oCheckMode = ClCheckMode::_Strict;
-        if (eeprom_read_word((uint16_t *)EEPROM_NOZZLE_DIAMETER_uM) == EEPROM_EMPTY_VALUE16)
-            eeprom_update_word((uint16_t *)EEPROM_NOZZLE_DIAMETER_uM, EEPROM_NOZZLE_DIAMETER_uM_DEFAULT);
+        eeprom_init_default_word((uint16_t *)EEPROM_NOZZLE_DIAMETER_uM, EEPROM_NOZZLE_DIAMETER_uM_DEFAULT);
     }
     oNozzleDiameter = (ClNozzleDiameter)eeprom_read_byte((uint8_t *)EEPROM_NOZZLE_DIAMETER);
     if ((oNozzleDiameter == ClNozzleDiameter::_Diameter_Undef) && !farm_mode) {

--- a/Firmware/util.h
+++ b/Firmware/util.h
@@ -23,17 +23,6 @@ extern bool force_selftest_if_fw_version();
 extern void update_current_firmware_version_to_eeprom();
 
 
-
-inline int8_t eeprom_read_int8(unsigned char* addr) {
-	uint8_t v = eeprom_read_byte(addr);
-	return *reinterpret_cast<int8_t*>(&v);
-}
-
-inline void eeprom_update_int8(unsigned char* addr, int8_t v) {
-	eeprom_update_byte(addr, *reinterpret_cast<uint8_t*>(&v));
-}
-
-
 //-//
 #define EEPROM_NOZZLE_DIAMETER_uM_DEFAULT 400
 


### PR DESCRIPTION
It looks like the amount of code surrounding eeprom_read/update_* is significant.
By introducing 4 functions which do the repeated stuff I've been able to save ~270B. The proposed principle can be extended further.