### PR TITLE
cmake: Remove usage warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,15 +49,6 @@ message(
 
 set(FN_PREFIX "FW${PROJECT_VERSION}${PROJECT_VERSION_SUFFIX_SHORT}")
 
-message(
-  WARNING
-    "
-***************** YOUR ATTENTION PLEASE *****************
-CMake support is experimental. There is no guarantee at this time. If you have problems you are encouraged to fall back to the tried-and-true methods.
-*********************** THANK YOU **********************
-We now return to your regularly scheduled Firmware Build."
-  )
-
 option(SECONDARY_LANGUAGES "Secondary language support in the firmware" ON)
 
 # Language configuration


### PR DESCRIPTION
The cmake build system is effectively on-par (and a lot better in most areas) than the old build system.

There's no need to warn developers anymore.