### PR TITLE
optimisation: use `CHECK_ALL_HEATERS` in more places

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -7805,9 +7805,7 @@ Sigma_Exit:
 		cancel_heatup = false;
 
 		bool is_pinda_cooling = false;
-		if ((degTargetBed() == 0) && (degTargetHotend(0) == 0)) {
-		    is_pinda_cooling = true;
-		}
+		if (!(CHECK_ALL_HEATERS)) is_pinda_cooling = true;
 
 		while ( ((!is_pinda_cooling) && (!cancel_heatup) && (current_temperature_pinda < set_target_pinda)) || (is_pinda_cooling && (current_temperature_pinda > set_target_pinda)) ) {
 			if ((_millis() - codenum) > 1000) //Print Temp Reading every 1 second while waiting.
@@ -9257,11 +9255,11 @@ void controllerFan()
  */
 static void handleSafetyTimer()
 {
-    if (printer_active() || (!degTargetBed() && !degTargetHotend(0)) || (!safetytimer_inactive_time))
+    if (printer_active() || !(CHECK_ALL_HEATERS) || !safetytimer_inactive_time)
     {
         safetyTimer.stop();
     }
-    else if ((degTargetBed() || degTargetHotend(0)) && (!safetyTimer.running()))
+    else if ((CHECK_ALL_HEATERS) && !safetyTimer.running())
     {
         safetyTimer.start();
     }


### PR DESCRIPTION
Note that `!a && !b` is equal to `!(a || b)`

* a = `bool(target_temperature[0])`
* b = `bool(target_temperature_bed)`

CHECK_ALL_HEATERS is essentially `(a || b)`

1. `(degTargetBed() == 0) && (degTargetHotend(0) == 0)` is equal to `(!a && !b)` or `!(a || b)` => `!(CHECK_ALL_HEATERS)`
2. `!degTargetBed() && !degTargetHotend(0)` is equal to same as 1) => `!(CHECK_ALL_HEATERS)`
3. `degTargetBed() || degTargetHotend(0)` is equal to `(a || b)` => `(CHECK_ALL_HEATERS)`

Change in memory:
Flash: -162 bytes
SRAM: 0 bytes