### PR TITLE
:construction: Introduce Unload from FSensor state

### DIFF
--- a/Firmware/mmu2/errors_list.h
+++ b/Firmware/mmu2/errors_list.h
@@ -265,12 +265,13 @@ static const char MSG_DESC_UNLOAD_MANUALLY[] PROGMEM_I1 = ISTR("Filament detecte
 static const char MSG_DESC_FILAMENT_EJECTED[] PROGMEM_I1 = ISTR("Remove the ejected filament from the front of the MMU."); ////MSG_DESC_FILAMENT_EJECTED c=20 r=8
 
 // Read explanation in mmu2_protocol_logic.cpp -> supportedMmuFWVersion
-static constexpr char MSG_DESC_FW_UPDATE_NEEDED[] PROGMEM_I1 = ISTR("The MMU firmware version incompatible with the printer's FW. Update to version 2.1.9."); ////MSG_DESC_FW_UPDATE_NEEDED c=20 r=8
+static constexpr char MSG_DESC_FW_UPDATE_NEEDED[] PROGMEM_I1 = ISTR("The MMU firmware version incompatible with the printer's FW. Update to version 2.1.10."); ////MSG_DESC_FW_UPDATE_NEEDED c=20 r=8
 static constexpr uint8_t szFWUN = sizeof(MSG_DESC_FW_UPDATE_NEEDED);
 // at least check the individual version characters in MSG_DESC_FW_UPDATE_NEEDED
-static_assert(MSG_DESC_FW_UPDATE_NEEDED[szFWUN - 7] == ('0' + mmuVersionMajor));
-static_assert(MSG_DESC_FW_UPDATE_NEEDED[szFWUN - 5] == ('0' + mmuVersionMinor));
-static_assert(MSG_DESC_FW_UPDATE_NEEDED[szFWUN - 3] == ('0' + mmuVersionPatch));
+static_assert(MSG_DESC_FW_UPDATE_NEEDED[szFWUN - 8] == ('0' + mmuVersionMajor));
+static_assert(MSG_DESC_FW_UPDATE_NEEDED[szFWUN - 6] == ('0' + mmuVersionMinor));
+static_assert(MSG_DESC_FW_UPDATE_NEEDED[szFWUN - 4] == ('0' + mmuVersionPatch / 10));
+static_assert(MSG_DESC_FW_UPDATE_NEEDED[szFWUN - 3] == ('0' + mmuVersionPatch % 10));
 
 static const char * const errorDescs[] PROGMEM = {
     _R(MSG_DESC_FINDA_DIDNT_TRIGGER),

--- a/Firmware/mmu2/progress_codes.h
+++ b/Firmware/mmu2/progress_codes.h
@@ -13,16 +13,16 @@ enum class ProgressCode : uint_fast8_t {
     UnloadingToFinda, // P3
     UnloadingToPulley, //P4
     FeedingToFinda, // P5
-    FeedingToExtruder, // P6
+    FeedingToBondtech, // P6
     FeedingToNozzle, // P7
     AvoidingGrind, // P8
     FinishingMoves, // P9
 
     ERRDisengagingIdler, // P10
-    ERREngagingIdler, // P11
+    ERREngagingIdler, // P11 - unused: intended for SlowLoad which is removed now
     ERRWaitingForUser, // P12
     ERRInternal, // P13
-    ERRHelpingFilament, // P14
+    ERRHelpingFilament, // P14 - unused: intended for SlowLoad which is removed now
     ERRTMCFailed, // P15
 
     UnloadingFilament, // P16
@@ -35,11 +35,19 @@ enum class ProgressCode : uint_fast8_t {
     ParkingSelector, // P23
     EjectingFilament, // P24
     RetractingFromFinda, // P25
-
     Homing, // P26
     MovingSelector, // P27
-
     FeedingToFSensor, // P28
+    UnloadingFilamentSlowly, // P29
+
+    HWTestBegin, // P31
+    HWTestIdler, // P31
+    HWTestSelector, // P32
+    HWTestPulley, // P33
+    HWTestCleanup, // P34
+    HWTestExec, // P35
+    HWTestDisplay, // P36
+    ErrHwTestFailed, // P37
 
     Empty = 0xff // dummy empty state
 };

--- a/Firmware/mmu2_progress_converter.cpp
+++ b/Firmware/mmu2_progress_converter.cpp
@@ -29,6 +29,7 @@ static const char MSG_PROGRESS_RETRACT_FINDA[] PROGMEM_I1    = ISTR("Retract fro
 static const char MSG_PROGRESS_HOMING[] PROGMEM_I1           = ISTR("Homing"); ////MSG_PROGRESS_HOMING c=20
 static const char MSG_PROGRESS_MOVING_SELECTOR[] PROGMEM_I1  = ISTR("Moving selector"); ////MSG_PROGRESS_MOVING_SELECTOR c=20
 static const char MSG_PROGRESS_FEED_FSENSOR[] PROGMEM_I1     = ISTR("Feeding to FSensor"); ////MSG_PROGRESS_FEED_FSENSOR c=20
+static const char MSG_PROGRESS_UNLOAD_FROM_FSENSOR[] PROGMEM_I1     = ISTR("Unload from FSensor"); ////MSG_PROGRESS_UNLOAD_FROM_FSENSOR c=20
 
 static const char * const progressTexts[] PROGMEM = {
     _R(MSG_PROGRESS_OK),
@@ -59,7 +60,8 @@ static const char * const progressTexts[] PROGMEM = {
     _R(MSG_PROGRESS_RETRACT_FINDA),
     _R(MSG_PROGRESS_HOMING),
     _R(MSG_PROGRESS_MOVING_SELECTOR),
-    _R(MSG_PROGRESS_FEED_FSENSOR)
+    _R(MSG_PROGRESS_FEED_FSENSOR),
+    _R(MSG_PROGRESS_UNLOAD_FROM_FSENSOR)
 };
 
 const char * ProgressCodeToText(uint16_t pc){

--- a/Firmware/mmu2_supported_version.h
+++ b/Firmware/mmu2_supported_version.h
@@ -5,6 +5,6 @@ namespace MMU2 {
 
 static constexpr uint8_t mmuVersionMajor = 2;
 static constexpr uint8_t mmuVersionMinor = 1;
-static constexpr uint8_t mmuVersionPatch = 9;
+static constexpr uint8_t mmuVersionPatch = 10;
 
 } // namespace MMU2


### PR DESCRIPTION
and sync progress_codes.h with the MMU repo / PR 271

Ideally,  the ramming sequence should be shortened and an extra 40mm unload move at 50mm/s should be planned on top of it while the MMU is already doing something. That should prevent extra thick strings from being held by the Bondtech gears and smoother and faster operation as well.