### PR TITLE
cleanup: Don't set root directory if SD card fails to mount + 3 renames

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1366,7 +1366,7 @@ void setup()
 	// but this times out if a blocking dialog is shown in setup().
 	card.mount();
 #ifdef DEBUG_SD_SPEED_TEST
-	if (card.cardOK)
+	if (card.mounted)
 	{
 		uint8_t* buff = (uint8_t*)block_buffer;
 		uint32_t block = 0;
@@ -5305,7 +5305,7 @@ void process_commands()
 	  - `S` - Index in bytes
     */
     case 26: 
-      if(card.cardOK && code_seen('S')) {
+      if(card.mounted && code_seen('S')) {
         long index = code_value_long();
         card.setIndex(index);
         // We don't disable interrupt during update of sdpos_atomic
@@ -5350,7 +5350,7 @@ void process_commands()
     
     */
     case 30:
-      if (card.cardOK){
+      if (card.mounted){
         card.closefile();
         card.removeFile(strchr_pointer + 4);
       }
@@ -5380,7 +5380,7 @@ void process_commands()
       if(strchr_pointer>namestartpos)
         call_procedure=false;  //false alert, 'P' found within filename
 
-      if( card.cardOK )
+      if( card.mounted )
       {
         card.openFileReadFilteredGcode(namestartpos,!call_procedure);
         if(code_seen('S'))

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1364,7 +1364,7 @@ void setup()
 
 	// Force SD card update. Otherwise the SD card update is done from loop() on card.checkautostart(false), 
 	// but this times out if a blocking dialog is shown in setup().
-	card.initsd();
+	card.mount();
 #ifdef DEBUG_SD_SPEED_TEST
 	if (card.cardOK)
 	{
@@ -5240,7 +5240,7 @@ void process_commands()
 	### M21 - Init SD card <a href="https://reprap.org/wiki/G-code#M21:_Initialize_SD_card">M21: Initialize SD card</a>
     */
     case 21:
-      card.initsd();
+      card.mount();
       break;
 
     /*!

--- a/Firmware/cardreader.cpp
+++ b/Firmware/cardreader.cpp
@@ -24,7 +24,7 @@ CardReader::CardReader()
    filesize = 0;
    sdpos = 0;
    sdprinting = false;
-   cardOK = false;
+   mounted = false;
    saving = false;
    logging = false;
    workDirDepth = 0;
@@ -200,7 +200,7 @@ void CardReader::ls(ls_param params)
 
 void CardReader::mount(bool doPresort/* = true*/)
 {
-  cardOK = false;
+  mounted = false;
   if(root.isOpen())
     root.close();
 #ifdef SDSLOW
@@ -226,12 +226,12 @@ void CardReader::mount(bool doPresort/* = true*/)
   }
   else 
   {
-    cardOK = true;
+    mounted = true;
     SERIAL_ECHO_START;
     SERIAL_ECHOLNRPGM(_n("SD card ok"));////MSG_SD_CARD_OK
   }
 
-  if (cardOK)
+  if (mounted)
   {
     cdroot(doPresort);
   }
@@ -252,14 +252,14 @@ void __attribute__((noinline)) CardReader::cdroot(bool doPresort)
 void CardReader::release()
 {
   sdprinting = false;
-  cardOK = false;
+  mounted = false;
   SERIAL_ECHO_START;
   SERIAL_ECHOLNRPGM(_n("SD card released"));////MSG_SD_CARD_RELEASED
 }
 
 void CardReader::startFileprint()
 {
-  if(cardOK)
+  if(mounted)
   {
     sdprinting = true;
     SetPrinterState(PrinterState::IsSDPrinting); //set printer state to hide LCD menu
@@ -384,7 +384,7 @@ static const char ofSDPrinting[] PROGMEM = "SD-PRINTING";
 static const char ofWritingToFile[] PROGMEM = "Writing to file: ";
 
 void CardReader::openFileReadFilteredGcode(const char* name, bool replace_current/* = false*/){
-    if(!cardOK)
+    if(!mounted)
         return;
     
     if(file.isOpen()){  //replacing current file by new file, or subfile call
@@ -449,7 +449,7 @@ void CardReader::openFileReadFilteredGcode(const char* name, bool replace_curren
 
 void CardReader::openFileWrite(const char* name)
 {
-    if(!cardOK)
+    if(!mounted)
         return;
     if(file.isOpen()){  //replacing current file by new file, or subfile call
 #if 0
@@ -513,7 +513,7 @@ void CardReader::openFileWrite(const char* name)
 
 void CardReader::removeFile(const char* name)
 {
-    if(!cardOK) return;
+    if(!mounted) return;
     file.close();
     sdprinting = false;
 
@@ -614,10 +614,10 @@ void CardReader::checkautostart(bool force)
       return;
   }
   autostart_stilltocheck = false;
-  if(!cardOK)
+  if(!mounted)
   {
     mount();
-    if(!cardOK) //fail
+    if(!mounted) //fail
       return;
   }
   

--- a/Firmware/cardreader.cpp
+++ b/Firmware/cardreader.cpp
@@ -198,7 +198,7 @@ void CardReader::ls(ls_param params)
 }
 
 
-void CardReader::initsd(bool doPresort/* = true*/)
+void CardReader::mount(bool doPresort/* = true*/)
 {
   cardOK = false;
   if(root.isOpen())
@@ -616,7 +616,7 @@ void CardReader::checkautostart(bool force)
   autostart_stilltocheck = false;
   if(!cardOK)
   {
-    initsd();
+    mount();
     if(!cardOK) //fail
       return;
   }

--- a/Firmware/cardreader.cpp
+++ b/Firmware/cardreader.cpp
@@ -233,11 +233,11 @@ void CardReader::initsd(bool doPresort/* = true*/)
 
   if (cardOK)
   {
-    setroot(doPresort);
+    cdroot(doPresort);
   }
 }
 
-void __attribute__((noinline)) CardReader::setroot(bool doPresort)
+void __attribute__((noinline)) CardReader::cdroot(bool doPresort)
 {
   workDir=root;
   workDirDepth = 0;
@@ -334,7 +334,7 @@ bool CardReader::diveSubfolder (const char *&fileName)
     const char *dirname_start, *dirname_end;
     if (fileName[0] == '/') // absolute path
     {
-        setroot(false);
+        cdroot(false);
         dirname_start = fileName + 1;
         while (*dirname_start)
         {

--- a/Firmware/cardreader.cpp
+++ b/Firmware/cardreader.cpp
@@ -230,29 +230,17 @@ void CardReader::initsd(bool doPresort/* = true*/)
     SERIAL_ECHO_START;
     SERIAL_ECHOLNRPGM(_n("SD card ok"));////MSG_SD_CARD_OK
   }
-  workDir=root;
-  curDir=&root;
-  workDirDepth = 0;
 
-  #ifdef SDCARD_SORT_ALPHA
-  if (doPresort)
-    presort();
-  #endif
-
-  /*
-  if(!workDir.openRoot(&volume))
+  if (cardOK)
   {
-    SERIAL_ECHOLNPGM(MSG_SD_WORKDIR_FAIL);
+    setroot(doPresort);
   }
-  */
-  
 }
 
-void CardReader::setroot(bool doPresort)
+void __attribute__((noinline)) CardReader::setroot(bool doPresort)
 {
   workDir=root;
   workDirDepth = 0;
-  
   curDir=&workDir;
 #ifdef SDCARD_SORT_ALPHA
 	if (doPresort)

--- a/Firmware/cardreader.h
+++ b/Firmware/cardreader.h
@@ -91,7 +91,7 @@ public:
   bool saving;
   bool logging;
   bool sdprinting ;  
-  bool cardOK ;
+  bool mounted;
   char filename[FILENAME_LENGTH];
   // There are scenarios when simple modification time is not enough (on MS Windows)
   // Therefore these timestamps hold the most recent one of creation/modification date/times

--- a/Firmware/cardreader.h
+++ b/Firmware/cardreader.h
@@ -59,7 +59,7 @@ public:
   void ls(ls_param params);
   bool chdir(const char * relpath, bool doPresort);
   void updir();
-  void setroot(bool doPresort);
+  void cdroot(bool doPresort);
 
   #ifdef SDCARD_SORT_ALPHA
      void presort();

--- a/Firmware/cardreader.h
+++ b/Firmware/cardreader.h
@@ -27,7 +27,7 @@ public:
     inline ls_param(bool LFN, bool timestamp):LFN(LFN), timestamp(timestamp) { }
   } __attribute__((packed));
   
-  void initsd(bool doPresort = true);
+  void mount(bool doPresort = true);
   void write_command(char *buf);
   void write_command_no_newline(char *buf);
   //files auto[0-9].g on the sd card are performed in a row

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5194,7 +5194,7 @@ static void lcd_main_menu()
 
     // Menu item for reprint
     if(!printer_active() && (heating_status == HeatingStatus::NO_HEATING)) {
-        if ((GetPrinterState() == PrinterState::SDPrintingFinished) && card.cardOK) {
+        if ((GetPrinterState() == PrinterState::SDPrintingFinished) && card.mounted) {
             MENU_ITEM_FUNCTION_P(_T(MSG_REPRINT), lcd_reprint_from_eeprom);
         } else if ((GetPrinterState() == PrinterState::HostPrintingFinished) && M79_timer_get_status()) {
             MENU_ITEM_FUNCTION_P(_T(MSG_REPRINT), lcd_send_action_start);
@@ -5259,7 +5259,7 @@ static void lcd_main_menu()
     )
     {
 #ifdef SDSUPPORT //!@todo SDSUPPORT undefined creates several issues in source code
-        if (card.cardOK || lcd_commands_type != LcdCommands::Idle) {
+        if (card.mounted || lcd_commands_type != LcdCommands::Idle) {
             if (!card.isFileOpen()) {
                 if (!usb_timer.running() && (lcd_commands_type == LcdCommands::Idle)) {
                     bMain=true;               // flag ('fake parameter') for 'lcd_sdcard_menu()' function
@@ -7307,7 +7307,7 @@ void menu_lcd_lcdupdate_func(void)
 		backlight_wake();
 		if (lcd_oldcardstatus)
 		{
-			if (!card.cardOK)
+			if (!card.mounted)
 			{
 				card.mount(false); //delay the sorting to the sd menu. Otherwise, removing the SD card while sorting will not menu_back()
 				card.presort_flag = true; //force sorting of the SD menu

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5586,7 +5586,7 @@ static void lcd_control_temperature_menu()
 static void lcd_sd_refresh()
 {
 #if SDCARDDETECT == -1
-  card.initsd();
+  card.mount();
 #else
   card.presort();
 #endif
@@ -7309,7 +7309,7 @@ void menu_lcd_lcdupdate_func(void)
 		{
 			if (!card.cardOK)
 			{
-				card.initsd(false); //delay the sorting to the sd menu. Otherwise, removing the SD card while sorting will not menu_back()
+				card.mount(false); //delay the sorting to the sd menu. Otherwise, removing the SD card while sorting will not menu_back()
 				card.presort_flag = true; //force sorting of the SD menu
 			}
 			LCD_MESSAGERPGM(MSG_WELCOME);


### PR DESCRIPTION
* Don't call `setroot()`/`cdroot()` if the SD card failed to mount. Also reduce duplicated call `initsd()`/`mount()`

I also added the following renames from Marlin 2.1:
* Rename `initsd()` to `mount()`
* Rename `cardOK` to `mounted`
* Rename `setroot()` to `cdroot()`

This isn't a necessary pull request, so I'm not adding it to any milestone for now