### PR TITLE
Speed up acceleration limit checking

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -6334,7 +6334,7 @@ Sigma_Exit:
               float factor = cs.axis_steps_per_unit[i] / value; // increase e constants if M92 E14 is given for netfab.
               cs.max_jerk[E_AXIS] *= factor;
               max_feedrate[i] *= factor;
-              axis_steps_per_sqr_second[i] *= factor;
+              max_acceleration_steps_per_s2[i] *= factor;
             }
             cs.axis_steps_per_unit[i] = value;
 #if defined(FILAMENT_SENSOR) && (FILAMENT_SENSOR_TYPE == FSENSOR_PAT9125)

--- a/Firmware/planner.cpp
+++ b/Firmware/planner.cpp
@@ -82,7 +82,7 @@ float* max_feedrate = cs.max_feedrate_normal;
 
 // Use M201 to override by software
 unsigned long* max_acceleration_units_per_sq_second = cs.max_acceleration_units_per_sq_second_normal;
-unsigned long axis_steps_per_sqr_second[NUM_AXIS];
+unsigned long max_acceleration_steps_per_s2[NUM_AXIS];
 
 #ifdef ENABLE_AUTO_BED_LEVELING
 // this holds the required transform to compensate for bed level
@@ -1064,14 +1064,14 @@ Having the real displacement of the head, we can calculate the total movement le
 
     // Limit acceleration per axis
     //FIXME Vojtech: One shall rather limit a projection of the acceleration vector instead of using the limit.
-    if(((float)accel * (float)block->steps_x.wide / (float)block->step_event_count.wide) > axis_steps_per_sqr_second[X_AXIS])
-	{  accel = axis_steps_per_sqr_second[X_AXIS]; }
-    if(((float)accel * (float)block->steps_y.wide / (float)block->step_event_count.wide) > axis_steps_per_sqr_second[Y_AXIS])
-	{  accel = axis_steps_per_sqr_second[Y_AXIS]; }
-    if(((float)accel * (float)block->steps_e.wide / (float)block->step_event_count.wide) > axis_steps_per_sqr_second[E_AXIS])
-	{  accel = axis_steps_per_sqr_second[E_AXIS]; }
-    if(((float)accel * (float)block->steps_z.wide / (float)block->step_event_count.wide ) > axis_steps_per_sqr_second[Z_AXIS])
-	{  accel = axis_steps_per_sqr_second[Z_AXIS]; }
+    if(((float)accel * (float)block->steps_x.wide / (float)block->step_event_count.wide) > max_acceleration_steps_per_s2[X_AXIS])
+	{  accel = max_acceleration_steps_per_s2[X_AXIS]; }
+    if(((float)accel * (float)block->steps_y.wide / (float)block->step_event_count.wide) > max_acceleration_steps_per_s2[Y_AXIS])
+	{  accel = max_acceleration_steps_per_s2[Y_AXIS]; }
+    if(((float)accel * (float)block->steps_e.wide / (float)block->step_event_count.wide) > max_acceleration_steps_per_s2[E_AXIS])
+	{  accel = max_acceleration_steps_per_s2[E_AXIS]; }
+    if(((float)accel * (float)block->steps_z.wide / (float)block->step_event_count.wide ) > max_acceleration_steps_per_s2[Z_AXIS])
+	{  accel = max_acceleration_steps_per_s2[Z_AXIS]; }
   }
   // Acceleration of the segment, in mm/sec^2
   block->acceleration_steps_per_s2 = accel;
@@ -1372,7 +1372,7 @@ void set_extrude_min_temp(int temp)
 void reset_acceleration_rates()
 {
 	for(int8_t i=0; i < NUM_AXIS; i++)
-        axis_steps_per_sqr_second[i] = max_acceleration_units_per_sq_second[i] * cs.axis_steps_per_unit[i];
+        max_acceleration_steps_per_s2[i] = max_acceleration_units_per_sq_second[i] * cs.axis_steps_per_unit[i];
 }
 
 #ifdef TMC2130

--- a/Firmware/planner.h
+++ b/Firmware/planner.h
@@ -71,7 +71,7 @@ union dda_usteps_t
 typedef struct {
   // Fields used by the bresenham algorithm for tracing the line
   // steps_x.y,z, step_event_count, acceleration_rate, direction_bits and active_extruder are set by plan_buffer_line().
-  dda_isteps_t steps[NUM_AXIS];  // Step count along each axis
+  dda_isteps_t steps[NUM_AXIS];             // Step count along each axis
   dda_usteps_t step_event_count;            // The number of step events required to complete this block
   uint32_t acceleration_rate;               // The acceleration rate used for acceleration calculation
   unsigned char direction_bits;             // The direction bit set for this block (refers to *_DIRECTION_BIT in config.h)

--- a/Firmware/planner.h
+++ b/Firmware/planner.h
@@ -71,7 +71,7 @@ union dda_usteps_t
 typedef struct {
   // Fields used by the bresenham algorithm for tracing the line
   // steps_x.y,z, step_event_count, acceleration_rate, direction_bits and active_extruder are set by plan_buffer_line().
-  dda_isteps_t steps_x, steps_y, steps_z, steps_e;  // Step count along each axis
+  dda_isteps_t steps[NUM_AXIS];  // Step count along each axis
   dda_usteps_t step_event_count;            // The number of step events required to complete this block
   uint32_t acceleration_rate;               // The acceleration rate used for acceleration calculation
   unsigned char direction_bits;             // The direction bit set for this block (refers to *_DIRECTION_BIT in config.h)

--- a/Firmware/planner.h
+++ b/Firmware/planner.h
@@ -188,7 +188,7 @@ extern float* max_feedrate;
 
 // Use M201 to override by software
 extern unsigned long* max_acceleration_units_per_sq_second; 
-extern unsigned long axis_steps_per_sqr_second[NUM_AXIS];
+extern unsigned long max_acceleration_steps_per_s2[NUM_AXIS];
 
 extern long position[NUM_AXIS];
 

--- a/Firmware/stepper.cpp
+++ b/Firmware/stepper.cpp
@@ -324,7 +324,7 @@ FORCE_INLINE void stepper_next_block()
   current_block = plan_get_current_block();
   if (current_block != NULL) {
 #ifdef BACKLASH_X
-	if (current_block->steps_x.wide)
+	if (current_block->steps[X_AXIS].wide)
 	{ //X-axis movement
 		if ((current_block->direction_bits ^ last_dir_bits) & 1)
 		{
@@ -347,7 +347,7 @@ FORCE_INLINE void stepper_next_block()
 	}
 #endif
 #ifdef BACKLASH_Y
-	if (current_block->steps_y.wide)
+	if (current_block->steps[Y_AXIS].wide)
 	{ //Y-axis movement
 		if ((current_block->direction_bits ^ last_dir_bits) & 2)
 		{
@@ -401,7 +401,7 @@ FORCE_INLINE void stepper_next_block()
       counter_z.lo = counter_x.lo;
       counter_e.lo = counter_x.lo;
 #ifdef LIN_ADVANCE
-      e_extruding = current_block->steps_e.lo != 0;
+      e_extruding = current_block->steps[E_AXIS].lo != 0;
 #endif
     } else {
       counter_x.wide = -(current_block->step_event_count.wide >> 1);
@@ -409,7 +409,7 @@ FORCE_INLINE void stepper_next_block()
       counter_z.wide = counter_x.wide;
       counter_e.wide = counter_x.wide;
 #ifdef LIN_ADVANCE
-      e_extruding = current_block->steps_e.wide != 0;
+      e_extruding = current_block->steps[E_AXIS].wide != 0;
 #endif
     }
     step_events_completed.wide = 0;
@@ -488,7 +488,7 @@ FORCE_INLINE void stepper_check_endstops()
         // Normal homing
         SET_BIT_TO(_endstop, X_AXIS, (READ(X_MIN_PIN) != X_MIN_ENDSTOP_INVERTING));
       #endif
-        if((_endstop & _old_endstop & _BV(X_AXIS)) && (current_block->steps_x.wide > 0)) {
+        if((_endstop & _old_endstop & _BV(X_AXIS)) && (current_block->steps[X_AXIS].wide > 0)) {
 #ifdef VERBOSE_CHECK_HIT_ENDSTOPS
           endstops_trigsteps[X_AXIS] = count_position[X_AXIS];
 #endif //VERBOSE_CHECK_HIT_ENDSTOPS
@@ -505,7 +505,7 @@ FORCE_INLINE void stepper_check_endstops()
         // Normal homing
           SET_BIT_TO(_endstop, X_AXIS + 4, (READ(X_MAX_PIN) != X_MAX_ENDSTOP_INVERTING));
         #endif
-        if((_endstop & _old_endstop & _BV(X_AXIS + 4)) && (current_block->steps_x.wide > 0)){
+        if((_endstop & _old_endstop & _BV(X_AXIS + 4)) && (current_block->steps[X_AXIS].wide > 0)){
 #ifdef VERBOSE_CHECK_HIT_ENDSTOPS
           endstops_trigsteps[X_AXIS] = count_position[X_AXIS];
 #endif //VERBOSE_CHECK_HIT_ENDSTOPS
@@ -529,7 +529,7 @@ FORCE_INLINE void stepper_check_endstops()
       // Normal homing
         SET_BIT_TO(_endstop, Y_AXIS, (READ(Y_MIN_PIN) != Y_MIN_ENDSTOP_INVERTING));
       #endif
-        if((_endstop & _old_endstop & _BV(Y_AXIS)) && (current_block->steps_y.wide > 0)) {
+        if((_endstop & _old_endstop & _BV(Y_AXIS)) && (current_block->steps[Y_AXIS].wide > 0)) {
 #ifdef VERBOSE_CHECK_HIT_ENDSTOPS
           endstops_trigsteps[Y_AXIS] = count_position[Y_AXIS];
 #endif //VERBOSE_CHECK_HIT_ENDSTOPS
@@ -546,7 +546,7 @@ FORCE_INLINE void stepper_check_endstops()
         // Normal homing
           SET_BIT_TO(_endstop, Y_AXIS + 4, (READ(Y_MAX_PIN) != Y_MAX_ENDSTOP_INVERTING));
         #endif
-        if((_endstop & _old_endstop & _BV(Y_AXIS + 4)) && (current_block->steps_y.wide > 0)){
+        if((_endstop & _old_endstop & _BV(Y_AXIS + 4)) && (current_block->steps[Y_AXIS].wide > 0)){
 #ifdef VERBOSE_CHECK_HIT_ENDSTOPS
           endstops_trigsteps[Y_AXIS] = count_position[Y_AXIS];
 #endif //VERBOSE_CHECK_HIT_ENDSTOPS
@@ -571,7 +571,7 @@ FORCE_INLINE void stepper_check_endstops()
         #else
           SET_BIT_TO(_endstop, Z_AXIS, (READ(Z_MIN_PIN) != Z_MIN_ENDSTOP_INVERTING));
         #endif //TMC2130_SG_HOMING
-        if((_endstop & _old_endstop & _BV(Z_AXIS)) && (current_block->steps_z.wide > 0)) {
+        if((_endstop & _old_endstop & _BV(Z_AXIS)) && (current_block->steps[Z_AXIS].wide > 0)) {
 #ifdef VERBOSE_CHECK_HIT_ENDSTOPS
           endstops_trigsteps[Z_AXIS] = count_position[Z_AXIS];
 #endif //VERBOSE_CHECK_HIT_ENDSTOPS
@@ -593,7 +593,7 @@ FORCE_INLINE void stepper_check_endstops()
         #else
         SET_BIT_TO(_endstop, Z_AXIS + 4, (READ(Z_MAX_PIN) != Z_MAX_ENDSTOP_INVERTING));
         #endif //TMC2130_SG_HOMING
-        if((_endstop & _old_endstop & _BV(Z_AXIS + 4)) && (current_block->steps_z.wide > 0)) {
+        if((_endstop & _old_endstop & _BV(Z_AXIS + 4)) && (current_block->steps[Z_AXIS].wide > 0)) {
 #ifdef VERBOSE_CHECK_HIT_ENDSTOPS
           endstops_trigsteps[Z_AXIS] = count_position[Z_AXIS];
 #endif //VERBOSE_CHECK_HIT_ENDSTOPS
@@ -646,7 +646,7 @@ FORCE_INLINE void stepper_tick_lowres()
   for (uint8_t i=0; i < step_loops; ++ i) { // Take multiple steps per interrupt (For high speed moves)
     MSerial.checkRx(); // Check for serial chars.
     // Step in X axis
-    counter_x.lo += current_block->steps_x.lo;
+    counter_x.lo += current_block->steps[X_AXIS].lo;
     if (counter_x.lo > 0) {
       STEP_NC_HI(X_AXIS);
 #ifdef DEBUG_XSTEP_DUP_PIN
@@ -660,7 +660,7 @@ FORCE_INLINE void stepper_tick_lowres()
 #endif //DEBUG_XSTEP_DUP_PIN
     }
     // Step in Y axis
-    counter_y.lo += current_block->steps_y.lo;
+    counter_y.lo += current_block->steps[Y_AXIS].lo;
     if (counter_y.lo > 0) {
       STEP_NC_HI(Y_AXIS);
 #ifdef DEBUG_YSTEP_DUP_PIN
@@ -674,7 +674,7 @@ FORCE_INLINE void stepper_tick_lowres()
 #endif //DEBUG_YSTEP_DUP_PIN    
     }
     // Step in Z axis
-    counter_z.lo += current_block->steps_z.lo;
+    counter_z.lo += current_block->steps[Z_AXIS].lo;
     if (counter_z.lo > 0) {
       STEP_NC_HI(Z_AXIS);
       counter_z.lo -= current_block->step_event_count.lo;
@@ -682,7 +682,7 @@ FORCE_INLINE void stepper_tick_lowres()
       STEP_NC_LO(Z_AXIS);
     }
     // Step in E axis
-    counter_e.lo += current_block->steps_e.lo;
+    counter_e.lo += current_block->steps[E_AXIS].lo;
     if (counter_e.lo > 0) {
 #ifndef LIN_ADVANCE
       STEP_NC_HI(E_AXIS);
@@ -708,7 +708,7 @@ FORCE_INLINE void stepper_tick_highres()
   for (uint8_t i=0; i < step_loops; ++ i) { // Take multiple steps per interrupt (For high speed moves)
     MSerial.checkRx(); // Check for serial chars.
     // Step in X axis
-    counter_x.wide += current_block->steps_x.wide;
+    counter_x.wide += current_block->steps[X_AXIS].wide;
     if (counter_x.wide > 0) {
       STEP_NC_HI(X_AXIS);
 #ifdef DEBUG_XSTEP_DUP_PIN
@@ -722,7 +722,7 @@ FORCE_INLINE void stepper_tick_highres()
 #endif //DEBUG_XSTEP_DUP_PIN
     }
     // Step in Y axis
-    counter_y.wide += current_block->steps_y.wide;
+    counter_y.wide += current_block->steps[Y_AXIS].wide;
     if (counter_y.wide > 0) {
       STEP_NC_HI(Y_AXIS);
 #ifdef DEBUG_YSTEP_DUP_PIN
@@ -736,7 +736,7 @@ FORCE_INLINE void stepper_tick_highres()
 #endif //DEBUG_YSTEP_DUP_PIN    
     }
     // Step in Z axis
-    counter_z.wide += current_block->steps_z.wide;
+    counter_z.wide += current_block->steps[Z_AXIS].wide;
     if (counter_z.wide > 0) {
       STEP_NC_HI(Z_AXIS);
       counter_z.wide -= current_block->step_event_count.wide;
@@ -744,7 +744,7 @@ FORCE_INLINE void stepper_tick_highres()
       STEP_NC_LO(Z_AXIS);
     }
     // Step in E axis
-    counter_e.wide += current_block->steps_e.wide;
+    counter_e.wide += current_block->steps[E_AXIS].wide;
     if (counter_e.wide > 0) {
 #ifndef LIN_ADVANCE
       STEP_NC_HI(E_AXIS);


### PR DESCRIPTION
This is how Marlin 2.1 implements it. I'll run some prints over the weekend, not sure how exactly to test this though, will think about it 🤔 

If the block acceleration is less than `max_acceleration_steps_per_s2`, then the firmware will no longer calculate a division on each respective axis.

The for-loop was essential to save memory, otherwise these changes would _add_ 100 bytes. I changed `dda_isteps_t steps_x, steps_y, steps_z, steps_e` to an array so it is easier to loop through.

Change in memory:
Flash: -314 bytes
SRAM: 0 bytes