### PR TITLE
Minor header cleanup in Marlin_main.cpp

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -66,7 +66,6 @@
 
 #include "menu.h"
 #include "ultralcd.h"
-#include "conv2str.h"
 #include "backlight.h"
 
 #include "planner.h"
@@ -11043,8 +11042,7 @@ void restore_print_from_eeprom(bool mbl_was_active) {
 	sprintf_P(cmd, PSTR("M220 S%d"), feedmultiply_rec);
 	enquecommand(cmd);
   // Set the fan speed saved at the power panic.
-	strcpy_P(cmd, PSTR("M106 S"));
-	strcat(cmd, itostr3(int(fan_speed_rec)));
+	sprintf_P(cmd, PSTR("M106 S%u"), fan_speed_rec);
 	enquecommand(cmd);
 
   // Set a position in the file.

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -113,10 +113,6 @@
 #include "Wire.h"
 #endif
 
-#ifdef ULTRALCD
-#include "ultralcd.h"
-#endif
-
 #if NUM_SERVOS > 0
 #include "Servo.h"
 #endif
@@ -129,8 +125,6 @@
 
 #define VERSION_STRING  "1.0.2"
 
-
-#include "ultralcd.h"
 #include "sound.h"
 
 #include "cmdqueue.h"
@@ -7336,7 +7330,7 @@ Sigma_Exit:
       break;
     #endif // NUM_SERVOS > 0
 
-    #if (LARGE_FLASH == true && ( BEEPER > 0 || defined(ULTRALCD) || defined(LCD_USE_I2C_BUZZER)))
+    #if (LARGE_FLASH == true && BEEPER > 0 )
     
     /*!
 	### M300 - Play tone <a href="https://reprap.org/wiki/G-code#M300:_Play_beep_sound">M300: Play beep sound</a>

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -76,7 +76,6 @@
 #include "cardreader.h"
 #include "ConfigurationStore.h"
 #include "language.h"
-#include "pins_arduino.h"
 #include "math.h"
 #include "util.h"
 #include "Timer.h"


### PR DESCRIPTION
* One step closer to delete conv2str.cpp/h. 🎅 
    * In this case `fan_speed_rec` is `uint8_t` so it cannot exceed 3 characters. `itostr3()` is therefore redundant here.
* `ultralcd.h` is included 3 times in `Marlin_main.cpp`, I removed the extra ones, only one include is needed.