### PR TITLE
🚧 `stop_and_save_print_to_ram` should not overwrite valid partial backup

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -9735,16 +9735,8 @@ void ThermalStop(bool allow_recovery)
 
                 // we cannot make a distinction for the host here, the pause must be instantaneous
                 // so we call the lcd_pause_print to save the print state internally. Thermal errors
-                // disable heaters and save the original temperatures to saved_*, which will get
-                // overwritten by stop_and_save_print_to_ram. For this corner-case, re-instate the
-                // original values after the pause handler is called.
-                uint8_t bed_temp = saved_bed_temperature;
-                uint16_t ext_temp = saved_extruder_temperature;
-                uint8_t fan_speed = saved_fan_speed;
+                // disable heaters and save the original temperatures to saved_*
                 lcd_pause_print();
-                saved_bed_temperature = bed_temp;
-                saved_extruder_temperature = ext_temp;
-                saved_fan_speed = fan_speed;
             }
         } else {
             // We got a hard thermal error and/or there is no print going on. Just stop.
@@ -10792,14 +10784,15 @@ void stop_and_save_print_to_ram(float z_move, float e_move)
 
 	planner_abort_hard(); //abort printing
 
-	memcpy(saved_pos, current_position, sizeof(saved_pos));
+    if (!isPartialBackupAvailable) {
+        refresh_print_state_in_ram();
+    }
+
     if (pos_invalid) saved_pos[X_AXIS] = X_COORD_INVALID;
 
-    saved_feedmultiply2 = feedmultiply; //save feedmultiply
-	saved_extruder_temperature = (uint16_t)degTargetHotend(active_extruder);
-	saved_bed_temperature = (uint8_t)degTargetBed();
-	saved_extruder_relative_mode = axis_relative_modes & E_AXIS_MASK;
-	saved_fan_speed = fanSpeed;
+    // Reset partial backup flag, we have a full back-up now
+    clear_print_state_in_ram();
+
 	cmdqueue_reset(); //empty cmdqueue
 	card.sdprinting = false;
 //	card.closefile();

--- a/Firmware/temperature.cpp
+++ b/Firmware/temperature.cpp
@@ -512,9 +512,7 @@ void set_temp_error(TempErrorSource source, uint8_t index, TempErrorType type)
 {
     // save the original target temperatures for recovery before disabling heaters
     if(!temp_error_state.error && !saved_printing) {
-        saved_bed_temperature = target_temperature_bed;
-        saved_extruder_temperature = target_temperature[index];
-        saved_fan_speed = fanSpeed;
+        refresh_print_state_in_ram();
     }
 
     // keep disabling heaters and keep fans on as long as the condition is asserted


### PR DESCRIPTION
Thermal errors need to take a backup of the target temperatures before disabling the heaters. When the print is then later paused, `stop_and_save_print_to_ram` should use the partial backup if it is still valid (`isPartialBackupAvailable=true`). After `stop_and_save_print_to_ram` is done running and we have a 'full' backup, `isPartialBackupAvailable` is cleared in favor of `saved_printing`

Change in memory:
Flash: -156 bytes
SRAM: 0 bytes