### PR TITLE
CI: Add a workflow to calculate PR flash/ram cost

### DIFF
--- a/.github/workflows/pr-size.sh
+++ b/.github/workflows/pr-size.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+MESSAGE=$1
+BASE_DIR=$2
+PR_DIR=$3
+shift 3
+
+# this assumes we're running from the repository root
+AVR_SIZE=$(echo .dependencies/avr-gcc-*/bin/avr-size)
+test -x "$AVR_SIZE" || exit 2
+
+avr_size()
+{
+    "$AVR_SIZE" --mcu=atmega2560 -C "$@"
+}
+
+avr_flash()
+{
+    avr_size "$@" | sed -ne 's/^Program: *\([0-9]\+\).*/\1/p'
+}
+
+avr_ram()
+{
+    avr_size "$@" | sed -ne 's/^Data: *\([0-9]\+\).*/\1/p'
+}
+
+echo "This PR will consume:" > "$MESSAGE"
+for TARGET in $@
+do
+    base_bin=$(echo ${BASE_DIR}/build_gen/*/$TARGET)
+    base_flash=$(avr_flash "$base_bin")
+    base_ram=$(avr_ram "$base_bin")
+
+    pr_bin=$(echo ${PR_DIR}/build_gen/*/$TARGET)
+    pr_flash=$(avr_flash "$pr_bin")
+    pr_ram=$(avr_ram "$pr_bin")
+
+    flash_d=$(($pr_flash - $base_flash))
+    ram_d=$(($pr_ram - $base_ram))
+
+    echo "- \`$TARGET\`: ${flash_d}b of flash, ${ram_d}b of ram" >> "$MESSAGE"
+done

--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -1,0 +1,66 @@
+name: pr-size
+
+on:
+  pull_request:
+    branches: [ MK3, MK3_* ]
+
+env:
+    TARGETS: "MK3S-EINSy10a_ENGLISH MK3-EINSy10a_ENGLISH"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+
+    # setup base required dependencies
+    - name: Setup dependencies
+      run: |
+          sudo apt-get install cmake ninja-build python3-pyelftools python3-regex python3-polib
+
+    # build the PR branch
+    - name: Checkout PR
+      uses: actions/checkout@v3
+
+    - name: Setup build dependencies
+      run: |
+          ./utils/bootstrap.py
+
+    - name: Build PR
+      run: |
+          rm -rf build-pr
+          mkdir build-pr
+          cd build-pr
+          cmake .. -DCMAKE_TOOLCHAIN_FILE="../cmake/AvrGcc.cmake" -DCMAKE_BUILD_TYPE=Release -G Ninja
+          ninja $TARGETS
+
+    # save pr-size for later use
+    - name: Save pr-size from PR
+      run: |
+          cp -f ./.github/workflows/pr-size.sh build-pr
+
+    # build the base branch
+    - name: Checkout base
+      uses: actions/checkout@v3
+      with:
+        clean: false
+        ref: ${{ github.event.pull_request.base.ref }}
+
+    - name: Build base
+      run: |
+          rm -rf build-base
+          mkdir build-base
+          cd build-base
+          cmake .. -DCMAKE_TOOLCHAIN_FILE="../cmake/AvrGcc.cmake" -DCMAKE_BUILD_TYPE=Release -G Ninja
+          ninja $TARGETS
+
+    # extract/show build differences
+    - name: Calculate binary changes
+      run: |
+          rm -rf build-changes
+          ./build-pr/pr-size.sh build-changes build-base build-pr $TARGETS
+
+    - name: Add PR Comment
+      uses: mshick/add-pr-comment@v2
+      with:
+        message-path: build-changes


### PR DESCRIPTION
Add a new github action workflow to calculate how much flash/ram a PR is going to take.

This will add a new message to the PR showing both for the MK3/MK3S builds. See https://github.com/wavexx/Prusa-Firmware/pull/12 for an example that includes code changes.

The message is sticky and will be updated to reflect each change in the PR.