### PR TITLE
Show an error screen when try-unload fails to push filament into nozzle

### DIFF
--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -440,33 +440,36 @@ bool MMU2::unload() {
     return true;
 }
 
-bool MMU2::cut_filament(uint8_t slot){
-    if( ! WaitForMMUReady())
-        return false;
-
-    if( FindaDetectsFilament() ){
-        unload();
-    }
-
-    ReportingRAII rep(CommandInProgress::CutFilament);
-    for(;;){
-        logic.CutFilament(slot);
-        if( manage_response(false, true) )
-            break;
-        IncrementMMUFails();
-    }
-    extruder = MMU2_NO_TOOL;
-    tool_change_extruder = MMU2_NO_TOOL;
-    Sound_MakeSound(e_SOUND_TYPE_StandardConfirm);
-    return true;
-}
-
 void FullScreenMsg(const char *pgmS, uint8_t slot){
     lcd_update_enable(false);
     lcd_clear();
     lcd_puts_at_P(0, 1, pgmS);
     lcd_print(' ');
     lcd_print(slot + 1);
+}
+
+bool MMU2::cut_filament(uint8_t slot){
+    if( ! WaitForMMUReady())
+        return false;
+
+    FullScreenMsg(_T(MSG_CUT_FILAMENT), slot);
+    {
+        if( FindaDetectsFilament() ){
+            unload();
+        }
+
+        ReportingRAII rep(CommandInProgress::CutFilament);
+        for(;;){
+            logic.CutFilament(slot);
+            if( manage_response(false, true) )
+                break;
+            IncrementMMUFails();
+        }
+    }
+    extruder = MMU2_NO_TOOL;
+    tool_change_extruder = MMU2_NO_TOOL;
+    Sound_MakeSound(e_SOUND_TYPE_StandardConfirm);
+    return true;
 }
 
 bool MMU2::loading_test(uint8_t slot){
@@ -541,16 +544,19 @@ bool MMU2::eject_filament(uint8_t slot, bool recover) {
     if( ! WaitForMMUReady())
         return false;
 
-    if( FindaDetectsFilament() ){
-        unload();
-    }
+    FullScreenMsg(_T(MSG_EJECT_FILAMENT), slot);
+    {
+        if( FindaDetectsFilament() ){
+            unload();
+        }
 
-    ReportingRAII rep(CommandInProgress::EjectFilament);
-    for(;;) {
-        logic.EjectFilament(slot);
-        if( manage_response(false, true) )
-            break;
-        IncrementMMUFails();
+        ReportingRAII rep(CommandInProgress::EjectFilament);
+        for(;;) {
+            logic.EjectFilament(slot);
+            if( manage_response(false, true) )
+                break;
+            IncrementMMUFails();
+        }
     }
     extruder = MMU2_NO_TOOL;
     tool_change_extruder = MMU2_NO_TOOL;

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -250,9 +250,9 @@ bool MMU2::VerifyFilamentEnteredPTFE()
     // MMU has finished its load, push the filament further by some defined constant length
     // If the filament sensor reads 0 at any moment, then report FAILURE
     current_position[E_AXIS] += MMU2_EXTRUDER_PTFE_LENGTH + MMU2_EXTRUDER_HEATBREAK_LENGTH - (logic.ExtraLoadDistance() - MMU2_FILAMENT_SENSOR_POSITION);
-    plan_buffer_line_curposXYZE(MMU2_LOAD_TO_NOZZLE_FEED_RATE);
+    plan_buffer_line_curposXYZE(MMU2_VERIFY_LOAD_TO_NOZZLE_FEED_RATE);
     current_position[E_AXIS] -= (MMU2_EXTRUDER_PTFE_LENGTH + MMU2_EXTRUDER_HEATBREAK_LENGTH - (logic.ExtraLoadDistance() - MMU2_FILAMENT_SENSOR_POSITION));
-    plan_buffer_line_curposXYZE(MMU2_LOAD_TO_NOZZLE_FEED_RATE);
+    plan_buffer_line_curposXYZE(MMU2_VERIFY_LOAD_TO_NOZZLE_FEED_RATE);
 
     while(blocks_queued())
     {

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -317,7 +317,7 @@ void MMU2::ToolChangeCommon(uint8_t slot){
         // Please see CheckUserInput() for details how we "leave" manage_response.
         // If manage_response returns false at this spot (MMU operation interrupted aka MMU reset)
         // we can safely continue because the MMU is not doing an operation now.
-        manage_response(true, true);
+        static_cast<void>(manage_response(true, true)); // yes, I'd like to silence [[nodiscard]] warning at this spot by casting to void
     }
 
     extruder = slot; //filament change is finished

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -309,7 +309,7 @@ void MMU2::ToolChangeCommon(uint8_t slot){
             break;
         } else {
             // failed autoretry, report an error by forcing a "printer" error into the MMU infrastructure - it is a hack to leverage existing code
-            logic.SetPrinterError(ErrorCode::TRY_LOAD_UNLOAD_FAILED);
+            logic.SetPrinterError(ErrorCode::LOAD_TO_EXTRUDER_FAILED);
             SaveAndPark(true);
             SaveHotendTemp(true);
             // We only have to wait for the user to fix the issue and press "Retry".

--- a/Firmware/mmu2.h
+++ b/Firmware/mmu2.h
@@ -294,6 +294,7 @@ private:
 
     /// Common processing of pushing filament into the extruder - shared by tool_change, load_to_nozzle and probably others
     void ToolChangeCommon(uint8_t slot);
+    bool ToolChangeCommonOnce(uint8_t slot);
 
     void HelpUnloadToFinda();
 

--- a/Firmware/mmu2/error_codes.h
+++ b/Firmware/mmu2/error_codes.h
@@ -54,6 +54,8 @@ enum class ErrorCode : uint_fast16_t {
     MOVE_IDLER_FAILED = MOVE_FAILED | TMC_IDLER_BIT, ///< E33033 the Idler was unable to move - unused at the time of creation, but added for completeness
     MOVE_PULLEY_FAILED = MOVE_FAILED | TMC_PULLEY_BIT, ///< E32841 the Pulley was unable to move - unused at the time of creation, but added for completeness
 
+    FILAMENT_EJECTED = 0x800c, ///< Filament was ejected, waiting for user input - technically, this is not an error
+
     LOAD_TO_EXTRUDER_FAILED = 0x802a, ///< E32811 internal error of the printer - try-load-unload sequence detected missing filament -> failed load into the nozzle
     QUEUE_FULL = 0x802b, ///< E32811 internal logic error - attempt to move with a full queue
     VERSION_MISMATCH = 0x802c, ///< E32812 internal error of the printer - incompatible version of the MMU FW

--- a/Firmware/mmu2/error_codes.h
+++ b/Firmware/mmu2/error_codes.h
@@ -56,7 +56,7 @@ enum class ErrorCode : uint_fast16_t {
 
     QUEUE_FULL = 0x802b, ///< E32811 internal logic error - attempt to move with a full queue
 
-    TRY_LOAD_UNLOAD_FAILED = 0x802b, ///< E32811 internal error of the printer - try-load-unload sequence detected missing filament -> failed load into the nozzle
+    LOAD_TO_EXTRUDER_FAILED = 0x802b, ///< E32811 internal error of the printer - try-load-unload sequence detected missing filament -> failed load into the nozzle
     VERSION_MISMATCH = 0x802c, ///< E32812 internal error of the printer - incompatible version of the MMU FW
     PROTOCOL_ERROR = 0x802d, ///< E32813 internal error of the printer - communication with the MMU got garbled - protocol decoder couldn't decode the incoming messages
     MMU_NOT_RESPONDING = 0x802e, ///< E32814 internal error of the printer - communication with the MMU is not working

--- a/Firmware/mmu2/error_codes.h
+++ b/Firmware/mmu2/error_codes.h
@@ -56,6 +56,7 @@ enum class ErrorCode : uint_fast16_t {
 
     QUEUE_FULL = 0x802b, ///< E32811 internal logic error - attempt to move with a full queue
 
+    TRY_LOAD_UNLOAD_FAILED = 0x802b, ///< E32811 internal error of the printer - try-load-unload sequence detected missing filament -> failed load into the nozzle
     VERSION_MISMATCH = 0x802c, ///< E32812 internal error of the printer - incompatible version of the MMU FW
     PROTOCOL_ERROR = 0x802d, ///< E32813 internal error of the printer - communication with the MMU got garbled - protocol decoder couldn't decode the incoming messages
     MMU_NOT_RESPONDING = 0x802e, ///< E32814 internal error of the printer - communication with the MMU is not working

--- a/Firmware/mmu2/error_codes.h
+++ b/Firmware/mmu2/error_codes.h
@@ -54,9 +54,8 @@ enum class ErrorCode : uint_fast16_t {
     MOVE_IDLER_FAILED = MOVE_FAILED | TMC_IDLER_BIT, ///< E33033 the Idler was unable to move - unused at the time of creation, but added for completeness
     MOVE_PULLEY_FAILED = MOVE_FAILED | TMC_PULLEY_BIT, ///< E32841 the Pulley was unable to move - unused at the time of creation, but added for completeness
 
+    LOAD_TO_EXTRUDER_FAILED = 0x802a, ///< E32811 internal error of the printer - try-load-unload sequence detected missing filament -> failed load into the nozzle
     QUEUE_FULL = 0x802b, ///< E32811 internal logic error - attempt to move with a full queue
-
-    LOAD_TO_EXTRUDER_FAILED = 0x802b, ///< E32811 internal error of the printer - try-load-unload sequence detected missing filament -> failed load into the nozzle
     VERSION_MISMATCH = 0x802c, ///< E32812 internal error of the printer - incompatible version of the MMU FW
     PROTOCOL_ERROR = 0x802d, ///< E32813 internal error of the printer - communication with the MMU got garbled - protocol decoder couldn't decode the incoming messages
     MMU_NOT_RESPONDING = 0x802e, ///< E32814 internal error of the printer - communication with the MMU is not working

--- a/Firmware/mmu2/errors_list.h
+++ b/Firmware/mmu2/errors_list.h
@@ -218,7 +218,7 @@ static const char MSG_DESC_FSENSOR_DIDNT_GO_OFF[] PROGMEM_I1 = ISTR("Filament se
 static const char MSG_DESC_PULLEY_STALLED[] PROGMEM_I1 = ISTR("Pulley motor stalled. Ensure the pulley can move and check the wiring."); ////MSG_DESC_PULLEY_STALLED c=20 r=8
 static const char MSG_DESC_FSENSOR_TOO_EARLY[] PROGMEM_I1 = ISTR("Filament sensor triggered too early while loading to extruder. Check there isn't anything stuck in PTFE tube. Check that sensor reads properly."); ////MSG_DESC_FSENSOR_TOO_EARLY c=20 r=8
 static const char MSG_DESC_INSPECT_FINDA[] PROGMEM_I1 = ISTR("Selector can't move due to FINDA detecting a filament. Make sure no filament is in selector and FINDA works properly."); ////MSG_DESC_INSPECT_FINDA c=20 r=8
-static const char MSG_DESC_LOAD_TO_EXTRUDER_FAILED[] PROGMEM_I1 = ISTR("@@TODO - load to extruder failed."); ////MSG_DESC_LOAD_TO_EXTRUDER_FAILED c=20 r=8
+static const char MSG_DESC_LOAD_TO_EXTRUDER_FAILED[] PROGMEM_I1 = ISTR("Loading to extruder failed. Inspect the filament tip shape. Refine the sensor calibration, if needed."); ////MSG_DESC_LOAD_TO_EXTRUDER_FAILED c=20 r=8
 static const char MSG_DESC_SELECTOR_CANNOT_HOME[] PROGMEM_I1 = ISTR("The Selector cannot home properly. Check for anything blocking its movement."); ////MSG_DESC_SELECTOR_CANNOT_HOME c=20 r=8
 static const char MSG_DESC_CANNOT_MOVE[] PROGMEM_I1 = ISTR("Can't move Selector or Idler."); /////MSG_DESC_CANNOT_MOVE c=20 r=4
 //static const char MSG_DESC_SELECTOR_CANNOT_MOVE[] PROGMEM_I1 = ISTR("The Selector cannot move. Check for anything blocking its movement. Check the wiring is correct.");
@@ -250,7 +250,7 @@ static const char MSG_DESC_INVALID_TOOL[] PROGMEM_I1 = ISTR("Requested filament 
 static const char MSG_DESC_QUEUE_FULL[] PROGMEM_I1 = ISTR("MMU Firmware internal error, please reset the MMU."); ////MSG_DESC_QUEUE_FULL c=20 r=8
 static const char MSG_DESC_FW_UPDATE_NEEDED[] PROGMEM_I1 = ISTR("The MMU unit reports its FW version incompatible with the printer's firmware. Make sure the MMU firmware is up to date."); ////MSG_DESC_FW_UPDATE_NEEDED c=20 r=9
 static const char MSG_DESC_FW_RUNTIME_ERROR[] PROGMEM_I1 = ISTR("Internal runtime error. Try resetting the MMU unit or updating the firmware. If the issue persists, contact support."); ////MSG_DESC_FW_RUNTIME_ERROR c=20 r=11
-static const char MSG_DESC_UNLOAD_MANUALLY[] PROGMEM_I1 = ISTR("Unexpected FINDA reading. Ensure no filament is under FINDA and the selector is free. Check FINDA connection."); ////MSG_DESC_UNLOAD_MANUALLY c=20 r=8
+static const char MSG_DESC_UNLOAD_MANUALLY[] PROGMEM_I1 = ISTR("Filament detected unexpectedly. Ensure no filament is loaded. Check the sensors and wiring."); ////MSG_DESC_UNLOAD_MANUALLY c=20 r=8
 
 static const char * const errorDescs[] PROGMEM = {
     _R(MSG_DESC_FINDA_DIDNT_TRIGGER),

--- a/Firmware/mmu2/errors_list.h
+++ b/Firmware/mmu2/errors_list.h
@@ -23,6 +23,7 @@ typedef enum : uint16_t {
     ERR_MECHANICAL_PULLEY_CANNOT_MOVE = 105,
     ERR_MECHANICAL_FSENSOR_TOO_EARLY = 106,
     ERR_MECHANICAL_INSPECT_FINDA = 107,
+    ERR_MECHANICAL_LOAD_TO_EXTRUDER_FAILED = 108,
     ERR_MECHANICAL_SELECTOR_CANNOT_HOME = 115,
     ERR_MECHANICAL_SELECTOR_CANNOT_MOVE = 116,
     ERR_MECHANICAL_IDLER_CANNOT_HOME = 125,
@@ -87,6 +88,7 @@ static const constexpr uint16_t errorCodes[] PROGMEM = {
     ERR_MECHANICAL_PULLEY_CANNOT_MOVE,
     ERR_MECHANICAL_FSENSOR_TOO_EARLY,
     ERR_MECHANICAL_INSPECT_FINDA,
+    ERR_MECHANICAL_LOAD_TO_EXTRUDER_FAILED,
     ERR_MECHANICAL_SELECTOR_CANNOT_HOME,
     ERR_MECHANICAL_SELECTOR_CANNOT_MOVE,
     ERR_MECHANICAL_IDLER_CANNOT_HOME,
@@ -130,6 +132,7 @@ static const char MSG_TITLE_FSENSOR_DIDNT_GO_OFF[] PROGMEM_I1    = ISTR("FSENSOR
 static const char MSG_TITLE_PULLEY_CANNOT_MOVE[] PROGMEM_I1      = ISTR("PULLEY CANNOT MOVE"); ////MSG_TITLE_PULLEY_CANNOT_MOVE c=20
 static const char MSG_TITLE_FSENSOR_TOO_EARLY[] PROGMEM_I1       = ISTR("FSENSOR TOO EARLY"); ////MSG_TITLE_FSENSOR_TOO_EARLY c=20
 static const char MSG_TITLE_INSPECT_FINDA[] PROGMEM_I1           = ISTR("INSPECT FINDA"); ////MSG_TITLE_INSPECT_FINDA c=20
+static const char MSG_TITLE_LOAD_TO_EXTRUDER_FAILED[] PROGMEM_I1 = ISTR("LOAD TO EXTR. FAILED"); ////MSG_TITLE_LOAD_TO_EXTRUDER_FAILED c=20
 static const char MSG_TITLE_SELECTOR_CANNOT_MOVE[] PROGMEM_I1    = ISTR("SELECTOR CANNOT MOVE"); ////MSG_TITLE_SELECTOR_CANNOT_MOVE c=20
 static const char MSG_TITLE_SELECTOR_CANNOT_HOME[] PROGMEM_I1    = ISTR("SELECTOR CANNOT HOME"); ////MSG_TITLE_SELECTOR_CANNOT_HOME c=20
 static const char MSG_TITLE_IDLER_CANNOT_MOVE[] PROGMEM_I1       = ISTR("IDLER CANNOT MOVE"); ////MSG_TITLE_IDLER_CANNOT_MOVE c=20
@@ -170,6 +173,7 @@ static const char * const errorTitles [] PROGMEM = {
     _R(MSG_TITLE_PULLEY_CANNOT_MOVE),
     _R(MSG_TITLE_FSENSOR_TOO_EARLY),
     _R(MSG_TITLE_INSPECT_FINDA),
+    _R(MSG_TITLE_LOAD_TO_EXTRUDER_FAILED),
     _R(MSG_TITLE_SELECTOR_CANNOT_HOME),
     _R(MSG_TITLE_SELECTOR_CANNOT_MOVE),
     _R(MSG_TITLE_IDLER_CANNOT_HOME),
@@ -214,6 +218,7 @@ static const char MSG_DESC_FSENSOR_DIDNT_GO_OFF[] PROGMEM_I1 = ISTR("Filament se
 static const char MSG_DESC_PULLEY_STALLED[] PROGMEM_I1 = ISTR("Pulley motor stalled. Ensure the pulley can move and check the wiring."); ////MSG_DESC_PULLEY_STALLED c=20 r=8
 static const char MSG_DESC_FSENSOR_TOO_EARLY[] PROGMEM_I1 = ISTR("Filament sensor triggered too early while loading to extruder. Check there isn't anything stuck in PTFE tube. Check that sensor reads properly."); ////MSG_DESC_FSENSOR_TOO_EARLY c=20 r=8
 static const char MSG_DESC_INSPECT_FINDA[] PROGMEM_I1 = ISTR("Selector can't move due to FINDA detecting a filament. Make sure no filament is in selector and FINDA works properly."); ////MSG_DESC_INSPECT_FINDA c=20 r=8
+static const char MSG_DESC_LOAD_TO_EXTRUDER_FAILED[] PROGMEM_I1 = ISTR("@@TODO - load to extruder failed."); ////MSG_DESC_LOAD_TO_EXTRUDER_FAILED c=20 r=8
 static const char MSG_DESC_SELECTOR_CANNOT_HOME[] PROGMEM_I1 = ISTR("The Selector cannot home properly. Check for anything blocking its movement."); ////MSG_DESC_SELECTOR_CANNOT_HOME c=20 r=8
 static const char MSG_DESC_CANNOT_MOVE[] PROGMEM_I1 = ISTR("Can't move Selector or Idler."); /////MSG_DESC_CANNOT_MOVE c=20 r=4
 //static const char MSG_DESC_SELECTOR_CANNOT_MOVE[] PROGMEM_I1 = ISTR("The Selector cannot move. Check for anything blocking its movement. Check the wiring is correct.");
@@ -255,6 +260,7 @@ static const char * const errorDescs[] PROGMEM = {
     _R(MSG_DESC_PULLEY_STALLED),
     _R(MSG_DESC_FSENSOR_TOO_EARLY),
     _R(MSG_DESC_INSPECT_FINDA),
+    _R(MSG_DESC_LOAD_TO_EXTRUDER_FAILED),
     _R(MSG_DESC_SELECTOR_CANNOT_HOME),
     _R(MSG_DESC_CANNOT_MOVE),
     _R(MSG_DESC_IDLER_CANNOT_HOME),
@@ -332,6 +338,7 @@ static const uint8_t errorButtons[] PROGMEM = {
     Btns(ButtonOperations::Retry, ButtonOperations::NoOperation),//PULLEY_STALLED
     Btns(ButtonOperations::Retry, ButtonOperations::NoOperation),//FSENSOR_TOO_EARLY
     Btns(ButtonOperations::Retry, ButtonOperations::NoOperation),//INSPECT_FINDA
+    Btns(ButtonOperations::Continue, ButtonOperations::NoOperation),//LOAD_TO_EXTRUDER_FAILED
     Btns(ButtonOperations::Retry, ButtonOperations::NoOperation),//SELECTOR_CANNOT_HOME
     Btns(ButtonOperations::Retry, ButtonOperations::NoOperation),//SELECTOR_CANNOT_MOVE
     Btns(ButtonOperations::Retry, ButtonOperations::NoOperation),//IDLER_CANNOT_HOME

--- a/Firmware/mmu2/errors_list.h
+++ b/Firmware/mmu2/errors_list.h
@@ -72,6 +72,7 @@ typedef enum : uint16_t {
     ERR_SYSTEM_FW_UPDATE_NEEDED = 504,
     ERR_SYSTEM_FW_RUNTIME_ERROR = 505,
     ERR_SYSTEM_UNLOAD_MANUALLY = 506,
+    ERR_SYSTEM_FILAMENT_EJECTED = 507,
 
     ERR_OTHER = 900
 } err_num_t;
@@ -121,7 +122,8 @@ static const constexpr uint16_t errorCodes[] PROGMEM = {
     ERR_SYSTEM_QUEUE_FULL, 
     ERR_SYSTEM_FW_UPDATE_NEEDED, 
     ERR_SYSTEM_FW_RUNTIME_ERROR,
-    ERR_SYSTEM_UNLOAD_MANUALLY
+    ERR_SYSTEM_UNLOAD_MANUALLY,
+    ERR_SYSTEM_FILAMENT_EJECTED
 };
 
 // @@TODO some of the strings are duplicates, can be merged into one     01234567890123456789
@@ -164,6 +166,7 @@ static const char MSG_TITLE_QUEUE_FULL[] PROGMEM_I1              = ISTR("QUEUE F
 static const char MSG_TITLE_FW_UPDATE_NEEDED[] PROGMEM_I1        = ISTR("MMU FW UPDATE NEEDED"); ////MSG_TITLE_FW_UPDATE_NEEDED c=20
 static const char MSG_TITLE_FW_RUNTIME_ERROR[] PROGMEM_I1        = ISTR("FW RUNTIME ERROR"); ////MSG_TITLE_FW_RUNTIME_ERROR c=20
 static const char MSG_TITLE_UNLOAD_MANUALLY[] PROGMEM_I1         = ISTR("UNLOAD MANUALLY"); ////MSG_TITLE_UNLOAD_MANUALLY c=20
+static const char MSG_TITLE_FILAMENT_EJECTED[] PROGMEM_I1        = ISTR("FILAMENT EJECTED"); ////MSG_TITLE_FILAMENT_EJECTED c=20
 
 static const char * const errorTitles [] PROGMEM = {
     _R(MSG_TITLE_FINDA_DIDNT_TRIGGER),
@@ -206,7 +209,8 @@ static const char * const errorTitles [] PROGMEM = {
     _R(MSG_TITLE_QUEUE_FULL),
     _R(MSG_TITLE_FW_UPDATE_NEEDED),
     _R(MSG_TITLE_FW_RUNTIME_ERROR),
-    _R(MSG_TITLE_UNLOAD_MANUALLY)
+    _R(MSG_TITLE_UNLOAD_MANUALLY),
+    _R(MSG_TITLE_FILAMENT_EJECTED)
 };
 
 // @@TODO looking at the texts, they can be composed of several parts and/or parametrized (could save a lot of space ;) )
@@ -251,6 +255,7 @@ static const char MSG_DESC_QUEUE_FULL[] PROGMEM_I1 = ISTR("MMU Firmware internal
 static const char MSG_DESC_FW_UPDATE_NEEDED[] PROGMEM_I1 = ISTR("The MMU unit reports its FW version incompatible with the printer's firmware. Make sure the MMU firmware is up to date."); ////MSG_DESC_FW_UPDATE_NEEDED c=20 r=9
 static const char MSG_DESC_FW_RUNTIME_ERROR[] PROGMEM_I1 = ISTR("Internal runtime error. Try resetting the MMU unit or updating the firmware. If the issue persists, contact support."); ////MSG_DESC_FW_RUNTIME_ERROR c=20 r=11
 static const char MSG_DESC_UNLOAD_MANUALLY[] PROGMEM_I1 = ISTR("Filament detected unexpectedly. Ensure no filament is loaded. Check the sensors and wiring."); ////MSG_DESC_UNLOAD_MANUALLY c=20 r=8
+static const char MSG_DESC_FILAMENT_EJECTED[] PROGMEM_I1 = ISTR("Remove the ejected filament from the front of the MMU unit."); ////MSG_DESC_FILAMENT_EJECTED c=20 r=8
 
 static const char * const errorDescs[] PROGMEM = {
     _R(MSG_DESC_FINDA_DIDNT_TRIGGER),
@@ -293,7 +298,8 @@ static const char * const errorDescs[] PROGMEM = {
     _R(MSG_DESC_QUEUE_FULL),
     _R(MSG_DESC_FW_UPDATE_NEEDED),
     _R(MSG_DESC_FW_RUNTIME_ERROR),
-    _R(MSG_DESC_UNLOAD_MANUALLY)
+    _R(MSG_DESC_UNLOAD_MANUALLY),
+    _R(MSG_DESC_FILAMENT_EJECTED)
 };
 
 // we have max 3 buttons/operations to select from
@@ -375,6 +381,7 @@ static const uint8_t errorButtons[] PROGMEM = {
     Btns(ButtonOperations::DisableMMU, ButtonOperations::NoOperation),//FW_UPDATE_NEEDED
     Btns(ButtonOperations::RestartMMU, ButtonOperations::NoOperation),//FW_RUNTIME_ERROR
     Btns(ButtonOperations::Retry, ButtonOperations::NoOperation),//UNLOAD_MANUALLY
+    Btns(ButtonOperations::Continue, ButtonOperations::NoOperation),//FILAMENT_EJECTED
 };
 
 static_assert( sizeof(errorCodes) / sizeof(errorCodes[0]) == sizeof(errorDescs) / sizeof (errorDescs[0]));

--- a/Firmware/mmu2/variants/config_MMU2.h
+++ b/Firmware/mmu2/variants/config_MMU2.h
@@ -33,6 +33,8 @@ static constexpr float MMU2_EXTRUDER_HEATBREAK_LENGTH  = 17.7f; // mm
 static constexpr float MMU2_LOAD_TO_NOZZLE_FEED_RATE = 20.0F; // mm/s
 static constexpr float MMU2_UNLOAD_TO_FINDA_FEED_RATE = 120.0F; // mm/s
 
+static constexpr float MMU2_VERIFY_LOAD_TO_NOZZLE_FEED_RATE = 50.0F; // mm/s
+
 // The first the MMU does is initialise its axis. Meanwhile the E-motor will unload 20mm of filament in approx. 1 second.
 static constexpr float MMU2_RETRY_UNLOAD_TO_FINDA_LENGTH = 80.0f; // mm
 static constexpr float MMU2_RETRY_UNLOAD_TO_FINDA_FEED_RATE = 80.0f; // mm/s

--- a/Firmware/mmu2/variants/config_MMU2S.h
+++ b/Firmware/mmu2/variants/config_MMU2S.h
@@ -33,6 +33,8 @@ static constexpr float MMU2_EXTRUDER_HEATBREAK_LENGTH  = 17.7f; // mm
 static constexpr float MMU2_LOAD_TO_NOZZLE_FEED_RATE = 20.0F; // mm/s
 static constexpr float MMU2_UNLOAD_TO_FINDA_FEED_RATE = 120.0F; // mm/s
 
+static constexpr float MMU2_VERIFY_LOAD_TO_NOZZLE_FEED_RATE = 50.0F; // mm/s
+
 // The first the MMU does is initialise its axis. Meanwhile the E-motor will unload 20mm of filament in approx. 1 second.
 static constexpr float MMU2_RETRY_UNLOAD_TO_FINDA_LENGTH = 80.0f; // mm
 static constexpr float MMU2_RETRY_UNLOAD_TO_FINDA_FEED_RATE = 80.0f; // mm/s

--- a/Firmware/mmu2_error_converter.cpp
+++ b/Firmware/mmu2_error_converter.cpp
@@ -49,6 +49,8 @@ uint8_t PrusaErrorCodeIndex(uint16_t ec) {
         return FindErrorIndex(ERR_MECHANICAL_FSENSOR_TOO_EARLY);
     case (uint16_t)ErrorCode::FINDA_FLICKERS:
         return FindErrorIndex(ERR_MECHANICAL_INSPECT_FINDA);
+    case (uint16_t)ErrorCode::LOAD_TO_EXTRUDER_FAILED:
+        return FindErrorIndex(ERR_MECHANICAL_LOAD_TO_EXTRUDER_FAILED);
 
     case (uint16_t)ErrorCode::STALLED_PULLEY:
     case (uint16_t)ErrorCode::MOVE_PULLEY_FAILED:
@@ -222,7 +224,14 @@ Buttons ButtonAvailable(uint16_t ec) {
             break;
         }
         break;
-        
+    case ERR_MECHANICAL_LOAD_TO_EXTRUDER_FAILED:
+        switch (buttonSelectedOperation) {
+        case ButtonOperations::Continue: // User solved the serious mechanical problem by hand - there is no other way around
+            return Middle;
+        default:
+            break;
+        }
+        break;
     case ERR_TEMPERATURE_PULLEY_WARNING_TMC_TOO_HOT:
     case ERR_TEMPERATURE_SELECTOR_WARNING_TMC_TOO_HOT:
     case ERR_TEMPERATURE_IDLER_WARNING_TMC_TOO_HOT:

--- a/Firmware/mmu2_error_converter.cpp
+++ b/Firmware/mmu2_error_converter.cpp
@@ -51,6 +51,8 @@ uint8_t PrusaErrorCodeIndex(uint16_t ec) {
         return FindErrorIndex(ERR_MECHANICAL_INSPECT_FINDA);
     case (uint16_t)ErrorCode::LOAD_TO_EXTRUDER_FAILED:
         return FindErrorIndex(ERR_MECHANICAL_LOAD_TO_EXTRUDER_FAILED);
+    case (uint16_t)ErrorCode::FILAMENT_EJECTED:
+        return FindErrorIndex(ERR_SYSTEM_FILAMENT_EJECTED);
 
     case (uint16_t)ErrorCode::STALLED_PULLEY:
     case (uint16_t)ErrorCode::MOVE_PULLEY_FAILED:
@@ -310,6 +312,15 @@ Buttons ButtonAvailable(uint16_t ec) {
             break;
         }
         break;
+    case ERR_SYSTEM_FILAMENT_EJECTED:
+        switch (buttonSelectedOperation) {
+        case ButtonOperations::Continue: // "Continue" - eject filament completed
+            return Middle;
+        default:
+            break;
+        }
+        break;
+
     default:
         break;
     }

--- a/Firmware/mmu2_protocol_logic.cpp
+++ b/Firmware/mmu2_protocol_logic.cpp
@@ -496,7 +496,8 @@ StepStatus ProtocolLogic::IdleStep() {
 }
 
 ProtocolLogic::ProtocolLogic(MMU2Serial *uart, uint8_t extraLoadDistance)
-    : currentScope(Scope::Stopped)
+    : explicitPrinterError(ErrorCode::OK)
+    , currentScope(Scope::Stopped)
     , scopeState(ScopeState::Ready)
     , plannedRq(RequestMsgCodes::unknown, 0)
     , lastUARTActivityMs(0)

--- a/Firmware/mmu2_protocol_logic.cpp
+++ b/Firmware/mmu2_protocol_logic.cpp
@@ -800,7 +800,8 @@ StepStatus ProtocolLogic::Step() {
     default:
         break;
     }
-    return currentStatus;
+    // special handling of explicit printer errors
+    return IsPrinterError() ? StepStatus::PrinterError : currentStatus;
 }
 
 uint8_t ProtocolLogic::CommandInProgress() const {

--- a/Firmware/mmu2_protocol_logic.cpp
+++ b/Firmware/mmu2_protocol_logic.cpp
@@ -6,7 +6,7 @@
 
 namespace MMU2 {
 
-static const uint8_t supportedMmuFWVersion[3] PROGMEM = { 2, 1, 5 };
+static const uint8_t supportedMmuFWVersion[3] PROGMEM = { 2, 1, 6 };
 
 const uint8_t ProtocolLogic::regs8Addrs[ProtocolLogic::regs8Count] PROGMEM = {
     8, // FINDA state

--- a/Firmware/mmu2_protocol_logic.h
+++ b/Firmware/mmu2_protocol_logic.h
@@ -40,6 +40,7 @@ enum StepStatus : uint_fast8_t {
     CommandRejected,      ///< the MMU rejected the command due to some other command in progress, may be the user is operating the MMU locally (button commands)
     CommandError,         ///< the command in progress stopped due to unrecoverable error, user interaction required
     VersionMismatch,      ///< the MMU reports its firmware version incompatible with our implementation
+    PrinterError,         ///< printer's explicit error - MMU is fine, but the printer was unable to complete the requested operation
     CommunicationRecovered,
     ButtonPushed, ///< The MMU reported the user pushed one of its three buttons.
 };
@@ -141,6 +142,19 @@ public:
     inline uint8_t MmuFwVersionRevision() const {
         return mmuFwVersion[2];
     }
+
+    inline void SetPrinterError(ErrorCode ec){
+        explicitPrinterError = ec;
+    }
+    inline void ClearPrinterError(){
+        explicitPrinterError = ErrorCode::OK;
+    }
+    inline bool IsPrinterError()const {
+        return explicitPrinterError != ErrorCode::OK;
+    }
+    inline ErrorCode PrinterError() const {
+        return explicitPrinterError;
+    }
 #ifndef UNITTEST
 private:
 #endif
@@ -161,6 +175,8 @@ private:
     void LogResponse();
     StepStatus SwitchFromIdleToCommand();
     void SwitchFromStartToIdle();
+
+    ErrorCode explicitPrinterError;
 
     enum class State : uint_fast8_t {
         Stopped,      ///< stopped for whatever reason

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5085,7 +5085,7 @@ static void mmu_eject_filament(uint8_t filament) {
 }
 
 static void mmu_fil_eject_menu() {
-    if (bFilamentAction) {
+    if (bFilamentAction || (!MMU2::mmu2.FindaDetectsFilament())) {
         MENU_BEGIN();
         MENU_ITEM_BACK_P(_T(MSG_MAIN));
         for (uint8_t i = 0; i < MMU_FILAMENT_COUNT; i++)
@@ -5103,7 +5103,7 @@ static inline void mmu_cut_filament_wrapper(uint8_t index){
 }
 
 static void mmu_cut_filament_menu() {
-    if (bFilamentAction) {
+    if (bFilamentAction || (!MMU2::mmu2.FindaDetectsFilament())) {
         MENU_BEGIN();
         MENU_ITEM_BACK_P(_T(MSG_MAIN));
         for (uint8_t i = 0; i < MMU_FILAMENT_COUNT; i++)


### PR DESCRIPTION
This is a prototype implementation of having the ability to show an MMU error screen even for printer's errors (during an MMU operation).
Also, the retry count of unloads after failed load the extruder tube is now limited to ~3 attempts.

Technically, since this very error is not an MMU's one (MMU is just fine at this stage) but a printer's one I tried to hack the existing error-reporting infrastructure to handle such a case.
The original idea of this approach was suggested by @vintagepc .

PFW-1446
PFW-1424
PFW-1443

FLASH: +414B :sob: 