### PR TITLE
Fixed printer_smodel_check for MK3/S and possible older MMU machines

### DIFF
--- a/Firmware/util.cpp
+++ b/Firmware/util.cpp
@@ -407,16 +407,19 @@ return pStrBegin;
 }
 
 void printer_smodel_check(const char *pStrPos, const char *actualPrinterSModel) {
-char* pResult;
-size_t nLength;
+    char* pResult;
+    size_t nLength;
+    size_t aLength;
 
-pResult=code_string(pStrPos,&nLength);
+    pResult=code_string(pStrPos,&nLength);
+    if(pResult != NULL) {
+        aLength=strlen_P(actualPrinterSModel);
+        if(aLength > nLength) nLength = aLength;
 
-if(pResult != NULL) {
-    // Only compare first 6 chars on MK3|MK3S
-    if (strncmp_P(pResult, PSTR("MK3"), 3) == 0) nLength = 6;
-    if (strncmp_P(pResult, actualPrinterSModel, nLength) == 0) return;
-}
+        // Only compare first 6 chars on MK3|MK3S if string longer than 4 characters
+        if (nLength > 4 && strncmp_P(pResult, PSTR("MK3"), 3) == 0) nLength = 6;
+        if (strncmp_P(pResult, actualPrinterSModel, nLength) == 0) return;
+    }
 
     render_M862_warnings(
         _T(MSG_GCODE_DIFF_PRINTER_CONTINUE)


### PR DESCRIPTION
Cherry-pick of PR#4265 into 3.13.0

Fixed printer_smodel_check for non MMU machines
Commit 136ef96 broke the compatibility check for MK3S without MMU.

May have fixed bug for older MMU machines.
Only comparing up to the length of the value from the g-code, would return equal on older MMU machines trying to run g-code sliced without the MMU. Unfortunately if that is a feature, it will cause the different printer warning.