### PR TITLE
Ensure E-Cool off during MMU2 load/unload.

### DIFF
--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -14,7 +14,7 @@
 
 #ifdef TMC2130
 #include "tmc2130.h"
-#include "Prusa_Farm.h"
+#include "Prusa_farm.h"
 #include "stepper.h"
 #endif //TMC2130
 

--- a/Firmware/mmu2.h
+++ b/Firmware/mmu2.h
@@ -229,6 +229,7 @@ private:
     void filament_ramming();
     void execute_extruder_sequence(const E_Step *sequence, uint8_t steps);
     void execute_load_to_nozzle_sequence();
+    bool load_unload_ecool_toggle(bool enable);
 
     /// Reports an error into attached ExtUIs
     /// @param ec error code, see ErrorCode


### PR DESCRIPTION
Temporarily toggles E-Cool off during MMU2 load/unload sequence to avoid issue with the many small steps used during those sequences. Meant to fix #3497.