### PR TITLE
mmu: Don't log Query (Q0) requests/responses when MMU is Idle

### DIFF
--- a/Firmware/mmu2_protocol_logic.h
+++ b/Firmware/mmu2_protocol_logic.h
@@ -152,6 +152,11 @@ public:
 
     uint8_t CommandInProgress() const;
 
+    /// @returns true if the protocol is processing a Query (Q0)
+    /// Note that asynchronous requests such as single register read (M707)
+    /// are not part of the Query.
+    bool IdleQueryInProgress() const;
+
     inline bool Running() const {
         return state == State::Running;
     }


### PR DESCRIPTION
An idea I have to resolve https://github.com/prusa3d/Prusa-Firmware/issues/4414

If a Query is running in Idle state machine, then don't log anything but still allow asynchronous requests/responses to be logged. For example a register read via M707 will still show up fine.

![image](https://github.com/prusa3d/Prusa-Firmware/assets/8218499/86fd4c56-4a2e-45da-9097-730e44ced178)


This makes the serial log muuch cleaner when the MMU is idle. When running a printjob, it is only when a command such as toolchange is running that everything will be logged again.