### PR TITLE
Shorten the Try-Load-Unload sequence

### DIFF
--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -234,8 +234,8 @@ bool MMU2::VerifyFilamentEnteredPTFE() {
     uint8_t fsensorState = 0;
     // MMU has finished its load, push the filament further by some defined constant length
     // If the filament sensor reads 0 at any moment, then report FAILURE
-    MoveE(MMU2_EXTRUDER_PTFE_LENGTH + MMU2_EXTRUDER_HEATBREAK_LENGTH - (logic.ExtraLoadDistance() - MMU2_FILAMENT_SENSOR_POSITION), MMU2_VERIFY_LOAD_TO_NOZZLE_FEED_RATE);
-    MoveE(-(MMU2_EXTRUDER_PTFE_LENGTH + MMU2_EXTRUDER_HEATBREAK_LENGTH - (logic.ExtraLoadDistance() - MMU2_FILAMENT_SENSOR_POSITION)), MMU2_VERIFY_LOAD_TO_NOZZLE_FEED_RATE);
+    MoveE(MMU2_EXTRUDER_PTFE_LENGTH + MMU2_EXTRUDER_HEATBREAK_LENGTH + MMU2_VERIFY_LOAD_TO_NOZZLE_TWEAK - (logic.ExtraLoadDistance() - MMU2_FILAMENT_SENSOR_POSITION), MMU2_VERIFY_LOAD_TO_NOZZLE_FEED_RATE);
+    MoveE(-(MMU2_EXTRUDER_PTFE_LENGTH + MMU2_EXTRUDER_HEATBREAK_LENGTH + MMU2_VERIFY_LOAD_TO_NOZZLE_TWEAK - (logic.ExtraLoadDistance() - MMU2_FILAMENT_SENSOR_POSITION)), MMU2_VERIFY_LOAD_TO_NOZZLE_FEED_RATE);
 
     while (planner_any_moves()) {
         // Wait for move to finish and monitor the fsensor the entire time

--- a/Firmware/mmu2/variants/config_MMU2.h
+++ b/Firmware/mmu2/variants/config_MMU2.h
@@ -34,6 +34,7 @@ static constexpr float MMU2_LOAD_TO_NOZZLE_FEED_RATE = 20.0F; // mm/s
 static constexpr float MMU2_UNLOAD_TO_FINDA_FEED_RATE = 120.0F; // mm/s
 
 static constexpr float MMU2_VERIFY_LOAD_TO_NOZZLE_FEED_RATE = 50.0F; // mm/s
+static constexpr float MMU2_VERIFY_LOAD_TO_NOZZLE_TWEAK = -5.F; // mm used to shorten/lenghten (negative number -> shorten) the distange of verify load to nozzle
 
 // The first the MMU does is initialise its axis. Meanwhile the E-motor will unload 20mm of filament in approx. 1 second.
 static constexpr float MMU2_RETRY_UNLOAD_TO_FINDA_LENGTH = 80.0f; // mm

--- a/Firmware/mmu2/variants/config_MMU2S.h
+++ b/Firmware/mmu2/variants/config_MMU2S.h
@@ -34,6 +34,7 @@ static constexpr float MMU2_LOAD_TO_NOZZLE_FEED_RATE = 20.0F; // mm/s
 static constexpr float MMU2_UNLOAD_TO_FINDA_FEED_RATE = 120.0F; // mm/s
 
 static constexpr float MMU2_VERIFY_LOAD_TO_NOZZLE_FEED_RATE = 50.0F; // mm/s
+static constexpr float MMU2_VERIFY_LOAD_TO_NOZZLE_TWEAK = -5.F; // mm used to shorten/lenghten (negative number -> shorten) the distange of verify load to nozzle
 
 // The first the MMU does is initialise its axis. Meanwhile the E-motor will unload 20mm of filament in approx. 1 second.
 static constexpr float MMU2_RETRY_UNLOAD_TO_FINDA_LENGTH = 80.0f; // mm


### PR DESCRIPTION
... and allow easier future tweking in case of need.

Also, save ~30B of code by returning the previous E-motor position.