### PR TITLE
optimisation: Timer constructor can be `constexpr`

### DIFF
--- a/Firmware/Timer.cpp
+++ b/Firmware/Timer.cpp
@@ -7,17 +7,6 @@
 #include "system_timer.h"
 
 /**
- * @brief construct Timer
- *
- * It is guaranteed, that construction is equivalent with zeroing all members.
- * This property can be exploited in menu_data.
- */
-template<typename T>
-Timer<T>::Timer() : m_isRunning(false), m_started()
-{
-}
-
-/**
  * @brief Start timer
  */
 template<typename T>

--- a/Firmware/Timer.h
+++ b/Firmware/Timer.h
@@ -17,7 +17,10 @@ template <class T>
 class Timer
 {
 public:
-    Timer();
+    inline constexpr Timer()
+    : m_isRunning(false)
+    , m_started(0) {};
+
     void start();
     void stop(){m_isRunning = false;}
     bool running()const {return m_isRunning;}


### PR DESCRIPTION
There could be more classes which can be optimised this way.

Change in memory:
Flash: -206 bytes
SRAM: -16 bytes