### PR TITLE
MK3 PAT9125 filament sensor fix to prevent false runouts

### DIFF
--- a/Firmware/Filament_sensor.cpp
+++ b/Firmware/Filament_sensor.cpp
@@ -482,7 +482,7 @@ bool PAT9125_sensor::updatePAT9125() {
             init(); // try to reinit.
         }
 
-        #if 0
+        #if PLUG_REFLEX_WORKAROUND
         // Detecting presence of transparent or black filament is difficult.
         // if with or without filament, sensor readings are very close:
         // pat9125_s == 17 and pat9125_b == 50..80

--- a/Firmware/Filament_sensor.cpp
+++ b/Firmware/Filament_sensor.cpp
@@ -517,13 +517,13 @@ bool PAT9125_sensor::updatePAT9125() {
                 oldPos = pat9125_y;
                 bool feed_ok = _stepCount > 0 ? optical_move > 8 : optical_move < -8;
                 if (!feed_ok) {
-                    jamErrCnt++;
+                    jamErrCnt += 2; // feed error counts 2x more than feed ok
                     if (jamErrCnt > 10) {
                         jamErrCnt = 0;
                         filJam();
                     }
-                } else {
-                    jamErrCnt = 0;
+                } else if (jamErrCnt) {
+                    jamErrCnt--;
                 }
             }
         }

--- a/Firmware/Filament_sensor.cpp
+++ b/Firmware/Filament_sensor.cpp
@@ -518,7 +518,7 @@ bool PAT9125_sensor::updatePAT9125() {
                 bool feed_ok = _stepCount > 0 ? optical_move > 8 : optical_move < -8;
                 if (!feed_ok) {
                     jamErrCnt += 2; // feed error counts 2x more than feed ok
-                    if (jamErrCnt > 10) {
+                    if (jamErrCnt > 20) {
                         jamErrCnt = 0;
                         filJam();
                     }

--- a/Firmware/Filament_sensor.cpp
+++ b/Firmware/Filament_sensor.cpp
@@ -515,7 +515,7 @@ bool PAT9125_sensor::updatePAT9125() {
                 resetStepCount();
                 int16_t optical_move = pat9125_y - oldPos;
                 oldPos = pat9125_y;
-                bool feed_ok = _stepCount > 0 ? optical_move > 8 : optical_move < -8;
+                bool feed_ok = _stepCount > 0 ? optical_move > 7 : optical_move < -7;
                 if (!feed_ok) {
                     jamErrCnt += 2; // feed error counts 2x more than feed ok
                     if (jamErrCnt > 20) {

--- a/Firmware/Filament_sensor.cpp
+++ b/Firmware/Filament_sensor.cpp
@@ -507,7 +507,7 @@ bool PAT9125_sensor::updatePAT9125() {
                 resetStepCount();
                 int16_t optical_move = pat9125_y - oldPos;
                 oldPos = pat9125_y;
-                bool feed_ok = _stepCount > 0 ? optical_move > 1 : optical_move < -1;
+                bool feed_ok = _stepCount > 0 ? optical_move > 8 : optical_move < -8;
                 if (!feed_ok) {
                     jamErrCnt++;
                     if (jamErrCnt > 10) {

--- a/Firmware/Filament_sensor.h
+++ b/Firmware/Filament_sensor.h
@@ -176,7 +176,7 @@ public:
     void settings_init();
 private:
     static constexpr uint16_t pollingPeriod = 10; //[ms]
-    static constexpr uint8_t filterCnt = 10; //how many checks need to be done in order to determine the filament presence precisely.
+    static constexpr uint8_t filterCnt = 5; //how many checks need to be done in order to determine the filament presence precisely.
     static constexpr uint8_t presence_threshold = 50; // TODO: eeprom config. Remove filament and Support -> Sensor info -> B: value of pat9125_b when pat9125_s >= 17
     ShortTimer pollingTimer;
     uint8_t filter;

--- a/Firmware/Filament_sensor.h
+++ b/Firmware/Filament_sensor.h
@@ -176,10 +176,12 @@ public:
     void settings_init();
 private:
     static constexpr uint16_t pollingPeriod = 10; //[ms]
-    static constexpr uint8_t filterCnt = 5; //how many checks need to be done in order to determine the filament presence precisely.
+    static constexpr uint8_t filterCnt = 10; //how many checks need to be done in order to determine the filament presence precisely.
+    static constexpr uint8_t presence_threshold = 60; // TODO: eeprom config. Remove filament and Support -> Sensor info -> B: value of pat9125_b when pat9125_s >= 17
     ShortTimer pollingTimer;
     uint8_t filter;
     uint8_t filterFilPresent;
+    int16_t oldPos_presence;
     
     bool jamDetection;
     int16_t oldPos;

--- a/Firmware/Filament_sensor.h
+++ b/Firmware/Filament_sensor.h
@@ -177,7 +177,7 @@ public:
 private:
     static constexpr uint16_t pollingPeriod = 10; //[ms]
     static constexpr uint8_t filterCnt = 10; //how many checks need to be done in order to determine the filament presence precisely.
-    static constexpr uint8_t presence_threshold = 60; // TODO: eeprom config. Remove filament and Support -> Sensor info -> B: value of pat9125_b when pat9125_s >= 17
+    static constexpr uint8_t presence_threshold = 50; // TODO: eeprom config. Remove filament and Support -> Sensor info -> B: value of pat9125_b when pat9125_s >= 17
     ShortTimer pollingTimer;
     uint8_t filter;
     uint8_t filterFilPresent;

--- a/Firmware/Filament_sensor.h
+++ b/Firmware/Filament_sensor.h
@@ -177,7 +177,7 @@ public:
 private:
     static constexpr uint16_t pollingPeriod = 10; //[ms]
     static constexpr uint8_t filterCnt = 5; //how many checks need to be done in order to determine the filament presence precisely.
-    static constexpr uint8_t presence_threshold = 40; // TODO: eeprom config. Remove filament and Support -> Sensor info -> B: value of pat9125_b when pat9125_s >= 17
+    static constexpr uint8_t presence_threshold = 35; // TODO: eeprom config. Remove filament and Support -> Sensor info -> B: value of pat9125_b when pat9125_s >= 17
     ShortTimer pollingTimer;
     uint8_t filter;
     uint8_t filterFilPresent;

--- a/Firmware/Filament_sensor.h
+++ b/Firmware/Filament_sensor.h
@@ -177,11 +177,11 @@ public:
 private:
     static constexpr uint16_t pollingPeriod = 10; //[ms]
     static constexpr uint8_t filterCnt = 5; //how many checks need to be done in order to determine the filament presence precisely.
-    static constexpr uint8_t presence_threshold = 30; // TODO: eeprom config. Remove filament and Support -> Sensor info -> B: value of pat9125_b when pat9125_s >= 17
+    static constexpr uint8_t presence_threshold = 50; // TODO: eeprom config. Remove filament and Support -> Sensor info -> B: value of pat9125_b when pat9125_s >= 17
     ShortTimer pollingTimer;
     uint8_t filter;
     uint8_t filterFilPresent;
-    #define PLUG_REFLEX_WORKAROUND 0
+    #define PLUG_REFLEX_WORKAROUND 1
     #if PLUG_REFLEX_WORKAROUND
     int16_t oldPos_presence;
     #endif

--- a/Firmware/Filament_sensor.h
+++ b/Firmware/Filament_sensor.h
@@ -177,7 +177,7 @@ public:
 private:
     static constexpr uint16_t pollingPeriod = 10; //[ms]
     static constexpr uint8_t filterCnt = 5; //how many checks need to be done in order to determine the filament presence precisely.
-    static constexpr uint8_t presence_threshold = 50; // TODO: eeprom config. Remove filament and Support -> Sensor info -> B: value of pat9125_b when pat9125_s >= 17
+    static constexpr uint8_t presence_threshold = 40; // TODO: eeprom config. Remove filament and Support -> Sensor info -> B: value of pat9125_b when pat9125_s >= 17
     ShortTimer pollingTimer;
     uint8_t filter;
     uint8_t filterFilPresent;

--- a/Firmware/Filament_sensor.h
+++ b/Firmware/Filament_sensor.h
@@ -177,7 +177,7 @@ public:
 private:
     static constexpr uint16_t pollingPeriod = 10; //[ms]
     static constexpr uint8_t filterCnt = 5; //how many checks need to be done in order to determine the filament presence precisely.
-    static constexpr uint8_t presence_threshold = 50; // TODO: eeprom config. Remove filament and Support -> Sensor info -> B: value of pat9125_b when pat9125_s >= 17
+    static constexpr uint8_t presence_threshold = 30; // TODO: eeprom config. Remove filament and Support -> Sensor info -> B: value of pat9125_b when pat9125_s >= 17
     ShortTimer pollingTimer;
     uint8_t filter;
     uint8_t filterFilPresent;

--- a/Firmware/Filament_sensor.h
+++ b/Firmware/Filament_sensor.h
@@ -177,7 +177,7 @@ public:
 private:
     static constexpr uint16_t pollingPeriod = 10; //[ms]
     static constexpr uint8_t filterCnt = 5; //how many checks need to be done in order to determine the filament presence precisely.
-    static constexpr uint8_t presence_threshold = 35; // TODO: eeprom config. Remove filament and Support -> Sensor info -> B: value of pat9125_b when pat9125_s >= 17
+    static constexpr uint8_t presence_threshold = 30; // TODO: eeprom config. Remove filament and Support -> Sensor info -> B: value of pat9125_b when pat9125_s >= 17
     ShortTimer pollingTimer;
     uint8_t filter;
     uint8_t filterFilPresent;

--- a/Firmware/Filament_sensor.h
+++ b/Firmware/Filament_sensor.h
@@ -181,7 +181,10 @@ private:
     ShortTimer pollingTimer;
     uint8_t filter;
     uint8_t filterFilPresent;
+    #define PLUG_REFLEX_WORKAROUND 0
+    #if PLUG_REFLEX_WORKAROUND
     int16_t oldPos_presence;
+    #endif
     
     bool jamDetection;
     int16_t oldPos;


### PR DESCRIPTION
For me it solves issues with black or transparent PETG,
filament runout and jam enabled and it keeps printing.

For further improvment I'd suggest filament presence
threshold to be some settings parameter stored in eeprom
so user can fine tune this for particular hardware differences.