### PR TITLE
Fix lcd update after PFW-1531

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3111,6 +3111,7 @@ exit:
     // is a submenu lcd_update_enable(true) will cause another call to the submenu immediately
     // and so won't allow the user to exit the submenu
     lcd_update_enabled = true;
+    lcd_draw_update = 2;
     return current_selection;
 }
 


### PR DESCRIPTION
Before #4307, when you selected "no" on the "Filament extruding & correct color?" msg., the menu exited and the screen immediately changed to "filament loading".
Now the yes/no selection stays on the LCD even after selecting the "no" option.

This restores the original behavior.