### PR TITLE
PFW-1294: Don't attempt to find SD file when recovering USB print

### DIFF
--- a/Firmware/eeprom.h
+++ b/Firmware/eeprom.h
@@ -368,6 +368,7 @@ static_assert(sizeof(Sheets) == EEPROM_SHEETS_SIZEOF, "Sizeof(Sheets) is not EEP
 | 0x0C97 3223 | uint8   | EEPROM_THERMAL_MODEL_VER              | 0-255        | ffh                   | Thermal Model Version                             | Thermal Model| D3 Ax0c97 C1
 | 0x0C95 3221 | PGM_P   | EEPROM_KILL_MESSAGE                   | 0-65535      | ff ffh                | Kill message PGM pointer                          | kill()       | D3 Ax0c95 C2
 | 0x0C94 3220 | uint8   | EEPROM_KILL_PENDING_FLAG              | 42h, ffh     | ffh                   | Kill pending flag (0x42 magic value)              | kill()       | D3 Ax0c94 C1
+| 0x0C91 3217 | char[3] | EEPROM_FILENAME_EXTENSION             | ???          | ffffffffh             | DOS 8.3 filename extension                        | ???          | D3 Ax0c91 C1
 
 |Address begin|Bit/Type | Name                                  | Valid values | Default/FactoryReset  | Description                                       |Gcode/Function| Debug code
 | :--:        | :--:    | :--:                                  | :--:         | :--:                  | :--:                                              | :--:         | :--:
@@ -606,8 +607,10 @@ static Sheets * const EEPROM_Sheets_base = (Sheets*)(EEPROM_SHEETS_BASE);
 #define EEPROM_KILL_MESSAGE (EEPROM_THERMAL_MODEL_VER-2) //PGM_P
 #define EEPROM_KILL_PENDING_FLAG (EEPROM_KILL_MESSAGE-1) //uint8
 
+#define EEPROM_FILENAME_EXTENSION (EEPROM_KILL_PENDING_FLAG - 3) // 3 x char
+
 //This is supposed to point to last item to allow EEPROM overrun check. Please update when adding new items.
-#define EEPROM_LAST_ITEM EEPROM_KILL_PENDING_FLAG
+#define EEPROM_LAST_ITEM EEPROM_FILENAME_EXTENSION
 // !!!!!
 // !!!!! this is end of EEPROM section ... all updates MUST BE inserted before this mark !!!!!
 // !!!!!

--- a/Firmware/power_panic.cpp
+++ b/Firmware/power_panic.cpp
@@ -430,23 +430,26 @@ void restore_file_from_sd()
     char dir_name[9];
     uint8_t depth = eeprom_read_byte((uint8_t*)EEPROM_DIR_DEPTH);
 
-    MYSERIAL.println(int(depth));
     for (uint8_t i = 0; i < depth; i++) {
         for (uint8_t j = 0; j < 8; j++) {
             dir_name[j] = eeprom_read_byte((uint8_t*)EEPROM_DIRS + j + 8 * i);
         }
         dir_name[8] = '\0';
-        MYSERIAL.println(dir_name);
         card.chdir(dir_name, false);
     }
 
     for (uint8_t i = 0; i < 8; i++) {
-        filename[i] = eeprom_read_byte((uint8_t*)EEPROM_FILENAME + i);
+        const char c = eeprom_read_byte((uint8_t*)EEPROM_FILENAME + i);
+        filename[i] = c;
+        if (c == '\0') break; // Filename is shorter than 8 characters
     }
+
+    // Add null delimiter in case all 8 characters were not NULL
     filename[8] = '\0';
 
-    MYSERIAL.print(filename);
+    // Add extension to complete the DOS 8.3 filename
     strcat_P(filename, PSTR(".gco"));
+
     enquecommandf_P(MSG_M23, filename);
 }
 

--- a/Firmware/power_panic.cpp
+++ b/Firmware/power_panic.cpp
@@ -438,11 +438,9 @@ void restore_file_from_sd()
         card.chdir(dir_name, false);
     }
 
-    for (uint8_t i = 0; i < 8; i++) {
-        const char c = eeprom_read_byte((uint8_t*)EEPROM_FILENAME + i);
-        filename[i] = c;
-        if (c == '\0') break; // Filename is shorter than 8 characters
-    }
+    // Recover DOS 8.3 filename without extension.
+    // Short filenames are always null terminated.
+    eeprom_read_block(filename, (const char *)EEPROM_FILENAME, 8);
 
     // Add null delimiter in case all 8 characters were not NULL
     filename[8] = '\0';

--- a/Firmware/power_panic.cpp
+++ b/Firmware/power_panic.cpp
@@ -428,6 +428,7 @@ void restore_file_from_sd()
 {
     char filename[FILENAME_LENGTH];
     char dir_name[9];
+    char extension_ptr[5];
     uint8_t depth = eeprom_read_byte((uint8_t*)EEPROM_DIR_DEPTH);
 
     for (uint8_t i = 0; i < depth; i++) {
@@ -443,8 +444,11 @@ void restore_file_from_sd()
     // Add null delimiter in case all 8 characters were not NULL
     filename[8] = '\0';
 
-    // Add extension to complete the DOS 8.3 filename
-    strcat_P(filename, PSTR(".gco"));
+    // Add extension to complete the DOS 8.3 filename e.g. ".gco" or ".g"
+    extension_ptr[0] = '.';
+    eeprom_read_block(&extension_ptr[1], (const char *)EEPROM_FILENAME_EXTENSION, 3);
+    extension_ptr[4] = '\0';
+    strcat(filename, extension_ptr);
 
     enquecommandf_P(MSG_M23, filename);
 }

--- a/Firmware/power_panic.cpp
+++ b/Firmware/power_panic.cpp
@@ -431,9 +431,7 @@ void restore_file_from_sd()
     uint8_t depth = eeprom_read_byte((uint8_t*)EEPROM_DIR_DEPTH);
 
     for (uint8_t i = 0; i < depth; i++) {
-        for (uint8_t j = 0; j < 8; j++) {
-            dir_name[j] = eeprom_read_byte((uint8_t*)EEPROM_DIRS + j + 8 * i);
-        }
+        eeprom_read_block(dir_name, (const char *)EEPROM_DIRS + 8 * i, 8);
         dir_name[8] = '\0';
         card.chdir(dir_name, false);
     }

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -7003,6 +7003,22 @@ static void menu_action_sdfile(const char* filename)
 	  }
   }
 
+    // Write the DOS 8.3 file extension into EEPROM
+    char * extension_ptr = strchr(selected_filename, '.');
+
+    if (extension_ptr) {
+        extension_ptr++; // skip the '.'
+    }
+
+    for (uint_least8_t i = 0; i < 3; i++)
+    {
+        if (extension_ptr == NULL || extension_ptr[i] == '\0') {
+            eeprom_update_byte((uint8_t*)EEPROM_FILENAME_EXTENSION + i, '\0');
+        } else {
+            eeprom_update_byte((uint8_t*)EEPROM_FILENAME_EXTENSION + i, extension_ptr[i]);
+        }
+    }
+
     const uint8_t depth = card.getWorkDirDepth();
     eeprom_write_byte((uint8_t*)EEPROM_DIR_DEPTH, depth);
 

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -6984,44 +6984,38 @@ static void menu_action_sdfile(const char* filename)
 {
   if(eFilamentAction != FilamentAction::None) return;
 
-  char cmd[30];
-  char* c;
-  bool result = true;
-  sprintf_P(cmd, MSG_M23, filename);
-  for (c = &cmd[4]; *c; c++)
-    *c = tolower(*c);
+    // Create a copy of card.filename on the stack since card.filename pointer
+    // will be modified by the SD card library when searching for the file
+    char selected_filename[FILENAME_LENGTH];
+    strcpy(selected_filename, filename);
 
-  const char end[5] = ".gco";
+  bool result = true;
 
   //we are storing just first 8 characters of 8.3 filename assuming that extension is always ".gco"
   for (uint_least8_t i = 0; i < 8; i++) {
-	  if (strcmp((cmd + i + 4), end) == 0) {
+	  if (selected_filename[i] == '\0' || selected_filename[i] == '.') {
 		  //filename is shorter then 8.3, store '\0' character on position where ".gco" string was found to terminate stored string properly
  		  eeprom_write_byte((uint8_t*)EEPROM_FILENAME + i, '\0');
 		  break;
 	  }
 	  else {
-		  eeprom_write_byte((uint8_t*)EEPROM_FILENAME + i, cmd[i + 4]);
+		  eeprom_write_byte((uint8_t*)EEPROM_FILENAME + i, selected_filename[i]);
 	  }
   }
 
-  uint8_t depth = card.getWorkDirDepth();
-  eeprom_write_byte((uint8_t*)EEPROM_DIR_DEPTH, depth);
+    const uint8_t depth = card.getWorkDirDepth();
+    eeprom_write_byte((uint8_t*)EEPROM_DIR_DEPTH, depth);
 
-  for (uint_least8_t i = 0; i < depth; i++) {
-	  for (uint_least8_t j = 0; j < 8; j++) {
-		  eeprom_write_byte((uint8_t*)EEPROM_DIRS + j + 8 * i, card.dir_names[i][j]);
-	  }
-  }
+    for (uint_least8_t i = 0; i < depth; i++) {
+        eeprom_update_block(card.dir_names[i], (uint8_t*)EEPROM_DIRS + 8 * i, 8);
+    }
 
-  //filename is just a pointer to card.filename, which changes everytime you try to open a file by filename. So you can't use filename directly
-  //to open a file. Instead, the cached filename in cmd is used as that one is static for the whole lifetime of this function.
-  if (!check_file(cmd + 4)) {
+  if (!check_file(selected_filename)) {
       result = !lcd_show_fullscreen_message_yes_no_and_wait_P(_i("File incomplete. Continue anyway?"), false);////MSG_FILE_INCOMPLETE c=20 r=3
       lcd_update_enable(true);
   }
   if (result) {
-	  enquecommand(cmd);
+	  enquecommandf_P(MSG_M23, selected_filename);
 	  enquecommand_P(MSG_M24);
   }
 


### PR DESCRIPTION
Summary of changes:

- **Remote host prints (serial and USB)**: there is no filename on the printer side (in RAM or EEPROM). Power panic recovery for remote prints should not attempt to recover a filename from the printer and interact with the SD card (which may not even be connected)
- **SD print**: The filename recovery is split into a separate function. This will be useful later to optimise code size in "Reprint" LCD menu. (PFW-1536)
- **SD print**: Support any valid DOS 8.3 filename. Previously `.gco` extension was hardcoded, but now `.g` will work as well. A new EEPROM entry is added `EEPROM_FILENAME_EXTENSION`
- **SD print**: Generally refactor reading and writing the filename & directory.
    - Write/read EEPROM blocks instead of one byte at a time.
    - Don't convert the SFN to lower case. The code that searches for the matching filename is not case sensitive.

TODO:

- [x] Test very short filename e.g. "test.gcode" (Starting a print, Power panic, and Power panic recovery)
- [x] Do some more testing and try to break things :)