### PR TITLE
Reduce XYZ cal code size

### DIFF
--- a/Firmware/xyzcal.cpp
+++ b/Firmware/xyzcal.cpp
@@ -415,22 +415,12 @@ void print_hysteresis(int16_t min_z, int16_t max_z, int16_t step){
 	}
 }
 
-void update_position_1_step(uint8_t axis, uint8_t dir){
-	if (axis & X_AXIS_MASK)
-		_X_ += dir & X_AXIS_MASK ? -1 : 1;
-	if (axis & Y_AXIS_MASK)
-		_Y_ += dir & Y_AXIS_MASK ? -1 : 1;
-	if (axis & Z_AXIS_MASK)
-		_Z_ += dir & Z_AXIS_MASK ? -1 : 1;
+void update_position_1_step(const uint8_t axis, const uint8_t dir) {
+	count_position[axis] += dir & _BV(axis) ? -1L : 1L;
 }
 
-void set_axes_dir(uint8_t axes, uint8_t dir){
-	if (axes & X_AXIS_MASK)
-		sm4_set_dir(X_AXIS, dir & X_AXIS_MASK);
-	if (axes & Y_AXIS_MASK)
-		sm4_set_dir(Y_AXIS, dir & Y_AXIS_MASK);
-	if (axes & Z_AXIS_MASK)
-		sm4_set_dir(Z_AXIS, dir & Z_AXIS_MASK);
+void __attribute__((noinline)) set_axes_dir(const uint8_t axis, const uint8_t dir) {
+	sm4_set_dir(axis, dir & _BV(axis));
 }
 
 /// Accelerate up to max.speed (defined by @min_delay_us)

--- a/Firmware/xyzcal.cpp
+++ b/Firmware/xyzcal.cpp
@@ -415,7 +415,7 @@ void print_hysteresis(int16_t min_z, int16_t max_z, int16_t step){
 	}
 }
 
-void update_position_1_step(const uint8_t axis, const uint8_t dir) {
+static void update_position_1_step(const uint8_t axis, const uint8_t dir) {
 	for (uint8_t i = X_AXIS, mask = X_AXIS_MASK; i <= Z_AXIS; i++, mask <<= 1) {
 		if (axis & mask) {
 			count_position[i] += dir & mask ? -1L : 1L;
@@ -423,7 +423,7 @@ void update_position_1_step(const uint8_t axis, const uint8_t dir) {
 	}
 }
 
-void __attribute__((noinline)) set_axes_dir(const uint8_t axis, const uint8_t dir) {
+static void __attribute__((noinline)) set_axes_dir(const uint8_t axis, const uint8_t dir) {
 	for (uint8_t i = X_AXIS, mask = X_AXIS_MASK; i <= Z_AXIS; i++, mask <<= 1) {
 		if (axis & mask) {
 			sm4_set_dir(i, dir & mask);

--- a/Firmware/xyzcal.cpp
+++ b/Firmware/xyzcal.cpp
@@ -416,11 +416,19 @@ void print_hysteresis(int16_t min_z, int16_t max_z, int16_t step){
 }
 
 void update_position_1_step(const uint8_t axis, const uint8_t dir) {
-	count_position[axis] += dir & _BV(axis) ? -1L : 1L;
+	for (uint8_t i = X_AXIS, mask = X_AXIS_MASK; i <= Z_AXIS; i++, mask <<= 1) {
+		if (axis & mask) {
+			count_position[i] += dir & mask ? -1L : 1L;
+		}
+	}
 }
 
 void __attribute__((noinline)) set_axes_dir(const uint8_t axis, const uint8_t dir) {
-	sm4_set_dir(axis, dir & _BV(axis));
+	for (uint8_t i = X_AXIS, mask = X_AXIS_MASK; i <= Z_AXIS; i++, mask <<= 1) {
+		if (axis & mask) {
+			sm4_set_dir(i, dir & mask);
+		}
+	}
 }
 
 /// Accelerate up to max.speed (defined by @min_delay_us)


### PR DESCRIPTION

Notes
* `_X_` is equal to `count_position[X_AXIS]`
* `X_AXIS_MASK` is equal to `_BV(X_AXIS)` i.e. `(1 << X_AXIS)`

Change in memory:
Flash: -46 bytes
SRAM: 0 bytes