### PR TITLE
cmake: Cache CUSTOM_COMPILE_OPTIONS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,10 @@ set(PROJECT_VERSION_TIMESTAMP
     ""
     CACHE STRING "Timestamp for the build. Resolved automatically if not specified."
     )
+set(CUSTOM_COMPILE_OPTIONS
+    ""
+    CACHE STRING "Allows adding custom C/C++ flags"
+    )
 
 include(cmake/ProjectVersion.cmake)
 resolve_version_variables()


### PR DESCRIPTION
This allows persisting custom flags across builds, as intended.

CUSTOM_COMPILE_OPTIONS was already handled, we just allow to persist it here.