### PR TITLE
MMU: Fix printing uint8_t value onto serial

### DIFF
--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -707,7 +707,7 @@ void MMU2::CheckUserInput() {
     case Buttons::Middle:
     case Buttons::Right:
         SERIAL_ECHOPGM("CheckUserInput-btnLMR ");
-        SERIAL_ECHOLN(buttons_to_uint8t(btn));
+        SERIAL_ECHOLN((int)buttons_to_uint8t(btn));
         ResumeHotendTemp(); // Recover the hotend temp before we attempt to do anything else...
 
         if (mmu2.MMULastErrorSource() == MMU2::ErrorSourceMMU) {


### PR DESCRIPTION
uint8_t values don't print correctly. Cast to 2-byte integer is required.

![image](https://github.com/prusa3d/Prusa-Firmware/assets/8218499/94454096-3ba3-43db-82cd-96140c2af535)
