### PR TITLE
Improve sound handling for MMU error screen

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3429,35 +3429,14 @@ static void mmu_M600_wait_and_beep() {
     // Beep and wait for user to remove old filament and prepare new filament for load
     KEEPALIVE_STATE(PAUSED_FOR_USER);
 
-    int counterBeep = 0;
     lcd_display_message_fullscreen_P(_i("Remove old filament and press the knob to start loading new filament.")); ////MSG_REMOVE_OLD_FILAMENT c=20 r=5
-    bool bFirst = true;
 
     while (!lcd_clicked()) {
         manage_heater();
         manage_inactivity(true);
-
-#if BEEPER > 0
-        if (counterBeep == 500) {
-            counterBeep = 0;
-        }
-        SET_OUTPUT(BEEPER);
-        if (counterBeep == 0) {
-            if ((eSoundMode == e_SOUND_MODE_BLIND) || (eSoundMode == e_SOUND_MODE_LOUD) || ((eSoundMode == e_SOUND_MODE_ONCE) && bFirst)) {
-                bFirst = false;
-                WRITE(BEEPER, HIGH);
-            }
-        }
-        if (counterBeep == 20) {
-            WRITE(BEEPER, LOW);
-        }
-
-        counterBeep++;
-#endif // BEEPER > 0
-
-        delay_keep_alive(4);
+        sound_wait_for_user();
     }
-    WRITE(BEEPER, LOW);
+    sound_wait_for_user_reset();
 }
 
 /**
@@ -11288,34 +11267,14 @@ void M600_wait_for_user(float HotendTempBckp) {
 
 		KEEPALIVE_STATE(PAUSED_FOR_USER);
 
-		int counterBeep = 0;
 		unsigned long waiting_start_time = _millis();
 		uint8_t wait_for_user_state = 0;
 		lcd_display_message_fullscreen_P(_T(MSG_PRESS_TO_UNLOAD));
-		bool bFirst=true;
 
 		while (!(wait_for_user_state == 0 && lcd_clicked())){
 			manage_heater();
 			manage_inactivity(true);
-
-			#if BEEPER > 0
-			if (counterBeep == 500) {
-				counterBeep = 0;
-			}
-			SET_OUTPUT(BEEPER);
-			if (counterBeep == 0) {
-				if((eSoundMode==e_SOUND_MODE_BLIND)|| (eSoundMode==e_SOUND_MODE_LOUD)||((eSoundMode==e_SOUND_MODE_ONCE)&&bFirst))
-				{
-					bFirst=false;
-					WRITE(BEEPER, HIGH);
-				}
-			}
-			if (counterBeep == 20) {
-				WRITE(BEEPER, LOW);
-			}
-				
-			counterBeep++;
-			#endif //BEEPER > 0
+      if (wait_for_user_state != 2) sound_wait_for_user();
 			
 			switch (wait_for_user_state) {
 			case 0: //nozzle is hot, waiting for user to press the knob to unload filament
@@ -11335,28 +11294,22 @@ void M600_wait_for_user(float HotendTempBckp) {
 				if (lcd_clicked()) {
 					setTargetHotend(HotendTempBckp);
 					lcd_wait_for_heater();
-
 					wait_for_user_state = 2;
 				}
 				break;
 			case 2: //waiting for nozzle to reach target temperature
-
 				if (fabs(degTargetHotend(active_extruder) - degHotend(active_extruder)) < 1) {
 					lcd_display_message_fullscreen_P(_T(MSG_PRESS_TO_UNLOAD));
 					waiting_start_time = _millis();
 					wait_for_user_state = 0;
-				}
-				else {
-					counterBeep = 20; //beeper will be inactive during waiting for nozzle preheat
+				} else {
 					lcd_set_cursor(1, 4);
 					lcd_printf_P(PSTR("%3d"), (int16_t)degHotend(active_extruder));
 				}
 				break;
-
 			}
-
 		}
-		WRITE(BEEPER, LOW);
+		sound_wait_for_user_reset();
 }
 
 void M600_load_filament_movements()

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -907,9 +907,6 @@ void MMU2::ReportError(ErrorCode ec, ErrorSource res) {
         // or if 'Retry' operation is not available
         // raise the MMU error sceen and wait for user input
         ReportErrorHook((CommandInProgress)logic.CommandInProgress(), (uint16_t)ec, uint8_t(lastErrorSource));
-
-        // Beep when error screen is shown for the first time
-        MakeSound(Prompt);
     }
 
     static_assert(mmu2Magic[0] == 'M'

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -253,7 +253,14 @@ void ReportErrorHook(CommandInProgress /*cip*/, uint16_t ec, uint8_t /*es*/) {
                 ReportErrorHookState = ReportErrorHookStates::RENDER_ERROR_SCREEN;
                 break;
             case 2:
-                ReportErrorHookState = ReportErrorHookStates::DISMISS_ERROR_SCREEN;
+                // Exit error screen and enable lcd updates
+                lcd_set_custom_characters();
+                lcd_update_enable(true);
+                lcd_return_to_status();
+                sound_wait_for_user_reset();
+                // Reset the state in case a new error is reported
+                mmu2.is_mmu_error_monitor_active = false;
+                ReportErrorHookState = ReportErrorHookStates::RENDER_ERROR_SCREEN;
                 break;
             default:
                 break;

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -243,6 +243,7 @@ void ReportErrorHook(CommandInProgress /*cip*/, uint16_t ec, uint8_t /*es*/) {
     case (uint8_t)ReportErrorHookStates::MONITOR_SELECTION:
         mmu2.is_mmu_error_monitor_active = true;
         ReportErrorHookDynamicRender(); // Render dynamic characters
+        sound_wait_for_user();
         switch (ReportErrorHookMonitor(ei)) {
             case 0:
                 // No choice selected, return to loop()
@@ -252,13 +253,7 @@ void ReportErrorHook(CommandInProgress /*cip*/, uint16_t ec, uint8_t /*es*/) {
                 ReportErrorHookState = ReportErrorHookStates::RENDER_ERROR_SCREEN;
                 break;
             case 2:
-                // Exit error screen and enable lcd updates
-                lcd_set_custom_characters();
-                lcd_update_enable(true);
-                lcd_return_to_status();
-                // Reset the state in case a new error is reported
-                mmu2.is_mmu_error_monitor_active = false;
-                ReportErrorHookState = ReportErrorHookStates::RENDER_ERROR_SCREEN;
+                ReportErrorHookState = ReportErrorHookStates::DISMISS_ERROR_SCREEN;
                 break;
             default:
                 break;
@@ -269,6 +264,7 @@ void ReportErrorHook(CommandInProgress /*cip*/, uint16_t ec, uint8_t /*es*/) {
         lcd_set_custom_characters();
         lcd_update_enable(true);
         lcd_return_to_status();
+        sound_wait_for_user_reset();
         // Reset the state in case a new error is reported
         mmu2.is_mmu_error_monitor_active = false;
         ReportErrorHookState = ReportErrorHookStates::RENDER_ERROR_SCREEN;

--- a/Firmware/sound.cpp
+++ b/Firmware/sound.cpp
@@ -203,7 +203,7 @@ void sound_wait_for_user() {
      // Handle case where only one beep is needed
      if (!bFirst) {
           if (eSoundMode == e_SOUND_MODE_ONCE) {
-               Sound_MakeSound(e_SOUND_TYPE_StandardPrompt);
+               Sound_MakeCustom(80, 0, false);
           }
           bFirst = true;
      }
@@ -212,7 +212,7 @@ void sound_wait_for_user() {
      if (beep_timer.expired_cont(CONTINOUS_BEEP_PERIOD)) {
           beep_timer.start();
           if (eSoundMode == e_SOUND_MODE_LOUD) {
-               Sound_MakeSound(e_SOUND_TYPE_StandardPrompt);
+               Sound_MakeCustom(80, 0, false);
           } else {
                // Assist (lower volume sound)
                Sound_MakeSound(e_SOUND_TYPE_ButtonEcho);

--- a/Firmware/sound.cpp
+++ b/Firmware/sound.cpp
@@ -207,13 +207,11 @@ void sound_wait_for_user() {
           }
           bFirst = true;
      }
-     
+
      // Handle case where there should be continous beeps
-     if (beep_timer.expired(CONTINOUS_BEEP_PERIOD))
-     {
+     if (beep_timer.expired_cont(CONTINOUS_BEEP_PERIOD)) {
           beep_timer.start();
-          if (eSoundMode == e_SOUND_MODE_LOUD)
-          {
+          if (eSoundMode == e_SOUND_MODE_LOUD) {
                Sound_MakeSound(e_SOUND_TYPE_StandardPrompt);
           } else {
                // Assist (lower volume sound)

--- a/Firmware/sound.cpp
+++ b/Firmware/sound.cpp
@@ -201,10 +201,9 @@ void sound_wait_for_user() {
      if (eSoundMode == e_SOUND_MODE_SILENT) return;
 
      // Handle case where only one beep is needed
-     if (!bFirst) {
-          if (eSoundMode == e_SOUND_MODE_ONCE) {
-               Sound_MakeCustom(80, 0, false);
-          }
+     if (eSoundMode == e_SOUND_MODE_ONCE) {
+          if (bFirst) return;
+          Sound_MakeCustom(80, 0, false);
           bFirst = true;
      }
 

--- a/Firmware/sound.h
+++ b/Firmware/sound.h
@@ -38,6 +38,8 @@ extern void Sound_Default(void);
 extern void Sound_CycleState(void);
 extern void Sound_MakeSound(eSOUND_TYPE eSoundType);
 extern void Sound_MakeCustom(uint16_t ms,uint16_t tone_ ,bool critical);
+void sound_wait_for_user();
+void sound_wait_for_user_reset();
 
 //static void Sound_DoSound_Echo(void);
 //static void Sound_DoSound_Prompt(void);


### PR DESCRIPTION
An idea I have to re-use M600 sound code for error screen.

The requirements are the same as for the M600 sound prompts.

* Loud mode => should continuously beep (loud prompt sound)
* Silent mode => should be silent
* Once mode => should beep only once
* Assist/Blind => Same as Loud mode but beep with slightly lower tone (same sound as when clicking or rotation the knob)

**TODO:**

- [x] Tune beeping period to be same as before in M600
- [x] Test M600 thoroughly (with all sounds settings)
- [x] Test MMU error screen (with all sound settings)

Testing:
* MMU Error screen:
    * Loud mode ✔️ 
    * Once mode ✔️  
    * Silent mode ✔️ 
    * Assist mode ✔️ 

Change in memory:
Flash: -148 bytes
SRAM: +4 bytes

PFW-831