### PR TITLE
Cleanup: remove `code_value_float()`

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -2050,7 +2050,7 @@ static float probe_pt(float x, float y, float z_before) {
     *  K<factor>                  Set advance K factor
     */
 inline void gcode_M900() {
-    float newK = code_seen('K') ? code_value_float() : -2;
+    float newK = code_seen('K') ? code_value() : -2;
 #ifdef LA_NOCOMPAT
     if (newK >= 0 && newK < LA_K_MAX)
         extruder_advance_K = newK;
@@ -5965,11 +5965,11 @@ Sigma_Exit:
         if(code_seen('Q')) print_percent_done_silent = code_value_uint8();
         if(code_seen('S')) print_time_remaining_silent = code_value();
         if(code_seen('C')){
-            float print_time_to_change_normal_f = code_value_float();
+            float print_time_to_change_normal_f = code_value();
             print_time_to_change_normal = ( print_time_to_change_normal_f <= 0 ) ? PRINT_TIME_REMAINING_INIT : print_time_to_change_normal_f;
         }
         if(code_seen('D')){
-            float print_time_to_change_silent_f = code_value_float();
+            float print_time_to_change_silent_f = code_value();
             print_time_to_change_silent = ( print_time_to_change_silent_f <= 0 ) ? PRINT_TIME_REMAINING_INIT : print_time_to_change_silent_f;
         }
         {
@@ -6995,8 +6995,8 @@ Sigma_Exit:
     case 214: //!@n M214 - Set Arc Parameters (Use M500 to store in eeprom) P<MM_PER_ARC_SEGMENT> S<MIN_MM_PER_ARC_SEGMENT> R<MIN_ARC_SEGMENTS> F<ARC_SEGMENTS_PER_SEC>
     {
         // Extract all possible parameters if they appear
-        float p = code_seen('P') ? code_value_float() : cs.mm_per_arc_segment;
-        float s = code_seen('S') ? code_value_float() : cs.min_mm_per_arc_segment;
+        float p = code_seen('P') ? code_value() : cs.mm_per_arc_segment;
+        float s = code_seen('S') ? code_value() : cs.min_mm_per_arc_segment;
         unsigned char n = code_seen('N') ? code_value() : cs.n_arc_correction;
         unsigned short r = code_seen('R') ? code_value() : cs.min_arc_segments;
         unsigned short f = code_seen('F') ? code_value() : cs.arc_segments_per_sec;
@@ -7925,7 +7925,7 @@ Sigma_Exit:
     case 862: // M862: print checking
           float nDummy;
           uint8_t nCommand;
-          nCommand=(uint8_t)(modff(code_value_float(),&nDummy)*10.0+0.5);
+          nCommand=(uint8_t)(modff(code_value(),&nDummy)*10.0+0.5);
           switch((ClPrintChecking)nCommand)
                {
                case ClPrintChecking::_Nozzle:     // ~ .1

--- a/Firmware/cmdqueue.h
+++ b/Firmware/cmdqueue.h
@@ -75,15 +75,4 @@ static inline long    code_value_long()    { return strtol(strchr_pointer+1, NUL
 static inline int16_t code_value_short()   { return int16_t(strtol(strchr_pointer+1, NULL, 10)); };
 static inline uint8_t code_value_uint8()   { return uint8_t(strtol(strchr_pointer+1, NULL, 10)); };
 
-static inline float code_value_float()
-{
-    char* e = strchr(strchr_pointer, 'E');
-    if (!e) return strtod(strchr_pointer + 1, NULL);
-    *e = 0;
-    float ret = strtod(strchr_pointer + 1, NULL);
-    *e = 'E';
-    return ret;
-}
-
-
 #endif //CMDQUEUE_H


### PR DESCRIPTION
The function adds a bit of overhead compared to `code_value()`

I suspect this function is a relic of the past. If we need to search for the `'E'` character. Why not just do it externally? It makes no sense to be apply this overhead on every use of `code_value_float()`. For floats we use `code_value()`

Change in memory:
Flash: -82 bytes
SRAM: 0 bytes