### PR TITLE
PFW-1503 Improve live Z babystep menu handling

### DIFF
--- a/Firmware/Filament_sensor.cpp
+++ b/Firmware/Filament_sensor.cpp
@@ -113,8 +113,7 @@ void Filament_sensor::triggerFilamentInserted() {
         && (! MMU2::mmu2.Enabled() ) // quick and dirty hack to prevent spurious runouts while the MMU is in charge
         && !(
             moves_planned() != 0
-            || IS_SD_PRINTING
-            || usb_timer.running()
+            || printJobOngoing()
             || (lcd_commands_type == LcdCommands::Layer1Cal)
             || eeprom_read_byte((uint8_t *)EEPROM_WIZARD_ACTIVE)
             )
@@ -131,8 +130,7 @@ void Filament_sensor::triggerFilamentRemoved() {
         && !saved_printing
         && (
             moves_planned() != 0
-            || IS_SD_PRINTING
-            || usb_timer.running()
+            || printJobOngoing()
             || (lcd_commands_type == LcdCommands::Layer1Cal)
             || eeprom_read_byte((uint8_t *)EEPROM_WIZARD_ACTIVE)
         )

--- a/Firmware/Filament_sensor.cpp
+++ b/Firmware/Filament_sensor.cpp
@@ -4,7 +4,6 @@
 
 #include "Filament_sensor.h"
 #include "Timer.h"
-#include "cardreader.h"
 #include "eeprom.h"
 #include "menu.h"
 #include "planner.h"

--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -354,7 +354,11 @@ extern LongTimer safetyTimer;
 
 #define PRINT_PERCENT_DONE_INIT 0xff
 
-extern bool printer_active();
+// Returns true if there is a print running. It does not matter if
+// the print is paused, that still counts as a "running" print.
+bool printJobOngoing();
+
+bool printer_active();
 
 //! Beware - mcode_in_progress is set as soon as the command gets really processed,
 //! which is not the same as posting the M600 command into the command queue

--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -370,7 +370,7 @@ bool check_fsensor();
 //! 2) Not allowed during Homing (printer busy)
 //! 3) Not allowed during Mesh Bed Leveling (printer busy)
 //! 4) Allowed if there are queued blocks OR there is a print job running
-bool BABYSTEP_ALLOWED();
+bool babystep_allowed();
 
 extern void calculate_extruder_multipliers();
 

--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -373,7 +373,9 @@ bool check_fsensor();
 //! 1) Z-axis position is less than 2.0mm (only allowed during the first couple of layers)
 //! 2) Not allowed during Homing (printer busy)
 //! 3) Not allowed during Mesh Bed Leveling (printer busy)
-//! 4) Allowed if there are queued blocks OR there is a print job running
+//! 4) Allowed if:
+//!         - First Layer Calibration is running
+//!         - OR there are queued blocks, printJob is running and it's not paused, and Z-axis position is less than 2.0mm (only allowed during the first couple of layers)
 bool babystep_allowed();
 
 extern void calculate_extruder_multipliers();

--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -366,7 +366,7 @@ extern bool printer_active();
 bool check_fsensor();
 
 //! Condition where Babystepping is allowed:
-//! 1) Axis are trusted: Z-axis position must be known
+//! 1) Z-axis position is less than 2.0mm (only allowed during the first couple of layers)
 //! 2) Not allowed during Homing (printer busy)
 //! 3) Not allowed during Mesh Bed Leveling (printer busy)
 //! 4) Allowed if there are queued blocks OR there is a print job running

--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -365,6 +365,13 @@ extern bool printer_active();
 //! I'd normally change this macro, but who knows what would happen in the MMU :)
 bool check_fsensor();
 
+//! Condition where Babystepping is allowed:
+//! 1) Axis are trusted: Z-axis position must be known
+//! 2) Not allowed during Homing (printer busy)
+//! 3) Not allowed during Mesh Bed Leveling (printer busy)
+//! 4) Allowed if there are queued blocks OR there is a print job running
+bool BABYSTEP_ALLOWED();
+
 extern void calculate_extruder_multipliers();
 
 // Similar to the default Arduino delay function, 

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -525,9 +525,12 @@ void servo_init()
   #endif
 }
 
+bool __attribute__((noinline)) printJobOngoing() {
+    return (IS_SD_PRINTING || usb_timer.running());
+}
+
 bool __attribute__((noinline)) printer_active() {
-    return IS_SD_PRINTING
-        || usb_timer.running()
+    return printJobOngoing()
         || isPrintPaused
         || (custom_message_type == CustomMsg::TempCal)
         || saved_printing
@@ -539,7 +542,7 @@ bool __attribute__((noinline)) printer_active() {
 
 // Currently only used in one place, allowed to be inlined
 bool check_fsensor() {
-    return (IS_SD_PRINTING || usb_timer.running())
+    return printJobOngoing()
         && mcode_in_progress != 600
         && !saved_printing
         && e_active();
@@ -548,7 +551,7 @@ bool check_fsensor() {
 bool __attribute__((noinline)) babystep_allowed() {
     return ( (current_position[Z_AXIS] < Z_HEIGHT_HIDE_LIVE_ADJUST_MENU)
         && !homing_flag && !mesh_bed_leveling_flag
-        && ( blocks_queued() || lcd_commands_type == LcdCommands::Layer1Cal || ( !isPrintPaused && (IS_SD_PRINTING || usb_timer.running()) ))
+        && ( blocks_queued() || lcd_commands_type == LcdCommands::Layer1Cal || ( !isPrintPaused && printJobOngoing() ))
     );
 }
 
@@ -9574,7 +9577,7 @@ void ThermalStop(bool allow_recovery)
         Stopped = true;
 
         // Either pause or stop the print
-        if(allow_recovery && (IS_SD_PRINTING || usb_timer.running())) {
+        if(allow_recovery && printJobOngoing()) {
             if (!isPrintPaused) {
                 lcd_setalertstatuspgm(_T(MSG_PAUSED_THERMAL_ERROR), LCD_STATUS_CRITICAL);
 

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -546,7 +546,7 @@ bool check_fsensor() {
 }
 
 bool __attribute__((noinline)) babystep_allowed() {
-    return (axis_known_position[Z_AXIS]
+    return ( (current_position[Z_AXIS] < Z_HEIGHT_HIDE_LIVE_ADJUST_MENU)
         && !homing_flag && !mesh_bed_leveling_flag
         && ( blocks_queued() || lcd_commands_type == LcdCommands::Layer1Cal || ( !isPrintPaused && (IS_SD_PRINTING || usb_timer.running()) ))
     );

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -545,7 +545,7 @@ bool check_fsensor() {
         && e_active();
 }
 
-bool __attribute__((noinline)) BABYSTEP_ALLOWED() {
+bool __attribute__((noinline)) babystep_allowed() {
     return (axis_known_position[Z_AXIS]
         && !homing_flag && !mesh_bed_leveling_flag
         && ( blocks_queued() || lcd_commands_type == LcdCommands::Layer1Cal || ( !isPrintPaused && (IS_SD_PRINTING || usb_timer.running()) ))

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -548,7 +548,7 @@ bool check_fsensor() {
 bool __attribute__((noinline)) BABYSTEP_ALLOWED() {
     return (axis_known_position[Z_AXIS]
         && !homing_flag && !mesh_bed_leveling_flag
-        && ( blocks_queued() || ( !isPrintPaused && (IS_SD_PRINTING || usb_timer.running()) ))
+        && ( blocks_queued() || lcd_commands_type == LcdCommands::Layer1Cal || ( !isPrintPaused && (IS_SD_PRINTING || usb_timer.running()) ))
     );
 }
 

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -549,9 +549,9 @@ bool check_fsensor() {
 }
 
 bool __attribute__((noinline)) babystep_allowed() {
-    return ( (current_position[Z_AXIS] < Z_HEIGHT_HIDE_LIVE_ADJUST_MENU)
-        && !homing_flag && !mesh_bed_leveling_flag
-        && ( blocks_queued() || lcd_commands_type == LcdCommands::Layer1Cal || ( !isPrintPaused && printJobOngoing() ))
+    return ( !homing_flag
+        && !mesh_bed_leveling_flag
+        && ( lcd_commands_type == LcdCommands::Layer1Cal || ( blocks_queued() && !isPrintPaused && printJobOngoing() && (current_position[Z_AXIS] < Z_HEIGHT_HIDE_LIVE_ADJUST_MENU)))
     );
 }
 

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -545,6 +545,13 @@ bool check_fsensor() {
         && e_active();
 }
 
+bool __attribute__((noinline)) BABYSTEP_ALLOWED() {
+    return (axis_known_position[Z_AXIS]
+        && !homing_flag && !mesh_bed_leveling_flag
+        && ( blocks_queued() || ( !isPrintPaused && (IS_SD_PRINTING || usb_timer.running()) ))
+    );
+}
+
 bool fans_check_enabled = true;
 
 #ifdef TMC2130

--- a/Firmware/fancheck.cpp
+++ b/Firmware/fancheck.cpp
@@ -85,7 +85,7 @@ void fanSpeedError(unsigned char _fan) {
     if (fan_check_error == EFCE_REPORTED) return;
     fan_check_error = EFCE_REPORTED;
 
-    if (IS_SD_PRINTING || usb_timer.running()) {
+    if (printJobOngoing()) {
         // A print is ongoing, pause the print normally
         if(!isPrintPaused) {
             if (usb_timer.running())

--- a/Firmware/fancheck.cpp
+++ b/Firmware/fancheck.cpp
@@ -1,6 +1,5 @@
 // fan control and check
 #include "fancheck.h"
-#include "cardreader.h"
 #include "ultralcd.h"
 #include "sound.h"
 #include "messages.h"

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5337,9 +5337,8 @@ static void lcd_main_menu()
     MENU_ITEM_FUNCTION_P(PSTR("power panic"), uvlo_);
 #endif //TMC2130_DEBUG
 
-    if ( babystep_allowed() ) {
+    if ( babystep_allowed() )
         MENU_ITEM_SUBMENU_P(_T(MSG_BABYSTEP_Z), lcd_babystep_z);//8
-    }
 
     if (farm_mode)
         MENU_ITEM_FUNCTION_P(_T(MSG_FILAMENTCHANGE), lcd_colorprint_change);//8

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -4628,7 +4628,7 @@ static void lcd_settings_menu()
     MENU_ITEM_TOGGLE_P(_T(MSG_RPI_PORT), (selectedSerialPort == 0) ? _T(MSG_OFF) : _T(MSG_ON), lcd_second_serial_set);
 #endif //HAS_SECOND_SERIAL
 
-	if ( BABYSTEP_ALLOWED() )
+	if ( babystep_allowed() )
 		MENU_ITEM_SUBMENU_P(_T(MSG_BABYSTEP_Z), lcd_babystep_z);
 
 #if (LANG_MODE != 0)
@@ -5337,7 +5337,7 @@ static void lcd_main_menu()
     MENU_ITEM_FUNCTION_P(PSTR("power panic"), uvlo_);
 #endif //TMC2130_DEBUG
 
-    if ( BABYSTEP_ALLOWED() ) {
+    if ( babystep_allowed() ) {
         MENU_ITEM_SUBMENU_P(_T(MSG_BABYSTEP_Z), lcd_babystep_z);//8
     }
 
@@ -7457,7 +7457,7 @@ void menu_lcd_longpress_func(void)
 
     // explicitely listed menus which are allowed to rise the move-z or live-adj-z functions
     // The lists are not the same for both functions, so first decide which function is to be performed
-    if (BABYSTEP_ALLOWED()){ // long press as live-adj-z
+    if (babystep_allowed()){ // long press as live-adj-z
         if ( menu_menu == lcd_status_screen // and in listed menus...
           || menu_menu == lcd_main_menu
           || menu_menu == lcd_tune_menu
@@ -7493,7 +7493,7 @@ void menu_lcd_longpress_func(void)
 static inline bool z_menu_expired()
 {
     return (menu_menu == lcd_babystep_z
-        && (!BABYSTEP_ALLOWED() || (lcd_commands_type == LcdCommands::Idle && lcd_timeoutToStatus.expired(LCD_TIMEOUT_TO_STATUS_BABYSTEP_Z))));
+        && (!babystep_allowed() || (lcd_commands_type == LcdCommands::Idle && lcd_timeoutToStatus.expired(LCD_TIMEOUT_TO_STATUS_BABYSTEP_Z))));
 }
 static inline bool other_menu_expired()
 {

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3495,7 +3495,7 @@ static void crash_mode_switch()
     {
         lcd_crash_detect_enable();
     }
-	if (IS_SD_PRINTING || usb_timer.running() || (lcd_commands_type == LcdCommands::Layer1Cal)) menu_goto(lcd_tune_menu, 9, true, true);
+	if (printJobOngoing() || (lcd_commands_type == LcdCommands::Layer1Cal)) menu_goto(lcd_tune_menu, 9, true, true);
 	else menu_goto(lcd_settings_menu, 9, true, true);
 }
 #endif //TMC2130
@@ -5371,7 +5371,7 @@ static void lcd_main_menu()
             }
         }
     }
-    if((IS_SD_PRINTING || usb_timer.running() || isPrintPaused) && (custom_message_type != CustomMsg::MeshBedLeveling) && !processing_tcode) {
+    if((printJobOngoing() || isPrintPaused) && (custom_message_type != CustomMsg::MeshBedLeveling) && !processing_tcode) {
         MENU_ITEM_SUBMENU_P(_T(MSG_STOP_PRINT), lcd_sdcard_stop);
     }
 #ifdef TEMP_MODEL
@@ -5399,7 +5399,7 @@ static void lcd_main_menu()
     }
 #endif //SDSUPPORT
 
-    if(!isPrintPaused && !IS_SD_PRINTING && !usb_timer.running() && (lcd_commands_type != LcdCommands::Layer1Cal)) {
+    if(!isPrintPaused && !printJobOngoing() && (lcd_commands_type != LcdCommands::Layer1Cal)) {
         if (!farm_mode) {
             const int8_t sheet = eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet));
             const int8_t nextSheet = eeprom_next_initialized_sheet(sheet);
@@ -5409,7 +5409,7 @@ static void lcd_main_menu()
         }
     }
 
-    if ( ! ( IS_SD_PRINTING || usb_timer.running() || (lcd_commands_type == LcdCommands::Layer1Cal || Stopped) ) ) {
+    if ( ! ( printJobOngoing() || (lcd_commands_type == LcdCommands::Layer1Cal || Stopped) ) ) {
         if (MMU2::mmu2.Enabled()) {
             MENU_ITEM_SUBMENU_P(_T(MSG_LOAD_FILAMENT), mmu_load_filament_menu);
             MENU_ITEM_SUBMENU_P(_i("Load to nozzle"), mmu_load_to_nozzle_menu);////MSG_LOAD_TO_NOZZLE c=18


### PR DESCRIPTION
Short history:
* I broke the behavior in here https://github.com/gudnimg/Prusa-Firmware/commit/2276217cbb47501a0558d988446c8d1a863a3384 with optimisations. This created a bug where the menu would close and not save the last Z value into EEPROM.
* The bug above was fixed recently here https://github.com/prusa3d/Prusa-Firmware/pull/4005 by @3d-gussner but later we discovered this created another bug where `menu_leave` is set to `1`, but it is then never set to `0` again. This bug appears only when first layer calibration is run twice consequatively and the LCD will freeze or stop behaving correctly.

In this PR I have a proposed solution which fixes the reported problem:

Improvements
====

* Add `BABYSTEP_ALLOWED` function to unify checks whether or not babystepping is allowed, if not the menu is dismissed and hidden from the user.
* The Z baby step menu closes automatically when first layer calibration is done. This is expected behavior but additionally now we don't need to wait for a timeout or close the menu manually by setting a variable.
* Do not allow the Z baby step menu to timeout when LcdCommands != Idle. This covers first layer calibration. In all other situations it times out as normal (after 90 seconds).

Change in memory:
Flash: -182 bytes
SRAM: 0 bytes