### PR TITLE
MK3_3.12 TM: reset fan measuring state when changing speed

### DIFF
--- a/Firmware/temperature.cpp
+++ b/Firmware/temperature.cpp
@@ -2632,6 +2632,11 @@ namespace temp_model_cal {
 // set current fan speed for both front/backend
 static __attribute__((noinline)) void set_fan_speed(uint8_t fan_speed)
 {
+#if (defined(EXTRUDER_0_AUTO_FAN_PIN) && EXTRUDER_0_AUTO_FAN_PIN > -1)
+    // reset the fan measuring state due to missing hysteresis handling on the checking side
+    fan_measuring = false;
+    extruder_autofan_last_check = _millis();
+#endif
     fanSpeed = fan_speed;
 #ifdef FAN_SOFT_PWM
     fanSpeedSoftPwm = fan_speed;


### PR DESCRIPTION
Ensure that fan checks are reset and use the new speed at each step of the calibration.

This also gives extra time to the fan to ramp-up from a cold start, when a fancheck could previously start right *after* the speed change.

Should fix #3791

Cherry-pick from https://github.com/prusa3d/Prusa-Firmware/pull/3814