### PR TITLE
optimisation: use `disable_heater()` in more places

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3102,8 +3102,7 @@ bool gcode_M45(bool onlyZ, int8_t verbosity_level)
     // Only Z calibration?
 	if (!onlyZ)
 	{
-		setTargetBed(0);
-		setTargetHotend(0);
+		disable_heater();
 		eeprom_adjust_bed_reset(); //reset bed level correction
 	}
 
@@ -9291,8 +9290,7 @@ static void handleSafetyTimer()
     }
     else if (safetyTimer.expired(farm_mode?FARM_DEFAULT_SAFETYTIMER_TIME_ms:safetytimer_inactive_time))
     {
-        setTargetBed(0);
-        setTargetHotend(0);
+        disable_heater();
         lcd_show_fullscreen_message_and_wait_P(_i("Heating disabled by safety timer."));////MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
     }
 }

--- a/Firmware/Prusa_farm.cpp
+++ b/Firmware/Prusa_farm.cpp
@@ -163,9 +163,7 @@ static void trace() {
 }
 
 void serial_read_stream() {
-
-    setTargetHotend(0);
-    setTargetBed(0);
+    disable_heater();
 
     lcd_clear();
     lcd_puts_P(PSTR(" Upload in progress"));

--- a/Firmware/power_panic.cpp
+++ b/Firmware/power_panic.cpp
@@ -78,8 +78,7 @@ void uvlo_() {
     }
 
     // Stop all heaters before continuing
-    setTargetHotend(0);
-    setTargetBed(0);
+    disable_heater();
 
     // Fetch data not included in a partial back-up
     if (!sd_print_saved_in_ram) {
@@ -233,8 +232,7 @@ static void uvlo_tiny() {
 #endif //TMC2130
 
     // Stop all heaters
-    setTargetHotend(0);
-    setTargetBed(0);
+    disable_heater();
 
     // When power is interrupted on the _first_ recovery an attempt can be made to raise the
     // extruder, causing the Z position to change. Similarly, when recovering, the Z position is

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1030,8 +1030,7 @@ static void lcd_move_menu_axis();
 
 static void lcd_cooldown()
 {
-  setTargetHotend(0);
-  setTargetBed(0);
+  disable_heater();
   fanSpeed = 0;
   lcd_return_to_status();
 }
@@ -2712,8 +2711,7 @@ void pid_extruder()
 
 #ifdef PINDA_THERMISTOR
 bool lcd_wait_for_pinda(float temp) {
-	setTargetHotend(0);
-	setTargetBed(0);
+	disable_heater();
 	LongTimer pinda_timeout;
 	pinda_timeout.start();
 	bool target_temp_reached = true;
@@ -2744,8 +2742,7 @@ void lcd_wait_for_heater() {
 }
 
 void lcd_wait_for_cool_down() {
-	setTargetHotend(0);
-	setTargetBed(0);
+	disable_heater();
 	uint8_t fanSpeedBckp = fanSpeed;
 	fanSpeed = 255;
 	while ((degHotend(0)>MAX_HOTEND_TEMP_CALIBRATION) || (degBed() > MAX_BED_TEMP_CALIBRATION)) {


### PR DESCRIPTION
This is just an idea. Needs to be verified.

Change in memory:
Flash: -84 bytes
SRAM: 0 bytes