### PR TITLE
MK3: Add translations for `Clear TM error` message

### DIFF
--- a/lang/po/Firmware.pot
+++ b/lang/po/Firmware.pot
@@ -327,6 +327,11 @@ msgstr ""
 msgid "Checks"
 msgstr ""
 
+#. MSG_TM_ACK_ERROR c=18
+#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:5490
+msgid "Clear TM error"
+msgstr ""
+
 #. MSG_NOT_COLOR c=19
 #: ../../Firmware/ultralcd.cpp:2223
 msgid "Color not correct"

--- a/lang/po/Firmware_cs.po
+++ b/lang/po/Firmware_cs.po
@@ -342,6 +342,11 @@ msgstr "Kontrola senzoru"
 msgid "Checks"
 msgstr "Kontrola"
 
+#. MSG_TM_ACK_ERROR c=18
+#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:5490
+msgid "Clear TM error"
+msgstr "Vymazat chybu TM"
+
 #. MSG_NOT_COLOR c=19
 #: ../../Firmware/ultralcd.cpp:2223
 msgid "Color not correct"

--- a/lang/po/Firmware_de.po
+++ b/lang/po/Firmware_de.po
@@ -344,6 +344,11 @@ msgstr "Prüfe Sensoren"
 msgid "Checks"
 msgstr "Kontrolle"
 
+#. MSG_TM_ACK_ERROR c=18
+#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:5490
+msgid "Clear TM error"
+msgstr "TM Fehler löschen"
+
 #. MSG_NOT_COLOR c=19
 #: ../../Firmware/ultralcd.cpp:2223
 msgid "Color not correct"

--- a/lang/po/Firmware_es.po
+++ b/lang/po/Firmware_es.po
@@ -342,6 +342,11 @@ msgstr "Comprobando sensores"
 msgid "Checks"
 msgstr "Comprobaciones"
 
+#. MSG_TM_ACK_ERROR c=18
+#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:5490
+msgid "Clear TM error"
+msgstr "Borrar error TM"
+
 #. MSG_NOT_COLOR c=19
 #: ../../Firmware/ultralcd.cpp:2223
 msgid "Color not correct"

--- a/lang/po/Firmware_fr.po
+++ b/lang/po/Firmware_fr.po
@@ -344,6 +344,11 @@ msgstr "Verif. des capteurs"
 msgid "Checks"
 msgstr "Verifications"
 
+#. MSG_TM_ACK_ERROR c=18
+#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:5490
+msgid "Clear TM error"
+msgstr "Effacer l'error TM"
+
 #. MSG_NOT_COLOR c=19
 #: ../../Firmware/ultralcd.cpp:2223
 msgid "Color not correct"

--- a/lang/po/Firmware_hr.po
+++ b/lang/po/Firmware_hr.po
@@ -342,6 +342,11 @@ msgstr "Provjera senzora"
 msgid "Checks"
 msgstr "Provjere"
 
+#. MSG_TM_ACK_ERROR c=18
+#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:5490
+msgid "Clear TM error"
+msgstr "Obriši TM pogrešku"
+
 #. MSG_NOT_COLOR c=19
 #: ../../Firmware/ultralcd.cpp:2223
 msgid "Color not correct"

--- a/lang/po/Firmware_hu.po
+++ b/lang/po/Firmware_hu.po
@@ -342,6 +342,11 @@ msgstr "Szenz. ellenorzese"
 msgid "Checks"
 msgstr "Ellenorzesek"
 
+#. MSG_TM_ACK_ERROR c=18
+#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:5490
+msgid "Clear TM error"
+msgstr "TM hiba törlése"
+
 #. MSG_NOT_COLOR c=19
 #: ../../Firmware/ultralcd.cpp:2223
 msgid "Color not correct"

--- a/lang/po/Firmware_it.po
+++ b/lang/po/Firmware_it.po
@@ -342,6 +342,11 @@ msgstr "Controllo sensori"
 msgid "Checks"
 msgstr "Controlli"
 
+#. MSG_TM_ACK_ERROR c=18
+#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:5490
+msgid "Clear TM error"
+msgstr "Cancella errore TM"
+
 #. MSG_NOT_COLOR c=19
 #: ../../Firmware/ultralcd.cpp:2223
 msgid "Color not correct"

--- a/lang/po/Firmware_nl.po
+++ b/lang/po/Firmware_nl.po
@@ -344,6 +344,11 @@ msgstr "Controleer sensors"
 msgid "Checks"
 msgstr "Checks"
 
+#. MSG_TM_ACK_ERROR c=18
+#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:5490
+msgid "Clear TM error"
+msgstr "TM-fout wissen"
+
 #. MSG_NOT_COLOR c=19
 #: ../../Firmware/ultralcd.cpp:2223
 msgid "Color not correct"

--- a/lang/po/Firmware_no.po
+++ b/lang/po/Firmware_no.po
@@ -343,6 +343,11 @@ msgstr "Sjekker sensorer"
 msgid "Checks"
 msgstr "G-code sjekk"
 
+#. MSG_TM_ACK_ERROR c=18
+#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:5490
+msgid "Clear TM error"
+msgstr "Fjern TM-feil"
+
 #. MSG_NOT_COLOR c=19
 #: ../../Firmware/ultralcd.cpp:2223
 msgid "Color not correct"

--- a/lang/po/Firmware_pl.po
+++ b/lang/po/Firmware_pl.po
@@ -342,6 +342,11 @@ msgstr "Kontrola czujnikow"
 msgid "Checks"
 msgstr "Testy"
 
+#. MSG_TM_ACK_ERROR c=18
+#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:5490
+msgid "Clear TM error"
+msgstr "Wyczyść błąd TM"
+
 #. MSG_NOT_COLOR c=19
 #: ../../Firmware/ultralcd.cpp:2223
 msgid "Color not correct"

--- a/lang/po/Firmware_ro.po
+++ b/lang/po/Firmware_ro.po
@@ -345,6 +345,11 @@ msgstr "Verificare senzori"
 msgid "Checks"
 msgstr "Verificari"
 
+#. MSG_TM_ACK_ERROR c=18
+#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:5490
+msgid "Clear TM error"
+msgstr "Ștergeți eroare TM"
+
 #. MSG_NOT_COLOR c=19
 #: ../../Firmware/ultralcd.cpp:2223
 msgid "Color not correct"

--- a/lang/po/Firmware_sk.po
+++ b/lang/po/Firmware_sk.po
@@ -342,6 +342,11 @@ msgstr "Kontrola senzorov"
 msgid "Checks"
 msgstr "Kontroly"
 
+#. MSG_TM_ACK_ERROR c=18
+#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:5490
+msgid "Clear TM error"
+msgstr "Vymazanie chyby TM"
+
 #. MSG_NOT_COLOR c=19
 #: ../../Firmware/ultralcd.cpp:2223
 msgid "Color not correct"

--- a/lang/po/Firmware_sv.po
+++ b/lang/po/Firmware_sv.po
@@ -342,6 +342,11 @@ msgstr "Kontroll sensorer"
 msgid "Checks"
 msgstr "Kontroller"
 
+#. MSG_TM_ACK_ERROR c=18
+#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:5490
+msgid "Clear TM error"
+msgstr "Rensa TM-fel"
+
 #. MSG_NOT_COLOR c=19
 #: ../../Firmware/ultralcd.cpp:2223
 msgid "Color not correct"


### PR DESCRIPTION
Please check if the translations are okay? This menu/message allows to acknowledge or clear a temp model error to "unlock" the printer.
Please vote with
:+1: if okay
:-1:  if needs to be changed  with a comment what is correct.
 
@Hauzman @AttilaSVK @Prime1910 @ingbrzy @shatter136 @Painkiller56 @OS-kar

- [x] Create Cherry-pick PR to MK3_3.12 branch