### PR TITLE
Allow "PRUSA SN" to print the SN in eeprom on all variants

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -4266,7 +4266,6 @@ void process_commands()
             asm volatile("jmp 0x3E000");
 #endif
         }
-#ifdef PRUSA_SN_SUPPORT
 	else if (code_seen_P(PSTR("SN"))) { // PRUSA SN
         char SN[20];
         eeprom_read_block(SN, (uint8_t*)EEPROM_PRUSA_SN, 20);
@@ -4275,7 +4274,6 @@ void process_commands()
         else
             puts(SN);
     }
-#endif //PRUSA_SN_SUPPORT
     else if(code_seen_P(PSTR("Fir"))){ // PRUSA Fir
 
       SERIAL_PROTOCOLLN(FW_VERSION_FULL);


### PR DESCRIPTION
I'm making a PR for this so I don't forget about it. I've had it for a good while already.
Fixes https://github.com/prusa3d/Prusa-Firmware/issues/3782
@TojikCZ please check if this helps with the issue that is linked