### PR TITLE
🚧 Improve handling of stepper inactivity timeout in `manage_inactivity()`

### DIFF
--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -123,7 +123,7 @@ bool is_buffer_empty();
 void process_commands();
 void ramming();
 
-void manage_inactivity(bool ignore_stepper_queue=false);
+void manage_inactivity(const bool no_stepper_sleep=false);
 
 #if defined(X_ENABLE_PIN) && X_ENABLE_PIN > -1
   #define  enable_x() WRITE(X_ENABLE_PIN, X_ENABLE_ON)

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1829,7 +1829,7 @@ void loop()
 }
   //check heater every n milliseconds
   manage_heater();
-  manage_inactivity(isPrintPaused);
+  manage_inactivity();
   checkHitEndstops();
   lcd_update(0);
 #ifdef TMC2130

--- a/Firmware/planner.cpp
+++ b/Firmware/planner.cpp
@@ -708,7 +708,7 @@ void plan_buffer_line(float x, float y, float z, const float &e, float feed_rate
       do {
           manage_heater(); 
           // Vojtech: Don't disable motors inside the planner!
-          manage_inactivity(false); 
+          manage_inactivity(true); 
           lcd_update(0);
       } while (block_buffer_tail == next_buffer_head);
   }


### PR DESCRIPTION
If steppers are not allowed to be disabled when `no_stepper_sleep = true` then `manage_inactivity()` should enforce this. This wasn't being done in Marlin 1, but I noticed this is now done in Marlin 2.1 and I think it is a good improvement.

I also added a log for the event when the steppers are disabled.