### PR TITLE
PFW-1457 Do not unload at start of First Layer Cal

### DIFF
--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -22,7 +22,6 @@
 #include "pins.h"
 #include "Timer.h"
 #include "mmu2.h"
-#include "cardreader.h" // for IS_SD_PRINTING
 extern uint8_t mbl_z_probe_nr;
 
 #ifndef AT90USB
@@ -364,7 +363,7 @@ extern bool printer_active();
 //! Instead, the fsensor uses another state variable :( , which is set to true, when the M600 command is enqued
 //! and is reset to false when the fsensor returns into its filament runout finished handler
 //! I'd normally change this macro, but who knows what would happen in the MMU :)
-#define CHECK_FSENSOR ((IS_SD_PRINTING || usb_timer.running()) && (mcode_in_progress != 600) && !saved_printing && e_active())
+bool check_fsensor();
 
 extern void calculate_extruder_multipliers();
 

--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -22,6 +22,7 @@
 #include "pins.h"
 #include "Timer.h"
 #include "mmu2.h"
+#include "cardreader.h" // for IS_SD_PRINTING
 extern uint8_t mbl_z_probe_nr;
 
 #ifndef AT90USB

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -563,6 +563,14 @@ bool __attribute__((noinline)) printer_active() {
         || mesh_bed_leveling_flag;
 }
 
+// Currently only used in one place, allowed to be inlined
+bool check_fsensor() {
+    return (IS_SD_PRINTING || usb_timer.running())
+        && mcode_in_progress != 600
+        && !saved_printing
+        && e_active();
+}
+
 bool fans_check_enabled = true;
 
 #ifdef TMC2130

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -14,7 +14,6 @@
 #include "strlen_cx.h"
 #include "temperature.h"
 #include "ultralcd.h"
-#include "cardreader.h" // for IS_SD_PRINTING
 #include "SpoolJoin.h"
 
 // As of FW 3.12 we only support building the FW with only one extruder, all the multi-extruder infrastructure will be removed.
@@ -384,9 +383,9 @@ bool MMU2::tool_change(uint8_t slot) {
         return false;
 
     if (slot != extruder) {
-        if (!IS_SD_PRINTING && !usb_timer.running()) {
+        if (FindaDetectsFilament()) {
             // If Tcodes are used manually through the serial
-            // we need to unload manually as well
+            // we need to unload manually as well -- but only if FINDA detects filament
             unload();
         }
 

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -245,7 +245,7 @@ void __attribute__((noinline)) MMU2::mmu_loop_inner(bool reportErrors) {
 
 void MMU2::CheckFINDARunout() {
     // Check for FINDA filament runout
-    if (!FindaDetectsFilament() && CHECK_FSENSOR) {
+    if (!FindaDetectsFilament() && check_fsensor()) {
         SERIAL_ECHOLNPGM("FINDA filament runout!");
         stop_and_save_print_to_ram(0, 0);
         restore_print_from_ram_and_continue(0);


### PR DESCRIPTION
Fixes issue where First Layer Cal. triggers an unload before any filament is loaded

The purpose of this `if()` statement is to handle the edge case where a user or developer is sending T-codes to the printer directly via Serial. Such as when one first sends `T0` and then `T4`. And unload must be triggered in-between.

My first solution was to simply check if a print is on-going. But this doesn't take into account first layer calibration. We can generalize the check to only apply when FINDA detects filament.

Change in memory:
Flash: -10 bytes
SRAM: 0 bytes