### PR TITLE
MBL: Default to EEPROM values

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -2821,12 +2821,14 @@ static void gcode_G80()
 #endif //PINDA_THERMISTOR
 
     uint8_t nMeasPoints = eeprom_read_byte((uint8_t*)EEPROM_MBL_POINTS_NR);
-    if (code_seen('N') && (code_value_uint8() == 7 || code_value_uint8() == 3))
-      nMeasPoints = code_value_uint8();
-    
+    bool bCodeSeen = code_seen('N');
+    if (uint8_t value = code_value_uint8(); bCodeSeen && (value == 7 || value == 3))
+      nMeasPoints = value;
+
     uint8_t nProbeRetryCount = eeprom_read_byte((uint8_t*)EEPROM_MBL_PROBE_NR);
-    if (code_seen('C') && code_value_uint8() >= 1 && code_value_uint8() <= 10)
-      nProbeRetryCount = code_value_uint8();
+    bCodeSeen = code_seen('C');
+    if (uint8_t value = code_value_uint8(); bCodeSeen && value >= 1 && value <= 10)
+      nProbeRetryCount = value;
 
     const float area_min_x = code_seen('X') ? code_value() - x_mesh_density - X_PROBE_OFFSET_FROM_EXTRUDER : -INFINITY;
     const float area_min_y = code_seen('Y') ? code_value() - y_mesh_density - Y_PROBE_OFFSET_FROM_EXTRUDER : -INFINITY;

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -2821,13 +2821,11 @@ static void gcode_G80()
 #endif //PINDA_THERMISTOR
 
     uint8_t nMeasPoints = eeprom_read_byte((uint8_t*)EEPROM_MBL_POINTS_NR);
-    bool bCodeSeen = code_seen('N');
-    if (uint8_t value = code_value_uint8(); bCodeSeen && (value == 7 || value == 3))
+    if (uint8_t codeSeen = code_seen('N'), value = code_value_uint8(); codeSeen && (value == 7 || value == 3))
       nMeasPoints = value;
 
     uint8_t nProbeRetryCount = eeprom_read_byte((uint8_t*)EEPROM_MBL_PROBE_NR);
-    bCodeSeen = code_seen('C');
-    if (uint8_t value = code_value_uint8(); bCodeSeen && value >= 1 && value <= 10)
+    if (uint8_t codeSeen = code_seen('C'), value = code_value_uint8(); codeSeen && value >= 1 && value <= 10)
       nProbeRetryCount = value;
 
     const float area_min_x = code_seen('X') ? code_value() - x_mesh_density - X_PROBE_OFFSET_FROM_EXTRUDER : -INFINITY;

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -2820,15 +2820,13 @@ static void gcode_G80()
     run = false;
 #endif //PINDA_THERMISTOR
 
-    uint8_t nMeasPoints = code_seen('N') ? code_value_uint8() : eeprom_read_byte((uint8_t*)EEPROM_MBL_POINTS_NR);
-    if (nMeasPoints != 7) {
-        nMeasPoints = 3;
-    }
-
-    uint8_t nProbeRetryCount = code_seen('C') ? code_value_uint8() : eeprom_read_byte((uint8_t*)EEPROM_MBL_PROBE_NR);
-    if (nProbeRetryCount > 10) {
-        nProbeRetryCount = 10;
-    }
+    uint8_t nMeasPoints = eeprom_read_byte((uint8_t*)EEPROM_MBL_POINTS_NR);
+    if (code_seen('N') && (code_value_uint8() == 7 || code_value_uint8() == 3))
+      nMeasPoints = code_value_uint8();
+    
+    uint8_t nProbeRetryCount = eeprom_read_byte((uint8_t*)EEPROM_MBL_PROBE_NR);
+    if (code_seen('C') && code_value_uint8() >= 1 && code_value_uint8() <= 10)
+      nProbeRetryCount = code_value_uint8();
 
     const float area_min_x = code_seen('X') ? code_value() - x_mesh_density - X_PROBE_OFFSET_FROM_EXTRUDER : -INFINITY;
     const float area_min_y = code_seen('Y') ? code_value() - y_mesh_density - Y_PROBE_OFFSET_FROM_EXTRUDER : -INFINITY;
@@ -4885,9 +4883,9 @@ void process_commands()
           G80 [ N | C | O | L | R | F | B | X | Y | W | H ]
       
 	#### Parameters
-      - `N` - Number of mesh points on x axis. Default is 3. Valid values are 3 and 7.
-      - `C` - Probe retry counts. Default 3 max. 10
-      - `O` - Return to origin. Default 1 (true)
+      - `N` - Number of mesh points on x axis. Default is value stored in EEPROM. Valid values are 3 and 7.
+      - `C` - Probe retry counts. Default is value stored in EEPROM. Valid values are 1 to 10.
+      - `O` - Return to origin. Default is 1. Valid values are 0 (false) and 1 (true).
       
       Using the following parameters enables additional "manual" bed leveling correction. Valid values are -100 microns to 100 microns.
     #### Additional Parameters


### PR DESCRIPTION
"Probe retry counts" didn't default to 3, it defaulted to the value stored in EEPROM. (Just like bed leveling corrections)
This is now also true for "Number of mesh points" and stated in the usage doc.