### PR TITLE
Add active sheet reporting to M503

### DIFF
--- a/Firmware/ConfigurationStore.cpp
+++ b/Firmware/ConfigurationStore.cpp
@@ -106,6 +106,15 @@ void Config_PrintSettings(uint8_t level)
 #ifdef THERMAL_MODEL
     thermal_model_report_settings();
 #endif
+    // Report Active sheet
+    {
+      const int8_t sheetNR = eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet));
+      char sheetName[8] = {0};
+      eeprom_read_block(sheetName, EEPROM_Sheets_base->s[sheetNR].name, 7);
+      printf_P(PSTR(
+          "%SActive sheet: %d %s\n"),
+          echomagic, sheetNR, sheetName);
+    }
 }
 #endif
 


### PR DESCRIPTION
Adds active sheet index and name reporting to M503.

Currently there is no way for connected host (Octoprint) to retrieve active sheet information.
For preventive checks / pauses / user prompts when changing materials and thus sheets, retrieving active sheet information is required.

Adding this information to M503 instead off comming up with a separate GCode made the most sense.