### PR TITLE
tmc2130: simplify parsing axis mask

### DIFF
--- a/Firmware/tmc2130.cpp
+++ b/Firmware/tmc2130.cpp
@@ -272,8 +272,7 @@ void tmc2130_home_enter(uint8_t axes_mask)
 		tmc2130_wait_standstill_xy(1000);
 	for (uint8_t axis = X_AXIS; axis <= Z_AXIS; axis++) //X Y and Z axes
 	{
-		uint8_t mask = (X_AXIS_MASK << axis);
-		if (axes_mask & mask)
+		if (const uint8_t mask = axes_mask & _BV(axis); mask)
 		{
 			tmc2130_sg_homing_axes_mask |= mask;
 			//Configuration to spreadCycle
@@ -281,8 +280,7 @@ void tmc2130_home_enter(uint8_t axes_mask)
 			tmc2130_wr(axis, TMC2130_REG_COOLCONF, (((uint32_t)tmc2130_sg_thr_home[axis]) << 16));
 			tmc2130_wr(axis, TMC2130_REG_TCOOLTHRS, __tcoolthrs(axis));
 			tmc2130_setup_chopper(axis, tmc2130_mres[axis], tmc2130_current_h[axis], tmc2130_current_r_home[axis]);
-			if (mask & (X_AXIS_MASK | Y_AXIS_MASK | Z_AXIS_MASK))
-				tmc2130_wr(axis, TMC2130_REG_GCONF, TMC2130_GCONF_SGSENS); //stallguard output DIAG1, DIAG1 = pushpull
+			tmc2130_wr(axis, TMC2130_REG_GCONF, TMC2130_GCONF_SGSENS); //stallguard output DIAG1, DIAG1 = pushpull
 		}
 	}
 #endif //TMC2130_SG_HOMING
@@ -298,8 +296,7 @@ void tmc2130_home_exit()
 	{
 		for (uint8_t axis = X_AXIS; axis <= Z_AXIS; axis++) //X Y and Z axes
 		{
-			uint8_t mask = (X_AXIS_MASK << axis);
-			if (tmc2130_sg_homing_axes_mask & mask & (X_AXIS_MASK | Y_AXIS_MASK | Z_AXIS_MASK))
+			if (tmc2130_sg_homing_axes_mask & _BV(axis))
 			{
 #ifndef TMC2130_STEALTH_Z
 				if ((tmc2130_mode == TMC2130_MODE_SILENT) && (axis != Z_AXIS))

--- a/Firmware/tmc2130.cpp
+++ b/Firmware/tmc2130.cpp
@@ -268,11 +268,11 @@ void tmc2130_home_enter(uint8_t axes_mask)
 {
 	printf_P(PSTR("tmc2130_home_enter(axes_mask=0x%02x)\n"), axes_mask);
 #ifdef TMC2130_SG_HOMING
-	if (axes_mask & 0x03) //X or Y
+	if (axes_mask & (X_AXIS_MASK | Y_AXIS_MASK)) //X or Y
 		tmc2130_wait_standstill_xy(1000);
-	for (uint8_t axis = X_AXIS; axis <= Z_AXIS; axis++) //X Y and Z axes
+	for (uint8_t axis = X_AXIS, mask = X_AXIS_MASK; axis <= Z_AXIS; axis++, mask <<= 1) //X Y and Z axes
 	{
-		if (const uint8_t mask = axes_mask & _BV(axis); mask)
+		if (axes_mask & mask)
 		{
 			tmc2130_sg_homing_axes_mask |= mask;
 			//Configuration to spreadCycle
@@ -294,9 +294,9 @@ void tmc2130_home_exit()
 		tmc2130_wait_standstill_xy(1000);
 	if (tmc2130_sg_homing_axes_mask)
 	{
-		for (uint8_t axis = X_AXIS; axis <= Z_AXIS; axis++) //X Y and Z axes
+		for (uint8_t axis = X_AXIS, mask = X_AXIS_MASK; axis <= Z_AXIS; axis++, mask <<= 1) //X Y and Z axes
 		{
-			if (tmc2130_sg_homing_axes_mask & _BV(axis))
+			if (tmc2130_sg_homing_axes_mask & mask)
 			{
 #ifndef TMC2130_STEALTH_Z
 				if ((tmc2130_mode == TMC2130_MODE_SILENT) && (axis != Z_AXIS))


### PR DESCRIPTION
There is no need to check for every axis bit with each for-loop iteration since we know only one of the bits is set. Instead check for one axis bit at a time.

The mask computation was also optimized in the iterations over all axes.

Change in memory:
Flash: -34 bytes
SRAM: 0 bytes