### PR TITLE
🚧 Simplify `mFilamentItem`

### DIFF
--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -189,7 +189,6 @@ enum class FilamentAction : uint_least8_t
 };
 
 extern FilamentAction eFilamentAction;
-void mFilamentItem(uint16_t nTemp,uint16_t nTempBed);
 void lcd_generic_preheat_menu();
 void unload_filament(float unloadLength);
 void lcd_AutoLoadFilament();


### PR DESCRIPTION
Ideas to simplify `mFilamentItem()`

Motivation for these changes
* Reduce calls to M701 and M702.
* Reduce duplicate code

Change in memory:
Flash: -120 bytes
SRAM: -1 byte