### PR TITLE
cmdqueue improvements

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -4022,7 +4022,6 @@ void process_commands()
 #endif /* CMDBUFFER_DEBUG */
   
   unsigned long codenum; //throw away variable
-  char *starpos = NULL;
 #ifdef ENABLE_AUTO_BED_LEVELING
   float x_tmp, y_tmp, z_tmp, real_z;
 #endif
@@ -4050,9 +4049,6 @@ void process_commands()
     */
     if (code_seen_P(PSTR("M117"))) //moved to highest priority place to be able to to print strings which includes "G", "PRUSA" and "^"
     {
-        starpos = (strchr(strchr_pointer + 5, '*'));
-        if (starpos != NULL)
-            *(starpos) = '\0';
         lcd_setstatus(strchr_pointer + 5);
         custom_message_type = CustomMsg::M117;
     }
@@ -4083,8 +4079,6 @@ void process_commands()
             codenum = code_value_long() * 1000; // seconds to wait
             hasS = codenum > 0;
         }
-        starpos = strchr(src, '*');
-        if (starpos != NULL) *(starpos) = '\0';
         while (*src == ' ') ++src;
         custom_message_type = CustomMsg::M0Wait;
         if (!hasP && !hasS && *src != '\0') {
@@ -5368,9 +5362,6 @@ void process_commands()
     
     */
     case 23: 
-      starpos = (strchr(strchr_pointer + 4,'*'));
-	  if(starpos!=NULL)
-        *(starpos)='\0';
       card.openFileReadFilteredGcode(strchr_pointer + 4, true);
       break;
 
@@ -5444,12 +5435,6 @@ void process_commands()
 	### M28 - Start SD write <a href="https://reprap.org/wiki/G-code#M28:_Begin_write_to_SD_card">M28: Begin write to SD card</a>
     */
     case 28: 
-      starpos = (strchr(strchr_pointer + 4,'*'));
-      if(starpos != NULL){
-        char* npos = strchr(CMDBUFFER_CURRENT_STRING, 'N');
-        strchr_pointer = strchr(npos,' ') + 1;
-        *(starpos) = '\0';
-      }
       card.openFileWrite(strchr_pointer+4);
       break;
 
@@ -5471,12 +5456,6 @@ void process_commands()
     case 30:
       if (card.cardOK){
         card.closefile();
-        starpos = (strchr(strchr_pointer + 4,'*'));
-        if(starpos != NULL){
-          char* npos = strchr(CMDBUFFER_CURRENT_STRING, 'N');
-          strchr_pointer = strchr(npos,' ') + 1;
-          *(starpos) = '\0';
-        }
         card.removeFile(strchr_pointer + 4);
       }
       break;
@@ -5491,7 +5470,6 @@ void process_commands()
         st_synchronize();
 
       }
-      starpos = (strchr(strchr_pointer + 4,'*'));
 
       const char* namestartpos = (strchr(strchr_pointer + 4,'!'));   //find ! to indicate filename string start.
       if(namestartpos==NULL)
@@ -5500,9 +5478,6 @@ void process_commands()
       }
       else
         namestartpos++; //to skip the '!'
-
-      if(starpos!=NULL)
-        *(starpos)='\0';
 
       bool call_procedure=(code_seen('P'));
 
@@ -5540,12 +5515,6 @@ void process_commands()
     
     */
     case 928: 
-      starpos = (strchr(strchr_pointer + 5,'*'));
-      if(starpos != NULL){
-        char* npos = strchr(CMDBUFFER_CURRENT_STRING, 'N');
-        strchr_pointer = strchr(npos,' ') + 1;
-        *(starpos) = '\0';
-      }
       card.openLogFile(strchr_pointer+5);
       break;
 

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -4047,9 +4047,10 @@ void process_commands()
         - TMC_SET_STEP
         - TMC_SET_CHOP
     */
-    if (code_seen_P(PSTR("M117"))) //moved to highest priority place to be able to to print strings which includes "G", "PRUSA" and "^"
+    if (strncmp_P(CMDBUFFER_CURRENT_STRING, PSTR("M117"), 4) == 0) //moved to highest priority place to be able to to print strings which includes "G", "PRUSA" and "^"
     {
-        lcd_setstatus(strchr_pointer + 5);
+        const char *src = CMDBUFFER_CURRENT_STRING + 4;
+        lcd_setstatus(*src? src + 1: src);
         custom_message_type = CustomMsg::M117;
     }
 
@@ -4067,8 +4068,9 @@ void process_commands()
     - `string` - Must for M1 and optional for M0 message to display on the LCD
     */
 
-    else if (code_seen_P(PSTR("M0")) || code_seen_P(PSTR("M1 "))) {// M0 and M1 - (Un)conditional stop - Wait for user button press on LCD
-        const char *src = strchr_pointer + 2;
+    else if ((strncmp_P(CMDBUFFER_CURRENT_STRING, PSTR("M0"), 2) == 0)
+          || (strncmp_P(CMDBUFFER_CURRENT_STRING, PSTR("M1 "), 3) == 0)) { // M0 and M1 - (Un)conditional stop - Wait for user button press on LCD
+        const char *src = CMDBUFFER_CURRENT_STRING + 2;
         codenum = 0;
         bool hasP = false, hasS = false;
         if (code_seen('P')) {
@@ -4222,7 +4224,7 @@ void process_commands()
 	}
 #endif //BACKLASH_Y
 #endif //TMC2130
-  else if(code_seen_P(PSTR("PRUSA"))){ 
+  else if(strncmp_P(CMDBUFFER_CURRENT_STRING, PSTR("PRUSA"), 5) == 0) {
     /*!
     ---------------------------------------------------------------------------------
     ### PRUSA - Internal command set <a href="https://reprap.org/wiki/G-code#G98:_Activate_farm_mode">G98: Activate farm mode - Notes</a>
@@ -6539,15 +6541,7 @@ Sigma_Exit:
       break;
 
       
-      /*
-        M117 moved up to get the high priority
-
-    case 117: // M117 display message
-      starpos = (strchr(strchr_pointer + 5,'*'));
-      if(starpos!=NULL)
-        *(starpos)='\0';
-      lcd_setstatus(strchr_pointer + 5);
-      break;*/
+    /* M117 moved up to get higher priority */
 
 #ifdef M120_M121_ENABLED
     /*!

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -6534,8 +6534,8 @@ Sigma_Exit:
     ### M117 - Display Message <a href="https://reprap.org/wiki/G-code#M117:_Display_Message">M117: Display Message</a>
     */
     case 117: {
-        const char *src = strchr_pointer;
-        lcd_setstatus(*src? src + 1: src);
+        const char *src = strchr_pointer + 4; // "M117"
+        lcd_setstatus(*src == ' '? src + 1: src);
         custom_message_type = CustomMsg::M117;
     }
     break;

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -4029,13 +4029,6 @@ void process_commands()
   // PRUSA GCODES
   KEEPALIVE_STATE(IN_HANDLER);
     /*!
-
-    ---------------------------------------------------------------------------------
-    ### M117 - Display Message <a href="https://reprap.org/wiki/G-code#M117:_Display_Message">M117: Display Message</a>
-    This causes the given message to be shown in the status line on an attached LCD.
-    It is processed early as to allow printing messages that contain G, M, N or T.
-
-    ---------------------------------------------------------------------------------
     ### Special internal commands
     These are used by internal functions to process certain actions in the right order. Some of these are also usable by the user.
     They are processed early as the commands are complex (strings).
@@ -4047,76 +4040,7 @@ void process_commands()
         - TMC_SET_STEP
         - TMC_SET_CHOP
     */
-    if (strncmp_P(CMDBUFFER_CURRENT_STRING, PSTR("M117"), 4) == 0) //moved to highest priority place to be able to to print strings which includes "G", "PRUSA" and "^"
-    {
-        const char *src = CMDBUFFER_CURRENT_STRING + 4;
-        lcd_setstatus(*src? src + 1: src);
-        custom_message_type = CustomMsg::M117;
-    }
-
-    /*!
-    ### M0, M1 - Stop the printer <a href="https://reprap.org/wiki/G-code#M0:_Stop_or_Unconditional_stop">M0: Stop or Unconditional stop</a>
-    #### Usage
-
-      M0 [P<ms<] [S<sec>] [string]
-      M1 [P<ms>] [S<sec>] [string] 
-
-    #### Parameters
-  
-    - `P<ms>`  - Expire time, in milliseconds
-    - `S<sec>` - Expire time, in seconds
-    - `string` - Must for M1 and optional for M0 message to display on the LCD
-    */
-
-    else if ((strncmp_P(CMDBUFFER_CURRENT_STRING, PSTR("M0"), 2) == 0)
-          || (strncmp_P(CMDBUFFER_CURRENT_STRING, PSTR("M1 "), 3) == 0)) { // M0 and M1 - (Un)conditional stop - Wait for user button press on LCD
-        const char *src = CMDBUFFER_CURRENT_STRING + 2;
-        codenum = 0;
-        bool hasP = false, hasS = false;
-        if (code_seen('P')) {
-            codenum = code_value_long(); // milliseconds to wait
-            hasP = codenum > 0;
-        }
-        if (code_seen('S')) {
-            codenum = code_value_long() * 1000; // seconds to wait
-            hasS = codenum > 0;
-        }
-        while (*src == ' ') ++src;
-        custom_message_type = CustomMsg::M0Wait;
-        if (!hasP && !hasS && *src != '\0') {
-            lcd_setstatus(src);
-        } else {
-            // farmers want to abuse a bug from the previous firmware releases
-            // - they need to see the filename on the status screen instead of "Wait for user..."
-            // So we won't update the message in farm mode...
-            if( ! farm_mode){ 
-                LCD_MESSAGERPGM(_i("Wait for user..."));////MSG_USERWAIT c=20
-            } else {
-                custom_message_type = CustomMsg::Status; // let the lcd display the name of the printed G-code file in farm mode
-            }
-        }
-        lcd_ignore_click();				//call lcd_ignore_click also for else ???
-        st_synchronize();
-        previous_millis_cmd.start();
-        if (codenum > 0 ) {
-            codenum += _millis();  // keep track of when we started waiting
-            KEEPALIVE_STATE(PAUSED_FOR_USER);
-            while(_millis() < codenum && !lcd_clicked()) {
-                manage_heater();
-                manage_inactivity(true);
-                lcd_update(0);
-            }
-            KEEPALIVE_STATE(IN_HANDLER);
-            lcd_ignore_click(false);
-        } else {
-            marlin_wait_for_click();
-        }
-        if (IS_SD_PRINTING)
-            custom_message_type = CustomMsg::Status;
-        else
-            LCD_MESSAGERPGM(MSG_WELCOME);
-    }
-
+	if (false) {} // allow chaining of optional next else if blocks
 #ifdef TMC2130
 	else if (strncmp_P(CMDBUFFER_CURRENT_STRING, PSTR("CRASH_"), 6) == 0)
 	{
@@ -5311,6 +5235,70 @@ void process_commands()
 
     switch(mcode_in_progress)
     {
+
+    /*!
+    ### M0, M1 - Stop the printer <a href="https://reprap.org/wiki/G-code#M0:_Stop_or_Unconditional_stop">M0: Stop or Unconditional stop</a>
+    #### Usage
+
+      M0 [P<ms<] [S<sec>] [string]
+      M1 [P<ms>] [S<sec>] [string]
+
+    #### Parameters
+
+    - `P<ms>`  - Expire time, in milliseconds
+    - `S<sec>` - Expire time, in seconds
+    - `string` - Must for M1 and optional for M0 message to display on the LCD
+    */
+
+    case 0:
+    case 1: {
+        const char *src = strchr_pointer + 2;
+        codenum = 0;
+        bool hasP = false, hasS = false;
+        if (code_seen('P')) {
+            codenum = code_value_long(); // milliseconds to wait
+            hasP = codenum > 0;
+        }
+        if (code_seen('S')) {
+            codenum = code_value_long() * 1000; // seconds to wait
+            hasS = codenum > 0;
+        }
+        while (*src == ' ') ++src;
+        custom_message_type = CustomMsg::M0Wait;
+        if (!hasP && !hasS && *src != '\0') {
+            lcd_setstatus(src);
+        } else {
+            // farmers want to abuse a bug from the previous firmware releases
+            // - they need to see the filename on the status screen instead of "Wait for user..."
+            // So we won't update the message in farm mode...
+            if( ! farm_mode){
+                LCD_MESSAGERPGM(_i("Wait for user..."));////MSG_USERWAIT c=20
+            } else {
+                custom_message_type = CustomMsg::Status; // let the lcd display the name of the printed G-code file in farm mode
+            }
+        }
+        lcd_ignore_click();				//call lcd_ignore_click also for else ???
+        st_synchronize();
+        previous_millis_cmd.start();
+        if (codenum > 0 ) {
+            codenum += _millis();  // keep track of when we started waiting
+            KEEPALIVE_STATE(PAUSED_FOR_USER);
+            while(_millis() < codenum && !lcd_clicked()) {
+                manage_heater();
+                manage_inactivity(true);
+                lcd_update(0);
+            }
+            KEEPALIVE_STATE(IN_HANDLER);
+            lcd_ignore_click(false);
+        } else {
+            marlin_wait_for_click();
+        }
+        if (IS_SD_PRINTING)
+            custom_message_type = CustomMsg::Status;
+        else
+            LCD_MESSAGERPGM(MSG_WELCOME);
+    }
+    break;
 
     /*!
 	### M17 - Enable all axes <a href="https://reprap.org/wiki/G-code#M17:_Enable.2FPower_all_stepper_motors">M17: Enable/Power all stepper motors</a>
@@ -6542,8 +6530,15 @@ Sigma_Exit:
 		gcode_M114();
       break;
 
-      
-    /* M117 moved up to get higher priority */
+    /*!
+    ### M117 - Display Message <a href="https://reprap.org/wiki/G-code#M117:_Display_Message">M117: Display Message</a>
+    */
+    case 117: {
+        const char *src = strchr_pointer;
+        lcd_setstatus(*src? src + 1: src);
+        custom_message_type = CustomMsg::M117;
+    }
+    break;
 
 #ifdef M120_M121_ENABLED
     /*!

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -4333,8 +4333,9 @@ void process_commands()
           else SERIAL_PROTOCOLLN((float)eeprom_read_word((uint16_t*)EEPROM_NOZZLE_DIAMETER_uM)/1000.0);
     }
   }
-  else if(code_seen('G'))
+  else if(*CMDBUFFER_CURRENT_STRING == 'G')
   {
+	strchr_pointer = CMDBUFFER_CURRENT_STRING;
 	gcode_in_progress = code_value_short();
 //	printf_P(_N("BEGIN G-CODE=%u\n"), gcode_in_progress);
     switch (gcode_in_progress)
@@ -5292,8 +5293,9 @@ void process_commands()
   
   */
 
-  else if(code_seen('M'))
+  else  if(*CMDBUFFER_CURRENT_STRING == 'M')
   {
+	  strchr_pointer = CMDBUFFER_CURRENT_STRING;
 
 	  int index;
 	  for (index = 1; *(strchr_pointer + index) == ' ' || *(strchr_pointer + index) == '\t'; index++);
@@ -8651,7 +8653,8 @@ Sigma_Exit:
   @n Tx Same as T?, except nozzle doesn't have to be preheated. Tc must be placed after extruder nozzle is preheated to finish filament load.
   @n Tc Load to nozzle after filament was prepared by Tc and extruder nozzle is already heated.
   */
-  else if(code_seen('T')){
+  else if(*CMDBUFFER_CURRENT_STRING == 'T') {
+        strchr_pointer = CMDBUFFER_CURRENT_STRING;
         TCodes(strchr_pointer, code_value_uint8());
   } // end if(code_seen('T')) (end of T codes)
   /*!
@@ -8662,8 +8665,9 @@ Sigma_Exit:
   *---------------------------------------------------------------------------------
   *# D codes
   */
-  else if (code_seen('D')) // D codes (debug)
+  else if(*CMDBUFFER_CURRENT_STRING == 'D') // D codes (debug)
   {
+    strchr_pointer = CMDBUFFER_CURRENT_STRING;
     switch(code_value_short())
     {
 

--- a/Firmware/cmdqueue.cpp
+++ b/Firmware/cmdqueue.cpp
@@ -419,15 +419,21 @@ void get_command()
 				  return;
 			  }
 		}
-        // if we don't receive 'N' but still see '*'
-        if (*(cmd_head != 'N') && (strchr(cmd_start, '*') != NULL))
+        else
         {
-            SERIAL_ERROR_START;
-            SERIAL_ERRORRPGM(_n("No Line Number with checksum, Last Line: "));////MSG_ERR_NO_LINENUMBER_WITH_CHECKSUM
-            SERIAL_ERRORLN(gcode_LastN);
-			FlushSerialRequestResend();
-            serial_count = 0;
-            return;
+            // move cmd_start past all spaces
+            while (*cmd_start == ' ') ++cmd_start;
+
+            // if we didn't receive 'N' but still see '*'
+            if (strchr(cmd_start, '*') != NULL)
+            {
+                SERIAL_ERROR_START;
+                SERIAL_ERRORRPGM(_n("No Line Number with checksum, Last Line: "));////MSG_ERR_NO_LINENUMBER_WITH_CHECKSUM
+                SERIAL_ERRORLN(gcode_LastN);
+                FlushSerialRequestResend();
+                serial_count = 0;
+                return;
+            }
         }
 
         // Handle KILL early, even when Stopped


### PR DESCRIPTION
:warning: This is stacked on top of #3822 

With #3822 I realized we already drop the checksum from the command queue, so I extended this to line numbers. Turns out this has *numerous* benefits.

- More space for the cmdqueue for serial commands
- No exceptions for the horrible PRUSA/related commands (they now parse fine with line numbers)
- No more scanning for the first gcode: it is always expected as the first entry
- No more ambiguous parsing: this reduces the overhead we had for M0/M1/M117 in addition to actually being more robust to serial noise.

Turns out we never supported checksums without line numbers, but according to https://reprap.org/wiki/G-code#.2A:_Checksum this *can* be possible?

There's also no clear indication as to leading whitespace needs to be supported or not. It looks like many commands assumed no initial whitespace should ever exist. The checksum calculation includes the leading whitespace into account.

~In this PR extra whitespace is supported after the line number, but not immediately at the start. It would be easy to drop this as well. The question is whether we should? @3d-gussner~