### PR TITLE
Allow `Statistics` menu while running 1st Layer cal

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5298,7 +5298,7 @@ static void lcd_main_menu()
     if(!isPrintPaused && (custom_message_type != CustomMsg::Resuming)) MENU_ITEM_SUBMENU_P(_T(MSG_CALIBRATION), lcd_calibration_menu);
     }
 
-    if (!usb_timer.running() && (lcd_commands_type == LcdCommands::Idle)) {
+    if (!usb_timer.running()) {
         MENU_ITEM_SUBMENU_P(_i("Statistics"), lcd_menu_statistics);////MSG_STATISTICS c=18
     }
 


### PR DESCRIPTION
There is no problem with opening the menu during first layer calibration. Removing this condition simplifies the code a little bit.

Changes tested on MK3S+ with MMU.

Change in memory:
Flash: -8 bytes
SRAM: 0 bytes