### PR TITLE
MMU: Remove unused LoadingToNozzleRAII

### DIFF
--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -49,7 +49,6 @@ MMU2::MMU2()
     , mmu_print_saved(SavedState::None)
     , loadFilamentStarted(false)
     , unloadFilamentStarted(false)
-    , loadingToNozzle(false)
     , toolchange_counter(0)
     , tmcFailures(0) {
 }
@@ -534,22 +533,9 @@ bool MMU2::load_filament(uint8_t slot) {
     return true;
 }
 
-struct LoadingToNozzleRAII {
-    MMU2 &mmu2;
-    explicit inline LoadingToNozzleRAII(MMU2 &mmu2)
-        : mmu2(mmu2) {
-        mmu2.loadingToNozzle = true;
-    }
-    inline ~LoadingToNozzleRAII() {
-        mmu2.loadingToNozzle = false;
-    }
-};
-
 bool MMU2::load_filament_to_nozzle(uint8_t slot) {
     if (!WaitForMMUReady())
         return false;
-
-    LoadingToNozzleRAII ln(*this);
 
     WaitForHotendTargetTempBeep();
 

--- a/Firmware/mmu2.h
+++ b/Firmware/mmu2.h
@@ -307,10 +307,6 @@ private:
     bool loadFilamentStarted;
     bool unloadFilamentStarted;
 
-    friend struct LoadingToNozzleRAII;
-    /// true in case we are doing the LoadToNozzle operation - that means the filament shall be loaded all the way down to the nozzle
-    /// unlike the mid-print ToolChange commands, which only load the first ~30mm and then the G-code takes over.
-    bool loadingToNozzle;
     uint16_t toolchange_counter;
     uint16_t tmcFailures;
 };


### PR DESCRIPTION
The variable is not used anywhere. I don't see it either in the buddy firmware repo except in `mmu2mk404.cpp` but that code seems outdated.

Change in memory:
Flash: -14 bytes
SRAM: -1 byte