### PR TITLE
`errorCode` should reflect the state of the MMU

### DIFF
--- a/Firmware/mmu2_protocol_logic.cpp
+++ b/Firmware/mmu2_protocol_logic.cpp
@@ -365,6 +365,7 @@ StepStatus ProtocolLogic::ProcessCommandQueryResponse() {
         // It can also be an X0 F which means MMU just successfully restarted.
         if (ReqMsg().code == rsp.request.code && ReqMsg().value == rsp.request.value) {
             progressCode = ProgressCode::OK;
+            errorCode = ErrorCode::OK;
             scopeState = ScopeState::Ready;
             rq = RequestMsg(RequestMsgCodes::unknown, 0); // clear the successfully finished request
             return Finished;


### PR DESCRIPTION
If the protocol reports an error and assigns `errorCode` a value, the value is not reset to `OK` when the error is actually resolved.

If the MMU is not in an error state I would expect `errorCode` to reflect that since we use it to check what is the "current" error code being reported (if any).

This fixes `MMUCurrentErrorCode()`

**Steps to reproduce:**
1. Add a serial print to log the value from `MMUCurrentErrorCode()` ---> `MYSERIAL.println((uint16_t)MMUCurrentErrorCode());`
2. Eject a filament
3. Notice the value is now 32780
4. Click Done on the LCD
5. Notice the value is still 32780, even though the MMU is no longer reporting the error code.

Change in memory:
Flash: +12 bytes
SRAM: 0 bytes