### PR TITLE
Remove colon parsing when printing from SD

### DIFF
--- a/Firmware/cmdqueue.cpp
+++ b/Firmware/cmdqueue.cpp
@@ -545,7 +545,7 @@ void get_command()
     char serial_char = (char)n;
     if( serial_char == '\n'
      || serial_char == '\r'
-     || ((serial_char == '#' || serial_char == ':') )
+     || serial_char == '#'
      || serial_count >= (MAX_CMD_SIZE - 1)
      || n==-1
     ){


### PR DESCRIPTION
Fix for #3977