### PR TITLE
Log event when planner aborts individual moves

### DIFF
--- a/Firmware/planner.cpp
+++ b/Firmware/planner.cpp
@@ -718,6 +718,8 @@ void plan_buffer_line(float x, float y, float z, const float &e, float feed_rate
 #endif /* PLANNER_DIAGNOSTICS */
   if(planner_aborted) {
       // avoid planning the block early if aborted
+      SERIAL_ECHO_START;
+      SERIAL_ECHOLNRPGM(_n("Move aborted"));
       return;
   }
 


### PR DESCRIPTION
It may be useful to see if any moves are lost. Maybe this can explain the lost Z-move in https://github.com/prusa3d/Prusa-Firmware/issues/4105 ?

Change in memory:
Flash: +32 bytes
SRAM: 0 bytes