### PR TITLE
Fix build failure when `TEMP_RESIDENCY_TIME` is not defined

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -9792,7 +9792,7 @@ static void wait_for_heater(long codenum, uint8_t extruder) {
 	while ((!cancel_heatup) && ((residencyStart == -1) ||
 		(residencyStart >= 0 && (((unsigned int)(_millis() - residencyStart)) < (TEMP_RESIDENCY_TIME * 1000UL))))) {
 #else
-	while (target_direction ? (isHeatingHotend(tmp_extruder)) : (isCoolingHotend(tmp_extruder) && (CooldownNoWait == false))) {
+	while (target_direction ? isHeatingHotend(active_extruder) : isCoolingHotend(active_extruder)) {
 #endif //TEMP_RESIDENCY_TIME
 		if ((_millis() - codenum) > 1000UL)
 		{ //Print Temp Reading and remaining time every 1 second while heating up/cooling down
@@ -9813,12 +9813,11 @@ static void wait_for_heater(long codenum, uint8_t extruder) {
 				{
 					SERIAL_PROTOCOLLN('?');
 				}
-			}
 #else
 				SERIAL_PROTOCOLLN();
 #endif
 				codenum = _millis();
-		}
+			}
 			manage_heater();
 			manage_inactivity(true); //do not disable steppers
 			lcd_update(0);
@@ -9832,6 +9831,7 @@ static void wait_for_heater(long codenum, uint8_t extruder) {
 				residencyStart = _millis();
 			}
 #endif //TEMP_RESIDENCY_TIME
+		}
 	}
 }
 

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -9792,7 +9792,7 @@ static void wait_for_heater(long codenum, uint8_t extruder) {
 	while ((!cancel_heatup) && ((residencyStart == -1) ||
 		(residencyStart >= 0 && (((unsigned int)(_millis() - residencyStart)) < (TEMP_RESIDENCY_TIME * 1000UL))))) {
 #else
-	while (target_direction ? isHeatingHotend(active_extruder) : isCoolingHotend(active_extruder)) {
+	while (target_direction ? isHeatingHotend(active_extruder) : (isCoolingHotend(active_extruder) && (CooldownNoWait == false))) {
 #endif //TEMP_RESIDENCY_TIME
 		if ((_millis() - codenum) > 1000UL)
 		{ //Print Temp Reading and remaining time every 1 second while heating up/cooling down

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -2479,7 +2479,7 @@ void gcode_M105(uint8_t extruder)
 
     SERIAL_PROTOCOLPGM(" @:");
 #ifdef EXTRUDER_WATTS
-    SERIAL_PROTOCOL((EXTRUDER_WATTS * getHeaterPower(tmp_extruder))/127);
+    SERIAL_PROTOCOL((EXTRUDER_WATTS * getHeaterPower(extruder))/127);
     SERIAL_PROTOCOLPGM("W");
 #else
     SERIAL_PROTOCOL(getHeaterPower(extruder));


### PR DESCRIPTION
* Fix build when `TEMP_RESIDENCY_TIME` is not defined
* Fix build when `EXTRUDER_WATTS` is defined