### PR TITLE
PFW-1504 fix conflicting UI issues

### DIFF
--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -546,14 +546,14 @@ void lcd_print(const char* s)
 	while (*s) lcd_write(*(s++));
 }
 
-char lcd_print_pad(const char* s, uint8_t len)
+uint8_t lcd_print_pad(const char* s, uint8_t len)
 {
     while (len && *s) {
         lcd_write(*(s++));
         --len;
     }
     lcd_space(len);
-    return *s;
+    return len;
 }
 
 uint8_t lcd_print_pad_P(const char* s, uint8_t len)

--- a/Firmware/lcd.h
+++ b/Firmware/lcd.h
@@ -56,7 +56,7 @@ extern void lcd_space(uint8_t n);
 extern void lcd_printNumber(unsigned long n, uint8_t base);
 
 extern void lcd_print(const char*);
-extern char lcd_print_pad(const char* s, uint8_t len);
+extern uint8_t lcd_print_pad(const char* s, uint8_t len);
 
 /// @brief print a string from PROGMEM with left-adjusted padding
 /// @param s string from PROGMEM.

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -305,6 +305,7 @@ bool MMU2::VerifyFilamentEnteredPTFE() {
     }
 
     Disable_E0();
+    TryLoadUnloadProgressbarDeinit();
 
     if (fsensorState) {
         IncrementLoadFails();

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -305,6 +305,7 @@ bool MMU2::VerifyFilamentEnteredPTFE() {
     }
 
     Disable_E0();
+    TryLoadUnloadProgressbarEcho();
     TryLoadUnloadProgressbarDeinit();
 
     if (fsensorState) {

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -1,4 +1,5 @@
 #include "mmu2.h"
+#include "mmu2_log.h"
 #include "mmu2_reporting.h"
 #include "mmu2_error_converter.h"
 #include "mmu2/error_codes.h"
@@ -290,6 +291,17 @@ void TryLoadUnloadProgressbarDeinit() {
     // Delay the next status message just so
     // the user can see the results clearly
     lcd_reset_status_message_timeout();
+}
+
+void TryLoadUnloadProgressbarEcho() {
+    char buf[LCD_WIDTH];
+    lcd_getstatus(buf);
+    for (uint8_t i = 0; i < sizeof(buf); i++) {
+        // 0xFF is -1 when converting from unsigned to signed char
+        // If the number is negative, that means filament is present
+        buf[i] = (buf[i] < 0) ? '1' : '0';
+    }
+    MMU2_ECHO_MSGLN(buf);
 }
 
 void TryLoadUnloadProgressbar(uint8_t col, bool sensorState) {

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -283,16 +283,19 @@ void ReportProgressHook(CommandInProgress cip, uint16_t ec) {
 }
 
 void TryLoadUnloadProgressbarInit() {
-    // Clear the status line
-    lcd_set_cursor(0, 3);
-    lcd_space(LCD_WIDTH);
+    lcd_clearstatus();
+}
+
+void TryLoadUnloadProgressbarDeinit() {
+    // Delay the next status message just so
+    // the user can see the results clearly
+    lcd_reset_status_message_timeout();
+    lcd_clearstatus();
 }
 
 void TryLoadUnloadProgressbar(uint8_t col, bool sensorState) {
-    // Set the cursor position each time in case some other
-    // part of the firmware changes the cursor position
-    lcd_putc_at(col, 3, sensorState ? '-' : LCD_STR_SOLID_BLOCK[0]);
-    lcd_reset_status_message_timeout();
+    lcd_insert_char_into_status(col, sensorState ? '-' : LCD_STR_SOLID_BLOCK[0]);
+    if (!lcd_update_enabled) lcdui_print_status_line();
 }
 
 void IncrementLoadFails(){

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -290,7 +290,6 @@ void TryLoadUnloadProgressbarDeinit() {
     // Delay the next status message just so
     // the user can see the results clearly
     lcd_reset_status_message_timeout();
-    lcd_clearstatus();
 }
 
 void TryLoadUnloadProgressbar(uint8_t col, bool sensorState) {

--- a/Firmware/mmu2_reporting.h
+++ b/Firmware/mmu2_reporting.h
@@ -38,6 +38,9 @@ void ReportProgressHook(CommandInProgress cip, uint16_t ec);
 /// @brief Clear the status line and setup the LCD cursor
 void TryLoadUnloadProgressbarInit();
 
+/// @brief Clear the status line and setup the LCD cursor
+void TryLoadUnloadProgressbarDeinit();
+
 /// @brief Add one block to the progress bar
 /// @param col pixel position on the LCD status line, should range from 0 to (LCD_WIDTH - 1)
 /// @param sensorState if true, filament is not present, else filament is present. This controls which character to render

--- a/Firmware/mmu2_reporting.h
+++ b/Firmware/mmu2_reporting.h
@@ -41,6 +41,9 @@ void TryLoadUnloadProgressbarInit();
 /// @brief Clear the status line and setup the LCD cursor
 void TryLoadUnloadProgressbarDeinit();
 
+/// @brief Report the results to serial
+void TryLoadUnloadProgressbarEcho();
+
 /// @brief Add one block to the progress bar
 /// @param col pixel position on the LCD status line, should range from 0 to (LCD_WIDTH - 1)
 /// @param sensorState if true, filament is not present, else filament is present. This controls which character to render

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -557,8 +557,6 @@ void lcdui_print_status_line(void) {
             return; // Nothing to do, waiting for delay to expire
         }
 
-        lcd_set_cursor(lcd_status_message_idx, 3);
-
         switch (custom_message_type) {
         case CustomMsg::M117:   // M117 Set the status line message on the LCD
         case CustomMsg::Status: // Nothing special, print status message normally
@@ -566,6 +564,7 @@ void lcdui_print_status_line(void) {
         case CustomMsg::FilamentLoading: // If loading filament, print status
         case CustomMsg::MMUProgress: // MMU Progress Codes
         {
+            lcd_set_cursor(lcd_status_message_idx, 3);
             const uint8_t padding = lcd_print_pad(&lcd_status_message[lcd_status_message_idx], LCD_WIDTH - lcd_status_message_idx);
             lcd_status_message_idx = LCD_WIDTH - padding;
         }

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -7079,6 +7079,10 @@ void lcd_clearstatus()
     lcd_status_message_idx = 0;
 }
 
+void lcd_getstatus(char buf[LCD_WIDTH]) {
+    strncpy(buf, lcd_status_message, LCD_WIDTH);
+}
+
 void lcd_setstatuspgm(const char* message)
 {
     if (lcd_message_check(LCD_STATUS_NONE))

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1001,7 +1001,7 @@ void lcd_commands()
 
 void lcd_return_to_status()
 {
-	lcdui_refresh(false); // to maybe revive the LCD if static electricity killed it.
+	lcdui_refresh(); // to maybe revive the LCD if static electricity killed it.
 	menu_goto(lcd_status_screen, 0, true);
 	menu_depth = 0;
     eFilamentAction = FilamentAction::None; // i.e. non-autoLoad

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -20,6 +20,9 @@ void ultralcd_init();
 #define LCD_STATUS_DELAYED_TIMEOUT 4000
 
 // Set the current status message (equivalent to LCD_STATUS_NONE)
+void lcdui_print_status_line(void);
+void lcd_clearstatus();
+void lcd_insert_char_into_status(uint8_t position, const char message);
 void lcd_setstatus(const char* message);
 void lcd_setstatuspgm(const char* message);
 void lcd_setstatus_serial(const char* message);

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -22,6 +22,10 @@ void ultralcd_init();
 // Set the current status message (equivalent to LCD_STATUS_NONE)
 void lcdui_print_status_line(void);
 void lcd_clearstatus();
+
+/// @brief Copy the contents of lcd_status_message
+/// @param buf destination buffer
+void lcd_getstatus(char buf[LCD_WIDTH]);
 void lcd_insert_char_into_status(uint8_t position, const char message);
 void lcd_setstatus(const char* message);
 void lcd_setstatuspgm(const char* message);


### PR DESCRIPTION
Proposal to fix some of the issues with the initial implementation it is safer to use the status line code to print the message so there aren't any conflicts in the LCD cursor position.

Allow inserting a byte into any position in the LCD status message

Also, add a variable to control from which index in the array should the message start printing. This is very useful for progress bars and messages which continually update. I think we can save some memory by applying this to Mesh Bed Leveling later.

Change in memory:
Flash: +208 bytes
SRAM: +1 byte