### PR TITLE
PFW-1184:Basic Printer name in EEPROM

### DIFF
--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -460,5 +460,4 @@ extern "C" void softReset();
 void stack_error();
 
 extern uint32_t IP_address;
-
 #endif

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -6397,12 +6397,14 @@ Sigma_Exit:
           // pause the print for 30s and ask the user to upgrade the firmware.
           show_upgrade_dialog_if_version_newer(++ strchr_pointer);
       } else {
+          char custom_mendel_name[MAX_CUSTOM_MENDEL_NAME_LENGTH];
+          eeprom_read_block(custom_mendel_name,(char*)EEPROM_CUSTOM_MENDEL_NAME,MAX_CUSTOM_MENDEL_NAME_LENGTH);
           SERIAL_ECHOPGM("FIRMWARE_NAME:Prusa-Firmware ");
           SERIAL_ECHORPGM(FW_VERSION_STR_P());
           SERIAL_ECHOPGM(" based on Marlin FIRMWARE_URL:https://github.com/prusa3d/Prusa-Firmware PROTOCOL_VERSION:");
           SERIAL_ECHOPGM(PROTOCOL_VERSION);
           SERIAL_ECHOPGM(" MACHINE_TYPE:");
-          SERIAL_ECHOPGM(CUSTOM_MENDEL_NAME);
+          SERIAL_PROTOCOL(custom_mendel_name);
           SERIAL_ECHOPGM(" EXTRUDER_COUNT:" STRINGIFY(EXTRUDERS));
           SERIAL_ECHOPGM(" UUID:");
           SERIAL_ECHOLNPGM(MACHINE_UUID);

--- a/Firmware/eeprom.cpp
+++ b/Firmware/eeprom.cpp
@@ -46,6 +46,12 @@ void eeprom_init()
     }
     check_babystep();
 
+    // initialize custom mendel name in eeprom
+    if (eeprom_read_byte((uint8_t*)EEPROM_CUSTOM_MENDEL_NAME) == EEPROM_EMPTY_VALUE) {
+        //SERIAL_ECHOLN("Init Custom Mendel Name");
+        eeprom_update_block(CUSTOM_MENDEL_NAME, (uint8_t*)EEPROM_CUSTOM_MENDEL_NAME, sizeof(CUSTOM_MENDEL_NAME));
+    } //else SERIAL_ECHOLN("Found Custom Mendel Name");
+
 #ifdef PINDA_TEMP_COMP
     eeprom_init_default_byte((uint8_t*)EEPROM_PINDA_TEMP_COMPENSATION, 0);
 #endif //PINDA_TEMP_COMP

--- a/Firmware/eeprom.h
+++ b/Firmware/eeprom.h
@@ -12,7 +12,17 @@
 #define EEPROM_H
 
 #include <stdint.h>
+#include "Configuration_var.h"
 
+// Custom Mendel Name
+#ifndef CUSTOM_MENDEL_NAME
+    #define CUSTOM_MENDEL_NAME "Prusa i3"
+#endif
+
+#define MAX_CUSTOM_MENDEL_NAME_LENGTH 17
+
+
+// Sheets
 #define MAX_SHEETS 8
 #define MAX_SHEET_NAME_LENGTH 7
 
@@ -371,6 +381,7 @@ static_assert(sizeof(Sheets) == EEPROM_SHEETS_SIZEOF, "Sizeof(Sheets) is not EEP
 | 0x0C95 3221 | PGM_P   | EEPROM_KILL_MESSAGE                   | 0-65535      | ff ffh                | Kill message PGM pointer                          | kill()       | D3 Ax0c95 C2
 | 0x0C94 3220 | uint8   | EEPROM_KILL_PENDING_FLAG              | 42h, ffh     | ffh                   | Kill pending flag (0x42 magic value)              | kill()       | D3 Ax0c94 C1
 | 0x0C91 3217 | char[3] | EEPROM_FILENAME_EXTENSION             | ???          | ffffffffh             | DOS 8.3 filename extension                        | Power Panic  | D3 Ax0c91 C1
+| 0x0C80 3200 | char[17]| EEPROM_CUSTOM_MENDEL_NAME             | Prusa i3 MK3S| ffffffffffffffffff... | Custom Printer Name                               |              | D3 Ax0c80 C17
 
 |Address begin|Bit/Type | Name                                  | Valid values | Default/FactoryReset  | Description                                       |Gcode/Function| Debug code
 | :--:        | :--:    | :--:                                  | :--:         | :--:                  | :--:                                              | :--:         | :--:
@@ -608,8 +619,8 @@ static Sheets * const EEPROM_Sheets_base = (Sheets*)(EEPROM_SHEETS_BASE);
 
 #define EEPROM_KILL_MESSAGE (EEPROM_THERMAL_MODEL_VER-2) //PGM_P
 #define EEPROM_KILL_PENDING_FLAG (EEPROM_KILL_MESSAGE-1) //uint8
-
 #define EEPROM_FILENAME_EXTENSION (EEPROM_KILL_PENDING_FLAG - 3) // 3 x char
+#define EEPROM_CUSTOM_MENDEL_NAME (EEPROM_FILENAME_EXTENSION-17) //char[17]
 
 //This is supposed to point to last item to allow EEPROM overrun check. Please update when adding new items.
 #define EEPROM_LAST_ITEM EEPROM_FILENAME_EXTENSION

--- a/Firmware/language.h
+++ b/Firmware/language.h
@@ -13,10 +13,6 @@
 
 #define PROTOCOL_VERSION "1.0"
 
-#ifndef CUSTOM_MENDEL_NAME
-    #define MACHINE_NAME "Mendel"
-#endif
-
 #ifndef MACHINE_UUID
    #define MACHINE_UUID "00000000-0000-0000-0000-000000000000"
 #endif


### PR DESCRIPTION
- Output with M115 works :heavy_check_mark:
- New printer name has been limited to 16 chars and can be modified in EEPROM using `D3` command.

