### PR TITLE
Restore previous Z-lift in M701/M702 + other PROGMEM optimisations

### DIFF
--- a/Firmware/Filament_sensor.cpp
+++ b/Firmware/Filament_sensor.cpp
@@ -163,7 +163,7 @@ void Filament_sensor::filRunout() {
     restore_print_from_ram_and_continue(0);
     eeprom_increment_byte((uint8_t *)EEPROM_FERROR_COUNT);
     eeprom_increment_word((uint16_t *)EEPROM_FERROR_COUNT_TOT);
-    enquecommand_front_P((PSTR("M600")));
+    enquecommand_front_P(MSG_M600);
 }
 
 void Filament_sensor::triggerError() {
@@ -483,7 +483,7 @@ void PAT9125_sensor::filJam() {
     restore_print_from_ram_and_continue(0);
     eeprom_increment_byte((uint8_t *)EEPROM_FERROR_COUNT);
     eeprom_increment_word((uint16_t *)EEPROM_FERROR_COUNT_TOT);
-    enquecommand_front_P((PSTR("M600")));
+    enquecommand_front_P(MSG_M600);
 }
 
 bool PAT9125_sensor::updatePAT9125() {

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -10789,7 +10789,7 @@ void recover_print(uint8_t automatic) {
         //Extrude some filament to stabilize the pressure
         enquecommand_P(PSTR("G1 E5 F120"));
         // Retract to be consistent with a short pause
-        sprintf_P(cmd, PSTR("G1 E%-0.3f F2700"), default_retraction);
+        sprintf_P(cmd, G1_E_F2700, default_retraction);
         enquecommand(cmd);
     }
 
@@ -10946,7 +10946,7 @@ void restore_print_from_eeprom(bool mbl_was_active) {
     enquecommand(cmd);
 
   // Unretract.
-    sprintf_P(cmd, PSTR("G1 E%0.3f F2700"), default_retraction);
+    sprintf_P(cmd, G1_E_F2700, default_retraction);
     enquecommand(cmd);
   // Recover final E axis position and mode
     float pos_e = eeprom_read_float((float*)(EEPROM_UVLO_CURRENT_POSITION_E));
@@ -11157,7 +11157,7 @@ void stop_and_save_print_to_ram(float z_move, float e_move)
         // A snprintf would have been a safer call, but since it is not used
         // in the whole program, its implementation would bring more bytes to the total size
         // The behavior of dtostrf 8,3 should be roughly the same as %-0.3
-        sprintf_P(buf, PSTR("G1 E%-0.3f F2700"), e_move);
+        sprintf_P(buf, G1_E_F2700, e_move);
         enquecommand(buf, false);
     }
 

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -255,7 +255,6 @@ uint8_t host_keepalive_interval = HOST_KEEPALIVE_INTERVAL;
 
 const char errormagic[] PROGMEM = "Error:";
 const char echomagic[] PROGMEM = "echo:";
-const char G28W0[] PROGMEM = "G28 W0";
 
 // Define some coordinates outside the clamp limits (making them invalid past the parsing stage) so
 // that they can be used later for various logical checks

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -2809,7 +2809,7 @@ static void gcode_G80()
         // Push the commands to the front of the message queue in the reverse order!
         // There shall be always enough space reserved for these commands.
         repeatcommand_front(); // repeat G80 with all its parameters
-        enquecommand_front_P(G28W0);
+        enquecommand_front_P(G28W);
         return;
     }
 
@@ -2842,7 +2842,7 @@ static void gcode_G80()
         temp_compensation_start();
         run = true;
         repeatcommand_front(); // repeat G80 with all its parameters
-        enquecommand_front_P(G28W0);
+        enquecommand_front_P(G28W);
         return;
     }
     run = false;
@@ -4736,7 +4736,7 @@ void process_commands()
             // Push the commands to the front of the message queue in the reverse order!
             // There shall be always enough space reserved for these commands.
             repeatcommand_front(); // repeat G76 with all its parameters
-            enquecommand_front_P(G28W0);
+            enquecommand_front_P(G28W);
             break;
         }
         lcd_show_fullscreen_message_and_wait_P(_i("Stable ambient temperature 21-26C is needed a rigid stand is required."));////MSG_TEMP_CAL_WARNING c=20 r=4
@@ -4881,7 +4881,7 @@ void process_commands()
 			// Push the commands to the front of the message queue in the reverse order!
 			// There shall be always enough space reserved for these commands.
 			repeatcommand_front(); // repeat G76 with all its parameters
-			enquecommand_front_P(G28W0);
+			enquecommand_front_P(G28W);
 			break;
 		}
 		puts_P(_N("PINDA probe calibration start"));
@@ -10101,7 +10101,7 @@ void bed_analysis(float x_dimension, float y_dimension, int x_points_num, int y_
 		// There shall be always enough space reserved for these commands.
 		repeatcommand_front(); // repeat G80 with all its parameters
 		
-		enquecommand_front_P(G28W0);
+		enquecommand_front_P(G28W);
 		enquecommand_front_P((PSTR("G1 Z5")));
 		return;
 	}

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -2082,7 +2082,7 @@ bool check_commands() {
 	
 		while (buflen)
 		{
-		if ((code_seen_P(PSTR("M84"))) || (code_seen_P(PSTR("M 84")))) end_command_found = true;
+		if ((code_seen_P(MSG_M84)) || (code_seen_P(PSTR("M 84")))) end_command_found = true;
 		if (!cmdbuffer_front_already_processed)
 			 cmdqueue_pop_front();
 		cmdbuffer_front_already_processed = false;
@@ -10783,7 +10783,7 @@ void recover_print(uint8_t automatic) {
 	sprintf_P(cmd, PSTR("M109 S%d"), target_temperature[active_extruder]);
 	enquecommand(cmd);
 
-	enquecommand_P(PSTR("M83")); //E axis relative mode
+	enquecommand_P(MSG_M83); //E axis relative mode
 
     // If not automatically recoreverd (long power loss)
     if(automatic == 0){
@@ -11150,7 +11150,7 @@ void stop_and_save_print_to_ram(float z_move, float e_move)
     {
         // First unretract (relative extrusion)
         if(!saved_extruder_relative_mode){
-            enquecommand(PSTR("M83"), true);
+            enquecommand_P(MSG_M83);
         }
         //retract 45mm/s
         // A single sprintf may not be faster, but is definitely 20B shorter

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -10915,7 +10915,7 @@ void restore_print_from_eeprom(bool mbl_was_active) {
 
 	MYSERIAL.print(filename);
 	strcat_P(filename, PSTR(".gco"));
-	sprintf_P(cmd, PSTR("M23 %s"), filename);
+	sprintf_P(cmd, MSG_M23, filename);
 	enquecommand(cmd);
 	uint32_t position = eeprom_read_dword((uint32_t*)(EEPROM_FILE_POSITION));
 	SERIAL_ECHOPGM("Position read from eeprom:");

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -4182,7 +4182,7 @@ void process_commands()
         }
         else if (code_seen_P(PSTR("uvlo"))) { // PRUSA uvlo
             eeprom_update_byte((uint8_t*)EEPROM_UVLO,0); 
-            enquecommand_P(PSTR("M24")); 
+            enquecommand_P(MSG_M24); 
         }
 		else if (code_seen_P(PSTR("MMURES"))) // PRUSA MMURES
 		{

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3584,7 +3584,7 @@ static void gcode_M600(bool automatic, float x_position, float y_position, float
         // Recover feed rate
         feedmultiply = feedmultiplyBckp;
         char cmd[9];
-        sprintf_P(cmd, PSTR("M220 S%i"), feedmultiplyBckp);
+        sprintf_P(cmd, MSG_M220, feedmultiplyBckp);
         enquecommand(cmd);
         
     }
@@ -10957,7 +10957,7 @@ void restore_print_from_eeprom(bool mbl_was_active) {
   // Set the feedrates saved at the power panic.
 	sprintf_P(cmd, PSTR("G1 F%d"), feedrate_rec);
 	enquecommand(cmd);
-	sprintf_P(cmd, PSTR("M220 S%d"), feedmultiply_rec);
+	sprintf_P(cmd, MSG_M220, feedmultiply_rec);
 	enquecommand(cmd);
   // Set the fan speed saved at the power panic.
 	sprintf_P(cmd, PSTR("M106 S%u"), fan_speed_rec);

--- a/Firmware/cardreader.cpp
+++ b/Firmware/cardreader.cpp
@@ -651,7 +651,7 @@ void CardReader::checkautostart(bool force)
     {
       char cmd[30];
       // M23: Select SD file
-      sprintf_P(cmd, PSTR("M23 %s"), autoname);
+      sprintf_P(cmd, MSG_M23, autoname);
       enquecommand(cmd);
       // M24: Start/resume SD print
       enquecommand_P(MSG_M24);

--- a/Firmware/cardreader.cpp
+++ b/Firmware/cardreader.cpp
@@ -654,7 +654,7 @@ void CardReader::checkautostart(bool force)
       sprintf_P(cmd, PSTR("M23 %s"), autoname);
       enquecommand(cmd);
       // M24: Start/resume SD print
-      enquecommand_P(PSTR("M24"));
+      enquecommand_P(MSG_M24);
       found=true;
     }
   }

--- a/Firmware/first_lay_cal.cpp
+++ b/Firmware/first_lay_cal.cpp
@@ -41,7 +41,7 @@ void lay1cal_wait_preheat()
 {
     const char * const preheat_cmd[] =
     {
-        PSTR("M107"),
+        MSG_M107,
         PSTR("M190"),
         PSTR("M109"),
         PSTR("G28"),
@@ -247,7 +247,6 @@ void lay1cal_square(uint8_t step, float layer_height, float extrusion_width)
 
 void lay1cal_finish(bool mmu_enabled)
 {
-    static const char cmd_cal_finish_0[] PROGMEM = "M107"; //turn off printer fan
     static const char cmd_cal_finish_1[] PROGMEM = "G1 E-0.075 F2100"; //retract
     static const char cmd_cal_finish_2[] PROGMEM = "M104 S0"; // turn off temperature
     static const char cmd_cal_finish_3[] PROGMEM = "M140 S0"; // turn off heatbed
@@ -256,7 +255,7 @@ void lay1cal_finish(bool mmu_enabled)
 
     static const char * const cmd_cal_finish[] PROGMEM =
     {
-            cmd_cal_finish_0,
+            MSG_M107, // turn off printer fan
             cmd_cal_finish_1,
             cmd_cal_finish_2,
             cmd_cal_finish_3,

--- a/Firmware/first_lay_cal.cpp
+++ b/Firmware/first_lay_cal.cpp
@@ -140,7 +140,6 @@ void lay1cal_intro_line(bool extraPurgeNeeded, float layer_height, float extrusi
 //! @brief Setup for printing meander
 void lay1cal_before_meander()
 {
-    static const char cmd_pre_meander_1[] PROGMEM = "G21"; //set units to millimeters TODO unsupported command
     static const char cmd_pre_meander_2[] PROGMEM = "G90"; //use absolute coordinates
     static const char cmd_pre_meander_4[] PROGMEM = "G1 E-1.5 F2100";
     static const char cmd_pre_meander_5[] PROGMEM = "G1 Z5 F7200";
@@ -150,7 +149,6 @@ void lay1cal_before_meander()
     static const char * const cmd_pre_meander[] PROGMEM =
     {
             zero_extrusion,
-            cmd_pre_meander_1,
             cmd_pre_meander_2,
             MSG_M83, // use relative distances for extrusion
             cmd_pre_meander_4,

--- a/Firmware/first_lay_cal.cpp
+++ b/Firmware/first_lay_cal.cpp
@@ -62,7 +62,7 @@ bool lay1cal_load_filament(char *cmd_buffer, uint8_t filament)
 {
     if (MMU2::mmu2.Enabled())
     {
-        enquecommand_P(PSTR("M83"));
+        enquecommand_P(MSG_M83);
         enquecommand_P(PSTR("G1 Y-3 F1000"));
         enquecommand_P(PSTR("G1 Z0.4 F1000"));
 
@@ -72,7 +72,7 @@ bool lay1cal_load_filament(char *cmd_buffer, uint8_t filament)
             return false;
         } else if( currentTool != (uint8_t)MMU2::FILAMENT_UNKNOWN){
             // some other slot is loaded, perform an unload first
-            enquecommand_P(PSTR("M702"));
+            enquecommand_P(MSG_M702_NO_LIFT);
         }
         // perform a toolchange
         // sprintf_P(cmd_buffer, PSTR("T%d"), filament);
@@ -142,7 +142,6 @@ void lay1cal_before_meander()
 {
     static const char cmd_pre_meander_1[] PROGMEM = "G21"; //set units to millimeters TODO unsupported command
     static const char cmd_pre_meander_2[] PROGMEM = "G90"; //use absolute coordinates
-    static const char cmd_pre_meander_3[] PROGMEM = "M83"; //use relative distances for extrusion TODO: duplicate
     static const char cmd_pre_meander_4[] PROGMEM = "G1 E-1.5 F2100";
     static const char cmd_pre_meander_5[] PROGMEM = "G1 Z5 F7200";
     static const char cmd_pre_meander_6[] PROGMEM = "M204 S1000"; //set acceleration
@@ -153,7 +152,7 @@ void lay1cal_before_meander()
             zero_extrusion,
             cmd_pre_meander_1,
             cmd_pre_meander_2,
-            cmd_pre_meander_3,
+            MSG_M83, // use relative distances for extrusion
             cmd_pre_meander_4,
             cmd_pre_meander_5,
             cmd_pre_meander_6,
@@ -254,8 +253,6 @@ void lay1cal_finish(bool mmu_enabled)
     static const char cmd_cal_finish_3[] PROGMEM = "M140 S0"; // turn off heatbed
     static const char cmd_cal_finish_4[] PROGMEM = "G1 Z10 F1300"; //lift Z
     static const char cmd_cal_finish_5[] PROGMEM = "G1 X10 Y180 F4000"; //Go to parking position
-    static const char cmd_cal_finish_6[] PROGMEM = "M702"; //unload from nozzle
-    static const char cmd_cal_finish_7[] PROGMEM = "M84";// disable motors
 
     static const char * const cmd_cal_finish[] PROGMEM =
     {
@@ -272,6 +269,6 @@ void lay1cal_finish(bool mmu_enabled)
         enquecommand_P(static_cast<char*>(pgm_read_ptr(&cmd_cal_finish[i])));
     }
 
-    if (mmu_enabled) enquecommand_P(cmd_cal_finish_6); //unload from nozzle
-    enquecommand_P(cmd_cal_finish_7);// disable motors
+    if (mmu_enabled) enquecommand_P(MSG_M702_NO_LIFT); //unload from nozzle
+    enquecommand_P(MSG_M84);// disable motors
 }

--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -230,6 +230,7 @@ const char MSG_LCD_STATUS_CHANGED[] PROGMEM_N1 = "LCD status changed";
 const char MSG_UNKNOWN_CODE[] PROGMEM_N1 = "Unknown %c code: %s\n";
 
 // Common G-gcodes
+const char G1_E_F2700[] PROGMEM_N1 = "G1 E%-0.3f F2700";
 const char G28W0[] PROGMEM_N1 = "G28 W0";
 const char MSG_M23[] PROGMEM_N1 = "M23 %s";
 const char MSG_M24[] PROGMEM_N1 = "M24";

--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -231,7 +231,7 @@ const char MSG_UNKNOWN_CODE[] PROGMEM_N1 = "Unknown %c code: %s\n";
 
 // Common G-gcodes
 const char G1_E_F2700[] PROGMEM_N1 = "G1 E%-0.3f F2700";
-const char G28W0[] PROGMEM_N1 = "G28 W0";
+const char G28W[] PROGMEM_N1 = "G28 W";
 const char MSG_M23[] PROGMEM_N1 = "M23 %s";
 const char MSG_M24[] PROGMEM_N1 = "M24";
 const char MSG_M83[] PROGMEM_N1 = "M83";

--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -235,6 +235,7 @@ const char MSG_M23[] PROGMEM_N1 = "M23 %s";
 const char MSG_M24[] PROGMEM_N1 = "M24";
 const char MSG_M83[] PROGMEM_N1 = "M83";
 const char MSG_M84[] PROGMEM_N1 = "M84";
+const char MSG_M107[] PROGMEM_N1 = "M107";
 const char MSG_M500[] PROGMEM_N1 = "M500";
 const char MSG_M600[] PROGMEM_N1 = "M600";
 const char MSG_M701_NO_LIFT[] PROGMEM_N1 = "M701 Z0";

--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -232,6 +232,7 @@ const char MSG_UNKNOWN_CODE[] PROGMEM_N1 = "Unknown %c code: %s\n";
 // Common G-gcodes
 const char MSG_M701_NO_LIFT[] PROGMEM_N1 = "M701 Z0";
 const char MSG_M702_NO_LIFT[] PROGMEM_N1 = "M702 Z0";
+const char MSG_M23[] PROGMEM_N1 = "M23 %s";
 const char MSG_M24[] PROGMEM_N1 = "M24";
 const char MSG_M83[] PROGMEM_N1 = "M83";
 const char MSG_M84[] PROGMEM_N1 = "M84";

--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -230,9 +230,10 @@ const char MSG_LCD_STATUS_CHANGED[] PROGMEM_N1 = "LCD status changed";
 const char MSG_UNKNOWN_CODE[] PROGMEM_N1 = "Unknown %c code: %s\n";
 
 // Common G-gcodes
-const char MSG_M701_NO_LIFT[] PROGMEM_N1 = "M701 Z0";
-const char MSG_M702_NO_LIFT[] PROGMEM_N1 = "M702 Z0";
 const char MSG_M23[] PROGMEM_N1 = "M23 %s";
 const char MSG_M24[] PROGMEM_N1 = "M24";
 const char MSG_M83[] PROGMEM_N1 = "M83";
 const char MSG_M84[] PROGMEM_N1 = "M84";
+const char MSG_M600[] PROGMEM_N1 = "M600";
+const char MSG_M701_NO_LIFT[] PROGMEM_N1 = "M701 Z0";
+const char MSG_M702_NO_LIFT[] PROGMEM_N1 = "M702 Z0";

--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -232,5 +232,6 @@ const char MSG_UNKNOWN_CODE[] PROGMEM_N1 = "Unknown %c code: %s\n";
 // Common G-gcodes
 const char MSG_M701_NO_LIFT[] PROGMEM_N1 = "M701 Z0";
 const char MSG_M702_NO_LIFT[] PROGMEM_N1 = "M702 Z0";
+const char MSG_M24[] PROGMEM_N1 = "M24";
 const char MSG_M83[] PROGMEM_N1 = "M83";
 const char MSG_M84[] PROGMEM_N1 = "M84";

--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -235,6 +235,7 @@ const char MSG_M23[] PROGMEM_N1 = "M23 %s";
 const char MSG_M24[] PROGMEM_N1 = "M24";
 const char MSG_M83[] PROGMEM_N1 = "M83";
 const char MSG_M84[] PROGMEM_N1 = "M84";
+const char MSG_M500[] PROGMEM_N1 = "M500";
 const char MSG_M600[] PROGMEM_N1 = "M600";
 const char MSG_M701_NO_LIFT[] PROGMEM_N1 = "M701 Z0";
 const char MSG_M702_NO_LIFT[] PROGMEM_N1 = "M702 Z0";

--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -236,6 +236,7 @@ const char MSG_M24[] PROGMEM_N1 = "M24";
 const char MSG_M83[] PROGMEM_N1 = "M83";
 const char MSG_M84[] PROGMEM_N1 = "M84";
 const char MSG_M107[] PROGMEM_N1 = "M107";
+const char MSG_M220[] PROGMEM_N1 = "M220 S%d";
 const char MSG_M500[] PROGMEM_N1 = "M500";
 const char MSG_M600[] PROGMEM_N1 = "M600";
 const char MSG_M701_NO_LIFT[] PROGMEM_N1 = "M701 Z0";

--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -228,3 +228,9 @@ const char MSG_ADVANCE_K[] PROGMEM_N1 = "Advance K:"; ////c=13
 const char MSG_POWERPANIC_DETECTED[] PROGMEM_N1 = "POWER PANIC DETECTED"; ////c=20
 const char MSG_LCD_STATUS_CHANGED[] PROGMEM_N1 = "LCD status changed";
 const char MSG_UNKNOWN_CODE[] PROGMEM_N1 = "Unknown %c code: %s\n";
+
+// Common G-gcodes
+const char MSG_M701_NO_LIFT[] PROGMEM_N1 = "M701 Z0";
+const char MSG_M702_NO_LIFT[] PROGMEM_N1 = "M702 Z0";
+const char MSG_M83[] PROGMEM_N1 = "M83";
+const char MSG_M84[] PROGMEM_N1 = "M84";

--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -230,6 +230,7 @@ const char MSG_LCD_STATUS_CHANGED[] PROGMEM_N1 = "LCD status changed";
 const char MSG_UNKNOWN_CODE[] PROGMEM_N1 = "Unknown %c code: %s\n";
 
 // Common G-gcodes
+const char G28W0[] PROGMEM_N1 = "G28 W0";
 const char MSG_M23[] PROGMEM_N1 = "M23 %s";
 const char MSG_M24[] PROGMEM_N1 = "M24";
 const char MSG_M83[] PROGMEM_N1 = "M83";

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -236,12 +236,13 @@ extern const char MSG_LCD_STATUS_CHANGED[];
 extern const char MSG_UNKNOWN_CODE[];
 
 // Common G-gcodes
-extern const char MSG_M701_NO_LIFT[];
-extern const char MSG_M702_NO_LIFT[];
 extern const char MSG_M23[];
 extern const char MSG_M24[];
 extern const char MSG_M83[];
 extern const char MSG_M84[];
+extern const char MSG_M600[];
+extern const char MSG_M701_NO_LIFT[];
+extern const char MSG_M702_NO_LIFT[];
 
 #if defined(__cplusplus)
 }

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -241,6 +241,7 @@ extern const char MSG_M23[];
 extern const char MSG_M24[];
 extern const char MSG_M83[];
 extern const char MSG_M84[];
+extern const char MSG_M500[];
 extern const char MSG_M600[];
 extern const char MSG_M701_NO_LIFT[];
 extern const char MSG_M702_NO_LIFT[];

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -241,6 +241,7 @@ extern const char MSG_M23[];
 extern const char MSG_M24[];
 extern const char MSG_M83[];
 extern const char MSG_M84[];
+extern const char MSG_M107[];
 extern const char MSG_M500[];
 extern const char MSG_M600[];
 extern const char MSG_M701_NO_LIFT[];

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -238,6 +238,7 @@ extern const char MSG_UNKNOWN_CODE[];
 // Common G-gcodes
 extern const char MSG_M701_NO_LIFT[];
 extern const char MSG_M702_NO_LIFT[];
+extern const char MSG_M23[];
 extern const char MSG_M24[];
 extern const char MSG_M83[];
 extern const char MSG_M84[];

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -235,6 +235,12 @@ extern const char MSG_POWERPANIC_DETECTED[];
 extern const char MSG_LCD_STATUS_CHANGED[];
 extern const char MSG_UNKNOWN_CODE[];
 
+// Common G-gcodes
+extern const char MSG_M701_NO_LIFT[];
+extern const char MSG_M702_NO_LIFT[];
+extern const char MSG_M83[];
+extern const char MSG_M84[];
+
 #if defined(__cplusplus)
 }
 #endif //defined(__cplusplus)

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -236,6 +236,7 @@ extern const char MSG_LCD_STATUS_CHANGED[];
 extern const char MSG_UNKNOWN_CODE[];
 
 // Common G-gcodes
+extern const char G1_E_F2700[];
 extern const char G28W0[];
 extern const char MSG_M23[];
 extern const char MSG_M24[];

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -238,6 +238,7 @@ extern const char MSG_UNKNOWN_CODE[];
 // Common G-gcodes
 extern const char MSG_M701_NO_LIFT[];
 extern const char MSG_M702_NO_LIFT[];
+extern const char MSG_M24[];
 extern const char MSG_M83[];
 extern const char MSG_M84[];
 

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -237,7 +237,7 @@ extern const char MSG_UNKNOWN_CODE[];
 
 // Common G-gcodes
 extern const char G1_E_F2700[];
-extern const char G28W0[];
+extern const char G28W[];
 extern const char MSG_M23[];
 extern const char MSG_M24[];
 extern const char MSG_M83[];

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -236,6 +236,7 @@ extern const char MSG_LCD_STATUS_CHANGED[];
 extern const char MSG_UNKNOWN_CODE[];
 
 // Common G-gcodes
+extern const char G28W0[];
 extern const char MSG_M23[];
 extern const char MSG_M24[];
 extern const char MSG_M83[];

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -242,6 +242,7 @@ extern const char MSG_M24[];
 extern const char MSG_M83[];
 extern const char MSG_M84[];
 extern const char MSG_M107[];
+extern const char MSG_M220[];
 extern const char MSG_M500[];
 extern const char MSG_M600[];
 extern const char MSG_M701_NO_LIFT[];

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -188,7 +188,7 @@ void MMU2::CheckFINDARunout() {
         if (SpoolJoin::spooljoin.isSpoolJoinEnabled() && get_current_tool() != (uint8_t)FILAMENT_UNKNOWN){ // Can't auto if F=?
             enquecommand_front_P(PSTR("M600 AUTO")); // save print and run M600 command
         } else {
-            enquecommand_front_P(PSTR("M600")); // save print and run M600 command
+            enquecommand_front_P(MSG_M600); // save print and run M600 command
         }
     }
 }

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -916,7 +916,7 @@ void lcd_commands()
 			if (_Kp != 0 || _Ki != 0 || _Kd != 0) {
 				sprintf_P(cmd1, PSTR("M301 P%.2f I%.2f D%.2f"), _Kp, _Ki, _Kd);
 				enquecommand(cmd1);
-				enquecommand_P(PSTR("M500"));
+				enquecommand_P(MSG_M500);
 			}
 			else {
 				SERIAL_ECHOPGM("Invalid PID cal. results. Not stored to EEPROM.");
@@ -950,7 +950,7 @@ void lcd_commands()
 
         case 2:
             if (temp_model_autotune_result())
-                enquecommand_P(PSTR("M500"));
+                enquecommand_P(MSG_M500);
             lcd_commands_step = 1;
             break;
 

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -7304,7 +7304,7 @@ static void menu_action_sdfile(const char* filename)
   }
   if (result) {
 	  enquecommand(cmd);
-	  enquecommand_P(PSTR("M24"));
+	  enquecommand_P(MSG_M24);
   }
 
   lcd_return_to_status();

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1847,10 +1847,10 @@ switch(eFilamentAction)
                // FALLTHRU
           case FilamentAction::Load:
                loading_flag=true;
-               enquecommand_P(PSTR("M701"));      // load filament
+               enquecommand_P(MSG_M701_NO_LIFT);      // load filament
                break;
           case FilamentAction::UnLoad:
-               enquecommand_P(PSTR("M702"));      // unload filament
+               enquecommand_P(MSG_M702_NO_LIFT);      // unload filament
                break;
           case FilamentAction::MmuLoad:
           case FilamentAction::MmuLoadingTest:
@@ -1908,11 +1908,11 @@ void mFilamentItem(uint16_t nTemp, uint16_t nTempBed)
                 if ((eFilamentAction == FilamentAction::Load) || (eFilamentAction == FilamentAction::AutoLoad))
                 {
                     loading_flag = true;
-                    enquecommand_P(PSTR("M701")); // load filament
+                    enquecommand_P(MSG_M701_NO_LIFT); // load filament
                     if (eFilamentAction == FilamentAction::AutoLoad) eFilamentAction = FilamentAction::None; // i.e. non-autoLoad
                 }
                 if (eFilamentAction == FilamentAction::UnLoad)
-                enquecommand_P(PSTR("M702")); // unload filament
+                enquecommand_P(MSG_M702_NO_LIFT); // unload filament
             }
             break;
         case FilamentAction::MmuLoad:
@@ -3804,7 +3804,7 @@ static void lcd_wizard_load() {
         loading_flag = true;
     }
     gcode_M701(FILAMENTCHANGE_FIRSTFEED, 0);
-    //enquecommand_P(PSTR("M701"));
+    //enquecommand_P(MSG_M701_NO_LIFT); // is enqueuecommand_P safe here?
 }
 
 static void wizard_lay1cal_message(bool cold)
@@ -4593,7 +4593,7 @@ static void lcd_settings_menu()
 	if (!printer_active() || isPrintPaused)
     {
 	    MENU_ITEM_SUBMENU_P(_i("Move axis"), lcd_move_menu_axis);////MSG_MOVE_AXIS c=18
-	    MENU_ITEM_GCODE_P(_i("Disable steppers"), PSTR("M84"));////MSG_DISABLE_STEPPERS c=18
+	    MENU_ITEM_GCODE_P(_i("Disable steppers"), MSG_M84);////MSG_DISABLE_STEPPERS c=18
     }
 
 #ifdef FILAMENT_SENSOR
@@ -6363,7 +6363,7 @@ bool lcd_selftest()
 		_progress = lcd_selftest_screen(TestScreen::Failed, _progress, 3, true, 5000);
 	}
 	lcd_reset_alert_level();
-	enquecommand_P(PSTR("M84"));
+	enquecommand_P(MSG_M84);
 	lcd_update_enable(true);
 	
 	if (_result)

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5490,7 +5490,7 @@ void stepper_timer_overflow() {
 
 static void lcd_colorprint_change() {
 	
-	enquecommand_P(PSTR("M600"));
+	enquecommand_P(MSG_M600);
 
 	custom_message_type = CustomMsg::FilamentLoading; //just print status message
 	lcd_setstatuspgm(_T(MSG_FINISHING_MOVEMENTS));

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -7269,7 +7269,7 @@ static void menu_action_sdfile(const char* filename)
   char cmd[30];
   char* c;
   bool result = true;
-  sprintf_P(cmd, PSTR("M23 %s"), filename);
+  sprintf_P(cmd, MSG_M23, filename);
   for (c = &cmd[4]; *c; c++)
     *c = tolower(*c);
 


### PR DESCRIPTION
Previously when the firmware called M701/M702 manually there was no Z lift. But after we added support for the Z parameter we set the default to 50mm.

Change strings `"M701"` to `"M701 Z0"` and `"M702"` to `"M702 Z0"` to restore the previous behavior from before 3.13.

Also pulled the gcodes into PROGMEM in message.cpp along with M83 and M84 to save memory. We can maybe save more memory with other gcodes.

Change in memory:
Flash: -124 bytes
SRAM: 0 bytes