### PR TITLE
buttons: Save 4 clock cycles in Temperature ISR

### DIFF
--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -818,8 +818,9 @@ void lcd_buttons_update(void)
 		if (abs(lcd_encoder_diff) >= ENCODER_PULSES_PER_STEP) {
 			lcd_backlight_wake_trigger = true; // flag event, knob rotated
 		}
+
+		lcd_encoder_bits = enc;
 	}
-	lcd_encoder_bits = enc;
 }
 
 

--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -782,34 +782,15 @@ void lcd_buttons_update(void)
 
 	lcd_buttons = newbutton;
 	//manage encoder rotation
+	#define ENCODER_SPIN(_E1, _E2) switch (lcd_encoder_bits) { case _E1: lcd_encoder_diff++; break; case _E2: lcd_encoder_diff--; }
+
 	if (newbutton != lcd_encoder_bits)
 	{
-		switch (newbutton)
-		{
-		case encrot0:
-			if (lcd_encoder_bits == encrot3)
-				lcd_encoder_diff++;
-			else if (lcd_encoder_bits == encrot1)
-				lcd_encoder_diff--;
-			break;
-		case encrot1:
-			if (lcd_encoder_bits == encrot0)
-				lcd_encoder_diff++;
-			else if (lcd_encoder_bits == encrot2)
-				lcd_encoder_diff--;
-			break;
-		case encrot2:
-			if (lcd_encoder_bits == encrot1)
-				lcd_encoder_diff++;
-			else if (lcd_encoder_bits == encrot3)
-				lcd_encoder_diff--;
-			break;
-		case encrot3:
-			if (lcd_encoder_bits == encrot2)
-				lcd_encoder_diff++;
-			else if (lcd_encoder_bits == encrot0)
-				lcd_encoder_diff--;
-			break;
+		switch (newbutton) {
+			case encrot0: ENCODER_SPIN(encrot3, encrot1); break;
+			case encrot1: ENCODER_SPIN(encrot0, encrot2); break;
+			case encrot2: ENCODER_SPIN(encrot1, encrot3); break;
+			case encrot3: ENCODER_SPIN(encrot2, encrot0); break;
 		}
 
 		if (abs(lcd_encoder_diff) >= ENCODER_PULSES_PER_STEP) {

--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -744,8 +744,8 @@ void lcd_buttons_update(void)
 {
     static uint8_t lcd_long_press_active = 0;
 	uint8_t newbutton = 0;
-	if (READ(BTN_EN1) == 0)  newbutton |= EN_A;
-	if (READ(BTN_EN2) == 0)  newbutton |= EN_B;
+	if (READ(BTN_EN1) == 0) newbutton |= EN_A;
+	if (READ(BTN_EN2) == 0) newbutton |= EN_B;
 
     if (READ(BTN_ENC) == 0)
     { //button is pressed
@@ -782,12 +782,9 @@ void lcd_buttons_update(void)
 
 	lcd_buttons = newbutton;
 	//manage encoder rotation
-	uint8_t enc = 0;
-	if (lcd_buttons & EN_A) enc |= B01;
-	if (lcd_buttons & EN_B) enc |= B10;
-	if (enc != lcd_encoder_bits)
+	if (newbutton != lcd_encoder_bits)
 	{
-		switch (enc)
+		switch (newbutton)
 		{
 		case encrot0:
 			if (lcd_encoder_bits == encrot3)
@@ -819,7 +816,7 @@ void lcd_buttons_update(void)
 			lcd_backlight_wake_trigger = true; // flag event, knob rotated
 		}
 
-		lcd_encoder_bits = enc;
+		lcd_encoder_bits = newbutton;
 	}
 }
 


### PR DESCRIPTION
* Use `newbutton` for encoder bits. No need to parse `EN_A` and `EN_B` bits twice.
* Don't set `lcd_encoder_bits` unless `newbutton` has changed.
* Add `ENCODER_SPIN()` to make the code a bit more readable. I spotted this in Marlin https://github.com/MarlinFirmware/Marlin/blob/d3527f5de42f087bfe313aa475b0bf5d07559fed/Marlin/src/lcd/marlinui.cpp#L1394 and think it is a good idea 👍 

Change in memory:
Flash: -8 bytes
SRAM: 0 bytes