### PR TITLE
Fix clicking noise during Toolchange when E-cool mode is enabled

### DIFF
--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -1054,6 +1054,11 @@ void MMU2::OnMMUProgressMsgSame(ProgressCode pc) {
             case FilamentState::NOT_PRESENT:
                 // fsensor not triggered, continue moving extruder
                 if (!planner_any_moves()) { // Only plan a move if there is no move ongoing
+                    // Plan a very long move, where 'very long' is hundreds
+                    // of millimeters. Keep in mind though the move can't be much longer
+                    // than 450mm because the firmware will ignore too long extrusions
+                    // for safety reasons. See PREVENT_LENGTHY_EXTRUDE.
+                    // Use 350mm to be safely away from the prevention threshold
                     MoveE(350.0f, MMU2_LOAD_TO_NOZZLE_FEED_RATE);
                 }
                 break;

--- a/Firmware/mmu2_marlin.h
+++ b/Firmware/mmu2_marlin.h
@@ -26,6 +26,7 @@ void MoveE(float delta, float feedRate);
 
 float MoveRaiseZ(float delta);
 
+void planner_abort_queued_moves();
 void planner_synchronize();
 bool planner_any_moves();
 float planner_get_machine_position_E_mm();

--- a/Firmware/mmu2_marlin1.cpp
+++ b/Firmware/mmu2_marlin1.cpp
@@ -18,6 +18,11 @@ float MoveRaiseZ(float delta) {
     return raise_z(delta);
 }
 
+void planner_abort_queued_moves() {
+    planner_abort_hard();
+    planner_aborted = false;
+}
+
 void planner_synchronize() {
     st_synchronize();
 }

--- a/Firmware/mmu2_marlin1.cpp
+++ b/Firmware/mmu2_marlin1.cpp
@@ -20,6 +20,12 @@ float MoveRaiseZ(float delta) {
 
 void planner_abort_queued_moves() {
     planner_abort_hard();
+
+    // Unblock the planner. This should be safe in the
+    // toolchange context. Currently we are mainly aborting
+    // excess E-moves after detecting filament during toolchange.
+    // If a MMU error is reported, the planner must be unblocked
+    // as well so the extruder can be parked safely.
     planner_aborted = false;
 }
 


### PR DESCRIPTION
Idea to fix https://github.com/prusa3d/Prusa-Firmware/issues/3497 by using the re-written MMU code on the MK3 side (3.13).

Kudos goes to @leptun for this idea, this is my attempt at implementing it.

Currently we are queuing many small 2 mm E-moves until the filament sensor triggers. We do this because we never abort any queued moves, so making small 2 mm moves ensures we do not move the E-motor more than 2 mm past the filament sensor.

Unfortunately, when E-cool mode is enabled, the E-motor will create audible clicking sounds (similar one hears during jam or a loose grub screw). A workaround for this is to queue one or more very long moves. Where _very long_ is something of the order of hundreds of millimeters. I have it set to 350 mm but it's just a random constant really. Keep in mind the firmware will block too large E-moves, if I recall correctly it was anything above > 450 mm (see `PREVENT_LENGTHY_EXTRUDE`)

In order to use very long moves, we must somehow stop the E-motor from moving once the filament sensor triggers. In other words, throw away what's left of the current E-motor move. For this simple purpose  we can use `planner_abort_hard()` but we must set `planner_aborted` to `false` afterwards because the code architecture does not allow the main `loop()` to run until the Toolchange command is done processing.


Video demonstration
=====

**BEFORE:** https://youtu.be/4BohuSCnrIU (Notice the clicking sound when the MMU changes state from Loading to Gears, to Loading to Fsensor)

**AFTER:** https://youtu.be/K3Io_GBRNfo (Clicking noise is gone, sound is smooth like normal) 


------

TO-DO list:
=====

- [x] Run a multi-color print with at least 100 toolchanges
- [x] Add more comments to the code, e.g. document function and our intention with the abort. It's only for E-moves.

-----

Change in memory:
Flash: +18 bytes
SRAM: 0 bytes