### PR TITLE
MK3: Fix `M862.4` with [strict] mode

### DIFF
--- a/Firmware/Configuration.h
+++ b/Firmware/Configuration.h
@@ -20,7 +20,7 @@ extern PGM_P sPrinterName;
 #define FW_MINOR 13
 #define FW_REVISION 0
 #define FW_FLAVOR ALPHA      //uncomment if DEBUG, DEVEL, ALPHA, BETA or RC
-#define FW_FLAVERSION 1     //uncomment if FW_FLAVOR is defined and versioning is needed.
+#define FW_FLAVERSION 1     //uncomment if FW_FLAVOR is defined and versioning is needed. Limited to max 8.
 #ifndef FW_FLAVOR
     #define FW_VERSION STR(FW_MAJOR) "." STR(FW_MINOR) "." STR(FW_REVISION)
 #else

--- a/Firmware/util.cpp
+++ b/Firmware/util.cpp
@@ -366,20 +366,19 @@ uint8_t mCompareValue(uint16_t nX, uint16_t nY) {
 }
 
 void fw_version_check(const char *pVersion) {
-    uint16_t aVersion[4];
-    uint8_t nCompareValueResult;
-
     if (oCheckVersion == ClCheckVersion::_None)
         return;
+
+    uint16_t aVersion[4];
+    uint8_t nCompareValueResult;
     parse_version(pVersion, aVersion);
     nCompareValueResult = mCompareValue(aVersion[0], eeprom_read_word((uint16_t *)EEPROM_FIRMWARE_VERSION_MAJOR)) << 6;
     nCompareValueResult += mCompareValue(aVersion[1], eeprom_read_word((uint16_t *)EEPROM_FIRMWARE_VERSION_MINOR)) << 4;
     nCompareValueResult += mCompareValue(aVersion[2], eeprom_read_word((uint16_t *)EEPROM_FIRMWARE_VERSION_REVISION)) << 2;
     nCompareValueResult += mCompareValue(aVersion[3], eeprom_read_word((uint16_t *)EEPROM_FIRMWARE_VERSION_FLAVOR));
-    if (nCompareValueResult == COMPARE_VALUE_EQUAL)
+    if (nCompareValueResult <= COMPARE_VALUE_EQUAL)
         return;
-    if ((nCompareValueResult < COMPARE_VALUE_EQUAL) && (oCheckVersion == ClCheckVersion::_Warn || oCheckVersion == ClCheckVersion::_Strict))
-        return;
+
 /*
     SERIAL_ECHO_START;
     SERIAL_ECHOLNPGM("Printer FW version differs from the G-code ...");
@@ -422,10 +421,9 @@ void fw_version_check(const char *pVersion) {
 void gcode_level_check(uint16_t nGcodeLevel) {
     if (oCheckGcode == ClCheckGcode::_None)
         return;
-    if (nGcodeLevel == (uint16_t)GCODE_LEVEL)
+    if (nGcodeLevel <= (uint16_t)GCODE_LEVEL)
         return;
-    if ((nGcodeLevel < (uint16_t)GCODE_LEVEL) && (oCheckGcode == ClCheckGcode::_Warn))
-        return;
+
     // SERIAL_ECHO_START;
     // SERIAL_ECHOLNPGM("Printer G-code level differs from the G-code ...");
     // SERIAL_ECHOPGM("actual  : ");

--- a/Firmware/util.cpp
+++ b/Firmware/util.cpp
@@ -378,27 +378,28 @@ void fw_version_check(const char *pVersion) {
     nCompareValueResult += mCompareValue(aVersion[3], eeprom_read_word((uint16_t *)EEPROM_FIRMWARE_VERSION_FLAVOR));
     if (nCompareValueResult == COMPARE_VALUE_EQUAL)
         return;
-    if ((nCompareValueResult < COMPARE_VALUE_EQUAL) && oCheckVersion == ClCheckVersion::_Warn)
+    if ((nCompareValueResult < COMPARE_VALUE_EQUAL) && (oCheckVersion == ClCheckVersion::_Warn || oCheckVersion == ClCheckVersion::_Strict))
         return;
-//    SERIAL_ECHO_START;
-//    SERIAL_ECHOLNPGM("Printer FW version differs from the G-code ...");
-//    SERIAL_ECHOPGM("actual  : ");
-//    SERIAL_ECHO(eeprom_read_word((uint16_t *)EEPROM_FIRMWARE_VERSION_MAJOR));
-//    SERIAL_ECHO('.');
-//    SERIAL_ECHO(eeprom_read_word((uint16_t *)EEPROM_FIRMWARE_VERSION_MINOR));
-//    SERIAL_ECHO('.');
-//    SERIAL_ECHO(eeprom_read_word((uint16_t *)EEPROM_FIRMWARE_VERSION_REVISION));
-//    SERIAL_ECHO('.');
-//    SERIAL_ECHO(eeprom_read_word((uint16_t *)EEPROM_FIRMWARE_VERSION_FLAVOR));
-//    SERIAL_ECHOPGM("\nexpected: ");
-//    SERIAL_ECHO(aVersion[0]);
-//    SERIAL_ECHO('.');
-//    SERIAL_ECHO(aVersion[1]);
-//    SERIAL_ECHO('.');
-//    SERIAL_ECHO(aVersion[2]);
-//    SERIAL_ECHO('.');
-//    SERIAL_ECHOLN(aVersion[3]);
-
+/*
+    SERIAL_ECHO_START;
+    SERIAL_ECHOLNPGM("Printer FW version differs from the G-code ...");
+    SERIAL_ECHOPGM("actual  : ");
+    SERIAL_ECHO(eeprom_read_word((uint16_t *)EEPROM_FIRMWARE_VERSION_MAJOR));
+    SERIAL_ECHO('.');
+    SERIAL_ECHO(eeprom_read_word((uint16_t *)EEPROM_FIRMWARE_VERSION_MINOR));
+    SERIAL_ECHO('.');
+    SERIAL_ECHO(eeprom_read_word((uint16_t *)EEPROM_FIRMWARE_VERSION_REVISION));
+    SERIAL_ECHO('.');
+    SERIAL_ECHO(eeprom_read_word((uint16_t *)EEPROM_FIRMWARE_VERSION_FLAVOR));
+    SERIAL_ECHOPGM("\nexpected: ");
+    SERIAL_ECHO(aVersion[0]);
+    SERIAL_ECHO('.');
+    SERIAL_ECHO(aVersion[1]);
+    SERIAL_ECHO('.');
+    SERIAL_ECHO(aVersion[2]);
+    SERIAL_ECHO('.');
+    SERIAL_ECHOLN(aVersion[3]);
+*/
     switch (oCheckVersion) {
     case ClCheckVersion::_Warn:
         //          lcd_show_fullscreen_message_and_wait_P(_i("Printer FW version differs from the G-code. Continue?"));

--- a/Firmware/util.h
+++ b/Firmware/util.h
@@ -4,12 +4,16 @@
 extern const char* FW_VERSION_STR_P();
 
 // Definition of a firmware flavor numerical values.
+// To keep it short as possible
+// DEVs/ALPHAs/BETAs limited to max 8 flavor versions
+// RCs limited to 32 flavor versions
+// Final Release always 64 as highest
 enum FirmwareRevisionFlavorType : uint16_t {
-    FIRMWARE_REVISION_RELEASED = 0,
-    FIRMWARE_REVISION_DEV = 0x0100,
-    FIRMWARE_REVISION_ALPHA = 0x0200,
-    FIRMWARE_REVISION_BETA = 0x0300,
-    FIRMWARE_REVISION_RC = 0x0400
+    FIRMWARE_REVISION_RELEASED = 0x0040,
+    FIRMWARE_REVISION_DEV = 0x0000,
+    FIRMWARE_REVISION_ALPHA = 0x008,
+    FIRMWARE_REVISION_BETA = 0x0010,
+    FIRMWARE_REVISION_RC = 0x0020
 };
 
 extern bool show_upgrade_dialog_if_version_newer(const char *version_string);


### PR DESCRIPTION
Max 8 flavor versions
Minor changes: easier to un-comment serial debug

Tested with MK404
Settings -> HW Setup -> Checks -> Firmware set to `[warn]`
- [X] Send `M862.4 P3.11.0` nothing happens as FW is newer
- [X] Send `M862.4 P3.13.0-RC1` warning shown on LCD to continue with print
- [X] Send `M862.4 P3.13.0` warning shown on LCD to continue with print

Settings -> HW Setup -> Checks -> Firmware set to `[strict]`
- [X] Send `M862.4 P3.11.0` nothing happens as FW is newer
- [X] Send `M862.4 P3.13.0-RC1` warning shown on LCD and print canceled 
- [X] Send `M862.4 P3.13.0` warning shown on LCD and print canceled

ToDo's:
- [ ] Cherry-pick to MK3_3.12