### PR TITLE
Fix factory reset menu overwritten by status screen

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -803,6 +803,7 @@ void lcd_splash()
 
 void factory_reset() 
 {
+	LcdUpdateDisabler lcdUpdateDisabler;
 	KEEPALIVE_STATE(PAUSED_FOR_USER);
 	if (!READ(BTN_ENC))
 	{


### PR DESCRIPTION
Bug introduced in https://github.com/prusa3d/Prusa-Firmware/commit/0cac7612db26d8d2c027b86907a0a03d1a3db651 with `delay_keep_alive(0);`