### PR TITLE
PFW-1440 Fix issue where cooldown timer is not set again after a failed retry

### DIFF
--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -1016,7 +1016,7 @@ void MMU2::OnMMUProgressMsgChanged(ProgressCode pc){
     }
 }
 
-void __attribute__((noiniline)) MMU2::HelpUnloadToFinda(){
+void __attribute__((noinline)) MMU2::HelpUnloadToFinda(){
     current_position[E_AXIS] -= MMU2_RETRY_UNLOAD_TO_FINDA_LENGTH;
     plan_buffer_line_curposXYZE(MMU2_RETRY_UNLOAD_TO_FINDA_FEED_RATE);
 }

--- a/Firmware/mmu2.h
+++ b/Firmware/mmu2.h
@@ -256,9 +256,13 @@ private:
     void OnMMUProgressMsgChanged(ProgressCode pc);
     /// Repeated calls when progress code remains the same
     void OnMMUProgressMsgSame(ProgressCode pc);
-    
+
+    /// @brief Save hotend temperature and set flag to cooldown hotend after 60 minutes
+    /// @param turn_off_nozzle if true, the hotend temperature will be set to 0degC after 60 minutes
+    void SaveHotendTemp(bool turn_off_nozzle);
+
     /// Save print and park the print head
-    void SaveAndPark(bool move_axes, bool turn_off_nozzle);
+    void SaveAndPark(bool move_axes);
 
     /// Resume hotend temperature, if it was cooled. Safe to call if we aren't saved.
     void ResumeHotendTemp();


### PR DESCRIPTION
The solution is split `SaveAndPark()` into two functions:
* `SaveAndPark()`
* `SaveHotendTemp()`

The bug in PFW-1440 looks like is caused by this => After a failed retry, the extruder is still in parking position. The cool-down timer is  only restarted when parking. But since the firmware doesn't park again on subsequent errors, the cool-down timer is not reset.

In this PR, parking and starting the cool-down timer are two separate steps (two functions) which don't depend on one another.

Change in memory:
Flash: +10 bytes
SRAM: 0 bytes