### PR TITLE
🚧 Optimise LCD update RAII

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3367,7 +3367,7 @@ static void mmu_M600_filament_change_screen(uint8_t eject_slot) {
 static void mmu_M600_unload_filament() {
     if (MMU2::mmu2.get_current_tool() == (uint8_t)MMU2::FILAMENT_UNKNOWN) return;
 
-    lcd_update_enable(false);
+    LCDUpdateEnableRAII lcdup;
     lcd_clear();
     lcd_puts_at_P(0, 1, _T(MSG_UNLOADING_FILAMENT));
     lcd_print(' ');
@@ -3375,7 +3375,6 @@ static void mmu_M600_unload_filament() {
 
     // unload just current filament for multimaterial printers (used also in M702)
     MMU2::mmu2.unload();
-    lcd_update_enable(true);
 }
 
 /// @brief load filament for mmu v2

--- a/Firmware/lcd.h
+++ b/Firmware/lcd.h
@@ -139,21 +139,22 @@ extern void lcd_buttons_update(void);
 //! When destroyed (gone out of scope), original state of LCD update is restored.
 //! It has zero overhead compared to storing bool saved = lcd_update_enabled
 //! and calling lcd_update_enable(false) and lcd_update_enable(saved).
-class LcdUpdateDisabler
+struct LCDUpdateEnableRAII
 {
 public:
-    LcdUpdateDisabler(): m_updateEnabled(lcd_update_enabled)
+    explicit inline __attribute__((always_inline)) LCDUpdateEnableRAII(): m_updateEnabled(lcd_update_enabled)
     {
-        lcd_update_enable(false);
+        lcd_update_enabled = 0;
     }
-    ~LcdUpdateDisabler()
-    {
-        lcd_update_enable(m_updateEnabled);
+    inline __attribute__((always_inline)) ~LCDUpdateEnableRAII() {
+        lcd_update_enabled = m_updateEnabled;
     }
 
 private:
-    bool m_updateEnabled;
+    uint8_t m_updateEnabled;
 };
+
+static_assert(sizeof(LCDUpdateEnableRAII) == 1);
 
 ////////////////////////////////////
 

--- a/Firmware/menu.cpp
+++ b/Firmware/menu.cpp
@@ -300,7 +300,7 @@ void __attribute__((noinline)) menu_item_function_E(const Sheet &sheet, menu_fun
         if (menu_clicked && (lcd_encoder == menu_item))
         {
             if (func) {
-                LCDUpdateEnableRAII();
+                LCDUpdateEnableRAII lcdup;
                 func();
             }
             menu_item_ret();
@@ -337,7 +337,7 @@ void menu_item_function_P(const char* str, menu_func_t func)
 		if (menu_clicked && (lcd_encoder == menu_item))
 		{
 			if (func) {
-				LCDUpdateEnableRAII();
+				LCDUpdateEnableRAII lcdup;
 				func();
 			}
 			menu_item_ret();
@@ -364,7 +364,7 @@ void menu_item_function_P(const char* str, char number, void (*func)(uint8_t), u
         if (menu_clicked && (lcd_encoder == menu_item))
         {
             if (func) {
-                LCDUpdateEnableRAII();
+                LCDUpdateEnableRAII lcdup;
                 func(fn_par);
             }
             menu_item_ret();
@@ -388,7 +388,7 @@ void menu_item_toggle_P(const char* str, const char* toggle, menu_func_t func, c
 			else // do the actual toggling
 			{
 				if (func) {
-					LCDUpdateEnableRAII();
+					LCDUpdateEnableRAII lcdup;
 					func();
 				}
 			}

--- a/Firmware/menu.cpp
+++ b/Firmware/menu.cpp
@@ -299,9 +299,10 @@ void __attribute__((noinline)) menu_item_function_E(const Sheet &sheet, menu_fun
         if (lcd_draw_update) menu_draw_item_select_sheet_E(' ', sheet);
         if (menu_clicked && (lcd_encoder == menu_item))
         {
-            lcd_update_enabled = 0;
-            if (func) func();
-            lcd_update_enabled = 1;
+            if (func) {
+                LCDUpdateEnableRAII();
+                func();
+            }
             menu_item_ret();
             return;
         }
@@ -335,9 +336,10 @@ void menu_item_function_P(const char* str, menu_func_t func)
 		if (lcd_draw_update) menu_draw_item_puts_P(' ', str);
 		if (menu_clicked && (lcd_encoder == menu_item))
 		{
-			lcd_update_enabled = 0;
-			if (func) func();
-			lcd_update_enabled = 1;
+			if (func) {
+				LCDUpdateEnableRAII();
+				func();
+			}
 			menu_item_ret();
 			return;
 		}
@@ -361,9 +363,10 @@ void menu_item_function_P(const char* str, char number, void (*func)(uint8_t), u
         if (lcd_draw_update) menu_draw_item_puts_P(' ', str, number);
         if (menu_clicked && (lcd_encoder == menu_item))
         {
-            lcd_update_enabled = 0;
-            if (func) func(fn_par);
-            lcd_update_enabled = 1;
+            if (func) {
+                LCDUpdateEnableRAII();
+                func(fn_par);
+            }
             menu_item_ret();
             return;
         }
@@ -384,9 +387,10 @@ void menu_item_toggle_P(const char* str, const char* toggle, menu_func_t func, c
 			}
 			else // do the actual toggling
 			{
-				lcd_update_enabled = 0;
-				if (func) func();
-				lcd_update_enabled = 1;
+				if (func) {
+					LCDUpdateEnableRAII();
+					func();
+				}
 			}
 			menu_item_ret();
 			return;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2942,7 +2942,7 @@ const char* lcd_display_message_fullscreen_P(const char *msg)
  */
 void lcd_show_fullscreen_message_and_wait_P(const char *msg)
 {
-    LcdUpdateDisabler lcdUpdateDisabler;
+    LCDUpdateEnableRAII lcdUpdateDisabler;
     const char *msg_next = lcd_display_message_fullscreen_P(msg);
     bool multi_screen = msg_next != NULL;
 	lcd_consume_click();

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -282,9 +282,8 @@ static void menu_item_sddir(const char* str_fn, char* str_fnl)
 	}
 	if (menu_clicked && (lcd_encoder == menu_item))
 	{
-		lcd_update_enabled = false;
+		LCDUpdateEnableRAII();
 		menu_action_sddirectory(str_fn);
-		lcd_update_enabled = true;
 		menu_item_ret();
 		return;
 	}
@@ -299,9 +298,8 @@ static void menu_item_sdfile(const char* str_fn, char* str_fnl)
 	}
 	if (menu_clicked && (lcd_encoder == menu_item))
 	{
-		lcd_update_enabled = false;
+		LCDUpdateEnableRAII();
 		menu_action_sdfile(str_fn);
-		lcd_update_enabled = true;
 		menu_item_ret();
 		return;
 	}
@@ -966,9 +964,10 @@ void lcd_commands()
                 lcd_commands_step = 3;
                 break;
             case 3:
-                lcd_update_enabled = false; //hack to avoid lcd_update recursion.
-                lcd_show_fullscreen_message_and_wait_P(_T(MSG_NOZZLE_CNG_READ_HELP));
-                lcd_update_enabled = true;
+                {
+                    LCDUpdateEnableRAII(); //hack to avoid lcd_update recursion.
+                    lcd_show_fullscreen_message_and_wait_P(_T(MSG_NOZZLE_CNG_READ_HELP));
+                }
                 lcd_draw_update = 2; //force lcd clear and update after the stack unwinds.
                 enquecommand_P(G28W);
                 enquecommand_P(PSTR("G1 X125 Z200 F1000"));
@@ -986,7 +985,7 @@ void lcd_commands()
                 //|tightend to specs?
                 //| Yes     No
                 enquecommand_P(PSTR("M84 XY"));
-                lcd_update_enabled = false; //hack to avoid lcd_update recursion.
+                LCDUpdateEnableRAII(); //hack to avoid lcd_update recursion.
                 if (lcd_show_fullscreen_message_yes_no_and_wait_P(_T(MSG_NOZZLE_CNG_CHANGED), false) == LCD_LEFT_BUTTON_CHOICE) {
                     setTargetHotend(0);
 #ifdef THERMAL_MODEL
@@ -994,7 +993,6 @@ void lcd_commands()
 #endif //THERMAL_MODEL
                     lcd_commands_step = 1;
                 }
-                lcd_update_enabled = true;
                 break;
             case 1:
                 lcd_setstatuspgm(MSG_WELCOME);
@@ -2942,7 +2940,7 @@ const char* lcd_display_message_fullscreen_P(const char *msg)
  */
 void lcd_show_fullscreen_message_and_wait_P(const char *msg)
 {
-    LCDUpdateEnableRAII lcdUpdateDisabler;
+    LCDUpdateEnableRAII();
     const char *msg_next = lcd_display_message_fullscreen_P(msg);
     bool multi_screen = msg_next != NULL;
 	lcd_consume_click();
@@ -3607,11 +3605,12 @@ void lcd_v2_calibration() {
 		if (fsensor.isReady()) {
 			loaded = fsensor.getFilamentPresent();
 		} else {
+			LCDUpdateEnableRAII();
 			loaded = !lcd_show_fullscreen_message_yes_no_and_wait_P(_T(MSG_FILAMENT_LOADED), false, LCD_MIDDLE_BUTTON_CHOICE);
-			lcd_update_enabled = true;
 		}
 
 		if (!loaded) {
+			LCDUpdateEnableRAII();
 			lcd_display_message_fullscreen_P(_i("Please load filament first."));////MSG_PLEASE_LOAD_PLA c=20 r=4
 			lcd_consume_click();
 			for (uint_least8_t i = 0; i < 20; i++) { //wait max. 2s
@@ -3620,7 +3619,6 @@ void lcd_v2_calibration() {
 					break;
 				}
 			}
-			lcd_update_enabled = true;
 			menu_back();
 			return;
 		}
@@ -5734,9 +5732,10 @@ void lcd_sdcard_menu()
 			if (card.presort_flag == true) //used to force resorting if sorting type is changed.
 			{
 				card.presort_flag = false;
-				lcd_update_enabled = false;
-				card.presort();
-				lcd_update_enabled = true;
+				{
+					LCDUpdateEnableRAII();
+					card.presort();
+				}
 			}
 			_md->fileCnt = card.getnrfilenames();
 			_md->sdSort = farm_mode ? SD_SORT_NONE : eeprom_read_byte((uint8_t*)EEPROM_SD_SORT);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -282,7 +282,7 @@ static void menu_item_sddir(const char* str_fn, char* str_fnl)
 	}
 	if (menu_clicked && (lcd_encoder == menu_item))
 	{
-		LCDUpdateEnableRAII();
+		LCDUpdateEnableRAII lcdup;
 		menu_action_sddirectory(str_fn);
 		menu_item_ret();
 		return;
@@ -298,7 +298,7 @@ static void menu_item_sdfile(const char* str_fn, char* str_fnl)
 	}
 	if (menu_clicked && (lcd_encoder == menu_item))
 	{
-		LCDUpdateEnableRAII();
+		LCDUpdateEnableRAII lcdup;
 		menu_action_sdfile(str_fn);
 		menu_item_ret();
 		return;
@@ -965,7 +965,7 @@ void lcd_commands()
                 break;
             case 3:
                 {
-                    LCDUpdateEnableRAII(); //hack to avoid lcd_update recursion.
+                    LCDUpdateEnableRAII lcdup; //hack to avoid lcd_update recursion.
                     lcd_show_fullscreen_message_and_wait_P(_T(MSG_NOZZLE_CNG_READ_HELP));
                 }
                 lcd_draw_update = 2; //force lcd clear and update after the stack unwinds.
@@ -985,7 +985,7 @@ void lcd_commands()
                 //|tightend to specs?
                 //| Yes     No
                 enquecommand_P(PSTR("M84 XY"));
-                LCDUpdateEnableRAII(); //hack to avoid lcd_update recursion.
+                LCDUpdateEnableRAII lcdup; //hack to avoid lcd_update recursion.
                 if (lcd_show_fullscreen_message_yes_no_and_wait_P(_T(MSG_NOZZLE_CNG_CHANGED), false) == LCD_LEFT_BUTTON_CHOICE) {
                     setTargetHotend(0);
 #ifdef THERMAL_MODEL
@@ -2940,7 +2940,7 @@ const char* lcd_display_message_fullscreen_P(const char *msg)
  */
 void lcd_show_fullscreen_message_and_wait_P(const char *msg)
 {
-    LCDUpdateEnableRAII();
+    LCDUpdateEnableRAII lcdup;
     const char *msg_next = lcd_display_message_fullscreen_P(msg);
     bool multi_screen = msg_next != NULL;
 	lcd_consume_click();
@@ -3587,6 +3587,7 @@ void lcd_first_layer_calibration_reset()
 }
 
 void lcd_v2_calibration() {
+	LCDUpdateEnableRAII lcdup;
 	if (MMU2::mmu2.Enabled()) {
 		const uint8_t filament = choose_menu_P(
 			_T(MSG_SELECT_FILAMENT),
@@ -3605,12 +3606,10 @@ void lcd_v2_calibration() {
 		if (fsensor.isReady()) {
 			loaded = fsensor.getFilamentPresent();
 		} else {
-			LCDUpdateEnableRAII();
 			loaded = !lcd_show_fullscreen_message_yes_no_and_wait_P(_T(MSG_FILAMENT_LOADED), false, LCD_MIDDLE_BUTTON_CHOICE);
 		}
 
 		if (!loaded) {
-			LCDUpdateEnableRAII();
 			lcd_display_message_fullscreen_P(_i("Please load filament first."));////MSG_PLEASE_LOAD_PLA c=20 r=4
 			lcd_consume_click();
 			for (uint_least8_t i = 0; i < 20; i++) { //wait max. 2s
@@ -5731,11 +5730,9 @@ void lcd_sdcard_menu()
 		{
 			if (card.presort_flag == true) //used to force resorting if sorting type is changed.
 			{
+				LCDUpdateEnableRAII lcdup;
 				card.presort_flag = false;
-				{
-					LCDUpdateEnableRAII();
-					card.presort();
-				}
+				card.presort();
 			}
 			_md->fileCnt = card.getnrfilenames();
 			_md->sdSort = farm_mode ? SD_SORT_NONE : eeprom_read_byte((uint8_t*)EEPROM_SD_SORT);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -979,6 +979,7 @@ void lcd_commands()
                 lcd_commands_step = 2;
                 break;
             case 2:
+            {
                 //|0123456789012456789|
                 //|Hotend at 280C!
                 //|Nozzle changed and
@@ -994,6 +995,7 @@ void lcd_commands()
                     lcd_commands_step = 1;
                 }
                 break;
+            }
             case 1:
                 lcd_setstatuspgm(MSG_WELCOME);
                 lcd_commands_step = 0;


### PR DESCRIPTION
Optimise and use the RAII for LCD update enable flag in more places in the firmware. This does increase memory usage somewhat but I think this is beneficial to add some "structure" to the LCD code.

Using `__attribute__((always_inline))` becomes critical when `LCDUpdateEnableRAII` is applied to the SD card menu items. For some reason, specifically the flash memory increases there significantly (I'm talking about ~100B)

Change in memory:
Flash: -14 bytes