### PR TITLE
3.13.2 Cherry-pick PFW-1542 Don't allow starting SD print if there is a thermal or fan error

### DIFF
--- a/Firmware/fancheck.cpp
+++ b/Firmware/fancheck.cpp
@@ -146,6 +146,7 @@ void checkFanSpeed()
     if ((fan_check_error == EFCE_FIXED) && !printer_active()){
         fan_check_error = EFCE_OK; //if the issue is fixed while the printer is doing nothing, reenable processing immediately.
         lcd_reset_alert_level(); //for another fan speed error
+        lcd_setstatuspgm(MSG_WELCOME); // Reset the status line message to visually show the error is gone
     }
     if (fans_check_enabled && (fan_check_error == EFCE_OK))
     {


### PR DESCRIPTION
Cherry-pick https://github.com/prusa3d/Prusa-Firmware/pull/4449 for 3.13.2

Two small fixes:

* Don't allow starting SD print if there is a thermal or fan error. Here I am reusing the exact same conditions which are applied to "Resume print" feature.
* Reset the status line message when the fan error is resolved automatically to show `"Prusa i3 MK3S OK"` instead of `"Err:HOTEND FAN ERROR"`