### PR TITLE
PF-build: improve storage and caching of dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,10 @@ language: minimal
 
 cache:
   directories:
-    .dependencies/
+    # cmake project dependencies
+    - .dependencies/
+    # legacy PF-build dependencies
+    - ./../PF-build-env/
 
 before_install:
   # Prepare the dependencies for the old build environment

--- a/PF-build.sh
+++ b/PF-build.sh
@@ -513,17 +513,13 @@ fi
 # Start: Check python ... needed during language build
 check_python()
 {
-if ! type python > /dev/null; then
+if ! type python3 > /dev/null; then
     if [ $TARGET_OS == "windows" ]; then
         echo "$(tput setaf 1)Missing 'python3' which is important to run this script"
         failures 4
     elif [ $TARGET_OS == "linux" ]; then
-        echo "$(tput setaf 1)Missing 'python' which is important to run this script"
-        echo "As Python 2.x will not be maintained from 2020 please,"
-        echo "install it with the command $(tput setaf 2)'sudo apt-get install python3'."
-        echo "Check which version of Python3 has been installed using 'ls /usr/bin/python3*'"
-        echo "Use 'sudo ln -sf /usr/bin/python3.x /usr/bin/python' (where 'x' is your version number) to make it default.$(tput sgr0)"
-        #sudo apt-get update && apt-get install python3 && ln -sf /usr/bin/python3 /usr/bin/python
+        echo "$(tput setaf 1)Missing 'python3' which is important to run this script"
+        echo "Install it with the command $(tput setaf 2)'sudo apt-get install python3'."
         failures 4
     fi
 fi

--- a/PF-build.sh
+++ b/PF-build.sh
@@ -1,6 +1,6 @@
-#!/bin/bash 
+#!/bin/bash
 # This bash script is used to compile automatically the Prusa firmware with a dedicated build environment and settings
-# 
+#
 # Supported OS: Windows 10, Linux64 bit
 # Beta OS: Linux32 bit
 #
@@ -35,12 +35,12 @@
 # Useful things to edit and compare your custom Firmware
 # 1. Download and install current and correct (64bit or 32bit) Notepad++ version https://notepad-plus-plus.org/download
 # 2. Another great tool to compare your custom mod and stock firmware is WinMerge http://winmerge.org/downloads/?lang=en
-# 
-# Example for MK3: open git bash and change to your Firmware directory 
+#
+# Example for MK3: open git bash and change to your Firmware directory
 # <username>@<machine name> MINGW64 /<drive>/path
 # bash build.sh 1_75mm_MK3-EINSy10a-E3Dv6full
 #
-# Example for MK25: open git bash and change to your directory 
+# Example for MK25: open git bash and change to your directory
 # gussner@WIN01 MINGW64 /d/Data/Prusa-Firmware/MK3
 # bash build.sh 1_75mm_MK25-RAMBo13a-E3Dv6full
 #
@@ -63,7 +63,7 @@
 # 17 Jan 2019, 3d-gussner, Build_3, Check for OS Windows or Linux and use the right build environment
 # 10 Feb 2019, ropaha, Pull Request, Select variant from list while using build.sh
 # 10 Feb 2019, ropaha, change FW_DEV_VERSION automatically depending on FW_VERSION RC/BETA/ALPHA
-# 10 Feb 2019, 3d-gussner, 1st tests with English only 
+# 10 Feb 2019, 3d-gussner, 1st tests with English only
 # 10 Feb 2019, ropaha, added compiling of all variants and English only
 # 10 Feb 2019, 3d-gussner, Set OUTPUT_FOLDER for hex files
 # 11 Feb 2019, 3d-gussner/ropaha, Minor changes and fixes
@@ -100,7 +100,7 @@
 # 14 Jul 2019, 3d-gussner, Update preferences and make it really portable
 # 15 Jul 2019, 3d-gussner, New PF-build-env GitHub branch
 # 16 Jul 2019, 3d-gussner, New Arduino_boards GitHub fork
-# 17 Jul 2019, 3d-gussner, Final tests under Windows 10 and Linux Subsystem for Windows   
+# 17 Jul 2019, 3d-gussner, Final tests under Windows 10 and Linux Subsystem for Windows
 # 18 Jul 2019, 3d-gussner, Added python check
 # 18 Jul 2019, deliopoulos, No need more for changing 'platform.txt' file as it comes with the Arduino Boards.
 # 18 Jul 2019, deliopoulos, Modified 'PF_BUILD_FILE_URL' to use 'BUILD_ENV' variable
@@ -144,7 +144,7 @@
 #                          01-14 prepare build env
 #                          21-32 prepare compiling
 #                          41-47 compiling
-#                          51-54 cleanup 
+#                          51-54 cleanup
 #                          61-62 MK404
 # 03 May 2021, 3d-gussner, Update documentation and change version to v1.2.0
 # 03 May 2021, 3d-gussner, Add SIM atmega404
@@ -155,7 +155,7 @@
 # 18 Jun 2021, 3d-gussner, Use atmega404 if extanded RAM or FLASH size are chosen
 # 18 Jun 2021, 3d-gussner, Remove MK404 copy of lang file as it has been fixed in MK404
 # 21 Jun 2021, 3d-gussner, Change atmega404 board flash argument to y
-#                          Use newer version of MK404-build.sh instead start the program 
+#                          Use newer version of MK404-build.sh instead start the program
 # 22 Jun 2021, 3d-gussner, Added _RAM-<value> and _FLASH-<value> as OUTPUT_FILE_SUFFIX if someone builds an atmega404 firmware
 #                          Added some logic if IDE 1.8.13 is used
 #                          Added some logic if Arduino_boards 1.0.4 is used
@@ -302,7 +302,7 @@ if [ ! -z "$verbose_IDE_flag" ]; then
     fi
 else
     verbose_IDE="0"
-fi  
+fi
 
 #Check if Build is selected with argument '-f'
 if [ ! -z "$board_flash_flag" ] ; then
@@ -368,13 +368,13 @@ else
 fi
 #End: Check if Arduino IDE version is correct
 
-#Start: Check if Output is selecetd via argument '-o' 
+#Start: Check if Output is selecetd via argument '-o'
 if [[ -z "$output_flag" || "$output_flag" == 1 ]] ; then
     OUTPUT=1
 else
     OUTPUT=0
 fi
-#End: Check if Output is selecetd via argument '-o' 
+#End: Check if Output is selecetd via argument '-o'
 ##}
 #### End: Check for options/flags
 
@@ -399,7 +399,7 @@ fi
 #### Start: Check Check if script has been canceled or failed nr1.
 check_script_failed_nr1()
 {
-#Check for "Configuration.tmp" 
+#Check for "Configuration.tmp"
 if [ -f "$SCRIPT_PATH/Firmware/Configuration.tmp" ]; then
     cp -f $SCRIPT_PATH/Firmware/Configuration.tmp $SCRIPT_PATH/Firmware/Configuration.h
     #echo "Found Configuration.tmp restore Configuration.h"
@@ -411,7 +411,7 @@ fi
 #### Start: Check if script has been canceled or failed nr2.
 check_script_failed_nr2()
 {
-#Check for "config.tmp" 
+#Check for "config.tmp"
     #echo "No config.tmp"
 if [ -f "$SCRIPT_PATH/Firmware/config.tmp" ]; then
     cp -f $SCRIPT_PATH/Firmware/config.tmp $SCRIPT_PATH/Firmware/config.h
@@ -527,7 +527,7 @@ fi
 # End: Check python ... needed during language build
 
 
-#### Start: Set build environment 
+#### Start: Set build environment
 set_build_env_variables()
 {
 BUILD_ENV="1.0.8"
@@ -738,12 +738,12 @@ if [[ ! -d "../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$P
     if [ ! -d ../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/packages/$BOARD_PACKAGE_NAME/hardware/avr ]; then
         mkdir ../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/packages/$BOARD_PACKAGE_NAME/hardware/avr
     fi
-    
+
     mv ../PF-build-env/$BUILD_ENV/$BOARD_FILENAME-$BOARD_VERSION ../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/packages/$BOARD_PACKAGE_NAME/hardware/avr/$BOARD_VERSION
     echo "# $BOARD_FILENAME-$BOARD_VERSION" >> ../PF-build-env/$BUILD_ENV/$BOARD_FILENAME-$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor.txt
 
     echo "$(tput sgr 0)"
-fi    
+fi
 
 # Download and extract Prusa Firmware specific library files
 if [[ "$BOARD_VERSION" == "1.0.3" || "$BOARD_VERSION" == "1.0.2" || "$BOARD_VERSION" == "1.0.1" ]]; then
@@ -777,7 +777,7 @@ if [ -d "../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Proc
     if [ $OUTPUT == "1" ] ; then
         sleep 2
     fi
-fi    
+fi
 if [ -d "../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/packages/arduino/tools/avr-gcc/4.9.2-atmel3.5.4-arduino2" ]; then
     echo "$(tput setaf 6)PrusaReasearch compatible tools have been manually updated...$(tput setaf 2)"
     if [ $OUTPUT == "1" ] ; then
@@ -790,7 +790,7 @@ if [ -d "../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Proc
     cp -f ../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/hardware/tools/avr/avr/lib/ldscripts/avr6.xn ../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/packages/arduino/tools/avr-gcc/4.9.2-atmel3.5.4-arduino2/avr/lib/ldscripts/avr6.xn
     echo "# PF-build-env-portable-$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor-$BUILD_ENV" >> ../PF-build-env/$BUILD_ENV/PF-build-env-portable-$BUILD_ENV-$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor.txt
     echo "$(tput sgr0)"
-fi    
+fi
 if [ -d "../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/packages/arduino/tools/avr-gcc/5.4.0-atmel3.6.1-arduino2" ]; then
     echo "$(tput setaf 1)Arduino IDE tools have been updated manually to a non supported version!!!"
     echo "Delete ../PF-build-env/$BUILD_ENV and start the script again"
@@ -817,7 +817,7 @@ if type git > /dev/null; then
 fi
 
 #
-# '-v' argument defines which variant of the Prusa Firmware will be compiled 
+# '-v' argument defines which variant of the Prusa Firmware will be compiled
 if [ -z "$variant_flag" ] ; then
     # Select which variant of the Prusa Firmware will be compiled, like
     PS3="Select a variant: "
@@ -848,7 +848,7 @@ if [ -z "$variant_flag" ] ; then
         esac
     done
 else
-    if [ -f "$SCRIPT_PATH/Firmware/variants/$variant_flag" ] ; then 
+    if [ -f "$SCRIPT_PATH/Firmware/variants/$variant_flag" ] ; then
         VARIANTS=$variant_flag
     elif [ "$variant_flag" == "All" ] ; then
         while IFS= read -r -d $'\0' f; do
@@ -879,7 +879,7 @@ if [ -z "$language_flag" ] ; then
                 LANGUAGES="ALL"
                 break
                 ;;
-            "English only") 
+            "English only")
                 LANGUAGES="EN_FARM"
                 break
                 ;;
@@ -988,7 +988,7 @@ prepare_code_for_compiling()
     FW_REVISION=$(grep --max-count=1 "\bFW_REVISION\b" $SCRIPT_PATH/Firmware/Configuration.h| sed -e's/  */ /g'|cut -d ' ' -f3)
     FW="$FW_MAJOR$FW_MINOR$FW_REVISION"
     #FW=$(grep --max-count=1 "\bFW_VERSION\b" $SCRIPT_PATH/Firmware/Configuration.h | sed -e's/  */ /g'|cut -d '"' -f2|sed 's/\.//g')
-    if [ -z "$BUILD" ] ; then    
+    if [ -z "$BUILD" ] ; then
         # Find build version in Configuration.h file and use it to generate the hex filename
         BUILD=$(grep --max-count=1 "\bFW_COMMIT_NR\b" $SCRIPT_PATH/Firmware/Configuration.h | sed -e's/  */ /g'|cut -d ' ' -f3)
     else
@@ -1077,7 +1077,7 @@ prepare_hex_folders()
         fi
         OUTPUT_FOLDER="PF-build-hex/FW$FW-Build$BUILD/$BOARD"
     fi
-    
+
     #Define OUTPUT_FILENAME
     OUTPUT_FILENAME=FW$FW-Build$BUILD-$VARIANT
     #Check for OUTPUT_FILENAME_SUFFIX and add it
@@ -1165,11 +1165,11 @@ prepare_variant_for_compiling()
         sed -i -- "s/^#define LANG_MODE *0/#define LANG_MODE              1/g" $SCRIPT_PATH/Firmware/config.h
         echo " "
     fi
-        
+
     #Check if compiler flags are set to Prusa specific needs for the rambo board.
     #if [ $TARGET_OS == "windows" ]; then
        #RAMBO_PLATFORM_FILE="PrusaResearchRambo/avr/platform.txt"
-    #fi    
+    #fi
 
     #New fresh PF-Firmware-build
     if [ "$new_build_flag" == "1" ]; then
@@ -1261,19 +1261,19 @@ compile_en_firmware()
     #Check if compiler flags are set to Prusa specific needs for the rambo board.
 #    if [ $TARGET_OS == "windows" ]; then
 #        RAMBO_PLATFORM_FILE="PrusaResearchRambo/avr/platform.txt"
-#    fi    
-    
+#    fi
+
     #### End of Prepare building
-        
+
     #### Start building
-        
+
     export ARDUINO=$BUILD_ENV_PATH
     #echo $BUILD_ENV_PATH
     #export BUILDER=$ARDUINO/arduino-builder
 
     echo
     #read -t 5 -p "Press Enter..."
-    echo 
+    echo
 
     echo "Start to build Prusa Firmware ..."
     echo "Using variant $VARIANT$(tput setaf 3)"
@@ -1339,13 +1339,13 @@ create_multi_firmware()
         else
             #Search for created firmware languages
             langs=$(find Firmware-intl-en_*.hex | cut -d "_" -f2 | cut -d "." -f1)
-            #Copy found firmware_*.hex files 
+            #Copy found firmware_*.hex files
                 for la in $langs; do
                     cp -f Firmware-intl-en_$la.hex $SCRIPT_PATH/../$OUTPUT_FOLDER/$OUTPUT_FILENAME-$la.hex
                 done
             cp -f $BUILD_PATH/Firmware.ino.elf $SCRIPT_PATH/../$OUTPUT_FOLDER/$OUTPUT_FILENAME.elf
             echo "$(tput setaf 2)Zip multi language firmware for MK2.5/miniRAMbo board to PF-build-hex folder$(tput sgr 0)"
-            if [ $TARGET_OS == "windows" ]; then 
+            if [ $TARGET_OS == "windows" ]; then
                 zip a $SCRIPT_PATH/../$OUTPUT_FOLDER/$OUTPUT_FILENAME.zip $SCRIPT_PATH/../$OUTPUT_FOLDER/$OUTPUT_FILENAME-??.hex
                 #rm $SCRIPT_PATH/../$OUTPUT_FOLDER/$OUTPUT_FILENAME-??.hex
             elif [ $TARGET_OS == "linux" ]; then
@@ -1604,7 +1604,7 @@ if [ ! -d "../PF-build-env/$BUILD_ENV" ]; then
     check_ArduinoIDE_User_interaction
 fi
 
-#### Start 
+#### Start
 set_paths
 check_branch_changed
 
@@ -1613,7 +1613,7 @@ do
     check_script_failed_nr1
     check_script_failed_nr2
     make_backup1
-    make_backup2    
+    make_backup2
     prepare_code_for_compiling
     prepare_hex_folders
     list_usefull_data

--- a/PF-build.sh
+++ b/PF-build.sh
@@ -588,18 +588,11 @@ echo ""
 # Start: Check if build exists and creates it if not
 check_create_build_folders()
 {
-if [ ! -d "../PF-build-dl" ]; then
-    mkdir ../PF-build-dl || failures 9
-fi
-
-cd ../PF-build-dl || failures 10
-BUILD_ENV_PATH="$( cd "$(dirname "$0")" ; pwd -P )"
-
-# Check if PF-build-env-<version> exists and downloads + creates it if not
+# Check if PF-build-env/<version> exists and downloads + creates it if not
 # The build environment is based on the supported Arduino IDE portable version with some changes
-if [ ! -d "../PF-build-env-$BUILD_ENV" ]; then
-    echo "$(tput setaf 6)PF-build-env-$BUILD_ENV is missing ... creating it now for you$(tput sgr 0)"
-    mkdir ../PF-build-env-$BUILD_ENV
+if [ ! -d "../PF-build-env/$BUILD_ENV" ]; then
+    echo "$(tput setaf 6)PF-build-env/$BUILD_ENV is missing ... creating it now for you$(tput sgr 0)"
+    mkdir -p ../PF-build-env/$BUILD_ENV
     if [ $OUTPUT == "1" ] ; then
         sleep 2
     fi
@@ -610,6 +603,13 @@ fi
 # Start: Download and extract supported Arduino IDE depending on OS
 download_prepare_arduinoIDE()
 {
+if [ ! -d "../PF-build-dl" ]; then
+    mkdir ../PF-build-dl || failures 9
+fi
+
+cd ../PF-build-dl || failures 10
+BUILD_ENV_PATH="$( cd "$(dirname "$0")" ; pwd -P )"
+
 # Windows
 if [ $TARGET_OS == "windows" ]; then
     if [ ! -f "arduino-$ARDUINO_ENV-windows.zip" ]; then
@@ -620,14 +620,14 @@ if [ $TARGET_OS == "windows" ]; then
         wget https://downloads.arduino.cc/arduino-$ARDUINO_ENV-windows.zip || failures 8
         echo "$(tput sgr 0)"
     fi
-    if [[ ! -d "../PF-build-env-$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor" && ! -e "../PF-build-env-$BUILD_ENV/arduino-$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor.txt" ]]; then
+    if [[ ! -d "../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor" && ! -e "../PF-build-env/$BUILD_ENV/arduino-$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor.txt" ]]; then
         echo "$(tput setaf 6)Unzipping Windows 32/64-bit Arduino IDE portable...$(tput setaf 2)"
         if [ $OUTPUT == "1" ] ; then
             sleep 2
         fi
-        unzip arduino-$ARDUINO_ENV-windows.zip -d ../PF-build-env-$BUILD_ENV || failures 11
-        mv ../PF-build-env-$BUILD_ENV/arduino-$ARDUINO_ENV ../PF-build-env-$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor
-        echo "# arduino-$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor" >> ../PF-build-env-$BUILD_ENV/arduino-$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor.txt
+        unzip arduino-$ARDUINO_ENV-windows.zip -d ../PF-build-env/$BUILD_ENV || failures 11
+        mv ../PF-build-env/$BUILD_ENV/arduino-$ARDUINO_ENV ../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor
+        echo "# arduino-$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor" >> ../PF-build-env/$BUILD_ENV/arduino-$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor.txt
         echo "$(tput sgr0)"
     fi
 fi
@@ -642,14 +642,14 @@ if [ $TARGET_OS == "linux" ]; then
         wget --no-check-certificate https://downloads.arduino.cc/arduino-$ARDUINO_ENV-linux$Processor.tar.xz || failures 8
         echo "$(tput sgr 0)"
     fi
-    if [[ ! -d "../PF-build-env-$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor" && ! -e "../PF-build-env-$BUILD_ENV/arduino-$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor.txt" ]]; then
+    if [[ ! -d "../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor" && ! -e "../PF-build-env/$BUILD_ENV/arduino-$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor.txt" ]]; then
         echo "$(tput setaf 6)Unzipping Linux $Processor Arduino IDE portable...$(tput setaf 2)"
         if [ $OUTPUT == "1" ] ; then
             sleep 2
         fi
-        tar -xvf arduino-$ARDUINO_ENV-linux$Processor.tar.xz -C ../PF-build-env-$BUILD_ENV/ || failures 11
-        mv ../PF-build-env-$BUILD_ENV/arduino-$ARDUINO_ENV ../PF-build-env-$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor
-        echo "# arduino-$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor" >> ../PF-build-env-$BUILD_ENV/arduino-$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor.txt
+        tar -xvf arduino-$ARDUINO_ENV-linux$Processor.tar.xz -C ../PF-build-env/$BUILD_ENV/ || failures 11
+        mv ../PF-build-env/$BUILD_ENV/arduino-$ARDUINO_ENV ../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor
+        echo "# arduino-$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor" >> ../PF-build-env/$BUILD_ENV/arduino-$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor.txt
         echo "$(tput sgr0)"
     fi
 fi
@@ -659,27 +659,27 @@ fi
 # Start: Make Arduino IDE portable
 portable_ArduinoIDE()
 {
-if [ ! -d ../PF-build-env-$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/ ]; then
-    mkdir ../PF-build-env-$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/
+if [ ! -d ../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/ ]; then
+    mkdir ../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/
 fi
 
-if [ ! -d ../PF-build-env-$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/ ]; then
-    mkdir ../PF-build-env-$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable
+if [ ! -d ../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/ ]; then
+    mkdir ../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable
 fi
-if [ ! -d ../PF-build-env-$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/output/ ]; then
-    mkdir ../PF-build-env-$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/output
+if [ ! -d ../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/output/ ]; then
+    mkdir ../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/output
 fi
-if [ ! -d ../PF-build-env-$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/packages/ ]; then
-    mkdir ../PF-build-env-$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/packages
+if [ ! -d ../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/packages/ ]; then
+    mkdir ../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/packages
 fi
-if [ ! -d ../PF-build-env-$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/sketchbook/ ]; then
-    mkdir ../PF-build-env-$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/sketchbook
+if [ ! -d ../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/sketchbook/ ]; then
+    mkdir ../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/sketchbook
 fi
-if [ ! -d ../PF-build-env-$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/sketchbook/libraries/ ]; then
-    mkdir ../PF-build-env-$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/sketchbook/libraries
+if [ ! -d ../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/sketchbook/libraries/ ]; then
+    mkdir ../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/sketchbook/libraries
 fi
-if [ ! -d ../PF-build-env-$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/staging/ ]; then
-    mkdir ../PF-build-env-$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/staging
+if [ ! -d ../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/staging/ ]; then
+    mkdir ../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/staging
 fi
 }
 # End: Make Arduino IDE portable
@@ -687,23 +687,23 @@ fi
 # Start: Change Arduino IDE preferences
 change_ArduinoIDEpreferances()
 {
-if [ ! -e ../PF-build-env-$BUILD_ENV/Preferences-$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor.txt ]; then
+if [ ! -e ../PF-build-env/$BUILD_ENV/Preferences-$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor.txt ]; then
     echo "$(tput setaf 6)Setting $ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor Arduino IDE preferences for portable GUI usage...$(tput setaf 2)"
     if [ $OUTPUT == "1" ] ; then
         sleep 2
     fi
     echo "update.check"
-    sed -i 's/update.check = true/update.check = false/g' ../PF-build-env-$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/lib/preferences.txt
+    sed -i 's/update.check = true/update.check = false/g' ../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/lib/preferences.txt
     echo "board"
-    sed -i "s/board = uno/board = $BOARD/g" ../PF-build-env-$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/lib/preferences.txt
+    sed -i "s/board = uno/board = $BOARD/g" ../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/lib/preferences.txt
     echo "editor.linenumbers"
-    sed -i 's/editor.linenumbers = false/editor.linenumbers = true/g' ../PF-build-env-$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/lib/preferences.txt
+    sed -i 's/editor.linenumbers = false/editor.linenumbers = true/g' ../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/lib/preferences.txt
     echo "boardsmanager.additional.urls"
-    echo "boardsmanager.additional.urls=$BOARD_URL" >>../PF-build-env-$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/lib/preferences.txt
-    echo "build.verbose=true" >>../PF-build-env-$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/lib/preferences.txt
-    echo "compiler.cache_core=false" >>../PF-build-env-$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/lib/preferences.txt
-    echo "compiler.warning_level=all" >>../PF-build-env-$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/lib/preferences.txt
-    echo "# Preferences-$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor" >> ../PF-build-env-$BUILD_ENV/Preferences-$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor.txt
+    echo "boardsmanager.additional.urls=$BOARD_URL" >>../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/lib/preferences.txt
+    echo "build.verbose=true" >>../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/lib/preferences.txt
+    echo "compiler.cache_core=false" >>../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/lib/preferences.txt
+    echo "compiler.warning_level=all" >>../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/lib/preferences.txt
+    echo "# Preferences-$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor" >> ../PF-build-env/$BUILD_ENV/Preferences-$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor.txt
     echo "$(tput sgr0)"
 fi
 }
@@ -720,27 +720,27 @@ if [ ! -f "$BOARD_FILENAME-$BOARD_VERSION.tar.bz2" ]; then
     fi
     wget $BOARD_FILE_URL || failures 8
 fi
-if [[ ! -d "../PF-build-env-$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/packages/$BOARD_PACKAGE_NAME/hardware/avr/$BOARD_VERSION" || ! -e "../PF-build-env-$BUILD_ENV/$BOARD_FILENAME-$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor.txt" ]]; then
+if [[ ! -d "../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/packages/$BOARD_PACKAGE_NAME/hardware/avr/$BOARD_VERSION" || ! -e "../PF-build-env/$BUILD_ENV/$BOARD_FILENAME-$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor.txt" ]]; then
     echo "$(tput setaf 6)Unzipping $BOARD_PACKAGE_NAME Arduino IDE portable...$(tput setaf 2)"
     if [ $OUTPUT == "1" ] ; then
         sleep 2
     fi
-    tar -xvf $BOARD_FILENAME-$BOARD_VERSION.tar.bz2 -C ../PF-build-env-$BUILD_ENV/ || failures 11
-    if [ ! -d ../PF-build-env-$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/packages/$BOARD_PACKAGE_NAME ]; then
-        mkdir ../PF-build-env-$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/packages/$BOARD_PACKAGE_NAME
+    tar -xvf $BOARD_FILENAME-$BOARD_VERSION.tar.bz2 -C ../PF-build-env/$BUILD_ENV/ || failures 11
+    if [ ! -d ../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/packages/$BOARD_PACKAGE_NAME ]; then
+        mkdir ../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/packages/$BOARD_PACKAGE_NAME
     fi
-    if [ ! -d ../PF-build-env-$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/packages/$BOARD_PACKAGE_NAME ]; then
-        mkdir ../PF-build-env-$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/packages/$BOARD_PACKAGE_NAME
+    if [ ! -d ../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/packages/$BOARD_PACKAGE_NAME ]; then
+        mkdir ../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/packages/$BOARD_PACKAGE_NAME
     fi
-    if [ ! -d ../PF-build-env-$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/packages/$BOARD_PACKAGE_NAME/hardware ]; then
-        mkdir ../PF-build-env-$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/packages/$BOARD_PACKAGE_NAME/hardware
+    if [ ! -d ../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/packages/$BOARD_PACKAGE_NAME/hardware ]; then
+        mkdir ../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/packages/$BOARD_PACKAGE_NAME/hardware
     fi
-    if [ ! -d ../PF-build-env-$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/packages/$BOARD_PACKAGE_NAME/hardware/avr ]; then
-        mkdir ../PF-build-env-$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/packages/$BOARD_PACKAGE_NAME/hardware/avr
+    if [ ! -d ../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/packages/$BOARD_PACKAGE_NAME/hardware/avr ]; then
+        mkdir ../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/packages/$BOARD_PACKAGE_NAME/hardware/avr
     fi
     
-    mv ../PF-build-env-$BUILD_ENV/$BOARD_FILENAME-$BOARD_VERSION ../PF-build-env-$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/packages/$BOARD_PACKAGE_NAME/hardware/avr/$BOARD_VERSION
-    echo "# $BOARD_FILENAME-$BOARD_VERSION" >> ../PF-build-env-$BUILD_ENV/$BOARD_FILENAME-$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor.txt
+    mv ../PF-build-env/$BUILD_ENV/$BOARD_FILENAME-$BOARD_VERSION ../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/packages/$BOARD_PACKAGE_NAME/hardware/avr/$BOARD_VERSION
+    echo "# $BOARD_FILENAME-$BOARD_VERSION" >> ../PF-build-env/$BUILD_ENV/$BOARD_FILENAME-$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor.txt
 
     echo "$(tput sgr 0)"
 fi    
@@ -755,13 +755,13 @@ if [[ "$BOARD_VERSION" == "1.0.3" || "$BOARD_VERSION" == "1.0.2" || "$BOARD_VERS
         wget $PF_BUILD_FILE_URL || failures 8
         echo "$(tput sgr 0)"
     fi
-    if [ ! -e "../PF-build-env-$BUILD_ENV/PF-build-env-$BUILD_ENV-$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor.txt" ]; then
+    if [ ! -e "../PF-build-env/$BUILD_ENV/PF-build-env/$BUILD_ENV-$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor.txt" ]; then
         echo "$(tput setaf 6)Unzipping Prusa Firmware build environment...$(tput setaf 2)"
         if [ $OUTPUT == "1" ] ; then
             sleep 2
         fi
-        unzip -o PF-build-env-WinLin-$BUILD_ENV.zip -d ../PF-build-env-$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor || failures 11
-        echo "# PF-build-env-$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor-$BUILD_ENV" >> ../PF-build-env-$BUILD_ENV/PF-build-env-$BUILD_ENV-$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor.txt
+        unzip -o PF-build-env-WinLin-$BUILD_ENV.zip -d ../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor || failures 11
+        echo "# PF-build-env-$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor-$BUILD_ENV" >> ../PF-build-env/$BUILD_ENV/PF-build-env/$BUILD_ENV-$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor.txt
         echo "$(tput sgr0)"
     fi
 fi
@@ -771,14 +771,14 @@ fi
 # Start: Check if User updated Arduino IDE 1.8.5 boardsmanager and tools
 check_ArduinoIDE_User_interaction()
 {
-if [ -d "../PF-build-env-$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/packages/arduino/tools" ]; then
+if [ -d "../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/packages/arduino/tools" ]; then
     echo "$(tput setaf 6)Arduino IDE boards / tools have been manually updated...$"
     echo "Please don't update the 'Arduino AVR boards' as this will prevent running this script (tput setaf 2)"
     if [ $OUTPUT == "1" ] ; then
         sleep 2
     fi
 fi    
-if [ -d "../PF-build-env-$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/packages/arduino/tools/avr-gcc/4.9.2-atmel3.5.4-arduino2" ]; then
+if [ -d "../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/packages/arduino/tools/avr-gcc/4.9.2-atmel3.5.4-arduino2" ]; then
     echo "$(tput setaf 6)PrusaReasearch compatible tools have been manually updated...$(tput setaf 2)"
     if [ $OUTPUT == "1" ] ; then
         sleep 2
@@ -787,13 +787,13 @@ if [ -d "../PF-build-env-$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Proc
     if [ $OUTPUT == "1" ] ; then
         sleep 2
     fi
-    cp -f ../PF-build-env-$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/hardware/tools/avr/avr/lib/ldscripts/avr6.xn ../PF-build-env-$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/packages/arduino/tools/avr-gcc/4.9.2-atmel3.5.4-arduino2/avr/lib/ldscripts/avr6.xn
-    echo "# PF-build-env-portable-$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor-$BUILD_ENV" >> ../PF-build-env-$BUILD_ENV/PF-build-env-portable-$BUILD_ENV-$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor.txt
+    cp -f ../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/hardware/tools/avr/avr/lib/ldscripts/avr6.xn ../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/packages/arduino/tools/avr-gcc/4.9.2-atmel3.5.4-arduino2/avr/lib/ldscripts/avr6.xn
+    echo "# PF-build-env-portable-$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor-$BUILD_ENV" >> ../PF-build-env/$BUILD_ENV/PF-build-env-portable-$BUILD_ENV-$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor.txt
     echo "$(tput sgr0)"
 fi    
-if [ -d "../PF-build-env-$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/packages/arduino/tools/avr-gcc/5.4.0-atmel3.6.1-arduino2" ]; then
+if [ -d "../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor/portable/packages/arduino/tools/avr-gcc/5.4.0-atmel3.6.1-arduino2" ]; then
     echo "$(tput setaf 1)Arduino IDE tools have been updated manually to a non supported version!!!"
-    echo "Delete ../PF-build-env-$BUILD_ENV and start the script again"
+    echo "Delete ../PF-build-env/$BUILD_ENV and start the script again"
     echo "Script will not continue until this have been fixed $(tput setaf 2)"
     if [ $OUTPUT == "1" ] ; then
         sleep 2
@@ -948,10 +948,10 @@ fi
 #### Start: Set needed Paths
 set_paths()
 {
-cd ../PF-build-env-$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor || failures 10
+cd ../PF-build-env/$BUILD_ENV/$ARDUINO_ENV-$BOARD_VERSION-$TARGET_OS-$Processor || failures 10
 BUILD_ENV_PATH="$( pwd -P )"
 
-cd ../..
+cd ../../..
 
 #Checkif BUILD_PATH exists and if not creates it
 if [ ! -d "Prusa-Firmware-build" ]; then
@@ -1593,14 +1593,16 @@ echo "Prepare build env"
 get_arguments
 set_build_env_variables
 output_useful_data
-check_create_build_folders
 
 #### Download/set needed apps and dependencies
-download_prepare_arduinoIDE
-portable_ArduinoIDE
-change_ArduinoIDEpreferances
-download_prepare_Prusa_build_files
-check_ArduinoIDE_User_interaction
+if [ ! -d "../PF-build-env/$BUILD_ENV" ]; then
+    check_create_build_folders
+    download_prepare_arduinoIDE
+    portable_ArduinoIDE
+    change_ArduinoIDEpreferances
+    download_prepare_Prusa_build_files
+    check_ArduinoIDE_User_interaction
+fi
 
 #### Start 
 set_paths


### PR DESCRIPTION
A few fixes for PF-build to improve caching of the dependencies:

- check for the correct python version (we only use python3)
- do not re-download dependencies if already extracted
- use an unversioned root so we can cache dependencies across versions
- add that root to the travis cache