### PR TITLE
PFW-1519 Hide Preload to MMU menu item if filament is detected

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5224,7 +5224,11 @@ static void lcd_main_menu()
 
     if ( ! ( printJobOngoing() || (lcd_commands_type == LcdCommands::Layer1Cal || Stopped) ) ) {
         if (MMU2::mmu2.Enabled()) {
-            MENU_ITEM_SUBMENU_P(_T(MSG_PRELOAD_TO_MMU), mmu_preload_filament_menu);
+            if(!MMU2::mmu2.FindaDetectsFilament() && !fsensor.getFilamentPresent()) {
+                // The MMU 'Load filament' state machine will reject the command if any 
+                // filament sensor is reporting a detected filament
+                MENU_ITEM_SUBMENU_P(_T(MSG_PRELOAD_TO_MMU), mmu_preload_filament_menu);
+            }
             MENU_ITEM_SUBMENU_P(_i("Load to nozzle"), lcd_mmuLoadFilament);////MSG_LOAD_TO_NOZZLE c=18
             MENU_ITEM_SUBMENU_P(_T(MSG_UNLOAD_FILAMENT), lcd_mmuUnloadFilament);
             MENU_ITEM_SUBMENU_P(_T(MSG_EJECT_FROM_MMU), lcd_mmuEjectFilament);


### PR DESCRIPTION
This is by far the simplest solution to prevent the user from sending a Load command to the MMU when FINDA or extruder filament sensor is detecting a filament. This may even happen if the sensors are poorly positioned. A Load in this scenario will make the MMU seem to hang as the state machine will reject the command.

We could add a full screen message to let the use know but it would require some memory resources. For now, just hide the menu item.

Resolves **PFW-1519** and **PFW-1492**

Change in memory:
Flash: +16 bytes
SRAM: 0 bytes