### PR TITLE
SD menu do not consume click in _scrolling state

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5872,7 +5872,8 @@ void lcd_sdcard_menu()
 		} break;
 		case _scrolling: //scrolling filename
 		{
-			const bool rewindFlag = lcd_clicked() || lcd_draw_update; //flag that says whether the menu should return to _standard state.
+            // LCD_CLICKED is used so that the click event is later consumed by the _standard state.
+			const bool rewindFlag = LCD_CLICKED || lcd_draw_update; //flag that says whether the menu should return to _standard state.
 			
 			if (_md->scrollPointer == NULL)
 			{


### PR DESCRIPTION
The click is handled by the _standard state. If the click is consumed in _scrolling, then on click while scrolling, the only thing that will happen will be that the menu will switch to the _standard rendering, but have no click event on the file and it would just start scrolling again after a small delay.
This PR makes it so that a click in the _scrolling state isn't consumed and is handled on the next lcd update event in the _standard state.

Related comment: https://github.com/prusa3d/Prusa-Firmware/issues/4126#issuecomment-1499672012