### PR TITLE
Speed optimisation: Replace `labs` with `fabs` in `wait_for_heater()`

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -9887,7 +9887,7 @@ static void wait_for_heater(long codenum, uint8_t extruder) {
 			or when current temp falls outside the hysteresis after target temp was reached */
 			if ((residencyStart == -1 && target_direction && (degHotend(extruder) >= (degTargetHotend(extruder) - TEMP_WINDOW))) ||
 				(residencyStart == -1 && !target_direction && (degHotend(extruder) <= (degTargetHotend(extruder) + TEMP_WINDOW))) ||
-				(residencyStart > -1 && labs(degHotend(extruder) - degTargetHotend(extruder)) > TEMP_HYSTERESIS))
+				(residencyStart > -1 && fabs(degHotend(extruder) - degTargetHotend(extruder)) > TEMP_HYSTERESIS))
 			{
 				residencyStart = _millis();
 			}


### PR DESCRIPTION
Both `degHotend` and `degTargetHotend` return a `float`
In this case it is better to use `fabs()`

Change in memory:
Flash: -14 bytes
SRAM: 0 bytes