### PR TITLE
M200: Don't process T parameter, active extruder should always be selected

### DIFF
--- a/Firmware/ConfigurationStore.cpp
+++ b/Firmware/ConfigurationStore.cpp
@@ -86,17 +86,9 @@ void Config_PrintSettings(uint8_t level)
   if (cs.volumetric_enabled) {
     printf_P(PSTR("%SFilament settings:\n%S   M200 D%.2f\n"),
       echomagic, echomagic, cs.filament_size[0]);
-#if EXTRUDERS > 1
-    printf_P(PSTR("%S   M200 T1 D%.2f\n"),
-      echomagic, echomagic, cs.filament_size[1]);
-#if EXTRUDERS > 2
-    printf_P(PSTR("%S   M200 T1 D%.2f\n"),
-      echomagic, echomagic, cs.filament_size[2]);
-#endif
-#endif
-    } else {
-        printf_P(PSTR("%SFilament settings: Disabled\n"), echomagic);
-    }
+  } else {
+    printf_P(PSTR("%SFilament settings: Disabled\n"), echomagic);
+  }
 #endif
   if (level >= 10) {
 #ifdef LIN_ADVANCE

--- a/Firmware/ConfigurationStore.cpp
+++ b/Firmware/ConfigurationStore.cpp
@@ -85,7 +85,7 @@ void Config_PrintSettings(uint8_t level)
 #endif
   if (cs.volumetric_enabled) {
     printf_P(PSTR("%SFilament settings:\n%S   M200 D%.2f\n"),
-      echomagic, echomagic, cs.filament_size[0]);
+      echomagic, echomagic, cs.filament_size);
   } else {
     printf_P(PSTR("%SFilament settings: Disabled\n"), echomagic);
   }
@@ -151,14 +151,7 @@ static const M500_conf default_conf PROGMEM =
     RETRACT_RECOVER_LENGTH,
     RETRACT_RECOVER_FEEDRATE,
     false,
-    {DEFAULT_NOMINAL_FILAMENT_DIA,
-#if EXTRUDERS > 1
     DEFAULT_NOMINAL_FILAMENT_DIA,
-#if EXTRUDERS > 2
-    DEFAULT_NOMINAL_FILAMENT_DIA,
-#endif
-#endif
-    },
     DEFAULT_MAX_FEEDRATE_SILENT,
     DEFAULT_MAX_ACCELERATION_SILENT,
 #ifdef TMC2130

--- a/Firmware/ConfigurationStore.h
+++ b/Firmware/ConfigurationStore.h
@@ -34,7 +34,7 @@ typedef struct
     float retract_recover_length;
     float retract_recover_feedrate;
     bool volumetric_enabled;
-    float filament_size[1]; //!< cross-sectional area of filament (in millimeters), typically around 1.75 or 2.85, 0 disables the volumetric calculations for the extruder.
+    float filament_size; //!< cross-sectional area of filament (in millimeters), typically around 1.75 or 2.85, 0 disables the volumetric calculations for the extruder.
     float max_feedrate_silent[4]; //!< max speeds for silent mode
     unsigned long max_acceleration_units_per_sq_second_silent[4];
     unsigned char axis_ustep_resolution[4];

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -6647,53 +6647,33 @@ Sigma_Exit:
     #endif //BLINKM
 
     /*!
-	### M200 - Set filament diameter <a href="https://reprap.org/wiki/G-code#M200:_Set_filament_diameter">M200: Set filament diameter</a>
-	#### Usage
-    
-	    M200 [ D | T ]
-	
+  ### M200 - Set filament diameter <a href="https://reprap.org/wiki/G-code#M200:_Set_filament_diameter">M200: Set filament diameter</a>
+  #### Usage
+
+      M200 [ D ]
+
     #### Parameters
-	  - `D` - Diameter in mm
-	  - `T` - Number of extruder (MMUs)
+    - `D` - Diameter in mm
     */
     case 200: // M200 D<millimeters> set filament diameter and set E axis units to cubic millimeters (use S0 to set back to millimeters).
       {
-
-        uint8_t extruder = active_extruder;
-        if(code_seen('T')) {
-          extruder = code_value_uint8();
-		  if(extruder >= EXTRUDERS) {
-            SERIAL_ECHO_START;
-            SERIAL_ECHO(_n("M200 Invalid extruder "));////MSG_M200_INVALID_EXTRUDER
-            break;
-          }
-        }
-        if(code_seen('D')) {
-		  float diameter = code_value();
-		  if (diameter == 0.0) {
-			// setting any extruder filament size disables volumetric on the assumption that
-			// slicers either generate in extruder values as cubic mm or as as filament feeds
-			// for all extruders
-		    cs.volumetric_enabled = false;
-		  } else {
-            cs.filament_size[extruder] = code_value();
-			// make sure all extruders have some sane value for the filament size
-			cs.filament_size[0] = (cs.filament_size[0] == 0.0 ? DEFAULT_NOMINAL_FILAMENT_DIA : cs.filament_size[0]);
-            #if EXTRUDERS > 1
-				cs.filament_size[1] = (cs.filament_size[1] == 0.0 ? DEFAULT_NOMINAL_FILAMENT_DIA : cs.filament_size[1]);
-				#if EXTRUDERS > 2
-					cs.filament_size[2] = (cs.filament_size[2] == 0.0 ? DEFAULT_NOMINAL_FILAMENT_DIA : cs.filament_size[2]);
-				#endif
-            #endif
-			cs.volumetric_enabled = true;
-		  }
+      if(code_seen('D')) {
+        float diameter = code_value();
+        if (diameter == 0.0) {
+          // setting any extruder filament size disables volumetric on the assumption that
+          // slicers either generate in extruder values as cubic mm or as as filament feeds
+          // for all extruders
+          cs.volumetric_enabled = false;
         } else {
-          //reserved for setting filament diameter via UFID or filament measuring device
-          break;
+          cs.filament_size[0] = code_value();
+          // make sure all extruders have some sane value for the filament size
+          cs.filament_size[0] = (cs.filament_size[0] == 0.0 ? DEFAULT_NOMINAL_FILAMENT_DIA : cs.filament_size[0]);
+          cs.volumetric_enabled = true;
         }
-		calculate_extruder_multipliers();
+        calculate_extruder_multipliers();
       }
       break;
+      }
 
     /*!
 	### M201 - Set Print Max Acceleration <a href="https://reprap.org/wiki/G-code#M201:_Set_max_acceleration">M201: Set max printing acceleration</a>

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -6665,9 +6665,9 @@ Sigma_Exit:
           // for all extruders
           cs.volumetric_enabled = false;
         } else {
-          cs.filament_size[0] = code_value();
+          cs.filament_size = code_value();
           // make sure all extruders have some sane value for the filament size
-          cs.filament_size[0] = (cs.filament_size[0] == 0.0 ? DEFAULT_NOMINAL_FILAMENT_DIA : cs.filament_size[0]);
+          cs.filament_size = (cs.filament_size == 0.0 ? DEFAULT_NOMINAL_FILAMENT_DIA : cs.filament_size);
           cs.volumetric_enabled = true;
         }
         calculate_extruder_multipliers();
@@ -9725,13 +9725,7 @@ float calculate_extruder_multiplier(float diameter) {
 }
 
 void calculate_extruder_multipliers() {
-	extruder_multiplier[0] = calculate_extruder_multiplier(cs.filament_size[0]);
-#if EXTRUDERS > 1
-	extruder_multiplier[1] = calculate_extruder_multiplier(cs.filament_size[1]);
-#if EXTRUDERS > 2
-	extruder_multiplier[2] = calculate_extruder_multiplier(cs.filament_size[2]);
-#endif
-#endif
+	extruder_multiplier[0] = calculate_extruder_multiplier(cs.filament_size);
 }
 
 void delay_keep_alive(unsigned int ms)

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -6657,23 +6657,23 @@ Sigma_Exit:
     */
     case 200: // M200 D<millimeters> set filament diameter and set E axis units to cubic millimeters (use S0 to set back to millimeters).
       {
-      if(code_seen('D')) {
-        float diameter = code_value();
-        if (diameter == 0.0) {
-          // setting any extruder filament size disables volumetric on the assumption that
-          // slicers either generate in extruder values as cubic mm or as as filament feeds
-          // for all extruders
-          cs.volumetric_enabled = false;
-        } else {
-          cs.filament_size = code_value();
-          // make sure all extruders have some sane value for the filament size
-          cs.filament_size = (cs.filament_size == 0.0 ? DEFAULT_NOMINAL_FILAMENT_DIA : cs.filament_size);
-          cs.volumetric_enabled = true;
+        if(code_seen('D')) {
+          float diameter = code_value();
+          if (diameter == 0.0) {
+            // setting any extruder filament size disables volumetric on the assumption that
+            // slicers either generate in extruder values as cubic mm or as as filament feeds
+            // for all extruders
+            cs.volumetric_enabled = false;
+          } else {
+            cs.filament_size = code_value();
+            // make sure all extruders have some sane value for the filament size
+            cs.filament_size = (cs.filament_size == 0.0 ? DEFAULT_NOMINAL_FILAMENT_DIA : cs.filament_size);
+            cs.volumetric_enabled = true;
+          }
+          calculate_extruder_multipliers();
         }
-        calculate_extruder_multipliers();
       }
       break;
-      }
 
     /*!
 	### M201 - Set Print Max Acceleration <a href="https://reprap.org/wiki/G-code#M201:_Set_max_acceleration">M201: Set max printing acceleration</a>


### PR DESCRIPTION
The active extruder is always selected regardless if the user has an MMU or not. This simplifies the M200 code a little bit and we save some precious memory too.

There is no need for us to update the RepRap wiki since there is no specific handling documented for Prusa firmware. :) 

Regarding the T parameter, we can rely on a similar definition as Marlin:

> T[index] Select the target extruder. If omitted, the active extruder.

Where Prusa Firmware simply assumes the T parameter is always omitted, and so active extruder is always used.

Change in memory:
Flash: -60 bytes
SRAM: 0 bytes