### PR TITLE
Optimisation: change `lcd_encoder` from `int32_t` to  `int16_t`

### DIFF
--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -633,8 +633,7 @@ void lcd_printNumber(unsigned long n, uint8_t base)
 
 uint8_t lcd_draw_update = 2;
 int16_t lcd_encoder = 0;
-uint8_t lcd_encoder_bits = 0;
-int8_t lcd_encoder_diff = 0;
+static int8_t lcd_encoder_diff = 0;
 
 uint8_t lcd_buttons = 0;
 uint8_t lcd_update_enabled = 1;

--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -632,9 +632,9 @@ void lcd_printNumber(unsigned long n, uint8_t base)
 }
 
 uint8_t lcd_draw_update = 2;
-int32_t lcd_encoder = 0;
-
-static int8_t lcd_encoder_diff = 0;
+int16_t lcd_encoder = 0;
+uint8_t lcd_encoder_bits = 0;
+int8_t lcd_encoder_diff = 0;
 
 uint8_t lcd_buttons = 0;
 uint8_t lcd_update_enabled = 1;

--- a/Firmware/lcd.h
+++ b/Firmware/lcd.h
@@ -98,7 +98,7 @@ typedef void (*lcd_lcdupdate_func_t)(void);
 //Set to none-zero when the LCD needs to draw, decreased after every draw. Set to 2 in LCD routines so the LCD gets at least 1 full redraw (first redraw is partial)
 extern uint8_t lcd_draw_update;
 
-extern int32_t lcd_encoder;
+extern int16_t lcd_encoder;
 
 //the last checked lcd_buttons in a bit array.
 extern uint8_t lcd_buttons;

--- a/Firmware/menu.cpp
+++ b/Firmware/menu.cpp
@@ -470,14 +470,14 @@ static void _menu_edit_P(void)
 	menu_data_edit_t* _md = (menu_data_edit_t*)&(menu_data[0]);
 	if (lcd_draw_update)
 	{
-		if (lcd_encoder < _md->minEditValue) lcd_encoder = _md->minEditValue;
-		else if (lcd_encoder > _md->maxEditValue) lcd_encoder = _md->maxEditValue;
+		// Constrain the value in case it's outside the allowed limits
+		_md->currentValue = constrain(_md->currentValue, _md->minEditValue, _md->maxEditValue);
 		lcd_set_cursor(0, 1);
-		menu_draw_P(' ', _md->editLabel, lcd_encoder);
+		menu_draw_P(' ', _md->editLabel, _md->currentValue);
 	}
 	if (lcd_clicked())
 	{
-		*((T)(_md->editValue)) = lcd_encoder;
+		*((T)(_md->editValue)) = _md->currentValue;
 		menu_back_no_reset();
 	}
 }

--- a/Firmware/menu.cpp
+++ b/Firmware/menu.cpp
@@ -64,7 +64,6 @@ void menu_goto(menu_func_t menu, const int16_t encoder, const bool feedback, boo
 
 void menu_start(void)
 {
-    if (lcd_encoder > INT8_MAX) lcd_encoder = 0;
     if (lcd_encoder < 0)
     {
         lcd_encoder = 0;

--- a/Firmware/menu.cpp
+++ b/Firmware/menu.cpp
@@ -45,7 +45,7 @@ void menu_data_reset(void)
 	memset(&menu_data, 0, sizeof(menu_data));
 }
 
-void menu_goto(menu_func_t menu, const uint32_t encoder, bool reset_menu_state, const bool feedback)
+void menu_goto(menu_func_t menu, const int16_t encoder, const bool feedback, bool reset_menu_state)
 {
 	CRITICAL_SECTION_START;
 	if (menu_menu != menu)

--- a/Firmware/menu.cpp
+++ b/Firmware/menu.cpp
@@ -45,7 +45,7 @@ void menu_data_reset(void)
 	memset(&menu_data, 0, sizeof(menu_data));
 }
 
-void menu_goto(menu_func_t menu, const int16_t encoder, const bool feedback, bool reset_menu_state)
+void menu_goto(menu_func_t menu, const int16_t encoder, bool reset_menu_state, const bool feedback)
 {
 	CRITICAL_SECTION_START;
 	if (menu_menu != menu)

--- a/Firmware/menu.cpp
+++ b/Firmware/menu.cpp
@@ -64,7 +64,7 @@ void menu_goto(menu_func_t menu, const uint32_t encoder, bool reset_menu_state, 
 
 void menu_start(void)
 {
-    if (lcd_encoder > 0x8000) lcd_encoder = 0;
+    if (lcd_encoder > INT8_MAX) lcd_encoder = 0;
     if (lcd_encoder < 0)
     {
         lcd_encoder = 0;
@@ -473,7 +473,7 @@ static void _menu_edit_P(void)
 		if (lcd_encoder < _md->minEditValue) lcd_encoder = _md->minEditValue;
 		else if (lcd_encoder > _md->maxEditValue) lcd_encoder = _md->maxEditValue;
 		lcd_set_cursor(0, 1);
-		menu_draw_P(' ', _md->editLabel, (int)lcd_encoder);
+		menu_draw_P(' ', _md->editLabel, lcd_encoder);
 	}
 	if (lcd_clicked())
 	{

--- a/Firmware/menu.h
+++ b/Firmware/menu.h
@@ -21,6 +21,7 @@ typedef struct
     //Variables used when editing values.
     const char* editLabel;
     void* editValue;
+    int16_t currentValue;
     int16_t minEditValue;
     int16_t maxEditValue;
 } menu_data_edit_t;

--- a/Firmware/menu.h
+++ b/Firmware/menu.h
@@ -65,7 +65,7 @@ extern menu_func_t menu_menu;
 
 extern void menu_data_reset(void);
 
-extern void menu_goto(menu_func_t menu, const int16_t encoder, const bool feedback, bool reset_menu_state);
+extern void menu_goto(menu_func_t menu, const int16_t encoder, bool reset_menu_state, const bool feedback=false);
 
 #define MENU_BEGIN() menu_start(); for(menu_row = 0; menu_row < LCD_HEIGHT; menu_row++, menu_line++) { menu_item = 0;
 void menu_start(void);

--- a/Firmware/menu.h
+++ b/Firmware/menu.h
@@ -21,8 +21,8 @@ typedef struct
     //Variables used when editing values.
     const char* editLabel;
     void* editValue;
-    int32_t minEditValue;
-    int32_t maxEditValue;
+    int16_t minEditValue;
+    int16_t maxEditValue;
 } menu_data_edit_t;
 
 extern uint8_t menu_data[MENU_DATA_SIZE];

--- a/Firmware/menu.h
+++ b/Firmware/menu.h
@@ -65,7 +65,7 @@ extern menu_func_t menu_menu;
 
 extern void menu_data_reset(void);
 
-extern void menu_goto(menu_func_t menu, const uint32_t encoder, bool reset_menu_state, const bool feedback=false);
+extern void menu_goto(menu_func_t menu, const int16_t encoder, const bool feedback, bool reset_menu_state);
 
 #define MENU_BEGIN() menu_start(); for(menu_row = 0; menu_row < LCD_HEIGHT; menu_row++, menu_line++) { menu_item = 0;
 void menu_start(void);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -704,25 +704,25 @@ void lcd_status_screen()                          // NOT static due to using ins
 	static uint8_t lcd_status_update_delay = 0;
 #ifdef ULTIPANEL_FEEDMULTIPLY
 	// Dead zone at 100% feedrate
-	if ((feedmultiply < 100 && (feedmultiply + int(lcd_encoder)) > 100) ||
-		(feedmultiply > 100 && (feedmultiply + int(lcd_encoder)) < 100))
+	if ((feedmultiply < 100 && (feedmultiply + lcd_encoder) > 100) ||
+		(feedmultiply > 100 && (feedmultiply + lcd_encoder) < 100))
 	{
 		lcd_encoder = 0;
 		feedmultiply = 100;
 	}
-	if (feedmultiply == 100 && int(lcd_encoder) > ENCODER_FEEDRATE_DEADZONE)
+	if (feedmultiply == 100 && lcd_encoder > ENCODER_FEEDRATE_DEADZONE)
 	{
-		feedmultiply += int(lcd_encoder) - ENCODER_FEEDRATE_DEADZONE;
+		feedmultiply += lcd_encoder - ENCODER_FEEDRATE_DEADZONE;
 		lcd_encoder = 0;
 	}
-	else if (feedmultiply == 100 && int(lcd_encoder) < -ENCODER_FEEDRATE_DEADZONE)
+	else if (feedmultiply == 100 && lcd_encoder < -ENCODER_FEEDRATE_DEADZONE)
 	{
-		feedmultiply += int(lcd_encoder) + ENCODER_FEEDRATE_DEADZONE;
+		feedmultiply += lcd_encoder + ENCODER_FEEDRATE_DEADZONE;
 		lcd_encoder = 0;
 	}
 	else if (feedmultiply != 100)
 	{
-		feedmultiply += int(lcd_encoder);
+		feedmultiply += lcd_encoder;
 		lcd_encoder = 0;
 	}
 #endif //ULTIPANEL_FEEDMULTIPLY
@@ -2395,7 +2395,7 @@ static void _lcd_move(const char *name, uint8_t axis, int min, int max)
 		refresh_cmd_timeout();
 		if (! planner_queue_full())
 		{
-			current_position[axis] += float((int)lcd_encoder);
+			current_position[axis] += lcd_encoder;
 			if (min_software_endstops && current_position[axis] < min) current_position[axis] = min;
 			if (max_software_endstops && current_position[axis] > max) current_position[axis] = max;
 			lcd_encoder = 0;
@@ -2423,7 +2423,7 @@ void lcd_move_e()
 			refresh_cmd_timeout();
 			if (! planner_queue_full())
 			{
-				current_position[E_AXIS] += float((int)lcd_encoder);
+				current_position[E_AXIS] += lcd_encoder;
 				lcd_encoder = 0;
 				plan_buffer_line_curposXYZE(manual_feedrate[E_AXIS] / 60);
 				lcd_draw_update = 1;
@@ -2610,7 +2610,7 @@ static void lcd_babystep_z()
 
 	if (lcd_encoder != 0)
 	{
-		_md->babystepMemZ += (int)lcd_encoder;
+		_md->babystepMemZ += lcd_encoder;
 
         if (_md->babystepMemZ < Z_BABYSTEP_MIN) _md->babystepMemZ = Z_BABYSTEP_MIN; //-3999 -> -9.99 mm
         else if (_md->babystepMemZ > Z_BABYSTEP_MAX) _md->babystepMemZ = Z_BABYSTEP_MAX; //0
@@ -2724,7 +2724,7 @@ void pid_extruder()
 {
 	lcd_clear();
 	lcd_puts_at_P(0, 0, _i("Set temperature:"));////MSG_SET_TEMPERATURE c=20
-	pid_temp += int(lcd_encoder);
+	pid_temp += lcd_encoder;
 	if (pid_temp > HEATER_0_MAXTEMP) pid_temp = HEATER_0_MAXTEMP;
 	if (pid_temp < HEATER_0_MINTEMP) pid_temp = HEATER_0_MINTEMP;
 	lcd_encoder = 0;
@@ -2825,7 +2825,7 @@ bool lcd_calibrate_z_end_stop_manual(bool only_z)
                 _delay(50);
                 if (! planner_queue_full()) {
                     // Only move up, whatever direction the user rotates the encoder.
-                    current_position[Z_AXIS] += fabs(lcd_encoder);
+                    current_position[Z_AXIS] += lcd_encoder;
                     lcd_encoder = 0;
                     plan_buffer_line_curposXYZE(manual_feedrate[Z_AXIS] / 60);
                 }

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2825,7 +2825,7 @@ bool lcd_calibrate_z_end_stop_manual(bool only_z)
                 _delay(50);
                 if (! planner_queue_full()) {
                     // Only move up, whatever direction the user rotates the encoder.
-                    current_position[Z_AXIS] += lcd_encoder;
+                    current_position[Z_AXIS] += abs(lcd_encoder);
                     lcd_encoder = 0;
                     plan_buffer_line_curposXYZE(manual_feedrate[Z_AXIS] / 60);
                 }


### PR DESCRIPTION
The 2nd commit is from https://github.com/prusa3d/Prusa-Firmware/pull/3985

Allowing `lcd_encoder` to be `int32_t` is very inefficient in terms of program size. It should never exceed more than 127 (int8_t). This PR also removes `lcd_encoder` from the Menu Editing menu items.

Change in memory:
Flash: -912 bytes
SRAM: -2 bytes