### PR TITLE
MMU: Sync `ReportingRAII` with 32-bit FW

### DIFF
--- a/Firmware/mmu2.h
+++ b/Firmware/mmu2.h
@@ -297,6 +297,7 @@ private:
     ErrorCode lastErrorCode = ErrorCode::MMU_NOT_RESPONDING;
     ErrorSource lastErrorSource = ErrorSource::ErrorSourceNone;
     Buttons lastButton = Buttons::NoButton;
+    uint8_t reportingStartedCnt;
 
     StepStatus logicStepLastStatus;
 


### PR DESCRIPTION
This does increase the memory usage quite a bit. I wonder if we can optimise this.

⚠️ The changes are currently untested.

I'm not sure if these changes are needed as `BeingReport()` and `EndReport()` should never be nested now.


Change in memory:
Flash: +210 bytes
SRAM: +2 bytes