### PR TITLE
Fix an issue where Altfan Override setting in EEPROM is not respected at boot-up

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1255,9 +1255,6 @@ void setup()
     temp_mgr_init();
 
 #ifdef EXTRUDER_ALTFAN_DETECT
-    if (eeprom_read_byte((uint8_t*)EEPROM_ALTFAN_OVERRIDE) == EEPROM_EMPTY_VALUE) {
-        eeprom_update_byte((uint8_t*)EEPROM_ALTFAN_OVERRIDE, 0);
-    }
     SERIAL_ECHORPGM(_n("Hotend fan type: "));
     if (extruder_altfan_detect())
         SERIAL_ECHOLNRPGM(PSTR("ALTFAN"));

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1257,12 +1257,12 @@ void setup()
 #ifdef EXTRUDER_ALTFAN_DETECT
     if (eeprom_read_byte((uint8_t*)EEPROM_ALTFAN_OVERRIDE) == EEPROM_EMPTY_VALUE) {
         eeprom_update_byte((uint8_t*)EEPROM_ALTFAN_OVERRIDE, 0);
-        SERIAL_ECHORPGM(_n("Hotend fan type: "));
-        if (extruder_altfan_detect())
-            SERIAL_ECHOLNRPGM(PSTR("ALTFAN"));
-        else
-            SERIAL_ECHOLNRPGM(PSTR("NOCTUA"));
     }
+    SERIAL_ECHORPGM(_n("Hotend fan type: "));
+    if (extruder_altfan_detect())
+        SERIAL_ECHOLNRPGM(PSTR("ALTFAN"));
+    else
+        SERIAL_ECHOLNRPGM(PSTR("NOCTUA"));
 #endif //EXTRUDER_ALTFAN_DETECT
 
 	plan_init();  // Initialize planner;

--- a/Firmware/fancheck.cpp
+++ b/Firmware/fancheck.cpp
@@ -164,6 +164,9 @@ bool extruder_altfan_detect()
 {
     // override isAltFan setting for detection
     altfanStatus.isAltfan = 0;
+
+    // During initialisation, use the EEPROM value
+    altfanStatus.altfanOverride = eeprom_read_byte((uint8_t *)EEPROM_ALTFAN_OVERRIDE);
     setExtruderAutoFanState(3);
 
     SET_INPUT(TACH_0);

--- a/Firmware/fancheck.cpp
+++ b/Firmware/fancheck.cpp
@@ -166,7 +166,7 @@ bool extruder_altfan_detect()
     altfanStatus.isAltfan = 0;
 
     // During initialisation, use the EEPROM value
-    altfanStatus.altfanOverride = eeprom_read_byte((uint8_t *)EEPROM_ALTFAN_OVERRIDE);
+    altfanStatus.altfanOverride = eeprom_init_default_byte((uint8_t*)EEPROM_ALTFAN_OVERRIDE, 0);
     setExtruderAutoFanState(3);
 
     SET_INPUT(TACH_0);


### PR DESCRIPTION
See comments in this Github issue: https://github.com/prusa3d/Prusa-Firmware/issues/3933 I could reproduce this issue on my end with 3.13.

Change in memory:
Flash: -2 bytes
SRAM: 0 bytes