### PR TITLE
Fix M706 lcd message stuck

### DIFF
--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -451,6 +451,7 @@ bool MMU2::cut_filament(uint8_t slot, bool enableFullScreenMsg /*= true*/) {
     extruder = MMU2_NO_TOOL;
     tool_change_extruder = MMU2_NO_TOOL;
     MakeSound(SoundType::Confirm);
+    ScreenUpdateEnable();
     return true;
 }
 


### PR DESCRIPTION
Fix `M706` to cut filament get stuck with `Cutting filament x` on LCD screen. 