### PR TITLE
Optimisation: Disable M351 when using TMC2130 and code related to it

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -8378,6 +8378,7 @@ Sigma_Exit:
     }
     break;
 
+#ifndef TMC2130
     /*!
 	### M351 - Toggle Microstep Pins <a href="https://reprap.org/wiki/G-code#M351:_Toggle_MS1_MS2_pins_directly">M351: Toggle MS1 MS2 pins directly</a>
     Toggle MS1 MS2 pins directly.
@@ -8411,6 +8412,7 @@ Sigma_Exit:
       #endif
     }
     break;
+#endif // !TMC2130
 
     /*!
     ### M701 - Load filament to extruder <a href="https://reprap.org/wiki/G-code#M701:_Load_filament">M701: Load filament</a>

--- a/Firmware/stepper.cpp
+++ b/Firmware/stepper.cpp
@@ -1073,10 +1073,10 @@ void st_init()
 {
 #ifdef TMC2130
 	tmc2130_init(TMCInitParams(false, FarmOrUserECool()));
-#endif //TMC2130
-
+#else
   st_current_init(); //Initialize Digipot Motor Current
   microstep_init(); //Initialize Microstepping Pins
+#endif //TMC2130
 
   //Initialize Dir Pins
   #if defined(X_DIR_PIN) && X_DIR_PIN > -1
@@ -1513,6 +1513,7 @@ void digitalPotWrite(int address, int value) // From Arduino DigitalPotControl e
 }
 #endif
 
+#ifndef TMC2130
 void st_current_init() //Initialize Digipot Motor Current
 {
 #ifdef MOTOR_CURRENT_PWM_XY_PIN
@@ -1541,8 +1542,6 @@ void st_current_init() //Initialize Digipot Motor Current
     TCCR5B = (TCCR5B & ~(_BV(CS50) | _BV(CS51) | _BV(CS52))) | _BV(CS50);
 #endif
 }
-
-
 
 #ifdef MOTOR_CURRENT_PWM_XY_PIN
 void st_current_set(uint8_t driver, int current)
@@ -1576,9 +1575,6 @@ void microstep_init()
   for(int i=0;i<=4;i++) microstep_mode(i,microstep_modes[i]);
   #endif
 }
-
-
-#ifndef TMC2130
 
 void microstep_ms(uint8_t driver, int8_t ms1, int8_t ms2)
 {
@@ -1637,4 +1633,4 @@ void microstep_readings()
       SERIAL_PROTOCOLLN( READ(E1_MS2_PIN));
       #endif
 }
-#endif //TMC2130
+#endif //!TMC2130

--- a/Firmware/stepper.h
+++ b/Firmware/stepper.h
@@ -76,12 +76,15 @@ void quickStop();
 #if defined(DIGIPOTSS_PIN) && DIGIPOTSS_PIN > -1
 void digitalPotWrite(int address, int value);
 #endif //defined(DIGIPOTSS_PIN) && DIGIPOTSS_PIN > -1
+
+#ifndef TMC2130
 void microstep_ms(uint8_t driver, int8_t ms1, int8_t ms2);
 void microstep_mode(uint8_t driver, uint8_t stepping);
 void st_current_init();
 void st_current_set(uint8_t driver, int current);
 void microstep_init();
 void microstep_readings();
+#endif //!TMC2130
 
 #ifdef BABYSTEPPING
   void babystep(const uint8_t axis,const bool direction); // perform a short step with a single stepper motor, outside of any convention

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3454,8 +3454,10 @@ static void lcd_silent_mode_set() {
   // Be safe than sorry, reset the stepper timer before re-enabling interrupts.
   st_reset_timer();
   sei();
+#else
+    st_current_init();
 #endif //TMC2130
-  st_current_init();
+  
 #ifdef TMC2130
   if (lcd_crash_detect_enabled() && (SilentModeMenu != SILENT_MODE_NORMAL))
 	  menu_submenu(lcd_crash_mode_info2);


### PR DESCRIPTION
It looks to me this code is only used when not using TMC2130 steppers. If I hopefully didn't miss something, then this is pretty nice memory savings.

Change in memory (MK3S+ multilang build)
Flash: -250 bytes
SRAM: 0 bytes