### PR TITLE
Add 'Yes' and 'No' choices to messages like: "G-code sliced for a different printer type. Continue?"

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3212,7 +3212,8 @@ uint8_t lcd_show_multiscreen_message_with_choices_and_wait_P(
         for (uint8_t i = 0; i < 100; ++i) {
             delay_keep_alive(50);
             if (allow_timeouting && _millis() - previous_millis_cmd > LCD_TIMEOUT_TO_STATUS) {
-                return LCD_BUTTON_TIMEOUT;
+                current_selection = LCD_BUTTON_TIMEOUT;
+                goto exit;
             }
             manage_heater();
             manage_inactivity(true);
@@ -3247,10 +3248,7 @@ uint8_t lcd_show_multiscreen_message_with_choices_and_wait_P(
             if (lcd_clicked()) {
                 Sound_MakeSound(e_SOUND_TYPE_ButtonEcho);
                 if (msg_next == NULL) {
-                    KEEPALIVE_STATE(IN_HANDLER);
-                    lcd_set_custom_characters();
-                    lcd_update_enable(true);
-                    return current_selection;
+                    goto exit;
                 } else
                     break;
             }
@@ -3265,6 +3263,11 @@ uint8_t lcd_show_multiscreen_message_with_choices_and_wait_P(
             lcd_show_choices_prompt_P(current_selection, first_choice, second_choice, second_col, third_choice);
         }
     }
+exit:
+    KEEPALIVE_STATE(IN_HANDLER);
+    lcd_set_custom_characters();
+    lcd_update_enable(true);
+    return current_selection;
 }
 
 //! @brief Display and wait for a Yes/No choice using the last line of the LCD

--- a/Firmware/util.cpp
+++ b/Firmware/util.cpp
@@ -291,7 +291,7 @@ void fCheckModeInit() {
 static void render_M862_warnings(const char* warning, const char* strict, uint8_t check)
 {
     if (check == 1) { // Warning, stop print if user selects 'No'
-        if (lcd_show_fullscreen_message_yes_no_and_wait_P(warning)) {
+        if (lcd_show_fullscreen_message_yes_no_and_wait_P(warning, true, LCD_LEFT_BUTTON_CHOICE) == LCD_MIDDLE_BUTTON_CHOICE) {
             lcd_print_stop();
         }
     } else if (check == 2) { // Strict, always stop print

--- a/Firmware/util.cpp
+++ b/Firmware/util.cpp
@@ -415,10 +415,7 @@ void gcode_level_check(uint16_t nGcodeLevel) {
     );
 }
 
-//-// -> cmdqueue ???
-#define PRINTER_NAME_LENGTH ((sizeof(PRINTER_MMU_NAME) > sizeof(PRINTER_NAME)) ? (sizeof(PRINTER_MMU_NAME) - 1) : (sizeof(PRINTER_NAME) - 1))
 #define GCODE_DELIMITER '"'
-#define ELLIPSIS "..."
 
 char *code_string(const char *pStr, size_t *nLength) {
 char* pStrBegin;


### PR DESCRIPTION
Fixes a minor thing that annoys me personally. If I get the this screen accidentally, then clicking the knob can't cancel the print.

This PR adds 'Yes' and 'No' choices for all the warning screens and we save flash too :)


Change in memory:
Flash: -98 bytes
SRAM: 0 bytes