### PR TITLE
PFW-1392 optimize TMC2130 configuration

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1084,10 +1084,10 @@ void setup()
     farm_mode_init();
 
 #ifdef TMC2130
-    if( FarmOrUserECool() ){
-		//increased extruder current (PFW363)
-		tmc2130_current_h[E_AXIS] = TMC2130_CURRENTS_FARM;
-		tmc2130_current_r[E_AXIS] = TMC2130_CURRENTS_FARM;
+    if(FarmOrUserECool()) {
+        //increased extruder current (PFW363)
+        currents[E_AXIS].iRun = TMC2130_CURRENTS_FARM;
+        currents[E_AXIS].iHold = TMC2130_CURRENTS_FARM;
     }
 #endif //TMC2130
 
@@ -4090,7 +4090,7 @@ void process_commands()
 				tmc2130_chopper_config[axis].hstr = chop1 & 7;
 				tmc2130_chopper_config[axis].hend = chop2 & 15;
 				tmc2130_chopper_config[axis].tbl = chop3 & 3;
-				tmc2130_setup_chopper(axis, tmc2130_mres[axis], tmc2130_current_h[axis], tmc2130_current_r[axis]);
+				tmc2130_setup_chopper(axis, tmc2130_mres[axis]);
 				//printf_P(_N("TMC_SET_CHOP_%c %d %d %d %d\n"), "xyze"[axis], chop0, chop1, chop2, chop3);
 			}
 		}
@@ -8066,9 +8066,9 @@ Sigma_Exit:
                 }
                 long cur_mA = code_value_long();
                 uint8_t val = tmc2130_cur2val(cur_mA);
-                tmc2130_set_current_h(i, val);
-                tmc2130_set_current_r(i, val);
-                //if (i == E_AXIS) printf_P(PSTR("E-axis current=%ldmA\n"), cur_mA);
+                currents[i].iHold = val;
+                currents[i].iRun = val;
+                tmc2130_setup_chopper(i, tmc2130_mres[i]);
             }
         }
 #else //TMC2130
@@ -8140,10 +8140,12 @@ Sigma_Exit:
     */
 	case 911: 
     {
-		if (code_seen('X')) tmc2130_set_current_h(0, code_value());
-		if (code_seen('Y')) tmc2130_set_current_h(1, code_value());
-        if (code_seen('Z')) tmc2130_set_current_h(2, code_value());
-        if (code_seen('E')) tmc2130_set_current_h(3, code_value());
+        for (uint8_t axis = 0; axis < NUM_AXIS; axis++) {
+            if (code_seen(axis_codes[axis])) {
+                currents[axis].iHold = code_value_uint8();
+                tmc2130_setup_chopper(axis, tmc2130_mres[axis]);
+          }
+        }
     }
     break;
 
@@ -8162,10 +8164,12 @@ Sigma_Exit:
     */
 	case 912: 
     {
-		if (code_seen('X')) tmc2130_set_current_r(0, code_value());
-		if (code_seen('Y')) tmc2130_set_current_r(1, code_value());
-        if (code_seen('Z')) tmc2130_set_current_r(2, code_value());
-        if (code_seen('E')) tmc2130_set_current_r(3, code_value());
+        for (uint8_t axis = 0; axis < NUM_AXIS; axis++) {
+            if (code_seen(axis_codes[axis])) {
+                currents[axis].iRun = code_value_uint8();
+                tmc2130_setup_chopper(axis, tmc2130_mres[axis]);
+            }
+        }
     }
     break;
 

--- a/Firmware/power_panic.cpp
+++ b/Firmware/power_panic.cpp
@@ -61,10 +61,12 @@ void uvlo_() {
 
     // Minimise Z and E motor currents (Hold and Run)
 #ifdef TMC2130
-    tmc2130_set_current_h(Z_AXIS, 20);
-    tmc2130_set_current_r(Z_AXIS, 20);
-    tmc2130_set_current_h(E_AXIS, 20);
-    tmc2130_set_current_r(E_AXIS, 20);
+    currents[Z_AXIS].iHold = 20;
+    currents[Z_AXIS].iRun = 20;
+    tmc2130_setup_chopper(Z_AXIS, tmc2130_mres[Z_AXIS]);
+    currents[E_AXIS].iHold = 20;
+    currents[E_AXIS].iRun = 20;
+    tmc2130_setup_chopper(E_AXIS, tmc2130_mres[E_AXIS]);
 #endif //TMC2130
 
     if (!sd_print_saved_in_ram && !isPartialBackupAvailable)
@@ -225,8 +227,9 @@ static void uvlo_tiny() {
     disable_e0();
 
 #ifdef TMC2130
-    tmc2130_set_current_h(Z_AXIS, 20);
-    tmc2130_set_current_r(Z_AXIS, 20);
+    currents[Z_AXIS].iHold = 20;
+    currents[Z_AXIS].iRun = 20;
+    tmc2130_setup_chopper(Z_AXIS, tmc2130_mres[Z_AXIS]);
 #endif //TMC2130
 
     // Stop all heaters

--- a/Firmware/tmc2130.cpp
+++ b/Firmware/tmc2130.cpp
@@ -46,31 +46,31 @@ MotorCurrents currents[NUM_AXIS] = {
 
 union ChopConfU {
 	struct __attribute__((packed)) S {
-		uint32_t toff : 4;
-		uint32_t hstrt : 3;
-		uint32_t hend : 4;
+		uint32_t toff : 4;     // Off time and driver enable
+		uint32_t hstrt : 3;    // Hysteresis start value added to HEND
+		uint32_t hend : 4;     // HEND hysteresis low value (chm = 0) or OFFSET sine wave offset (chm = 1)
 		uint32_t fd : 1;
-		uint32_t disfdcc : 1;
-		uint32_t rndtf : 1;
-		uint32_t chm : 1;
-		uint32_t tbl : 2;
-		uint32_t vsense : 1;
-		uint32_t vhighfs : 1;
-		uint32_t vhighchm : 1;
-		uint32_t sync : 4;
-		uint32_t mres : 4;
-		uint32_t intpol : 1;
-		uint32_t dedge : 1;
-		uint32_t diss2g : 1;
-		uint32_t reserved : 1;
+		uint32_t disfdcc : 1;  // Fast decay mode
+		uint32_t rndtf : 1;    // Random TOFF time 
+		uint32_t chm : 1;      // Chopper mode
+		uint32_t tbl : 2;      // Blank time select
+		uint32_t vsense : 1;   // Sense resistor voltage based current scaling
+		uint32_t vhighfs : 1;  // High velocity fullstep selection
+		uint32_t vhighchm : 1; // High velocity chopper mode
+		uint32_t sync : 4;     // PWM synchronization clock
+		uint32_t mres : 4;     // Micro step resolution
+		uint32_t intpol : 1;   // Interpolation to 256 microsteps
+		uint32_t dedge : 1;    // Enable double edgestep pulses
+		uint32_t diss2g : 1;   // Short to GND protection disable
+		uint32_t reserved : 1; // Reserved, set to 0
 		constexpr S(bool vsense, uint8_t mres)
 			: toff(TMC2130_TOFF_XYZ)
 			, hstrt(5)
 			, hend(1)
 			, fd(0)
 			, disfdcc(0)
-			, rndtf(0)
-			, chm(0)
+			, rndtf(0)   // Chopper off time is fixed as set by TOFF
+			, chm(0)     // Standard mode (spreadCycle)
 			, tbl(2)
 			, vsense(vsense)
 			, vhighfs(0)
@@ -79,7 +79,7 @@ union ChopConfU {
 			, mres(mres)
 			, intpol(0)
 			, dedge(default_dedge_bit)
-			, diss2g(0)
+			, diss2g(0)  // Short to GND protection is on
 			, reserved(0) {}
 	} s;
 	uint32_t dw;

--- a/Firmware/tmc2130.cpp
+++ b/Firmware/tmc2130.cpp
@@ -473,19 +473,16 @@ void tmc2130_setup_chopper(uint8_t axis, uint8_t mres, uint8_t current_h, uint8_
         chopconf.s.intpol = 0;
     }
 #endif
-//	DBG(_n("tmc2130_setup_chopper(axis=%d, mres=%d, curh=%d, curr=%d\n"), axis, mres, current_h, current_r);
-//	DBG(_n(" toff=%d, hstr=%d, hend=%d, tbl=%d\n"), toff, hstrt, hend, tbl);
 	if (current_r <= 31)
 	{
 		chopconf.s.vsense = 1;
-		tmc2130_wr_CHOPCONF(axis, chopconf.dw);
-		tmc2130_wr(axis, TMC2130_REG_IHOLD_IRUN, 0x000f0000 | ((current_r & 0x1f) << 8) | (current_h & 0x1f));
+	} else {
+		current_r >>= 1;
+		current_h >>= 1;
 	}
-	else
-	{
-		tmc2130_wr_CHOPCONF(axis, chopconf.dw);
-		tmc2130_wr(axis, TMC2130_REG_IHOLD_IRUN, 0x000f0000 | (((current_r >> 1) & 0x1f) << 8) | ((current_h >> 1) & 0x1f));
-	}
+
+	tmc2130_wr_CHOPCONF(axis, chopconf.dw);
+	tmc2130_wr(axis, TMC2130_REG_IHOLD_IRUN, 0x000f0000 | ((current_r & 0x1f) << 8) | (current_h & 0x1f));
 }
 
 void tmc2130_set_current_h(uint8_t axis, uint8_t current)

--- a/Firmware/tmc2130.cpp
+++ b/Firmware/tmc2130.cpp
@@ -143,11 +143,45 @@ uint8_t tmc2130_home_fsteps[2] = {48, 48};
 
 uint8_t tmc2130_wave_fac[4] = {0, 0, 0, 0};
 
-tmc2130_chopper_config_t tmc2130_chopper_config[4] = {
-	{TMC2130_TOFF_XYZ, 5, 1, 2, 0},
-	{TMC2130_TOFF_XYZ, 5, 1, 2, 0},
-	{TMC2130_TOFF_XYZ, 5, 1, 2, 0},
-	{TMC2130_TOFF_E, 5, 1, 2, 0}
+tmc2130_chopper_config_t tmc2130_chopper_config[NUM_AXIS] = {
+	{ // X axis
+		.toff = TMC2130_TOFF_XYZ,
+		.hstr = 5,
+		.hend = 1,
+		.tbl = 2,
+		.res = 0
+	},
+	{ // Y axis
+		.toff = TMC2130_TOFF_XYZ,
+		.hstr = 5,
+		.hend = 1,
+		.tbl = 2,
+		.res = 0
+	},
+	{ // Z axis
+		.toff = TMC2130_TOFF_XYZ,
+		.hstr = 5,
+		.hend = 1,
+		.tbl = 2,
+		.res = 0
+	},
+#ifdef TMC2130_CNSTOFF_E
+	{ // E axis
+		.toff = TMC2130_TOFF_E,
+		.hstr = 0,
+		.hend = 0,
+		.tbl = 2,
+		.res = 0
+	}
+#else // !TMC2130_CNSTOFF_E
+	{ // E axis
+		.toff = TMC2130_TOFF_E,
+		.hstr = 5,
+		.hend = 1,
+		.tbl = 2,
+		.res = 0
+	}
+#endif
 };
 
 bool tmc2130_sg_stop_on_crash = true;
@@ -499,13 +533,6 @@ void tmc2130_setup_chopper(uint8_t axis, uint8_t mres, uint8_t current_h, uint8_
 	chopconf.s.hstrt = tmc2130_chopper_config[axis].hstr; // initial 4, modified to 5
 	chopconf.s.hend = tmc2130_chopper_config[axis].hend; // original value = 1
 	chopconf.s.tbl = tmc2130_chopper_config[axis].tbl; //blanking time, original value = 2
-
-#ifdef TMC2130_CNSTOFF_E
-	if (axis == E_AXIS) {
-		chopconf.s.hstrt = 0; // fd0..2
-		chopconf.s.hend = 0; // sine wave offset
-	}
-#endif //TMC2130_CNSTOFF_E
 
 	tmc2130_wr_CHOPCONF(axis, chopconf.dw);
 	tmc2130_wr(axis, TMC2130_REG_IHOLD_IRUN, 0x000f0000 | ((current_r & 0x1f) << 8) | (current_h & 0x1f));

--- a/Firmware/tmc2130.h
+++ b/Firmware/tmc2130.h
@@ -2,11 +2,10 @@
 #define TMC2130_H
 
 #include <stdint.h>
+#include "Configuration_var.h"
 
 //mode
 extern uint8_t tmc2130_mode;
-extern uint8_t tmc2130_current_h[4];
-extern uint8_t tmc2130_current_r[4];
 //microstep resolution (0 means 256usteps, 8 means 1ustep
 extern uint8_t tmc2130_mres[4];
 
@@ -60,6 +59,19 @@ typedef struct
 
 extern tmc2130_chopper_config_t tmc2130_chopper_config[NUM_AXIS];
 
+struct MotorCurrents {
+    bool vSense; ///< VSense current scaling
+    uint8_t iRun; ///< Running current
+    uint8_t iHold; ///< Holding current
+
+    constexpr inline __attribute__((always_inline)) MotorCurrents(uint8_t ir, uint8_t ih)
+        : vSense((ir < 32) ? 1 : 0)
+        , iRun((ir < 32) ? ir : (ir >> 1))
+        , iHold((ir < 32) ? ih : (ih >> 1)) {}
+};
+
+extern MotorCurrents currents[NUM_AXIS];
+
 //initialize tmc2130
 
 struct TMCInitParams {
@@ -94,7 +106,7 @@ extern void tmc2130_sg_measure_start(uint8_t axis);
 //stop current stallguard measuring and report result
 extern uint16_t tmc2130_sg_measure_stop();
 
-extern void tmc2130_setup_chopper(uint8_t axis, uint8_t mres, uint8_t current_h, uint8_t current_r);
+extern void tmc2130_setup_chopper(uint8_t axis, uint8_t mres);
 
 //set holding current for any axis (M911)
 extern void tmc2130_set_current_h(uint8_t axis, uint8_t current);

--- a/Firmware/tmc2130.h
+++ b/Firmware/tmc2130.h
@@ -58,7 +58,7 @@ typedef struct
 } tmc2130_chopper_config_t;
 #pragma pack(pop)
 
-extern tmc2130_chopper_config_t tmc2130_chopper_config[4];
+extern tmc2130_chopper_config_t tmc2130_chopper_config[NUM_AXIS];
 
 //initialize tmc2130
 


### PR DESCRIPTION
An idea from the MMU FW where we use a union to gather the configuration bits into one dword. Makes it a bit easier to copy all the information.

Change in memory:
Flash: -664 bytes
SRAM: +4 bytes