### PR TITLE
TM: Restore extruder autofan state when stopping/resuming

### DIFF
--- a/Firmware/fancheck.cpp
+++ b/Firmware/fancheck.cpp
@@ -294,3 +294,13 @@ void hotendFanSetFullSpeed()
 #endif //FAN_SOFT_PWM
     fanSpeed = 255;
 }
+
+void hotendDefaultAutoFanState()
+{
+#if (defined(EXTRUDER_0_AUTO_FAN_PIN) && EXTRUDER_0_AUTO_FAN_PIN > -1)
+#ifdef EXTRUDER_ALTFAN_DETECT
+    altfanStatus.altfanOverride = eeprom_read_byte((uint8_t*)EEPROM_ALTFAN_OVERRIDE);
+#endif
+    setExtruderAutoFanState(1);
+#endif
+}

--- a/Firmware/fancheck.cpp
+++ b/Firmware/fancheck.cpp
@@ -280,11 +280,18 @@ void checkFans()
 #endif //DEBUG_DISABLE_FANCHECK
 }
 
+void resetFanCheck() {
+    fan_measuring = false;
+    extruder_autofan_last_check = _millis();
+}
+
+
 void hotendFanSetFullSpeed()
 {
 #ifdef EXTRUDER_ALTFAN_DETECT
     altfanStatus.altfanOverride = 1; //full speed
 #endif //EXTRUDER_ALTFAN_DETECT
+    resetFanCheck();
     setExtruderAutoFanState(3);
     SET_OUTPUT(FAN_PIN);
 #ifdef FAN_SOFT_PWM
@@ -301,6 +308,7 @@ void hotendDefaultAutoFanState()
 #ifdef EXTRUDER_ALTFAN_DETECT
     altfanStatus.altfanOverride = eeprom_read_byte((uint8_t*)EEPROM_ALTFAN_OVERRIDE);
 #endif
+    resetFanCheck();
     setExtruderAutoFanState(1);
 #endif
 }

--- a/Firmware/fancheck.h
+++ b/Firmware/fancheck.h
@@ -33,3 +33,4 @@ void checkExtruderAutoFans();
 
 void checkFans();
 void hotendFanSetFullSpeed();
+void hotendDefaultAutoFanState();

--- a/Firmware/fancheck.h
+++ b/Firmware/fancheck.h
@@ -32,5 +32,7 @@ void checkExtruderAutoFans();
 #endif
 
 void checkFans();
+void resetFanCheck(); // resets the fan measuring state
+
 void hotendFanSetFullSpeed();
 void hotendDefaultAutoFanState();

--- a/Firmware/temperature.cpp
+++ b/Firmware/temperature.cpp
@@ -2632,11 +2632,9 @@ namespace temp_model_cal {
 // set current fan speed for both front/backend
 static __attribute__((noinline)) void set_fan_speed(uint8_t fan_speed)
 {
-#if (defined(EXTRUDER_0_AUTO_FAN_PIN) && EXTRUDER_0_AUTO_FAN_PIN > -1)
     // reset the fan measuring state due to missing hysteresis handling on the checking side
-    fan_measuring = false;
-    extruder_autofan_last_check = _millis();
-#endif
+    resetFanCheck();
+
     fanSpeed = fan_speed;
 #ifdef FAN_SOFT_PWM
     fanSpeedSoftPwm = fan_speed;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5260,7 +5260,12 @@ void lcd_resume_print()
     st_synchronize();
     custom_message_type = CustomMsg::Resuming;
     isPrintPaused = false;
-    Stopped = false; // resume processing USB commands again
+
+    // resume processing USB commands again and restore hotend fan state (in case the print was
+    // stopped due to a thermal error)
+    hotendDefaultAutoFanState();
+    Stopped = false;
+
     restore_print_from_ram_and_continue(default_retraction);
     pause_time += (_millis() - start_pause_print); //accumulate time when print is paused for correct statistics calculation
     refresh_cmd_timeout();
@@ -5888,6 +5893,9 @@ void lcd_print_stop_finish()
     } else {
         // Turn off the print fan
         fanSpeed = 0;
+
+        // restore the auto hotend state
+        hotendDefaultAutoFanState();
     }
 
     if (MMU2::mmu2.Enabled() && MMU2::mmu2.FindaDetectsFilament())


### PR DESCRIPTION
During thermal errors all fans are set to full speed.

When the print is resumed or stopped *and* the thermal error is gone, also restore the autofan state.

Fixes https://github.com/prusa3d/Prusa-Firmware/issues/3893