### PR TITLE
🚧 Remove two 5mm extrusions when resuming a print

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3535,12 +3535,6 @@ static void gcode_M600(const bool automatic, const float x_position, const float
     
         // Not let's go back to print
         fanSpeed = fanSpeedBckp;
-    
-        // Feed a little of filament to stabilize pressure
-        if (!automatic) {
-            current_position[E_AXIS] += FILAMENTCHANGE_RECFEED;
-            plan_buffer_line_curposXYZE(FILAMENTCHANGE_EXFEED);
-        }
 
         // Move XY back
         plan_buffer_line(lastpos[X_AXIS], lastpos[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], FILAMENTCHANGE_XYFEED);

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -10648,10 +10648,8 @@ void recover_print(uint8_t automatic) {
 
     // If not automatically recoreverd (long power loss)
     if(automatic == 0){
-        //Extrude some filament to stabilize the pressure
-        enquecommand_P(PSTR("G1 E5 F120"));
         // Retract to be consistent with a short pause
-        enquecommandf_P(G1_E_F2700, default_retraction);
+        enquecommandf_P(G1_E_F2700, -default_retraction);
     }
 
 	printf_P(_N("After waiting for temp:\nCurrent pos X_AXIS:%.3f\nCurrent pos Y_AXIS:%.3f\n"), current_position[X_AXIS], current_position[Y_AXIS]);


### PR DESCRIPTION
Two scenarios which have the exact same extrusion move:

1. When the printer unparks the extruder after running M600 (only when SpoolJoin is disabled)
2. When recovering a print after a long power outage (a long power outage here just means the nozzle is below 175°C)

I think these moves do more harm than good. I've only looked at the power panic scenario so far but I suspect the M600 one is also not helping. Needs to be tested more.

Change in memory:
Flash: -92 bytes
SRAM: 0 bytes