### PR TITLE
Limit scope of `is_mmu_error_monitor_active`

### DIFF
--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -38,8 +38,7 @@ void WaitForHotendTargetTempBeep() {
 MMU2 mmu2;
 
 MMU2::MMU2()
-    : is_mmu_error_monitor_active(false)
-    , logic(&mmu2Serial, MMU2_TOOL_CHANGE_LOAD_LENGTH, MMU2_LOAD_TO_NOZZLE_FEED_RATE)
+    : logic(&mmu2Serial, MMU2_TOOL_CHANGE_LOAD_LENGTH, MMU2_LOAD_TO_NOZZLE_FEED_RATE)
     , extruder(MMU2_NO_TOOL)
     , tool_change_extruder(MMU2_NO_TOOL)
     , resume_position()
@@ -171,7 +170,7 @@ void MMU2::mmu_loop() {
 void __attribute__((noinline)) MMU2::mmu_loop_inner(bool reportErrors) {
     logicStepLastStatus = LogicStep(reportErrors); // it looks like the mmu_loop doesn't need to be a blocking call
 
-    if (is_mmu_error_monitor_active) {
+    if (isErrorScreenRunning()) {
         // Call this every iteration to keep the knob rotation responsive
         // This includes when mmu_loop is called within manage_response
         ReportErrorHook((CommandInProgress)logic.CommandInProgress(), (uint16_t)lastErrorCode, uint8_t(lastErrorSource));

--- a/Firmware/mmu2.h
+++ b/Firmware/mmu2.h
@@ -172,9 +172,6 @@ public:
         }
     }
 
-    // Helper variable to monitor knob in MMU error screen in blocking functions e.g. manage_response
-    bool is_mmu_error_monitor_active;
-
     /// Method to read-only mmu_print_saved
     inline bool MMU_PRINT_SAVED() const { return mmu_print_saved != SavedState::None; }
 

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -212,6 +212,13 @@ enum class ReportErrorHookStates : uint8_t {
 
 enum ReportErrorHookStates ReportErrorHookState = ReportErrorHookStates::RENDER_ERROR_SCREEN;
 
+// Helper variable to monitor knob in MMU error screen in blocking functions e.g. manage_response
+static bool is_mmu_error_monitor_active;
+
+bool isErrorScreenRunning() {
+    return is_mmu_error_monitor_active;
+}
+
 void ReportErrorHook(CommandInProgress /*cip*/, uint16_t ec, uint8_t /*es*/) {
     if (mmu2.MMUCurrentErrorCode() == ErrorCode::OK && mmu2.MMULastErrorSource() == MMU2::ErrorSourceMMU) {
         // If the error code suddenly changes to OK, that means
@@ -228,7 +235,7 @@ void ReportErrorHook(CommandInProgress /*cip*/, uint16_t ec, uint8_t /*es*/) {
         ReportErrorHookState = ReportErrorHookStates::MONITOR_SELECTION;
         [[fallthrough]];
     case (uint8_t)ReportErrorHookStates::MONITOR_SELECTION:
-        mmu2.is_mmu_error_monitor_active = true;
+        is_mmu_error_monitor_active = true;
         ReportErrorHookDynamicRender(); // Render dynamic characters
         sound_wait_for_user();
         switch (ReportErrorHookMonitor(ei)) {
@@ -246,7 +253,7 @@ void ReportErrorHook(CommandInProgress /*cip*/, uint16_t ec, uint8_t /*es*/) {
                 lcd_return_to_status();
                 sound_wait_for_user_reset();
                 // Reset the state in case a new error is reported
-                mmu2.is_mmu_error_monitor_active = false;
+                is_mmu_error_monitor_active = false;
                 ReportErrorHookState = ReportErrorHookStates::RENDER_ERROR_SCREEN;
                 break;
             default:
@@ -260,7 +267,7 @@ void ReportErrorHook(CommandInProgress /*cip*/, uint16_t ec, uint8_t /*es*/) {
         lcd_return_to_status();
         sound_wait_for_user_reset();
         // Reset the state in case a new error is reported
-        mmu2.is_mmu_error_monitor_active = false;
+        is_mmu_error_monitor_active = false;
         ReportErrorHookState = ReportErrorHookStates::RENDER_ERROR_SCREEN;
         break;
     default:

--- a/Firmware/mmu2_reporting.h
+++ b/Firmware/mmu2_reporting.h
@@ -22,6 +22,9 @@ void BeginReport(CommandInProgress cip, uint16_t ec);
 /// Called at the end of every MMU operation
 void EndReport(CommandInProgress cip, uint16_t ec);
 
+/// Return true if the printer's LCD is drawing the error screen
+bool isErrorScreenRunning();
+
 /// @brief Called when the MMU or MK3S sends operation error (even repeatedly).
 /// Render MMU error screen on the LCD. This must be non-blocking
 /// and allow the MMU and printer to communicate with each other.


### PR DESCRIPTION
Move the variable to `mmu2_reporting.cpp` and make it `static`

Change in memory:
Flash: -6 bytes
SRAM: 0 bytes