### PR TITLE
Fix `M0` click not consumed

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -5221,18 +5221,13 @@ void process_commands()
     case 1: {
         const char *src = strchr_pointer + 2;
         codenum = 0;
-        bool hasP = false, hasS = false;
-        if (code_seen('P')) {
-            codenum = code_value_long(); // milliseconds to wait
-            hasP = codenum > 0;
-        }
-        if (code_seen('S')) {
-            codenum = code_value_long() * 1000; // seconds to wait
-            hasS = codenum > 0;
-        }
+        if (code_seen('P')) codenum = code_value_long(); // milliseconds to wait
+        if (code_seen('S')) codenum = code_value_long() * 1000; // seconds to wait
+        bool expiration_time_set = bool(codenum);
+
         while (*src == ' ') ++src;
         custom_message_type = CustomMsg::M0Wait;
-        if (!hasP && !hasS && *src != '\0') {
+        if (!expiration_time_set && *src != '\0') {
             lcd_setstatus(src);
         } else {
             // farmers want to abuse a bug from the previous firmware releases
@@ -5247,7 +5242,7 @@ void process_commands()
         st_synchronize();
         menu_set_block(MENU_BLOCK_STATUS_SCREEN_M0);
         previous_millis_cmd.start();
-        if (codenum > 0 ) {
+        if (expiration_time_set) {
             codenum += _millis();  // keep track of when we started waiting
             KEEPALIVE_STATE(PAUSED_FOR_USER);
             while(_millis() < codenum && !lcd_clicked()) {

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -5244,8 +5244,8 @@ void process_commands()
                 custom_message_type = CustomMsg::Status; // let the lcd display the name of the printed G-code file in farm mode
             }
         }
-        lcd_ignore_click();				//call lcd_ignore_click also for else ???
         st_synchronize();
+        menu_set_block(MENU_BLOCK_STATUS_SCREEN_M0);
         previous_millis_cmd.start();
         if (codenum > 0 ) {
             codenum += _millis();  // keep track of when we started waiting
@@ -5254,10 +5254,10 @@ void process_commands()
                 delay_keep_alive(0);
             }
             KEEPALIVE_STATE(IN_HANDLER);
-            lcd_ignore_click(false);
         } else {
             marlin_wait_for_click();
         }
+        menu_unset_block(MENU_BLOCK_STATUS_SCREEN_M0);
         if (IS_SD_PRINTING)
             custom_message_type = CustomMsg::Status;
         else

--- a/Firmware/menu.h
+++ b/Firmware/menu.h
@@ -38,6 +38,7 @@ enum ESeriousErrors {
 #ifdef TEMP_MODEL
 	MENU_BLOCK_TEMP_MODEL_AUTOTUNE = 0x02,
 #endif
+    MENU_BLOCK_STATUS_SCREEN_M0    = 0x04,
 }; // and possibly others in the future.
 
 //! this is a flag for disabling entering the main menu and longpress. If this is set to anything !=
@@ -49,7 +50,8 @@ extern uint8_t menu_block_mask;
 //! a c++ class would have been better
 #define menu_set_block(x) menu_block_mask |= x;
 #define menu_unset_block(x) menu_block_mask &= ~x;
-#define menu_is_blocked(x) (menu_block_mask & x) != 0
+#define menu_is_blocked(x) (menu_block_mask & x)
+#define menu_is_any_block() (menu_block_mask != MENU_BLOCK_NONE)
 
 extern uint8_t menu_line;
 extern uint8_t menu_item;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -98,7 +98,6 @@ static const char* lcd_display_message_fullscreen_nonBlocking_P(const char *msg)
 // void copy_and_scalePID_d();
 
 /* Different menus */
-//static void lcd_status_screen();                // NOT static due to using inside "Marlin_main" module ("manage_inactivity()")
 #if (LANG_MODE != 0)
 static void lcd_language_menu();
 #endif
@@ -255,9 +254,6 @@ bool lcd_oldcardstatus;
 #endif
 
 uint8_t selected_sheet = 0;
-
-bool ignore_click = false;
-bool wait_for_unclick;
 
 bool bMain;                                       // flag (i.e. 'fake parameter') for 'lcd_sdcard_menu()' function
 bool bSettings;                                   // flag (i.e. 'fake parameter') for 'lcd_hw_setup_menu()' function
@@ -757,29 +753,7 @@ void lcd_status_screen()                          // NOT static due to using ins
 			lcd_commands();
 	}
 
-	bool current_click = lcd_clicked();
-
-	if (ignore_click)
-	{
-		if (wait_for_unclick)
-		{
-			if (!current_click)
-				ignore_click = wait_for_unclick = false;
-			else
-				current_click = false;
-		}
-		else if (current_click)
-		{
-			lcd_draw_update = 2;
-			wait_for_unclick = true;
-			current_click = false;
-		}
-	}
-
-	if (current_click
-		&& ( menu_block_mask == MENU_BLOCK_NONE ) // or a serious error blocks entering the menu
-	)
-	{
+    if (!menu_is_any_block() && lcd_clicked()) {
 		menu_depth = 0; //redundant, as already done in lcd_return_to_status(), just to be sure
 		menu_submenu(lcd_main_menu);
 		lcd_refresh(); // to maybe revive the LCD if static electricity killed it.
@@ -7212,12 +7186,6 @@ void ultralcd_init()
   strncpy_P(lcd_status_message, MSG_WELCOME, LCD_WIDTH);
 }
 
-void lcd_ignore_click(bool b)
-{
-  ignore_click = b;
-  wait_for_unclick = false;
-}
-
 static bool lcd_message_check(uint8_t priority)
 {
     // regular priority check
@@ -7314,7 +7282,7 @@ void menu_lcd_longpress_func(void)
     // Wake up the LCD backlight and,
     // start LCD inactivity timer
     lcd_timeoutToStatus.start();
-    if (homing_flag || mesh_bed_leveling_flag || menu_menu == lcd_babystep_z || menu_menu == lcd_move_z || menu_block_mask != MENU_BLOCK_NONE || Stopped)
+    if (homing_flag || mesh_bed_leveling_flag || menu_menu == lcd_babystep_z || menu_menu == lcd_move_z || menu_is_any_block() || Stopped)
     {
         // disable longpress during re-entry, while homing, calibration or if a serious error
         lcd_draw_update = 2;

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -168,7 +168,6 @@ extern bool isPrintPaused;
 extern uint8_t scrollstuff;
 
 
-void lcd_ignore_click(bool b=true);
 void lcd_commands();
 
 


### PR DESCRIPTION
Fix the need to click the knob twice to dismiss `M0`. Also some code optimization.

Flash: -90B
SRAM: -2B