### PR TITLE
Disable M47 if TMC2130 drivers are used

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -5643,13 +5643,13 @@ void process_commands()
     /*!
 	### M47 - Show end stops dialog on the display <a href="https://reprap.org/wiki/G-code#M47:_Show_end_stops_dialog_on_the_display">M47: Show end stops dialog on the display</a>
     */
+#ifndef TMC2130
     case 47:
-        
 		KEEPALIVE_STATE(PAUSED_FOR_USER);
         lcd_diag_show_end_stops();
 		KEEPALIVE_STATE(IN_HANDLER);
         break;
-
+#endif //!TMC2130
 #if 0
     case 48: // M48: scan the bed induction sensor points, print the sensor trigger coordinates to the serial line for visualization on the PC.
     {

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3357,6 +3357,7 @@ void lcd_temp_cal_show_result(bool result) {
 	lcd_update(2);
 }
 
+#ifndef TMC2130
 static void lcd_show_end_stops() {
 	lcd_puts_at_P(0, 0, (PSTR("End stops diag")));
 	lcd_puts_at_P(0, 1, (READ(X_MIN_PIN) ^ (bool)X_MIN_ENDSTOP_INVERTING) ? (PSTR("X1")) : (PSTR("X0")));
@@ -3364,16 +3365,11 @@ static void lcd_show_end_stops() {
 	lcd_puts_at_P(0, 3, (READ(Z_MIN_PIN) ^ (bool)Z_MIN_ENDSTOP_INVERTING) ? (PSTR("Z1")) : (PSTR("Z0")));
 }
 
-#ifndef TMC2130
 static void menu_show_end_stops() {
     lcd_show_end_stops();
     if (LCD_CLICKED) menu_back();
 }
-#endif // not defined TMC2130
 
-// Lets the user move the Z carriage up to the end stoppers.
-// When done, it sets the current Z to Z_MAX_POS and returns true.
-// Otherwise the Z calibration is not changed and false is returned.
 void lcd_diag_show_end_stops()
 {
     lcd_clear();
@@ -3389,6 +3385,7 @@ void lcd_diag_show_end_stops()
     lcd_clear();
     lcd_return_to_status();
 }
+#endif // not defined TMC2130
 
 static void lcd_print_state(uint8_t state)
 {

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -94,12 +94,11 @@ extern uint8_t lcd_show_multiscreen_message_yes_no_and_wait_P(const char *msg, b
 
 #ifndef TMC2130
 extern bool lcd_calibrate_z_end_stop_manual(bool only_z);
+extern void lcd_diag_show_end_stops();
 #endif
 
 // Show the result of the calibration process on the LCD screen.
-  extern void lcd_bed_calibration_show_result(BedSkewOffsetDetectionResultType result, uint8_t point_too_far_mask);
-
-extern void lcd_diag_show_end_stops();
+extern void lcd_bed_calibration_show_result(BedSkewOffsetDetectionResultType result, uint8_t point_too_far_mask);
 
 
 #define LCD_MESSAGEPGM(x) lcd_setstatuspgm(PSTR(x))


### PR DESCRIPTION
M47 only makes sense for printers that use actual endstops. The "virtual endstop" of the TMC driver only gives pulses during the stall event, so it doesn't make sense to show the state of the DIAG pins on screen.
It also made little sense that this menu actually showed the X/Y/Z endstop pin states on the einsy, where X and Y are not connected to anything, and Z is connected to the PINDA. Since we have the sensors submenu in support, this menu/mcode can be disabled safely on the MK3/S.

flash: -126B
RAM: 0B