### PR TITLE
Optimisation: Simplify parsing M862

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -8011,10 +8011,9 @@ Sigma_Exit:
 	
     */
     case 862: // M862: print checking
-          float nDummy;
-          uint8_t nCommand;
-          nCommand=(uint8_t)(modff(code_value(),&nDummy)*10.0+0.5);
-          switch((ClPrintChecking)nCommand)
+    {
+        ClPrintChecking nCommand = static_cast<ClPrintChecking>(strtol(strchr_pointer+5, NULL, 10));
+        switch(nCommand)
                {
                case ClPrintChecking::_Nozzle:     // ~ .1
                     uint16_t nDiameter;
@@ -8064,7 +8063,8 @@ Sigma_Exit:
                          SERIAL_PROTOCOLLN(GCODE_LEVEL);
                     break;
                }
-    break;
+        break;
+    }
 
 #ifdef LIN_ADVANCE
     /*!

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -8012,7 +8012,9 @@ Sigma_Exit:
     */
     case 862: // M862: print checking
     {
-        ClPrintChecking nCommand = static_cast<ClPrintChecking>(strtol(strchr_pointer+5, NULL, 10));
+        // Read the decimal by multiplying the float value by 10 e.g. 862.1 becomes 8621
+        // This method consumes less flash memory compared to checking the string length.
+        ClPrintChecking nCommand = static_cast<ClPrintChecking>((uint16_t)(code_value()*10) - 8620u);
         switch(nCommand)
                {
                case ClPrintChecking::_Nozzle:     // ~ .1


### PR DESCRIPTION
This gets rid of float conversion.
We just need to check the 6th character when M862 is detected.

Change in memory:
Flash: -20 bytes
SRAM: 0 bytes