### PR TITLE
Fix Z crash and update to 3.13.1

### DIFF
--- a/Firmware/Configuration.h
+++ b/Firmware/Configuration.h
@@ -15,16 +15,16 @@ extern const char _sPrinterMmuName[] PROGMEM;
 // Firmware version
 #define FW_MAJOR 3
 #define FW_MINOR 13
-#define FW_REVISION 0
+#define FW_REVISION 1
 //#define FW_FLAVOR RC      //uncomment if DEBUG, DEVEL, ALPHA, BETA or RC
-#define FW_FLAVERSION 1     //uncomment if FW_FLAVOR is defined and versioning is needed. Limited to max 8.
+//#define FW_FLAVERSION 1     //uncomment if FW_FLAVOR is defined and versioning is needed. Limited to max 8.
 #ifndef FW_FLAVOR
     #define FW_VERSION STR(FW_MAJOR) "." STR(FW_MINOR) "." STR(FW_REVISION)
 #else
     #define FW_VERSION STR(FW_MAJOR) "." STR(FW_MINOR) "." STR(FW_REVISION) "-" STR(FW_FLAVOR) "" STR(FW_FLAVERSION)
 #endif
 
-#define FW_COMMIT_NR 6873
+#define FW_COMMIT_NR 6876
 
 // FW_VERSION_UNKNOWN means this is an unofficial build.
 // The firmware should only be checked into github with this symbol.

--- a/Firmware/mesh_bed_calibration.cpp
+++ b/Firmware/mesh_bed_calibration.cpp
@@ -2790,16 +2790,22 @@ canceled:
 #endif //NEW_XYZCAL
 
 bool sample_z() {
-	bool sampled = true;
-	//make space
-	raise_z(150);
-	lcd_show_fullscreen_message_and_wait_P(_T(MSG_PLACE_STEEL_SHEET));
+    bool sampled = true;
+    // make some space for the sheet
+    // Avoid calling raise_z(), because a false triggering stallguard may prevent the Z from moving.
+    // The extruder then may ram the sheet hard if not going down from some ~150mm height
+    current_position[Z_AXIS] = 0.F;
+    destination[Z_AXIS] = 150.F;
+    plan_buffer_line_destinationXYZE(homing_feedrate[Z_AXIS] / 60);
 
-	// Sample Z heights for the mesh bed leveling.
-	// In addition, store the results into an eeprom, to be used later for verification of the bed leveling process.
-	if (!sample_mesh_and_store_reference()) sampled = false;
+    lcd_show_fullscreen_message_and_wait_P(_T(MSG_PLACE_STEEL_SHEET));
 
-	return sampled;
+    // Sample Z heights for the mesh bed leveling.
+    // In addition, store the results into an eeprom, to be used later for verification of the bed leveling process.
+    if (!sample_mesh_and_store_reference())
+        sampled = false;
+
+    return sampled;
 }
 
 void go_home_with_z_lift()


### PR DESCRIPTION
Cherry pick https://github.com/prusa3d/Prusa-Firmware/pull/4357 to v3.13.0 based release

- [ ] With the release the MMU3 hex has to be [MMU3_3.0.0+814.hex](https://github.com/prusa3d/Prusa-Firmware/releases/download/v3.13.0/MMU3_3.0.0+814.hex)