### PR TITLE
Disable MMU2S by default

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1122,7 +1122,8 @@ void setup()
 	SERIAL_ECHO_START;
 	puts_P(PSTR(" " FW_VERSION_FULL));
 
-	if (eeprom_read_byte((uint8_t *)EEPROM_MMU_ENABLED)) {
+	// by default the MMU shall remain disabled - PFW-1418
+	if (eeprom_init_default_byte((uint8_t *)EEPROM_MMU_ENABLED, 0)) {
 		MMU2::mmu2.Start();
 	}
 	SpoolJoin::spooljoin.initSpoolJoinStatus();

--- a/Firmware/eeprom.h
+++ b/Firmware/eeprom.h
@@ -343,7 +343,7 @@ static_assert(sizeof(Sheets) == EEPROM_SHEETS_SIZEOF, "Sizeof(Sheets) is not EEP
 | 0x0CB2 3250 | float   | EEPROM_TEMP_MODEL_W                   | ???          | ff ff ff ffh          | Temp model warning threshold (K/s)                | Temp model   | D3 Ax0cb2 C4
 | 0x0CAE 3246 | float   | EEPROM_TEMP_MODEL_E                   | ???          | ff ff ff ffh          | Temp model error threshold (K/s)                  | Temp model   | D3 Ax0cae C4
 | 0x0CAD 3245 | uint8   | EEPROM_FSENSOR_JAM_DETECTION          | 01h 1        | ff/01                 | fsensor pat9125 jam detection feature             | LCD menu     | D3 Ax0cad C1
-| 0x0CAC 3244 | uint8   | EEPROM_MMU_ENABLED                    | 01h 1        | ff/01                 | MMU enabled                                       | LCD menu     | D3 Ax0cac C1
+| 0x0CAC 3244 | uint8   | EEPROM_MMU_ENABLED                    | 00h 0        | ff/00                 | MMU enabled                                       | LCD menu     | D3 Ax0cac C1
 | 0x0CA8 3240 | uint32  | EEPROM_MMU_MATERIAL_CHANGES           | ???          | ff ff ff ffh          | MMU toolchange counter over printers lifetime     | LCD statistic| D3 Ax0ca8 C4
 | 0x0CA7 3239 | uint8   | EEPROM_HEAT_BED_ON_LOAD_FILAMENT      | ffh 255      | ffh 255               | Heat bed on load filament unknown state           | LCD menu     | D3 Ax0ca7 C1
 | ^           | ^       | ^                                     | 00h 0        | ^                     | Do not heat bed on load filament                  | ^            | ^


### PR DESCRIPTION
On printers without the MMU no error screen should occur and no attempts of communication with the MMU should be performed -> EEPROM_MMU_ENABLED should default to 0.

PFW-1418