### PR TITLE
:construction: Optimisation: re-use `delay_keep_alive()` in a few places

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -9672,18 +9672,18 @@ static void wait_for_heater(long codenum, uint8_t extruder) {
 			SERIAL_PROTOCOL((int)extruder);
 
 #ifdef TEMP_RESIDENCY_TIME
-				SERIAL_PROTOCOLPGM(" W:");
-				if (residencyStart > -1)
-				{
-					codenum = ((TEMP_RESIDENCY_TIME * 1000UL) - (_millis() - residencyStart)) / 1000UL;
-					SERIAL_PROTOCOLLN(codenum);
-				}
-				else
-				{
-					SERIAL_PROTOCOLLN('?');
-				}
+			SERIAL_PROTOCOLPGM(" W:");
+			if (residencyStart > -1)
+			{
+				codenum = ((TEMP_RESIDENCY_TIME * 1000UL) - (_millis() - residencyStart)) / 1000UL;
+				SERIAL_PROTOCOLLN(codenum);
+			}
+			else
+			{
+				SERIAL_PROTOCOLLN('?');
+			}
 #else
-				SERIAL_PROTOCOLLN();
+			SERIAL_PROTOCOLLN();
 #endif
 		}
 		delay_keep_alive(1000);

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -4378,8 +4378,8 @@ void process_commands()
         }
       }
       st_synchronize();
-      delay_keep_alive(codenum);
       previous_millis_cmd.start();
+      delay_keep_alive(codenum);
       break;
 
 

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -743,9 +743,7 @@ bool MMU2::manage_response(const bool move_axes, const bool turn_off_nozzle) {
         // - still running -> wait normally in idle()
         // - failed -> then do the safety moves on the printer like before
         // - finished ok -> proceed with reading other commands
-        manage_heater();
-        manage_inactivity(true); // calls LogicStep() and remembers its return status
-        lcd_update(0);
+        delay_keep_alive(0); // calls LogicStep() and remembers its return status
 
         if (mmu_print_saved & SavedState::CooldownPending){
             if (!nozzleTimeout.running()){

--- a/Firmware/planner.cpp
+++ b/Firmware/planner.cpp
@@ -712,10 +712,7 @@ void plan_buffer_line(float x, float y, float z, const float &e, float feed_rate
   // Rest here until there is room in the buffer.
   if (block_buffer_tail == next_buffer_head) {
       do {
-          manage_heater(); 
-          // Vojtech: Don't disable motors inside the planner!
-          manage_inactivity(false); 
-          lcd_update(0);
+          delay_keep_alive(0);
       } while (block_buffer_tail == next_buffer_head);
   }
 #ifdef PLANNER_DIAGNOSTICS

--- a/Firmware/stepper.cpp
+++ b/Firmware/stepper.cpp
@@ -1333,10 +1333,7 @@ void st_synchronize()
 			lcd_update(0);
 		}
 #else //TMC2130
-		manage_heater();
-		// Vojtech: Don't disable motors inside the planner!
-		manage_inactivity(true);
-		lcd_update(0);
+		delay_keep_alive(0);
 #endif //TMC2130
 	}
 }

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3847,10 +3847,7 @@ void lcd_language()
 	lcd_draw_update = 2;
 	while ((menu_menu != lcd_status_screen) && (!lang_is_selected()))
 	{
-		_delay(50);
-		lcd_update(0);
-		manage_heater();
-		manage_inactivity(true);
+		delay_keep_alive(50);
 	}
 	if (lang_is_selected())
 		lcd_return_to_status();


### PR DESCRIPTION
The optimisation is based on seeing these three lines together:

```c
manage_heater();
manage_inactivity(true);
lcd_update(0);
```

To reduce code size we can call one function instead: `delay_keep_alive()` which will then call the above three functions.

Note that `delay_keep_alive()` assumes `manage_inactivity()` takes `true` for it's argument. A few places don't specify this value, I believe using `true` is safe in most cases.

Change in memory on **Multi-lang** build (MK3S+):
Flash: -360 bytes
SRAM: 0 bytes

Change in memory on **English only** build (MK3S+):
Flash: -316 bytes
SRAM: 0 bytes