### PR TITLE
Always allow Live Adjust Z in Settings

### DIFF
--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -336,13 +336,19 @@ bool printer_active();
 bool check_fsensor();
 
 //! Condition where Babystepping is allowed:
-//! 1) Z-axis position is less than 2.0mm (only allowed during the first couple of layers)
-//! 2) Not allowed during Homing (printer busy)
-//! 3) Not allowed during Mesh Bed Leveling (printer busy)
+//! 1) Not allowed during Homing (printer busy)
+//! 2) Not allowed during Mesh Bed Leveling (printer busy)
+//! 3) Not allowed when a print job is paused
 //! 4) Allowed if:
-//!         - First Layer Calibration is running
-//!         - OR there are queued blocks, printJob is running and it's not paused, and Z-axis position is less than 2.0mm (only allowed during the first couple of layers)
+//!         - First Layer Calibration is running (the event when heaters are turned off is used to dismiss the menu)
+//!         - A print job is running
+//!         - If the printer is idle with not planned moves
 bool babystep_allowed();
+
+//! Same as babystep_allowed() but additionally adds a requirement
+//! where the Z-axis position must be less than 2.0mm (only allowed
+//! during the first couple of layers)
+bool babystep_allowed_strict();
 
 extern void calculate_extruder_multipliers();
 

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -542,8 +542,16 @@ bool check_fsensor() {
 bool __attribute__((noinline)) babystep_allowed() {
     return ( !homing_flag
         && !mesh_bed_leveling_flag
-        && ( lcd_commands_type == LcdCommands::Layer1Cal || ( blocks_queued() && !isPrintPaused && printJobOngoing() && (current_position[Z_AXIS] < Z_HEIGHT_HIDE_LIVE_ADJUST_MENU)))
+        && !isPrintPaused
+        && ((lcd_commands_type == LcdCommands::Layer1Cal && CHECK_ALL_HEATERS)
+            || printJobOngoing()
+            || lcd_commands_type == LcdCommands::Idle
+        )
     );
+}
+
+bool __attribute__((noinline)) babystep_allowed_strict() {
+    return ( babystep_allowed() && current_position[Z_AXIS] < Z_HEIGHT_HIDE_LIVE_ADJUST_MENU);
 }
 
 bool fans_check_enabled = true;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -4470,8 +4470,7 @@ static void lcd_settings_menu()
     MENU_ITEM_TOGGLE_P(_T(MSG_RPI_PORT), (selectedSerialPort == 0) ? _T(MSG_OFF) : _T(MSG_ON), lcd_second_serial_set);
 #endif //HAS_SECOND_SERIAL
 
-	if ( babystep_allowed() )
-		MENU_ITEM_SUBMENU_P(_T(MSG_BABYSTEP_Z), lcd_babystep_z);
+    MENU_ITEM_SUBMENU_P(_T(MSG_BABYSTEP_Z), lcd_babystep_z);
 
 #if (LANG_MODE != 0)
 	MENU_ITEM_SUBMENU_P(_T(MSG_SELECT_LANGUAGE), lcd_language_menu);


### PR DESCRIPTION
While the printer is idle, it should be possible to change the Live Adjust Z value from Settings.
The Settings menu is accessible only while the printer is idle, so it is safe to show the menu item at all times.