### PR TITLE
TM: Do not emit an "error:" on the serial for recoverable errors

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -9472,6 +9472,8 @@ void ThermalStop(bool allow_recovery)
 {
     if(Stopped == false) {
         Stopped = true;
+
+        // Either pause or stop the print
         if(allow_recovery && (IS_SD_PRINTING || usb_timer.running())) {
             if (!isPrintPaused) {
                 lcd_setalertstatuspgm(_T(MSG_PAUSED_THERMAL_ERROR), LCD_STATUS_CRITICAL);
@@ -9494,8 +9496,8 @@ void ThermalStop(bool allow_recovery)
             print_stop();
         }
 
-        // Report the status on the serial, switch to a busy state
-        SERIAL_ERROR_START;
+        // Report the error on the serial
+        serialprintPGM(allow_recovery ? echomagic : errormagic);
         SERIAL_ERRORLNRPGM(MSG_ERR_STOPPED);
 
         // Eventually report the stopped status on the lcd (though this is usually overridden by a


### PR DESCRIPTION
Use "echo:" for thermal model error reporting to avoid octoprint automatically sending a M112 kill.

Keep using "error:" instead for other thermal errors (MAXTEMP/etc).

This should allow resuming a thermal mode pause with the default octoprint settings (see https://github.com/prusa3d/Prusa-Firmware/issues/3636#issuecomment-1406971627)