### PR TITLE
Fix filament autoloading

### DIFF
--- a/Firmware/Filament_sensor.cpp
+++ b/Firmware/Filament_sensor.cpp
@@ -117,7 +117,7 @@ void Filament_sensor::triggerFilamentInserted() {
             || eeprom_read_byte((uint8_t *)EEPROM_WIZARD_ACTIVE)
             )
         ) {
-        lcd_AutoLoadFilament();
+        menu_submenu(lcd_AutoLoadFilament, true);
     }
 }
 


### PR DESCRIPTION
Closes #4126. The autoload action is a submenu. Correctly switch to that submenu.