### PR TITLE
optimisation: re-use `delay_keep_alive()` in a few places PR2

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -5285,9 +5285,7 @@ void process_commands()
             codenum += _millis();  // keep track of when we started waiting
             KEEPALIVE_STATE(PAUSED_FOR_USER);
             while(_millis() < codenum && !lcd_clicked()) {
-                manage_heater();
-                manage_inactivity(true);
-                lcd_update(0);
+                delay_keep_alive(0);
             }
             KEEPALIVE_STATE(IN_HANDLER);
             lcd_ignore_click(false);
@@ -9711,9 +9709,7 @@ static void wait_for_heater(long codenum, uint8_t extruder) {
 #endif
 				codenum = _millis();
 		}
-			manage_heater();
-			manage_inactivity(true); //do not disable steppers
-			lcd_update(0);
+		delay_keep_alive(0); //do not disable steppers
 #ifdef TEMP_RESIDENCY_TIME
 			/* start/restart the TEMP_RESIDENCY_TIME timer whenever we reach target temp for the first time
 			or when current temp falls outside the hysteresis after target temp was reached */
@@ -11425,9 +11421,7 @@ void marlin_wait_for_click()
     lcd_consume_click();
     while(!lcd_clicked())
     {
-        manage_heater();
-        manage_inactivity(true);
-        lcd_update(0);
+        delay_keep_alive(0);
     }
     KEEPALIVE_STATE(busy_state_backup);
 }

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -739,9 +739,7 @@ bool MMU2::manage_response(const bool move_axes, const bool turn_off_nozzle) {
         // - still running -> wait normally in idle()
         // - failed -> then do the safety moves on the printer like before
         // - finished ok -> proceed with reading other commands
-        manage_heater();
-        manage_inactivity(true); // calls LogicStep() and remembers its return status
-        lcd_update(0);
+        delay_keep_alive(0); // calls LogicStep() and remembers its return status
 
         if (mmu_print_saved & SavedState::CooldownPending){
             if (!nozzleTimeout.running()){

--- a/Firmware/stepper.cpp
+++ b/Firmware/stepper.cpp
@@ -1333,10 +1333,8 @@ void st_synchronize()
 			lcd_update(0);
 		}
 #else //TMC2130
-		manage_heater();
 		// Vojtech: Don't disable motors inside the planner!
-		manage_inactivity(true);
-		lcd_update(0);
+		delay_keep_alive(0);
 #endif //TMC2130
 	}
 }

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3847,10 +3847,7 @@ void lcd_language()
 	lcd_draw_update = 2;
 	while ((menu_menu != lcd_status_screen) && (!lang_is_selected()))
 	{
-		_delay(50);
-		lcd_update(0);
-		manage_heater();
-		manage_inactivity(true);
+		delay_keep_alive(50);
 	}
 	if (lang_is_selected())
 		lcd_return_to_status();


### PR DESCRIPTION
Pulled all optimisations from https://github.com/prusa3d/Prusa-Firmware/pull/3857 which don't change any behavior in the firmware.

Change in memory (on multilang build):
Flash: -52 bytes
SRAM: 0 bytes