### PR TITLE
🚧 Various MMU LCD fixes

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3457,11 +3457,7 @@ static void mmu_M600_load_filament(bool automatic, float nozzle_temp) {
     }
 
     setTargetHotend(nozzle_temp);
-
-    MMU2::mmu2.load_filament_to_nozzle(slot);
-
-    load_filament_final_feed(); // @@TODO verify
-    st_synchronize();
+    lcd_mmu_load_to_nozzle(slot);
 }
 
 static void gcode_M600(const bool automatic, const float x_position, const float y_position, const float z_shift, const float e_shift, const float e_shift_late) {
@@ -3526,7 +3522,7 @@ static void gcode_M600(const bool automatic, const float x_position, const float
             if (!automatic) {
                 if (saved_printing){
                     // if M600 was invoked by filament senzor (FINDA) eject filament so user can easily remove it
-                    MMU2::mmu2.eject_filament(MMU2::mmu2.get_current_tool(), false);
+                    MMU2::mmu2.eject_filament(MMU2::mmu2.get_current_tool());
                 }
                 mmu_M600_wait_and_beep();
             }
@@ -3576,7 +3572,7 @@ void gcode_M701(float fastLoadLength, uint8_t mmuSlotIndex){
 
     if (MMU2::mmu2.Enabled()) {
         if (mmuSlotIndex < MMU_FILAMENT_COUNT) {
-          MMU2::mmu2.load_filament_to_nozzle(mmuSlotIndex);
+          lcd_mmu_load_to_nozzle(mmuSlotIndex);
         } // else do nothing
     } else {
         custom_message_type = CustomMsg::FilamentLoading;
@@ -3617,7 +3613,7 @@ static void gcodes_M704_M705_M706(uint16_t gcode)
                 MMU2::mmu2.load_filament(mmuSlotIndex);
                 break;
             case 705:
-                MMU2::mmu2.eject_filament(mmuSlotIndex, false);
+                MMU2::mmu2.eject_filament(mmuSlotIndex);
                 break;
             case 706:
 #ifdef MMU_HAS_CUTTER

--- a/Firmware/mmu2.h
+++ b/Firmware/mmu2.h
@@ -118,12 +118,12 @@ public:
 
     /// Move MMU's selector aside and push the selected filament forward.
     /// Usable for improving filament's tip or pulling the remaining piece of filament out completely.
-    bool eject_filament(uint8_t slot, bool enableFullScreenMsg = true);
+    bool eject_filament(uint8_t slot);
 
     /// Issue a Cut command into the MMU
     /// Requires unloaded filament from the printer (obviously)
     /// @returns false if the operation cannot be performed (Stopped)
-    bool cut_filament(uint8_t slot, bool enableFullScreenMsg = true);
+    bool cut_filament(uint8_t slot);
 
     /// Issue a planned request for statistics data from MMU
     void get_statistics();

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -302,30 +302,6 @@ void MakeSound(SoundType s){
     Sound_MakeSound( (eSOUND_TYPE)s);
 }
 
-static void FullScreenMsg(const char *pgmS, uint8_t slot){
-    lcd_update_enable(false);
-    lcd_clear();
-    lcd_puts_at_P(0, 1, pgmS);
-    lcd_print(' ');
-    lcd_print(slot + 1);
-}
-
-void FullScreenMsgCut(uint8_t slot){
-    FullScreenMsg(_T(MSG_CUT_FILAMENT), slot);
-}
-
-void FullScreenMsgEject(uint8_t slot){
-    FullScreenMsg(_T(MSG_EJECT_FROM_MMU), slot);
-}
-
-void FullScreenMsgTest(uint8_t slot){
-    FullScreenMsg(_T(MSG_TESTING_FILAMENT), slot);
-}
-
-void FullScreenMsgLoad(uint8_t slot){
-    FullScreenMsg(_T(MSG_LOADING_FILAMENT), slot);
-}
-
 void FullScreenMsgRestoringTemperature(){
     lcd_display_message_fullscreen_P(_i("MMU Retry: Restoring temperature...")); ////MSG_MMU_RESTORE_TEMP c=20 r=4
 }

--- a/Firmware/mmu2_reporting.h
+++ b/Firmware/mmu2_reporting.h
@@ -68,10 +68,6 @@ enum SoundType {
 
 void MakeSound(SoundType s);
 
-void FullScreenMsgCut(uint8_t slot);
-void FullScreenMsgEject(uint8_t slot);
-void FullScreenMsgTest(uint8_t slot);
-void FullScreenMsgLoad(uint8_t slot);
 void FullScreenMsgRestoringTemperature();
 
 void ScreenUpdateEnable();

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -4758,19 +4758,19 @@ static void FullScreenMsg(const char *pgmS, uint8_t slot){
     lcd_print(slot + 1);
 }
 
-void FullScreenMsgCut(uint8_t slot){
+static void FullScreenMsgCut(uint8_t slot){
     FullScreenMsg(_T(MSG_CUT_FILAMENT), slot);
 }
 
-void FullScreenMsgEject(uint8_t slot){
+static void FullScreenMsgEject(uint8_t slot){
     FullScreenMsg(_T(MSG_EJECT_FROM_MMU), slot);
 }
 
-void FullScreenMsgTest(uint8_t slot){
+static void FullScreenMsgTest(uint8_t slot){
     FullScreenMsg(_T(MSG_TESTING_FILAMENT), slot);
 }
 
-void FullScreenMsgLoad(uint8_t slot){
+static void FullScreenMsgLoad(uint8_t slot){
     FullScreenMsg(_T(MSG_LOADING_FILAMENT), slot);
 }
 

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -193,7 +193,8 @@ void mFilamentItem(uint16_t nTemp,uint16_t nTempBed);
 void lcd_generic_preheat_menu();
 void unload_filament(float unloadLength);
 void lcd_AutoLoadFilament();
-
+void lcd_mmu_load_to_nozzle(uint8_t slot);
+void lcd_mmu_eject_filament(uint8_t slot);
 
 void lcd_wait_for_heater();
 void lcd_wait_for_cool_down();


### PR DESCRIPTION
⚠️ **I will try to split these changes into multiple PRs!**

----

Move the Full Screen message from MMU code
to the LCD code. Also don't allow the MMU
code to control LCD updates when running operations. This should be taken care of by the LCD menu code.

* Fixes an issue where the ramming sequence is run twice when executing "Load to Nozzle" on the same slot which is already loaded
* Fixes issue where Load to Nozzle operation will enable LCD updates, this allows some of the M600
menus to time out to the status screen. That's not supposed to happen
* Fix edge case where the Load to Nozzle operation can be run with the target temperature set to 0°C

Change in memory:
Flash: -66 bytes
SRAM: 0 bytes