### PR TITLE
MMU: M600: Remove `mmu_M600_wait_and_beep()`

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3411,20 +3411,6 @@ void gcode_M123()
 }
 #endif //FANCHECK and TACH_0 or TACH_1
 
-static void mmu_M600_wait_and_beep() {
-    // Beep and wait for user to remove old filament and prepare new filament for load
-    KEEPALIVE_STATE(PAUSED_FOR_USER);
-
-    lcd_display_message_fullscreen_P(_i("Remove old filament and press the knob to start loading new filament.")); ////MSG_REMOVE_OLD_FILAMENT c=20 r=4
-
-    while (!lcd_clicked()) {
-        manage_heater();
-        manage_inactivity(true);
-        sound_wait_for_user();
-    }
-    sound_wait_for_user_reset();
-}
-
 /**
  * @brief Handling of unload when using MMU with M600
  * A fullscreen message showing "Unloading Filament x"
@@ -3528,7 +3514,6 @@ static void gcode_M600(const bool automatic, const float x_position, const float
                     // if M600 was invoked by filament senzor (FINDA) eject filament so user can easily remove it
                     MMU2::mmu2.eject_filament(MMU2::mmu2.get_current_tool(), false);
                 }
-                mmu_M600_wait_and_beep();
             }
             mmu_M600_load_filament(automatic, HotendTempBckp);
         }
@@ -11215,10 +11200,9 @@ void M600_check_state(float nozzle_temp)
                 // Unload filament
                 mmu_M600_unload_filament();
 
-                // Ask to remove any old filament and load new
-                mmu_M600_wait_and_beep();
-
-                // After user clicks knob, MMU will load the filament
+                // Load new filament
+                // If SpoolJoin is OFF: a menu appears asking the user to select filament slot to load
+                // If SpoolJoin is ON:  the next filament slot is automatically selected.
                 mmu_M600_load_filament(false, nozzle_temp);
             } else {
                 M600_load_filament_movements();

--- a/lang/po/Firmware.pot
+++ b/lang/po/Firmware.pot
@@ -1721,11 +1721,6 @@ msgstr ""
 msgid "Recovering print"
 msgstr ""
 
-#. MSG_REMOVE_OLD_FILAMENT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3434
-msgid "Remove old filament and press the knob to start loading new filament."
-msgstr ""
-
 #. MSG_DESC_FILAMENT_EJECTED c=20 r=8
 #: ../../Firmware/mmu2/errors_list.h:265 ../../Firmware/mmu2/errors_list.h:318
 msgid "Remove the ejected filament from the front of the MMU."

--- a/lang/po/Firmware_cs.po
+++ b/lang/po/Firmware_cs.po
@@ -1734,11 +1734,6 @@ msgstr "Vzadu [µm]"
 msgid "Recovering print"
 msgstr "Obnovovani tisku"
 
-#. MSG_REMOVE_OLD_FILAMENT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3434
-msgid "Remove old filament and press the knob to start loading new filament."
-msgstr "Vyjmete stary filament a stisknete tlacitko pro zavedeni noveho."
-
 #. MSG_RENAME c=18
 #: ../../Firmware/ultralcd.cpp:5284
 msgid "Rename"
@@ -2621,3 +2616,6 @@ msgstr ""
 
 #~ msgid "Temp. model autotune"
 #~ msgstr "Ladeni tepl. modelu"
+
+#~ msgid "Remove old filament and press the knob to start loading new filament."
+#~ msgstr "Vyjmete stary filament a stisknete tlacitko pro zavedeni noveho."

--- a/lang/po/Firmware_de.po
+++ b/lang/po/Firmware_de.po
@@ -1754,11 +1754,6 @@ msgstr "Hinten [µm]"
 msgid "Recovering print"
 msgstr "Druck wiederherst"
 
-#. MSG_REMOVE_OLD_FILAMENT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3434
-msgid "Remove old filament and press the knob to start loading new filament."
-msgstr "Entferne das alte Fil. und drücke den Knopf, um das neue zu laden."
-
 #. MSG_RENAME c=18
 #: ../../Firmware/ultralcd.cpp:5284
 msgid "Rename"
@@ -2651,3 +2646,6 @@ msgstr ""
 
 #~ msgid "Temp. model autotune"
 #~ msgstr "Temp. Model Autokal."
+
+#~ msgid "Remove old filament and press the knob to start loading new filament."
+#~ msgstr "Entferne das alte Fil. und drücke den Knopf, um das neue zu laden."

--- a/lang/po/Firmware_es.po
+++ b/lang/po/Firmware_es.po
@@ -1753,12 +1753,6 @@ msgstr "Trasera [µm]"
 msgid "Recovering print"
 msgstr "Recuper. impresion"
 
-#. MSG_REMOVE_OLD_FILAMENT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3434
-msgid "Remove old filament and press the knob to start loading new filament."
-msgstr ""
-"Retira el fil. viejo y presione el dial para comenzar a cargar el nuevo."
-
 #. MSG_RENAME c=18
 #: ../../Firmware/ultralcd.cpp:5284
 msgid "Rename"
@@ -2645,3 +2639,7 @@ msgstr ""
 
 #~ msgid "Temp. model autotune"
 #~ msgstr "Autotune model temp."
+
+#~ msgid "Remove old filament and press the knob to start loading new filament."
+#~ msgstr ""
+"Retira el fil. viejo y presione el dial para comenzar a cargar el nuevo."

--- a/lang/po/Firmware_fr.po
+++ b/lang/po/Firmware_fr.po
@@ -1761,12 +1761,6 @@ msgstr "Arriere [µm]"
 msgid "Recovering print"
 msgstr "Recup. impression"
 
-#. MSG_REMOVE_OLD_FILAMENT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3434
-msgid "Remove old filament and press the knob to start loading new filament."
-msgstr ""
-"Retirez l'ancien fil. puis appuyez sur le bouton pour charger le nouveau."
-
 #. MSG_RENAME c=18
 #: ../../Firmware/ultralcd.cpp:5284
 msgid "Rename"
@@ -2660,3 +2654,7 @@ msgstr ""
 
 #~ msgid "Temp. model autotune"
 #~ msgstr "Regl. auto mod temp."
+
+#~ msgid "Remove old filament and press the knob to start loading new filament."
+#~ msgstr ""
+"Retirez l'ancien fil. puis appuyez sur le bouton pour charger le nouveau."

--- a/lang/po/Firmware_hr.po
+++ b/lang/po/Firmware_hr.po
@@ -1748,11 +1748,6 @@ msgstr "Zad. str.[µm]"
 msgid "Recovering print"
 msgstr "Oporavak printa"
 
-#. MSG_REMOVE_OLD_FILAMENT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3434
-msgid "Remove old filament and press the knob to start loading new filament."
-msgstr "Uklonite stari fil. i pritisnite gumb za pocetak stavljanja novog."
-
 #. MSG_RENAME c=18
 #: ../../Firmware/ultralcd.cpp:5284
 msgid "Rename"
@@ -2651,3 +2646,6 @@ msgstr ""
 #~ msgstr ""
 #~ "XYZ kalibracija nije uspjela. Lijeva prednja tocka kalibracije nije "
 #~ "dostupna."
+
+#~ msgid "Remove old filament and press the knob to start loading new filament."
+#~ msgstr "Uklonite stari fil. i pritisnite gumb za pocetak stavljanja novog."

--- a/lang/po/Firmware_hu.po
+++ b/lang/po/Firmware_hu.po
@@ -1752,11 +1752,6 @@ msgstr "Hatso old.[µm]"
 msgid "Recovering print"
 msgstr "Nyomt. visszaallit"
 
-#. MSG_REMOVE_OLD_FILAMENT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3434
-msgid "Remove old filament and press the knob to start loading new filament."
-msgstr "Vedd ki a regi fil., majd nyomd meg a gombot az uj fil. betoltesehez."
-
 #. MSG_RENAME c=18
 #: ../../Firmware/ultralcd.cpp:5284
 msgid "Rename"
@@ -2664,3 +2659,6 @@ msgstr ""
 #~ msgstr ""
 #~ "A firmware beta verziojat hasznalod. Ez egy fejlesztoknek szant verzio es "
 #~ "nem ajanlott a hasznalata."
+
+#~ msgid "Remove old filament and press the knob to start loading new filament."
+#~ msgstr "Vedd ki a regi fil., majd nyomd meg a gombot az uj fil. betoltesehez."

--- a/lang/po/Firmware_it.po
+++ b/lang/po/Firmware_it.po
@@ -1753,11 +1753,6 @@ msgstr "Retro [µm]"
 msgid "Recovering print"
 msgstr "Recupero stampa"
 
-#. MSG_REMOVE_OLD_FILAMENT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3434
-msgid "Remove old filament and press the knob to start loading new filament."
-msgstr "Rimuovi il fil. precedente e premi la manopola per caricare il nuovo."
-
 #. MSG_RENAME c=18
 #: ../../Firmware/ultralcd.cpp:5284
 msgid "Rename"
@@ -2650,3 +2645,6 @@ msgstr ""
 
 #~ msgid "XYZ calibration failed. Left front calibration point not reachable."
 #~ msgstr "Calibrazione XYZ fallita. Punto anteriore sinistro non raggiungibile."
+
+#~ msgid "Remove old filament and press the knob to start loading new filament."
+#~ msgstr "Rimuovi il fil. precedente e premi la manopola per caricare il nuovo."

--- a/lang/po/Firmware_nl.po
+++ b/lang/po/Firmware_nl.po
@@ -1756,12 +1756,6 @@ msgstr "Achterkant[µm]"
 msgid "Recovering print"
 msgstr "Print herstellen"
 
-#. MSG_REMOVE_OLD_FILAMENT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3434
-msgid "Remove old filament and press the knob to start loading new filament."
-msgstr ""
-"Verwijder de oude filament en druk op de knop om nieuwe filament te laden."
-
 #. MSG_RENAME c=18
 #: ../../Firmware/ultralcd.cpp:5284
 msgid "Rename"
@@ -2650,3 +2644,7 @@ msgstr ""
 
 #~ msgid "XYZ calibration failed. Left front calibration point not reachable."
 #~ msgstr "XYZ-kalibratie mislukt. Kalibratiepunt linksvoor niet bereikbaar."
+
+#~ msgid "Remove old filament and press the knob to start loading new filament."
+#~ msgstr ""
+"Verwijder de oude filament en druk op de knop om nieuwe filament te laden."

--- a/lang/po/Firmware_no.po
+++ b/lang/po/Firmware_no.po
@@ -1741,11 +1741,6 @@ msgstr "Baksiden [µm]"
 msgid "Recovering print"
 msgstr "Gjenopptar print"
 
-#. MSG_REMOVE_OLD_FILAMENT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3434
-msgid "Remove old filament and press the knob to start loading new filament."
-msgstr "Ta bort det gamle filamentet og trykk valghjulet for å laste et nytt."
-
 #. MSG_RENAME c=18
 #: ../../Firmware/ultralcd.cpp:5284
 msgid "Rename"
@@ -2627,3 +2622,6 @@ msgstr ""
 #~ msgid "XYZ calibration failed. Left front calibration point not reachable."
 #~ msgstr ""
 #~ "XYZ kalibreringen feilet. Fremre venstre kalibreringspunkt kan ikke nås"
+
+#~ msgid "Remove old filament and press the knob to start loading new filament."
+#~ msgstr "Ta bort det gamle filamentet og trykk valghjulet for å laste et nytt."

--- a/lang/po/Firmware_pl.po
+++ b/lang/po/Firmware_pl.po
@@ -1749,11 +1749,6 @@ msgstr "Tyl [µm]"
 msgid "Recovering print"
 msgstr "Wznawianie wydruku"
 
-#. MSG_REMOVE_OLD_FILAMENT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3434
-msgid "Remove old filament and press the knob to start loading new filament."
-msgstr "Wyciagnij poprzedni filament i nacisnij pokretlo aby zaladowac nowy."
-
 #. MSG_RENAME c=18
 #: ../../Firmware/ultralcd.cpp:5284
 msgid "Rename"
@@ -2638,3 +2633,6 @@ msgstr ""
 
 #~ msgid "Temp. model autotune"
 #~ msgstr "Autotune modelu temp"
+
+#~ msgid "Remove old filament and press the knob to start loading new filament."
+#~ msgstr "Wyciagnij poprzedni filament i nacisnij pokretlo aby zaladowac nowy."

--- a/lang/po/Firmware_ro.po
+++ b/lang/po/Firmware_ro.po
@@ -1751,11 +1751,6 @@ msgstr "Spate [µm]"
 msgid "Recovering print"
 msgstr "Recuperare print"
 
-#. MSG_REMOVE_OLD_FILAMENT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3434
-msgid "Remove old filament and press the knob to start loading new filament."
-msgstr "Scoateti fil. vechi si apasati butonul pentru a incarca nou."
-
 #. MSG_RENAME c=18
 #: ../../Firmware/ultralcd.cpp:5284
 msgid "Rename"
@@ -2663,3 +2658,6 @@ msgstr ""
 #~ msgstr ""
 #~ "Utilizati vers. beta de FW. Acesta este vers. de dezvoltare. Folosind "
 #~ "aceasta versiune nu este recomandata si poate cauza deteriorarea imprimantei"
+
+#~ msgid "Remove old filament and press the knob to start loading new filament."
+#~ msgstr "Scoateti fil. vechi si apasati butonul pentru a incarca nou."

--- a/lang/po/Firmware_sk.po
+++ b/lang/po/Firmware_sk.po
@@ -1746,11 +1746,6 @@ msgstr "Zadna str.[µm]"
 msgid "Recovering print"
 msgstr "Obnovovanie tlace"
 
-#. MSG_REMOVE_OLD_FILAMENT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3434
-msgid "Remove old filament and press the knob to start loading new filament."
-msgstr "Vyberte stary filament a stlacte tlacidlo pre zavedenie noveho."
-
 #. MSG_RENAME c=18
 #: ../../Firmware/ultralcd.cpp:5284
 msgid "Rename"
@@ -2643,3 +2638,6 @@ msgstr ""
 #~ msgstr ""
 #~ "Pouzivate BETA verziu firmveru. Toto je vyvojova verzia. Pouzivanie tejto "
 #~ "verzie sa neodporuca a moze sposobit poskodenie tlaciarne."
+
+#~ msgid "Remove old filament and press the knob to start loading new filament."
+#~ msgstr "Vyberte stary filament a stlacte tlacidlo pre zavedenie noveho."

--- a/lang/po/Firmware_sv.po
+++ b/lang/po/Firmware_sv.po
@@ -1752,11 +1752,6 @@ msgstr "Baksida [µm]"
 msgid "Recovering print"
 msgstr "Återställer utskrift"
 
-#. MSG_REMOVE_OLD_FILAMENT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3434
-msgid "Remove old filament and press the knob to start loading new filament."
-msgstr "Ta bort det gamla fil. och tryck på knappen för att börja ladda nytt."
-
 #. MSG_RENAME c=18
 #: ../../Firmware/ultralcd.cpp:5284
 msgid "Rename"
@@ -2639,3 +2634,6 @@ msgstr ""
 
 #~ msgid "XYZ calibration failed. Left front calibration point not reachable."
 #~ msgstr "XYZ-kalibrering felade. Främre vä kalibreringspunkt kan ej nås."
+
+#~ msgid "Remove old filament and press the knob to start loading new filament."
+#~ msgstr "Ta bort det gamla fil. och tryck på knappen för att börja ladda nytt."


### PR DESCRIPTION
I suspect `mmu_M600_wait_and_beep()` is remnant from the old MMU code.

When SpoolJoin is off, the old MMU code would load the same slot and not ask the user to select the slot. But with the rewrite of the MMU code, M600 now asks the user to select the slot to load (similar to Load to Nozzle menu, or Cut filament menu). This is all done in `mmu_M600_load_filament()` so I propose `mmu_M600_wait_and_beep()` be removed to make the user experience better.

No need to make the user click the knob twice :)

Change in memory:
Flash: -134 bytes
SRAM: 0 bytes