### PR TITLE
Leave user's MMU-loaded filament loaded after first layer cal

### DIFF
--- a/Firmware/first_lay_cal.cpp
+++ b/Firmware/first_lay_cal.cpp
@@ -66,7 +66,7 @@ void lay1cal_wait_preheat()
 //! @brief Load filament
 //! @param cmd_buffer character buffer needed to format gcodes
 //! @param filament filament to use (applies for MMU only)
-//! @returns true if extra purge distance is needed in case of MMU prints (after a toolchange), otherwise false
+//! @returns true if filament has been changed (therefore an extra purge distance is needed in case of MMU prints), otherwise false
 bool lay1cal_load_filament(uint8_t filament)
 {
     if (MMU2::mmu2.Enabled())
@@ -225,7 +225,7 @@ void lay1cal_square(uint8_t step, float layer_height, float extrusion_width)
     }
 }
 
-void lay1cal_finish(bool mmu_enabled)
+void lay1cal_finish(bool unload_filament)
 {
     static const char cmd_cal_finish_1[] PROGMEM = "G1 E-0.075 F2100"; //retract
     static const char cmd_cal_finish_2[] PROGMEM = "M104 S0"; // turn off temperature
@@ -245,6 +245,6 @@ void lay1cal_finish(bool mmu_enabled)
 
     lay1cal_common_enqueue_loop(cmd_cal_finish, (sizeof(cmd_cal_finish)/sizeof(cmd_cal_finish[0])));
 
-    if (mmu_enabled) enquecommand_P(MSG_M702); //unload from nozzle
+    if (unload_filament) enquecommand_P(MSG_M702); //unload from nozzle
     enquecommand_P(MSG_M84);// disable motors
 }

--- a/Firmware/first_lay_cal.h
+++ b/Firmware/first_lay_cal.h
@@ -13,6 +13,6 @@ void lay1cal_before_meander();
 void lay1cal_meander_start(float layer_height, float extrusion_width);
 void lay1cal_meander(float layer_height, float extrusion_width);
 void lay1cal_square(uint8_t step, float layer_height, float extrusion_width);
-void lay1cal_finish(bool mmu_enabled);
+void lay1cal_finish(bool unload_filament);
 
 #endif /* FIRMWARE_FIRST_LAY_CAL_H_ */

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -67,7 +67,7 @@ int8_t SilentModeMenu = SILENT_MODE_OFF;
 
 LcdCommands lcd_commands_type = LcdCommands::Idle;
 static uint8_t lcd_commands_step = 0;
-static bool extraPurgeNeeded = false; ///< lcd_commands - detect if extra purge after MMU-toolchange is necessary or not
+static bool filament_changed = false; ///< lcd_commands - detect if extra purge after MMU-toolchange is necessary or not
 
 CustomMsg custom_message_type = CustomMsg::Status;
 uint8_t custom_message_state = 0;
@@ -807,13 +807,13 @@ void lcd_commands()
                 lay1cal_wait_preheat();
                 break;
             case 11:
-                extraPurgeNeeded = lay1cal_load_filament(lay1cal_filament);
+                filament_changed = lay1cal_load_filament(lay1cal_filament);
                 break;
             case 10:
                 lcd_clear();
                 menu_depth = 0;
                 menu_submenu(lcd_babystep_z, true);
-                lay1cal_intro_line(extraPurgeNeeded, layer_height, extrusion_width);
+                lay1cal_intro_line(filament_changed, layer_height, extrusion_width);
                 break;
             case 9:
                 lay1cal_before_meander();
@@ -837,7 +837,7 @@ void lcd_commands()
                 lay1cal_square(12, layer_height, extrusion_width);
                 break;
             case 2:
-                lay1cal_finish(MMU2::mmu2.Enabled());
+                lay1cal_finish(MMU2::mmu2.Enabled() && filament_changed);
                 break;
             case 1:
                 lcd_setstatuspgm(MSG_WELCOME);


### PR DESCRIPTION
Presently, if user runs the first layer calibration with the filament that's been loaded into the nozzle by MMU, this filament will be unloaded after the calibration is complete.

This behavior seems unexpected from user experience point of view: if you load a filament into the nozzle and proceed to first layer calibration, you did so for a reason and probably don't want it unloaded after the first try (just like you wouldn't want it unloaded if you did so without the MMU).

Any other filament that's not been previously loaded into the nozzle is fair game to unload (as it was before).

I was, sadly, unable to test this. I successfully flashed this firmware onto my printer, but I was unable to find the applicable MMU firmware version/build process. (There used to be a `MMU2_dev` branch here that I'd hoped would contain the latest developments but it seems gone?)