### PR TITLE
Disable reading MMU register 0x21

### DIFF
--- a/Firmware/mmu2_protocol_logic.cpp
+++ b/Firmware/mmu2_protocol_logic.cpp
@@ -35,7 +35,6 @@ const uint8_t ProtocolLogic::regs8Addrs[ProtocolLogic::regs8Count] PROGMEM = {
 const uint8_t ProtocolLogic::regs16Addrs[ProtocolLogic::regs16Count] PROGMEM = {
     4,    // MMU errors - aka statistics
     0x1a, // Pulley position [mm]
-    0x21, // MCU bandgap voltage
 };
 
 const uint8_t ProtocolLogic::initRegs8Addrs[ProtocolLogic::initRegs8Count] PROGMEM = {

--- a/Firmware/mmu2_protocol_logic.h
+++ b/Firmware/mmu2_protocol_logic.h
@@ -365,10 +365,10 @@ private:
     uint8_t regs8[regs8Count] = { 0, 0, 0 };
 
     // 16bit registers
-    static constexpr uint8_t regs16Count = 3;
+    static constexpr uint8_t regs16Count = 2;
     static_assert(regs16Count > 0); // code is not ready for empty lists of registers
     static const uint8_t regs16Addrs[regs16Count] PROGMEM;
-    uint16_t regs16[regs16Count] = { 0, 0, 0 };
+    uint16_t regs16[regs16Count] = { 0, 0 };
 
     // 8bit init values to be sent to the MMU after line up
     static constexpr uint8_t initRegs8Count = 2;


### PR DESCRIPTION
It has proven to be too unreliable and may provide incorrect readings and confuse end users.