### PR TITLE
Remove redundant lcd_draw_update assignment

### DIFF
--- a/Firmware/menu.cpp
+++ b/Firmware/menu.cpp
@@ -90,7 +90,6 @@ void menu_end(void)
 	if (((uint8_t)lcd_encoder) >= menu_top + LCD_HEIGHT)
 	{
 		menu_top = lcd_encoder - LCD_HEIGHT + 1;
-		lcd_draw_update = 1;
 		menu_line = menu_top - 1;
 		menu_row = -1;
 	}


### PR DESCRIPTION
When scrolling through menu items, the rotation event on the knob takes care of updating the LCD by setting `lcd_draw_update`. The menu code doesn't need to do it as well.

Change in memory:
Flash: -6 bytes
SRAM: 0 bytes