### PR TITLE
Remove dead code (G-code level check in menus)

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -4337,22 +4337,6 @@ void process_commands()
                 plan_set_z_position(current_position[Z_AXIS]);
             }
         }
-
-//-//
-/*
-    } else if(code_seen("rrr")) {
-MYSERIAL.println("=== checking ===");
-MYSERIAL.println(eeprom_read_byte((uint8_t*)EEPROM_CHECK_MODE),DEC);
-MYSERIAL.println(eeprom_read_byte((uint8_t*)EEPROM_NOZZLE_DIAMETER),DEC);
-MYSERIAL.println(eeprom_read_word((uint16_t*)EEPROM_NOZZLE_DIAMETER_uM),DEC);
-MYSERIAL.println(farm_mode,DEC);
-MYSERIAL.println(eCheckMode,DEC);
-    } else if(code_seen("www")) {
-MYSERIAL.println("=== @ FF ===");
-eeprom_update_byte((uint8_t*)EEPROM_CHECK_MODE,0xFF);
-eeprom_update_byte((uint8_t*)EEPROM_NOZZLE_DIAMETER,0xFF);
-eeprom_update_word((uint16_t*)EEPROM_NOZZLE_DIAMETER_uM,0xFFFF);
-*/
     } else if (code_seen_P(PSTR("nozzle"))) { // PRUSA nozzle
           uint16_t nDiameter;
           if(code_seen('D'))
@@ -4369,52 +4353,8 @@ eeprom_update_word((uint16_t*)EEPROM_NOZZLE_DIAMETER_uM,0xFFFF);
                eeprom_update_word((uint16_t*)EEPROM_NOZZLE_DIAMETER_uM,nDiameter);
                }
           else SERIAL_PROTOCOLLN((float)eeprom_read_word((uint16_t*)EEPROM_NOZZLE_DIAMETER_uM)/1000.0);
-
-//-// !!! SupportMenu
-/*
-// musi byt PRED "PRUSA model"
-    } else if (code_seen("smodel")) { //! PRUSA smodel
-          size_t nOffset;
-// ! -> "l"
-          strchr_pointer+=5*sizeof(*strchr_pointer); // skip 1st - 5th char (~ 'smode')
-          nOffset=strspn(strchr_pointer+1," \t\n\r\v\f");
-          if(*(strchr_pointer+1+nOffset))
-               printer_smodel_check(strchr_pointer);
-          else SERIAL_PROTOCOLLN(PRINTER_NAME);
-    } else if (code_seen("model")) { //! PRUSA model
-          uint16_t nPrinterModel;
-          strchr_pointer+=4*sizeof(*strchr_pointer); // skip 1st - 4th char (~ 'mode')
-          nPrinterModel=(uint16_t)code_value_long();
-          if(nPrinterModel!=0)
-               printer_model_check(nPrinterModel);
-          else SERIAL_PROTOCOLLN(PRINTER_TYPE);
-    } else if (code_seen("version")) { //! PRUSA version
-          strchr_pointer+=7*sizeof(*strchr_pointer); // skip 1st - 7th char (~ 'version')
-          while(*strchr_pointer==' ')             // skip leading spaces
-               strchr_pointer++;
-          if(*strchr_pointer!=0)
-               fw_version_check(strchr_pointer);
-          else SERIAL_PROTOCOLLN(FW_VERSION);
-    } else if (code_seen("gcode")) { //! PRUSA gcode
-          uint16_t nGcodeLevel;
-          strchr_pointer+=4*sizeof(*strchr_pointer); // skip 1st - 4th char (~ 'gcod')
-          nGcodeLevel=(uint16_t)code_value_long();
-          if(nGcodeLevel!=0)
-               gcode_level_check(nGcodeLevel);
-          else SERIAL_PROTOCOLLN(GCODE_LEVEL);
-*/
-	}	
-    //else if (code_seen('Cal')) {
-		//  lcd_calibration();
-	  // }
-
-  } 
-  // This prevents reading files with "^" in their names.
-  // Since it is unclear, if there is some usage of this construct,
-  // it will be deprecated in 3.9 alpha a possibly completely removed in the future:
-  // else if (code_seen('^')) {
-  //  // nothing, this is a version line
-  // }
+    }
+  }
   else if(code_seen('G'))
   {
 	gcode_in_progress = code_value_short();

--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -131,7 +131,6 @@ const char MSG_NONE[] PROGMEM_I1 = ISTR("None"); ////MSG_NONE c=8
 const char MSG_WARN[] PROGMEM_I1 = ISTR("Warn"); ////MSG_WARN c=8
 const char MSG_STRICT[] PROGMEM_I1 = ISTR("Strict"); ////MSG_STRICT c=8
 const char MSG_MODEL[] PROGMEM_I1 = ISTR("Model"); ////MSG_MODEL c=8
-const char MSG_GCODE[] PROGMEM_I1 = ISTR("Gcode"); ////MSG_GCODE c=8
 const char MSG_GCODE_DIFF_PRINTER_CONTINUE[] PROGMEM_I1 = ISTR("G-code sliced for a different printer type. Continue?"); ////MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=5
 const char MSG_GCODE_DIFF_PRINTER_CANCELLED[] PROGMEM_I1 =ISTR("G-code sliced for a different printer type. Please re-slice the model again. Print cancelled."); ////MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
 const char MSG_NOZZLE_DIAMETER[] PROGMEM_I1 = ISTR("Nozzle d."); ////MSG_NOZZLE_DIAMETER c=10

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -136,7 +136,6 @@ extern const char MSG_NONE[];
 extern const char MSG_WARN[];
 extern const char MSG_STRICT[];
 extern const char MSG_MODEL[];
-extern const char MSG_GCODE[];
 extern const char MSG_GCODE_DIFF_PRINTER_CONTINUE[];
 extern const char MSG_GCODE_DIFF_PRINTER_CANCELLED[];
 extern const char MSG_NOZZLE_DIAMETER[];

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -4604,47 +4604,6 @@ do\
 }\
 while (0)
 
-#if 0 // temporarily unused
-static void lcd_check_gcode_set(void)
-{
-switch(oCheckGcode)
-     {
-     case ClCheckGcode::_None:
-          oCheckGcode=ClCheckGcode::_Warn;
-          break;
-     case ClCheckGcode::_Warn:
-          oCheckGcode=ClCheckGcode::_Strict;
-          break;
-     case ClCheckGcode::_Strict:
-          oCheckGcode=ClCheckGcode::_None;
-          break;
-     default:
-          oCheckGcode=ClCheckGcode::_None;
-     }
-eeprom_update_byte((uint8_t*)EEPROM_CHECK_GCODE,(uint8_t)oCheckGcode);
-}
-#endif
-
-#define SETTINGS_GCODE \
-do\
-{\
-    switch(oCheckGcode)\
-         {\
-         case ClCheckGcode::_None:\
-              MENU_ITEM_TOGGLE_P(_T(MSG_GCODE), _T(MSG_NONE), lcd_check_gcode_set);\
-              break;\
-         case ClCheckGcode::_Warn:\
-              MENU_ITEM_TOGGLE_P(_T(MSG_GCODE), _T(MSG_WARN), lcd_check_gcode_set);\
-              break;\
-         case ClCheckGcode::_Strict:\
-              MENU_ITEM_TOGGLE_P(_T(MSG_GCODE), _T(MSG_STRICT), lcd_check_gcode_set);\
-              break;\
-         default:\
-              MENU_ITEM_TOGGLE_P(_T(MSG_GCODE), _T(MSG_NONE), lcd_check_gcode_set);\
-         }\
-}\
-while (0)
-
 static void lcd_checking_menu(void)
 {
 MENU_BEGIN();
@@ -4652,8 +4611,6 @@ MENU_ITEM_BACK_P(_T(MSG_HW_SETUP));
 SETTINGS_MODE;
 SETTINGS_MODEL;
 SETTINGS_VERSION;
-//-// temporarily disabled
-//SETTINGS_GCODE;
 MENU_END();
 }
 

--- a/lang/po/Firmware.pot
+++ b/lang/po/Firmware.pot
@@ -797,13 +797,6 @@ msgid ""
 "cancelled."
 msgstr ""
 
-#. MSG_GCODE c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4611
-#: ../../Firmware/ultralcd.cpp:4614 ../../Firmware/ultralcd.cpp:4617
-#: ../../Firmware/ultralcd.cpp:4620
-msgid "Gcode"
-msgstr ""
-
 #. MSG_HW_SETUP c=18
 #: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4628
 #: ../../Firmware/ultralcd.cpp:4647 ../../Firmware/ultralcd.cpp:4747

--- a/lang/po/Firmware_cs.po
+++ b/lang/po/Firmware_cs.po
@@ -835,13 +835,6 @@ msgstr ""
 "G-code je pripraven pro novejsi firmware. Prosim aktualizujte firmware. Tisk "
 "zrusen."
 
-#. MSG_GCODE c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4611
-#: ../../Firmware/ultralcd.cpp:4614 ../../Firmware/ultralcd.cpp:4617
-#: ../../Firmware/ultralcd.cpp:4620
-msgid "Gcode"
-msgstr "Gcode"
-
 #. MSG_HW_SETUP c=18
 #: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4628
 #: ../../Firmware/ultralcd.cpp:4647 ../../Firmware/ultralcd.cpp:4747

--- a/lang/po/Firmware_da.po
+++ b/lang/po/Firmware_da.po
@@ -804,13 +804,6 @@ msgid ""
 "cancelled."
 msgstr ""
 
-#. MSG_GCODE c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4611
-#: ../../Firmware/ultralcd.cpp:4614 ../../Firmware/ultralcd.cpp:4617
-#: ../../Firmware/ultralcd.cpp:4620
-msgid "Gcode"
-msgstr ""
-
 #. MSG_HW_SETUP c=18
 #: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4628
 #: ../../Firmware/ultralcd.cpp:4647 ../../Firmware/ultralcd.cpp:4747

--- a/lang/po/Firmware_de.po
+++ b/lang/po/Firmware_de.po
@@ -841,13 +841,6 @@ msgstr ""
 "G-Code ist für eine neuere Firmware geslict. Bitte die Firmware updaten. "
 "Druck abgebrochen."
 
-#. MSG_GCODE c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4611
-#: ../../Firmware/ultralcd.cpp:4614 ../../Firmware/ultralcd.cpp:4617
-#: ../../Firmware/ultralcd.cpp:4620
-msgid "Gcode"
-msgstr "Gcode"
-
 #. MSG_HW_SETUP c=18
 #: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4628
 #: ../../Firmware/ultralcd.cpp:4647 ../../Firmware/ultralcd.cpp:4747

--- a/lang/po/Firmware_es.po
+++ b/lang/po/Firmware_es.po
@@ -837,13 +837,6 @@ msgstr ""
 "Codigo G laminado para nuevo firmware. Por favor actualiza el firmware. "
 "Impresion cancelada."
 
-#. MSG_GCODE c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4611
-#: ../../Firmware/ultralcd.cpp:4614 ../../Firmware/ultralcd.cpp:4617
-#: ../../Firmware/ultralcd.cpp:4620
-msgid "Gcode"
-msgstr "Código G"
-
 #. MSG_HW_SETUP c=18
 #: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4628
 #: ../../Firmware/ultralcd.cpp:4647 ../../Firmware/ultralcd.cpp:4747

--- a/lang/po/Firmware_fr.po
+++ b/lang/po/Firmware_fr.po
@@ -843,13 +843,6 @@ msgstr ""
 "Le G-code a ete prepare pour une version plus recente du firmware. Veuillez "
 "mettre a jour le firmware. L'impression annulee."
 
-#. MSG_GCODE c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4611
-#: ../../Firmware/ultralcd.cpp:4614 ../../Firmware/ultralcd.cpp:4617
-#: ../../Firmware/ultralcd.cpp:4620
-msgid "Gcode"
-msgstr "Gcode"
-
 #. MSG_HW_SETUP c=18
 #: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4628
 #: ../../Firmware/ultralcd.cpp:4647 ../../Firmware/ultralcd.cpp:4747

--- a/lang/po/Firmware_hr.po
+++ b/lang/po/Firmware_hr.po
@@ -834,13 +834,6 @@ msgstr ""
 "G-kod izrezan za noviji firmware. Molimo azurirajte firmware. Prime je "
 "otkazan."
 
-#. MSG_GCODE c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4611
-#: ../../Firmware/ultralcd.cpp:4614 ../../Firmware/ultralcd.cpp:4617
-#: ../../Firmware/ultralcd.cpp:4620
-msgid "Gcode"
-msgstr "Gkod"
-
 #. MSG_HW_SETUP c=18
 #: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4628
 #: ../../Firmware/ultralcd.cpp:4647 ../../Firmware/ultralcd.cpp:4747

--- a/lang/po/Firmware_hu.po
+++ b/lang/po/Firmware_hu.po
@@ -837,13 +837,6 @@ msgstr ""
 "A G-kod ujabb firmverre lett elokesztve. Frissitsd a nyomtato firmveret. "
 "Nyomtatas megallitva."
 
-#. MSG_GCODE c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4611
-#: ../../Firmware/ultralcd.cpp:4614 ../../Firmware/ultralcd.cpp:4617
-#: ../../Firmware/ultralcd.cpp:4620
-msgid "Gcode"
-msgstr "Gcode"
-
 #. MSG_HW_SETUP c=18
 #: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4628
 #: ../../Firmware/ultralcd.cpp:4647 ../../Firmware/ultralcd.cpp:4747

--- a/lang/po/Firmware_it.po
+++ b/lang/po/Firmware_it.po
@@ -838,13 +838,6 @@ msgstr ""
 "G-code processato per un firmware piu recente. Per favore aggiorna il "
 "firmware. Stampa annullata."
 
-#. MSG_GCODE c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4611
-#: ../../Firmware/ultralcd.cpp:4614 ../../Firmware/ultralcd.cpp:4617
-#: ../../Firmware/ultralcd.cpp:4620
-msgid "Gcode"
-msgstr "Gcode"
-
 #. MSG_HW_SETUP c=18
 #: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4628
 #: ../../Firmware/ultralcd.cpp:4647 ../../Firmware/ultralcd.cpp:4747

--- a/lang/po/Firmware_lb.po
+++ b/lang/po/Firmware_lb.po
@@ -804,13 +804,6 @@ msgid ""
 "cancelled."
 msgstr ""
 
-#. MSG_GCODE c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4611
-#: ../../Firmware/ultralcd.cpp:4614 ../../Firmware/ultralcd.cpp:4617
-#: ../../Firmware/ultralcd.cpp:4620
-msgid "Gcode"
-msgstr ""
-
 #. MSG_HW_SETUP c=18
 #: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4628
 #: ../../Firmware/ultralcd.cpp:4647 ../../Firmware/ultralcd.cpp:4747

--- a/lang/po/Firmware_lt.po
+++ b/lang/po/Firmware_lt.po
@@ -804,13 +804,6 @@ msgid ""
 "cancelled."
 msgstr ""
 
-#. MSG_GCODE c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4611
-#: ../../Firmware/ultralcd.cpp:4614 ../../Firmware/ultralcd.cpp:4617
-#: ../../Firmware/ultralcd.cpp:4620
-msgid "Gcode"
-msgstr ""
-
 #. MSG_HW_SETUP c=18
 #: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4628
 #: ../../Firmware/ultralcd.cpp:4647 ../../Firmware/ultralcd.cpp:4747

--- a/lang/po/Firmware_nl.po
+++ b/lang/po/Firmware_nl.po
@@ -839,13 +839,6 @@ msgstr ""
 "G-Code is voor een nieuwere firmware geslict. Update de firmware "
 "alsjeblieft. Druk geannuleerd."
 
-#. MSG_GCODE c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4611
-#: ../../Firmware/ultralcd.cpp:4614 ../../Firmware/ultralcd.cpp:4617
-#: ../../Firmware/ultralcd.cpp:4620
-msgid "Gcode"
-msgstr "Gcode"
-
 #. MSG_HW_SETUP c=18
 #: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4628
 #: ../../Firmware/ultralcd.cpp:4647 ../../Firmware/ultralcd.cpp:4747

--- a/lang/po/Firmware_no.po
+++ b/lang/po/Firmware_no.po
@@ -832,13 +832,6 @@ msgid ""
 msgstr ""
 "G-code sliced for nyere fastvare. Vennligst oppdater systemet. Print avbrutt."
 
-#. MSG_GCODE c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4611
-#: ../../Firmware/ultralcd.cpp:4614 ../../Firmware/ultralcd.cpp:4617
-#: ../../Firmware/ultralcd.cpp:4620
-msgid "Gcode"
-msgstr "Gcode"
-
 #. MSG_HW_SETUP c=18
 #: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4628
 #: ../../Firmware/ultralcd.cpp:4647 ../../Firmware/ultralcd.cpp:4747

--- a/lang/po/Firmware_pl.po
+++ b/lang/po/Firmware_pl.po
@@ -836,13 +836,6 @@ msgid ""
 msgstr ""
 "G-code pociety dla nowszego firmware. Zaktualizuj firmware. Druk anulowany."
 
-#. MSG_GCODE c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4611
-#: ../../Firmware/ultralcd.cpp:4614 ../../Firmware/ultralcd.cpp:4617
-#: ../../Firmware/ultralcd.cpp:4620
-msgid "Gcode"
-msgstr "Gcode"
-
 #. MSG_HW_SETUP c=18
 #: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4628
 #: ../../Firmware/ultralcd.cpp:4647 ../../Firmware/ultralcd.cpp:4747

--- a/lang/po/Firmware_ro.po
+++ b/lang/po/Firmware_ro.po
@@ -839,13 +839,6 @@ msgstr ""
 "G-code pregatit pentru firmware mai nou. Va rugam actualizati firmware-ul. "
 "Print anulat."
 
-#. MSG_GCODE c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4611
-#: ../../Firmware/ultralcd.cpp:4614 ../../Firmware/ultralcd.cpp:4617
-#: ../../Firmware/ultralcd.cpp:4620
-msgid "Gcode"
-msgstr "Gcode"
-
 #. MSG_HW_SETUP c=18
 #: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4628
 #: ../../Firmware/ultralcd.cpp:4647 ../../Firmware/ultralcd.cpp:4747

--- a/lang/po/Firmware_sk.po
+++ b/lang/po/Firmware_sk.po
@@ -835,13 +835,6 @@ msgstr ""
 "G-code je pripraveny pre novsi firmware. Prosim aktualizujte firmware. Tlac "
 "zrusena."
 
-#. MSG_GCODE c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4611
-#: ../../Firmware/ultralcd.cpp:4614 ../../Firmware/ultralcd.cpp:4617
-#: ../../Firmware/ultralcd.cpp:4620
-msgid "Gcode"
-msgstr "G-code"
-
 #. MSG_HW_SETUP c=18
 #: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4628
 #: ../../Firmware/ultralcd.cpp:4647 ../../Firmware/ultralcd.cpp:4747

--- a/lang/po/Firmware_sl.po
+++ b/lang/po/Firmware_sl.po
@@ -804,13 +804,6 @@ msgid ""
 "cancelled."
 msgstr ""
 
-#. MSG_GCODE c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4611
-#: ../../Firmware/ultralcd.cpp:4614 ../../Firmware/ultralcd.cpp:4617
-#: ../../Firmware/ultralcd.cpp:4620
-msgid "Gcode"
-msgstr ""
-
 #. MSG_HW_SETUP c=18
 #: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4628
 #: ../../Firmware/ultralcd.cpp:4647 ../../Firmware/ultralcd.cpp:4747

--- a/lang/po/Firmware_sv.po
+++ b/lang/po/Firmware_sv.po
@@ -836,13 +836,6 @@ msgstr ""
 "G-code genererad för en nyare firmware. Vänligen uppdatera firmware. "
 "Utskriften avbröts."
 
-#. MSG_GCODE c=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:4611
-#: ../../Firmware/ultralcd.cpp:4614 ../../Firmware/ultralcd.cpp:4617
-#: ../../Firmware/ultralcd.cpp:4620
-msgid "Gcode"
-msgstr "Gcode"
-
 #. MSG_HW_SETUP c=18
 #: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4628
 #: ../../Firmware/ultralcd.cpp:4647 ../../Firmware/ultralcd.cpp:4747


### PR DESCRIPTION
The code was added in v3.8.0 but the menu was never implemented according to the Git history. The menu code has always been commented out. I propose we remove this code so it doesn't need to be maintained.

Translation list is one item shorter :)