### PR TITLE
PFW-1453 Stop Print: Don't unload if FINDA is not triggered

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5863,14 +5863,14 @@ void print_stop()
         fanSpeed = 0;
     }
 
-    if (MMU2::mmu2.Enabled())
+    if (MMU2::mmu2.Enabled() && MMU2::mmu2.FindaDetectsFilament())
     {
         if (isPrintPaused)
         {
             // Restore temperature saved in ram after pausing print
             restore_extruder_temperature_from_ram();
         }
-        MMU2::mmu2.unload(); //M702 C
+        MMU2::mmu2.unload(); // M702
     }
 
     lcd_cooldown(); //turns off heaters and fan; goes to status screen.


### PR DESCRIPTION
If FINDA does not detect filament, then U0 command doesn't do anything.