### PR TITLE
MMU: add `UnloadInner` and `CutFilamentInner`

### DIFF
--- a/Firmware/mmu2.h
+++ b/Firmware/mmu2.h
@@ -286,6 +286,8 @@ private:
     bool ToolChangeCommonOnce(uint8_t slot);
 
     void HelpUnloadToFinda();
+    void UnloadInner();
+    void CutFilamentInner(uint8_t slot);
 
     ProtocolLogic logic;          ///< implementation of the protocol logic layer
     uint8_t extruder;             ///< currently active slot in the MMU ... somewhat... not sure where to get it from yet


### PR DESCRIPTION
Sync a little bit with the 32-bit side.
The ReportingRAII does not handle recursion.

Fixes an issue with the multiple calls to
`BeginReport()` and `EndReport()` which triggered unwanted changes to the LCD status line.

Tested on MK3S+ by adding MYSERIAL printfs to `BeginReport()` and `EndReport()`, I can confirm the issue is fixed on my end.

Change in memory:
Flash: +14 bytes
SRAM: 0 bytes