### PR TITLE
🚧 filament runout: only allowed if E-axis is active

### DIFF
--- a/Firmware/Filament_sensor.cpp
+++ b/Firmware/Filament_sensor.cpp
@@ -128,7 +128,7 @@ void Filament_sensor::triggerFilamentRemoved() {
     if (runoutEnabled
         && (eFilamentAction == FilamentAction::None)
         && (
-            moves_planned() != 0
+            e_active()
             || printJobOngoing()
         )
         && !(


### PR DESCRIPTION
Only allow filament runouts when the extruder motor is moving. We do this for FINDA runouts, so why not Fsensor as well? 

I think this may improve situations like https://github.com/prusa3d/Prusa-Firmware/issues/4323

Change in memory:
Flash: -6 bytes
SRAM: 0 bytes