### PR TITLE
MMU logging improvements

### DIFF
--- a/Firmware/mmu2_log.h
+++ b/Firmware/mmu2_log.h
@@ -22,17 +22,15 @@ void LogEchoEvent_P(const char *msg);
 
 #define SERIAL_MMU2() { serialprintPGM(mmu2Magic); }
 
-#define MMU2_ECHO_MSG(S) do{ SERIAL_ECHO_START; SERIAL_MMU2(); SERIAL_ECHO(S); }while(0)
-#define MMU2_ERROR_MSG(S) MMU2_ECHO_MSG(S) //!@todo Decide MMU2 errors  on serial line
+#define MMU2_ECHO_MSGLN(S) do{ SERIAL_ECHO_START; SERIAL_MMU2(); SERIAL_ECHOLN(S); }while(0)
+#define MMU2_ERROR_MSGLN(S) MMU2_ECHO_MSGLN(S) //!@todo Decide MMU2 errors  on serial line
 #define MMU2_ECHO_MSGRPGM(S) do{ SERIAL_ECHO_START; SERIAL_MMU2(); SERIAL_ECHORPGM(S); }while(0)
 #define MMU2_ERROR_MSGRPGM(S) MMU2_ECHO_MSGRPGM(S) //!@todo Decide MMU2 errors  on serial line
 
 #else // #ifndef UNITTEST
 
-#define MMU2_ECHO_MSG(S) /* */
-#define MMU2_ERROR_MSG(S) /* */
-#define SERIAL_ECHO(S) /* */
-#define SERIAL_ECHOLN(S) /* */
+#define MMU2_ECHO_MSGLN(S) /* */
+#define MMU2_ERROR_MSGLN(S) /* */
 #define MMU2_ECHO_MSGRPGM(S) /* */
 #define MMU2_ERROR_MSGRPGM(S) /* */
 

--- a/Firmware/mmu2_protocol_logic.cpp
+++ b/Firmware/mmu2_protocol_logic.cpp
@@ -693,7 +693,7 @@ void ProtocolLogic::FormatLastResponseMsgAndClearLRB(char *dst) {
 }
 
 void ProtocolLogic::LogRequestMsg(const uint8_t *txbuff, uint8_t size) {
-    constexpr uint_fast8_t rqs = modules::protocol::Protocol::MaxRequestSize() + 2;
+    constexpr uint_fast8_t rqs = modules::protocol::Protocol::MaxRequestSize() + 1;
     char tmp[rqs] = ">";
     static char lastMsg[rqs] = "";
     for (uint8_t i = 0; i < size; ++i) {
@@ -704,9 +704,8 @@ void ProtocolLogic::LogRequestMsg(const uint8_t *txbuff, uint8_t size) {
             b = '.';
         tmp[i + 1] = b;
     }
-    tmp[size + 1] = '\n';
-    tmp[size + 2] = 0;
-    if (!strncmp_P(tmp, PSTR(">S0*99.\n"), rqs) && !strncmp(lastMsg, tmp, rqs)) {
+    tmp[size + 1] = 0;
+    if (!strncmp_P(tmp, PSTR(">S0*99."), rqs) && !strncmp(lastMsg, tmp, rqs)) {
         // @@TODO we skip the repeated request msgs for now
         // to avoid spoiling the whole log just with ">S0" messages
         // especially when the MMU is not connected.
@@ -714,7 +713,7 @@ void ProtocolLogic::LogRequestMsg(const uint8_t *txbuff, uint8_t size) {
         // trying to find the MMU, but since it has been reliable in the past
         // we can live without it for now.
     } else {
-        MMU2_ECHO_MSG(tmp);
+        MMU2_ECHO_MSGLN(tmp);
     }
     memcpy(lastMsg, tmp, rqs);
 }
@@ -731,8 +730,7 @@ void ProtocolLogic::LogError(const char *reason_P) {
 void ProtocolLogic::LogResponse() {
     char lrb[lastReceivedBytes.size()];
     FormatLastResponseMsgAndClearLRB(lrb);
-    MMU2_ECHO_MSG(lrb);
-    SERIAL_ECHOLN();
+    MMU2_ECHO_MSGLN(lrb);
 }
 
 StepStatus ProtocolLogic::SuppressShortDropOuts(const char *msg_P, StepStatus ss) {

--- a/Firmware/mmu2_protocol_logic.cpp
+++ b/Firmware/mmu2_protocol_logic.cpp
@@ -705,7 +705,7 @@ void ProtocolLogic::LogRequestMsg(const uint8_t *txbuff, uint8_t size) {
         tmp[i + 1] = b;
     }
     tmp[size + 1] = 0;
-    if (!strncmp_P(tmp, PSTR(">S0*99."), rqs) && !strncmp(lastMsg, tmp, rqs)) {
+    if (!strncmp_P(tmp, PSTR(">S0*c6."), rqs) && !strncmp(lastMsg, tmp, rqs)) {
         // @@TODO we skip the repeated request msgs for now
         // to avoid spoiling the whole log just with ">S0" messages
         // especially when the MMU is not connected.

--- a/Firmware/mmu2_protocol_logic.cpp
+++ b/Firmware/mmu2_protocol_logic.cpp
@@ -715,7 +715,7 @@ void ProtocolLogic::LogRequestMsg(const uint8_t *txbuff, uint8_t size) {
     } else {
         MMU2_ECHO_MSGLN(tmp);
     }
-    memcpy(lastMsg, tmp, rqs);
+    strncpy(lastMsg, tmp, rqs);
 }
 
 void ProtocolLogic::LogError(const char *reason_P) {

--- a/Firmware/mmu2_protocol_logic.h
+++ b/Firmware/mmu2_protocol_logic.h
@@ -9,7 +9,7 @@ public:
     array() = default;
     inline constexpr T* begin()const { return data; }
     inline constexpr T* end()const { return data + N; }
-    constexpr uint8_t size()const { return N; }
+    static constexpr uint8_t size() { return N; }
     inline T &operator[](uint8_t i){
         return data[i];
     }


### PR DESCRIPTION
Improve the debugging experience by removing repeated ACK responses from the serial:

- Update "S0" CRC on replies so that the message is properly silenced.
- Do the same for "ok" responses.