### PR TITLE
MBL print area

### DIFF
--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -236,7 +236,7 @@ enum class HeatingStatus : uint8_t
 extern HeatingStatus heating_status;
 
 extern bool fans_check_enabled;
-extern float homing_feedrate[];
+constexpr float homing_feedrate[] = HOMING_FEEDRATE;
 extern uint8_t axis_relative_modes;
 extern float feedrate;
 extern int feedmultiply;

--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -22,7 +22,6 @@
 #include "pins.h"
 #include "Timer.h"
 #include "mmu2.h"
-extern uint8_t mbl_z_probe_nr;
 
 #ifndef AT90USB
 #define  HardwareSerial_h // trick to disable the standard HWserial

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -2832,10 +2832,10 @@ static void gcode_G80()
         nProbeRetry = 10;
     }
 
-    const float area_min_x = code_seen('X') ? code_value() - MESH_X_DIST - X_PROBE_OFFSET_FROM_EXTRUDER : -INFINITY;
-    const float area_min_y = code_seen('Y') ? code_value() - MESH_Y_DIST - Y_PROBE_OFFSET_FROM_EXTRUDER : -INFINITY;
-    const float area_max_x = code_seen('W') ? area_min_x + code_value() + 2 * MESH_X_DIST : INFINITY;
-    const float area_max_y = code_seen('H') ? area_min_y + code_value() + 2 * MESH_Y_DIST : INFINITY;
+    const float area_min_x = code_seen('X') ? code_value() - x_mesh_density - X_PROBE_OFFSET_FROM_EXTRUDER : -INFINITY;
+    const float area_min_y = code_seen('Y') ? code_value() - y_mesh_density - Y_PROBE_OFFSET_FROM_EXTRUDER : -INFINITY;
+    const float area_max_x = code_seen('W') ? area_min_x + code_value() + 2 * x_mesh_density : INFINITY;
+    const float area_max_y = code_seen('H') ? area_min_y + code_value() + 2 * y_mesh_density : INFINITY;
 
     mbl.reset(); //reset mesh bed leveling
     mbl.z_values[0][0] = min_pos[Z_AXIS];

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -2865,8 +2865,8 @@ static void gcode_G80()
                 if (!isOn3x3Mesh)
                     continue;
             } else {
-                const float x_pos = BED_X(col, MESH_NUM_X_POINTS);
-                const float y_pos = BED_Y(row, MESH_NUM_Y_POINTS);
+                const float x_pos = BED_X(col);
+                const float y_pos = BED_Y(row);
                 if ((x_pos < area_min_x || x_pos > area_max_x || y_pos < area_min_y || y_pos > area_max_y) && (!isOn3x3Mesh || has_z)) {
                     continue;
                 }
@@ -2898,8 +2898,8 @@ static void gcode_G80()
         uint8_t iy = mesh_point / MESH_NUM_X_POINTS;
         if (iy & 1) ix = (MESH_NUM_X_POINTS - 1) - ix; // Zig zag
         bool isOn3x3Mesh = ((ix % 3 == 0) && (iy % 3 == 0));
-        float x_pos = BED_X(ix, MESH_NUM_X_POINTS);
-        float y_pos = BED_Y(iy, MESH_NUM_Y_POINTS);
+        float x_pos = BED_X(ix);
+        float y_pos = BED_Y(iy);
 
         if ((nMeasPoints == 3) && !isOn3x3Mesh) {
             mesh_point++;

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3030,7 +3030,7 @@ static void gcode_G80()
         }
         return 0;
     };
-    int8_t correction[4] = {
+    const int8_t correction[4] = {
         bedCorrectHelper('L', (uint8_t*)EEPROM_BED_CORRECTION_LEFT),
         bedCorrectHelper('R', (uint8_t*)EEPROM_BED_CORRECTION_RIGHT),
         bedCorrectHelper('F', (uint8_t*)EEPROM_BED_CORRECTION_FRONT),

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3058,7 +3058,7 @@ static void gcode_G80()
     mbl.upsample_3x3(); //interpolation from 3x3 to 7x7 points using largrangian polynomials while using the same array z_values[iy][ix] for storing (just coppying measured data to new destination and interpolating between them)
 
     if (nMeasPoints == 7 && magnet_elimination) {
-        mbl_interpolation(nMeasPoints);
+        mbl_magnet_elimination();
     }
 
     mbl.active = 1; //activate mesh bed leveling

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -2970,7 +2970,11 @@ static void gcode_G80()
     current_position[Z_AXIS] = MESH_HOME_Z_SEARCH;
     plan_buffer_line_curposXYZE(Z_LIFT_FEEDRATE);
     st_synchronize();
+    static uint8_t g80_fail_cnt = 0;
     if (mesh_point != MESH_NUM_X_POINTS * MESH_NUM_Y_POINTS) {
+        if (g80_fail_cnt++ >= 2) {
+            kill(_i("Mesh bed leveling failed. Please run Z calibration"));
+        }
         Sound_MakeSound(e_SOUND_TYPE_StandardAlert);
         bool bState;
         do   {                             // repeat until Z-leveling o.k.
@@ -3005,6 +3009,8 @@ static void gcode_G80()
         repeatcommand_front();             // re-run (i.e. of "G80")
         return;
     }
+    g80_fail_cnt = 0; // no fail was detected. Reset the error counter.
+
     clean_up_after_endstop_move(l_feedmultiply);
 
 #ifndef PINDA_THERMISTOR

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -2856,6 +2856,8 @@ static void gcode_G80()
                     const float z0 = mbl.z_values[0][0] + *reinterpret_cast<int16_t*>(&z_offset_u) * 0.01;
                     mbl.set_z(col, row, z0);
                 }
+            } else {
+                mbl.set_z(col, row, NAN);
             }
 
             // check for points that are skipped

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -148,8 +148,6 @@
 CardReader card;
 #endif
 
-uint8_t mbl_z_probe_nr = 3; //numer of Z measurements for each point in mesh bed leveling calibration
-
 //used for PINDA temp calibration and pause print
 #define DEFAULT_RETRACTION    1
 #define DEFAULT_RETRACTION_MM 4 //MM

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -2915,10 +2915,11 @@ static void gcode_G80()
         // Move Z up to the probe height of the current Z point.
         const float z0 = mbl.z_values[iy][ix];
         const float init_z_bckp = !has_z ? MESH_HOME_Z_SEARCH : z0 + MESH_HOME_Z_SEARCH_FAST;
-        if (init_z_bckp > current_position[Z_AXIS])
+        if (init_z_bckp > current_position[Z_AXIS]) {
             current_position[Z_AXIS] = init_z_bckp;
-        plan_buffer_line_curposXYZE(Z_LIFT_FEEDRATE);
-        st_synchronize();
+            plan_buffer_line_curposXYZE(Z_LIFT_FEEDRATE);
+            st_synchronize();
+        }
 
         // Move to XY position of the sensor point.
         current_position[X_AXIS] = x_pos;

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3054,7 +3054,14 @@ static void gcode_G80()
     }
 
     mbl.active = 1; //activate mesh bed leveling
-    go_home_with_z_lift();
+
+    if (code_seen('O') && !code_value_uint8()) {
+        // Don't let the manage_inactivity() function remove power from the motors.
+        refresh_cmd_timeout();
+    } else {
+        go_home_with_z_lift();
+    }
+
 #ifndef PINDA_THERMISTOR
     //unretract (after PINDA preheat retraction)
     if (temp_compensation_retracted) {
@@ -4852,6 +4859,7 @@ void process_commands()
 	#### Parameters
       - `N` - Number of mesh points on x axis. Default is 3. Valid values are 3 and 7.
       - `R` - Probe retries. Default 3 max. 10
+      - `O` - Return to origin. Default 1 (true)
       
       Using the following parameters enables additional "manual" bed leveling correction. Valid values are -100 microns to 100 microns.
     #### Additional Parameters

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -2792,6 +2792,7 @@ static void gcode_G80()
     constexpr float XY_AXIS_FEEDRATE = (homing_feedrate[X_AXIS] * 3) / 60;
     constexpr float Z_LIFT_FEEDRATE = homing_feedrate[Z_AXIS] / 60;
     constexpr float Z_CALIBRATION_THRESHOLD = 1.f;
+    constexpr float MESH_HOME_Z_SEARCH_FAST = 0.35f;
     st_synchronize();
     if (planner_aborted)
         return;
@@ -2913,7 +2914,7 @@ static void gcode_G80()
 
         // Move Z up to the probe height of the current Z point.
         const float z0 = mbl.z_values[iy][ix];
-        const float init_z_bckp = !has_z ? MESH_HOME_Z_SEARCH : z0 + 0.35;
+        const float init_z_bckp = !has_z ? MESH_HOME_Z_SEARCH : z0 + MESH_HOME_Z_SEARCH_FAST;
         if (init_z_bckp > current_position[Z_AXIS])
             current_position[Z_AXIS] = init_z_bckp;
         plan_buffer_line_curposXYZE(Z_LIFT_FEEDRATE);

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -2832,8 +2832,6 @@ static void gcode_G80()
         nProbeRetry = 10;
     }
 
-    const uint8_t magnet_elimination = eeprom_read_byte((uint8_t*)EEPROM_MBL_MAGNET_ELIMINATION);
-
     const float area_min_x = code_seen('X') ? code_value() - MESH_X_DIST - X_PROBE_OFFSET_FROM_EXTRUDER : -INFINITY;
     const float area_min_y = code_seen('Y') ? code_value() - MESH_Y_DIST - Y_PROBE_OFFSET_FROM_EXTRUDER : -INFINITY;
     const float area_max_x = code_seen('W') ? area_min_x + code_value() + 2 * MESH_X_DIST : INFINITY;
@@ -3054,7 +3052,7 @@ static void gcode_G80()
 
     mbl.upsample_3x3(); //interpolation from 3x3 to 7x7 points using largrangian polynomials while using the same array z_values[iy][ix] for storing (just coppying measured data to new destination and interpolating between them)
 
-    if (nMeasPoints == 7 && magnet_elimination) {
+    if (nMeasPoints == 7 && eeprom_read_byte((uint8_t*)EEPROM_MBL_MAGNET_ELIMINATION)) {
         mbl_magnet_elimination();
     }
 

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -4957,7 +4957,7 @@ void process_commands()
     Default 3x3 grid can be changed on MK2.5/s and MK3/s to 7x7 grid.
     #### Usage
 	  
-          G80 [ N | R | V | L | R | F | B ]
+          G80 [ N | R | V | L | R | F | B | X | Y | W | H ]
       
 	#### Parameters
       - `N` - Number of mesh points on x axis. Default is 3. Valid values are 3 and 7.
@@ -4970,16 +4970,13 @@ void process_commands()
       - `R` - Right Bed Level correct value in um.
       - `F` - Front Bed Level correct value in um.
       - `B` - Back Bed Level correct value in um.
+
+      The following parameters are used to define the area used by the print:
+      - `X` - area lower left point X coordinate
+      - `Y` - area lower left point Y coordinate
+      - `W` - area width (on X axis)
+      - `H` - area height (on Y axis)
     */
-  
-	/*
-    * Probes a grid and produces a mesh to compensate for variable bed height
-	* The S0 report the points as below
-	*  +----> X-axis
-	*  |
-	*  |
-	*  v Y-axis
-	*/
 
 	case 80: {
         gcode_G80();

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3124,7 +3124,7 @@ static void gcode_G80()
               + correction[0] * (MESH_NUM_X_POINTS - 1 - col)
               + correction[1] * col
               + correction[2] * (MESH_NUM_Y_POINTS - 1 - row)
-              + correction[3] * row) / (float)(nMeasPoints - 1);
+              + correction[3] * row) / (float)(MESH_NUM_X_POINTS - 1);
         }
     }
     //		SERIAL_ECHOLNPGM("Bed leveling correction finished");

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -4870,20 +4870,7 @@ void process_commands()
         */
         case 81:
             if (mbl.active) {
-                SERIAL_PROTOCOLPGM("Num X,Y: ");
-                SERIAL_PROTOCOL(MESH_NUM_X_POINTS);
-                SERIAL_PROTOCOL(',');
-                SERIAL_PROTOCOL(MESH_NUM_Y_POINTS);
-                SERIAL_PROTOCOLPGM("\nZ search height: ");
-                SERIAL_PROTOCOL(MESH_HOME_Z_SEARCH);
-                SERIAL_PROTOCOLLNPGM("\nMeasured points:");
-                for (uint8_t y = MESH_NUM_Y_POINTS; y-- > 0;) {
-                    for (uint8_t x = 0; x < MESH_NUM_X_POINTS; x++) {
-                        SERIAL_PROTOCOLPGM("  ");
-                        SERIAL_PROTOCOL_F(mbl.z_values[y][x], 5);
-                    }
-                    SERIAL_PROTOCOLLN();
-                }
+                mbl.print();
             }
             else
                 SERIAL_PROTOCOLLNPGM("Mesh bed leveling not active.");

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3016,7 +3016,7 @@ static void gcode_G80()
     
     // Apply the bed level correction to the mesh
     bool eeprom_bed_correction_valid = eeprom_read_byte((unsigned char*)EEPROM_BED_CORRECTION_VALID) == 1;
-    auto bedCorrectHelper = [&] (char code, uint8_t *eep_address) -> int8_t {
+    auto bedCorrectHelper = [eeprom_bed_correction_valid] (char code, uint8_t *eep_address) -> int8_t {
         if (code_seen(code)) {
             // Verify value is within allowed range
             int16_t temp = code_value_short();

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -2947,12 +2947,12 @@ static void gcode_G80()
                 break;
             }
             if (MESH_HOME_Z_SEARCH - current_position[Z_AXIS] < 0.1f) {
-                puts_P(PSTR("Bed leveling failed. Sensor disconnected or cable broken."));
+                puts_P(PSTR("Bed leveling failed. Sensor triggered too soon"));
                 break;
             }
         }
         if (has_z && fabs(z0 - current_position[Z_AXIS]) > Z_CALIBRATION_THRESHOLD) { //if we have data from z calibration, max. allowed difference is 1mm for each point
-            puts_P(PSTR("Bed leveling failed. Sensor triggered too high."));
+            puts_P(PSTR("Bed leveling failed. Too much variation from eeprom mesh"));
             break;
         }
 
@@ -2973,7 +2973,7 @@ static void gcode_G80()
     static uint8_t g80_fail_cnt = 0;
     if (mesh_point != MESH_NUM_X_POINTS * MESH_NUM_Y_POINTS) {
         if (g80_fail_cnt++ >= 2) {
-            kill(_i("Mesh bed leveling failed. Please run Z calibration"));
+            kill(PSTR("Mesh bed leveling failed. Please run Z calibration."));
         }
         Sound_MakeSound(e_SOUND_TYPE_StandardAlert);
         bool bState;

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3004,7 +3004,7 @@ static void gcode_G80()
     babystep_apply(); // Apply Z height correction aka baby stepping before mesh bed leveing gets activated.
     bool eeprom_bed_correction_valid = eeprom_read_byte((unsigned char*)EEPROM_BED_CORRECTION_VALID) == 1;
     const constexpr uint8_t sides = 4;
-    int8_t correction[sides] = {0};
+    int8_t correction[sides];
     for (uint8_t i = 0; i < sides; ++i) {
         static const char codes[sides] PROGMEM = { 'L', 'R', 'F', 'B' };
         static uint8_t *const eep_addresses[sides] PROGMEM = {
@@ -3013,23 +3013,21 @@ static void gcode_G80()
           (uint8_t*)EEPROM_BED_CORRECTION_FRONT,
           (uint8_t*)EEPROM_BED_CORRECTION_REAR,
         };
-        if (code_seen(pgm_read_byte(&codes[i])))
-        { // Verify value is within allowed range
+        if (code_seen(pgm_read_byte(&codes[i]))) {
+            // Verify value is within allowed range
             int32_t temp = code_value_long();
             if (labs(temp) > BED_ADJUSTMENT_UM_MAX) {
-                SERIAL_ERROR_START;
-                SERIAL_ECHOPGM("Excessive bed leveling correction: ");
-                SERIAL_ECHO(temp);
-                SERIAL_ECHOLNPGM(" microns");
+                printf_P(PSTR("%SExcessive bed leveling correction: %li microns\n"), errormagic, temp);
                 correction[i] = 0;
             } else {
               // Value is valid, save it
               correction[i] = (int8_t)temp;
             }
-        } else if (eeprom_bed_correction_valid)
+        } else if (eeprom_bed_correction_valid) {
             correction[i] = (int8_t)eeprom_read_byte((uint8_t*)pgm_read_ptr(&eep_addresses[i]));
-        if (correction[i] == 0)
-            continue;
+        } else {
+            correction[i] = 0;
+        }
     }
     for (uint8_t row = 0; row < MESH_NUM_Y_POINTS; ++row) {
         for (uint8_t col = 0; col < MESH_NUM_X_POINTS; ++col) {

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -2789,7 +2789,7 @@ static void gcode_G80()
 {
     constexpr float XY_AXIS_FEEDRATE = (homing_feedrate[X_AXIS] * 3) / 60;
     constexpr float Z_LIFT_FEEDRATE = homing_feedrate[Z_AXIS] / 60;
-    constexpr float Z_CALIBRATION_THRESHOLD = 1.f;
+    constexpr float Z_CALIBRATION_THRESHOLD = 0.35f;
     constexpr float MESH_HOME_Z_SEARCH_FAST = 0.35f;
     st_synchronize();
     if (planner_aborted)

--- a/Firmware/mesh_bed_calibration.cpp
+++ b/Firmware/mesh_bed_calibration.cpp
@@ -685,11 +685,11 @@ bool is_bed_z_jitter_data_valid()
 // offsets of the Z heiths of the calibration points from the first point are saved as 16bit signed int, scaled to tenths of microns
 // if at least one 16bit integer has different value then -1 (0x0FFFF), data are considered valid and function returns true, otherwise it returns false
 {	
-	bool data_valid = false;
 	for (int8_t i = 0; i < 8; ++i) {
-		if (eeprom_read_word((uint16_t*)(EEPROM_BED_CALIBRATION_Z_JITTER + i * 2)) != 0x0FFFF) data_valid = true;
+		if (eeprom_read_word((uint16_t*)(EEPROM_BED_CALIBRATION_Z_JITTER + i * 2)) != 0x0FFFF)
+            return true;
 	}
-    return data_valid;
+    return false;
 }
 
 static void world2machine_update(const float vec_x[2], const float vec_y[2], const float cntr[2])

--- a/Firmware/mesh_bed_calibration.cpp
+++ b/Firmware/mesh_bed_calibration.cpp
@@ -2186,12 +2186,14 @@ inline void scan_bed_induction_sensor_point()
 
 float __attribute__((noinline)) BED_X(const uint8_t col)
 {
-    return ((float)col * (BED_Xn - BED_X0) / (MESH_NUM_X_POINTS - 1) + BED_X0);
+    constexpr float x_mesh_density = (BED_Xn - BED_X0) / (MESH_NUM_X_POINTS - 1);
+    return ((float)col * x_mesh_density + BED_X0);
 }
 
 float __attribute__((noinline)) BED_Y(const uint8_t row)
 {
-    return ((float)row * (BED_Yn - BED_Y0) / (MESH_NUM_Y_POINTS - 1) + BED_Y0);
+    constexpr float y_mesh_density = (BED_Yn - BED_Y0) / (MESH_NUM_Y_POINTS - 1);
+    return ((float)row * y_mesh_density + BED_Y0);
 }
 
 BedSkewOffsetDetectionResultType find_bed_offset_and_skew(int8_t verbosity_level, uint8_t &too_far_mask)

--- a/Firmware/mesh_bed_calibration.cpp
+++ b/Firmware/mesh_bed_calibration.cpp
@@ -2814,16 +2814,16 @@ void go_home_with_z_lift()
     // Go home.
     // First move up to a safe height.
     current_position[Z_AXIS] = MESH_HOME_Z_SEARCH;
-    go_to_current(homing_feedrate[Z_AXIS]/60);
+    go_to_current(homing_feedrate[Z_AXIS] / 60);
     // Second move to XY [0, 0].
-    current_position[X_AXIS] = X_MIN_POS+0.2;
-    current_position[Y_AXIS] = Y_MIN_POS+0.2;
+    current_position[X_AXIS] = X_MIN_POS + 0.2;
+    current_position[Y_AXIS] = Y_MIN_POS + 0.2;
     // Clamp to the physical coordinates.
     world2machine_clamp(current_position[X_AXIS], current_position[Y_AXIS]);
-	go_to_current(homing_feedrate[X_AXIS]/20);
+    go_to_current((3 * homing_feedrate[X_AXIS]) / 60);
     // Third move up to a safe height.
     current_position[Z_AXIS] = Z_MIN_POS;
-    go_to_current(homing_feedrate[Z_AXIS]/60);    
+    go_to_current(homing_feedrate[Z_AXIS] / 60);
 }
 
 // Sample the 9 points of the bed and store them into the EEPROM as a reference.
@@ -3033,9 +3033,12 @@ bool scan_bed_induction_points(int8_t verbosity_level)
 // To replace loading of the babystep correction.
 static void shift_z(float delta)
 {
-    plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS] - delta, current_position[E_AXIS], homing_feedrate[Z_AXIS]/40);
+    const float curpos_z = current_position[Z_AXIS];
+    current_position[Z_AXIS] -= delta;
+    plan_buffer_line_curposXYZE(homing_feedrate[Z_AXIS] / 60);
     st_synchronize();
-    plan_set_z_position(current_position[Z_AXIS]);
+    current_position[Z_AXIS] = curpos_z;
+    plan_set_z_position(curpos_z);
 }
 
 // Number of baby steps applied

--- a/Firmware/mesh_bed_calibration.cpp
+++ b/Firmware/mesh_bed_calibration.cpp
@@ -2493,8 +2493,8 @@ BedSkewOffsetDetectionResultType find_bed_offset_and_skew(int8_t verbosity_level
 					uint8_t ix = mesh_point % MESH_MEAS_NUM_X_POINTS; // from 0 to MESH_NUM_X_POINTS - 1
 					uint8_t iy = mesh_point / MESH_MEAS_NUM_X_POINTS;
 					if (iy & 1) ix = (MESH_MEAS_NUM_X_POINTS - 1) - ix;
-					current_position[X_AXIS] = BED_X(ix);
-					current_position[Y_AXIS] = BED_Y(iy);
+					current_position[X_AXIS] = BED_X(ix * 3);
+					current_position[Y_AXIS] = BED_Y(iy * 3);
 					go_to_current(homing_feedrate[X_AXIS] / 60);
 					delay_keep_alive(3000);
 				}
@@ -2896,8 +2896,8 @@ bool sample_mesh_and_store_reference()
 		uint8_t ix = mesh_point % MESH_MEAS_NUM_X_POINTS;
 		uint8_t iy = mesh_point / MESH_MEAS_NUM_X_POINTS;
 		if (iy & 1) ix = (MESH_MEAS_NUM_X_POINTS - 1) - ix; // Zig zag
-		current_position[X_AXIS] = BED_X(ix);
-		current_position[Y_AXIS] = BED_Y(iy);
+		current_position[X_AXIS] = BED_X(ix * 3);
+		current_position[Y_AXIS] = BED_Y(iy * 3);
         world2machine_clamp(current_position[X_AXIS], current_position[Y_AXIS]);
         go_to_current(homing_feedrate[X_AXIS]/60);
 #ifdef MESH_BED_CALIBRATION_SHOW_LCD
@@ -3015,8 +3015,8 @@ bool scan_bed_induction_points(int8_t verbosity_level)
 		uint8_t ix = mesh_point % MESH_MEAS_NUM_X_POINTS; // from 0 to MESH_NUM_X_POINTS - 1
 		uint8_t iy = mesh_point / MESH_MEAS_NUM_X_POINTS;
 		if (iy & 1) ix = (MESH_MEAS_NUM_X_POINTS - 1) - ix;
-		float bedX = BED_X(ix);
-		float bedY = BED_Y(iy);
+		float bedX = BED_X(ix * 3);
+		float bedY = BED_Y(iy * 3);
         current_position[X_AXIS] = vec_x[0] * bedX + vec_y[0] * bedY + cntr[0];
         current_position[Y_AXIS] = vec_x[1] * bedX + vec_y[1] * bedY + cntr[1];
         // The calibration points are very close to the min Y.

--- a/Firmware/mesh_bed_calibration.cpp
+++ b/Firmware/mesh_bed_calibration.cpp
@@ -3124,7 +3124,7 @@ void mbl_settings_init() {
 //magnet elimination: use aaproximate Z-coordinate instead of measured values for points which are near magnets
 	eeprom_init_default_byte((uint8_t*)EEPROM_MBL_MAGNET_ELIMINATION, 1);
 	eeprom_init_default_byte((uint8_t*)EEPROM_MBL_POINTS_NR, 3);
-	mbl_z_probe_nr = eeprom_init_default_byte((uint8_t*)EEPROM_MBL_PROBE_NR, 3);
+	eeprom_init_default_byte((uint8_t*)EEPROM_MBL_PROBE_NR, 3);
 }
 
 //parameter ix: index of mesh bed leveling point in X-axis (for meas_points == 7 is valid range from 0 to 6; for meas_points == 3 is valid range from 0 to 2 )  

--- a/Firmware/mesh_bed_calibration.cpp
+++ b/Firmware/mesh_bed_calibration.cpp
@@ -776,7 +776,7 @@ void world2machine_revert_to_uncorrected()
 static inline bool vec_undef(const float v[2])
 {
     const uint32_t *vx = (const uint32_t*)v;
-    return vx[0] == 0x0FFFFFFFF || vx[1] == 0x0FFFFFFFF;
+    return vx[0] == 0xFFFFFFFF || vx[1] == 0xFFFFFFFF;
 }
 
 

--- a/Firmware/mesh_bed_calibration.cpp
+++ b/Firmware/mesh_bed_calibration.cpp
@@ -2184,6 +2184,16 @@ inline void scan_bed_induction_sensor_point()
 
 #define MESH_BED_CALIBRATION_SHOW_LCD
 
+float __attribute__((noinline)) BED_X(const uint8_t col)
+{
+    return ((float)col * (BED_Xn - BED_X0) / (MESH_NUM_X_POINTS - 1) + BED_X0);
+}
+
+float __attribute__((noinline)) BED_Y(const uint8_t row)
+{
+    return ((float)row * (BED_Yn - BED_Y0) / (MESH_NUM_Y_POINTS - 1) + BED_Y0);
+}
+
 BedSkewOffsetDetectionResultType find_bed_offset_and_skew(int8_t verbosity_level, uint8_t &too_far_mask)
 {	
     // Don't let the manage_inactivity() function remove power from the motors.
@@ -2481,8 +2491,8 @@ BedSkewOffsetDetectionResultType find_bed_offset_and_skew(int8_t verbosity_level
 					uint8_t ix = mesh_point % MESH_MEAS_NUM_X_POINTS; // from 0 to MESH_NUM_X_POINTS - 1
 					uint8_t iy = mesh_point / MESH_MEAS_NUM_X_POINTS;
 					if (iy & 1) ix = (MESH_MEAS_NUM_X_POINTS - 1) - ix;
-					current_position[X_AXIS] = BED_X(ix, MESH_MEAS_NUM_X_POINTS);
-					current_position[Y_AXIS] = BED_Y(iy, MESH_MEAS_NUM_Y_POINTS);
+					current_position[X_AXIS] = BED_X(ix);
+					current_position[Y_AXIS] = BED_Y(iy);
 					go_to_current(homing_feedrate[X_AXIS] / 60);
 					delay_keep_alive(3000);
 				}
@@ -2884,8 +2894,8 @@ bool sample_mesh_and_store_reference()
 		uint8_t ix = mesh_point % MESH_MEAS_NUM_X_POINTS;
 		uint8_t iy = mesh_point / MESH_MEAS_NUM_X_POINTS;
 		if (iy & 1) ix = (MESH_MEAS_NUM_X_POINTS - 1) - ix; // Zig zag
-		current_position[X_AXIS] = BED_X(ix, MESH_MEAS_NUM_X_POINTS);
-		current_position[Y_AXIS] = BED_Y(iy, MESH_MEAS_NUM_Y_POINTS);
+		current_position[X_AXIS] = BED_X(ix);
+		current_position[Y_AXIS] = BED_Y(iy);
         world2machine_clamp(current_position[X_AXIS], current_position[Y_AXIS]);
         go_to_current(homing_feedrate[X_AXIS]/60);
 #ifdef MESH_BED_CALIBRATION_SHOW_LCD
@@ -3003,8 +3013,8 @@ bool scan_bed_induction_points(int8_t verbosity_level)
 		uint8_t ix = mesh_point % MESH_MEAS_NUM_X_POINTS; // from 0 to MESH_NUM_X_POINTS - 1
 		uint8_t iy = mesh_point / MESH_MEAS_NUM_X_POINTS;
 		if (iy & 1) ix = (MESH_MEAS_NUM_X_POINTS - 1) - ix;
-		float bedX = BED_X(ix, MESH_MEAS_NUM_X_POINTS);
-		float bedY = BED_Y(iy, MESH_MEAS_NUM_Y_POINTS);
+		float bedX = BED_X(ix);
+		float bedY = BED_Y(iy);
         current_position[X_AXIS] = vec_x[0] * bedX + vec_y[0] * bedY + cntr[0];
         current_position[Y_AXIS] = vec_x[1] * bedX + vec_y[1] * bedY + cntr[1];
         // The calibration points are very close to the min Y.

--- a/Firmware/mesh_bed_calibration.cpp
+++ b/Firmware/mesh_bed_calibration.cpp
@@ -2951,8 +2951,7 @@ bool sample_mesh_and_store_reference()
             }
     }
 
-    mbl.upsample_3x3();
-    mbl.active = true;
+    mbl.reset();
 
     go_home_with_z_lift();
 

--- a/Firmware/mesh_bed_calibration.cpp
+++ b/Firmware/mesh_bed_calibration.cpp
@@ -2186,13 +2186,11 @@ inline void scan_bed_induction_sensor_point()
 
 float __attribute__((noinline)) BED_X(const uint8_t col)
 {
-    constexpr float x_mesh_density = (BED_Xn - BED_X0) / (MESH_NUM_X_POINTS - 1);
     return ((float)col * x_mesh_density + BED_X0);
 }
 
 float __attribute__((noinline)) BED_Y(const uint8_t row)
 {
-    constexpr float y_mesh_density = (BED_Yn - BED_Y0) / (MESH_NUM_Y_POINTS - 1);
     return ((float)row * y_mesh_density + BED_Y0);
 }
 

--- a/Firmware/mesh_bed_calibration.h
+++ b/Firmware/mesh_bed_calibration.h
@@ -203,6 +203,5 @@ extern void count_xyz_details(float (&distanceMin)[2]);
 extern bool sample_z();
 
 extern void mbl_settings_init();
-
-extern bool mbl_point_measurement_valid(uint8_t ix, uint8_t iy, uint8_t meas_points, bool zigzag);
-extern void mbl_interpolation(uint8_t meas_points);
+extern bool mbl_point_measurement_valid(uint8_t ix, uint8_t iy);
+extern void mbl_magnet_elimination();

--- a/Firmware/mesh_bed_calibration.h
+++ b/Firmware/mesh_bed_calibration.h
@@ -21,9 +21,6 @@
 
 #endif //not HEATBED_V2
 
-#define BED_X(i, n) ((float)i * (BED_Xn - BED_X0) / (n - 1) + BED_X0)
-#define BED_Y(i, n)  ((float)i * (BED_Yn - BED_Y0) / (n - 1) + BED_Y0)
-
 // Exact positions of the print head above the bed reference points, in the world coordinates.
 // The world coordinates match the machine coordinates only in case, when the machine
 // is built properly, the end stops are at the correct positions and the axes are perpendicular.
@@ -145,6 +142,17 @@ inline bool world2machine_clamp(float &x, float &y)
         machine2world(tmpx, tmpy, x, y);
     return clamped;
 }
+
+/// @brief For a given column on the mesh calculate the bed X coordinate
+/// @param col column index on mesh
+/// @return Bed X coordinate
+float BED_X(const uint8_t col);
+
+/// @brief For a given row on the mesh calculate the bed Y coordinate
+/// @param row row index on mesh
+/// @return Bed Y coordinate
+float BED_Y(const uint8_t row);
+
 /**
  * @brief Bed skew and offest detection result
  *

--- a/Firmware/mesh_bed_calibration.h
+++ b/Firmware/mesh_bed_calibration.h
@@ -21,6 +21,9 @@
 
 #endif //not HEATBED_V2
 
+constexpr float x_mesh_density = (BED_Xn - BED_X0) / (MESH_NUM_X_POINTS - 1);
+constexpr float y_mesh_density = (BED_Yn - BED_Y0) / (MESH_NUM_Y_POINTS - 1);
+
 // Exact positions of the print head above the bed reference points, in the world coordinates.
 // The world coordinates match the machine coordinates only in case, when the machine
 // is built properly, the end stops are at the correct positions and the axes are perpendicular.

--- a/Firmware/mesh_bed_leveling.cpp
+++ b/Firmware/mesh_bed_leveling.cpp
@@ -149,4 +149,17 @@ void mesh_bed_leveling::upsample_3x3()
 }
 #endif // (MESH_NUM_X_POINTS>=5 && MESH_NUM_Y_POINTS>=5 && (MESH_NUM_X_POINTS&1)==1 && (MESH_NUM_Y_POINTS&1)==1)
 
+void mesh_bed_leveling::print() {
+    SERIAL_PROTOCOLLNPGM("Num X,Y: " STRINGIFY(MESH_NUM_X_POINTS) "," STRINGIFY(MESH_NUM_Y_POINTS));
+    SERIAL_PROTOCOLLNPGM("Z search height: " STRINGIFY(MESH_HOME_Z_SEARCH));
+    SERIAL_PROTOCOLLNPGM("Measured points:");
+    for (uint8_t y = MESH_NUM_Y_POINTS; y-- > 0;) {
+        for (uint8_t x = 0; x < MESH_NUM_X_POINTS; x++) {
+            SERIAL_PROTOCOLPGM("  ");
+            SERIAL_PROTOCOL_F(z_values[y][x], 5);
+        }
+        SERIAL_PROTOCOLLN();
+    }
+}
+
 #endif  // MESH_BED_LEVELING

--- a/Firmware/mesh_bed_leveling.cpp
+++ b/Firmware/mesh_bed_leveling.cpp
@@ -15,26 +15,26 @@ float mesh_bed_leveling::get_z(float x, float y) {
     int   i, j;
     float s, t;
     
-    i = int(floor((x - MESH_MIN_X) / MESH_X_DIST));
+    i = int(floor((x - (BED_X0 + X_PROBE_OFFSET_FROM_EXTRUDER)) / x_mesh_density));
     if (i < 0) {
         i = 0;
-        s = (x - MESH_MIN_X) / MESH_X_DIST;
+        s = (x - (BED_X0 + X_PROBE_OFFSET_FROM_EXTRUDER)) / x_mesh_density;
     } else {
         if (i > MESH_NUM_X_POINTS - 2) {
             i = MESH_NUM_X_POINTS - 2;
         }
-        s = (x - get_x(i)) / MESH_X_DIST;
+        s = (x - get_x(i)) / x_mesh_density;
     }
 
-    j = int(floor((y - MESH_MIN_Y) / MESH_Y_DIST));
+    j = int(floor((y - (BED_Y0 + Y_PROBE_OFFSET_FROM_EXTRUDER)) / y_mesh_density));
     if (j < 0) {
         j = 0;
-        t = (y - MESH_MIN_Y) / MESH_Y_DIST;
+        t = (y - (BED_Y0 + Y_PROBE_OFFSET_FROM_EXTRUDER)) / y_mesh_density;
     } else {
         if (j > MESH_NUM_Y_POINTS - 2) {
             j = MESH_NUM_Y_POINTS - 2;
         }
-        t = (y - get_y(j)) / MESH_Y_DIST;
+        t = (y - get_y(j)) / y_mesh_density;
     }
     
     float si = 1.f-s;
@@ -51,9 +51,9 @@ void mesh_bed_leveling::upsample_3x3()
     int idx2 = MESH_NUM_X_POINTS - 1;
     {
         // First interpolate the points in X axis.
-        static const float x0 = MESH_MIN_X;
-        static const float x1 = 0.5f * float(MESH_MIN_X + MESH_MAX_X);
-        static const float x2 = MESH_MAX_X;
+        static const float x0 = (BED_X0 + X_PROBE_OFFSET_FROM_EXTRUDER);
+        static const float x1 = 0.5f * float(BED_X0 + BED_Xn) + X_PROBE_OFFSET_FROM_EXTRUDER;
+        static const float x2 = BED_Xn + X_PROBE_OFFSET_FROM_EXTRUDER;
         for (int j = 0; j < MESH_NUM_Y_POINTS; ++ j) {
             // Interpolate the remaining values by Largrangian polynomials.
             for (int i = 0; i < MESH_NUM_X_POINTS; ++ i) {
@@ -69,9 +69,9 @@ void mesh_bed_leveling::upsample_3x3()
     }
     {
         // Second interpolate the points in Y axis.
-        static const float y0 = MESH_MIN_Y;
-        static const float y1 = 0.5f * float(MESH_MIN_Y + MESH_MAX_Y);
-        static const float y2 = MESH_MAX_Y;
+        static const float y0 = (BED_Y0 + Y_PROBE_OFFSET_FROM_EXTRUDER);
+        static const float y1 = 0.5f * float(BED_Y0 + BED_Yn) + Y_PROBE_OFFSET_FROM_EXTRUDER;
+        static const float y2 = BED_Yn + Y_PROBE_OFFSET_FROM_EXTRUDER;
         for (int i = 0; i < MESH_NUM_X_POINTS; ++ i) {
             // Interpolate the remaining values by Largrangian polynomials.
             for (int j = 1; j + 1 < MESH_NUM_Y_POINTS; ++ j) {

--- a/Firmware/mesh_bed_leveling.cpp
+++ b/Firmware/mesh_bed_leveling.cpp
@@ -15,32 +15,6 @@ float mesh_bed_leveling::get_z(float x, float y) {
     int   i, j;
     float s, t;
     
-#if MESH_NUM_X_POINTS==3 && MESH_NUM_Y_POINTS==3
-#define MESH_MID_X (0.5f*(MESH_MIN_X+MESH_MAX_X))
-#define MESH_MID_Y (0.5f*(MESH_MIN_Y+MESH_MAX_Y))
-    if (x < MESH_MID_X) {
-        i = 0;
-        s = (x - MESH_MIN_X) / MESH_X_DIST;
-        if (s > 1.f)
-            s = 1.f;
-    } else {
-        i = 1;
-        s = (x - MESH_MID_X) / MESH_X_DIST;
-        if (s < 0)
-            s = 0;
-    }
-    if (y < MESH_MID_Y) {
-        j = 0;
-        t = (y - MESH_MIN_Y) / MESH_Y_DIST;
-        if (t > 1.f)
-            t = 1.f;
-    } else {
-        j = 1;
-        t = (y - MESH_MID_Y) / MESH_Y_DIST;
-        if (t < 0)
-            t = 0;
-    }
-#else
     i = int(floor((x - MESH_MIN_X) / MESH_X_DIST));
     if (i < 0) {
         i = 0;
@@ -78,27 +52,12 @@ float mesh_bed_leveling::get_z(float x, float y) {
         else if (t > 1.f)
             t = 1.f;
     }
-#endif /* MESH_NUM_X_POINTS==3 && MESH_NUM_Y_POINTS==3 */
     
     float si = 1.f-s;
     float z0 = si * z_values[j  ][i] + s * z_values[j  ][i+1];
     float z1 = si * z_values[j+1][i] + s * z_values[j+1][i+1];
     return (1.f-t) * z0 + t * z1;
 }
-
-int mesh_bed_leveling::select_x_index(float x) {
-    int i = 1;
-    while (x > get_x(i) && i < MESH_NUM_X_POINTS - 1) i++;
-    return i - 1;
-}
-
-int mesh_bed_leveling::select_y_index(float y) {
-    int i = 1;
-    while (y > get_y(i) && i < MESH_NUM_Y_POINTS - 1) i++;
-    return i - 1;
-}
-
-#if MESH_NUM_X_POINTS>=5 && MESH_NUM_Y_POINTS>=5 && (MESH_NUM_X_POINTS&1)==1 && (MESH_NUM_Y_POINTS&1)==1
 // Works for an odd number of MESH_NUM_X_POINTS and MESH_NUM_Y_POINTS
 
 void mesh_bed_leveling::upsample_3x3()
@@ -143,7 +102,6 @@ void mesh_bed_leveling::upsample_3x3()
         }
     }
 }
-#endif // (MESH_NUM_X_POINTS>=5 && MESH_NUM_Y_POINTS>=5 && (MESH_NUM_X_POINTS&1)==1 && (MESH_NUM_Y_POINTS&1)==1)
 
 void mesh_bed_leveling::print() {
     SERIAL_PROTOCOLLNPGM("Num X,Y: " STRINGIFY(MESH_NUM_X_POINTS) "," STRINGIFY(MESH_NUM_Y_POINTS));

--- a/Firmware/mesh_bed_leveling.cpp
+++ b/Firmware/mesh_bed_leveling.cpp
@@ -6,8 +6,6 @@
 
 mesh_bed_leveling mbl;
 
-mesh_bed_leveling::mesh_bed_leveling() { reset(); }
-
 void mesh_bed_leveling::reset() {
     active = 0;
     for (uint8_t row = 0; row < MESH_NUM_Y_POINTS; ++row) {
@@ -17,10 +15,91 @@ void mesh_bed_leveling::reset() {
     }
 }
 
-static inline bool vec_undef(const float v[2])
-{
-    const uint32_t *vx = (const uint32_t*)v;
-    return vx[0] == 0xFFFFFFFF || vx[1] == 0xFFFFFFFF;
+float mesh_bed_leveling::get_z(float x, float y) {
+    int   i, j;
+    float s, t;
+    
+#if MESH_NUM_X_POINTS==3 && MESH_NUM_Y_POINTS==3
+#define MESH_MID_X (0.5f*(MESH_MIN_X+MESH_MAX_X))
+#define MESH_MID_Y (0.5f*(MESH_MIN_Y+MESH_MAX_Y))
+    if (x < MESH_MID_X) {
+        i = 0;
+        s = (x - MESH_MIN_X) / MESH_X_DIST;
+        if (s > 1.f)
+            s = 1.f;
+    } else {
+        i = 1;
+        s = (x - MESH_MID_X) / MESH_X_DIST;
+        if (s < 0)
+            s = 0;
+    }
+    if (y < MESH_MID_Y) {
+        j = 0;
+        t = (y - MESH_MIN_Y) / MESH_Y_DIST;
+        if (t > 1.f)
+            t = 1.f;
+    } else {
+        j = 1;
+        t = (y - MESH_MID_Y) / MESH_Y_DIST;
+        if (t < 0)
+            t = 0;
+    }
+#else
+    i = int(floor((x - MESH_MIN_X) / MESH_X_DIST));
+    if (i < 0) {
+        i = 0;
+        s = (x - MESH_MIN_X) / MESH_X_DIST;
+        if (s > 1.f)
+            s = 1.f;
+    }
+    else if (i > MESH_NUM_X_POINTS - 2) {
+        i = MESH_NUM_X_POINTS - 2;
+        s = (x - get_x(i)) / MESH_X_DIST;
+        if (s < 0)
+            s = 0;
+    } else {
+        s = (x - get_x(i)) / MESH_X_DIST;
+        if (s < 0)
+            s = 0;
+        else if (s > 1.f)
+            s = 1.f;
+    }
+    j = int(floor((y - MESH_MIN_Y) / MESH_Y_DIST));
+    if (j < 0) {
+        j = 0;
+        t = (y - MESH_MIN_Y) / MESH_Y_DIST;
+        if (t > 1.f)
+            t = 1.f;
+    } else if (j > MESH_NUM_Y_POINTS - 2) {
+        j = MESH_NUM_Y_POINTS - 2;
+        t = (y - get_y(j)) / MESH_Y_DIST;
+        if (t < 0)
+            t = 0;
+    } else {
+        t = (y - get_y(j)) / MESH_Y_DIST;
+        if (t < 0)
+            t = 0;
+        else if (t > 1.f)
+            t = 1.f;
+    }
+#endif /* MESH_NUM_X_POINTS==3 && MESH_NUM_Y_POINTS==3 */
+    
+    float si = 1.f-s;
+    float z0 = si * z_values[j  ][i] + s * z_values[j  ][i+1];
+    float z1 = si * z_values[j+1][i] + s * z_values[j+1][i+1];
+    return (1.f-t) * z0 + t * z1;
+}
+
+int mesh_bed_leveling::select_x_index(float x) {
+    int i = 1;
+    while (x > get_x(i) && i < MESH_NUM_X_POINTS - 1) i++;
+    return i - 1;
+}
+
+int mesh_bed_leveling::select_y_index(float y) {
+    int i = 1;
+    while (y > get_y(i) && i < MESH_NUM_Y_POINTS - 1) i++;
+    return i - 1;
 }
 
 #if MESH_NUM_X_POINTS>=5 && MESH_NUM_Y_POINTS>=5 && (MESH_NUM_X_POINTS&1)==1 && (MESH_NUM_Y_POINTS&1)==1
@@ -80,24 +159,7 @@ void mesh_bed_leveling::upsample_3x3()
             }
         }
     }
-
-/*
-    // Relax the non-measured points.
-    const float weight = 0.2f;
-    for (uint8_t iter = 0; iter < 20; ++ iter) {
-        for (int8_t j = 1; j < 6; ++ j) {
-            for (int8_t i = 1; i < 6; ++ i) {
-                if (i == 3 || j == 3)
-                    continue;
-                if ((i % 3) == 0 && (j % 3) == 0)
-                    continue;
-                float avg = 0.25f * (z_values[j][i-1]+z_values[j][i+1]+z_values[j-1][i]+z_values[j+1][i]);
-                z_values[j][i] = (1.f-weight)*z_values[j][i] + weight*avg;
-            }
-        }
-    }
-*/
 }
-#endif
+#endif // (MESH_NUM_X_POINTS>=5 && MESH_NUM_Y_POINTS>=5 && (MESH_NUM_X_POINTS&1)==1 && (MESH_NUM_Y_POINTS&1)==1)
 
 #endif  // MESH_BED_LEVELING

--- a/Firmware/mesh_bed_leveling.cpp
+++ b/Firmware/mesh_bed_leveling.cpp
@@ -8,11 +8,7 @@ mesh_bed_leveling mbl;
 
 void mesh_bed_leveling::reset() {
     active = 0;
-    for (uint8_t row = 0; row < MESH_NUM_Y_POINTS; ++row) {
-        for (uint8_t col = 0; col < MESH_NUM_X_POINTS; ++col) {
-            mbl.z_values[row][col] = NAN;
-        }
-    }
+    memset(z_values, 0, sizeof(z_values));
 }
 
 float mesh_bed_leveling::get_z(float x, float y) {

--- a/Firmware/mesh_bed_leveling.cpp
+++ b/Firmware/mesh_bed_leveling.cpp
@@ -105,7 +105,6 @@ int mesh_bed_leveling::select_y_index(float y) {
 #if MESH_NUM_X_POINTS>=5 && MESH_NUM_Y_POINTS>=5 && (MESH_NUM_X_POINTS&1)==1 && (MESH_NUM_Y_POINTS&1)==1
 // Works for an odd number of MESH_NUM_X_POINTS and MESH_NUM_Y_POINTS
 
-// #define MBL_BILINEAR
 void mesh_bed_leveling::upsample_3x3()
 {
     int idx0 = 0;
@@ -122,16 +121,10 @@ void mesh_bed_leveling::upsample_3x3()
                 if (!isnan(z_values[j][i]))
                     continue;
                 float x = get_x(i);
-                #ifdef MBL_BILINEAR
-                z_values[j][i] = (x < x1) ?
-                    ((z_values[j][idx0] * (x - x0) + z_values[j][idx1] * (x1 - x)) / (x1 - x0)) :
-                    ((z_values[j][idx1] * (x - x1) + z_values[j][idx2] * (x2 - x)) / (x2 - x1));
-                #else
                 z_values[j][i] = 
                     z_values[j][idx0] * (x - x1) * (x - x2) / ((x0 - x1) * (x0 - x2)) +
                     z_values[j][idx1] * (x - x0) * (x - x2) / ((x1 - x0) * (x1 - x2)) +
                     z_values[j][idx2] * (x - x0) * (x - x1) / ((x2 - x0) * (x2 - x1));
-                #endif
             }
         }
     }
@@ -146,16 +139,10 @@ void mesh_bed_leveling::upsample_3x3()
                 if (!isnan(z_values[j][i]))
                     continue;
                 float y = get_y(j);
-                #ifdef MBL_BILINEAR
-                z_values[j][i] = (y < y1) ? 
-                    ((z_values[idx0][i] * (y - y0) + z_values[idx1][i] * (y1 - y)) / (y1 - y0)) :
-                    ((z_values[idx1][i] * (y - y1) + z_values[idx2][i] * (y2 - y)) / (y2 - y1));
-                #else
                 z_values[j][i] = 
                     z_values[idx0][i] * (y - y1) * (y - y2) / ((y0 - y1) * (y0 - y2)) +
                     z_values[idx1][i] * (y - y0) * (y - y2) / ((y1 - y0) * (y1 - y2)) +
                     z_values[idx2][i] * (y - y0) * (y - y1) / ((y2 - y0) * (y2 - y1));
-                #endif
             }
         }
     }

--- a/Firmware/mesh_bed_leveling.cpp
+++ b/Firmware/mesh_bed_leveling.cpp
@@ -19,38 +19,22 @@ float mesh_bed_leveling::get_z(float x, float y) {
     if (i < 0) {
         i = 0;
         s = (x - MESH_MIN_X) / MESH_X_DIST;
-        if (s > 1.f)
-            s = 1.f;
-    }
-    else if (i > MESH_NUM_X_POINTS - 2) {
-        i = MESH_NUM_X_POINTS - 2;
-        s = (x - get_x(i)) / MESH_X_DIST;
-        if (s < 0)
-            s = 0;
     } else {
+        if (i > MESH_NUM_X_POINTS - 2) {
+            i = MESH_NUM_X_POINTS - 2;
+        }
         s = (x - get_x(i)) / MESH_X_DIST;
-        if (s < 0)
-            s = 0;
-        else if (s > 1.f)
-            s = 1.f;
     }
+
     j = int(floor((y - MESH_MIN_Y) / MESH_Y_DIST));
     if (j < 0) {
         j = 0;
         t = (y - MESH_MIN_Y) / MESH_Y_DIST;
-        if (t > 1.f)
-            t = 1.f;
-    } else if (j > MESH_NUM_Y_POINTS - 2) {
-        j = MESH_NUM_Y_POINTS - 2;
-        t = (y - get_y(j)) / MESH_Y_DIST;
-        if (t < 0)
-            t = 0;
     } else {
+        if (j > MESH_NUM_Y_POINTS - 2) {
+            j = MESH_NUM_Y_POINTS - 2;
+        }
         t = (y - get_y(j)) / MESH_Y_DIST;
-        if (t < 0)
-            t = 0;
-        else if (t > 1.f)
-            t = 1.f;
     }
     
     float si = 1.f-s;

--- a/Firmware/mesh_bed_leveling.h
+++ b/Firmware/mesh_bed_leveling.h
@@ -13,106 +13,21 @@ public:
     uint8_t active;
     float z_values[MESH_NUM_Y_POINTS][MESH_NUM_X_POINTS];
     
-    mesh_bed_leveling();
+    mesh_bed_leveling() { reset(); }
     
     void reset();
+
+    static float get_x(int i) { return float(MESH_MIN_X) + float(MESH_X_DIST) * float(i); }
+    static float get_y(int i) { return float(MESH_MIN_Y) + float(MESH_Y_DIST) * float(i); }
+    float get_z(float x, float y);
+    void set_z(uint8_t ix, uint8_t iy, float z) { z_values[iy][ix] = z; }
+    
+    int select_x_index(float x);
+    int select_y_index(float y);
     
 #if MESH_NUM_X_POINTS>=5 && MESH_NUM_Y_POINTS>=5 && (MESH_NUM_X_POINTS&1)==1 && (MESH_NUM_Y_POINTS&1)==1
     void upsample_3x3();
 #endif
-    
-    static float get_x(int i) { return float(MESH_MIN_X) + float(MESH_X_DIST) * float(i); }
-    static float get_y(int i) { return float(MESH_MIN_Y) + float(MESH_Y_DIST) * float(i); }
-    
-    void set_z(uint8_t ix, uint8_t iy, float z) { z_values[iy][ix] = z; }
-    
-    int select_x_index(float x) {
-        int i = 1;
-        while (x > get_x(i) && i < MESH_NUM_X_POINTS - 1) i++;
-        return i - 1;
-    }
-    
-    int select_y_index(float y) {
-        int i = 1;
-        while (y > get_y(i) && i < MESH_NUM_Y_POINTS - 1) i++;
-        return i - 1;
-    }
-    
-    float get_z(float x, float y) {
-        int   i, j;
-        float s, t;
-        
-#if MESH_NUM_X_POINTS==3 && MESH_NUM_Y_POINTS==3
-#define MESH_MID_X (0.5f*(MESH_MIN_X+MESH_MAX_X))
-#define MESH_MID_Y (0.5f*(MESH_MIN_Y+MESH_MAX_Y))
-        if (x < MESH_MID_X) {
-            i = 0;
-            s = (x - MESH_MIN_X) / MESH_X_DIST;
-            if (s > 1.f)
-                s = 1.f;
-        } else {
-            i = 1;
-            s = (x - MESH_MID_X) / MESH_X_DIST;
-            if (s < 0)
-                s = 0;
-        }
-        if (y < MESH_MID_Y) {
-            j = 0;
-            t = (y - MESH_MIN_Y) / MESH_Y_DIST;
-            if (t > 1.f)
-                t = 1.f;
-        } else {
-            j = 1;
-            t = (y - MESH_MID_Y) / MESH_Y_DIST;
-            if (t < 0)
-                t = 0;
-        }
-#else
-        i = int(floor((x - MESH_MIN_X) / MESH_X_DIST));
-        if (i < 0) {
-            i = 0;
-            s = (x - MESH_MIN_X) / MESH_X_DIST;
-            if (s > 1.f)
-                s = 1.f;
-        }
-        else if (i > MESH_NUM_X_POINTS - 2) {
-            i = MESH_NUM_X_POINTS - 2;
-            s = (x - get_x(i)) / MESH_X_DIST;
-            if (s < 0)
-                s = 0;
-        } else {
-            s = (x - get_x(i)) / MESH_X_DIST;
-            if (s < 0)
-                s = 0;
-            else if (s > 1.f)
-                s = 1.f;
-        }
-        j = int(floor((y - MESH_MIN_Y) / MESH_Y_DIST));
-        if (j < 0) {
-            j = 0;
-            t = (y - MESH_MIN_Y) / MESH_Y_DIST;
-            if (t > 1.f)
-                t = 1.f;
-        } else if (j > MESH_NUM_Y_POINTS - 2) {
-            j = MESH_NUM_Y_POINTS - 2;
-            t = (y - get_y(j)) / MESH_Y_DIST;
-            if (t < 0)
-                t = 0;
-        } else {
-            t = (y - get_y(j)) / MESH_Y_DIST;
-            if (t < 0)
-                t = 0;
-            else if (t > 1.f)
-                t = 1.f;
-        }
-#endif /* MESH_NUM_X_POINTS==3 && MESH_NUM_Y_POINTS==3 */
-        
-        float si = 1.f-s;
-        float z0 = si * z_values[j  ][i] + s * z_values[j  ][i+1];
-        float z1 = si * z_values[j+1][i] + s * z_values[j+1][i+1];
-        return (1.f-t) * z0 + t * z1;
-    }
-    
 };
 
 extern mesh_bed_leveling mbl;

--- a/Firmware/mesh_bed_leveling.h
+++ b/Firmware/mesh_bed_leveling.h
@@ -1,9 +1,7 @@
 #include "Marlin.h"
+#include "mesh_bed_calibration.h"
 
 #ifdef MESH_BED_LEVELING
-
-#define MESH_X_DIST (float(MESH_MAX_X - MESH_MIN_X)/float(MESH_NUM_X_POINTS - 1))
-#define MESH_Y_DIST (float(MESH_MAX_Y - MESH_MIN_Y)/float(MESH_NUM_Y_POINTS - 1))
 
 class mesh_bed_leveling {
 public:
@@ -14,8 +12,8 @@ public:
     
     void reset();
 
-    static float get_x(int i) { return float(MESH_MIN_X) + float(MESH_X_DIST) * float(i); }
-    static float get_y(int i) { return float(MESH_MIN_Y) + float(MESH_Y_DIST) * float(i); }
+    static float get_x(int i) { return BED_X(i) + X_PROBE_OFFSET_FROM_EXTRUDER; }
+    static float get_y(int i) { return BED_Y(i) + Y_PROBE_OFFSET_FROM_EXTRUDER; }
     float get_z(float x, float y);
     void set_z(uint8_t ix, uint8_t iy, float z) { z_values[iy][ix] = z; }
     void upsample_3x3();

--- a/Firmware/mesh_bed_leveling.h
+++ b/Firmware/mesh_bed_leveling.h
@@ -2,9 +2,6 @@
 
 #ifdef MESH_BED_LEVELING
 
-#define MEAS_NUM_X_DIST (float(MESH_MAX_X - MESH_MIN_X)/float(MESH_MEAS_NUM_X_POINTS - 1))
-#define MEAS_NUM_Y_DIST (float(MESH_MAX_Y - MESH_MIN_Y)/float(MESH_MEAS_NUM_Y_POINTS - 1))
-
 #define MESH_X_DIST (float(MESH_MAX_X - MESH_MIN_X)/float(MESH_NUM_X_POINTS - 1))
 #define MESH_Y_DIST (float(MESH_MAX_Y - MESH_MIN_Y)/float(MESH_NUM_Y_POINTS - 1))
 
@@ -21,13 +18,7 @@ public:
     static float get_y(int i) { return float(MESH_MIN_Y) + float(MESH_Y_DIST) * float(i); }
     float get_z(float x, float y);
     void set_z(uint8_t ix, uint8_t iy, float z) { z_values[iy][ix] = z; }
-    
-    int select_x_index(float x);
-    int select_y_index(float y);
-    
-#if MESH_NUM_X_POINTS>=5 && MESH_NUM_Y_POINTS>=5 && (MESH_NUM_X_POINTS&1)==1 && (MESH_NUM_Y_POINTS&1)==1
     void upsample_3x3();
-#endif
     void print();
 };
 

--- a/Firmware/mesh_bed_leveling.h
+++ b/Firmware/mesh_bed_leveling.h
@@ -28,6 +28,7 @@ public:
 #if MESH_NUM_X_POINTS>=5 && MESH_NUM_Y_POINTS>=5 && (MESH_NUM_X_POINTS&1)==1 && (MESH_NUM_Y_POINTS&1)==1
     void upsample_3x3();
 #endif
+    void print();
 };
 
 extern mesh_bed_leveling mbl;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5457,7 +5457,7 @@ static void mbl_mesh_toggle() {
 }
 
 static void mbl_probe_nr_toggle() {
-	mbl_z_probe_nr = eeprom_read_byte((uint8_t*)EEPROM_MBL_PROBE_NR);
+	uint8_t mbl_z_probe_nr = eeprom_read_byte((uint8_t*)EEPROM_MBL_PROBE_NR);
 	switch (mbl_z_probe_nr) {
 		case 1: mbl_z_probe_nr = 3; break;
 		case 3: mbl_z_probe_nr = 5; break;
@@ -5472,6 +5472,7 @@ static void lcd_mesh_bed_leveling_settings()
 
 	bool magnet_elimination = (eeprom_read_byte((uint8_t*)EEPROM_MBL_MAGNET_ELIMINATION) > 0);
 	uint8_t points_nr = eeprom_read_byte((uint8_t*)EEPROM_MBL_POINTS_NR);
+    uint8_t mbl_z_probe_nr = eeprom_read_byte((uint8_t*)EEPROM_MBL_PROBE_NR);
 	char sToggle[4]; //enough for nxn format
 
 	MENU_BEGIN();

--- a/Firmware/variants/MK25-RAMBo10a.h
+++ b/Firmware/variants/MK25-RAMBo10a.h
@@ -273,12 +273,6 @@
 
 #define MBL_Z_STEP 0.01
 
-// Mesh definitions
-#define MESH_MIN_X 24
-#define MESH_MAX_X 228
-#define MESH_MIN_Y 6
-#define MESH_MAX_Y 210
-
 // Mesh upsample definition
 #define MESH_NUM_X_POINTS 7
 #define MESH_NUM_Y_POINTS 7

--- a/Firmware/variants/MK25-RAMBo13a.h
+++ b/Firmware/variants/MK25-RAMBo13a.h
@@ -274,12 +274,6 @@
 
 #define MBL_Z_STEP 0.01
 
-// Mesh definitions
-#define MESH_MIN_X 24
-#define MESH_MAX_X 228
-#define MESH_MIN_Y 6
-#define MESH_MAX_Y 210
-
 // Mesh upsample definition
 #define MESH_NUM_X_POINTS 7
 #define MESH_NUM_Y_POINTS 7

--- a/Firmware/variants/MK25S-RAMBo10a.h
+++ b/Firmware/variants/MK25S-RAMBo10a.h
@@ -273,12 +273,6 @@
 
 #define MBL_Z_STEP 0.01
 
-// Mesh definitions
-#define MESH_MIN_X 24
-#define MESH_MAX_X 228
-#define MESH_MIN_Y 6
-#define MESH_MAX_Y 210
-
 // Mesh upsample definition
 #define MESH_NUM_X_POINTS 7
 #define MESH_NUM_Y_POINTS 7

--- a/Firmware/variants/MK25S-RAMBo13a.h
+++ b/Firmware/variants/MK25S-RAMBo13a.h
@@ -274,12 +274,6 @@
 
 #define MBL_Z_STEP 0.01
 
-// Mesh definitions
-#define MESH_MIN_X 24
-#define MESH_MAX_X 228
-#define MESH_MIN_Y 6
-#define MESH_MAX_Y 210
-
 // Mesh upsample definition
 #define MESH_NUM_X_POINTS 7
 #define MESH_NUM_Y_POINTS 7

--- a/Firmware/variants/MK3.h
+++ b/Firmware/variants/MK3.h
@@ -423,12 +423,6 @@
 
 #define MBL_Z_STEP 0.01
 
-// Mesh definitions
-#define MESH_MIN_X 24
-#define MESH_MAX_X 228
-#define MESH_MIN_Y 6
-#define MESH_MAX_Y 210
-
 // Mesh upsample definition
 #define MESH_NUM_X_POINTS 7
 #define MESH_NUM_Y_POINTS 7

--- a/Firmware/variants/MK3S.h
+++ b/Firmware/variants/MK3S.h
@@ -427,12 +427,6 @@
 
 #define MBL_Z_STEP 0.01
 
-// Mesh definitions
-#define MESH_MIN_X 24
-#define MESH_MAX_X 228
-#define MESH_MIN_Y 6
-#define MESH_MAX_Y 210
-
 // Mesh upsample definition
 #define MESH_NUM_X_POINTS 7
 #define MESH_NUM_Y_POINTS 7

--- a/Firmware/variants/obsolete/1_75mm_MK2-RAMBo10a-E3Dv6full.h
+++ b/Firmware/variants/obsolete/1_75mm_MK2-RAMBo10a-E3Dv6full.h
@@ -202,12 +202,6 @@ BED SETTINGS
 
 #define MBL_Z_STEP 0.01
 
-// Mesh definitions
-#define MESH_MIN_X 35
-#define MESH_MAX_X 238
-#define MESH_MIN_Y 6
-#define MESH_MAX_Y 202
-
 // Mesh upsample definition
 #define MESH_NUM_X_POINTS 7
 #define MESH_NUM_Y_POINTS 7

--- a/Firmware/variants/obsolete/1_75mm_MK2-RAMBo13a-E3Dv6full.h
+++ b/Firmware/variants/obsolete/1_75mm_MK2-RAMBo13a-E3Dv6full.h
@@ -201,12 +201,6 @@ BED SETTINGS
 
 #define MBL_Z_STEP 0.01
 
-// Mesh definitions
-#define MESH_MIN_X 35
-#define MESH_MAX_X 238
-#define MESH_MIN_Y 6
-#define MESH_MAX_Y 202
-
 // Mesh upsample definition
 #define MESH_NUM_X_POINTS 7
 #define MESH_NUM_Y_POINTS 7


### PR DESCRIPTION
Similar implementation of the print area UBL from the Buddy firmware, but instead of using `M555` for defining the print area, `G80` uses additional parameters. The `G80` print area is defined with `X`, `Y`, `W` and `H`, just like with `M555`. If the print area is not specified, the whole bed is probed. Gcode future and backward compatibility is maintained since old firmware will ignore these extra parameters.

With this PR, if a print area is provided, the 7x7 MBL will only probe those points. This results in a quicker, precise MBL where precision is needed. Besides the print area probed points, the rest of the 7x7 mesh uses interpolation of the data sorted in eeprom during Z calibration so that the toolhead can safely exit the print area and not cause a nozzle crash with a warped bed.

**Tasks after merge**
- [ ] Update rep-rap Gcode documentation
- [x] Update PrusaSlicer profiles
- [x] Update translation (`kill(PSTR("Mesh bed leveling failed. Please run Z calibration."));`)
- [x] Add `O` in `G80 [ N | R | L | R | F | B | X | Y | W | H ]` list

https://user-images.githubusercontent.com/17808203/235438936-5a1d4750-c54e-4ca1-b04d-6058d9f225a9.MOV

![image (25)](https://user-images.githubusercontent.com/17808203/235439076-a9124283-7dff-4654-9828-6c6b296ff339.png)

https://user-images.githubusercontent.com/17808203/235439037-07113fb1-cba4-4f4a-847b-9709a6b06f1b.MOV


In case the 3x3 mesh in eeprom from Z calibration is missing/invalid, the 3x3 points are also probed besides the print area:

https://user-images.githubusercontent.com/17808203/235439240-6f7d648f-204e-4c27-b208-c8271e6d7415.MOV

Another interesting feature enabled by this PR is the ability to load and activate the mesh stored in eeprom without probing any point ~(besides point 0)~. This can be achieved with `G80 W` since it results in the print area being completely outside the bed.

Closes https://github.com/prusa3d/Prusa-Firmware/issues/3224