### PR TITLE
Lcd encoder improvements

### DIFF
--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -786,8 +786,8 @@ void lcd_buttons_update(void)
 	static const int8_t encrot_table[] PROGMEM = {
 		0, -1, 1, 2,
 		1, 0, 2, -1,
-		-1, 2, 0, 1,
-		2, 1, -1, 0,
+		-1, -2, 0, 1,
+		-2, 1, -1, 0,
 	};
 
 	static uint8_t enc_bits_old = 0;

--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -751,7 +751,6 @@ void lcd_buttons_update(void)
 {
     static uint8_t lcd_long_press_active = 0;
     static uint8_t lcd_button_pressed = 0;
-    static uint8_t lcd_encoder_bits = 0;
     if (READ(BTN_ENC) == 0)
     { //button is pressed
         if (buttonBlanking.expired_cont(BUTTON_BLANKING_TIME)) {
@@ -784,24 +783,27 @@ void lcd_buttons_update(void)
     }
 
     //manage encoder rotation
-    #define ENCODER_SPIN(_E1, _E2) switch (lcd_encoder_bits) { case _E1: lcd_encoder_diff++; break; case _E2: lcd_encoder_diff--; }
-    uint8_t enc = 0;
-    if (READ(BTN_EN1) == 0) enc |= B01;
-    if (READ(BTN_EN2) == 0) enc |= B10;
-    if (enc != lcd_encoder_bits)
+	static const int8_t encrot_table[] PROGMEM = {
+		0, -1, 1, 2,
+		1, 0, 2, -1,
+		-1, 2, 0, 1,
+		2, 1, -1, 0,
+	};
+
+	static uint8_t enc_bits_old = 0;
+	uint8_t enc_bits = 0;
+    if (!READ(BTN_EN1)) enc_bits |= _BV(0);
+    if (!READ(BTN_EN2)) enc_bits |= _BV(1);
+    
+	if (enc_bits != enc_bits_old)
     {
-        switch (enc)
-        {
-            case encrot0: ENCODER_SPIN(encrot3, encrot1); break;
-            case encrot1: ENCODER_SPIN(encrot0, encrot2); break;
-            case encrot2: ENCODER_SPIN(encrot1, encrot3); break;
-            case encrot3: ENCODER_SPIN(encrot2, encrot0); break;
-        }
+		int8_t newDiff = pgm_read_byte(&encrot_table[(enc_bits_old << 2) | enc_bits]);
+		lcd_encoder_diff += newDiff;
 
         if (abs(lcd_encoder_diff) >= ENCODER_PULSES_PER_STEP) {
             lcd_backlight_wake_trigger = true; // flag event, knob rotated
         }
-        lcd_encoder_bits = enc;
+        enc_bits_old = enc_bits;
     }
 }
 

--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -635,7 +635,7 @@ uint8_t lcd_draw_update = 2;
 int16_t lcd_encoder = 0;
 static int8_t lcd_encoder_diff = 0;
 
-uint8_t lcd_buttons = 0;
+uint8_t lcd_click_trigger = 0;
 uint8_t lcd_update_enabled = 1;
 static bool lcd_backlight_wake_trigger; // Flag set by interrupt when the knob is pressed or rotated
 
@@ -776,7 +776,7 @@ void lcd_buttons_update(void)
             lcd_button_pressed = 0; // Reset to prevent double triggering
             if (!lcd_long_press_active)
             { //button released before long press gets activated
-                lcd_buttons |= EN_C; // This flag is reset when the event is consumed
+                lcd_click_trigger = 1; // This flag is reset when the event is consumed
             }
             lcd_backlight_wake_trigger = true; // flag event, knob pressed
             lcd_long_press_active = 0;

--- a/Firmware/lcd.h
+++ b/Firmware/lcd.h
@@ -100,8 +100,7 @@ extern uint8_t lcd_draw_update;
 
 extern int16_t lcd_encoder;
 
-//the last checked lcd_buttons in a bit array.
-extern uint8_t lcd_buttons;
+extern uint8_t lcd_click_trigger;
 
 extern uint8_t lcd_update_enabled;
 
@@ -156,20 +155,7 @@ private:
     bool m_updateEnabled;
 };
 
-
 ////////////////////////////////////
-// Setup button and encode mappings for each panel (into 'lcd_buttons' variable
-//
-// This is just to map common functions (across different panels) onto the same 
-// macro name. The mapping is independent of whether the button is directly connected or 
-// via a shift/i2c register.
-
-#define BLEN_B 1
-#define BLEN_A 0
-#define EN_B (1<<BLEN_B) // The two encoder pins are connected through BTN_EN1 and BTN_EN2
-#define EN_A (1<<BLEN_A)
-#define BLEN_C 2 
-#define EN_C (1<<BLEN_C) 
 
 //! @brief Was button clicked?
 //!
@@ -180,9 +166,8 @@ private:
 //!
 //! @retval 0 button was not clicked
 //! @retval 1 button was clicked
-#define LCD_CLICKED (lcd_buttons&EN_C)
+#define LCD_CLICKED (lcd_click_trigger)
 
-////////////////////////
 // Setup Rotary Encoder Bit Values (for two pin encoders to indicate movement)
 // These values are independent of which pins are used for EN_A and EN_B indications
 // The rotary encoder part is also independent to the chipset used for the LCD
@@ -191,6 +176,7 @@ private:
 #define encrot2 3
 #define encrot3 1
 
+////////////////////////////////////
 
 //Custom characters defined in the first 8 characters of the LCD
 #define LCD_STR_BEDTEMP      "\x00"
@@ -212,7 +198,7 @@ extern void lcd_set_custom_characters_nextpage(void);
 //! @brief Consume click and longpress event
 inline void lcd_consume_click()
 {
-    lcd_buttons = 0;
+    lcd_click_trigger = 0;
     lcd_longpress_trigger = 0;
 }
 

--- a/Firmware/lcd.h
+++ b/Firmware/lcd.h
@@ -168,14 +168,6 @@ private:
 //! @retval 1 button was clicked
 #define LCD_CLICKED (lcd_click_trigger)
 
-// Setup Rotary Encoder Bit Values (for two pin encoders to indicate movement)
-// These values are independent of which pins are used for EN_A and EN_B indications
-// The rotary encoder part is also independent to the chipset used for the LCD
-#define encrot0 0
-#define encrot1 2
-#define encrot2 3
-#define encrot3 1
-
 ////////////////////////////////////
 
 //Custom characters defined in the first 8 characters of the LCD


### PR DESCRIPTION
Lcd encoder code optimization. Instead of nested switch statements in an ISR, just use a small lookup table. This lookup table also correctly handles the scenario where the knob turns two substeps from one ISR to the next. In the old code, the lcd_encoder_diff would become out of phase by 2 ticks if that happened. The new code keeps lcd_encoder_diff in sync with the hard encoder ticks at all times. Even so, it's not perfect since there is no way to determine in which direction the encoder rotated when that happens, but at least now it doesn't get out of sync.