### PR TITLE
PFW-1515 Fix an issue with Thermal Anomaly message

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -562,7 +562,9 @@ void lcdui_print_status_line(void) {
             scrollstuff = 0;
         }
     } else { // Otherwise check for other special events
-        if (!lcd_status_message_timeout.expired_cont(LCD_STATUS_DELAYED_TIMEOUT))
+        if ( custom_message_type != CustomMsg::Status
+        && lcd_status_message_timeout.running()
+        && lcd_status_message_timeout.elapsed() < LCD_STATUS_DELAYED_TIMEOUT)
         {
             return; // Nothing to do, waiting for delay to expire
         }


### PR DESCRIPTION
Issue introduced with PFW-1504

Problem with `expired_cont()` and `expired()` is they will stop the timer once expired is true. For the purpose of just delaying the next progress message when rendering the MMU visualisation, this was not the intended behavior. We just want to wait for 4 seconds to pass. For now don't apply this delay/waiting when the custom message type is `Status`.

Change in memory:
Flash: +40 bytes
SRAM: 0 bytes