### PR TITLE
PFW-1458 Reduce MMU loading test length

### DIFF
--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -318,9 +318,9 @@ bool MMU2::VerifyFilamentEnteredPTFE()
     uint8_t fsensorState = 0;
     // MMU has finished its load, push the filament further by some defined constant length
     // If the filament sensor reads 0 at any moment, then report FAILURE
-    current_position[E_AXIS] += MMU2_EXTRUDER_PTFE_LENGTH + MMU2_EXTRUDER_HEATBREAK_LENGTH - logic.ExtraLoadDistance();
+    current_position[E_AXIS] += MMU2_EXTRUDER_PTFE_LENGTH - logic.ExtraLoadDistance();
     plan_buffer_line_curposXYZE(MMU2_LOAD_TO_NOZZLE_FEED_RATE);
-    current_position[E_AXIS] -= (MMU2_EXTRUDER_PTFE_LENGTH + MMU2_EXTRUDER_HEATBREAK_LENGTH - logic.ExtraLoadDistance());
+    current_position[E_AXIS] -= (MMU2_EXTRUDER_PTFE_LENGTH - logic.ExtraLoadDistance());
     plan_buffer_line_curposXYZE(MMU2_LOAD_TO_NOZZLE_FEED_RATE);
 
     while(blocks_queued())


### PR DESCRIPTION
The issue is very apparent with a cold extruder. For example when starting a single color print with the MMU. I can hear grinding in the extruder gears at the very end of the sequence. This means the sequence is too long and we are likely pushing the filament too far into the extruder.

The purpose of the test is to check if the filament is actually present in the PTFE tube. My proposal is we reduce the length of the test to only cover the *length* of the PTFE tube. 

Change in memory:
Flash: 0 bytes
SRAM: 0 bytes