### PR TITLE
optimisation: re-use `adjust_bed_reset()`

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3195,16 +3195,6 @@ static void gcode_G80()
     mesh_bed_leveling_flag = false;
 }
 
-
-void adjust_bed_reset()
-{
-	eeprom_update_byte((unsigned char*)EEPROM_BED_CORRECTION_VALID, 1);
-	eeprom_update_byte((unsigned char*)EEPROM_BED_CORRECTION_LEFT, 0);
-	eeprom_update_byte((unsigned char*)EEPROM_BED_CORRECTION_RIGHT, 0);
-	eeprom_update_byte((unsigned char*)EEPROM_BED_CORRECTION_FRONT, 0);
-	eeprom_update_byte((unsigned char*)EEPROM_BED_CORRECTION_REAR, 0);
-}
-
 //! @brief Calibrate XYZ
 //! @param onlyZ if true, calibrate only Z axis
 //! @param verbosity_level
@@ -3224,7 +3214,7 @@ bool gcode_M45(bool onlyZ, int8_t verbosity_level)
 	{
 		setTargetBed(0);
 		setTargetHotend(0);
-		adjust_bed_reset(); //reset bed level correction
+		eeprom_adjust_bed_reset(); //reset bed level correction
 	}
 
 	// Disable the default update procedure of the display. We will do a modal dialog.

--- a/Firmware/eeprom.cpp
+++ b/Firmware/eeprom.cpp
@@ -62,6 +62,14 @@ void eeprom_init()
 
 }
 
+void eeprom_adjust_bed_reset() {
+    eeprom_update_byte((uint8_t*)EEPROM_BED_CORRECTION_VALID, 1);
+    eeprom_update_byte((uint8_t*)EEPROM_BED_CORRECTION_LEFT, 0);
+    eeprom_update_byte((uint8_t*)EEPROM_BED_CORRECTION_RIGHT, 0);
+    eeprom_update_byte((uint8_t*)EEPROM_BED_CORRECTION_FRONT, 0);
+    eeprom_update_byte((uint8_t*)EEPROM_BED_CORRECTION_REAR, 0);
+}
+
 //! @brief Get default sheet name for index
 //!
 //! | index | sheetName |

--- a/Firmware/eeprom.h
+++ b/Firmware/eeprom.h
@@ -620,6 +620,7 @@ enum
 
 #ifdef __cplusplus
 void eeprom_init();
+void eeprom_adjust_bed_reset();
 struct SheetName
 {
     char c[sizeof(Sheet::name) + 1];

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2746,11 +2746,7 @@ static_assert(sizeof(menu_data)>= sizeof(_menu_data_adjust_bed_t),"_menu_data_ad
 
 void lcd_adjust_bed_reset(void)
 {
-	eeprom_update_byte((unsigned char*)EEPROM_BED_CORRECTION_VALID, 1);
-	eeprom_update_byte((unsigned char*)EEPROM_BED_CORRECTION_LEFT , 0);
-	eeprom_update_byte((unsigned char*)EEPROM_BED_CORRECTION_RIGHT, 0);
-	eeprom_update_byte((unsigned char*)EEPROM_BED_CORRECTION_FRONT, 0);
-	eeprom_update_byte((unsigned char*)EEPROM_BED_CORRECTION_REAR , 0);
+	eeprom_adjust_bed_reset();
 	_menu_data_adjust_bed_t* _md = (_menu_data_adjust_bed_t*)&(menu_data[0]);
 	_md->status = 0;
 }


### PR DESCRIPTION
Moved `adjust_bed_reset()` into `eeprom.cpp` since we're only working with EEPROM

Change in memory:
Flash: -42 bytes
SRAM: 0 bytes