### PR TITLE
Remove Done button on FINDA-related MMU error screens

### DIFF
--- a/Firmware/mmu2/errors_list.h
+++ b/Firmware/mmu2/errors_list.h
@@ -345,8 +345,8 @@ uint8_t constexpr Btns(ButtonOperations bMiddle, ButtonOperations bRight){
 }
 
 static const uint8_t errorButtons[] PROGMEM = {
-    Btns(ButtonOperations::Retry, ButtonOperations::Continue),//FINDA_DIDNT_TRIGGER
-    Btns(ButtonOperations::Retry, ButtonOperations::Continue),//FINDA_DIDNT_GO_OFF
+    Btns(ButtonOperations::Retry, ButtonOperations::NoOperation),//FINDA_DIDNT_TRIGGER
+    Btns(ButtonOperations::Retry, ButtonOperations::NoOperation),//FINDA_DIDNT_GO_OFF
     Btns(ButtonOperations::Retry, ButtonOperations::NoOperation),//FSENSOR_DIDNT_TRIGGER
     Btns(ButtonOperations::Retry, ButtonOperations::NoOperation),//FSENSOR_DIDNT_GO_OFF
 

--- a/Firmware/mmu2_error_converter.cpp
+++ b/Firmware/mmu2_error_converter.cpp
@@ -199,15 +199,6 @@ Buttons ButtonAvailable(uint16_t ec) {
     switch ( PrusaErrorCode(ei) ) {
     case ERR_MECHANICAL_FINDA_DIDNT_TRIGGER:
     case ERR_MECHANICAL_FINDA_DIDNT_GO_OFF:
-        switch (buttonSelectedOperation) {
-        case ButtonOperations::Retry: // "Repeat action"
-            return Middle;
-        case ButtonOperations::Continue: // "Continue"
-            return Right;
-        default:
-            break;
-        }
-        break;
     case ERR_MECHANICAL_FSENSOR_DIDNT_TRIGGER:
     case ERR_MECHANICAL_FSENSOR_DIDNT_GO_OFF:
     case ERR_MECHANICAL_FSENSOR_TOO_EARLY:
@@ -227,6 +218,7 @@ Buttons ButtonAvailable(uint16_t ec) {
         }
         break;
     case ERR_MECHANICAL_LOAD_TO_EXTRUDER_FAILED:
+    case ERR_SYSTEM_FILAMENT_EJECTED:
         switch (buttonSelectedOperation) {
         case ButtonOperations::Continue: // User solved the serious mechanical problem by hand - there is no other way around
             return Middle;
@@ -309,14 +301,6 @@ Buttons ButtonAvailable(uint16_t ec) {
             return StopPrint;
         case ButtonOperations::RestartMMU: // "Restart MMU"
             return RestartMMU;
-        default:
-            break;
-        }
-        break;
-    case ERR_SYSTEM_FILAMENT_EJECTED:
-        switch (buttonSelectedOperation) {
-        case ButtonOperations::Continue: // "Continue" - eject filament completed
-            return Middle;
         default:
             break;
         }


### PR DESCRIPTION
Follows the requirements from Prusa-Error-Codes yaml definition. Saves a few bytes as well as the button switch() statement got simplified.

PFW-1494