### PR TITLE
PFW-1531 Fix a possible recursion in fullscreen code

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3095,7 +3095,11 @@ uint8_t lcd_show_multiscreen_message_with_choices_and_wait_P(
 exit:
     KEEPALIVE_STATE(IN_HANDLER);
     lcd_set_custom_characters();
-    lcd_update_enable(true);
+    // Enable LCD updates again. We may not call lcd_update_enable(true)
+    // because it may create a recursion scenario when the caller of lcd_show_multiscreen_message_with_choices_and_wait_P
+    // is a submenu lcd_update_enable(true) will cause another call to the submenu immediately
+    // and so won't allow the user to exit the submenu
+    lcd_update_enabled = true;
     return current_selection;
 }
 


### PR DESCRIPTION
We may not call `lcd_update_enable(true)` in `lcd_show_multiscreen_message_with_choices_and_wait_P` when running a menu item. Because this can cause a recursion scenario such as in `lcd_v2_calibration` menu.

Fixes #4300

No change in memory