### PR TITLE
PFW-1542 Don't allow starting SD print if there is a thermal or fan error

### DIFF
--- a/Firmware/fancheck.cpp
+++ b/Firmware/fancheck.cpp
@@ -146,6 +146,7 @@ void checkFanSpeed()
     if ((fan_check_error == EFCE_FIXED) && !printer_active()){
         fan_check_error = EFCE_OK; //if the issue is fixed while the printer is doing nothing, reenable processing immediately.
         lcd_reset_alert_level(); //for another fan speed error
+        lcd_setstatuspgm(MSG_WELCOME); // Reset the status line message to visually show the error is gone
     }
     if (fans_check_enabled && (fan_check_error == EFCE_OK))
     {

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5222,25 +5222,34 @@ static void lcd_main_menu()
         MENU_ITEM_SUBMENU_P(_T(MSG_TM_ACK_ERROR), lcd_print_stop);
     }
 #endif
+
+    // only allow starting SD print if hardware errors (temperature or fan) are cleared
+    if(!get_temp_error()
+#ifdef FANCHECK
+            && fan_check_error != EFCE_REPORTED
+#endif //FANCHECK
+    )
+    {
 #ifdef SDSUPPORT //!@todo SDSUPPORT undefined creates several issues in source code
-    if (card.cardOK || lcd_commands_type != LcdCommands::Idle) {
-        if (!card.isFileOpen()) {
-            if (!usb_timer.running() && (lcd_commands_type == LcdCommands::Idle)) {
-                bMain=true;               // flag ('fake parameter') for 'lcd_sdcard_menu()' function
-                MENU_ITEM_SUBMENU_P(_T(MSG_CARD_MENU), lcd_sdcard_menu);
-            }
+        if (card.cardOK || lcd_commands_type != LcdCommands::Idle) {
+            if (!card.isFileOpen()) {
+                if (!usb_timer.running() && (lcd_commands_type == LcdCommands::Idle)) {
+                    bMain=true;               // flag ('fake parameter') for 'lcd_sdcard_menu()' function
+                    MENU_ITEM_SUBMENU_P(_T(MSG_CARD_MENU), lcd_sdcard_menu);
+                }
 #if SDCARDDETECT < 1
-        MENU_ITEM_GCODE_P(_i("Change SD card"), PSTR("M21"));  // SD-card changed by user ////MSG_CNG_SDCARD c=18
+            MENU_ITEM_GCODE_P(_i("Change SD card"), PSTR("M21"));  // SD-card changed by user ////MSG_CNG_SDCARD c=18
+#endif //SDCARDDETECT
+            }
+        } else {
+            bMain=true;                                   // flag (i.e. 'fake parameter') for 'lcd_sdcard_menu()' function
+            MENU_ITEM_SUBMENU_P(_i("No SD card"), lcd_sdcard_menu); ////MSG_NO_CARD c=18
+#if SDCARDDETECT < 1
+            MENU_ITEM_GCODE_P(_i("Init. SD card"), PSTR("M21")); // Manually initialize the SD-card via user interface ////MSG_INIT_SDCARD c=18
 #endif //SDCARDDETECT
         }
-    } else {
-        bMain=true;                                   // flag (i.e. 'fake parameter') for 'lcd_sdcard_menu()' function
-        MENU_ITEM_SUBMENU_P(_i("No SD card"), lcd_sdcard_menu); ////MSG_NO_CARD c=18
-#if SDCARDDETECT < 1
-        MENU_ITEM_GCODE_P(_i("Init. SD card"), PSTR("M21")); // Manually initialize the SD-card via user interface ////MSG_INIT_SDCARD c=18
-#endif //SDCARDDETECT
-    }
 #endif //SDSUPPORT
+    }
 
     if(!printer_active() && !farm_mode) {
         const int8_t sheet = eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet));


### PR DESCRIPTION
Two small fixes:
* Don't allow starting SD print if there is a thermal or fan error. Here I am reusing the exact same conditions which are applied to "Resume print" feature.
* Reset the status line message when the fan error is resolved automatically to show `"Prusa i3 MK3S OK"` instead of `"Err:HOTEND FAN ERROR"`

Steps to reproduce issue:

1. Start a print
2. Once the purge line is started to extrude => block the hotend fan until error appears
3. Print is paused due to fan error (note that the print can’t be resumed)
4. Keep blocking the fan and stop the print
5. **Observe issue:** A new print can be started even if the fan error is still active/unresolved. 