### PR TITLE
Stepper ISR: compare `uint16_t` against `uint16_t`

### DIFF
--- a/Firmware/stepper.cpp
+++ b/Firmware/stepper.cpp
@@ -867,7 +867,7 @@ FORCE_INLINE void isr() {
             step_rate = acc_step_rate - step_rate; // Decelerate from acceleration end point.
 
             // lower limit
-            if (step_rate < current_block->final_rate)
+            if (step_rate < uint16_t(current_block->final_rate))
                 step_rate = uint16_t(current_block->final_rate);
         }
 


### PR DESCRIPTION
Just an idea to optimise things. I noticed we're assigning `step_rate` with the 16-bit cast value of `final_rate` I would expect the comparison to be 16-bit also then.

Change in memory:
Flash: -32 bytes
SRAM: 0 bytes