### PR TITLE
optimisation: reduce code size in status screen

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -5277,17 +5277,17 @@ void process_commands()
                 custom_message_type = CustomMsg::Status; // let the lcd display the name of the printed G-code file in farm mode
             }
         }
-        lcd_ignore_click();				//call lcd_ignore_click also for else ???
         st_synchronize();
         previous_millis_cmd.start();
         if (codenum > 0 ) {
             codenum += _millis();  // keep track of when we started waiting
             KEEPALIVE_STATE(PAUSED_FOR_USER);
-            while(_millis() < codenum && !lcd_clicked()) {
+            wait_for_user = true;    // LCD click or M108 will clear this
+            while(_millis() < codenum && wait_for_user) {
                 delay_keep_alive(0);
             }
             KEEPALIVE_STATE(IN_HANDLER);
-            lcd_ignore_click(false);
+            wait_for_user = false; // set to false, in case of timeout
         } else {
             marlin_wait_for_click();
         }

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -169,9 +169,8 @@ extern bool cancel_heatup;
 extern bool isPrintPaused;
 
 extern uint8_t scrollstuff;
+extern bool wait_for_user;
 
-
-void lcd_ignore_click(bool b=true);
 void lcd_commands();
 
 


### PR DESCRIPTION
Had this stashed locally, thought I should commit in case we need the memory.

Good ideas from Marlin 2. IMO this new code is a little bit more readable.

Change in memory:
Flash: -36 bytes
SRAM: 0 bytes