### PR TITLE
Delay Z-Axis on Autoload

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3576,7 +3576,7 @@ static void gcode_M600(const bool automatic, const float x_position, const float
     custom_message_type = CustomMsg::Status;
 }
 
-void gcode_M701(float fastLoadLength, uint8_t mmuSlotIndex){
+void gcode_M701(float fastLoadLength, uint8_t mmuSlotIndex, bool raise_z_axis = false){
     FSensorBlockRunout fsBlockRunout;
 
     prusa_statistics(22);
@@ -3591,6 +3591,10 @@ void gcode_M701(float fastLoadLength, uint8_t mmuSlotIndex){
 
         current_position[E_AXIS] += fastLoadLength;
         plan_buffer_line_curposXYZE(FILAMENTCHANGE_EFEED_FIRST); //fast sequence
+
+        if (raise_z_axis) { // backwards compatibility for 3.12 and older FW
+          raise_z_above(MIN_Z_FOR_LOAD);
+        }
 
         load_filament_final_feed(); // slow sequence
         st_synchronize();
@@ -8769,13 +8773,12 @@ Sigma_Exit:
 
         // Z lift. For safety only allow positive values
         if (code_seen('Z')) z_target = fabs(code_value());
-        else raise_z_above(MIN_Z_FOR_LOAD); // backwards compatibility for 3.12 and older FW
-
+        
         // Raise the Z axis
         float delta = raise_z(z_target);
 
         // Load filament
-        gcode_M701(fastLoadLength, mmuSlotIndex);
+        gcode_M701(fastLoadLength, mmuSlotIndex, !code_seen('Z')); // if no z -> trigger MIN_Z_FOR_LOAD for backwards compatibility on 3.12 and older FW 
 
         // Restore Z axis
         raise_z(-delta);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1988,7 +1988,6 @@ void mFilamentItem(uint16_t nTemp, uint16_t nTempBed)
             // modified elsewhere and needs to be redrawn in full.
 
             // reset bFilamentWaitingFlag immediately to avoid re-entry from raise_z_above()!
-            bool once = !bFilamentWaitingFlag;
             bFilamentWaitingFlag = true;
 
             // also force-enable lcd_draw_update (might be 0 when called from outside a menu)
@@ -2005,12 +2004,10 @@ void mFilamentItem(uint16_t nTemp, uint16_t nTempBed)
             case FilamentAction::MmuLoad:
             case FilamentAction::MmuLoadingTest:
                 lcd_puts_P(_T(MSG_PREHEATING_TO_LOAD));
-                if (once) raise_z_above(MIN_Z_FOR_LOAD);
                 break;
             case FilamentAction::UnLoad:
             case FilamentAction::MmuUnLoad:
                 lcd_puts_P(_T(MSG_PREHEATING_TO_UNLOAD));
-                if (once) raise_z_above(MIN_Z_FOR_UNLOAD);
                 break;
             case FilamentAction::MmuEject:
                 lcd_puts_P(_T(MSG_PREHEATING_TO_EJECT));


### PR DESCRIPTION
Delay z-axis movement when the operators hand is close to the printhead.

This is my proposed solution to resolve https://github.com/prusa3d/Prusa-Firmware/issues/4115.

The basic idea is to wait with z-axis movement until the user removed his hand from the printhead.
Instead of moving as soon as the filament sensor is triggered, the filament is first grabbed by "fast load" and after that the z-axis is moved up.
 
How to reproduce:
1. Unload filament if loaded.
2. Make sure filament sensor is activated.
3. Make sure the printed does not know the current z position of the extruder or the z position is below MIN_Z_FOR_LOAD (Currently 50mm).
4. Insert filament.

Original behavior: Printhead lifts Z position to MIN_Z_FOR_LOAD (50mm) as soon as filament sensor is triggered and then starts fast loading the filament.

New behavior: Printhead grabs filament with fast load and then moves Z axis up to MIN_Z_FOR_LOAD (50mm).