### PR TITLE
Fix lcd_update() FW crashes

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -9437,6 +9437,9 @@ void manage_inactivity(bool ignore_stepper_queue/*=false*/) //default argument s
   check_axes_activity();
   MMU2::mmu2.mmu_loop();
 
+  lcd_knob_update();
+  backlight_update();
+
   // handle longpress
   if(lcd_longpress_trigger)
   {

--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -690,11 +690,7 @@ void lcd_quick_feedback(void)
   lcd_beeper_quick_feedback();
 }
 
-void lcd_update(uint8_t lcdDrawUpdateOverride)
-{
-	if (lcd_draw_update < lcdDrawUpdateOverride)
-		lcd_draw_update = lcdDrawUpdateOverride;
-
+void lcd_knob_update() {
 	if (lcd_backlight_wake_trigger) {
 		lcd_backlight_wake_trigger = false;
 		backlight_wake();
@@ -711,8 +707,12 @@ void lcd_update(uint8_t lcdDrawUpdateOverride)
 			lcd_draw_update = 1;
 		}
 	}
+}
 
-	backlight_update();
+void lcd_update(uint8_t lcdDrawUpdateOverride)
+{
+	if (lcd_draw_update < lcdDrawUpdateOverride)
+		lcd_draw_update = lcdDrawUpdateOverride;
 
 	if (!lcd_update_enabled) return;
 

--- a/Firmware/lcd.h
+++ b/Firmware/lcd.h
@@ -123,6 +123,10 @@ extern void lcd_beeper_quick_feedback(void);
 //Cause an LCD refresh, and give the user visual or audible feedback that something has happened
 extern void lcd_quick_feedback(void);
 
+/// @brief Check whether knob is rotated or clicked and update relevant
+///variables. Flags are set by lcd_buttons_update in ISR context.
+extern void lcd_knob_update();
+
 extern void lcd_update(uint8_t lcdDrawUpdateOverride);
 
 extern void lcd_update_enable(uint8_t enabled);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2208,7 +2208,8 @@ uint8_t lcd_alright() {
     lcd_consume_click();
     while (1)
     {
-        delay_keep_alive(0);
+        manage_heater();
+        manage_inactivity(true);
 
         if (lcd_encoder)
         {
@@ -4696,7 +4697,8 @@ uint8_t choose_menu_P(const char *header, const char *item, const char *last_ite
 	KEEPALIVE_STATE(PAUSED_FOR_USER);
 	while (1)
 	{
-		delay_keep_alive(0);
+		manage_heater();
+        manage_inactivity(true);
 
 		if (lcd_encoder)
 		{
@@ -4787,7 +4789,8 @@ char reset_menu() {
 			lcd_puts_at_P(1, i, item[first + i]);
 		}
 
-		delay_keep_alive(0);
+		manage_heater();
+        manage_inactivity(true);
 
 		if (lcd_encoder) {
 			if (lcd_encoder < 0) {

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -6909,6 +6909,7 @@ static bool lcd_selftest_manual_fan_check(int _fan, bool check_opposite,
 
 
 		manage_heater();
+		manage_inactivity(true);
 		_delay(100);
 
 	} while (!lcd_clicked());


### PR DESCRIPTION
My proposal to fix issue in https://github.com/prusa3d/Prusa-Firmware/pull/4129.

The main change is `lcd_encoder` is no longer updated by calling `lcd_update()`. This way checking for knob rotation is now decoupled from `lcd_update()` and can always be called in `manage_inactivity()` as the encoder flags are updated through the temperature ISR. We may even remove a few `lcd_update()` calls now with this change but they need to be evaluated one by one.

By using `manage_inactivity()` the encoder rotation event can be checked in both the main loop and during blocking operations such as factory reset menu or "choose filament" menu (MMU only).

**Other changes:**
* Fixes an issue where encoder did not work in manual fan check menu. It was missing a call to `manage_inactivity()`. Fix was tested on MK3S+.

----

Tests on MK3S+ with MMU
* ✅ First layer calibration
* ✅ MMU error screen (2 button choices). 
    * ✔️ The M600-like sound prompts also work correctly.
    * ✔️ MORE button works and and cycling through the details error message works and upon cycling through the message the error screen is shown correctly again.
* ✅ LCD menu item: Load to Nozzle
* ✅ M600 when not printing
* ✅ M600 when printing
* ✅ Pause, Resume and Stop print
* ✅ Z Calibration
* ✅ Selftest
* ✅ XYZ Calibration
* ✅ Belt test
----

Change in memory:
Flash: +16 bytes
SRAM: 0 bytes