### PR TITLE
Introduce MMU EEPROM reset feature

### DIFF
--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -91,6 +91,9 @@ void MMU2::Reset(ResetForm level) {
     case CutThePower:
         PowerCycle();
         break;
+    case EraseEEPROM:
+        ResetX42();
+        break;
     default:
         break;
     }
@@ -98,6 +101,10 @@ void MMU2::Reset(ResetForm level) {
 
 void MMU2::ResetX0() {
     logic.ResetMMU(); // Send soft reset
+}
+
+void MMU2::ResetX42(){
+    logic.ResetMMU(42);
 }
 
 void MMU2::TriggerResetPin() {

--- a/Firmware/mmu2.h
+++ b/Firmware/mmu2.h
@@ -50,7 +50,8 @@ public:
     enum ResetForm : uint8_t {
         Software = 0,   ///< sends a X0 command into the MMU, the MMU will watchdog-reset itself
         ResetPin = 1,   ///< trigger the reset pin of the MMU
-        CutThePower = 2 ///< power off and power on (that includes +5V and +24V power lines)
+        CutThePower = 2, ///< power off and power on (that includes +5V and +24V power lines)
+        EraseEEPROM = 42, ///< erase MMU EEPROM and then perform a software reset
     };
 
     /// Saved print state on error.
@@ -195,6 +196,9 @@ public:
 private:
     /// Perform software self-reset of the MMU (sends an X0 command)
     void ResetX0();
+
+    /// Perform software self-reset of the MMU + erase its EEPROM (sends X2a command)
+    void ResetX42();
 
     /// Trigger reset pin of the MMU
     void TriggerResetPin();

--- a/Firmware/mmu2/errors_list.h
+++ b/Firmware/mmu2/errors_list.h
@@ -259,7 +259,7 @@ static const char MSG_DESC_UNLOAD_MANUALLY[] PROGMEM_I1 = ISTR("Filament detecte
 static const char MSG_DESC_FILAMENT_EJECTED[] PROGMEM_I1 = ISTR("Remove the ejected filament from the front of the MMU unit."); ////MSG_DESC_FILAMENT_EJECTED c=20 r=8
 
 // Read explanation in mmu2_protocol_logic.cpp -> supportedMmuFWVersion
-static constexpr char MSG_DESC_FW_UPDATE_NEEDED[] PROGMEM_I1 = ISTR("The MMU unit firmware version incompatible with the printer's FW. Update to version 2.1.6."); ////MSG_DESC_FW_UPDATE_NEEDED c=20 r=9
+static constexpr char MSG_DESC_FW_UPDATE_NEEDED[] PROGMEM_I1 = ISTR("The MMU unit firmware version incompatible with the printer's FW. Update to version 2.1.7."); ////MSG_DESC_FW_UPDATE_NEEDED c=20 r=9
 static constexpr uint8_t szFWUN = sizeof(MSG_DESC_FW_UPDATE_NEEDED);
 // at least check the individual version characters in MSG_DESC_FW_UPDATE_NEEDED
 static_assert(MSG_DESC_FW_UPDATE_NEEDED[szFWUN - 7] == ('0' + mmuVersionMajor));

--- a/Firmware/mmu2_protocol_logic.cpp
+++ b/Firmware/mmu2_protocol_logic.cpp
@@ -579,8 +579,8 @@ void ProtocolLogic::CutFilament(uint8_t slot) {
     PlanGenericRequest(RequestMsg(RequestMsgCodes::Cut, slot));
 }
 
-void ProtocolLogic::ResetMMU() {
-    PlanGenericRequest(RequestMsg(RequestMsgCodes::Reset, 0));
+void ProtocolLogic::ResetMMU(uint8_t mode /* = 0 */) {
+    PlanGenericRequest(RequestMsg(RequestMsgCodes::Reset, mode));
 }
 
 void ProtocolLogic::Button(uint8_t index) {

--- a/Firmware/mmu2_protocol_logic.h
+++ b/Firmware/mmu2_protocol_logic.h
@@ -105,7 +105,7 @@ public:
     void LoadFilament(uint8_t slot);
     void EjectFilament(uint8_t slot);
     void CutFilament(uint8_t slot);
-    void ResetMMU();
+    void ResetMMU(uint8_t mode = 0);
     void Button(uint8_t index);
     void Home(uint8_t mode);
     void ReadRegister(uint8_t address);

--- a/Firmware/mmu2_supported_version.h
+++ b/Firmware/mmu2_supported_version.h
@@ -5,6 +5,6 @@ namespace MMU2 {
 
 static constexpr uint8_t mmuVersionMajor = 2;
 static constexpr uint8_t mmuVersionMinor = 1;
-static constexpr uint8_t mmuVersionPatch = 6;
+static constexpr uint8_t mmuVersionPatch = 7;
 
 } // namespace MMU2


### PR DESCRIPTION
This new feature requires MMU FW v 2.1.7 (which brings some more small changes). It is not being used yet in the MK3S FW, but we may decide to add it as an option into some menu.

MMU-193