### PR TITLE
Fix blank LCD while err. Load to Extr. Failed

### DIFF
--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -301,7 +301,7 @@ bool MMU2::ToolChangeCommonOnce(uint8_t slot){
         } else { // Prepare a retry attempt
             unload();
             if( retries == 2 && eeprom_read_byte((uint8_t*)EEPROM_MMU_CUTTER_ENABLED) == EEPROM_MMU_CUTTER_ENABLED_enabled){
-                cut_filament(slot); // try cutting filament tip at the last attempt
+                cut_filament(slot, false); // try cutting filament tip at the last attempt
             }
         }
     }
@@ -451,11 +451,13 @@ void FullScreenMsg(const char *pgmS, uint8_t slot){
     lcd_print(slot + 1);
 }
 
-bool MMU2::cut_filament(uint8_t slot){
+bool MMU2::cut_filament(uint8_t slot, bool enableFullScreenMsg /* = true */){
     if( ! WaitForMMUReady())
         return false;
 
-    FullScreenMsg(_T(MSG_CUT_FILAMENT), slot);
+    if( enableFullScreenMsg ){
+        FullScreenMsg(_T(MSG_CUT_FILAMENT), slot);
+    }
     {
         if( FindaDetectsFilament() ){
             unload();
@@ -543,11 +545,13 @@ bool MMU2::load_filament_to_nozzle(uint8_t slot) {
     return true;
 }
 
-bool MMU2::eject_filament(uint8_t slot, bool recover) {
+bool MMU2::eject_filament(uint8_t slot, bool enableFullScreenMsg /* = true */) {
     if( ! WaitForMMUReady())
         return false;
 
-    FullScreenMsg(_T(MSG_EJECT_FILAMENT), slot);
+    if( enableFullScreenMsg ){
+        FullScreenMsg(_T(MSG_EJECT_FILAMENT), slot);
+    }
     {
         if( FindaDetectsFilament() ){
             unload();

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -300,7 +300,7 @@ bool MMU2::ToolChangeCommonOnce(uint8_t slot){
             return true; // success
         } else { // Prepare a retry attempt
             unload();
-            if( retries == 1 && eeprom_read_byte((uint8_t*)EEPROM_MMU_CUTTER_ENABLED) == EEPROM_MMU_CUTTER_ENABLED_enabled){
+            if( retries == 2 && eeprom_read_byte((uint8_t*)EEPROM_MMU_CUTTER_ENABLED) == EEPROM_MMU_CUTTER_ENABLED_enabled){
                 cut_filament(slot); // try cutting filament tip at the last attempt
             }
         }
@@ -683,6 +683,8 @@ void MMU2::CheckUserInput(){
             // we'll actually wait for it automagically in manage_response and after it finishes correctly,
             // we'll issue another command (like toolchange)
             logic.ClearPrinterError();
+            lastErrorCode = ErrorCode::OK;
+            lastErrorSource = ErrorSourceNone; // this seems to help clearing the error screen
         }
 
         ResumeHotendTemp(); // Recover the hotend temp before we attempt to do anything else...

--- a/Firmware/mmu2.h
+++ b/Firmware/mmu2.h
@@ -126,12 +126,12 @@ public:
 
     /// Move MMU's selector aside and push the selected filament forward.
     /// Usable for improving filament's tip or pulling the remaining piece of filament out completely.
-    bool eject_filament(uint8_t slot, bool recover);
+    bool eject_filament(uint8_t slot, bool enableFullScreenMsg = true);
 
     /// Issue a Cut command into the MMU
     /// Requires unloaded filament from the printer (obviously)
     /// @returns false if the operation cannot be performed (Stopped)
-    bool cut_filament(uint8_t slot);
+    bool cut_filament(uint8_t slot, bool enableFullScreenMsg = true);
 
     /// Issue a planned request for statistics data from MMU
     void get_statistics();


### PR DESCRIPTION
Because Load to Extr. Failed error is not an MMU error but a printer one, the existing infrastructure has been bent to support such a scenario. During testing it turned out, that some machines fail to draw the error screen due to previous internal states. This PR resets the internal states so that the conditions for drawing the error screen are met.

Cutting was invoked one step later before this PR - so even after cutting the filament tip successfully and the load would have been successful, the operation failed with an error. This is now fixed as well.

Operations CutFilament and EjectFilament now also support suppression of their FullScreenMsgs, which is especially usefull in case when called from a ToolChange.

PFW-1474