### PR TITLE
Don't show full screen message meant for single color setup

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3879,11 +3879,11 @@ static void lcd_wizard_load() {
     } else {
         lcd_show_fullscreen_message_and_wait_P(
             _i("Please insert filament into the extruder, then press the knob to load it.")); ////MSG_WIZARD_LOAD_FILAMENT c=20 r=6
+        lcd_update_enable(false);
+        lcd_clear();
+        lcd_puts_at_P(0, 2, _T(MSG_LOADING_FILAMENT));
+        loading_flag = true;
     }
-    lcd_update_enable(false);
-    lcd_clear();
-    lcd_puts_at_P(0, 2, _T(MSG_LOADING_FILAMENT));
-    loading_flag = true;
     gcode_M701(FILAMENTCHANGE_FIRSTFEED, 0);
     //enquecommand_P(PSTR("M701"));
 }

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3876,6 +3876,9 @@ static void lcd_wizard_load() {
     if (MMU2::mmu2.Enabled()) {
         lcd_show_fullscreen_message_and_wait_P(
             _i("Please insert filament into the first tube of the MMU, then press the knob to load it.")); ////MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
+        // NOTE: a full screen message showing which filament is being inserted
+        // is performed by M701. For this reason MSG_LOADING_FILAMENT is not
+        // used here when a MMU is used.
     } else {
         lcd_show_fullscreen_message_and_wait_P(
             _i("Please insert filament into the extruder, then press the knob to load it.")); ////MSG_WIZARD_LOAD_FILAMENT c=20 r=6


### PR DESCRIPTION
`load_filament_to_nozzle()` will show a more precise full screen message when an MMU is used. `loading_flag` is also not used with MMU in M701 (autoloading).