### PR TITLE
MMU: Set PAUSED_FOR_USER state on MMU error screen

### DIFF
--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -248,6 +248,7 @@ void ReportErrorHook(CommandInProgress /*cip*/, ErrorCode ec, uint8_t /*es*/) {
 
     switch ((uint8_t)ReportErrorHookState) {
     case (uint8_t)ReportErrorHookStates::RENDER_ERROR_SCREEN:
+        KEEPALIVE_STATE(PAUSED_FOR_USER);
         ReportErrorHookStaticRender(ei);
         ReportErrorHookState = ReportErrorHookStates::MONITOR_SELECTION;
         [[fallthrough]];
@@ -270,6 +271,7 @@ void ReportErrorHook(CommandInProgress /*cip*/, ErrorCode ec, uint8_t /*es*/) {
                 sound_wait_for_user_reset();
                 // Reset the state in case a new error is reported
                 is_mmu_error_monitor_active = false;
+                KEEPALIVE_STATE(IN_HANDLER);
                 ReportErrorHookState = ReportErrorHookStates::RENDER_ERROR_SCREEN;
                 break;
             default:
@@ -283,6 +285,7 @@ void ReportErrorHook(CommandInProgress /*cip*/, ErrorCode ec, uint8_t /*es*/) {
         sound_wait_for_user_reset();
         // Reset the state in case a new error is reported
         is_mmu_error_monitor_active = false;
+        KEEPALIVE_STATE(IN_HANDLER);
         ReportErrorHookState = ReportErrorHookStates::RENDER_ERROR_SCREEN;
         break;
     default:


### PR DESCRIPTION
Setting this state notifies PrusaLink/PrusaConnect that the printer is waiting for user input (attention).

Resolves https://github.com/prusa3d/Prusa-Firmware/issues/4470

Change in memory:
Flash: +12 bytes
SRAM: 0 bytes