### PR TITLE
CI: Cache dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 dist: focal
 language: minimal
 
+cache:
+  directories:
+    .dependencies/
+
 before_install:
   # Prepare the dependencies for the old build environment
   - sudo apt-get install -y python3-polib python3-pyelftools python3-regex


### PR DESCRIPTION
Attempt to cache dependencies with the travis cache. This avoids redownloading avr-gcc for each stage of the pipeline.

This /might/ improve the download failures we're seeing recently, although the travis cache is also networked.