### PR TITLE
optimisation: TCodes accepts `uint8_t` not `float`

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -8767,7 +8767,7 @@ Sigma_Exit:
   @n Tc Load to nozzle after filament was prepared by Tc and extruder nozzle is already heated.
   */
   else if(code_seen('T')){
-        TCodes(strchr_pointer, code_value());
+        TCodes(strchr_pointer, code_value_uint8());
   } // end if(code_seen('T')) (end of T codes)
   /*!
   #### End of T-Codes


### PR DESCRIPTION
Note the type of `codeValue` in `void TCodes(char *const strchr_pointer, uint8_t codeValue) `

Change in memory:
Flash: -20 bytes
SRAM: 0 bytes