### PR TITLE
backlight: always allow backlight to dim/wake

### DIFF
--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -787,7 +787,6 @@ void lcd_buttons_update(void)
 	if (lcd_buttons & EN_B) enc |= B10;
 	if (enc != lcd_encoder_bits)
 	{
-		lcd_backlight_wake_trigger = true; // flag event, knob rotated
 		switch (enc)
 		{
 		case encrot0:
@@ -814,6 +813,10 @@ void lcd_buttons_update(void)
 			else if (lcd_encoder_bits == encrot0)
 				lcd_encoder_diff--;
 			break;
+		}
+
+		if (abs(lcd_encoder_diff) >= ENCODER_PULSES_PER_STEP) {
+			lcd_backlight_wake_trigger = true; // flag event, knob rotated
 		}
 	}
 	lcd_encoder_bits = enc;

--- a/Firmware/sound.cpp
+++ b/Firmware/sound.cpp
@@ -56,7 +56,6 @@ Sound_SaveMode();
 
 //if critical is true then silend and once mode is ignored
 void __attribute__((noinline)) Sound_MakeCustom(uint16_t ms,uint16_t tone_,bool critical){
-    backlight_wake();
      if (critical || eSoundMode != e_SOUND_MODE_SILENT) {
           if(!tone_) {
                WRITE(BEEPER, HIGH);
@@ -127,7 +126,6 @@ static void Sound_DoSound_Blind_Alert(void)
 
  static void Sound_DoSound_Encoder_Move(void)
 {
-    backlight_wake();
 uint8_t nI;
 
  for(nI=0;nI<5;nI++)
@@ -141,7 +139,6 @@ uint8_t nI;
 
 static void Sound_DoSound_Echo(void)
 {
-    backlight_wake();
 uint8_t nI;
 
 for(nI=0;nI<10;nI++)
@@ -163,7 +160,6 @@ WRITE(BEEPER,LOW);
 
 static void Sound_DoSound_Alert(bool bOnce)
 {
-    backlight_wake();
 uint8_t nI,nMax;
 
 nMax=bOnce?1:3;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -7446,7 +7446,6 @@ void menu_lcd_longpress_func(void)
     // Wake up the LCD backlight and,
     // start LCD inactivity timer
     lcd_timeoutToStatus.start();
-    backlight_wake();
     if (homing_flag || mesh_bed_leveling_flag || menu_menu == lcd_babystep_z || menu_menu == lcd_move_z || menu_block_mask != MENU_BLOCK_NONE || Stopped)
     {
         // disable longpress during re-entry, while homing, calibration or if a serious error
@@ -7551,7 +7550,6 @@ void menu_lcd_lcdupdate_func(void)
 		}
 	}
 #endif//CARDINSERTED
-	backlight_update();
 	if (lcd_next_update_millis < _millis())
 	{
 		if (abs(lcd_encoder_diff) >= ENCODER_PULSES_PER_STEP)
@@ -7562,13 +7560,11 @@ void menu_lcd_lcdupdate_func(void)
 			Sound_MakeSound(e_SOUND_TYPE_EncoderMove);
 			lcd_encoder_diff = 0;
 			lcd_timeoutToStatus.start();
-			backlight_wake();
 		}
 
 		if (LCD_CLICKED)
 		{
 			lcd_timeoutToStatus.start();
-			backlight_wake();
 		}
 
 		(*menu_menu)();


### PR DESCRIPTION
This commit adds the ability for the firmware to dim and wake the backlight when LCD updates are disabled. Such as in the MMU error screen or when rendering full screen messages which typically disable the LCD updates to prevent the status screen from rendering.

Fixes #2777

Fixes an issue where the backlight may stay dim on MMU error screen even though the knob is pressed or rotated. Only happens when the Sound settings are set to Silent.

Change in memory:
Flash: -6 bytes
SRAM: +1 byte