### PR TITLE
m600: power panic: unset isPartialBackupAvailable on M600 exit

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -7644,6 +7644,11 @@ Sigma_Exit:
         automatic = true;
 
     gcode_M600(automatic, x_position, y_position, z_shift, e_shift_init, e_shift_late);
+
+    // From this point forward, power panic should not use
+    // the partial backup in RAM since the extruder is no
+    // longer in parking position
+    clear_print_state_in_ram();
     }
     break;
     #endif //FILAMENTCHANGEENABLE


### PR DESCRIPTION
Minor fix after PFW-1510, I noticed this line was missing by mistake.

If no power outage occurred during M600 we should clear `isPartialBackupAvailable` to let the power panic code know to not use the partial backup (as it is invalid upon M600 exit). We want the partial backup _only while_ the extruder is parked after a print is saved e.g. caused by filament runout event.

Steps to reproduce issue:
======

1. Start a print
2. Trigger M600 (Can be done for example with a filament runout or adding M600 on a specific layer in PrusaSlicer)
    * Note where the extruder is positioned at this instant (this position is saved via partial backup)
3. Resolve the M600 by re-loading a new filament
4. Print resumes correctly
5. Let the print run for a bit
6. When the extruder is a bit away from the position in step 2), trigger a power panic
    * Note where the extruder is positioned at this instant (this position is saved via partial backup)
7. Wait a few seconds
8. Turn on the printer again and try to recover the print
9. Observe issue

* ✅ **Expected behavior** in step 9) -- Print recovers correctly and resume at position saved in step 6)
* :x: **Actual behavior** in step 9) -- Print recovers but at the position saved in step 2)

See:

```c
    // When there is no position already saved, then we must grab whatever the current position is.
    // This is most likely a position where the printer is in the middle of a G-code move
    if (!sd_print_saved_in_ram && !isPartialBackupAvailable)
    {
        memcpy(saved_pos, current_position, sizeof(saved_pos));
        if (pos_invalid) saved_pos[X_AXIS] = X_COORD_INVALID;
    }
```

Change in memory:
Flash: +4 bytes
SRAM: 0 bytes