### PR TITLE
planner: optimise acceleration limit checking

### DIFF
--- a/Firmware/planner.cpp
+++ b/Firmware/planner.cpp
@@ -1054,9 +1054,9 @@ Having the real displacement of the head, we can calculate the total movement le
         if (e_D_ratio > 3.0)
             block->use_advance_lead = false;
         else if (e_D_ratio > 0) {
-            const float max_accel_per_s2 = cs.max_jerk[E_AXIS] / (extruder_advance_K * e_D_ratio) * steps_per_mm;
-            if (accel > max_accel_per_s2) {
-                accel = ceil(max_accel_per_s2);
+            const uint32_t max_accel_steps_per_s2 = ceil(cs.max_jerk[E_AXIS] / (extruder_advance_K * e_D_ratio) * steps_per_mm);
+            if (accel > max_accel_steps_per_s2) {
+                accel = max_accel_steps_per_s2;
                 #ifdef LA_DEBUG
                 SERIAL_ECHOLNPGM("LA: Block acceleration limited due to max E-jerk");
                 #endif

--- a/Firmware/planner.h
+++ b/Firmware/planner.h
@@ -99,10 +99,10 @@ typedef struct {
 
   // Settings for the trapezoid generator (runs inside an interrupt handler).
   // Changing the following values in the planner needs to be synchronized with the interrupt handler by disabling the interrupts.
-  unsigned long nominal_rate;                        // The nominal step rate for this block in step_events/sec 
-  unsigned long initial_rate;                        // The jerk-adjusted step rate at start of block  
-  unsigned long final_rate;                          // The minimal rate at exit
-  unsigned long acceleration_st;                     // acceleration steps/sec^2
+  uint32_t nominal_rate;              // The nominal step rate for this block in step_events/sec 
+  uint32_t initial_rate;              // The jerk-adjusted step rate at start of block  
+  uint32_t final_rate;                // The minimal rate at exit
+  uint32_t acceleration_steps_per_s2; // acceleration steps/sec^2
   //FIXME does it have to be int? Probably uint8_t would be just fine. Need to change in other places as well
   int fan_speed;
   volatile char busy;


### PR DESCRIPTION
Rename `acceleration_st` to `acceleration_steps_per_s2` to be same as Marlin 2

Store the acceleration into a local variable `accel` while performing the limit checks.

When limit checks are done we can assign the block it's acceleration. Especially
`block->acceleration_steps_per_s2` is now only written to once, instead of reading/writing to it often in the limit checks.

Change in memory:
Flash: -142 bytes
SRAM: 0 bytes