### PR TITLE
Make M300 S0 pause like Marlin

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -7277,7 +7277,6 @@ Sigma_Exit:
     #endif // NUM_SERVOS > 0
 
     #if (LARGE_FLASH == true && BEEPER > 0 )
-    
     /*!
 	### M300 - Play tone <a href="https://reprap.org/wiki/G-code#M300:_Play_beep_sound">M300: Play beep sound</a>
 	In Prusa Firmware the defaults are `100Hz` and `1000ms`, so that `M300` without parameters will beep for a second.
@@ -7291,12 +7290,19 @@ Sigma_Exit:
     */
     case 300: // M300
     {
-      uint16_t beepS = code_seen('S') ? code_value() : 0;
       uint16_t beepP = code_seen('P') ? code_value() : 1000;
-      #if BEEPER > 0
-      if (beepP > 0)
-        Sound_MakeCustom(beepP,beepS,false);
-      #endif
+      uint16_t beepS;
+      if (!code_seen('S'))
+          beepS = 0;
+      else {
+          beepS = code_value();
+          if (!beepS) {
+              // handle S0 as a pause
+              _delay(beepP);
+              break;
+          }
+      }
+      Sound_MakeCustom(beepP, beepS, false);
     }
     break;
     #endif // M300

--- a/Firmware/sound.cpp
+++ b/Firmware/sound.cpp
@@ -84,7 +84,6 @@ void Sound_MakeCustom(uint16_t ms,uint16_t tone_,bool critical){
                WRITE(BEEPER, HIGH);
                _delay(ms);
                WRITE(BEEPER, LOW);
-               _delay(ms);
           }
           else{
                _tone(BEEPER, tone_);


### PR DESCRIPTION
Follow Marlin's behavior and simply insert a delay for the requested duration when using M300 S0.

When S is not specified, use the default tone instead.

Fixes https://github.com/prusa3d/Prusa-Firmware/issues/3856