### PR TITLE
PFW-1523 Add the `S` parameter to `M79`

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -5857,12 +5857,22 @@ Sigma_Exit:
     Restart the printer-host enable keepalive timer. While the timer has not expired, the printer will enable host specific features.
     #### Usage
 
-        M79
+        M79 [ S ]
     #### Parameters
-       None
+       - `S` - Quoted string containing two characters e.g. "PL"
     */
     case 79:
         M79_timer_restart();
+
+        if (code_seen('S'))
+        {
+            unquoted_string str = unquoted_string(strchr_pointer);
+            if (str.WasFound())
+            {
+                ResetHostStatusScreenName();
+                SetHostStatusScreenName(str.GetUnquotedString());
+            }
+        }
         break;
 
     /*!

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -5853,8 +5853,8 @@ Sigma_Exit:
     }
 
     /*!
-    ### M79 - TODO
-    Restart the printer-host enable keepalive timer. While the timer has not expired, the printer will enable host specific features.
+    ### M79 - Start host timer <a href="https://reprap.org/wiki/G-code#M79:_Start_host_timer">M79: Start host timer</a>
+    Start the printer-host enable keep-alive timer. While the timer has not expired, the printer will enable host specific features.
     #### Usage
 
         M79 [ S ]

--- a/Firmware/host.cpp
+++ b/Firmware/host.cpp
@@ -1,8 +1,23 @@
+#include <string.h>
 #include "Configuration_adv.h"
 #include "host.h"
 #include "Timer.h"
 
 static LongTimer M79_timer;
+static char host_status_screen_name[3];
+
+void SetHostStatusScreenName(const char * name) {
+    strncpy(host_status_screen_name, name, 2);
+    host_status_screen_name[2] = '\0';
+}
+
+char * GetHostStatusScreenName() {
+    return host_status_screen_name;
+}
+
+void ResetHostStatusScreenName() {
+    memset(host_status_screen_name, 0, sizeof(host_status_screen_name));
+}
 
 void M79_timer_restart() {
     M79_timer.start();

--- a/Firmware/host.h
+++ b/Firmware/host.h
@@ -1,5 +1,15 @@
 #pragma once
 
+/// Assigns host name with up to two characters which will be shown on
+/// the UI when printing. The function forces the third byte to be null delimiter.
+void SetHostStatusScreenName(const char * name);
+
+/// Returns a pointer to the host name
+char * GetHostStatusScreenName();
+
+/// Reset the memory to NULL when the host name should not be used
+void ResetHostStatusScreenName();
+
 /// Restart the M79 timer
 void M79_timer_restart();
 

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -375,7 +375,7 @@ void lcdui_print_percent_done(void)
 		}
 	}
 
-    if (M79_timer_get_status() && GetHostStatusScreenName())
+    if (!IS_SD_PRINTING && M79_timer_get_status() && GetHostStatusScreenName())
     {
         // Overwrite the name
         char * hostName = GetHostStatusScreenName();

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -19,7 +19,7 @@
 #include "menu.h"
 
 #include "backlight.h"
-
+#include "host.h"
 #include "util.h"
 #include "mesh_bed_leveling.h"
 #include "mesh_bed_calibration.h"
@@ -359,8 +359,7 @@ void lcdui_print_feedrate(void)
 // Print percent done in form "USB---%", " SD---%", "   ---%" (7 chars total)
 void lcdui_print_percent_done(void)
 {
-	const char* src = usb_timer.running()?_N("USB"):(IS_SD_PRINTING?_N(" SD"):_N("   "));
-	char per[4];
+	const char* src = usb_timer.running()?_N(" HO"):(IS_SD_PRINTING?_N(" SD"):_N("   "));
 	bool num = IS_SD_PRINTING || (printer_active() && (print_percent_done_normal != PRINT_PERCENT_DONE_INIT));
 	if (!num || heating_status != HeatingStatus::NO_HEATING) // either not printing or heating
 	{
@@ -375,8 +374,18 @@ void lcdui_print_percent_done(void)
 			return; //do not also print the percentage
 		}
 	}
-	sprintf_P(per, num?_N("%3d"):_N("---"), calc_percent_done());
-	lcd_printf_P(_N("%3S%3s%%"), src, per);
+
+    if (M79_timer_get_status() && GetHostStatusScreenName())
+    {
+        // Overwrite the name
+        char * hostName = GetHostStatusScreenName();
+        lcd_space(1);    // Blank space
+        lcd_print(hostName); // Two characters
+    } else {
+        lcd_printf_P(PSTR("%3S"), src);
+    }
+
+    lcd_printf_P(num ? _N("%3d%%"):_N("---%%"), calc_percent_done());
 }
 
 // Print extruder status (5 chars total)

--- a/Firmware/util.cpp
+++ b/Firmware/util.cpp
@@ -385,36 +385,16 @@ void gcode_level_check(uint16_t nGcodeLevel) {
     );
 }
 
-#define GCODE_DELIMITER '"'
-
-char *code_string(const char *pStr, size_t *nLength) {
-char* pStrBegin;
-char* pStrEnd;
-
-pStrBegin=strchr(pStr,GCODE_DELIMITER);
-if(!pStrBegin)
-     return(NULL);
-pStrBegin++;
-pStrEnd=strchr(pStrBegin,GCODE_DELIMITER);
-if(!pStrEnd)
-     return(NULL);
-*nLength=pStrEnd-pStrBegin;
-return pStrBegin;
-}
 
 void printer_smodel_check(const char *pStrPos, const char *actualPrinterSModel) {
-    char* pResult;
-    size_t nLength;
-    size_t aLength;
+    unquoted_string smodel = unquoted_string(pStrPos);
 
-    pResult=code_string(pStrPos,&nLength);
-    if(pResult != NULL) {
-        aLength=strlen_P(actualPrinterSModel);
-        if(aLength > nLength) nLength = aLength;
+    if(smodel.WasFound()) {
+        const uint8_t compareLength = strlen_P(actualPrinterSModel);
 
-        // Only compare first 6 chars on MK3|MK3S if string longer than 4 characters
-        if (nLength > 4 && strncmp_P(pResult, PSTR("MK3"), 3) == 0) nLength = 6;
-        if (strncmp_P(pResult, actualPrinterSModel, nLength) == 0) return;
+        if(compareLength == smodel.GetLength()) {
+            if (strncmp_P(smodel.GetUnquotedString(), actualPrinterSModel, compareLength) == 0) return;
+        }
     }
 
     render_M862_warnings(

--- a/Firmware/util.h
+++ b/Firmware/util.h
@@ -89,7 +89,8 @@ struct unquoted_string {
 public:
     /// @brief Given a pointer to a quoted string, filter out the quotes
     /// @param pStr A constant pointer to a constant string to be searched/filtered. Modifying the pointer is strictly forbidden.
-    unquoted_string(const char * const pStr)
+    /// NOTE: Forcing inline saves ~36 bytes of flash
+    inline __attribute__((always_inline)) unquoted_string(const char * const pStr)
     : len(0)
     , found(false)
     {

--- a/Firmware/util.h
+++ b/Firmware/util.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <stdint.h>
+#include <string.h>
 
 extern const uint16_t FW_VERSION_NR[4];
 const char* FW_VERSION_STR_P();
@@ -82,6 +83,45 @@ enum class ClCompareValue:uint_least8_t
     _Less=0,
     _Equal=1,
     _Greater=2
+};
+
+struct unquoted_string {
+public:
+    /// @brief Given a pointer to a quoted string, filter out the quotes
+    /// @param pStr A constant pointer to a constant string to be searched/filtered. Modifying the pointer is strictly forbidden.
+    unquoted_string(const char * const pStr)
+    : len(0)
+    , found(false)
+    {
+        char * pStrEnd = NULL;
+
+        // Start of the string
+        this->ptr = strchr(pStr, '"');
+        if (!this->ptr) {
+            // First quote not found
+            return;
+        }
+
+        // Skip the leading quote
+        this->ptr++; 
+
+        // End of the string
+        pStrEnd = strchr(this->ptr, '"');
+        if(!pStrEnd) {
+            // Second quote not found
+            return;
+        }
+        this->len = pStrEnd - this->ptr;
+        this->found = true;
+    }
+
+    bool WasFound() { return found; }
+    uint8_t GetLength() { return len; }
+    const char * GetUnquotedString() { return ptr; }
+private:
+    const char * ptr = NULL;
+    uint8_t len;
+    bool found;
 };
 
 extern ClNozzleDiameter oNozzleDiameter;

--- a/Firmware/util.h
+++ b/Firmware/util.h
@@ -104,7 +104,7 @@ public:
         }
 
         // Skip the leading quote
-        this->ptr++; 
+        this->ptr++;
 
         // End of the string
         pStrEnd = strchr(this->ptr, '"');


### PR DESCRIPTION
Continuation of https://github.com/prusa3d/Prusa-Firmware/pull/4460

Add the `S` parameter to `M79`. When the M79 timer is running, the S parameter will change the letters on "percentage done" text on the status screen to something customizable. The requirement was this be at most 2 characters and only activated when the M79 timer is running (when printing).

Another UI change is "USB" text is removed. Instead "HO" is shown which stands for "Host". "USB" wasn't really accurate when printing through a raspberry pi.

In the image below, "PL" stands for PrusaLink.

![IMG_4117](https://github.com/prusa3d/Prusa-Firmware/assets/8218499/94c8346a-68bf-495e-bab2-c3edf1f85dad)


I've tried to minimize memory usage and re-used the parsing from `M862.3 P`. I tested `M862.3 P` by disabling and enabling the MMU and in both cases it works fine.

TODO:

- [x] Double-check that `unquoted_string()` does not modify `strchr_pointer`.
- [ ] Update RepRap G-code wiki
