### PR TITLE
PFW-1506 Load to nozzle: Fix too short purge distance

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -4775,6 +4775,11 @@ static void mmu_load_filament_menu() {
 static inline void lcd_mmu_load_to_nozzle_wrapper(uint8_t index){
     MMU2::mmu2.load_filament_to_nozzle(index);
 
+    // Extrude a little bit of filament so the user
+    // can see the color is correct
+    load_filament_final_feed();
+    st_synchronize();
+
     // Ask user if the extruded color is correct:
     lcd_return_to_status();
     lcd_load_filament_color_check();


### PR DESCRIPTION
In the test below I had orange filament before and then loaded yellow filament.
|  BEFORE  |  AFTER  |
|-----------|----------|
| ![IMG_3274](https://user-images.githubusercontent.com/8218499/236627224-db3ede98-e997-4237-9608-1b194b524d1c.jpg) | ![IMG_3275](https://user-images.githubusercontent.com/8218499/236627240-503caf26-a481-4ba5-80d3-3d0c73b95f70.jpg) |

Change in memory:
Flash: +8 bytes
SRAM: 0 bytes