### PR TITLE
Fix a few ambiguous overloaded calls

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3463,7 +3463,7 @@ static void mmu_M600_unload_filament() {
     lcd_clear();
     lcd_puts_at_P(0, 1, _T(MSG_UNLOADING_FILAMENT));
     lcd_print(' ');
-    lcd_print(MMU2::mmu2.get_current_tool() + 1);
+    lcd_print(uint8_t(MMU2::mmu2.get_current_tool() + 1));
 
     // unload just current filament for multimaterial printers (used also in M702)
     MMU2::mmu2.unload();

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -320,7 +320,7 @@ static void FullScreenMsg(const char *pgmS, uint8_t slot){
     lcd_clear();
     lcd_puts_at_P(0, 1, pgmS);
     lcd_print(' ');
-    lcd_print(slot + 1);
+    lcd_print(uint8_t(slot + 1));
 }
 
 void FullScreenMsgCut(uint8_t slot){

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -583,7 +583,7 @@ void lcdui_print_status_line(void) {
                 lcd_space(LCD_WIDTH);
                 lcd_puts_at_P(0, 3, _T(MSG_CALIBRATE_Z_AUTO));
                 lcd_puts_P(PSTR(" : "));
-                lcd_print(custom_message_state - 10);
+                lcd_print(uint8_t(custom_message_state - 10));
             } else {
                 if (custom_message_state == 3) {
                     lcd_setstatuspgm(MSG_WELCOME);
@@ -4823,7 +4823,7 @@ uint8_t choose_menu_P(const char *header, const char *item, const char *last_ite
         for (uint_least8_t i = 0; i < ordinary_items; i++)
         {
             lcd_set_cursor(2 + item_len, i+1);
-            lcd_print(first + i + 1);
+            lcd_print(uint8_t(first + i + 1));
         }
 
         if (last_item&&last_visible) lcd_puts_at_P(1, 3, last_item);


### PR DESCRIPTION
Noticed this when exploring another optimization

By specifying exactly which overloaded function to use we save some memory. I suspect `uint8_t` was being promoted to `int16_t` or `uint16_t` (will need to look at the assembly to see what is happening).
Seems to have something to do with doing arithmetic in the function argument

Change in memory:
Flash: -156 bytes
SRAM: 0 bytes