### PR TITLE
cleanup: Remove unused `LcdCommands` state `LoadFilament`

### DIFF
--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -113,7 +113,6 @@ extern void lcd_bed_calibration_show_result(BedSkewOffsetDetectionResultType res
 enum class LcdCommands : uint_least8_t
 {
 	Idle,
-	LoadFilament,
 	StopPrint,
 	LongPause,
 	PidExtruder,


### PR DESCRIPTION
This may help the compiler generate smaller code

Change in memory:
Flash: -2 bytes
SRAM: 0 bytes