### PR TITLE
Various optimization around print time statistics

### DIFF
--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -306,8 +306,9 @@ extern float retract_recover_length_swap;
 
 extern uint8_t host_keepalive_interval;
 
-extern unsigned long starttime;
-extern unsigned long stoptime;
+extern uint32_t starttime; // milliseconds
+extern uint32_t pause_time; // milliseconds
+extern uint32_t start_pause_print; // milliseconds
 extern ShortTimer usb_timer;
 extern bool processing_tcode;
 extern bool homing_flag;
@@ -327,11 +328,6 @@ extern int fan_speed[2];
 // Active extruder becomes a #define to make the whole firmware compilable.
 // We may even remove the references to it wherever possible in the future
 #define active_extruder 0
-
-//Long pause
-extern unsigned long pause_time;
-extern unsigned long start_pause_print;
-extern unsigned long t_fan_rising_edge;
 
 extern bool mesh_bed_leveling_flag;
 

--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -312,8 +312,12 @@ extern ShortTimer usb_timer;
 extern bool processing_tcode;
 extern bool homing_flag;
 extern bool loading_flag;
-extern unsigned long total_filament_used;
-void save_statistics(unsigned long _total_filament_used, unsigned long _total_print_time);
+extern uint32_t total_filament_used; // mm/100 or 10um
+
+/// @brief Save print statistics to EEPROM
+/// @param _total_filament_used has unit mm/100 or 10um
+/// @param _total_print_time has unit minutes, for example 123 minutes
+void save_statistics(uint32_t _total_filament_used, uint32_t _total_print_time);
 extern uint8_t heating_status_counter;
 
 extern bool fan_state[2];

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -173,9 +173,7 @@ int extrudemultiply=100; //100->1 200->2
 
 bool homing_flag = false;
 
-unsigned long pause_time = 0;
-unsigned long start_pause_print = _millis();
-unsigned long t_fan_rising_edge = _millis();
+static uint32_t t_fan_rising_edge;
 LongTimer safetyTimer;
 static LongTimer crashDetTimer;
 
@@ -306,8 +304,9 @@ unsigned long max_inactive_time = 0;
 static unsigned long stepper_inactive_time = DEFAULT_STEPPER_DEACTIVE_TIME*1000l;
 static unsigned long safetytimer_inactive_time = DEFAULT_SAFETYTIMER_TIME_MINS*60*1000ul;
 
-unsigned long starttime=0;
-unsigned long stoptime=0;
+uint32_t starttime;
+uint32_t pause_time;
+uint32_t start_pause_print;
 ShortTimer usb_timer;
 
 bool Stopped=false;
@@ -5515,12 +5514,11 @@ void process_commands()
     */
     case 31: //M31 take time since the start of the SD print or an M109 command
       {
-      stoptime=_millis();
       char time[30];
-      unsigned long t=(stoptime-starttime)/1000;
-      int sec,min;
-      min=t/60;
-      sec=t%60;
+      uint32_t t = (_millis() - starttime) / 1000;
+      int16_t sec, min;
+      min = t / 60;
+      sec = t % 60;
       sprintf_P(time, PSTR("%i min, %i sec"), min, sec);
       SERIAL_ECHO_START;
       SERIAL_ECHOLN(time);

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -183,7 +183,7 @@ static LongTimer crashDetTimer;
 
 bool mesh_bed_leveling_flag = false;
 
-unsigned long total_filament_used;
+uint32_t total_filament_used;
 HeatingStatus heating_status;
 uint8_t heating_status_counter;
 bool loading_flag = false;
@@ -9716,11 +9716,11 @@ void setPwmFrequency(uint8_t pin, int val)
 }
 #endif //FAST_PWM_FAN
 
-void save_statistics(unsigned long _total_filament_used, unsigned long _total_print_time) { //_total_filament_used unit: mm/100; print time in s
-    uint32_t _previous_filament = eeprom_init_default_dword((uint32_t *)EEPROM_FILAMENTUSED, 0); //_previous_filament unit: cm
+void save_statistics(uint32_t _total_filament_used, uint32_t _total_print_time) {
+    uint32_t _previous_filament = eeprom_init_default_dword((uint32_t *)EEPROM_FILAMENTUSED, 0); //_previous_filament unit: meter
     uint32_t _previous_time = eeprom_init_default_dword((uint32_t *)EEPROM_TOTALTIME, 0);        //_previous_time unit: min
 
-    eeprom_update_dword((uint32_t *)EEPROM_TOTALTIME, _previous_time + (_total_print_time / 60)); // EEPROM_TOTALTIME unit: min
+    eeprom_update_dword((uint32_t *)EEPROM_TOTALTIME, _previous_time + _total_print_time); // EEPROM_TOTALTIME unit: min
     eeprom_update_dword((uint32_t *)EEPROM_FILAMENTUSED, _previous_filament + (_total_filament_used / 1000));
 
     total_filament_used = 0;

--- a/Firmware/Prusa_farm.cpp
+++ b/Firmware/Prusa_farm.cpp
@@ -92,7 +92,7 @@ static void prusa_stat_printinfo() {
     SERIAL_ECHO(card.longFilename[0] ? card.longFilename : card.filename);
     SERIAL_ECHOPGM("][TIM:");
     if (starttime != 0) {
-        SERIAL_ECHO(_millis() / 1000 - starttime / 1000);
+        SERIAL_ECHO((_millis() - starttime) / 1000);
     }
     else {
         SERIAL_ECHO(0);

--- a/Firmware/cmdqueue.cpp
+++ b/Firmware/cmdqueue.cpp
@@ -626,11 +626,11 @@ void get_command()
           SERIAL_PROTOCOLLNRPGM(_n("Done printing file"));////MSG_FILE_PRINTED
           stoptime=_millis();
           char time[30];
-          unsigned long t=(stoptime-starttime-pause_time)/1000;
+          uint32_t t = (stoptime-starttime-pause_time) / 60000;
           pause_time = 0;
           int hours, minutes;
-          minutes=(t/60)%60;
-          hours=t/60/60;
+          minutes = t % 60;
+          hours = t / 60;
           save_statistics(total_filament_used, t);
           sprintf_P(time, PSTR("%i hours %i minutes"),hours, minutes);
           SERIAL_ECHO_START;

--- a/Firmware/cmdqueue.cpp
+++ b/Firmware/cmdqueue.cpp
@@ -624,9 +624,8 @@ void get_command()
           card.closefile();
 
           SERIAL_PROTOCOLLNRPGM(_n("Done printing file"));////MSG_FILE_PRINTED
-          stoptime=_millis();
           char time[30];
-          uint32_t t = (stoptime-starttime-pause_time) / 60000;
+          uint32_t t = (_millis() - starttime - pause_time) / 60000;
           pause_time = 0;
           int hours, minutes;
           minutes = t % 60;

--- a/Firmware/eeprom.h
+++ b/Firmware/eeprom.h
@@ -97,8 +97,8 @@ static_assert(sizeof(Sheets) == EEPROM_SHEETS_SIZEOF, "Sizeof(Sheets) is not EEP
 | ^           | ^       | ^                                     | fah 250      | ^                     | needs XYZ calibration                             | ^            | ^
 | ^           | ^       | ^                                     | 00h 0        | ^                     | Unknown (legacy)                                  | ^            | ^
 | 0x0FF5 4085 | uint16  | EEPROM_BABYSTEP_Z0                    | ???          | ff ffh 65535          | Babystep for Z ???                                | ???          | D3 Ax0ff5 C2
-| 0x0FF1 4081 | unint32 | EEPROM_FILAMENTUSED                   | ???          | 00 00 00 00h 0 __S/P__| Filament used in meters                           | ???          | D3 Ax0ff1 C4
-| 0x0FED 4077 | unint32 | EEPROM_TOTALTIME                      | ???          | 00 00 00 00h 0 __S/P__| Total print time                                  | ???          | D3 Ax0fed C4
+| 0x0FF1 4081 | uint32  | EEPROM_FILAMENTUSED                   | ???          | 00 00 00 00h 0 __S/P__| Filament used in meters                           | ???          | D3 Ax0ff1 C4
+| 0x0FED 4077 | uint32  | EEPROM_TOTALTIME                      | ???          | 00 00 00 00h 0 __S/P__| Total print time in minutes                       | ???          | D3 Ax0fed C4
 | 0x0FE5 4069 | float   | EEPROM_BED_CALIBRATION_CENTER         | ???          | ff ff ff ffh          | ???                                               | ???          | D3 Ax0fe5 C8
 | 0x0FDD 4061 | float   | EEPROM_BED_CALIBRATION_VEC_X          | ???          | ff ff ff ffh          | ???                                               | ???          | D3 Ax0fdd C8
 | 0x0FD5 4053 | float   | EEPROM_BED_CALIBRATION_VEC_Y          | ???          | ff ff ff ffh          | ???                                               | ???          | D3 Ax0fd5 C8

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2349,9 +2349,9 @@ void lcd_menu_statistics()
 	{
 		const float _met = ((float)total_filament_used) / (100000.f);
 		const uint32_t _t = (_millis() - starttime) / 1000ul;
-		const uint32_t _h = _t / 3600;
-		const uint8_t _m = (_t - (_h * 3600ul)) / 60ul;
-		const uint8_t _s = _t - ((_h * 3600ul) + (_m * 60ul));
+		const uint32_t _h = (_t / 60) / 60;
+		const uint8_t _m = (_t / 60) % 60;
+		const uint8_t _s = _t % 60;
 
         lcd_home();
 		lcd_printf_P(_N(
@@ -2371,9 +2371,9 @@ void lcd_menu_statistics()
 		uint8_t _hours, _minutes;
 		uint32_t _days;
 		float _filament_m = (float)_filament/100;
-		_days = _time / 1440;
-		_hours = (_time - (_days * 1440)) / 60;
-		_minutes = _time - ((_days * 1440) + (_hours * 60));
+		_days  = (_time / 60) / 24;
+		_hours = (_time / 60) % 24;
+		_minutes = _time % 60;
 
 		lcd_home();
 		lcd_printf_P(_N(

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5715,11 +5715,8 @@ static void lcd_sd_updir()
 // continue stopping the print from the main loop after lcd_print_stop() is called
 void lcd_print_stop_finish()
 {
-    // save printing time
-    stoptime = _millis();
-
     // Convert the time from ms to minutes, divide by 60 * 1000
-    uint32_t t = (stoptime - starttime - pause_time) / 60000;
+    uint32_t t = (_millis() - starttime - pause_time) / 60000;
     save_statistics(total_filament_used, t);
 
     // lift Z

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -497,11 +497,11 @@ void lcdui_print_time(void)
             print_t = print_tr;
             suff = 'R';
         } else 
-            print_t = _millis() / 60000 - starttime / 60000;
+            print_t = (_millis() - starttime) / 60000;
 
         if (feedmultiply != 100 && (print_t == print_tr || print_t == print_tc)) {
             suff_doubt = '?';
-            print_t = 100ul * print_t / feedmultiply;
+            print_t = (100 * print_t) / feedmultiply;
         }
 
         if (print_t < 6000) //time<100h
@@ -2366,8 +2366,8 @@ void lcd_menu_statistics()
 	}
 	else
 	{
-		unsigned long _filament = eeprom_read_dword((uint32_t *)EEPROM_FILAMENTUSED);
-		unsigned long _time = eeprom_read_dword((uint32_t *)EEPROM_TOTALTIME); //in minutes
+		uint32_t _filament = eeprom_read_dword((uint32_t *)EEPROM_FILAMENTUSED); // in meters
+		uint32_t _time = eeprom_read_dword((uint32_t *)EEPROM_TOTALTIME); // in minutes
 		uint8_t _hours, _minutes;
 		uint32_t _days;
 		float _filament_m = (float)_filament/100;
@@ -5717,7 +5717,9 @@ void lcd_print_stop_finish()
 {
     // save printing time
     stoptime = _millis();
-    unsigned long t = (stoptime - starttime - pause_time) / 1000; //time in s
+
+    // Convert the time from ms to minutes, divide by 60 * 1000
+    uint32_t t = (stoptime - starttime - pause_time) / 60000;
     save_statistics(total_filament_used, t);
 
     // lift Z


### PR DESCRIPTION
Various optimisation surround the print time statistic:

1. Remove subtractions when calculating total print time statistic. Also eliminates overflow risk (Saves ~20B)
2. Time input into `save_statistics()` is now always in minutes. Reduces risk of incorrect units.
3. Remove redundant divisions
    * Example: `_millis() / 60000 - starttime / 60000` should  be `(_millis() - starttime) / 60000`
4. Remove global variable `stoptime`, this didn't save SRAM so I assume it was already being optimised away.
5. Don't initialize variables with `_millis()` when they're declared. It's cheaper memory-wise to just to let the compiler zero-initialize these for us.

Change in memory on Multilang build:
Flash: -156 bytes
SRAM: 0 bytes

Change in memory on English build:
Flash: -210 bytes
SRAM: 0 bytes