### PR TITLE
🚧 PFW-880 Re-work menus to allow editing `uint8_t` and `float` values

### DIFF
--- a/Firmware/backlight.cpp
+++ b/Firmware/backlight.cpp
@@ -14,8 +14,8 @@
 #define BL_FLASH_DELAY_MS 25
 
 bool backlightSupport = 0; //only if it's true will any of the settings be visible to the user
-int16_t backlightLevel_HIGH = 0;
-int16_t backlightLevel_LOW = 0;
+uint8_t backlightLevel_HIGH = 0;
+uint8_t backlightLevel_LOW = 0;
 uint8_t backlightMode = BACKLIGHT_MODE_BRIGHT;
 int16_t backlightTimer_period = 10;
 LongTimer backlightTimer;
@@ -62,8 +62,8 @@ void backlight_wake(const uint8_t flashNo)
 
 void backlight_save() //saves all backlight data to eeprom.
 {
-    eeprom_update_byte((uint8_t *)EEPROM_BACKLIGHT_LEVEL_HIGH, (uint8_t)backlightLevel_HIGH);
-    eeprom_update_byte((uint8_t *)EEPROM_BACKLIGHT_LEVEL_LOW, (uint8_t)backlightLevel_LOW);
+    eeprom_update_byte((uint8_t *)EEPROM_BACKLIGHT_LEVEL_HIGH, backlightLevel_HIGH);
+    eeprom_update_byte((uint8_t *)EEPROM_BACKLIGHT_LEVEL_LOW, backlightLevel_LOW);
     eeprom_update_byte((uint8_t *)EEPROM_BACKLIGHT_MODE, backlightMode);
     eeprom_update_word((uint16_t *)EEPROM_BACKLIGHT_TIMEOUT, backlightTimer_period);
 }

--- a/Firmware/backlight.h
+++ b/Firmware/backlight.h
@@ -13,8 +13,8 @@ enum Backlight_Mode
 	BACKLIGHT_MODE_AUTO    = 2,
 };
 
-extern int16_t backlightLevel_HIGH;
-extern int16_t backlightLevel_LOW;
+extern uint8_t backlightLevel_HIGH;
+extern uint8_t backlightLevel_LOW;
 extern uint8_t backlightMode;
 extern bool backlightSupport;
 extern int16_t backlightTimer_period;

--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -632,7 +632,7 @@ void lcd_printNumber(unsigned long n, uint8_t base)
 }
 
 uint8_t lcd_draw_update = 2;
-int32_t lcd_encoder = 0;
+int8_t lcd_encoder = 0;
 uint8_t lcd_encoder_bits = 0;
 int8_t lcd_encoder_diff = 0;
 

--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -633,6 +633,7 @@ void lcd_printNumber(unsigned long n, uint8_t base)
 
 uint8_t lcd_draw_update = 2;
 int8_t lcd_encoder = 0;
+uint8_t limit_lcd_encoder = 0;
 uint8_t lcd_encoder_bits = 0;
 int8_t lcd_encoder_diff = 0;
 
@@ -653,6 +654,19 @@ static ShortTimer buttonBlanking;
 ShortTimer longPressTimer;
 LongTimer lcd_timeoutToStatus;
 
+/// @brief Handle updating lcd_encoder
+/// @details some parts of the menus rely on lcd_encoder to not go below 0. In that case limit_lcd_encoder should be set to 1
+void lcd_update_encoder()
+{
+	int16_t lcd_encoder_limit = lcd_encoder + (lcd_encoder_diff / ENCODER_PULSES_PER_STEP);
+	if ((limit_lcd_encoder && lcd_encoder_limit < 0) || lcd_encoder_limit > INT8_MAX) {
+		Sound_MakeSound(e_SOUND_TYPE_BlindAlert);
+	} else {
+		lcd_encoder += lcd_encoder_diff / ENCODER_PULSES_PER_STEP;
+		Sound_MakeSound(e_SOUND_TYPE_EncoderMove);
+	}
+	lcd_encoder = constrain(lcd_encoder_limit, limit_lcd_encoder ? 0 : INT8_MIN, INT8_MAX);
+}
 
 //! @brief Was button clicked?
 //!

--- a/Firmware/lcd.h
+++ b/Firmware/lcd.h
@@ -98,7 +98,7 @@ typedef void (*lcd_lcdupdate_func_t)(void);
 //Set to none-zero when the LCD needs to draw, decreased after every draw. Set to 2 in LCD routines so the LCD gets at least 1 full redraw (first redraw is partial)
 extern uint8_t lcd_draw_update;
 
-extern int32_t lcd_encoder;
+extern int8_t lcd_encoder; // Increments with each knob rotation. Only useful when LCD updates are enabled!
 
 extern uint8_t lcd_encoder_bits;
 

--- a/Firmware/lcd.h
+++ b/Firmware/lcd.h
@@ -99,6 +99,9 @@ typedef void (*lcd_lcdupdate_func_t)(void);
 extern uint8_t lcd_draw_update;
 
 extern int8_t lcd_encoder; // Increments with each knob rotation. Only useful when LCD updates are enabled!
+extern uint8_t limit_lcd_encoder; // If 1, then lcd_encoder will be constrained to range [0, 127], else [-127, 127] is allowed
+
+void lcd_update_encoder();
 
 extern uint8_t lcd_encoder_bits;
 

--- a/Firmware/menu.cpp
+++ b/Firmware/menu.cpp
@@ -455,7 +455,7 @@ void menu_draw_item_P(char chr, const char* str, int16_t val)
 	lcd_putc(chr);
 	uint8_t len = lcd_print_pad_P(str, LCD_WIDTH - 1);
 	lcd_set_cursor_column((LCD_WIDTH - 1) - len + 1);
-	lcd_putc(':');
+	lcd_putc(' ');
 
 	// The value is right adjusted, set the cursor then render the value
 	if (val < 10) { // 1 digit
@@ -470,10 +470,7 @@ void menu_draw_item_P(char chr, const char* str, int16_t val)
 
 void __attribute__((noinline)) menu_draw_edit_P(char chr, const char* str, int16_t val, uint8_t isFloat)
 {
-    menu_data_edit_t* _md = (menu_data_edit_t*)&(menu_data[0]);
-    if (val <= _md->minEditValue) {
-        menu_draw_toggle_puts_P(str, _T(MSG_OFF), 0x04 | 0x02 | (chr=='>'));
-    } else if (isFloat) {
+    if (isFloat) {
         float temp = menu_edit_convert_to_float(val, 3);
         lcd_printf_P(menu_fmt_float13, chr, str, temp);
     } else {

--- a/Firmware/menu.cpp
+++ b/Firmware/menu.cpp
@@ -442,11 +442,10 @@ void menu_draw_item_P(char chr, const char* str, int16_t val)
 	lcd_print(val);
 }
 
-template<typename T>
-void menu_draw_edit_P(char chr, const char* str, T val)
+void menu_draw_edit_P(char chr, const char* str, int16_t val)
 {
     menu_data_edit_t* _md = (menu_data_edit_t*)&(menu_data[0]);
-    if (val <= (T)(_md->minEditValue))
+    if (val <= _md->minEditValue)
     {
         menu_draw_toggle_puts_P(str, _T(MSG_OFF), 0x04 | 0x02 | (chr=='>'));
     }
@@ -496,7 +495,7 @@ static void _menu_edit_P()
 		if (_md->currentValue < _md->minEditValue) _md->currentValue = _md->minEditValue;
 		else if (_md->currentValue > _md->maxEditValue) _md->currentValue = _md->maxEditValue;
 		lcd_set_cursor(0, 1);
-		menu_draw_edit_P<T>(' ', _md->editLabel, (T)_md->currentValue);
+		menu_draw_edit_P(' ', _md->editLabel, _md->currentValue);
 	}
 	if (LCD_CLICKED)
 	{
@@ -512,7 +511,7 @@ uint8_t menu_item_edit_P(const char* str, T pval, T min_val, T max_val)
 	menu_data_edit_t* _md = (menu_data_edit_t*)&(menu_data[0]);
 	if (menu_item == menu_line)
 	{
-		if (lcd_draw_update) 
+		if (lcd_draw_update)
 		{
 			lcd_set_cursor(0, menu_row);
 			menu_draw_item_P(menu_selection_mark(), str, (int16_t)pval);

--- a/Firmware/menu.cpp
+++ b/Firmware/menu.cpp
@@ -429,7 +429,7 @@ const char menu_fmt_float31[] PROGMEM = "%-12.12S%+8.1f";
 
 const char menu_fmt_float13[] PROGMEM = "%c%-13.13S%+5.3f";
 
-static __attribute__((noinline)) float menu_edit_convert_to_float(const int16_t val, const uint8_t decimals)
+static float menu_edit_convert_to_float(const int16_t val, const uint8_t decimals)
 {
 	return ((float)val / (10 * decimals));
 }
@@ -440,7 +440,7 @@ static int16_t menu_edit_convert_from_float(const float val, const uint8_t decim
 }
 
 template <typename T>
-static __attribute__((noinline)) T menu_edit_get_current_value(T val, const uint8_t decimals)
+static T menu_edit_get_current_value(T val, const uint8_t decimals)
 {
 	if (sizeof(T) > 2) {
 		return menu_edit_convert_from_float(val, decimals);

--- a/Firmware/menu.cpp
+++ b/Firmware/menu.cpp
@@ -36,7 +36,7 @@ uint8_t menu_leaving = 0;
 
 menu_func_t menu_menu = 0;
 
-static_assert(sizeof(menu_data)>= sizeof(menu_data_edit_t),"menu_data_edit_t doesn't fit into menu_data");
+static_assert(sizeof(menu_data)>= sizeof(menu_data_edit_t<int16_t>),"menu_data_edit_t doesn't fit into menu_data");
 
 void menu_data_reset(void)
 {
@@ -508,10 +508,10 @@ void menu_draw_float13(const char* str, float val)
 	lcd_printf_P(menu_fmt_float13, ' ', str, val);
 }
 
-template <typename T>
+template <typename T, typename D>
 static void _menu_edit_P()
 {
-	menu_data_edit_t* _md = (menu_data_edit_t*)&(menu_data[0]);
+	menu_data_edit_t<D>* _md = (menu_data_edit_t<D>*)&(menu_data[0]);
 	if (lcd_draw_update)
 	{
 		// Increment the current value
@@ -540,8 +540,6 @@ static void _menu_edit_P()
 template <typename T, typename D>
 uint8_t __attribute__((noinline)) menu_item_edit_P(const char* str, T* const pval, const D* settings, const uint8_t is_progmem, const uint8_t decimals)
 {
-	menu_data_edit_t* _md = (menu_data_edit_t*)&(menu_data[0]);
-	_md->decimals = decimals;
 	if (menu_item == menu_line)
 	{
 		if (lcd_draw_update)
@@ -551,11 +549,13 @@ uint8_t __attribute__((noinline)) menu_item_edit_P(const char* str, T* const pva
 		}
 		if (menu_clicked && (lcd_encoder == menu_item))
 		{
+			menu_data_edit_t<D>* _md = (menu_data_edit_t<D>*)&(menu_data[0]);
 			// Initialise the menu data before opening edit menu
 			D jumpEditValue = 0;
 			_md->editLabel = str;
 			_md->editValue = pval;
 			_md->currentValue = menu_edit_get_current_value<T>(*pval, decimals);
+			_md->decimals = decimals;
 			if (!is_progmem) {
 				_md->minEditValue = (D)settings[0];
 				_md->maxEditValue = (D)settings[1];
@@ -581,7 +581,7 @@ uint8_t __attribute__((noinline)) menu_item_edit_P(const char* str, T* const pva
 			}
 
 			// Render the editing menu
-			menu_submenu_no_reset(_menu_edit_P<T>);
+			menu_submenu_no_reset(_menu_edit_P<T, D>);
 
 			return menu_item_ret();
 		}

--- a/Firmware/menu.cpp
+++ b/Firmware/menu.cpp
@@ -473,7 +473,7 @@ void __attribute__((noinline)) menu_draw_edit_P(char chr, const char* str, int16
     menu_data_edit_t* _md = (menu_data_edit_t*)&(menu_data[0]);
     if (val <= _md->minEditValue) {
         menu_draw_toggle_puts_P(str, _T(MSG_OFF), 0x04 | 0x02 | (chr=='>'));
-    } if (isFloat) {
+    } else if (isFloat) {
         float temp = menu_edit_convert_to_float(val, 3);
         lcd_printf_P(menu_fmt_float13, chr, str, temp);
     } else {

--- a/Firmware/menu.cpp
+++ b/Firmware/menu.cpp
@@ -492,8 +492,12 @@ static void _menu_edit_P()
 	menu_data_edit_t* _md = (menu_data_edit_t*)&(menu_data[0]);
 	if (lcd_draw_update)
 	{
-		if (_md->currentValue < _md->minEditValue) _md->currentValue = _md->minEditValue;
-		else if (_md->currentValue > _md->maxEditValue) _md->currentValue = _md->maxEditValue;
+		// Increment the current value
+		_md->currentValue += lcd_encoder;
+		lcd_encoder = 0;
+
+		// Constrain the value in case it's outside the allowed limits
+		_md->currentValue = constrain(_md->currentValue, _md->minEditValue, _md->maxEditValue);
 		lcd_set_cursor(0, 1);
 		menu_draw_edit_P(' ', _md->editLabel, _md->currentValue);
 	}

--- a/Firmware/menu.h
+++ b/Firmware/menu.h
@@ -16,17 +16,6 @@ typedef struct
     int8_t position;
 } menu_record_t;
 
-typedef struct
-{
-    //Variables used when editing values.
-    const char* editLabel;
-    void* editValue; // Pointer to variable which the menu will modify when knob is clicked
-    int16_t currentValue; // current value shown on the LCD. Value is not saved until the knob is clicked
-    int16_t minEditValue; // Constant set by menu
-    int16_t maxEditValue; // Constant set by menu
-    uint8_t decimals; // denotes number of decimals places when editing floats
-} menu_data_edit_t;
-
 extern uint8_t menu_data[MENU_DATA_SIZE];
 
 extern uint8_t menu_depth;
@@ -206,6 +195,17 @@ static const constexpr uint8_t PRINT_FAN_EDIT_MENU[] PROGMEM = {
     0,   // Minimum value
     255, // Maximum value
     LCD_JUMP_FAN_SPEED    // Jump value
+};
+
+template <typename D>
+struct menu_data_edit_t
+{
+    const char* editLabel;
+    void* editValue; // Pointer to variable which the menu will modify when knob is clicked
+    D currentValue; // current value shown on the LCD. Value is not saved until the knob is clicked
+    D minEditValue; // Constant set by menu
+    D maxEditValue; // Constant set by menu
+    uint8_t decimals; // denotes number of decimals places when editing floats
 };
 
 // The backlight menu has limits which can change at runtime. So we

--- a/Firmware/menu.h
+++ b/Firmware/menu.h
@@ -149,14 +149,86 @@ struct SheetFormatBuffer
 
 extern void menu_format_sheet_E(const Sheet &sheet_E, SheetFormatBuffer &buffer);
 
+static const constexpr int16_t TEMPERATURE_NOZZLE_EDIT_MENU[] PROGMEM = {
+    0, // Minimum value
+    HEATER_0_MAXTEMP - 10, // Maximum value
+    LCD_JUMP_HOTEND_TEMP // Jump value
+};
+
+static const constexpr int16_t TEMPERATURE_BED_EDIT_MENU[] PROGMEM = {
+    0, // Minimum value
+    BED_MAXTEMP - 3, // Maximum value
+    LCD_JUMP_BED_TEMP // Jump value
+};
+
+static const constexpr int16_t SPEED_EDIT_MENU[] PROGMEM = {
+    10, // Minimum value
+    999, // Maximum value
+    0 // Jump value
+};
+
+static const constexpr int16_t FLOW_EDIT_MENU[] PROGMEM = {
+    10, // Minimum value
+    999, // Maximum value
+    0 // Jump value
+};
+
+static const constexpr int16_t BACKLIGHT_TIMER_EDIT_MENU[] PROGMEM = {
+    1, // Minimum value
+    999, // Maximum value
+    0 // Jump value
+};
+
+#ifdef LA_LIVE_K
+static const constexpr int16_t ADJUST_K_EDIT_MENU[] PROGMEM = {
+    1, // Minimum value
+    999, // Maximum value
+    0 // Jump value
+};
+#endif // LA_LIVE_K
+
+static const constexpr int8_t ADJUST_BED_OFFSET_EDIT_MENU[] PROGMEM = {
+    (int8_t)-BED_ADJUSTMENT_UM_MAX, // Minimum value
+    (int8_t)BED_ADJUSTMENT_UM_MAX, // Maximum value
+    0 // Jump value
+};
+
+#ifdef TMC2130
+#include "tmc2130.h"
+static const constexpr uint8_t TMC_LINEARITY_CORRECTION_EDIT_MENU[] PROGMEM = {
+    (uint8_t)(TMC2130_WAVE_FAC1000_MIN-TMC2130_WAVE_FAC1000_STP), // Minimum value
+    (uint8_t)(TMC2130_WAVE_FAC1000_MAX), // Maximum value
+    0 // Jump value
+};
+#endif //TMC2130
+
+static const constexpr uint8_t PRINT_FAN_EDIT_MENU[] PROGMEM = {
+    0,   // Minimum value
+    255, // Maximum value
+    LCD_JUMP_FAN_SPEED    // Jump value
+};
+
+// The backlight menu has limits which can change at runtime. So we
+// cannot save them in PROGMEM. In this case gather the data and 
+// place them in an array which the menu_item_edit function understands
+#define INIT_ARR(VAR_NAME, ...) uint8_t VAR_NAME[] = {__VA_ARGS__}
+#define MENU_ITEM_EDIT_MANUAL_P(str, pval, minval, maxval, jumpval) \
+do { \
+    INIT_ARR(buf, minval, maxval, jumpval); \
+    MENU_ITEM_EDIT_ISPROGMEM_P(str, pval, buf, 0); \
+} while (0) \
+
 // NOTE: due to memory restrictions, we're limited to use int16_t for minval and maxval
 //       especially when floats are used for pval
 template <typename T, typename D>
-uint8_t menu_item_edit_P(const char* str, T* const pval, const D min_val, const D max_val, const uint8_t decimals = 3);
-#define MENU_ITEM_EDIT_P(str, pval, minval, maxval) do { if (menu_item_edit_P(str, pval, minval, maxval)) return; } while (0)
+uint8_t menu_item_edit_P(const char* str, T* const pval, const D* settings, const uint8_t is_progmem = 1, const uint8_t decimals = 3);
+#define MENU_ITEM_EDIT_P(str, pval, settings) do { if (menu_item_edit_P(str, pval, settings)) return; } while (0)
 
-// Same as MENU_ITEM_EDIT_P but gives control of number of decimal places in pval
-#define MENU_ITEM_EDIT_FLOAT_P(str, pval, minval, maxval, decimals) do { if (menu_item_edit_P(str, pval, minval, maxval, (uint8_t)decimals)) return; } while (0)
+// Variant of MENU_ITEM_EDIT_P which gives control over the optional progmem argument
+#define MENU_ITEM_EDIT_ISPROGMEM_P(str, pval, settings, is_progmem) do { if (menu_item_edit_P(str, pval, settings, is_progmem)) return; } while (0)
+
+// Variant of MENU_ITEM_EDIT_P whicch gives control of number of decimal places in pval. Only intended for float.
+#define MENU_ITEM_EDIT_FLOAT_P(str, pval, settings, decimals) do { if (menu_item_edit_P(str, pval, settings, (uint8_t)decimals)) return; } while (0)
 
 extern void menu_progressbar_init(uint16_t total, const char* title);
 extern void menu_progressbar_update(uint16_t newVal);

--- a/Firmware/menu.h
+++ b/Firmware/menu.h
@@ -149,7 +149,7 @@ struct SheetFormatBuffer
 extern void menu_format_sheet_E(const Sheet &sheet_E, SheetFormatBuffer &buffer);
 
 template <typename T>
-uint8_t menu_item_edit_P(const char* str, T pval, T min_val, T max_val);
+uint8_t menu_item_edit_P(const char* str, T *pval, T min_val, T max_val);
 #define MENU_ITEM_EDIT_P(str, pval, minval, maxval) do { if (menu_item_edit_P(str, pval, minval, maxval)) return; } while (0)
 
 extern void menu_progressbar_init(uint16_t total, const char* title);

--- a/Firmware/menu.h
+++ b/Firmware/menu.h
@@ -24,6 +24,7 @@ typedef struct
     int16_t currentValue; // current value shown on the LCD. Value is not saved until the knob is clicked
     int16_t minEditValue; // Constant set by menu
     int16_t maxEditValue; // Constant set by menu
+    uint8_t decimals; // denotes number of decimals places when editing floats
 } menu_data_edit_t;
 
 extern uint8_t menu_data[MENU_DATA_SIZE];
@@ -148,9 +149,14 @@ struct SheetFormatBuffer
 
 extern void menu_format_sheet_E(const Sheet &sheet_E, SheetFormatBuffer &buffer);
 
-template <typename T>
-uint8_t menu_item_edit_P(const char* str, T *pval, T min_val, T max_val);
+// NOTE: due to memory restrictions, we're limited to use int16_t for minval and maxval
+//       especially when floats are used for pval
+template <typename T, typename D>
+uint8_t menu_item_edit_P(const char* str, T* const pval, const D min_val, const D max_val, const uint8_t decimals = 3);
 #define MENU_ITEM_EDIT_P(str, pval, minval, maxval) do { if (menu_item_edit_P(str, pval, minval, maxval)) return; } while (0)
+
+// Same as MENU_ITEM_EDIT_P but gives control of number of decimal places in pval
+#define MENU_ITEM_EDIT_FLOAT_P(str, pval, minval, maxval, decimals) do { if (menu_item_edit_P(str, pval, minval, maxval, (uint8_t)decimals)) return; } while (0)
 
 extern void menu_progressbar_init(uint16_t total, const char* title);
 extern void menu_progressbar_update(uint16_t newVal);

--- a/Firmware/menu.h
+++ b/Firmware/menu.h
@@ -205,6 +205,7 @@ struct menu_data_edit_t
     D currentValue; // current value shown on the LCD. Value is not saved until the knob is clicked
     D minEditValue; // Constant set by menu
     D maxEditValue; // Constant set by menu
+    D jumpEditValue; // Constant set by menu
     uint8_t decimals; // denotes number of decimals places when editing floats
 };
 

--- a/Firmware/menu.h
+++ b/Firmware/menu.h
@@ -20,9 +20,10 @@ typedef struct
 {
     //Variables used when editing values.
     const char* editLabel;
-    void* editValue;
-    int32_t minEditValue;
-    int32_t maxEditValue;
+    void* editValue; // Pointer to variable which the menu will modify when knob is clicked
+    int16_t currentValue; // current value shown on the LCD. Value is not saved until the knob is clicked
+    int16_t minEditValue; // Constant set by menu
+    int16_t maxEditValue; // Constant set by menu
 } menu_data_edit_t;
 
 extern uint8_t menu_data[MENU_DATA_SIZE];
@@ -64,7 +65,12 @@ extern menu_func_t menu_menu;
 
 extern void menu_data_reset(void);
 
-extern void menu_goto(menu_func_t menu, const uint32_t encoder, const bool feedback, bool reset_menu_state);
+/// @brief Go to a specific LCD menu
+/// @param menu pointer to function which runs the menu. If equal to the currently running menu, nothing happens
+/// @param encoder starting menu row position, ranges from 0 to 127
+/// @param feedback if true, a feedback sound is played when the menu changes
+/// @param reset_menu_state if true, any background menu data is erased
+void menu_goto(menu_func_t menu, const int8_t encoder, const bool feedback, bool reset_menu_state);
 
 #define MENU_BEGIN() menu_start(); for(menu_row = 0; menu_row < LCD_HEIGHT; menu_row++, menu_line++) { menu_item = 0;
 void menu_start(void);
@@ -142,11 +148,9 @@ struct SheetFormatBuffer
 
 extern void menu_format_sheet_E(const Sheet &sheet_E, SheetFormatBuffer &buffer);
 
-
-#define MENU_ITEM_EDIT_int3_P(str, pval, minval, maxval) do { if (menu_item_edit_P(str, pval, minval, maxval)) return; } while (0)
-//#define MENU_ITEM_EDIT_int3_P(str, pval, minval, maxval) MENU_ITEM_EDIT(int3, str, pval, minval, maxval)
 template <typename T>
-extern uint8_t menu_item_edit_P(const char* str, T pval, int16_t min_val, int16_t max_val);
+uint8_t menu_item_edit_P(const char* str, T pval, T min_val, T max_val);
+#define MENU_ITEM_EDIT_P(str, pval, minval, maxval) do { if (menu_item_edit_P(str, pval, minval, maxval)) return; } while (0)
 
 extern void menu_progressbar_init(uint16_t total, const char* title);
 extern void menu_progressbar_update(uint16_t newVal);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2668,8 +2668,8 @@ static void lcd_babystep_z()
 
 
 typedef struct
-{   // 12 bytes + 5 bytes = 17 bytes total
-    menu_data_edit_t reserved; // 12 bytes reserved for number editing functions
+{   // 11 bytes + 5 bytes = 16 bytes total
+    menu_data_edit_t<int16_t> reserved; // 11 bytes reserved for number editing functions
     int8_t status;             // 1 byte
     int8_t left;               // 1 byte
     int8_t right;              // 1 byte
@@ -5494,7 +5494,7 @@ static void lcd_tune_menu()
 {
 	typedef struct
 	{
-	    menu_data_edit_t reserved; //!< reserved for number editing functions
+		menu_data_edit_t<int16_t> reserved; //!< reserved for number editing functions
 		int8_t  status; //!< To recognize, whether the menu has been just initialized.
 		//! Backup of extrudemultiply, to recognize, that the value has been changed and
 		//! it needs to be applied.

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2722,10 +2722,10 @@ void lcd_adjust_bed(void)
         eeprom_update_byte((uint8_t*)EEPROM_BED_CORRECTION_VALID, 1);
     );
     MENU_ITEM_BACK_P(_T(MSG_BACK));
-    MENU_ITEM_EDIT_P(_i("Left side [\xe4m]"), &_md->left,  (int8_t)(-BED_ADJUSTMENT_UM_MAX), (int8_t)(BED_ADJUSTMENT_UM_MAX));////MSG_BED_CORRECTION_LEFT c=14
-    MENU_ITEM_EDIT_P(_i("Right side[\xe4m]"), &_md->right, (int8_t)(-BED_ADJUSTMENT_UM_MAX), (int8_t)(BED_ADJUSTMENT_UM_MAX));////MSG_BED_CORRECTION_RIGHT c=14
-    MENU_ITEM_EDIT_P(_i("Front side[\xe4m]"), &_md->front, (int8_t)(-BED_ADJUSTMENT_UM_MAX), (int8_t)(BED_ADJUSTMENT_UM_MAX));////MSG_BED_CORRECTION_FRONT c=14
-    MENU_ITEM_EDIT_P(_i("Rear side [\xe4m]"), &_md->rear,  (int8_t)(-BED_ADJUSTMENT_UM_MAX), (int8_t)(BED_ADJUSTMENT_UM_MAX));////MSG_BED_CORRECTION_REAR c=14
+    MENU_ITEM_EDIT_P(_i("Left side [\xe4m]"), &_md->left,  ADJUST_BED_OFFSET_EDIT_MENU);////MSG_BED_CORRECTION_LEFT c=14
+    MENU_ITEM_EDIT_P(_i("Right side[\xe4m]"), &_md->right, ADJUST_BED_OFFSET_EDIT_MENU);////MSG_BED_CORRECTION_RIGHT c=14
+    MENU_ITEM_EDIT_P(_i("Front side[\xe4m]"), &_md->front, ADJUST_BED_OFFSET_EDIT_MENU);////MSG_BED_CORRECTION_FRONT c=14
+    MENU_ITEM_EDIT_P(_i("Rear side [\xe4m]"), &_md->rear,  ADJUST_BED_OFFSET_EDIT_MENU);////MSG_BED_CORRECTION_REAR c=14
     MENU_ITEM_FUNCTION_P(_T(MSG_RESET), lcd_adjust_bed_reset);
     MENU_END();
 }
@@ -4068,11 +4068,11 @@ void lcd_settings_linearity_correction_menu(void)
 #ifdef TMC2130_LINEARITY_CORRECTION_XYZ
 	//tmc2130_wave_fac[X_AXIS]
 
-	MENU_ITEM_EDIT_P(_i("X-correct:"),  &tmc2130_wave_fac[X_AXIS],  (uint8_t)(TMC2130_WAVE_FAC1000_MIN-TMC2130_WAVE_FAC1000_STP), (uint8_t)(TMC2130_WAVE_FAC1000_MAX));////MSG_X_CORRECTION c=13
-	MENU_ITEM_EDIT_P(_i("Y-correct:"),  &tmc2130_wave_fac[Y_AXIS],  (uint8_t)(TMC2130_WAVE_FAC1000_MIN-TMC2130_WAVE_FAC1000_STP), (uint8_t)(TMC2130_WAVE_FAC1000_MAX));////MSG_Y_CORRECTION c=13
-	MENU_ITEM_EDIT_P(_i("Z-correct:"),  &tmc2130_wave_fac[Z_AXIS],  (uint8_t)(TMC2130_WAVE_FAC1000_MIN-TMC2130_WAVE_FAC1000_STP), (uint8_t)(TMC2130_WAVE_FAC1000_MAX));////MSG_Z_CORRECTION c=13
+	MENU_ITEM_EDIT_P(_i("X-correct:"),  &tmc2130_wave_fac[X_AXIS], TMC_LINEARITY_CORRECTION_EDIT_MENU);////MSG_X_CORRECTION c=13
+	MENU_ITEM_EDIT_P(_i("Y-correct:"),  &tmc2130_wave_fac[Y_AXIS], TMC_LINEARITY_CORRECTION_EDIT_MENU);////MSG_Y_CORRECTION c=13
+	MENU_ITEM_EDIT_P(_i("Z-correct:"),  &tmc2130_wave_fac[Z_AXIS], TMC_LINEARITY_CORRECTION_EDIT_MENU);////MSG_Z_CORRECTION c=13
 #endif //TMC2130_LINEARITY_CORRECTION_XYZ
-	MENU_ITEM_EDIT_P(_i("E-correct:"),  &tmc2130_wave_fac[E_AXIS],  (uint8_t)(TMC2130_WAVE_FAC1000_MIN-TMC2130_WAVE_FAC1000_STP), (uint8_t)(TMC2130_WAVE_FAC1000_MAX));////MSG_EXTRUDER_CORRECTION c=13
+	MENU_ITEM_EDIT_P(_i("E-correct:"),  &tmc2130_wave_fac[E_AXIS], TMC_LINEARITY_CORRECTION_EDIT_MENU);////MSG_EXTRUDER_CORRECTION c=13
 	MENU_END();
 }
 #endif // TMC2130
@@ -5519,15 +5519,15 @@ static void lcd_tune_menu()
 
 	MENU_BEGIN();
 	MENU_ITEM_BACK_P(_T(MSG_MAIN)); //1
-	MENU_ITEM_EDIT_P(_i("Speed"), &feedmultiply, 10, 999);//2////MSG_SPEED c=15
+	MENU_ITEM_EDIT_P(_i("Speed"), &feedmultiply, SPEED_EDIT_MENU);//2////MSG_SPEED c=15
 
-	MENU_ITEM_EDIT_P(_T(MSG_NOZZLE), &target_temperature[0], 0, HEATER_0_MAXTEMP - 10);//3
-	MENU_ITEM_EDIT_P(_T(MSG_BED), &target_temperature_bed, 0, BED_MAXTEMP - 10);
+	MENU_ITEM_EDIT_P(_T(MSG_NOZZLE), &target_temperature[0], TEMPERATURE_NOZZLE_EDIT_MENU);//3
+	MENU_ITEM_EDIT_P(_T(MSG_BED), &target_temperature_bed, TEMPERATURE_BED_EDIT_MENU);
 
-	MENU_ITEM_EDIT_P(_T(MSG_FAN_SPEED), (uint8_t *)&fanSpeed, (uint8_t)0, (uint8_t)255);//5
-	MENU_ITEM_EDIT_P(_i("Flow"), &extrudemultiply, 10, 999);//6////MSG_FLOW c=15
+	MENU_ITEM_EDIT_P(_T(MSG_FAN_SPEED), (uint8_t *)&fanSpeed, PRINT_FAN_EDIT_MENU);//5
+	MENU_ITEM_EDIT_P(_i("Flow"), &extrudemultiply, FLOW_EDIT_MENU);//6////MSG_FLOW c=15
 #ifdef LA_LIVE_K
-	MENU_ITEM_EDIT_FLOAT_P(MSG_ADVANCE_K, &extruder_advance_K, 0, 999, 2);//7
+	MENU_ITEM_EDIT_FLOAT_P(MSG_ADVANCE_K, &extruder_advance_K, ADJUST_K_EDIT_MENU, 2);//7
 #endif // LA_LIVE_K
 #ifdef FILAMENTCHANGEENABLE
     if (!farm_mode)
@@ -5650,10 +5650,10 @@ static void lcd_backlight_menu()
     );
 
     MENU_ITEM_BACK_P(_T(MSG_BACK));
-    MENU_ITEM_EDIT_P(_T(MSG_BL_HIGH), &backlightLevel_HIGH, backlightLevel_LOW, (uint8_t)255);
-    MENU_ITEM_EDIT_P(_T(MSG_BL_LOW), &backlightLevel_LOW, (uint8_t)0, backlightLevel_HIGH);
+    MENU_ITEM_EDIT_MANUAL_P(_T(MSG_BL_HIGH), &backlightLevel_HIGH, backlightLevel_LOW, (uint8_t)255, (uint8_t)0);
+    MENU_ITEM_EDIT_MANUAL_P(_T(MSG_BL_LOW), &backlightLevel_LOW, (uint8_t)0, backlightLevel_HIGH, (uint8_t)0);
     MENU_ITEM_TOGGLE_P(_T(MSG_MODE), ((backlightMode==BACKLIGHT_MODE_BRIGHT) ? _T(MSG_BRIGHT) : ((backlightMode==BACKLIGHT_MODE_DIM) ? _T(MSG_DIM) : _T(MSG_AUTO))), backlight_mode_toggle);
-    MENU_ITEM_EDIT_P(_T(MSG_TIMEOUT), &backlightTimer_period, 1, 999);
+    MENU_ITEM_EDIT_P(_T(MSG_TIMEOUT), &backlightTimer_period, BACKLIGHT_TIMER_EDIT_MENU);
 
     MENU_END();
 }
@@ -5664,7 +5664,7 @@ static void lcd_control_temperature_menu()
   MENU_BEGIN();
   MENU_ITEM_BACK_P(_T(MSG_SETTINGS));
 #if TEMP_SENSOR_0 != 0
-  MENU_ITEM_EDIT_P(_T(MSG_NOZZLE), &target_temperature[0], 0, HEATER_0_MAXTEMP - 10);
+  MENU_ITEM_EDIT_P(_T(MSG_NOZZLE), &target_temperature[0], TEMPERATURE_NOZZLE_EDIT_MENU);
 #endif
 #if TEMP_SENSOR_1 != 0
   MENU_ITEM_EDIT_P(_n("Nozzle2"), &target_temperature[1], 0, HEATER_1_MAXTEMP - 10);
@@ -5673,9 +5673,9 @@ static void lcd_control_temperature_menu()
   MENU_ITEM_EDIT_P(_n("Nozzle3"), &target_temperature[2], 0, HEATER_2_MAXTEMP - 10);
 #endif
 #if TEMP_SENSOR_BED != 0
-  MENU_ITEM_EDIT_P(_T(MSG_BED), &target_temperature_bed, 0, BED_MAXTEMP - 3);
+  MENU_ITEM_EDIT_P(_T(MSG_BED), &target_temperature_bed, TEMPERATURE_BED_EDIT_MENU);
 #endif
-  MENU_ITEM_EDIT_P(_T(MSG_FAN_SPEED), (uint8_t*)&fanSpeed, (uint8_t)0, (uint8_t)255);
+  MENU_ITEM_EDIT_P(_T(MSG_FAN_SPEED), (uint8_t*)&fanSpeed, PRINT_FAN_EDIT_MENU);
 #if defined AUTOTEMP && (TEMP_SENSOR_0 != 0)
 //MENU_ITEM_EDIT removed, following code must be redesigned if AUTOTEMP enabled
   MENU_ITEM_EDIT(bool, MSG_AUTOTEMP, &autotemp_enabled);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2722,10 +2722,10 @@ void lcd_adjust_bed(void)
         eeprom_update_byte((uint8_t*)EEPROM_BED_CORRECTION_VALID, 1);
     );
     MENU_ITEM_BACK_P(_T(MSG_BACK));
-    MENU_ITEM_EDIT_P(_i("Left side [\xe4m]"), _md->left,  (int8_t)(-BED_ADJUSTMENT_UM_MAX), (int8_t)(BED_ADJUSTMENT_UM_MAX));////MSG_BED_CORRECTION_LEFT c=14
-    MENU_ITEM_EDIT_P(_i("Right side[\xe4m]"), _md->right, (int8_t)(-BED_ADJUSTMENT_UM_MAX), (int8_t)(BED_ADJUSTMENT_UM_MAX));////MSG_BED_CORRECTION_RIGHT c=14
-    MENU_ITEM_EDIT_P(_i("Front side[\xe4m]"), _md->front, (int8_t)(-BED_ADJUSTMENT_UM_MAX), (int8_t)(BED_ADJUSTMENT_UM_MAX));////MSG_BED_CORRECTION_FRONT c=14
-    MENU_ITEM_EDIT_P(_i("Rear side [\xe4m]"), _md->rear,  (int8_t)(-BED_ADJUSTMENT_UM_MAX), (int8_t)(BED_ADJUSTMENT_UM_MAX));////MSG_BED_CORRECTION_REAR c=14
+    MENU_ITEM_EDIT_P(_i("Left side [\xe4m]"), &_md->left,  (int8_t)(-BED_ADJUSTMENT_UM_MAX), (int8_t)(BED_ADJUSTMENT_UM_MAX));////MSG_BED_CORRECTION_LEFT c=14
+    MENU_ITEM_EDIT_P(_i("Right side[\xe4m]"), &_md->right, (int8_t)(-BED_ADJUSTMENT_UM_MAX), (int8_t)(BED_ADJUSTMENT_UM_MAX));////MSG_BED_CORRECTION_RIGHT c=14
+    MENU_ITEM_EDIT_P(_i("Front side[\xe4m]"), &_md->front, (int8_t)(-BED_ADJUSTMENT_UM_MAX), (int8_t)(BED_ADJUSTMENT_UM_MAX));////MSG_BED_CORRECTION_FRONT c=14
+    MENU_ITEM_EDIT_P(_i("Rear side [\xe4m]"), &_md->rear,  (int8_t)(-BED_ADJUSTMENT_UM_MAX), (int8_t)(BED_ADJUSTMENT_UM_MAX));////MSG_BED_CORRECTION_REAR c=14
     MENU_ITEM_FUNCTION_P(_T(MSG_RESET), lcd_adjust_bed_reset);
     MENU_END();
 }
@@ -4068,11 +4068,11 @@ void lcd_settings_linearity_correction_menu(void)
 #ifdef TMC2130_LINEARITY_CORRECTION_XYZ
 	//tmc2130_wave_fac[X_AXIS]
 
-	MENU_ITEM_EDIT_P(_i("X-correct:"),  tmc2130_wave_fac[X_AXIS],  (uint8_t)(TMC2130_WAVE_FAC1000_MIN-TMC2130_WAVE_FAC1000_STP), (uint8_t)(TMC2130_WAVE_FAC1000_MAX));////MSG_X_CORRECTION c=13
-	MENU_ITEM_EDIT_P(_i("Y-correct:"),  tmc2130_wave_fac[Y_AXIS],  (uint8_t)(TMC2130_WAVE_FAC1000_MIN-TMC2130_WAVE_FAC1000_STP), (uint8_t)(TMC2130_WAVE_FAC1000_MAX));////MSG_Y_CORRECTION c=13
-	MENU_ITEM_EDIT_P(_i("Z-correct:"),  tmc2130_wave_fac[Z_AXIS],  (uint8_t)(TMC2130_WAVE_FAC1000_MIN-TMC2130_WAVE_FAC1000_STP), (uint8_t)(TMC2130_WAVE_FAC1000_MAX));////MSG_Z_CORRECTION c=13
+	MENU_ITEM_EDIT_P(_i("X-correct:"),  &tmc2130_wave_fac[X_AXIS],  (uint8_t)(TMC2130_WAVE_FAC1000_MIN-TMC2130_WAVE_FAC1000_STP), (uint8_t)(TMC2130_WAVE_FAC1000_MAX));////MSG_X_CORRECTION c=13
+	MENU_ITEM_EDIT_P(_i("Y-correct:"),  &tmc2130_wave_fac[Y_AXIS],  (uint8_t)(TMC2130_WAVE_FAC1000_MIN-TMC2130_WAVE_FAC1000_STP), (uint8_t)(TMC2130_WAVE_FAC1000_MAX));////MSG_Y_CORRECTION c=13
+	MENU_ITEM_EDIT_P(_i("Z-correct:"),  &tmc2130_wave_fac[Z_AXIS],  (uint8_t)(TMC2130_WAVE_FAC1000_MIN-TMC2130_WAVE_FAC1000_STP), (uint8_t)(TMC2130_WAVE_FAC1000_MAX));////MSG_Z_CORRECTION c=13
 #endif //TMC2130_LINEARITY_CORRECTION_XYZ
-	MENU_ITEM_EDIT_P(_i("E-correct:"),  tmc2130_wave_fac[E_AXIS],  (uint8_t)(TMC2130_WAVE_FAC1000_MIN-TMC2130_WAVE_FAC1000_STP), (uint8_t)(TMC2130_WAVE_FAC1000_MAX));////MSG_EXTRUDER_CORRECTION c=13
+	MENU_ITEM_EDIT_P(_i("E-correct:"),  &tmc2130_wave_fac[E_AXIS],  (uint8_t)(TMC2130_WAVE_FAC1000_MIN-TMC2130_WAVE_FAC1000_STP), (uint8_t)(TMC2130_WAVE_FAC1000_MAX));////MSG_EXTRUDER_CORRECTION c=13
 	MENU_END();
 }
 #endif // TMC2130
@@ -5573,13 +5573,13 @@ static void lcd_tune_menu()
 
 	MENU_BEGIN();
 	MENU_ITEM_BACK_P(_T(MSG_MAIN)); //1
-	MENU_ITEM_EDIT_P(_i("Speed"), feedmultiply, 10, 999);//2////MSG_SPEED c=15
+	MENU_ITEM_EDIT_P(_i("Speed"), &feedmultiply, 10, 999);//2////MSG_SPEED c=15
 
-	MENU_ITEM_EDIT_P(_T(MSG_NOZZLE), target_temperature[0], 0, HEATER_0_MAXTEMP - 10);//3
-	MENU_ITEM_EDIT_P(_T(MSG_BED), target_temperature_bed, 0, BED_MAXTEMP - 10);
+	MENU_ITEM_EDIT_P(_T(MSG_NOZZLE), &target_temperature[0], 0, HEATER_0_MAXTEMP - 10);//3
+	MENU_ITEM_EDIT_P(_T(MSG_BED), &target_temperature_bed, 0, BED_MAXTEMP - 10);
 
-	MENU_ITEM_EDIT_P(_T(MSG_FAN_SPEED), (uint8_t)fanSpeed, (uint8_t)0, (uint8_t)255);//5
-	MENU_ITEM_EDIT_P(_i("Flow"), extrudemultiply, 10, 999);//6////MSG_FLOW c=15
+	MENU_ITEM_EDIT_P(_T(MSG_FAN_SPEED), (uint8_t *)&fanSpeed, (uint8_t)0, (uint8_t)255);//5
+	MENU_ITEM_EDIT_P(_i("Flow"), &extrudemultiply, 10, 999);//6////MSG_FLOW c=15
 #ifdef LA_LIVE_K
 	MENU_ITEM_EDIT_advance_K();//7
 #endif
@@ -5704,10 +5704,10 @@ static void lcd_backlight_menu()
     );
 
     MENU_ITEM_BACK_P(_T(MSG_BACK));
-    MENU_ITEM_EDIT_P(_T(MSG_BL_HIGH), backlightLevel_HIGH, backlightLevel_LOW, (uint8_t)255);
-    MENU_ITEM_EDIT_P(_T(MSG_BL_LOW), backlightLevel_LOW, (uint8_t)0, backlightLevel_HIGH);
+    MENU_ITEM_EDIT_P(_T(MSG_BL_HIGH), &backlightLevel_HIGH, backlightLevel_LOW, (uint8_t)255);
+    MENU_ITEM_EDIT_P(_T(MSG_BL_LOW), &backlightLevel_LOW, (uint8_t)0, backlightLevel_HIGH);
     MENU_ITEM_TOGGLE_P(_T(MSG_MODE), ((backlightMode==BACKLIGHT_MODE_BRIGHT) ? _T(MSG_BRIGHT) : ((backlightMode==BACKLIGHT_MODE_DIM) ? _T(MSG_DIM) : _T(MSG_AUTO))), backlight_mode_toggle);
-    MENU_ITEM_EDIT_P(_T(MSG_TIMEOUT), backlightTimer_period, 1, 999);
+    MENU_ITEM_EDIT_P(_T(MSG_TIMEOUT), &backlightTimer_period, 1, 999);
 
     MENU_END();
 }
@@ -5718,18 +5718,18 @@ static void lcd_control_temperature_menu()
   MENU_BEGIN();
   MENU_ITEM_BACK_P(_T(MSG_SETTINGS));
 #if TEMP_SENSOR_0 != 0
-  MENU_ITEM_EDIT_P(_T(MSG_NOZZLE), target_temperature[0], 0, HEATER_0_MAXTEMP - 10);
+  MENU_ITEM_EDIT_P(_T(MSG_NOZZLE), &target_temperature[0], 0, HEATER_0_MAXTEMP - 10);
 #endif
 #if TEMP_SENSOR_1 != 0
-  MENU_ITEM_EDIT_P(_n("Nozzle2"), target_temperature[1], 0, HEATER_1_MAXTEMP - 10);
+  MENU_ITEM_EDIT_P(_n("Nozzle2"), &target_temperature[1], 0, HEATER_1_MAXTEMP - 10);
 #endif
 #if TEMP_SENSOR_2 != 0
-  MENU_ITEM_EDIT_P(_n("Nozzle3"), target_temperature[2], 0, HEATER_2_MAXTEMP - 10);
+  MENU_ITEM_EDIT_P(_n("Nozzle3"), &target_temperature[2], 0, HEATER_2_MAXTEMP - 10);
 #endif
 #if TEMP_SENSOR_BED != 0
-  MENU_ITEM_EDIT_P(_T(MSG_BED), target_temperature_bed, 0, BED_MAXTEMP - 3);
+  MENU_ITEM_EDIT_P(_T(MSG_BED), &target_temperature_bed, 0, BED_MAXTEMP - 3);
 #endif
-  MENU_ITEM_EDIT_P(_T(MSG_FAN_SPEED), (uint8_t)fanSpeed, (uint8_t)0, (uint8_t)255);
+  MENU_ITEM_EDIT_P(_T(MSG_FAN_SPEED), (uint8_t*)&fanSpeed, (uint8_t)0, (uint8_t)255);
 #if defined AUTOTEMP && (TEMP_SENSOR_0 != 0)
 //MENU_ITEM_EDIT removed, following code must be redesigned if AUTOTEMP enabled
   MENU_ITEM_EDIT(bool, MSG_AUTOTEMP, &autotemp_enabled);
@@ -7555,17 +7555,7 @@ void menu_lcd_lcdupdate_func(void)
 			if (lcd_draw_update == 0) lcd_draw_update = 1;
 
 			// Constrain lcd_encoder between 0 and 127
-			int16_t lcd_encoder_limit = lcd_encoder + (lcd_encoder_diff / ENCODER_PULSES_PER_STEP);
-			if (lcd_encoder_limit > INT8_MAX) {
-				lcd_encoder = INT8_MAX;
-				Sound_MakeSound(e_SOUND_TYPE_BlindAlert);
-			} else if (lcd_encoder_limit < 0) {
-				lcd_encoder = 0;
-				Sound_MakeSound(e_SOUND_TYPE_BlindAlert);
-			} else {
-				lcd_encoder += lcd_encoder_diff / ENCODER_PULSES_PER_STEP;
-				Sound_MakeSound(e_SOUND_TYPE_EncoderMove);
-			}
+			lcd_update_encoder();
 			lcd_encoder_diff = 0;
 			lcd_timeoutToStatus.start();
 		}

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5490,60 +5490,6 @@ static void lcd_colorprint_change() {
 	lcd_draw_update = 3;
 }
 
-
-#ifdef LA_LIVE_K
-// @wavexx: looks like there's no generic float editing function in menu.cpp so we
-//          redefine our custom handling functions to mimick other tunables
-const char menu_fmt_float13off[] PROGMEM = "%c%-13.13S%6.6S";
-
-static void lcd_advance_draw_K(char chr, float val)
-{
-    if (val <= 0)
-        lcd_printf_P(menu_fmt_float13off, chr, MSG_ADVANCE_K, _T(MSG_OFF));
-    else
-        lcd_printf_P(menu_fmt_float13, chr, MSG_ADVANCE_K, val);
-}
-
-static void lcd_advance_edit_K(void)
-{
-    if (lcd_draw_update)
-    {
-        if (lcd_encoder < 0) lcd_encoder = 0;
-        if (lcd_encoder > 999) lcd_encoder = 999;
-        lcd_set_cursor(0, 1);
-        lcd_advance_draw_K(' ', 0.01 * lcd_encoder);
-    }
-    if (LCD_CLICKED)
-    {
-        extruder_advance_K = 0.01 * lcd_encoder;
-        menu_back_no_reset();
-    }
-}
-
-static uint8_t lcd_advance_K()
-{
-    if (menu_item == menu_line)
-    {
-        if (lcd_draw_update)
-        {
-            lcd_set_cursor(0, menu_row);
-            lcd_advance_draw_K((lcd_encoder == menu_item)?'>':' ', extruder_advance_K);
-        }
-        if (menu_clicked && (lcd_encoder == menu_item))
-        {
-            menu_submenu_no_reset(lcd_advance_edit_K);
-            lcd_encoder = 100. * extruder_advance_K;
-            return menu_item_ret();
-        }
-    }
-    menu_item++;
-    return 0;
-}
-
-#define MENU_ITEM_EDIT_advance_K() do { if (lcd_advance_K()) return; } while (0)
-#endif
-
-
 static void lcd_tune_menu()
 {
 	typedef struct
@@ -5581,8 +5527,8 @@ static void lcd_tune_menu()
 	MENU_ITEM_EDIT_P(_T(MSG_FAN_SPEED), (uint8_t *)&fanSpeed, (uint8_t)0, (uint8_t)255);//5
 	MENU_ITEM_EDIT_P(_i("Flow"), &extrudemultiply, 10, 999);//6////MSG_FLOW c=15
 #ifdef LA_LIVE_K
-	MENU_ITEM_EDIT_advance_K();//7
-#endif
+	MENU_ITEM_EDIT_FLOAT_P(MSG_ADVANCE_K, &extruder_advance_K, 0, 999, 2);//7
+#endif // LA_LIVE_K
 #ifdef FILAMENTCHANGEENABLE
     if (!farm_mode)
         MENU_ITEM_FUNCTION_P(_T(MSG_FILAMENTCHANGE), lcd_colorprint_change);//8

--- a/Firmware/variants/1_75mm_MK25-RAMBo10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK25-RAMBo10a-E3Dv6full.h
@@ -406,6 +406,10 @@
 #define FLEX_PREHEAT_HOTEND_TEMP 240
 #define FLEX_PREHEAT_HPB_TEMP 50
 
+#define LCD_JUMP_HOTEND_TEMP 200
+#define LCD_JUMP_BED_TEMP 50
+#define LCD_JUMP_FAN_SPEED 127
+
 /*------------------------------------
  THERMISTORS SETTINGS
  *------------------------------------*/

--- a/Firmware/variants/1_75mm_MK25-RAMBo13a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK25-RAMBo13a-E3Dv6full.h
@@ -407,6 +407,10 @@
 #define FLEX_PREHEAT_HOTEND_TEMP 240
 #define FLEX_PREHEAT_HPB_TEMP 50
 
+#define LCD_JUMP_HOTEND_TEMP 200
+#define LCD_JUMP_BED_TEMP 50
+#define LCD_JUMP_FAN_SPEED 127
+
 /*------------------------------------
  THERMISTORS SETTINGS
  *------------------------------------*/

--- a/Firmware/variants/1_75mm_MK25S-RAMBo10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK25S-RAMBo10a-E3Dv6full.h
@@ -406,6 +406,10 @@
 #define FLEX_PREHEAT_HOTEND_TEMP 240
 #define FLEX_PREHEAT_HPB_TEMP 50
 
+#define LCD_JUMP_HOTEND_TEMP 200
+#define LCD_JUMP_BED_TEMP 50
+#define LCD_JUMP_FAN_SPEED 127
+
 /*------------------------------------
  THERMISTORS SETTINGS
  *------------------------------------*/

--- a/Firmware/variants/1_75mm_MK25S-RAMBo13a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK25S-RAMBo13a-E3Dv6full.h
@@ -407,6 +407,10 @@
 #define FLEX_PREHEAT_HOTEND_TEMP 240
 #define FLEX_PREHEAT_HPB_TEMP 50
 
+#define LCD_JUMP_HOTEND_TEMP 200
+#define LCD_JUMP_BED_TEMP 50
+#define LCD_JUMP_FAN_SPEED 127
+
 /*------------------------------------
  THERMISTORS SETTINGS
  *------------------------------------*/

--- a/Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h
@@ -557,6 +557,10 @@
 #define FLEX_PREHEAT_HOTEND_TEMP 240
 #define FLEX_PREHEAT_HPB_TEMP 50
 
+#define LCD_JUMP_HOTEND_TEMP 200
+#define LCD_JUMP_BED_TEMP 50
+#define LCD_JUMP_FAN_SPEED 127
+
 /*------------------------------------
  THERMISTORS SETTINGS
  *------------------------------------*/

--- a/Firmware/variants/1_75mm_MK3S-EINSy10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK3S-EINSy10a-E3Dv6full.h
@@ -561,6 +561,10 @@
 #define FLEX_PREHEAT_HOTEND_TEMP 240
 #define FLEX_PREHEAT_HPB_TEMP 50
 
+#define LCD_JUMP_HOTEND_TEMP 200
+#define LCD_JUMP_BED_TEMP 50
+#define LCD_JUMP_FAN_SPEED 127
+
 /*------------------------------------
  THERMISTORS SETTINGS
  *------------------------------------*/

--- a/Firmware/variants/obsolete/1_75mm_MK2-RAMBo10a-E3Dv6full.h
+++ b/Firmware/variants/obsolete/1_75mm_MK2-RAMBo10a-E3Dv6full.h
@@ -322,6 +322,10 @@ PREHEAT SETTINGS
 #define FLEX_PREHEAT_HOTEND_TEMP 230
 #define FLEX_PREHEAT_HPB_TEMP 50
 
+#define LCD_JUMP_HOTEND_TEMP 200
+#define LCD_JUMP_BED_TEMP 50
+#define LCD_JUMP_FAN_SPEED 127
+
 /*------------------------------------
 THERMISTORS SETTINGS
 *------------------------------------*/

--- a/Firmware/variants/obsolete/1_75mm_MK2-RAMBo13a-E3Dv6full.h
+++ b/Firmware/variants/obsolete/1_75mm_MK2-RAMBo13a-E3Dv6full.h
@@ -321,6 +321,10 @@ PREHEAT SETTINGS
 #define FLEX_PREHEAT_HOTEND_TEMP 230
 #define FLEX_PREHEAT_HPB_TEMP 50
 
+#define LCD_JUMP_HOTEND_TEMP 200
+#define LCD_JUMP_BED_TEMP 50
+#define LCD_JUMP_FAN_SPEED 127
+
 /*------------------------------------
 THERMISTORS SETTINGS
 *------------------------------------*/


### PR DESCRIPTION
There are number of improvements in this PR:

* `lcd_encoder` was changed from `int32_t` to `int8_t`. This is the biggest optimisation by far, it comes down to the idea that we should use `lcd_encoder `for anything other than to track changes in the LCD's knob rotation.
    * Add new veriable `currentValue` to the menu edit data to replace `lcd_encoder`. Previously we were using `lcd_encoder` to hold the temperorary unsaved value on the screen.
* The above will break the Live K adjustment menu (which is by default not included in the firmware). I fixed it by making the menu code support editing float values. This adds a little bit overhead but I think it is worth it as we can apply this menu code to other functions in the firmware.
* `MENU_ITEM_EDIT_int3_P()` renamed to `MENU_ITEM_EDIT_P()`.

TODO:
Add callback functionality. There are several different variants that needs to be configured and they must be configurable such that only one of the below callbacks are used.
- [ ] add callback to save value on menu exit
    * Extrusion multiplier menu
- [ ] add callback to save value live
    * K adjust menu
    * Move X, Y, Z
    * Z-live adjust
    * E move

Change in memory:
Flash: -820 bytes
SRAM: -4 bytes