### PR TITLE
Optimisations 3.13.1

### DIFF
--- a/Firmware/Dcodes.cpp
+++ b/Firmware/Dcodes.cpp
@@ -3,6 +3,7 @@
 #include "Configuration.h"
 #include "language.h"
 #include "cmdqueue.h"
+#include "util.h"
 #include <stdio.h>
 #include <avr/pgmspace.h>
 

--- a/Firmware/Dcodes.cpp
+++ b/Firmware/Dcodes.cpp
@@ -822,7 +822,7 @@ void dcode_2130()
 			}
 			else if (strcmp(strchr_pointer + 7, "wave") == 0)
 			{
-				tmc2130_get_wave(axis, 0, stdout);
+				tmc2130_get_wave(axis, 0);
 			}
 		}
 		else if (strchr_pointer[1+5] == '!')

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -8210,8 +8210,8 @@ Sigma_Exit:
     break;
 
     /*!
-	### M916 - Set TMC2130 Stallguard sensitivity threshold <a href="https://reprap.org/wiki/G-code#M916:_Set_TMC2130_Stallguard_sensitivity_threshold">M916: Set TMC2130 Stallguard sensitivity threshold</a>
-	Not active in default, only if `TMC2130_SERVICE_CODES_M910_M918` is defined in source code.
+    ### M916 - Set TMC2130 Stallguard sensitivity threshold <a href="https://reprap.org/wiki/G-code#M916:_Set_TMC2130_Stallguard_sensitivity_threshold">M916: Set TMC2130 Stallguard sensitivity threshold</a>
+    Not active in default, only if `TMC2130_SERVICE_CODES_M910_M918` is defined in source code.
     #### Usage
     
         M916 [ X | Y | Z | E ]
@@ -8222,20 +8222,20 @@ Sigma_Exit:
     - `Z` - Z stepper driver stallguard sensitivity threshold value
     - `E` - Extruder stepper driver stallguard sensitivity threshold value
     */
-	case 916:
+    case 916:
     {
-		if (code_seen('X')) tmc2130_sg_thr[X_AXIS] = code_value();
-		if (code_seen('Y')) tmc2130_sg_thr[Y_AXIS] = code_value();
-		if (code_seen('Z')) tmc2130_sg_thr[Z_AXIS] = code_value();
-		if (code_seen('E')) tmc2130_sg_thr[E_AXIS] = code_value();
-		for (uint8_t a = X_AXIS; a <= E_AXIS; a++)
-			printf_P(_N("tmc2130_sg_thr[%c]=%d\n"), "XYZE"[a], tmc2130_sg_thr[a]);
+        for (uint8_t axis = 0; axis < NUM_AXIS; axis++) {
+            if (code_seen(axis_codes[axis])) {
+                    tmc2130_sg_thr[axis] = code_value_uint8();
+            }
+            printf_P(_N("tmc2130_sg_thr[%c]=%d\n"), "XYZE"[axis], tmc2130_sg_thr[axis]);
+        }
     }
     break;
 
     /*!
-	### M917 - Set TMC2130 PWM amplitude offset (pwm_ampl) <a href="https://reprap.org/wiki/G-code#M917:_Set_TMC2130_PWM_amplitude_offset_.28pwm_ampl.29">M917: Set TMC2130 PWM amplitude offset (pwm_ampl)</a>
-	Not active in default, only if `TMC2130_SERVICE_CODES_M910_M918` is defined in source code.
+    ### M917 - Set TMC2130 PWM amplitude offset (pwm_ampl) <a href="https://reprap.org/wiki/G-code#M917:_Set_TMC2130_PWM_amplitude_offset_.28pwm_ampl.29">M917: Set TMC2130 PWM amplitude offset (pwm_ampl)</a>
+    Not active in default, only if `TMC2130_SERVICE_CODES_M910_M918` is defined in source code.
     #### Usage
     
         M917 [ X | Y | Z | E ]
@@ -8246,18 +8246,19 @@ Sigma_Exit:
     - `Z` - Z stepper driver PWM amplitude offset value
     - `E` - Extruder stepper driver PWM amplitude offset value
     */
-	case 917:
+    case 917:
     {
-		if (code_seen('X')) tmc2130_set_pwm_ampl(0, code_value());
-		if (code_seen('Y')) tmc2130_set_pwm_ampl(1, code_value());
-        if (code_seen('Z')) tmc2130_set_pwm_ampl(2, code_value());
-        if (code_seen('E')) tmc2130_set_pwm_ampl(3, code_value());
+        for (uint8_t axis = 0; axis < NUM_AXIS; axis++) {
+            if (code_seen(axis_codes[axis])) {
+                    tmc2130_set_pwm_ampl(axis, code_value_uint8());
+            }
+        }
     }
     break;
 
     /*!
-	### M918 - Set TMC2130 PWM amplitude gradient (pwm_grad) <a href="https://reprap.org/wiki/G-code#M918:_Set_TMC2130_PWM_amplitude_gradient_.28pwm_grad.29">M918: Set TMC2130 PWM amplitude gradient (pwm_grad)</a>
-	Not active in default, only if `TMC2130_SERVICE_CODES_M910_M918` is defined in source code.
+    ### M918 - Set TMC2130 PWM amplitude gradient (pwm_grad) <a href="https://reprap.org/wiki/G-code#M918:_Set_TMC2130_PWM_amplitude_gradient_.28pwm_grad.29">M918: Set TMC2130 PWM amplitude gradient (pwm_grad)</a>
+    Not active in default, only if `TMC2130_SERVICE_CODES_M910_M918` is defined in source code.
     #### Usage
     
         M918 [ X | Y | Z | E ]
@@ -8268,12 +8269,13 @@ Sigma_Exit:
     - `Z` - Z stepper driver PWM amplitude gradient value
     - `E` - Extruder stepper driver PWM amplitude gradient value
     */
-	case 918:
+    case 918:
     {
-		if (code_seen('X')) tmc2130_set_pwm_grad(0, code_value());
-		if (code_seen('Y')) tmc2130_set_pwm_grad(1, code_value());
-        if (code_seen('Z')) tmc2130_set_pwm_grad(2, code_value());
-        if (code_seen('E')) tmc2130_set_pwm_grad(3, code_value());
+        for (uint8_t axis = 0; axis < NUM_AXIS; axis++) {
+            if (code_seen(axis_codes[axis])) {
+                    tmc2130_set_pwm_grad(axis, code_value_uint8());
+            }
+        }
     }
     break;
 

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -898,7 +898,8 @@ void update_sec_lang_from_external_flash()
 		if (lang_get_header(lang, &header, &src_addr))
 		{
 			lcd_puts_at_P(1,0,PSTR("Language update"));
-			for (uint8_t i = 0; i < state; i++) fputc('.', lcdout);
+			for (uint8_t i = 0; i < state; i++)
+				lcd_print('.');
 			_delay(100);
 			boot_reserved = (boot_reserved & 0xF8) | ((state + 1) & 0x07);
 			if ((state * LANGBOOT_BLOCKSIZE) < header.size)
@@ -1441,7 +1442,7 @@ void setup()
 	uint16_t sec_lang_code = lang_get_code(1);
 	uint16_t ui = _SEC_LANG_TABLE; //table pointer
 	printf_P(_n("lang_selected=%d\nlang_table=0x%04x\nSEC_LANG_CODE=0x%04x (%c%c)\n"), lang_selected, ui, sec_lang_code, sec_lang_code >> 8, sec_lang_code & 0xff);
-	lang_print_sec_lang(uartout);
+	lang_print_sec_lang();
 #endif //DEBUG_SEC_LANG
 
 #endif //(LANG_MODE != 0)

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -4597,8 +4597,7 @@ void process_commands()
             SERIAL_PROTOCOLPGM(" Y: ");
             SERIAL_PROTOCOL(current_position[Y_AXIS]);
             SERIAL_PROTOCOLPGM(" Z: ");
-            SERIAL_PROTOCOL(current_position[Z_AXIS]);
-            SERIAL_PROTOCOLPGM("\n");
+            SERIAL_PROTOCOLLN(current_position[Z_AXIS]);
 
             clean_up_after_endstop_move(l_feedmultiply);
         }
@@ -7217,8 +7216,7 @@ Sigma_Exit:
         SERIAL_PROTOCOLPGM(" i:");
         SERIAL_PROTOCOL(unscalePID_i(cs.Ki));
         SERIAL_PROTOCOLPGM(" d:");
-        SERIAL_PROTOCOL(unscalePID_d(cs.Kd));
-        SERIAL_PROTOCOLLN();
+        SERIAL_PROTOCOLLN(unscalePID_d(cs.Kd));
       }
       break;
     #endif //PIDTEMP

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -8065,7 +8065,7 @@ Sigma_Exit:
                     SERIAL_ECHOLNPGM(", M907 E ignored");
                     continue;
                 }
-                long cur_mA = code_value_long();
+                float cur_mA = code_value();
                 uint8_t val = tmc2130_cur2val(cur_mA);
                 currents[i].iHold = val;
                 currents[i].iRun = val;

--- a/Firmware/bootapp.c
+++ b/Firmware/bootapp.c
@@ -6,19 +6,17 @@
 
 
 #include <stdio.h>
-extern FILE _uartout;
-#define uartout (&_uartout)
 
 extern void softReset();
 
 void bootapp_print_vars(void)
 {
-	fprintf_P(uartout, PSTR("boot_src_addr  =0x%08lx\n"), boot_src_addr);
-	fprintf_P(uartout, PSTR("boot_dst_addr  =0x%08lx\n"), boot_dst_addr);
-	fprintf_P(uartout, PSTR("boot_copy_size =0x%04x\n"), boot_copy_size);
-	fprintf_P(uartout, PSTR("boot_reserved  =0x%02x\n"), boot_reserved);
-	fprintf_P(uartout, PSTR("boot_app_flags =0x%02x\n"), boot_app_flags);
-	fprintf_P(uartout, PSTR("boot_app_magic =0x%08lx\n"), boot_app_magic);
+	printf_P(PSTR("boot_src_addr  =0x%08lx\n"), boot_src_addr);
+	printf_P(PSTR("boot_dst_addr  =0x%08lx\n"), boot_dst_addr);
+	printf_P(PSTR("boot_copy_size =0x%04x\n"), boot_copy_size);
+	printf_P(PSTR("boot_reserved  =0x%02x\n"), boot_reserved);
+	printf_P(PSTR("boot_app_flags =0x%02x\n"), boot_app_flags);
+	printf_P(PSTR("boot_app_magic =0x%08lx\n"), boot_app_magic);
 }
 
 

--- a/Firmware/language.c
+++ b/Firmware/language.c
@@ -276,7 +276,7 @@ const char* lang_get_sec_lang_str_by_id(uint16_t id)
 	return ui + pgm_read_word(((uint16_t*)(ui + 16 + id * 2))); //read relative offset and return calculated pointer
 }
 
-uint16_t lang_print_sec_lang(FILE* out)
+uint16_t lang_print_sec_lang()
 {
 	printf_P(_n("&_SEC_LANG        = 0x%04x\n"), &_SEC_LANG);
 	printf_P(_n("sizeof(_SEC_LANG) = 0x%04x\n"), sizeof(_SEC_LANG));
@@ -298,7 +298,7 @@ uint16_t lang_print_sec_lang(FILE* out)
 	puts_P(_n(" strings:\n"));
 	uint16_t ui = _SEC_LANG_TABLE; //table pointer
 	for (ui = 0; ui < _lt_count; ui++)
-		fprintf_P(out, _n("  %3d %S\n"), ui, lang_get_sec_lang_str_by_id(ui));
+		printf_P(_n("  %3d %S\n"), ui, lang_get_sec_lang_str_by_id(ui));
 	return _lt_count;
 }
 #endif //DEBUG_SEC_LANG

--- a/Firmware/language.h
+++ b/Firmware/language.h
@@ -171,7 +171,7 @@ extern uint8_t lang_is_selected(void);
 
 #ifdef DEBUG_SEC_LANG
 extern const char* lang_get_sec_lang_str_by_id(uint16_t id);
-extern uint16_t lang_print_sec_lang(FILE* out);
+extern uint16_t lang_print_sec_lang();
 #endif //DEBUG_SEC_LANG
 
 extern void lang_boot_update_start(uint8_t lang);

--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -129,18 +129,17 @@ static void lcd_send(uint8_t data, uint8_t flags, uint16_t duration = LCD_DEFAUL
 	_delay_us(5);
 	lcd_writebits(data);
 #ifndef LCD_8BIT
-	if (!(flags & LCD_HALF_FLAG))
-	{
-		_delay_us(LCD_DEFAULT_DELAY);
-		lcd_writebits(data<<4);
+	if (!(flags & LCD_HALF_FLAG)) {
+		// _delay_us(LCD_DEFAULT_DELAY); // should not be needed when sending a two nibble instruction.
+		lcd_writebits((data << 4) | (data >> 4)); //force efficient swap opcode even though the lower nibble is ignored in this case
 	}
 #endif
 	delayMicroseconds(duration);
 }
 
-static void lcd_command(uint8_t value, uint16_t delayExtra = 0)
+static void lcd_command(uint8_t value, uint16_t duration = LCD_DEFAULT_DELAY)
 {
-	lcd_send(value, LOW, LCD_DEFAULT_DELAY + delayExtra);
+	lcd_send(value, LOW, duration);
 }
 
 static void lcd_write(uint8_t value)

--- a/Firmware/pat9125.cpp
+++ b/Firmware/pat9125.cpp
@@ -100,10 +100,6 @@ static void pat9125_wr_reg(uint8_t addr, uint8_t data);
 static uint8_t pat9125_wr_reg_verify(uint8_t addr, uint8_t data);
 static uint8_t pat9125_wr_seq(const uint8_t* seq);
 
-extern FILE _uartout;
-#define uartout (&_uartout)
-
-
 uint8_t pat9125_probe()
 {
 #if defined(PAT9125_SWI2C)

--- a/Firmware/planner.cpp
+++ b/Firmware/planner.cpp
@@ -690,7 +690,6 @@ void plan_set_position_curposXYZE(){
     plan_set_position(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS]);
 }
 
-float junction_deviation = 0.1;
 // Add a new linear movement to the buffer. steps_x, _y and _z is the absolute position in 
 // mm. Microseconds specify how many microseconds the move should take to perform. To aid acceleration
 // calculation the caller must also provide the physical length of the line in millimeters.

--- a/Firmware/tmc2130.cpp
+++ b/Firmware/tmc2130.cpp
@@ -855,7 +855,7 @@ void tmc2130_goto_step(uint8_t axis, uint8_t step, uint8_t dir, uint16_t delay_u
 	}
 }
 
-void tmc2130_get_wave(uint8_t axis, uint8_t* data, FILE* stream)
+void tmc2130_get_wave(uint8_t axis, uint8_t* data)
 {
 	uint8_t pwr = tmc2130_get_pwr(axis);
 	tmc2130_set_pwr(axis, 0);
@@ -867,13 +867,10 @@ void tmc2130_get_wave(uint8_t axis, uint8_t* data, FILE* stream)
 		uint32_t val = tmc2130_rd_MSCURACT(axis);
 		uint16_t mscnt = tmc2130_rd_MSCNT(axis);
 		int curA = (val & 0xff) | ((val << 7) & 0x8000);
-		if (stream)
-		{
-			if (mscnt == i)
-				fprintf_P(stream, PSTR("%d\t%d\n"), i, curA);
-			else //TODO - remove this check
-				fprintf_P(stream, PSTR("!! (i=%d MSCNT=%d)\n"), i, mscnt);
-		}
+		if (mscnt == i)
+			printf_P(PSTR("%d\t%d\n"), i, curA);
+		else //TODO - remove this check
+			printf_P(PSTR("!! (i=%d MSCNT=%d)\n"), i, mscnt);
 		if (data) *(data++) = curA;
 		tmc2130_do_step(axis);
 		delayMicroseconds(100);

--- a/Firmware/tmc2130.cpp
+++ b/Firmware/tmc2130.cpp
@@ -870,7 +870,7 @@ void tmc2130_get_wave(uint8_t axis, uint8_t* data)
 		if (mscnt == i)
 			printf_P(PSTR("%d\t%d\n"), i, curA);
 		else //TODO - remove this check
-			printf_P(PSTR("!! (i=%d MSCNT=%d)\n"), i, mscnt);
+			printf_P(PSTR("! (i=%d MSCNT=%d)\n"), i, mscnt);
 		if (data) *(data++) = curA;
 		tmc2130_do_step(axis);
 		delayMicroseconds(100);

--- a/Firmware/tmc2130.h
+++ b/Firmware/tmc2130.h
@@ -139,7 +139,7 @@ extern void tmc2130_set_dir(uint8_t axis, uint8_t dir);
 extern void tmc2130_do_step(uint8_t axis);
 extern void tmc2130_do_steps(uint8_t axis, uint16_t steps, uint8_t dir, uint16_t delay_us);
 extern void tmc2130_goto_step(uint8_t axis, uint8_t step, uint8_t dir, uint16_t delay_us, uint16_t microstep_resolution);
-extern void tmc2130_get_wave(uint8_t axis, uint8_t* data, FILE* stream);
+extern void tmc2130_get_wave(uint8_t axis, uint8_t* data);
 extern void tmc2130_set_wave(uint8_t axis, uint8_t amp, uint8_t fac1000);
 
 extern bool tmc2130_home_calibrate(uint8_t axis);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3335,7 +3335,7 @@ static void lcd_crash_mode_info()
 	if ((tim + 1000) < _millis())
 	{
 		lcd_clear();
-		fputs_P(_i("Crash detection can\nbe turned on only in\nNormal mode"), lcdout);////MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
+		lcd_puts_P(_i("Crash detection can\nbe turned on only in\nNormal mode"));////MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
 		tim = _millis();
 	}
     menu_back_if_clicked();
@@ -3348,7 +3348,7 @@ static void lcd_crash_mode_info2()
 	if ((tim + 1000) < _millis())
 	{
 		lcd_clear();
-		fputs_P(_i("WARNING:\nCrash detection\ndisabled in\nStealth mode"), lcdout);////MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
+		lcd_puts_P(_i("WARNING:\nCrash detection\ndisabled in\nStealth mode"));////MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
 		tim = _millis();
 	}
     menu_back_if_clicked();

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2686,7 +2686,7 @@ void pid_extruder()
 	lcd_puts_at_P(0, 0, _i("Set temperature:"));////MSG_SET_TEMPERATURE c=20
 	pid_temp += lcd_encoder;
 	if (pid_temp > HEATER_0_MAXTEMP) pid_temp = HEATER_0_MAXTEMP;
-	if (pid_temp < HEATER_0_MINTEMP) pid_temp = HEATER_0_MINTEMP;
+	else if (pid_temp < HEATER_0_MINTEMP) pid_temp = HEATER_0_MINTEMP;
 	lcd_encoder = 0;
 	lcd_set_cursor(1, 2);
 	lcd_printf_P(PSTR("%3u"), pid_temp);


### PR DESCRIPTION
I went through all the commits in https://github.com/prusa3d/Prusa-Firmware/pull/3378/commits and pulled in the changes which are still relevant. IMO I think creating a new PR would be less work than trying to rebase the original PR as we have made soo many changes.


Change in memory:
Flash: -168 bytes
SRAM: 0 bytes

Additionally 148 bytes of Flash memory are saved when `TMC2130_SERVICE_CODES_M910_M918` is enabled