### PR TITLE
Recover from MMU restart while performing a command

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -9754,20 +9754,21 @@ bool setTargetedHotend(int code, uint8_t &extruder)
   return false;
 }
 
-void save_statistics(unsigned long _total_filament_used, unsigned long _total_print_time) //_total_filament_used unit: mm/100; print time in s
-{
-	uint32_t _previous_filament = eeprom_init_default_dword((uint32_t *)EEPROM_FILAMENTUSED, 0); //_previous_filament unit: cm
-	uint32_t _previous_time = eeprom_init_default_dword((uint32_t *)EEPROM_TOTALTIME, 0); //_previous_time unit: min
+void save_statistics(unsigned long _total_filament_used, unsigned long _total_print_time) { //_total_filament_used unit: mm/100; print time in s
+    uint32_t _previous_filament = eeprom_init_default_dword((uint32_t *)EEPROM_FILAMENTUSED, 0); //_previous_filament unit: cm
+    uint32_t _previous_time = eeprom_init_default_dword((uint32_t *)EEPROM_TOTALTIME, 0);        //_previous_time unit: min
 
-	eeprom_update_dword((uint32_t *)EEPROM_TOTALTIME, _previous_time + (_total_print_time/60)); //EEPROM_TOTALTIME unit: min
-	eeprom_update_dword((uint32_t *)EEPROM_FILAMENTUSED, _previous_filament + (_total_filament_used / 1000));
+    eeprom_update_dword((uint32_t *)EEPROM_TOTALTIME, _previous_time + (_total_print_time / 60)); // EEPROM_TOTALTIME unit: min
+    eeprom_update_dword((uint32_t *)EEPROM_FILAMENTUSED, _previous_filament + (_total_filament_used / 1000));
 
-	total_filament_used = 0;
+    total_filament_used = 0;
 
-  if (MMU2::mmu2.Enabled())
-  {
-    MMU2::mmu2.update_tool_change_counter_eeprom();
-  }
+    if (MMU2::mmu2.Enabled()) {
+        eeprom_add_dword((uint32_t *)EEPROM_TOTAL_TOOLCHANGE_COUNT, MMU2::mmu2.ToolChangeCounter());
+        // @@TODO why were EEPROM_MMU_FAIL_TOT and EEPROM_MMU_LOAD_FAIL_TOT behaving differently - i.e. updated with every change?
+        MMU2::mmu2.ClearToolChangeCounter();
+        MMU2::mmu2.ClearTMCFailures(); // not stored into EEPROM
+    }
 }
 
 float calculate_extruder_multiplier(float diameter) {

--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -67,6 +67,7 @@ const char MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1[] PROGMEM_I1 = ISTR("Measuring
 const char MSG_CALIBRATION[] PROGMEM_I1 = ISTR("Calibration"); ////MSG_CALIBRATION c=18
 const char MSG_MMU_FAILS[] PROGMEM_I1 = ISTR("MMU fails"); ////MSG_MMU_FAILS c=15
 const char MSG_MMU_LOAD_FAILS[] PROGMEM_I1 = ISTR("MMU load fails"); ////MSG_MMU_LOAD_FAILS c=15
+const char MSG_MMU_POWER_FAILS[] PROGMEM_I1 = ISTR("MMU power fails"); ////MSG_MMU_POWER_FAILS c=15
 const char MSG_NO[] PROGMEM_I1 = ISTR("No"); ////MSG_NO c=4
 const char MSG_NOZZLE[] PROGMEM_I1 = ISTR("Nozzle"); ////MSG_NOZZLE c=10
 const char MSG_PAPER[] PROGMEM_I1 = ISTR("Place a sheet of paper under the nozzle during the calibration of first 4 points. If the nozzle catches the paper, power off the printer immediately."); ////MSG_PAPER c=20 r=10

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -72,6 +72,7 @@ extern const char MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1[];
 extern const char MSG_CALIBRATION[];
 extern const char MSG_MMU_FAILS[];
 extern const char MSG_MMU_LOAD_FAILS[];
+extern const char MSG_MMU_POWER_FAILS[];
 extern const char MSG_NO[];
 extern const char MSG_NOZZLE[];
 extern const char MSG_PAPER[];

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -44,8 +44,8 @@ static constexpr float MMU2_LOAD_TO_NOZZLE_LENGTH = 87.0F + 5.0F;
 // The printer intercepts such a call and sets its extra load distance to match the new value as well.
 static constexpr uint8_t MMU2_TOOL_CHANGE_LOAD_LENGTH = 5; // mm
 
-static constexpr uint8_t MMU2_EXTRUDER_PTFE_LENGTH = 42.3f; // mm
-static constexpr uint8_t MMU2_EXTRUDER_HEATBREAK_LENGTH  = 17.7f; // mm
+static constexpr float MMU2_EXTRUDER_PTFE_LENGTH = 42.3f; // mm
+static constexpr float MMU2_EXTRUDER_HEATBREAK_LENGTH  = 17.7f; // mm
 
 static constexpr float MMU2_LOAD_TO_NOZZLE_FEED_RATE = 20.0F; // mm/s
 static constexpr float MMU2_UNLOAD_TO_FINDA_FEED_RATE = 120.0F; // mm/s

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -340,9 +340,9 @@ bool MMU2::VerifyFilamentEnteredPTFE()
 }
 
 void MMU2::ToolChangeCommon(uint8_t slot){
-    tool_change_extruder = slot;
     for(;;) { // while not successfully fed into extruder's PTFE tube
         for(;;) {
+            tool_change_extruder = slot;
             logic.ToolChange(slot); // let the MMU pull the filament out and push a new one in
             if( manage_response(true, true) )
                 break;

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -349,6 +349,12 @@ void MMU2::ToolChangeCommon(uint8_t slot){
                 break;
             // otherwise: failed to perform the command - unload first and then let it run again
             IncrementMMUFails();
+
+            // just in case we stood in an error screen for too long and the hotend got cold
+            ResumeHotendTemp();
+            // if the extruder has been parked, it will get unparked once the ToolChange command finishes OK
+            // - so no ResumeUnpark() at this spot
+
             unload();
             // if we run out of retries, we must do something ... may be raise an error screen and allow the user to do something
             // but honestly - if the MMU restarts during every toolchange,
@@ -771,7 +777,7 @@ bool MMU2::manage_response(const bool move_axes, const bool turn_off_nozzle) {
             if (!nozzleTimeout.running()){
                 nozzleTimeout.start();
                 LogEchoEvent_P(PSTR("Cooling Timeout started"));
-            } else if (nozzleTimeout.expired(DEFAULT_SAFETYTIMER_TIME_MINS*60*1000ul)){ // mins->msec. TODO: do we use the global or have our own independent timeout
+            } else if (nozzleTimeout.expired(DEFAULT_SAFETYTIMER_TIME_MINS*60*1000ul)){ // mins->msec.
                 mmu_print_saved &= ~(SavedState::CooldownPending);
                 mmu_print_saved |= SavedState::Cooldown;
                 setAllTargetHotends(0);

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -328,6 +328,8 @@ bool MMU2::VerifyFilamentEnteredPTFE()
         // Wait for move to finish and monitor the fsensor the entire time
         // A single 0 reading will set the bit.
         fsensorState |= !fsensor.getFilamentPresent();
+        manage_heater();
+        manage_inactivity(true);
     }
 
     if (fsensorState)

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -918,7 +918,17 @@ void MMU2::ReportError(ErrorCode ec, ErrorSource res) {
             IncrementMMUFails();
 
             // check if it is a "power" failure - we consider TMC-related errors as power failures
-            if( (uint16_t)ec & 0x7e00 ){ // @@TODO can be optimized to uint8_t operation
+            static constexpr uint16_t tmcMask =
+                ( (uint16_t)ErrorCode::TMC_IOIN_MISMATCH
+                | (uint16_t)ErrorCode::TMC_RESET
+                | (uint16_t)ErrorCode::TMC_UNDERVOLTAGE_ON_CHARGE_PUMP
+                | (uint16_t)ErrorCode::TMC_SHORT_TO_GROUND
+                | (uint16_t)ErrorCode::TMC_OVER_TEMPERATURE_WARN
+                | (uint16_t)ErrorCode::TMC_OVER_TEMPERATURE_ERROR
+                | (uint16_t)ErrorCode::MMU_SOLDERING_NEEDS_ATTENTION ) & 0x7fffU; // skip the top bit
+            static_assert(tmcMask == 0x7e00); // just make sure we fail compilation if any of the TMC error codes change
+
+            if ((uint16_t)ec & tmcMask) { // @@TODO can be optimized to uint8_t operation
                 // TMC-related errors are from 0x8200 higher
                 IncrementTMCFailures();
             }

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -334,7 +334,7 @@ bool MMU2::VerifyFilamentEnteredPTFE()
     } else {
         // else, happy printing! :)
         // Revert the movements
-        current_position[E_AXIS] -= MMU2_EXTRUDER_PTFE_LENGTH + MMU2_EXTRUDER_HEATBREAK_LENGTH;
+        current_position[E_AXIS] -= (MMU2_EXTRUDER_PTFE_LENGTH + MMU2_EXTRUDER_HEATBREAK_LENGTH);
         plan_buffer_line_curposXYZE(MMU2_LOAD_TO_NOZZLE_FEED_RATE);
         st_synchronize();
         return true;

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -880,6 +880,16 @@ void MMU2::ReportError(ErrorCode ec, ErrorSource res) {
         lastErrorCode = ec;
         lastErrorSource = res;
         LogErrorEvent_P( _O(PrusaErrorTitle(PrusaErrorCodeIndex((uint16_t)ec))) );
+
+        if( ec != ErrorCode::OK ){
+            IncrementMMUFails();
+
+            // check if it is a "power" failure - we consider TMC-related errors as power failures
+            if( (uint16_t)ec & 0x7e00 ){ // @@TODO can be optimized to uint8_t operation
+                // TMC-related errors are from 0x8200 higher
+                IncrementTMCFailures();
+            }
+        }
     }
 
     if( !mmu2.RetryIfPossible((uint16_t)ec) ) {

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -318,7 +318,7 @@ bool MMU2::VerifyFilamentEnteredPTFE()
     uint8_t fsensorState = 0;
     // MMU has finished its load, push the filament further by some defined constant length
     // If the filament sensor reads 0 at any moment, then report FAILURE
-    current_position[E_AXIS] += MMU2_EXTRUDER_PTFE_LENGTH + MMU2_EXTRUDER_HEATBREAK_LENGTH;
+    current_position[E_AXIS] += MMU2_EXTRUDER_PTFE_LENGTH + MMU2_EXTRUDER_HEATBREAK_LENGTH - logic.ExtraLoadDistance();
     plan_buffer_line_curposXYZE(MMU2_LOAD_TO_NOZZLE_FEED_RATE);
 
     while(blocks_queued())
@@ -334,7 +334,7 @@ bool MMU2::VerifyFilamentEnteredPTFE()
     } else {
         // else, happy printing! :)
         // Revert the movements
-        current_position[E_AXIS] -= (MMU2_EXTRUDER_PTFE_LENGTH + MMU2_EXTRUDER_HEATBREAK_LENGTH);
+        current_position[E_AXIS] -= (MMU2_EXTRUDER_PTFE_LENGTH + MMU2_EXTRUDER_HEATBREAK_LENGTH - logic.ExtraLoadDistance());
         plan_buffer_line_curposXYZE(MMU2_LOAD_TO_NOZZLE_FEED_RATE);
         st_synchronize();
         return true;

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -320,10 +320,13 @@ bool MMU2::VerifyFilamentEnteredPTFE()
     // If the filament sensor reads 0 at any moment, then report FAILURE
     current_position[E_AXIS] += MMU2_EXTRUDER_PTFE_LENGTH + MMU2_EXTRUDER_HEATBREAK_LENGTH - logic.ExtraLoadDistance();
     plan_buffer_line_curposXYZE(MMU2_LOAD_TO_NOZZLE_FEED_RATE);
+    current_position[E_AXIS] -= (MMU2_EXTRUDER_PTFE_LENGTH + MMU2_EXTRUDER_HEATBREAK_LENGTH - logic.ExtraLoadDistance());
+    plan_buffer_line_curposXYZE(MMU2_LOAD_TO_NOZZLE_FEED_RATE);
 
     while(blocks_queued())
     {
         // Wait for move to finish and monitor the fsensor the entire time
+        // A single 0 reading will set the bit.
         fsensorState |= !fsensor.getFilamentPresent();
     }
 
@@ -333,10 +336,6 @@ bool MMU2::VerifyFilamentEnteredPTFE()
         return false;
     } else {
         // else, happy printing! :)
-        // Revert the movements
-        current_position[E_AXIS] -= (MMU2_EXTRUDER_PTFE_LENGTH + MMU2_EXTRUDER_HEATBREAK_LENGTH - logic.ExtraLoadDistance());
-        plan_buffer_line_curposXYZE(MMU2_LOAD_TO_NOZZLE_FEED_RATE);
-        st_synchronize();
         return true;
     }
 }

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -311,7 +311,7 @@ void MMU2::update_tool_change_counter_eeprom() {
     reset_toolchange_counter();
 }
 
-void MMU2::MMU2::ToolChangeCommon(uint8_t slot){
+void MMU2::ToolChangeCommon(uint8_t slot){
     tool_change_extruder = slot;
     do {
         for(;;) {
@@ -320,10 +320,15 @@ void MMU2::MMU2::ToolChangeCommon(uint8_t slot){
                 break;
             // otherwise: failed to perform the command - unload first and then let it run again
             unload();
+            // if we run out of retries, we must do something ... may be raise an error screen and allow the user to do something
+            // but honestly - if the MMU restarts during every toolchange,
+            // something else is seriously broken and stopping a print is probably our best option.
         }
         // reset current position to whatever the planner thinks it is
         plan_set_e_position(current_position[E_AXIS]);
     } while (0); // while not successfully fed into etruder's PTFE tube
+    // when we run out of feeding retries, we should call an unload + cut before trying again.
+    // + we need some error screen report
 
     extruder = slot; //filament change is finished
     SpoolJoin::spooljoin.setSlot(slot);

--- a/Firmware/mmu2.h
+++ b/Firmware/mmu2.h
@@ -195,21 +195,17 @@ public:
     // Called by the MMU protocol when a sent button is acknowledged.
     void DecrementRetryAttempts();
 
-    /// Updates toolchange counter in EEPROM
-    /// ATmega2560 EEPROM has only 100'000 write/erase cycles
-    /// so we can't call this function on every tool change.
-    void update_tool_change_counter_eeprom();
-
     /// @return count for toolchange in current print
-    inline uint16_t read_toolchange_counter() const { return toolchange_counter; };
+    inline uint16_t ToolChangeCounter() const { return toolchange_counter; };
 
     /// Set toolchange counter to zero
-    inline void reset_toolchange_counter() { toolchange_counter = 0; };
+    inline void ClearToolChangeCounter() { toolchange_counter = 0; };
+
+    inline uint16_t TMCFailures()const { return tmcFailures; }
+    inline void IncrementTMCFailures() { ++tmcFailures; }
+    inline void ClearTMCFailures() { tmcFailures = 0; }
 
 private:
-    // Increment the toolchange counter via SRAM to reserve EEPROM write cycles
-    inline void increment_tool_change_counter() { ++toolchange_counter; };
-
     /// Reset the retryAttempts back to the default value
     void ResetRetryAttempts();
     /// Perform software self-reset of the MMU (sends an X0 command)
@@ -315,6 +311,7 @@ private:
     bool inAutoRetry;
     uint8_t retryAttempts;
     uint16_t toolchange_counter;
+    uint16_t tmcFailures;
 };
 
 /// following Marlin's way of doing stuff - one and only instance of MMU implementation in the code base

--- a/Firmware/mmu2.h
+++ b/Firmware/mmu2.h
@@ -280,11 +280,10 @@ private:
     /// @returns false if the MMU is not ready to perform the command (for whatever reason)
     bool WaitForMMUReady();
 
-    /// Redundancy test. After MMU completes a tool-change command
-    /// the printer will retract the filament by a distance set by the
-    //  Extra Loading Distance MMU register. If the Fsensor untriggers
-    /// at any moment the test fails. Else test passes, and the E-motor retraction
-    /// is reverted.
+    /// After MMU completes a tool-change command
+    /// the printer will push the filament by a constant distance. If the Fsensor untriggers
+    /// at any moment the test fails. Else the test passes, and the E-motor retracts the
+    /// filament back to its original position.
     /// @returns false if test fails, true otherwise
     bool VerifyFilamentEnteredPTFE();
 

--- a/Firmware/mmu2.h
+++ b/Firmware/mmu2.h
@@ -104,9 +104,9 @@ public:
     void mmu_loop();
 
     /// The main MMU command - select a different slot
-    /// @param index of the slot to be selected
+    /// @param slot of the slot to be selected
     /// @returns false if the operation cannot be performed (Stopped)
-    bool tool_change(uint8_t index);
+    bool tool_change(uint8_t slot);
     
     /// Handling of special Tx, Tc, T? commands
     bool tool_change(char code, uint8_t slot);
@@ -118,20 +118,20 @@ public:
 
     /// Load (insert) filament just into the MMU (not into printer's nozzle)
     /// @returns false if the operation cannot be performed (Stopped)
-    bool load_filament(uint8_t index);
+    bool load_filament(uint8_t slot);
     
     /// Load (push) filament from the MMU into the printer's nozzle
     /// @returns false if the operation cannot be performed (Stopped or cold extruder)
-    bool load_filament_to_nozzle(uint8_t index);
+    bool load_filament_to_nozzle(uint8_t slot);
 
     /// Move MMU's selector aside and push the selected filament forward.
     /// Usable for improving filament's tip or pulling the remaining piece of filament out completely.
-    bool eject_filament(uint8_t index, bool recover);
+    bool eject_filament(uint8_t slot, bool recover);
 
     /// Issue a Cut command into the MMU
     /// Requires unloaded filament from the printer (obviously)
     /// @returns false if the operation cannot be performed (Stopped)
-    bool cut_filament(uint8_t index);
+    bool cut_filament(uint8_t slot);
 
     /// Issue a planned request for statistics data from MMU
     void get_statistics();
@@ -140,9 +140,9 @@ public:
     /// It behaves very similarly like a ToolChange, but it doesn't load the filament
     /// all the way down to the nozzle. The sole purpose of this operation
     /// is to check, that the filament will be ready for printing.
-    /// @param index index of slot to be tested
+    /// @param slot index of slot to be tested
     /// @returns true
-    bool loading_test(uint8_t index);
+    bool loading_test(uint8_t slot);
 
     /// @returns the active filament slot index (0-4) or 0xff in case of no active tool
     uint8_t get_current_tool() const;
@@ -150,7 +150,7 @@ public:
     /// @returns The filament slot index (0 to 4) that will be loaded next, 0xff in case of no active tool change 
     uint8_t get_tool_change_tool() const;
 
-    bool set_filament_type(uint8_t index, uint8_t type);
+    bool set_filament_type(uint8_t slot, uint8_t type);
 
     /// Issue a "button" click into the MMU - to be used from Error screens of the MMU
     /// to select one of the 3 possible options to resolve the issue
@@ -285,7 +285,7 @@ private:
     bool WaitForMMUReady();
 
     /// Common processing of pushing filament into the extruder - shared by tool_change, load_to_nozzle and probably others
-    void ToolChangeCommon(uint8_t index);
+    void ToolChangeCommon(uint8_t slot);
 
     ProtocolLogic logic; ///< implementation of the protocol logic layer
     uint8_t extruder; ///< currently active slot in the MMU ... somewhat... not sure where to get it from yet

--- a/Firmware/mmu2.h
+++ b/Firmware/mmu2.h
@@ -284,6 +284,9 @@ private:
     /// @returns false if the MMU is not ready to perform the command (for whatever reason)
     bool WaitForMMUReady();
 
+    /// Common processing of pushing filament into the extruder - shared by tool_change, load_to_nozzle and probably others
+    void ToolChangeCommon(uint8_t index);
+
     ProtocolLogic logic; ///< implementation of the protocol logic layer
     uint8_t extruder; ///< currently active slot in the MMU ... somewhat... not sure where to get it from yet
     uint8_t tool_change_extruder; ///< only used for UI purposes

--- a/Firmware/mmu2.h
+++ b/Firmware/mmu2.h
@@ -227,7 +227,8 @@ private:
 
     /// Along with the mmu_loop method, this loops until a response from the MMU is received and acts upon.
     /// In case of an error, it parks the print head and turns off nozzle heating
-    void manage_response(const bool move_axes, const bool turn_off_nozzle);
+    /// @returns false if the command could not have been completed (MMU interrupted)
+    [[nodiscard]] bool manage_response(const bool move_axes, const bool turn_off_nozzle);
 
     /// The inner private implementation of mmu_loop()
     /// which is NOT (!!!) recursion-guarded. Use caution - but we do need it during waiting for hotend resume to keep comms alive!

--- a/Firmware/mmu2.h
+++ b/Firmware/mmu2.h
@@ -286,7 +286,7 @@ private:
     /// at any moment the test fails. Else test passes, and the E-motor retraction
     /// is reverted.
     /// @returns false if test fails, true otherwise
-    bool FSensorCalibrationCheck();
+    bool VerifyFilamentEnteredPTFE();
 
     /// Common processing of pushing filament into the extruder - shared by tool_change, load_to_nozzle and probably others
     void ToolChangeCommon(uint8_t slot);

--- a/Firmware/mmu2.h
+++ b/Firmware/mmu2.h
@@ -280,6 +280,14 @@ private:
     /// @returns false if the MMU is not ready to perform the command (for whatever reason)
     bool WaitForMMUReady();
 
+    /// Redundancy test. After MMU completes a tool-change command
+    /// the printer will retract the filament by a distance set by the
+    //  Extra Loading Distance MMU register. If the Fsensor untriggers
+    /// at any moment the test fails. Else test passes, and the E-motor retraction
+    /// is reverted.
+    /// @returns false if test fails, true otherwise
+    bool FSensorCalibrationCheck();
+
     /// Common processing of pushing filament into the extruder - shared by tool_change, load_to_nozzle and probably others
     void ToolChangeCommon(uint8_t slot);
 

--- a/Firmware/mmu2_protocol_logic.cpp
+++ b/Firmware/mmu2_protocol_logic.cpp
@@ -351,8 +351,6 @@ StepStatus ProtocolLogic::ProcessCommandQueryResponse() {
             return Finished;
         } else {
             // got response to some other command - the originally issued command was interrupted!
-            static const char intr[] PROGMEM = "Intr2"; // @@TODO clean up
-            MMU2_ERROR_MSGRPGM(intr);
             return Interrupted;
         }
     default:
@@ -444,8 +442,6 @@ StepStatus ProtocolLogic::IdleStep() {
                 if( ReqMsg().code != RequestMsgCodes::unknown ){
                     // got reset while doing some other command - the originally issued command was interrupted!
                     // this must be solved by the upper layer, protocol logic doesn't have all the context (like unload before trying again)
-                    static const char intr[] PROGMEM = "Intr1"; // @@TODO cleanup
-                    MMU2_ERROR_MSGRPGM(intr);
                     IdleRestart();
                     return Interrupted;
                 }

--- a/Firmware/mmu2_protocol_logic.h
+++ b/Firmware/mmu2_protocol_logic.h
@@ -33,7 +33,8 @@ class ProtocolLogic;
 enum StepStatus : uint_fast8_t {
     Processing = 0,
     MessageReady, ///< a message has been successfully decoded from the received bytes
-    Finished,
+    Finished, ///< Scope finished successfully
+    Interrupted, ///< received "Finished" message related to a different command than originally issued (most likely the MMU restarted while doing something)
     CommunicationTimeout, ///< the MMU failed to respond to a request within a specified time frame
     ProtocolError,        ///< bytes read from the MMU didn't form a valid response
     CommandRejected,      ///< the MMU rejected the command due to some other command in progress, may be the user is operating the MMU locally (button commands)

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -233,14 +233,6 @@ void ReportErrorHook(uint16_t ec) {
     case (uint8_t)ReportErrorHookStates::RENDER_ERROR_SCREEN:
         ReportErrorHookStaticRender(ei);
         ReportErrorHookState = ReportErrorHookStates::MONITOR_SELECTION;
-        IncrementMMUFails();
-
-        // check if it is a "power" failure - we consider TMC-related errors as power failures
-        if( (uint16_t)ec & 0x7e00 ){ // @@TODO can be optimized to uint8_t operation
-            // TMC-related errors are from 0x8200 higher
-            // we can increment a power error at this spot
-            mmu2.IncrementTMCFailures();
-        }
         [[fallthrough]];
     case (uint8_t)ReportErrorHookStates::MONITOR_SELECTION:
         mmu2.is_mmu_error_monitor_active = true;

--- a/Firmware/mmu2_reporting.h
+++ b/Firmware/mmu2_reporting.h
@@ -46,4 +46,11 @@ bool MMUAvailable();
 /// Global Enable/Disable use MMU (to be stored in EEPROM)
 bool UseMMU();
 
+/// Increments EEPROM cell - number of failed loads into the nozzle
+/// Note: technically, this is not an MMU error but an error of the printer.
+void IncrementLoadFails();
+
+/// Increments EEPROM cell - number of MMU errors
+void IncrementMMUFails();
+
 } // namespace

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1156,7 +1156,7 @@ static void lcd_menu_fails_stats_mmu_total() {
         _T(MSG_TOTAL_FAILURES),
         _T(MSG_MMU_FAILS), clamp999( eeprom_read_word((uint16_t*)EEPROM_MMU_FAIL_TOT) ),
         _T(MSG_MMU_LOAD_FAILS), clamp999( eeprom_read_word((uint16_t*)EEPROM_MMU_LOAD_FAIL_TOT) ),
-        _i("MMU power fails"), clamp999( MMU2::mmu2.TMCFailures() ));
+        _T(MSG_MMU_POWER_FAILS), clamp999( MMU2::mmu2.TMCFailures() ));
     menu_back_if_clicked_fb();
 }
 

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1120,11 +1120,14 @@ static void lcd_menu_fails_stats_mmu()
 //! |                    |
 //! ----------------------
 //! @endcode
-static void lcd_menu_fails_stats_mmu_print()
-{
-	lcd_timeoutToStatus.stop(); //infinite timeout
+static void lcd_menu_fails_stats_mmu_print() {
+    lcd_timeoutToStatus.stop(); //infinite timeout
     lcd_home();
-    lcd_printf_P(PSTR("%S\n" " %-16.16S%-3d\n" " %-16.16S%-3d"), 
+    lcd_printf_P(
+        PSTR("%S\n"
+             " %-16.16S%-3d\n"
+             " %-16.16S%-3d"
+        ),
         _T(MSG_LAST_PRINT_FAILURES),
         _T(MSG_MMU_FAILS), clamp999( eeprom_read_byte((uint8_t*)EEPROM_MMU_FAIL) ),
         _T(MSG_MMU_LOAD_FAILS), clamp999( eeprom_read_byte((uint8_t*)EEPROM_MMU_LOAD_FAIL) ));
@@ -1141,31 +1144,20 @@ static void lcd_menu_fails_stats_mmu_print()
 //! | MMU power fails 000|	MSG_MMU_POWER_FAILS c=15
 //! ----------------------
 //! @endcode
-//! @todo Positioning of the messages and values on LCD aren't fixed to their exact place. This causes issues with translations.
-static void lcd_menu_fails_stats_mmu_total()
-{
-    typedef struct
-    {
-        bool initialized;              // 1byte
-    } _menu_data_t;
-    static_assert(sizeof(menu_data)>= sizeof(_menu_data_t),"_menu_data_t doesn't fit into menu_data");
-    _menu_data_t* _md = (_menu_data_t*)&(menu_data[0]);
-    if(_md->initialized) {
-        MMU2::mmu2.get_statistics();
-        lcd_timeoutToStatus.stop(); //infinite timeout
-        _md->initialized = false;
-    }
+static void lcd_menu_fails_stats_mmu_total() {
+    lcd_timeoutToStatus.stop(); //infinite timeout
     lcd_home();
-    lcd_printf_P(PSTR("%S\n" " %-16.16S%-3d\n"/* " %-16.16S%-3d\n" " %-16.16S%-3d"*/), 
+    lcd_printf_P(
+        PSTR("%S\n"
+             " %-16.16S%-3d\n"
+             " %-16.16S%-3d\n"
+             " %-16.16S%-3d"
+        ),
         _T(MSG_TOTAL_FAILURES),
-        _T(MSG_MMU_FAILS), clamp999( MMU2::mmu2.TotalFailStatistics() ));//,
-        //_T(MSG_MMU_LOAD_FAILS), clamp999( eeprom_read_word((uint16_t*)EEPROM_MMU_LOAD_FAIL_TOT) ),
-        //_i("MMU power fails"), clamp999( mmu_power_failures )); ////MSG_MMU_POWER_FAILS c=15
-    if (lcd_clicked())
-    {
-        lcd_quick_feedback();
-        menu_back();
-    }
+        _T(MSG_MMU_FAILS), clamp999( eeprom_read_word((uint16_t*)EEPROM_MMU_FAIL_TOT) ),
+        _T(MSG_MMU_LOAD_FAILS), clamp999( eeprom_read_word((uint16_t*)EEPROM_MMU_LOAD_FAIL_TOT) ),
+        _i("MMU power fails"), clamp999( MMU2::mmu2.TMCFailures() ));
+    menu_back_if_clicked_fb();
 }
 
 //! @brief Show Total Failures Statistics MMU


### PR DESCRIPTION
This PR will bring smooth recovery from accidental MMU restarts while performing a command. 
Both printer and MMU are capable of recovering cleanly, it just hasn't been addressed yet to full extent.

Moreover, the infrastructure will be possibly leveraged to recovery of failed loads into extruder PTFE tube.

PFW-1427
PFW-1407
PFW-1432
PFW-1355