### PR TITLE
optimisation: re-use `serialecho_temperatures()`

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -6206,14 +6206,7 @@ Sigma_Exit:
           if(( _millis() - codenum) > 1000 ) //Print Temp Reading every 1 second while heating up.
           {
 			  if (!farm_mode) {
-				  float tt = degHotend(active_extruder);
-				  SERIAL_PROTOCOLPGM("T:");
-				  SERIAL_PROTOCOL(tt);
-				  SERIAL_PROTOCOLPGM(" E:");
-				  SERIAL_PROTOCOL((int)active_extruder);
-				  SERIAL_PROTOCOLPGM(" B:");
-				  SERIAL_PROTOCOL_F(degBed(), 1);
-				  SERIAL_PROTOCOLLN();
+				  serialecho_temperatures();
 			  }
 				  codenum = _millis();
 			  


### PR DESCRIPTION
Extracted optimisation from https://github.com/prusa3d/Prusa-Firmware/pull/3857 since this is a low hanging fruit

Change in memory:
Flash: -82 bytes
SRAM: 0 bytes