### PR TITLE
M701/M702: Set default Z value to 0

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -8399,13 +8399,13 @@ Sigma_Exit:
     - `P` - n index of MMU slot (zero based, so 0-4 like T0 and T4)
     - `T` - Alias of `P`. Used for compatibility with Marlin
     - `L` - Extrude distance for insertion (positive value)(manual reload)
-    - `Z` - Move the Z axis by this distance. Default value MIN_Z_FOR_LOAD
+    - `Z` - Move the Z axis by this distance. Default value is 0 to maintain backwards compatibility with older gcodes.
     */
     case 701:
     {
         uint8_t mmuSlotIndex = 0xffU;
         float fastLoadLength = FILAMENTCHANGE_FIRSTFEED; // Only used without MMU
-        float z_target = MIN_Z_FOR_LOAD;
+        float z_target = 0;
         if( MMU2::mmu2.Enabled() )
         {
             if( code_seen('P') || code_seen('T') ) {
@@ -8437,11 +8437,11 @@ Sigma_Exit:
     
     #### Parameters
     - `U` - Retract distance for removal (manual reload). Default value is 0.
-    - `Z` - Move the Z axis by this distance. Default value MIN_Z_FOR_UNLOAD.
+    - `Z` - Move the Z axis by this distance. Default value is 0 to maintain backwards compatibility with older gcodes.
     */
     case 702:
     {
-        float z_target = MIN_Z_FOR_UNLOAD;
+        float z_target = 0;
         float unloadLength = FILAMENTCHANGE_FINALRETRACT;
         if (code_seen('U')) unloadLength = code_value();
 

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -8417,6 +8417,7 @@ Sigma_Exit:
 
         // Z lift. For safety only allow positive values
         if (code_seen('Z')) z_target = fabs(code_value());
+        else raise_z_above(MIN_Z_FOR_LOAD); // backwards compatibility for 3.12 and older FW
 
         // Raise the Z axis
         float delta = raise_z(z_target);
@@ -8447,6 +8448,7 @@ Sigma_Exit:
 
         // For safety only allow positive values
         if (code_seen('Z')) z_target = fabs(code_value());
+        else raise_z_above(MIN_Z_FOR_UNLOAD); // backwards compatibility for 3.12 and older FW
 
         // Raise the Z axis
         float delta = raise_z(z_target);

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3575,8 +3575,10 @@ void gcode_M701(float fastLoadLength, uint8_t mmuSlotIndex){
     
     prusa_statistics(22);
 
-    if (MMU2::mmu2.Enabled() && mmuSlotIndex < MMU_FILAMENT_COUNT) {
-        MMU2::mmu2.load_filament_to_nozzle(mmuSlotIndex);
+    if (MMU2::mmu2.Enabled()) {
+        if (mmuSlotIndex < MMU_FILAMENT_COUNT) {
+          MMU2::mmu2.load_filament_to_nozzle(mmuSlotIndex);
+        } // else do nothing
     } else {
         custom_message_type = CustomMsg::FilamentLoading;
         lcd_setstatuspgm(_T(MSG_LOADING_FILAMENT));

--- a/Firmware/first_lay_cal.cpp
+++ b/Firmware/first_lay_cal.cpp
@@ -81,7 +81,7 @@ bool lay1cal_load_filament(uint8_t filament)
             return false;
         } else if( currentTool != (uint8_t)MMU2::FILAMENT_UNKNOWN){
             // some other slot is loaded, perform an unload first
-            enquecommand_P(MSG_M702_NO_LIFT);
+            enquecommand_P(MSG_M702);
         }
         // perform a toolchange
         enquecommandf_P(PSTR("T%d"), filament);
@@ -245,6 +245,6 @@ void lay1cal_finish(bool mmu_enabled)
 
     lay1cal_common_enqueue_loop(cmd_cal_finish, (sizeof(cmd_cal_finish)/sizeof(cmd_cal_finish[0])));
 
-    if (mmu_enabled) enquecommand_P(MSG_M702_NO_LIFT); //unload from nozzle
+    if (mmu_enabled) enquecommand_P(MSG_M702); //unload from nozzle
     enquecommand_P(MSG_M84);// disable motors
 }

--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -240,5 +240,5 @@ const char MSG_M107[] PROGMEM_N1 = "M107";
 const char MSG_M220[] PROGMEM_N1 = "M220 S%d";
 const char MSG_M500[] PROGMEM_N1 = "M500";
 const char MSG_M600[] PROGMEM_N1 = "M600";
-const char MSG_M701_NO_LIFT[] PROGMEM_N1 = "M701 Z0";
-const char MSG_M702_NO_LIFT[] PROGMEM_N1 = "M702 Z0";
+const char MSG_M701[] PROGMEM_N1 = "M701";
+const char MSG_M702[] PROGMEM_N1 = "M702";

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -246,8 +246,8 @@ extern const char MSG_M107[];
 extern const char MSG_M220[];
 extern const char MSG_M500[];
 extern const char MSG_M600[];
-extern const char MSG_M701_NO_LIFT[];
-extern const char MSG_M702_NO_LIFT[];
+extern const char MSG_M701[];
+extern const char MSG_M702[];
 
 #if defined(__cplusplus)
 }

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1805,10 +1805,10 @@ switch(eFilamentAction)
                // FALLTHRU
           case FilamentAction::Load:
                loading_flag=true;
-               enquecommand_P(MSG_M701_NO_LIFT);      // load filament
+               enquecommand_P(MSG_M701);      // load filament
                break;
           case FilamentAction::UnLoad:
-               enquecommand_P(MSG_M702_NO_LIFT);      // unload filament
+               enquecommand_P(MSG_M702);      // unload filament
                break;
           case FilamentAction::MmuLoad:
           case FilamentAction::MmuLoadingTest:
@@ -1868,11 +1868,11 @@ void mFilamentItem(uint16_t nTemp, uint16_t nTempBed)
                 if ((eFilamentAction == FilamentAction::Load) || (eFilamentAction == FilamentAction::AutoLoad))
                 {
                     loading_flag = true;
-                    enquecommand_P(MSG_M701_NO_LIFT); // load filament
+                    enquecommand_P(MSG_M701); // load filament
                     if (eFilamentAction == FilamentAction::AutoLoad) eFilamentAction = FilamentAction::None; // i.e. non-autoLoad
                 }
                 if (eFilamentAction == FilamentAction::UnLoad)
-                enquecommand_P(MSG_M702_NO_LIFT); // unload filament
+                enquecommand_P(MSG_M702); // unload filament
             }
             break;
         case FilamentAction::MmuLoad:
@@ -3717,8 +3717,7 @@ static void lcd_wizard_load() {
         lcd_puts_at_P(0, 2, _T(MSG_LOADING_FILAMENT));
         loading_flag = true;
     }
-    gcode_M701(FILAMENTCHANGE_FIRSTFEED, 0);
-    //enquecommand_P(MSG_M701_NO_LIFT); // is enqueuecommand_P safe here?
+    enquecommand_P(MSG_M701);
 }
 
 static void wizard_lay1cal_message(bool cold)

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3717,7 +3717,9 @@ static void lcd_wizard_load() {
         lcd_puts_at_P(0, 2, _T(MSG_LOADING_FILAMENT));
         loading_flag = true;
     }
-    enquecommand_P(MSG_M701);
+
+    // When MMU is disabled P parameter is ignored
+    enquecommand_P(PSTR("M701 P0"));
 }
 
 static void wizard_lay1cal_message(bool cold)


### PR DESCRIPTION
Set default Z value to 0 to maintain backwards compatibility with older gcodes.


What needs to be tested:
* M600 with and without MMU
* See how print finish behavior is with MMU. Should now be like 3.12
* Any other functionality which uses M701 and M702.

Change in memory:
Flash: -24 bytes
SRAM: 0 bytes