### PR TITLE
Reduce code size in First Layer Calibration

### DIFF
--- a/Firmware/first_lay_cal.cpp
+++ b/Firmware/first_lay_cal.cpp
@@ -47,12 +47,16 @@ static const char zero_extrusion[] PROGMEM = "G92 E0";
 //! @brief Wait for preheat
 void lay1cal_wait_preheat()
 {
-    const char * const preheat_cmd[] =
+    static const char preheat_cmd_2[] PROGMEM = "M190";
+    static const char preheat_cmd_3[] PROGMEM = "M109";
+    static const char preheat_cmd_4[] PROGMEM = "G28";
+
+    static const char * const preheat_cmd[] PROGMEM =
     {
         MSG_M107,
-        PSTR("M190"),
-        PSTR("M109"),
-        PSTR("G28"),
+        preheat_cmd_2,
+        preheat_cmd_3,
+        preheat_cmd_4,
         zero_extrusion
     };
 

--- a/Firmware/first_lay_cal.cpp
+++ b/Firmware/first_lay_cal.cpp
@@ -33,6 +33,14 @@ static constexpr float spacing(float layer_height, float extrusion_width, float 
     return extrusion_width - layer_height * (overlap_factor - M_PI/4);
 }
 
+// Common code extracted into one function to reduce code size
+static void lay1cal_common_enqueue_loop(const char * const * cmd_sequence) {
+    for (uint8_t i = 0; i < (sizeof(cmd_sequence)/sizeof(cmd_sequence[0])); ++i)
+    {
+        enquecommand_P(static_cast<char*>(pgm_read_ptr(&cmd_sequence[i])));
+    }
+}
+
 static const char extrude_fmt[] PROGMEM = "G1 X%d Y%d E%-.5f";
 static const char zero_extrusion[] PROGMEM = "G92 E0";
 
@@ -48,10 +56,7 @@ void lay1cal_wait_preheat()
         zero_extrusion
     };
 
-    for (uint8_t i = 0; i < (sizeof(preheat_cmd)/sizeof(preheat_cmd[0])); ++i)
-    {
-        enquecommand_P(preheat_cmd[i]);
-    }
+    lay1cal_common_enqueue_loop(preheat_cmd);
 }
 
 //! @brief Load filament
@@ -157,10 +162,7 @@ void lay1cal_before_meander()
             cmd_pre_meander_7,
     };
 
-    for (uint8_t i = 0; i < (sizeof(cmd_pre_meander)/sizeof(cmd_pre_meander[0])); ++i)
-    {
-        enquecommand_P(static_cast<char*>(pgm_read_ptr(&cmd_pre_meander[i])));
-    }
+    lay1cal_common_enqueue_loop(cmd_pre_meander);
 }
 
 //! @brief Print meander start
@@ -261,10 +263,7 @@ void lay1cal_finish(bool mmu_enabled)
             cmd_cal_finish_5
     };
 
-    for (uint8_t i = 0; i < (sizeof(cmd_cal_finish)/sizeof(cmd_cal_finish[0])); ++i)
-    {
-        enquecommand_P(static_cast<char*>(pgm_read_ptr(&cmd_cal_finish[i])));
-    }
+    lay1cal_common_enqueue_loop(cmd_cal_finish);
 
     if (mmu_enabled) enquecommand_P(MSG_M702_NO_LIFT); //unload from nozzle
     enquecommand_P(MSG_M84);// disable motors

--- a/Firmware/first_lay_cal.cpp
+++ b/Firmware/first_lay_cal.cpp
@@ -34,10 +34,10 @@ static constexpr float spacing(float layer_height, float extrusion_width, float 
 }
 
 // Common code extracted into one function to reduce code size
-static void lay1cal_common_enqueue_loop(const char * const * cmd_sequence) {
-    for (uint8_t i = 0; i < (sizeof(cmd_sequence)/sizeof(cmd_sequence[0])); ++i)
+static void lay1cal_common_enqueue_loop(const char * const * cmd_sequence, const uint8_t steps) {
+    for (uint8_t i = 0; i < steps; ++i)
     {
-        enquecommand_P(static_cast<char*>(pgm_read_ptr(&cmd_sequence[i])));
+        enquecommand_P(static_cast<char*>(pgm_read_ptr(cmd_sequence + i)));
     }
 }
 
@@ -60,7 +60,7 @@ void lay1cal_wait_preheat()
         zero_extrusion
     };
 
-    lay1cal_common_enqueue_loop(preheat_cmd);
+    lay1cal_common_enqueue_loop(preheat_cmd, sizeof(preheat_cmd)/sizeof(preheat_cmd[0]));
 }
 
 //! @brief Load filament
@@ -166,7 +166,7 @@ void lay1cal_before_meander()
             cmd_pre_meander_7,
     };
 
-    lay1cal_common_enqueue_loop(cmd_pre_meander);
+    lay1cal_common_enqueue_loop(cmd_pre_meander, (sizeof(cmd_pre_meander)/sizeof(cmd_pre_meander[0])));
 }
 
 //! @brief Print meander start
@@ -267,7 +267,7 @@ void lay1cal_finish(bool mmu_enabled)
             cmd_cal_finish_5
     };
 
-    lay1cal_common_enqueue_loop(cmd_cal_finish);
+    lay1cal_common_enqueue_loop(cmd_cal_finish, (sizeof(cmd_cal_finish)/sizeof(cmd_cal_finish[0])));
 
     if (mmu_enabled) enquecommand_P(MSG_M702_NO_LIFT); //unload from nozzle
     enquecommand_P(MSG_M84);// disable motors


### PR DESCRIPTION
* Create a common function to enqueue an array of `PROGMEM` commands. The array is required to be in program memory.
* Added `preheat_cmd` into `PROGMEM`, this required adding all it's commands into `PROGMEM` as well, `PSTR()` was not accepted by the compiler.

Change in memory:
Flash: -60 bytes
SRAM: 0 bytes