### PR TITLE
Fix a typo in `PSU_Delta` define

### DIFF
--- a/Firmware/tmc2130.h
+++ b/Firmware/tmc2130.h
@@ -73,7 +73,7 @@ struct TMCInitParams {
     inline explicit TMCInitParams(bool bSuppressFlag, bool enableECool):bSuppressFlag(bSuppressFlag), enableECool(enableECool) { }
     inline explicit TMCInitParams(bool enableECool)
         : bSuppressFlag(
-#ifdef PSU_delta
+#ifdef PSU_Delta
         1
 #else
         0


### PR DESCRIPTION
Symbol names are case sensitive: "PSU_delta" --> "PSU_Delta"

I'm not sure what the consequences of this is. It's been like this for a long time.