### PR TITLE
Address 3 different start scenarios 1st lay cal + MMU

### DIFF
--- a/Firmware/first_lay_cal.h
+++ b/Firmware/first_lay_cal.h
@@ -7,8 +7,8 @@
 #include <stdint.h>
 
 void lay1cal_wait_preheat();
-void lay1cal_load_filament(char *cmd_buffer, uint8_t filament);
-void lay1cal_intro_line();
+[[nodiscard]] bool lay1cal_load_filament(char *cmd_buffer, uint8_t filament);
+void lay1cal_intro_line(bool skipExtraPurge);
 void lay1cal_before_meander();
 void lay1cal_meander(char *cmd_buffer);
 void lay1cal_square(char *cmd_buffer, uint8_t i);

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -7,6 +7,7 @@
 #include "mmu2_progress_converter.h"
 #include "mmu2_reporting.h"
 
+#include "cardreader.h" // for IS_SD_PRINTING
 #include "Marlin.h"
 #include "language.h"
 #include "messages.h"
@@ -334,7 +335,10 @@ bool MMU2::tool_change(uint8_t slot) {
         return false;
 
     if (slot != extruder) {
-        if (FindaDetectsFilament()) {
+        if (/*FindaDetectsFilament()*/
+            /*!IS_SD_PRINTING && !usb_timer.running()*/
+            ! printer_active()
+            ) {
             // If Tcodes are used manually through the serial
             // we need to unload manually as well -- but only if FINDA detects filament
             unload();
@@ -385,7 +389,7 @@ void MMU2::get_statistics() {
     logic.Statistics();
 }
 
-uint8_t MMU2::get_current_tool() const {
+uint8_t __attribute__((noinline)) MMU2::get_current_tool() const {
     return extruder == MMU2_NO_TOOL ? (uint8_t)FILAMENT_UNKNOWN : extruder;
 }
 

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -68,6 +68,7 @@ int8_t FSensorStateMenu = 1;
 
 LcdCommands lcd_commands_type = LcdCommands::Idle;
 static uint8_t lcd_commands_step = 0;
+static bool extraPurgeNeeded = false; ///< lcd_commands - detect if extra purge after MMU-toolchange is necessary or not
 
 CustomMsg custom_message_type = CustomMsg::Status;
 uint8_t custom_message_state = 0;
@@ -874,14 +875,14 @@ void lcd_commands()
                 lcd_commands_step = 10;
                 break;
             case 10:
-                lay1cal_load_filament(cmd1, lay1cal_filament);
+                extraPurgeNeeded = lay1cal_load_filament(cmd1, lay1cal_filament);
                 lcd_commands_step = 9;
                 break;
             case 9:
                 lcd_clear();
                 menu_depth = 0;
                 menu_submenu(lcd_babystep_z);
-                lay1cal_intro_line();
+                lay1cal_intro_line(extraPurgeNeeded);
                 lcd_commands_step = 8;
                 break;
             case 8:


### PR DESCRIPTION
 This PR tries to address the 3 different startup scenarios for 1st layer calibration with the MMU:

- 1st lay cal started with correct filament already loaded in the nozzle - we should continue, but skip the first 58mm (first 2 g-codes in the hard coded sequence) of purge line extrusion
- 1st lay cal started with other filament already loaded in the nozzle - we should unload and then issue a toolchange with no extra unload
- 1st lay cal started without loaded filament - we should just do a toolchange with no extra unload

PFW-1457

todo:
- [ ] solve the mysterious condition in mmu2::toolchange unload
- [x] rebase this PR onto #3850 once merged