### PR TITLE
Fix HBed on Load for MMU Loading test

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1783,6 +1783,7 @@ bool shouldPreheatOnlyNozzle() {
         case FilamentAction::UnLoad:
         case FilamentAction::MmuLoad:
         case FilamentAction::MmuUnLoad:
+        case FilamentAction::MmuLoadingTest:
         case FilamentAction::MmuEject:
         case FilamentAction::MmuCut:
             return true;


### PR DESCRIPTION
During testing I have found the LCD Settings -> Load Test ignores the Settings -> Hbed on load state. This fixes the issue