### PR TITLE
Generalize description of MMU MCU power errors

### DIFF
--- a/Firmware/mmu2/errors_list.h
+++ b/Firmware/mmu2/errors_list.h
@@ -62,7 +62,7 @@ typedef enum : uint16_t {
     ERR_ELECTRICAL_MMU_SELECTOR_SELFTEST_FAILED = 315,
     ERR_ELECTRICAL_MMU_IDLER_SELFTEST_FAILED = 325,
 
-    ERR_ELECTRICAL_MCU_UNDERVOLTAGE_VCC = 306,
+    ERR_ELECTRICAL_MMU_MCU_ERROR = 306,
 
     ERR_CONNECT = 400,
     ERR_CONNECT_MMU_NOT_RESPONDING = 401,
@@ -119,7 +119,7 @@ static const constexpr uint16_t errorCodes[] PROGMEM = {
     ERR_ELECTRICAL_MMU_PULLEY_SELFTEST_FAILED,
     ERR_ELECTRICAL_MMU_SELECTOR_SELFTEST_FAILED,
     ERR_ELECTRICAL_MMU_IDLER_SELFTEST_FAILED,
-    ERR_ELECTRICAL_MCU_UNDERVOLTAGE_VCC,
+    ERR_ELECTRICAL_MMU_MCU_ERROR,
     ERR_CONNECT_MMU_NOT_RESPONDING,
     ERR_CONNECT_COMMUNICATION_ERROR,
     ERR_SYSTEM_FILAMENT_ALREADY_LOADED, 
@@ -173,7 +173,7 @@ static const char MSG_TITLE_SELFTEST_FAILED[] PROGMEM_I1      = ISTR("MMU SELFTE
 //static const char MSG_TITLE_MMU_PULLEY_SELFTEST_FAILED[] PROGMEM_I1      = ISTR("MMU SELFTEST FAILED");
 //static const char MSG_TITLE_MMU_SELECTOR_SELFTEST_FAILED[] PROGMEM_I1      = ISTR("MMU SELFTEST FAILED");
 //static const char MSG_TITLE_MMU_IDLER_SELFTEST_FAILED[] PROGMEM_I1      = ISTR("MMU SELFTEST FAILED");
-static const char MSG_TITLE_MCU_UNDERVOLTAGE_VCC[] PROGMEM_I1      = ISTR("MMU MCU UNDERPOWER"); ////MSG_TITLE_MCU_UNDERVOLTAGE_VCC c=20
+static const char MSG_TITLE_MMU_MCU_ERROR[] PROGMEM_I1      = ISTR("MMU MCU ERROR"); ////MSG_TITLE_MMU_MCU_ERROR c=20
 static const char MSG_TITLE_MMU_NOT_RESPONDING[] PROGMEM_I1      = ISTR("MMU NOT RESPONDING"); ////MSG_TITLE_MMU_NOT_RESPONDING c=20
 static const char MSG_TITLE_COMMUNICATION_ERROR[] PROGMEM_I1     = ISTR("COMMUNICATION ERROR"); ////MSG_TITLE_COMMUNICATION_ERROR c=20
 static const char MSG_TITLE_FILAMENT_ALREADY_LOADED[] PROGMEM_I1 = ISTR("FIL. ALREADY LOADED"); ////MSG_TITLE_FILAMENT_ALREADY_LOADED c=20
@@ -219,7 +219,7 @@ static const char * const errorTitles [] PROGMEM = {
     _R(MSG_TITLE_SELFTEST_FAILED),
     _R(MSG_TITLE_SELFTEST_FAILED),
     _R(MSG_TITLE_SELFTEST_FAILED),
-    _R(MSG_TITLE_MCU_UNDERVOLTAGE_VCC),
+    _R(MSG_TITLE_MMU_MCU_ERROR),
     _R(MSG_TITLE_MMU_NOT_RESPONDING),
     _R(MSG_TITLE_COMMUNICATION_ERROR),
     _R(MSG_TITLE_FILAMENT_ALREADY_LOADED),
@@ -240,7 +240,7 @@ static const char MSG_DESC_FSENSOR_DIDNT_TRIGGER[] PROGMEM_I1 = ISTR("Filament s
 static const char MSG_DESC_FSENSOR_FILAMENT_STUCK[] PROGMEM_I1 = ISTR("Filament sensor didn't switch off while unloading filament. Ensure filament can move and the sensor works."); ////MSG_DESC_FSENSOR_FILAMENT_STUCK c=20 r=8
 static const char MSG_DESC_PULLEY_CANNOT_MOVE[] PROGMEM_I1 = ISTR("Pulley motor stalled. Ensure the pulley can move and check the wiring."); ////MSG_DESC_PULLEY_CANNOT_MOVE c=20 r=8
 static const char MSG_DESC_FSENSOR_TOO_EARLY[] PROGMEM_I1 = ISTR("Filament sensor triggered too early while loading to extruder. Check there isn't anything stuck in PTFE tube. Check that sensor reads properly."); ////MSG_DESC_FSENSOR_TOO_EARLY c=20 r=8
-static const char MSG_DESC_INSPECT_FINDA[] PROGMEM_I1 = ISTR("Selector can't move due to FINDA detecting a filament. Make sure no filament is in selector and FINDA works properly."); ////MSG_DESC_INSPECT_FINDA c=20 r=8
+static const char MSG_DESC_INSPECT_FINDA[] PROGMEM_I1 = ISTR("Selector can't move due to FINDA detecting a filament. Make sure no filament is in Selector and FINDA works properly."); ////MSG_DESC_INSPECT_FINDA c=20 r=8
 static const char MSG_DESC_LOAD_TO_EXTRUDER_FAILED[] PROGMEM_I1 = ISTR("Loading to extruder failed. Inspect the filament tip shape. Refine the sensor calibration, if needed."); ////MSG_DESC_LOAD_TO_EXTRUDER_FAILED c=20 r=8
 static const char MSG_DESC_SELECTOR_CANNOT_HOME[] PROGMEM_I1 = ISTR("The Selector cannot home properly. Check for anything blocking its movement."); ////MSG_DESC_SELECTOR_CANNOT_HOME c=20 r=8
 static const char MSG_DESC_CANNOT_MOVE[] PROGMEM_I1 = ISTR("Can't move Selector or Idler."); /////MSG_DESC_CANNOT_MOVE c=20 r=4
@@ -269,7 +269,7 @@ static const char MSG_DESC_TMC[] PROGMEM_I1 = ISTR("More details online."); ////
 //static const char MSG_DESC_MMU_PULLEY_SELFTEST_FAILED[] PROGMEM_I1 = ISTR("MMU selftest failed on the Pulley TMC driver. Check the wiring and connectors. If the issue persists contact support.");
 //static const char MSG_DESC_MMU_SELECTOR_SELFTEST_FAILED[] PROGMEM_I1 = ISTR("MMU selftest failed on the Selector TMC driver. Check the wiring and connectors. If the issue persists contact support.");
 //static const char MSG_DESC_MMU_IDLER_SELFTEST_FAILED[] PROGMEM_I1 = ISTR("MMU selftest failed on the Idler TMC driver. Check the wiring and connectors. If the issue persists contact support.");
-//static const char MSG_DESC_MCU_UNDERVOLTAGE_VCC[] PROGMEM_I1 = ISTR("MMU MCU detected a 5V undervoltage. There might be an issue with the electronics. Check the wiring and connectors"); ////MSG_DESC_MCU_UNDERVOLTAGE_VCC c=20 r=8
+//static const char MSG_DESC_MMU_MCU_ERROR[] PROGMEM_I1 = ISTR("MMU detected a power-related issue. Check the wiring and connectors. If the issue persists, contact support."); ////MSG_DESC_MMU_MCU_ERROR c=20 r=8
 static const char MSG_DESC_MMU_NOT_RESPONDING[] PROGMEM_I1 = ISTR("MMU not responding. Check the wiring and connectors."); ////MSG_DESC_MMU_NOT_RESPONDING c=20 r=4
 static const char MSG_DESC_COMMUNICATION_ERROR[] PROGMEM_I1 = ISTR("MMU not responding correctly. Check the wiring and connectors."); ////MSG_DESC_COMMUNICATION_ERROR c=20 r=4
 static const char MSG_DESC_FILAMENT_ALREADY_LOADED[] PROGMEM_I1 = ISTR("Cannot perform the action, filament is already loaded. Unload it first."); ////MSG_DESC_FILAMENT_ALREADY_LOADED c=20 r=8
@@ -322,7 +322,7 @@ static const char * const errorDescs[] PROGMEM = {
     _R(MSG_DESC_TMC), // descMMU_PULLEY_SELFTEST_FAILED
     _R(MSG_DESC_TMC), // descMMU_SELECTOR_SELFTEST_FAILED
     _R(MSG_DESC_TMC), // descMMU_IDLER_SELFTEST_FAILED
-    _R(MSG_DESC_TMC), // descMSG_DESC_MCU_UNDERVOLTAGE_VCC
+    _R(MSG_DESC_TMC), // descMSG_DESC_MMU_MCU_ERROR
     _R(MSG_DESC_MMU_NOT_RESPONDING),
     _R(MSG_DESC_COMMUNICATION_ERROR),
     _R(MSG_DESC_FILAMENT_ALREADY_LOADED),
@@ -405,7 +405,7 @@ static const uint8_t errorButtons[] PROGMEM = {
     Btns(ButtonOperations::ResetMMU, ButtonOperations::NoOperation),//MMU_PULLEY_SELFTEST_FAILED
     Btns(ButtonOperations::ResetMMU, ButtonOperations::NoOperation),//MMU_SELECTOR_SELFTEST_FAILED
     Btns(ButtonOperations::ResetMMU, ButtonOperations::NoOperation),//MMU_IDLER_SELFTEST_FAILED
-    Btns(ButtonOperations::ResetMMU, ButtonOperations::NoOperation),//MCU_UNDERVOLTAGE_VCC
+    Btns(ButtonOperations::ResetMMU, ButtonOperations::NoOperation),//MMU_MCU_ERROR
     Btns(ButtonOperations::ResetMMU, ButtonOperations::DisableMMU),//MMU_NOT_RESPONDING
     Btns(ButtonOperations::ResetMMU, ButtonOperations::DisableMMU),//COMMUNICATION_ERROR
 

--- a/Firmware/mmu2_error_converter.cpp
+++ b/Firmware/mmu2_error_converter.cpp
@@ -85,7 +85,7 @@ uint8_t PrusaErrorCodeIndex(uint16_t ec) {
     case (uint16_t)ErrorCode::FINDA_VS_EEPROM_DISREPANCY:
         return FindErrorIndex(ERR_SYSTEM_UNLOAD_MANUALLY);
     case (uint16_t)ErrorCode::MCU_UNDERVOLTAGE_VCC:
-        return FindErrorIndex(ERR_ELECTRICAL_MCU_UNDERVOLTAGE_VCC);
+        return FindErrorIndex(ERR_ELECTRICAL_MMU_MCU_ERROR);
     }
     
     // Electrical issues which can be detected somehow.
@@ -267,7 +267,7 @@ Buttons ButtonAvailable(uint16_t ec) {
 
     case ERR_SYSTEM_QUEUE_FULL:
     case ERR_SYSTEM_FW_RUNTIME_ERROR:
-    case ERR_ELECTRICAL_MCU_UNDERVOLTAGE_VCC:
+    case ERR_ELECTRICAL_MMU_MCU_ERROR:
         switch (buttonSelectedOperation) {
         case ButtonOperations::ResetMMU: // "Reset MMU"
             return ResetMMU;

--- a/lang/po/Firmware.pot
+++ b/lang/po/Firmware.pot
@@ -1870,7 +1870,7 @@ msgstr ""
 #: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:298
 msgid ""
 "Selector can't move due to FINDA detecting a filament. Make sure no filament"
-" is in selector and FINDA works properly."
+" is in Selector and FINDA works properly."
 msgstr ""
 
 #. MSG_SELFTEST_OK c=20

--- a/lang/po/Firmware.pot
+++ b/lang/po/Firmware.pot
@@ -1088,9 +1088,9 @@ msgstr ""
 msgid "MMU Firmware internal error, please reset the MMU."
 msgstr ""
 
-#. MSG_TITLE_MCU_UNDERVOLTAGE_VCC c=20
+#. MSG_TITLE_MCU_ERROR c=20
 #: ../../Firmware/mmu2/errors_list.h:176 ../../Firmware/mmu2/errors_list.h:222
-msgid "MMU MCU UNDERPOWER"
+msgid "MMU MCU ERROR"
 msgstr ""
 
 #. MSG_MMU_MODE c=8

--- a/lang/po/Firmware_cs.po
+++ b/lang/po/Firmware_cs.po
@@ -1117,7 +1117,7 @@ msgstr "MMU opakovani: Obnova teploty..."
 #: ../../Firmware/mmu2/errors_list.h:172 ../../Firmware/mmu2/errors_list.h:219
 #: ../../Firmware/mmu2/errors_list.h:220 ../../Firmware/mmu2/errors_list.h:221
 msgid "MMU SELFTEST FAILED"
-msgstr "MMU SELFTEST SELAHL"
+msgstr "MMU SELFTEST SELHAL"
 
 #. MSG_MMU_FAILS c=15
 #: ../../Firmware/messages.cpp:68 ../../Firmware/ultralcd.cpp:1118
@@ -2468,10 +2468,10 @@ msgstr ""
 "Načítání do extrudéru se nezdařilo. Zkontrolujte tvar špičky vlákna. V "
 "případě potřeby upřesněte kalibraci snímače."
 
-#. MSG_TITLE_MCU_UNDERVOLTAGE_VCC c=20
+#. MSG_TITLE_MCU_ERROR c=20
 #: ../../Firmware/mmu2/errors_list.h:176 ../../Firmware/mmu2/errors_list.h:222
-msgid "MMU MCU UNDERPOWER"
-msgstr "MCU PODPĚTÍ VCC"
+msgid "MMU MCU ERROR"
+msgstr "MMU MCU CHYBA"
 
 #. MSG_MATERIAL_CHANGES c=18
 #: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:1095

--- a/lang/po/Firmware_cs.po
+++ b/lang/po/Firmware_cs.po
@@ -2493,7 +2493,7 @@ msgstr "ResetMMU"
 #: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:298
 msgid ""
 "Selector can't move due to FINDA detecting a filament. Make sure no filament"
-" is in selector and FINDA works properly."
+" is in Selector and FINDA works properly."
 msgstr ""
 "Selektor se nemůže pohybovat, protože FINDA detekuje vlákno. Ujistěte se, že"
 " ve voliči není žádné vlákno a FINDA funguje správně."

--- a/lang/po/Firmware_de.po
+++ b/lang/po/Firmware_de.po
@@ -2496,10 +2496,10 @@ msgstr ""
 "Laden in den Extruder fehlgeschlagen. Überprüfe die Form der Filamentspitze."
 " Verfeiner die Sensorkalibrierung, falls erforderlich."
 
-#. MSG_TITLE_MCU_UNDERVOLTAGE_VCC c=20
+#. MSG_TITLE_MCU_ERROR c=20
 #: ../../Firmware/mmu2/errors_list.h:176 ../../Firmware/mmu2/errors_list.h:222
-msgid "MMU MCU UNDERPOWER"
-msgstr "MCU-UNTERSPANN. VCC"
+msgid "MMU MCU ERROR"
+msgstr "MMU MCU FEHLER"
 
 #. MSG_MATERIAL_CHANGES c=18
 #: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:1095

--- a/lang/po/Firmware_de.po
+++ b/lang/po/Firmware_de.po
@@ -2521,7 +2521,7 @@ msgstr "ResetMMU"
 #: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:298
 msgid ""
 "Selector can't move due to FINDA detecting a filament. Make sure no filament"
-" is in selector and FINDA works properly."
+" is in Selector and FINDA works properly."
 msgstr ""
 "Selektor kann sich nicht bewegen, da FINDA Fil. erkennt wird. Stelle sicher,"
 " dass sich kein Fil. im Selektor befindet und FINDA ricchtig funktioniert."

--- a/lang/po/Firmware_es.po
+++ b/lang/po/Firmware_es.po
@@ -2516,7 +2516,7 @@ msgstr "ResetMMU"
 #: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:298
 msgid ""
 "Selector can't move due to FINDA detecting a filament. Make sure no filament"
-" is in selector and FINDA works properly."
+" is in Selector and FINDA works properly."
 msgstr ""
 "El selector no se puede mover debido a que FINDA detecta un filamento. "
 "Asegúrese de que no haya fil. en el selector y que FINDA funcione "

--- a/lang/po/Firmware_es.po
+++ b/lang/po/Firmware_es.po
@@ -2491,10 +2491,10 @@ msgstr ""
 "Error al cargar en la extrusora. Inspeccione la forma de la punta del "
 "filamento. Refine la calibración del sensor, si es necesario."
 
-#. MSG_TITLE_MCU_UNDERVOLTAGE_VCC c=20
+#. MSG_TITLE_MCU_ERROR c=20
 #: ../../Firmware/mmu2/errors_list.h:176 ../../Firmware/mmu2/errors_list.h:222
-msgid "MMU MCU UNDERPOWER"
-msgstr "MCU BAJO VOLTAJE VCC"
+msgid "MMU MCU ERROR"
+msgstr "MMU MCU ERROR"
 
 #. MSG_MATERIAL_CHANGES c=18
 #: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:1095

--- a/lang/po/Firmware_fr.po
+++ b/lang/po/Firmware_fr.po
@@ -2506,10 +2506,10 @@ msgstr ""
 "Le chargement dans l'extrudeuse a échoué. Inspectez la forme de la pointe du"
 " filament. Affiner l'étalonnage du capteur, si nécessaire."
 
-#. MSG_TITLE_MCU_UNDERVOLTAGE_VCC c=20
+#. MSG_TITLE_MCU_ERROR c=20
 #: ../../Firmware/mmu2/errors_list.h:176 ../../Firmware/mmu2/errors_list.h:222
-msgid "MMU MCU UNDERPOWER"
-msgstr "MCU SOUS-TENSION VCC"
+msgid "MMU MCU ERROR"
+msgstr "MMU MCU ERREUR"
 
 #. MSG_MATERIAL_CHANGES c=18
 #: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:1095

--- a/lang/po/Firmware_fr.po
+++ b/lang/po/Firmware_fr.po
@@ -2531,7 +2531,7 @@ msgstr "ResetMMU"
 #: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:298
 msgid ""
 "Selector can't move due to FINDA detecting a filament. Make sure no filament"
-" is in selector and FINDA works properly."
+" is in Selector and FINDA works properly."
 msgstr ""
 "Le sélecteur ne peut pas bouger car FINDA détecte un filament. Assurez-vous "
 "qu'aucun fil. n'est dans le sélecteur et que FINDA fonctionne correctement."

--- a/lang/po/Firmware_hr.po
+++ b/lang/po/Firmware_hr.po
@@ -2485,10 +2485,10 @@ msgstr ""
 "Učitavanje u ekstruder nije uspjelo. Provjerite oblik vrha žarne niti. "
 "Poboljšajte kalibraciju senzora, ako je potrebno."
 
-#. MSG_TITLE_MCU_UNDERVOLTAGE_VCC c=20
+#. MSG_TITLE_MCU_ERROR c=20
 #: ../../Firmware/mmu2/errors_list.h:176 ../../Firmware/mmu2/errors_list.h:222
-msgid "MMU MCU UNDERPOWER"
-msgstr "MCU PODNAPON VCC"
+msgid "MMU MCU ERROR"
+msgstr "MMU MCU GRESKA"
 
 #. MSG_MATERIAL_CHANGES c=18
 #: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:1095

--- a/lang/po/Firmware_hr.po
+++ b/lang/po/Firmware_hr.po
@@ -2510,7 +2510,7 @@ msgstr "ResetMMU"
 #: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:298
 msgid ""
 "Selector can't move due to FINDA detecting a filament. Make sure no filament"
-" is in selector and FINDA works properly."
+" is in Selector and FINDA works properly."
 msgstr ""
 "Selektor se ne može pomaknuti jer FINDA otkriva nit. Uvjerite se da niti "
 "jedna nit nije u selektoru i da FINDA radi ispravno."

--- a/lang/po/Firmware_hu.po
+++ b/lang/po/Firmware_hu.po
@@ -2514,7 +2514,7 @@ msgstr "ResetMMU"
 #: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:298
 msgid ""
 "Selector can't move due to FINDA detecting a filament. Make sure no filament"
-" is in selector and FINDA works properly."
+" is in Selector and FINDA works properly."
 msgstr ""
 "A szelektor nem tud mozogni, mert a FINDA filamentet észlelt. Győződj meg "
 "arról,hogy nincs fil. a szelektorban, és a FINDA megfelelően működik."

--- a/lang/po/Firmware_hu.po
+++ b/lang/po/Firmware_hu.po
@@ -2489,10 +2489,10 @@ msgstr ""
 "Az extruderbe való betöltés nem sikerült. Ellenőrizze az fil. hegyének "
 "alakját. Ha szükséges, finomítsd az érzékelő kalibrálását."
 
-#. MSG_TITLE_MCU_UNDERVOLTAGE_VCC c=20
+#. MSG_TITLE_MCU_ERROR c=20
 #: ../../Firmware/mmu2/errors_list.h:176 ../../Firmware/mmu2/errors_list.h:222
-msgid "MMU MCU UNDERPOWER"
-msgstr "MCU VCC ALACSONY"
+msgid "MMU MCU ERROR"
+msgstr "MMU MCU HIBA"
 
 #. MSG_MATERIAL_CHANGES c=18
 #: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:1095

--- a/lang/po/Firmware_it.po
+++ b/lang/po/Firmware_it.po
@@ -2490,10 +2490,10 @@ msgstr ""
 "Caricamento nell' estrusore non riuscito. Ispezionare la forma della punta "
 "del fil. Affinare la calib. del sensore, se necessario."
 
-#. MSG_TITLE_MCU_UNDERVOLTAGE_VCC c=20
+#. MSG_TITLE_MCU_ERROR c=20
 #: ../../Firmware/mmu2/errors_list.h:176 ../../Firmware/mmu2/errors_list.h:222
-msgid "MMU MCU UNDERPOWER"
-msgstr "SOTTOTENSION MCU VCC"
+msgid "MMU MCU ERROR"
+msgstr "ERRORE MMU MCU"
 
 #. MSG_MATERIAL_CHANGES c=18
 #: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:1095

--- a/lang/po/Firmware_it.po
+++ b/lang/po/Firmware_it.po
@@ -2515,7 +2515,7 @@ msgstr "ResetMMU"
 #: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:298
 msgid ""
 "Selector can't move due to FINDA detecting a filament. Make sure no filament"
-" is in selector and FINDA works properly."
+" is in Selector and FINDA works properly."
 msgstr ""
 "Il selettore non può muoversi perché FINDA rileva un fil. Assicurati che "
 "nessun fil. sia nel selettore e che FINDA funzioni correttamente."

--- a/lang/po/Firmware_nl.po
+++ b/lang/po/Firmware_nl.po
@@ -2494,10 +2494,10 @@ msgstr ""
 "Laden naar extruder is mislukt. Inspecteer de vorm van de filamenttip. "
 "Verfijn de sensorkalibratie, indien nodig."
 
-#. MSG_TITLE_MCU_UNDERVOLTAGE_VCC c=20
+#. MSG_TITLE_MCU_ERROR c=20
 #: ../../Firmware/mmu2/errors_list.h:176 ../../Firmware/mmu2/errors_list.h:222
-msgid "MMU MCU UNDERPOWER"
-msgstr "MCU ONDERSPANN. VCC"
+msgid "MMU MCU ERROR"
+msgstr "MMU MCU FOUT"
 
 #. MSG_MATERIAL_CHANGES c=18
 #: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:1095

--- a/lang/po/Firmware_nl.po
+++ b/lang/po/Firmware_nl.po
@@ -2519,7 +2519,7 @@ msgstr "ResetMMU"
 #: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:298
 msgid ""
 "Selector can't move due to FINDA detecting a filament. Make sure no filament"
-" is in selector and FINDA works properly."
+" is in Selector and FINDA works properly."
 msgstr ""
 "Selector kan niet bewegen omdat FINDA een filament detecteert. Zorg ervoor "
 "dat er geen fil. in de selector zit en dat FINDA naar behoren werkt."

--- a/lang/po/Firmware_no.po
+++ b/lang/po/Firmware_no.po
@@ -2492,7 +2492,7 @@ msgstr "ResetMMU"
 #: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:298
 msgid ""
 "Selector can't move due to FINDA detecting a filament. Make sure no filament"
-" is in selector and FINDA works properly."
+" is in Selector and FINDA works properly."
 msgstr ""
 "Velgeren kan ikke bevege seg på grunn av at FINDA oppdager en filament. Sørg"
 " for at ingen fil. er i velgeren og at FINDA fungerer som den skal."

--- a/lang/po/Firmware_no.po
+++ b/lang/po/Firmware_no.po
@@ -2467,10 +2467,10 @@ msgstr ""
 "Lasting til ekstruder mislyktes. Inspiser filamentspissens form. Avgrens "
 "sensorkalibreringen om nødvendig."
 
-#. MSG_TITLE_MCU_UNDERVOLTAGE_VCC c=20
+#. MSG_TITLE_MCU_ERROR c=20
 #: ../../Firmware/mmu2/errors_list.h:176 ../../Firmware/mmu2/errors_list.h:222
-msgid "MMU MCU UNDERPOWER"
-msgstr "MCU UNDERSPENN. VCC"
+msgid "MMU MCU ERROR"
+msgstr "MMU MCU FEIL"
 
 #. MSG_MATERIAL_CHANGES c=18
 #: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:1095

--- a/lang/po/Firmware_pl.po
+++ b/lang/po/Firmware_pl.po
@@ -2511,7 +2511,7 @@ msgstr "ResetMMU"
 #: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:298
 msgid ""
 "Selector can't move due to FINDA detecting a filament. Make sure no filament"
-" is in selector and FINDA works properly."
+" is in Selector and FINDA works properly."
 msgstr ""
 "Selektor nie może się poruszyć, ponieważ program FINDA wykrył żarnik. "
 "Upewnij się, że w selektorze nie ma filamentu i że FINDA działa prawidłowo."

--- a/lang/po/Firmware_pl.po
+++ b/lang/po/Firmware_pl.po
@@ -2486,10 +2486,10 @@ msgstr ""
 "Ładowanie do ekstrudera nie powiodło się. Sprawdź kształt końcówki "
 "filamentu. W razie potrzeby doprecyzuj kalibrację czujnika."
 
-#. MSG_TITLE_MCU_UNDERVOLTAGE_VCC c=20
+#. MSG_TITLE_MCU_ERROR c=20
 #: ../../Firmware/mmu2/errors_list.h:176 ../../Firmware/mmu2/errors_list.h:222
-msgid "MMU MCU UNDERPOWER"
-msgstr "MCU POD NAPIĘCI. VCC"
+msgid "MMU MCU ERROR"
+msgstr "MMU MCU BLAD"
 
 #. MSG_MATERIAL_CHANGES c=18
 #: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:1095

--- a/lang/po/Firmware_ro.po
+++ b/lang/po/Firmware_ro.po
@@ -2514,7 +2514,7 @@ msgstr "ResetMMU"
 #: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:298
 msgid ""
 "Selector can't move due to FINDA detecting a filament. Make sure no filament"
-" is in selector and FINDA works properly."
+" is in Selector and FINDA works properly."
 msgstr ""
 "Selectorul nu se poate mișca deoarece FINDA detectează un filament. "
 "Asigurați-vă că nu există filament în selector și că FINDA funcționează "

--- a/lang/po/Firmware_ro.po
+++ b/lang/po/Firmware_ro.po
@@ -2489,10 +2489,10 @@ msgstr ""
 "Încărcarea în extruder nu a reușit. Inspectați forma vârfului filamentului. "
 "Rafinați calibrarea senzorului, dacă este necesar."
 
-#. MSG_TITLE_MCU_UNDERVOLTAGE_VCC c=20
+#. MSG_TITLE_MCU_ERROR c=20
 #: ../../Firmware/mmu2/errors_list.h:176 ../../Firmware/mmu2/errors_list.h:222
-msgid "MMU MCU UNDERPOWER"
-msgstr "MCU SUBTENSIUNE VCC"
+msgid "MMU MCU ERROR"
+msgstr "MMU: EROARE MCU"
 
 #. MSG_MATERIAL_CHANGES c=18
 #: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:1095

--- a/lang/po/Firmware_sk.po
+++ b/lang/po/Firmware_sk.po
@@ -2498,7 +2498,7 @@ msgstr "ResetMMU"
 #: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:298
 msgid ""
 "Selector can't move due to FINDA detecting a filament. Make sure no filament"
-" is in selector and FINDA works properly."
+" is in Selector and FINDA works properly."
 msgstr ""
 "Selektor sa nemôže pohybovať, pretože FINDA zistila filament. Uistite sa, že"
 " v selektore nie je žiadny filament a FINDA funguje správne."

--- a/lang/po/Firmware_sk.po
+++ b/lang/po/Firmware_sk.po
@@ -2473,10 +2473,10 @@ msgstr ""
 "Zavedenie do extrudéra zlyhalo. Skontrolujte tvar konca filamentu. V prípade"
 " potreby upravte kalibráciu snímača."
 
-#. MSG_TITLE_MCU_UNDERVOLTAGE_VCC c=20
+#. MSG_TITLE_MCU_ERROR c=20
 #: ../../Firmware/mmu2/errors_list.h:176 ../../Firmware/mmu2/errors_list.h:222
-msgid "MMU MCU UNDERPOWER"
-msgstr "MMU MCU UNDERPOWER"
+msgid "MMU MCU ERROR"
+msgstr "MMU MCU CHYBA"
 
 #. MSG_MATERIAL_CHANGES c=18
 #: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:1095

--- a/lang/po/Firmware_sv.po
+++ b/lang/po/Firmware_sv.po
@@ -2480,10 +2480,10 @@ msgstr ""
 "Det gick inte att ladda till extrudern. Inspektera filamentspetsens form. "
 "Förfina sensorkalibreringen vid behov."
 
-#. MSG_TITLE_MCU_UNDERVOLTAGE_VCC c=20
+#. MSG_TITLE_MCU_ERROR c=20
 #: ../../Firmware/mmu2/errors_list.h:176 ../../Firmware/mmu2/errors_list.h:222
-msgid "MMU MCU UNDERPOWER"
-msgstr "MCU UNDERSPÄNN. VCC"
+msgid "MMU MCU ERROR"
+msgstr "MMU MCU FEL"
 
 #. MSG_MATERIAL_CHANGES c=18
 #: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:1095

--- a/lang/po/Firmware_sv.po
+++ b/lang/po/Firmware_sv.po
@@ -2505,7 +2505,7 @@ msgstr "ResetMMU"
 #: ../../Firmware/mmu2/errors_list.h:243 ../../Firmware/mmu2/errors_list.h:298
 msgid ""
 "Selector can't move due to FINDA detecting a filament. Make sure no filament"
-" is in selector and FINDA works properly."
+" is in Selector and FINDA works properly."
 msgstr ""
 "Väljaren kan inte röra sig på grund av att FINDA detekterar en filament. Se "
 "till att inget glödtråd är i väljaren och att FINDA fungerar korrekt."


### PR DESCRIPTION
as requested in Prusa-Error-Codes PR#97

There will be more separate sources of MCU power errors in the future and reporting each of them separately doesn't make much sense - especially when the only thing a user can do about it is to check the connectors.

So based on this, the error title has changed a bit (we are not using the full text description in 8bit FW)

MMU-254