### PR TITLE
Postponed kill() message with softReset

### DIFF
--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -234,7 +234,7 @@ void FlushSerialRequestResend();
 void ClearToSend();
 void update_currents();
 
-void kill(const char *full_screen_message = NULL, unsigned char id = 0);
+void kill(const char *full_screen_message = NULL);
 void finishAndDisableSteppers();
 
 void UnconditionalStop();                   // Stop heaters, motion and clear current print status

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1041,11 +1041,11 @@ static void fw_crash_init()
 
 static void fw_kill_init() {
     if (eeprom_read_byte((uint8_t*)EEPROM_KILL_PENDING_FLAG) == KILL_PENDING_FLAG) {
-        PGM_P kill_msg = (PGM_P)eeprom_read_word((uint16_t*)EEPROM_KILL_MESSAGE);
         // clear pending message event
         eeprom_write_byte((uint8_t*)EEPROM_KILL_PENDING_FLAG, EEPROM_EMPTY_VALUE);
 
         // display the kill message
+        PGM_P kill_msg = (PGM_P)eeprom_read_word((uint16_t*)EEPROM_KILL_MESSAGE);
         lcd_show_fullscreen_message_and_wait_P(kill_msg);
     }
 }

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1037,11 +1037,13 @@ static void fw_crash_init()
     eeprom_update_byte((uint8_t*)EEPROM_FW_CRASH_FLAG, 0xFF);
 }
 
+#define KILL_PENDING_FLAG 0x42
+
 static void fw_kill_init() {
-    PGM_P kill_msg = (PGM_P)eeprom_init_default_word((uint16_t*)EEPROM_KILL_MESSAGE, 0);
-    if (kill_msg) {
+    if (eeprom_read_byte((uint8_t*)EEPROM_KILL_PENDING_FLAG) == KILL_PENDING_FLAG) {
+        PGM_P kill_msg = (PGM_P)eeprom_read_word((uint16_t*)EEPROM_KILL_MESSAGE);
         // clear pending message event
-        eeprom_write_word((uint16_t*)EEPROM_KILL_MESSAGE, 0);
+        eeprom_write_byte((uint8_t*)EEPROM_KILL_PENDING_FLAG, EEPROM_EMPTY_VALUE);
 
         // display the kill message
         lcd_show_fullscreen_message_and_wait_P(kill_msg);
@@ -9501,6 +9503,7 @@ void kill(const char *full_screen_message) {
 
     // update eeprom with the correct kill message to be shown on startup
     eeprom_write_word((uint16_t*)EEPROM_KILL_MESSAGE, (uint16_t)full_screen_message);
+    eeprom_write_byte((uint8_t*)EEPROM_KILL_PENDING_FLAG, KILL_PENDING_FLAG);
 
     softReset();
 }

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1355,6 +1355,9 @@ void setup()
     if (!xflash_success)
         xflash_err_msg();
 
+    // report kill() events
+    fw_kill_init();
+
 #ifdef FILAMENT_SENSOR
     fsensor.init();
 #endif //FILAMENT_SENSOR
@@ -1587,9 +1590,6 @@ void setup()
 
     // report crash failures
     fw_crash_init();
-
-    // report kill() events
-    fw_kill_init();
 
 #ifdef UVLO_SUPPORT
   if (eeprom_read_byte((uint8_t*)EEPROM_UVLO) != 0) { //previous print was terminated by UVLO

--- a/Firmware/cardreader.cpp
+++ b/Firmware/cardreader.cpp
@@ -402,7 +402,7 @@ void CardReader::openFileReadFilteredGcode(const char* name, bool replace_curren
                 // SERIAL_ERROR_START;
                 // SERIAL_ERRORPGM("trying to call sub-gcode files with too many levels. MAX level is:");
                 // SERIAL_ERRORLN(SD_PROCEDURE_DEPTH);
-                kill(ofKill, 1);
+                kill(ofKill);
                 return;
             }
             
@@ -469,7 +469,7 @@ void CardReader::openFileWrite(const char* name)
             // SERIAL_ERROR_START;
             // SERIAL_ERRORPGM("trying to call sub-gcode files with too many levels. MAX level is:");
             // SERIAL_ERRORLN(SD_PROCEDURE_DEPTH);
-            kill(ofKill, 1);
+            kill(ofKill);
             return;
         }
         

--- a/Firmware/cmdqueue.cpp
+++ b/Firmware/cmdqueue.cpp
@@ -455,7 +455,7 @@ void get_command()
 
         // Handle KILL early, even when Stopped
         if(strcmp_P(cmd_start, PSTR("M112")) == 0)
-          kill(MSG_M112_KILL, 2);
+          kill(MSG_M112_KILL);
 
         // Bypass Stopped for some commands
         bool allow_when_stopped = false;

--- a/Firmware/eeprom.h
+++ b/Firmware/eeprom.h
@@ -363,6 +363,7 @@ static_assert(sizeof(Sheets) == EEPROM_SHEETS_SIZEOF, "Sizeof(Sheets) is not EEP
 | 0x0C99 3225 | uint16  | EEPROM_TEMP_MODEL_L                   | 0-2160       | ff ffh                | Temp model sim. response lag (ms)                 | Temp model   | D3 Ax0c99 C2
 | 0x0C98 3224 | uint8   | EEPROM_TEMP_MODEL_VER                 | 0-255        | ffh                   | Temp model Version                                | Temp model   | D3 Ax0c98 C1
 | 0x0C96 3222 | PGM_P   | EEPROM_KILL_MESSAGE                   | 0-65535      | ff ffh                | Kill message PGM pointer                          | kill()       | D3 Ax0c96 C2
+| 0x0C95 3221 | uint8   | EEPROM_KILL_PENDING_FLAG              | 42h, ffh     | ffh                   | Kill pending flag (0x42 magic value)              | kill()       | D3 Ax0c95 C1
 
 |Address begin|Bit/Type | Name                                  | Valid values | Default/FactoryReset  | Description                                       |Gcode/Function| Debug code
 | :--:        | :--:    | :--:                                  | :--:         | :--:                  | :--:                                              | :--:         | :--:
@@ -599,9 +600,10 @@ static Sheets * const EEPROM_Sheets_base = (Sheets*)(EEPROM_SHEETS_BASE);
 #define EEPROM_TEMP_MODEL_VER (EEPROM_TEMP_MODEL_L-1) //uint8_t
 
 #define EEPROM_KILL_MESSAGE (EEPROM_TEMP_MODEL_VER-2) //PGM_P
+#define EEPROM_KILL_PENDING_FLAG (EEPROM_KILL_MESSAGE-1) //uint8
 
 //This is supposed to point to last item to allow EEPROM overrun check. Please update when adding new items.
-#define EEPROM_LAST_ITEM EEPROM_KILL_MESSAGE
+#define EEPROM_LAST_ITEM EEPROM_KILL_PENDING_FLAG
 // !!!!!
 // !!!!! this is end of EEPROM section ... all updates MUST BE inserted before this mark !!!!!
 // !!!!!

--- a/Firmware/eeprom.h
+++ b/Firmware/eeprom.h
@@ -361,6 +361,8 @@ static_assert(sizeof(Sheets) == EEPROM_SHEETS_SIZEOF, "Sizeof(Sheets) is not EEP
 | 0x0CA1 3233 | float   | EEPROM_TEMP_MODEL_V                   | ???          | ff ff ff ffh          | Temp model linear temperature intercept (W/W)     | Temp model   | D3 Ax0ca1 C4
 | 0x0C9D 3229 | float   | EEPROM_TEMP_MODEL_D                   | ???          | ff ff ff ffh          | Temp model sim. 1st order IIR filter factor       | Temp model   | D3 Ax0c9d C4
 | 0x0C99 3225 | uint16  | EEPROM_TEMP_MODEL_L                   | 0-2160       | ff ffh                | Temp model sim. response lag (ms)                 | Temp model   | D3 Ax0c99 C2
+| 0x0C98 3224 | uint8   | EEPROM_TEMP_MODEL_VER                 | 0-255        | ffh                   | Temp model Version                                | Temp model   | D3 Ax0c98 C1
+| 0x0C96 3222 | PGM_P   | EEPROM_KILL_MESSAGE                   | 0-65535      | ff ffh                | Kill message PGM pointer                          | kill()       | D3 Ax0c96 C2
 
 |Address begin|Bit/Type | Name                                  | Valid values | Default/FactoryReset  | Description                                       |Gcode/Function| Debug code
 | :--:        | :--:    | :--:                                  | :--:         | :--:                  | :--:                                              | :--:         | :--:
@@ -599,7 +601,7 @@ static Sheets * const EEPROM_Sheets_base = (Sheets*)(EEPROM_SHEETS_BASE);
 #define EEPROM_KILL_MESSAGE (EEPROM_TEMP_MODEL_VER-2) //PGM_P
 
 //This is supposed to point to last item to allow EEPROM overrun check. Please update when adding new items.
-#define EEPROM_LAST_ITEM EEPROM_TEMP_MODEL_VER
+#define EEPROM_LAST_ITEM EEPROM_KILL_MESSAGE
 // !!!!!
 // !!!!! this is end of EEPROM section ... all updates MUST BE inserted before this mark !!!!!
 // !!!!!

--- a/Firmware/eeprom.h
+++ b/Firmware/eeprom.h
@@ -357,13 +357,13 @@ static_assert(sizeof(Sheets) == EEPROM_SHEETS_SIZEOF, "Sizeof(Sheets) is not EEP
 | ^           | ^       | ^                                     | 20h 32       | ^                     | Free bit                                          | ^            | ^
 | ^           | ^       | ^                                     | 40h 64       | ^                     | Free bit                                          | ^            | ^
 | ^           | ^       | ^                                     | 80h 128      | ^                     | Unknown                                           | ^            | ^
-| 0x0CA5 3237 | float   | EEPROM_TEMP_MODEL_U                   | ???          | ff ff ff ffh          | Temp model linear temperature coefficient (W/K/W) | Temp model   | D3 Ax0ca5 C4
-| 0x0CA1 3233 | float   | EEPROM_TEMP_MODEL_V                   | ???          | ff ff ff ffh          | Temp model linear temperature intercept (W/W)     | Temp model   | D3 Ax0ca1 C4
-| 0x0C9D 3229 | float   | EEPROM_TEMP_MODEL_D                   | ???          | ff ff ff ffh          | Temp model sim. 1st order IIR filter factor       | Temp model   | D3 Ax0c9d C4
-| 0x0C99 3225 | uint16  | EEPROM_TEMP_MODEL_L                   | 0-2160       | ff ffh                | Temp model sim. response lag (ms)                 | Temp model   | D3 Ax0c99 C2
-| 0x0C98 3224 | uint8   | EEPROM_TEMP_MODEL_VER                 | 0-255        | ffh                   | Temp model Version                                | Temp model   | D3 Ax0c98 C1
-| 0x0C96 3222 | PGM_P   | EEPROM_KILL_MESSAGE                   | 0-65535      | ff ffh                | Kill message PGM pointer                          | kill()       | D3 Ax0c96 C2
-| 0x0C95 3221 | uint8   | EEPROM_KILL_PENDING_FLAG              | 42h, ffh     | ffh                   | Kill pending flag (0x42 magic value)              | kill()       | D3 Ax0c95 C1
+| 0x0CA2 3234 | float   | EEPROM_TEMP_MODEL_U                   | ???          | ff ff ff ffh          | Temp model linear temperature coefficient (W/K/W) | Temp model   | D3 Ax0ca2 C4
+| 0x0C9E 3230 | float   | EEPROM_TEMP_MODEL_V                   | ???          | ff ff ff ffh          | Temp model linear temperature intercept (W/W)     | Temp model   | D3 Ax0c9e C4
+| 0x0C9A 3226 | float   | EEPROM_TEMP_MODEL_D                   | ???          | ff ff ff ffh          | Temp model sim. 1st order IIR filter factor       | Temp model   | D3 Ax0c9a C4
+| 0x0C98 3224 | uint16  | EEPROM_TEMP_MODEL_L                   | 0-2160       | ff ffh                | Temp model sim. response lag (ms)                 | Temp model   | D3 Ax0c98 C2
+| 0x0C97 3223 | uint8   | EEPROM_TEMP_MODEL_VER                 | 0-255        | ffh                   | Temp model Version                                | Temp model   | D3 Ax0c97 C1
+| 0x0C95 3221 | PGM_P   | EEPROM_KILL_MESSAGE                   | 0-65535      | ff ffh                | Kill message PGM pointer                          | kill()       | D3 Ax0c95 C2
+| 0x0C94 3220 | uint8   | EEPROM_KILL_PENDING_FLAG              | 42h, ffh     | ffh                   | Kill pending flag (0x42 magic value)              | kill()       | D3 Ax0c94 C1
 
 |Address begin|Bit/Type | Name                                  | Valid values | Default/FactoryReset  | Description                                       |Gcode/Function| Debug code
 | :--:        | :--:    | :--:                                  | :--:         | :--:                  | :--:                                              | :--:         | :--:

--- a/Firmware/eeprom.h
+++ b/Firmware/eeprom.h
@@ -596,6 +596,8 @@ static Sheets * const EEPROM_Sheets_base = (Sheets*)(EEPROM_SHEETS_BASE);
 #define EEPROM_TEMP_MODEL_L (EEPROM_TEMP_MODEL_D-2) //uint16_t
 #define EEPROM_TEMP_MODEL_VER (EEPROM_TEMP_MODEL_L-1) //uint8_t
 
+#define EEPROM_KILL_MESSAGE (EEPROM_TEMP_MODEL_VER-2) //PGM_P
+
 //This is supposed to point to last item to allow EEPROM overrun check. Please update when adding new items.
 #define EEPROM_LAST_ITEM EEPROM_TEMP_MODEL_VER
 // !!!!!

--- a/Firmware/temperature.cpp
+++ b/Firmware/temperature.cpp
@@ -598,7 +598,7 @@ static float analog2temp(int raw, uint8_t e) {
       SERIAL_ERROR_START;
       SERIAL_ERROR((int)e);
       SERIAL_ERRORLNPGM(" - Invalid extruder number !");
-      kill(NULL, 6);
+      kill();
       return 0.0;
   } 
   #ifdef HEATER_0_USES_MAX6675


### PR DESCRIPTION
This is a prototype implementation. Relevant comments copied from slack:

---

@leptun
I have a proposal that might fix a lot of our issues regarding kill():
Current situation. When kill is called, we turn off the interrupts, disable all heaters, show an LCD message and we halt. This has the problem that not all MCU peripherals are reset, pins stay in their previous state (see the BEEPER issue with the thermal model), the message can't be multi-page since the timebase is disabled at that point (no interrupts).
Proposal: We display the kill message just like with the crash dump message. So when kill gets called, we store the kill message pointer somewhere (might be uninitialized ram or eeprom), we trigger a softReset() so that a watchdog reset gets executed and all MCU peripherals/registers get reset. On startup we then check if the firmware reset due to kill() and we show the kill message early during startup, with the timebase and interrupts enabled. This solves both the beeper issue and the multi-page error message issue. I also think this approach is safer in general since it is guaranteed that watchdog brings the printer into a safe state, unlike whatever we do now in kill()

Now the question remains if this new approach would ask the user to reset the printer. I'd say no. In this case, the user should only need to press the knob to confirm the message and then the firmware should finish booting up.

And so that the octoprint users don't complain about the kill messages preventing bootup, the kill message pending flag (whatever that will be) should be cleared before showing the message so that a subsequent printer reset doesn't show the message again on startup.

---

The kill message pointer is stored in eeprom in this prototype.