### PR TITLE
Optimisation: implement `lcd_print_pad_P()`

### DIFF
--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -538,6 +538,16 @@ char lcd_print_pad(const char* s, uint8_t len)
     return *s;
 }
 
+char lcd_print_pad_P(const char* s, uint8_t len)
+{
+    while (len && pgm_read_byte(s)) {
+        lcd_write(pgm_read_byte(s++));
+        --len;
+    }
+    lcd_space(len);
+    return *s;
+}
+
 void lcd_print(char c, int base)
 {
 	lcd_print((long) c, base);

--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -66,6 +66,8 @@
 #define LCD_RS_FLAG 0x01
 #define LCD_HALF_FLAG 0x02
 
+constexpr uint8_t row_offsets[] PROGMEM = { 0x00, 0x40, 0x14, 0x54 };
+
 FILE _lcdout; // = {0}; Global variable is always zero initialized, no need to explicitly state that.
 
 uint8_t lcd_displayfunction = 0;
@@ -341,8 +343,7 @@ static void FORCE_INLINE lcd_set_current_row(uint8_t row)
 /// @return row offset which the LCD register understands
 static uint8_t __attribute__((noinline)) lcd_get_row_offset(uint8_t row)
 {
-	uint8_t row_offsets[] = { 0x00, 0x40, 0x14, 0x54 };
-	return row_offsets[min(row, LCD_HEIGHT - 1)];
+	return pgm_read_byte(row_offsets[min(row, LCD_HEIGHT - 1)]);
 }
 
 void lcd_set_cursor(uint8_t col, uint8_t row)

--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -329,13 +329,31 @@ void lcd_no_autoscroll(void)
 }
 #endif
 
-void lcd_set_cursor(uint8_t col, uint8_t row)
+/// @brief set the current LCD row
+/// @param row LCD row number, ranges from 0 to LCD_HEIGHT - 1
+static void FORCE_INLINE lcd_set_current_row(uint8_t row)
+{
+	lcd_currline = min(row, LCD_HEIGHT - 1);
+}
+
+/// @brief Calculate the LCD row offset
+/// @param row LCD row number, ranges from 0 to LCD_HEIGHT - 1
+/// @return row offset which the LCD register understands
+static uint8_t __attribute__((noinline)) lcd_get_row_offset(uint8_t row)
 {
 	uint8_t row_offsets[] = { 0x00, 0x40, 0x14, 0x54 };
-	if (row >= LCD_HEIGHT)
-		row = LCD_HEIGHT - 1;    // we count rows starting w/0
-	lcd_currline = row;  
-	lcd_command(LCD_SETDDRAMADDR | (col + row_offsets[row]));
+	return row_offsets[min(row, LCD_HEIGHT - 1)];
+}
+
+void lcd_set_cursor(uint8_t col, uint8_t row)
+{
+	lcd_set_current_row(row);
+	lcd_command(LCD_SETDDRAMADDR | (col + lcd_get_row_offset(lcd_currline)));
+}
+
+void lcd_set_cursor_column(uint8_t col)
+{
+	lcd_command(LCD_SETDDRAMADDR | (col + lcd_get_row_offset(lcd_currline)));
 }
 
 // Allows us to fill the first 8 CGRAM locations

--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -343,7 +343,7 @@ static void FORCE_INLINE lcd_set_current_row(uint8_t row)
 /// @return row offset which the LCD register understands
 static uint8_t __attribute__((noinline)) lcd_get_row_offset(uint8_t row)
 {
-	return pgm_read_byte(row_offsets[min(row, LCD_HEIGHT - 1)]);
+	return pgm_read_byte(row_offsets + min(row, LCD_HEIGHT - 1));
 }
 
 void lcd_set_cursor(uint8_t col, uint8_t row)

--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -538,14 +538,14 @@ char lcd_print_pad(const char* s, uint8_t len)
     return *s;
 }
 
-char lcd_print_pad_P(const char* s, uint8_t len)
+uint8_t lcd_print_pad_P(const char* s, uint8_t len)
 {
     while (len && pgm_read_byte(s)) {
         lcd_write(pgm_read_byte(s++));
         --len;
     }
     lcd_space(len);
-    return *s;
+    return len;
 }
 
 void lcd_print(char c, int base)

--- a/Firmware/lcd.h
+++ b/Firmware/lcd.h
@@ -54,6 +54,7 @@ extern void lcd_printFloat(double number, uint8_t digits);
 
 extern void lcd_print(const char*);
 extern char lcd_print_pad(const char* s, uint8_t len);
+char lcd_print_pad_P(const char* s, uint8_t len);
 extern void lcd_print(char, int = 0);
 extern void lcd_print(unsigned char, int = 0);
 extern void lcd_print(int, int = 10);

--- a/Firmware/lcd.h
+++ b/Firmware/lcd.h
@@ -54,7 +54,12 @@ extern void lcd_printFloat(double number, uint8_t digits);
 
 extern void lcd_print(const char*);
 extern char lcd_print_pad(const char* s, uint8_t len);
-char lcd_print_pad_P(const char* s, uint8_t len);
+
+/// @brief print a string from PROGMEM with left-adjusted padding
+/// @param s string from PROGMEM.
+/// @param len maximum number of characters to print, including padding. Ranges from 0 to LCD_WIDTH.
+/// @return number of padded bytes. 0 means there was no padding.
+uint8_t lcd_print_pad_P(const char* s, uint8_t len);
 extern void lcd_print(char, int = 0);
 extern void lcd_print(unsigned char, int = 0);
 extern void lcd_print(int, int = 10);

--- a/Firmware/lcd.h
+++ b/Firmware/lcd.h
@@ -37,6 +37,10 @@ extern void lcd_no_autoscroll(void);*/
 
 extern void lcd_set_cursor(uint8_t col, uint8_t row);
 
+/// @brief Change the cursor column position while preserving the current row position
+/// @param col column number, ranges from 0 to LCD_WIDTH - 1
+void lcd_set_cursor_column(uint8_t col);
+
 extern void lcd_createChar_P(uint8_t, const uint8_t*);
 
 

--- a/Firmware/menu.cpp
+++ b/Firmware/menu.cpp
@@ -435,13 +435,21 @@ static void menu_draw_P(char chr, const char* str, int16_t val);
 template<>
 void menu_draw_P<int16_t*>(char chr, const char* str, int16_t val)
 {
-	int text_len = strlen_P(str);
-	if (text_len > 15) text_len = 15;
-	char spaces[LCD_WIDTH + 1] = {0};
-    memset(spaces,' ', LCD_WIDTH);
-	if (val <= -100) spaces[15 - text_len - 1] = 0;
-	else spaces[15 - text_len] = 0;
-	lcd_printf_P(menu_fmt_int3, chr, str, spaces, val);
+	// The LCD row position is controlled externally. We may only modify the column here
+	lcd_putc(chr);
+	uint8_t len = lcd_print_pad_P(str, LCD_WIDTH - 1);
+	lcd_set_cursor_column((LCD_WIDTH - 1) - len + 1);
+	lcd_putc(':');
+
+	// The value is right adjusted, set the cursor then render the value
+	if (val < 10) { // 1 digit
+		lcd_set_cursor_column(LCD_WIDTH - 1);
+	} else if (val < 100) { // 2 digits
+		lcd_set_cursor_column(LCD_WIDTH - 2);
+	} else { // 3 digits
+		lcd_set_cursor_column(LCD_WIDTH - 3);
+	}
+	lcd_print(val);
 }
 
 template<>

--- a/Firmware/menu.cpp
+++ b/Firmware/menu.cpp
@@ -173,13 +173,22 @@ static void menu_draw_toggle_puts_P(const char* str, const char* toggle, const u
     //a = selection mark. If it's set(1), then '>' will be used as the first character on the line. Else leave blank
     //b = toggle string is from progmem
     //c = do not set cursor at all. Must be handled externally.
-    char lineStr[LCD_WIDTH + 1];
-    const char eol = (toggle == NULL)?LCD_STR_ARROW_RIGHT[0]:' ';
+    uint8_t is_progmem = settings & 0x02;
+    const char eol = (toggle == NULL) ? LCD_STR_ARROW_RIGHT[0] : ' ';
     if (toggle == NULL) toggle = _T(MSG_NA);
-    sprintf_P(lineStr, PSTR("%c%-18.18S"), (settings & 0x01)?'>':' ', str);
-    sprintf_P(lineStr + LCD_WIDTH - ((settings & 0x02)?strlen_P(toggle):strlen(toggle)) - 3, (settings & 0x02)?PSTR("[%S]%c"):PSTR("[%s]%c"), toggle, eol);
+    uint8_t len = 4 + (is_progmem ? strlen_P(toggle) : strlen(toggle));
     if (!(settings & 0x04)) lcd_set_cursor(0, menu_row);
-    lcd_print_pad(lineStr, LCD_WIDTH);
+    lcd_putc((settings & 0x01) ? '>' : ' ');
+    lcd_print_pad_P(str, LCD_WIDTH - len);
+    lcd_putc('[');
+    if (is_progmem)
+    {
+        lcd_puts_P(toggle);
+    } else {
+        lcd_print(toggle);
+    }
+    lcd_putc(']');
+    lcd_putc(eol);
 }
 
 //! @brief Format sheet name

--- a/Firmware/menu.cpp
+++ b/Firmware/menu.cpp
@@ -154,26 +154,6 @@ uint8_t menu_item_ret(void)
 	return 1;
 }
 
-/*
-int menu_draw_item_printf_P(char type_char, const char* format, ...)
-{
-	va_list args;
-	va_start(args, format);
-	int ret = 0;
-    lcd_set_cursor(0, menu_row);
-	if (lcd_encoder == menu_item)
-		lcd_print('>');
-	else
-		lcd_print(' ');
-	int cnt = vfprintf_P(lcdout, format, args);
-	for (int i = cnt; i < 18; i++)
-		lcd_print(' ');
-	lcd_print(type_char);
-	va_end(args);
-	return ret;
-}
-*/
-
 static char menu_selection_mark(){
 	return (lcd_encoder == menu_item)?'>':' ';
 }
@@ -181,7 +161,9 @@ static char menu_selection_mark(){
 static void menu_draw_item_puts_P(char type_char, const char* str)
 {
     lcd_set_cursor(0, menu_row);
-    lcd_printf_P(PSTR("%c%-18.18S%c"), menu_selection_mark(), str, type_char);
+    lcd_putc(menu_selection_mark());
+    lcd_print_pad_P(str, LCD_WIDTH - 2);
+    lcd_putc(type_char);
 }
 
 static void menu_draw_toggle_puts_P(const char* str, const char* toggle, const uint8_t settings)
@@ -197,7 +179,7 @@ static void menu_draw_toggle_puts_P(const char* str, const char* toggle, const u
     sprintf_P(lineStr, PSTR("%c%-18.18S"), (settings & 0x01)?'>':' ', str);
     sprintf_P(lineStr + LCD_WIDTH - ((settings & 0x02)?strlen_P(toggle):strlen(toggle)) - 3, (settings & 0x02)?PSTR("[%S]%c"):PSTR("[%s]%c"), toggle, eol);
     if (!(settings & 0x04)) lcd_set_cursor(0, menu_row);
-    fputs(lineStr, lcdout);
+    lcd_print_pad(lineStr, LCD_WIDTH);
 }
 
 //! @brief Format sheet name
@@ -233,7 +215,9 @@ static void menu_draw_item_select_sheet_E(char type_char, const Sheet &sheet)
     lcd_set_cursor(0, menu_row);
     SheetFormatBuffer buffer;
     menu_format_sheet_select_E(sheet, buffer);
-    lcd_printf_P(PSTR("%c%-18.18s%c"), menu_selection_mark(), buffer.c, type_char);
+    lcd_putc(menu_selection_mark());
+    lcd_print_pad(buffer.c, LCD_WIDTH - 2);
+    lcd_putc(type_char);
 }
 
 
@@ -242,25 +226,19 @@ static void menu_draw_item_puts_E(char type_char, const Sheet &sheet)
     lcd_set_cursor(0, menu_row);
     SheetFormatBuffer buffer;
     menu_format_sheet_E(sheet, buffer);
-    lcd_printf_P(PSTR("%c%-18.18s%c"), menu_selection_mark(), buffer.c, type_char);
+    lcd_putc(menu_selection_mark());
+    lcd_print_pad(buffer.c, LCD_WIDTH - 2);
+    lcd_putc(type_char);
 }
 
 static void menu_draw_item_puts_P(char type_char, const char* str, char num)
 {
     lcd_set_cursor(0, menu_row);
-    lcd_printf_P(PSTR("%c%-.16S "), menu_selection_mark(), str);
+    lcd_putc(menu_selection_mark());
+    lcd_print_pad_P(str, LCD_WIDTH - 3);
     lcd_putc(num);
-    lcd_putc_at(19, menu_row, type_char);
+    lcd_putc(type_char);
 }
-
-/*
-int menu_draw_item_puts_P_int16(char type_char, const char* str, int16_t val, )
-{
-    lcd_set_cursor(0, menu_row);
-	int cnt = lcd_printf_P(PSTR("%c%-18S%c"), (lcd_encoder == menu_item)?'>':' ', str, type_char);
-	return cnt;
-}
-*/
 
 void menu_item_dummy(void)
 {
@@ -558,7 +536,8 @@ void menu_progressbar_init(uint16_t total, const char* title)
 	progressbar_total = total;
 	
 	lcd_set_cursor(0, 1);
-	lcd_printf_P(PSTR("%-20.20S\n"), title);
+	lcd_print_pad_P(title, LCD_WIDTH);
+	lcd_set_cursor(0, 2);
 }
 
 void menu_progressbar_update(uint16_t newVal)

--- a/Firmware/menu.cpp
+++ b/Firmware/menu.cpp
@@ -242,11 +242,11 @@ static void menu_draw_item_puts_E(char type_char, const Sheet &sheet)
 
 static void menu_draw_item_puts_P(char type_char, const char* str, char num)
 {
-    lcd_set_cursor(0, menu_row);
-    lcd_putc(menu_selection_mark());
-    lcd_print_pad_P(str, LCD_WIDTH - 3);
-    lcd_putc(num);
-    lcd_putc(type_char);
+    const uint8_t max_strlen = LCD_WIDTH - 3;
+    lcd_putc_at(0, menu_row, menu_selection_mark());
+    uint8_t len = lcd_print_pad_P(str, max_strlen);
+    lcd_putc_at((max_strlen - len) + 2, menu_row, num);
+    lcd_putc_at(LCD_WIDTH - 1, menu_row, type_char);
 }
 
 void menu_item_dummy(void)


### PR DESCRIPTION
Used `lcd_print_pad_P` is some obvious places (mainly the menu code). We can probably use this function in more places to further save flash memory

Skimming through the menus I didn't see any issues. This needs to be tested well :) 

Change in memory:
Flash: -496 bytes
SRAM: -4 bytes