### PR TITLE
TM: Set the cal status bit when running `M310 A` directly (3.12)

### DIFF
--- a/Firmware/temperature.cpp
+++ b/Firmware/temperature.cpp
@@ -32,7 +32,7 @@
 #include "stepper.h"
 #include "ultralcd.h"
 #include "menu.h"
-#include "sound.h"
+#include "util.h"
 #include "fancheck.h"
 #include "messages.h"
 #include "language.h"
@@ -2946,6 +2946,7 @@ void temp_model_autotune(int16_t temp, bool selftest)
         memcpy(temp_model::data.R, orig_R, sizeof(temp_model::data.R));
         temp_model_set_enabled(orig_enabled);
     } else {
+        calibration_status_set(CALIBRATION_STATUS_TEMP_MODEL);
         lcd_setstatuspgm(MSG_WELCOME);
         temp_model_cal::set_fan_speed(0);
         temp_model_set_enabled(orig_enabled);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1064,7 +1064,6 @@ void lcd_commands()
             lcd_commands_step = 0;
             lcd_commands_type = LcdCommands::Idle;
             bool res = temp_model_autotune_result();
-            if (res) calibration_status_set(CALIBRATION_STATUS_TEMP_MODEL);
             if (eeprom_read_byte((uint8_t*)EEPROM_WIZARD_ACTIVE)) {
                 // resume the wizard
                 lcd_wizard(res ? WizState::Restore : WizState::Failed);


### PR DESCRIPTION
Backport of #3922 for 3.12