### PR TITLE
M600: reduce stack usage

### DIFF
--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -449,8 +449,8 @@ void gcode_M701(float fastLoadLength, uint8_t mmuSlotIndex);
 
 void M600_load_filament();
 void M600_load_filament_movements();
-void M600_wait_for_user(float HotendTempBckp);
-void M600_check_state(float nozzle_temp);
+void M600_wait_for_user();
+void M600_check_state();
 void load_filament_final_feed();
 void marlin_wait_for_click();
 float raise_z(float delta);


### PR DESCRIPTION
To handle power panic in M600 we started saving relevant data at the start of M600 gcode in RAM (starting with 3.13.2). We are currently also saving the same data within `gcode_M600()` which is saved on the stack. I propose we just use the data already saved in SRAM to reduce stack usage.

Change in memory:
Flash: -64 bytes
SRAM: 0 bytes