### PR TITLE
optimisation: only check feedrate if knob is rotated

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -693,34 +693,29 @@ void lcd_status_screen()                          // NOT static due to using ins
 {
 	static uint8_t lcd_status_update_delay = 0;
 #ifdef ULTIPANEL_FEEDMULTIPLY
-	// Dead zone at 100% feedrate
-	if ((feedmultiply < 100 && (feedmultiply + lcd_encoder) > 100) ||
-		(feedmultiply > 100 && (feedmultiply + lcd_encoder) < 100))
-	{
-		lcd_encoder = 0;
-		feedmultiply = 100;
-	}
-	if (feedmultiply == 100 && lcd_encoder > ENCODER_FEEDRATE_DEADZONE)
-	{
-		feedmultiply += lcd_encoder - ENCODER_FEEDRATE_DEADZONE;
-		lcd_encoder = 0;
-	}
-	else if (feedmultiply == 100 && lcd_encoder < -ENCODER_FEEDRATE_DEADZONE)
-	{
-		feedmultiply += lcd_encoder + ENCODER_FEEDRATE_DEADZONE;
-		lcd_encoder = 0;
-	}
-	else if (feedmultiply != 100)
-	{
-		feedmultiply += lcd_encoder;
-		lcd_encoder = 0;
-	}
-#endif //ULTIPANEL_FEEDMULTIPLY
+    if (lcd_encoder)
+    {
+        const int16_t initial_feedmultiply = feedmultiply;
+        // Dead zone at 100% feedrate
+        if ((feedmultiply < 100 && (feedmultiply + lcd_encoder) > 100) ||
+            (feedmultiply > 100 && (feedmultiply + lcd_encoder) < 100))
+        {
+            feedmultiply = 100;
+        }
+        else if (feedmultiply == 100 && lcd_encoder > ENCODER_FEEDRATE_DEADZONE) {
+            feedmultiply += lcd_encoder - ENCODER_FEEDRATE_DEADZONE;
+        }
+        else if (feedmultiply == 100 && lcd_encoder < -ENCODER_FEEDRATE_DEADZONE) {
+            feedmultiply += lcd_encoder + ENCODER_FEEDRATE_DEADZONE;
+        }
+        else if (feedmultiply != 100) feedmultiply += lcd_encoder;
 
-	if (feedmultiply < 10)
-		feedmultiply = 10;
-	else if (feedmultiply > 999)
-		feedmultiply = 999;
+        if (initial_feedmultiply != feedmultiply) {
+            feedmultiply = constrain(feedmultiply, 10, 999);
+            lcd_encoder = 0; // Consume rotation event
+        }
+    }
+#endif //ULTIPANEL_FEEDMULTIPLY
 
 	if (lcd_draw_update) {
 		// Update the status screen immediately


### PR DESCRIPTION
Guard the feedmultiply code with lcd_encoder.

if `lcd_encoder = 0`, then there is no need to check if `feedmultiply` should be updated.

Also set `lcd_encoder` to zero in one line to consume the rotation event.

Change in memory:
Flash: -40 bytes
SRAM: 0 bytes