### PR TITLE
Fix build issues when filament sensor is not defined

### DIFF
--- a/Firmware/Filament_sensor.cpp
+++ b/Firmware/Filament_sensor.cpp
@@ -40,6 +40,7 @@ FSensorBlockRunout::FSensorBlockRunout() { }
 FSensorBlockRunout::~FSensorBlockRunout() { }
 #endif // FILAMENT_SENSOR
 
+#ifdef FILAMENT_SENSOR
 void Filament_sensor::setEnabled(bool enabled) {
     eeprom_update_byte((uint8_t *)EEPROM_FSENSOR, enabled);
     if (enabled) {
@@ -520,3 +521,4 @@ bool PAT9125_sensor::updatePAT9125() {
     return (filter == 0); // return stability
 }
 #endif // #if (FILAMENT_SENSOR_TYPE == FSENSOR_PAT9125)
+#endif // FILAMENT_SENSOR

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -5360,7 +5360,11 @@ void process_commands()
       starttime=_millis();
       if (MMU2::mmu2.Enabled())
       {
+#ifdef FILAMENT_SENSOR
         if (MMU2::mmu2.FindaDetectsFilament() && !fsensor.getFilamentPresent())
+#else
+        if (MMU2::mmu2.FindaDetectsFilament())
+#endif
         { // Filament only half way into the PTFE. Unload the filament.
           MMU2::mmu2.unload();
           // Tx and Tc gcodes take care of loading the filament to the nozzle.

--- a/Firmware/mmu2_fsensor.cpp
+++ b/Firmware/mmu2_fsensor.cpp
@@ -4,7 +4,11 @@
 namespace MMU2 {
 
 FilamentState WhereIsFilament(){
+#ifdef FILAMENT_SENSOR
     return fsensor.getFilamentPresent() ? FilamentState::AT_FSENSOR : FilamentState::NOT_PRESENT;
+#else
+    return FilamentState::NOT_PRESENT;
+#endif
 }
 
 } // namespace MMU2

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -36,8 +36,9 @@ void EndReport(CommandInProgress /*cip*/, uint16_t /*ec*/) {
 extern void ReportErrorHookDynamicRender(void){
     // beware - this optimization abuses the fact, that FindaDetectsFilament returns 0 or 1 and '0' is followed by '1' in the ASCII table
     lcd_putc_at(3, 2, mmu2.FindaDetectsFilament() + '0');
+#ifdef FILAMENT_SENSOR
     lcd_putc_at(8, 2, fsensor.getFilamentPresent() + '0');
-
+#endif
     // print active/changing filament slot
     lcd_set_cursor(10, 2);
     lcdui_print_extruder();

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5273,7 +5273,11 @@ static void lcd_main_menu()
 
     if ( ! ( printJobOngoing() || (lcd_commands_type != LcdCommands::Idle) || (eFilamentAction != FilamentAction::None) || Stopped ) ) {
         if (MMU2::mmu2.Enabled()) {
+#ifdef FILAMENT_SENSOR
             if(!MMU2::mmu2.FindaDetectsFilament() && !fsensor.getFilamentPresent()) {
+#else
+            if(!MMU2::mmu2.FindaDetectsFilament()) {
+#endif
                 // The MMU 'Load filament' state machine will reject the command if any 
                 // filament sensor is reporting a detected filament
                 MENU_ITEM_SUBMENU_P(_T(MSG_PRELOAD_TO_MMU), mmu_preload_filament_menu);


### PR DESCRIPTION
In Firmware/variants/M*-RAMBo*.h there is a `#define FILAMENT_SENSOR` however the code doesn't compile when this define is removed. Maybe all printers have a filament sensor now but mine doesn't, So I would like to compile the firmware without it.

This PR fixes the compile issues in the way that seems to make sense.

