### PR TITLE
🚧 optimisation: Simplify if statement check

### DIFF
--- a/Firmware/Timer.cpp
+++ b/Firmware/Timer.cpp
@@ -46,7 +46,7 @@ bool Timer<T>::expired(T msPeriod)
     if (!m_isRunning) return false;
     bool expired = false;
     const T now = _millis();
-    if (m_started <=  m_started + msPeriod)
+    if (msPeriod >= 0)
     {
         if ((now >= m_started + msPeriod) || (now < m_started))
         {


### PR DESCRIPTION
Let's call:
`m_started` := X
`msPeriod` := Y

Then `m_started <=  m_started + msPeriod` becomes
```math
X ≤  X + Y\\
```
Subtract X from both sides gives
```math
0 ≤ Y
```
or equivalently:
```math
Y ≥ 0
```
For this reason,
`m_started <=  m_started + msPeriod` is equivalent to `msPeriod >= 0`

Using ≥ instead of ≤ seems to save 2 bytes

Change in memory:
Flash: -40 bytes
SRAM: 0 bytes