### PR TITLE
Minor UI fixes for MMU status line during toolchange

### DIFF
--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -20,7 +20,9 @@ void BeginReport(CommandInProgress /*cip*/, uint16_t ec) {
 
 void EndReport(CommandInProgress /*cip*/, uint16_t /*ec*/) {
     // clear the status msg line - let the printed filename get visible again
-    lcd_setstatuspgm(MSG_WELCOME); // should be seen only when the printer is not printing a file
+    if (!printJobOngoing()) {
+        lcd_setstatuspgm(MSG_WELCOME);
+    }
     custom_message_type = CustomMsg::Status;
 }
 

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -272,11 +272,6 @@ void ReportProgressHook(CommandInProgress cip, uint16_t ec) {
     if (cip != CommandInProgress::NoCommand) {
         custom_message_type = CustomMsg::MMUProgress;
         lcd_setstatuspgm( _T(ProgressCodeToText(ec)) );
-    } else {
-        // If there is no command in progress we can display other
-        // useful information such as the name of the SD file 
-        // being printed
-        custom_message_type = CustomMsg::Status;
     }
 }
 


### PR DESCRIPTION
Minor MMU specific fixes pulled from https://github.com/prusa3d/Prusa-Firmware/pull/4080

- Fixes issue where toolchange visualization is cut-off in the middle due to the status message being set incorrectly by `ReportProgressHook()`. The function `EndReport()` takes care of changing `CustomMsg::MMUProgress` to `CustomMsg::Status`
- Fixes a minor issue where `MSG_WELCOME` is always written to the status line after MMU command is done. This should only be done when NOT printing.

Change in memory:
Flash: +2 bytes
SRAM:  0 bytes