### PR TITLE
optimisation: simplify two LCD messages

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3340,27 +3340,15 @@ static void lcd_sort_type_set() {
 #ifdef TMC2130
 static void lcd_crash_mode_info()
 {
-	lcd_update_enable(true);
-	static uint32_t tim = 0;
-	if ((tim + 1000) < _millis())
-	{
-		lcd_clear();
-		lcd_puts_P(_i("Crash detection can\nbe turned on only in\nNormal mode"));////MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-		tim = _millis();
-	}
+    lcd_home();
+    lcd_puts_P(_i("Crash detection can\nbe turned on only in\nNormal mode"));////MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
     menu_back_if_clicked();
 }
 
 static void lcd_crash_mode_info2()
 {
-	lcd_update_enable(true);
-	static uint32_t tim = 0;
-	if ((tim + 1000) < _millis())
-	{
-		lcd_clear();
-		lcd_puts_P(_i("WARNING:\nCrash detection\ndisabled in\nStealth mode"));////MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-		tim = _millis();
-	}
+    lcd_home();
+    lcd_puts_P(_i("WARNING:\nCrash detection\ndisabled in\nStealth mode"));////MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
     menu_back_if_clicked();
 }
 #endif //TMC2130


### PR DESCRIPTION
There is no need to restrict how often the message is rendered. It was being restricted to render every 1 second. We don't do this for most of the static menus. So I propose this 1 second period be removed.

Tested on MK3S+

Change in memory:
Flash: -168 bytes
SRAM: -8 bytes