### PR TITLE
Add M125

### DIFF
--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -232,7 +232,6 @@ extern int feedmultiply;
 extern int extrudemultiply; // Sets extrude multiply factor (in percent) for all extruders
 extern float extruder_multiplier[EXTRUDERS]; // reciprocal of cross-sectional area of filament (in square millimeters), stored this way to reduce computational burden in planner
 extern float current_position[NUM_AXIS] ;
-extern float pause_position[3];
 extern float destination[NUM_AXIS] ;
 extern float min_pos[3];
 extern float max_pos[3];

--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -232,6 +232,7 @@ extern int feedmultiply;
 extern int extrudemultiply; // Sets extrude multiply factor (in percent) for all extruders
 extern float extruder_multiplier[EXTRUDERS]; // reciprocal of cross-sectional area of filament (in square millimeters), stored this way to reduce computational burden in planner
 extern float current_position[NUM_AXIS] ;
+extern float pause_position[3];
 extern float destination[NUM_AXIS] ;
 extern float min_pos[3];
 extern float max_pos[3];

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -7705,21 +7705,15 @@ Sigma_Exit:
     case 125:
     case 601:
     {
-        float temp_pause_position[3] = { X_PAUSE_POS, Y_PAUSE_POS, Z_PAUSE_LIFT };
+        // Set default values
+        pause_position[X_AXIS] = X_PAUSE_POS;
+        pause_position[Y_AXIS] = Y_PAUSE_POS;
+        pause_position[Z_AXIS] = Z_PAUSE_LIFT;
+
         for (uint8_t axis = 0; axis < E_AXIS; axis++) {
-          if (code_seen(axis_codes[axis])) temp_pause_position[axis] = code_value();
-        }
-        //Check that the X pause position is within printer limits
-        if ((temp_pause_position[X_AXIS] >= X_MIN_POS) && (temp_pause_position[X_AXIS] <= X_MAX_POS-1)) {
-            pause_position[X_AXIS] = temp_pause_position[X_AXIS];
+          if (code_seen(axis_codes[axis])) {
+            pause_position[axis] = constrain(code_value(), min_pos[axis], max_pos[axis]);
           }
-        //Check that the Y pause position is within printer limits
-        if ((temp_pause_position[Y_AXIS] >= Y_MIN_POS) && (temp_pause_position[Y_AXIS] <= Y_MAX_POS-1)) {
-          pause_position[Y_AXIS] = temp_pause_position[Y_AXIS];
-        }
-        //Check that the Z lift position is within printer limits
-        if (temp_pause_position[Z_AXIS] <=Z_MAX_POS) {
-          pause_position[Z_AXIS] = temp_pause_position[Z_AXIS];
         }
 
         if (code_seen('S')) {

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -7705,9 +7705,9 @@ Sigma_Exit:
     case 125:
     case 601:
     {
-        if (code_seen('X')) pause_position[1] = code_value_uint8();
-        if (code_seen('Y')) pause_position[2] = code_value_uint8();
-        if (code_seen('Z')) pause_position[3] = code_value_uint8();
+        if (code_seen('X')) pause_position[1] = code_value();
+        if (code_seen('Y')) pause_position[2] = code_value();
+        if (code_seen('Z')) pause_position[3] = code_value();
         if (code_seen('S')) {
             if ( code_value_uint8() == 0 ) {
                 pause_position[1] = X_PAUSE_POS;

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -200,7 +200,7 @@ float min_pos[3] = { X_MIN_POS, Y_MIN_POS, Z_MIN_POS };
 float max_pos[3] = { X_MAX_POS, Y_MAX_POS, Z_MAX_POS };
 bool axis_known_position[3] = {false, false, false};
 
-float pause_position[3] = { X_PAUSE_POS, Y_PAUSE_POS, Z_PAUSE_LIFT };
+static float pause_position[3] = { X_PAUSE_POS, Y_PAUSE_POS, Z_PAUSE_LIFT };
 
 uint8_t fanSpeed = 0;
 uint8_t newFanSpeed = 0;

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -7673,54 +7673,70 @@ Sigma_Exit:
 
     /*!
     ### M601 - Pause print <a href="https://reprap.org/wiki/G-code#M601:_Pause_print">M601: Pause print</a>
-    Without any parameters it will park the extruder to default.
+    Without any parameters it will park the extruder to default or last set position.
+    The default pause position will be set during power up and a reset, the new pause positions aren't permanent.
     #### Usage
 
          M601 [ X | Y | Z | S ]
 
     #### Parameters
-     - `X` - X position to park at (otherwise X_PAUSE_POS 50) these are saved until change or reset.
-     - `Y` - Y position to park at (otherwise Y_PAUSE_POS 190) these are saved until change or reset.
-     - `Z` - Z raise before park (otherwise Z_PAUSE_LIFT 20) these are saved until change or reset.
-     - `S` - Set values [S0 = set default | S1 = set values only without pausing]
+     - `X` - X position to park at (default X_PAUSE_POS 50) these are saved until change or reset.
+     - `Y` - Y position to park at (default Y_PAUSE_POS 190) these are saved until change or reset.
+     - `Z` - Z raise before park (default Z_PAUSE_LIFT 20) these are saved until change or reset.
+     - `S` - Set values [S0 = set to default values | S1 = set values] without pausing
     */
     /*!
 
     ### M125 - Pause print <a href="https://reprap.org/wiki/G-code#M125:_Pause_print">M125: Pause print</a>
-    Without any parameters it will park the extruderthe extruder to default.
+    Without any parameters it will park the extruder to default or last set position.
+    The default pause position will be set during power up and a reset, the new pause positions aren't permanent.
     #### Usage
 
          M125 [ X | Y | Z | S ]
 
     #### Parameters
-     - `X` - X position to park at (otherwise X_PAUSE_POS 50) these are saved until change or reset.
-     - `Y` - Y position to park at (otherwise Y_PAUSE_POS 190 these are saved until change or reset.
-     - `Z` - Z raise before park (otherwise Z_PAUSE_LIFT 20) these are saved until change or reset.
-     - `S` - Set values [S0 = set to default values | S1 = set values only without pausing]
+     - `X` - X position to park at (default X_PAUSE_POS 50) these are saved until change or reset.
+     - `Y` - Y position to park at (default Y_PAUSE_POS 190) these are saved until change or reset.
+     - `Z` - Z raise before park (default Z_PAUSE_LIFT 20) these are saved until change or reset.
+     - `S` - Set values [S0 = set to default values | S1 = set values] without pausing
     */
     /*!
     ### M25 - Pause SD print <a href="https://reprap.org/wiki/G-code#M25:_Pause_SD_print">M25: Pause SD print</a>
+    Without any parameters it will park the extruder to default or last set position.
+    The default pause position will be set during power up and a reset, the new pause positions aren't permanent.
+    #### Usage
+
+         M25 [ X | Y | Z | S ]
+
+    #### Parameters
+     - `X` - X position to park at (default X_PAUSE_POS 50) these are saved until change or reset.
+     - `Y` - Y position to park at (default Y_PAUSE_POS 190) these are saved until change or reset.
+     - `Z` - Z raise before park (default Z_PAUSE_LIFT 20) these are saved until change or reset.
+     - `S` - Set values [S0 = set to default values | S1 = set values] without pausing
     */
     case 25:
     case 125:
     case 601:
     {
+        //Set new pause position for all three axis XYZ
         for (uint8_t axis = 0; axis < E_AXIS; axis++) {
           if (code_seen(axis_codes[axis])) {
+            //Check that the positions are within hardware limits
             pause_position[axis] = constrain(code_value(), min_pos[axis], max_pos[axis]);
           }
         }
-
+        //Set default or new pause position without pausing
         if (code_seen('S')) {
             if ( code_value_uint8() == 0 ) {
                 pause_position[X_AXIS] = X_PAUSE_POS;
                 pause_position[Y_AXIS] = Y_PAUSE_POS;
                 pause_position[Z_AXIS] = Z_PAUSE_LIFT;
-            } else {
-                break;
             }
+        break;
         }
-/*      SERIAL_ECHOPGM("X:");
+/*
+        //Debug serial output
+        SERIAL_ECHOPGM("X:");
         SERIAL_ECHOLN(pause_position[X_AXIS]);
         SERIAL_ECHOPGM("Y:");
         SERIAL_ECHOLN(pause_position[Y_AXIS]);

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -558,8 +558,8 @@ void crashdet_stop_and_save_print()
 
 void crashdet_restore_print_and_continue()
 {
-	restore_print_from_ram_and_continue(default_retraction); //XYZ = orig, E +1mm unretract
-//	babystep_apply();
+  restore_print_from_ram_and_continue(default_retraction); //XYZ = orig, E +1mm unretract
+//babystep_apply();
 }
 
 void crashdet_fmt_error(char* buf, uint8_t mask)
@@ -633,8 +633,8 @@ void crashdet_detected(uint8_t mask)
 
 void crashdet_recover()
 {
-	crashdet_restore_print_and_continue();
-	if (lcd_crash_detect_enabled()) tmc2130_sg_stop_on_crash = true;
+  if (!isPrintPaused) crashdet_restore_print_and_continue();
+  if (lcd_crash_detect_enabled()) tmc2130_sg_stop_on_crash = true;
 }
 
 void crashdet_cancel()
@@ -7696,7 +7696,7 @@ Sigma_Exit:
      - `X` - X position to park at (otherwise X_PAUSE_POS 50) these are saved until change or reset.
      - `Y` - Y position to park at (otherwise Y_PAUSE_POS 190 these are saved until change or reset.
      - `Z` - Z raise before park (otherwise Z_PAUSE_LIFT 20) these are saved until change or reset.
-     - `S` - Set values [S0 = set to default values | S1 = sset values only without pausing]
+     - `S` - Set values [S0 = set to default values | S1 = set values only without pausing]
     */
     /*!
     ### M25 - Pause SD print <a href="https://reprap.org/wiki/G-code#M25:_Pause_SD_print">M25: Pause SD print</a>
@@ -7705,18 +7705,40 @@ Sigma_Exit:
     case 125:
     case 601:
     {
-        if (code_seen('X')) pause_position[1] = code_value();
-        if (code_seen('Y')) pause_position[2] = code_value();
-        if (code_seen('Z')) pause_position[3] = code_value();
+        if (code_seen('X')) {
+          //Check that the X pause position is within printer limits
+          if ((code_value() >= X_MIN_POS) && (code_value() <= X_MAX_POS-1)) {
+            pause_position[X_AXIS] = code_value();
+          } else pause_position[X_AXIS] = X_PAUSE_POS;
+        }
+        if (code_seen('Y')) {
+          //Check that the Y pause position is within printer limits
+          if ((code_value() >= Y_MIN_POS) && (code_value() <= Y_MAX_POS-1)) {
+            pause_position[Y_AXIS] = code_value();
+          } else pause_position[Y_AXIS] = Y_PAUSE_POS;
+        }
+        if (code_seen('Z')) {
+          //Check that the Z pause lift is within printer limits
+          if (code_value() <=Z_MAX_POS) {
+            pause_position[Z_AXIS] = code_value();
+          } else pause_position[Z_AXIS] = Z_PAUSE_LIFT;
+        }
         if (code_seen('S')) {
             if ( code_value_uint8() == 0 ) {
-                pause_position[1] = X_PAUSE_POS;
-                pause_position[2] = Y_PAUSE_POS;
-                pause_position[3] = Z_PAUSE_LIFT;
+                pause_position[X_AXIS] = X_PAUSE_POS;
+                pause_position[Y_AXIS] = Y_PAUSE_POS;
+                pause_position[Z_AXIS] = Z_PAUSE_LIFT;
             } else {
                 break;
             }
         }
+/*      SERIAL_ECHOPGM("X:");
+        SERIAL_ECHOLN(pause_position[X_AXIS]);
+        SERIAL_ECHOPGM("Y:");
+        SERIAL_ECHOLN(pause_position[Y_AXIS]);
+        SERIAL_ECHOPGM("Z:");
+        SERIAL_ECHOLN(pause_position[Z_AXIS]);
+*/
         if (!isPrintPaused) {
             st_synchronize();
             ClearToSend(); //send OK even before the command finishes executing because we want to make sure it is not skipped because of cmdqueue_pop_front();
@@ -10441,12 +10463,12 @@ void long_pause() //long pause print
     setTargetHotend(0);
 
     // Lift z
-    raise_z(pause_position[3]);
+    raise_z(pause_position[Z_AXIS]);
 
     // Move XY to side
     if (axis_known_position[X_AXIS] && axis_known_position[Y_AXIS]) {
-        current_position[X_AXIS] = pause_position[1];
-        current_position[Y_AXIS] = pause_position[2];
+        current_position[X_AXIS] = pause_position[X_AXIS];
+        current_position[Y_AXIS] = pause_position[Y_AXIS];
         plan_buffer_line_curposXYZE(50);
     }
 

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -7705,11 +7705,6 @@ Sigma_Exit:
     case 125:
     case 601:
     {
-        // Set default values
-        pause_position[X_AXIS] = X_PAUSE_POS;
-        pause_position[Y_AXIS] = Y_PAUSE_POS;
-        pause_position[Z_AXIS] = Z_PAUSE_LIFT;
-
         for (uint8_t axis = 0; axis < E_AXIS; axis++) {
           if (code_seen(axis_codes[axis])) {
             pause_position[axis] = constrain(code_value(), min_pos[axis], max_pos[axis]);

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -7705,24 +7705,23 @@ Sigma_Exit:
     case 125:
     case 601:
     {
-        if (code_seen('X')) {
-          //Check that the X pause position is within printer limits
-          if ((code_value() >= X_MIN_POS) && (code_value() <= X_MAX_POS-1)) {
-            pause_position[X_AXIS] = code_value();
-          } else pause_position[X_AXIS] = X_PAUSE_POS;
+        float temp_pause_position[3] = { X_PAUSE_POS, Y_PAUSE_POS, Z_PAUSE_LIFT };
+        for (uint8_t axis = 0; axis < E_AXIS; axis++) {
+          if (code_seen(axis_codes[axis])) temp_pause_position[axis] = code_value();
         }
-        if (code_seen('Y')) {
-          //Check that the Y pause position is within printer limits
-          if ((code_value() >= Y_MIN_POS) && (code_value() <= Y_MAX_POS-1)) {
-            pause_position[Y_AXIS] = code_value();
-          } else pause_position[Y_AXIS] = Y_PAUSE_POS;
+        //Check that the X pause position is within printer limits
+        if ((temp_pause_position[X_AXIS] >= X_MIN_POS) && (temp_pause_position[X_AXIS] <= X_MAX_POS-1)) {
+            pause_position[X_AXIS] = temp_pause_position[X_AXIS];
+          }
+        //Check that the Y pause position is within printer limits
+        if ((temp_pause_position[Y_AXIS] >= Y_MIN_POS) && (temp_pause_position[Y_AXIS] <= Y_MAX_POS-1)) {
+          pause_position[Y_AXIS] = temp_pause_position[Y_AXIS];
         }
-        if (code_seen('Z')) {
-          //Check that the Z pause lift is within printer limits
-          if (code_value() <=Z_MAX_POS) {
-            pause_position[Z_AXIS] = code_value();
-          } else pause_position[Z_AXIS] = Z_PAUSE_LIFT;
+        //Check that the Z lift position is within printer limits
+        if (temp_pause_position[Z_AXIS] <=Z_MAX_POS) {
+          pause_position[Z_AXIS] = temp_pause_position[Z_AXIS];
         }
+
         if (code_seen('S')) {
             if ( code_value_uint8() == 0 ) {
                 pause_position[X_AXIS] = X_PAUSE_POS;


### PR DESCRIPTION
Added M125 with few parameters to set XYZ positions.

There have been requests by the community to allow to change the pause/park position.

During testing the pausing a XY crash would recover the print without reseting the pause state.
Fixed it by checking if printer is in pausing/paused state before trying the recovery.
If the hotend crashes during pausing it will try to home X Y only and not pause at PAUSE POS but recovers correctly.
Tested on MK404 with `lite with Quad_HR`
- Normal pause :heavy_check_mark:
- `M125 X254 Y212.5 Z210` :heavy_check_mark:
- `M125 X254 Y212.5 Z210` and causing a X crash during printer pauses :heavy_check_mark:

The print always continues where it paused in first place, even with the forced X crash, 

Todo
- [X] Check XYZ don't exceed MIN MAX XY positions and limits
- [ ] Update RepRap Wiki
