### PR TITLE
PFW-1522 Implement filament change screen

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3423,11 +3423,13 @@ static void mmu_M600_filament_change_screen(uint8_t eject_slot) {
             MMU2::mmu2.clearPrinterButtonOperation();
 
             if (btn == MMU2::Buttons::Eject) {
-                MMU2::mmu2.eject_filament(eject_slot, true);
-                // The MMU will raise FILAMENT_EJECTED screen, and ask the user to confirm
-                // the operation is done. We must be careful to not raise FILAMENT_CHANGE
-                // screen too quickly
-                continue;
+                if (eject_slot != (uint8_t)MMU2::FILAMENT_UNKNOWN) {
+                    MMU2::mmu2.eject_filament(eject_slot, true);
+                    // The MMU will raise FILAMENT_EJECTED screen, and ask the user to confirm
+                    // the operation is done. We must be careful to not raise FILAMENT_CHANGE
+                    // screen too quickly
+                    continue;
+                }
             }
             else if (btn == MMU2::Buttons::Load)
             {

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3405,18 +3405,40 @@ void gcode_M123()
 }
 #endif //FANCHECK and TACH_0 or TACH_1
 
-static void mmu_M600_wait_and_beep() {
-    // Beep and wait for user to remove old filament and prepare new filament for load
-    KEEPALIVE_STATE(PAUSED_FOR_USER);
-
-    lcd_display_message_fullscreen_P(_i("Remove old filament and press the knob to start loading new filament.")); ////MSG_REMOVE_OLD_FILAMENT c=20 r=4
-
-    while (!lcd_clicked()) {
+/// @brief Re-use the MMU error screen UI to present choices for filament change
+/// There are two button actions, Load and Eject
+/// Load will exit the screen and continue as normally by asking the user which slot to load from
+/// Eject will eject the depleted filament, very useful after FINDA runout events.
+/// @param eject_slot the MMU slot to eject if the user selects the Eject button choice
+static void mmu_M600_filament_change_screen(uint8_t eject_slot) {
+    MMU2::Buttons btn;
+    for(;;)
+    {
         manage_heater();
         manage_inactivity(true);
-        sound_wait_for_user();
+
+        btn = MMU2::mmu2.getPrinterButtonOperation();
+        if (btn != MMU2::Buttons::NoButton)
+        {
+            MMU2::mmu2.clearPrinterButtonOperation();
+
+            if (btn == MMU2::Buttons::Eject) {
+                MMU2::mmu2.eject_filament(eject_slot, true);
+                // The MMU will raise FILAMENT_EJECTED screen, and ask the user to confirm
+                // the operation is done. We must be careful to not raise FILAMENT_CHANGE
+                // screen too quickly
+                continue;
+            }
+            else if (btn == MMU2::Buttons::Load)
+            {
+                // External caller is expected to load the filament
+                // This event is used to exit the endless loop
+                return;
+            }
+        }
+
+        MMU2::mmu2.InvokeErrorScreen(ErrorCode::FILAMENT_CHANGE);
     }
-    sound_wait_for_user_reset();
 }
 
 /**
@@ -3462,8 +3484,13 @@ static void gcode_M600(const bool automatic, const float x_position, const float
     st_synchronize();
     float lastpos[4];
 
-        prusa_statistics(22);
-    
+    // When using an MMU, save the currently use slot number
+    // so the firmware can know which slot to eject after the filament
+    // is unloaded.
+    uint8_t eject_slot = 0;
+
+    prusa_statistics(22);
+
     //First backup current position and settings
     int feedmultiplyBckp = feedmultiply;
     float HotendTempBckp = degTargetHotend(active_extruder);
@@ -3490,6 +3517,7 @@ static void gcode_M600(const bool automatic, const float x_position, const float
 
     // Unload filament
     if (MMU2::mmu2.Enabled()) {
+        eject_slot = MMU2::mmu2.get_current_tool();
         mmu_M600_unload_filament();
     } else {
         // Beep, manage nozzle heater and wait for user to start unload filament
@@ -3517,13 +3545,7 @@ static void gcode_M600(const bool automatic, const float x_position, const float
         }
         else // MMU is enabled
         {
-            if (!automatic) {
-                if (saved_printing){
-                    // if M600 was invoked by filament senzor (FINDA) eject filament so user can easily remove it
-                    MMU2::mmu2.eject_filament(MMU2::mmu2.get_current_tool(), false);
-                }
-                mmu_M600_wait_and_beep();
-            }
+            if (!automatic) mmu_M600_filament_change_screen(eject_slot);
             mmu_M600_load_filament(automatic, HotendTempBckp);
         }
         if (!automatic)
@@ -10811,12 +10833,14 @@ void M600_check_state(float nozzle_temp)
         {
         // Filament failed to load so load it again
         case 2:
-            if (MMU2::mmu2.Enabled()){
+            if (MMU2::mmu2.Enabled()) {
+                uint8_t eject_slot = MMU2::mmu2.get_current_tool();
+
                 // Unload filament
                 mmu_M600_unload_filament();
 
                 // Ask to remove any old filament and load new
-                mmu_M600_wait_and_beep();
+                mmu_M600_filament_change_screen(eject_slot);
 
                 // After user clicks knob, MMU will load the filament
                 mmu_M600_load_filament(false, nozzle_temp);

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -978,7 +978,7 @@ void MMU2::ReportError(ErrorCode ec, ErrorSource res) {
         lastErrorSource = res;
         LogErrorEvent_P(_O(PrusaErrorTitle(PrusaErrorCodeIndex((uint16_t)ec))));
 
-        if (ec != ErrorCode::OK && ec != ErrorCode::FILAMENT_EJECTED) {
+        if (ec != ErrorCode::OK && ec != ErrorCode::FILAMENT_EJECTED && ec != ErrorCode::FILAMENT_CHANGE) {
             IncrementMMUFails();
 
             // check if it is a "power" failure - we consider TMC-related errors as power failures

--- a/Firmware/mmu2.h
+++ b/Firmware/mmu2.h
@@ -199,6 +199,37 @@ public:
     inline uint16_t GetLastReadRegisterValue() const {
         return lastReadRegisterValue;
     };
+    inline void InvokeErrorScreen(ErrorCode ec) {
+        // The printer may not raise an error when the MMU is busy
+        if ( !logic.CommandInProgress() // MMU must not be busy
+            && MMUCurrentErrorCode() == ErrorCode::OK // The protocol must not be in error state
+            && lastErrorCode != ec) // The error code is not a duplicate
+        {
+            ReportError(ec, ErrorSource::ErrorSourcePrinter);
+        }
+    }
+
+    void ClearPrinterError() {
+        logic.ClearPrinterError();
+        lastErrorCode = ErrorCode::OK;
+        lastErrorSource = ErrorSource::ErrorSourceNone;
+    }
+
+    /// @brief Queue a button operation which the printer can act upon
+    /// @param btn Button operation
+    inline void setPrinterButtonOperation(Buttons btn) {
+        printerButtonOperation = btn;
+    }
+
+    /// @brief Get the printer button operation
+    /// @return currently set printer button operation, it can be NoButton if nothing is queued
+    inline Buttons getPrinterButtonOperation() {
+        return printerButtonOperation;
+    }
+
+    inline void clearPrinterButtonOperation() {
+        printerButtonOperation = Buttons::NoButton;
+    }
 
 private:
     /// Perform software self-reset of the MMU (sends an X0 command)
@@ -308,6 +339,7 @@ private:
     ErrorSource lastErrorSource = ErrorSource::ErrorSourceNone;
     Buttons lastButton = Buttons::NoButton;
     uint16_t lastReadRegisterValue = 0;
+    Buttons printerButtonOperation = Buttons::NoButton;
 
     StepStatus logicStepLastStatus;
 

--- a/Firmware/mmu2/buttons.h
+++ b/Firmware/mmu2/buttons.h
@@ -13,11 +13,13 @@ enum class ButtonOperations : uint8_t {
     NoOperation = 0,
     Retry       = 1,
     Continue    = 2,
-    ResetMMU  = 3,
+    ResetMMU    = 3,
     Unload      = 4,
-    StopPrint   = 5,
-    DisableMMU  = 6,
-    Tune = 7,
+    Load        = 5,
+    Eject       = 6,
+    Tune        = 7,
+    StopPrint   = 8,
+    DisableMMU  = 9,
 };
 
 /// Button codes + extended actions performed on the printer's side
@@ -28,6 +30,8 @@ enum Buttons : uint8_t {
     
     // performed on the printer's side
     ResetMMU,
+    Load,
+    Eject,
     StopPrint,
     DisableMMU,
     TuneMMU, // Printer changes MMU register value

--- a/Firmware/mmu2/error_codes.h
+++ b/Firmware/mmu2/error_codes.h
@@ -58,7 +58,8 @@ enum class ErrorCode : uint_fast16_t {
 
     MCU_UNDERVOLTAGE_VCC = 0x800d, ///< MCU VCC rail undervoltage.
 
-    LOAD_TO_EXTRUDER_FAILED = 0x802a, ///< E32811 internal error of the printer - try-load-unload sequence detected missing filament -> failed load into the nozzle
+    FILAMENT_CHANGE = 0x8029, ///< E32809 internal error of the printer - try-load-unload sequence detected missing filament -> failed load into the nozzle
+    LOAD_TO_EXTRUDER_FAILED = 0x802a, ///< E32810 internal error of the printer - try-load-unload sequence detected missing filament -> failed load into the nozzle
     QUEUE_FULL = 0x802b, ///< E32811 internal logic error - attempt to move with a full queue
     VERSION_MISMATCH = 0x802c, ///< E32812 internal error of the printer - incompatible version of the MMU FW
     PROTOCOL_ERROR = 0x802d, ///< E32813 internal error of the printer - communication with the MMU got garbled - protocol decoder couldn't decode the incoming messages

--- a/Firmware/mmu2/errors_list.h
+++ b/Firmware/mmu2/errors_list.h
@@ -428,7 +428,7 @@ static const uint8_t errorButtons[] PROGMEM = {
     Btns(ButtonOperations::ResetMMU, ButtonOperations::NoOperation),//FW_RUNTIME_ERROR
     Btns(ButtonOperations::Retry, ButtonOperations::NoOperation),//UNLOAD_MANUALLY
     Btns(ButtonOperations::Continue, ButtonOperations::NoOperation),//FILAMENT_EJECTED
-    Btns(ButtonOperations::Load, ButtonOperations::Eject),//FILAMENT_CHANGE
+    Btns(ButtonOperations::Eject, ButtonOperations::Load),//FILAMENT_CHANGE
     Btns(ButtonOperations::ResetMMU, ButtonOperations::NoOperation),//UNKOWN_ERROR
 };
 

--- a/Firmware/mmu2/errors_list.h
+++ b/Firmware/mmu2/errors_list.h
@@ -77,6 +77,7 @@ typedef enum : uint16_t {
     ERR_SYSTEM_FW_RUNTIME_ERROR = 505,
     ERR_SYSTEM_UNLOAD_MANUALLY = 506,
     ERR_SYSTEM_FILAMENT_EJECTED = 507,
+    ERR_SYSTEM_FILAMENT_CHANGE = 508,
 
     ERR_OTHER_UNKNOWN_ERROR = 900
 } err_num_t;
@@ -129,6 +130,7 @@ static const constexpr uint16_t errorCodes[] PROGMEM = {
     ERR_SYSTEM_FW_RUNTIME_ERROR,
     ERR_SYSTEM_UNLOAD_MANUALLY,
     ERR_SYSTEM_FILAMENT_EJECTED,
+    ERR_SYSTEM_FILAMENT_CHANGE,
     ERR_OTHER_UNKNOWN_ERROR
 };
 
@@ -183,6 +185,7 @@ static const char MSG_TITLE_FW_UPDATE_NEEDED[] PROGMEM_I1        = ISTR("MMU FW 
 static const char MSG_TITLE_FW_RUNTIME_ERROR[] PROGMEM_I1        = ISTR("FW RUNTIME ERROR"); ////MSG_TITLE_FW_RUNTIME_ERROR c=20
 static const char MSG_TITLE_UNLOAD_MANUALLY[] PROGMEM_I1         = ISTR("UNLOAD MANUALLY"); ////MSG_TITLE_UNLOAD_MANUALLY c=20
 static const char MSG_TITLE_FILAMENT_EJECTED[] PROGMEM_I1        = ISTR("FILAMENT EJECTED"); ////MSG_TITLE_FILAMENT_EJECTED c=20
+static const char MSG_TITLE_FILAMENT_CHANGE[] PROGMEM_I1         = ISTR("FILAMENT CHANGE"); ////MSG_TITLE_FILAMENT_CHANGE c=20
 static const char MSG_TITLE_UNKNOWN_ERROR[] PROGMEM_I1           = ISTR("UNKNOWN ERROR"); ////MSG_TITLE_UNKNOWN_ERROR c=20
 
 static const char * const errorTitles [] PROGMEM = {
@@ -229,6 +232,7 @@ static const char * const errorTitles [] PROGMEM = {
     _R(MSG_TITLE_FW_RUNTIME_ERROR),
     _R(MSG_TITLE_UNLOAD_MANUALLY),
     _R(MSG_TITLE_FILAMENT_EJECTED),
+    _R(MSG_TITLE_FILAMENT_CHANGE),
     _R(MSG_TITLE_UNKNOWN_ERROR)
 };
 
@@ -278,6 +282,7 @@ static const char MSG_DESC_QUEUE_FULL[] PROGMEM_I1 = ISTR("MMU Firmware internal
 static const char MSG_DESC_FW_RUNTIME_ERROR[] PROGMEM_I1 = ISTR("Internal runtime error. Try resetting the MMU or updating the firmware."); ////MSG_DESC_FW_RUNTIME_ERROR c=20 r=8
 static const char MSG_DESC_UNLOAD_MANUALLY[] PROGMEM_I1 = ISTR("Filament detected unexpectedly. Ensure no filament is loaded. Check the sensors and wiring."); ////MSG_DESC_UNLOAD_MANUALLY c=20 r=8
 static const char MSG_DESC_FILAMENT_EJECTED[] PROGMEM_I1 = ISTR("Remove the ejected filament from the front of the MMU."); ////MSG_DESC_FILAMENT_EJECTED c=20 r=8
+static const char MSG_DESC_FILAMENT_CHANGE[] PROGMEM_I1 = ISTR("Printer is running M600 command"); ////MSG_DESC_FILAMENT_CHANGE c=20 r=8
 static const char MSG_DESC_UNKNOWN_ERROR[] PROGMEM_I1    = ISTR("Unexpected error occurred."); ////MSG_DESC_UNKNOWN_ERROR c=20 r=8
 
 // Read explanation in mmu2_protocol_logic.cpp -> supportedMmuFWVersion
@@ -332,6 +337,7 @@ static const char * const errorDescs[] PROGMEM = {
     _R(MSG_DESC_FW_RUNTIME_ERROR),
     _R(MSG_DESC_UNLOAD_MANUALLY),
     _R(MSG_DESC_FILAMENT_EJECTED),
+    _R(MSG_DESC_FILAMENT_CHANGE),
     _R(MSG_DESC_UNKNOWN_ERROR)
 };
 
@@ -347,6 +353,8 @@ static const char MSG_BTN_RETRY[] PROGMEM_I1 = ISTR("Retry"); ////MSG_BTN_RETRY 
 static const char MSG_BTN_CONTINUE[] PROGMEM_I1 = ISTR("Done"); ////MSG_BTN_CONTINUE c=8
 static const char MSG_BTN_RESET_MMU[] PROGMEM_I1 = ISTR("ResetMMU"); ////MSG_BTN_RESET_MMU c=8
 static const char MSG_BTN_UNLOAD[] PROGMEM_I1 = ISTR("Unload"); ////MSG_BTN_UNLOAD c=8
+static const char MSG_BTN_LOAD[] PROGMEM_I1 = ISTR("Load"); ////MSG_BTN_LOAD c=8
+static const char MSG_BTN_EJECT[] PROGMEM_I1 = ISTR("Eject"); ////MSG_BTN_EJECT c=8
 static const char MSG_BTN_STOP[] PROGMEM_I1 = ISTR("Stop"); ////MSG_BTN_STOP c=8
 static const char MSG_BTN_DISABLE_MMU[] PROGMEM_I1 = ISTR("Disable"); ////MSG_BTN_DISABLE_MMU c=8
 static const char MSG_BTN_TUNE_MMU[] PROGMEM_I1 = ISTR("Tune"); ////MSG_BTN_TUNE_MMU c=8
@@ -358,6 +366,8 @@ static const char * const btnOperation[] PROGMEM = {
     _R(MSG_BTN_CONTINUE),
     _R(MSG_BTN_RESET_MMU),
     _R(MSG_BTN_UNLOAD),
+    _R(MSG_BTN_LOAD),
+    _R(MSG_BTN_EJECT),
     _R(MSG_BTN_STOP),
     _R(MSG_BTN_DISABLE_MMU),
     _R(MSG_BTN_TUNE_MMU),
@@ -418,6 +428,7 @@ static const uint8_t errorButtons[] PROGMEM = {
     Btns(ButtonOperations::ResetMMU, ButtonOperations::NoOperation),//FW_RUNTIME_ERROR
     Btns(ButtonOperations::Retry, ButtonOperations::NoOperation),//UNLOAD_MANUALLY
     Btns(ButtonOperations::Continue, ButtonOperations::NoOperation),//FILAMENT_EJECTED
+    Btns(ButtonOperations::Load, ButtonOperations::Eject),//FILAMENT_CHANGE
     Btns(ButtonOperations::ResetMMU, ButtonOperations::NoOperation),//UNKOWN_ERROR
 };
 

--- a/Firmware/mmu2/errors_list.h
+++ b/Firmware/mmu2/errors_list.h
@@ -282,7 +282,7 @@ static const char MSG_DESC_QUEUE_FULL[] PROGMEM_I1 = ISTR("MMU Firmware internal
 static const char MSG_DESC_FW_RUNTIME_ERROR[] PROGMEM_I1 = ISTR("Internal runtime error. Try resetting the MMU or updating the firmware."); ////MSG_DESC_FW_RUNTIME_ERROR c=20 r=8
 static const char MSG_DESC_UNLOAD_MANUALLY[] PROGMEM_I1 = ISTR("Filament detected unexpectedly. Ensure no filament is loaded. Check the sensors and wiring."); ////MSG_DESC_UNLOAD_MANUALLY c=20 r=8
 static const char MSG_DESC_FILAMENT_EJECTED[] PROGMEM_I1 = ISTR("Remove the ejected filament from the front of the MMU."); ////MSG_DESC_FILAMENT_EJECTED c=20 r=8
-static const char MSG_DESC_FILAMENT_CHANGE[] PROGMEM_I1 = ISTR("Printer is running M600 command"); ////MSG_DESC_FILAMENT_CHANGE c=20 r=8
+static const char MSG_DESC_FILAMENT_CHANGE[] PROGMEM_I1 = ISTR("M600 Filament Change. Load a new filament or eject the old one."); ////MSG_DESC_FILAMENT_CHANGE c=20 r=8
 static const char MSG_DESC_UNKNOWN_ERROR[] PROGMEM_I1    = ISTR("Unexpected error occurred."); ////MSG_DESC_UNKNOWN_ERROR c=20 r=8
 
 // Read explanation in mmu2_protocol_logic.cpp -> supportedMmuFWVersion

--- a/Firmware/mmu2_error_converter.cpp
+++ b/Firmware/mmu2_error_converter.cpp
@@ -53,6 +53,8 @@ uint8_t PrusaErrorCodeIndex(uint16_t ec) {
         return FindErrorIndex(ERR_MECHANICAL_LOAD_TO_EXTRUDER_FAILED);
     case (uint16_t)ErrorCode::FILAMENT_EJECTED:
         return FindErrorIndex(ERR_SYSTEM_FILAMENT_EJECTED);
+    case (uint16_t)ErrorCode::FILAMENT_CHANGE:
+        return FindErrorIndex(ERR_SYSTEM_FILAMENT_CHANGE);
 
     case (uint16_t)ErrorCode::STALLED_PULLEY:
     case (uint16_t)ErrorCode::MOVE_PULLEY_FAILED:
@@ -234,6 +236,16 @@ Buttons ButtonAvailable(uint16_t ec) {
         switch (buttonSelectedOperation) {
         case ButtonOperations::Continue: // User solved the serious mechanical problem by hand - there is no other way around
             return Middle;
+        default:
+            break;
+        }
+        break;
+    case ERR_SYSTEM_FILAMENT_CHANGE:
+        switch (buttonSelectedOperation) {
+        case ButtonOperations::Load:
+            return Load;
+        case ButtonOperations::Eject:
+            return Eject;
         default:
             break;
         }

--- a/lang/po/Firmware.pot
+++ b/lang/po/Firmware.pot
@@ -471,6 +471,11 @@ msgstr ""
 msgid "ERROR:"
 msgstr ""
 
+#. MSG_BTN_EJECT c=8
+#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:369
+msgid "Eject"
+msgstr ""
+
 #. MSG_EJECT_FROM_MMU c=16
 #: ../../Firmware/messages.cpp:60 ../../Firmware/mmu2_reporting.cpp:325
 #: ../../Firmware/ultralcd.cpp:4804 ../../Firmware/ultralcd.cpp:5234
@@ -537,6 +542,11 @@ msgstr ""
 #. MSG_TITLE_FILAMENT_ALREADY_LOADED c=20
 #: ../../Firmware/mmu2/errors_list.h:179 ../../Firmware/mmu2/errors_list.h:225
 msgid "FIL. ALREADY LOADED"
+msgstr ""
+
+#. MSG_TITLE_FILAMENT_CHANGE c=20
+#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
+msgid "FILAMENT CHANGE"
 msgstr ""
 
 #. MSG_TITLE_FILAMENT_EJECTED c=20
@@ -1018,6 +1028,11 @@ msgstr ""
 msgid "Live adjust Z"
 msgstr ""
 
+#. MSG_BTN_LOAD c=8
+#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:368
+msgid "Load"
+msgstr ""
+
 #. MSG_LOAD_ALL c=18
 #: ../../Firmware/messages.cpp:181 ../../Firmware/ultralcd.cpp:4766
 #: ../../Firmware/ultralcd.cpp:4835
@@ -1070,6 +1085,11 @@ msgstr ""
 #: ../../Firmware/messages.cpp:152 ../../Firmware/ultralcd.cpp:4158
 #: ../../Firmware/ultralcd.cpp:4170
 msgid "Loud"
+msgstr ""
+
+#. MSG_DESC_FILAMENT_CHANGE c=20 r=8
+#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
+msgid "M600 Filament Change. Load a new filament or eject the old one."
 msgstr ""
 
 #. MSG_TITLE_FW_UPDATE_NEEDED c=20

--- a/lang/po/Firmware_cs.po
+++ b/lang/po/Firmware_cs.po
@@ -2529,6 +2529,26 @@ msgstr "NEZNÁMÁ CHYBA"
 msgid "Unexpected error occurred."
 msgstr "Došlo k neočekávané chybě."
 
+#. MSG_BTN_EJECT c=8
+#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:369
+msgid "Eject"
+msgstr "Vyhodit"
+
+#. MSG_TITLE_FILAMENT_CHANGE c=20
+#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
+msgid "FILAMENT CHANGE"
+msgstr "VÝMĚNA FILAMENTU"
+
+#. MSG_BTN_LOAD c=8
+#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:368
+msgid "Load"
+msgstr "Nacist"
+
+#. MSG_DESC_FILAMENT_CHANGE c=20 r=8
+#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
+msgid "M600 Filament Change. Load a new filament or eject the old one."
+msgstr "Výměna vlákna M600. Vložte nové vlákno nebo vyjměte staré."
+
 #~ msgid "XFLASH init"
 #~ msgstr "XFLASH init"
 

--- a/lang/po/Firmware_cs.po
+++ b/lang/po/Firmware_cs.po
@@ -2532,7 +2532,7 @@ msgstr "Došlo k neočekávané chybě."
 #. MSG_BTN_EJECT c=8
 #: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:369
 msgid "Eject"
-msgstr "Vyhodit"
+msgstr "Vysunout"
 
 #. MSG_TITLE_FILAMENT_CHANGE c=20
 #: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
@@ -2542,12 +2542,12 @@ msgstr "VÝMĚNA FILAMENTU"
 #. MSG_BTN_LOAD c=8
 #: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:368
 msgid "Load"
-msgstr "Nacist"
+msgstr "Zavést"
 
 #. MSG_DESC_FILAMENT_CHANGE c=20 r=8
 #: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
 msgid "M600 Filament Change. Load a new filament or eject the old one."
-msgstr "Výměna vlákna M600. Vložte nové vlákno nebo vyjměte staré."
+msgstr "Výměna filamentu M600. Vložte nový filament nebo vysuňte starý."
 
 #~ msgid "XFLASH init"
 #~ msgstr "XFLASH init"

--- a/lang/po/Firmware_de.po
+++ b/lang/po/Firmware_de.po
@@ -2555,6 +2555,26 @@ msgstr "UNBEKANNTER FEHLER"
 msgid "Unexpected error occurred."
 msgstr "Ein unerwarteter Fehler ist aufgetreten."
 
+#. MSG_BTN_EJECT c=8
+#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:369
+msgid "Eject"
+msgstr "Auswerf."
+
+#. MSG_TITLE_FILAMENT_CHANGE c=20
+#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
+msgid "FILAMENT CHANGE"
+msgstr "FILAMENTWECHSEL"
+
+#. MSG_BTN_LOAD c=8
+#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:368
+msgid "Load"
+msgstr "Laden"
+
+#. MSG_DESC_FILAMENT_CHANGE c=20 r=8
+#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
+msgid "M600 Filament Change. Load a new filament or eject the old one."
+msgstr "M600 Filamentwechsel. Laden Sie ein neues Filament oder werfen Sie das alte aus."
+
 #~ msgid "XFLASH init"
 #~ msgstr "XFLASH init"
 

--- a/lang/po/Firmware_es.po
+++ b/lang/po/Firmware_es.po
@@ -2553,6 +2553,26 @@ msgstr "ERROR DESCONOCIDO"
 msgid "Unexpected error occurred."
 msgstr "Ocurrió un error inesperado."
 
+#. MSG_BTN_EJECT c=8
+#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:369
+msgid "Eject"
+msgstr "Expulsar"
+
+#. MSG_TITLE_FILAMENT_CHANGE c=20
+#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
+msgid "FILAMENT CHANGE"
+msgstr "CAMBIO DE FILAMENTO"
+
+#. MSG_BTN_LOAD c=8
+#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:368
+msgid "Load"
+msgstr "Cargar"
+
+#. MSG_DESC_FILAMENT_CHANGE c=20 r=8
+#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
+msgid "M600 Filament Change. Load a new filament or eject the old one."
+msgstr "Cambio de filamento M600. Cargue un filamento nuevo o expulse el anterior."
+
 #~ msgid "XFLASH init"
 #~ msgstr "XFLASH init"
 

--- a/lang/po/Firmware_fr.po
+++ b/lang/po/Firmware_fr.po
@@ -2567,6 +2567,26 @@ msgstr "ERREUR INCONNUE"
 msgid "Unexpected error occurred."
 msgstr "Une erreur inattendue s'est produite."
 
+#. MSG_BTN_EJECT c=8
+#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:369
+msgid "Eject"
+msgstr "Éjecter"
+
+#. MSG_TITLE_FILAMENT_CHANGE c=20
+#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
+msgid "FILAMENT CHANGE"
+msgstr "CHANGEMENT DE FILAM."
+
+#. MSG_BTN_LOAD c=8
+#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:368
+msgid "Load"
+msgstr "Charger"
+
+#. MSG_DESC_FILAMENT_CHANGE c=20 r=8
+#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
+msgid "M600 Filament Change. Load a new filament or eject the old one."
+msgstr "Changement de filament M600. Chargez un nouveau filament ou éjectez l'ancien."
+
 #~ msgid "XFLASH init"
 #~ msgstr "Init XFLASH"
 

--- a/lang/po/Firmware_hr.po
+++ b/lang/po/Firmware_hr.po
@@ -2546,6 +2546,26 @@ msgstr "NEPOZNATA POGREŠKA"
 msgid "Unexpected error occurred."
 msgstr "Došlo je do neočekivane pogreške."
 
+#. MSG_BTN_EJECT c=8
+#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:369
+msgid "Eject"
+msgstr "Izbaciti"
+
+#. MSG_TITLE_FILAMENT_CHANGE c=20
+#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
+msgid "FILAMENT CHANGE"
+msgstr "PROMJENA FILAMENTA"
+
+#. MSG_BTN_LOAD c=8
+#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:368
+msgid "Load"
+msgstr "Napunite"
+
+#. MSG_DESC_FILAMENT_CHANGE c=20 r=8
+#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
+msgid "M600 Filament Change. Load a new filament or eject the old one."
+msgstr "Promjena žarne niti M600. Stavite novu nit ili izbacite staru."
+
 #~ msgid "XFLASH init"
 #~ msgstr "XFLASH  validacija"
 

--- a/lang/po/Firmware_hr.po
+++ b/lang/po/Firmware_hr.po
@@ -2564,7 +2564,7 @@ msgstr "Napunite"
 #. MSG_DESC_FILAMENT_CHANGE c=20 r=8
 #: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
 msgid "M600 Filament Change. Load a new filament or eject the old one."
-msgstr "Promjena žarne niti M600. Stavite novu nit ili izbacite staru."
+msgstr "Promjena filamenta M600. Stavite novu nit ili izbacite staru."
 
 #~ msgid "XFLASH init"
 #~ msgstr "XFLASH  validacija"

--- a/lang/po/Firmware_hu.po
+++ b/lang/po/Firmware_hu.po
@@ -2550,6 +2550,26 @@ msgstr "ISMERETLEN HIBA"
 msgid "Unexpected error occurred."
 msgstr "Váratlan hiba történt."
 
+#. MSG_BTN_EJECT c=8
+#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:369
+msgid "Eject"
+msgstr "Kidobás"
+
+#. MSG_TITLE_FILAMENT_CHANGE c=20
+#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
+msgid "FILAMENT CHANGE"
+msgstr "FILAMENT CSERÉJE"
+
+#. MSG_BTN_LOAD c=8
+#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:368
+msgid "Load"
+msgstr "Betolt."
+
+#. MSG_DESC_FILAMENT_CHANGE c=20 r=8
+#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
+msgid "M600 Filament Change. Load a new filament or eject the old one."
+msgstr "M600 Izzószálcsere. Helyezzen be egy új izzószálat, vagy vegye ki a régit."
+
 #~ msgid "XFLASH init"
 #~ msgstr "XFLASH inicializal"
 

--- a/lang/po/Firmware_hu.po
+++ b/lang/po/Firmware_hu.po
@@ -2553,22 +2553,22 @@ msgstr "Váratlan hiba történt."
 #. MSG_BTN_EJECT c=8
 #: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:369
 msgid "Eject"
-msgstr "Kidobás"
+msgstr "Kiadás"
 
 #. MSG_TITLE_FILAMENT_CHANGE c=20
 #: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
 msgid "FILAMENT CHANGE"
-msgstr "FILAMENT CSERÉJE"
+msgstr "FILAMENT CSERE"
 
 #. MSG_BTN_LOAD c=8
 #: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:368
 msgid "Load"
-msgstr "Betolt."
+msgstr "Betöltés"
 
 #. MSG_DESC_FILAMENT_CHANGE c=20 r=8
 #: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
 msgid "M600 Filament Change. Load a new filament or eject the old one."
-msgstr "M600 Izzószálcsere. Helyezzen be egy új izzószálat, vagy vegye ki a régit."
+msgstr "M600 Filamentcsere. Helyezz be egy új filamentet, vagy vedd ki a régit."
 
 #~ msgid "XFLASH init"
 #~ msgstr "XFLASH inicializal"

--- a/lang/po/Firmware_it.po
+++ b/lang/po/Firmware_it.po
@@ -2551,6 +2551,26 @@ msgstr "ERRORE SCONOSCIUTO"
 msgid "Unexpected error occurred."
 msgstr "Si è verificato un errore imprevisto."
 
+#. MSG_BTN_EJECT c=8
+#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:369
+msgid "Eject"
+msgstr "Espelli"
+
+#. MSG_TITLE_FILAMENT_CHANGE c=20
+#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
+msgid "FILAMENT CHANGE"
+msgstr "CAMBIO FILAMENTO"
+
+#. MSG_BTN_LOAD c=8
+#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:368
+msgid "Load"
+msgstr "Carica"
+
+#. MSG_DESC_FILAMENT_CHANGE c=20 r=8
+#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
+msgid "M600 Filament Change. Load a new filament or eject the old one."
+msgstr "Cambio filamento M600. Carica un nuovo filamento o espelli quello vecchio."
+
 #~ msgid "XFLASH init"
 #~ msgstr "Inizializza XFLASH"
 

--- a/lang/po/Firmware_nl.po
+++ b/lang/po/Firmware_nl.po
@@ -2555,6 +2555,26 @@ msgstr "ONBEKENDE FOUT"
 msgid "Unexpected error occurred."
 msgstr "Er is een onverwachte fout opgetreden."
 
+#. MSG_BTN_EJECT c=8
+#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:369
+msgid "Eject"
+msgstr "Uitwerp."
+
+#. MSG_TITLE_FILAMENT_CHANGE c=20
+#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
+msgid "FILAMENT CHANGE"
+msgstr "FILAMENTWISSELING"
+
+#. MSG_BTN_LOAD c=8
+#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:368
+msgid "Load"
+msgstr "Laad"
+
+#. MSG_DESC_FILAMENT_CHANGE c=20 r=8
+#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
+msgid "M600 Filament Change. Load a new filament or eject the old one."
+msgstr "M600-filamentwissel. Laad een nieuw filament of werp het oude uit."
+
 #~ msgid "XFLASH init"
 #~ msgstr "XFLASH init"
 

--- a/lang/po/Firmware_no.po
+++ b/lang/po/Firmware_no.po
@@ -2541,7 +2541,7 @@ msgstr "ENDRING AV FILAMENT"
 #. MSG_BTN_LOAD c=8
 #: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:368
 msgid "Load"
-msgstr "Laste"
+msgstr "Last"
 
 #. MSG_DESC_FILAMENT_CHANGE c=20 r=8
 #: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340

--- a/lang/po/Firmware_no.po
+++ b/lang/po/Firmware_no.po
@@ -2528,6 +2528,26 @@ msgstr "UKJENT FEIL"
 msgid "Unexpected error occurred."
 msgstr "Det oppstod en uventet feil."
 
+#. MSG_BTN_EJECT c=8
+#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:369
+msgid "Eject"
+msgstr "Løs ut"
+
+#. MSG_TITLE_FILAMENT_CHANGE c=20
+#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
+msgid "FILAMENT CHANGE"
+msgstr "ENDRING AV FILAMENT"
+
+#. MSG_BTN_LOAD c=8
+#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:368
+msgid "Load"
+msgstr "Laste"
+
+#. MSG_DESC_FILAMENT_CHANGE c=20 r=8
+#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
+msgid "M600 Filament Change. Load a new filament or eject the old one."
+msgstr "M600 filamentskifte. Sett inn en ny filament eller løs ut den gamle."
+
 #~ msgid "XFLASH init"
 #~ msgstr "XFLASH init"
 

--- a/lang/po/Firmware_pl.po
+++ b/lang/po/Firmware_pl.po
@@ -2547,6 +2547,26 @@ msgstr "NIEZNANY BŁĄD"
 msgid "Unexpected error occurred."
 msgstr "Pojawił się nieoczekiwany błąd."
 
+#. MSG_BTN_EJECT c=8
+#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:369
+msgid "Eject"
+msgstr "Wyrzucać"
+
+#. MSG_TITLE_FILAMENT_CHANGE c=20
+#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
+msgid "FILAMENT CHANGE"
+msgstr "ZMIANA FILAMENTU"
+
+#. MSG_BTN_LOAD c=8
+#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:368
+msgid "Load"
+msgstr "Zaladuj"
+
+#. MSG_DESC_FILAMENT_CHANGE c=20 r=8
+#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
+msgid "M600 Filament Change. Load a new filament or eject the old one."
+msgstr "Zmiana filamentu M600. Załaduj nowy filament lub wyjmij stary."
+
 #~ msgid "XFLASH init"
 #~ msgstr "XFLASH init"
 

--- a/lang/po/Firmware_pl.po
+++ b/lang/po/Firmware_pl.po
@@ -2550,7 +2550,7 @@ msgstr "Pojawił się nieoczekiwany błąd."
 #. MSG_BTN_EJECT c=8
 #: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:369
 msgid "Eject"
-msgstr "Wyrzucać"
+msgstr "Wypuść"
 
 #. MSG_TITLE_FILAMENT_CHANGE c=20
 #: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
@@ -2560,12 +2560,12 @@ msgstr "ZMIANA FILAMENTU"
 #. MSG_BTN_LOAD c=8
 #: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:368
 msgid "Load"
-msgstr "Zaladuj"
+msgstr "Załaduj"
 
 #. MSG_DESC_FILAMENT_CHANGE c=20 r=8
 #: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
 msgid "M600 Filament Change. Load a new filament or eject the old one."
-msgstr "Zmiana filamentu M600. Załaduj nowy filament lub wyjmij stary."
+msgstr "Załaduj nowy filament lub wyładuj poprzedni."
 
 #~ msgid "XFLASH init"
 #~ msgstr "XFLASH init"

--- a/lang/po/Firmware_ro.po
+++ b/lang/po/Firmware_ro.po
@@ -2559,7 +2559,7 @@ msgstr "Scoateți"
 #. MSG_TITLE_FILAMENT_CHANGE c=20
 #: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
 msgid "FILAMENT CHANGE"
-msgstr "SCHIMBAREA FILAMENT."
+msgstr "SCHIMBARE FILAMENT"
 
 #. MSG_BTN_LOAD c=8
 #: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:368
@@ -2569,7 +2569,7 @@ msgstr "Incarca"
 #. MSG_DESC_FILAMENT_CHANGE c=20 r=8
 #: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
 msgid "M600 Filament Change. Load a new filament or eject the old one."
-msgstr "Schimbarea filamentului M600. Încărcați un filament nou sau scoateți cel vechi."
+msgstr "M600: Schimbare filament. Încarcă un filament nou sau scoate-l pe cel vechi."
 
 #~ msgid "XFLASH init"
 #~ msgstr "Init XFLASH"

--- a/lang/po/Firmware_ro.po
+++ b/lang/po/Firmware_ro.po
@@ -2551,6 +2551,26 @@ msgstr "EROARE NECUNOSCUTĂ"
 msgid "Unexpected error occurred."
 msgstr "A apărut o eroare neașteptată."
 
+#. MSG_BTN_EJECT c=8
+#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:369
+msgid "Eject"
+msgstr "Scoateți"
+
+#. MSG_TITLE_FILAMENT_CHANGE c=20
+#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
+msgid "FILAMENT CHANGE"
+msgstr "SCHIMBAREA FILAMENT."
+
+#. MSG_BTN_LOAD c=8
+#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:368
+msgid "Load"
+msgstr "Incarca"
+
+#. MSG_DESC_FILAMENT_CHANGE c=20 r=8
+#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
+msgid "M600 Filament Change. Load a new filament or eject the old one."
+msgstr "Schimbarea filamentului M600. Încărcați un filament nou sau scoateți cel vechi."
+
 #~ msgid "XFLASH init"
 #~ msgstr "Init XFLASH"
 

--- a/lang/po/Firmware_sk.po
+++ b/lang/po/Firmware_sk.po
@@ -2552,7 +2552,7 @@ msgstr "Zaviest"
 #. MSG_DESC_FILAMENT_CHANGE c=20 r=8
 #: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
 msgid "M600 Filament Change. Load a new filament or eject the old one."
-msgstr "Výmena vlákna M600. Vložte nové vlákno alebo vysuňte staré."
+msgstr "Výmena filamentu M600. Vložte nový filament alebo vysuňte starý."
 
 #~ msgid "XFLASH init"
 #~ msgstr "XFLASH init"

--- a/lang/po/Firmware_sk.po
+++ b/lang/po/Firmware_sk.po
@@ -2534,6 +2534,26 @@ msgstr "NEZNÁMA CHYBA"
 msgid "Unexpected error occurred."
 msgstr "Vyskytla sa neočakávaná chyba."
 
+#. MSG_BTN_EJECT c=8
+#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:369
+msgid "Eject"
+msgstr "Vysunúť"
+
+#. MSG_TITLE_FILAMENT_CHANGE c=20
+#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
+msgid "FILAMENT CHANGE"
+msgstr "ZMENA FILAMENTU"
+
+#. MSG_BTN_LOAD c=8
+#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:368
+msgid "Load"
+msgstr "Zaviest"
+
+#. MSG_DESC_FILAMENT_CHANGE c=20 r=8
+#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
+msgid "M600 Filament Change. Load a new filament or eject the old one."
+msgstr "Výmena vlákna M600. Vložte nové vlákno alebo vysuňte staré."
+
 #~ msgid "XFLASH init"
 #~ msgstr "XFLASH init"
 

--- a/lang/po/Firmware_sk.po
+++ b/lang/po/Firmware_sk.po
@@ -2547,7 +2547,7 @@ msgstr "ZMENA FILAMENTU"
 #. MSG_BTN_LOAD c=8
 #: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:368
 msgid "Load"
-msgstr "Zaviest"
+msgstr "Zaviesť"
 
 #. MSG_DESC_FILAMENT_CHANGE c=20 r=8
 #: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340

--- a/lang/po/Firmware_sv.po
+++ b/lang/po/Firmware_sv.po
@@ -2541,6 +2541,26 @@ msgstr "OKÄNT FEL"
 msgid "Unexpected error occurred."
 msgstr "Ett oväntat fel inträffade."
 
+#. MSG_BTN_EJECT c=8
+#: ../../Firmware/mmu2/errors_list.h:357 ../../Firmware/mmu2/errors_list.h:369
+msgid "Eject"
+msgstr "Mata ut"
+
+#. MSG_TITLE_FILAMENT_CHANGE c=20
+#: ../../Firmware/mmu2/errors_list.h:188 ../../Firmware/mmu2/errors_list.h:235
+msgid "FILAMENT CHANGE"
+msgstr "FILAMENTBYTE"
+
+#. MSG_BTN_LOAD c=8
+#: ../../Firmware/mmu2/errors_list.h:356 ../../Firmware/mmu2/errors_list.h:368
+msgid "Load"
+msgstr "Ladda"
+
+#. MSG_DESC_FILAMENT_CHANGE c=20 r=8
+#: ../../Firmware/mmu2/errors_list.h:285 ../../Firmware/mmu2/errors_list.h:340
+msgid "M600 Filament Change. Load a new filament or eject the old one."
+msgstr "M600 filamentbyte. Ladda en ny filament eller mata ut den gamla."
+
 #~ msgid "XFLASH init"
 #~ msgstr "XFLASH init"
 


### PR DESCRIPTION
The pull request implements a new filament change screen for MMU users as proposed in PFW-1522. The screen is only shown when SpoolJoin is OFF. When SpoolJoin is ON, the printer will automatically try to load the next adjacent slot.

The screen behaves exactly like the new MMU error screens so I won't go into detailed describing that behavior here. The user can select `Eject` to remove any old filament (or just cut the tip of the filament to re-use it). **The screen will only be dismissed after clicking the Load button**. After pressing the `Load` button, the user is presented with a menu to select which slot to load from Filament 1 to Filament 5.

Screenshot of the fullscreen on MK3S+
====

* Default choice is `Load` (always the middle button)

<img src="https://github.com/prusa3d/Prusa-Firmware/assets/8218499/12433dbe-8162-42a1-b687-318e5268a1db" width="500">

Screenshot of the 'More' description fullscreen on MK3S+
====

* Clicking the knob will re-render the menu shown in the image above.

<img src="https://github.com/prusa3d/Prusa-Firmware/assets/8218499/9e4ab635-e7c8-4571-8f78-638ffa83fba2" width="500">

----

Note that since this is not an "error" -- similar to `EJECTED_FILAMENT` -- we need to make sure that the new error code `FILAMENT_CHANGE` does not increment any failure statistic counters.

----
- [x] Update the description when 'More' button is clicked to reflect https://github.com/prusa3d/Prusa-Error-Codes/pull/92/files
- [x] Load filament button should be the default choice (Middle button)
- [x] Make sure `FILAMENT_CHANGE` does not increment any failure statistics.
- [X] Update po files
- [x] Internal translators review
  - [x] CS @DRracer :heavy_check_mark: 
  - [x] DE @3d-gussner :heavy_check_mark: 
  - [x] ES
  - [x] FR
  - [x] IT @wavexx 
  - [x] PL
- [ ] Community translators review
  - [x] HR  @Prime1910 
  - [x] HU @AttilaSVK @Hauzman
  - [x] NL @3d-gussner :heavy_check_mark:  @vintagepc @stelgenhof
  - [x] NO @OS-kar @trondkla
  - [x] RO @leptun @Hauzman 
  - [x] SK @ingbrzy @DRracer :heavy_check_mark: 
  - [x] SV @Painkiller56 
- [X] _Merge PR https://github.com/prusa3d/Prusa-Error-Codes/pull/92_

Change in memory:
Flash: +152 bytes
SRAM: +1 byte