### PR TITLE
PFW-1434: MK3 Temp model calibration during wizard

### DIFF
--- a/Firmware/Configuration.h
+++ b/Firmware/Configuration.h
@@ -555,7 +555,7 @@ enum CalibrationStatus
 	CALIBRATION_STATUS_TEMP_MODEL_CALIBRATION = 235,
 #endif //TEMP_MODEL
 
-// The XYZ calibration AND OR Temp model calibartion has been performed, now it remains to run the V2Calibration.gcode.
+// The XYZ calibration AND OR Temp model calibration has been performed, now it remains to run the V2Calibration.gcode.
 	CALIBRATION_STATUS_LIVE_ADJUST = 230,
 
     // Calibrated, ready to print.

--- a/Firmware/Configuration.h
+++ b/Firmware/Configuration.h
@@ -550,7 +550,12 @@ enum CalibrationStatus
 	// For the wizard: factory assembled, needs to run Z calibration.
 	CALIBRATION_STATUS_Z_CALIBRATION = 240,
 
-	// The XYZ calibration has been performed, now it remains to run the V2Calibration.gcode.
+#ifdef TEMP_MODEL
+	// The XYZ calibration has been performed, needs to run Temp model calibration.
+	CALIBRATION_STATUS_TEMP_MODEL_CALIBRATION = 235,
+#endif //TEMP_MODEL
+
+// The XYZ calibration AND OR Temp model calibartion has been performed, now it remains to run the V2Calibration.gcode.
 	CALIBRATION_STATUS_LIVE_ADJUST = 230,
 
     // Calibrated, ready to print.

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1524,7 +1524,7 @@ void setup()
 	  }
 #ifdef TEMP_MODEL
 	  else if (calibration_status() == CALIBRATION_STATUS_TEMP_MODEL_CALIBRATION) {
-		  lcd_show_fullscreen_message_and_wait_P(_i("Temp model calibration not calibrated yet."));////MSG_TEMP_MODEL_NOT_CAL c=20 c=4
+		  lcd_show_fullscreen_message_and_wait_P(_T(MSG_TM_NOT_CAL));
 		  lcd_update_enable(true);
 	  }
 #endif //TEMP_MODEL
@@ -3401,7 +3401,7 @@ bool gcode_M45(bool onlyZ, int8_t verbosity_level)
 				{
 #ifdef TEMP_MODEL
 					calibration_status_store(CALIBRATION_STATUS_TEMP_MODEL_CALIBRATION);
-					if (eeprom_read_byte((uint8_t*)EEPROM_WIZARD_ACTIVE) != 1) lcd_show_fullscreen_message_and_wait_P(_i("Temp model calibration not calibrated yet."));
+					if (eeprom_read_byte((uint8_t*)EEPROM_WIZARD_ACTIVE) != 1) lcd_show_fullscreen_message_and_wait_P(_T(MSG_TM_NOT_CAL));
 #else
 					// Calibration valid, the machine should be able to print. Advise the user to run the V2Calibration.gcode.
 					calibration_status_store(CALIBRATION_STATUS_LIVE_ADJUST);

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1522,6 +1522,12 @@ void setup()
 		  // Show the message.
 		  lcd_show_fullscreen_message_and_wait_P(_T(MSG_FOLLOW_CALIBRATION_FLOW));
 	  }
+#ifdef TEMP_MODEL
+	  else if (calibration_status() == CALIBRATION_STATUS_TEMP_MODEL_CALIBRATION) {
+		  lcd_show_fullscreen_message_and_wait_P(_i("Temp model calibration not calibrated yet."));////MSG_TEMP_MODEL_NOT_CAL c=20 c=4
+		  lcd_update_enable(true);
+	  }
+#endif //TEMP_MODEL
 	  else if (calibration_status() == CALIBRATION_STATUS_LIVE_ADJUST) {
 		  // Show the message.
 		  lcd_show_fullscreen_message_and_wait_P(_T(MSG_BABYSTEP_Z_NOT_SET));
@@ -3393,9 +3399,14 @@ bool gcode_M45(bool onlyZ, int8_t verbosity_level)
 				lcd_bed_calibration_show_result(result, point_too_far_mask);
 				if (result >= 0)
 				{
+#ifdef TEMP_MODEL
+					calibration_status_store(CALIBRATION_STATUS_TEMP_MODEL_CALIBRATION);
+					if (eeprom_read_byte((uint8_t*)EEPROM_WIZARD_ACTIVE) != 1) lcd_show_fullscreen_message_and_wait_P(_i("Temp model calibration not calibrated yet."));
+#else
 					// Calibration valid, the machine should be able to print. Advise the user to run the V2Calibration.gcode.
 					calibration_status_store(CALIBRATION_STATUS_LIVE_ADJUST);
 					if (eeprom_read_byte((uint8_t*)EEPROM_WIZARD_ACTIVE) != 1) lcd_show_fullscreen_message_and_wait_P(_T(MSG_BABYSTEP_Z_NOT_SET));
+#endif //TEMP_MODEL
 					final_result = true;
 				}
 			}

--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -167,6 +167,7 @@ const char MSG_IR_UNKNOWN[] PROGMEM_I1 = ISTR("unknown state");////MSG_IR_UNKNOW
 extern const char MSG_PAUSED_THERMAL_ERROR[] PROGMEM_I1 = ISTR("PAUSED THERMAL ERROR");////MSG_PAUSED_THERMAL_ERROR c=20
 #ifdef TEMP_MODEL
 extern const char MSG_THERMAL_ANOMALY[] PROGMEM_I1 = ISTR("THERMAL ANOMALY");////MSG_THERMAL_ANOMALY c=20
+extern const char MSG_TM_NOT_CAL[] PROGMEM_I1 = ISTR("Temp model not calibrated yet.");////MSG_TM_NOT_CAL c=20 r=4
 #endif
 extern const char MSG_LOAD_ALL[] PROGMEM_I1 = ISTR("Load All"); ////MSG_LOAD_ALL c=18
 

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -171,6 +171,7 @@ extern const char MSG_IR_UNKNOWN[];
 extern const char MSG_PAUSED_THERMAL_ERROR[];
 #ifdef TEMP_MODEL
 extern const char MSG_THERMAL_ANOMALY[];
+extern const char MSG_TM_NOT_CAL[];
 #endif
 extern const char MSG_LOAD_ALL[];
 

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -4051,7 +4051,7 @@ void lcd_wizard(WizState state)
 			break;
 #ifdef TEMP_MODEL
 		case S::TempModel:
-			lcd_show_fullscreen_message_and_wait_P(_i("Temp model cal. takes apporx. 12 mins."));////MSG_TM_CAL c=20 r=4
+			lcd_show_fullscreen_message_and_wait_P(_i("Temp model cal. takes approx. 12 mins."));////MSG_TM_CAL c=20 r=4
 			lcd_commands_type = LcdCommands::TempModel;
 			end = true; // Leave wizard temporarily for Temp model cal.
 			break;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3964,7 +3964,7 @@ void lcd_wizard(WizState state)
     FORCE_BL_ON_START;
 	
     while (!end) {
-		printf_P(PSTR("Wizard state: %d\n"), state);
+		printf_P(PSTR("Wizard state: %d\n"), (uint8_t)state);
 		switch (state) {
 		case S::Run: //Run wizard?
 			
@@ -4117,7 +4117,7 @@ void lcd_wizard(WizState state)
     
     FORCE_BL_ON_END;
     
-	printf_P(_N("Wizard end state: %d\n"), state);
+	printf_P(_N("Wizard end state: %d\n"), (uint8_t)state);
 	switch (state) { //final message
 	case S::Restore: //printer was already calibrated
 		msg = _T(MSG_WIZARD_DONE);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -997,8 +997,12 @@ void lcd_commands()
         //if (lcd_commands_step == 1 && calibrated()) {
         if (lcd_commands_step == 1 && temp_model_valid()) {
             enquecommand_P(PSTR("M500"));
-            lcd_commands_step = 0;
-            lcd_commands_type = LcdCommands::Idle;
+            if (eeprom_read_byte((uint8_t*)EEPROM_WIZARD_ACTIVE) == 1) {
+                lcd_wizard(WizState::IsFil);
+            } else {
+                lcd_commands_step = 0;
+                lcd_commands_type = LcdCommands::Idle;
+            }
         }
     }
 #endif //TEMP_MODEL
@@ -3994,6 +3998,9 @@ void lcd_wizard(WizState state)
 			case CALIBRATION_STATUS_ASSEMBLED: state = S::Selftest; break; //run selftest
 			case CALIBRATION_STATUS_XYZ_CALIBRATION: state = S::Xyz; break; //run xyz cal.
 			case CALIBRATION_STATUS_Z_CALIBRATION: state = S::Z; break; //run z cal.
+#ifdef TEMP_MODEL
+			case CALIBRATION_STATUS_TEMP_MODEL_CALIBRATION: state = S::TempModel; break; //run temp model cal.
+#endif //TEMP_MODEL
 			case CALIBRATION_STATUS_LIVE_ADJUST: state = S::IsFil; break; //run live adjust
 			case CALIBRATION_STATUS_CALIBRATED: end = true; eeprom_update_byte((uint8_t*)EEPROM_WIZARD_ACTIVE, 0); break;
 			default: state = S::Selftest; break; //if calibration status is unknown, run wizard from the beginning
@@ -4011,8 +4018,13 @@ void lcd_wizard(WizState state)
 		case S::Xyz:
 			lcd_show_fullscreen_message_and_wait_P(_i("I will run xyz calibration now. It will take approx. 12 mins."));////MSG_WIZARD_XYZ_CAL c=20 r=8
 			wizard_event = gcode_M45(false, 0);
-			if (wizard_event) state = S::IsFil;
-			else end = true;
+			if (wizard_event) {
+#ifdef TEMP_MODEL
+			state = S::TempModel;
+#else
+			state = S::IsFil;
+#endif //TEMP_MODEL
+			} else end = true;
 			break;
 		case S::Z:
 			lcd_show_fullscreen_message_and_wait_P(_i("Please remove shipping helpers first."));////MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
@@ -4038,6 +4050,13 @@ void lcd_wizard(WizState state)
 			}
 			else end = true;
 			break;
+#ifdef TEMP_MODEL
+		case S::TempModel:
+			lcd_show_fullscreen_message_and_wait_P(_i("Temp model cal. takes apporx. 12 mins."));////MSG_TM_CAL c=20 r=4
+			lcd_commands_type = LcdCommands::TempModel;
+			end = true; // Leave wizard temporarily for Temp model cal.
+			break;
+#endif //TEMP_MODEL
 		case S::IsFil:
 		    //start to preheat nozzle and bed to save some time later
 			setTargetHotend(PLA_PREHEAT_HOTEND_TEMP, 0);
@@ -4108,6 +4127,10 @@ void lcd_wizard(WizState state)
 	case S::Z: //z cal.
 		msg = _T(MSG_WIZARD_CALIBRATION_FAILED);
 		break;
+#ifdef TEMP_MODEL
+	case S::TempModel: //Temp model calibration
+//		break;
+#endif //TEMP_MODEL
 	case S::Finish: //we are finished
 
 		msg = _T(MSG_WIZARD_DONE);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -4018,6 +4018,7 @@ void lcd_wizard(WizState state)
 			wizard_event = gcode_M45(false, 0);
 			if (wizard_event) {
 #ifdef TEMP_MODEL
+			lcd_reset_alert_level();
 			state = S::TempModel;
 #else
 			state = S::IsFil;

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -230,6 +230,9 @@ enum class WizState : uint8_t
     Selftest,       //!< self test
     Xyz,            //!< xyz calibration
     Z,              //!< z calibration
+#ifdef TEMP_MODEL
+    TempModel,      //!< Temp model calibration
+#endif //TEMP_MODEL
     IsFil,          //!< Is filament loaded? First step of 1st layer calibration
     PreheatPla,     //!< waiting for preheat nozzle for PLA
     Preheat,        //!< Preheat for any material

--- a/lang/po/Firmware.pot
+++ b/lang/po/Firmware.pot
@@ -2032,7 +2032,7 @@ msgstr ""
 
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
-msgid "Temp model cal. takes apporx. 12 mins."
+msgid "Temp model cal. takes approx. 12 mins."
 msgstr ""
 
 #. MSG_TM_NOT_CAL c=20 r=4

--- a/lang/po/Firmware.pot
+++ b/lang/po/Firmware.pot
@@ -2030,6 +2030,17 @@ msgstr ""
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr ""
 
+#. MSG_TM_CAL c=20 r=4
+#: ../../Firmware/ultralcd.cpp:4054
+msgid "Temp model cal. takes apporx. 12 mins."
+msgstr ""
+
+#. MSG_TM_NOT_CAL c=20 r=4
+#: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
+#: ../../Firmware/messages.cpp:170
+msgid "Temp model not calibrated yet."
+msgstr ""
+
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4717
 msgid "Temperature"

--- a/lang/po/Firmware_cs.po
+++ b/lang/po/Firmware_cs.po
@@ -2108,7 +2108,7 @@ msgstr "TMC CHYBA NIZKE NAP."
 
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
-msgid "Temp model cal. takes apporx. 12 mins."
+msgid "Temp model cal. takes approx. 12 mins."
 msgstr "Kalkulace teplotního modelu trvá přibližně. 12 minut."
 
 #. MSG_TM_NOT_CAL c=20 r=4

--- a/lang/po/Firmware_cs.po
+++ b/lang/po/Firmware_cs.po
@@ -2109,7 +2109,7 @@ msgstr "TMC CHYBA NIZKE NAP."
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
 msgid "Temp model cal. takes approx. 12 mins."
-msgstr "Kalkulace teplotního modelu trvá přibližně. 12 minut."
+msgstr "Kalibrace teplotního modelu trvá asi 12 minut."
 
 #. MSG_TM_NOT_CAL c=20 r=4
 #: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404

--- a/lang/po/Firmware_cs.po
+++ b/lang/po/Firmware_cs.po
@@ -2106,6 +2106,17 @@ msgstr "TMC CHYBA: PREHRATI"
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr "TMC CHYBA NIZKE NAP."
 
+#. MSG_TM_CAL c=20 r=4
+#: ../../Firmware/ultralcd.cpp:4054
+msgid "Temp model cal. takes apporx. 12 mins."
+msgstr "Kalkulace teplotního modelu trvá přibližně. 12 minut."
+
+#. MSG_TM_NOT_CAL c=20 r=4
+#: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
+#: ../../Firmware/messages.cpp:170
+msgid "Temp model not calibrated yet."
+msgstr "Teplotní model zatím nebyl kalibrován."
+
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4717
 msgid "Temperature"

--- a/lang/po/Firmware_da.po
+++ b/lang/po/Firmware_da.po
@@ -2041,7 +2041,7 @@ msgstr ""
 
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
-msgid "Temp model cal. takes apporx. 12 mins."
+msgid "Temp model cal. takes approx. 12 mins."
 msgstr ""
 
 #. MSG_TM_NOT_CAL c=20 r=4

--- a/lang/po/Firmware_da.po
+++ b/lang/po/Firmware_da.po
@@ -2039,6 +2039,17 @@ msgstr ""
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr ""
 
+#. MSG_TM_CAL c=20 r=4
+#: ../../Firmware/ultralcd.cpp:4054
+msgid "Temp model cal. takes apporx. 12 mins."
+msgstr ""
+
+#. MSG_TM_NOT_CAL c=20 r=4
+#: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
+#: ../../Firmware/messages.cpp:170
+msgid "Temp model not calibrated yet."
+msgstr ""
+
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4717
 msgid "Temperature"

--- a/lang/po/Firmware_de.po
+++ b/lang/po/Firmware_de.po
@@ -2128,7 +2128,7 @@ msgstr "TMC UNTERSPANN.FEHL."
 
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
-msgid "Temp model cal. takes apporx. 12 mins."
+msgid "Temp model cal. takes approx. 12 mins."
 msgstr "Die Kalibrierung des Temperaturmodells dauert etwa 12 Minuten."
 
 #. MSG_TM_NOT_CAL c=20 r=4

--- a/lang/po/Firmware_de.po
+++ b/lang/po/Firmware_de.po
@@ -2129,13 +2129,13 @@ msgstr "TMC UNTERSPANN.FEHL."
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
 msgid "Temp model cal. takes approx. 12 mins."
-msgstr "Die Kalibrierung des Temperaturmodells dauert etwa 12 Minuten."
+msgstr "Tempmodell Kal. benötigt ca. 12 Min."
 
 #. MSG_TM_NOT_CAL c=20 r=4
 #: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
 #: ../../Firmware/messages.cpp:170
 msgid "Temp model not calibrated yet."
-msgstr "Das Temperaturmodell ist noch nicht kalibriert."
+msgstr "Tempmodell noch unkalibriert."
 
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4717

--- a/lang/po/Firmware_de.po
+++ b/lang/po/Firmware_de.po
@@ -2126,6 +2126,17 @@ msgstr "TMC ÜBERHITZ.FEHL."
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr "TMC UNTERSPANN.FEHL."
 
+#. MSG_TM_CAL c=20 r=4
+#: ../../Firmware/ultralcd.cpp:4054
+msgid "Temp model cal. takes apporx. 12 mins."
+msgstr "Die Kalibrierung des Temperaturmodells dauert etwa 12 Minuten."
+
+#. MSG_TM_NOT_CAL c=20 r=4
+#: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
+#: ../../Firmware/messages.cpp:170
+msgid "Temp model not calibrated yet."
+msgstr "Das Temperaturmodell ist noch nicht kalibriert."
+
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4717
 msgid "Temperature"

--- a/lang/po/Firmware_es.po
+++ b/lang/po/Firmware_es.po
@@ -2129,13 +2129,13 @@ msgstr "ERROR SBRVOLTAJE TMC"
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
 msgid "Temp model cal. takes approx. 12 mins."
-msgstr "La calibración del modelo de temperatura tarda aprox. 12 minutos."
+msgstr "Cal. modelo temp. tarda 12 mins. aprox."
 
 #. MSG_TM_NOT_CAL c=20 r=4
 #: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
 #: ../../Firmware/messages.cpp:170
 msgid "Temp model not calibrated yet."
-msgstr "El modelo de temperatura aún no está calibrado."
+msgstr "Modelo temp. todavia sin cal."
 
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4717

--- a/lang/po/Firmware_es.po
+++ b/lang/po/Firmware_es.po
@@ -2128,7 +2128,7 @@ msgstr "ERROR SBRVOLTAJE TMC"
 
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
-msgid "Temp model cal. takes apporx. 12 mins."
+msgid "Temp model cal. takes approx. 12 mins."
 msgstr "La calibración del modelo de temperatura tarda aprox. 12 minutos."
 
 #. MSG_TM_NOT_CAL c=20 r=4

--- a/lang/po/Firmware_es.po
+++ b/lang/po/Firmware_es.po
@@ -2126,6 +2126,17 @@ msgstr "ERROR SOBRECAL TMC"
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr "ERROR SBRVOLTAJE TMC"
 
+#. MSG_TM_CAL c=20 r=4
+#: ../../Firmware/ultralcd.cpp:4054
+msgid "Temp model cal. takes apporx. 12 mins."
+msgstr "La calibración del modelo de temperatura tarda aprox. 12 minutos."
+
+#. MSG_TM_NOT_CAL c=20 r=4
+#: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
+#: ../../Firmware/messages.cpp:170
+msgid "Temp model not calibrated yet."
+msgstr "El modelo de temperatura aún no está calibrado."
+
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4717
 msgid "Temperature"

--- a/lang/po/Firmware_fr.po
+++ b/lang/po/Firmware_fr.po
@@ -2132,13 +2132,13 @@ msgstr "ERR SOUS TENSION TMC"
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
 msgid "Temp model cal. takes approx. 12 mins."
-msgstr "L'étalonnage du modèle de température prend environ 12 minutes."
+msgstr "Cal. du modele temp. dure env. 12 min."
 
 #. MSG_TM_NOT_CAL c=20 r=4
 #: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
 #: ../../Firmware/messages.cpp:170
 msgid "Temp model not calibrated yet."
-msgstr "Le modèle de température n'est pas encore calibré."
+msgstr "Modele de temp. non calibre."
 
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4717

--- a/lang/po/Firmware_fr.po
+++ b/lang/po/Firmware_fr.po
@@ -2131,7 +2131,7 @@ msgstr "ERR SOUS TENSION TMC"
 
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
-msgid "Temp model cal. takes apporx. 12 mins."
+msgid "Temp model cal. takes approx. 12 mins."
 msgstr "L'étalonnage du modèle de température prend environ 12 minutes."
 
 #. MSG_TM_NOT_CAL c=20 r=4

--- a/lang/po/Firmware_fr.po
+++ b/lang/po/Firmware_fr.po
@@ -2129,6 +2129,17 @@ msgstr "ERR SURCHAUFFE TMC"
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr "ERR SOUS TENSION TMC"
 
+#. MSG_TM_CAL c=20 r=4
+#: ../../Firmware/ultralcd.cpp:4054
+msgid "Temp model cal. takes apporx. 12 mins."
+msgstr "L'étalonnage du modèle de température prend environ 12 minutes."
+
+#. MSG_TM_NOT_CAL c=20 r=4
+#: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
+#: ../../Firmware/messages.cpp:170
+msgid "Temp model not calibrated yet."
+msgstr "Le modèle de température n'est pas encore calibré."
+
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4717
 msgid "Temperature"

--- a/lang/po/Firmware_hr.po
+++ b/lang/po/Firmware_hr.po
@@ -2117,13 +2117,13 @@ msgstr "TMC NISKA VOLTAZA"
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
 msgid "Temp model cal. takes approx. 12 mins."
-msgstr ""
+msgstr "Temp model kal. traje cca. 12 min."
 
 #. MSG_TM_NOT_CAL c=20 r=4
 #: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
 #: ../../Firmware/messages.cpp:170
 msgid "Temp model not calibrated yet."
-msgstr ""
+msgstr "Temp model još nije kalibriran."
 
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4717

--- a/lang/po/Firmware_hr.po
+++ b/lang/po/Firmware_hr.po
@@ -2116,7 +2116,7 @@ msgstr "TMC NISKA VOLTAZA"
 
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
-msgid "Temp model cal. takes apporx. 12 mins."
+msgid "Temp model cal. takes approx. 12 mins."
 msgstr ""
 
 #. MSG_TM_NOT_CAL c=20 r=4

--- a/lang/po/Firmware_hr.po
+++ b/lang/po/Firmware_hr.po
@@ -2114,6 +2114,17 @@ msgstr "TMC GRESKA PREGRIJAN"
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr "TMC NISKA VOLTAZA"
 
+#. MSG_TM_CAL c=20 r=4
+#: ../../Firmware/ultralcd.cpp:4054
+msgid "Temp model cal. takes apporx. 12 mins."
+msgstr ""
+
+#. MSG_TM_NOT_CAL c=20 r=4
+#: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
+#: ../../Firmware/messages.cpp:170
+msgid "Temp model not calibrated yet."
+msgstr ""
+
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4717
 msgid "Temperature"

--- a/lang/po/Firmware_hu.po
+++ b/lang/po/Firmware_hu.po
@@ -2118,7 +2118,7 @@ msgstr "TMC ALACSONY FESZ."
 
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
-msgid "Temp model cal. takes apporx. 12 mins."
+msgid "Temp model cal. takes approx. 12 mins."
 msgstr ""
 
 #. MSG_TM_NOT_CAL c=20 r=4

--- a/lang/po/Firmware_hu.po
+++ b/lang/po/Firmware_hu.po
@@ -2119,13 +2119,13 @@ msgstr "TMC ALACSONY FESZ."
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
 msgid "Temp model cal. takes approx. 12 mins."
-msgstr ""
+msgstr "Hőmérsékleti modell kal. kb. 12 percet."
 
 #. MSG_TM_NOT_CAL c=20 r=4
 #: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
 #: ../../Firmware/messages.cpp:170
 msgid "Temp model not calibrated yet."
-msgstr ""
+msgstr "A hőmérsékleti modell még nincs kalibrálva."
 
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4717

--- a/lang/po/Firmware_hu.po
+++ b/lang/po/Firmware_hu.po
@@ -2116,6 +2116,17 @@ msgstr "TMC TULHEVULES HIBA"
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr "TMC ALACSONY FESZ."
 
+#. MSG_TM_CAL c=20 r=4
+#: ../../Firmware/ultralcd.cpp:4054
+msgid "Temp model cal. takes apporx. 12 mins."
+msgstr ""
+
+#. MSG_TM_NOT_CAL c=20 r=4
+#: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
+#: ../../Firmware/messages.cpp:170
+msgid "Temp model not calibrated yet."
+msgstr ""
+
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4717
 msgid "Temperature"

--- a/lang/po/Firmware_it.po
+++ b/lang/po/Firmware_it.po
@@ -2121,7 +2121,7 @@ msgstr "TMC UNDERVOLTAGE ERR"
 
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
-msgid "Temp model cal. takes apporx. 12 mins."
+msgid "Temp model cal. takes approx. 12 mins."
 msgstr "La calibrazione del modello di temperatura richiede circa 12 minuti."
 
 #. MSG_TM_NOT_CAL c=20 r=4

--- a/lang/po/Firmware_it.po
+++ b/lang/po/Firmware_it.po
@@ -2122,13 +2122,13 @@ msgstr "TMC UNDERVOLTAGE ERR"
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
 msgid "Temp model cal. takes approx. 12 mins."
-msgstr "La calibrazione del modello di temperatura richiede circa 12 minuti."
+msgstr "Calib mod temp richiede circa 12 min."
 
 #. MSG_TM_NOT_CAL c=20 r=4
 #: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
 #: ../../Firmware/messages.cpp:170
 msgid "Temp model not calibrated yet."
-msgstr "Modello di temperatura non ancora calibrato."
+msgstr "Modello temp non calibrato."
 
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4717

--- a/lang/po/Firmware_it.po
+++ b/lang/po/Firmware_it.po
@@ -2119,6 +2119,17 @@ msgstr "ERR TMC SURRISCALD"
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr "TMC UNDERVOLTAGE ERR"
 
+#. MSG_TM_CAL c=20 r=4
+#: ../../Firmware/ultralcd.cpp:4054
+msgid "Temp model cal. takes apporx. 12 mins."
+msgstr "La calibrazione del modello di temperatura richiede circa 12 minuti."
+
+#. MSG_TM_NOT_CAL c=20 r=4
+#: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
+#: ../../Firmware/messages.cpp:170
+msgid "Temp model not calibrated yet."
+msgstr "Modello di temperatura non ancora calibrato."
+
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4717
 msgid "Temperature"

--- a/lang/po/Firmware_lb.po
+++ b/lang/po/Firmware_lb.po
@@ -2041,7 +2041,7 @@ msgstr ""
 
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
-msgid "Temp model cal. takes apporx. 12 mins."
+msgid "Temp model cal. takes approx. 12 mins."
 msgstr ""
 
 #. MSG_TM_NOT_CAL c=20 r=4

--- a/lang/po/Firmware_lb.po
+++ b/lang/po/Firmware_lb.po
@@ -2039,6 +2039,17 @@ msgstr ""
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr ""
 
+#. MSG_TM_CAL c=20 r=4
+#: ../../Firmware/ultralcd.cpp:4054
+msgid "Temp model cal. takes apporx. 12 mins."
+msgstr ""
+
+#. MSG_TM_NOT_CAL c=20 r=4
+#: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
+#: ../../Firmware/messages.cpp:170
+msgid "Temp model not calibrated yet."
+msgstr ""
+
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4717
 msgid "Temperature"

--- a/lang/po/Firmware_lt.po
+++ b/lang/po/Firmware_lt.po
@@ -2041,7 +2041,7 @@ msgstr ""
 
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
-msgid "Temp model cal. takes apporx. 12 mins."
+msgid "Temp model cal. takes approx. 12 mins."
 msgstr ""
 
 #. MSG_TM_NOT_CAL c=20 r=4

--- a/lang/po/Firmware_lt.po
+++ b/lang/po/Firmware_lt.po
@@ -2039,6 +2039,17 @@ msgstr ""
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr ""
 
+#. MSG_TM_CAL c=20 r=4
+#: ../../Firmware/ultralcd.cpp:4054
+msgid "Temp model cal. takes apporx. 12 mins."
+msgstr ""
+
+#. MSG_TM_NOT_CAL c=20 r=4
+#: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
+#: ../../Firmware/messages.cpp:170
+msgid "Temp model not calibrated yet."
+msgstr ""
+
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4717
 msgid "Temperature"

--- a/lang/po/Firmware_nl.po
+++ b/lang/po/Firmware_nl.po
@@ -2126,7 +2126,7 @@ msgstr "TMC ONDERVOLT. FOUT"
 
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
-msgid "Temp model cal. takes apporx. 12 mins."
+msgid "Temp model cal. takes approx. 12 mins."
 msgstr "Kalibratie van het tempmodel duurt ongeveer. 12 minuten."
 
 #. MSG_TM_NOT_CAL c=20 r=4

--- a/lang/po/Firmware_nl.po
+++ b/lang/po/Firmware_nl.po
@@ -2127,13 +2127,13 @@ msgstr "TMC ONDERVOLT. FOUT"
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
 msgid "Temp model cal. takes approx. 12 mins."
-msgstr "Kalibratie van het tempmodel duurt ongeveer. 12 minuten."
+msgstr "Temp model kal. duurt ongeveer 12 min."
 
 #. MSG_TM_NOT_CAL c=20 r=4
 #: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
 #: ../../Firmware/messages.cpp:170
 msgid "Temp model not calibrated yet."
-msgstr "Temp model nog niet gekalibreerd."
+msgstr "Temp model nog ongekalibreerd."
 
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4717

--- a/lang/po/Firmware_nl.po
+++ b/lang/po/Firmware_nl.po
@@ -2124,6 +2124,17 @@ msgstr "TMC OVERHITTINGSFOUT"
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr "TMC ONDERVOLT. FOUT"
 
+#. MSG_TM_CAL c=20 r=4
+#: ../../Firmware/ultralcd.cpp:4054
+msgid "Temp model cal. takes apporx. 12 mins."
+msgstr "Kalibratie van het tempmodel duurt ongeveer. 12 minuten."
+
+#. MSG_TM_NOT_CAL c=20 r=4
+#: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
+#: ../../Firmware/messages.cpp:170
+msgid "Temp model not calibrated yet."
+msgstr "Temp model nog niet gekalibreerd."
+
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4717
 msgid "Temperature"

--- a/lang/po/Firmware_no.po
+++ b/lang/po/Firmware_no.po
@@ -2099,14 +2099,14 @@ msgstr "TMC LAVSPENNING FEIL"
 
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
-msgid "Temp model cal. takes apporx. 12 mins."
-msgstr ""
+msgid "Temp model cal. takes approx. 12 mins."
+msgstr "Temp modell kal. tar omtrent 12 min."
 
 #. MSG_TM_NOT_CAL c=20 r=4
 #: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
 #: ../../Firmware/messages.cpp:170
 msgid "Temp model not calibrated yet."
-msgstr ""
+msgstr "Temp modell ikke kalibrert enda."
 
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4717

--- a/lang/po/Firmware_no.po
+++ b/lang/po/Firmware_no.po
@@ -2097,6 +2097,17 @@ msgstr "TMC OVEROPPHETING"
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr "TMC LAVSPENNING FEIL"
 
+#. MSG_TM_CAL c=20 r=4
+#: ../../Firmware/ultralcd.cpp:4054
+msgid "Temp model cal. takes apporx. 12 mins."
+msgstr ""
+
+#. MSG_TM_NOT_CAL c=20 r=4
+#: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
+#: ../../Firmware/messages.cpp:170
+msgid "Temp model not calibrated yet."
+msgstr ""
+
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4717
 msgid "Temperature"

--- a/lang/po/Firmware_pl.po
+++ b/lang/po/Firmware_pl.po
@@ -2116,7 +2116,7 @@ msgstr "ZA NIS. NAPIECIE TMC"
 
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
-msgid "Temp model cal. takes apporx. 12 mins."
+msgid "Temp model cal. takes approx. 12 mins."
 msgstr "Kalibracja modelu temperatury trwa ok. 12 minut."
 
 #. MSG_TM_NOT_CAL c=20 r=4

--- a/lang/po/Firmware_pl.po
+++ b/lang/po/Firmware_pl.po
@@ -2117,13 +2117,13 @@ msgstr "ZA NIS. NAPIECIE TMC"
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
 msgid "Temp model cal. takes approx. 12 mins."
-msgstr "Kalibracja modelu temperatury trwa ok. 12 minut."
+msgstr "Kal. modelu temp. moze zajac ok. 12min."
 
 #. MSG_TM_NOT_CAL c=20 r=4
 #: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
 #: ../../Firmware/messages.cpp:170
 msgid "Temp model not calibrated yet."
-msgstr "Model temperatury jeszcze nie skalibrowany."
+msgstr "Model temp. nie zostal skalib."
 
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4717

--- a/lang/po/Firmware_pl.po
+++ b/lang/po/Firmware_pl.po
@@ -2114,6 +2114,17 @@ msgstr "PRZEGRZANIE TMC"
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr "ZA NIS. NAPIECIE TMC"
 
+#. MSG_TM_CAL c=20 r=4
+#: ../../Firmware/ultralcd.cpp:4054
+msgid "Temp model cal. takes apporx. 12 mins."
+msgstr "Kalibracja modelu temperatury trwa ok. 12 minut."
+
+#. MSG_TM_NOT_CAL c=20 r=4
+#: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
+#: ../../Firmware/messages.cpp:170
+msgid "Temp model not calibrated yet."
+msgstr "Model temperatury jeszcze nie skalibrowany."
+
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4717
 msgid "Temperature"

--- a/lang/po/Firmware_ro.po
+++ b/lang/po/Firmware_ro.po
@@ -2118,7 +2118,7 @@ msgstr "ERR subtensiune TMC"
 
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
-msgid "Temp model cal. takes apporx. 12 mins."
+msgid "Temp model cal. takes approx. 12 mins."
 msgstr ""
 
 #. MSG_TM_NOT_CAL c=20 r=4

--- a/lang/po/Firmware_ro.po
+++ b/lang/po/Firmware_ro.po
@@ -2119,13 +2119,13 @@ msgstr "ERR subtensiune TMC"
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
 msgid "Temp model cal. takes approx. 12 mins."
-msgstr ""
+msgstr "Cal. Model de temp dureaza aprox. 12 min."
 
 #. MSG_TM_NOT_CAL c=20 r=4
 #: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
 #: ../../Firmware/messages.cpp:170
 msgid "Temp model not calibrated yet."
-msgstr ""
+msgstr "Modelul de temp. nu este inca calibrat."
 
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4717

--- a/lang/po/Firmware_ro.po
+++ b/lang/po/Firmware_ro.po
@@ -2116,6 +2116,17 @@ msgstr "ERR TMC supraincalz."
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr "ERR subtensiune TMC"
 
+#. MSG_TM_CAL c=20 r=4
+#: ../../Firmware/ultralcd.cpp:4054
+msgid "Temp model cal. takes apporx. 12 mins."
+msgstr ""
+
+#. MSG_TM_NOT_CAL c=20 r=4
+#: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
+#: ../../Firmware/messages.cpp:170
+msgid "Temp model not calibrated yet."
+msgstr ""
+
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4717
 msgid "Temperature"

--- a/lang/po/Firmware_sk.po
+++ b/lang/po/Firmware_sk.po
@@ -2110,13 +2110,13 @@ msgstr "TMC UNDERVOLTAGE ERR"
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
 msgid "Temp model cal. takes approx. 12 mins."
-msgstr ""
+msgstr "Výpočet teplotného modelu trvá približne 12 minút."
 
 #. MSG_TM_NOT_CAL c=20 r=4
 #: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
 #: ../../Firmware/messages.cpp:170
 msgid "Temp model not calibrated yet."
-msgstr ""
+msgstr "Teplotný model zatiaľ nebol kalibrovaný"
 
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4717

--- a/lang/po/Firmware_sk.po
+++ b/lang/po/Firmware_sk.po
@@ -2109,7 +2109,7 @@ msgstr "TMC UNDERVOLTAGE ERR"
 
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
-msgid "Temp model cal. takes apporx. 12 mins."
+msgid "Temp model cal. takes approx. 12 mins."
 msgstr ""
 
 #. MSG_TM_NOT_CAL c=20 r=4

--- a/lang/po/Firmware_sk.po
+++ b/lang/po/Firmware_sk.po
@@ -2107,6 +2107,17 @@ msgstr "TMC OVERHEAT ERROR"
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr "TMC UNDERVOLTAGE ERR"
 
+#. MSG_TM_CAL c=20 r=4
+#: ../../Firmware/ultralcd.cpp:4054
+msgid "Temp model cal. takes apporx. 12 mins."
+msgstr ""
+
+#. MSG_TM_NOT_CAL c=20 r=4
+#: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
+#: ../../Firmware/messages.cpp:170
+msgid "Temp model not calibrated yet."
+msgstr ""
+
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4717
 msgid "Temperature"

--- a/lang/po/Firmware_sl.po
+++ b/lang/po/Firmware_sl.po
@@ -2041,7 +2041,7 @@ msgstr ""
 
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
-msgid "Temp model cal. takes apporx. 12 mins."
+msgid "Temp model cal. takes approx. 12 mins."
 msgstr ""
 
 #. MSG_TM_NOT_CAL c=20 r=4

--- a/lang/po/Firmware_sl.po
+++ b/lang/po/Firmware_sl.po
@@ -2039,6 +2039,17 @@ msgstr ""
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr ""
 
+#. MSG_TM_CAL c=20 r=4
+#: ../../Firmware/ultralcd.cpp:4054
+msgid "Temp model cal. takes apporx. 12 mins."
+msgstr ""
+
+#. MSG_TM_NOT_CAL c=20 r=4
+#: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
+#: ../../Firmware/messages.cpp:170
+msgid "Temp model not calibrated yet."
+msgstr ""
+
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4717
 msgid "Temperature"

--- a/lang/po/Firmware_sv.po
+++ b/lang/po/Firmware_sv.po
@@ -2118,7 +2118,7 @@ msgstr "TMC UNDERSPÄNNINGFEL"
 
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
-msgid "Temp model cal. takes apporx. 12 mins."
+msgid "Temp model cal. takes approx. 12 mins."
 msgstr ""
 
 #. MSG_TM_NOT_CAL c=20 r=4

--- a/lang/po/Firmware_sv.po
+++ b/lang/po/Firmware_sv.po
@@ -2119,13 +2119,13 @@ msgstr "TMC UNDERSPÄNNINGFEL"
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
 msgid "Temp model cal. takes approx. 12 mins."
-msgstr ""
+msgstr "Temp modell kal. tar ca. 12 min."
 
 #. MSG_TM_NOT_CAL c=20 r=4
 #: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
 #: ../../Firmware/messages.cpp:170
 msgid "Temp model not calibrated yet."
-msgstr ""
+msgstr "Temp-modellen är inte kalibrerad ännu."
 
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4717

--- a/lang/po/Firmware_sv.po
+++ b/lang/po/Firmware_sv.po
@@ -2116,6 +2116,17 @@ msgstr "TMC ÖVERHETTNINGSFEL"
 msgid "TMC UNDERVOLTAGE ERR"
 msgstr "TMC UNDERSPÄNNINGFEL"
 
+#. MSG_TM_CAL c=20 r=4
+#: ../../Firmware/ultralcd.cpp:4054
+msgid "Temp model cal. takes apporx. 12 mins."
+msgstr ""
+
+#. MSG_TM_NOT_CAL c=20 r=4
+#: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
+#: ../../Firmware/messages.cpp:170
+msgid "Temp model not calibrated yet."
+msgstr ""
+
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4717
 msgid "Temperature"


### PR DESCRIPTION
Add Temp model calibration to Wizard

- Unhack Selftest hack during Wizard
- Update `pot` and `po` files
  - Translated messages 
    - [x] CS with Deepl
    - [x] DE
    - [x] ES with Deepl
    - [x] FR with Deepl
    - [x] IT with Deepl
    - [x] PL with Deepl
    - Community translators please translate these two messages asap.
    - [X] NL @vintagepc please review
    - [x] RO @Hauzman 
    - [x] HU @AttilaSVK 
    - [ ] HR  @Prime1910 
    - [x] SK @ingbrzy 
    - [ ] SV @Painkiller56 
    - [x] NO @OS-kar

Tests
- [X] Prusa MK3S without MMU2 Factory reset All Data
  - [X] Wizard
  - [X] Selftest
  - [X] Reset printer during Wizard Temp model calibration
    - [X] Recover with Wizard at Temp model calibration
- [X] Prusa MK3S without MMU2 Factory reset Prep Shipping
- [X] Prusa MK3S with MMU2 Factory reset All Data
  - [X] Wizard
  - [X] Selftest
  - [X] Reset printer during Wizard Temp model calibration
    - [X] Recover with Wizard at Temp model calibration

- [X] Prusa MK2.5S without MMU2 Factory reset All Data
