### PR TITLE
:construction: PFW-1206:Inital M75-M78

### DIFF
--- a/Firmware/cardreader.cpp
+++ b/Firmware/cardreader.cpp
@@ -577,7 +577,7 @@ void CardReader::getStatus(bool arg_P)
         SERIAL_PROTOCOL(sdpos);
         SERIAL_PROTOCOL('/');
         SERIAL_PROTOCOLLN(filesize);
-        uint16_t time = ( _millis() - starttime ) / 60000U;
+        uint32_t time = ( _millis() - starttime ) / 60000U;
         SERIAL_PROTOCOL((int)(time / 60));
         SERIAL_PROTOCOL(':');
         SERIAL_PROTOCOLLN((int)(time % 60));

--- a/Firmware/cmdqueue.cpp
+++ b/Firmware/cmdqueue.cpp
@@ -657,17 +657,17 @@ void get_command()
           card.closefile();
 
           SERIAL_PROTOCOLLNRPGM(_n("Done printing file"));////MSG_FILE_PRINTED
-          char time[30];
+//          char time[30];
           uint32_t t = (_millis() - starttime - pause_time) / 60000;
-          pause_time = 0;
-          int hours, minutes;
-          minutes = t % 60;
-          hours = t / 60;
+//          pause_time = 0;
+//          int hours, minutes;
+//          minutes = t % 60;
+//          hours = t / 60;
           save_statistics(total_filament_used, t);
-          sprintf_P(time, PSTR("%i hours %i minutes"),hours, minutes);
-          SERIAL_ECHO_START;
-          SERIAL_ECHOLN(time);
-          lcd_setstatus(time);
+//          sprintf_P(time, PSTR("%i hours %i minutes"),hours, minutes);
+//          SERIAL_ECHO_START;
+//          SERIAL_ECHOLN(time);
+//          lcd_setstatus(time);
           card.printingHasFinished();
           card.checkautostart(true);
 

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -412,7 +412,7 @@ struct _menu_tune_data_t
 };
 
 static_assert(sizeof(_menu_tune_data_t) == 18);
-static_assert(sizeof(menu_data)>= sizeof(_menu_tune_data_t),"_menu_tune_data_t doesn't fit into menu_data");
+static_assert(sizeof(menu_data) >= sizeof(_menu_tune_data_t),"_menu_tune_data_t doesn't fit into menu_data");
 
 void tuneIdlerStallguardThresholdMenu() {
     static constexpr _menu_tune_data_t * const _md = (_menu_tune_data_t*)&(menu_data[0]);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -478,7 +478,7 @@ void lcdui_print_time(void)
             print_t = print_tr;
             suff = 'R';
         } else
-            print_t = (_millis() - starttime) / 60000;
+            print_t = (_millis() - starttime - pause_time) / 60000;
 
         if (feedmultiply != 100 && (print_t == print_tr || print_t == print_tc)) {
             suff_doubt = '?';
@@ -2297,10 +2297,10 @@ void lcd_AutoLoadFilament() {
 void lcd_menu_statistics()
 {
     lcd_timeoutToStatus.stop(); //infinite timeout
-	if (IS_SD_PRINTING)
+	if (printJobOngoing())
 	{
 		const float _met = ((float)total_filament_used) / (100000.f);
-		const uint32_t _t = (_millis() - starttime) / 1000ul;
+		const uint32_t _t = (_millis() - starttime - pause_time) / 1000ul;
 		const uint32_t _h = (_t / 60) / 60;
 		const uint8_t _m = (_t / 60) % 60;
 		const uint8_t _s = _t % 60;
@@ -5292,9 +5292,9 @@ static void lcd_main_menu()
         if(!isPrintPaused) MENU_ITEM_SUBMENU_P(_T(MSG_CALIBRATION), lcd_calibration_menu);
     }
 
-    if (!usb_timer.running()) {
+    //if (!usb_timer.running()) {
         MENU_ITEM_SUBMENU_P(_i("Statistics"), lcd_menu_statistics);////MSG_STATISTICS c=18
-    }
+    //}
 
 #if defined(TMC2130) || defined(FILAMENT_SENSOR)
     MENU_ITEM_SUBMENU_P(_i("Fail stats"), lcd_menu_fails_stats);////MSG_FAIL_STATS c=18


### PR DESCRIPTION
Initial M75-M78 gcode and update PL/HOST print statistics
In Octoprint Settings GCODE
Add `M75` in start
Add `M76` in pause
Add `M75` in resume
Add `M77` in stop


Known issue:
Sometimes after a longer USB print PAUSE the total print time completely wrong.
@gudnimg  Can you please have a look?