### PR TITLE
PFW-1530 Add "Tune" button to IDLER CANNOT HOME screen

### DIFF
--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -156,10 +156,10 @@ bool MMU2::WriteRegister(uint8_t address, uint16_t data) {
 
     // special cases - intercept requests of registers which influence the printer's behaviour too + perform the change even on the printer's side
     switch (address) {
-    case 0x0b:
+    case (uint8_t)Register::Extra_Load_Distance:
         logic.PlanExtraLoadDistance(data);
         break;
-    case 0x14:
+    case (uint8_t)Register::Pulley_Slow_Feedrate:
         logic.PlanPulleySlowFeedRate(data);
         break;
     default:

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -819,7 +819,7 @@ bool MMU2::manage_response(const bool move_axes, const bool turn_off_nozzle) {
             // the E may have some more moves to finish - wait for them
             ResumeHotendTemp();
             ResumeUnpark();             // We can now travel back to the tower or wherever we were when we saved.
-            if (!isErrorScreenSleeping())
+            if (!TuneMenuEntered())
             {
                 // If the error screen is sleeping (running 'Tune' menu)
                 // then don't reset retry attempts because we this will trigger

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -78,6 +78,19 @@ void MMU2::StopKeepPowered() {
     mmu2Serial.close();
 }
 
+void MMU2::Tune() {
+    switch (lastErrorCode) {
+    case ErrorCode::HOMING_IDLER_FAILED:
+    {
+        // Prompt a menu for different values
+        tuneIdlerStallguardThreshold();
+        break;
+    }
+    default:
+        break;
+    }
+}
+
 void MMU2::Reset(ResetForm level) {
     switch (level) {
     case Software:
@@ -741,6 +754,9 @@ void MMU2::CheckUserInput() {
         default:
             break;
         }
+        break;
+    case TuneMMU:
+        Tune();
         break;
     case ResetMMU:
         Reset(ResetPin); // we cannot do power cycle on the MK3

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -174,7 +174,7 @@ bool MMU2::ReadRegisterInner(uint8_t address) {
     return true;
 }
 
-bool MMU2::WriteRegister(uint8_t address, uint16_t data) {
+bool __attribute__((noinline)) MMU2::WriteRegister(uint8_t address, uint16_t data) {
     if (!WaitForMMUReady())
         return false;
 

--- a/Firmware/mmu2.h
+++ b/Firmware/mmu2.h
@@ -88,12 +88,6 @@ public:
     /// @returns true upon success
     bool ReadRegister(uint8_t address);
 
-    /// Variant of ReadRegister which runs in blocking context such as manage_response()
-    /// Be careful of using this as it is not recursion protected!
-    /// @param address Address of register in hexidecimal
-    /// @return true upon success
-    bool ReadRegisterInner(uint8_t address);
-
     /// Write from a MMU register (See gcode M708)
     /// @param address Address of register in hexidecimal
     /// @param data Data to write to register

--- a/Firmware/mmu2.h
+++ b/Firmware/mmu2.h
@@ -69,6 +69,10 @@ public:
         ErrorSourceNone = 0xFF,
     };
 
+    /// Tune value in MMU registers as a way to recover from errors
+    /// e.g. Idler Stallguard threshold
+    void Tune();
+
     /// Perform a reset of the MMU
     /// @param level physical form of the reset
     void Reset(ResetForm level);

--- a/Firmware/mmu2.h
+++ b/Firmware/mmu2.h
@@ -88,6 +88,12 @@ public:
     /// @returns true upon success
     bool ReadRegister(uint8_t address);
 
+    /// Variant of ReadRegister which runs in blocking context such as manage_response()
+    /// Be careful of using this as it is not recursion protected!
+    /// @param address Address of register in hexidecimal
+    /// @return true upon success
+    bool ReadRegisterInner(uint8_t address);
+
     /// Write from a MMU register (See gcode M708)
     /// @param address Address of register in hexidecimal
     /// @param data Data to write to register
@@ -193,6 +199,12 @@ public:
     inline uint16_t TMCFailures() const { return tmcFailures; }
     inline void IncrementTMCFailures() { ++tmcFailures; }
     inline void ClearTMCFailures() { tmcFailures = 0; }
+
+    /// Retrieve cached value parsed from ReadRegister()
+    /// or using M707
+    inline uint16_t GetLastReadRegisterValue() const {
+        return lastReadRegisterValue;
+    };
 
 private:
     /// Perform software self-reset of the MMU (sends an X0 command)
@@ -301,6 +313,7 @@ private:
     ErrorCode lastErrorCode = ErrorCode::MMU_NOT_RESPONDING;
     ErrorSource lastErrorSource = ErrorSource::ErrorSourceNone;
     Buttons lastButton = Buttons::NoButton;
+    uint16_t lastReadRegisterValue = 0;
 
     StepStatus logicStepLastStatus;
 

--- a/Firmware/mmu2/buttons.h
+++ b/Firmware/mmu2/buttons.h
@@ -17,6 +17,7 @@ enum class ButtonOperations : uint8_t {
     Unload      = 4,
     StopPrint   = 5,
     DisableMMU  = 6,
+    Tune = 7,
 };
 
 /// Button codes + extended actions performed on the printer's side
@@ -29,6 +30,7 @@ enum Buttons : uint8_t {
     ResetMMU,
     StopPrint,
     DisableMMU,
+    TuneMMU, // Printer changes MMU register value
     
     NoButton = 0xff // shall be kept last
 };

--- a/Firmware/mmu2/errors_list.h
+++ b/Firmware/mmu2/errors_list.h
@@ -349,7 +349,7 @@ static const char MSG_BTN_RESET_MMU[] PROGMEM_I1 = ISTR("ResetMMU"); ////MSG_BTN
 static const char MSG_BTN_UNLOAD[] PROGMEM_I1 = ISTR("Unload"); ////MSG_BTN_UNLOAD c=8
 static const char MSG_BTN_STOP[] PROGMEM_I1 = ISTR("Stop"); ////MSG_BTN_STOP c=8
 static const char MSG_BTN_DISABLE_MMU[] PROGMEM_I1 = ISTR("Disable"); ////MSG_BTN_DISABLE_MMU c=8
-static const char MSG_BTN_TUNE_MMU[] PROGMEM_I1 = ISTR("Tune"); ////MSG_BTN_DISABLE_MMU c=8
+static const char MSG_BTN_TUNE_MMU[] PROGMEM_I1 = ISTR("Tune"); ////MSG_BTN_TUNE_MMU c=8
 static const char MSG_BTN_MORE[] PROGMEM_N1 = "\x06";
 
 // Used to parse the buttons from Btns().

--- a/Firmware/mmu2/errors_list.h
+++ b/Firmware/mmu2/errors_list.h
@@ -349,6 +349,7 @@ static const char MSG_BTN_RESET_MMU[] PROGMEM_I1 = ISTR("ResetMMU"); ////MSG_BTN
 static const char MSG_BTN_UNLOAD[] PROGMEM_I1 = ISTR("Unload"); ////MSG_BTN_UNLOAD c=8
 static const char MSG_BTN_STOP[] PROGMEM_I1 = ISTR("Stop"); ////MSG_BTN_STOP c=8
 static const char MSG_BTN_DISABLE_MMU[] PROGMEM_I1 = ISTR("Disable"); ////MSG_BTN_DISABLE_MMU c=8
+static const char MSG_BTN_TUNE_MMU[] PROGMEM_I1 = ISTR("Tune"); ////MSG_BTN_DISABLE_MMU c=8
 static const char MSG_BTN_MORE[] PROGMEM_N1 = "\x06";
 
 // Used to parse the buttons from Btns().
@@ -359,6 +360,7 @@ static const char * const btnOperation[] PROGMEM = {
     _R(MSG_BTN_UNLOAD),
     _R(MSG_BTN_STOP),
     _R(MSG_BTN_DISABLE_MMU),
+    _R(MSG_BTN_TUNE_MMU),
 };
 
 // We have 8 different operations/buttons at this time, so we need at least 4 bits to encode each.
@@ -380,7 +382,7 @@ static const uint8_t errorButtons[] PROGMEM = {
     Btns(ButtonOperations::Continue, ButtonOperations::NoOperation),//LOAD_TO_EXTRUDER_FAILED
     Btns(ButtonOperations::Retry, ButtonOperations::NoOperation),//SELECTOR_CANNOT_HOME
     Btns(ButtonOperations::Retry, ButtonOperations::NoOperation),//SELECTOR_CANNOT_MOVE
-    Btns(ButtonOperations::Retry, ButtonOperations::NoOperation),//IDLER_CANNOT_HOME
+    Btns(ButtonOperations::Retry, ButtonOperations::Tune),//IDLER_CANNOT_HOME
     Btns(ButtonOperations::Retry, ButtonOperations::NoOperation),//IDLER_CANNOT_MOVE
 
     Btns(ButtonOperations::Continue, ButtonOperations::ResetMMU),//WARNING_TMC_PULLEY_TOO_HOT

--- a/Firmware/mmu2/errors_list.h
+++ b/Firmware/mmu2/errors_list.h
@@ -380,7 +380,7 @@ static const uint8_t errorButtons[] PROGMEM = {
     Btns(ButtonOperations::Retry, ButtonOperations::NoOperation),//FSENSOR_TOO_EARLY
     Btns(ButtonOperations::Retry, ButtonOperations::NoOperation),//INSPECT_FINDA
     Btns(ButtonOperations::Continue, ButtonOperations::NoOperation),//LOAD_TO_EXTRUDER_FAILED
-    Btns(ButtonOperations::Retry, ButtonOperations::NoOperation),//SELECTOR_CANNOT_HOME
+    Btns(ButtonOperations::Retry, ButtonOperations::Tune),//SELECTOR_CANNOT_HOME
     Btns(ButtonOperations::Retry, ButtonOperations::NoOperation),//SELECTOR_CANNOT_MOVE
     Btns(ButtonOperations::Retry, ButtonOperations::Tune),//IDLER_CANNOT_HOME
     Btns(ButtonOperations::Retry, ButtonOperations::NoOperation),//IDLER_CANNOT_MOVE

--- a/Firmware/mmu2_error_converter.cpp
+++ b/Firmware/mmu2_error_converter.cpp
@@ -207,12 +207,22 @@ Buttons ButtonAvailable(uint16_t ec) {
     case ERR_MECHANICAL_INSPECT_FINDA:
     case ERR_MECHANICAL_SELECTOR_CANNOT_HOME:
     case ERR_MECHANICAL_SELECTOR_CANNOT_MOVE:
-    case ERR_MECHANICAL_IDLER_CANNOT_HOME:
     case ERR_MECHANICAL_IDLER_CANNOT_MOVE:
     case ERR_MECHANICAL_PULLEY_CANNOT_MOVE:
     case ERR_SYSTEM_UNLOAD_MANUALLY:
         switch (buttonSelectedOperation) {
         // may be allow move selector right and left in the future
+        case ButtonOperations::Retry: // "Repeat action"
+            return Middle;
+        default:
+            break;
+        }
+        break;
+    case ERR_MECHANICAL_IDLER_CANNOT_HOME:
+        switch (buttonSelectedOperation) {
+        // may be allow move selector right and left in the future
+        case ButtonOperations::Tune: // Tune Stallguard threshold
+            return TuneMMU;
         case ButtonOperations::Retry: // "Repeat action"
             return Middle;
         default:

--- a/Firmware/mmu2_error_converter.cpp
+++ b/Firmware/mmu2_error_converter.cpp
@@ -205,7 +205,6 @@ Buttons ButtonAvailable(uint16_t ec) {
     case ERR_MECHANICAL_FSENSOR_FILAMENT_STUCK:
     case ERR_MECHANICAL_FSENSOR_TOO_EARLY:
     case ERR_MECHANICAL_INSPECT_FINDA:
-    case ERR_MECHANICAL_SELECTOR_CANNOT_HOME:
     case ERR_MECHANICAL_SELECTOR_CANNOT_MOVE:
     case ERR_MECHANICAL_IDLER_CANNOT_MOVE:
     case ERR_MECHANICAL_PULLEY_CANNOT_MOVE:
@@ -218,6 +217,7 @@ Buttons ButtonAvailable(uint16_t ec) {
             break;
         }
         break;
+    case ERR_MECHANICAL_SELECTOR_CANNOT_HOME:
     case ERR_MECHANICAL_IDLER_CANNOT_HOME:
         switch (buttonSelectedOperation) {
         // may be allow move selector right and left in the future

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -410,7 +410,7 @@ void tuneIdlerStallguardThresholdMenu() {
         memcpy_P(&(_md->item), &TuneItems[offset], sizeof(TuneItem));
 
         // Fetch the value which is currently in MMU EEPROM
-        mmu2.ReadRegister((uint8_t)_md->item.address);
+        mmu2.ReadRegister(_md->item.address);
         _md->currentValue = mmu2.GetLastReadRegisterValue();
     }
 

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -227,7 +227,7 @@ bool isErrorScreenRunning() {
     return is_mmu_error_monitor_active;
 }
 
-bool isErrorScreenSleeping() {
+bool TuneMenuEntered() {
     return putErrorScreenToSleep;
 }
 

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -386,10 +386,7 @@ void tuneIdlerStallguardThreshold() {
     tuningDone = false;
     menu_goto(tuneIdlerStallguardThresholdMenu, 0, 0, 0);
     while(!tuningDone) {
-        manage_heater();
-        // Manage inactivity, but don't disable steppers on timeout.
-        manage_inactivity(true);
-        lcd_update(0);
+        delay_keep_alive(0);
     }
     lcd_return_to_status();
 }

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -385,13 +385,13 @@ static const TuneItem TuneItems[] PROGMEM = {
 
 static_assert(sizeof(TuneItems)/sizeof(TuneItem) == 2);
 
-typedef struct
+struct _menu_tune_data_t
 {
     menu_data_edit_t reserved; //13 bytes reserved for number editing functions
     int8_t status;             // 1 byte
     uint8_t currentValue;      // 1 byte
     TuneItem item;             // 3 bytes
-} _menu_tune_data_t;
+};
 
 static_assert(sizeof(_menu_tune_data_t) == 18);
 static_assert(sizeof(menu_data)>= sizeof(_menu_tune_data_t),"_menu_tune_data_t doesn't fit into menu_data");

--- a/Firmware/mmu2_reporting.h
+++ b/Firmware/mmu2_reporting.h
@@ -25,6 +25,11 @@ void EndReport(CommandInProgress cip, uint16_t ec);
 /// Return true if the printer's LCD is drawing the error screen
 bool isErrorScreenRunning();
 
+/// Return true if the error screen is sleeping in the background
+/// Error screen sleeps when the firmware is rendering complementary
+/// UI to resolve the error screen, for example tuning Idler Stallguard Threshold
+bool isErrorScreenSleeping();
+
 /// @brief Called when the MMU or MK3S sends operation error (even repeatedly).
 /// Render MMU error screen on the LCD. This must be non-blocking
 /// and allow the MMU and printer to communicate with each other.

--- a/Firmware/mmu2_reporting.h
+++ b/Firmware/mmu2_reporting.h
@@ -86,4 +86,6 @@ void FullScreenMsgRestoringTemperature();
 void ScreenUpdateEnable();
 void ScreenClear();
 
+void tuneIdlerStallguardThreshold();
+
 } // namespace

--- a/Firmware/mmu2_reporting.h
+++ b/Firmware/mmu2_reporting.h
@@ -28,7 +28,7 @@ bool isErrorScreenRunning();
 /// Return true if the error screen is sleeping in the background
 /// Error screen sleeps when the firmware is rendering complementary
 /// UI to resolve the error screen, for example tuning Idler Stallguard Threshold
-bool isErrorScreenSleeping();
+bool TuneMenuEntered();
 
 /// @brief Called when the MMU or MK3S sends operation error (even repeatedly).
 /// Render MMU error screen on the LCD. This must be non-blocking


### PR DESCRIPTION
TODOs:
- [x] Change "Idler" text to something more descriptive while also being less than 17 characters
- [x] Add similar options to SELECTOR CANNOT HOME screen ( with range 1 to 4)
- [x] Try to change the screen such that it reads the current value from MMU EEPROM instead of showing a hard-coded value on the printer side.

----

Instead of adding a new Stallguard Threshold editing menu to the LCD Experimental menu, I propose to add a new _Tune_ button option to the MMU error screen. The Experimental menu is not accessible at all when the MMU error screen is active and so I think having the options available during the MMU error UI itself is more user friendly. Which ever way we go there is a lot of memory consumed by this since the menu code is very memory (flash) hungry.

Below are some images to show the new UI. Note that "Idler" text will be changed, I only took these photos to show the concept.

When the _Done_ button is clicked, the MMU error screen will disappear and the Idler will attempt to re-home with the new setting.

| Error screen with new option| Tune menu |
|------|------|
| ![IMG_3793](https://github.com/prusa3d/Prusa-Firmware/assets/8218499/f679601f-a3fb-496d-bf42-cf5c3aed0240)    |   ![IMG_3794](https://github.com/prusa3d/Prusa-Firmware/assets/8218499/f213e71f-9cb6-4d38-ac74-a22937e3ec08)   |

