### PR TITLE
MMU2 split variant config

### DIFF
--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -1,4 +1,5 @@
 #include "mmu2.h"
+#include "mmu2_config.h"
 #include "mmu2_error_converter.h"
 #include "mmu2_fsensor.h"
 #include "mmu2_log.h"
@@ -17,76 +18,6 @@
 #include "cardreader.h" // for IS_SD_PRINTING
 #include "SpoolJoin.h"
 
-// As of FW 3.12 we only support building the FW with only one extruder, all the multi-extruder infrastructure will be removed.
-// Saves at least 800B of code size
-static_assert(EXTRUDERS==1);
-
-// Settings for filament load / unload from the LCD menu.
-// This is for Prusa MK3-style extruders. Customize for your hardware.
-#define MMU2_FILAMENTCHANGE_EJECT_FEED 80.0
-
-#define NOZZLE_PARK_XY_FEEDRATE 50
-#define NOZZLE_PARK_Z_FEEDRATE 15
-
-// Nominal distance from the extruder gear to the nozzle tip is 87mm
-// However, some slipping may occur and we need separate distances for
-// LoadToNozzle and ToolChange.
-// - +5mm seemed good for LoadToNozzle,
-// - but too much (made blobs) for a ToolChange
-static constexpr float MMU2_LOAD_TO_NOZZLE_LENGTH = 87.0F + 5.0F;
-
-// As discussed with our PrusaSlicer profile specialist
-// - ToolChange shall not try to push filament into the very tip of the nozzle
-// to have some space for additional G-code to tune the extruded filament length
-// in the profile
-// Beware - this value is used to initialize the MMU logic layer - it will be sent to the MMU upon line up (written into its 8bit register 0x0b)
-// However - in the G-code we can get a request to set the extra load distance at runtime to something else (M708 A0xb Xsomething).
-// The printer intercepts such a call and sets its extra load distance to match the new value as well.
-static constexpr uint8_t MMU2_TOOL_CHANGE_LOAD_LENGTH = 5; // mm
-
-static constexpr float MMU2_EXTRUDER_PTFE_LENGTH = 42.3f; // mm
-static constexpr float MMU2_EXTRUDER_HEATBREAK_LENGTH  = 17.7f; // mm
-
-static constexpr float MMU2_LOAD_TO_NOZZLE_FEED_RATE = 20.0F; // mm/s
-static constexpr float MMU2_UNLOAD_TO_FINDA_FEED_RATE = 120.0F; // mm/s
-
-// The first the MMU does is initialise its axis. Meanwhile the E-motor will unload 20mm of filament in approx. 1 second.
-static constexpr float MMU2_RETRY_UNLOAD_TO_FINDA_LENGTH = 80.0f; // mm
-static constexpr float MMU2_RETRY_UNLOAD_TO_FINDA_FEED_RATE = 80.0f; // mm/s
-
-static constexpr uint8_t MMU2_NO_TOOL = 99;
-static constexpr uint32_t MMU_BAUD = 115200;
-
-struct E_Step {
-    float extrude;       ///< extrude distance in mm
-    float feedRate; ///< feed rate in mm/s
-};
-
-static constexpr E_Step ramming_sequence[] PROGMEM = {
-    { 0.2816F,  1339.0F / 60.F},
-    { 0.3051F,  1451.0F / 60.F},
-    { 0.3453F,  1642.0F / 60.F},
-    { 0.3990F,  1897.0F / 60.F},
-    { 0.4761F,  2264.0F / 60.F},
-    { 0.5767F,  2742.0F / 60.F},
-    { 0.5691F,  3220.0F / 60.F},
-    { 0.1081F,  3220.0F / 60.F},
-    { 0.7644F,  3635.0F / 60.F},
-    { 0.8248F,  3921.0F / 60.F},
-    { 0.8483F,  4033.0F / 60.F},
-    { -15.0F,   6000.0F / 60.F},
-    { -24.5F,   1200.0F / 60.F},
-    { -7.0F,    600.0F / 60.F},
-    { -3.5F,    360.0F / 60.F},
-    { 20.0F,    454.0F / 60.F},
-    { -20.0F,   303.0F / 60.F},
-    { -35.0F,   2000.0F / 60.F},
-};
-
-static constexpr E_Step load_to_nozzle_sequence[] PROGMEM = { 
-    { 10.0F,  810.0F / 60.F}, // feed rate = 13.5mm/s - Load fast until filament reach end of nozzle
-    { 25.0F,  198.0F / 60.F}, // feed rate = 3.3mm/s  - Load slower once filament is out of the nozzle
-};
 
 namespace MMU2 {
 

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -18,6 +18,9 @@
 #include "cardreader.h" // for IS_SD_PRINTING
 #include "SpoolJoin.h"
 
+// As of FW 3.12 we only support building the FW with only one extruder, all the multi-extruder infrastructure will be removed.
+// Saves at least 800B of code size
+static_assert(EXTRUDERS==1);
 
 namespace MMU2 {
 

--- a/Firmware/mmu2/variants/config_MMU2.h
+++ b/Firmware/mmu2/variants/config_MMU2.h
@@ -23,9 +23,9 @@ static constexpr float MMU2_LOAD_TO_NOZZLE_LENGTH = 87.0F + 5.0F;
 // Beware - this value is used to initialize the MMU logic layer - it will be sent to the MMU upon line up (written into its 8bit register 0x0b)
 // However - in the G-code we can get a request to set the extra load distance at runtime to something else (M708 A0xb Xsomething).
 // The printer intercepts such a call and sets its extra load distance to match the new value as well.
-static constexpr uint8_t MMU2_TOOL_CHANGE_LOAD_LENGTH = 5; // mm
+static constexpr uint8_t MMU2_TOOL_CHANGE_LOAD_LENGTH = 5 + 16; // mm
 
-static constexpr float MMU2_EXTRUDER_PTFE_LENGTH = 42.3f; // mm
+static constexpr float MMU2_EXTRUDER_PTFE_LENGTH = 50.f; // mm
 static constexpr float MMU2_EXTRUDER_HEATBREAK_LENGTH  = 17.7f; // mm
 
 static constexpr float MMU2_LOAD_TO_NOZZLE_FEED_RATE = 20.0F; // mm/s

--- a/Firmware/mmu2/variants/config_MMU2.h
+++ b/Firmware/mmu2/variants/config_MMU2.h
@@ -1,0 +1,70 @@
+#pragma once
+#include <inttypes.h>
+#include <avr/pgmspace.h>
+
+// Settings for filament load / unload from the LCD menu.
+// This is for Prusa MK3-style extruders. Customize for your hardware.
+#define MMU2_FILAMENTCHANGE_EJECT_FEED 80.0
+
+#define NOZZLE_PARK_XY_FEEDRATE 50
+#define NOZZLE_PARK_Z_FEEDRATE 15
+
+// Nominal distance from the extruder gear to the nozzle tip is 87mm
+// However, some slipping may occur and we need separate distances for
+// LoadToNozzle and ToolChange.
+// - +5mm seemed good for LoadToNozzle,
+// - but too much (made blobs) for a ToolChange
+static constexpr float MMU2_LOAD_TO_NOZZLE_LENGTH = 87.0F + 5.0F;
+
+// As discussed with our PrusaSlicer profile specialist
+// - ToolChange shall not try to push filament into the very tip of the nozzle
+// to have some space for additional G-code to tune the extruded filament length
+// in the profile
+// Beware - this value is used to initialize the MMU logic layer - it will be sent to the MMU upon line up (written into its 8bit register 0x0b)
+// However - in the G-code we can get a request to set the extra load distance at runtime to something else (M708 A0xb Xsomething).
+// The printer intercepts such a call and sets its extra load distance to match the new value as well.
+static constexpr uint8_t MMU2_TOOL_CHANGE_LOAD_LENGTH = 5; // mm
+
+static constexpr float MMU2_EXTRUDER_PTFE_LENGTH = 42.3f; // mm
+static constexpr float MMU2_EXTRUDER_HEATBREAK_LENGTH  = 17.7f; // mm
+
+static constexpr float MMU2_LOAD_TO_NOZZLE_FEED_RATE = 20.0F; // mm/s
+static constexpr float MMU2_UNLOAD_TO_FINDA_FEED_RATE = 120.0F; // mm/s
+
+// The first the MMU does is initialise its axis. Meanwhile the E-motor will unload 20mm of filament in approx. 1 second.
+static constexpr float MMU2_RETRY_UNLOAD_TO_FINDA_LENGTH = 80.0f; // mm
+static constexpr float MMU2_RETRY_UNLOAD_TO_FINDA_FEED_RATE = 80.0f; // mm/s
+
+static constexpr uint8_t MMU2_NO_TOOL = 99;
+static constexpr uint32_t MMU_BAUD = 115200;
+
+struct E_Step {
+    float extrude;       ///< extrude distance in mm
+    float feedRate; ///< feed rate in mm/s
+};
+
+static constexpr E_Step ramming_sequence[] PROGMEM = {
+    { 0.2816F,  1339.0F / 60.F},
+    { 0.3051F,  1451.0F / 60.F},
+    { 0.3453F,  1642.0F / 60.F},
+    { 0.3990F,  1897.0F / 60.F},
+    { 0.4761F,  2264.0F / 60.F},
+    { 0.5767F,  2742.0F / 60.F},
+    { 0.5691F,  3220.0F / 60.F},
+    { 0.1081F,  3220.0F / 60.F},
+    { 0.7644F,  3635.0F / 60.F},
+    { 0.8248F,  3921.0F / 60.F},
+    { 0.8483F,  4033.0F / 60.F},
+    { -15.0F,   6000.0F / 60.F},
+    { -24.5F,   1200.0F / 60.F},
+    { -7.0F,    600.0F / 60.F},
+    { -3.5F,    360.0F / 60.F},
+    { 20.0F,    454.0F / 60.F},
+    { -20.0F,   303.0F / 60.F},
+    { -35.0F,   2000.0F / 60.F},
+};
+
+static constexpr E_Step load_to_nozzle_sequence[] PROGMEM = { 
+    { 10.0F,  810.0F / 60.F}, // feed rate = 13.5mm/s - Load fast until filament reach end of nozzle
+    { 25.0F,  198.0F / 60.F}, // feed rate = 3.3mm/s  - Load slower once filament is out of the nozzle
+};

--- a/Firmware/mmu2/variants/config_MMU2S.h
+++ b/Firmware/mmu2/variants/config_MMU2S.h
@@ -1,0 +1,70 @@
+#pragma once
+#include <inttypes.h>
+#include <avr/pgmspace.h>
+
+// Settings for filament load / unload from the LCD menu.
+// This is for Prusa MK3-style extruders. Customize for your hardware.
+#define MMU2_FILAMENTCHANGE_EJECT_FEED 80.0
+
+#define NOZZLE_PARK_XY_FEEDRATE 50
+#define NOZZLE_PARK_Z_FEEDRATE 15
+
+// Nominal distance from the extruder gear to the nozzle tip is 87mm
+// However, some slipping may occur and we need separate distances for
+// LoadToNozzle and ToolChange.
+// - +5mm seemed good for LoadToNozzle,
+// - but too much (made blobs) for a ToolChange
+static constexpr float MMU2_LOAD_TO_NOZZLE_LENGTH = 87.0F + 5.0F;
+
+// As discussed with our PrusaSlicer profile specialist
+// - ToolChange shall not try to push filament into the very tip of the nozzle
+// to have some space for additional G-code to tune the extruded filament length
+// in the profile
+// Beware - this value is used to initialize the MMU logic layer - it will be sent to the MMU upon line up (written into its 8bit register 0x0b)
+// However - in the G-code we can get a request to set the extra load distance at runtime to something else (M708 A0xb Xsomething).
+// The printer intercepts such a call and sets its extra load distance to match the new value as well.
+static constexpr uint8_t MMU2_TOOL_CHANGE_LOAD_LENGTH = 5; // mm
+
+static constexpr float MMU2_EXTRUDER_PTFE_LENGTH = 42.3f; // mm
+static constexpr float MMU2_EXTRUDER_HEATBREAK_LENGTH  = 17.7f; // mm
+
+static constexpr float MMU2_LOAD_TO_NOZZLE_FEED_RATE = 20.0F; // mm/s
+static constexpr float MMU2_UNLOAD_TO_FINDA_FEED_RATE = 120.0F; // mm/s
+
+// The first the MMU does is initialise its axis. Meanwhile the E-motor will unload 20mm of filament in approx. 1 second.
+static constexpr float MMU2_RETRY_UNLOAD_TO_FINDA_LENGTH = 80.0f; // mm
+static constexpr float MMU2_RETRY_UNLOAD_TO_FINDA_FEED_RATE = 80.0f; // mm/s
+
+static constexpr uint8_t MMU2_NO_TOOL = 99;
+static constexpr uint32_t MMU_BAUD = 115200;
+
+struct E_Step {
+    float extrude;       ///< extrude distance in mm
+    float feedRate; ///< feed rate in mm/s
+};
+
+static constexpr E_Step ramming_sequence[] PROGMEM = {
+    { 0.2816F,  1339.0F / 60.F},
+    { 0.3051F,  1451.0F / 60.F},
+    { 0.3453F,  1642.0F / 60.F},
+    { 0.3990F,  1897.0F / 60.F},
+    { 0.4761F,  2264.0F / 60.F},
+    { 0.5767F,  2742.0F / 60.F},
+    { 0.5691F,  3220.0F / 60.F},
+    { 0.1081F,  3220.0F / 60.F},
+    { 0.7644F,  3635.0F / 60.F},
+    { 0.8248F,  3921.0F / 60.F},
+    { 0.8483F,  4033.0F / 60.F},
+    { -15.0F,   6000.0F / 60.F},
+    { -24.5F,   1200.0F / 60.F},
+    { -7.0F,    600.0F / 60.F},
+    { -3.5F,    360.0F / 60.F},
+    { 20.0F,    454.0F / 60.F},
+    { -20.0F,   303.0F / 60.F},
+    { -35.0F,   2000.0F / 60.F},
+};
+
+static constexpr E_Step load_to_nozzle_sequence[] PROGMEM = { 
+    { 10.0F,  810.0F / 60.F}, // feed rate = 13.5mm/s - Load fast until filament reach end of nozzle
+    { 25.0F,  198.0F / 60.F}, // feed rate = 3.3mm/s  - Load slower once filament is out of the nozzle
+};

--- a/Firmware/mmu2_config.h
+++ b/Firmware/mmu2_config.h
@@ -1,0 +1,6 @@
+/// @file
+#pragma once
+
+// Include the correct MMU2 config based on the printer variant.
+#include "Configuration_var.h"
+#include MMU_CONFIG_FILE

--- a/Firmware/variants/1_75mm_MK25-RAMBo10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK25-RAMBo10a-E3Dv6full.h
@@ -502,6 +502,8 @@
 
 //#define SUPPORT_VERBOSITY
 
+#define MMU_CONFIG_FILE "mmu2/variants/config_MMU2.h"
+
 #define MMU_FILAMENT_COUNT 5
 
 #define MMU_REQUIRED_FW_BUILDNR 132

--- a/Firmware/variants/1_75mm_MK25-RAMBo13a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK25-RAMBo13a-E3Dv6full.h
@@ -503,6 +503,8 @@
 
 //#define SUPPORT_VERBOSITY
 
+#define MMU_CONFIG_FILE "mmu2/variants/config_MMU2.h"
+
 #define MMU_FILAMENT_COUNT 5
 
 #define MMU_REQUIRED_FW_BUILDNR 132

--- a/Firmware/variants/1_75mm_MK25S-RAMBo10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK25S-RAMBo10a-E3Dv6full.h
@@ -502,6 +502,8 @@
 
 //#define SUPPORT_VERBOSITY
 
+#define MMU_CONFIG_FILE "mmu2/variants/config_MMU2S.h"
+
 #define MMU_FILAMENT_COUNT 5
 
 #define MMU_REQUIRED_FW_BUILDNR 132

--- a/Firmware/variants/1_75mm_MK25S-RAMBo13a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK25S-RAMBo13a-E3Dv6full.h
@@ -503,6 +503,8 @@
 
 //#define SUPPORT_VERBOSITY
 
+#define MMU_CONFIG_FILE "mmu2/variants/config_MMU2S.h"
+
 #define MMU_FILAMENT_COUNT 5
 
 #define MMU_REQUIRED_FW_BUILDNR 132

--- a/Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h
@@ -676,6 +676,8 @@
 
 //#define SUPPORT_VERBOSITY
 
+#define MMU_CONFIG_FILE "mmu2/variants/config_MMU2.h"
+
 #define MMU_FILAMENT_COUNT 5
 
 #define MMU_REQUIRED_FW_BUILDNR 83

--- a/Firmware/variants/1_75mm_MK3S-EINSy10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK3S-EINSy10a-E3Dv6full.h
@@ -680,6 +680,8 @@
 
 //#define SUPPORT_VERBOSITY
 
+#define MMU_CONFIG_FILE "mmu2/variants/config_MMU2S.h"
+
 #define MMU_FILAMENT_COUNT 5
 
 #define MMU_REQUIRED_FW_BUILDNR 83


### PR DESCRIPTION
Separate the MMU2 config from the MMU2S config. This is due to the different extruder requiring different lengths of filament to be pushed/pulled.
This PR also changes the load to nozzle sequence so that it pushes enough filament.