### PR TITLE
Add Nozzle change menu to FARM mode under Settings

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -4685,7 +4685,7 @@ static void lcd_settings_menu()
     {
         bSettings=true;                              // flag ('fake parameter') for 'lcd_hw_setup_menu()' function
         MENU_ITEM_SUBMENU_P(_T(MSG_HW_SETUP), lcd_hw_setup_menu);
-    }
+    } else MENU_ITEM_FUNCTION_P(_T(MSG_NOZZLE_CNG_MENU),nozzle_change);
 
 	MENU_ITEM_SUBMENU_P(_T(MSG_MESH_BED_LEVELING), lcd_mesh_bed_leveling_settings);
 


### PR DESCRIPTION
In FARM mode the HW-Setup menu is disabled
- [x] Cherry-pick to MK3_3.12