### PR TITLE
MMU: Simplify `T?` processing

### DIFF
--- a/Firmware/Tcodes.cpp
+++ b/Firmware/Tcodes.cpp
@@ -4,7 +4,6 @@
 #include "language.h"
 #include "messages.h"
 #include "mmu2.h"
-#include "stepper.h"
 #include "ultralcd.h"
 #include <avr/pgmspace.h>
 #include <stdint.h>
@@ -40,7 +39,6 @@ void TCodes(char *const strchr_pointer, const uint8_t codeValue) {
             MMU2::mmu2.tool_change(strchr_pointer[index], MMU2::mmu2.get_current_tool());
         }
     } else { // Process T0 ... T4
-        st_synchronize();
         if (MMU2::mmu2.Enabled()) {
             if (codeValue == MMU2::mmu2.get_current_tool()){ 
                 // don't execute the same T-code twice in a row

--- a/Firmware/Tcodes.h
+++ b/Firmware/Tcodes.h
@@ -2,4 +2,4 @@
 #pragma once
 #include <stdint.h>
 
-void TCodes(char * const strchr_pointer, uint8_t codeValue);
+void TCodes(char * const strchr_pointer, const uint8_t codeValue);


### PR DESCRIPTION
We can use `bool MMU2::tool_change(char code, uint8_t slot)` to process `T?`. This way we don't need to call `load_filament_to_nozzle()` in `TCodes.cpp`. This also reduces the code complexity quite a bit.

Tested on MK3S+:
* ✅ T0
* ✅ Tx and Tc by starting a print
* ✅ T?
* ✅ Load to Nozzle from LCD

Change in memory:
Flash: -64 bytes
SRAM: 0 bytes