### PR TITLE
Reduce code size in fan check selftest

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -9464,6 +9464,9 @@ void manage_inactivity(bool ignore_stepper_queue/*=false*/) //default argument s
   check_axes_activity();
   MMU2::mmu2.mmu_loop();
 
+  lcd_knob_update();
+  backlight_update();
+
   // handle longpress
   if(lcd_longpress_trigger)
   {

--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -690,11 +690,7 @@ void lcd_quick_feedback(void)
   lcd_beeper_quick_feedback();
 }
 
-void lcd_update(uint8_t lcdDrawUpdateOverride)
-{
-	if (lcd_draw_update < lcdDrawUpdateOverride)
-		lcd_draw_update = lcdDrawUpdateOverride;
-
+void lcd_knob_update() {
 	if (lcd_backlight_wake_trigger) {
 		lcd_backlight_wake_trigger = false;
 		backlight_wake();
@@ -711,8 +707,12 @@ void lcd_update(uint8_t lcdDrawUpdateOverride)
 			lcd_draw_update = 1;
 		}
 	}
+}
 
-	backlight_update();
+void lcd_update(uint8_t lcdDrawUpdateOverride)
+{
+	if (lcd_draw_update < lcdDrawUpdateOverride)
+		lcd_draw_update = lcdDrawUpdateOverride;
 
 	if (!lcd_update_enabled) return;
 

--- a/Firmware/lcd.h
+++ b/Firmware/lcd.h
@@ -123,6 +123,10 @@ extern void lcd_beeper_quick_feedback(void);
 //Cause an LCD refresh, and give the user visual or audible feedback that something has happened
 extern void lcd_quick_feedback(void);
 
+/// @brief Check whether knob is rotated or clicked and update relevant
+///variables. Flags are set by lcd_buttons_update in ISR context.
+extern void lcd_knob_update();
+
 extern void lcd_update(uint8_t lcdDrawUpdateOverride);
 
 extern void lcd_update_enable(uint8_t enabled);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2213,7 +2213,8 @@ uint8_t lcd_alright() {
     lcd_consume_click();
     while (1)
     {
-        delay_keep_alive(0);
+        manage_heater();
+        manage_inactivity(true);
 
         if (lcd_encoder)
         {
@@ -4713,7 +4714,8 @@ uint8_t choose_menu_P(const char *header, const char *item, const char *last_ite
 	KEEPALIVE_STATE(PAUSED_FOR_USER);
 	while (1)
 	{
-		delay_keep_alive(0);
+		manage_heater();
+        manage_inactivity(true);
 
 		if (lcd_encoder)
 		{
@@ -4805,7 +4807,8 @@ char reset_menu() {
 			lcd_puts_at_P(1, i, item[first + i]);
 		}
 
-		delay_keep_alive(0);
+		manage_heater();
+        manage_inactivity(true);
 
 		if (lcd_encoder) {
 			if (lcd_encoder < 0) {

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -6939,6 +6939,7 @@ static bool lcd_selftest_manual_fan_check(int _fan, bool check_opposite,
 
 
 		manage_heater();
+		manage_inactivity(true);
 		_delay(100);
 
 	} while (!lcd_clicked());

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -191,9 +191,9 @@ enum class TestError : uint_least8_t
 };
 
 static uint8_t  lcd_selftest_screen(TestScreen screen, uint8_t _progress, uint8_t _progress_scale, bool _clear, uint16_t _delay);
-static void lcd_selftest_screen_step(uint8_t _row, uint8_t _col, uint8_t _state, const char *_name, const char _indicator);
-static bool lcd_selftest_manual_fan_check(int _fan, bool check_opposite,
-	bool _default=false);
+static void lcd_selftest_screen_step(const uint8_t _row, const uint8_t _col, const uint8_t _state, const char *_name, const char _indicator);
+static bool lcd_selftest_manual_fan_check(const uint8_t _fan, const bool check_opposite,
+	const bool _default=false);
 
 #ifdef FANCHECK
 /** Enumerate for lcd_selftest_fan_auto function.
@@ -5027,16 +5027,22 @@ static void lcd_test_menu()
 }
 #endif //LCD_TEST
 
+/// @brief Set print fan speed
+/// @param speed ranges from 0 to 255
+static void lcd_selftest_setfan(const uint8_t speed) {
+    fanSpeed = speed;
+#ifdef FAN_SOFT_PWM
+    fanSpeedSoftPwm = speed;
+#endif
+    manage_heater();
+}
+
 static bool fan_error_selftest()
 {
 #ifdef FANCHECK
     if (!fans_check_enabled) return 0;
 
-    fanSpeed = 255;
-#ifdef FAN_SOFT_PWM
-	fanSpeedSoftPwm = 255;
-#endif //FAN_SOFT_PWM
-    manage_heater(); //enables print fan
+    lcd_selftest_setfan(255);
     setExtruderAutoFanState(3); //force enables the hotend fan
 #ifdef FAN_SOFT_PWM
     extruder_autofan_last_check = _millis();
@@ -5044,12 +5050,8 @@ static bool fan_error_selftest()
 #endif //FAN_SOFT_PWM
     _delay(1000); //delay_keep_alive would turn off hotend fan, because temerature is too low (maybe)
     manage_heater();
-    fanSpeed = 0;
-	setExtruderAutoFanState(1); //releases lock on the hotend fan
-#ifdef FAN_SOFT_PWM
-    fanSpeedSoftPwm = 0;
-#endif //FAN_SOFT_PWM
-    manage_heater();
+    setExtruderAutoFanState(1); //releases lock on the hotend fan
+    lcd_selftest_setfan(0);
 #ifdef TACH_0
     if (fan_speed[0] <= 20) { //hotend fan error
         LCD_ALERTMESSAGERPGM(MSG_FANCHECK_HOTEND);
@@ -6878,8 +6880,8 @@ static bool selftest_irsensor()
 #endif //(FILAMENT_SENSOR_TYPE == FSENSOR_IR) || (FILAMENT_SENSOR_TYPE == FSENSOR_IR_ANALOG)
 #endif //FILAMENT_SENSOR
 
-static bool lcd_selftest_manual_fan_check(int _fan, bool check_opposite,
-	bool _default)
+static bool lcd_selftest_manual_fan_check(const uint8_t _fan, const bool check_opposite,
+	const bool _default)
 {
 
 	bool _result = check_opposite;
@@ -6897,20 +6899,14 @@ static bool lcd_selftest_manual_fan_check(int _fan, bool check_opposite,
 	case 1:
 		// object cooling fan
 		lcd_puts_at_P(0, 1, check_opposite ? _T(MSG_SELFTEST_HOTEND_FAN) : _T(MSG_SELFTEST_PART_FAN));
-		SET_OUTPUT(FAN_PIN);
-#ifdef FAN_SOFT_PWM
-		fanSpeedSoftPwm = 255;
-#else //FAN_SOFT_PWM
-		analogWrite(FAN_PIN, 255);
-#endif //FAN_SOFT_PWM
-
+		lcd_selftest_setfan(255);
 		break;
 	}
 	_delay(500);
 
 	lcd_puts_at_P(1, 2, _T(MSG_SELFTEST_FAN_YES));
 	lcd_putc_at(0, 3, '>');
-	lcd_puts_at_P(1, 3, _T(MSG_SELFTEST_FAN_NO));
+	lcd_puts_P(_T(MSG_SELFTEST_FAN_NO));
 
 	lcd_encoder = _default;
 
@@ -6922,21 +6918,16 @@ static bool lcd_selftest_manual_fan_check(int _fan, bool check_opposite,
 			if (lcd_encoder < 0) {
 				_result = !check_opposite;
 				lcd_putc_at(0, 2, '>');
-				lcd_puts_at_P(1, 2, _T(MSG_SELFTEST_FAN_YES));
 				lcd_putc_at(0, 3, ' ');
-				lcd_puts_at_P(1, 3, _T(MSG_SELFTEST_FAN_NO));
 			}
 
 			if (lcd_encoder > 0) {
 				_result = check_opposite;
 				lcd_putc_at(0, 2, ' ');
-				lcd_puts_at_P(1, 2, _T(MSG_SELFTEST_FAN_YES));
 				lcd_putc_at(0, 3, '>');
-				lcd_puts_at_P(1, 3, _T(MSG_SELFTEST_FAN_NO));
 			}
 			lcd_encoder = 0;
 		}
-
 
 		manage_heater();
 		manage_inactivity(true);
@@ -6944,30 +6935,13 @@ static bool lcd_selftest_manual_fan_check(int _fan, bool check_opposite,
 
 	} while (!lcd_clicked());
 	KEEPALIVE_STATE(IN_HANDLER);
-	setExtruderAutoFanState(0);
-	SET_OUTPUT(FAN_PIN);
-#ifdef FAN_SOFT_PWM
-	fanSpeedSoftPwm = 0;
-#else //FAN_SOFT_PWM
-	analogWrite(FAN_PIN, 0);
-#endif //FAN_SOFT_PWM
-	fanSpeed = 0;
-	manage_heater();
+	setExtruderAutoFanState(0); // Turn off hotend fan
+	lcd_selftest_setfan(0); // Turn off print fan
 
 	return _result;
 }
 
 #ifdef FANCHECK
-// Set print fan speed
-static void lcd_selftest_setfan(uint8_t speed) {
-    // set the fan speed
-    fanSpeed = speed;
-#ifdef FAN_SOFT_PWM
-    fanSpeedSoftPwm = speed;
-#endif
-    manage_heater();
-}
-
 // Wait for the specified number of seconds while displaying some single-character indicator on the
 // screen coordinate col/row, then perform fan measurement
 static void lcd_selftest_measure_fans(uint8_t delay, uint8_t col, uint8_t row) {
@@ -7098,21 +7072,19 @@ static uint8_t lcd_selftest_screen(TestScreen screen, uint8_t _progress, uint8_t
 	return (_progress >= _progress_scale * 2) ? 0 : _progress;
 }
 
-static void lcd_selftest_screen_step(uint8_t _row, uint8_t _col, uint8_t _state, const char *_name_PROGMEM, const char _indicator)
+static void lcd_selftest_screen_step(const uint8_t _row, const uint8_t _col, const uint8_t _state, const char *_name_PROGMEM, const char _indicator)
 {
 	lcd_set_cursor(_col, _row);
-    uint8_t strlenNameP = strlen_P(_name_PROGMEM);
-
 	switch (_state)
 	{
 	case 1:
 		lcd_puts_P(_name_PROGMEM);
-		lcd_putc_at(_col + strlenNameP, _row, ':');
+		lcd_putc(':');
 		lcd_putc(_indicator);
 		break;
 	case 2:
 		lcd_puts_P(_name_PROGMEM);
-		lcd_putc_at(_col + strlenNameP, _row, ':');
+		lcd_putc(':');
 		lcd_puts_P(MSG_OK_CAPS);
 		break;
 	default:


### PR DESCRIPTION
⚠️ https://github.com/prusa3d/Prusa-Firmware/pull/4143 must be merged first! since we need the encoder rotation to be fixed again to test these changes. This branch is built ontop of PR 4143.


Tested on MK3S+

I tested `lcd_selftest_manual_fan_check` by calling it manually. I did not actually swap my fans on the hardware.

Change in memory:
Flash: -174 bytes
SRAM: 0 bytes