### PR TITLE
preheat: improve target temperature threshold

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -11424,7 +11424,7 @@ void M600_wait_for_user(float HotendTempBckp) {
 				}
 				break;
 			case 2: //waiting for nozzle to reach target temperature
-				if (fabs(degTargetHotend(active_extruder) - degHotend(active_extruder)) < 1) {
+				if (fabs(degTargetHotend(active_extruder) - degHotend(active_extruder)) < TEMP_HYSTERESIS) {
 					lcd_display_message_fullscreen_P(_T(MSG_PRESS_TO_UNLOAD));
 					waiting_start_time = _millis();
 					wait_for_user_state = 0;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1888,7 +1888,7 @@ void mFilamentItem(uint16_t nTemp, uint16_t nTempBed)
 
     lcd_timeoutToStatus.stop();
 
-    if (fabs(current_temperature[0] - target_temperature[0]) > TEMP_HYSTERESIS)
+    if (abs((int)current_temperature[0] - nTemp) > TEMP_HYSTERESIS)
     {
         switch (eFilamentAction)
         {

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3772,7 +3772,7 @@ static void wait_preheat()
     plan_buffer_line_curposXYZE(homing_feedrate[Z_AXIS] / 60);
     delay_keep_alive(2000);
     lcd_display_message_fullscreen_P(_T(MSG_WIZARD_HEATING));
-	while (fabs(degHotend(0) - degTargetHotend(0)) > 3) {
+    while (fabs(degHotend(0) - degTargetHotend(0)) > TEMP_HYSTERESIS) {
         lcd_display_message_fullscreen_P(_T(MSG_WIZARD_HEATING));
 
         lcd_set_cursor(0, 4);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1888,7 +1888,7 @@ void mFilamentItem(uint16_t nTemp, uint16_t nTempBed)
 
     lcd_timeoutToStatus.stop();
 
-    if (current_temperature[0] > (target_temperature[0] * 0.95))
+    if (fabs(current_temperature[0] - target_temperature[0]) > TEMP_HYSTERESIS)
     {
         switch (eFilamentAction)
         {


### PR DESCRIPTION
Use 5°C threshold to be consistent with other parts of the firmware.

Relying on 95% of the target temperature creates
a dependency on the temperature. I don't see any other part of the firmware do this except the Preheat menu.

| Material       | Set Target           | Current Threshold  | Proposed Threshold |
| ------------- |-------------| -----|----|
| PLA     | 215°C  | 204.25 °C | 210°C |
| PETG   | 230°C  | 218.5 °C | 225°C |
| ABS     | 255°C  | 242.25 °C | 250°C |
| ASA     | 260°C  | 247 °C | 255°C |
| PC     | 275°C  | 261.25 °C | 270°C |

My proposal is we instead use a constant
`TEMP_HYSTERESIS = 5`, which is consistent with
M109, and behavior when restoring print from RAM
and some of the MMU code (like unload function)

Change in memory:
Flash: -14 bytes
SRAM: 0 bytes