### PR TITLE
🚧 G76: Add PINDA_TEMP_COMP ifdef

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -4728,6 +4728,7 @@ void process_commands()
             SERIAL_ECHOLNPGM("No PINDA thermistor");
             break;
         }
+#ifdef PINDA_TEMP_COMP
 
         if (!calibration_status_get(CALIBRATION_STATUS_XYZ)) {
             //we need to know accurate position of first calibration point
@@ -4876,7 +4877,7 @@ void process_commands()
         }
         lcd_temp_cal_show_result(true);
         homing_flag = false;
-
+#endif // PINDA_TEMP_COMP
 #else //PINDA_THERMISTOR
 
 		setTargetBed(PINDA_MIN_T);


### PR DESCRIPTION
**NOTE: this only applies to MK3/S/+**
If `PINDA_TEMP_COMP` is not defined then users cannot run this code. Temperature calibration is required to run G76 when a PINDA thermistor is present. For users like myself on MK3S+, temperature compensation is not possible. The
menu is not shown because the SuperPinda does not require temperature compensation.

Change in memory on MK3S+
Flash: -2834 bytes
SRAM: 0 bytes