### PR TITLE
Reduce calls to `__divsf3` when calculating feedrate

### DIFF
--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -287,6 +287,11 @@ void prepare_move(uint16_t start_segment_idx = 0);
 void prepare_arc_move(bool isclockwise, uint16_t start_segment_idx = 0);
 uint16_t restore_interrupted_gcode();
 
+///@brief Helper function to reduce code size, cheaper to call function than to inline division
+///@param feedrate_mm_min feedrate with unit mm per minute
+///@returns feedrate with unit mm per second
+float __attribute__((noinline)) get_feedrate_mm_s(const float feedrate_mm_min);
+
 #ifdef TMC2130
 void homeaxis(uint8_t axis, uint8_t cnt = 1, uint8_t* pstep = 0);
 #else

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2418,7 +2418,7 @@ static void _lcd_move(const char *name, uint8_t axis, int min, int max)
 			if (max_software_endstops && current_position[axis] > max) current_position[axis] = max;
 			lcd_encoder = 0;
 			world2machine_clamp(current_position[X_AXIS], current_position[Y_AXIS]);
-			plan_buffer_line_curposXYZE(manual_feedrate[axis] / 60);
+			plan_buffer_line_curposXYZE(get_feedrate_mm_s(manual_feedrate[axis]));
 			lcd_draw_update = 1;
 		}
 	}


### PR DESCRIPTION
For non-time critical code it is more efficient to call a function rather than inlining each division operation.

Most of the time there is no call to `__divsf3` but this PR optimizes the few exceptions.

Change in memory:
Flash: -122 bytes
SRAM: 0 bytes