### PR TITLE
Remove `MSG_BTN_MORE` from translation list

### DIFF
--- a/Firmware/mmu2/errors_list.h
+++ b/Firmware/mmu2/errors_list.h
@@ -332,7 +332,7 @@ static const char MSG_BTN_RESTART_MMU[] PROGMEM_I1 = ISTR("RstMMU"); ////MSG_BTN
 static const char MSG_BTN_UNLOAD[] PROGMEM_I1 = ISTR("Unload"); ////MSG_BTN_UNLOAD c=8
 static const char MSG_BTN_STOP[] PROGMEM_I1 = ISTR("Stop"); ////MSG_BTN_STOP c=8
 static const char MSG_BTN_DISABLE_MMU[] PROGMEM_I1 = ISTR("Disable"); ////MSG_BTN_DISABLE_MMU c=8
-static const char MSG_BTN_MORE[] PROGMEM_I1 = ISTR("\x06"); ////MSG_BTN_MORE c=8
+static const char MSG_BTN_MORE[] PROGMEM_N1 = "\x06";
 
 // Used to parse the buttons from Btns().
 static const char * const btnOperation[] PROGMEM = {

--- a/Firmware/mmu2_error_converter.cpp
+++ b/Firmware/mmu2_error_converter.cpp
@@ -172,7 +172,7 @@ const char * PrusaErrorButtonTitle(uint8_t bi){
 }
 
 const char * PrusaErrorButtonMore(){
-    return _R(MSG_BTN_MORE);
+    return MSG_BTN_MORE;
 }
 
 struct ResetOnExit {

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -77,7 +77,7 @@ static void ReportErrorHookStaticRender(uint8_t ei) {
     ReportErrorHookSensorLineRender();
 
     // Render the choices
-    lcd_show_choices_prompt_P(two_choices ? LCD_LEFT_BUTTON_CHOICE : LCD_MIDDLE_BUTTON_CHOICE, _T(PrusaErrorButtonTitle(button_op_middle)), _T(two_choices ? PrusaErrorButtonMore() : PrusaErrorButtonTitle(button_op_right)), two_choices ? 18 : 9, two_choices ? nullptr : _T(PrusaErrorButtonMore()));
+    lcd_show_choices_prompt_P(two_choices ? LCD_LEFT_BUTTON_CHOICE : LCD_MIDDLE_BUTTON_CHOICE, _T(PrusaErrorButtonTitle(button_op_middle)), two_choices ? PrusaErrorButtonMore() : _T(PrusaErrorButtonTitle(button_op_right)), two_choices ? 18 : 9, two_choices ? nullptr : PrusaErrorButtonMore());
 }
 
 void ReportErrorHookSensorLineRender(){

--- a/lang/po/Firmware.pot
+++ b/lang/po/Firmware.pot
@@ -2430,12 +2430,6 @@ msgstr ""
 msgid "unknown state"
 msgstr ""
 
-#. MSG_BTN_MORE c=8
-#: ../../Firmware/mmu2/errors_list.h:335
-#: ../../Firmware/mmu2_error_converter.cpp:175
-msgid "⏬"
-msgstr ""
-
 #. MSG_REFRESH c=18
 #: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:5943
 #: ../../Firmware/ultralcd.cpp:5946

--- a/lang/po/Firmware_cs.po
+++ b/lang/po/Firmware_cs.po
@@ -2530,12 +2530,6 @@ msgstr ""
 "Verze firmwaru MMU není kompatibilní s FW tiskárny. Aktualizujte na verzi "
 "2.1.9."
 
-#. MSG_BTN_MORE c=8
-#: ../../Firmware/mmu2/errors_list.h:335
-#: ../../Firmware/mmu2_error_converter.cpp:175
-msgid "⏬"
-msgstr "⏬"
-
 #~ msgid "Eject filament"
 #~ msgstr "Vysunout fil."
 

--- a/lang/po/Firmware_de.po
+++ b/lang/po/Firmware_de.po
@@ -2558,12 +2558,6 @@ msgstr ""
 "Die Firmware-Version der MMU ist mit der FW des Druckers nicht kompatibel. "
 "Update auf Version 2.1.9."
 
-#. MSG_BTN_MORE c=8
-#: ../../Firmware/mmu2/errors_list.h:335
-#: ../../Firmware/mmu2_error_converter.cpp:175
-msgid "⏬"
-msgstr "⏬"
-
 #~ msgid "Eject filament"
 #~ msgstr "Filamentauswurf"
 

--- a/lang/po/Firmware_es.po
+++ b/lang/po/Firmware_es.po
@@ -2554,12 +2554,6 @@ msgstr ""
 "La versión de firmware de la MMU es incompatible con el FW de la impresora. "
 "Actualizar a la versión 2.1.9."
 
-#. MSG_BTN_MORE c=8
-#: ../../Firmware/mmu2/errors_list.h:335
-#: ../../Firmware/mmu2_error_converter.cpp:175
-msgid "⏬"
-msgstr "⏬"
-
 #~ msgid "Reset MMU"
 #~ msgstr "Reset MMU"
 

--- a/lang/po/Firmware_fr.po
+++ b/lang/po/Firmware_fr.po
@@ -2568,12 +2568,6 @@ msgstr ""
 "La version du MMU est incompatible avec le FW de l'imprimante. Mise à jour "
 "vers la version 2.1.9."
 
-#. MSG_BTN_MORE c=8
-#: ../../Firmware/mmu2/errors_list.h:335
-#: ../../Firmware/mmu2_error_converter.cpp:175
-msgid "⏬"
-msgstr "⏬"
-
 #~ msgid "Reset MMU"
 #~ msgstr "Reini MMU"
 

--- a/lang/po/Firmware_hr.po
+++ b/lang/po/Firmware_hr.po
@@ -2547,12 +2547,6 @@ msgstr ""
 "Verzija firmware-a MMU nekompatibilna s FW-om pisača. Ažuriranje na verziju "
 "2.1.9."
 
-#. MSG_BTN_MORE c=8
-#: ../../Firmware/mmu2/errors_list.h:335
-#: ../../Firmware/mmu2_error_converter.cpp:175
-msgid "⏬"
-msgstr "⏬"
-
 #~ msgid "Reset MMU"
 #~ msgstr "Reset MMU"
 

--- a/lang/po/Firmware_hu.po
+++ b/lang/po/Firmware_hu.po
@@ -2551,12 +2551,6 @@ msgstr ""
 "Az MMU firmware-verziója nem kompatibilis a nyomtató FW-vel. Frissítés a "
 "2.1.9-es verzióra."
 
-#. MSG_BTN_MORE c=8
-#: ../../Firmware/mmu2/errors_list.h:335
-#: ../../Firmware/mmu2_error_converter.cpp:175
-msgid "⏬"
-msgstr "⏬"
-
 #~ msgid "Reset MMU"
 #~ msgstr "MMUreszet"
 

--- a/lang/po/Firmware_it.po
+++ b/lang/po/Firmware_it.po
@@ -2552,12 +2552,6 @@ msgstr ""
 "La versione del firmware dell MMU non è compatibile con il firmware della "
 "stampante. Aggiornamento alla versione 2.1.9."
 
-#. MSG_BTN_MORE c=8
-#: ../../Firmware/mmu2/errors_list.h:335
-#: ../../Firmware/mmu2_error_converter.cpp:175
-msgid "⏬"
-msgstr "⏬"
-
 #~ msgid "Reset MMU"
 #~ msgstr "Reset MMU"
 

--- a/lang/po/Firmware_nl.po
+++ b/lang/po/Firmware_nl.po
@@ -2556,12 +2556,6 @@ msgstr ""
 "De firmwareversie van de MMU is niet compatibel met de firmware van de "
 "printer. Update naar versie 2.1.9."
 
-#. MSG_BTN_MORE c=8
-#: ../../Firmware/mmu2/errors_list.h:335
-#: ../../Firmware/mmu2_error_converter.cpp:175
-msgid "⏬"
-msgstr "⏬"
-
 #~ msgid "Reset MMU"
 #~ msgstr "Reset MMU"
 

--- a/lang/po/Firmware_no.po
+++ b/lang/po/Firmware_no.po
@@ -2529,12 +2529,6 @@ msgstr ""
 "MMU fastvareversjon er inkompatibel med skriverens FW. Oppdatering til "
 "versjon 2.1.9."
 
-#. MSG_BTN_MORE c=8
-#: ../../Firmware/mmu2/errors_list.h:335
-#: ../../Firmware/mmu2_error_converter.cpp:175
-msgid "⏬"
-msgstr "⏬"
-
 #~ msgid "Reset MMU"
 #~ msgstr "Reset MMU"
 

--- a/lang/po/Firmware_pl.po
+++ b/lang/po/Firmware_pl.po
@@ -2548,12 +2548,6 @@ msgstr ""
 "Wersja oprogramowania układowego MMU jest niezgodna z oprogramowaniem "
 "sprzętowym drukarki. Zaktualizuj do wersji 2.1.9."
 
-#. MSG_BTN_MORE c=8
-#: ../../Firmware/mmu2/errors_list.h:335
-#: ../../Firmware/mmu2_error_converter.cpp:175
-msgid "⏬"
-msgstr "⏬"
-
 #~ msgid "Reset MMU"
 #~ msgstr "Reset MMU"
 

--- a/lang/po/Firmware_ro.po
+++ b/lang/po/Firmware_ro.po
@@ -2552,12 +2552,6 @@ msgstr ""
 "Versiunea de firmware a MMU este incompatibilă cu FW-ul imprimantei. "
 "Actualizați la versiunea 2.1.9."
 
-#. MSG_BTN_MORE c=8
-#: ../../Firmware/mmu2/errors_list.h:335
-#: ../../Firmware/mmu2_error_converter.cpp:175
-msgid "⏬"
-msgstr "⏬"
-
 #~ msgid "Reset MMU"
 #~ msgstr "Reset MMU"
 

--- a/lang/po/Firmware_sk.po
+++ b/lang/po/Firmware_sk.po
@@ -2535,12 +2535,6 @@ msgstr ""
 "Verzia firmvéru MMU nie je kompatibilná s FW tlačiarne. Aktualizácia na "
 "verziu 2.1.9."
 
-#. MSG_BTN_MORE c=8
-#: ../../Firmware/mmu2/errors_list.h:335
-#: ../../Firmware/mmu2_error_converter.cpp:175
-msgid "⏬"
-msgstr "⏬"
-
 #~ msgid "Reset MMU"
 #~ msgstr "Reset MMU"
 

--- a/lang/po/Firmware_sv.po
+++ b/lang/po/Firmware_sv.po
@@ -2542,12 +2542,6 @@ msgstr ""
 "MMU firmwareversion är inkompatibel med skrivarens FW. Uppdatering till "
 "version 2.1.9."
 
-#. MSG_BTN_MORE c=8
-#: ../../Firmware/mmu2/errors_list.h:335
-#: ../../Firmware/mmu2_error_converter.cpp:175
-msgid "⏬"
-msgstr "⏬"
-
 #~ msgid "Reset MMU"
 #~ msgstr "Reset MMU"
 


### PR DESCRIPTION
There was just one extra `_T()` we needed to remove, the more button renders correctly on my printer when using the multilang build. To reproduce an error screen, just select Load to Nozzle and don't feed any filament to the FINDA.

Change in memory:
Flash: -8 bytes
SRAM: 0 bytes