### PR TITLE
PFW-1448 Fix underextrusion + compensate load to nozzle extruder sequence for Extra Loading Distance

### DIFF
--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -249,9 +249,9 @@ bool MMU2::VerifyFilamentEnteredPTFE()
     uint8_t fsensorState = 0;
     // MMU has finished its load, push the filament further by some defined constant length
     // If the filament sensor reads 0 at any moment, then report FAILURE
-    current_position[E_AXIS] += MMU2_EXTRUDER_PTFE_LENGTH + MMU2_EXTRUDER_HEATBREAK_LENGTH - MMU2_LOAD_DISTANCE_PAST_GEARS;
+    current_position[E_AXIS] += MMU2_EXTRUDER_PTFE_LENGTH + MMU2_EXTRUDER_HEATBREAK_LENGTH - (logic.ExtraLoadDistance() - MMU2_FILAMENT_SENSOR_POSITION);
     plan_buffer_line_curposXYZE(MMU2_LOAD_TO_NOZZLE_FEED_RATE);
-    current_position[E_AXIS] -= (MMU2_EXTRUDER_PTFE_LENGTH + MMU2_EXTRUDER_HEATBREAK_LENGTH - MMU2_LOAD_DISTANCE_PAST_GEARS);
+    current_position[E_AXIS] -= (MMU2_EXTRUDER_PTFE_LENGTH + MMU2_EXTRUDER_HEATBREAK_LENGTH - (logic.ExtraLoadDistance() - MMU2_FILAMENT_SENSOR_POSITION));
     plan_buffer_line_curposXYZE(MMU2_LOAD_TO_NOZZLE_FEED_RATE);
 
     while(blocks_queued())
@@ -840,7 +840,7 @@ void MMU2::execute_extruder_sequence(const E_Step *sequence, uint8_t steps) {
 void MMU2::execute_load_to_nozzle_sequence() {
     st_synchronize();
     // Compensate for configurable Extra Loading Distance
-    current_position[E_AXIS] -= MMU2_LOAD_DISTANCE_PAST_GEARS;
+    current_position[E_AXIS] -= (logic.ExtraLoadDistance() - MMU2_FILAMENT_SENSOR_POSITION);
     execute_extruder_sequence((const E_Step *)load_to_nozzle_sequence, sizeof(load_to_nozzle_sequence) / sizeof (load_to_nozzle_sequence[0]));
 }
 

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -355,7 +355,7 @@ bool MMU2::tool_change(char code, uint8_t slot) {
 
     case 'c': {
         waitForHotendTargetTemp(100, []{});
-        execute_load_to_nozzle_sequence((const E_Step *)load_to_nozzle_sequence, sizeof(load_to_nozzle_sequence) / sizeof (load_to_nozzle_sequence[0]));
+        execute_load_to_nozzle_sequence();
     } break;
     }
 
@@ -506,7 +506,7 @@ bool MMU2::load_filament_to_nozzle(uint8_t slot) {
         ToolChangeCommon(slot);
 
         // Finish loading to the nozzle with finely tuned steps.
-        execute_load_to_nozzle_sequence((const E_Step *)load_to_nozzle_sequence, sizeof(load_to_nozzle_sequence) / sizeof (load_to_nozzle_sequence[0]));
+        execute_load_to_nozzle_sequence();
         Sound_MakeSound(e_SOUND_TYPE_StandardConfirm);
     }
     lcd_update_enable(true);
@@ -837,11 +837,11 @@ void MMU2::execute_extruder_sequence(const E_Step *sequence, uint8_t steps) {
     }
 }
 
-void MMU2::execute_load_to_nozzle_sequence(const E_Step *sequence, uint8_t steps) {
+void MMU2::execute_load_to_nozzle_sequence() {
     st_synchronize();
     // Compensate for configurable Extra Loading Distance
     current_position[E_AXIS] -= logic.ExtraLoadDistance();
-    execute_extruder_sequence(sequence, steps);
+    execute_extruder_sequence((const E_Step *)load_to_nozzle_sequence, sizeof(load_to_nozzle_sequence) / sizeof (load_to_nozzle_sequence[0]));
 }
 
 void MMU2::ReportError(ErrorCode ec, ErrorSource res) {

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -249,9 +249,9 @@ bool MMU2::VerifyFilamentEnteredPTFE()
     uint8_t fsensorState = 0;
     // MMU has finished its load, push the filament further by some defined constant length
     // If the filament sensor reads 0 at any moment, then report FAILURE
-    current_position[E_AXIS] += MMU2_EXTRUDER_PTFE_LENGTH + MMU2_EXTRUDER_HEATBREAK_LENGTH - logic.ExtraLoadDistance();
+    current_position[E_AXIS] += MMU2_EXTRUDER_PTFE_LENGTH + MMU2_EXTRUDER_HEATBREAK_LENGTH - MMU2_LOAD_DISTANCE_PAST_GEARS;
     plan_buffer_line_curposXYZE(MMU2_LOAD_TO_NOZZLE_FEED_RATE);
-    current_position[E_AXIS] -= (MMU2_EXTRUDER_PTFE_LENGTH + MMU2_EXTRUDER_HEATBREAK_LENGTH - logic.ExtraLoadDistance());
+    current_position[E_AXIS] -= (MMU2_EXTRUDER_PTFE_LENGTH + MMU2_EXTRUDER_HEATBREAK_LENGTH - MMU2_LOAD_DISTANCE_PAST_GEARS);
     plan_buffer_line_curposXYZE(MMU2_LOAD_TO_NOZZLE_FEED_RATE);
 
     while(blocks_queued())
@@ -840,7 +840,7 @@ void MMU2::execute_extruder_sequence(const E_Step *sequence, uint8_t steps) {
 void MMU2::execute_load_to_nozzle_sequence() {
     st_synchronize();
     // Compensate for configurable Extra Loading Distance
-    current_position[E_AXIS] -= logic.ExtraLoadDistance();
+    current_position[E_AXIS] -= MMU2_LOAD_DISTANCE_PAST_GEARS;
     execute_extruder_sequence((const E_Step *)load_to_nozzle_sequence, sizeof(load_to_nozzle_sequence) / sizeof (load_to_nozzle_sequence[0]));
 }
 

--- a/Firmware/mmu2.h
+++ b/Firmware/mmu2.h
@@ -239,7 +239,7 @@ private:
     
     void filament_ramming();
     void execute_extruder_sequence(const E_Step *sequence, uint8_t steps);
-    void execute_load_to_nozzle_sequence(const E_Step *sequence, uint8_t steps);
+    void execute_load_to_nozzle_sequence();
 
     /// Reports an error into attached ExtUIs
     /// @param ec error code, see ErrorCode

--- a/Firmware/mmu2.h
+++ b/Firmware/mmu2.h
@@ -239,6 +239,7 @@ private:
     
     void filament_ramming();
     void execute_extruder_sequence(const E_Step *sequence, uint8_t steps);
+    void execute_load_to_nozzle_sequence(const E_Step *sequence, uint8_t steps);
 
     /// Reports an error into attached ExtUIs
     /// @param ec error code, see ErrorCode

--- a/Firmware/mmu2/variants/config_MMU2.h
+++ b/Firmware/mmu2/variants/config_MMU2.h
@@ -23,7 +23,9 @@ static constexpr float MMU2_LOAD_TO_NOZZLE_LENGTH = 87.0F + 5.0F;
 // Beware - this value is used to initialize the MMU logic layer - it will be sent to the MMU upon line up (written into its 8bit register 0x0b)
 // However - in the G-code we can get a request to set the extra load distance at runtime to something else (M708 A0xb Xsomething).
 // The printer intercepts such a call and sets its extra load distance to match the new value as well.
-static constexpr uint8_t MMU2_TOOL_CHANGE_LOAD_LENGTH = 5 + 16; // mm
+static constexpr float MMU2_FILAMENT_SENSOR_POSITION = 16; // mm
+static constexpr float MMU2_LOAD_DISTANCE_PAST_GEARS = 5; // mm
+static constexpr uint8_t MMU2_TOOL_CHANGE_LOAD_LENGTH = static_cast<uint8_t>(MMU2_FILAMENT_SENSOR_POSITION + MMU2_LOAD_DISTANCE_PAST_GEARS); // mm
 
 static constexpr float MMU2_EXTRUDER_PTFE_LENGTH = 50.f; // mm
 static constexpr float MMU2_EXTRUDER_HEATBREAK_LENGTH  = 17.7f; // mm

--- a/Firmware/mmu2/variants/config_MMU2.h
+++ b/Firmware/mmu2/variants/config_MMU2.h
@@ -64,7 +64,7 @@ static constexpr E_Step ramming_sequence[] PROGMEM = {
     { -35.0F,   2000.0F / 60.F},
 };
 
-static constexpr E_Step load_to_nozzle_sequence[] PROGMEM = { 
-    { 10.0F,  810.0F / 60.F}, // feed rate = 13.5mm/s - Load fast until filament reach end of nozzle
-    { 25.0F,  198.0F / 60.F}, // feed rate = 3.3mm/s  - Load slower once filament is out of the nozzle
+static constexpr E_Step load_to_nozzle_sequence[] PROGMEM = {
+    { MMU2_EXTRUDER_PTFE_LENGTH,       810.0F / 60.F}, // feed rate = 13.5mm/s - Load fast while not at heatbreak
+    { MMU2_EXTRUDER_HEATBREAK_LENGTH,  198.0F / 60.F}, // feed rate = 3.3mm/s  - Load slower once filament reaches heatbreak
 };

--- a/Firmware/mmu2/variants/config_MMU2S.h
+++ b/Firmware/mmu2/variants/config_MMU2S.h
@@ -23,7 +23,9 @@ static constexpr float MMU2_LOAD_TO_NOZZLE_LENGTH = 87.0F + 5.0F;
 // Beware - this value is used to initialize the MMU logic layer - it will be sent to the MMU upon line up (written into its 8bit register 0x0b)
 // However - in the G-code we can get a request to set the extra load distance at runtime to something else (M708 A0xb Xsomething).
 // The printer intercepts such a call and sets its extra load distance to match the new value as well.
-static constexpr uint8_t MMU2_TOOL_CHANGE_LOAD_LENGTH = 5; // mm
+static constexpr float MMU2_FILAMENT_SENSOR_POSITION = 0; // mm
+static constexpr float MMU2_LOAD_DISTANCE_PAST_GEARS = 5; // mm
+static constexpr uint8_t MMU2_TOOL_CHANGE_LOAD_LENGTH = static_cast<uint8_t>(MMU2_FILAMENT_SENSOR_POSITION + MMU2_LOAD_DISTANCE_PAST_GEARS); // mm
 
 static constexpr float MMU2_EXTRUDER_PTFE_LENGTH = 42.3f; // mm
 static constexpr float MMU2_EXTRUDER_HEATBREAK_LENGTH  = 17.7f; // mm

--- a/Firmware/mmu2/variants/config_MMU2S.h
+++ b/Firmware/mmu2/variants/config_MMU2S.h
@@ -64,7 +64,7 @@ static constexpr E_Step ramming_sequence[] PROGMEM = {
     { -35.0F,   2000.0F / 60.F},
 };
 
-static constexpr E_Step load_to_nozzle_sequence[] PROGMEM = { 
-    { 10.0F,  810.0F / 60.F}, // feed rate = 13.5mm/s - Load fast until filament reach end of nozzle
-    { 25.0F,  198.0F / 60.F}, // feed rate = 3.3mm/s  - Load slower once filament is out of the nozzle
+static constexpr E_Step load_to_nozzle_sequence[] PROGMEM = {
+    { MMU2_EXTRUDER_PTFE_LENGTH,       810.0F / 60.F}, // feed rate = 13.5mm/s - Load fast while not at heatbreak
+    { MMU2_EXTRUDER_HEATBREAK_LENGTH,  198.0F / 60.F}, // feed rate = 3.3mm/s  - Load slower once filament reaches heatbreak
 };


### PR DESCRIPTION
The Extra Loading Distance parameter is configurable by the user. We need to compensate the hard-coded extruder sequence
such that it does not extrude too much or too little. Currently the firmware extrudes too little.

The problem is split in two:
* The current sequence is too short
* The sequence was made even shorter when the Extra Loading Distance was changed from 30mm to 5mm in development.

Where is this sequence used?

* M600: Loading filament
* M701: Loading filament
* `T?` gcode
* `Tc` gcode (single color print with MMU)
* LCD menu "Load to Nozzle"