### PR TITLE
PFW-1434: MK3_3.12 Temp model calibration during wizard

### DIFF
--- a/Firmware/Configuration.h
+++ b/Firmware/Configuration.h
@@ -545,7 +545,12 @@ enum CalibrationStatus
 	// For the wizard: factory assembled, needs to run Z calibration.
 	CALIBRATION_STATUS_Z_CALIBRATION = 240,
 
-	// The XYZ calibration has been performed, now it remains to run the V2Calibration.gcode.
+#ifdef TEMP_MODEL
+	// The XYZ calibration has been performed, needs to run Temp model calibration.
+	CALIBRATION_STATUS_TEMP_MODEL_CALIBRATION = 235,
+#endif //TEMP_MODEL
+
+// The XYZ calibration AND OR Temp model calibartion has been performed, now it remains to run the V2Calibration.gcode.
 	CALIBRATION_STATUS_LIVE_ADJUST = 230,
 
     // Calibrated, ready to print.

--- a/Firmware/Configuration.h
+++ b/Firmware/Configuration.h
@@ -550,7 +550,7 @@ enum CalibrationStatus
 	CALIBRATION_STATUS_TEMP_MODEL_CALIBRATION = 235,
 #endif //TEMP_MODEL
 
-// The XYZ calibration AND OR Temp model calibartion has been performed, now it remains to run the V2Calibration.gcode.
+// The XYZ calibration AND OR Temp model calibration has been performed, now it remains to run the V2Calibration.gcode.
 	CALIBRATION_STATUS_LIVE_ADJUST = 230,
 
     // Calibrated, ready to print.

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1547,6 +1547,12 @@ void setup()
 		  // Show the message.
 		  lcd_show_fullscreen_message_and_wait_P(_T(MSG_FOLLOW_CALIBRATION_FLOW));
 	  }
+#ifdef TEMP_MODEL
+	  else if (calibration_status() == CALIBRATION_STATUS_TEMP_MODEL_CALIBRATION) {
+		  lcd_show_fullscreen_message_and_wait_P(_i("Temp model calibration not calibrated yet."));////MSG_TEMP_MODEL_NOT_CAL c=20 c=4
+		  lcd_update_enable(true);
+	  }
+#endif //TEMP_MODEL
 	  else if (calibration_status() == CALIBRATION_STATUS_LIVE_ADJUST) {
 		  // Show the message.
 		  lcd_show_fullscreen_message_and_wait_P(_T(MSG_BABYSTEP_Z_NOT_SET));
@@ -3406,9 +3412,14 @@ bool gcode_M45(bool onlyZ, int8_t verbosity_level)
 				lcd_bed_calibration_show_result(result, point_too_far_mask);
 				if (result >= 0)
 				{
+#ifdef TEMP_MODEL
+					calibration_status_store(CALIBRATION_STATUS_TEMP_MODEL_CALIBRATION);
+					if (eeprom_read_byte((uint8_t*)EEPROM_WIZARD_ACTIVE) != 1) lcd_show_fullscreen_message_and_wait_P(_i("Temp model calibration not calibrated yet."));
+#else
 					// Calibration valid, the machine should be able to print. Advise the user to run the V2Calibration.gcode.
 					calibration_status_store(CALIBRATION_STATUS_LIVE_ADJUST);
 					if (eeprom_read_byte((uint8_t*)EEPROM_WIZARD_ACTIVE) != 1) lcd_show_fullscreen_message_and_wait_P(_T(MSG_BABYSTEP_Z_NOT_SET));
+#endif //TEMP_MODEL
 					final_result = true;
 				}
 			}

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1549,7 +1549,7 @@ void setup()
 	  }
 #ifdef TEMP_MODEL
 	  else if (calibration_status() == CALIBRATION_STATUS_TEMP_MODEL_CALIBRATION) {
-		  lcd_show_fullscreen_message_and_wait_P(_i("Temp model calibration not calibrated yet."));////MSG_TEMP_MODEL_NOT_CAL c=20 c=4
+		  lcd_show_fullscreen_message_and_wait_P(_T(MSG_TM_NOT_CAL));
 		  lcd_update_enable(true);
 	  }
 #endif //TEMP_MODEL
@@ -3414,7 +3414,7 @@ bool gcode_M45(bool onlyZ, int8_t verbosity_level)
 				{
 #ifdef TEMP_MODEL
 					calibration_status_store(CALIBRATION_STATUS_TEMP_MODEL_CALIBRATION);
-					if (eeprom_read_byte((uint8_t*)EEPROM_WIZARD_ACTIVE) != 1) lcd_show_fullscreen_message_and_wait_P(_i("Temp model calibration not calibrated yet."));
+					if (eeprom_read_byte((uint8_t*)EEPROM_WIZARD_ACTIVE) != 1) lcd_show_fullscreen_message_and_wait_P(_T(MSG_TM_NOT_CAL));
 #else
 					// Calibration valid, the machine should be able to print. Advise the user to run the V2Calibration.gcode.
 					calibration_status_store(CALIBRATION_STATUS_LIVE_ADJUST);

--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -164,6 +164,7 @@ const char MSG_IR_UNKNOWN[] PROGMEM_I1 = ISTR("unknown state");////MSG_IR_UNKNOW
 extern const char MSG_PAUSED_THERMAL_ERROR[] PROGMEM_I1 = ISTR("PAUSED THERMAL ERROR");////MSG_PAUSED_THERMAL_ERROR c=20
 #ifdef TEMP_MODEL
 extern const char MSG_THERMAL_ANOMALY[] PROGMEM_I1 = ISTR("THERMAL ANOMALY");////MSG_THERMAL_ANOMALY c=20
+extern const char MSG_TM_NOT_CAL[] PROGMEM_I1 = ISTR("Temp model not calibrated yet.");////MSG_TM_NOT_CAL c=20 r=4
 #endif
 
 //not internationalized messages

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -168,6 +168,7 @@ extern const char MSG_IR_UNKNOWN[];
 extern const char MSG_PAUSED_THERMAL_ERROR[];
 #ifdef TEMP_MODEL
 extern const char MSG_THERMAL_ANOMALY[];
+extern const char MSG_TM_NOT_CAL[];
 #endif
 
 //not internationalized messages

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -4132,7 +4132,7 @@ void lcd_wizard(WizState state)
 			break;
 #ifdef TEMP_MODEL
 		case S::TempModel:
-			lcd_show_fullscreen_message_and_wait_P(_i("Temp model cal. takes apporx. 12 mins."));////MSG_TM_CAL c=20 r=4
+			lcd_show_fullscreen_message_and_wait_P(_i("Temp model cal. takes approx. 12 mins."));////MSG_TM_CAL c=20 r=4
 			lcd_commands_type = LcdCommands::TempModel;
 			end = true; // Leave wizard temporarily for Temp model cal.
 			break;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -4047,7 +4047,7 @@ void lcd_wizard(WizState state)
     FORCE_BL_ON_START;
 	
     while (!end) {
-		printf_P(PSTR("Wizard state: %d\n"), state);
+		printf_P(PSTR("Wizard state: %d\n"), (uint8_t)state);
 		switch (state) {
 		case S::Run: //Run wizard?
 			
@@ -4204,7 +4204,7 @@ void lcd_wizard(WizState state)
     
     FORCE_BL_ON_END;
     
-	printf_P(_N("Wizard end state: %d\n"), state);
+	printf_P(_N("Wizard end state: %d\n"), (uint8_t)state);
 	switch (state) { //final message
 	case S::Restore: //printer was already calibrated
 		msg = _T(MSG_WIZARD_DONE);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1055,12 +1055,11 @@ void lcd_commands()
         }
         //if (lcd_commands_step == 1 && calibrated()) {
         if (lcd_commands_step == 1 && temp_model_valid()) {
+            lcd_commands_step = 0;
+            lcd_commands_type = LcdCommands::Idle;
             enquecommand_P(PSTR("M500"));
             if (eeprom_read_byte((uint8_t*)EEPROM_WIZARD_ACTIVE) == 1) {
                 lcd_wizard(WizState::IsFil);
-            } else {
-                lcd_commands_step = 0;
-                lcd_commands_type = LcdCommands::Idle;
             }
         }
     }
@@ -4038,8 +4037,12 @@ void lcd_wizard(WizState state)
 {
     using S = WizState;
 	bool end = false;
+<<<<<<< HEAD
 	int8_t wizard_event;
 	const char *msg = NULL;
+=======
+	uint8_t wizard_event;
+>>>>>>> b147fcee (XYZ calibration fixes)
 	// Make sure EEPROM_WIZARD_ACTIVE is true if entering using different entry point
 	// other than WizState::Run - it is useful for debugging wizard.
 	if (state != S::Run) eeprom_update_byte((uint8_t*)EEPROM_WIZARD_ACTIVE, 1);
@@ -4204,6 +4207,7 @@ void lcd_wizard(WizState state)
     
     FORCE_BL_ON_END;
     
+    const char *msg = NULL;
 	printf_P(_N("Wizard end state: %d\n"), (uint8_t)state);
 	switch (state) { //final message
 	case S::Restore: //printer was already calibrated
@@ -4216,23 +4220,23 @@ void lcd_wizard(WizState state)
 		break;
 #ifdef TEMP_MODEL
 	case S::TempModel: //Temp model calibration
-//		break;
+		break;
 #endif //TEMP_MODEL
 	case S::Finish: //we are finished
-
 		msg = _T(MSG_WIZARD_DONE);
 		lcd_reset_alert_level();
 		lcd_setstatuspgm(MSG_WELCOME);
 		lcd_return_to_status(); 
 		break;
-
+    case S::Preheat:
+    case S::Lay1CalCold:
+    case S::Lay1CalHot:
+        break;
 	default:
 		msg = _T(MSG_WIZARD_QUIT);
 		break;
-
 	}
-	if (!((S::Lay1CalCold == state) || (S::Lay1CalHot == state) || (S::Preheat == state)))
-	{
+	if (msg) {
 		lcd_show_fullscreen_message_and_wait_P(msg);
 	}
 	lcd_update_enable(true);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -4106,6 +4106,7 @@ void lcd_wizard(WizState state)
 			wizard_event = gcode_M45(false, 0);
 			if (wizard_event) {
 #ifdef TEMP_MODEL
+			lcd_reset_alert_level();
 			state = S::TempModel;
 #else
 			state = S::IsFil;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -4037,12 +4037,7 @@ void lcd_wizard(WizState state)
 {
     using S = WizState;
 	bool end = false;
-<<<<<<< HEAD
-	int8_t wizard_event;
-	const char *msg = NULL;
-=======
 	uint8_t wizard_event;
->>>>>>> b147fcee (XYZ calibration fixes)
 	// Make sure EEPROM_WIZARD_ACTIVE is true if entering using different entry point
 	// other than WizState::Run - it is useful for debugging wizard.
 	if (state != S::Run) eeprom_update_byte((uint8_t*)EEPROM_WIZARD_ACTIVE, 1);

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -224,6 +224,9 @@ enum class WizState : uint8_t
     Selftest,       //!< self test
     Xyz,            //!< xyz calibration
     Z,              //!< z calibration
+#ifdef TEMP_MODEL
+    TempModel,      //!< Temp model calibration
+#endif //TEMP_MODEL
     IsFil,          //!< Is filament loaded? First step of 1st layer calibration
     PreheatPla,     //!< waiting for preheat nozzle for PLA
     Preheat,        //!< Preheat for any material

--- a/lang/po/Firmware.pot
+++ b/lang/po/Firmware.pot
@@ -1722,7 +1722,7 @@ msgstr ""
 
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
-msgid "Temp model cal. takes apporx. 12 mins."
+msgid "Temp model cal. takes approx. 12 mins."
 msgstr ""
 
 #. MSG_TM_NOT_CAL c=20 r=4

--- a/lang/po/Firmware.pot
+++ b/lang/po/Firmware.pot
@@ -1720,6 +1720,17 @@ msgstr ""
 msgid "THERMAL ANOMALY"
 msgstr ""
 
+#. MSG_TM_CAL c=20 r=4
+#: ../../Firmware/ultralcd.cpp:4054
+msgid "Temp model cal. takes apporx. 12 mins."
+msgstr ""
+
+#. MSG_TM_NOT_CAL c=20 r=4
+#: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
+#: ../../Firmware/messages.cpp:170
+msgid "Temp model not calibrated yet."
+msgstr ""
+
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4816
 msgid "Temperature"

--- a/lang/po/Firmware_cs.po
+++ b/lang/po/Firmware_cs.po
@@ -1783,7 +1783,7 @@ msgstr "TEPLOTNI VYJIMKA"
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
 msgid "Temp model cal. takes approx. 12 mins."
-msgstr "Kalkulace teplotního modelu trvá přibližně. 12 minut."
+msgstr "Kalibrace teplotního modelu trvá asi 12 minut."
 
 #. MSG_TM_NOT_CAL c=20 r=4
 #: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404

--- a/lang/po/Firmware_cs.po
+++ b/lang/po/Firmware_cs.po
@@ -1782,7 +1782,7 @@ msgstr "TEPLOTNI VYJIMKA"
 
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
-msgid "Temp model cal. takes apporx. 12 mins."
+msgid "Temp model cal. takes approx. 12 mins."
 msgstr "Kalkulace teplotního modelu trvá přibližně. 12 minut."
 
 #. MSG_TM_NOT_CAL c=20 r=4

--- a/lang/po/Firmware_cs.po
+++ b/lang/po/Firmware_cs.po
@@ -1780,6 +1780,17 @@ msgstr "Prohozene"
 msgid "THERMAL ANOMALY"
 msgstr "TEPLOTNI VYJIMKA"
 
+#. MSG_TM_CAL c=20 r=4
+#: ../../Firmware/ultralcd.cpp:4054
+msgid "Temp model cal. takes apporx. 12 mins."
+msgstr "Kalkulace teplotního modelu trvá přibližně. 12 minut."
+
+#. MSG_TM_NOT_CAL c=20 r=4
+#: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
+#: ../../Firmware/messages.cpp:170
+msgid "Temp model not calibrated yet."
+msgstr "Teplotní model zatím nebyl kalibrován."
+
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4816
 msgid "Temperature"

--- a/lang/po/Firmware_da.po
+++ b/lang/po/Firmware_da.po
@@ -1733,7 +1733,7 @@ msgstr ""
 
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
-msgid "Temp model cal. takes apporx. 12 mins."
+msgid "Temp model cal. takes approx. 12 mins."
 msgstr ""
 
 #. MSG_TM_NOT_CAL c=20 r=4

--- a/lang/po/Firmware_da.po
+++ b/lang/po/Firmware_da.po
@@ -1731,6 +1731,17 @@ msgstr ""
 msgid "THERMAL ANOMALY"
 msgstr ""
 
+#. MSG_TM_CAL c=20 r=4
+#: ../../Firmware/ultralcd.cpp:4054
+msgid "Temp model cal. takes apporx. 12 mins."
+msgstr ""
+
+#. MSG_TM_NOT_CAL c=20 r=4
+#: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
+#: ../../Firmware/messages.cpp:170
+msgid "Temp model not calibrated yet."
+msgstr ""
+
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4816
 msgid "Temperature"

--- a/lang/po/Firmware_de.po
+++ b/lang/po/Firmware_de.po
@@ -1797,13 +1797,13 @@ msgstr "THERMISCHE ANOMALIE"
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
 msgid "Temp model cal. takes approx. 12 mins."
-msgstr "Die Kalibrierung des Temperaturmodells dauert etwa 12 Minuten."
+msgstr "Tempmodell Kal. benötigt ca. 12 Min."
 
 #. MSG_TM_NOT_CAL c=20 r=4
 #: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
 #: ../../Firmware/messages.cpp:170
 msgid "Temp model not calibrated yet."
-msgstr "Das Temperaturmodell ist noch nicht kalibriert."
+msgstr "Tempmodell noch unkalibriert."
 
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4816

--- a/lang/po/Firmware_de.po
+++ b/lang/po/Firmware_de.po
@@ -1796,7 +1796,7 @@ msgstr "THERMISCHE ANOMALIE"
 
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
-msgid "Temp model cal. takes apporx. 12 mins."
+msgid "Temp model cal. takes approx. 12 mins."
 msgstr "Die Kalibrierung des Temperaturmodells dauert etwa 12 Minuten."
 
 #. MSG_TM_NOT_CAL c=20 r=4

--- a/lang/po/Firmware_de.po
+++ b/lang/po/Firmware_de.po
@@ -1794,6 +1794,17 @@ msgstr "Ausgetauscht"
 msgid "THERMAL ANOMALY"
 msgstr "THERMISCHE ANOMALIE"
 
+#. MSG_TM_CAL c=20 r=4
+#: ../../Firmware/ultralcd.cpp:4054
+msgid "Temp model cal. takes apporx. 12 mins."
+msgstr "Die Kalibrierung des Temperaturmodells dauert etwa 12 Minuten."
+
+#. MSG_TM_NOT_CAL c=20 r=4
+#: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
+#: ../../Firmware/messages.cpp:170
+msgid "Temp model not calibrated yet."
+msgstr "Das Temperaturmodell ist noch nicht kalibriert."
+
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4816
 msgid "Temperature"

--- a/lang/po/Firmware_es.po
+++ b/lang/po/Firmware_es.po
@@ -1799,7 +1799,7 @@ msgstr "ANOMALIA TERMICA"
 
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
-msgid "Temp model cal. takes apporx. 12 mins."
+msgid "Temp model cal. takes approx. 12 mins."
 msgstr "La calibración del modelo de temperatura tarda aprox. 12 minutos."
 
 #. MSG_TM_NOT_CAL c=20 r=4

--- a/lang/po/Firmware_es.po
+++ b/lang/po/Firmware_es.po
@@ -1800,13 +1800,13 @@ msgstr "ANOMALIA TERMICA"
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
 msgid "Temp model cal. takes approx. 12 mins."
-msgstr "La calibración del modelo de temperatura tarda aprox. 12 minutos."
+msgstr "Cal. modelo temp. tarda 12 mins. aprox."
 
 #. MSG_TM_NOT_CAL c=20 r=4
 #: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
 #: ../../Firmware/messages.cpp:170
 msgid "Temp model not calibrated yet."
-msgstr "El modelo de temperatura aún no está calibrado."
+msgstr "Modelo temp. todavia sin cal."
 
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4816

--- a/lang/po/Firmware_es.po
+++ b/lang/po/Firmware_es.po
@@ -1797,6 +1797,17 @@ msgstr "Intercambiado"
 msgid "THERMAL ANOMALY"
 msgstr "ANOMALIA TERMICA"
 
+#. MSG_TM_CAL c=20 r=4
+#: ../../Firmware/ultralcd.cpp:4054
+msgid "Temp model cal. takes apporx. 12 mins."
+msgstr "La calibración del modelo de temperatura tarda aprox. 12 minutos."
+
+#. MSG_TM_NOT_CAL c=20 r=4
+#: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
+#: ../../Firmware/messages.cpp:170
+msgid "Temp model not calibrated yet."
+msgstr "El modelo de temperatura aún no está calibrado."
+
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4816
 msgid "Temperature"

--- a/lang/po/Firmware_fr.po
+++ b/lang/po/Firmware_fr.po
@@ -1803,13 +1803,13 @@ msgstr "ANOMALIE THERMIQUE"
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
 msgid "Temp model cal. takes approx. 12 mins."
-msgstr "L'étalonnage du modèle de température prend environ 12 minutes."
+msgstr "Cal. du modele temp. dure env. 12 min."
 
 #. MSG_TM_NOT_CAL c=20 r=4
 #: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
 #: ../../Firmware/messages.cpp:170
 msgid "Temp model not calibrated yet."
-msgstr "Le modèle de température n'est pas encore calibré."
+msgstr "Modele de temp. non calibre."
 
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4816

--- a/lang/po/Firmware_fr.po
+++ b/lang/po/Firmware_fr.po
@@ -1802,7 +1802,7 @@ msgstr "ANOMALIE THERMIQUE"
 
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
-msgid "Temp model cal. takes apporx. 12 mins."
+msgid "Temp model cal. takes approx. 12 mins."
 msgstr "L'étalonnage du modèle de température prend environ 12 minutes."
 
 #. MSG_TM_NOT_CAL c=20 r=4

--- a/lang/po/Firmware_fr.po
+++ b/lang/po/Firmware_fr.po
@@ -1800,6 +1800,17 @@ msgstr "Echange"
 msgid "THERMAL ANOMALY"
 msgstr "ANOMALIE THERMIQUE"
 
+#. MSG_TM_CAL c=20 r=4
+#: ../../Firmware/ultralcd.cpp:4054
+msgid "Temp model cal. takes apporx. 12 mins."
+msgstr "L'étalonnage du modèle de température prend environ 12 minutes."
+
+#. MSG_TM_NOT_CAL c=20 r=4
+#: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
+#: ../../Firmware/messages.cpp:170
+msgid "Temp model not calibrated yet."
+msgstr "Le modèle de température n'est pas encore calibré."
+
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4816
 msgid "Temperature"

--- a/lang/po/Firmware_hr.po
+++ b/lang/po/Firmware_hr.po
@@ -1789,7 +1789,7 @@ msgstr "TERMALNA ANOMALIJA"
 
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
-msgid "Temp model cal. takes apporx. 12 mins."
+msgid "Temp model cal. takes approx. 12 mins."
 msgstr ""
 
 #. MSG_TM_NOT_CAL c=20 r=4

--- a/lang/po/Firmware_hr.po
+++ b/lang/po/Firmware_hr.po
@@ -1790,13 +1790,13 @@ msgstr "TERMALNA ANOMALIJA"
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
 msgid "Temp model cal. takes approx. 12 mins."
-msgstr ""
+msgstr "Temp model kal. traje cca. 12 min."
 
 #. MSG_TM_NOT_CAL c=20 r=4
 #: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
 #: ../../Firmware/messages.cpp:170
 msgid "Temp model not calibrated yet."
-msgstr ""
+msgstr "Temp model još nije kalibriran."
 
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4816

--- a/lang/po/Firmware_hr.po
+++ b/lang/po/Firmware_hr.po
@@ -1787,6 +1787,17 @@ msgstr "Zamjenjeno"
 msgid "THERMAL ANOMALY"
 msgstr "TERMALNA ANOMALIJA"
 
+#. MSG_TM_CAL c=20 r=4
+#: ../../Firmware/ultralcd.cpp:4054
+msgid "Temp model cal. takes apporx. 12 mins."
+msgstr ""
+
+#. MSG_TM_NOT_CAL c=20 r=4
+#: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
+#: ../../Firmware/messages.cpp:170
+msgid "Temp model not calibrated yet."
+msgstr ""
+
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4816
 msgid "Temperature"

--- a/lang/po/Firmware_hu.po
+++ b/lang/po/Firmware_hu.po
@@ -1791,7 +1791,7 @@ msgstr "Homersekl. anomalia"
 
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
-msgid "Temp model cal. takes apporx. 12 mins."
+msgid "Temp model cal. takes approx. 12 mins."
 msgstr ""
 
 #. MSG_TM_NOT_CAL c=20 r=4

--- a/lang/po/Firmware_hu.po
+++ b/lang/po/Firmware_hu.po
@@ -1789,6 +1789,17 @@ msgstr "Felcserelve"
 msgid "THERMAL ANOMALY"
 msgstr "Homersekl. anomalia"
 
+#. MSG_TM_CAL c=20 r=4
+#: ../../Firmware/ultralcd.cpp:4054
+msgid "Temp model cal. takes apporx. 12 mins."
+msgstr ""
+
+#. MSG_TM_NOT_CAL c=20 r=4
+#: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
+#: ../../Firmware/messages.cpp:170
+msgid "Temp model not calibrated yet."
+msgstr ""
+
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4816
 msgid "Temperature"

--- a/lang/po/Firmware_hu.po
+++ b/lang/po/Firmware_hu.po
@@ -1792,13 +1792,13 @@ msgstr "Homersekl. anomalia"
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
 msgid "Temp model cal. takes approx. 12 mins."
-msgstr ""
+msgstr "Hőmérsékleti modell kal. kb. 12 percet."
 
 #. MSG_TM_NOT_CAL c=20 r=4
 #: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
 #: ../../Firmware/messages.cpp:170
 msgid "Temp model not calibrated yet."
-msgstr ""
+msgstr "A hőmérsékleti modell még nincs kalibrálva."
 
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4816

--- a/lang/po/Firmware_it.po
+++ b/lang/po/Firmware_it.po
@@ -1792,7 +1792,7 @@ msgstr "ANOMALIA TERMICA"
 
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
-msgid "Temp model cal. takes apporx. 12 mins."
+msgid "Temp model cal. takes approx. 12 mins."
 msgstr "La calibrazione del modello di temperatura richiede circa 12 minuti."
 
 #. MSG_TM_NOT_CAL c=20 r=4

--- a/lang/po/Firmware_it.po
+++ b/lang/po/Firmware_it.po
@@ -1790,6 +1790,17 @@ msgstr "Scambiato"
 msgid "THERMAL ANOMALY"
 msgstr "ANOMALIA TERMICA"
 
+#. MSG_TM_CAL c=20 r=4
+#: ../../Firmware/ultralcd.cpp:4054
+msgid "Temp model cal. takes apporx. 12 mins."
+msgstr "La calibrazione del modello di temperatura richiede circa 12 minuti."
+
+#. MSG_TM_NOT_CAL c=20 r=4
+#: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
+#: ../../Firmware/messages.cpp:170
+msgid "Temp model not calibrated yet."
+msgstr "Modello di temperatura non ancora calibrato."
+
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4816
 msgid "Temperature"

--- a/lang/po/Firmware_it.po
+++ b/lang/po/Firmware_it.po
@@ -1793,13 +1793,13 @@ msgstr "ANOMALIA TERMICA"
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
 msgid "Temp model cal. takes approx. 12 mins."
-msgstr "La calibrazione del modello di temperatura richiede circa 12 minuti."
+msgstr "Calib mod temp richiede circa 12 min."
 
 #. MSG_TM_NOT_CAL c=20 r=4
 #: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
 #: ../../Firmware/messages.cpp:170
 msgid "Temp model not calibrated yet."
-msgstr "Modello di temperatura non ancora calibrato."
+msgstr "Modello temp non calibrato."
 
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4816

--- a/lang/po/Firmware_lb.po
+++ b/lang/po/Firmware_lb.po
@@ -1733,7 +1733,7 @@ msgstr ""
 
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
-msgid "Temp model cal. takes apporx. 12 mins."
+msgid "Temp model cal. takes approx. 12 mins."
 msgstr ""
 
 #. MSG_TM_NOT_CAL c=20 r=4

--- a/lang/po/Firmware_lb.po
+++ b/lang/po/Firmware_lb.po
@@ -1731,6 +1731,17 @@ msgstr ""
 msgid "THERMAL ANOMALY"
 msgstr ""
 
+#. MSG_TM_CAL c=20 r=4
+#: ../../Firmware/ultralcd.cpp:4054
+msgid "Temp model cal. takes apporx. 12 mins."
+msgstr ""
+
+#. MSG_TM_NOT_CAL c=20 r=4
+#: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
+#: ../../Firmware/messages.cpp:170
+msgid "Temp model not calibrated yet."
+msgstr ""
+
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4816
 msgid "Temperature"

--- a/lang/po/Firmware_lt.po
+++ b/lang/po/Firmware_lt.po
@@ -1733,7 +1733,7 @@ msgstr ""
 
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
-msgid "Temp model cal. takes apporx. 12 mins."
+msgid "Temp model cal. takes approx. 12 mins."
 msgstr ""
 
 #. MSG_TM_NOT_CAL c=20 r=4

--- a/lang/po/Firmware_lt.po
+++ b/lang/po/Firmware_lt.po
@@ -1731,6 +1731,17 @@ msgstr ""
 msgid "THERMAL ANOMALY"
 msgstr ""
 
+#. MSG_TM_CAL c=20 r=4
+#: ../../Firmware/ultralcd.cpp:4054
+msgid "Temp model cal. takes apporx. 12 mins."
+msgstr ""
+
+#. MSG_TM_NOT_CAL c=20 r=4
+#: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
+#: ../../Firmware/messages.cpp:170
+msgid "Temp model not calibrated yet."
+msgstr ""
+
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4816
 msgid "Temperature"

--- a/lang/po/Firmware_nl.po
+++ b/lang/po/Firmware_nl.po
@@ -1799,13 +1799,13 @@ msgstr "THERMISCHE ANOMALIE"
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
 msgid "Temp model cal. takes approx. 12 mins."
-msgstr "Kalibratie van het tempmodel duurt ongeveer. 12 minuten."
+msgstr "Temp model kal. duurt ongeveer 12 min."
 
 #. MSG_TM_NOT_CAL c=20 r=4
 #: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
 #: ../../Firmware/messages.cpp:170
 msgid "Temp model not calibrated yet."
-msgstr "Temp model nog niet gekalibreerd."
+msgstr "Temp model nog ongekalibreerd."
 
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4816

--- a/lang/po/Firmware_nl.po
+++ b/lang/po/Firmware_nl.po
@@ -1796,6 +1796,17 @@ msgstr "Gewisseld"
 msgid "THERMAL ANOMALY"
 msgstr "THERMISCHE ANOMALIE"
 
+#. MSG_TM_CAL c=20 r=4
+#: ../../Firmware/ultralcd.cpp:4054
+msgid "Temp model cal. takes apporx. 12 mins."
+msgstr "Kalibratie van het tempmodel duurt ongeveer. 12 minuten."
+
+#. MSG_TM_NOT_CAL c=20 r=4
+#: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
+#: ../../Firmware/messages.cpp:170
+msgid "Temp model not calibrated yet."
+msgstr "Temp model nog niet gekalibreerd."
+
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4816
 msgid "Temperature"

--- a/lang/po/Firmware_nl.po
+++ b/lang/po/Firmware_nl.po
@@ -1798,7 +1798,7 @@ msgstr "THERMISCHE ANOMALIE"
 
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
-msgid "Temp model cal. takes apporx. 12 mins."
+msgid "Temp model cal. takes approx. 12 mins."
 msgstr "Kalibratie van het tempmodel duurt ongeveer. 12 minuten."
 
 #. MSG_TM_NOT_CAL c=20 r=4

--- a/lang/po/Firmware_no.po
+++ b/lang/po/Firmware_no.po
@@ -1773,14 +1773,14 @@ msgstr "THERMISK ANOMALI"
 
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
-msgid "Temp model cal. takes apporx. 12 mins."
-msgstr ""
+msgid "Temp model cal. takes approx. 12 mins."
+msgstr "Temp modell kal. tar omtrent 12 min."
 
 #. MSG_TM_NOT_CAL c=20 r=4
 #: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
 #: ../../Firmware/messages.cpp:170
 msgid "Temp model not calibrated yet."
-msgstr ""
+msgstr "Temp modell ikke kalibrert enda."
 
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4816

--- a/lang/po/Firmware_no.po
+++ b/lang/po/Firmware_no.po
@@ -1771,6 +1771,17 @@ msgstr "Byttet"
 msgid "THERMAL ANOMALY"
 msgstr "THERMISK ANOMALI"
 
+#. MSG_TM_CAL c=20 r=4
+#: ../../Firmware/ultralcd.cpp:4054
+msgid "Temp model cal. takes apporx. 12 mins."
+msgstr ""
+
+#. MSG_TM_NOT_CAL c=20 r=4
+#: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
+#: ../../Firmware/messages.cpp:170
+msgid "Temp model not calibrated yet."
+msgstr ""
+
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4816
 msgid "Temperature"

--- a/lang/po/Firmware_pl.po
+++ b/lang/po/Firmware_pl.po
@@ -1785,6 +1785,17 @@ msgstr "Zamieniono"
 msgid "THERMAL ANOMALY"
 msgstr "THERMAL ANOMALY"
 
+#. MSG_TM_CAL c=20 r=4
+#: ../../Firmware/ultralcd.cpp:4054
+msgid "Temp model cal. takes apporx. 12 mins."
+msgstr "Kalibracja modelu temperatury trwa ok. 12 minut."
+
+#. MSG_TM_NOT_CAL c=20 r=4
+#: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
+#: ../../Firmware/messages.cpp:170
+msgid "Temp model not calibrated yet."
+msgstr "Model temperatury jeszcze nie skalibrowany."
+
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4816
 msgid "Temperature"

--- a/lang/po/Firmware_pl.po
+++ b/lang/po/Firmware_pl.po
@@ -1788,13 +1788,13 @@ msgstr "THERMAL ANOMALY"
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
 msgid "Temp model cal. takes approx. 12 mins."
-msgstr "Kalibracja modelu temperatury trwa ok. 12 minut."
+msgstr "Kal. modelu temp. moze zajac ok. 12min."
 
 #. MSG_TM_NOT_CAL c=20 r=4
 #: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
 #: ../../Firmware/messages.cpp:170
 msgid "Temp model not calibrated yet."
-msgstr "Model temperatury jeszcze nie skalibrowany."
+msgstr "Model temp. nie zostal skalib."
 
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4816

--- a/lang/po/Firmware_pl.po
+++ b/lang/po/Firmware_pl.po
@@ -1787,7 +1787,7 @@ msgstr "THERMAL ANOMALY"
 
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
-msgid "Temp model cal. takes apporx. 12 mins."
+msgid "Temp model cal. takes approx. 12 mins."
 msgstr "Kalibracja modelu temperatury trwa ok. 12 minut."
 
 #. MSG_TM_NOT_CAL c=20 r=4

--- a/lang/po/Firmware_ro.po
+++ b/lang/po/Firmware_ro.po
@@ -1789,7 +1789,7 @@ msgstr "ANOMALIE TERMICA"
 
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
-msgid "Temp model cal. takes apporx. 12 mins."
+msgid "Temp model cal. takes approx. 12 mins."
 msgstr ""
 
 #. MSG_TM_NOT_CAL c=20 r=4

--- a/lang/po/Firmware_ro.po
+++ b/lang/po/Firmware_ro.po
@@ -1790,13 +1790,13 @@ msgstr "ANOMALIE TERMICA"
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
 msgid "Temp model cal. takes approx. 12 mins."
-msgstr ""
+msgstr "Cal. Model de temp dureaza aprox. 12 min."
 
 #. MSG_TM_NOT_CAL c=20 r=4
 #: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
 #: ../../Firmware/messages.cpp:170
 msgid "Temp model not calibrated yet."
-msgstr ""
+msgstr "Modelul de temp. nu este inca calibrat."
 
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4816

--- a/lang/po/Firmware_ro.po
+++ b/lang/po/Firmware_ro.po
@@ -1787,6 +1787,17 @@ msgstr "inversate"
 msgid "THERMAL ANOMALY"
 msgstr "ANOMALIE TERMICA"
 
+#. MSG_TM_CAL c=20 r=4
+#: ../../Firmware/ultralcd.cpp:4054
+msgid "Temp model cal. takes apporx. 12 mins."
+msgstr ""
+
+#. MSG_TM_NOT_CAL c=20 r=4
+#: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
+#: ../../Firmware/messages.cpp:170
+msgid "Temp model not calibrated yet."
+msgstr ""
+
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4816
 msgid "Temperature"

--- a/lang/po/Firmware_sk.po
+++ b/lang/po/Firmware_sk.po
@@ -1781,7 +1781,7 @@ msgstr "THERMAL ANOMALY"
 
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
-msgid "Temp model cal. takes apporx. 12 mins."
+msgid "Temp model cal. takes approx. 12 mins."
 msgstr ""
 
 #. MSG_TM_NOT_CAL c=20 r=4

--- a/lang/po/Firmware_sk.po
+++ b/lang/po/Firmware_sk.po
@@ -1779,6 +1779,17 @@ msgstr "Prehodene"
 msgid "THERMAL ANOMALY"
 msgstr "THERMAL ANOMALY"
 
+#. MSG_TM_CAL c=20 r=4
+#: ../../Firmware/ultralcd.cpp:4054
+msgid "Temp model cal. takes apporx. 12 mins."
+msgstr ""
+
+#. MSG_TM_NOT_CAL c=20 r=4
+#: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
+#: ../../Firmware/messages.cpp:170
+msgid "Temp model not calibrated yet."
+msgstr ""
+
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4816
 msgid "Temperature"

--- a/lang/po/Firmware_sk.po
+++ b/lang/po/Firmware_sk.po
@@ -1782,13 +1782,13 @@ msgstr "THERMAL ANOMALY"
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
 msgid "Temp model cal. takes approx. 12 mins."
-msgstr ""
+msgstr "Výpočet teplotného modelu trvá približne 12 minút."
 
 #. MSG_TM_NOT_CAL c=20 r=4
 #: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
 #: ../../Firmware/messages.cpp:170
 msgid "Temp model not calibrated yet."
-msgstr ""
+msgstr "Teplotný model zatiaľ nebol kalibrovaný"
 
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4816

--- a/lang/po/Firmware_sl.po
+++ b/lang/po/Firmware_sl.po
@@ -1733,7 +1733,7 @@ msgstr ""
 
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
-msgid "Temp model cal. takes apporx. 12 mins."
+msgid "Temp model cal. takes approx. 12 mins."
 msgstr ""
 
 #. MSG_TM_NOT_CAL c=20 r=4

--- a/lang/po/Firmware_sl.po
+++ b/lang/po/Firmware_sl.po
@@ -1731,6 +1731,17 @@ msgstr ""
 msgid "THERMAL ANOMALY"
 msgstr ""
 
+#. MSG_TM_CAL c=20 r=4
+#: ../../Firmware/ultralcd.cpp:4054
+msgid "Temp model cal. takes apporx. 12 mins."
+msgstr ""
+
+#. MSG_TM_NOT_CAL c=20 r=4
+#: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
+#: ../../Firmware/messages.cpp:170
+msgid "Temp model not calibrated yet."
+msgstr ""
+
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4816
 msgid "Temperature"

--- a/lang/po/Firmware_sv.po
+++ b/lang/po/Firmware_sv.po
@@ -1788,6 +1788,17 @@ msgstr "Utbytt"
 msgid "THERMAL ANOMALY"
 msgstr "TERMISK ANOMALI"
 
+#. MSG_TM_CAL c=20 r=4
+#: ../../Firmware/ultralcd.cpp:4054
+msgid "Temp model cal. takes apporx. 12 mins."
+msgstr ""
+
+#. MSG_TM_NOT_CAL c=20 r=4
+#: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
+#: ../../Firmware/messages.cpp:170
+msgid "Temp model not calibrated yet."
+msgstr ""
+
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4816
 msgid "Temperature"

--- a/lang/po/Firmware_sv.po
+++ b/lang/po/Firmware_sv.po
@@ -1791,13 +1791,13 @@ msgstr "TERMISK ANOMALI"
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
 msgid "Temp model cal. takes approx. 12 mins."
-msgstr ""
+msgstr "Temp modell kal. tar ca. 12 min."
 
 #. MSG_TM_NOT_CAL c=20 r=4
 #: ../../Firmware/Marlin_main.cpp:1527 ../../Firmware/Marlin_main.cpp:3404
 #: ../../Firmware/messages.cpp:170
 msgid "Temp model not calibrated yet."
-msgstr ""
+msgstr "Temp-modellen är inte kalibrerad ännu."
 
 #. MSG_TEMPERATURE c=18
 #: ../../Firmware/ultralcd.cpp:4816

--- a/lang/po/Firmware_sv.po
+++ b/lang/po/Firmware_sv.po
@@ -1790,7 +1790,7 @@ msgstr "TERMISK ANOMALI"
 
 #. MSG_TM_CAL c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4054
-msgid "Temp model cal. takes apporx. 12 mins."
+msgid "Temp model cal. takes approx. 12 mins."
 msgstr ""
 
 #. MSG_TM_NOT_CAL c=20 r=4


### PR DESCRIPTION
Cherry-pick from https://github.com/prusa3d/Prusa-Firmware/pull/3769

-[X] Tested with Prusa MK3S without MMU2

Missing for final:
Translations cherry-pick:
  - Translated messages 
    - [x] CS with Deepl
    - [x] DE
    - [x] ES with Deepl
    - [x] FR with Deepl
    - [x] IT with Deepl
    - [x] PL with Deepl
    - Community translators please translate these two messages asap.
    - [X] NL @vintagepc please review
    - [x] RO @Hauzman 
    - [x] HU @AttilaSVK 
    - [ ] HR  @Prime1910 
    - [x] SL @ingbrzy 
    - [ ] SV @Painkiller56 
    - [x] NO @OS-kar
