### PR TITLE
lang: Do not hardcode python executable name

### DIFF
--- a/lang/update-pot.py
+++ b/lang/update-pot.py
@@ -67,7 +67,7 @@ def main():
     try:
         subprocess.check_call(
             [
-                "python",
+                sys.executable,
                 SCRIPT_PATH,
                 "--no-missing",
                 "-s",


### PR DESCRIPTION
Use sys.executable instead to ensure the executable used by "env" is kept.

This fixes update-pot.py when run within a virtualenv and/or if "python" is not available (python3 is the default)