### PR TITLE
Fix Calibration XYZ

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -2174,7 +2174,7 @@ bool calibrate_z_auto()
 	plan_buffer_line_destinationXYZE(feedrate / 60);
 	st_synchronize();
 	enable_endstops(endstops_enabled);
-	if (PRINTER_TYPE == PRINTER_MK3) {
+	if((PRINTER_TYPE == PRINTER_MK3) || (PRINTER_TYPE == PRINTER_MK3S)){
 		current_position[Z_AXIS] = Z_MAX_POS + 2.0;
 	}
 	else {


### PR DESCRIPTION
This is the solution for XYZ Calibration. For MK3S and MK3S+. There is no height defined here for the MK3S machine, only for the MK2 MK2.5 MK3.

MK3S.h Configuration
// Printer revision
#define PRINTER_TYPE PRINTER_MK3S
#define PRINTER_NAME PRINTER_MK3S_NAME
#define PRINTER_NAME_ALTERNATE PRINTER_MK3_NAME //the other similar printer to this. #define PRINTER_MMU_TYPE PRINTER_MK3S_MMU3
#define PRINTER_MMU_NAME PRINTER_MK3S_MMU3_NAME