### PR TITLE
PFW-1478 MK3 Move Z to top during Nozzle change

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1037,7 +1037,7 @@ void lcd_commands()
                 lcd_update_enabled = true;
                 lcd_draw_update = 2; //force lcd clear and update after the stack unwinds.
                 enquecommand_P(PSTR("G28 W"));
-                enquecommand_P(PSTR("G1 X125 Y10 Z150 F1000"));
+                enquecommand_P(PSTR("G1 X125 Z200 F1000"));
                 enquecommand_P(PSTR("M109 S280"));
 #ifdef TEMP_MODEL
                 was_enabled = temp_model_enabled();


### PR DESCRIPTION
Minor change to allow more work space during the nozzle change, thanks to @laskr1999 requesting the change https://github.com/prusa3d/Prusa-Firmware/issues/3889
In our opinion it makes still sense to move the extruder in the middle of the x-axis.

Before
```
Sketch uses 253040 bytes (99%) of program storage space. Maximum is 253952 bytes.
Global variables use 5658 bytes of dynamic memory.
```
With this PR
```
Sketch uses 253036 bytes (99%) of program storage space. Maximum is 253952 bytes.
Global variables use 5658 bytes of dynamic memory.
```
-4 Flash
+- 0 RAM

- [x] Cherry-pick to MK3_3.12