### PR TITLE
Fix a bug where Load filament menu disappears

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1833,13 +1833,8 @@ switch(eFilamentAction)
 
 void mFilamentBack()
 {
-    if (eFilamentAction == FilamentAction::AutoLoad ||
-        eFilamentAction == FilamentAction::Preheat ||
-        eFilamentAction == FilamentAction::Lay1Cal)
-    {
-        // filament action has been cancelled
-        eFilamentAction = FilamentAction::None;
-    }
+    // filament action has been cancelled
+    eFilamentAction = FilamentAction::None;
 }
 
 void mFilamentItem(uint16_t nTemp, uint16_t nTempBed)


### PR DESCRIPTION
Kudos to @3d-gussner for finding the issue

Steps to reproduce:
1. Boot up printer
2. Select "Load filament" menu
3. Select "Back" to leave the menu
4. **Observe issue** => "Load filament" menu and other MMU menus are gone!
5. **Workaround**: Got the "Preheat" menu, and Select "Back".

The issue also appears when a filament action actually completes running. For example by unloading filament.

This commit is my proposed fix.

When `eFilamentAction` is equal to
`FilamentAction::Load` we must reset it to `FilamentAction::None` when the Back button in Load Filament is selected

Issue was likely introduced with https://github.com/prusa3d/Prusa-Firmware/pull/3564

Change in memory:
Flash: -82 bytes
SRAM: 0 bytes