### PR TITLE
Cleanup: move filAutoLoad to ultralcd code and various cleanup

### DIFF
--- a/Firmware/Filament_sensor.cpp
+++ b/Firmware/Filament_sensor.cpp
@@ -117,7 +117,7 @@ void Filament_sensor::triggerFilamentInserted() {
             || eeprom_read_byte((uint8_t *)EEPROM_WIZARD_ACTIVE)
             )
         ) {
-        filAutoLoad();
+        lcd_AutoLoadFilament();
     }
 }
 
@@ -141,16 +141,6 @@ void Filament_sensor::triggerFilamentRemoved() {
     }
 }
 
-void Filament_sensor::filAutoLoad() {
-    eFilamentAction = FilamentAction::AutoLoad;
-    if (target_temperature[0] >= EXTRUDE_MINTEMP) {
-        bFilamentPreheatState = true;
-        menu_submenu(mFilamentItemForce);
-    } else {
-        menu_submenu(lcd_generic_preheat_menu);
-        lcd_timeoutToStatus.start();
-    }
-}
 
 void Filament_sensor::filRunout() {
 //    SERIAL_ECHOLNPGM("filRunout");

--- a/Firmware/Filament_sensor.h
+++ b/Firmware/Filament_sensor.h
@@ -69,9 +69,7 @@ protected:
     void triggerFilamentInserted();
     
     void triggerFilamentRemoved();
-    
-    static void filAutoLoad();
-    
+
     void filRunout();
     
     void triggerError();

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -124,7 +124,7 @@ static void lcd_v2_calibration();
 static void mmu_fil_eject_menu();
 static void mmu_load_to_nozzle_menu();
 static void mmu_loading_test_menu();
-static void preheat_or_continue();
+static void preheat_or_continue(FilamentAction action);
 
 #ifdef MMU_HAS_CUTTER
 static void mmu_cut_filament_menu();
@@ -2139,16 +2139,14 @@ void lcd_generic_preheat_menu()
     MENU_END();
 }
 
-void lcd_unLoadFilament()
+static void lcd_unLoadFilament()
 {
-     eFilamentAction=FilamentAction::UnLoad;
-     preheat_or_continue();
+     preheat_or_continue(FilamentAction::UnLoad);
 }
 
 static void mmu_unload_filament()
 {
-    eFilamentAction = FilamentAction::MmuUnLoad;
-    preheat_or_continue();
+    preheat_or_continue(FilamentAction::MmuUnLoad);
 }
 
 
@@ -2297,7 +2295,8 @@ static void lcd_menu_AutoLoadFilament()
 }
 #endif //FILAMENT_SENSOR
 
-static void preheat_or_continue() {
+static void preheat_or_continue(FilamentAction action) {
+    eFilamentAction = action;
     if (target_temperature[0] >= extrude_min_temp) {
         bFilamentPreheatState = true;
         mFilamentItem(target_temperature[0], target_temperature_bed);
@@ -2308,13 +2307,11 @@ static void preheat_or_continue() {
 
 static void lcd_LoadFilament()
 {
-    eFilamentAction = FilamentAction::Load;
-    preheat_or_continue();
+    preheat_or_continue(FilamentAction::Load);
 }
 
 void lcd_AutoLoadFilament() {
-    eFilamentAction = FilamentAction::AutoLoad;
-    preheat_or_continue();
+    preheat_or_continue(FilamentAction::AutoLoad);
 }
 
 
@@ -4938,8 +4935,7 @@ static void mmu_load_to_nozzle_menu() {
             MENU_ITEM_FUNCTION_NR_P(_T(MSG_LOAD_FILAMENT), i + '1', lcd_mmu_load_to_nozzle_wrapper, i); ////MSG_LOAD_FILAMENT c=16
         MENU_END();
     } else {
-        eFilamentAction = FilamentAction::MmuLoad;
-        preheat_or_continue();
+        preheat_or_continue(FilamentAction::MmuLoad);
     }
 }
 
@@ -4956,8 +4952,7 @@ static void mmu_fil_eject_menu() {
             MENU_ITEM_FUNCTION_NR_P(_T(MSG_EJECT_FROM_MMU), i + '1', mmu_eject_filament, i); ////MSG_EJECT_FROM_MMU c=16
         MENU_END();
     } else {
-        eFilamentAction = FilamentAction::MmuEject;
-        preheat_or_continue();
+        preheat_or_continue(FilamentAction::MmuEject);
     }
 }
 
@@ -4974,8 +4969,7 @@ static void mmu_cut_filament_menu() {
             MENU_ITEM_FUNCTION_NR_P(_T(MSG_CUT_FILAMENT), i + '1', mmu_cut_filament_wrapper, i); ////MSG_CUT_FILAMENT c=16
         MENU_END();
     } else {
-        eFilamentAction=FilamentAction::MmuCut;
-        preheat_or_continue();
+        preheat_or_continue(FilamentAction::MmuCut);
     }
 }
 #endif //MMU_HAS_CUTTER
@@ -4999,8 +4993,7 @@ static void mmu_loading_test_menu() {
             MENU_ITEM_FUNCTION_NR_P(_T(MSG_LOAD_FILAMENT), i + '1', loading_test_wrapper, i); ////MSG_LOAD_FILAMENT c=16
         MENU_END();
     } else {
-        eFilamentAction = FilamentAction::MmuLoadingTest;
-        preheat_or_continue();
+        preheat_or_continue(FilamentAction::MmuLoadingTest);
     }
 }
 

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2318,6 +2318,11 @@ static void lcd_LoadFilament()
     preheat_or_continue();
 }
 
+void lcd_AutoLoadFilament() {
+    eFilamentAction = FilamentAction::AutoLoad;
+    preheat_or_continue();
+}
+
 
 //! @brief Show filament used a print time
 //!

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -57,6 +57,11 @@ static void lcd_mesh_bed_leveling_settings();
 static void lcd_backlight_menu();
 #endif
 
+FilamentAction eFilamentAction=FilamentAction::None; // must be initialized as 'non-autoLoad'
+static bool bFilamentPreheatState;
+static bool bFilamentAction = false;
+static bool bFilamentWaitingFlag = false;
+
 int8_t ReInitLCD = 0;
 uint8_t scrollstuff = 0;
 
@@ -1765,11 +1770,6 @@ void lcd_cutter_enabled()
     }
 }
 #endif //MMU_HAS_CUTTER
-
-FilamentAction eFilamentAction=FilamentAction::None; // must be initialized as 'non-autoLoad'
-bool bFilamentPreheatState;
-bool bFilamentAction=false;
-static bool bFilamentWaitingFlag=false;
 
 bool shouldPreheatOnlyNozzle() {
     uint8_t eeprom_setting = eeprom_read_byte((uint8_t*)EEPROM_HEAT_BED_ON_LOAD_FILAMENT);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2139,12 +2139,6 @@ void lcd_generic_preheat_menu()
     MENU_END();
 }
 
-void mFilamentItemForce()
-{
-mFilamentItem(target_temperature[0],target_temperature_bed);
-}
-
-
 void lcd_unLoadFilament()
 {
      eFilamentAction=FilamentAction::UnLoad;

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -197,7 +197,6 @@ extern FilamentAction eFilamentAction;
 extern bool bFilamentPreheatState;
 extern bool bFilamentAction;
 void mFilamentItem(uint16_t nTemp,uint16_t nTempBed);
-void mFilamentItemForce();
 void lcd_generic_preheat_menu();
 void unload_filament(float unloadLength);
 void lcd_AutoLoadFilament();

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -194,8 +194,6 @@ enum class FilamentAction : uint_least8_t
 };
 
 extern FilamentAction eFilamentAction;
-extern bool bFilamentPreheatState;
-extern bool bFilamentAction;
 void mFilamentItem(uint16_t nTemp,uint16_t nTempBed);
 void lcd_generic_preheat_menu();
 void unload_filament(float unloadLength);

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -200,6 +200,7 @@ void mFilamentItem(uint16_t nTemp,uint16_t nTempBed);
 void mFilamentItemForce();
 void lcd_generic_preheat_menu();
 void unload_filament(float unloadLength);
+void lcd_AutoLoadFilament();
 
 
 void lcd_wait_for_heater();


### PR DESCRIPTION
This PR moves `filAutoLoad()` over to the ultralcd.cpp code so we can re-used `preheat_or_continue()`

Additional cleanup:

* `lcd_unLoadFilament()` is now `static`
* `bFilamentPreheatState` and `bFilamentAction` are now `static`

Change in memory:
Flash: -52 bytes
SRAM: 0 bytes