### PR TITLE
PFW-1097 M600: Fix filament change behavior when print is paused

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3414,7 +3414,7 @@ static void gcode_M600(const bool automatic, const float x_position, const float
 
     //First backup current position and settings
     int feedmultiplyBckp = feedmultiply;
-    float HotendTempBckp = degTargetHotend(active_extruder);
+    float HotendTempBckp = saved_extruder_temperature;
     uint8_t fanSpeedBckp = fanSpeed;
 
     memcpy(lastpos, current_position, sizeof(lastpos));
@@ -3423,9 +3423,16 @@ static void gcode_M600(const bool automatic, const float x_position, const float
     fanSpeed = 0;
 
     // Retract E
-    current_position[E_AXIS] += e_shift;
-    plan_buffer_line_curposXYZE(FILAMENTCHANGE_RFEED);
-    st_synchronize();
+    if (!isPrintPaused)
+    {
+      current_position[E_AXIS] += e_shift;
+      plan_buffer_line_curposXYZE(FILAMENTCHANGE_RFEED);
+      st_synchronize();
+    } else {
+        // Print is paused and the extruder may be cold
+        // Filament change can be issued via the Tune menu
+        restore_extruder_temperature_from_ram();
+    }
 
     // Raise the Z axis
     raise_z(z_shift);
@@ -3479,8 +3486,21 @@ static void gcode_M600(const bool automatic, const float x_position, const float
     
         // Feed a little of filament to stabilize pressure
         if (!automatic) {
-            current_position[E_AXIS] += FILAMENTCHANGE_RECFEED;
-            plan_buffer_line_curposXYZE(FILAMENTCHANGE_EXFEED);
+            if (isPrintPaused)
+            {
+                // Return to retracted state during a pause
+                current_position[E_AXIS] -= default_retraction;
+                plan_buffer_line_curposXYZE(FILAMENTCHANGE_RFEED);
+
+                // Cooldown the extruder again
+                setTargetHotend(0);
+            }
+            else
+            {
+                // Feed a little of filament to stabilize pressure
+                current_position[E_AXIS] += FILAMENTCHANGE_RECFEED;
+                plan_buffer_line_curposXYZE(FILAMENTCHANGE_EXFEED);
+            }
         }
 
         // Move XY back
@@ -3501,8 +3521,8 @@ static void gcode_M600(const bool automatic, const float x_position, const float
         feedmultiply = feedmultiplyBckp;
         enquecommandf_P(MSG_M220, feedmultiplyBckp);
     }
-    
-    lcd_setstatuspgm(MSG_WELCOME);
+    if (isPrintPaused) lcd_setstatuspgm(_T(MSG_PRINT_PAUSED));
+    else lcd_setstatuspgm(MSG_WELCOME);
     custom_message_type = CustomMsg::Status;
 }
 

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3489,6 +3489,7 @@ static void gcode_M600(const bool automatic, const float x_position, const float
             if (isPrintPaused)
             {
                 // Return to retracted state during a pause
+                // @todo is retraction really needed? E-position is reverted a few lines below
                 current_position[E_AXIS] -= default_retraction;
                 plan_buffer_line_curposXYZE(FILAMENTCHANGE_RFEED);
 

--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -76,6 +76,7 @@ const char MSG_NO[] PROGMEM_I1 = ISTR("No"); ////MSG_NO c=4
 const char MSG_NOZZLE[] PROGMEM_I1 = ISTR("Nozzle"); ////MSG_NOZZLE c=10
 const char MSG_PAPER[] PROGMEM_I1 = ISTR("Place a sheet of paper under the nozzle during the calibration of first 4 points. If the nozzle catches the paper, power off the printer immediately."); ////MSG_PAPER c=20 r=8
 const char MSG_PAUSE_PRINT[] PROGMEM_I1 = ISTR("Pause print");////MSG_PAUSE_PRINT c=18
+const char MSG_PRINT_PAUSED[] PROGMEM_I1 = ISTR("Print paused");////MSG_PAUSE_PRINT c=20
 const char MSG_PLACE_STEEL_SHEET[] PROGMEM_I1 = ISTR("Please place steel sheet on heatbed."); ////MSG_PLACE_STEEL_SHEET c=20 r=4
 const char MSG_PLEASE_WAIT[] PROGMEM_I1 = ISTR("Please wait"); ////MSG_PLEASE_WAIT c=20
 const char MSG_POWER_FAILURES[] PROGMEM_I1 = ISTR("Power failures"); ////MSG_POWER_FAILURES c=15

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -78,6 +78,7 @@ extern const char MSG_NO[];
 extern const char MSG_NOZZLE[];
 extern const char MSG_PAPER[];
 extern const char MSG_PAUSE_PRINT[];
+extern const char MSG_PRINT_PAUSED[];
 extern const char MSG_PLACE_STEEL_SHEET[];
 extern const char MSG_PLEASE_WAIT[];
 extern const char MSG_POWER_FAILURES[];

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -787,7 +787,7 @@ void lcd_commands()
 			if (custom_message_type != CustomMsg::M117)
 			{
 				custom_message_type = CustomMsg::Status;
-				lcd_setstatuspgm(_i("Print paused"));////MSG_PRINT_PAUSED c=20
+				lcd_setstatuspgm(_T(MSG_PRINT_PAUSED));
 			}
 			lcd_commands_type = LcdCommands::Idle;
 			lcd_commands_step = 0;


### PR DESCRIPTION
Reimplementing PR 2390 https://github.com/prusa3d/Prusa-Firmware/pull/2390 from @wavexx ontop of latest MK3 branch with some minor additional changes

Tested on MK3S+ with MMU3.

Steps to test:
1. Start print
2. Pause print
3. Wait for while
4. Go to Tune -> Color change
5. Cold nozzle should now be re-heated
6. Filament is loaded successfully
7. Nozzle target temperature is set to 0°C again since the print is still paused.
8. Resume print => print resumes without issues