### PR TITLE
3.12 Fix an issue where Altfan Override setting in EEPROM is not respected at boot-up

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1300,14 +1300,11 @@ void setup()
     temp_mgr_init();
 
 #ifdef EXTRUDER_ALTFAN_DETECT
-    if (eeprom_read_byte((uint8_t*)EEPROM_ALTFAN_OVERRIDE) == EEPROM_EMPTY_VALUE) {
-        eeprom_update_byte((uint8_t*)EEPROM_ALTFAN_OVERRIDE, 0);
-        SERIAL_ECHORPGM(_n("Hotend fan type: "));
-        if (extruder_altfan_detect())
-            SERIAL_ECHOLNRPGM(PSTR("ALTFAN"));
-        else
-            SERIAL_ECHOLNRPGM(PSTR("NOCTUA"));
-    }
+    SERIAL_ECHORPGM(_n("Hotend fan type: "));
+    if (extruder_altfan_detect())
+        SERIAL_ECHOLNRPGM(PSTR("ALTFAN"));
+    else
+        SERIAL_ECHOLNRPGM(PSTR("NOCTUA"));
 #endif //EXTRUDER_ALTFAN_DETECT
 
 	plan_init();  // Initialize planner;

--- a/Firmware/fancheck.cpp
+++ b/Firmware/fancheck.cpp
@@ -164,6 +164,10 @@ bool extruder_altfan_detect()
 {
     // override isAltFan setting for detection
     altfanStatus.isAltfan = 0;
+    if (eeprom_read_byte((uint8_t*)EEPROM_ALTFAN_OVERRIDE) == EEPROM_EMPTY_VALUE) {
+        eeprom_update_byte((uint8_t*)EEPROM_ALTFAN_OVERRIDE, 0);
+    }
+    altfanStatus.altfanOverride = eeprom_read_byte((uint8_t*)EEPROM_ALTFAN_OVERRIDE);
     setExtruderAutoFanState(3);
 
     SET_INPUT(TACH_0);


### PR DESCRIPTION
This is a backport of the same fix for 3.13 here: https://github.com/prusa3d/Prusa-Firmware/pull/3939

Additionally, always show in the logs whether the fantype is ALTFAN or NOCTUA like in 3.11 and previous firmwares

Steps to reproduce issue on 3.12.1 RC1:

1. Go to the `Settings -> HW setup -> Experimental` menu and set `Altfan det.` toggle to `OFF`
2. Restart the printer (via Reset button or Power cycle)
3. Go to the `Settings -> HW setup -> Experimental` menu and observe issue => `Altfan det.` toggle shows `ON` when it should be `OFF`
