### PR TITLE
PFW-1435 Nozzle change menu

### DIFF
--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -170,6 +170,9 @@ extern const char MSG_PAUSED_THERMAL_ERROR[] PROGMEM_I1 = ISTR("PAUSED THERMAL E
 extern const char MSG_THERMAL_ANOMALY[] PROGMEM_I1 = ISTR("THERMAL ANOMALY");////MSG_THERMAL_ANOMALY c=20
 #endif
 extern const char MSG_LOAD_ALL[] PROGMEM_I1 = ISTR("Load All"); ////MSG_LOAD_ALL c=18
+extern const char MSG_NOZZLE_CNG_MENU [] PROGMEM_I1 = ISTR("Nozzle change");////MSG_NOZZLE_CNG_MENU c=18
+extern const char MSG_NOZZLE_CNG_READ_HELP [] PROGMEM_I1 = ISTR("For a Nozzle change please read\nprusa.io/nozzle-mk3s");////MSG_NOZZLE_CNG_READ_HELP c=20 r=4
+extern const char MSG_NOZZLE_CNG_CHANGED [] PROGMEM_I1 = ISTR("Hotend at 280C! Nozzle changed and tightened to specs?");////MSG_NOZZLE_CNG_CHANGED c=20 r=6
 
 //not internationalized messages
 #if 0

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -174,6 +174,9 @@ extern const char MSG_PAUSED_THERMAL_ERROR[];
 extern const char MSG_THERMAL_ANOMALY[];
 #endif
 extern const char MSG_LOAD_ALL[];
+extern const char MSG_NOZZLE_CNG_MENU [];
+extern const char MSG_NOZZLE_CNG_READ_HELP [];
+extern const char MSG_NOZZLE_CNG_CHANGED [];
 
 //not internationalized messages
 #if 0

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -823,6 +823,7 @@ void print_stop();
 
 void lcd_commands()
 {
+    // printf_P(PSTR("lcd_commands begin, lcd_commands_type=%u, lcd_commands_step=%u\n"), (uint8_t)lcd_commands_type, lcd_commands_step);
     if (planner_aborted) {
         // we are still within an aborted command. do not process any LCD command until we return
         return;
@@ -1016,7 +1017,10 @@ void lcd_commands()
                 lcd_commands_step = 3;
                 break;
             case 3:
+                lcd_update_enabled = false; //hack to avoid lcd_update recursion.
                 lcd_show_fullscreen_message_and_wait_P(_T(MSG_NOZZLE_CNG_READ_HELP));
+                lcd_update_enabled = true;
+                lcd_draw_update = 2; //force lcd clear and update after the stack unwinds.
                 enquecommand_P(PSTR("G28W"));
                 enquecommand_P(PSTR("G1 X125 Y10 Z150 F1000"));
                 enquecommand_P(PSTR("M109 S280"));
@@ -1033,6 +1037,7 @@ void lcd_commands()
                 //|tightend to specs?
                 //| Yes     No
                 enquecommand_P(PSTR("M84 XY"));
+                lcd_update_enabled = false; //hack to avoid lcd_update recursion.
                 if (lcd_show_fullscreen_message_yes_no_and_wait_P(_T(MSG_NOZZLE_CNG_CHANGED), false) == LCD_LEFT_BUTTON_CHOICE) {
 #ifdef TEMP_MODEL
                 //enquecommand_P(PSTR("M310 S1"));
@@ -1042,6 +1047,7 @@ void lcd_commands()
                 setTargetHotendSafe(0,0);
                 lcd_commands_step = 1;
                 }
+                lcd_update_enabled = true;
                 break;
             case 1:
                 lcd_setstatuspgm(MSG_WELCOME);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1021,7 +1021,7 @@ void lcd_commands()
                 lcd_show_fullscreen_message_and_wait_P(_T(MSG_NOZZLE_CNG_READ_HELP));
                 lcd_update_enabled = true;
                 lcd_draw_update = 2; //force lcd clear and update after the stack unwinds.
-                enquecommand_P(PSTR("G28W"));
+                enquecommand_P(PSTR("G28 W"));
                 enquecommand_P(PSTR("G1 X125 Y10 Z150 F1000"));
                 enquecommand_P(PSTR("M109 S280"));
 #ifdef TEMP_MODEL

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2994,6 +2994,11 @@ static const char* lcd_display_message_fullscreen_nonBlocking_P(const char *msg)
             char c = char(pgm_read_byte(msg));
             if (c == '~')
                 c = ' ';
+            else if (c == '\n') {
+                // Abort early if '\n' is encontered.
+                // This character is used to force the following words to be printed on the next line.
+                break;
+            }
             lcd_print(c);
         }
     }

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1005,6 +1005,52 @@ void lcd_commands()
         }
     }
 #endif //TEMP_MODEL
+
+	if (lcd_commands_type == LcdCommands::NozzleCNG)
+	{
+        if (!blocks_queued() && cmd_buffer_empty() && !saved_printing)
+        {
+            switch(lcd_commands_step)
+            {
+            case 0:
+                lcd_commands_step = 3;
+                break;
+            case 3:
+                lcd_show_fullscreen_message_and_wait_P(_T(MSG_NOZZLE_CNG_READ_HELP));
+                enquecommand_P(PSTR("G28W"));
+                enquecommand_P(PSTR("G1 X125 Y10 Z150 F1000"));
+                enquecommand_P(PSTR("M109 S280"));
+#ifdef TEMP_MODEL
+                //enquecommand_P(PSTR("M310 S0"));
+                temp_model_set_enabled(false);
+#endif //TEMP_MODEL
+                lcd_commands_step = 2;
+                break;
+            case 2:
+                //|0123456789012456789|
+                //|Hotend at 280C!
+                //|Nozzle changed and
+                //|tightend to specs?
+                //| Yes     No
+                enquecommand_P(PSTR("M84 XY"));
+                if (lcd_show_fullscreen_message_yes_no_and_wait_P(_T(MSG_NOZZLE_CNG_CHANGED), false) == LCD_LEFT_BUTTON_CHOICE) {
+#ifdef TEMP_MODEL
+                //enquecommand_P(PSTR("M310 S1"));
+                temp_model_set_enabled(true);
+#endif //TEMP_MODEL
+                //enquecommand_P(PSTR("M104 S0"));
+                setTargetHotendSafe(0,0);
+                lcd_commands_step = 1;
+                }
+                break;
+            case 1:
+                lcd_setstatuspgm(MSG_WELCOME);
+                lcd_commands_step = 0;
+                lcd_commands_type = LcdCommands::Idle;
+                break;
+            }
+        }
+    }
 }
 
 void lcd_return_to_status()
@@ -4503,6 +4549,12 @@ static void sheets_menu()
     MENU_END();
 }
 
+static void nozzle_change()
+{
+    lcd_commands_type = LcdCommands::NozzleCNG;
+    lcd_return_to_status();
+}
+
 void lcd_hw_setup_menu(void)                      // can not be "static"
 {
     typedef struct
@@ -4525,6 +4577,7 @@ void lcd_hw_setup_menu(void)                      // can not be "static"
 
     MENU_ITEM_SUBMENU_P(_T(MSG_STEEL_SHEETS), sheets_menu);
     SETTINGS_NOZZLE;
+    MENU_ITEM_FUNCTION_P(_T(MSG_NOZZLE_CNG_MENU),nozzle_change);
     MENU_ITEM_SUBMENU_P(_i("Checks"), lcd_checking_menu);  ////MSG_CHECKS c=18
 
 #if defined(FILAMENT_SENSOR) && (FILAMENT_SENSOR_TYPE == FSENSOR_IR_ANALOG)

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -119,6 +119,7 @@ enum class LcdCommands : uint_least8_t
 #ifdef TEMP_MODEL
     TempModel,
 #endif //TEMP_MODEL
+    NozzleCNG,
 };
 
 extern LcdCommands lcd_commands_type;

--- a/lang/po/Firmware.pot
+++ b/lang/po/Firmware.pot
@@ -743,6 +743,13 @@ msgstr ""
 msgid "Flow"
 msgstr ""
 
+#. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:1019
+msgid ""
+"For a Nozzle change please read\n"
+"prusa.io/nozzle-mk3s"
+msgstr ""
+
 #. MSG_SELFTEST_PART_FAN c=20
 #: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:6977
 #: ../../Firmware/ultralcd.cpp:7129 ../../Firmware/ultralcd.cpp:7134
@@ -851,6 +858,11 @@ msgstr ""
 #: ../../Firmware/mmu2_progress_converter.cpp:29
 #: ../../Firmware/mmu2_progress_converter.cpp:60
 msgid "Homing"
+msgstr ""
+
+#. MSG_NOZZLE_CNG_CHANGED c=20 r=6
+#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:1036
+msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr ""
 
 #. MSG_HOTEND_FAN_SPEED c=15
@@ -1293,6 +1305,11 @@ msgstr ""
 #: ../../Firmware/ultralcd.cpp:4455 ../../Firmware/ultralcd.cpp:4458
 #: ../../Firmware/ultralcd.cpp:5707 ../../Firmware/ultralcd.cpp:5854
 msgid "Nozzle"
+msgstr ""
+
+#. MSG_NOZZLE_CNG_MENU c=18
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:4580
+msgid "Nozzle change"
 msgstr ""
 
 #. MSG_NOZZLE_DIAMETER c=10

--- a/lang/po/Firmware_cs.po
+++ b/lang/po/Firmware_cs.po
@@ -775,6 +775,15 @@ msgstr ""
 msgid "Flow"
 msgstr "Prutok"
 
+#. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:1019
+msgid ""
+"For a Nozzle change please read\n"
+"prusa.io/nozzle-mk3s"
+msgstr ""
+"Pro výměnu trysek si přečtěte\n"
+"prusa.io/nozzle-mk3s"
+
 #. MSG_SELFTEST_PART_FAN c=20
 #: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:6977
 #: ../../Firmware/ultralcd.cpp:7129 ../../Firmware/ultralcd.cpp:7134
@@ -894,6 +903,11 @@ msgstr "Vys. vykon"
 #: ../../Firmware/mmu2_progress_converter.cpp:60
 msgid "Homing"
 msgstr "Homing"
+
+#. MSG_NOZZLE_CNG_CHANGED c=20 r=6
+#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:1036
+msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
+msgstr "Hotend při 280C! Tryska vyměněna a dotažena podle specifikací?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
 #: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1137
@@ -1344,6 +1358,11 @@ msgstr "Nyni odstrante testovaci vytisk z tiskoveho platu."
 #: ../../Firmware/ultralcd.cpp:5707 ../../Firmware/ultralcd.cpp:5854
 msgid "Nozzle"
 msgstr "Tryska"
+
+#. MSG_NOZZLE_CNG_MENU c=18
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:4580
+msgid "Nozzle change"
+msgstr "Výměna trysek"
 
 #. MSG_NOZZLE_DIAMETER c=10
 #: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4502

--- a/lang/po/Firmware_cs.po
+++ b/lang/po/Firmware_cs.po
@@ -781,7 +781,7 @@ msgid ""
 "For a Nozzle change please read\n"
 "prusa.io/nozzle-mk3s"
 msgstr ""
-"Pro výměnu trysek si přečtěte\n"
+"Instrukce pro výměnu trysky najdete na\n"
 "prusa.io/nozzle-mk3s"
 
 #. MSG_SELFTEST_PART_FAN c=20
@@ -907,7 +907,7 @@ msgstr "Homing"
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
 #: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:1036
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
-msgstr "Hotend při 280C! Tryska vyměněna a dotažena podle specifikací?"
+msgstr "Hotend má 280C! Tryska vyměněna a dotažena dle instrukcí?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
 #: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1137

--- a/lang/po/Firmware_da.po
+++ b/lang/po/Firmware_da.po
@@ -750,6 +750,13 @@ msgstr ""
 msgid "Flow"
 msgstr ""
 
+#. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:1019
+msgid ""
+"For a Nozzle change please read\n"
+"prusa.io/nozzle-mk3s"
+msgstr ""
+
 #. MSG_SELFTEST_PART_FAN c=20
 #: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:6977
 #: ../../Firmware/ultralcd.cpp:7129 ../../Firmware/ultralcd.cpp:7134
@@ -860,6 +867,11 @@ msgstr ""
 #: ../../Firmware/mmu2_progress_converter.cpp:29
 #: ../../Firmware/mmu2_progress_converter.cpp:60
 msgid "Homing"
+msgstr ""
+
+#. MSG_NOZZLE_CNG_CHANGED c=20 r=6
+#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:1036
+msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr ""
 
 #. MSG_HOTEND_FAN_SPEED c=15
@@ -1302,6 +1314,11 @@ msgstr ""
 #: ../../Firmware/ultralcd.cpp:4455 ../../Firmware/ultralcd.cpp:4458
 #: ../../Firmware/ultralcd.cpp:5707 ../../Firmware/ultralcd.cpp:5854
 msgid "Nozzle"
+msgstr ""
+
+#. MSG_NOZZLE_CNG_MENU c=18
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:4580
+msgid "Nozzle change"
 msgstr ""
 
 #. MSG_NOZZLE_DIAMETER c=10

--- a/lang/po/Firmware_de.po
+++ b/lang/po/Firmware_de.po
@@ -781,6 +781,15 @@ msgstr ""
 msgid "Flow"
 msgstr "Durchfluss"
 
+#. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:1019
+msgid ""
+"For a Nozzle change please read\n"
+"prusa.io/nozzle-mk3s"
+msgstr ""
+"Für Düsenwechsel lesen Sie bitte\n"
+"prusa.io/nozzle-mk3s"
+
 #. MSG_SELFTEST_PART_FAN c=20
 #: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:6977
 #: ../../Firmware/ultralcd.cpp:7129 ../../Firmware/ultralcd.cpp:7134
@@ -901,6 +910,13 @@ msgstr "Hohe leist"
 #: ../../Firmware/mmu2_progress_converter.cpp:60
 msgid "Homing"
 msgstr "Startposition"
+
+#. MSG_NOZZLE_CNG_CHANGED c=20 r=6
+#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:1036
+msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
+msgstr ""
+"Hotend bei 280C! Wurde die Düse ausgetauscht und entsprechend den "
+"Spezifikationen angezogen?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
 #: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1137
@@ -1357,6 +1373,11 @@ msgstr "Testdruck jetzt von Stahlblech entfernen."
 #: ../../Firmware/ultralcd.cpp:5707 ../../Firmware/ultralcd.cpp:5854
 msgid "Nozzle"
 msgstr "Düse"
+
+#. MSG_NOZZLE_CNG_MENU c=18
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:4580
+msgid "Nozzle change"
+msgstr "Düsenwechsel"
 
 #. MSG_NOZZLE_DIAMETER c=10
 #: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4502

--- a/lang/po/Firmware_de.po
+++ b/lang/po/Firmware_de.po
@@ -914,9 +914,7 @@ msgstr "Startposition"
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
 #: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:1036
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
-msgstr ""
-"Hotend bei 280C! Wurde die Düse ausgetauscht und entsprechend den "
-"Spezifikationen angezogen?"
+msgstr "Hotend bei 280C! Düse gewechselt, gemäß Spezifikation angezogen?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
 #: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1137

--- a/lang/po/Firmware_es.po
+++ b/lang/po/Firmware_es.po
@@ -783,7 +783,7 @@ msgid ""
 "For a Nozzle change please read\n"
 "prusa.io/nozzle-mk3s"
 msgstr ""
-"Para un cambio de boquilla por fa. lea\n"
+"Para un cambio de boquilla, lee\n"
 "prusa.io/nozzle-mk3s"
 
 #. MSG_SELFTEST_PART_FAN c=20
@@ -910,8 +910,7 @@ msgstr "Homing"
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
 #: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:1036
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
-msgstr "Calentador a 280C! Se ha cambiado la boquilla y se ha ajustado a "
-"las especificaciones?"
+msgstr "Fusor a 280C! Boquilla cambiado y ajust. a la medida?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
 #: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1137

--- a/lang/po/Firmware_es.po
+++ b/lang/po/Firmware_es.po
@@ -777,6 +777,15 @@ msgstr ""
 msgid "Flow"
 msgstr "Flujo"
 
+#. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:1019
+msgid ""
+"For a Nozzle change please read\n"
+"prusa.io/nozzle-mk3s"
+msgstr ""
+"Para un cambio de boquilla por fa. lea\n"
+"prusa.io/nozzle-mk3s"
+
 #. MSG_SELFTEST_PART_FAN c=20
 #: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:6977
 #: ../../Firmware/ultralcd.cpp:7129 ../../Firmware/ultralcd.cpp:7134
@@ -897,6 +906,12 @@ msgstr "Rend.pleno"
 #: ../../Firmware/mmu2_progress_converter.cpp:60
 msgid "Homing"
 msgstr "Homing"
+
+#. MSG_NOZZLE_CNG_CHANGED c=20 r=6
+#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:1036
+msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
+msgstr "Calentador a 280C! Se ha cambiado la boquilla y se ha ajustado a "
+"las especificaciones?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
 #: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1137
@@ -1350,6 +1365,11 @@ msgstr "Ahora retira la prueba de la lamina de acero."
 #: ../../Firmware/ultralcd.cpp:5707 ../../Firmware/ultralcd.cpp:5854
 msgid "Nozzle"
 msgstr "Boquilla"
+
+#. MSG_NOZZLE_CNG_MENU c=18
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:4580
+msgid "Nozzle change"
+msgstr "Cambio de boquilla"
 
 #. MSG_NOZZLE_DIAMETER c=10
 #: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4502

--- a/lang/po/Firmware_fr.po
+++ b/lang/po/Firmware_fr.po
@@ -787,7 +787,7 @@ msgid ""
 "For a Nozzle change please read\n"
 "prusa.io/nozzle-mk3s"
 msgstr ""
-"For a Nozzle change please read\n"
+"Pour un changement de buse, lire\n"
 "prusa.io/nozzle-mk3s"
 
 #. MSG_SELFTEST_PART_FAN c=20
@@ -916,7 +916,7 @@ msgstr "Mise a zero"
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
 #: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:1036
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
-msgstr "Hotend at 280C! Nozzle changed and tightened to specs?"
+msgstr "Hotend à 280C! Buse changée et resserrée aux spécifications?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
 #: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1137

--- a/lang/po/Firmware_fr.po
+++ b/lang/po/Firmware_fr.po
@@ -781,6 +781,15 @@ msgstr ""
 msgid "Flow"
 msgstr "Flux"
 
+#. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:1019
+msgid ""
+"For a Nozzle change please read\n"
+"prusa.io/nozzle-mk3s"
+msgstr ""
+"For a Nozzle change please read\n"
+"prusa.io/nozzle-mk3s"
+
 #. MSG_SELFTEST_PART_FAN c=20
 #: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:6977
 #: ../../Firmware/ultralcd.cpp:7129 ../../Firmware/ultralcd.cpp:7134
@@ -903,6 +912,11 @@ msgstr "Haut.puiss"
 #: ../../Firmware/mmu2_progress_converter.cpp:60
 msgid "Homing"
 msgstr "Mise a zero"
+
+#. MSG_NOZZLE_CNG_CHANGED c=20 r=6
+#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:1036
+msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
+msgstr "Hotend at 280C! Nozzle changed and tightened to specs?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
 #: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1137
@@ -1358,6 +1372,11 @@ msgstr "Retirez maintenant l'impression de test de la plaque en acier."
 #: ../../Firmware/ultralcd.cpp:5707 ../../Firmware/ultralcd.cpp:5854
 msgid "Nozzle"
 msgstr "Buse"
+
+#. MSG_NOZZLE_CNG_MENU c=18
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:4580
+msgid "Nozzle change"
+msgstr "Changement de buse"
 
 #. MSG_NOZZLE_DIAMETER c=10
 #: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4502

--- a/lang/po/Firmware_hr.po
+++ b/lang/po/Firmware_hr.po
@@ -774,6 +774,13 @@ msgstr ""
 msgid "Flow"
 msgstr "Protok"
 
+#. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:1019
+msgid ""
+"For a Nozzle change please read\n"
+"prusa.io/nozzle-mk3s"
+msgstr ""
+
 #. MSG_SELFTEST_PART_FAN c=20
 #: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:6977
 #: ../../Firmware/ultralcd.cpp:7129 ../../Firmware/ultralcd.cpp:7134
@@ -894,6 +901,11 @@ msgstr "Visoka sna"
 #: ../../Firmware/mmu2_progress_converter.cpp:60
 msgid "Homing"
 msgstr "Navodjenje"
+
+#. MSG_NOZZLE_CNG_CHANGED c=20 r=6
+#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:1036
+msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
+msgstr ""
 
 #. MSG_HOTEND_FAN_SPEED c=15
 #: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1137
@@ -1347,6 +1359,11 @@ msgstr "Sada uklonite probni print sa celicne ploce."
 #: ../../Firmware/ultralcd.cpp:5707 ../../Firmware/ultralcd.cpp:5854
 msgid "Nozzle"
 msgstr "Mlaznica"
+
+#. MSG_NOZZLE_CNG_MENU c=18
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:4580
+msgid "Nozzle change"
+msgstr ""
 
 #. MSG_NOZZLE_DIAMETER c=10
 #: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4502

--- a/lang/po/Firmware_hu.po
+++ b/lang/po/Firmware_hu.po
@@ -777,6 +777,13 @@ msgstr ""
 msgid "Flow"
 msgstr "Flow"
 
+#. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:1019
+msgid ""
+"For a Nozzle change please read\n"
+"prusa.io/nozzle-mk3s"
+msgstr ""
+
 #. MSG_SELFTEST_PART_FAN c=20
 #: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:6977
 #: ../../Firmware/ultralcd.cpp:7129 ../../Firmware/ultralcd.cpp:7134
@@ -897,6 +904,11 @@ msgstr "Magas ero"
 #: ../../Firmware/mmu2_progress_converter.cpp:60
 msgid "Homing"
 msgstr "Homeolas"
+
+#. MSG_NOZZLE_CNG_CHANGED c=20 r=6
+#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:1036
+msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
+msgstr ""
 
 #. MSG_HOTEND_FAN_SPEED c=15
 #: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1137
@@ -1350,6 +1362,11 @@ msgstr "Vedd le a tesztnyomatot az acellaprol."
 #: ../../Firmware/ultralcd.cpp:5707 ../../Firmware/ultralcd.cpp:5854
 msgid "Nozzle"
 msgstr "Fuvoka"
+
+#. MSG_NOZZLE_CNG_MENU c=18
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:4580
+msgid "Nozzle change"
+msgstr ""
 
 #. MSG_NOZZLE_DIAMETER c=10
 #: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4502

--- a/lang/po/Firmware_it.po
+++ b/lang/po/Firmware_it.po
@@ -778,6 +778,15 @@ msgstr ""
 msgid "Flow"
 msgstr "Flusso"
 
+#. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:1019
+msgid ""
+"For a Nozzle change please read\n"
+"prusa.io/nozzle-mk3s"
+msgstr ""
+"Per la sostituzione dell'ugello, leggere\n"
+"prusa.io/nozzle-mk3s"
+
 #. MSG_SELFTEST_PART_FAN c=20
 #: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:6977
 #: ../../Firmware/ultralcd.cpp:7129 ../../Firmware/ultralcd.cpp:7134
@@ -898,6 +907,11 @@ msgstr "Forte"
 #: ../../Firmware/mmu2_progress_converter.cpp:60
 msgid "Homing"
 msgstr "Homing"
+
+#. MSG_NOZZLE_CNG_CHANGED c=20 r=6
+#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:1036
+msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
+msgstr "Hotend a 280C! Ugello cambiato e serrato secondo le specifiche?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
 #: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1137
@@ -1349,6 +1363,11 @@ msgstr "Ora rimuovete la stampa di prova dalla piastra in acciaio."
 #: ../../Firmware/ultralcd.cpp:5707 ../../Firmware/ultralcd.cpp:5854
 msgid "Nozzle"
 msgstr "Ugello"
+
+#. MSG_NOZZLE_CNG_MENU c=18
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:4580
+msgid "Nozzle change"
+msgstr "Cambio dell'ugello"
 
 #. MSG_NOZZLE_DIAMETER c=10
 #: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4502

--- a/lang/po/Firmware_lb.po
+++ b/lang/po/Firmware_lb.po
@@ -750,6 +750,13 @@ msgstr ""
 msgid "Flow"
 msgstr ""
 
+#. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:1019
+msgid ""
+"For a Nozzle change please read\n"
+"prusa.io/nozzle-mk3s"
+msgstr ""
+
 #. MSG_SELFTEST_PART_FAN c=20
 #: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:6977
 #: ../../Firmware/ultralcd.cpp:7129 ../../Firmware/ultralcd.cpp:7134
@@ -860,6 +867,11 @@ msgstr ""
 #: ../../Firmware/mmu2_progress_converter.cpp:29
 #: ../../Firmware/mmu2_progress_converter.cpp:60
 msgid "Homing"
+msgstr ""
+
+#. MSG_NOZZLE_CNG_CHANGED c=20 r=6
+#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:1036
+msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr ""
 
 #. MSG_HOTEND_FAN_SPEED c=15
@@ -1302,6 +1314,11 @@ msgstr ""
 #: ../../Firmware/ultralcd.cpp:4455 ../../Firmware/ultralcd.cpp:4458
 #: ../../Firmware/ultralcd.cpp:5707 ../../Firmware/ultralcd.cpp:5854
 msgid "Nozzle"
+msgstr ""
+
+#. MSG_NOZZLE_CNG_MENU c=18
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:4580
+msgid "Nozzle change"
 msgstr ""
 
 #. MSG_NOZZLE_DIAMETER c=10

--- a/lang/po/Firmware_lt.po
+++ b/lang/po/Firmware_lt.po
@@ -750,6 +750,13 @@ msgstr ""
 msgid "Flow"
 msgstr ""
 
+#. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:1019
+msgid ""
+"For a Nozzle change please read\n"
+"prusa.io/nozzle-mk3s"
+msgstr ""
+
 #. MSG_SELFTEST_PART_FAN c=20
 #: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:6977
 #: ../../Firmware/ultralcd.cpp:7129 ../../Firmware/ultralcd.cpp:7134
@@ -860,6 +867,11 @@ msgstr ""
 #: ../../Firmware/mmu2_progress_converter.cpp:29
 #: ../../Firmware/mmu2_progress_converter.cpp:60
 msgid "Homing"
+msgstr ""
+
+#. MSG_NOZZLE_CNG_CHANGED c=20 r=6
+#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:1036
+msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr ""
 
 #. MSG_HOTEND_FAN_SPEED c=15
@@ -1302,6 +1314,11 @@ msgstr ""
 #: ../../Firmware/ultralcd.cpp:4455 ../../Firmware/ultralcd.cpp:4458
 #: ../../Firmware/ultralcd.cpp:5707 ../../Firmware/ultralcd.cpp:5854
 msgid "Nozzle"
+msgstr ""
+
+#. MSG_NOZZLE_CNG_MENU c=18
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:4580
+msgid "Nozzle change"
 msgstr ""
 
 #. MSG_NOZZLE_DIAMETER c=10

--- a/lang/po/Firmware_nl.po
+++ b/lang/po/Firmware_nl.po
@@ -779,6 +779,15 @@ msgstr ""
 msgid "Flow"
 msgstr "Stromen"
 
+#. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:1019
+msgid ""
+"For a Nozzle change please read\n"
+"prusa.io/nozzle-mk3s"
+msgstr ""
+"Voor een spuitstukwissel lees\n"
+"prusa.io/nozzle-mk3s"
+
 #. MSG_SELFTEST_PART_FAN c=20
 #: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:6977
 #: ../../Firmware/ultralcd.cpp:7129 ../../Firmware/ultralcd.cpp:7134
@@ -899,6 +908,11 @@ msgstr "Hoog verm."
 #: ../../Firmware/mmu2_progress_converter.cpp:60
 msgid "Homing"
 msgstr "Startpositie"
+
+#. MSG_NOZZLE_CNG_CHANGED c=20 r=6
+#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:1036
+msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
+msgstr "Hotend op 280C! Mondstuk vervangen en aangedraaid volgens specificaties?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
 #: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1137
@@ -1350,6 +1364,11 @@ msgstr "Verwijder nu de testprint van staalplaat."
 #: ../../Firmware/ultralcd.cpp:5707 ../../Firmware/ultralcd.cpp:5854
 msgid "Nozzle"
 msgstr "Tuit"
+
+#. MSG_NOZZLE_CNG_MENU c=18
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:4580
+msgid "Nozzle change"
+msgstr "Tuit wisselen"
 
 #. MSG_NOZZLE_DIAMETER c=10
 #: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4502

--- a/lang/po/Firmware_no.po
+++ b/lang/po/Firmware_no.po
@@ -775,6 +775,13 @@ msgstr "Først skal jeg kjøre en selvtest for å sjekke vanlige byggefeil."
 msgid "Flow"
 msgstr "Flyt"
 
+#. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:1019
+msgid ""
+"For a Nozzle change please read\n"
+"prusa.io/nozzle-mk3s"
+msgstr ""
+
 #. MSG_SELFTEST_PART_FAN c=20
 #: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:6977
 #: ../../Firmware/ultralcd.cpp:7129 ../../Firmware/ultralcd.cpp:7134
@@ -891,6 +898,11 @@ msgstr "Høy styrke"
 #: ../../Firmware/mmu2_progress_converter.cpp:60
 msgid "Homing"
 msgstr "Søker"
+
+#. MSG_NOZZLE_CNG_CHANGED c=20 r=6
+#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:1036
+msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
+msgstr ""
 
 #. MSG_HOTEND_FAN_SPEED c=15
 #: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1137
@@ -1341,6 +1353,11 @@ msgstr "Fjern nå testprintet fra stålplaten."
 #: ../../Firmware/ultralcd.cpp:5707 ../../Firmware/ultralcd.cpp:5854
 msgid "Nozzle"
 msgstr "Dyse"
+
+#. MSG_NOZZLE_CNG_MENU c=18
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:4580
+msgid "Nozzle change"
+msgstr ""
 
 #. MSG_NOZZLE_DIAMETER c=10
 #: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4502

--- a/lang/po/Firmware_pl.po
+++ b/lang/po/Firmware_pl.po
@@ -778,6 +778,15 @@ msgstr ""
 msgid "Flow"
 msgstr "Przeplyw"
 
+#. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:1019
+msgid ""
+"For a Nozzle change please read\n"
+"prusa.io/nozzle-mk3s"
+msgstr ""
+"W celu wymiany dyszy należy przeczytać\n"
+"prusa.io/nozzle-mk3s"
+
 #. MSG_SELFTEST_PART_FAN c=20
 #: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:6977
 #: ../../Firmware/ultralcd.cpp:7129 ../../Firmware/ultralcd.cpp:7134
@@ -895,6 +904,11 @@ msgstr "Wysoka wyd"
 #: ../../Firmware/mmu2_progress_converter.cpp:60
 msgid "Homing"
 msgstr "Bazowanie"
+
+#. MSG_NOZZLE_CNG_CHANGED c=20 r=6
+#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:1036
+msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
+msgstr "Hotend w temperaturze 280C! Wymieniona dysza i dokręcona do specyfikacji?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
 #: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1137
@@ -1347,6 +1361,11 @@ msgstr "Teraz zdejmij wydruk testowy ze stolu."
 #: ../../Firmware/ultralcd.cpp:5707 ../../Firmware/ultralcd.cpp:5854
 msgid "Nozzle"
 msgstr "Dysza"
+
+#. MSG_NOZZLE_CNG_MENU c=18
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:4580
+msgid "Nozzle change"
+msgstr "Wymiana dyszy"
 
 #. MSG_NOZZLE_DIAMETER c=10
 #: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4502

--- a/lang/po/Firmware_pl.po
+++ b/lang/po/Firmware_pl.po
@@ -908,7 +908,7 @@ msgstr "Bazowanie"
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
 #: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:1036
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
-msgstr "Hotend w temperaturze 280C! Wymieniona dysza i dokręcona do specyfikacji?"
+msgstr "Hotend rozgrzany do 280°C! Dysza wymieniona i dokręcona wg specyfikacji?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
 #: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1137

--- a/lang/po/Firmware_ro.po
+++ b/lang/po/Firmware_ro.po
@@ -779,6 +779,13 @@ msgstr ""
 msgid "Flow"
 msgstr "Flow"
 
+#. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:1019
+msgid ""
+"For a Nozzle change please read\n"
+"prusa.io/nozzle-mk3s"
+msgstr ""
+
 #. MSG_SELFTEST_PART_FAN c=20
 #: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:6977
 #: ../../Firmware/ultralcd.cpp:7129 ../../Firmware/ultralcd.cpp:7134
@@ -898,6 +905,11 @@ msgstr "Put. max"
 #: ../../Firmware/mmu2_progress_converter.cpp:60
 msgid "Homing"
 msgstr "Homing"
+
+#. MSG_NOZZLE_CNG_CHANGED c=20 r=6
+#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:1036
+msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
+msgstr ""
 
 #. MSG_HOTEND_FAN_SPEED c=15
 #: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1137
@@ -1348,6 +1360,11 @@ msgstr "Acum inlaturati printul de test de pe suprafata de print."
 #: ../../Firmware/ultralcd.cpp:5707 ../../Firmware/ultralcd.cpp:5854
 msgid "Nozzle"
 msgstr "Varf"
+
+#. MSG_NOZZLE_CNG_MENU c=18
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:4580
+msgid "Nozzle change"
+msgstr ""
 
 #. MSG_NOZZLE_DIAMETER c=10
 #: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4502

--- a/lang/po/Firmware_sk.po
+++ b/lang/po/Firmware_sk.po
@@ -776,6 +776,13 @@ msgstr ""
 msgid "Flow"
 msgstr "Prietok"
 
+#. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:1019
+msgid ""
+"For a Nozzle change please read\n"
+"prusa.io/nozzle-mk3s"
+msgstr ""
+
 #. MSG_SELFTEST_PART_FAN c=20
 #: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:6977
 #: ../../Firmware/ultralcd.cpp:7129 ../../Firmware/ultralcd.cpp:7134
@@ -894,6 +901,11 @@ msgstr "Vys. vykon"
 #: ../../Firmware/mmu2_progress_converter.cpp:60
 msgid "Homing"
 msgstr "Navrat"
+
+#. MSG_NOZZLE_CNG_CHANGED c=20 r=6
+#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:1036
+msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
+msgstr ""
 
 #. MSG_HOTEND_FAN_SPEED c=15
 #: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1137
@@ -1344,6 +1356,11 @@ msgstr "Teraz odstrante testovaci vytlacok z platne."
 #: ../../Firmware/ultralcd.cpp:5707 ../../Firmware/ultralcd.cpp:5854
 msgid "Nozzle"
 msgstr "Tryska"
+
+#. MSG_NOZZLE_CNG_MENU c=18
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:4580
+msgid "Nozzle change"
+msgstr ""
 
 #. MSG_NOZZLE_DIAMETER c=10
 #: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4502

--- a/lang/po/Firmware_sl.po
+++ b/lang/po/Firmware_sl.po
@@ -750,6 +750,13 @@ msgstr ""
 msgid "Flow"
 msgstr ""
 
+#. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:1019
+msgid ""
+"For a Nozzle change please read\n"
+"prusa.io/nozzle-mk3s"
+msgstr ""
+
 #. MSG_SELFTEST_PART_FAN c=20
 #: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:6977
 #: ../../Firmware/ultralcd.cpp:7129 ../../Firmware/ultralcd.cpp:7134
@@ -860,6 +867,11 @@ msgstr ""
 #: ../../Firmware/mmu2_progress_converter.cpp:29
 #: ../../Firmware/mmu2_progress_converter.cpp:60
 msgid "Homing"
+msgstr ""
+
+#. MSG_NOZZLE_CNG_CHANGED c=20 r=6
+#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:1036
+msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr ""
 
 #. MSG_HOTEND_FAN_SPEED c=15
@@ -1302,6 +1314,11 @@ msgstr ""
 #: ../../Firmware/ultralcd.cpp:4455 ../../Firmware/ultralcd.cpp:4458
 #: ../../Firmware/ultralcd.cpp:5707 ../../Firmware/ultralcd.cpp:5854
 msgid "Nozzle"
+msgstr ""
+
+#. MSG_NOZZLE_CNG_MENU c=18
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:4580
+msgid "Nozzle change"
 msgstr ""
 
 #. MSG_NOZZLE_DIAMETER c=10

--- a/lang/po/Firmware_sv.po
+++ b/lang/po/Firmware_sv.po
@@ -776,6 +776,13 @@ msgstr ""
 msgid "Flow"
 msgstr "Flöde"
 
+#. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:1019
+msgid ""
+"For a Nozzle change please read\n"
+"prusa.io/nozzle-mk3s"
+msgstr ""
+
 #. MSG_SELFTEST_PART_FAN c=20
 #: ../../Firmware/messages.cpp:87 ../../Firmware/ultralcd.cpp:6977
 #: ../../Firmware/ultralcd.cpp:7129 ../../Firmware/ultralcd.cpp:7134
@@ -896,6 +903,11 @@ msgstr "Hög kraft"
 #: ../../Firmware/mmu2_progress_converter.cpp:60
 msgid "Homing"
 msgstr "Flyttar till hempos"
+
+#. MSG_NOZZLE_CNG_CHANGED c=20 r=6
+#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:1036
+msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
+msgstr ""
 
 #. MSG_HOTEND_FAN_SPEED c=15
 #: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:1137
@@ -1349,6 +1361,11 @@ msgstr "Ta nu bort testutskriften från metallskivan."
 #: ../../Firmware/ultralcd.cpp:5707 ../../Firmware/ultralcd.cpp:5854
 msgid "Nozzle"
 msgstr "Munstycke"
+
+#. MSG_NOZZLE_CNG_MENU c=18
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:4580
+msgid "Nozzle change"
+msgstr ""
 
 #. MSG_NOZZLE_DIAMETER c=10
 #: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:4502


### PR DESCRIPTION
Added basic nozzle change menu.

The `prusa.io/nozzle-mk3s` is 20 chars long and the message above should not exceed c=20 r=2 as the last char on LCD page is a :white_check_mark: and will cover the `s` of the `nozzle-mk3s` link if the message uses a 3rd row.

Shorten the messages due to limited space for translations. 

Odd issue:
- [x] Switching sometimes hangs until a Gcode is send via serial line. @leptun Do you have an idea how that is happening?

ToDo:
- [x] Translations:
- [ ] French is at its limit and can't be translated.