### PR TITLE
Set the fanSpeed=0 in order to stop the fan during the manual actions on a filament change…

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3525,7 +3525,11 @@ static void gcode_M600(bool automatic, float x_position, float y_position, float
     st_synchronize();
 
     //Beep, manage nozzle heater and wait for user to start unload filament
-    if(!mmu_enabled) M600_wait_for_user(HotendTempBckp);
+    if(!mmu_enabled)
+    {
+      fanSpeed = 0;
+      M600_wait_for_user(HotendTempBckp);
+    } 
 
     lcd_change_fil_state = 0;
 


### PR DESCRIPTION
Sometimes the M600 is inside a gcode and you are not in front of the print so can be a little time with the fan cooling the hotend.
I was reviewing the code of the gcode_M600 and this already take care about the restore to the previous fan speed but never stop it, so I added the stop of the fan when the M600 is executed without MMU.