### PR TITLE
If an old firmware is detected, make sure the protocol is actually stopped

### DIFF
--- a/Firmware/mmu2_protocol_logic.cpp
+++ b/Firmware/mmu2_protocol_logic.cpp
@@ -124,8 +124,6 @@ struct OldMMUFWDetector {
             return State::MatchingPart;
         } else if(ok == 1 && c == 'k'){
             ++ok;
-            return State::MatchingPart;
-        } else if(ok == 2 && c == '\n'){
             return State::Matched;
         }
         return State::SomethingElse;
@@ -154,10 +152,8 @@ StepStatus ProtocolLogic::ExpectingMessage() {
             // consume old MMU FW's data if any -> avoid confusion of protocol decoder
             auto old = oldMMUh4x0r.Detect(c);
             if( old == OldMMUFWDetector::State::Matched ){
-                // hack bad FW version - BEWARE - we silently assume that the first query is an "S0"
-                // The old MMU FW responds with "ok\n" and we fake the response to a bad FW version at this spot
-                rsp = ResponseMsg(RequestMsg(RequestMsgCodes::Version, 0), ResponseMsgParamCodes::Accepted, 0);
-                return MessageReady;
+                // Old MMU FW 1.0.6 detected. Firmwares are incompatible.
+                return VersionMismatch;
             } else if( old == OldMMUFWDetector::State::MatchingPart ){
                 break;
             }
@@ -171,7 +167,7 @@ StepStatus ProtocolLogic::ExpectingMessage() {
     if (bytesConsumed != 0) {
         RecordUARTActivity(); // something has happened on the UART, update the timeout record
         return Processing;    // consumed some bytes, but message still not ready
-    } else if (Elapsed(linkLayerTimeout)) {
+    } else if (Elapsed(linkLayerTimeout) && currentScope != Scope::Stopped) {
         return CommunicationTimeout;
     }
     return Processing;
@@ -796,7 +792,6 @@ StepStatus ProtocolLogic::Step() {
         break;
     case VersionMismatch:
         LogError(PSTR("Version mismatch"));
-        Stop(); // cannot continue
         break;
     case ProtocolError:
         currentStatus = HandleProtocolError();


### PR DESCRIPTION
If `StopKeepPowered()` has been called, the Printer's MMU protocol should shut up until it is started again :) `CommunicationTimeout` was triggered in this state and would restart the MMU protocol so you would repeatedly get more S0 queries.

Fixes:
* Fix `ok\n` detection from old MMU FW. The `\n` is actually never seen, probably consumed by the MMU protocol parsing. This was accidently creating `ProtocolError` (which will force send S0 again).
* If `ok` is detected from the old MMU FW, report `VersionMismatch` immediately to let the user know of the problem.
* Don't report `CommunicationTimeout` error if the protocol was stopped with `StopKeepPowered()`. 

----

Change in memory:
Flash: -108 bytes
SRAM: 0 bytes

----

Steps I used to test this:

1. Flash old FW 1.0.6 on the MMU2S
2. Open Serial port to see the logs
3. S0 is sent to MMU
4. MMU responds with "ok"
5. => Expected behavior is a VersionMismatch error and MMU serial port is disabled
6. => Actual behavior is Printer sends S0 endlessly, and MMU responds with multiple "ok". Essentially floods the serial port.
