### PR TITLE
wizard: Do no set "Self test OK" as an alert message

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -6456,7 +6456,7 @@ bool lcd_selftest()
 	
 	if (_result)
 	{
-		LCD_ALERTMESSAGERPGM(_i("Self test OK"));////MSG_SELFTEST_OK c=20
+		lcd_setstatuspgm(_i("Self test OK"));////MSG_SELFTEST_OK c=20
 		calibration_status_set(CALIBRATION_STATUS_SELFTEST);
 	}
 	else

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -6456,8 +6456,9 @@ bool lcd_selftest()
 	
 	if (_result)
 	{
-		lcd_setstatuspgm(_i("Self test OK"));////MSG_SELFTEST_OK c=20
 		calibration_status_set(CALIBRATION_STATUS_SELFTEST);
+		lcd_setstatuspgm(_i("Self test OK"));////MSG_SELFTEST_OK c=20
+		lcd_return_to_status();
 	}
 	else
 	{


### PR DESCRIPTION
Alert messages are intended to persist above "info" messages, thus preventing further calibration status updates to be shown (such as thermal model calibration).

Just set the message as a regular status message.

Fixes #3892

@3d-gussner as an extra test we need to ensure there is no sort of "workflow" that requires "Self test OK" to persist above other messages for some odd reason.