### PR TITLE
Fix `lcd_encoder_diff` getting out of sync with the knob hard steps

### DIFF
--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -684,9 +684,11 @@ void lcd_knob_update() {
 	if (lcd_backlight_wake_trigger) {
 		lcd_backlight_wake_trigger = false;
 		backlight_wake();
-		if (abs(lcd_encoder_diff) >= ENCODER_PULSES_PER_STEP) {
-			lcd_encoder += lcd_encoder_diff / ENCODER_PULSES_PER_STEP;
-			lcd_encoder_diff = 0;
+		int8_t enc_diff = lcd_encoder_diff;
+		if (abs(enc_diff) >= ENCODER_PULSES_PER_STEP) {
+			lcd_encoder += enc_diff / ENCODER_PULSES_PER_STEP;
+			enc_diff %= ENCODER_PULSES_PER_STEP;
+			lcd_encoder_diff = enc_diff;
 			Sound_MakeSound(e_SOUND_TYPE_EncoderMove);
 		} else {
 			Sound_MakeSound(e_SOUND_TYPE_ButtonEcho);

--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -692,6 +692,11 @@ void lcd_knob_update() {
 				lcd_encoder_diff %= ENCODER_PULSES_PER_STEP;
 				did_rotate = true;
 			}
+			else {
+				// Get lcd_encoder_diff in sync with the encoder hard steps.
+				// We assume that a click happens only when the knob is rotated into a stable position
+				lcd_encoder_diff = 0;
+			}
 		}
 		Sound_MakeSound(did_rotate ? e_SOUND_TYPE_EncoderMove : e_SOUND_TYPE_ButtonEcho);
 

--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <avr/pgmspace.h>
+#include <util/atomic.h>
 #include <util/delay.h>
 #include "Timer.h"
 
@@ -684,15 +685,15 @@ void lcd_knob_update() {
 	if (lcd_backlight_wake_trigger) {
 		lcd_backlight_wake_trigger = false;
 		backlight_wake();
-		int8_t enc_diff = lcd_encoder_diff;
-		if (abs(enc_diff) >= ENCODER_PULSES_PER_STEP) {
-			lcd_encoder += enc_diff / ENCODER_PULSES_PER_STEP;
-			enc_diff %= ENCODER_PULSES_PER_STEP;
-			lcd_encoder_diff = enc_diff;
-			Sound_MakeSound(e_SOUND_TYPE_EncoderMove);
-		} else {
-			Sound_MakeSound(e_SOUND_TYPE_ButtonEcho);
+		bool did_rotate = false;
+		ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
+			if (abs(lcd_encoder_diff) >= ENCODER_PULSES_PER_STEP) {
+				lcd_encoder += lcd_encoder_diff / ENCODER_PULSES_PER_STEP;
+				lcd_encoder_diff %= ENCODER_PULSES_PER_STEP;
+				did_rotate = true;
+			}
 		}
+		Sound_MakeSound(did_rotate ? e_SOUND_TYPE_EncoderMove : e_SOUND_TYPE_ButtonEcho);
 
 		if (lcd_draw_update == 0) {
 			// Update LCD rendering at minimum


### PR DESCRIPTION
Two issues were fixed:
- lcd_encoder_diff should not be cleared to 0 whenever a step is made. Consider the following scenario: lcd_encoder_diff is equal to 6. That means there is one lcd_encoder step to be made, but there are also the two remaining lcd_encoder_diff steps. With the old code, lcd_encoder would be incremented and lcd_encoder_diff would be set to 0, so those remaining 2 substeps would be reset to 0. In this case, the knob would get out of sync with the hard steps of the physical knob.
- lcd_encoder_diff was not being modified atomically. It is updated from an ISR, but also from the main context.

Flash: +22B
SRAM: 0B