### PR TITLE
MK3: French shorten translation

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2763,10 +2763,10 @@ void lcd_adjust_bed_reset(void)
 //! @code{.unparsed}
 //! |01234567890123456789|
 //! |Settings:           |	MSG_SETTINGS
-//! |Left side [μm]:     |	MSG_BED_CORRECTION_LEFT
-//! |Right side[μm]:     |	MSG_BED_CORRECTION_RIGHT
-//! |Front side[μm]:     |	MSG_BED_CORRECTION_FRONT
-//! |Rear side [μm]:     |	MSG_BED_CORRECTION_REAR
+//! |Left side [µm]:     |	MSG_BED_CORRECTION_LEFT
+//! |Right side[µm]:     |	MSG_BED_CORRECTION_RIGHT
+//! |Front side[µm]:     |	MSG_BED_CORRECTION_FRONT
+//! |Rear side [µm]:     |	MSG_BED_CORRECTION_REAR
 //! |Reset               |	MSG_BED_CORRECTION_RESET
 //! ----------------------
 //! @endcode

--- a/lang/lib/charset.py
+++ b/lang/lib/charset.py
@@ -2,10 +2,9 @@
 CUSTOM_CHARS = {
     '\x06': '⏬',
     '\x04': '🔃',
-    '\xe4': 'µ',
     '\xdf': '°',
     '\xe1': 'ä',
-    '\xe4': 'μ',
+    '\xe4': 'µ', #on keyboard AltGr+m it is \xC2\xB5
     '\xef': 'ö',
     '\xf5': 'ü',
 }

--- a/lang/po/Firmware.pot
+++ b/lang/po/Firmware.pot
@@ -758,7 +758,7 @@ msgstr ""
 
 #. MSG_BED_CORRECTION_FRONT c=14
 #: ../../Firmware/ultralcd.cpp:2745
-msgid "Front side[μm]"
+msgid "Front side[µm]"
 msgstr ""
 
 #. MSG_SELFTEST_FANS c=20
@@ -984,7 +984,7 @@ msgstr ""
 
 #. MSG_BED_CORRECTION_LEFT c=14
 #: ../../Firmware/ultralcd.cpp:2743
-msgid "Left side [μm]"
+msgid "Left side [µm]"
 msgstr ""
 
 #. MSG_BL_HIGH c=12
@@ -1671,7 +1671,7 @@ msgstr ""
 
 #. MSG_BED_CORRECTION_REAR c=14
 #: ../../Firmware/ultralcd.cpp:2746
-msgid "Rear side [μm]"
+msgid "Rear side [µm]"
 msgstr ""
 
 #. MSG_RECOVERING_PRINT c=20
@@ -1747,7 +1747,7 @@ msgstr ""
 
 #. MSG_BED_CORRECTION_RIGHT c=14
 #: ../../Firmware/ultralcd.cpp:2744
-msgid "Right side[μm]"
+msgid "Right side[µm]"
 msgstr ""
 
 #. MSG_WIZARD_RERUN c=20 r=7

--- a/lang/po/Firmware_cs.po
+++ b/lang/po/Firmware_cs.po
@@ -792,8 +792,8 @@ msgstr "Predni tiskovy vent?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
 #: ../../Firmware/ultralcd.cpp:2745
-msgid "Front side[μm]"
-msgstr "Vpredu [μm]"
+msgid "Front side[µm]"
+msgstr "Vpredu [µm]"
 
 #. MSG_SELFTEST_FANS c=20
 #: ../../Firmware/ultralcd.cpp:7001
@@ -1032,8 +1032,8 @@ msgstr "Levy vent na trysce?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
 #: ../../Firmware/ultralcd.cpp:2743
-msgid "Left side [μm]"
-msgstr "Vlevo [μm]"
+msgid "Left side [µm]"
+msgstr "Vlevo [µm]"
 
 #. MSG_BL_HIGH c=12
 #: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5834
@@ -1739,8 +1739,8 @@ msgstr "RPi port"
 
 #. MSG_BED_CORRECTION_REAR c=14
 #: ../../Firmware/ultralcd.cpp:2746
-msgid "Rear side [μm]"
-msgstr "Vzadu [μm]"
+msgid "Rear side [µm]"
+msgstr "Vzadu [µm]"
 
 #. MSG_RECOVERING_PRINT c=20
 #: ../../Firmware/Marlin_main.cpp:10896
@@ -1817,8 +1817,8 @@ msgstr "Vpravo"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
 #: ../../Firmware/ultralcd.cpp:2744
-msgid "Right side[μm]"
-msgstr "Vpravo [μm]"
+msgid "Right side[µm]"
+msgstr "Vpravo [µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
 #: ../../Firmware/ultralcd.cpp:3846

--- a/lang/po/Firmware_da.po
+++ b/lang/po/Firmware_da.po
@@ -765,7 +765,7 @@ msgstr ""
 
 #. MSG_BED_CORRECTION_FRONT c=14
 #: ../../Firmware/ultralcd.cpp:2745
-msgid "Front side[μm]"
+msgid "Front side[µm]"
 msgstr ""
 
 #. MSG_SELFTEST_FANS c=20
@@ -993,7 +993,7 @@ msgstr ""
 
 #. MSG_BED_CORRECTION_LEFT c=14
 #: ../../Firmware/ultralcd.cpp:2743
-msgid "Left side [μm]"
+msgid "Left side [µm]"
 msgstr ""
 
 #. MSG_BL_HIGH c=12
@@ -1680,7 +1680,7 @@ msgstr ""
 
 #. MSG_BED_CORRECTION_REAR c=14
 #: ../../Firmware/ultralcd.cpp:2746
-msgid "Rear side [μm]"
+msgid "Rear side [µm]"
 msgstr ""
 
 #. MSG_RECOVERING_PRINT c=20
@@ -1756,7 +1756,7 @@ msgstr ""
 
 #. MSG_BED_CORRECTION_RIGHT c=14
 #: ../../Firmware/ultralcd.cpp:2744
-msgid "Right side[μm]"
+msgid "Right side[µm]"
 msgstr ""
 
 #. MSG_WIZARD_RERUN c=20 r=7

--- a/lang/po/Firmware_de.po
+++ b/lang/po/Firmware_de.po
@@ -798,8 +798,8 @@ msgstr "Drucklüfter?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
 #: ../../Firmware/ultralcd.cpp:2745
-msgid "Front side[μm]"
-msgstr "Vorne [μm]"
+msgid "Front side[µm]"
+msgstr "Vorne [µm]"
 
 #. MSG_SELFTEST_FANS c=20
 #: ../../Firmware/ultralcd.cpp:7001
@@ -1044,8 +1044,8 @@ msgstr "Extruderlüfter?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
 #: ../../Firmware/ultralcd.cpp:2743
-msgid "Left side [μm]"
-msgstr "Links [μm]"
+msgid "Left side [µm]"
+msgstr "Links [µm]"
 
 #. MSG_BL_HIGH c=12
 #: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5834
@@ -1755,8 +1755,8 @@ msgstr "RPi port"
 
 #. MSG_BED_CORRECTION_REAR c=14
 #: ../../Firmware/ultralcd.cpp:2746
-msgid "Rear side [μm]"
-msgstr "Hinten [μm]"
+msgid "Rear side [µm]"
+msgstr "Hinten [µm]"
 
 #. MSG_RECOVERING_PRINT c=20
 #: ../../Firmware/Marlin_main.cpp:10896
@@ -1835,8 +1835,8 @@ msgstr "Rechts"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
 #: ../../Firmware/ultralcd.cpp:2744
-msgid "Right side[μm]"
-msgstr "Rechts [μm]"
+msgid "Right side[µm]"
+msgstr "Rechts [µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
 #: ../../Firmware/ultralcd.cpp:3846

--- a/lang/po/Firmware_es.po
+++ b/lang/po/Firmware_es.po
@@ -130,7 +130,7 @@ msgstr "Longitud del eje"
 #: ../../Firmware/ultralcd.cpp:4212 ../../Firmware/ultralcd.cpp:5833
 #: ../../Firmware/ultralcd.cpp:7812
 msgid "Back"
-msgstr "atras"
+msgstr "Atras"
 
 #. MSG_BED c=13
 #: ../../Firmware/Marlin_main.cpp:2025 ../../Firmware/Marlin_main.cpp:4789
@@ -794,8 +794,8 @@ msgstr "Vent. frontal?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
 #: ../../Firmware/ultralcd.cpp:2745
-msgid "Front side[μm]"
-msgstr "Frontal [μm]"
+msgid "Front side[µm]"
+msgstr "Frontal [µm]"
 
 #. MSG_SELFTEST_FANS c=20
 #: ../../Firmware/ultralcd.cpp:7001
@@ -1036,8 +1036,8 @@ msgstr "Vent. izquierdo?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
 #: ../../Firmware/ultralcd.cpp:2743
-msgid "Left side [μm]"
-msgstr "Izquierda [μm]"
+msgid "Left side [µm]"
+msgstr "Izquierda [µm]"
 
 #. MSG_BL_HIGH c=12
 #: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5834
@@ -1749,8 +1749,8 @@ msgstr "Puerto RPi"
 
 #. MSG_BED_CORRECTION_REAR c=14
 #: ../../Firmware/ultralcd.cpp:2746
-msgid "Rear side [μm]"
-msgstr "Trasera [μm]"
+msgid "Rear side [µm]"
+msgstr "Trasera [µm]"
 
 #. MSG_RECOVERING_PRINT c=20
 #: ../../Firmware/Marlin_main.cpp:10896
@@ -1830,8 +1830,8 @@ msgstr "Derecha"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
 #: ../../Firmware/ultralcd.cpp:2744
-msgid "Right side[μm]"
-msgstr "Derecha [μm]"
+msgid "Right side[µm]"
+msgstr "Derecha [µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
 #: ../../Firmware/ultralcd.cpp:3846

--- a/lang/po/Firmware_fr.po
+++ b/lang/po/Firmware_fr.po
@@ -798,8 +798,8 @@ msgstr "Ventilo impr avant?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
 #: ../../Firmware/ultralcd.cpp:2745
-msgid "Front side[μm]"
-msgstr "Avant [μm]"
+msgid "Front side[µm]"
+msgstr "Avant [µm]"
 
 #. MSG_SELFTEST_FANS c=20
 #: ../../Firmware/ultralcd.cpp:7001
@@ -1044,8 +1044,8 @@ msgstr "Ventilo gauche?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
 #: ../../Firmware/ultralcd.cpp:2743
-msgid "Left side [μm]"
-msgstr "Gauche [μm]"
+msgid "Left side [µm]"
+msgstr "Gauche [µm]"
 
 #. MSG_BL_HIGH c=12
 #: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5834
@@ -1756,8 +1756,8 @@ msgstr "Port RPi"
 
 #. MSG_BED_CORRECTION_REAR c=14
 #: ../../Firmware/ultralcd.cpp:2746
-msgid "Rear side [μm]"
-msgstr "Arriere [μm]"
+msgid "Rear side [µm]"
+msgstr "Arriere [µm]"
 
 #. MSG_RECOVERING_PRINT c=20
 #: ../../Firmware/Marlin_main.cpp:10896
@@ -1835,8 +1835,8 @@ msgstr "Droite"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
 #: ../../Firmware/ultralcd.cpp:2744
-msgid "Right side[μm]"
-msgstr "Droite [μm]"
+msgid "Right side[µm]"
+msgstr "Droite [µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
 #: ../../Firmware/ultralcd.cpp:3846

--- a/lang/po/Firmware_fr.po
+++ b/lang/po/Firmware_fr.po
@@ -447,9 +447,8 @@ msgid ""
 "Please follow the manual, chapter First steps, section First layer "
 "calibration."
 msgstr ""
-"La distance entre de la buse et du plateau n'a pas "
-"encore ete reglee. Suivez le manuel, chapitre Premiers pas, section "
-"Calibration de la premiere couche."
+"La distance entre de la buse et du plateau n'a pas encore ete reglee. Suivez "
+"le manuel, chap. Premiers pas - Calibration de la premiere couche."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
 #: ../../Firmware/ultralcd.cpp:4096
@@ -718,7 +717,7 @@ msgstr "Filament non charge"
 #: ../../Firmware/ultralcd.cpp:7011 ../../Firmware/ultralcd.cpp:7015
 #: ../../Firmware/ultralcd.cpp:7310
 msgid "Filament sensor"
-msgstr "Capteur de fil."
+msgstr "Capteur Fil."
 
 #. MSG_DESC_FSENSOR_DIDNT_GO_OFF c=20 r=8
 #: ../../Firmware/mmu2/errors_list.h:209 ../../Firmware/mmu2/errors_list.h:249
@@ -726,8 +725,8 @@ msgid ""
 "Filament sensor didn't switch off while unloading filament. Ensure filament "
 "can move and the sensor works."
 msgstr ""
-"Capteur de filament non desactive lors du dechargement du filament. Assurez-"
-"vous que le filament peut bouger et que le capteur fonctionne."
+"Capteur de f. non desactive lors du dechargement du filament. Assurez-vous "
+"que le filament peut bouger et que le capteur fonctionne."
 
 #. MSG_DESC_FSENSOR_DIDNT_TRIGGER c=20 r=8
 #: ../../Firmware/mmu2/errors_list.h:208 ../../Firmware/mmu2/errors_list.h:248
@@ -735,8 +734,8 @@ msgid ""
 "Filament sensor didn't trigger while loading the filament. Ensure the "
 "filament reached the fsensor and the sensor works."
 msgstr ""
-"Capteur de filament non declenche lors du chargement du filament. Assurez-"
-"vous que le filament a atteint le capteur f et que le capteur fonctionne."
+"Capteur de f. non declenche lors du chargement du filament. Assurez-vous que "
+"le filament a atteint le capteur f et que le capteur fonctionne."
 
 #. MSG_DESC_FSENSOR_TOO_EARLY c=20 r=8
 #: ../../Firmware/mmu2/errors_list.h:211 ../../Firmware/mmu2/errors_list.h:251
@@ -744,7 +743,7 @@ msgid ""
 "Filament sensor triggered too early while loading to extruder. Check there "
 "isn't anything stuck in PTFE tube. Check that sensor reads properly."
 msgstr ""
-"Capteur de filament declenche trop tot lors du chargement dans l'extrudeur. "
+"Capteur de f. declenche trop tot lors du chargement dans l'extrudeur. "
 "Verifiez le tube PTFE. Verifiez que le capteur fonctionne."
 
 #. MSG_FILAMENT_USED c=19
@@ -773,8 +772,8 @@ msgstr "Cal. 1ere couche"
 #: ../../Firmware/ultralcd.cpp:4021
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
-"D'abord, je vais lancer le Auto-test pour verifier les problemes "
-"d'assemblage les plus communs."
+"Je vais lancer le Auto-test pour verifier les problemes d'assemblage les "
+"plus communs."
 
 #. MSG_FLOW c=15
 #: ../../Firmware/ultralcd.cpp:5711
@@ -817,8 +816,8 @@ msgid ""
 "G-code sliced for a different level. Please re-slice the model again. Print "
 "cancelled."
 msgstr ""
-"Le G-code a ete prepare pour un niveau different. Veuillez decouper le "
-"modele a nouveau. L'impression a ete annulee."
+"G-code a ete prepare pour un niveau different. Decouper le modele a nouveau. "
+"Impression annulée."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=5
 #: ../../Firmware/messages.cpp:135 ../../Firmware/util.cpp:323
@@ -834,8 +833,8 @@ msgid ""
 "G-code sliced for a different printer type. Please re-slice the model again. "
 "Print cancelled."
 msgstr ""
-"Le G-code a ete prepare pour une autre version de l'imprimante. Veuillez "
-"decouper le modele a nouveau. L'impression a ete annulee."
+"G-code pour un type d'imprimante différent. Decouper le modele a nouveau. "
+"Impression annulée."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=5
 #: ../../Firmware/util.cpp:370
@@ -849,8 +848,8 @@ msgid ""
 "G-code sliced for a newer firmware. Please update the firmware. Print "
 "cancelled."
 msgstr ""
-"Le G-code a ete prepare pour une version plus recente du firmware. Veuillez "
-"mettre a jour le firmware. L'impression annulee."
+"G-code a ete prepare pour un nouveau firmware. Mettre a jour le firmware. "
+"Impression annulee."
 
 #. MSG_HW_SETUP c=18
 #: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:4628
@@ -887,9 +886,9 @@ msgid ""
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
 "ready to print."
 msgstr ""
-"Bonjour, je suis votre imprimante Original Prusa i3. Je vais vous "
-"accompagner au cours d'un bref processus de reglage, qui permettra de "
-"calibrer le Z-axis. Apres cela, tout sera pret pour imprimer."
+"Bonjour, je suis votre imprimante Original Prusa i3. Je vais vous guider au "
+"cours d'un bref processus de reglage, qui permettra de calibrer le Z-axis. "
+"Apres cela, tout sera pret pour imprimer."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
 #: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:4000
@@ -898,7 +897,7 @@ msgid ""
 "through the setup process?"
 msgstr ""
 "Bonjour, je suis votre imprimante Original Prusa i3. Voulez-vous que je vous "
-"guide a travers le processus d'installation?"
+"guide dans le processus d'installation?"
 
 #. MSG_HIGH_POWER c=10
 #: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:4345
@@ -999,8 +998,8 @@ msgid ""
 "Internal runtime error. Try resetting the MMU unit or updating the firmware. "
 "If the issue persists, contact support."
 msgstr ""
-"Erreur d'execution interne. Essayez de reinitialiser l'unite MMU ou de "
-"mettre a jour le firmware. Si le probleme persiste, contactez le support."
+"Erreur d'execution interne. Essayez de reinitialiser MMU ou de mettre a jour "
+"le firmware. Si le probleme persiste, contactez le support."
 
 #. MSG_FILAMENT_LOADED c=20 r=2
 #: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:3816
@@ -1123,7 +1122,7 @@ msgstr "MAJ FW MMU NECESS."
 #. MSG_DESC_QUEUE_FULL c=20 r=8
 #: ../../Firmware/mmu2/errors_list.h:240 ../../Firmware/mmu2/errors_list.h:281
 msgid "MMU Firmware internal error, please reset the MMU."
-msgstr "Erreur interne du firmware du MMU, veuillez reinitialiser le MMU."
+msgstr "Erreur interne du firmware du MMU, reinitialiser le MMU."
 
 #. MSG_MMU_MODE c=8
 #: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4368
@@ -1352,8 +1351,8 @@ msgstr "Ne tourne pas"
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr ""
-"Maintenant je vais calibrer la distance entre de la buse et la "
-"surface du plateau."
+"Maintenant je vais calibrer la distance entre de la buse et la surface du "
+"plateau."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
 #: ../../Firmware/ultralcd.cpp:4048
@@ -1517,7 +1516,7 @@ msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
 msgstr ""
-"Merci de consulter notre manuel et de corriger le probleme. Poursuivez alors "
+"Consultez notre manuel et de corriger le probleme. Poursuivez alors "
 "l'assistant en redemarrant l'imprimante."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
@@ -1554,8 +1553,8 @@ msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
 msgstr ""
-"Veuillez inserer le filament dans le premier tube du MMU, puis appuyez sur "
-"le bouton pour le charger."
+"Inserer le filament dans le premier tube du MMU, puis appuyez sur le bouton "
+"pour le charger."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
 #: ../../Firmware/ultralcd.cpp:3824
@@ -1713,14 +1712,12 @@ msgid ""
 "steps, section Calibration flow."
 msgstr ""
 "L'imprimante n'a pas encore ete calibree. Suivez le manuel, chapitre "
-"Premiers pas, section Processus de calibration."
+"Premiers pas - Processus de calibration."
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=5
 #: ../../Firmware/util.cpp:289
 msgid "Printer nozzle diameter differs from the G-code. Continue?"
-msgstr ""
-"Diametre de la buse dans les reglages ne correspond pas a celui dans le G-"
-"Code. Continuer?"
+msgstr "Diamètre de la buse diffère du modèle dans le G-Code. Continuer?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=9
 #: ../../Firmware/util.cpp:295
@@ -1728,8 +1725,8 @@ msgid ""
 "Printer nozzle diameter differs from the G-code. Please check the value in "
 "settings. Print cancelled."
 msgstr ""
-"Diametre de la buse dans les reglages ne correspond pas a celui dans le G-"
-"Code. Merci de verifier le parametre dans les reglages. Impression annulee."
+"Diamètre de la buse diffère du modèle dans le G-Code. Vérifiez la valeur. "
+"Impression annulee."
 
 #. MSG_DESC_PULLEY_STALLED c=20 r=8
 #: ../../Firmware/mmu2/errors_list.h:210 ../../Firmware/mmu2/errors_list.h:250
@@ -1886,7 +1883,7 @@ msgid ""
 "screen menu."
 msgstr ""
 "Choisissez un filament pour la Calibration de la Premiere Couche et "
-"selectionnez-le depuis le menu a l'ecran."
+"selectionnez-le dans le menu."
 
 #. MSG_SELECT_EXTRUDER c=20
 #: ../../Firmware/Marlin_main.cpp:3516 ../../Firmware/Tcodes.cpp:35
@@ -2207,8 +2204,7 @@ msgid ""
 "chapter)."
 msgstr ""
 "L'imprimante commencera a imprimer une ligne en zig-zag. Tournez le bouton "
-"jusqu'a atteindre la hauteur optimale. Consultez les photos dans le manuel "
-"(chapitre Calibration)."
+"jusqu'a atteindre la hauteur optimale. Consultez les photos dans le manuel."
 
 #. MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=9
 #: ../../Firmware/Marlin_main.cpp:1535 ../../Firmware/messages.cpp:43
@@ -2216,8 +2212,8 @@ msgid ""
 "There is still a need to make Z calibration. Please follow the manual, "
 "chapter First steps, section Calibration flow."
 msgstr ""
-"Il faut toujours effectuer la Calibration Z. Veuillez suivre le manuel, "
-"chapitre Premiers pas, section Processus de calibration."
+"Il faut toujours effectuer la Calibration Z. Suivre le manuel, chapitre "
+"Premiers pas - Processus de calibration."
 
 #. MSG_SORT_TIME c=8
 #: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:4780

--- a/lang/po/Firmware_hr.po
+++ b/lang/po/Firmware_hr.po
@@ -791,8 +791,8 @@ msgstr "Prednji print vent?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
 #: ../../Firmware/ultralcd.cpp:2745
-msgid "Front side[μm]"
-msgstr "Prednj str[μm]"
+msgid "Front side[µm]"
+msgstr "Prednj str[µm]"
 
 #. MSG_SELFTEST_FANS c=20
 #: ../../Firmware/ultralcd.cpp:7001
@@ -1033,8 +1033,8 @@ msgstr "Lijevi hotend vent?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
 #: ../../Firmware/ultralcd.cpp:2743
-msgid "Left side [μm]"
-msgstr "Lijeva str[μm]"
+msgid "Left side [µm]"
+msgstr "Lijeva str[µm]"
 
 #. MSG_BL_HIGH c=12
 #: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5834
@@ -1739,8 +1739,8 @@ msgstr "RPi utor"
 
 #. MSG_BED_CORRECTION_REAR c=14
 #: ../../Firmware/ultralcd.cpp:2746
-msgid "Rear side [μm]"
-msgstr "Zad. str.[μm]"
+msgid "Rear side [µm]"
+msgstr "Zad. str.[µm]"
 
 #. MSG_RECOVERING_PRINT c=20
 #: ../../Firmware/Marlin_main.cpp:10896
@@ -1819,8 +1819,8 @@ msgstr "Tocno"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
 #: ../../Firmware/ultralcd.cpp:2744
-msgid "Right side[μm]"
-msgstr "Desna str.[μm]"
+msgid "Right side[µm]"
+msgstr "Desna str.[µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
 #: ../../Firmware/ultralcd.cpp:3846

--- a/lang/po/Firmware_hu.po
+++ b/lang/po/Firmware_hu.po
@@ -794,8 +794,8 @@ msgstr "Elso targyhuto vent?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
 #: ../../Firmware/ultralcd.cpp:2745
-msgid "Front side[μm]"
-msgstr "Elulso old[μm]"
+msgid "Front side[µm]"
+msgstr "Elulso old[µm]"
 
 #. MSG_SELFTEST_FANS c=20
 #: ../../Firmware/ultralcd.cpp:7001
@@ -1037,8 +1037,8 @@ msgstr "Bal hotend vent.?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
 #: ../../Firmware/ultralcd.cpp:2743
-msgid "Left side [μm]"
-msgstr "Bal [μm]"
+msgid "Left side [µm]"
+msgstr "Bal [µm]"
 
 #. MSG_BL_HIGH c=12
 #: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5834
@@ -1744,8 +1744,8 @@ msgstr "RPi port"
 
 #. MSG_BED_CORRECTION_REAR c=14
 #: ../../Firmware/ultralcd.cpp:2746
-msgid "Rear side [μm]"
-msgstr "Hatso old.[μm]"
+msgid "Rear side [µm]"
+msgstr "Hatso old.[µm]"
 
 #. MSG_RECOVERING_PRINT c=20
 #: ../../Firmware/Marlin_main.cpp:10896
@@ -1824,8 +1824,8 @@ msgstr "Jobb"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
 #: ../../Firmware/ultralcd.cpp:2744
-msgid "Right side[μm]"
-msgstr "Jobb old.[μm]"
+msgid "Right side[µm]"
+msgstr "Jobb old.[µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
 #: ../../Firmware/ultralcd.cpp:3846

--- a/lang/po/Firmware_it.po
+++ b/lang/po/Firmware_it.po
@@ -795,8 +795,8 @@ msgstr "Ventola frontale?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
 #: ../../Firmware/ultralcd.cpp:2745
-msgid "Front side[μm]"
-msgstr "Fronte [μm]"
+msgid "Front side[µm]"
+msgstr "Fronte [µm]"
 
 #. MSG_SELFTEST_FANS c=20
 #: ../../Firmware/ultralcd.cpp:7001
@@ -1037,8 +1037,8 @@ msgstr "Vent SX hotend?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
 #: ../../Firmware/ultralcd.cpp:2743
-msgid "Left side [μm]"
-msgstr "Sinistra [μm]"
+msgid "Left side [µm]"
+msgstr "Sinistra [µm]"
 
 #. MSG_BL_HIGH c=12
 #: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5834
@@ -1745,8 +1745,8 @@ msgstr "Porta RPi"
 
 #. MSG_BED_CORRECTION_REAR c=14
 #: ../../Firmware/ultralcd.cpp:2746
-msgid "Rear side [μm]"
-msgstr "Retro [μm]"
+msgid "Rear side [µm]"
+msgstr "Retro [µm]"
 
 #. MSG_RECOVERING_PRINT c=20
 #: ../../Firmware/Marlin_main.cpp:10896
@@ -1825,8 +1825,8 @@ msgstr "Destra"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
 #: ../../Firmware/ultralcd.cpp:2744
-msgid "Right side[μm]"
-msgstr "Destra [μm]"
+msgid "Right side[µm]"
+msgstr "Destra [µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
 #: ../../Firmware/ultralcd.cpp:3846

--- a/lang/po/Firmware_lb.po
+++ b/lang/po/Firmware_lb.po
@@ -765,7 +765,7 @@ msgstr ""
 
 #. MSG_BED_CORRECTION_FRONT c=14
 #: ../../Firmware/ultralcd.cpp:2745
-msgid "Front side[μm]"
+msgid "Front side[µm]"
 msgstr ""
 
 #. MSG_SELFTEST_FANS c=20
@@ -993,7 +993,7 @@ msgstr ""
 
 #. MSG_BED_CORRECTION_LEFT c=14
 #: ../../Firmware/ultralcd.cpp:2743
-msgid "Left side [μm]"
+msgid "Left side [µm]"
 msgstr ""
 
 #. MSG_BL_HIGH c=12
@@ -1680,7 +1680,7 @@ msgstr ""
 
 #. MSG_BED_CORRECTION_REAR c=14
 #: ../../Firmware/ultralcd.cpp:2746
-msgid "Rear side [μm]"
+msgid "Rear side [µm]"
 msgstr ""
 
 #. MSG_RECOVERING_PRINT c=20
@@ -1756,7 +1756,7 @@ msgstr ""
 
 #. MSG_BED_CORRECTION_RIGHT c=14
 #: ../../Firmware/ultralcd.cpp:2744
-msgid "Right side[μm]"
+msgid "Right side[µm]"
 msgstr ""
 
 #. MSG_WIZARD_RERUN c=20 r=7

--- a/lang/po/Firmware_lt.po
+++ b/lang/po/Firmware_lt.po
@@ -765,7 +765,7 @@ msgstr ""
 
 #. MSG_BED_CORRECTION_FRONT c=14
 #: ../../Firmware/ultralcd.cpp:2745
-msgid "Front side[μm]"
+msgid "Front side[µm]"
 msgstr ""
 
 #. MSG_SELFTEST_FANS c=20
@@ -993,7 +993,7 @@ msgstr ""
 
 #. MSG_BED_CORRECTION_LEFT c=14
 #: ../../Firmware/ultralcd.cpp:2743
-msgid "Left side [μm]"
+msgid "Left side [µm]"
 msgstr ""
 
 #. MSG_BL_HIGH c=12
@@ -1680,7 +1680,7 @@ msgstr ""
 
 #. MSG_BED_CORRECTION_REAR c=14
 #: ../../Firmware/ultralcd.cpp:2746
-msgid "Rear side [μm]"
+msgid "Rear side [µm]"
 msgstr ""
 
 #. MSG_RECOVERING_PRINT c=20
@@ -1756,7 +1756,7 @@ msgstr ""
 
 #. MSG_BED_CORRECTION_RIGHT c=14
 #: ../../Firmware/ultralcd.cpp:2744
-msgid "Right side[μm]"
+msgid "Right side[µm]"
 msgstr ""
 
 #. MSG_WIZARD_RERUN c=20 r=7

--- a/lang/po/Firmware_nl.po
+++ b/lang/po/Firmware_nl.po
@@ -130,7 +130,7 @@ msgstr "Aslengte"
 #: ../../Firmware/ultralcd.cpp:4212 ../../Firmware/ultralcd.cpp:5833
 #: ../../Firmware/ultralcd.cpp:7812
 msgid "Back"
-msgstr "terug"
+msgstr "Terug"
 
 #. MSG_BED c=13
 #: ../../Firmware/Marlin_main.cpp:2025 ../../Firmware/Marlin_main.cpp:4789
@@ -796,8 +796,8 @@ msgstr "Voorzijde fan?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
 #: ../../Firmware/ultralcd.cpp:2745
-msgid "Front side[μm]"
-msgstr "Voorkant [μm]"
+msgid "Front side[µm]"
+msgstr "Voorkant [µm]"
 
 #. MSG_SELFTEST_FANS c=20
 #: ../../Firmware/ultralcd.cpp:7001
@@ -1038,8 +1038,8 @@ msgstr "Linker hotend fan?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
 #: ../../Firmware/ultralcd.cpp:2743
-msgid "Left side [μm]"
-msgstr "Linkerkant[μm]"
+msgid "Left side [µm]"
+msgstr "Linkerkant[µm]"
 
 #. MSG_BL_HIGH c=12
 #: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5834
@@ -1748,8 +1748,8 @@ msgstr "RPi port"
 
 #. MSG_BED_CORRECTION_REAR c=14
 #: ../../Firmware/ultralcd.cpp:2746
-msgid "Rear side [μm]"
-msgstr "Achterkant[μm]"
+msgid "Rear side [µm]"
+msgstr "Achterkant[µm]"
 
 #. MSG_RECOVERING_PRINT c=20
 #: ../../Firmware/Marlin_main.cpp:10896
@@ -1827,8 +1827,8 @@ msgstr "Rechts"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
 #: ../../Firmware/ultralcd.cpp:2744
-msgid "Right side[μm]"
-msgstr "Recht.kant[μm]"
+msgid "Right side[µm]"
+msgstr "Recht.kant[µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
 #: ../../Firmware/ultralcd.cpp:3846

--- a/lang/po/Firmware_no.po
+++ b/lang/po/Firmware_no.po
@@ -792,8 +792,8 @@ msgstr "Fremre printvifte?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
 #: ../../Firmware/ultralcd.cpp:2745
-msgid "Front side[μm]"
-msgstr "Fremsiden [μm]"
+msgid "Front side[µm]"
+msgstr "Fremsiden [µm]"
 
 #. MSG_SELFTEST_FANS c=20
 #: ../../Firmware/ultralcd.cpp:7001
@@ -1029,8 +1029,8 @@ msgstr "Venst. hotendvifte?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
 #: ../../Firmware/ultralcd.cpp:2743
-msgid "Left side [μm]"
-msgstr "Vens. side[μm]"
+msgid "Left side [µm]"
+msgstr "Vens. side[µm]"
 
 #. MSG_BL_HIGH c=12
 #: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5834
@@ -1731,8 +1731,8 @@ msgstr "RPi port"
 
 #. MSG_BED_CORRECTION_REAR c=14
 #: ../../Firmware/ultralcd.cpp:2746
-msgid "Rear side [μm]"
-msgstr "Baksiden [μm]"
+msgid "Rear side [µm]"
+msgstr "Baksiden [µm]"
 
 #. MSG_RECOVERING_PRINT c=20
 #: ../../Firmware/Marlin_main.cpp:10896
@@ -1809,8 +1809,8 @@ msgstr "Høyre"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
 #: ../../Firmware/ultralcd.cpp:2744
-msgid "Right side[μm]"
-msgstr "Høyre side[μm]"
+msgid "Right side[µm]"
+msgstr "Høyre side[µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
 #: ../../Firmware/ultralcd.cpp:3846

--- a/lang/po/Firmware_pl.po
+++ b/lang/po/Firmware_pl.po
@@ -795,8 +795,8 @@ msgstr "Przedni went. druku?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
 #: ../../Firmware/ultralcd.cpp:2745
-msgid "Front side[μm]"
-msgstr "Przod [μm]"
+msgid "Front side[µm]"
+msgstr "Przod [µm]"
 
 #. MSG_SELFTEST_FANS c=20
 #: ../../Firmware/ultralcd.cpp:7001
@@ -1035,8 +1035,8 @@ msgstr "Lewy went hotendu?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
 #: ../../Firmware/ultralcd.cpp:2743
-msgid "Left side [μm]"
-msgstr "Lewo [μm]"
+msgid "Left side [µm]"
+msgstr "Lewo [µm]"
 
 #. MSG_BL_HIGH c=12
 #: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5834
@@ -1742,8 +1742,8 @@ msgstr "Port RPi"
 
 #. MSG_BED_CORRECTION_REAR c=14
 #: ../../Firmware/ultralcd.cpp:2746
-msgid "Rear side [μm]"
-msgstr "Tyl [μm]"
+msgid "Rear side [µm]"
+msgstr "Tyl [µm]"
 
 #. MSG_RECOVERING_PRINT c=20
 #: ../../Firmware/Marlin_main.cpp:10896
@@ -1820,8 +1820,8 @@ msgstr "Prawa"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
 #: ../../Firmware/ultralcd.cpp:2744
-msgid "Right side[μm]"
-msgstr "Prawo [μm]"
+msgid "Right side[µm]"
+msgstr "Prawo [µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
 #: ../../Firmware/ultralcd.cpp:3846

--- a/lang/po/Firmware_ro.po
+++ b/lang/po/Firmware_ro.po
@@ -796,8 +796,8 @@ msgstr "Vent. print?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
 #: ../../Firmware/ultralcd.cpp:2745
-msgid "Front side[μm]"
-msgstr "Fata [μm]"
+msgid "Front side[µm]"
+msgstr "Fata [µm]"
 
 #. MSG_SELFTEST_FANS c=20
 #: ../../Firmware/ultralcd.cpp:7001
@@ -1036,8 +1036,8 @@ msgstr "Vent. hotend?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
 #: ../../Firmware/ultralcd.cpp:2743
-msgid "Left side [μm]"
-msgstr "Stanga [μm]"
+msgid "Left side [µm]"
+msgstr "Stanga [µm]"
 
 #. MSG_BL_HIGH c=12
 #: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5834
@@ -1743,8 +1743,8 @@ msgstr "Port RPi"
 
 #. MSG_BED_CORRECTION_REAR c=14
 #: ../../Firmware/ultralcd.cpp:2746
-msgid "Rear side [μm]"
-msgstr "Spate [μm]"
+msgid "Rear side [µm]"
+msgstr "Spate [µm]"
 
 #. MSG_RECOVERING_PRINT c=20
 #: ../../Firmware/Marlin_main.cpp:10896
@@ -1822,8 +1822,8 @@ msgstr "Dreapta"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
 #: ../../Firmware/ultralcd.cpp:2744
-msgid "Right side[μm]"
-msgstr "Dreapta [μm]"
+msgid "Right side[µm]"
+msgstr "Dreapta [µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
 #: ../../Firmware/ultralcd.cpp:3846

--- a/lang/po/Firmware_sk.po
+++ b/lang/po/Firmware_sk.po
@@ -793,8 +793,8 @@ msgstr "Predny tlacovy vent?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
 #: ../../Firmware/ultralcd.cpp:2745
-msgid "Front side[μm]"
-msgstr "Predna st.[μm]"
+msgid "Front side[µm]"
+msgstr "Predna st.[µm]"
 
 #. MSG_SELFTEST_FANS c=20
 #: ../../Firmware/ultralcd.cpp:7001
@@ -1032,8 +1032,8 @@ msgstr "Lavy vent na tryske?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
 #: ../../Firmware/ultralcd.cpp:2743
-msgid "Left side [μm]"
-msgstr "Lava str.[μm]"
+msgid "Left side [µm]"
+msgstr "Lava str.[µm]"
 
 #. MSG_BL_HIGH c=12
 #: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5834
@@ -1740,8 +1740,8 @@ msgstr "RPi port"
 
 #. MSG_BED_CORRECTION_REAR c=14
 #: ../../Firmware/ultralcd.cpp:2746
-msgid "Rear side [μm]"
-msgstr "Zadna str.[μm]"
+msgid "Rear side [µm]"
+msgstr "Zadna str.[µm]"
 
 #. MSG_RECOVERING_PRINT c=20
 #: ../../Firmware/Marlin_main.cpp:10896
@@ -1818,8 +1818,8 @@ msgstr "Vpravo"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
 #: ../../Firmware/ultralcd.cpp:2744
-msgid "Right side[μm]"
-msgstr "Prava str.[μm]"
+msgid "Right side[µm]"
+msgstr "Prava str.[µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
 #: ../../Firmware/ultralcd.cpp:3846

--- a/lang/po/Firmware_sl.po
+++ b/lang/po/Firmware_sl.po
@@ -765,7 +765,7 @@ msgstr ""
 
 #. MSG_BED_CORRECTION_FRONT c=14
 #: ../../Firmware/ultralcd.cpp:2745
-msgid "Front side[μm]"
+msgid "Front side[µm]"
 msgstr ""
 
 #. MSG_SELFTEST_FANS c=20
@@ -993,7 +993,7 @@ msgstr ""
 
 #. MSG_BED_CORRECTION_LEFT c=14
 #: ../../Firmware/ultralcd.cpp:2743
-msgid "Left side [μm]"
+msgid "Left side [µm]"
 msgstr ""
 
 #. MSG_BL_HIGH c=12
@@ -1680,7 +1680,7 @@ msgstr ""
 
 #. MSG_BED_CORRECTION_REAR c=14
 #: ../../Firmware/ultralcd.cpp:2746
-msgid "Rear side [μm]"
+msgid "Rear side [µm]"
 msgstr ""
 
 #. MSG_RECOVERING_PRINT c=20
@@ -1756,7 +1756,7 @@ msgstr ""
 
 #. MSG_BED_CORRECTION_RIGHT c=14
 #: ../../Firmware/ultralcd.cpp:2744
-msgid "Right side[μm]"
+msgid "Right side[µm]"
 msgstr ""
 
 #. MSG_WIZARD_RERUN c=20 r=7

--- a/lang/po/Firmware_sv.po
+++ b/lang/po/Firmware_sv.po
@@ -793,8 +793,8 @@ msgstr "Frontfläkt?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
 #: ../../Firmware/ultralcd.cpp:2745
-msgid "Front side[μm]"
-msgstr "Frontsida[μm]"
+msgid "Front side[µm]"
+msgstr "Frontsida[µm]"
 
 #. MSG_SELFTEST_FANS c=20
 #: ../../Firmware/ultralcd.cpp:7001
@@ -1036,8 +1036,8 @@ msgstr "Vänst hotend fläkt?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
 #: ../../Firmware/ultralcd.cpp:2743
-msgid "Left side [μm]"
-msgstr "Vänstsida [μm]"
+msgid "Left side [µm]"
+msgstr "Vänstsida [µm]"
 
 #. MSG_BL_HIGH c=12
 #: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:5834
@@ -1745,8 +1745,8 @@ msgstr "RPi port"
 
 #. MSG_BED_CORRECTION_REAR c=14
 #: ../../Firmware/ultralcd.cpp:2746
-msgid "Rear side [μm]"
-msgstr "Baksida [μm]"
+msgid "Rear side [µm]"
+msgstr "Baksida [µm]"
 
 #. MSG_RECOVERING_PRINT c=20
 #: ../../Firmware/Marlin_main.cpp:10896
@@ -1825,8 +1825,8 @@ msgstr "Höger"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
 #: ../../Firmware/ultralcd.cpp:2744
-msgid "Right side[μm]"
-msgstr "Höger sida[μm]"
+msgid "Right side[µm]"
+msgstr "Höger sida[µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
 #: ../../Firmware/ultralcd.cpp:3846


### PR DESCRIPTION
Fix `[μm]` in translations

- [X] Create cherry-pick to MK3_3.12