### PR TITLE
MMU: Fix bug with button choice on MMU error screen isn't reset

### DIFF
--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -101,6 +101,7 @@ static uint8_t ReportErrorHookMonitor(uint8_t ei) {
     uint8_t ret = 0;
     bool two_choices = false;
     static int8_t enc_dif = lcd_encoder_diff;
+    static uint8_t reset_button_selection = 1;
 
     if (lcd_encoder_diff == 0)
     {
@@ -122,6 +123,14 @@ static uint8_t ReportErrorHookMonitor(uint8_t ei) {
 
     static int8_t current_selection = two_choices ? LCD_LEFT_BUTTON_CHOICE : LCD_MIDDLE_BUTTON_CHOICE;
     static int8_t choice_selected = -1;
+
+    if (reset_button_selection) {
+        // If a new error screen is shown, we must reset the button selection
+        // Default selection is different depending on how many buttons are present
+        current_selection = two_choices ? LCD_LEFT_BUTTON_CHOICE : LCD_MIDDLE_BUTTON_CHOICE;
+        choice_selected = -1;
+        reset_button_selection = 0;
+    }
 
     // Check if knob was rotated
     if (abs(enc_dif - lcd_encoder_diff) >= ENCODER_PULSES_PER_STEP) {
@@ -203,9 +212,8 @@ static uint8_t ReportErrorHookMonitor(uint8_t ei) {
         ret = 2;
     }
 
-    // Reset static variables to their default value
-    current_selection = two_choices ? LCD_LEFT_BUTTON_CHOICE : LCD_MIDDLE_BUTTON_CHOICE;
-    choice_selected = -1;
+    // Next MMU error screen should reset the choice selection
+    reset_button_selection = 1;
     return ret;
 }
 

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -101,7 +101,7 @@ static uint8_t ReportErrorHookMonitor(uint8_t ei) {
     uint8_t ret = 0;
     bool two_choices = false;
     static int8_t enc_dif = lcd_encoder_diff;
-    static uint8_t reset_button_selection = 1;
+    static uint8_t reset_button_selection;
 
     if (lcd_encoder_diff == 0)
     {


### PR DESCRIPTION
PFW-1381

Fix issue where button selection on MMU error screen is not reset correctly

The issue only appears after two error screens with different number of buttons.

Step-by-step description of issue:

1. Trigger an MMU error screen with 3 buttons. Select any button to resolve it.
2. On closing the screen, current_selection would be reset to the default button selection with respect to a error screen with 3 buttons.
3. Trigger an MMU error screen with 2 buttons. Select default button.
4. Notice issue. Firmware thinks you selected the OTHER button. This is due to the fact the screen uses the default choices as if it was a 3 button screen. current_selection still has the values from step 2.

The solution is to reset the button choice when we enter `ReportErrorHookMonitor()` for the first time on a new MMU error screen. I added a new variable reset_button_selection to track this. After the changes in this PR I can no longer reproduce the issue.

Change in memory:
Flash: +16 bytes
SRAM: +1 bytes