### PR TITLE
Convert `fanSpeed` and `saved_fan_speed` to `uint8_t`

### DIFF
--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -278,7 +278,7 @@ extern float destination[NUM_AXIS] ;
 extern float min_pos[3];
 extern float max_pos[3];
 extern bool axis_known_position[3];
-extern int fanSpeed;
+extern uint8_t fanSpeed; //!< Print fan speed, ranges from 0 to 255
 extern uint8_t newFanSpeed;
 extern float default_retraction;
 
@@ -340,7 +340,7 @@ extern uint8_t saved_printing_type;
 
 extern float saved_extruder_temperature; //!< Active extruder temperature
 extern float saved_bed_temperature; //!< Bed temperature
-extern int saved_fan_speed; //!< Print fan speed
+extern uint8_t saved_fan_speed; //!< Print fan speed, ranges from 0 to 255
 
 //estimated time to end of the print
 extern uint8_t print_percent_done_normal;

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -216,7 +216,7 @@ float min_pos[3] = { X_MIN_POS, Y_MIN_POS, Z_MIN_POS };
 float max_pos[3] = { X_MAX_POS, Y_MAX_POS, Z_MAX_POS };
 bool axis_known_position[3] = {false, false, false};
 
-int fanSpeed=0;
+uint8_t fanSpeed = 0;
 uint8_t newFanSpeed = 0;
 
 #ifdef FWRETRACT
@@ -336,7 +336,7 @@ static int saved_feedmultiply2 = 0;
 float saved_extruder_temperature = 0.0; //!< Active extruder temperature
 float saved_bed_temperature = 0.0;
 static bool saved_extruder_relative_mode = false;
-int saved_fan_speed = 0; //!< Print fan speed
+uint8_t saved_fan_speed = 0; //!< Print fan speed
 //! @}
 
 static int saved_feedmultiply_mm = 100;
@@ -3433,7 +3433,7 @@ void gcode_M114()
 #if (defined(FANCHECK) && (((defined(TACH_0) && (TACH_0 >-1)) || (defined(TACH_1) && (TACH_1 > -1)))))
 void gcode_M123()
 {
-  printf_P(_N("E0:%d RPM PRN1:%d RPM E0@:%u PRN1@:%d\n"), 60*fan_speed[active_extruder], 60*fan_speed[1], newFanSpeed, fanSpeed);
+  printf_P(_N("E0:%d RPM PRN1:%d RPM E0@:%u PRN1@:%u\n"), 60*fan_speed[active_extruder], 60*fan_speed[1], newFanSpeed, fanSpeed);
 }
 #endif //FANCHECK and TACH_0 or TACH_1
 
@@ -3499,7 +3499,7 @@ static void gcode_M600(bool automatic, float x_position, float y_position, float
     //First backup current position and settings
     int feedmultiplyBckp = feedmultiply;
     float HotendTempBckp = degTargetHotend(active_extruder);
-    int fanSpeedBckp = fanSpeed;
+    uint8_t fanSpeedBckp = fanSpeed;
 
     memcpy(lastpos, current_position, sizeof(lastpos));
 
@@ -9590,7 +9590,7 @@ void ThermalStop(bool allow_recovery)
                 // original values after the pause handler is called.
                 float bed_temp = saved_bed_temperature;
                 float ext_temp = saved_extruder_temperature;
-                int fan_speed = saved_fan_speed;
+                uint8_t fan_speed = saved_fan_speed;
                 lcd_pause_print();
                 saved_bed_temperature = bed_temp;
                 saved_extruder_temperature = ext_temp;

--- a/Firmware/backlight.cpp
+++ b/Firmware/backlight.cpp
@@ -14,8 +14,8 @@
 #define BL_FLASH_DELAY_MS 25
 
 bool backlightSupport = 0; //only if it's true will any of the settings be visible to the user
-int16_t backlightLevel_HIGH = 0;
-int16_t backlightLevel_LOW = 0;
+uint8_t backlightLevel_HIGH = 0;
+uint8_t backlightLevel_LOW = 0;
 uint8_t backlightMode = BACKLIGHT_MODE_BRIGHT;
 int16_t backlightTimer_period = 10;
 LongTimer backlightTimer;
@@ -62,8 +62,8 @@ void backlight_wake(const uint8_t flashNo)
 
 void backlight_save() //saves all backlight data to eeprom.
 {
-    eeprom_update_byte((uint8_t *)EEPROM_BACKLIGHT_LEVEL_HIGH, (uint8_t)backlightLevel_HIGH);
-    eeprom_update_byte((uint8_t *)EEPROM_BACKLIGHT_LEVEL_LOW, (uint8_t)backlightLevel_LOW);
+    eeprom_update_byte((uint8_t *)EEPROM_BACKLIGHT_LEVEL_HIGH, backlightLevel_HIGH);
+    eeprom_update_byte((uint8_t *)EEPROM_BACKLIGHT_LEVEL_LOW, backlightLevel_LOW);
     eeprom_update_byte((uint8_t *)EEPROM_BACKLIGHT_MODE, backlightMode);
     eeprom_update_word((uint16_t *)EEPROM_BACKLIGHT_TIMEOUT, backlightTimer_period);
 }

--- a/Firmware/backlight.h
+++ b/Firmware/backlight.h
@@ -13,8 +13,8 @@ enum Backlight_Mode
 	BACKLIGHT_MODE_AUTO    = 2,
 };
 
-extern int16_t backlightLevel_HIGH;
-extern int16_t backlightLevel_LOW;
+extern uint8_t backlightLevel_HIGH;
+extern uint8_t backlightLevel_LOW;
 extern uint8_t backlightMode;
 extern bool backlightSupport;
 extern int16_t backlightTimer_period;

--- a/Firmware/menu.cpp
+++ b/Firmware/menu.cpp
@@ -172,12 +172,10 @@ static void menu_draw_toggle_puts_P(const char* str, const char* toggle, const u
     //xxxxxcba
     //a = selection mark. If it's set(1), then '>' will be used as the first character on the line. Else leave blank
     //b = toggle string is from progmem
-    //c = do not set cursor at all. Must be handled externally.
     uint8_t is_progmem = settings & 0x02;
     const char eol = (toggle == NULL) ? LCD_STR_ARROW_RIGHT[0] : ' ';
     if (toggle == NULL) toggle = _T(MSG_NA);
     uint8_t len = 4 + (is_progmem ? strlen_P(toggle) : strlen(toggle));
-    if (!(settings & 0x04)) lcd_set_cursor(0, menu_row);
     lcd_putc((settings & 0x01) ? '>' : ' ');
     lcd_print_pad_P(str, LCD_WIDTH - len);
     lcd_putc('[');
@@ -429,11 +427,10 @@ const char menu_fmt_float31[] PROGMEM = "%-12.12S%+8.1f";
 
 const char menu_fmt_float13[] PROGMEM = "%c%-13.13S%+5.3f";
 
-template<typename T>
-static void menu_draw_P(char chr, const char* str, int16_t val);
 
-template<>
-void menu_draw_P<int16_t*>(char chr, const char* str, int16_t val)
+
+template <typename T>
+void menu_draw_P(char chr, const char* str, T val)
 {
 	// The LCD row position is controlled externally. We may only modify the column here
 	lcd_putc(chr);
@@ -452,20 +449,8 @@ void menu_draw_P<int16_t*>(char chr, const char* str, int16_t val)
 	lcd_print(val);
 }
 
-template<>
-void menu_draw_P<uint8_t*>(char chr, const char* str, int16_t val)
-{
-    menu_data_edit_t* _md = (menu_data_edit_t*)&(menu_data[0]);
-    float factor = 1.0f + static_cast<float>(val) / 1000.0f;
-    if (val <= _md->minEditValue)
-    {
-        menu_draw_toggle_puts_P(str, _T(MSG_OFF), 0x04 | 0x02 | (chr=='>'));
-    }
-    else
-    {
-        lcd_printf_P(menu_fmt_float13, chr, str, factor);
-    }
-}
+template void menu_draw_P<int16_t>(char chr, const char* str, int16_t val);
+template void menu_draw_P<uint8_t>(char chr, const char* str, uint8_t val);
 
 //! @brief Draw up to 10 chars of text and a float number in format from +0.0 to +12345.0. The increased range is necessary
 //! for displaying large values of extruder positions, which caused text overflow in the previous implementation.
@@ -506,7 +491,7 @@ static void _menu_edit_P(void)
 		if (lcd_encoder < _md->minEditValue) lcd_encoder = _md->minEditValue;
 		else if (lcd_encoder > _md->maxEditValue) lcd_encoder = _md->maxEditValue;
 		lcd_set_cursor(0, 1);
-		menu_draw_P<T>(' ', _md->editLabel, (int)lcd_encoder);
+		menu_draw_P(' ', _md->editLabel, (int)lcd_encoder);
 	}
 	if (LCD_CLICKED)
 	{
@@ -524,7 +509,7 @@ uint8_t menu_item_edit_P(const char* str, T pval, int16_t min_val, int16_t max_v
 		if (lcd_draw_update) 
 		{
 			lcd_set_cursor(0, menu_row);
-			menu_draw_P<T>(menu_selection_mark(), str, *pval);
+			menu_draw_P(menu_selection_mark(), str, *pval);
 		}
 		if (menu_clicked && (lcd_encoder == menu_item))
 		{

--- a/Firmware/menu.h
+++ b/Firmware/menu.h
@@ -148,6 +148,9 @@ extern void menu_format_sheet_E(const Sheet &sheet_E, SheetFormatBuffer &buffer)
 template <typename T>
 extern uint8_t menu_item_edit_P(const char* str, T pval, int16_t min_val, int16_t max_val);
 
+template <typename T>
+extern void menu_draw_P(char chr, const char* str, T val);
+
 extern void menu_progressbar_init(uint16_t total, const char* title);
 extern void menu_progressbar_update(uint16_t newVal);
 extern void menu_progressbar_finish(void);

--- a/Firmware/planner.cpp
+++ b/Firmware/planner.cpp
@@ -530,11 +530,11 @@ bool e_active()
 
 void check_axes_activity()
 {
-  unsigned char x_active = 0;
-  unsigned char y_active = 0;  
-  unsigned char z_active = 0;
-  unsigned char e_active = 0;
-  unsigned char tail_fan_speed = fanSpeed;
+  uint8_t x_active = 0;
+  uint8_t y_active = 0;  
+  uint8_t z_active = 0;
+  uint8_t e_active = 0;
+  uint8_t tail_fan_speed = fanSpeed;
   block_t *block;
 
   if(block_buffer_tail != block_buffer_head)

--- a/Firmware/planner.h
+++ b/Firmware/planner.h
@@ -103,8 +103,7 @@ typedef struct {
   uint32_t initial_rate;              // The jerk-adjusted step rate at start of block  
   uint32_t final_rate;                // The minimal rate at exit
   uint32_t acceleration_steps_per_s2; // acceleration steps/sec^2
-  //FIXME does it have to be int? Probably uint8_t would be just fine. Need to change in other places as well
-  int fan_speed;
+  uint8_t fan_speed; // Print fan speed, ranges from 0 to 255
   volatile char busy;
 
 

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2796,7 +2796,7 @@ void lcd_wait_for_heater() {
 void lcd_wait_for_cool_down() {
 	setTargetHotend(0);
 	setTargetBed(0);
-	int fanSpeedBckp = fanSpeed;
+	uint8_t fanSpeedBckp = fanSpeed;
 	fanSpeed = 255;
 	while ((degHotend(0)>MAX_HOTEND_TEMP_CALIBRATION) || (degBed() > MAX_BED_TEMP_CALIBRATION)) {
 		lcd_display_message_fullscreen_P(_i("Waiting for nozzle and bed cooling"));////MSG_WAITING_TEMP c=20 r=4
@@ -5553,7 +5553,7 @@ static void lcd_tune_menu()
 	MENU_ITEM_EDIT_int3_P(_T(MSG_NOZZLE), &target_temperature[0], 0, HEATER_0_MAXTEMP - 10);//3
 	MENU_ITEM_EDIT_int3_P(_T(MSG_BED), &target_temperature_bed, 0, BED_MAXTEMP - 10);
 
-	MENU_ITEM_EDIT_int3_P(_T(MSG_FAN_SPEED), &fanSpeed, 0, 255);//5
+	MENU_ITEM_EDIT_int3_P(_T(MSG_FAN_SPEED), (int16_t*)&fanSpeed, 0, 255);//5
 	MENU_ITEM_EDIT_int3_P(_i("Flow"), &extrudemultiply, 10, 999);//6////MSG_FLOW c=15
 #ifdef LA_LIVE_K
 	MENU_ITEM_EDIT_advance_K();//7
@@ -5678,7 +5678,7 @@ static void lcd_control_temperature_menu()
 #if TEMP_SENSOR_BED != 0
   MENU_ITEM_EDIT_int3_P(_T(MSG_BED), &target_temperature_bed, 0, BED_MAXTEMP - 3);
 #endif
-  MENU_ITEM_EDIT_int3_P(_T(MSG_FAN_SPEED), &fanSpeed, 0, 255);
+  MENU_ITEM_EDIT_int3_P(_T(MSG_FAN_SPEED), (int16_t*)&fanSpeed, 0, 255);
 #if defined AUTOTEMP && (TEMP_SENSOR_0 != 0)
 //MENU_ITEM_EDIT removed, following code must be redesigned if AUTOTEMP enabled
   MENU_ITEM_EDIT(bool, MSG_AUTOTEMP, &autotemp_enabled);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5553,7 +5553,7 @@ static void lcd_tune_menu()
 	MENU_ITEM_EDIT_int3_P(_T(MSG_NOZZLE), &target_temperature[0], 0, HEATER_0_MAXTEMP - 10);//3
 	MENU_ITEM_EDIT_int3_P(_T(MSG_BED), &target_temperature_bed, 0, BED_MAXTEMP - 10);
 
-	MENU_ITEM_EDIT_int3_P(_T(MSG_FAN_SPEED), (int16_t*)&fanSpeed, 0, 255);//5
+	MENU_ITEM_EDIT_int3_P(_T(MSG_FAN_SPEED), &fanSpeed, 0, 255);//5
 	MENU_ITEM_EDIT_int3_P(_i("Flow"), &extrudemultiply, 10, 999);//6////MSG_FLOW c=15
 #ifdef LA_LIVE_K
 	MENU_ITEM_EDIT_advance_K();//7
@@ -5678,7 +5678,7 @@ static void lcd_control_temperature_menu()
 #if TEMP_SENSOR_BED != 0
   MENU_ITEM_EDIT_int3_P(_T(MSG_BED), &target_temperature_bed, 0, BED_MAXTEMP - 3);
 #endif
-  MENU_ITEM_EDIT_int3_P(_T(MSG_FAN_SPEED), (int16_t*)&fanSpeed, 0, 255);
+  MENU_ITEM_EDIT_int3_P(_T(MSG_FAN_SPEED), &fanSpeed, 0, 255);
 #if defined AUTOTEMP && (TEMP_SENSOR_0 != 0)
 //MENU_ITEM_EDIT removed, following code must be redesigned if AUTOTEMP enabled
   MENU_ITEM_EDIT(bool, MSG_AUTOTEMP, &autotemp_enabled);


### PR DESCRIPTION
The fan speed variables only range from 0 to 255 and should be `uint8_t` (1 byte). Even in the planner/block this applies and sync the code a little bit with Marlin 2.

Change in memory (Multilang MK3S build):
Flash: -324 bytes
SRAM: -20 bytes