### PR TITLE
Refactor LCD knob rotation and click event handling

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -9478,11 +9478,11 @@ void manage_inactivity(bool ignore_stepper_queue/*=false*/) //default argument s
   // handle longpress
   if(lcd_longpress_trigger)
   {
+      lcd_consume_click(); // Reset trigger to prevent recursion
       // long press is not possible in modal mode, wait until ready
       if (lcd_longpress_func && lcd_update_enabled)
       {
           lcd_longpress_func();
-          lcd_longpress_trigger = 0;
       }
   }
 

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1273,8 +1273,6 @@ void setup()
   eeprom_init_default_byte((uint8_t*)EEPROM_SILENT, SILENT_MODE_OFF);
   eeprom_init_default_byte((uint8_t*)EEPROM_WIZARD_ACTIVE, 1); //run wizard if uninitialized
 
-  lcd_encoder_diff=0;
-
 #ifdef TMC2130
 	uint8_t silentMode = eeprom_read_byte((uint8_t*)EEPROM_SILENT);
 	if (silentMode == 0xff) silentMode = 0;

--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -634,7 +634,7 @@ void lcd_printNumber(unsigned long n, uint8_t base)
 uint8_t lcd_draw_update = 2;
 int32_t lcd_encoder = 0;
 uint8_t lcd_encoder_bits = 0;
-int8_t lcd_encoder_diff = 0;
+static int8_t lcd_encoder_diff = 0;
 
 uint8_t lcd_buttons = 0;
 uint8_t lcd_button_pressed = 0;
@@ -702,7 +702,8 @@ void lcd_update(uint8_t lcdDrawUpdateOverride)
 		lcd_backlight_wake_trigger = false;
 		backlight_wake();
 		if (abs(lcd_encoder_diff) >= ENCODER_PULSES_PER_STEP) {
-			// TODO: update lcd_encoder here
+			lcd_encoder += lcd_encoder_diff / ENCODER_PULSES_PER_STEP;
+			lcd_encoder_diff = 0;
 			Sound_MakeSound(e_SOUND_TYPE_EncoderMove);
 		} else {
 			Sound_MakeSound(e_SOUND_TYPE_ButtonEcho);

--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -701,6 +701,12 @@ void lcd_update(uint8_t lcdDrawUpdateOverride)
 	if (lcd_backlight_wake_trigger) {
 		lcd_backlight_wake_trigger = false;
 		backlight_wake();
+		if (abs(lcd_encoder_diff) >= ENCODER_PULSES_PER_STEP) {
+			// TODO: update lcd_encoder here
+			Sound_MakeSound(e_SOUND_TYPE_EncoderMove);
+		} else {
+			Sound_MakeSound(e_SOUND_TYPE_ButtonEcho);
+		}
 	}
 
 	backlight_update();

--- a/Firmware/lcd.h
+++ b/Firmware/lcd.h
@@ -105,8 +105,6 @@ extern uint8_t lcd_encoder_bits;
 //the last checked lcd_buttons in a bit array.
 extern uint8_t lcd_buttons;
 
-extern uint8_t lcd_button_pressed;
-
 extern uint8_t lcd_update_enabled;
 
 extern LongTimer lcd_timeoutToStatus;
@@ -212,8 +210,7 @@ extern void lcd_set_custom_characters_nextpage(void);
 //! @brief Consume click and longpress event
 inline void lcd_consume_click()
 {
-    lcd_button_pressed = 0;
-    lcd_buttons &= 0xff^EN_C;
+    lcd_buttons = 0;
     lcd_longpress_trigger = 0;
 }
 

--- a/Firmware/lcd.h
+++ b/Firmware/lcd.h
@@ -100,8 +100,6 @@ extern uint8_t lcd_draw_update;
 
 extern int32_t lcd_encoder;
 
-extern uint8_t lcd_encoder_bits;
-
 //the last checked lcd_buttons in a bit array.
 extern uint8_t lcd_buttons;
 

--- a/Firmware/lcd.h
+++ b/Firmware/lcd.h
@@ -102,9 +102,6 @@ extern int32_t lcd_encoder;
 
 extern uint8_t lcd_encoder_bits;
 
-// lcd_encoder_diff is updated from interrupt context and added to lcd_encoder every LCD update
-extern int8_t lcd_encoder_diff;
-
 //the last checked lcd_buttons in a bit array.
 extern uint8_t lcd_buttons;
 

--- a/Firmware/menu.cpp
+++ b/Firmware/menu.cpp
@@ -119,15 +119,6 @@ void menu_back_if_clicked(void)
 		menu_back();
 }
 
-void menu_back_if_clicked_fb(void)
-{
-	if (lcd_clicked())
-	{
-        lcd_quick_feedback();
-		menu_back();
-	}
-}
-
 void menu_submenu(menu_func_t submenu)
 {
 	if (menu_depth < MENU_DEPTH_MAX)

--- a/Firmware/menu.h
+++ b/Firmware/menu.h
@@ -78,8 +78,6 @@ extern void menu_back(uint8_t nLevel);
 
 extern void menu_back_if_clicked(void);
 
-extern void menu_back_if_clicked_fb(void);
-
 extern void menu_submenu(menu_func_t submenu);
 extern void menu_submenu_no_reset(menu_func_t submenu);
 

--- a/Firmware/menu.h
+++ b/Firmware/menu.h
@@ -64,7 +64,7 @@ extern menu_func_t menu_menu;
 
 extern void menu_data_reset(void);
 
-extern void menu_goto(menu_func_t menu, const uint32_t encoder, const bool feedback, bool reset_menu_state);
+extern void menu_goto(menu_func_t menu, const uint32_t encoder, bool reset_menu_state, const bool feedback=false);
 
 #define MENU_BEGIN() menu_start(); for(menu_row = 0; menu_row < LCD_HEIGHT; menu_row++, menu_line++) { menu_item = 0;
 void menu_start(void);
@@ -78,8 +78,8 @@ extern void menu_back(uint8_t nLevel);
 
 extern void menu_back_if_clicked(void);
 
-extern void menu_submenu(menu_func_t submenu);
-extern void menu_submenu_no_reset(menu_func_t submenu);
+extern void menu_submenu(menu_func_t submenu, const bool feedback=false);
+extern void menu_submenu_no_reset(menu_func_t submenu, const bool feedback=false);
 
 extern uint8_t menu_item_ret(void);
 

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -179,14 +179,12 @@ static uint8_t ReportErrorHookMonitor(uint8_t ei) {
             // More button for two button screen
             lcd_putc_at(18, 3, current_selection == LCD_MIDDLE_BUTTON_CHOICE ? '>': ' ');
         }
-        // Consume rotation event and make feedback sound
+        // Consume rotation event
         enc_dif = lcd_encoder_diff;
-        Sound_MakeSound(e_SOUND_TYPE_EncoderMove);
     }
 
     // Check if knob was clicked and consume the event
     if (lcd_clicked()) {
-        Sound_MakeSound(e_SOUND_TYPE_ButtonEcho);
         choice_selected = current_selection;
     } else {
         // continue monitoring

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -99,15 +99,7 @@ void ReportErrorHookSensorLineRender(){
 static uint8_t ReportErrorHookMonitor(uint8_t ei) {
     uint8_t ret = 0;
     bool two_choices = false;
-    static int8_t enc_dif = lcd_encoder_diff;
     static uint8_t reset_button_selection;
-
-    if (lcd_encoder_diff == 0)
-    {
-         // lcd_update_enable(true) was called outside ReportErrorHookMonitor
-         // It will set lcd_encoder_diff to 0, sync enc_dif
-        enc_dif = 0;
-    }
 
     // Read and determine what operations should be shown on the menu
     const uint8_t button_operation   = PrusaErrorButtons(ei);
@@ -132,20 +124,20 @@ static uint8_t ReportErrorHookMonitor(uint8_t ei) {
     }
 
     // Check if knob was rotated
-    if (abs(enc_dif - lcd_encoder_diff) >= ENCODER_PULSES_PER_STEP) {
+    if (lcd_encoder) {
         if (two_choices == false) { // third_choice is not nullptr, safe to dereference
-            if (enc_dif > lcd_encoder_diff && current_selection != LCD_LEFT_BUTTON_CHOICE) {
+            if (lcd_encoder > 0 && current_selection != LCD_LEFT_BUTTON_CHOICE) {
                 // Rotating knob counter clockwise
                 current_selection--;
-            } else if (enc_dif < lcd_encoder_diff && current_selection != LCD_RIGHT_BUTTON_CHOICE) {
+            } else if (lcd_encoder < 0 && current_selection != LCD_RIGHT_BUTTON_CHOICE) {
                 // Rotating knob clockwise
                 current_selection++;
             }
         } else {
-            if (enc_dif > lcd_encoder_diff && current_selection != LCD_LEFT_BUTTON_CHOICE) {
+            if (lcd_encoder > 0 && current_selection != LCD_LEFT_BUTTON_CHOICE) {
                 // Rotating knob counter clockwise
                 current_selection = LCD_LEFT_BUTTON_CHOICE;
-            } else if (enc_dif < lcd_encoder_diff && current_selection != LCD_MIDDLE_BUTTON_CHOICE) {
+            } else if (lcd_encoder < 0 && current_selection != LCD_MIDDLE_BUTTON_CHOICE) {
                 // Rotating knob clockwise
                 current_selection = LCD_MIDDLE_BUTTON_CHOICE;
             }
@@ -180,7 +172,7 @@ static uint8_t ReportErrorHookMonitor(uint8_t ei) {
             lcd_putc_at(18, 3, current_selection == LCD_MIDDLE_BUTTON_CHOICE ? '>': ' ');
         }
         // Consume rotation event
-        enc_dif = lcd_encoder_diff;
+        lcd_encoder = 0;
     }
 
     // Check if knob was clicked and consume the event

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1147,7 +1147,7 @@ static void lcd_menu_fails_stats_mmu_print() {
         _T(MSG_LAST_PRINT_FAILURES),
         _T(MSG_MMU_FAILS), clamp999( eeprom_read_byte((uint8_t*)EEPROM_MMU_FAIL) ),
         _T(MSG_MMU_LOAD_FAILS), clamp999( eeprom_read_byte((uint8_t*)EEPROM_MMU_LOAD_FAIL) ));
-    menu_back_if_clicked_fb();
+    menu_back_if_clicked();
 }
 
 //! @brief Show Total Failures Statistics MMU
@@ -1173,7 +1173,7 @@ static void lcd_menu_fails_stats_mmu_total() {
         _T(MSG_MMU_FAILS), clamp999( eeprom_read_word((uint16_t*)EEPROM_MMU_FAIL_TOT) ),
         _T(MSG_MMU_LOAD_FAILS), clamp999( eeprom_read_word((uint16_t*)EEPROM_MMU_LOAD_FAIL_TOT) ),
         _T(MSG_MMU_POWER_FAILS), clamp999( MMU2::mmu2.TMCFailures() ));
-    menu_back_if_clicked_fb();
+    menu_back_if_clicked();
 }
 
 //! @brief Show Total Failures Statistics MMU
@@ -1202,8 +1202,7 @@ static void lcd_menu_toolchange_stats_mmu_total()
         lcd_print(eeprom_read_dword((uint32_t*)EEPROM_MMU_MATERIAL_CHANGES));
         _md->initialized = true;
     }
-
-    menu_back_if_clicked_fb();
+    menu_back_if_clicked();
 }
 
 #if defined(TMC2130) && defined(FILAMENT_SENSOR)
@@ -1230,7 +1229,7 @@ static void lcd_menu_fails_stats_total()
         _T(MSG_CRASH),
             clamp999( eeprom_read_word((uint16_t*)EEPROM_CRASH_COUNT_X_TOT) ), 
             clamp999( eeprom_read_word((uint16_t*)EEPROM_CRASH_COUNT_Y_TOT) ));
-    menu_back_if_clicked_fb();
+    menu_back_if_clicked();
 }
 
 //! @brief Show Last Print Failures Statistics
@@ -1257,7 +1256,7 @@ static void lcd_menu_fails_stats_print()
         _T(MSG_POWER_FAILURES), power,
         _T(MSG_FIL_RUNOUTS), filam,
         _T(MSG_CRASH), crashX, crashY);
-    menu_back_if_clicked_fb();
+    menu_back_if_clicked();
 }
 
 //! @brief Open fail statistics menu
@@ -1354,7 +1353,7 @@ static void lcd_menu_debug()
         " heap_end: 0x%04x"), SP_min, __malloc_heap_start, __malloc_heap_end);  ////c=14
 #endif //DEBUG_STACK_MONITOR
 
-	menu_back_if_clicked_fb();
+	menu_back_if_clicked();
 }
 #endif /* DEBUG_BUILD */
 
@@ -2359,7 +2358,7 @@ void lcd_menu_statistics()
 		    ),
             _i("Filament used"), _met,  ////MSG_FILAMENT_USED c=19
             _i("Print time"), _h, _m, _s);  ////MSG_PRINT_TIME c=19
-		menu_back_if_clicked_fb();
+		menu_back_if_clicked();
 	}
 	else
 	{
@@ -2381,7 +2380,7 @@ void lcd_menu_statistics()
             ),
             _i("Total filament"), _filament_m,  ////MSG_TOTAL_FILAMENT c=19
             _i("Total print time"), _days, _hours, _minutes);  ////MSG_TOTAL_PRINT_TIME c=19
-        menu_back_if_clicked_fb();
+        menu_back_if_clicked();
 	}
 }
 

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -296,8 +296,6 @@ uint8_t menu_item_sddir(const char* str_fn, char* str_fnl)
 		}
 		if (menu_clicked && (lcd_encoder == menu_item))
 		{
-			menu_clicked = false;
-			lcd_consume_click();
 			lcd_update_enabled = false;
 			menu_action_sddirectory(str_fn);
 			lcd_update_enabled = true;
@@ -318,8 +316,6 @@ static uint8_t menu_item_sdfile(const char* str_fn, char* str_fnl)
 		}
 		if (menu_clicked && (lcd_encoder == menu_item))
 		{
-			menu_clicked = false;
-			lcd_consume_click();
 			lcd_update_enabled = false;
 			menu_action_sdfile(str_fn);
 			lcd_update_enabled = true;
@@ -762,7 +758,7 @@ void lcd_status_screen()                          // NOT static due to using ins
 			lcd_commands();
 	}
 
-	bool current_click = LCD_CLICKED;
+	bool current_click = lcd_clicked();
 
 	if (ignore_click)
 	{
@@ -775,7 +771,7 @@ void lcd_status_screen()                          // NOT static due to using ins
 		}
 		else if (current_click)
 		{
-			lcd_quick_feedback();
+			lcd_draw_update = 2;
 			wait_for_unclick = true;
 			current_click = false;
 		}
@@ -853,7 +849,7 @@ void lcd_commands()
             case 10:
                 lcd_clear();
                 menu_depth = 0;
-                menu_submenu(lcd_babystep_z);
+                menu_submenu(lcd_babystep_z, true);
                 lay1cal_intro_line(extraPurgeNeeded, layer_height, extrusion_width);
                 break;
             case 9:
@@ -1023,7 +1019,7 @@ void lcd_commands()
 void lcd_return_to_status()
 {
 	lcd_refresh(); // to maybe revive the LCD if static electricity killed it.
-	menu_goto(lcd_status_screen, 0, false, true);
+	menu_goto(lcd_status_screen, 0, true);
 	menu_depth = 0;
     eFilamentAction = FilamentAction::None; // i.e. non-autoLoad
 }
@@ -1901,7 +1897,7 @@ void mFilamentItem(uint16_t nTemp, uint16_t nTempBed)
         case FilamentAction::Load:
         case FilamentAction::AutoLoad:
         case FilamentAction::UnLoad:
-            if (bFilamentWaitingFlag) menu_submenu(mFilamentPrompt);
+            if (bFilamentWaitingFlag) menu_submenu(mFilamentPrompt, true);
             else
             {
                 nLevel = bFilamentPreheatState ? 1 : 2;
@@ -1920,13 +1916,13 @@ void mFilamentItem(uint16_t nTemp, uint16_t nTempBed)
             nLevel = bFilamentPreheatState ? 1 : 2;
             bFilamentAction = true;
             menu_back(nLevel);
-            menu_submenu(mmu_load_to_nozzle_menu);
+            menu_submenu(mmu_load_to_nozzle_menu, true);
             break;
         case FilamentAction::MmuLoadingTest:
             nLevel = bFilamentPreheatState ? 1 : 2;
             bFilamentAction = true;
             menu_back(nLevel);
-            menu_submenu(mmu_loading_test_menu);
+            menu_submenu(mmu_loading_test_menu, true);
             break;
         case FilamentAction::MmuUnLoad:
             nLevel = bFilamentPreheatState ? 1 : 2;
@@ -1938,14 +1934,14 @@ void mFilamentItem(uint16_t nTemp, uint16_t nTempBed)
             nLevel = bFilamentPreheatState ? 1 : 2;
             bFilamentAction = true;
             menu_back(nLevel);
-            menu_submenu(mmu_fil_eject_menu);
+            menu_submenu(mmu_fil_eject_menu, true);
             break;
         case FilamentAction::MmuCut:
 #ifdef MMU_HAS_CUTTER
             nLevel=bFilamentPreheatState?1:2;
             bFilamentAction=true;
             menu_back(nLevel);
-            menu_submenu(mmu_cut_filament_menu);
+            menu_submenu(mmu_cut_filament_menu, true);
 #endif //MMU_HAS_CUTTER
             break;
         case FilamentAction::None:
@@ -2423,7 +2419,7 @@ static void _lcd_move(const char *name, uint8_t axis, int min, int max)
 		menu_draw_float31(name, current_position[axis]);
 	}
 	if (menu_leaving || LCD_CLICKED) (void)enable_endstops(_md->endstopsEnabledPrevious);
-	if (LCD_CLICKED) menu_back();
+    menu_back_if_clicked();
 }
 
 
@@ -2449,7 +2445,7 @@ void lcd_move_e()
 			// the implementation of menu_draw_float31
 			menu_draw_float31(PSTR("Extruder:"), current_position[E_AXIS]);
 		}
-		if (LCD_CLICKED) menu_back();
+		menu_back_if_clicked();
 	}
 	else
 	{
@@ -2656,7 +2652,7 @@ static void lcd_babystep_z()
 #endif //PINDA_THERMISTOR
 		calibration_status_set(CALIBRATION_STATUS_LIVE_ADJUST);
 	}
-	if (LCD_CLICKED) menu_back();
+	menu_back_if_clicked();
 }
 
 
@@ -3268,7 +3264,7 @@ static void lcd_show_end_stops() {
 
 static void menu_show_end_stops() {
     lcd_show_end_stops();
-    if (LCD_CLICKED) menu_back();
+    menu_back_if_clicked();
 }
 
 void lcd_diag_show_end_stops()
@@ -3631,7 +3627,7 @@ void lcd_first_layer_calibration_reset()
     static_assert(sizeof(menu_data)>= sizeof(MenuData),"_menu_data_t doesn't fit into menu_data");
     MenuData* menuData = (MenuData*)&(menu_data[0]);
 
-    if(LCD_CLICKED || !eeprom_is_sheet_initialized(eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet))) ||
+    if(lcd_clicked() || !eeprom_is_sheet_initialized(eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet))) ||
             (!calibration_status_get(CALIBRATION_STATUS_LIVE_ADJUST)) ||
             (0 == static_cast<int16_t>(eeprom_read_word(reinterpret_cast<uint16_t*>
             (&EEPROM_Sheets_base->s[(eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet)))].z_offset)))))
@@ -3640,7 +3636,7 @@ void lcd_first_layer_calibration_reset()
         {
             eeprom_update_word(reinterpret_cast<uint16_t*>(&EEPROM_Sheets_base->s[(eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet)))].z_offset), 0xffff);
         }
-        menu_goto(lcd_v2_calibration,0,true,true);
+        menu_goto(lcd_v2_calibration, 0, true, true);
     }
 
     if (lcd_encoder > 0)
@@ -3966,7 +3962,7 @@ void lcd_wizard(WizState state)
 			}
 			break;
 		case S::Preheat:
-		    menu_goto(lcd_preheat_menu,0,false,true);
+			menu_goto(lcd_preheat_menu, 0, true);
 		    lcd_show_fullscreen_message_and_wait_P(_i("Select nozzle preheat temperature which matches your material."));////MSG_SEL_PREHEAT_TEMP c=20 r=6
 		    end = true; // Leave wizard temporarily for lcd_preheat_menu
 		    break;
@@ -3981,7 +3977,7 @@ void lcd_wizard(WizState state)
             break;
 		case S::Lay1CalCold:
             wizard_lay1cal_message(true);
-			menu_goto(lcd_v2_calibration,0,false,true);
+			menu_goto(lcd_v2_calibration, 0, true);
 			end = true; // Leave wizard temporarily for lcd_v2_calibration
 			break;
         case S::Lay1CalHot:
@@ -4821,36 +4817,36 @@ char reset_menu() {
 		delay_keep_alive(0);
 
 		if (lcd_encoder) {
-            if (lcd_encoder > 0) {
-                cursor_pos--;
-            }
+			if (lcd_encoder > 0) {
+				cursor_pos--;
+			}
 
-            if (lcd_encoder < 0) {
-                cursor_pos++;
-            }
+			if (lcd_encoder < 0) {
+				cursor_pos++;
+			}
 
-            if (cursor_pos > 3) {
-                cursor_pos = 3;
-                Sound_MakeSound(e_SOUND_TYPE_BlindAlert);
-                if (first < (uint8_t)(sizeof(item) / sizeof(item[0])) - 4) {
-                    first++;
-                    lcd_clear();
-                }
-            }
+			if (cursor_pos > 3) {
+				cursor_pos = 3;
+				Sound_MakeSound(e_SOUND_TYPE_BlindAlert);
+				if (first < (uint8_t)(sizeof(item) / sizeof(item[0])) - 4) {
+					first++;
+					lcd_clear();
+				}
+			}
 
-            if (cursor_pos < 0) {
-                cursor_pos = 0;
-                Sound_MakeSound(e_SOUND_TYPE_BlindAlert);
-                if (first > 0) {
-                    first--;
-                    lcd_clear();
-                }
-            }
-            lcd_puts_at_P(0, 0, PSTR(" \n \n \n "));
-            lcd_set_cursor(0, cursor_pos);
-            lcd_putc('>');
-            lcd_encoder = 0;
-            _delay(100);
+			if (cursor_pos < 0) {
+				cursor_pos = 0;
+				Sound_MakeSound(e_SOUND_TYPE_BlindAlert);
+				if (first > 0) {
+					first--;
+					lcd_clear();
+				}
+			}
+			lcd_puts_at_P(0, 0, PSTR(" \n \n \n "));
+			lcd_set_cursor(0, cursor_pos);
+			lcd_putc('>');
+			lcd_encoder = 0;
+			_delay(100);
 		}
 
 		if (lcd_clicked()) {
@@ -5460,7 +5456,7 @@ static void lcd_advance_edit_K(void)
         lcd_set_cursor(0, 1);
         lcd_advance_draw_K(' ', 0.01 * lcd_encoder);
     }
-    if (LCD_CLICKED)
+    if (lcd_clicked())
     {
         extruder_advance_K = 0.01 * lcd_encoder;
         menu_back_no_reset();
@@ -5839,7 +5835,7 @@ void lcd_sdcard_menu()
 				_md->lcd_scrollTimer.start();
 				lcd_draw_update = 1; //forces last load before switching to scrolling.
 			}
-			if (lcd_draw_update == 0 && !LCD_CLICKED)
+			if (lcd_draw_update == 0 && !lcd_clicked())
 				return; // nothing to do (so don't thrash the SD card)
 			
 			_md->row = -1; // assume that no SD file/dir is currently selected. Once they are rendered, it will be changed to the correct row for the _scrolling state.
@@ -5890,7 +5886,7 @@ void lcd_sdcard_menu()
 		} break;
 		case _scrolling: //scrolling filename
 		{
-			const bool rewindFlag = LCD_CLICKED || lcd_draw_update; //flag that says whether the menu should return to _standard state.
+			const bool rewindFlag = lcd_clicked() || lcd_draw_update; //flag that says whether the menu should return to _standard state.
 			
 			if (_md->scrollPointer == NULL)
 			{
@@ -5903,7 +5899,7 @@ void lcd_sdcard_menu()
 				_md->scrollPointer = (card.longFilename[0] == '\0') ? card.filename : card.longFilename;
 			}
 			
-			if (rewindFlag == 1)
+			if (rewindFlag)
 				_md->offset = 0; //redraw once again from the beginning.
 			if (_md->lcd_scrollTimer.expired(300) || rewindFlag)
 			{
@@ -6930,7 +6926,6 @@ static bool lcd_selftest_manual_fan_check(int _fan, bool check_opposite,
 
 	KEEPALIVE_STATE(PAUSED_FOR_USER);
 
-	lcd_button_pressed = false;
 	do
 	{
 		if (lcd_encoder) {
@@ -6949,7 +6944,7 @@ static bool lcd_selftest_manual_fan_check(int _fan, bool check_opposite,
 				lcd_putc_at(0, 3, '>');
 				lcd_puts_at_P(1, 3, _T(MSG_SELFTEST_FAN_NO));
 			}
-            lcd_encoder = 0;
+			lcd_encoder = 0;
 		}
 
 
@@ -7365,13 +7360,13 @@ void menu_lcd_longpress_func(void)
     if (homing_flag || mesh_bed_leveling_flag || menu_menu == lcd_babystep_z || menu_menu == lcd_move_z || menu_block_mask != MENU_BLOCK_NONE || Stopped)
     {
         // disable longpress during re-entry, while homing, calibration or if a serious error
-        lcd_quick_feedback();
+        lcd_draw_update = 2;
         return;
     }
     if (menu_menu == lcd_hw_setup_menu)
     {
         // only toggle the experimental menu visibility flag
-        lcd_quick_feedback();
+        lcd_draw_update = 2;
         eeprom_toggle((uint8_t *)EEPROM_EXPERIMENTAL_VISIBILITY);
         return;
     }
@@ -7457,7 +7452,7 @@ void menu_lcd_lcdupdate_func(void)
 			}
 			LCD_MESSAGERPGM(MSG_WELCOME);
 			bMain=false;                       // flag (i.e. 'fake parameter') for 'lcd_sdcard_menu()' function
-			menu_submenu(lcd_sdcard_menu);
+			menu_submenu(lcd_sdcard_menu, true);
 			lcd_timeoutToStatus.start();
 		}
 		else
@@ -7469,14 +7464,7 @@ void menu_lcd_lcdupdate_func(void)
 #endif//CARDINSERTED
 	if (lcd_next_update_millis < _millis())
 	{
-		if (lcd_encoder)
-		{
-			if (lcd_draw_update == 0) lcd_draw_update = 1;
-			lcd_timeoutToStatus.start();
-		}
-
-		if (LCD_CLICKED)
-		{
+		if (lcd_draw_update) {
 			lcd_timeoutToStatus.start();
 		}
 

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2235,8 +2235,7 @@ uint8_t lcd_alright() {
     lcd_consume_click();
     while (1)
     {
-        manage_heater();
-        manage_inactivity(true);
+        delay_keep_alive(0);
 
         if (abs(enc_dif - lcd_encoder_diff) >= ENCODER_PULSES_PER_STEP)
         {
@@ -2262,13 +2261,11 @@ uint8_t lcd_alright() {
 
             // Consume rotation event and make feedback sound
             enc_dif = lcd_encoder_diff;
-            Sound_MakeSound(e_SOUND_TYPE_EncoderMove);
             _delay(100);
         }
 
         if (lcd_clicked())
         {
-            Sound_MakeSound(e_SOUND_TYPE_ButtonEcho);
             lcd_clear();
             lcd_return_to_status();
             return cursor_pos;
@@ -3137,14 +3134,12 @@ uint8_t lcd_show_multiscreen_message_with_choices_and_wait_P(
                     }
                     lcd_show_choices_prompt_P(current_selection, first_choice, second_choice, second_col, third_choice);
                     enc_dif = lcd_encoder_diff;
-                    Sound_MakeSound(e_SOUND_TYPE_EncoderMove);
                 } else {
                     Sound_MakeSound(e_SOUND_TYPE_BlindAlert);
                     break; // turning knob skips waiting loop
                 }
             }
             if (lcd_clicked()) {
-                Sound_MakeSound(e_SOUND_TYPE_ButtonEcho);
                 if (msg_next == NULL) {
                     goto exit;
                 } else
@@ -4741,8 +4736,7 @@ uint8_t choose_menu_P(const char *header, const char *item, const char *last_ite
 	KEEPALIVE_STATE(PAUSED_FOR_USER);
 	while (1)
 	{
-		manage_heater();
-		manage_inactivity(true);
+		delay_keep_alive(0);
 
 		if (abs((enc_dif - lcd_encoder_diff)) > 4)
 		{
@@ -4756,7 +4750,6 @@ uint8_t choose_menu_P(const char *header, const char *item, const char *last_ite
                 cursor_pos++;
             }
             enc_dif = lcd_encoder_diff;
-			Sound_MakeSound(e_SOUND_TYPE_EncoderMove);
 		}
 
 		if (cursor_pos > 3)
@@ -4807,7 +4800,6 @@ uint8_t choose_menu_P(const char *header, const char *item, const char *last_ite
 
 		if (lcd_clicked())
 		{
-			Sound_MakeSound(e_SOUND_TYPE_ButtonEcho);
 		    KEEPALIVE_STATE(IN_HANDLER);
 			lcd_encoder_diff = 0;
 			return(cursor_pos + first - 1);
@@ -4839,8 +4831,7 @@ char reset_menu() {
 			lcd_puts_at_P(1, i, item[first + i]);
 		}
 
-		manage_heater();
-		manage_inactivity(true);
+		delay_keep_alive(0);
 
 		if (abs((enc_dif - lcd_encoder_diff)) > 4) {
 
@@ -4873,7 +4864,6 @@ char reset_menu() {
 				lcd_puts_at_P(0, 0, PSTR(" \n \n \n "));
 				lcd_set_cursor(0, cursor_pos);
 				lcd_putc('>');
-				Sound_MakeSound(e_SOUND_TYPE_EncoderMove);
 				enc_dif = lcd_encoder_diff;
 				_delay(100);
 			}
@@ -4881,7 +4871,6 @@ char reset_menu() {
 		}
 
 		if (lcd_clicked()) {
-			Sound_MakeSound(e_SOUND_TYPE_ButtonEcho);
 			return(cursor_pos + first);
 		}
 
@@ -7504,7 +7493,6 @@ void menu_lcd_lcdupdate_func(void)
 			if (lcd_draw_update == 0)
 			lcd_draw_update = 1;
 			lcd_encoder += lcd_encoder_diff / ENCODER_PULSES_PER_STEP;
-			Sound_MakeSound(e_SOUND_TYPE_EncoderMove);
 			lcd_encoder_diff = 0;
 			lcd_timeoutToStatus.start();
 		}

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2219,7 +2219,6 @@ void lcd_loading_filament() {
 
 
 uint8_t lcd_alright() {
-    int8_t enc_dif = 0;
     uint8_t cursor_pos = 1;
 
     lcd_clear();
@@ -2229,20 +2228,18 @@ uint8_t lcd_alright() {
     lcd_puts_at_P(1, 3, _i("Color not correct"));////MSG_NOT_COLOR c=19
     lcd_putc_at(0, 1, '>');
 
-
-    enc_dif = lcd_encoder_diff;
     lcd_consume_click();
     while (1)
     {
         delay_keep_alive(0);
 
-        if (abs(enc_dif - lcd_encoder_diff) >= ENCODER_PULSES_PER_STEP)
+        if (lcd_encoder)
         {
 
-            if (enc_dif > lcd_encoder_diff ) {
+            if (lcd_encoder > 0 ) {
                 // Rotating knob counter clockwise
                 cursor_pos--;
-            } else if (enc_dif < lcd_encoder_diff) {
+            } else if (lcd_encoder < 0) {
                 // Rotating knob clockwise
                 cursor_pos++;
             }
@@ -2259,7 +2256,7 @@ uint8_t lcd_alright() {
             lcd_putc_at(0, cursor_pos, '>');
 
             // Consume rotation event and make feedback sound
-            enc_dif = lcd_encoder_diff;
+            lcd_encoder = 0;
             _delay(100);
         }
 
@@ -2833,15 +2830,12 @@ bool lcd_calibrate_z_end_stop_manual(bool only_z)
         const bool    multi_screen        = msg_next != NULL;
         unsigned long previous_millis_msg = _millis();
         // Until the user finishes the z up movement.
-        lcd_encoder_diff = 0;
         lcd_encoder = 0;
         for (;;) {
             manage_heater();
             manage_inactivity(true);
-            if (abs(lcd_encoder_diff) >= ENCODER_PULSES_PER_STEP) {
+            if (lcd_encoder) {
                 _delay(50);
-                lcd_encoder += abs(lcd_encoder_diff / ENCODER_PULSES_PER_STEP);
-                lcd_encoder_diff = 0;
                 if (! planner_queue_full()) {
                     // Only move up, whatever direction the user rotates the encoder.
                     current_position[Z_AXIS] += fabs(lcd_encoder);
@@ -3102,7 +3096,6 @@ uint8_t lcd_show_multiscreen_message_with_choices_and_wait_P(
     }
     // Wait for user confirmation or a timeout.
     unsigned long previous_millis_cmd = _millis();
-    int8_t enc_dif = lcd_encoder_diff;
     lcd_consume_click();
     KEEPALIVE_STATE(PAUSED_FOR_USER);
     for (;;) {
@@ -3112,27 +3105,27 @@ uint8_t lcd_show_multiscreen_message_with_choices_and_wait_P(
                 current_selection = LCD_BUTTON_TIMEOUT;
                 goto exit;
             }
-            if (abs(enc_dif - lcd_encoder_diff) >= ENCODER_PULSES_PER_STEP) {
+            if (lcd_encoder) {
                 if (msg_next == NULL) {
                     if (third_choice) { // third_choice is not nullptr, safe to dereference
-                        if (enc_dif > lcd_encoder_diff && current_selection != LCD_LEFT_BUTTON_CHOICE) {
+                        if (lcd_encoder > 0 && current_selection != LCD_LEFT_BUTTON_CHOICE) {
                             // Rotating knob counter clockwise
                             current_selection--;
-                        } else if (enc_dif < lcd_encoder_diff && current_selection != LCD_RIGHT_BUTTON_CHOICE) {
+                        } else if (lcd_encoder < 0 && current_selection != LCD_RIGHT_BUTTON_CHOICE) {
                             // Rotating knob clockwise
                             current_selection++;
                         }
                     } else {
-                        if (enc_dif > lcd_encoder_diff && current_selection != LCD_LEFT_BUTTON_CHOICE) {
+                        if (lcd_encoder > 0 && current_selection != LCD_LEFT_BUTTON_CHOICE) {
                             // Rotating knob counter clockwise
                             current_selection = LCD_LEFT_BUTTON_CHOICE;
-                        } else if (enc_dif < lcd_encoder_diff && current_selection != LCD_MIDDLE_BUTTON_CHOICE) {
+                        } else if (lcd_encoder < 0 && current_selection != LCD_MIDDLE_BUTTON_CHOICE) {
                             // Rotating knob clockwise
                             current_selection = LCD_MIDDLE_BUTTON_CHOICE;
                         }
                     }
                     lcd_show_choices_prompt_P(current_selection, first_choice, second_choice, second_col, third_choice);
-                    enc_dif = lcd_encoder_diff;
+                    lcd_encoder = 0;
                 } else {
                     Sound_MakeSound(e_SOUND_TYPE_BlindAlert);
                     break; // turning knob skips waiting loop
@@ -3479,7 +3472,6 @@ static void lcd_silent_mode_set() {
 #ifdef TMC2130
   if (lcd_crash_detect_enabled() && (SilentModeMenu != SILENT_MODE_NORMAL))
 	  menu_submenu(lcd_crash_mode_info2);
-  lcd_encoder_diff=0;                             // reset 'encoder buffer'
 #endif //TMC2130
 }
 
@@ -4727,7 +4719,6 @@ uint8_t choose_menu_P(const char *header, const char *item, const char *last_ite
     const int8_t items_no = last_item?(MMU2::mmu2.Enabled()?6:5):(MMU2::mmu2.Enabled()?5:4);
     const uint8_t item_len = item?strlen_P(item):0;
 	int8_t first = 0;
-	int8_t enc_dif = lcd_encoder_diff;
 	int8_t cursor_pos = 1;
 	
 	lcd_clear();
@@ -4737,18 +4728,18 @@ uint8_t choose_menu_P(const char *header, const char *item, const char *last_ite
 	{
 		delay_keep_alive(0);
 
-		if (abs((enc_dif - lcd_encoder_diff)) > 4)
+		if (lcd_encoder)
 		{
-            if (enc_dif > lcd_encoder_diff)
+            if (lcd_encoder > 0)
             {
                 cursor_pos--;
             }
 
-            if (enc_dif < lcd_encoder_diff)
+            if (lcd_encoder < 0)
             {
                 cursor_pos++;
             }
-            enc_dif = lcd_encoder_diff;
+            lcd_encoder = 0;
 		}
 
 		if (cursor_pos > 3)
@@ -4800,7 +4791,6 @@ uint8_t choose_menu_P(const char *header, const char *item, const char *last_ite
 		if (lcd_clicked())
 		{
 		    KEEPALIVE_STATE(IN_HANDLER);
-			lcd_encoder_diff = 0;
 			return(cursor_pos + first - 1);
 		}
 	}
@@ -4808,7 +4798,6 @@ uint8_t choose_menu_P(const char *header, const char *item, const char *last_ite
 
 char reset_menu() {
 	static int8_t first = 0;
-	int8_t enc_dif = 0;
 	char cursor_pos = 0;
 
 	const char *const item[] = {
@@ -4818,8 +4807,7 @@ char reset_menu() {
 		PSTR("Service prep"),
 		PSTR("All Data"),
 	};
-	
-	enc_dif = lcd_encoder_diff;
+
 	lcd_clear();
 	lcd_set_cursor(0, 0);
 	lcd_putc('>');
@@ -4832,41 +4820,37 @@ char reset_menu() {
 
 		delay_keep_alive(0);
 
-		if (abs((enc_dif - lcd_encoder_diff)) > 4) {
+		if (lcd_encoder) {
+            if (lcd_encoder > 0) {
+                cursor_pos--;
+            }
 
-			if ((abs(enc_dif - lcd_encoder_diff)) > 1) {
-				if (enc_dif > lcd_encoder_diff) {
-					cursor_pos--;
-				}
+            if (lcd_encoder < 0) {
+                cursor_pos++;
+            }
 
-				if (enc_dif < lcd_encoder_diff) {
-					cursor_pos++;
-				}
+            if (cursor_pos > 3) {
+                cursor_pos = 3;
+                Sound_MakeSound(e_SOUND_TYPE_BlindAlert);
+                if (first < (uint8_t)(sizeof(item) / sizeof(item[0])) - 4) {
+                    first++;
+                    lcd_clear();
+                }
+            }
 
-				if (cursor_pos > 3) {
-					cursor_pos = 3;
-					Sound_MakeSound(e_SOUND_TYPE_BlindAlert);
-					if (first < (uint8_t)(sizeof(item) / sizeof(item[0])) - 4) {
-						first++;
-						lcd_clear();
-					}
-				}
-
-				if (cursor_pos < 0) {
-					cursor_pos = 0;
-					Sound_MakeSound(e_SOUND_TYPE_BlindAlert);
-					if (first > 0) {
-						first--;
-						lcd_clear();
-					}
-				}
-				lcd_puts_at_P(0, 0, PSTR(" \n \n \n "));
-				lcd_set_cursor(0, cursor_pos);
-				lcd_putc('>');
-				enc_dif = lcd_encoder_diff;
-				_delay(100);
-			}
-
+            if (cursor_pos < 0) {
+                cursor_pos = 0;
+                Sound_MakeSound(e_SOUND_TYPE_BlindAlert);
+                if (first > 0) {
+                    first--;
+                    lcd_clear();
+                }
+            }
+            lcd_puts_at_P(0, 0, PSTR(" \n \n \n "));
+            lcd_set_cursor(0, cursor_pos);
+            lcd_putc('>');
+            lcd_encoder = 0;
+            _delay(100);
 		}
 
 		if (lcd_clicked()) {
@@ -6942,15 +6926,15 @@ static bool lcd_selftest_manual_fan_check(int _fan, bool check_opposite,
 	lcd_putc_at(0, 3, '>');
 	lcd_puts_at_P(1, 3, _T(MSG_SELFTEST_FAN_NO));
 
-	int8_t enc_dif = int(_default)*3;
+	lcd_encoder = _default;
 
 	KEEPALIVE_STATE(PAUSED_FOR_USER);
 
 	lcd_button_pressed = false;
 	do
 	{
-		if (abs((enc_dif - lcd_encoder_diff)) > 2) {
-			if (enc_dif > lcd_encoder_diff) {
+		if (lcd_encoder) {
+			if (lcd_encoder > 0) {
 				_result = !check_opposite;
 				lcd_putc_at(0, 2, '>');
 				lcd_puts_at_P(1, 2, _T(MSG_SELFTEST_FAN_YES));
@@ -6958,15 +6942,14 @@ static bool lcd_selftest_manual_fan_check(int _fan, bool check_opposite,
 				lcd_puts_at_P(1, 3, _T(MSG_SELFTEST_FAN_NO));
 			}
 
-			if (enc_dif < lcd_encoder_diff) {
+			if (lcd_encoder < 0) {
 				_result = check_opposite;
 				lcd_putc_at(0, 2, ' ');
 				lcd_puts_at_P(1, 2, _T(MSG_SELFTEST_FAN_YES));
 				lcd_putc_at(0, 3, '>');
 				lcd_puts_at_P(1, 3, _T(MSG_SELFTEST_FAN_NO));
 			}
-			enc_dif = 0;
-			lcd_encoder_diff = 0;
+            lcd_encoder = 0;
 		}
 
 
@@ -7272,7 +7255,6 @@ void ultralcd_init()
   _delay_ms(1); //wait for the pullups to raise the line
   lcd_oldcardstatus = IS_SD_INSERTED;
 #endif//(SDCARDDETECT > 0)
-  lcd_encoder_diff = 0;
 
   // Initialise status line
   strncpy_P(lcd_status_message, MSG_WELCOME, LCD_WIDTH);
@@ -7487,12 +7469,9 @@ void menu_lcd_lcdupdate_func(void)
 #endif//CARDINSERTED
 	if (lcd_next_update_millis < _millis())
 	{
-		if (abs(lcd_encoder_diff) >= ENCODER_PULSES_PER_STEP)
+		if (lcd_encoder)
 		{
-			if (lcd_draw_update == 0)
-			lcd_draw_update = 1;
-			lcd_encoder += lcd_encoder_diff / ENCODER_PULSES_PER_STEP;
-			lcd_encoder_diff = 0;
+			if (lcd_draw_update == 0) lcd_draw_update = 1;
 			lcd_timeoutToStatus.start();
 		}
 


### PR DESCRIPTION
This should do everything I wanted to do with https://github.com/prusa3d/Prusa-Firmware/pull/3473 but ALSO does it for LCD screens which have the LCD update disabled :) It's a win-win.

This commit adds the ability for firmware to make sounds when the knob is clicked or rotated when LCD updates are disabled. The improvement here is the sound is being made with one line of code regardless whether or not LCD updates are enabled or disabled. Should make things more consistent.

Some long standing issues fixed:

* Fixed an issue where menu items don't consume knob click events consistently.
* Fixed an issue when clicking on a menu item, the buzzer can produce two or more beeps. We can now better control whether a submenu should create a feedback sound. We don't want to do this when clicking the knob, otherwise there are two beeps.
* Using `lcd_buttons` to check for a knob click was very unreliable since it is cleared on the next Temperature ISR service. Now fixed.

Change in memory:
Flash: -196 bytes
SRAM: -9 bytes