### PR TITLE
Fixed printer_smodel_check for MK3/S and possible older MMU machines

### DIFF
--- a/Firmware/util.cpp
+++ b/Firmware/util.cpp
@@ -408,13 +408,13 @@ return pStrBegin;
 
 void printer_smodel_check(const char *pStrPos, const char *actualPrinterSModel) {
     char* pResult;
-    char gStr[12];
+    char gStr[8];
     size_t nLength;
 
     pResult=code_string(pStrPos,&nLength);
     if(pResult != NULL) {
 
-        if(nLength > 11) nLength = 11;
+        if(nLength > 7) nLength = 7;
         memcpy(gStr, pResult, nLength);
         gStr[nLength] = 0;
 

--- a/Firmware/util.cpp
+++ b/Firmware/util.cpp
@@ -407,16 +407,21 @@ return pStrBegin;
 }
 
 void printer_smodel_check(const char *pStrPos, const char *actualPrinterSModel) {
-char* pResult;
-size_t nLength;
+    char* pResult;
+    char gStr[12];
+    size_t nLength;
 
-pResult=code_string(pStrPos,&nLength);
+    pResult=code_string(pStrPos,&nLength);
+    if(pResult != NULL) {
 
-if(pResult != NULL) {
-    // Only compare first 6 chars on MK3|MK3S
-    if (strncmp_P(pResult, PSTR("MK3"), 3) == 0) nLength = 6;
-    if (strncmp_P(pResult, actualPrinterSModel, nLength) == 0) return;
-}
+        if(nLength > 11) nLength = 11;
+        memcpy(gStr, pResult, nLength);
+        gStr[nLength] = 0;
+
+        // Only compare first 5 chars on MK3|MK3S
+        if(strncmp_P(gStr, PSTR("MK3"), 3) == 0) nLength = 5;    
+        if (strncmp_P(gStr, actualPrinterSModel, nLength) == 0) return;
+    }
 
     render_M862_warnings(
         _T(MSG_GCODE_DIFF_PRINTER_CONTINUE)

--- a/Firmware/util.cpp
+++ b/Firmware/util.cpp
@@ -408,19 +408,17 @@ return pStrBegin;
 
 void printer_smodel_check(const char *pStrPos, const char *actualPrinterSModel) {
     char* pResult;
-    char gStr[8];
     size_t nLength;
+    size_t aLength;
 
     pResult=code_string(pStrPos,&nLength);
     if(pResult != NULL) {
+        aLength=strlen_P(actualPrinterSModel);
+        if(aLength > nLength) nLength = aLength;
 
-        if(nLength > 7) nLength = 7;
-        memcpy(gStr, pResult, nLength);
-        gStr[nLength] = 0;
-
-        // Only compare first 5 chars on MK3|MK3S
-        if(strncmp_P(gStr, PSTR("MK3"), 3) == 0) nLength = 5;    
-        if (strncmp_P(gStr, actualPrinterSModel, nLength) == 0) return;
+        // Only compare first 6 chars on MK3|MK3S if string longer than 4 characters
+        if (nLength > 4 && strncmp_P(pResult, PSTR("MK3"), 3) == 0) nLength = 6;
+        if (strncmp_P(pResult, actualPrinterSModel, nLength) == 0) return;
     }
 
     render_M862_warnings(


### PR DESCRIPTION
As seen in [this bug report](https://github.com/prusa3d/Prusa-Firmware/issues/4258), commit [136ef96](https://github.com/prusa3d/Prusa-Firmware/commit/136ef9696d51715481a6e3f3774d9eaef3ea5d57) broke the compatibility check for MK3/S without MMU.

### MK3/S (non-MMU) Problem
The problem was caused by setting `nLength` to 6 for MK3 machines. This is because the string that is being compared is a pointer directly to the gcode string, which there is no null terminator character, causing a double quote to be included in the comparison (i.e. MK3S" to MK3S). This is actually what probably hid the issue from non-MMU machines.

### Older MMU Machines
I also believe I found and fixed another bug for the older MMU machines.
`nLength` is retrieved from `code_string`, which causes only the length of the gcode value to be compared.
If you were using a MK2SMMU, and were trying to run gcode sliced for MK2S, it would only compare 4 characters, causing `strncmp_P` to return equal, not displaying the warning.
I'm not 100% sure this isn't a feature though, maybe the older MMU machines are capable of running gcode sliced for non-MMU machine? This wasn't a problem for the MK3/S MMU because `nLength` was getting set to 6.

### Fix
All that was needed to fix the issue was to add a length check as seen on line 420,
and for older machines, making `strncmp_P` compare to the maximum length of both values, as seen on line 417.


### Before merging
If the older MMU machines are **not supposed to be warned when running non-MMU g-code**, a couple changes need to be made.
Currently **my code will give them a warning,** so if it is correct in that they should receive a warning, it is safe to merge.
If anyone can confirm that it is actually a feature to not be displayed the warning, I will make the changes and make a new commit.
