### PR TITLE
PFW-1527 `FILAMENT_EJECTED` should not increment fail statistic

### DIFF
--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -929,7 +929,7 @@ void MMU2::ReportError(ErrorCode ec, ErrorSource res) {
         lastErrorSource = res;
         LogErrorEvent_P(_O(PrusaErrorTitle(PrusaErrorCodeIndex((uint16_t)ec))));
 
-        if (ec != ErrorCode::OK) {
+        if (ec != ErrorCode::OK && ec != ErrorCode::FILAMENT_EJECTED) {
             IncrementMMUFails();
 
             // check if it is a "power" failure - we consider TMC-related errors as power failures


### PR DESCRIPTION
Because `FILAMENT_EJECTED` is not really an error, it should not be incrementing the MMU failure statistics in the menus.

Change in memory:
Flash: +8 bytes
SRAM: 0 bytes