### PR TITLE
Cleanup: use setTargetHotend consistently for one extruder

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -611,7 +611,7 @@ void crashdet_detected(uint8_t mask)
 	if (automatic_recovery_after_crash) {
 		enquecommand_P(PSTR("CRASH_RECOVER"));
 	}else{
-		setTargetHotend(0, active_extruder);
+		setTargetHotend(0);
 
         // notify the user of *all* the axes previously affected, not just the last one
         lcd_update_enable(false);
@@ -3223,7 +3223,7 @@ bool gcode_M45(bool onlyZ, int8_t verbosity_level)
 	if (!onlyZ)
 	{
 		setTargetBed(0);
-		setAllTargetHotends(0);
+		setTargetHotend(0);
 		adjust_bed_reset(); //reset bed level correction
 	}
 
@@ -3501,7 +3501,7 @@ static void mmu_M600_load_filament(bool automatic, float nozzle_temp) {
         slot = choose_menu_P(_T(MSG_SELECT_EXTRUDER), _T(MSG_EXTRUDER));
     }
 
-    setTargetHotend(nozzle_temp, active_extruder);
+    setTargetHotend(nozzle_temp);
 
     MMU2::mmu2.load_filament_to_nozzle(slot);
 
@@ -4787,7 +4787,6 @@ void process_commands()
         if (start_temp < current_temperature_pinda) start_temp += 5;
         printf_P(_N("start temperature: %.1f\n"), start_temp);
 
-//			setTargetHotend(200, 0);
         setTargetBed(70 + (start_temp - 30));
 
         custom_message_type = CustomMsg::TempCal;
@@ -4843,7 +4842,6 @@ void process_commands()
             printf_P(_N("\nStep: %d/6\n"), i + 2);
             custom_message_state = i + 2;
             setTargetBed(50 + 10 * (temp - 30) / 5);
-//				setTargetHotend(255, 0);
             current_position[Z_AXIS] = MESH_HOME_Z_SEARCH;
             plan_buffer_line_curposXYZE(3000 / 60);
             current_position[X_AXIS] = PINDA_PREHEAT_X;
@@ -5988,7 +5986,7 @@ Sigma_Exit:
     {
           if (code_seen('S'))
           {
-              setTargetHotendSafe(code_value(), active_extruder);
+              setTargetHotend(code_value());
           }
           break;
     }
@@ -6101,9 +6099,9 @@ Sigma_Exit:
         autotemp_enabled=false;
       #endif
       if (code_seen('S')) {
-          setTargetHotendSafe(code_value(), active_extruder);
+          setTargetHotend(code_value());
             } else if (code_seen('R')) {
-                setTargetHotendSafe(code_value(), active_extruder);
+                setTargetHotend(code_value());
       }
       #ifdef AUTOTEMP
         if (code_seen('S')) autotemp_min=code_value();
@@ -9273,7 +9271,7 @@ static void handleSafetyTimer()
     else if (safetyTimer.expired(farm_mode?FARM_DEFAULT_SAFETYTIMER_TIME_ms:safetytimer_inactive_time))
     {
         setTargetBed(0);
-        setAllTargetHotends(0);
+        setTargetHotend(0);
         lcd_show_fullscreen_message_and_wait_P(_i("Heating disabled by safety timer."));////MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
     }
 }
@@ -10303,7 +10301,7 @@ void long_pause() //long pause print
 
     // Stop heaters
     heating_status = HeatingStatus::NO_HEATING;
-    setAllTargetHotends(0);
+    setTargetHotend(0);
 
     // Lift z
     raise_z(Z_PAUSE_LIFT);
@@ -10369,7 +10367,7 @@ void uvlo_()
     // Stop all heaters
     uint8_t saved_target_temperature_bed = target_temperature_bed;
     uint16_t saved_target_temperature_ext = target_temperature[active_extruder];
-    setAllTargetHotends(0);
+    setTargetHotend(0);
     setTargetBed(0);
 
     // Calculate the file position, from which to resume this print.
@@ -10541,7 +10539,7 @@ void uvlo_tiny()
 #endif //TMC2130
 
     // Stop all heaters
-    setAllTargetHotends(0);
+    setTargetHotend(0);
     setTargetBed(0);
 
     // When power is interrupted on the _first_ recovery an attempt can be made to raise the
@@ -11083,7 +11081,7 @@ void stop_and_save_print_to_ram(float z_move, float e_move)
 void restore_extruder_temperature_from_ram() {
     if (degTargetHotend(active_extruder) != saved_extruder_temperature)
     {
-        setTargetHotendSafe(saved_extruder_temperature, active_extruder);
+        setTargetHotend(saved_extruder_temperature);
         heating_status = HeatingStatus::EXTRUDER_HEATING;
         wait_for_heater(_millis(), active_extruder);
         heating_status = HeatingStatus::EXTRUDER_HEATING_COMPLETE;
@@ -11334,18 +11332,16 @@ void M600_wait_for_user(float HotendTempBckp) {
 				if (_millis() > waiting_start_time + (unsigned long)M600_TIMEOUT * 1000) {
 					lcd_display_message_fullscreen_P(_i("Press the knob to preheat nozzle and continue."));////MSG_PRESS_TO_PREHEAT c=20 r=4
 					wait_for_user_state = 1;
-					setAllTargetHotends(0);
+					setTargetHotend(0);
 					st_synchronize();
 					disable_e0();
-					disable_e1();
-					disable_e2();
 				}
 				break;
 			case 1: //nozzle target temperature is set to zero, waiting for user to start nozzle preheat
 				delay_keep_alive(4);
 		
 				if (lcd_clicked()) {
-					setTargetHotend(HotendTempBckp, active_extruder);
+					setTargetHotend(HotendTempBckp);
 					lcd_wait_for_heater();
 
 					wait_for_user_state = 2;

--- a/Firmware/Prusa_farm.cpp
+++ b/Firmware/Prusa_farm.cpp
@@ -163,7 +163,7 @@ static void trace() {
 
 void serial_read_stream() {
 
-    setAllTargetHotends(0);
+    setTargetHotend(0);
     setTargetBed(0);
 
     lcd_clear();

--- a/Firmware/fancheck.cpp
+++ b/Firmware/fancheck.cpp
@@ -96,7 +96,7 @@ void fanSpeedError(unsigned char _fan) {
     }
     else {
         // Nothing is going on, but still turn off heaters and report the error
-        setTargetHotend0(0);
+        setTargetHotend(0);
         heating_status = HeatingStatus::NO_HEATING;
     }
     switch (_fan) {

--- a/Firmware/mmu2_marlin1.cpp
+++ b/Firmware/mmu2_marlin1.cpp
@@ -99,7 +99,7 @@ void thermal_setExtrudeMintemp(int16_t t) {
 }
 
 void thermal_setTargetHotend(int16_t t) {
-    setTargetHotend(t, 0);
+    setTargetHotend(t);
 }
 
 void safe_delay_keep_alive(uint16_t t) {

--- a/Firmware/planner.cpp
+++ b/Firmware/planner.cpp
@@ -507,7 +507,7 @@ void getHighESpeed()
     t=AUTOTEMP_OLDWEIGHT*oldt+(1-AUTOTEMP_OLDWEIGHT)*t;
   }
   oldt=t;
-  setTargetHotend0(t);
+  setTargetHotend(t);
 }
 #endif
 

--- a/Firmware/stepper.cpp
+++ b/Firmware/stepper.cpp
@@ -216,9 +216,7 @@ void checkHitEndstops()
      card.sdprinting = false;
      card.closefile();
      quickStop();
-     setTargetHotend0(0);
-     setTargetHotend1(0);
-     setTargetHotend2(0);
+     setTargetHotend(0);
    }
 #endif
  }

--- a/Firmware/temperature.cpp
+++ b/Firmware/temperature.cpp
@@ -2209,7 +2209,7 @@ ISR(TIMERx_COMPA_vect)
 
 void disable_heater()
 {
-  setAllTargetHotends(0);
+  setTargetHotend(0);
   setTargetBed(0);
 
   ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {

--- a/Firmware/temperature.h
+++ b/Firmware/temperature.h
@@ -129,24 +129,10 @@ FORCE_INLINE float degTargetBed() {
 };
 
 // Doesn't save FLASH when FORCE_INLINE removed.
-FORCE_INLINE void setTargetHotend(const float &celsius, uint8_t extruder) {  
-  target_temperature[extruder] = celsius;
-  resetPID(extruder);
+FORCE_INLINE void setTargetHotend(const float &celsius) {  
+  target_temperature[0] = celsius;
+  resetPID(0);
 };
-
-// Doesn't save FLASH when not inlined.
-static inline void setTargetHotendSafe(const float &celsius, uint8_t extruder)
-{
-    if (extruder<EXTRUDERS) {
-        setTargetHotend(celsius, extruder);
-    }
-}
-
-// Doesn't save FLASH when not inlined.
-static inline void setAllTargetHotends(const float &celsius)
-{
-    for(uint8_t i = 0; i < EXTRUDERS; i++) setTargetHotend(celsius, i);
-}
 
 FORCE_INLINE void setTargetBed(const float &celsius) {  
   target_temperature_bed = celsius;
@@ -170,30 +156,8 @@ FORCE_INLINE bool isCoolingBed() {
 
 #define degHotend0() degHotend(0)
 #define degTargetHotend0() degTargetHotend(0)
-#define setTargetHotend0(_celsius) setTargetHotend((_celsius), 0)
 #define isHeatingHotend0() isHeatingHotend(0)
 #define isCoolingHotend0() isCoolingHotend(0)
-#if EXTRUDERS > 1
-#define degHotend1() degHotend(1)
-#define degTargetHotend1() degTargetHotend(1)
-#define setTargetHotend1(_celsius) setTargetHotend((_celsius), 1)
-#define isHeatingHotend1() isHeatingHotend(1)
-#define isCoolingHotend1() isCoolingHotend(1)
-#else
-#define setTargetHotend1(_celsius) do{}while(0)
-#endif
-#if EXTRUDERS > 2
-#define degHotend2() degHotend(2)
-#define degTargetHotend2() degTargetHotend(2)
-#define setTargetHotend2(_celsius) setTargetHotend((_celsius), 2)
-#define isHeatingHotend2() isHeatingHotend(2)
-#define isCoolingHotend2() isCoolingHotend(2)
-#else
-#define setTargetHotend2(_celsius) do{}while(0)
-#endif
-#if EXTRUDERS > 3
-#error Invalid number of extruders
-#endif
 
 // return "false", if all heaters are 'off' (ie. "true", if any heater is 'on')
 #define CHECK_ALL_HEATERS (checkAllHotends()||(target_temperature_bed!=0))
@@ -209,7 +173,7 @@ FORCE_INLINE void autotempShutdown(){
  {
   autotemp_enabled=false;
   if(degTargetHotend(active_extruder)>autotemp_min)
-    setTargetHotend(0,active_extruder);
+    setTargetHotend(0);
  }
  #endif
 }

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -961,7 +961,7 @@ void lcd_commands()
 		if (lcd_commands_step == 2 && !pidTuningRunning()) { //saving to eeprom
 			custom_message_state = 0;
 			lcd_setstatuspgm(_i("PID cal. finished"));////MSG_PID_FINISHED c=20
-			setAllTargetHotends(0);  // reset all hotends temperature including the number displayed on the main screen
+			setTargetHotend(0);
 			if (_Kp != 0 || _Ki != 0 || _Kd != 0) {
 				sprintf_P(cmd1, PSTR("M301 P%.2f I%.2f D%.2f"), _Kp, _Ki, _Kd);
 				enquecommand(cmd1);
@@ -1052,7 +1052,7 @@ void lcd_commands()
                 enquecommand_P(PSTR("M84 XY"));
                 lcd_update_enabled = false; //hack to avoid lcd_update recursion.
                 if (lcd_show_fullscreen_message_yes_no_and_wait_P(_T(MSG_NOZZLE_CNG_CHANGED), false) == LCD_LEFT_BUTTON_CHOICE) {
-                    setAllTargetHotends(0);
+                    setTargetHotend(0);
 #ifdef TEMP_MODEL
                     temp_model_set_enabled(was_enabled);
 #endif //TEMP_MODEL
@@ -1105,7 +1105,7 @@ static void lcd_move_menu_axis();
 
 static void lcd_cooldown()
 {
-  setAllTargetHotends(0);
+  setTargetHotend(0);
   setTargetBed(0);
   fanSpeed = 0;
   lcd_return_to_status();
@@ -1896,11 +1896,9 @@ switch(eFilamentAction)
 #endif //FILAMENT_SENSOR
     ) {
      nLevel=2;
-     if(!bFilamentPreheatState)
-          {
-          nLevel++;
-//          setTargetHotend0(0.0);                  // uncoment if return to base-state is required
-          }
+     if(!bFilamentPreheatState) {
+        nLevel++;
+     }
      menu_back(nLevel);
      switch(eFilamentAction)
           {
@@ -1931,7 +1929,7 @@ void mFilamentItem(uint16_t nTemp, uint16_t nTempBed)
 {
     uint8_t nLevel;
 
-    setTargetHotend0((float)nTemp);
+    setTargetHotend((float)nTemp);
     if (!shouldPreheatOnlyNozzle()) setTargetBed((float)nTempBed);
 
     {
@@ -2075,8 +2073,8 @@ void mFilamentItem(uint16_t nTemp, uint16_t nTempBed)
             bFilamentWaitingFlag = false;
             if (!bFilamentPreheatState)
             {
-                setTargetHotend0(0.0);
-                if (!isPrintPaused) setTargetBed(0.0);
+                setTargetHotend(0);
+                if (!isPrintPaused) setTargetBed(0);
                 menu_back();
             }
             menu_back();
@@ -2831,7 +2829,7 @@ void pid_extruder()
 
 #ifdef PINDA_THERMISTOR
 bool lcd_wait_for_pinda(float temp) {
-	setAllTargetHotends(0);
+	setTargetHotend(0);
 	setTargetBed(0);
 	LongTimer pinda_timeout;
 	pinda_timeout.start();
@@ -2865,7 +2863,7 @@ void lcd_wait_for_heater() {
 }
 
 void lcd_wait_for_cool_down() {
-	setAllTargetHotends(0);
+	setTargetHotend(0);
 	setTargetBed(0);
 	int fanSpeedBckp = fanSpeed;
 	fanSpeed = 255;
@@ -4024,14 +4022,14 @@ void lcd_wizard(WizState state)
 				raise_z_above(MIN_Z_FOR_SWAP);
 				//current filament needs to be unloaded and then new filament should be loaded
 				//start to preheat nozzle for unloading remaining PLA filament
-				setTargetHotend(PLA_PREHEAT_HOTEND_TEMP, 0);
+				setTargetHotend(PLA_PREHEAT_HOTEND_TEMP);
 				lcd_display_message_fullscreen_P(_i("Now I will preheat nozzle for PLA.")); ////MSG_WIZARD_WILL_PREHEAT c=20 r=4
 				wait_preheat();
 				//unload current filament
 				unload_filament(FILAMENTCHANGE_FINALRETRACT);
 				//load filament
 				lcd_wizard_load();
-				setTargetHotend(0, 0); //we are finished, cooldown nozzle
+				setTargetHotend(0); //we are finished, cooldown nozzle
 				state = S::Restore;
 			}
 			break;
@@ -4044,7 +4042,7 @@ void lcd_wizard(WizState state)
 #endif //TEMP_MODEL
 		case S::IsFil:
 		    //start to preheat nozzle and bed to save some time later
-			setTargetHotend(PLA_PREHEAT_HOTEND_TEMP, 0);
+			setTargetHotend(PLA_PREHEAT_HOTEND_TEMP);
 			setTargetBed(PLA_PREHEAT_HPB_TEMP);
 			wizard_event = lcd_show_fullscreen_message_yes_no_and_wait_P(_T(MSG_FILAMENT_LOADED), true);
 			if (wizard_event == LCD_LEFT_BUTTON_CHOICE) {
@@ -7010,17 +7008,15 @@ static bool selftest_irsensor()
     {
     public:
         TempBackup():
-            m_temp(degTargetHotend(active_extruder)),
-            m_extruder(active_extruder){}
-        ~TempBackup(){setTargetHotend(m_temp,m_extruder);}
+            m_temp(degTargetHotend(active_extruder)){}
+        ~TempBackup(){setTargetHotend(m_temp);}
     private:
         float m_temp;
-        uint8_t m_extruder;
     };
     uint8_t progress;
     {
         TempBackup tempBackup;
-        setTargetHotend(ABS_PREHEAT_HOTEND_TEMP,active_extruder);
+        setTargetHotend(ABS_PREHEAT_HOTEND_TEMP);
         progress = lcd_selftest_screen(TestScreen::Fsensor, 0, 1, true, 0);
     }
     progress = lcd_selftest_screen(TestScreen::Fsensor, progress, 1, true, 0);


### PR DESCRIPTION
Main changes:
* `setAllTargetHotends()` is removed
* `setTargetHotendSafe()` is removed
* Extruder parameter on `setTargetHotend()` is dropped since it is always 0.

Change in memory:
Flash: -192 bytes
SRAM: 0 bytes