### PR TITLE
Fix issue where Tx gcode doesnt reset custom_message_type

### DIFF
--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -401,8 +401,7 @@ bool MMU2::tool_change(char code, uint8_t slot) {
 
     case 'x': {
         thermal_setExtrudeMintemp(0); // Allow cold extrusion since Tx only loads to the gears not nozzle
-        planner_synchronize();
-        ToolChangeCommon(slot); // the only difference was manage_response(false, false), but probably good enough
+        tool_change(slot);
         thermal_setExtrudeMintemp(EXTRUDE_MINTEMP);
     } break;
 


### PR DESCRIPTION
We need to call BeginReport and EndReport
otherwise the SD filename is not shown when printing

This only affects single material MMU gcodes

Similar to https://github.com/prusa3d/Prusa-Firmware/pull/4154 but only fix this one bug. Don't touch any other area of the code.

Things to test:
* Printing with single material MMU profile (Tx/Tc)

Change in memory:
Flash: -4 bytes
SRAM: 0 bytes