### PR TITLE
Revised firmware calibration and upgrade checks (3.12)

### DIFF
--- a/Firmware/Configuration.h
+++ b/Firmware/Configuration.h
@@ -532,36 +532,6 @@ your extruder heater takes 2 minutes to hit the target on heating.
 
 #define DEFAULT_NOMINAL_FILAMENT_DIA  1.75  //Enter the diameter (in mm) of the filament generally used (3.0 mm or 1.75 mm). Used by the volumetric extrusion.
 
-// Calibration status of the machine, to be stored into the EEPROM,
-// (unsigned char*)EEPROM_CALIBRATION_STATUS
-enum CalibrationStatus
-{
-	// Freshly assembled, needs to peform a self-test and the XYZ calibration.
-	CALIBRATION_STATUS_ASSEMBLED = 255,
-
-	// For the wizard: self test has been performed, now the XYZ calibration is needed.
-	CALIBRATION_STATUS_XYZ_CALIBRATION = 250,
-
-	// For the wizard: factory assembled, needs to run Z calibration.
-	CALIBRATION_STATUS_Z_CALIBRATION = 240,
-
-#ifdef TEMP_MODEL
-	// The XYZ calibration has been performed, needs to run Temp model calibration.
-	CALIBRATION_STATUS_TEMP_MODEL_CALIBRATION = 235,
-#endif //TEMP_MODEL
-
-// The XYZ calibration AND OR Temp model calibration has been performed, now it remains to run the V2Calibration.gcode.
-	CALIBRATION_STATUS_LIVE_ADJUST = 230,
-
-    // Calibrated, ready to print.
-    CALIBRATION_STATUS_CALIBRATED = 1,
-
-    // Legacy: resetted by issuing a G86 G-code.
-    // This value can only be expected after an upgrade from the initial MK2 firmware releases.
-    // Currently the G86 sets the calibration status to 
-    CALIBRATION_STATUS_UNKNOWN = 0,
-};
-
 // Try to maintain a minimum distance from the bed even when Z is
 // unknown when doing the following operations
 #define MIN_Z_FOR_LOAD    50 // lcd filament loading or autoload

--- a/Firmware/ConfigurationStore.h
+++ b/Firmware/ConfigurationStore.h
@@ -65,7 +65,4 @@ FORCE_INLINE void Config_StoreSettings() {}
 FORCE_INLINE void Config_RetrieveSettings() { Config_ResetDefault(); Config_PrintSettings(); }
 #endif
 
-inline uint8_t calibration_status() { return eeprom_read_byte((uint8_t*)EEPROM_CALIBRATION_STATUS); }
-inline void calibration_status_store(uint8_t status) { eeprom_update_byte((uint8_t*)EEPROM_CALIBRATION_STATUS, status); }
-inline bool calibration_status_pinda() { return eeprom_read_byte((uint8_t*)EEPROM_CALIBRATION_STATUS_PINDA); }
 #endif//CONFIG_STORE_H

--- a/Firmware/Dcodes.cpp
+++ b/Firmware/Dcodes.cpp
@@ -598,7 +598,7 @@ void dcode_9()
 void dcode_10()
 {//Tell the printer that XYZ calibration went OK
 	LOG("D10 - XYZ calibration = OK\n");
-	calibration_status_store(CALIBRATION_STATUS_LIVE_ADJUST); 
+	calibration_status_set(CALIBRATION_STATUS_XYZ);
 }
 
     /*!

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1553,10 +1553,15 @@ void setup()
               // printer upgraded from FW<3.2.0.4 and requires re-running selftest
               lcd_show_fullscreen_message_and_wait_P(_i("Selftest will be run to calibrate accurate sensorless rehoming."));////MSG_FORCE_SELFTEST c=20 r=8
               calibration_status &= ~CALIBRATION_STATUS_SELFTEST;
-              run_wizard = true;
           }
       }
       eeprom_update_byte((uint8_t*)EEPROM_CALIBRATION_STATUS_V2, calibration_status);
+  }
+  if (eeprom_fw_version_older_than_p(FW_VERSION_NR)) {
+      if (!calibration_status_get(CALIBRATION_WIZARD_STEPS)) {
+          // we just did a FW upgrade and some (new) wizard step is missing: resume the wizard
+          run_wizard = true;
+      }
   }
   update_current_firmware_version_to_eeprom();
 

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3381,8 +3381,9 @@ bool gcode_M45(bool onlyZ, int8_t verbosity_level)
 			else
 			{
 				// Reset the baby step value and the baby step applied flag.
-				calibration_status_store(CALIBRATION_STATUS_XYZ_CALIBRATION);
-                    eeprom_update_word(reinterpret_cast<uint16_t *>(&(EEPROM_Sheets_base->s[(eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet)))].z_offset)),0);
+				calibration_status_clear(CALIBRATION_STATUS_LIVE_ADJUST);
+				eeprom_update_word(reinterpret_cast<uint16_t *>(&(EEPROM_Sheets_base->s[(eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet)))].z_offset)),0);
+
 				// Complete XYZ calibration.
 				uint8_t point_too_far_mask = 0;
 				BedSkewOffsetDetectionResultType result = find_bed_offset_and_skew(verbosity_level, point_too_far_mask);
@@ -5267,7 +5268,7 @@ eeprom_update_word((uint16_t*)EEPROM_NOZZLE_DIAMETER_uM,0xFFFF);
         (Prusa3D specific)
         */
         case 86:
-            calibration_status_store(CALIBRATION_STATUS_LIVE_ADJUST);
+            calibration_status_clear(CALIBRATION_STATUS_LIVE_ADJUST);
             break;
            
 
@@ -5278,7 +5279,7 @@ eeprom_update_word((uint16_t*)EEPROM_NOZZLE_DIAMETER_uM,0xFFFF);
         (Prusa3D specific)
         */
         case 87:
-			calibration_status_store(CALIBRATION_STATUS_CALIBRATED);
+            calibration_status_set(CALIBRATION_STATUS_LIVE_ADJUST);
             break;
 
         /*!
@@ -5682,9 +5683,9 @@ eeprom_update_word((uint16_t*)EEPROM_NOZZLE_DIAMETER_uM,0xFFFF);
     */
     case 44: // M44: Prusa3D: Reset the bed skew and offset calibration.
 
-		// Reset the baby step value and the baby step applied flag.
-		calibration_status_store(CALIBRATION_STATUS_ASSEMBLED);
-          eeprom_update_word(reinterpret_cast<uint16_t *>(&(EEPROM_Sheets_base->s[(eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet)))].z_offset)),0);
+        // Reset the baby step value and the baby step applied flag.
+        calibration_status_clear(CALIBRATION_STATUS_LIVE_ADJUST);
+        eeprom_update_word(reinterpret_cast<uint16_t *>(&(EEPROM_Sheets_base->s[(eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet)))].z_offset)),0);
 
         // Reset the skew and offset in both RAM and EEPROM.
         reset_bed_offset_and_skew();

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -2882,7 +2882,7 @@ static void gcode_G80()
         run = true;
         repeatcommand_front(); // repeat G80 with all its parameters
         enquecommand_front_P(G28W0);
-        break;
+        return;
     }
     run = false;
 #endif //PINDA_THERMISTOR
@@ -10468,12 +10468,12 @@ static void temp_compensation_start() {
 	if ((int)degHotend(active_extruder) > extrude_min_temp) {
 		current_position[E_AXIS] -= default_retraction;
 	}
-	plan_buffer_line_curposXYZE(400, active_extruder);
+	plan_buffer_line_curposXYZE(400);
 	
 	current_position[X_AXIS] = PINDA_PREHEAT_X;
 	current_position[Y_AXIS] = PINDA_PREHEAT_Y;
 	current_position[Z_AXIS] = PINDA_PREHEAT_Z;
-	plan_buffer_line_curposXYZE(3000 / 60, active_extruder);
+	plan_buffer_line_curposXYZE(3000 / 60);
 	st_synchronize();
 	while (fabs(degBed() - target_temperature_bed) > 1) delay_keep_alive(1000);
 
@@ -10492,7 +10492,7 @@ static void temp_compensation_apply() {
 	int z_shift = 0;
 	float z_shift_mm;
 
-	if (calibration_status() == CALIBRATION_STATUS_CALIBRATED) {
+	if (calibration_status_pinda()) {
 		if (target_temperature_bed % 10 == 0 && target_temperature_bed >= 60 && target_temperature_bed <= 100) {
 			i_add = (target_temperature_bed - 60) / 10;
 			z_shift = eeprom_read_word((uint16_t*)EEPROM_PROBE_TEMP_SHIFT + i_add);

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1569,9 +1569,8 @@ void setup()
   }
 
 #if !defined (DEBUG_DISABLE_FORCE_SELFTEST) && defined (TMC2130)
-  if (force_selftest_if_fw_version() && calibration_status() < CALIBRATION_STATUS_ASSEMBLED) {
+  if (eeprom_fw_version_older_than({3, 2, 0, 4}) && calibration_status() < CALIBRATION_STATUS_ASSEMBLED) {
 	  lcd_show_fullscreen_message_and_wait_P(_i("Selftest will be run to calibrate accurate sensorless rehoming."));////MSG_FORCE_SELFTEST c=20 r=8
-	  update_current_firmware_version_to_eeprom();
 	  lcd_selftest();
   }
 #endif //TMC2130 && !DEBUG_DISABLE_FORCE_SELFTEST

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1266,11 +1266,14 @@ void setup()
     temp_mgr_init();
 
 #ifdef EXTRUDER_ALTFAN_DETECT
-	SERIAL_ECHORPGM(_n("Hotend fan type: "));
-	if (extruder_altfan_detect())
-		SERIAL_ECHOLNRPGM(PSTR("ALTFAN"));
-	else
-		SERIAL_ECHOLNRPGM(PSTR("NOCTUA"));
+    if (eeprom_read_byte((uint8_t*)EEPROM_ALTFAN_OVERRIDE) == EEPROM_EMPTY_VALUE) {
+        eeprom_update_byte((uint8_t*)EEPROM_ALTFAN_OVERRIDE, 0);
+        SERIAL_ECHORPGM(_n("Hotend fan type: "));
+        if (extruder_altfan_detect())
+            SERIAL_ECHOLNRPGM(PSTR("ALTFAN"));
+        else
+            SERIAL_ECHOLNRPGM(PSTR("NOCTUA"));
+    }
 #endif //EXTRUDER_ALTFAN_DETECT
 
 	plan_init();  // Initialize planner;

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1548,7 +1548,8 @@ void setup()
           // calibrated printer upgraded from FW<3.12
           calibration_status |= (CALIBRATION_STATUS_SELFTEST | CALIBRATION_STATUS_XYZ | CALIBRATION_STATUS_Z | CALIBRATION_STATUS_LIVE_ADJUST);
 
-          if (eeprom_fw_version_older_than({3, 2, 0, 4})) {
+          static const uint16_t v3_2_0_4[] PROGMEM = {3, 2, 0, 4};
+          if (eeprom_fw_version_older_than_p(v3_2_0_4)) {
               // printer upgraded from FW<3.2.0.4 and requires re-running selftest
               lcd_show_fullscreen_message_and_wait_P(_i("Selftest will be run to calibrate accurate sensorless rehoming."));////MSG_FORCE_SELFTEST c=20 r=8
               calibration_status &= ~CALIBRATION_STATUS_SELFTEST;

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -758,9 +758,10 @@ static void factory_reset(char level)
 	case 3: // Level 3: Preparation after being serviced
 		// Force language selection at the next boot up.
 		lang_reset();
-		// Force the "Follow calibration flow" message at the next boot up.
-		calibration_status_store(CALIBRATION_STATUS_Z_CALIBRATION);
-		eeprom_write_byte((uint8_t*)EEPROM_WIZARD_ACTIVE, 2); //run wizard
+
+		// Force the wizard in "Follow calibration flow" mode at the next boot up
+		calibration_status_clear(CALIBRATION_FORCE_PREP);
+		eeprom_write_byte((uint8_t*)EEPROM_WIZARD_ACTIVE, 2);
 		farm_disable();
 
 #ifdef FILAMENT_SENSOR

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1539,45 +1539,51 @@ void setup()
 	  lcd_show_fullscreen_message_and_wait_P(_i("Old settings found. Default PID, Esteps etc. will be set.")); //if EEPROM version or printer type was changed, inform user that default setting were loaded////MSG_DEFAULT_SETTINGS_LOADED c=20 r=6
 	  Config_StoreSettings();
   }
-  if (eeprom_read_byte((uint8_t*)EEPROM_WIZARD_ACTIVE) >= 1) {
-	  lcd_wizard(WizState::Run);
-  }
-  if (eeprom_read_byte((uint8_t*)EEPROM_WIZARD_ACTIVE) == 0) { //dont show calibration status messages if wizard is currently active
-	  if (calibration_status() == CALIBRATION_STATUS_ASSEMBLED ||
-		  calibration_status() == CALIBRATION_STATUS_UNKNOWN || 
-		  calibration_status() == CALIBRATION_STATUS_XYZ_CALIBRATION) {
-		  // Reset the babystepping values, so the printer will not move the Z axis up when the babystepping is enabled.
-            eeprom_update_word(reinterpret_cast<uint16_t *>(&(EEPROM_Sheets_base->s[(eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet)))].z_offset)),0);
-		  // Show the message.
-		  lcd_show_fullscreen_message_and_wait_P(_T(MSG_FOLLOW_CALIBRATION_FLOW));
-	  }
-#ifdef TEMP_MODEL
-	  else if (calibration_status() == CALIBRATION_STATUS_TEMP_MODEL_CALIBRATION) {
-		  lcd_show_fullscreen_message_and_wait_P(_T(MSG_TM_NOT_CAL));
-		  lcd_update_enable(true);
-	  }
-#endif //TEMP_MODEL
-	  else if (calibration_status() == CALIBRATION_STATUS_LIVE_ADJUST) {
-		  // Show the message.
-		  lcd_show_fullscreen_message_and_wait_P(_T(MSG_BABYSTEP_Z_NOT_SET));
-		  lcd_update_enable(true);
-	  }
-	  else if (calibration_status() == CALIBRATION_STATUS_CALIBRATED && eeprom_read_byte((unsigned char *)EEPROM_TEMP_CAL_ACTIVE) && calibration_status_pinda() == false) {
-		  //lcd_show_fullscreen_message_and_wait_P(_i("Temperature calibration has not been run yet"));////MSG_PINDA_NOT_CALIBRATED c=20 r=4
-		  lcd_update_enable(true);
-	  }
-	  else if (calibration_status() == CALIBRATION_STATUS_Z_CALIBRATION) {
-		  // Show the message.
-		  lcd_show_fullscreen_message_and_wait_P(_T(MSG_FOLLOW_Z_CALIBRATION_FLOW));
-	  }
+
+  // handle calibration status upgrade
+  bool run_wizard = false;
+  if (calibration_status_get(CALIBRATION_STATUS_UNKNOWN)) {
+      CalibrationStatus calibration_status = 0;
+      if (eeprom_read_byte((uint8_t*)EEPROM_CALIBRATION_STATUS_V1) == 1) {
+          // calibrated printer upgraded from FW<3.12
+          calibration_status |= (CALIBRATION_STATUS_SELFTEST | CALIBRATION_STATUS_XYZ | CALIBRATION_STATUS_Z | CALIBRATION_STATUS_LIVE_ADJUST);
+
+          if (eeprom_fw_version_older_than({3, 2, 0, 4})) {
+              // printer upgraded from FW<3.2.0.4 and requires re-running selftest
+              lcd_show_fullscreen_message_and_wait_P(_i("Selftest will be run to calibrate accurate sensorless rehoming."));////MSG_FORCE_SELFTEST c=20 r=8
+              calibration_status &= ~CALIBRATION_STATUS_SELFTEST;
+              run_wizard = true;
+          }
+      }
+      eeprom_update_byte((uint8_t*)EEPROM_CALIBRATION_STATUS_V2, calibration_status);
   }
 
-#if !defined (DEBUG_DISABLE_FORCE_SELFTEST) && defined (TMC2130)
-  if (eeprom_fw_version_older_than({3, 2, 0, 4}) && calibration_status() < CALIBRATION_STATUS_ASSEMBLED) {
-	  lcd_show_fullscreen_message_and_wait_P(_i("Selftest will be run to calibrate accurate sensorless rehoming."));////MSG_FORCE_SELFTEST c=20 r=8
-	  lcd_selftest();
+  if (eeprom_read_byte((uint8_t*)EEPROM_WIZARD_ACTIVE)) {
+      // first time run of wizard or service prep
+      lcd_wizard(WizState::Run);
   }
-#endif //TMC2130 && !DEBUG_DISABLE_FORCE_SELFTEST
+  else if (run_wizard) {
+      // some wizard steps required by the upgrade checks
+      lcd_wizard(WizState::Restore);
+  }
+  else {
+      if (!calibration_status_get(CALIBRATION_STATUS_SELFTEST)) {
+          // aborted or missing wizard: show a single warning
+          lcd_show_fullscreen_message_and_wait_P(_T(MSG_FOLLOW_CALIBRATION_FLOW));
+      }
+      else if (!calibration_status_get(CALIBRATION_STATUS_Z)) {
+          // wizard reset after service prep
+          lcd_show_fullscreen_message_and_wait_P(_T(MSG_FOLLOW_Z_CALIBRATION_FLOW));
+      } else {
+          // warn about other important steps individually
+          if (!calibration_status_get(CALIBRATION_STATUS_LIVE_ADJUST))
+              lcd_show_fullscreen_message_and_wait_P(_T(MSG_BABYSTEP_Z_NOT_SET));
+#ifdef TEMP_MODEL
+          if (!calibration_status_get(CALIBRATION_STATUS_TEMP_MODEL))
+              lcd_show_fullscreen_message_and_wait_P(_T(MSG_TM_NOT_CAL));
+#endif //TEMP_MODEL
+      }
+  }
 
   KEEPALIVE_STATE(IN_PROCESS);
 #endif //DEBUG_DISABLE_STARTMSGS

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1540,7 +1540,7 @@ void setup()
 	  Config_StoreSettings();
   }
 
-  // handle calibration status upgrade
+  // handle FW and calibration status upgrade
   bool run_wizard = false;
   if (calibration_status_get(CALIBRATION_STATUS_UNKNOWN)) {
       CalibrationStatus calibration_status = 0;
@@ -1557,6 +1557,7 @@ void setup()
       }
       eeprom_update_byte((uint8_t*)EEPROM_CALIBRATION_STATUS_V2, calibration_status);
   }
+  update_current_firmware_version_to_eeprom();
 
   if (eeprom_read_byte((uint8_t*)EEPROM_WIZARD_ACTIVE)) {
       // first time run of wizard or service prep
@@ -1590,9 +1591,6 @@ void setup()
   lcd_update_enable(true);
   lcd_clear();
   lcd_update(2);
-  // Store the currently running firmware into an eeprom,
-  // so the next time the firmware gets updated, it will know from which version it has been updated.
-  update_current_firmware_version_to_eeprom();
 
 #ifdef TMC2130
   	tmc2130_home_origin[X_AXIS] = eeprom_read_byte((uint8_t*)EEPROM_TMC2130_HOME_X_ORIGIN);

--- a/Firmware/eeprom.h
+++ b/Firmware/eeprom.h
@@ -89,13 +89,13 @@ static_assert(sizeof(Sheets) == EEPROM_SHEETS_SIZEOF, "Sizeof(Sheets) is not EEP
 | 0x0FFA 4090 | uint16  | EEPROM_BABYSTEP_Y                     | ???          | ff ffh 65535          | Babystep for Y axis _unsued_                      | ^            | D3 Ax0ffa C2
 | 0x0FF8 4088 | uint16  | EEPROM_BABYSTEP_Z                     | ???          | ff ffh 65535          | Babystep for Z axis _lagacy_                      | ^            | D3 Ax0ff8 C2
 | ^           | ^       | ^                                     | ^            | ^                     | multiple values stored now in EEPROM_Sheets_base  | ^            | ^
-| 0x0FF7 4087 | uint8   | EEPROM_CALIBRATION_STATUS             | ffh 255      | ffh 255               | Assembled _default_                               | ???          | D3 Ax0ff7 C1
+| 0x0FF7 4087 | uint8   | EEPROM_CALIBRATION_STATUS_V1          | ffh 255      | ffh 255               | Calibration status (<v3.12)                       | ???          | D3 Ax0ff7 C1
 | ^           | ^       | ^                                     | 01h 1        | ^                     | Calibrated                                        | ^            | ^
 | ^           | ^       | ^                                     | e6h 230      | ^                     | needs Live Z adjustment                           | ^            | ^
 | ^           | ^       | ^                                     | ebh 235      | ^                     | needs Temp Model calibration                      | ^            | ^
 | ^           | ^       | ^                                     | f0h 240      | ^               __P__ | needs Z calibration                               | ^            | ^
 | ^           | ^       | ^                                     | fah 250      | ^                     | needs XYZ calibration                             | ^            | ^
-| ^           | ^       | ^                                     | 00h 0        | ^                     | Unknown                                           | ^            | ^
+| ^           | ^       | ^                                     | 00h 0        | ^                     | Unknown (legacy)                                  | ^            | ^
 | 0x0FF5 4085 | uint16  | EEPROM_BABYSTEP_Z0                    | ???          | ff ffh 65535          | Babystep for Z ???                                | ???          | D3 Ax0ff5 C2
 | 0x0FF1 4081 | unint32 | EEPROM_FILAMENTUSED                   | ???          | 00 00 00 00h 0 __S/P__| Filament used in meters                           | ???          | D3 Ax0ff1 C4
 | 0x0FED 4077 | unint32 | EEPROM_TOTALTIME                      | ???          | 00 00 00 00h 0 __S/P__| Total print time                                  | ???          | D3 Ax0fed C4
@@ -348,6 +348,7 @@ static_assert(sizeof(Sheets) == EEPROM_SHEETS_SIZEOF, "Sizeof(Sheets) is not EEP
 | 0x0CA7 3239 | uint8   | EEPROM_HEAT_BED_ON_LOAD_FILAMENT      | ffh 255      | ffh 255               | Heat bed on load filament unknown state           | LCD menu     | D3 Ax0ca7 C1
 | ^           | ^       | ^                                     | 00h 0        | ^                     | Do not heat bed on load filament                  | ^            | ^
 | ^           | ^       | ^                                     | 01h 1        | ^                     | Heat bed on load filament                         | ^            | ^
+| 0x0CA6 3238 | uint8   | EEPROM_CALIBRATION_STATUS_V2          | ffh 255      | ffh 255               | Calibration status (>=v3.12)                      | ???          | D3 Ax0ca6 C1
 
 |Address begin|Bit/Type | Name                                  | Valid values | Default/FactoryReset  | Description                                       |Gcode/Function| Debug code
 | :--:        | :--:    | :--:                                  | :--:         | :--:                  | :--:                                              | :--:         | :--:
@@ -370,7 +371,7 @@ static_assert(sizeof(Sheets) == EEPROM_SHEETS_SIZEOF, "Sizeof(Sheets) is not EEP
 #define EEPROM_BABYSTEP_X 4092 //unused
 #define EEPROM_BABYSTEP_Y 4090 //unused
 #define EEPROM_BABYSTEP_Z 4088 //legacy, multiple values stored now in EEPROM_Sheets_base
-#define EEPROM_CALIBRATION_STATUS 4087
+#define EEPROM_CALIBRATION_STATUS_V1 4087 // legacy, used up to v3.11
 #define EEPROM_BABYSTEP_Z0 4085
 #define EEPROM_FILAMENTUSED 4081
 // uint32_t
@@ -575,9 +576,10 @@ static Sheets * const EEPROM_Sheets_base = (Sheets*)(EEPROM_SHEETS_BASE);
 #define EEPROM_MMU_ENABLED (EEPROM_FSENSOR_JAM_DETECTION-1) // uint8_t
 #define EEPROM_TOTAL_TOOLCHANGE_COUNT (EEPROM_MMU_ENABLED-4)
 #define EEPROM_HEAT_BED_ON_LOAD_FILAMENT (EEPROM_TOTAL_TOOLCHANGE_COUNT-1) //uint8
+#define EEPROM_CALIBRATION_STATUS_V2 (EEPROM_HEAT_BED_ON_LOAD_FILAMENT-1) //uint8
 
 //This is supposed to point to last item to allow EEPROM overrun check. Please update when adding new items.
-#define EEPROM_LAST_ITEM EEPROM_HEAT_BED_ON_LOAD_FILAMENT
+#define EEPROM_LAST_ITEM EEPROM_CALIBRATION_STATUS_V2
 // !!!!!
 // !!!!! this is end of EEPROM section ... all updates MUST BE inserted before this mark !!!!!
 // !!!!!

--- a/Firmware/eeprom.h
+++ b/Firmware/eeprom.h
@@ -292,7 +292,7 @@ static_assert(sizeof(Sheets) == EEPROM_SHEETS_SIZEOF, "Sizeof(Sheets) is not EEP
 | 0x0D9D 3485 | uint16  | ^                                     | 00 00h 0     | ff ffh 65535          | 8th sheet - Z offset                              | ^            | D3 Ax0d9d C2
 | 0x0D9F 3487 | uint8   | ^                                     | 00h 0        | ffh 255               | 8th sheet - bed temp                              | ^            | D3 Ax0d9f C1
 | 0x0DA0 3488 | uint8   | ^                                     | 00h 0        | ffh 255               | 8th sheet - PINDA temp                            | ^            | D3 Ax0da0 C1
-| 0x0DA1 3489 | uint8   | ???                                   | 00h 0        | ffh 255               | ???                                               | ???          | D3 Ax0da1 C1
+| 0x0DA1 3489 | uint8   | active_sheet                          | 00h 0        | ffh 255               | Active sheet index                                | ^            | D3 Ax0da1 C1
 | 0x0D48 3400 | uint8   | EEPROM_FSENSOR_PCB                    | ffh 255      | ffh 255               | Filament Sensor type IR unknown                   | LCD Support  | D3 Ax0d48 C1
 | ^           | ^       | ^                                     | 00h 0        | ^                     | Filament Sensor type IR 0.3 or older              | ^            | ^
 | ^           | ^       | ^                                     | 01h 1        | ^                     | Filament Sensor type IR 0.4 or newer              | ^            | ^
@@ -342,6 +342,12 @@ static_assert(sizeof(Sheets) == EEPROM_SHEETS_SIZEOF, "Sizeof(Sheets) is not EEP
 | 0x0CB6 3254 | float   | EEPROM_TEMP_MODEL_Ta_corr             | ???          | ff ff ff ffh          | Temp model ambient temperature correction (K)     | Temp model   | D3 Ax0cb6 C4
 | 0x0CB2 3250 | float   | EEPROM_TEMP_MODEL_W                   | ???          | ff ff ff ffh          | Temp model warning threshold (K/s)                | Temp model   | D3 Ax0cb2 C4
 | 0x0CAE 3246 | float   | EEPROM_TEMP_MODEL_E                   | ???          | ff ff ff ffh          | Temp model error threshold (K/s)                  | Temp model   | D3 Ax0cae C4
+| 0x0CAD 3245 | uint8   | EEPROM_FSENSOR_JAM_DETECTION          | 01h 1        | ff/01                 | fsensor pat9125 jam detection feature             | LCD menu     | D3 Ax0cad C1
+| 0x0CAC 3244 | uint8   | EEPROM_MMU_ENABLED                    | 01h 1        | ff/01                 | MMU enabled                                       | LCD menu     | D3 Ax0cac C1
+| 0x0CA8 3240 | uint32  | EEPROM_TOTAL_TOOLCHANGE_COUNT         | ???          | ff ff ff ffh          | MMU toolchange counter over printers lifetime     | LCD statistic| D3 Ax0ca8 C4
+| 0x0CA7 3239 | uint8   | EEPROM_HEAT_BED_ON_LOAD_FILAMENT      | ffh 255      | ffh 255               | Heat bed on load filament unknown state           | LCD menu     | D3 Ax0d02 C1
+| ^           | ^       | ^                                     | 00h 0        | ^                     | Do not heat bed on load filament                  | ^            | ^
+| ^           | ^       | ^                                     | 01h 1        | ^                     | Heat bed on load filament                         | ^            | ^
 
 |Address begin|Bit/Type | Name                                  | Valid values | Default/FactoryReset  | Description                                       |Gcode/Function| Debug code
 | :--:        | :--:    | :--:                                  | :--:         | :--:                  | :--:                                              | :--:         | :--:
@@ -565,8 +571,13 @@ static Sheets * const EEPROM_Sheets_base = (Sheets*)(EEPROM_SHEETS_BASE);
 #define EEPROM_TEMP_MODEL_W (EEPROM_TEMP_MODEL_Ta_corr-4) // float
 #define EEPROM_TEMP_MODEL_E (EEPROM_TEMP_MODEL_W-4) // float
 
+#define EEPROM_FSENSOR_JAM_DETECTION (EEPROM_TEMP_MODEL_E-1) // uint8_t
+#define EEPROM_MMU_ENABLED (EEPROM_FSENSOR_JAM_DETECTION-1) // uint8_t
+#define EEPROM_TOTAL_TOOLCHANGE_COUNT (EEPROM_MMU_ENABLED-4)
+#define EEPROM_HEAT_BED_ON_LOAD_FILAMENT (EEPROM_TOTAL_TOOLCHANGE_COUNT-1) //uint8
+
 //This is supposed to point to last item to allow EEPROM overrun check. Please update when adding new items.
-#define EEPROM_LAST_ITEM EEPROM_TEMP_MODEL_E
+#define EEPROM_LAST_ITEM EEPROM_HEAT_BED_ON_LOAD_FILAMENT
 // !!!!!
 // !!!!! this is end of EEPROM section ... all updates MUST BE inserted before this mark !!!!!
 // !!!!!

--- a/Firmware/eeprom.h
+++ b/Firmware/eeprom.h
@@ -345,7 +345,7 @@ static_assert(sizeof(Sheets) == EEPROM_SHEETS_SIZEOF, "Sizeof(Sheets) is not EEP
 | 0x0CAD 3245 | uint8   | EEPROM_FSENSOR_JAM_DETECTION          | 01h 1        | ff/01                 | fsensor pat9125 jam detection feature             | LCD menu     | D3 Ax0cad C1
 | 0x0CAC 3244 | uint8   | EEPROM_MMU_ENABLED                    | 01h 1        | ff/01                 | MMU enabled                                       | LCD menu     | D3 Ax0cac C1
 | 0x0CA8 3240 | uint32  | EEPROM_TOTAL_TOOLCHANGE_COUNT         | ???          | ff ff ff ffh          | MMU toolchange counter over printers lifetime     | LCD statistic| D3 Ax0ca8 C4
-| 0x0CA7 3239 | uint8   | EEPROM_HEAT_BED_ON_LOAD_FILAMENT      | ffh 255      | ffh 255               | Heat bed on load filament unknown state           | LCD menu     | D3 Ax0d02 C1
+| 0x0CA7 3239 | uint8   | EEPROM_HEAT_BED_ON_LOAD_FILAMENT      | ffh 255      | ffh 255               | Heat bed on load filament unknown state           | LCD menu     | D3 Ax0ca7 C1
 | ^           | ^       | ^                                     | 00h 0        | ^                     | Do not heat bed on load filament                  | ^            | ^
 | ^           | ^       | ^                                     | 01h 1        | ^                     | Heat bed on load filament                         | ^            | ^
 

--- a/Firmware/fancheck.cpp
+++ b/Firmware/fancheck.cpp
@@ -162,18 +162,11 @@ ISR(INT6_vect) {
 
 bool extruder_altfan_detect()
 {
+    // override isAltFan setting for detection
+    altfanStatus.isAltfan = 0;
     setExtruderAutoFanState(3);
 
     SET_INPUT(TACH_0);
-
-    uint8_t overrideVal = eeprom_read_byte((uint8_t *)EEPROM_ALTFAN_OVERRIDE);
-    if (overrideVal == EEPROM_EMPTY_VALUE)
-    {
-        overrideVal = (calibration_status() == CALIBRATION_STATUS_CALIBRATED) ? 1 : 0;
-        eeprom_update_byte((uint8_t *)EEPROM_ALTFAN_OVERRIDE, overrideVal);
-    }
-    altfanStatus.altfanOverride = overrideVal;
-
     CRITICAL_SECTION_START;
     EICRB &= ~(1 << ISC61);
     EICRB |= (1 << ISC60);
@@ -187,8 +180,11 @@ bool extruder_altfan_detect()
     EIMSK &= ~(1 << INT6);
 
     countFanSpeed();
+
+    // restore fan state
     altfanStatus.isAltfan = fan_speed[0] > 100;
     setExtruderAutoFanState(1);
+
     return altfanStatus.isAltfan;
 }
 

--- a/Firmware/mesh_bed_calibration.cpp
+++ b/Firmware/mesh_bed_calibration.cpp
@@ -1,5 +1,6 @@
 #include "Configuration.h"
 #include "ConfigurationStore.h"
+#include "util.h"
 #include "language.h"
 #include "mesh_bed_calibration.h"
 #include "mesh_bed_leveling.h"
@@ -3044,7 +3045,7 @@ void babystep_load()
 {
 	babystepLoadZ = 0;
     // Apply Z height correction aka baby stepping before mesh bed leveling gets activated.
-    if (calibration_status() < CALIBRATION_STATUS_LIVE_ADJUST)
+    if (calibration_status_get(CALIBRATION_STATUS_LIVE_ADJUST))
     {
         check_babystep(); //checking if babystep is in allowed range, otherwise setting babystep to 0
         

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3974,6 +3974,7 @@ void lcd_wizard() {
 		result = !lcd_show_multiscreen_message_yes_no_and_wait_P(_i("Running Wizard will delete current calibration results and start from the beginning. Continue?"), false);////MSG_WIZARD_RERUN c=20 r=7
 	}
 	if (result) {
+		calibration_status_clear(CALIBRATION_WIZARD_STEPS);
 		lcd_wizard(WizState::Run);
 	} else {
 		lcd_return_to_status();
@@ -4135,7 +4136,6 @@ void lcd_wizard(WizState state)
 				if (wizard_event == LCD_LEFT_BUTTON_CHOICE) {
 					state = S::Restore;
 					eeprom_update_byte((uint8_t*)EEPROM_WIZARD_ACTIVE, 1);
-					calibration_status_clear(CALIBRATION_WIZARD_STEPS);
 				} else {
 					// user interrupted
 					eeprom_update_byte((uint8_t*)EEPROM_WIZARD_ACTIVE, 0);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -4180,9 +4180,11 @@ void lcd_wizard(WizState state)
 		case S::Z:
 			lcd_show_fullscreen_message_and_wait_P(_i("Please remove shipping helpers first."));////MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
 			lcd_show_fullscreen_message_and_wait_P(_i("Now remove the test print from steel sheet."));////MSG_REMOVE_TEST_PRINT c=20 r=4
+			wizard_event = lcd_show_fullscreen_message_yes_no_and_wait_P(_T(MSG_STEEL_SHEET_CHECK), false);
+			if (wizard_event == LCD_MIDDLE_BUTTON_CHOICE) {
+				lcd_show_fullscreen_message_and_wait_P(_T(MSG_PLACE_STEEL_SHEET));
+			}
 			lcd_show_fullscreen_message_and_wait_P(_i("I will run z calibration now."));////MSG_WIZARD_Z_CAL c=20 r=8
-			wizard_event = lcd_show_fullscreen_message_yes_no_and_wait_P(_T(MSG_STEEL_SHEET_CHECK), false, false);
-			if (!wizard_event) lcd_show_fullscreen_message_and_wait_P(_T(MSG_PLACE_STEEL_SHEET));
 			wizard_event = gcode_M45(true, 0);
 			if (!wizard_event) {
 				state = S::Failed;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -6665,6 +6665,7 @@ bool lcd_selftest()
 	if (_result)
 	{
 		LCD_ALERTMESSAGERPGM(_i("Self test OK"));////MSG_SELFTEST_OK c=20
+		calibration_status_set(CALIBRATION_STATUS_SELFTEST);
 	}
 	else
 	{

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1063,16 +1063,11 @@ void lcd_commands()
         case 1:
             lcd_commands_step = 0;
             lcd_commands_type = LcdCommands::Idle;
-
-            if (temp_model_autotune_result()) {
-                if (calibration_status() == CALIBRATION_STATUS_TEMP_MODEL_CALIBRATION) {
-                    // move to the next calibration step if not fully calibrated
-                    calibration_status_store(CALIBRATION_STATUS_LIVE_ADJUST);
-                }
-                if ((eeprom_read_byte((uint8_t*)EEPROM_WIZARD_ACTIVE) == 1)) {
-                    // successful: resume the wizard
-                    lcd_wizard(WizState::IsFil);
-                }
+            bool res = temp_model_autotune_result();
+            if (res) calibration_status_set(CALIBRATION_STATUS_TEMP_MODEL);
+            if (eeprom_read_byte((uint8_t*)EEPROM_WIZARD_ACTIVE)) {
+                // resume the wizard
+                lcd_wizard(res ? WizState::Restore : WizState::Failed);
             }
             break;
         }

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -4941,11 +4941,10 @@ static void lcd_settings_menu()
 #if defined (TMC2130) && defined (LINEARITY_CORRECTION)
     MENU_ITEM_SUBMENU_P(_i("Lin. correction"), lcd_settings_linearity_correction_menu);////MSG_LIN_CORRECTION c=18
 #endif //LINEARITY_CORRECTION && TMC2130
+#ifdef PINDA_THERMISTOR
     if(has_temperature_compensation())
-    {
         MENU_ITEM_TOGGLE_P(_T(MSG_PINDA_CALIBRATION), eeprom_read_byte((unsigned char *)EEPROM_TEMP_CAL_ACTIVE) ? _T(MSG_ON) : _T(MSG_OFF), lcd_temp_calibration_set);
-    }
-
+#endif
 #ifdef HAS_SECOND_SERIAL_PORT
     MENU_ITEM_TOGGLE_P(_T(MSG_RPI_PORT), (selectedSerialPort == 0) ? _T(MSG_OFF) : _T(MSG_ON), lcd_second_serial_set);
 #endif //HAS_SECOND_SERIAL
@@ -5031,10 +5030,10 @@ static void lcd_calibration_menu()
     MENU_ITEM_SUBMENU_P(_i("Show end stops"), menu_show_end_stops);////MSG_SHOW_END_STOPS c=18
 #endif
     MENU_ITEM_GCODE_P(_i("Reset XYZ calibr."), PSTR("M44"));////MSG_CALIBRATE_BED_RESET c=18
+#ifdef PINDA_THERMISTOR
     if(has_temperature_compensation())
-    {
 	    MENU_ITEM_FUNCTION_P(_T(MSG_PINDA_CALIBRATION), lcd_calibrate_pinda);
-    }
+#endif
   }
 #ifdef TEMP_MODEL
     MENU_ITEM_SUBMENU_P(_n("Temp Model cal."), lcd_temp_model_cal);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -7025,6 +7025,10 @@ static bool lcd_selfcheck_check_heater(bool _isbed)
 
 	target_temperature[0] = (_isbed) ? 0 : 200;
 	target_temperature_bed = (_isbed) ? 100 : 0;
+#ifdef TEMP_MODEL
+	bool tm_was_enabled = temp_model_enabled();
+	temp_model_set_enabled(false);
+#endif //TEMP_MODEL
 	manage_heater();
 	manage_inactivity(true);
 
@@ -7061,26 +7065,21 @@ static bool lcd_selfcheck_check_heater(bool _isbed)
 	*/
 
     bool _stepresult = false;
-    if (Stopped)
+    if (Stopped || _opposite_result < ((_isbed) ? 30 : 9))
     {
-        // thermal error occurred while heating the nozzle
-        lcd_selftest_error(TestError::Heater, "", "");
+        if (!Stopped && _checked_result >= ((_isbed) ? 9 : 30))
+            _stepresult = true;
+        else
+            lcd_selftest_error(TestError::Heater, "", "");
     }
     else
     {
-        if (_opposite_result < ((_isbed) ? 30 : 9))
-        {
-            if (_checked_result >= ((_isbed) ? 9 : 30))
-                _stepresult = true;
-            else
-                lcd_selftest_error(TestError::Heater, "", "");
-        }
-        else
-        {
-            lcd_selftest_error(TestError::Bed, "", "");
-        }
+        lcd_selftest_error(TestError::Bed, "", "");
     }
 
+#ifdef TEMP_MODEL
+	temp_model_set_enabled(tm_was_enabled);
+#endif //TEMP_MODEL
 	manage_heater();
 	manage_inactivity(true);
 	return _stepresult;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -952,10 +952,8 @@ void lcd_commands()
                 lcd_setstatuspgm(MSG_WELCOME);
                 lcd_commands_step = 0;
                 lcd_commands_type = LcdCommands::Idle;
-                if (eeprom_read_byte((uint8_t*)EEPROM_WIZARD_ACTIVE) == 1)
-                {
+                if (eeprom_read_byte((uint8_t*)EEPROM_WIZARD_ACTIVE))
                     lcd_wizard(WizState::RepeatLay1Cal);
-                }
                 break;
 		}
 			}
@@ -3976,14 +3974,13 @@ void lcd_v2_calibration()
 
 void lcd_wizard() {
 	bool result = true;
-	if (calibration_status() != CALIBRATION_STATUS_ASSEMBLED) {
-		result = lcd_show_multiscreen_message_yes_no_and_wait_P(_i("Running Wizard will delete current calibration results and start from the beginning. Continue?"), false, false);////MSG_WIZARD_RERUN c=20 r=7
+	if (calibration_status_get(CALIBRATION_WIZARD_STEPS)) {
+		// calibration already performed: ask before clearing the previous status
+		result = !lcd_show_multiscreen_message_yes_no_and_wait_P(_i("Running Wizard will delete current calibration results and start from the beginning. Continue?"), false);////MSG_WIZARD_RERUN c=20 r=7
 	}
 	if (result) {
-		calibration_status_store(CALIBRATION_STATUS_ASSEMBLED);
 		lcd_wizard(WizState::Run);
-	}
-	else {
+	} else {
 		lcd_return_to_status();
 		lcd_update_enable(true);
 		lcd_update(2);
@@ -4134,52 +4131,56 @@ void lcd_wizard(WizState state)
 			saved_printing = false;
 			
 			if( eeprom_read_byte((uint8_t*)EEPROM_WIZARD_ACTIVE)==2){
+				// printer pre-assembled: finish remaining steps
 				lcd_show_fullscreen_message_and_wait_P(_T(MSG_WIZARD_WELCOME_SHIPPING));
 				state = S::Restore;
 			} else {
-				wizard_event = lcd_show_multiscreen_message_yes_no_and_wait_P(_T(MSG_WIZARD_WELCOME), false, true);
-				if (wizard_event) {
+				// new printer, factory reset or manual invocation
+				wizard_event = lcd_show_multiscreen_message_yes_no_and_wait_P(_T(MSG_WIZARD_WELCOME), false, LCD_LEFT_BUTTON_CHOICE);
+				if (wizard_event == LCD_LEFT_BUTTON_CHOICE) {
 					state = S::Restore;
 					eeprom_update_byte((uint8_t*)EEPROM_WIZARD_ACTIVE, 1);
+					calibration_status_clear(CALIBRATION_WIZARD_STEPS);
 				} else {
+					// user interrupted
 					eeprom_update_byte((uint8_t*)EEPROM_WIZARD_ACTIVE, 0);
 					end = true;
 				}
 			}
 			break;
 		case S::Restore:
-			switch (calibration_status()) {
-			case CALIBRATION_STATUS_ASSEMBLED: state = S::Selftest; break; //run selftest
-			case CALIBRATION_STATUS_XYZ_CALIBRATION: state = S::Xyz; break; //run xyz cal.
-			case CALIBRATION_STATUS_Z_CALIBRATION: state = S::Z; break; //run z cal.
+			// clear any previous error for make _new_ errors visible
+			lcd_reset_alert_level();
+
+			// determine the next step in the required order
+			if (!calibration_status_get(CALIBRATION_STATUS_SELFTEST)) {
+				state = S::Selftest;
+			} else if (!calibration_status_get(CALIBRATION_STATUS_XYZ)) {
+				// S::Xyz *includes* S::Z so it needs to come before
+				// to avoid repeating Z alignment
+				state = S::Xyz;
+			} else if (!calibration_status_get(CALIBRATION_STATUS_Z)) {
+				state = S::Z;
 #ifdef TEMP_MODEL
-			case CALIBRATION_STATUS_TEMP_MODEL_CALIBRATION: state = S::TempModel; break; //run temp model cal.
+			} else if (!calibration_status_get(CALIBRATION_STATUS_TEMP_MODEL)) {
+				state = S::TempModel;
 #endif //TEMP_MODEL
-			case CALIBRATION_STATUS_LIVE_ADJUST: state = S::IsFil; break; //run live adjust
-			case CALIBRATION_STATUS_CALIBRATED: end = true; eeprom_update_byte((uint8_t*)EEPROM_WIZARD_ACTIVE, 0); break;
-			default: state = S::Selftest; break; //if calibration status is unknown, run wizard from the beginning
+			} else if (!calibration_status_get(CALIBRATION_STATUS_LIVE_ADJUST)) {
+				state = S::IsFil;
+			} else {
+				// all required steps completed, finish successfully
+				state = S::Finish;
 			}
-			break; 
+			break;
 		case S::Selftest:
 			lcd_show_fullscreen_message_and_wait_P(_i("First, I will run the selftest to check most common assembly problems."));////MSG_WIZARD_SELFTEST c=20 r=8
 			wizard_event = lcd_selftest();
-			if (wizard_event) {
-				calibration_status_store(CALIBRATION_STATUS_XYZ_CALIBRATION);
-				state = S::Xyz;
-			}
-			else end = true;
+			state = (wizard_event ? S::Restore : S::Failed);
 			break;
 		case S::Xyz:
 			lcd_show_fullscreen_message_and_wait_P(_i("I will run xyz calibration now. It will take up to 24 mins."));////MSG_WIZARD_XYZ_CAL c=20 r=8
 			wizard_event = gcode_M45(false, 0);
-			if (wizard_event) {
-#ifdef TEMP_MODEL
-			lcd_reset_alert_level();
-			state = S::TempModel;
-#else
-			state = S::IsFil;
-#endif //TEMP_MODEL
-			} else end = true;
+			state = (wizard_event ? S::Restore : S::Failed);
 			break;
 		case S::Z:
 			lcd_show_fullscreen_message_and_wait_P(_i("Please remove shipping helpers first."));////MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
@@ -4188,7 +4189,10 @@ void lcd_wizard(WizState state)
 			wizard_event = lcd_show_fullscreen_message_yes_no_and_wait_P(_T(MSG_STEEL_SHEET_CHECK), false, false);
 			if (!wizard_event) lcd_show_fullscreen_message_and_wait_P(_T(MSG_PLACE_STEEL_SHEET));
 			wizard_event = gcode_M45(true, 0);
-			if (wizard_event) {
+			if (!wizard_event) {
+				state = S::Failed;
+			} else {
+				raise_z_above(MIN_Z_FOR_SWAP);
 				//current filament needs to be unloaded and then new filament should be loaded
 				//start to preheat nozzle for unloading remaining PLA filament
 				setTargetHotend(PLA_PREHEAT_HOTEND_TEMP, 0);
@@ -4199,9 +4203,8 @@ void lcd_wizard(WizState state)
 				//load filament
 				lcd_wizard_load();
 				setTargetHotend(0, 0); //we are finished, cooldown nozzle
-				state = S::Finish; //shipped, no need to set first layer, go to final message directly
+				state = S::Restore;
 			}
-			else end = true;
 			break;
 #ifdef TEMP_MODEL
 		case S::TempModel:
@@ -4261,16 +4264,15 @@ void lcd_wizard(WizState state)
 			}
 			else
 			{
-			    lcd_show_fullscreen_message_and_wait_P(_i("If you have additional steel sheets, calibrate their presets in Settings - HW Setup - Steel sheets."));////MSG_ADDITIONAL_SHEETS c=20 r=9
-				state = S::Finish;
+				lcd_show_fullscreen_message_and_wait_P(_i("If you have additional steel sheets, calibrate their presets in Settings - HW Setup - Steel sheets."));////MSG_ADDITIONAL_SHEETS c=20 r=9
+				state = S::Restore;
 			}
 			break;
 		case S::Finish:
+		case S::Failed:
 			eeprom_update_byte((uint8_t*)EEPROM_WIZARD_ACTIVE, 0);
 			end = true;
 			break;
-
-		default: break;
 		}
 	}
     
@@ -4278,30 +4280,27 @@ void lcd_wizard(WizState state)
     
     const char *msg = NULL;
 	printf_P(_N("Wizard end state: %d\n"), (uint8_t)state);
-	switch (state) { //final message
-	case S::Restore: //printer was already calibrated
-		msg = _T(MSG_WIZARD_DONE);
+	switch (state) {
+	case S::Run:
+		// user interrupted
+		msg = _T(MSG_WIZARD_QUIT);
 		break;
-	case S::Selftest: //selftest
-	case S::Xyz: //xyz cal.
-	case S::Z: //z cal.
-		msg = _T(MSG_WIZARD_CALIBRATION_FAILED);
-		break;
-	case S::Finish: //we are finished
+
+	case S::Finish:
+		// we are successfully finished
 		msg = _T(MSG_WIZARD_DONE);
 		lcd_reset_alert_level();
 		lcd_setstatuspgm(MSG_WELCOME);
-		lcd_return_to_status(); 
+		lcd_return_to_status();
 		break;
-    case S::Preheat:
-    case S::Lay1CalCold:
-    case S::Lay1CalHot:
-#ifdef TEMP_MODEL
-	case S::TempModel: // exiting for calibration
-#endif //TEMP_MODEL
-        break;
+
+	case S::Failed:
+		// aborted due to failure
+		msg = _T(MSG_WIZARD_CALIBRATION_FAILED);
+		break;
+
 	default:
-		msg = _T(MSG_WIZARD_QUIT);
+		// exiting for later re-entry
 		break;
 	}
 	if (msg) {

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2726,7 +2726,7 @@ static void lcd_babystep_z()
 		}
 
 		// same logic as in babystep_load
-	    if (calibration_status() >= CALIBRATION_STATUS_LIVE_ADJUST)
+	    if (!calibration_status_get(CALIBRATION_STATUS_LIVE_ADJUST))
 			_md->babystepMemZ = 0;
 
 		_md->babystepMemMMZ = _md->babystepMemZ/cs.axis_steps_per_unit[Z_AXIS];
@@ -2768,7 +2768,7 @@ static void lcd_babystep_z()
 #ifdef PINDA_THERMISTOR        
 		eeprom_update_byte(&(EEPROM_Sheets_base->s[active_sheet].pinda_temp),current_temperature_pinda);
 #endif //PINDA_THERMISTOR
-		calibration_status_store(CALIBRATION_STATUS_CALIBRATED);
+		calibration_status_set(CALIBRATION_STATUS_LIVE_ADJUST);
 	}
 	if (LCD_CLICKED) menu_back();
 }
@@ -3889,7 +3889,7 @@ void lcd_first_layer_calibration_reset()
     MenuData* menuData = (MenuData*)&(menu_data[0]);
 
     if(LCD_CLICKED || !eeprom_is_sheet_initialized(eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet))) ||
-            (calibration_status() >= CALIBRATION_STATUS_LIVE_ADJUST) ||
+            (!calibration_status_get(CALIBRATION_STATUS_LIVE_ADJUST)) ||
             (0 == static_cast<int16_t>(eeprom_read_word(reinterpret_cast<uint16_t*>
             (&EEPROM_Sheets_base->s[(eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet)))].z_offset)))))
     {
@@ -5518,10 +5518,8 @@ static void lcd_reset_sheet()
 	if (selected_sheet == eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet)))
 	{
         eeprom_switch_to_next_sheet();
-        if((-1 == eeprom_next_initialized_sheet(0)) && (CALIBRATION_STATUS_CALIBRATED == calibration_status()))
-        {
-            calibration_status_store(CALIBRATION_STATUS_LIVE_ADJUST);
-        }
+        if (-1 == eeprom_next_initialized_sheet(0))
+            calibration_status_clear(CALIBRATION_STATUS_LIVE_ADJUST);
 	}
 
 	menu_back();

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -69,7 +69,12 @@ void lcd_crash_detect_enable();
 void lcd_crash_detect_disable();
 #endif
 
-extern const char* lcd_display_message_fullscreen_P(const char *msg, uint8_t &nlines);
+enum LCDButtonChoice : int_fast8_t {
+    LCD_LEFT_BUTTON_CHOICE = 1,
+    LCD_MIDDLE_BUTTON_CHOICE = 0,
+    LCD_BUTTON_TIMEOUT      = -1,
+};
+
 extern const char* lcd_display_message_fullscreen_P(const char *msg);
 
 extern void lcd_return_to_status();

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -235,11 +235,9 @@ enum class WizState : uint8_t
     TempModel,      //!< Temp model calibration
 #endif //TEMP_MODEL
     IsFil,          //!< Is filament loaded? First step of 1st layer calibration
-    PreheatPla,     //!< waiting for preheat nozzle for PLA
     Preheat,        //!< Preheat for any material
     LoadFilCold,    //!< Load filament for MMU
     LoadFilHot,     //!< Load filament without MMU
-    IsPla,          //!< Is PLA filament?
     Lay1CalCold,    //!< First layer calibration, temperature not selected yet
     Lay1CalHot,     //!< First layer calibration, temperature already selected
     RepeatLay1Cal,  //!< Repeat first layer calibration?

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -241,7 +241,8 @@ enum class WizState : uint8_t
     Lay1CalCold,    //!< First layer calibration, temperature not selected yet
     Lay1CalHot,     //!< First layer calibration, temperature already selected
     RepeatLay1Cal,  //!< Repeat first layer calibration?
-    Finish,         //!< Deactivate wizard
+    Finish,         //!< Deactivate wizard (success)
+    Failed,         //!< Deactivate wizard (failure)
 };
 
 void lcd_wizard(WizState state);

--- a/Firmware/util.cpp
+++ b/Firmware/util.cpp
@@ -522,3 +522,24 @@ void ip4_to_str(char* dest, uint8_t* IP)
 {
     sprintf_P(dest, PSTR("%u.%u.%u.%u"), IP[0], IP[1], IP[2], IP[3]);
 }
+
+
+bool calibration_status_get(CalibrationStatus components)
+{
+    CalibrationStatus status = eeprom_read_byte((uint8_t*)EEPROM_CALIBRATION_STATUS_V2);
+    return ((status & components) == components);
+}
+
+void calibration_status_set(CalibrationStatus components)
+{
+    CalibrationStatus status = eeprom_read_byte((uint8_t*)EEPROM_CALIBRATION_STATUS_V2);
+    status |= components;
+    eeprom_update_byte((uint8_t*)EEPROM_CALIBRATION_STATUS_V2, status);
+}
+
+void calibration_status_clear(CalibrationStatus components)
+{
+    CalibrationStatus status = eeprom_read_byte((uint8_t*)EEPROM_CALIBRATION_STATUS_V2);
+    status &= ~components;
+    eeprom_update_byte((uint8_t*)EEPROM_CALIBRATION_STATUS_V2, status);
+}

--- a/Firmware/util.cpp
+++ b/Firmware/util.cpp
@@ -181,19 +181,19 @@ inline int8_t is_provided_version_newer(const char *version_string)
     return 0;
 }
 
-bool eeprom_fw_version_older_than(const uint16_t (&ver_req)[4])
+bool eeprom_fw_version_older_than_p(const uint16_t (&ver_req)[4])
 {
     uint16_t ver_eeprom[4];
-
     ver_eeprom[0] = eeprom_read_word((uint16_t*)EEPROM_FIRMWARE_VERSION_MAJOR);
     ver_eeprom[1] = eeprom_read_word((uint16_t*)EEPROM_FIRMWARE_VERSION_MINOR);
     ver_eeprom[2] = eeprom_read_word((uint16_t*)EEPROM_FIRMWARE_VERSION_REVISION);
     ver_eeprom[3] = eeprom_read_word((uint16_t*)EEPROM_FIRMWARE_VERSION_FLAVOR);
 
     for (uint8_t i = 0; i < 4; ++i) {
-        if (ver_req[i] > ver_eeprom[i])
+        uint16_t v = pgm_read_word(&ver_req[i]);
+        if (v > ver_eeprom[i])
             return true;
-        else if (ver_req[i] < ver_eeprom[i])
+        else if (v < ver_eeprom[i])
             break;
     }
 

--- a/Firmware/util.cpp
+++ b/Firmware/util.cpp
@@ -181,32 +181,23 @@ inline int8_t is_provided_version_newer(const char *version_string)
     return 0;
 }
 
-bool force_selftest_if_fw_version()
+bool eeprom_fw_version_older_than(const uint16_t (&ver_req)[4])
 {
-	//if fw version used before flashing new firmware (fw version currently stored in eeprom) is lower then 3.1.2-RC2, function returns true to force selftest
+    uint16_t ver_eeprom[4];
 
-	uint16_t ver_eeprom[4];
-	uint16_t ver_with_calibration[4] = {3, 1, 2, 4}; //hardcoded 3.1.2-RC2 version
-	bool force_selftest = false;
+    ver_eeprom[0] = eeprom_read_word((uint16_t*)EEPROM_FIRMWARE_VERSION_MAJOR);
+    ver_eeprom[1] = eeprom_read_word((uint16_t*)EEPROM_FIRMWARE_VERSION_MINOR);
+    ver_eeprom[2] = eeprom_read_word((uint16_t*)EEPROM_FIRMWARE_VERSION_REVISION);
+    ver_eeprom[3] = eeprom_read_word((uint16_t*)EEPROM_FIRMWARE_VERSION_FLAVOR);
 
-	ver_eeprom[0] = eeprom_read_word((uint16_t*)EEPROM_FIRMWARE_VERSION_MAJOR);
-	ver_eeprom[1] = eeprom_read_word((uint16_t*)EEPROM_FIRMWARE_VERSION_MINOR);
-	ver_eeprom[2] = eeprom_read_word((uint16_t*)EEPROM_FIRMWARE_VERSION_REVISION);
-	ver_eeprom[3] = eeprom_read_word((uint16_t*)EEPROM_FIRMWARE_VERSION_FLAVOR);
+    for (uint8_t i = 0; i < 4; ++i) {
+        if (ver_req[i] > ver_eeprom[i])
+            return true;
+        else if (ver_req[i] < ver_eeprom[i])
+            break;
+    }
 
-	for (uint8_t i = 0; i < 4; ++i) {
-		if (ver_with_calibration[i] > ver_eeprom[i]) {
-			force_selftest = true;
-			break;
-		}
-		else if (ver_with_calibration[i] < ver_eeprom[i])
-			break;
-	}
-
-	//force selftest also in case that version used before flashing new firmware was 3.2.0-RC1
-	if ((ver_eeprom[0] == 3) && (ver_eeprom[1] == 2) && (ver_eeprom[2] == 0) && (ver_eeprom[3] == 3)) force_selftest = true;
-	
-	return force_selftest;
+    return false;
 }
 
 bool show_upgrade_dialog_if_version_newer(const char *version_string)

--- a/Firmware/util.cpp
+++ b/Firmware/util.cpp
@@ -10,7 +10,7 @@
 
 // Allocate the version string in the program memory. Otherwise the string lands either on the stack or in the global RAM.
 static const char FW_VERSION_STR[] PROGMEM = FW_VERSION;
-static const uint16_t FW_VERSION_NR[4] PROGMEM = {
+const uint16_t FW_VERSION_NR[4] PROGMEM = {
     FW_MAJOR,
     FW_MINOR,
     FW_REVISION,

--- a/Firmware/util.h
+++ b/Firmware/util.h
@@ -17,7 +17,7 @@ enum FirmwareRevisionFlavorType : uint16_t {
 };
 
 bool show_upgrade_dialog_if_version_newer(const char *version_string);
-bool eeprom_fw_version_older_than(const uint16_t (&req_ver)[4]);
+bool eeprom_fw_version_older_than_p(const uint16_t (&req_ver)[4]);
 void update_current_firmware_version_to_eeprom();
 
 

--- a/Firmware/util.h
+++ b/Firmware/util.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <stdint.h>
 
+extern const uint16_t FW_VERSION_NR[4];
 extern const char* FW_VERSION_STR_P();
 
 // Definition of a firmware flavor numerical values.

--- a/Firmware/util.h
+++ b/Firmware/util.h
@@ -16,10 +16,9 @@ enum FirmwareRevisionFlavorType : uint16_t {
     FIRMWARE_REVISION_RC = 0x0020
 };
 
-extern bool show_upgrade_dialog_if_version_newer(const char *version_string);
-extern bool force_selftest_if_fw_version();
-
-extern void update_current_firmware_version_to_eeprom();
+bool show_upgrade_dialog_if_version_newer(const char *version_string);
+bool eeprom_fw_version_older_than(const uint16_t (&req_ver)[4]);
+void update_current_firmware_version_to_eeprom();
 
 
 

--- a/Firmware/util.h
+++ b/Firmware/util.h
@@ -1,5 +1,5 @@
-#ifndef UTIL_H
-#define UTIL_H
+#pragma once
+#include <stdint.h>
 
 extern const char* FW_VERSION_STR_P();
 
@@ -111,4 +111,34 @@ void fSetMmuMode(bool bMMu);
 #define IP4_STR_SIZE 16
 extern void ip4_to_str(char* dest, uint8_t* IP);
 
-#endif /* UTIL_H */
+// Calibration status of the machine
+// (unsigned char*)EEPROM_CALIBRATION_STATUS_V2
+typedef uint8_t CalibrationStatus;
+const CalibrationStatus CALIBRATION_STATUS_SELFTEST    = 0b00000001; // Selftest
+const CalibrationStatus CALIBRATION_STATUS_XYZ         = 0b00000010; // XYZ calibration
+const CalibrationStatus CALIBRATION_STATUS_Z           = 0b00000100; // Z calibration
+#ifdef TEMP_MODEL
+const CalibrationStatus CALIBRATION_STATUS_TEMP_MODEL  = 0b00001000; // Temperature model calibration
+#endif
+const CalibrationStatus CALIBRATION_STATUS_LIVE_ADJUST = 0b00010000; // 1st layer calibration
+const CalibrationStatus CALIBRATION_STATUS_UNKNOWN     = 0b10000000; // Freshly assembled or unknown status
+
+// Calibration steps performed by the wizard
+const CalibrationStatus CALIBRATION_WIZARD_STEPS =
+    CALIBRATION_STATUS_SELFTEST |
+    CALIBRATION_STATUS_XYZ |
+    CALIBRATION_STATUS_Z |
+#ifdef TEMP_MODEL
+    CALIBRATION_STATUS_TEMP_MODEL |
+#endif
+    CALIBRATION_STATUS_LIVE_ADJUST;
+
+// Calibration steps enforced after service prep
+const CalibrationStatus CALIBRATION_FORCE_PREP = CALIBRATION_STATUS_Z;
+
+bool calibration_status_get(CalibrationStatus components);
+void calibration_status_set(CalibrationStatus components);
+void calibration_status_clear(CalibrationStatus components);
+
+// PINDA has an independent calibration flag
+inline bool calibration_status_pinda() { return eeprom_read_byte((uint8_t*)EEPROM_CALIBRATION_STATUS_PINDA); }


### PR DESCRIPTION
Backport of #3855

- Includes updated eeprom offsets
- Stubbed definition of LCDButtonChoice to reduce changes
