### PR TITLE
Improve `lcdui_print_extruder` to cover two more scenarios

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -455,12 +455,12 @@ uint8_t lcdui_print_extruder(void) {
     lcd_space(1);
     if (MMU2::mmu2.get_current_tool() == MMU2::mmu2.get_tool_change_tool()) {
         lcd_putc('F');
-        lcd_putc(MMU2::mmu2.get_current_tool() == (uint8_t)MMU2::FILAMENT_UNKNOWN ? '?' : MMU2::mmu2.get_current_tool() + 1);
+        lcd_putc(MMU2::mmu2.get_current_tool() == (uint8_t)MMU2::FILAMENT_UNKNOWN ? '?' : MMU2::mmu2.get_current_tool() + '1');
         chars += 2;
     } else {
-        lcd_putc(MMU2::mmu2.get_current_tool() == (uint8_t)MMU2::FILAMENT_UNKNOWN ? '?' : MMU2::mmu2.get_current_tool() + 1);
+        lcd_putc(MMU2::mmu2.get_current_tool() == (uint8_t)MMU2::FILAMENT_UNKNOWN ? '?' : MMU2::mmu2.get_current_tool() + '1');
         lcd_putc('>');
-        lcd_putc(MMU2::mmu2.get_tool_change_tool() == (uint8_t)MMU2::FILAMENT_UNKNOWN ? '?' : MMU2::mmu2.get_tool_change_tool() + 1);
+        lcd_putc(MMU2::mmu2.get_tool_change_tool() == (uint8_t)MMU2::FILAMENT_UNKNOWN ? '?' : MMU2::mmu2.get_tool_change_tool() + '1');
         chars += 3;
     }
     return chars;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -441,24 +441,27 @@ void lcdui_print_percent_done(void)
 // Scenario 3: "?>[nr.]"
 //              [nr.] ranges from 1 to 5.
 //              There is no filament currently loaded, but [nr.] is currently being loaded via tool change
-// Scenario 4: "[nr1.] > [nr2.]"
+// Scenario 4: "[nr.]>?"
+//              [nr.] ranges from 1 to 5.
+//              This scenario indicates a bug in the firmware if ? is on the right side
+// Scenario 5: "[nr1.]>[nr2.]"
 //              [nr1.] ranges from 1 to 5.
 //              [nr2.] ranges from 1 to 5.
 //              Filament [nr1.] was loaded, but [nr2.] is currently being loaded via tool change
+// Scenario 6: "?>?"
+//              This scenario should not be possible and indicates a bug in the firmware
 uint8_t lcdui_print_extruder(void) {
-    uint8_t chars = 0;
+    uint8_t chars = 1;
+    lcd_space(1);
     if (MMU2::mmu2.get_current_tool() == MMU2::mmu2.get_tool_change_tool()) {
-        if (MMU2::mmu2.get_current_tool() == (uint8_t)MMU2::FILAMENT_UNKNOWN) {
-            chars = lcd_printf_P(_N(" F?"));
-        } else {
-            chars = lcd_printf_P(_N(" F%u"), MMU2::mmu2.get_current_tool() + 1);
-        }
+        lcd_putc('F');
+        lcd_putc(MMU2::mmu2.get_current_tool() == (uint8_t)MMU2::FILAMENT_UNKNOWN ? '?' : MMU2::mmu2.get_current_tool() + 1);
+        chars += 2;
     } else {
-        if (MMU2::mmu2.get_current_tool() == (uint8_t)MMU2::FILAMENT_UNKNOWN) {
-            chars = lcd_printf_P(_N(" ?>%u"), MMU2::mmu2.get_tool_change_tool() + 1);
-        } else {
-            chars = lcd_printf_P(_N(" %u>%u"), MMU2::mmu2.get_current_tool() + 1, MMU2::mmu2.get_tool_change_tool() + 1);
-        }
+        lcd_putc(MMU2::mmu2.get_current_tool() == (uint8_t)MMU2::FILAMENT_UNKNOWN ? '?' : MMU2::mmu2.get_current_tool() + 1);
+        lcd_putc('>');
+        lcd_putc(MMU2::mmu2.get_tool_change_tool() == (uint8_t)MMU2::FILAMENT_UNKNOWN ? '?' : MMU2::mmu2.get_tool_change_tool() + 1);
+        chars += 3;
     }
     return chars;
 }


### PR DESCRIPTION
Simplify the rendering to cover more scenarios:
* `"[nr.]>?"`
* `"?>?"`
Both of these new scenarios indicate there is a bug in the firmware. Currently these scenarios were not rendered correctly and would result in the status screen being corrupted. This is because the firmware was trying to write a 3 digit number where there is no space on the LCD for it.

| BEFORE  |  AFTER  |
|---|---|
|  ![IMG_2676](https://user-images.githubusercontent.com/8218499/202872054-b3f8af6c-5745-4829-9ebe-9bd6c7dab320.jpg) |  ![IMG_2677](https://user-images.githubusercontent.com/8218499/202872078-d05b4f6a-5222-422a-b618-a5b9eee7980c.jpg) |

Change in memory:
Flash: -52 bytes
SRAM: 0 bytes