### PR TITLE
Fix `FW_COMMIT_HASH` compiler warning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,6 +81,7 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         submodules: true
+        fetch-depth: 0
 
     - name: Checkout ${{ github.event.ref }}
       uses: actions/checkout@v3
@@ -88,6 +89,7 @@ jobs:
       with:
         ref: ${{ github.event.ref }}
         submodules: true
+        fetch-depth: 0
 
     - name: Cache Dependencies
       uses: actions/cache@v3.0.11
@@ -126,6 +128,7 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         submodules: true
+        fetch-depth: 0
 
     - name: Checkout ${{ github.event.ref }}
       uses: actions/checkout@v3
@@ -133,6 +136,7 @@ jobs:
       with:
         ref: ${{ github.event.ref }}
         submodules: true
+        fetch-depth: 0
 
     - name: Cache Dependencies
       uses: actions/cache@v3.0.11

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,7 @@ if (NO_TAG_IS_FATAL)
 else()
     MESSAGE(STATUS "Git was not found or an error occurred parsing the tag. Falling back to Configuration.h values (${PROJECT_VERSION}).")
 endif()
-set(FW_COMMIT_HASH "0") # Clear it, the code expects a binary...
+set(FW_COMMIT_HASH ${FW_COMMIT_HASH_UNKNOWN}) # Clear it, the code expects a binary...
 set(PROJECT_VERSION_TIMESTAMP "0")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -439,7 +439,7 @@ function(fw_add_variant variant_name)
     add_custom_target(
       check_lang_${variant_name}_${LANG}
       COMMENT "Checking ${variant_name} language ${LANG}"
-      COMMAND ${CMAKE_SOURCE_DIR}/lang/lang-check.py --map ${LANG_MAP} ${PO_FILE}
+      COMMAND "${Python3_EXECUTABLE}" ${CMAKE_SOURCE_DIR}/lang/lang-check.py --map ${LANG_MAP} ${PO_FILE}
       DEPENDS ${LANG_MAP} ${PO_FILE}
       USES_TERMINAL
       )
@@ -511,7 +511,7 @@ function(fw_add_variant variant_name)
       add_custom_command(
         OUTPUT ${FW_LANG_FINAL}.bin
         COMMAND ${CMAKE_OBJCOPY} -O binary ${FW_LANG_BASE} ${FW_LANG_FINAL}.bin
-        COMMAND ${CMAKE_SOURCE_DIR}/lang/lang-patchsec.py ${FW_LANG_BASE} ${LANG_BIN}
+        COMMAND "${Python3_EXECUTABLE}" ${CMAKE_SOURCE_DIR}/lang/lang-patchsec.py ${FW_LANG_BASE} ${LANG_BIN}
                 ${FW_LANG_FINAL}.bin
         DEPENDS ${FW_LANG_BASE} ${LANG_BIN}
         COMMENT "Generating ${FW_LANG_FINAL}.bin"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -367,7 +367,8 @@ function(add_base_binary variant_name)
   target_compile_definitions(
     ${variant_name}
     PRIVATE CMAKE_CONTROL FW_REPOSITORY="${PROJECT_REPOSITORY}"
-            FW_COMMIT_HASH=0x${FW_COMMIT_HASH}
+            FW_COMMIT_HASH="${FW_COMMIT_HASH}"
+            FW_COMMIT_HASH_LENGTH=${FW_COMMIT_HASH_LENGTH}
             FW_MAJOR=${PROJECT_VERSION_MAJOR}
             FW_MINOR=${PROJECT_VERSION_MINOR}
             FW_REVISION=${PROJECT_VERSION_REV}

--- a/Firmware/Configuration.h
+++ b/Firmware/Configuration.h
@@ -40,7 +40,8 @@ extern const char _sPrinterMmuName[] PROGMEM;
 
 // The full version string and repository source are set via cmake
 #ifndef CMAKE_CONTROL
-#define FW_COMMIT_HASH 0
+#define FW_COMMIT_HASH_LENGTH 1
+#define FW_COMMIT_HASH "0"
 #define FW_REPOSITORY "Unknown"
 #define FW_VERSION_FULL FW_VERSION "-unknown"
 #endif

--- a/Firmware/util.cpp
+++ b/Firmware/util.cpp
@@ -17,7 +17,13 @@ const uint16_t FW_VERSION_NR[4] PROGMEM = {
     FW_TWEAK,
 };
 
-const uint32_t FW_VERSION_HASH PROGMEM = FW_COMMIT_HASH;
+const char FW_VERSION_HASH[] PROGMEM = FW_COMMIT_HASH;
+static_assert(sizeof(FW_VERSION_HASH) == FW_COMMIT_HASH_LENGTH + 1);
+
+const char* FW_VERSION_HASH_P()
+{
+    return FW_VERSION_HASH;
+}
 
 const char* FW_VERSION_STR_P()
 {

--- a/Firmware/util.h
+++ b/Firmware/util.h
@@ -2,10 +2,10 @@
 #include <stdint.h>
 
 extern const uint16_t FW_VERSION_NR[4];
-extern const char* FW_VERSION_STR_P();
+const char* FW_VERSION_STR_P();
 
-extern const uint32_t FW_VERSION_HASH PROGMEM;
-static inline uint32_t FW_VERSION_HASH_P() { return (uint32_t)pgm_read_dword(&FW_VERSION_HASH); }
+extern const char FW_VERSION_HASH[];
+const char* FW_VERSION_HASH_P();
 
 // Definition of a firmware flavor numerical values.
 // To keep it short as possible

--- a/cmake/ProjectVersion.cmake
+++ b/cmake/ProjectVersion.cmake
@@ -87,6 +87,12 @@ ENDIF()
 
 set(PROJECT_VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_REV}.${PROJECT_VERSION_TWEAK}")
 
+# Define a constant length for the commit hash
+set(FW_COMMIT_HASH_LENGTH 9)
+
+# Create fallback value with constant length
+string(REPEAT "0" ${FW_COMMIT_HASH_LENGTH} FW_COMMIT_HASH_UNKNOWN)
+
 function(resolve_version_variables)
   if(FW_COMMIT_DSC)
     return()
@@ -94,11 +100,17 @@ function(resolve_version_variables)
   if(NOT GIT_FOUND)
     find_package(Git QUIET)
   endif()
-  git_head_commit_data(FW_COMMIT_HASH "%h")
+
+  # Get the full commit hash
+  git_head_commit_data(FW_COMMIT_HASH "%H")
+
+  # Keep only the first 'FW_COMMIT_HASH_LENGTH' characters
+  string(SUBSTRING "${FW_COMMIT_HASH}" 0 ${FW_COMMIT_HASH_LENGTH} FW_COMMIT_HASH)
+
   set(ERRORS "GIT-NOTFOUND" "HEAD-FORMAT-NOTFOUND")
   if(FW_COMMIT_HASH IN_LIST ERRORS)
     # git not available, set fallback values
-    set(FW_COMMIT_HASH "UNKNOWN")
+    set(FW_COMMIT_HASH ${FW_COMMIT_HASH_UNKNOWN})
     set(FW_COMMIT_DSC "v${PROJECT_VERSION}-${FW_COMMIT_HASH}")
     string(TIMESTAMP FW_COMMIT_DATE "%s")
   else()


### PR DESCRIPTION
On my end, the default length for the abbreviated commit hash is 9 characters and won't fit into `uint32_t`.

To fix this I propose to change `FW_COMMIT_HASH` into a string and create preprocessor symbol for the string length so that it's known at compile time.

If the string should be longer or shorter then only `FW_COMMIT_HASH_LENGTH` needs to be configured on the CMake side

- [ ] Cherry-pick PR to MK3_3.13.2