### PR TITLE
PFW-1528 Intercept MMU register `0x14`

### DIFF
--- a/Firmware/mmu2_protocol_logic.h
+++ b/Firmware/mmu2_protocol_logic.h
@@ -122,6 +122,17 @@ public:
         return initRegs8[0];
     }
 
+    /// Sets the Pulley slow feed rate to be reported to the MMU.
+    /// Beware - this call doesn't send anything to the MMU.
+    /// The MMU gets the newly set value either by a communication restart or via an explicit WriteRegister call
+    inline void PlanPulleySlowFeedRate(uint8_t psfr) {
+        initRegs8[1] = psfr;
+    }
+    /// @returns the currently preset Pulley slow feed rate
+    inline uint8_t PulleySlowFeedRate() const {
+        return initRegs8[1]; // even though MMU register 0x14 is 16bit, reasonable speeds are way below 255mm/s - saving space ;)
+    }
+
     /// Step the state machine
     StepStatus Step();
 


### PR DESCRIPTION
This commit syncs the 8-bit firmware with the 32-bit

Test procedure:
1. Read the value of the register by sending `M707 A0x14`
2. Run a toolchange and print out the feedrate being used onto serial.
   * Value should be `20` be default.
4. Write the value of the register by sending `M708 A0x14 X40`
5. Read the value of the register by sending `M707 A0x14`
   * Value read should be `40`
6. Run a toolchange and print out the feedrate being used onto serial. It should be `40`

Change in memory:
Flash: +56 bytes
SRAM: 0 bytes