### PR TITLE
Remove T parameter from M221

### DIFF
--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -272,7 +272,6 @@ extern uint8_t axis_relative_modes;
 extern float feedrate;
 extern int feedmultiply;
 extern int extrudemultiply; // Sets extrude multiply factor (in percent) for all extruders
-extern int extruder_multiply[EXTRUDERS]; // sets extrude multiply factor (in percent) for each extruder individually
 extern float extruder_multiplier[EXTRUDERS]; // reciprocal of cross-sectional area of filament (in square millimeters), stored this way to reduce computational burden in planner
 extern float current_position[NUM_AXIS] ;
 extern float destination[NUM_AXIS] ;

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -178,15 +178,6 @@ uint8_t axis_relative_modes = 0;
 
 int feedmultiply=100; //100->1 200->2
 int extrudemultiply=100; //100->1 200->2
-int extruder_multiply[EXTRUDERS] = {100
-  #if EXTRUDERS > 1
-    , 100
-    #if EXTRUDERS > 2
-      , 100
-    #endif
-  #endif
-};
-
 
 bool homing_flag = false;
 
@@ -7195,34 +7186,22 @@ Sigma_Exit:
 	### M221 - Set extrude factor override percentage <a href="https://reprap.org/wiki/G-code#M221:_Set_extrude_factor_override_percentage">M221: Set extrude factor override percentage</a>
 	#### Usage
     
-        M221 [ S | T ]
+        M221 [ S ]
     
     #### Parameters
 	- `S` - Extrude factor override percentage (0..100 or higher), default 100%
-	- `T` - Extruder drive number (Prusa Firmware only), default 0 if not set.
     */
     case 221: // M221 S<factor in percent>- set extrude factor override percentage
     {
         if (code_seen('S'))
         {
-            int tmp_code = code_value_short();
-            if (code_seen('T'))
-            {
-                uint8_t extruder;
-                if (setTargetedHotend(221, extruder))
-                    break;
-                extruder_multiply[extruder] = tmp_code;
-            }
-            else
-            {
-                extrudemultiply = tmp_code ;
-            }
+            extrudemultiply = code_value_short();
+            calculate_extruder_multipliers();
         }
         else
         {
             printf_P(PSTR("%i%%\n"), extrudemultiply);
         }
-        calculate_extruder_multipliers();
     }
     break;
 


### PR DESCRIPTION
Fixes #3852

Just a proposal. The T parameter doesn't work anyway from what I can see.

We decided a few months ago the firmware should only support one extruder, so I doubt we will fix the T parameter to work.

Change in memory:
Flash: -28 bytes
SRAM: 0 bytes