### PR TITLE
optimisation: always inline `ReportingRAII`

### DIFF
--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -194,11 +194,11 @@ void MMU2::CheckFINDARunout() {
 
 struct ReportingRAII {
     CommandInProgress cip;
-    explicit inline ReportingRAII(CommandInProgress cip)
+    explicit inline __attribute__((always_inline)) ReportingRAII(CommandInProgress cip)
         : cip(cip) {
         BeginReport(cip, (uint16_t)ProgressCode::EngagingIdler);
     }
-    inline ~ReportingRAII() {
+    inline __attribute__((always_inline)) ~ReportingRAII() {
         EndReport(cip, (uint16_t)ProgressCode::OK);
     }
 };


### PR DESCRIPTION
Tested on MK3S+ using the LCD.

Change in memory:
Flash: -80 bytes
SRAM: 0 bytes