### PR TITLE
`crashdet_cancel()` doesnt cleanup all variables when USB printing

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -635,16 +635,9 @@ void crashdet_recover()
   if (lcd_crash_detect_enabled()) tmc2130_sg_stop_on_crash = true;
 }
 
-void crashdet_cancel()
-{
-	saved_printing = false;
-	tmc2130_sg_stop_on_crash = true;
-	if (saved_printing_type == PowerPanic::PRINT_TYPE_SD) {
-		print_stop();
-	}else if(saved_printing_type == PowerPanic::PRINT_TYPE_USB){
-		SERIAL_ECHOLNRPGM(MSG_OCTOPRINT_CANCEL); //for Octoprint: works the same as clicking "Abort" button in Octoprint GUI
-		cmdqueue_reset();
-	}
+/// Crash detection cancels the print
+void crashdet_cancel() {
+    print_stop();
 }
 
 #endif //TMC2130
@@ -9693,8 +9686,10 @@ void UnconditionalStop()
     cmdqueue_serial_disabled = false;
 
     // Reset the sd status
-    card.sdprinting = false;
-    card.closefile();
+    if (card.sdprinting) {
+        card.sdprinting = false;
+        card.closefile();
+    }
 
     st_reset_timer();
     CRITICAL_SECTION_END;

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -9685,12 +9685,6 @@ void UnconditionalStop()
     cmdqueue_reset();
     cmdqueue_serial_disabled = false;
 
-    // Reset the sd status
-    if (card.sdprinting) {
-        card.sdprinting = false;
-        card.closefile();
-    }
-
     st_reset_timer();
     CRITICAL_SECTION_END;
 }

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -631,12 +631,16 @@ void crashdet_detected(uint8_t mask)
 
 void crashdet_recover()
 {
-  if (!print_job_timer.isPaused()) crashdet_restore_print_and_continue();
-  if (lcd_crash_detect_enabled()) tmc2130_sg_stop_on_crash = true;
+	if (!print_job_timer.isPaused()) crashdet_restore_print_and_continue();
+	crashdet_use_eeprom_setting();
 }
 
 /// Crash detection cancels the print
 void crashdet_cancel() {
+    // Restore crash detection
+    crashdet_use_eeprom_setting();
+
+    // Abort the print
     print_stop();
 }
 
@@ -1269,14 +1273,11 @@ void setup()
 	if (silentMode == 0xff) silentMode = 0;
 	tmc2130_mode = TMC2130_MODE_NORMAL;
 
-	if (lcd_crash_detect_enabled() && !farm_mode)
-	{
-		lcd_crash_detect_enable();
-	    puts_P(_N("CrashDetect ENABLED!"));
-	}
-	else
-	{
-	    lcd_crash_detect_disable();
+  tmc2130_sg_stop_on_crash = eeprom_init_default_byte((uint8_t*)EEPROM_CRASH_DET, farm_mode ? false : true);
+
+	if (tmc2130_sg_stop_on_crash) {
+    puts_P(_N("CrashDetect ENABLED!"));
+	} else {
 	    puts_P(_N("CrashDetect DISABLED"));
 	}
 

--- a/Firmware/tmc2130.cpp
+++ b/Firmware/tmc2130.cpp
@@ -390,6 +390,9 @@ void tmc2130_st_isr()
 	}
 }
 
+void crashdet_use_eeprom_setting() {
+	tmc2130_sg_stop_on_crash = eeprom_read_byte((uint8_t*)EEPROM_CRASH_DET);
+}
 
 bool tmc2130_update_sg()
 {

--- a/Firmware/tmc2130.h
+++ b/Firmware/tmc2130.h
@@ -162,6 +162,9 @@ extern void tmc2130_sg_measure_start(uint8_t axis);
 //stop current stallguard measuring and report result
 extern uint16_t tmc2130_sg_measure_stop();
 
+// Enable or Disable crash detection according to EEPROM
+void crashdet_use_eeprom_setting();
+
 extern void tmc2130_setup_chopper(uint8_t axis, uint8_t mres);
 
 //set holding current for any axis (M911)

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5646,7 +5646,11 @@ void print_stop(bool interactive)
     // called by the main loop one iteration later.
     UnconditionalStop();
 
-    if (!card.sdprinting) {
+    if (card.sdprinting) {
+        // Reset the sd status
+        card.sdprinting = false;
+        card.closefile();
+    } else {
         SERIAL_ECHOLNRPGM(MSG_OCTOPRINT_CANCEL); // for Octoprint
     }
 

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -71,12 +71,6 @@ void lcd_status_screen();                         // NOT static due to using ins
 void lcd_menu_extruder_info();                    // NOT static due to using inside "Marlin_main" module ("manage_inactivity()")
 void lcd_menu_show_sensors_state();               // NOT static due to using inside "Marlin_main" module ("manage_inactivity()")
 
-#ifdef TMC2130
-bool lcd_crash_detect_enabled();
-void lcd_crash_detect_enable();
-void lcd_crash_detect_disable();
-#endif
-
 enum LCDButtonChoice : uint_fast8_t {
     LCD_LEFT_BUTTON_CHOICE = 0,
     LCD_MIDDLE_BUTTON_CHOICE = 1,


### PR DESCRIPTION
This function doesn't look correct to me 🤔 I would think that this should behave similarly as when stopping the print via the LCD. This PR is my proposed improvement, un-tested at the moment.

Changed `UnconditionalStop()` to not close the SD card file if we're using Octoprint. Then there shouldnt be any file open.

Some of the variables which were not reset:
`isPrintPaused`
`pause_time`
`saved_start_position`
`saved_printing_type`

It seems like the bed heater could also be left enabled?



Fixes https://github.com/prusa3d/Prusa-Firmware/issues/4324

Change in memory:
Flash: -28 bytes
SRAM: 0 bytes