### PR TITLE
🚧 Improve MMU "Unload Filament" menu behavior

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3434,15 +3434,8 @@ static void mmu_M600_wait_and_beep() {
 static void mmu_M600_unload_filament() {
     if (MMU2::mmu2.get_current_tool() == (uint8_t)MMU2::FILAMENT_UNKNOWN) return;
 
-    lcd_update_enable(false);
-    lcd_clear();
-    lcd_puts_at_P(0, 1, _T(MSG_UNLOADING_FILAMENT));
-    lcd_print(' ');
-    lcd_print(MMU2::mmu2.get_current_tool() + 1);
-
     // unload just current filament for multimaterial printers (used also in M702)
-    MMU2::mmu2.unload();
-    lcd_update_enable(true);
+    MMU2::mmu2.unload(true);
 }
 
 /// @brief load filament for mmu v2
@@ -5337,7 +5330,7 @@ void process_commands()
       {
         if (MMU2::mmu2.FindaDetectsFilament() && !fsensor.getFilamentPresent())
         { // Filament only half way into the PTFE. Unload the filament.
-          MMU2::mmu2.unload();
+          MMU2::mmu2.unload(false);
           // Tx and Tc gcodes take care of loading the filament to the nozzle.
         }
       }
@@ -8416,7 +8409,7 @@ Sigma_Exit:
         float delta = raise_z(z_target);
 
         // Unload filament
-        if (MMU2::mmu2.Enabled())  MMU2::mmu2.unload();
+        if (MMU2::mmu2.Enabled())  MMU2::mmu2.unload(true);
         else unload_filament(unloadLength);
 
         // Restore Z axis

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -370,7 +370,7 @@ bool MMU2::tool_change(uint8_t slot) {
             !marlin_printingIsActive()) {
             // If Tcodes are used manually through the serial
             // we need to unload manually as well -- but only if FINDA detects filament
-            unload();
+            unload(false);
         }
 
         ReportingRAII rep(CommandInProgress::ToolChange);
@@ -463,14 +463,22 @@ void MMU2::UnloadInner() {
     tool_change_extruder = MMU2_NO_TOOL;
 }
 
-bool MMU2::unload() {
+bool MMU2::unload(bool enableFullScreenMsg) {
     if (!WaitForMMUReady())
         return false;
 
     WaitForHotendTargetTempBeep();
 
+    if (enableFullScreenMsg) {
+        FullScreenMsgUnload(get_current_tool());
+    }
+
     ReportingRAII rep(CommandInProgress::UnloadFilament);
     UnloadInner();
+
+    if (enableFullScreenMsg) {
+        ScreenUpdateEnable();
+    }
 
     return true;
 }
@@ -494,7 +502,7 @@ bool MMU2::cut_filament(uint8_t slot, bool enableFullScreenMsg /*= true*/) {
     }
     {
         if (FindaDetectsFilament()) {
-            unload();
+            unload(false);
         }
 
         ReportingRAII rep(CommandInProgress::CutFilament);
@@ -511,7 +519,7 @@ bool MMU2::loading_test(uint8_t slot) {
     FullScreenMsgTest(slot);
     tool_change(slot);
     planner_synchronize();
-    unload();
+    unload(false);
     ScreenUpdateEnable();
     return true;
 }
@@ -573,7 +581,7 @@ bool MMU2::eject_filament(uint8_t slot, bool enableFullScreenMsg /* = true */) {
     }
     {
         if (FindaDetectsFilament()) {
-            unload();
+            unload(false);
         }
 
         ReportingRAII rep(CommandInProgress::EjectFilament);

--- a/Firmware/mmu2.h
+++ b/Firmware/mmu2.h
@@ -106,7 +106,7 @@ public:
     /// Unload of filament in collaboration with the MMU.
     /// That includes rotating the printer's extruder in order to release filament.
     /// @returns false if the operation cannot be performed (Stopped or cold extruder)
-    bool unload();
+    bool unload(bool enableFullScreenMsg = true);
 
     /// Load (insert) filament just into the MMU (not into printer's nozzle)
     /// @returns false if the operation cannot be performed (Stopped)

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -314,7 +314,21 @@ static void FullScreenMsg(const char *pgmS, uint8_t slot){
     lcd_clear();
     lcd_puts_at_P(0, 1, pgmS);
     lcd_print(' ');
-    lcd_print(slot + 1);
+    if (slot > MMU_FILAMENT_COUNT) {
+        // If the current tool is unknown, show '?'
+        // instead of '256'. There is only space for
+        // one digit/character on the display when
+        // unloading for example.
+        lcd_putc('?');
+    } else {
+        lcd_print(slot + 1);
+    }
+    
+    
+}
+
+void FullScreenMsgUnload(uint8_t slot){
+    FullScreenMsg(_T(MSG_UNLOADING_FILAMENT), slot);
 }
 
 void FullScreenMsgCut(uint8_t slot){

--- a/Firmware/mmu2_reporting.h
+++ b/Firmware/mmu2_reporting.h
@@ -71,6 +71,7 @@ enum SoundType {
 
 void MakeSound(SoundType s);
 
+void FullScreenMsgUnload(uint8_t slot);
 void FullScreenMsgCut(uint8_t slot);
 void FullScreenMsgEject(uint8_t slot);
 void FullScreenMsgTest(uint8_t slot);


### PR DESCRIPTION
Disable LCD updates while unloading to prevent the user from triggering another unload while the previous unload is not done yet.

Additionally, the following scenarios also show the fullscreen:
* When print is stopped, this restores 3.11 behavior
* When M702 is executed

Change in memory:
Flash: +36 bytes
SRAM: 0 bytes