### PR TITLE
PFW-1482: wizard: Disable TM warnings during calibration (3.12)

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1050,6 +1050,7 @@ void lcd_commands()
             [[fallthrough]];
 
         case 3:
+            temp_model_set_warn_beep(false);
             enquecommand_P(PSTR("M310 A F1"));
             lcd_commands_step = 2;
             break;
@@ -1063,6 +1064,7 @@ void lcd_commands()
         case 1:
             lcd_commands_step = 0;
             lcd_commands_type = LcdCommands::Idle;
+            temp_model_set_warn_beep(true);
             bool res = temp_model_autotune_result();
             if (eeprom_read_byte((uint8_t*)EEPROM_WIZARD_ACTIVE)) {
                 // resume the wizard


### PR DESCRIPTION
Backport of #3941 for 3.12