### PR TITLE
Fix regression where time remaining can overflow on status screen

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -446,9 +446,9 @@ void lcdui_print_time(void)
     //if remaining print time estimation is available print it else print elapsed time
     int chars = 0;
     if (printer_active()) {
-        uint16_t print_t = PRINT_TIME_REMAINING_INIT;
-        uint16_t print_tr = PRINT_TIME_REMAINING_INIT;
-        uint16_t print_tc = PRINT_TIME_REMAINING_INIT;
+        uint16_t print_t = PRINT_TIME_REMAINING_INIT;  // unit: minutes
+        uint16_t print_tr = PRINT_TIME_REMAINING_INIT; // unit: minutes
+        uint16_t print_tc = PRINT_TIME_REMAINING_INIT; // unit: minutes
         char suff = ' ';
         char suff_doubt = ' ';
 
@@ -491,7 +491,8 @@ void lcdui_print_time(void)
 
         if (feedmultiply != 100 && (print_t == print_tr || print_t == print_tc)) {
             suff_doubt = '?';
-            print_t = (100 * print_t) / feedmultiply;
+            // (print_t * 100) overflows uint16_t at 10.9 hours, uint32_t is required
+            print_t = (uint16_t)((100UL * (uint32_t)print_t) / feedmultiply);
         }
 
         if (print_t < 6000) //time<100h


### PR DESCRIPTION
If the remaining print time is more than 10.9 hours at 100% then increasing the feedrate multiplier
to 101% or more will yield an unrealistic time due to overflow occuring.

Video demonstration of the bug in action: https://www.youtube.com/shorts/PLXyA_Jf9ck

When my print reached 10h51m@100% the overflow went away, I believe this supports my suspicion. This bug was introduced here https://github.com/prusa3d/Prusa-Firmware/pull/3971/commits/040087923aabbd1abaeaa2b93733017343e2eb6d#diff-5fbfdca43c192573e31d8e78d255c510fb6e213b118cf38173277ec2a2163880R504

Change in memory:
Flash +2 bytes
SRAM: 0 bytes