### PR TITLE
MMU: Remove call to `Enable_E0()` and add one `Disable_E0()`

### DIFF
--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -298,6 +298,8 @@ bool MMU2::VerifyFilamentEnteredPTFE() {
         }
     }
 
+    Disable_E0();
+
     if (fsensorState) {
         IncrementLoadFails();
         return false;

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -871,7 +871,6 @@ void MMU2::filament_ramming() {
 
 void MMU2::execute_extruder_sequence(const E_Step *sequence, uint8_t steps) {
     planner_synchronize();
-    Enable_E0();
 
     const E_Step *step = sequence;
     for (uint8_t i = steps; i ; --i) {


### PR DESCRIPTION
* The call to `Enable_E0()` is redundant because the planner will automatically enable the E-axis when it is moved.
* Disable the E-motor after finishing running try-load-unload sequence. There is no visual/audible difference to the user except for when using `Tx` (single material MMU prints), motor stays quiet while the heaters are heating up :) 

Change in memory:
Flash: +2 bytes
SRAM: 0 bytes