### PR TITLE
MMU: Always reset `custom_message_type` when command is done processing

### DIFF
--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -402,8 +402,7 @@ bool MMU2::tool_change(char code, uint8_t slot) {
 
     case 'x': {
         thermal_setExtrudeMintemp(0); // Allow cold extrusion since Tx only loads to the gears not nozzle
-        planner_synchronize();
-        ToolChangeCommon(slot); // the only difference was manage_response(false, false), but probably good enough
+        tool_change(slot);
         thermal_setExtrudeMintemp(EXTRUDE_MINTEMP);
     } break;
 

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -270,7 +270,6 @@ void ReportErrorHook(CommandInProgress /*cip*/, uint16_t ec, uint8_t /*es*/) {
 
 void ReportProgressHook(CommandInProgress cip, uint16_t ec) {
     if (cip != CommandInProgress::NoCommand) {
-        custom_message_type = CustomMsg::MMUProgress;
         lcd_setstatuspgm( _T(ProgressCodeToText(ec)) );
     }
 }


### PR DESCRIPTION
* Fix issue where `Tx` gcode wasn't using `BeginReport()`/`EndReport()`. This resulted in the SD filename not being shown on the status line when printing -- only affects single material MMU gcodes. Issue introduced with https://github.com/prusa3d/Prusa-Firmware/pull/4123
* Don't set `custom_message_type` in `ReportProgressHook()`. We need to use `BeginReport()`/`EndReport()` instead to ensure `custom_message_type` is reset to `CustomMsg::Status` once the MMU command is done processing. This will for example allow showing SD file name again when printing.

Changes tested on MK3S+

Change in memory:
Flash: -8 bytes
SRAM: 0 bytes