### PR TITLE
wizard: Do not complain about missing calibration if model is disabled

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1556,7 +1556,7 @@ void setup()
           if (!calibration_status_get(CALIBRATION_STATUS_LIVE_ADJUST))
               lcd_show_fullscreen_message_and_wait_P(_T(MSG_BABYSTEP_Z_NOT_SET));
 #ifdef TEMP_MODEL
-          if (!calibration_status_get(CALIBRATION_STATUS_TEMP_MODEL))
+          if (!calibration_status_get(CALIBRATION_STATUS_TEMP_MODEL) && temp_model_enabled())
               lcd_show_fullscreen_message_and_wait_P(_T(MSG_TM_NOT_CAL));
 #endif //TEMP_MODEL
       }


### PR DESCRIPTION
This fixes #3891 without having to set the calibration bit, meaning that if the model is later re-enabled without a real calibration, a prompt is shown as expected.