### PR TITLE
Fix MMU2_CHECK_FILAMENT_PRESENCE_EXTRUSION_LENGTH for MMU2

### DIFF
--- a/Firmware/mmu2/variants/config_MMU2.h
+++ b/Firmware/mmu2/variants/config_MMU2.h
@@ -43,7 +43,7 @@ static constexpr float MMU2_RETRY_UNLOAD_TO_FINDA_FEED_RATE = 80.0f; // mm/s
 // After loading a new filament, the printer will extrude the filament by this distance
 // and then retract it back to the original position. This is used to check if the
 // filament sensor reading flickers or filament is jammed.
-static constexpr float MMU2_CHECK_FILAMENT_PRESENCE_EXTRUSION_LENGTH = MMU2_EXTRUDER_PTFE_LENGTH + MMU2_EXTRUDER_HEATBREAK_LENGTH + MMU2_VERIFY_LOAD_TO_NOZZLE_TWEAK - MMU2_FILAMENT_SENSOR_POSITION;
+static constexpr float MMU2_CHECK_FILAMENT_PRESENCE_EXTRUSION_LENGTH = MMU2_EXTRUDER_PTFE_LENGTH + MMU2_EXTRUDER_HEATBREAK_LENGTH + MMU2_VERIFY_LOAD_TO_NOZZLE_TWEAK + MMU2_FILAMENT_SENSOR_POSITION;
 
 static constexpr uint8_t MMU2_NO_TOOL = 99;
 static constexpr uint32_t MMU_BAUD = 115200;

--- a/Firmware/mmu2/variants/config_MMU2S.h
+++ b/Firmware/mmu2/variants/config_MMU2S.h
@@ -43,7 +43,7 @@ static constexpr float MMU2_RETRY_UNLOAD_TO_FINDA_FEED_RATE = 80.0f; // mm/s
 // After loading a new filament, the printer will extrude the filament by this distance
 // and then retract it back to the original position. This is used to check if the
 // filament sensor reading flickers or filament is jammed.
-static constexpr float MMU2_CHECK_FILAMENT_PRESENCE_EXTRUSION_LENGTH = MMU2_EXTRUDER_PTFE_LENGTH + MMU2_EXTRUDER_HEATBREAK_LENGTH + MMU2_VERIFY_LOAD_TO_NOZZLE_TWEAK - MMU2_FILAMENT_SENSOR_POSITION;
+static constexpr float MMU2_CHECK_FILAMENT_PRESENCE_EXTRUSION_LENGTH = MMU2_EXTRUDER_PTFE_LENGTH + MMU2_EXTRUDER_HEATBREAK_LENGTH + MMU2_VERIFY_LOAD_TO_NOZZLE_TWEAK + MMU2_FILAMENT_SENSOR_POSITION;
 
 static constexpr uint8_t MMU2_NO_TOOL = 99;
 static constexpr uint32_t MMU_BAUD = 115200;


### PR DESCRIPTION
Fix flipped sign so that the filament is pushed far enough into the hotend when checking if the load was successful.
Tested with PETG on MK2.5 with MMU2. No filament was extruded by this check out of the nozzle. The change should have no effect on MMU2S since the filament sensor position is 0 in that config.