### PR TITLE
TM: Also clear the status flags when disabling the model

### DIFF
--- a/Firmware/temperature.cpp
+++ b/Firmware/temperature.cpp
@@ -2370,20 +2370,20 @@ void model_data::step(uint8_t heater_pwm, uint8_t fan_pwm, float heater_temp, fl
 }
 
 // clear error flags and mark as uninitialized
-void reinitialize()
+static void reinitialize()
 {
     data.flags = 1; // shorcut to reset all error flags
     warning_state.assert = false; // explicitly clear assertions
 }
 
 // verify calibration status and trigger a model reset if valid
-void setup()
+static void setup()
 {
     if(!calibrated()) enabled = false;
     reinitialize();
 }
 
-bool calibrated()
+static bool calibrated()
 {
     if(!(data.P >= 0)) return false;
     if(!(data.C >= 0)) return false;
@@ -2397,7 +2397,7 @@ bool calibrated()
     return true;
 }
 
-void check()
+static void check()
 {
     if(!enabled) return;
 
@@ -2426,7 +2426,7 @@ void check()
     }
 }
 
-void handle_warning()
+static void handle_warning()
 {
     // update values
     float warn = data.warn;
@@ -2459,7 +2459,7 @@ void handle_warning()
 }
 
 #ifdef TEMP_MODEL_DEBUG
-void log_usr()
+static void log_usr()
 {
     if(!log_buf.enabled) return;
 
@@ -2489,7 +2489,7 @@ void log_usr()
         (int)cur_pwm, (unsigned long)cur_temp_b, (unsigned long)cur_amb_b);
 }
 
-void log_isr()
+static void log_isr()
 {
     if(!log_buf.enabled) return;
 

--- a/Firmware/temperature.cpp
+++ b/Firmware/temperature.cpp
@@ -2369,11 +2369,18 @@ void model_data::step(uint8_t heater_pwm, uint8_t fan_pwm, float heater_temp, fl
     flag_bits.warning = (fabsf(dT_err_f) > warn_s);
 }
 
+// clear error flags and mark as uninitialized
+void reinitialize()
+{
+    data.flags = 1; // shorcut to reset all error flags
+    warning_state.assert = false; // explicitly clear assertions
+}
+
 // verify calibration status and trigger a model reset if valid
 void setup()
 {
     if(!calibrated()) enabled = false;
-    data.flag_bits.uninitialized = true;
+    reinitialize();
 }
 
 bool calibrated()
@@ -2504,7 +2511,7 @@ static void temp_model_reset_enabled(bool enabled)
 {
     TempMgrGuard temp_mgr_guard;
     temp_model::enabled = enabled;
-    temp_model::data.flag_bits.uninitialized = true;
+    temp_model::reinitialize();
 }
 
 bool temp_model_enabled()
@@ -2584,7 +2591,7 @@ void temp_model_reset_settings()
     temp_model::data.err = TEMP_MODEL_E;
     temp_model::warn_beep = true;
     temp_model::enabled = true;
-    temp_model::data.flag_bits.uninitialized = true;
+    temp_model::reinitialize();
 }
 
 void temp_model_load_settings()


### PR DESCRIPTION
Disabling the model during a warn/error condition will also stop updating the warning/error flag, keeping the printer in an error state.

Clear all flags as well when changing model settings.