### PR TITLE
Fix Load filament issues with MMU FW1.0.6

### DIFF
--- a/Firmware/mmu.h
+++ b/Firmware/mmu.h
@@ -15,7 +15,8 @@ extern uint8_t mmu_extruder;
 extern uint8_t tmp_extruder;
 
 extern int8_t mmu_finda;
-extern LongTimer mmu_last_finda_response;
+extern uint32_t mmu_last_finda_response;
+//extern LongTimer mmu_last_finda_response;
 extern bool ir_sensor_detected;
 
 extern int16_t mmu_version;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3520,7 +3520,8 @@ static void lcd_show_sensors_state()
 	uint8_t idler_state = STATE_NA;
 
 	pinda_state = READ(Z_MIN_PIN);
-	if (mmu_enabled && !mmu_last_finda_response.expired(1000))
+	if (mmu_enabled && ((_millis() - mmu_last_finda_response) < 1000ul))
+	//if (mmu_enabled && !mmu_last_finda_response.expired(1000))
 	{
 		finda_state = mmu_finda;
 	}


### PR DESCRIPTION
Revert `LongTimers` to `uint32_t` to fix issues with MMU2 FW1.0.6.
This PR is only for Firmware 3.12.x NOT 3.13.x !!!  
Should fix https://github.com/prusa3d/Prusa-Firmware/issues/3895

```
Sketch uses 246490 bytes (97%) of program storage space. Maximum is 253952 bytes.
Global variables use 5569 bytes of dynamic memory.
```
before
```
Sketch uses 246296 bytes (96%) of program storage space. Maximum is 253952 bytes.
Global variables use 5572 bytes of dynamic memory.
```
+194 flash
-3 RAM

PFW-1462