### PR TITLE
Explicitly use `Buttons` namespace

### DIFF
--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -241,7 +241,7 @@ bool MMU2::RetryIfPossible(uint16_t ec) {
     if (logic.RetryAttempts()) {
         SetButtonResponse(ButtonOperations::Retry);
         // check, that Retry is actually allowed on that operation
-        if (ButtonAvailable(ec) != NoButton) {
+        if (ButtonAvailable(ec) != Buttons::NoButton) {
             logic.SetInAutoRetry(true);
             SERIAL_ECHOLNPGM("RetryButtonPressed");
             // We don't decrement until the button is acknowledged by the MMU.
@@ -733,9 +733,9 @@ void MMU2::CheckUserInput() {
     }
 
     switch (btn) {
-    case Left:
-    case Middle:
-    case Right:
+    case Buttons::Left:
+    case Buttons::Middle:
+    case Buttons::Right:
         SERIAL_ECHOPGM("CheckUserInput-btnLMR ");
         SERIAL_ECHOLN(btn);
         ResumeHotendTemp(); // Recover the hotend temp before we attempt to do anything else...
@@ -757,22 +757,22 @@ void MMU2::CheckUserInput() {
             break;
         }
         break;
-    case TuneMMU:
+    case Buttons::TuneMMU:
         Tune();
         break;
-    case Load:
-    case Eject:
+    case Buttons::Load:
+    case Buttons::Eject:
         // High level operation
         setPrinterButtonOperation(btn);
         break;
-    case ResetMMU:
+    case Buttons::ResetMMU:
         Reset(ResetPin); // we cannot do power cycle on the MK3
         // ... but mmu2_power.cpp knows this and triggers a soft-reset instead.
         break;
-    case DisableMMU:
+    case Buttons::DisableMMU:
         Stop(); // Poweroff handles updating the EEPROM shutoff.
         break;
-    case StopPrint:
+    case Buttons::StopPrint:
         // @@TODO not sure if we shall handle this high level operation at this spot
         break;
     default:

--- a/Firmware/mmu2_error_converter.cpp
+++ b/Firmware/mmu2_error_converter.cpp
@@ -186,7 +186,7 @@ struct ResetOnExit {
 
 Buttons ButtonPressed(uint16_t ec) {
     if (buttonSelectedOperation == ButtonOperations::NoOperation) {
-        return NoButton; // no button
+        return Buttons::NoButton; // no button
     }
     
     ResetOnExit ros; // clear buttonSelectedOperation on exit from this call
@@ -214,7 +214,7 @@ Buttons ButtonAvailable(uint16_t ec) {
         switch (buttonSelectedOperation) {
         // may be allow move selector right and left in the future
         case ButtonOperations::Retry: // "Repeat action"
-            return Middle;
+            return Buttons::Middle;
         default:
             break;
         }
@@ -224,9 +224,9 @@ Buttons ButtonAvailable(uint16_t ec) {
         switch (buttonSelectedOperation) {
         // may be allow move selector right and left in the future
         case ButtonOperations::Tune: // Tune Stallguard threshold
-            return TuneMMU;
+            return Buttons::TuneMMU;
         case ButtonOperations::Retry: // "Repeat action"
-            return Middle;
+            return Buttons::Middle;
         default:
             break;
         }
@@ -235,7 +235,7 @@ Buttons ButtonAvailable(uint16_t ec) {
     case ERR_SYSTEM_FILAMENT_EJECTED:
         switch (buttonSelectedOperation) {
         case ButtonOperations::Continue: // User solved the serious mechanical problem by hand - there is no other way around
-            return Middle;
+            return Buttons::Middle;
         default:
             break;
         }
@@ -243,9 +243,9 @@ Buttons ButtonAvailable(uint16_t ec) {
     case ERR_SYSTEM_FILAMENT_CHANGE:
         switch (buttonSelectedOperation) {
         case ButtonOperations::Load:
-            return Load;
+            return Buttons::Load;
         case ButtonOperations::Eject:
-            return Eject;
+            return Buttons::Eject;
         default:
             break;
         }
@@ -255,9 +255,9 @@ Buttons ButtonAvailable(uint16_t ec) {
     case ERR_TEMPERATURE_WARNING_TMC_IDLER_TOO_HOT:
         switch (buttonSelectedOperation) {
         case ButtonOperations::Continue: // "Continue"
-            return Left;
+            return Buttons::Left;
         case ButtonOperations::ResetMMU: // "Reset MMU"
-            return ResetMMU;
+            return Buttons::ResetMMU;
         default:
             break;
         }
@@ -292,7 +292,7 @@ Buttons ButtonAvailable(uint16_t ec) {
     case ERR_ELECTRICAL_MMU_MCU_ERROR:
         switch (buttonSelectedOperation) {
         case ButtonOperations::ResetMMU: // "Reset MMU"
-            return ResetMMU;
+            return Buttons::ResetMMU;
         default:
             break;
         }
@@ -302,9 +302,9 @@ Buttons ButtonAvailable(uint16_t ec) {
     case ERR_SYSTEM_FW_UPDATE_NEEDED:
         switch (buttonSelectedOperation) {
         case ButtonOperations::DisableMMU: // "Disable"
-            return DisableMMU;
+            return Buttons::DisableMMU;
         case ButtonOperations::ResetMMU: // "ResetMMU"
-            return ResetMMU;
+            return Buttons::ResetMMU;
         default:
             break;
         }
@@ -312,9 +312,9 @@ Buttons ButtonAvailable(uint16_t ec) {
     case ERR_SYSTEM_FILAMENT_ALREADY_LOADED:
         switch (buttonSelectedOperation) {
         case ButtonOperations::Unload: // "Unload"
-            return Left;
+            return Buttons::Left;
         case ButtonOperations::Continue: // "Proceed/Continue"
-            return Right;
+            return Buttons::Right;
         default:
             break;
         }
@@ -323,9 +323,9 @@ Buttons ButtonAvailable(uint16_t ec) {
     case ERR_SYSTEM_INVALID_TOOL:
         switch (buttonSelectedOperation) {
         case ButtonOperations::StopPrint: // "Stop print"
-            return StopPrint;
+            return Buttons::StopPrint;
         case ButtonOperations::ResetMMU: // "Reset MMU"
-            return ResetMMU;
+            return Buttons::ResetMMU;
         default:
             break;
         }
@@ -335,7 +335,7 @@ Buttons ButtonAvailable(uint16_t ec) {
         break;
     }
     
-    return NoButton;
+    return Buttons::NoButton;
 }
 
 void SetButtonResponse(ButtonOperations rsp){

--- a/Firmware/mmu2_protocol_logic.cpp
+++ b/Firmware/mmu2_protocol_logic.cpp
@@ -532,7 +532,7 @@ ProtocolLogic::ProtocolLogic(MMU2Serial *uart, uint8_t extraLoadDistance, uint8_
     , uart(uart)
     , errorCode(ErrorCode::OK)
     , progressCode(ProgressCode::OK)
-    , buttonCode(NoButton)
+    , buttonCode(Buttons::NoButton)
     , lastFSensor((uint8_t)WhereIsFilament())
     , regIndex(0)
     , retryAttempts(MAX_RETRIES)


### PR DESCRIPTION
I thought about first removing the `Buttons::` on the 32-bit side, but I think it is better to have it. So this PR adds it to the 8-bit FW.

This change syncs the code a little bit with the 32-bit FW

No change in memory