### PR TITLE
PFW-1508 Fix issue where Loading Test always starts with unload

### DIFF
--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -366,9 +366,7 @@ bool MMU2::tool_change(uint8_t slot) {
         return false;
 
     if (slot != extruder) {
-        if (/*FindaDetectsFilament()*/
-            /*!IS_SD_PRINTING && !usb_timer.running()*/
-            !marlin_printingIsActive()) {
+        if (FindaDetectsFilament() && !marlin_printingIsActive()) {
             // If Tcodes are used manually through the serial
             // we need to unload manually as well -- but only if FINDA detects filament
             unload();


### PR DESCRIPTION
The condition where a unload is run on a toolchange should only be done when the FINDA detects filament (here we can safely assume the FINDA is calibrated correctly).
Change in memory:
Flash: +8 bytes
SRAM: 0 bytes