### PR TITLE
:construction: PFW-1480 MMU: Add support for the M command 

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1118,14 +1118,15 @@ void setup()
 	SERIAL_ECHO_START;
 	puts_P(PSTR(" " FW_VERSION_FULL));
 
-	// by default the MMU shall remain disabled - PFW-1418
-	if (eeprom_init_default_byte((uint8_t *)EEPROM_MMU_ENABLED, 0)) {
-		MMU2::mmu2.Start();
-	}
-	MMU2::mmu2.Status();
-	SpoolJoin::spooljoin.initSpoolJoinStatus();
-
-	//SERIAL_ECHOPAIR("Active sheet before:", static_cast<unsigned long int>(eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet))));
+    // by default the MMU shall remain disabled - PFW-1418
+    if (eeprom_init_default_byte((uint8_t *)EEPROM_MMU_ENABLED, 0))
+    {
+        MMU2::mmu2.Start();
+        uint8_t mode = eeprom_init_default_byte((uint8_t*)EEPROM_MMU_STEALTH, MMU2::Normal);
+        MMU2::mmu2.Mode(mode ? MMU2::Stealth : MMU2::Normal);
+    }
+    MMU2::mmu2.Status();
+    SpoolJoin::spooljoin.initSpoolJoinStatus();
 
 #ifdef DEBUG_SEC_LANG
 	lang_table_header_t header;
@@ -1458,7 +1459,6 @@ void setup()
 
 	//mbl_mode_init();
 	mbl_settings_init();
-	eeprom_init_default_byte((uint8_t*)EEPROM_MMU_STEALTH, 1);
 
 #if (!defined(DEBUG_DISABLE_FANCHECK) && defined(FANCHECK) && defined(TACH_1) && (TACH_1 >-1))
 	setup_fan_interrupt();

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -606,6 +606,13 @@ void MMU2::Button(uint8_t index) {
     logic.Button(index);
 }
 
+void MMU2::Mode(uint8_t mode) {
+    logic.Mode(mode);
+
+    // Wait for the command to report as finished
+    (void) manage_response(false, false);
+}
+
 void MMU2::Home(uint8_t mode) {
     logic.Home(mode);
 }

--- a/Firmware/mmu2.h
+++ b/Firmware/mmu2.h
@@ -22,6 +22,11 @@ enum : uint8_t {
     FILAMENT_UNKNOWN = 0xffU
 };
 
+enum MotorMode : uint8_t {
+    Stealth,
+    Normal
+};
+
 struct Version {
     uint8_t major, minor, build;
 };
@@ -151,6 +156,9 @@ public:
     /// Issue a "button" click into the MMU - to be used from Error screens of the MMU
     /// to select one of the 3 possible options to resolve the issue
     void Button(uint8_t index);
+
+    /// Issue a Mode change on the MMU side (Normal or Silent mode)
+    void Mode(uint8_t mode);
 
     /// Issue an explicit "homing" command into the MMU
     void Home(uint8_t mode);

--- a/Firmware/mmu2_protocol_logic.cpp
+++ b/Firmware/mmu2_protocol_logic.cpp
@@ -604,6 +604,10 @@ void ProtocolLogic::Button(uint8_t index) {
     PlanGenericRequest(RequestMsg(RequestMsgCodes::Button, index));
 }
 
+void ProtocolLogic::Mode(uint8_t mode) {
+    PlanGenericRequest(RequestMsg(RequestMsgCodes::Mode, mode));
+}
+
 void ProtocolLogic::Home(uint8_t mode) {
     PlanGenericRequest(RequestMsg(RequestMsgCodes::Home, mode));
 }

--- a/Firmware/mmu2_protocol_logic.h
+++ b/Firmware/mmu2_protocol_logic.h
@@ -112,6 +112,7 @@ public:
     void CutFilament(uint8_t slot);
     void ResetMMU(uint8_t mode = 0);
     void Button(uint8_t index);
+    void Mode(uint8_t mode);
     void Home(uint8_t mode);
     void ReadRegister(uint8_t address);
     void WriteRegister(uint8_t address, uint16_t data);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3369,11 +3369,10 @@ static void lcd_sound_state_set(void) {
     Sound_CycleState();
 }
 
-#ifndef MMU_FORCE_STEALTH_MODE
 static void lcd_mmu_mode_toggle() {
     eeprom_toggle((uint8_t*)EEPROM_MMU_STEALTH);
+    MMU2::mmu2.Mode(eeprom_read_byte((uint8_t*)EEPROM_MMU_STEALTH) ? MMU2::Stealth : MMU2::Normal);
 }
-#endif //MMU_FORCE_STEALTH_MODE
 
 static void lcd_silent_mode_set() {
 	switch (SilentModeMenu) {
@@ -4074,9 +4073,7 @@ static void menuitems_MMU_settings_common()
     }
 #endif // MMU_HAS_CUTTER
 
-#ifndef MMU_FORCE_STEALTH_MODE
     MENU_ITEM_TOGGLE_P(_T(MSG_MMU_MODE), eeprom_read_byte((uint8_t *)EEPROM_MMU_STEALTH) ? _T(MSG_STEALTH) : _T(MSG_NORMAL), lcd_mmu_mode_toggle);
-#endif // MMU_FORCE_STEALTH_MODE
 }
 
 static void mmu_enable_switch()

--- a/Firmware/variants/MK25-RAMBo10a.h
+++ b/Firmware/variants/MK25-RAMBo10a.h
@@ -481,7 +481,6 @@
 
 #define MMU_CONFIG_FILE "mmu2/variants/config_MMU2.h"
 #define MMU_FILAMENT_COUNT 5
-#define MMU_FORCE_STEALTH_MODE
 #define MMU_DEBUG //print communication between MMU and printer on serial
 #define MMU_HAS_CUTTER
 

--- a/Firmware/variants/MK25-RAMBo13a.h
+++ b/Firmware/variants/MK25-RAMBo13a.h
@@ -482,7 +482,6 @@
 
 #define MMU_CONFIG_FILE "mmu2/variants/config_MMU2.h"
 #define MMU_FILAMENT_COUNT 5
-#define MMU_FORCE_STEALTH_MODE
 #define MMU_DEBUG //print communication between MMU and printer on serial
 #define MMU_HAS_CUTTER
 

--- a/Firmware/variants/MK25S-RAMBo10a.h
+++ b/Firmware/variants/MK25S-RAMBo10a.h
@@ -481,7 +481,6 @@
 
 #define MMU_CONFIG_FILE "mmu2/variants/config_MMU2S.h"
 #define MMU_FILAMENT_COUNT 5
-#define MMU_FORCE_STEALTH_MODE
 #define MMU_DEBUG //print communication between MMU and printer on serial
 #define MMU_HAS_CUTTER
 

--- a/Firmware/variants/MK25S-RAMBo13a.h
+++ b/Firmware/variants/MK25S-RAMBo13a.h
@@ -482,7 +482,6 @@
 
 #define MMU_CONFIG_FILE "mmu2/variants/config_MMU2S.h"
 #define MMU_FILAMENT_COUNT 5
-#define MMU_FORCE_STEALTH_MODE
 #define MMU_DEBUG //print communication between MMU and printer on serial
 #define MMU_HAS_CUTTER
 

--- a/Firmware/variants/MK3-E3DREVO.h
+++ b/Firmware/variants/MK3-E3DREVO.h
@@ -645,7 +645,6 @@
 
 #define MMU_CONFIG_FILE "mmu2/variants/config_MMU2.h"
 #define MMU_FILAMENT_COUNT 5
-//#define MMU_FORCE_STEALTH_MODE
 #define MMU_HWRESET
 #define MMU_DEBUG //print communication between MMU and printer on serial
 #define MMU_HAS_CUTTER

--- a/Firmware/variants/MK3-E3DREVO_HF_60W.h
+++ b/Firmware/variants/MK3-E3DREVO_HF_60W.h
@@ -646,7 +646,6 @@
 
 #define MMU_CONFIG_FILE "mmu2/variants/config_MMU2.h"
 #define MMU_FILAMENT_COUNT 5
-//#define MMU_FORCE_STEALTH_MODE
 #define MMU_HWRESET
 #define MMU_DEBUG //print communication between MMU and printer on serial
 #define MMU_HAS_CUTTER

--- a/Firmware/variants/MK3.h
+++ b/Firmware/variants/MK3.h
@@ -648,7 +648,6 @@
 
 #define MMU_CONFIG_FILE "mmu2/variants/config_MMU2.h"
 #define MMU_FILAMENT_COUNT 5
-//#define MMU_FORCE_STEALTH_MODE
 #define MMU_HWRESET
 #define MMU_DEBUG //print communication between MMU and printer on serial
 #define MMU_HAS_CUTTER

--- a/Firmware/variants/MK3S-E3DREVO.h
+++ b/Firmware/variants/MK3S-E3DREVO.h
@@ -649,7 +649,6 @@
 
 #define MMU_CONFIG_FILE "mmu2/variants/config_MMU2S.h"
 #define MMU_FILAMENT_COUNT 5
-//#define MMU_FORCE_STEALTH_MODE
 #define MMU_HWRESET
 #define MMU_DEBUG //print communication between MMU and printer on serial
 #define MMU_HAS_CUTTER

--- a/Firmware/variants/MK3S-E3DREVO_HF_60W.h
+++ b/Firmware/variants/MK3S-E3DREVO_HF_60W.h
@@ -650,7 +650,6 @@
 
 #define MMU_CONFIG_FILE "mmu2/variants/config_MMU2S.h"
 #define MMU_FILAMENT_COUNT 5
-//#define MMU_FORCE_STEALTH_MODE
 #define MMU_HWRESET
 #define MMU_DEBUG //print communication between MMU and printer on serial
 #define MMU_HAS_CUTTER

--- a/Firmware/variants/MK3S.h
+++ b/Firmware/variants/MK3S.h
@@ -652,7 +652,6 @@
 
 #define MMU_CONFIG_FILE "mmu2/variants/config_MMU2S.h"
 #define MMU_FILAMENT_COUNT 5
-//#define MMU_FORCE_STEALTH_MODE
 #define MMU_HWRESET
 #define MMU_DEBUG //print communication between MMU and printer on serial
 #define MMU_HAS_CUTTER


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is on hold until a decision is made whether or not supporting the M command makes sense. The PR is ready for merge otherwise. If merged, this will need to be added to the MK4 as well.

The M command is used to change the TMC2130
motor modes between Stealth and Normal mode.

**Note:** MMU FW >3.0.0 is required since the current FW does not process the `'M'` on the protocol level. To test, you should see the below in the serial logs:

```
echo:MMU2:>M1*e.      ; M1 means changing from Stealth to Normal, M0 would be opposite
echo:MMU2:<M1 A*c1.   ; Command accepted
echo:MMU2:>Q0*ea.     ; Query request
echo:MMU2:<M1 F0*d7.  ; Command finished 
```

Change in memory:
Flash: +76 bytes
SRAM: 0 bytes