### PR TITLE
Fix an issue with using echo on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -306,6 +306,7 @@ function(add_base_binary variant_name)
   add_custom_command(
     TARGET ${variant_name}
     POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E echo_append "${variant_name} "
     COMMAND ${CMAKE_SIZE_UTIL} -C --mcu=atmega2560 ${variant_name}
     )
   report_size(${variant_name})

--- a/cmake/Utilities.cmake
+++ b/cmake/Utilities.cmake
@@ -58,7 +58,7 @@ endfunction()
 function(report_size target)
   add_custom_command(
     TARGET ${target} POST_BUILD
-    COMMAND echo "" # visually separate the output
+    COMMAND ${CMAKE_COMMAND} -E echo "" # visually separate the output
     COMMAND "${CMAKE_SIZE_UTIL}" -B "$<TARGET_FILE:${target}>"
     USES_TERMINAL
     )

--- a/cmake/Utilities.cmake
+++ b/cmake/Utilities.cmake
@@ -58,7 +58,6 @@ endfunction()
 function(report_size target)
   add_custom_command(
     TARGET ${target} POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E echo "" # visually separate the output
     COMMAND "${CMAKE_SIZE_UTIL}" -B "$<TARGET_FILE:${target}>"
     USES_TERMINAL
     )


### PR DESCRIPTION
* Use CMake's built-in `echo` command to ensure behavior is the same between different platforms
* Append the target name to the memory usage results post build. This is done using CMake's built-in command `echo_append`


**Before:**
Notice the string `"ECHO is on"` string appears. It should not be there.
![image](https://user-images.githubusercontent.com/8218499/215278448-4446c45a-5e22-4918-b936-da732be116d3.png)



**After:**
![image](https://user-images.githubusercontent.com/8218499/215285706-e84a39c1-94d5-453b-acc9-2d0def5fa5cf.png)
