### PR TITLE
tmc2130: Fix wrong values report by M913 when Hold > Run and more bugs

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1085,8 +1085,8 @@ void setup()
 #ifdef TMC2130
     if(FarmOrUserECool()) {
         //increased extruder current (PFW363)
-        currents[E_AXIS].iRun = TMC2130_CURRENTS_FARM;
-        currents[E_AXIS].iHold = TMC2130_CURRENTS_FARM;
+        currents[E_AXIS].setiRun(TMC2130_CURRENTS_FARM);
+        currents[E_AXIS].setiHold(TMC2130_CURRENTS_FARM);
     }
 #endif //TMC2130
 
@@ -8059,8 +8059,8 @@ Sigma_Exit:
                 }
                 float cur_mA = code_value();
                 uint8_t val = tmc2130_cur2val(cur_mA);
-                currents[i].iHold = val;
-                currents[i].iRun = val;
+                currents[i].setiHold(val);
+                currents[i].setiRun(val);
                 tmc2130_setup_chopper(i, tmc2130_mres[i]);
             }
         }
@@ -8135,7 +8135,7 @@ Sigma_Exit:
     {
         for (uint8_t axis = 0; axis < NUM_AXIS; axis++) {
             if (code_seen(axis_codes[axis])) {
-                currents[axis].iHold = code_value_uint8();
+                currents[axis].setiHold(code_value_uint8());
                 tmc2130_setup_chopper(axis, tmc2130_mres[axis]);
           }
         }
@@ -8159,7 +8159,7 @@ Sigma_Exit:
     {
         for (uint8_t axis = 0; axis < NUM_AXIS; axis++) {
             if (code_seen(axis_codes[axis])) {
-                currents[axis].iRun = code_value_uint8();
+                currents[axis].setiRun(code_value_uint8());
                 tmc2130_setup_chopper(axis, tmc2130_mres[axis]);
             }
         }

--- a/Firmware/power_panic.cpp
+++ b/Firmware/power_panic.cpp
@@ -61,11 +61,11 @@ void uvlo_() {
 
     // Minimise Z and E motor currents (Hold and Run)
 #ifdef TMC2130
-    currents[Z_AXIS].iHold = 20;
-    currents[Z_AXIS].iRun = 20;
+    currents[Z_AXIS].setiHold(20);
+    currents[Z_AXIS].setiRun(20);
     tmc2130_setup_chopper(Z_AXIS, tmc2130_mres[Z_AXIS]);
-    currents[E_AXIS].iHold = 20;
-    currents[E_AXIS].iRun = 20;
+    currents[E_AXIS].setiHold(20);
+    currents[E_AXIS].setiRun(20);
     tmc2130_setup_chopper(E_AXIS, tmc2130_mres[E_AXIS]);
 #endif //TMC2130
 
@@ -227,8 +227,8 @@ static void uvlo_tiny() {
     disable_e0();
 
 #ifdef TMC2130
-    currents[Z_AXIS].iHold = 20;
-    currents[Z_AXIS].iRun = 20;
+    currents[Z_AXIS].setiHold(20);
+    currents[Z_AXIS].setiRun(20);
     tmc2130_setup_chopper(Z_AXIS, tmc2130_mres[Z_AXIS]);
 #endif //TMC2130
 

--- a/Firmware/tmc2130.cpp
+++ b/Firmware/tmc2130.cpp
@@ -282,6 +282,8 @@ uint16_t __tcoolthrs(uint8_t axis)
 
 static void tmc2130_XYZ_reg_init(uint8_t axis)
 {
+	tmc2130_setup_chopper(axis, tmc2130_mres[axis]);
+	tmc2130_wr(axis, TMC2130_REG_TPOWERDOWN, 0x00000000);
 	const bool isStealth = (tmc2130_mode == TMC2130_MODE_SILENT);
 	if (axis == Z_AXIS) {
 #ifdef TMC2130_STEALTH_Z
@@ -300,8 +302,6 @@ static void tmc2130_XYZ_reg_init(uint8_t axis)
 		tmc2130_wr(axis, TMC2130_REG_PWMCONF, pwmconf[axis].dw);
 		tmc2130_wr(axis, TMC2130_REG_TPWMTHRS, TMC2130_TPWMTHRS);
 	}
-	tmc2130_setup_chopper(axis, tmc2130_mres[axis]);
-	tmc2130_wr(axis, TMC2130_REG_TPOWERDOWN, 0x00000000);
 }
 
 void tmc2130_init(TMCInitParams params)


### PR DESCRIPTION
This PR fixes 3 bugs:

1. M913 doesn't report correct current values if Hold > Run and Hold current was truncated to match Run current
2. Hold current isn't updated correctly if the vSense bit changes due to Run current being increased or decreased (the case when Run decreases was not handled at all)
3. Fixed wrong order of register writes in `tmc2130_init` which were unintentionally changed in PFW-1392. CHOPCONF and TPOWERDOWN were written last (3.13.1) instead of first (3.13.0 and before).

----

The firmware will ensure that the Hold current can never exceed the Run current. In this scenario we must update the global current array so that M913 reflects the actual register settings.

Added a echo to serial when this truncation happens.

Steps to reproduce (MK3S+):

1. Enable `TMC2130_SERVICE_CODES_M910_M918`
2. Boot up printer and send `M913` to get default current values
```
tmc2130_print_currents()
	H	R
X	16	16
Y	20	20
Z	17	17
E	30	30
ok
```
4. Send `M911 Z35 E35`
5. Send M913 again and compare
```
tmc2130_print_currents()
	H	R
X	16	16
Y	20	20
Z	35	17
E	35	30
ok
```
7. Observe issue

✅ **Expected behavior:** M913 should show same values in steps 5) and 2)
:x: **Actual behavior:** M913 shows different values

Kudos to @ojrik for finding this issue 😄 

Change in memory:
Flash: +136 bytes
SRAM: 0 bytes