### PR TITLE
build: Report target sizes only once in AVR format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,11 +235,12 @@ if(CMAKE_CROSSCOMPILING)
   set(CMAKE_C_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE})
 
   # mcu and target-related settings
+  set(TARGET_MCU "atmega2560")
   add_compile_options(
-    -mmcu=atmega2560 -DF_CPU=16000000L -DARDUINO=10819 -DARDUINO_AVR_PRUSA_EINSY_RAMBO
+    -mmcu=${TARGET_MCU} -DF_CPU=16000000L -DARDUINO=10819 -DARDUINO_AVR_PRUSA_EINSY_RAMBO
     -DARDUINO_ARCH_AVR
     )
-  add_link_options(-mmcu=atmega2560 -Wl,-u,vfprintf -lprintf_flt -lm)
+  add_link_options(-mmcu=${TARGET_MCU} -Wl,-u,vfprintf -lprintf_flt -lm)
 
   # disable some C++ language features
   add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fno-threadsafe-statics>)
@@ -303,12 +304,7 @@ function(add_base_binary variant_name)
     )
 
   # inform about the firmware's size in terminal
-  add_custom_command(
-    TARGET ${variant_name}
-    POST_BUILD
-    COMMAND ${CMAKE_SIZE_UTIL} -C --mcu=atmega2560 ${variant_name}
-    )
-  report_size(${variant_name})
+  report_size(${variant_name} ${TARGET_MCU})
 
   # generate linker map file
   target_link_options(

--- a/cmake/Utilities.cmake
+++ b/cmake/Utilities.cmake
@@ -55,11 +55,12 @@ function(objcopy target format suffix)
     )
 endfunction()
 
-function(report_size target)
+function(report_size target mcu)
   add_custom_command(
     TARGET ${target} POST_BUILD
     COMMAND echo "" # visually separate the output
-    COMMAND "${CMAKE_SIZE_UTIL}" -B "$<TARGET_FILE:${target}>"
+    COMMAND echo -n "${target} "
+    COMMAND "${CMAKE_SIZE_UTIL}" -C --mcu=${mcu} "$<TARGET_FILE:${target}>"
     USES_TERMINAL
     )
 endfunction()


### PR DESCRIPTION
cmake currently reports the binary sizes twice, once without the real mcu set and the second in AVR format.

The double reporting is confusing, and we really seem to prefer the AVR format. Change the `report_size` function to use the current mcu and remove the double (confusing) reporting.

This results in:

```
MK3S-EINSy10a_ENGLISH AVR Memory Usage
----------------
Device: atmega2560

Program:  235188 bytes (89.7% Full)
(.text + .data + .bootloader)

Data:       5662 bytes (69.1% Full)
(.data + .bss + .noinit)
```

Note the current target name in the header