### PR TITLE
Optimisation: Don't print floats with `lcd_print()`

### DIFF
--- a/Firmware/MarlinSerial.cpp
+++ b/Firmware/MarlinSerial.cpp
@@ -312,7 +312,7 @@ void MarlinSerial::println(double n, int digits)
 void MarlinSerial::printNumber(unsigned long n, uint8_t base)
 {
   unsigned char buf[8 * sizeof(long)]; // Assumes 8-bit chars. 
-  unsigned long i = 0;
+  uint8_t i = 0;
 
   if (n == 0) {
     print('0');

--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -612,12 +612,6 @@ void lcd_print(unsigned long n, int base)
 		lcd_printNumber(n, base);
 }
 
-void lcd_print(double n, int digits)
-{
-  lcd_printFloat(n, digits);
-}
-
-
 void lcd_printNumber(unsigned long n, uint8_t base)
 {
 	unsigned char buf[8 * sizeof(long)]; // Assumes 8-bit chars. 
@@ -635,37 +629,6 @@ void lcd_printNumber(unsigned long n, uint8_t base)
 	for (; i > 0; i--)
 		lcd_print((char) (buf[i - 1] < 10 ?	'0' + buf[i - 1] : 'A' + buf[i - 1] - 10));
 }
-
-void lcd_printFloat(double number, uint8_t digits) 
-{ 
-	// Handle negative numbers
-	if (number < 0.0)
-	{
-		lcd_print('-');
-		number = -number;
-	}
-	// Round correctly so that print(1.999, 2) prints as "2.00"
-	double rounding = 0.5;
-	for (uint8_t i=0; i<digits; ++i)
-		rounding /= 10.0;
-	number += rounding;
-	// Extract the integer part of the number and print it
-	unsigned long int_part = (unsigned long)number;
-	double remainder = number - (double)int_part;
-	lcd_print(int_part);
-	// Print the decimal point, but only if there are digits beyond
-	if (digits > 0)
-		lcd_print('.'); 
-	// Extract digits from the remainder one at a time
-	while (digits-- > 0)
-	{
-		remainder *= 10.0;
-		int toPrint = int(remainder);
-		lcd_print(toPrint);
-		remainder -= toPrint; 
-	} 
-}
-
 
 uint8_t lcd_draw_update = 2;
 int32_t lcd_encoder = 0;

--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -621,7 +621,7 @@ void lcd_print(double n, int digits)
 void lcd_printNumber(unsigned long n, uint8_t base)
 {
 	unsigned char buf[8 * sizeof(long)]; // Assumes 8-bit chars. 
-	unsigned long i = 0;
+	uint8_t i = 0;
 	if (n == 0)
 	{
 		lcd_print('0');

--- a/Firmware/lcd.h
+++ b/Firmware/lcd.h
@@ -54,7 +54,6 @@ extern int lcd_printf_P(const char* format, ...);
 extern void lcd_space(uint8_t n);
 
 extern void lcd_printNumber(unsigned long n, uint8_t base);
-extern void lcd_printFloat(double number, uint8_t digits);
 
 extern void lcd_print(const char*);
 extern char lcd_print_pad(const char* s, uint8_t len);
@@ -70,7 +69,6 @@ extern void lcd_print(int, int = 10);
 extern void lcd_print(unsigned int, int = 10);
 extern void lcd_print(long, int = 10);
 extern void lcd_print(unsigned long, int = 10);
-extern void lcd_print(double, int = 2);
 
 //! @brief Clear screen
 #define ESC_2J     "\x1b[2J"

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2597,12 +2597,11 @@ static void lcd_menu_xyz_skew()
 	 _i("Slight skew"), _deg(bed_skew_angle_mild),  ////MSG_SLIGHT_SKEW c=14
 	 _i("Severe skew"), _deg(bed_skew_angle_extreme)  ////MSG_SEVERE_SKEW c=14
 	);
+	lcd_set_cursor(15, 0);
 	if (angleDiff < 100){
-		lcd_set_cursor(15,0);
 		lcd_printf_P(_N("%3.2f\x01"), _deg(angleDiff));
-	}
-	else{
-		lcd_puts_at_P(15,0, _T(MSG_NA));
+	} else {
+		lcd_puts_P(_T(MSG_NA));
 	}
     if (lcd_clicked())
         menu_goto(lcd_menu_xyz_offset, 0, true, true);
@@ -2622,19 +2621,10 @@ static void lcd_menu_xyz_offset()
 {
     lcd_puts_at_P(0, 0, _i("[0;0] point offset"));////MSG_MEASURED_OFFSET c=20
     lcd_puts_at_P(0, 1, separator);
-    lcd_puts_at_P(0, 2, PSTR("X"));
-    lcd_puts_at_P(0, 3, PSTR("Y"));
 
-    float vec_x[2];
-    float vec_y[2];
-    float cntr[2];
-    world2machine_read_valid(vec_x, vec_y, cntr);
-
-    for (uint_least8_t i = 0; i < 2; i++)
-    {
-        lcd_set_cursor((cntr[i] < 0) ? 13 : 14, i+2);
-        lcd_print(cntr[i]);
-        lcd_puts_at_P(18, i + 2, PSTR("mm"));
+    for (uint8_t i = 0; i < 2; i++) {
+        lcd_set_cursor(0, i + 2);
+        lcd_printf_P(PSTR("%c%17.2fmm"), 'X' + i, eeprom_read_float((float*)(EEPROM_BED_CALIBRATION_CENTER+4*i)));
     }
     menu_back_if_clicked();
 }


### PR DESCRIPTION
Two optimisations:

1. When printing a number with `MarlinSerial::printNumber()` and `lcd_printNumber()`, there can be at most 8 * 4 = 32 digits (characters). We can use a `uint8_t` instead of `uint32_t` index to keep track of the number of digits.
2. Don't print `float` with `lcd_print()`. Currently there is only one place in the firmware which does this. See the menu `Support->XYZ cal. details`. This is very inefficient and we're better off using `lcd_printf_P()`.

Change in memory (on multilang MK3S build):
Flash: -594 bytes
SRAM: 0 bytes