### PR TITLE
PFW-831 Add single buzzer beep when an MMU error screen is shown for the first time

### DIFF
--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -911,6 +911,9 @@ void MMU2::ReportError(ErrorCode ec, ErrorSource res) {
         // or if 'Retry' operation is not available
         // raise the MMU error sceen and wait for user input
         ReportErrorHook((CommandInProgress)logic.CommandInProgress(), (uint16_t)ec, uint8_t(lastErrorSource));
+
+        // Beep when error screen is shown for the first time
+        MakeSound(Prompt);
     }
 
     static_assert(mmu2Magic[0] == 'M'


### PR DESCRIPTION
If the user has the sound settings set to 'Silent' then this beep should be silent

Change in memory:
Flash: +4 bytes
SRAM: 0 bytes