### PR TITLE
MMU: always wait for a request's expected response

### DIFF
--- a/Firmware/mmu2_protocol_logic.cpp
+++ b/Firmware/mmu2_protocol_logic.cpp
@@ -809,14 +809,11 @@ StepStatus ProtocolLogic::Step() {
         // We are ok, switching to Idle if there is no potential next request planned.
         // But the trouble is we must report a finished command if the previous command has just been finished
         // i.e. only try to find some planned command if we just finished the Idle cycle
-        bool previousCommandFinished = currentScope == Scope::Command; // @@TODO this is a nasty hack :(
         if (!ActivatePlannedRequest()) {                               // if nothing is planned, switch to Idle
             SwitchToIdle();
-        } else {
+        } else if (ExpectsResponse()) {
             // if the previous cycle was Idle and now we have planned a new command -> avoid returning Finished
-            if (!previousCommandFinished && currentScope == Scope::Command) {
-                currentStatus = Processing;
-            }
+            currentStatus = Processing;
         }
     } break;
     case CommandRejected:


### PR DESCRIPTION
If a planned request is activated when the protocol status is `Finished` then the firmware must wait for the response when the respective request is expecting it.

`manage_response` shouldn't return `Finished` unless the response is received/parsed because the printer needs to be able to act on it in a deterministic way. In other words always make sure a response is followed by its respective request before leaving `manage_response`.

An example is a register read using `ReadRegister()`.

Step to reproduce issue:
1. Fail selector homing
2. Select 'Tune' item
3. Observe issue. In this situation you can see the value for the previous register read is shown. Which is 0. This is very timing dependent and does not always happen.
4. Repeat step 2 until the issue appears. It may take a few times.


Some serial logs I had locally:

| BEFORE | AFTER |
|------|------|
|  ![mmu-bug-log](https://github.com/prusa3d/Prusa-Firmware/assets/8218499/412c432b-75d4-44d1-b11d-0bbf1118cc29)    |   ![mmu-fix-log](https://github.com/prusa3d/Prusa-Firmware/assets/8218499/f125945e-6763-4f08-a4c7-d5d4e7fd273b)   |

I've observed this issue on Write Register requests and MMU Button requests. Probably applies to all requests which expect a response.