### PR TITLE
Add active steel sheet check to M862

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -7992,7 +7992,7 @@ Sigma_Exit:
       - M862.3 { P"<model_name>" | Q }
       - M862.4 { P<fw_version> | Q }
       - M862.5 { P<gcode_level> | Q }
-      - M862.6 { P<active_sheet> | Q }
+      - M862.7 { P<active_sheet> | Q }
     
     When run with P<> argument, the check is performed against the input value.
     When run with Q argument, the current value is shown.
@@ -8075,7 +8075,7 @@ Sigma_Exit:
                     else if(code_seen('Q'))
                          SERIAL_PROTOCOLLN(GCODE_LEVEL);
                     break;
-               case ClPrintChecking::_ActiveSheet:      // ~ .6
+               case ClPrintChecking::_ActiveSheet:      // ~ .7
                     if(code_seen('P')) {
                       uint8_t sheetIdx = code_value_uint8();
                       active_sheet_check(sheetIdx);

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -7992,6 +7992,7 @@ Sigma_Exit:
       - M862.3 { P"<model_name>" | Q }
       - M862.4 { P<fw_version> | Q }
       - M862.5 { P<gcode_level> | Q }
+      - M862.6 { P<active_sheet> | Q }
     
     When run with P<> argument, the check is performed against the input value.
     When run with Q argument, the current value is shown.
@@ -8073,6 +8074,21 @@ Sigma_Exit:
                          }
                     else if(code_seen('Q'))
                          SERIAL_PROTOCOLLN(GCODE_LEVEL);
+                    break;
+               case ClPrintChecking::_ActiveSheet:      // ~ .6
+                    if(code_seen('P')) {
+                      uint8_t sheetIdx = code_value_uint8();
+                      active_sheet_check(sheetIdx);
+                    }
+                    else if(code_seen('Q')) {
+                      char sheet_name[8] = {0};
+		                  const int8_t activeSheetIdx = eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet));
+                      eeprom_read_block(sheet_name, &EEPROM_Sheets_base->s[activeSheetIdx].name, 7);
+                      SERIAL_PROTOCOLPGM("Sheet ");
+                      SERIAL_PROTOCOL(activeSheetIdx);
+                      SERIAL_PROTOCOLPGM(": ");
+                      SERIAL_PROTOCOLLN(sheet_name);
+                    }
                     break;
                }
         break;

--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -141,6 +141,8 @@ const char MSG_GCODE_NEWER_FIRMWARE_CONTINUE[] PROGMEM_I1 = ISTR("G-code sliced 
 const char MSG_GCODE_NEWER_FIRMWARE_CANCELLED[] PROGMEM_I1 = ISTR("G-code sliced for a newer firmware. Please update the firmware. Print cancelled."); ////MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
 const char MSG_GCODE_DIFF_CONTINUE[] PROGMEM_I1 = ISTR("G-code sliced for a different level. Continue?"); ////MSG_GCODE_DIFF_CONTINUE c=20 r=3
 const char MSG_GCODE_DIFF_CANCELLED[] PROGMEM_I1 = ISTR("G-code sliced for a different level. Please re-slice the model again. Print cancelled."); ////MSG_GCODE_DIFF_CANCELLED c=20 r=8
+const char MSG_GCODE_DIFF_SHEET_CONTINUE[] PROGMEM_I1 = ISTR("Printer active sheet differs from the G-code. Continue?"); ////MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=5
+const char MSG_GCODE_DIFF_SHEET_CANCELLED[] PROGMEM_I1 = ISTR("Printer active sheet differs from the G-code. Please check the value in settings. Print cancelled."); ////MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=9
 const char MSG_NOZZLE_DIFFERS_CONTINUE[] PROGMEM_I1 = ISTR("Nozzle diameter differs from the G-code. Continue?"); ////MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
 const char MSG_NOZZLE_DIFFERS_CANCELLED[] PROGMEM_I1 = ISTR("Nozzle diameter differs from the G-code. Please check the value in settings. Print cancelled."); ////MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
 const char MSG_NOZZLE_DIAMETER[] PROGMEM_I1 = ISTR("Nozzle d."); ////MSG_NOZZLE_DIAMETER c=10

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -146,6 +146,8 @@ extern const char MSG_GCODE_NEWER_FIRMWARE_CONTINUE[];
 extern const char MSG_GCODE_NEWER_FIRMWARE_CANCELLED[];
 extern const char MSG_GCODE_DIFF_CONTINUE[];
 extern const char MSG_GCODE_DIFF_CANCELLED[];
+extern const char MSG_GCODE_DIFF_SHEET_CONTINUE[];
+extern const char MSG_GCODE_DIFF_SHEET_CANCELLED[];
 extern const char MSG_NOZZLE_DIFFERS_CONTINUE[];
 extern const char MSG_NOZZLE_DIFFERS_CANCELLED[];
 extern const char MSG_NOZZLE_DIAMETER[];

--- a/Firmware/util.cpp
+++ b/Firmware/util.cpp
@@ -389,6 +389,29 @@ void gcode_level_check(uint16_t nGcodeLevel) {
     );
 }
 
+
+void active_sheet_check(uint8_t sheetIdx) {
+    if (oCheckModel == ClCheckModel::_None)
+        return;
+
+    int8_t activeSheetIdx = eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet));
+    if (sheetIdx == activeSheetIdx)
+        return;
+
+    // SERIAL_ECHO_START;
+    // SERIAL_ECHOLNPGM("Printer G-code level differs from the G-code ...");
+    // SERIAL_ECHOPGM("actual  : ");
+    // SERIAL_ECHOLN(activeSheetIdx);
+    // SERIAL_ECHOPGM("expected: ");
+    // SERIAL_ECHOLN(sheetIdx);
+        
+    render_M862_warnings(
+        _i("Printer active sheet differs from the G-code. Continue?") ////MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=5
+        ,_i("Printer active sheet differs from the G-code. Please check the value in settings. Print cancelled.") ////MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=9
+        ,(uint8_t)oCheckMode
+    );
+}
+
 #define GCODE_DELIMITER '"'
 
 char *code_string(const char *pStr, size_t *nLength) {

--- a/Firmware/util.cpp
+++ b/Firmware/util.cpp
@@ -406,8 +406,8 @@ void active_sheet_check(uint8_t sheetIdx) {
     // SERIAL_ECHOLN(sheetIdx);
         
     render_M862_warnings(
-        _i("Printer active sheet differs from the G-code. Continue?") ////MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=5
-        ,_i("Printer active sheet differs from the G-code. Please check the value in settings. Print cancelled.") ////MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=9
+        _T(MSG_GCODE_DIFF_SHEET_CONTINUE)
+        ,_T(MSG_GCODE_DIFF_SHEET_CANCELLED)
         ,(uint8_t)oCheckMode
     );
 }

--- a/Firmware/util.h
+++ b/Firmware/util.h
@@ -29,7 +29,8 @@ enum class ClPrintChecking:uint_least8_t
     _Model=2,
     _Smodel=3,
     _Version=4,
-    _Gcode=5
+    _Gcode=5,
+    _ActiveSheet=6
 };
 
 enum class ClNozzleDiameter:uint_least8_t
@@ -93,6 +94,7 @@ void printer_model_check(uint16_t nPrinterModel, uint16_t actualPrinterModel);
 void printer_smodel_check(const char *pStrPos, const char *actualPrinterSModel);
 void fw_version_check(const char *pVersion);
 void gcode_level_check(uint16_t nGcodeLevel);
+void active_sheet_check(uint8_t sheetIdx);
 
 uint16_t nPrinterType(bool bMMu);
 const char *sPrinterType(bool bMMu);

--- a/Firmware/util.h
+++ b/Firmware/util.h
@@ -30,7 +30,8 @@ enum class ClPrintChecking:uint_least8_t
     _Smodel=3,
     _Version=4,
     _Gcode=5,
-    _ActiveSheet=6
+    _FirmwareFeatures=6,
+    _ActiveSheet=7
 };
 
 enum class ClNozzleDiameter:uint_least8_t


### PR DESCRIPTION
Adds check / query for active steel sheet to M862 as `M862.6`.

Alternative to my other PR #3947, which adds the same information to M503. 
Just after creating that PR I discovered M862 which could be the beter option of the 2.

I'll leave both PRs open for now until feedback provides insight on which of the routes to take.