### PR TITLE
Refactor mmu2.cpp and related interfaces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,7 @@ set(FW_SOURCES
     mmu2_error_converter.cpp
     mmu2_fsensor.cpp
     mmu2_log.cpp
+    mmu2_marlin1.cpp
     mmu2_power.cpp
     mmu2_progress_converter.cpp
     mmu2_protocol.cpp

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -577,7 +577,7 @@ void MMU2::SaveAndPark(bool move_axes) {
             resume_position = planner_current_position(); // save current pos
 
             // lift Z
-            raise_z(MMU_ERR_Z_PAUSE_LIFT);
+            MoveRaiseZ(MMU_ERR_Z_PAUSE_LIFT);
 
             // move XY aside
             if (all_axes_homed()) {

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -836,9 +836,9 @@ void MMU2::execute_extruder_sequence(const E_Step *sequence, uint8_t steps) {
     const E_Step *step = sequence;
     for (uint8_t i = 0; i < steps; i++) {
         const float es = pgm_read_float(&(step->extrude));
-        const feedRate_t fr_mm_m = pgm_read_float(&(step->feedRate));
+        const feedRate_t fr_mm_s = pgm_read_float(&(step->feedRate));
         planner_set_current_position_E(planner_get_current_position_E() + es);
-        planner_line_to_current_position(MMM_TO_MMS(fr_mm_m));
+        planner_line_to_current_position(fr_mm_s);
 
         step++;
     }
@@ -1010,26 +1010,6 @@ void MMU2::OnMMUProgressMsgSame(ProgressCode pc) {
         // do nothing yet
         break;
     }
-}
-
-//void MMU2::LogErrorEvent(const char *msg) {
-//    MMU2_ERROR_MSG(msg);
-//    SERIAL_ECHOLN();
-//}
-
-void MMU2::LogErrorEvent_P(const char *msg_P) {
-    MMU2_ERROR_MSGRPGM(msg_P);
-    SERIAL_ECHOLN();
-}
-
-//void MMU2::LogEchoEvent(const char *msg) {
-//    MMU2_ECHO_MSG(msg);
-//    SERIAL_ECHOLN();
-//}
-
-void MMU2::LogEchoEvent_P(const char *msg_P) {
-    MMU2_ECHO_MSGRPGM(msg_P);
-    SERIAL_ECHOLN();
 }
 
 } // namespace MMU2

--- a/Firmware/mmu2.h
+++ b/Firmware/mmu2.h
@@ -7,12 +7,13 @@
 #ifdef __AVR__
 #include "mmu2_protocol_logic.h"
 typedef float feedRate_t;
+
 #else
 
-#include "protocol_logic.h"
-#include "../../Marlin/src/core/macros.h"
-#include "../../Marlin/src/core/types.h"
-#include <atomic>
+    #include "protocol_logic.h"
+    #include "../../Marlin/src/core/macros.h"
+    #include "../../Marlin/src/core/types.h"
+    #include <atomic>
 #endif
 
 struct E_Step;
@@ -34,34 +35,34 @@ struct Version {
 class MMU2 {
 public:
     MMU2();
-    
+
     /// Powers ON the MMU, then initializes the UART and protocol logic
     void Start();
-    
+
     /// Stops the protocol logic, closes the UART, powers OFF the MMU
     void Stop();
-    
+
     inline xState State() const { return state; }
-    
-    inline bool Enabled()const { return State() == xState::Active; }
+
+    inline bool Enabled() const { return State() == xState::Active; }
 
     /// Different levels of resetting the MMU
     enum ResetForm : uint8_t {
-        Software = 0, ///< sends a X0 command into the MMU, the MMU will watchdog-reset itself
-        ResetPin = 1, ///< trigger the reset pin of the MMU
+        Software = 0,   ///< sends a X0 command into the MMU, the MMU will watchdog-reset itself
+        ResetPin = 1,   ///< trigger the reset pin of the MMU
         CutThePower = 2 ///< power off and power on (that includes +5V and +24V power lines)
     };
 
     /// Saved print state on error.
-    enum SavedState: uint8_t {
-        None = 0, // No state saved. 
-        ParkExtruder = 1, // The extruder was parked. 
-        Cooldown = 2, // The extruder was allowed to cool.
+    enum SavedState : uint8_t {
+        None = 0,         // No state saved.
+        ParkExtruder = 1, // The extruder was parked.
+        Cooldown = 2,     // The extruder was allowed to cool.
         CooldownPending = 4,
     };
 
     /// Source of operation error
-    enum ErrorSource: uint8_t {
+    enum ErrorSource : uint8_t {
         ErrorSourcePrinter = 0,
         ErrorSourceMMU = 1,
         ErrorSourceNone = 0xFF,
@@ -70,10 +71,10 @@ public:
     /// Perform a reset of the MMU
     /// @param level physical form of the reset
     void Reset(ResetForm level);
-    
+
     /// Power off the MMU (cut the power)
     void PowerOff();
-    
+
     /// Power on the MMU
     void PowerOn();
 
@@ -97,7 +98,7 @@ public:
     /// @param slot of the slot to be selected
     /// @returns false if the operation cannot be performed (Stopped)
     bool tool_change(uint8_t slot);
-    
+
     /// Handling of special Tx, Tc, T? commands
     bool tool_change(char code, uint8_t slot);
 
@@ -109,7 +110,7 @@ public:
     /// Load (insert) filament just into the MMU (not into printer's nozzle)
     /// @returns false if the operation cannot be performed (Stopped)
     bool load_filament(uint8_t slot);
-    
+
     /// Load (push) filament from the MMU into the printer's nozzle
     /// @returns false if the operation cannot be performed (Stopped or cold extruder)
     bool load_filament_to_nozzle(uint8_t slot);
@@ -137,7 +138,7 @@ public:
     /// @returns the active filament slot index (0-4) or 0xff in case of no active tool
     uint8_t get_current_tool() const;
 
-    /// @returns The filament slot index (0 to 4) that will be loaded next, 0xff in case of no active tool change 
+    /// @returns The filament slot index (0 to 4) that will be loaded next, 0xff in case of no active tool change
     uint8_t get_tool_change_tool() const;
 
     bool set_filament_type(uint8_t slot, uint8_t type);
@@ -145,14 +146,14 @@ public:
     /// Issue a "button" click into the MMU - to be used from Error screens of the MMU
     /// to select one of the 3 possible options to resolve the issue
     void Button(uint8_t index);
-    
+
     /// Issue an explicit "homing" command into the MMU
     void Home(uint8_t mode);
 
     /// @returns current state of FINDA (true=filament present, false=filament not present)
-    inline bool FindaDetectsFilament()const { return logic.FindaPressed(); }
+    inline bool FindaDetectsFilament() const { return logic.FindaPressed(); }
 
-    inline uint16_t TotalFailStatistics()const { return logic.FailStatistics(); }
+    inline uint16_t TotalFailStatistics() const { return logic.FailStatistics(); }
 
     /// @returns Current error code
     inline ErrorCode MMUCurrentErrorCode() const { return logic.Error(); }
@@ -162,11 +163,11 @@ public:
 
     /// @returns the version of the connected MMU FW.
     /// In the future we'll return the trully detected FW version
-    Version GetMMUFWVersion()const {
-        if( State() == xState::Active ){
+    Version GetMMUFWVersion() const {
+        if (State() == xState::Active) {
             return { logic.MmuFwVersionMajor(), logic.MmuFwVersionMinor(), logic.MmuFwVersionRevision() };
         } else {
-            return { 0, 0, 0}; 
+            return { 0, 0, 0 };
         }
     }
 
@@ -187,21 +188,21 @@ public:
     /// Set toolchange counter to zero
     inline void ClearToolChangeCounter() { toolchange_counter = 0; };
 
-    inline uint16_t TMCFailures()const { return tmcFailures; }
+    inline uint16_t TMCFailures() const { return tmcFailures; }
     inline void IncrementTMCFailures() { ++tmcFailures; }
     inline void ClearTMCFailures() { tmcFailures = 0; }
 
 private:
     /// Perform software self-reset of the MMU (sends an X0 command)
     void ResetX0();
-    
+
     /// Trigger reset pin of the MMU
     void TriggerResetPin();
-    
+
     /// Perform power cycle of the MMU (cold boot)
     /// Please note this is a blocking operation (sleeps for some time inside while doing the power cycle)
     void PowerCycle();
-    
+
     /// Stop the communication, but keep the MMU powered on (for scenarios with incorrect FW version)
     void StopKeepPowered();
 
@@ -220,7 +221,7 @@ private:
     /// Updates the global state of MMU (Active/Connecting/Stopped) at runtime, see @ref State
     /// @param reportErrors true if Errors should raise MMU Error screen, false otherwise
     StepStatus LogicStep(bool reportErrors);
-    
+
     void filament_ramming();
     void execute_extruder_sequence(const E_Step *sequence, uint8_t steps);
     void execute_load_to_nozzle_sequence();
@@ -233,7 +234,7 @@ private:
     /// Reports progress of operations into attached ExtUIs
     /// @param pc progress code, see ProgressCode
     void ReportProgress(ProgressCode pc);
-    
+
     /// Responds to a change of MMU's progress
     /// - plans additional steps, e.g. starts the E-motor after fsensor trigger
     void OnMMUProgressMsg(ProgressCode pc);
@@ -296,26 +297,26 @@ private:
 
     void HelpUnloadToFinda();
 
-    ProtocolLogic logic; ///< implementation of the protocol logic layer
-    uint8_t extruder; ///< currently active slot in the MMU ... somewhat... not sure where to get it from yet
+    ProtocolLogic logic;          ///< implementation of the protocol logic layer
+    uint8_t extruder;             ///< currently active slot in the MMU ... somewhat... not sure where to get it from yet
     uint8_t tool_change_extruder; ///< only used for UI purposes
 
     pos3d resume_position;
     int16_t resume_hotend_temp;
-    
+
     ProgressCode lastProgressCode = ProgressCode::OK;
     ErrorCode lastErrorCode = ErrorCode::MMU_NOT_RESPONDING;
     ErrorSource lastErrorSource = ErrorSource::ErrorSourceNone;
     Buttons lastButton = Buttons::NoButton;
 
     StepStatus logicStepLastStatus;
-    
+
     enum xState state;
 
     uint8_t mmu_print_saved;
     bool loadFilamentStarted;
     bool unloadFilamentStarted;
-    
+
     friend struct LoadingToNozzleRAII;
     /// true in case we are doing the LoadToNozzle operation - that means the filament shall be loaded all the way down to the nozzle
     /// unlike the mid-print ToolChange commands, which only load the first ~30mm and then the G-code takes over.

--- a/Firmware/mmu2.h
+++ b/Firmware/mmu2.h
@@ -175,7 +175,7 @@ public:
     bool is_mmu_error_monitor_active;
 
     /// Method to read-only mmu_print_saved
-    bool MMU_PRINT_SAVED() const { return mmu_print_saved != SavedState::None; }
+    inline bool MMU_PRINT_SAVED() const { return mmu_print_saved != SavedState::None; }
 
     /// Automagically "press" a Retry button if we have any retry attempts left
     /// @param ec ErrorCode enum value
@@ -242,20 +242,6 @@ private:
     void OnMMUProgressMsgChanged(ProgressCode pc);
     /// Repeated calls when progress code remains the same
     void OnMMUProgressMsgSame(ProgressCode pc);
-
-    /// Report the msg into the general logging subsystem (through Marlin's SERIAL_ECHO stuff)
-    // void LogErrorEvent(const char *msg);
-    /// Report the msg into the general logging subsystem.
-    /// On the AVR platform this variant reads the input string from PROGMEM.
-    /// On the ARM platform it calls LogErrorEvent directly (silently expecting the compiler to optimize it away)
-    void LogErrorEvent_P(const char *msg_P);
-
-    /// Report the msg into the general logging subsystem (through Marlin's SERIAL_ECHO stuff)
-    // void LogEchoEvent(const char *msg);
-    /// Report the msg into the general logging subsystem.
-    /// On the AVR platform this variant reads the input string from PROGMEM.
-    /// On the ARM platform it calls LogEchoEvent directly (silently expecting the compiler to optimize it away)
-    void LogEchoEvent_P(const char *msg_P);
 
     /// @brief Save hotend temperature and set flag to cooldown hotend after 60 minutes
     /// @param turn_off_nozzle if true, the hotend temperature will be set to 0degC after 60 minutes

--- a/Firmware/mmu2/variants/config_MMU2S.h
+++ b/Firmware/mmu2/variants/config_MMU2S.h
@@ -43,7 +43,7 @@ static constexpr uint8_t MMU2_NO_TOOL = 99;
 static constexpr uint32_t MMU_BAUD = 115200;
 
 struct E_Step {
-    float extrude;       ///< extrude distance in mm
+    float extrude;  ///< extrude distance in mm
     float feedRate; ///< feed rate in mm/s
 };
 

--- a/Firmware/mmu2_error_converter.cpp
+++ b/Firmware/mmu2_error_converter.cpp
@@ -19,7 +19,7 @@ constexpr InputIt find_if_cx(InputIt first, InputIt last, UnaryPredicate p) {
     return last;
 }
 
-// Making a constexpr FindError should instruct the compiler to optimize the ConvertMMUErrorCode
+// Making a constexpr FindError should instruct the compiler to optimize the PrusaErrorCodeIndex
 // in such a way that no searching will ever be done at runtime.
 // A call to FindError then compiles to a single instruction even on the AVR.
 static constexpr uint8_t FindErrorIndex(uint16_t pec) {

--- a/Firmware/mmu2_error_converter.h
+++ b/Firmware/mmu2_error_converter.h
@@ -11,11 +11,11 @@ uint8_t PrusaErrorCodeIndex(uint16_t ec);
 
 /// @returns pointer to a PROGMEM string representing the Title of the Prusa-Error-Codes error
 /// @param i index of the error - obtained by calling ErrorCodeIndex
-const char * PrusaErrorTitle(uint8_t i);
+const char *PrusaErrorTitle(uint8_t i);
 
 /// @returns pointer to a PROGMEM string representing the multi-page Description of the Prusa-Error-Codes error
 /// @param i index of the error - obtained by calling ErrorCodeIndex
-const char * PrusaErrorDesc(uint8_t i);
+const char *PrusaErrorDesc(uint8_t i);
 
 /// @returns the actual numerical value of the Prusa-Error-Codes error
 /// @param i index of the error - obtained by calling ErrorCodeIndex
@@ -27,10 +27,10 @@ uint8_t PrusaErrorButtons(uint8_t i);
 
 /// @returns pointer to a PROGMEM string representing the Title of a button
 /// @param i index of the error - obtained by calling PrusaErrorButtons + extracting low or high nibble from the Btns pair
-const char * PrusaErrorButtonTitle(uint8_t bi);
+const char *PrusaErrorButtonTitle(uint8_t bi);
 
 /// @returns pointer to a PROGMEM string representing the "More" button
-const char * PrusaErrorButtonMore();
+const char *PrusaErrorButtonMore();
 
 /// Sets the selected button for later pick-up by the MMU state machine.
 /// Used to save the GUI selection/decoupling

--- a/Firmware/mmu2_fsensor.h
+++ b/Firmware/mmu2_fsensor.h
@@ -9,7 +9,8 @@ namespace MMU2 {
 enum class FilamentState : uint_fast8_t {
     NOT_PRESENT = 0, ///< filament sensor doesn't see the filament
     AT_FSENSOR = 1, ///< filament detected by the filament sensor, but the nozzle has not detected the filament yet
-    IN_NOZZLE = 2 ///< filament detected by the filament sensor and also loaded in the nozzle
+    IN_NOZZLE = 2, ///< filament detected by the filament sensor and also loaded in the nozzle
+    UNAVAILABLE = 3  ///< sensor not available (likely not connected due broken cable)
 };
 
 FilamentState WhereIsFilament();

--- a/Firmware/mmu2_fsensor.h
+++ b/Firmware/mmu2_fsensor.h
@@ -8,8 +8,8 @@ namespace MMU2 {
 /// Beware, the numeric codes are important and sent into the MMU
 enum class FilamentState : uint_fast8_t {
     NOT_PRESENT = 0, ///< filament sensor doesn't see the filament
-    AT_FSENSOR = 1, ///< filament detected by the filament sensor, but the nozzle has not detected the filament yet
-    IN_NOZZLE = 2, ///< filament detected by the filament sensor and also loaded in the nozzle
+    AT_FSENSOR = 1,  ///< filament detected by the filament sensor, but the nozzle has not detected the filament yet
+    IN_NOZZLE = 2,   ///< filament detected by the filament sensor and also loaded in the nozzle
     UNAVAILABLE = 3  ///< sensor not available (likely not connected due broken cable)
 };
 

--- a/Firmware/mmu2_log.h
+++ b/Firmware/mmu2_log.h
@@ -20,18 +20,36 @@ void LogEchoEvent_P(const char *msg);
 
 } // namespace
 
-#define SERIAL_MMU2() { serialprintPGM(mmu2Magic); }
+    #define SERIAL_MMU2() \
+        { serialprintPGM(mmu2Magic); }
 
-#define MMU2_ECHO_MSGLN(S) do{ SERIAL_ECHO_START; SERIAL_MMU2(); SERIAL_ECHOLN(S); }while(0)
-#define MMU2_ERROR_MSGLN(S) MMU2_ECHO_MSGLN(S) //!@todo Decide MMU2 errors  on serial line
-#define MMU2_ECHO_MSGRPGM(S) do{ SERIAL_ECHO_START; SERIAL_MMU2(); SERIAL_ECHORPGM(S); }while(0)
-#define MMU2_ERROR_MSGRPGM(S) MMU2_ECHO_MSGRPGM(S) //!@todo Decide MMU2 errors  on serial line
+    #define MMU2_ECHO_MSGLN(S)   \
+        do {                     \
+            SERIAL_ECHO_START(); \
+            SERIAL_MMU2();       \
+            SERIAL_ECHOLN(S);    \
+        } while (0)
+    #define MMU2_ERROR_MSGLN(S) MMU2_ECHO_MSGLN(S) //!@todo Decide MMU2 errors  on serial line
+    #define MMU2_ECHO_MSGRPGM(S) \
+        do {                     \
+            SERIAL_ECHO_START(); \
+            SERIAL_MMU2();       \
+            SERIAL_ECHO(S);      \
+        } while (0)
+    #define MMU2_ERROR_MSGRPGM(S) MMU2_ECHO_MSGRPGM(S) //!@todo Decide MMU2 errors  on serial line
+    #define MMU2_ECHO_MSG(S)     \
+        do {                     \
+            SERIAL_ECHO_START(); \
+            SERIAL_MMU2();       \
+            SERIAL_ECHO(S);      \
+        } while (0)
+    #define MMU2_ERROR_MSG(S) MMU2_ECHO_MSG(S) //!@todo Decide MMU2 errors  on serial line
 
 #else // #ifndef UNITTEST
 
-#define MMU2_ECHO_MSGLN(S) /* */
-#define MMU2_ERROR_MSGLN(S) /* */
-#define MMU2_ECHO_MSGRPGM(S) /* */
-#define MMU2_ERROR_MSGRPGM(S) /* */
+    #define MMU2_ECHO_MSGLN(S)    /* */
+    #define MMU2_ERROR_MSGLN(S)   /* */
+    #define MMU2_ECHO_MSGRPGM(S)  /* */
+    #define MMU2_ERROR_MSGRPGM(S) /* */
 
 #endif // #ifndef UNITTEST

--- a/Firmware/mmu2_log.h
+++ b/Firmware/mmu2_log.h
@@ -12,10 +12,14 @@ namespace MMU2 {
 
 /// Report the msg into the general logging subsystem (through Marlin's SERIAL_ECHO stuff)
 /// @param msg pointer to a string in PROGMEM
+/// On the AVR platform this variant reads the input string from PROGMEM.
+/// On the ARM platform it calls LogErrorEvent directly (silently expecting the compiler to optimize it away)
 void LogErrorEvent_P(const char *msg);
 
 /// Report the msg into the general logging subsystem (through Marlin's SERIAL_ECHO stuff)
 /// @param msg pointer to a string in PROGMEM
+/// On the AVR platform this variant reads the input string from PROGMEM.
+/// On the ARM platform it calls LogErrorEvent directly (silently expecting the compiler to optimize it away)
 void LogEchoEvent_P(const char *msg);
 
 } // namespace

--- a/Firmware/mmu2_log.h
+++ b/Firmware/mmu2_log.h
@@ -25,21 +25,21 @@ void LogEchoEvent_P(const char *msg);
 
     #define MMU2_ECHO_MSGLN(S)   \
         do {                     \
-            SERIAL_ECHO_START(); \
+            SERIAL_ECHO_START;   \
             SERIAL_MMU2();       \
             SERIAL_ECHOLN(S);    \
         } while (0)
     #define MMU2_ERROR_MSGLN(S) MMU2_ECHO_MSGLN(S) //!@todo Decide MMU2 errors  on serial line
     #define MMU2_ECHO_MSGRPGM(S) \
         do {                     \
-            SERIAL_ECHO_START(); \
+            SERIAL_ECHO_START;   \
             SERIAL_MMU2();       \
             SERIAL_ECHO(S);      \
         } while (0)
     #define MMU2_ERROR_MSGRPGM(S) MMU2_ECHO_MSGRPGM(S) //!@todo Decide MMU2 errors  on serial line
     #define MMU2_ECHO_MSG(S)     \
         do {                     \
-            SERIAL_ECHO_START(); \
+            SERIAL_ECHO_START;   \
             SERIAL_MMU2();       \
             SERIAL_ECHO(S);      \
         } while (0)

--- a/Firmware/mmu2_log.h
+++ b/Firmware/mmu2_log.h
@@ -34,7 +34,7 @@ void LogEchoEvent_P(const char *msg);
         do {                     \
             SERIAL_ECHO_START;   \
             SERIAL_MMU2();       \
-            SERIAL_ECHO(S);      \
+            SERIAL_ECHORPGM(S);  \
         } while (0)
     #define MMU2_ERROR_MSGRPGM(S) MMU2_ECHO_MSGRPGM(S) //!@todo Decide MMU2 errors  on serial line
     #define MMU2_ECHO_MSG(S)     \

--- a/Firmware/mmu2_marlin.h
+++ b/Firmware/mmu2_marlin.h
@@ -32,6 +32,7 @@ float planner_get_machine_position_E_mm();
 float planner_get_current_position_E();
 void planner_set_current_position_E(float e);
 void planner_line_to_current_position(float feedRate_mm_s);
+void planner_line_to_current_position_sync(float feedRate_mm_s);
 pos3d planner_current_position();
 
 void motion_do_blocking_move_to_xy(float rx, float ry, float feedRate_mm_s);

--- a/Firmware/mmu2_marlin.h
+++ b/Firmware/mmu2_marlin.h
@@ -1,0 +1,63 @@
+/// @file
+/// The sole purpose of this interface is to separate Marlin1/Marlin2 from the MMU2 top logic layer.
+/// Why?
+/// - unify implementation among MK3 and Buddy FW
+/// - enable unit testing of MMU2 top layer
+#pragma once
+#include <stdint.h>
+
+namespace MMU2 {
+
+/// @@TODO hmmm, 12 bytes... may be we can reduce that
+struct pos3d {
+    float xyz[3];
+    pos3d() = default;
+    inline constexpr pos3d(float x, float y, float z)
+        : xyz { x, y, z } {}
+    pos3d operator=(const float *newP){
+        for(uint8_t i = 0; i < 3; ++i){
+            xyz[i] = newP[i];
+        }
+        return *this;
+    }
+};
+
+void MoveE(float delta, float feedRate);
+
+float raise_z(float delta);
+
+void planner_synchronize();
+bool planner_any_moves();
+float planner_get_machine_position_E_mm();
+float planner_get_current_position_E();
+void planner_set_current_position_E(float e);
+void planner_line_to_current_position(float feedRate_mm_s);
+pos3d planner_current_position();
+
+void motion_do_blocking_move_to_xy(float rx, float ry, float feedRate_mm_s);
+void motion_do_blocking_move_to_z(float z, float feedRate_mm_s);
+
+void nozzle_park();
+
+bool marlin_printingIsActive();
+void marlin_manage_heater();
+void marlin_manage_inactivity(bool b);
+void marlin_idle(bool b);
+
+int16_t thermal_degTargetHotend();
+int16_t thermal_degHotend();
+void thermal_setExtrudeMintemp(int16_t t);
+void thermal_setTargetHotend(int16_t t);
+
+void safe_delay_keep_alive(uint16_t t);
+
+void Enable_E0();
+void Disable_E0();
+
+bool all_axes_homed();
+
+void gcode_reset_stepper_timeout();
+
+bool cutter_enabled();
+
+} // namespace MMU2

--- a/Firmware/mmu2_marlin.h
+++ b/Firmware/mmu2_marlin.h
@@ -24,7 +24,7 @@ struct pos3d {
 
 void MoveE(float delta, float feedRate);
 
-float raise_z(float delta);
+float MoveRaiseZ(float delta);
 
 void planner_synchronize();
 bool planner_any_moves();

--- a/Firmware/mmu2_marlin1.cpp
+++ b/Firmware/mmu2_marlin1.cpp
@@ -11,7 +11,7 @@ namespace MMU2 {
 
 void MoveE(float delta, float feedRate) {
     current_position[E_AXIS] += delta;
-    plan_buffer_line_curposXYZE(feedRate);
+    planner_line_to_current_position(feedRate);
 }
 
 float MoveRaiseZ(float delta) {
@@ -40,7 +40,11 @@ void planner_set_current_position_E(float e){
 
 void planner_line_to_current_position(float feedRate_mm_s){
      plan_buffer_line_curposXYZE(feedRate_mm_s);
-     st_synchronize();
+}
+
+void planner_line_to_current_position_sync(float feedRate_mm_s){
+    planner_line_to_current_position(feedRate_mm_s);
+    planner_synchronize();
 }
 
 pos3d planner_current_position(){
@@ -48,23 +52,20 @@ pos3d planner_current_position(){
 }
 
 void motion_do_blocking_move_to_xy(float rx, float ry, float feedRate_mm_s){
-        current_position[X_AXIS] = rx;
-        current_position[Y_AXIS] = ry;
-        plan_buffer_line_curposXYZE(feedRate_mm_s);
-        st_synchronize();
+    current_position[X_AXIS] = rx;
+    current_position[Y_AXIS] = ry;
+    planner_line_to_current_position_sync(feedRate_mm_s);
 }
 
 void motion_do_blocking_move_to_z(float z, float feedRate_mm_s){
-        current_position[Z_AXIS] = z;
-        plan_buffer_line_curposXYZE(feedRate_mm_s);
-        st_synchronize();
+    current_position[Z_AXIS] = z;
+    planner_line_to_current_position_sync(feedRate_mm_s);
 }
 
 void nozzle_park() {
     current_position[X_AXIS] = MMU_ERR_X_PAUSE_POS;
     current_position[Y_AXIS] = MMU_ERR_Y_PAUSE_POS;
-    planner_line_to_current_position(NOZZLE_PARK_XY_FEEDRATE);
-    st_synchronize();
+    planner_line_to_current_position_sync(NOZZLE_PARK_XY_FEEDRATE);
 }
 
 bool marlin_printingIsActive() {

--- a/Firmware/mmu2_marlin1.cpp
+++ b/Firmware/mmu2_marlin1.cpp
@@ -1,0 +1,123 @@
+/// @file
+/// MK3 / Marlin1 implementation of support routines for the MMU2
+#include "Marlin.h"
+#include "stepper.h"
+#include "planner.h"
+#include "mmu2_config.h"
+#include "temperature.h"
+
+namespace MMU2 {
+
+void MoveE(float delta, float feedRate) {
+    current_position[E_AXIS] += delta;
+    plan_buffer_line_curposXYZE(feedRate);
+}
+
+float raise_z(float delta) {
+    // @@TODO
+    return 0.0F;
+}
+
+void planner_synchronize() {
+    st_synchronize();
+}
+
+bool planner_any_moves() {
+    return blocks_queued();
+}
+
+float planner_get_machine_position_E_mm(){
+// @@TODO    return Planner::get_machine_position_mm()[3];
+}
+
+float planner_get_current_position_E(){
+    return current_position[E_AXIS];
+}
+
+void planner_set_current_position_E(float e){
+        current_position[E_AXIS] = e;
+}
+
+void planner_line_to_current_position(float feedRate_mm_s){
+     plan_buffer_line_curposXYZE(feedRate_mm_s);
+     st_synchronize();
+}
+
+pos3d planner_current_position(){
+    return pos3d(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS]);
+}
+
+void motion_do_blocking_move_to_xy(float rx, float ry, float feedRate_mm_s){
+        current_position[X_AXIS] = rx;
+        current_position[Y_AXIS] = ry;
+        plan_buffer_line_curposXYZE(feedRate_mm_s);
+        st_synchronize();
+}
+
+void motion_do_blocking_move_to_z(float z, float feedRate_mm_s){
+        current_position[Z_AXIS] = z;
+        plan_buffer_line_curposXYZE(feedRate_mm_s);
+        st_synchronize();
+}
+
+void nozzle_park() {
+    current_position[X_AXIS] = MMU_ERR_X_PAUSE_POS;
+    current_position[Y_AXIS] = MMU_ERR_Y_PAUSE_POS;
+    planner_line_to_current_position(NOZZLE_PARK_XY_FEEDRATE);
+    st_synchronize();
+}
+
+bool marlin_printingIsActive() {
+    // return IS_SD_PRINTING || usb_timer_running();
+    return printer_active();
+}
+
+void marlin_manage_heater(){
+    manage_heater();
+}
+
+void marlin_manage_inactivity(bool b){
+    manage_inactivity(b);
+}
+
+void marlin_idle(bool b){
+    manage_heater();
+    manage_inactivity(true);
+}
+
+int16_t thermal_degTargetHotend() {
+    return degTargetHotend(0);
+}
+
+int16_t thermal_degHotend() {
+    return degHotend(0);
+}
+
+void thermal_setExtrudeMintemp(int16_t t) {
+    set_extrude_min_temp(t);
+}
+
+void thermal_setTargetHotend(int16_t t) {
+    setTargetHotend(t, 0);
+}
+
+void safe_delay_keep_alive(uint16_t t) {
+    delay_keep_alive(t);
+}
+
+void gcode_reset_stepper_timeout(){
+    // empty
+}
+
+void Enable_E0(){ enable_e0(); }
+void Disable_E0(){ disable_e0(); }
+
+bool all_axes_homed(){
+    return axis_known_position[X_AXIS] && axis_known_position[Y_AXIS];
+}
+
+bool cutter_enabled(){
+    return eeprom_read_byte((uint8_t*)EEPROM_MMU_CUTTER_ENABLED) == EEPROM_MMU_CUTTER_ENABLED_enabled;
+}
+
+} // namespace MMU2

--- a/Firmware/mmu2_marlin1.cpp
+++ b/Firmware/mmu2_marlin1.cpp
@@ -1,5 +1,6 @@
 /// @file
 /// MK3 / Marlin1 implementation of support routines for the MMU2
+#include "mmu2_marlin.h"
 #include "Marlin.h"
 #include "stepper.h"
 #include "planner.h"
@@ -13,9 +14,8 @@ void MoveE(float delta, float feedRate) {
     plan_buffer_line_curposXYZE(feedRate);
 }
 
-float raise_z(float delta) {
-    // @@TODO
-    return 0.0F;
+float MoveRaiseZ(float delta) {
+    return raise_z(delta);
 }
 
 void planner_synchronize() {
@@ -27,7 +27,7 @@ bool planner_any_moves() {
 }
 
 float planner_get_machine_position_E_mm(){
-// @@TODO    return Planner::get_machine_position_mm()[3];
+    return current_position[E_AXIS];
 }
 
 float planner_get_current_position_E(){
@@ -82,7 +82,7 @@ void marlin_manage_inactivity(bool b){
 
 void marlin_idle(bool b){
     manage_heater();
-    manage_inactivity(true);
+    manage_inactivity(b);
 }
 
 int16_t thermal_degTargetHotend() {

--- a/Firmware/mmu2_marlin_macros.h
+++ b/Firmware/mmu2_marlin_macros.h
@@ -1,0 +1,16 @@
+/// @file
+/// This file will not be the same on Marlin1 and Marlin2.
+/// Its purpose is to unify different macros in either of Marlin incarnations.
+#pragma once
+
+#ifdef __AVR__
+    #include "Marlin.h"
+    // brings _O and _T macros into MMU
+    #include "language.h"
+    #define MARLIN_KEEPALIVE_STATE_IN_PROCESS KEEPALIVE_STATE(IN_PROCESS)
+#else
+    #include "../../gcode/gcode.h"
+    #define _O(x)                             x
+    #define _T(x)                             x
+    #define MARLIN_KEEPALIVE_STATE_IN_PROCESS KEEPALIVE_STATE(IN_PROCESS)
+#endif

--- a/Firmware/mmu2_power.cpp
+++ b/Firmware/mmu2_power.cpp
@@ -10,13 +10,18 @@ namespace MMU2 {
 
 // sadly, on MK3 we cannot do actual power cycle on HW...
 // so we just block the MMU via EEPROM var instead.
-void power_on()
-{
+void power_on() {
+#ifdef MMU_HWRESET
+    WRITE(MMU_RST_PIN, 1);
+    SET_OUTPUT(MMU_RST_PIN); // setup reset pin
+#endif //MMU_HWRESET
+
     eeprom_update_byte((uint8_t *)EEPROM_MMU_ENABLED, true);
+
+    reset();
 }
 
-void power_off()
-{
+void power_off() {
     eeprom_update_byte((uint8_t *)EEPROM_MMU_ENABLED, false);
 }
 

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -217,7 +217,7 @@ enum class ReportErrorHookStates : uint8_t {
 
 enum ReportErrorHookStates ReportErrorHookState = ReportErrorHookStates::RENDER_ERROR_SCREEN;
 
-void ReportErrorHook(uint16_t ec) {
+void ReportErrorHook(CommandInProgress /*cip*/, uint16_t ec, uint8_t /*es*/) {
     if (mmu2.MMUCurrentErrorCode() == ErrorCode::OK && mmu2.MMULastErrorSource() == MMU2::ErrorSourceMMU) {
         // If the error code suddenly changes to OK, that means
         // a button was pushed on the MMU and the LCD should
@@ -290,6 +290,46 @@ void IncrementLoadFails(){
 void IncrementMMUFails(){
     eeprom_increment_byte((uint8_t *)EEPROM_MMU_FAIL);
     eeprom_increment_word((uint16_t *)EEPROM_MMU_FAIL_TOT);
+}
+
+void MakeSound(SoundType s){
+    Sound_MakeSound( (eSOUND_TYPE)s);
+}
+
+static void FullScreenMsg(const char *pgmS, uint8_t slot){
+    lcd_update_enable(false);
+    lcd_clear();
+    lcd_puts_at_P(0, 1, pgmS);
+    lcd_print(' ');
+    lcd_print(slot + 1);
+}
+
+void FullScreenMsgCut(uint8_t slot){
+    FullScreenMsg(_T(MSG_CUT_FILAMENT), slot);
+}
+
+void FullScreenMsgEject(uint8_t slot){
+    FullScreenMsg(_T(MSG_EJECT_FILAMENT), slot);
+}
+
+void FullScreenMsgTest(uint8_t slot){
+    FullScreenMsg(_T(MSG_TESTING_FILAMENT), slot);
+}
+
+void FullScreenMsgLoad(uint8_t slot){
+    FullScreenMsg(_T(MSG_LOADING_FILAMENT), slot);
+}
+
+void FullScreenMsgRestoringTemperature(){
+    lcd_display_message_fullscreen_P(_i("MMU Retry: Restoring temperature...")); ////MSG_MMU_RESTORE_TEMP c=20 r=4
+}
+
+void ScreenUpdateEnable(){
+    lcd_update_enable(true);
+}
+
+void ScreenClear(){
+    lcd_clear();
 }
 
 } // namespace MMU2

--- a/Firmware/mmu2_reporting.h
+++ b/Firmware/mmu2_reporting.h
@@ -22,13 +22,12 @@ void BeginReport(CommandInProgress cip, uint16_t ec);
 /// Called at the end of every MMU operation
 void EndReport(CommandInProgress cip, uint16_t ec);
 
-/**
- * @brief Called when the MMU or MK3S sends operation error (even repeatedly).
- * Render MMU error screen on the LCD. This must be non-blocking
- * and allow the MMU and printer to communicate with each other.
- * @param[in] ec error code
- */
-void ReportErrorHook(uint16_t ec);
+/// @brief Called when the MMU or MK3S sends operation error (even repeatedly).
+/// Render MMU error screen on the LCD. This must be non-blocking
+/// and allow the MMU and printer to communicate with each other.
+/// @param[in] ec error code
+/// @param[in] es error source
+void ReportErrorHook(CommandInProgress cip, uint16_t ec, uint8_t es);
 
 /// Called when the MMU sends operation progress update
 void ReportProgressHook(CommandInProgress cip, uint16_t ec);
@@ -52,5 +51,22 @@ void IncrementLoadFails();
 
 /// Increments EEPROM cell - number of MMU errors
 void IncrementMMUFails();
+
+// Beware: enum values intentionally chosen to match the 8bit FW to save code size
+enum SoundType {
+    Prompt = 2,
+    Confirm = 3
+};
+
+void MakeSound(SoundType s);
+
+void FullScreenMsgCut(uint8_t slot);
+void FullScreenMsgEject(uint8_t slot);
+void FullScreenMsgTest(uint8_t slot);
+void FullScreenMsgLoad(uint8_t slot);
+void FullScreenMsgRestoringTemperature();
+
+void ScreenUpdateEnable();
+void ScreenClear();
 
 } // namespace

--- a/Firmware/mmu2_state.h
+++ b/Firmware/mmu2_state.h
@@ -1,0 +1,21 @@
+/**
+ * @file mmu_state.h
+ * @brief status of mmu
+ */
+#pragma once
+#include <stdint.h>
+namespace MMU2 {
+/// States of a printer with the MMU:
+/// - Active
+/// - Connecting
+/// - Stopped
+///
+/// When the printer's FW starts, the MMU2 mode is either Stopped or NotResponding (based on user's preference).
+/// When the MMU successfully establishes communication, the state changes to Active.
+enum class xState : uint_fast8_t {
+    Active,     ///< MMU has been detected, connected, communicates and is ready to be worked with.
+    Connecting, ///< MMU is connected but it doesn't communicate (yet). The user wants the MMU, but it is not ready to be worked with.
+    Stopped     ///< The user doesn't want the printer to work with the MMU. The MMU itself is not powered and does not work at all.
+};
+
+} // namespace MMU2

--- a/Firmware/strlen_cx.h
+++ b/Firmware/strlen_cx.h
@@ -1,5 +1,5 @@
 #pragma once
 
-constexpr inline int strlen_constexpr(const char* str){
+constexpr inline int strlen_constexpr(const char *str) {
     return *str ? 1 + strlen_constexpr(str + 1) : 0;
 }


### PR DESCRIPTION
The general idea is to keep platform specific implementation away from the MMU state machines as much as we can. That would enable unit testing the top level MMU state machine and integration into other projects (Marlin2) as well if needed.