### PR TITLE
cmake: Remove unused SECONDARY_LANGUAGES option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,8 +58,6 @@ CMake support is experimental. There is no guarantee at this time. If you have p
 We now return to your regularly scheduled Firmware Build."
   )
 
-option(SECONDARY_LANGUAGES "Secondary language support in the firmware" ON)
-
 # Language configuration
 set(MAIN_LANGUAGES
     cs de es fr it pl


### PR DESCRIPTION
The option SECONDARY_LANGUAGES is no longer being used.

cmake always allows en/multilang for all selected variants by using the appropriate target now (ALL_ENGLISH).