### PR TITLE
Hardcode expected MMU FW version into the error message v2

### DIFF
--- a/Firmware/mmu2/errors_list.h
+++ b/Firmware/mmu2/errors_list.h
@@ -6,6 +6,8 @@
 #include "../language.h"
 #include <avr/pgmspace.h>
 #include "buttons.h"
+#include "../strlen_cx.h"
+#include "../mmu2_supported_version.h"
 
 namespace MMU2 {
 
@@ -252,10 +254,17 @@ static const char MSG_DESC_COMMUNICATION_ERROR[] PROGMEM_I1 = ISTR("MMU unit not
 static const char MSG_DESC_FILAMENT_ALREADY_LOADED[] PROGMEM_I1 = ISTR("Cannot perform the action, filament is already loaded. Unload it first."); ////MSG_DESC_FILAMENT_ALREADY_LOADED c=20 r=8
 static const char MSG_DESC_INVALID_TOOL[] PROGMEM_I1 = ISTR("Requested filament tool is not available on this hardware. Check the G-code for tool index out of range (T0-T4)."); ////MSG_DESC_INVALID_TOOL c=20 r=8
 static const char MSG_DESC_QUEUE_FULL[] PROGMEM_I1 = ISTR("MMU Firmware internal error, please reset the MMU."); ////MSG_DESC_QUEUE_FULL c=20 r=8
-static const char MSG_DESC_FW_UPDATE_NEEDED[] PROGMEM_I1 = ISTR("The MMU unit reports its FW version incompatible with the printer's firmware. Make sure the MMU firmware is up to date."); ////MSG_DESC_FW_UPDATE_NEEDED c=20 r=9
 static const char MSG_DESC_FW_RUNTIME_ERROR[] PROGMEM_I1 = ISTR("Internal runtime error. Try resetting the MMU unit or updating the firmware. If the issue persists, contact support."); ////MSG_DESC_FW_RUNTIME_ERROR c=20 r=11
 static const char MSG_DESC_UNLOAD_MANUALLY[] PROGMEM_I1 = ISTR("Filament detected unexpectedly. Ensure no filament is loaded. Check the sensors and wiring."); ////MSG_DESC_UNLOAD_MANUALLY c=20 r=8
 static const char MSG_DESC_FILAMENT_EJECTED[] PROGMEM_I1 = ISTR("Remove the ejected filament from the front of the MMU unit."); ////MSG_DESC_FILAMENT_EJECTED c=20 r=8
+
+// Read explanation in mmu2_protocol_logic.cpp -> supportedMmuFWVersion
+static constexpr char MSG_DESC_FW_UPDATE_NEEDED[] PROGMEM_I1 = ISTR("The MMU unit firmware version incompatible with the printer's FW. Update to version 2.1.6."); ////MSG_DESC_FW_UPDATE_NEEDED c=20 r=9
+static constexpr uint8_t szFWUN = sizeof(MSG_DESC_FW_UPDATE_NEEDED);
+// at least check the individual version characters in MSG_DESC_FW_UPDATE_NEEDED
+static_assert(MSG_DESC_FW_UPDATE_NEEDED[szFWUN - 7] == ('0' + mmuVersionMajor));
+static_assert(MSG_DESC_FW_UPDATE_NEEDED[szFWUN - 5] == ('0' + mmuVersionMinor));
+static_assert(MSG_DESC_FW_UPDATE_NEEDED[szFWUN - 3] == ('0' + mmuVersionPatch));
 
 static const char * const errorDescs[] PROGMEM = {
     _R(MSG_DESC_FINDA_DIDNT_TRIGGER),

--- a/Firmware/mmu2_protocol_logic.cpp
+++ b/Firmware/mmu2_protocol_logic.cpp
@@ -12,10 +12,19 @@
 #endif
 
 #include <string.h>
+#include "mmu2_supported_version.h"
 
 namespace MMU2 {
 
-static const uint8_t supportedMmuFWVersion[3] PROGMEM = { 2, 1, 6 };
+/// Beware:
+/// Changing the supportedMmuVersion numbers requires patching MSG_DESC_FW_UPDATE_NEEDED and all its related translations by hand.
+///
+/// The message reads:
+///   "The MMU unit firmware version incompatible with the printer's FW. Update to version 2.1.6."
+///
+/// Currently, this is not possible to perform automatically at compile time with the existing languages/translations infrastructure.
+/// To save space a "dumb" solution was chosen + a few static_assert checks in errors_list.h preventing the code from compiling when the string doesn't match.
+static constexpr uint8_t supportedMmuFWVersion[3] PROGMEM = { mmuVersionMajor, mmuVersionMinor, mmuVersionPatch };
 
 const uint8_t ProtocolLogic::regs8Addrs[ProtocolLogic::regs8Count] PROGMEM = {
     8,    // FINDA state

--- a/Firmware/mmu2_supported_version.h
+++ b/Firmware/mmu2_supported_version.h
@@ -1,0 +1,10 @@
+#pragma once
+#include <stdint.h>
+
+namespace MMU2 {
+
+static constexpr uint8_t mmuVersionMajor = 2;
+static constexpr uint8_t mmuVersionMinor = 1;
+static constexpr uint8_t mmuVersionPatch = 6;
+
+} // namespace MMU2


### PR DESCRIPTION
This is an 80% solution to PFW-1488 which should be somewhat compatible with the existing languages/translations infrastructure. 
I don't see a point in extending the infrastructure a great deal to support some compile-time replacement in order to patch just MSG_DESC_FW_UPDATE_NEEDED.

Related PR: https://github.com/prusa3d/Prusa-Firmware/pull/3993 (shall be closed if this PR makes it into the FW)