### PR TITLE
MMU: Fix an issue where LCD freezes during loading test

### DIFF
--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -241,8 +241,7 @@ bool MMU2::VerifyFilamentEnteredPTFE() {
         // Wait for move to finish and monitor the fsensor the entire time
         // A single 0 reading will set the bit.
         fsensorState |= (WhereIsFilament() == FilamentState::NOT_PRESENT);
-        marlin_manage_heater();
-        marlin_manage_inactivity(true);
+        safe_delay_keep_alive(0);
     }
 
     if (fsensorState) {


### PR DESCRIPTION
It may be useful to view the Sensors menu
while the toolchange loading test is taking
place. For example to see if the reading is flickering

The firmware needs to call `lcd_update(0)` to update the screen rendering.

Change in memory:
Flash: -2 bytes
SRAM: 0 bytes