### PR TITLE
Add en- and disable MMU to M709

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -8581,14 +8581,15 @@ Sigma_Exit:
     } break;
 
     /*!
-    ### M709 - MMU reset <a href="https://reprap.org/wiki/G-code#M709:_MMU_reset">M709: MMU reset</a>
-    The MK3S cannot not power off the MMU, for that reason the functionality is not supported.
+    ### M709 - MMU power & reset <a href="https://reprap.org/wiki/G-code#M709:_MMU_power_&_reset">M709: MMU power & reset</a>
+    The MK3S cannot not power off the MMU, but we can en- and disable the MMU.
     #### Usage
 
-        M709 [ X ]
+        M709 [ S | X ]
 
     #### Parameters
-    - `X` - Reset MMU (0:soft reset | 1:hardware reset)
+    - `X` - Reset MMU (0:soft reset | 1:hardware reset | 42: erease MMU eeprom)
+    - `S` - En-/disable the MMU (0:off | 1:on)
 
     #### Example
 
@@ -8596,9 +8597,28 @@ Sigma_Exit:
 
     M709 X1 - toggle the MMU's reset pin (hardware reset)
 
+    M709 S1 - enable MMU
+
+    M709 S0 - disable MMU
+
+    M709    - Serial message if en- or disabled
     */
     case 709:
     {
+        if (code_seen('S'))
+        {
+            switch (code_value_uint8())
+            {
+            case 0:
+                MMU2::mmu2.Stop();
+                break;
+            case 1:
+                MMU2::mmu2.Start();
+                break;
+            default:
+                break;
+            }
+        }
         if (MMU2::mmu2.Enabled() && code_seen('X'))
         {
             switch (code_value_uint8())
@@ -8609,10 +8629,14 @@ Sigma_Exit:
             case 1:
                 MMU2::mmu2.Reset(MMU2::MMU2::ResetPin);
                 break;
+            case 42:
+                MMU2::mmu2.Reset(MMU2::MMU2::EraseEEPROM);
+                break;
             default:
                 break;
             }
         }
+        printf_P(_n("MMU state:%d\n"), MMU2::mmu2.Enabled());
     }
     break;
 

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -8583,7 +8583,7 @@ Sigma_Exit:
 
     /*!
     ### M709 - MMU power & reset <a href="https://reprap.org/wiki/G-code#M709:_MMU_power_&_reset">M709: MMU power & reset</a>
-    The MK3S cannot not power off the MMU, but we can en- and disable the MMU and will be also stored in EEPROM.
+    The MK3S cannot not power off the MMU, but we can en- and disable the MMU.
 
     The new state of the MMU is stored in printer's EEPROM - i.e. if you disable the MMU via M709, it will not be activated after the printer resets.
     #### Usage
@@ -8599,6 +8599,8 @@ Sigma_Exit:
     M709 X0 - issue an X0 command via communication into the MMU (soft reset)
 
     M709 X1 - toggle the MMU's reset pin (hardware reset)
+
+    M709 X42 - erase MMU EEPROM
 
     M709 S1 - enable MMU
 

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1125,6 +1125,7 @@ void setup()
 	if (eeprom_init_default_byte((uint8_t *)EEPROM_MMU_ENABLED, 0)) {
 		MMU2::mmu2.Start();
 	}
+	MMU2::mmu2.Status();
 	SpoolJoin::spooljoin.initSpoolJoinStatus();
 
 	//SERIAL_ECHOPAIR("Active sheet before:", static_cast<unsigned long int>(eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet))));
@@ -8640,7 +8641,7 @@ Sigma_Exit:
                 break;
             }
         }
-        printf_P(_n("MMU state:%d\n"), MMU2::mmu2.Enabled());
+    MMU2::mmu2.Status();
     }
     break;
 

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -8582,13 +8582,13 @@ Sigma_Exit:
 
     /*!
     ### M709 - MMU power & reset <a href="https://reprap.org/wiki/G-code#M709:_MMU_power_&_reset">M709: MMU power & reset</a>
-    The MK3S cannot not power off the MMU, but we can en- and disable the MMU.
+    The MK3S cannot not power off the MMU, but we can en- and disable the MMU and will be also stored in EEPROM.
     #### Usage
 
         M709 [ S | X ]
 
     #### Parameters
-    - `X` - Reset MMU (0:soft reset | 1:hardware reset | 42: erease MMU eeprom)
+    - `X` - Reset MMU (0:soft reset | 1:hardware reset | 42: erase MMU eeprom)
     - `S` - En-/disable the MMU (0:off | 1:on)
 
     #### Example
@@ -8610,9 +8610,11 @@ Sigma_Exit:
             switch (code_value_uint8())
             {
             case 0:
+                eeprom_update_byte((uint8_t *)EEPROM_MMU_ENABLED, false);
                 MMU2::mmu2.Stop();
                 break;
             case 1:
+                eeprom_update_byte((uint8_t *)EEPROM_MMU_ENABLED, true);
                 MMU2::mmu2.Start();
                 break;
             default:

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -8583,6 +8583,8 @@ Sigma_Exit:
     /*!
     ### M709 - MMU power & reset <a href="https://reprap.org/wiki/G-code#M709:_MMU_power_&_reset">M709: MMU power & reset</a>
     The MK3S cannot not power off the MMU, but we can en- and disable the MMU and will be also stored in EEPROM.
+
+    The new state of the MMU is stored in printer's EEPROM - i.e. if you disable the MMU via M709, it will not be activated after the printer resets.
     #### Usage
 
         M709 [ S | X ]

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -12,6 +12,9 @@
 #include "strlen_cx.h"
 #include "SpoolJoin.h"
 
+#include "messages.h"
+#include "language.h"
+
 #ifdef __AVR__
 // As of FW 3.12 we only support building the FW with only one extruder, all the multi-extruder infrastructure will be removed.
 // Saves at least 800B of code size
@@ -50,6 +53,17 @@ MMU2::MMU2()
     , unloadFilamentStarted(false)
     , toolchange_counter(0)
     , tmcFailures(0) {
+}
+
+void MMU2::Status() {
+    // Useful information to see during bootup and change state
+    SERIAL_ECHOPGM("MMU is ");
+    uint8_t status = eeprom_init_default_byte((uint8_t*)EEPROM_MMU_ENABLED, 0);
+    if (status == 1) {
+        SERIAL_ECHOLNRPGM(_O(MSG_ON));
+    } else {
+        SERIAL_ECHOLNRPGM(_O(MSG_OFF));
+    }
 }
 
 void MMU2::Start() {

--- a/Firmware/mmu2.h
+++ b/Firmware/mmu2.h
@@ -39,6 +39,9 @@ public:
     /// Stops the protocol logic, closes the UART, powers OFF the MMU
     void Stop();
 
+    /// Serial output of MMU state
+    void Status();
+
     inline xState State() const { return state; }
 
     inline bool Enabled() const { return State() == xState::Active; }

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -347,6 +347,7 @@ void TryLoadUnloadReporter::DumpToSerial(){
 /// Disables MMU in EEPROM
 void DisableMMUInSettings() {
     eeprom_update_byte((uint8_t *)EEPROM_MMU_ENABLED, false);
+    mmu2.Status();
 }
 
 void IncrementLoadFails(){

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -4093,6 +4093,7 @@ static void mmu_enable_switch()
     }
 
     eeprom_toggle((uint8_t *)EEPROM_MMU_ENABLED);
+    MMU2::mmu2.Status();
 }
 
 static void SETTINGS_SILENT_MODE()


### PR DESCRIPTION
Add X42 to erase the MMU eeprom

@gudnimg Any optimization possible?

Related to https://github.com/prusa3d/Prusa-Firmware/issues/4473 and https://github.com/prusa3d/Prusa-Link/issues/872

- [X] Update Doxygen
- [x] Update RepRap wiki
- [x] Update `M709` for MK4
   - [X]  `S0|0` and `X0|X1` already implemented
   - [x] Add `X42` to erase the MMU eeprom