### PR TITLE
PFW-1542 Handle fan error sooner when waiting for heating to complete

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -6039,6 +6039,12 @@ Sigma_Exit:
 
         while ( (!cancel_heatup) && (target_direction ? (isHeatingBed()) : (isCoolingBed()&&(CooldownNoWait==false))) )
         {
+          if (lcd_commands_type == LcdCommands::LongPause) {
+            // Print was suddenly paused, break out of the loop
+            // This can happen when the firmware report a fan error
+            break;
+          }
+
           if(( _millis() - codenum) > 1000 ) //Print Temp Reading every 1 second while heating up.
           {
 			  if (!farm_mode) {
@@ -9677,6 +9683,11 @@ static void wait_for_heater(long codenum, uint8_t extruder) {
 #else
 	while (target_direction ? (isHeatingHotend(tmp_extruder)) : (isCoolingHotend(tmp_extruder) && (CooldownNoWait == false))) {
 #endif //TEMP_RESIDENCY_TIME
+        if (lcd_commands_type == LcdCommands::LongPause) {
+            // Print was suddenly paused, break out of the loop
+            // This can happen when the firmware report a fan error
+            break;
+        }
 		if ((_millis() - codenum) > 1000UL)
 		{ //Print Temp Reading and remaining time every 1 second while heating up/cooling down
 			if (!farm_mode) {


### PR DESCRIPTION
While waiting for the nozzle to reach a certain temperature, a sudden fan error should disable the hotend heater immediately. If printing, it will should also pause the print.

Previously the printer would wait for the nozzle to heat up before pausing the print and turning off the hotend heater.

We rely on `LcdCommands::LongPause` and must return to the top level loop to process it. Waiting in the while loop e.g. in M190 does not make sense. 