### PR TITLE
Always disable E-motor during inactivity

### DIFF
--- a/Firmware/Configuration.h
+++ b/Firmware/Configuration.h
@@ -275,7 +275,7 @@ your extruder heater takes 2 minutes to hit the target on heating.
 #define DISABLE_X 0
 #define DISABLE_Y 0
 #define DISABLE_Z 0
-#define DISABLE_E 0// For all extruders
+#define DISABLE_E 1 // By default, disable the E-motor during inactivity
 
 
 // ENDSTOP SETTINGS:

--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -199,6 +199,7 @@ void manage_inactivity(bool ignore_stepper_queue=false);
 #if defined(E0_ENABLE_PIN) && (E0_ENABLE_PIN > -1)
   #define enable_e0() WRITE(E0_ENABLE_PIN, E_ENABLE_ON)
   #define disable_e0() WRITE(E0_ENABLE_PIN,!E_ENABLE_ON)
+  #define is_enabled_e0() READ(E0_ENABLE_PIN)
 #else
   #define enable_e0()  /* nothing */
   #define disable_e0() /* nothing */

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -541,7 +541,7 @@ bool check_fsensor() {
     return (IS_SD_PRINTING || usb_timer.running())
         && mcode_in_progress != 600
         && !saved_printing
-        && e_active();
+        && is_enabled_e0();
 }
 
 bool fans_check_enabled = true;

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -278,7 +278,6 @@ bool MMU2::ToolChangeCommonOnce(uint8_t slot){
     static_assert(MAX_RETRIES > 1); // need >1 retries to do the cut in the last attempt
     for(uint8_t retries = MAX_RETRIES; retries; --retries){
         for(;;) {
-            disable_e0(); // it may seem counterintuitive to disable the E-motor, but it gets enabled in the planner whenever the E-motor is to move
             tool_change_extruder = slot;
             logic.ToolChange(slot); // let the MMU pull the filament out and push a new one in
             if( manage_response(true, true) )
@@ -430,7 +429,6 @@ bool MMU2::unload() {
         // we assume the printer managed to relieve filament tip from the gears,
         // so repeating that part in case of an MMU restart is not necessary
         for(;;) {
-            disable_e0();
             logic.UnloadFilament();
             if( manage_response(false, true) )
                 break;
@@ -468,7 +466,6 @@ bool MMU2::cut_filament(uint8_t slot, bool enableFullScreenMsg /* = true */){
 
         ReportingRAII rep(CommandInProgress::CutFilament);
         for(;;){
-            disable_e0();
             logic.CutFilament(slot);
             if( manage_response(false, true) )
                 break;
@@ -498,7 +495,6 @@ bool MMU2::load_filament(uint8_t slot) {
 
     ReportingRAII rep(CommandInProgress::LoadFilament);
     for(;;) {
-        disable_e0();
         logic.LoadFilament(slot);
         if( manage_response(false, false) )
             break;
@@ -564,7 +560,6 @@ bool MMU2::eject_filament(uint8_t slot, bool enableFullScreenMsg /* = true */) {
 
         ReportingRAII rep(CommandInProgress::EjectFilament);
         for(;;) {
-            disable_e0();
             logic.EjectFilament(slot);
             if( manage_response(false, true) )
                 break;
@@ -590,7 +585,6 @@ void MMU2::SaveHotendTemp(bool turn_off_nozzle) {
     if (mmu_print_saved & SavedState::Cooldown) return;
 
     if (turn_off_nozzle && !(mmu_print_saved & SavedState::CooldownPending)){
-        disable_e0();
         resume_hotend_temp = degTargetHotend(active_extruder);
         mmu_print_saved |= SavedState::CooldownPending;
         LogEchoEvent_P(PSTR("Heater cooldown pending"));
@@ -600,7 +594,6 @@ void MMU2::SaveHotendTemp(bool turn_off_nozzle) {
 void MMU2::SaveAndPark(bool move_axes) {
     if (mmu_print_saved == SavedState::None) { // First occurrence. Save current position, park print head, disable nozzle heater.
         LogEchoEvent_P(PSTR("Saving and parking"));
-        disable_e0();
         st_synchronize();
 
         if (move_axes){

--- a/Firmware/planner.cpp
+++ b/Firmware/planner.cpp
@@ -554,12 +554,8 @@ void check_axes_activity()
   if((DISABLE_X) && (x_active == 0)) disable_x();
   if((DISABLE_Y) && (y_active == 0)) disable_y();
   if((DISABLE_Z) && (z_active == 0)) disable_z();
-  if((DISABLE_E) && (e_active == 0))
-  {
-    disable_e0();
-    disable_e1();
-    disable_e2(); 
-  }
+  if((DISABLE_E) && (e_active == 0)) disable_e0();
+
 #if defined(FAN_PIN) && FAN_PIN > -1
   #ifdef FAN_KICKSTART_TIME
     static unsigned long fan_kick_end;

--- a/Firmware/planner.cpp
+++ b/Firmware/planner.cpp
@@ -511,23 +511,6 @@ void getHighESpeed()
 }
 #endif
 
-bool e_active()
-{
-	unsigned char e_active = 0;
-	block_t *block;
-  if(block_buffer_tail != block_buffer_head)
-  {
-    uint8_t block_index = block_buffer_tail;
-    while(block_index != block_buffer_head)
-    {
-      block = &block_buffer[block_index];
-      if(block->steps_e.wide != 0) e_active++;
-      block_index = (block_index+1) & (BLOCK_BUFFER_SIZE - 1);
-    }
-  }
-  return (e_active > 0) ? true : false ;
-}
-
 void check_axes_activity()
 {
   unsigned char x_active = 0;

--- a/Firmware/planner.h
+++ b/Firmware/planner.h
@@ -179,8 +179,6 @@ void plan_reset_next_e();
 inline void set_current_to_destination() { memcpy(current_position, destination, sizeof(current_position)); }
 inline void set_destination_to_current() { memcpy(destination, current_position, sizeof(destination)); }
 
-extern bool e_active();
-
 void check_axes_activity();
 
 // Use M203 to override by software


### PR DESCRIPTION

Changes:
* Simplifies the FINDA runout check
* This will also ensure the E-motor is always disabled when inactive, such as during paused prints.
* Also affects single color setup which don't have MMU.

Change in memory:
Flash: -72 bytes
SRAM: 0 bytes