### PR TITLE
MMU: Remove gcode_reset_stepper_timeout

### DIFF
--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -639,9 +639,6 @@ void MMU2::SaveAndPark(bool move_axes) {
             }
         }
     }
-    // keep the motors powered forever (until some other strategy is chosen)
-    // @@TODO do we need that in 8bit?
-    gcode_reset_stepper_timeout();
 }
 
 void MMU2::ResumeHotendTemp() {

--- a/Firmware/mmu2_marlin.h
+++ b/Firmware/mmu2_marlin.h
@@ -60,6 +60,4 @@ void Disable_E0();
 
 bool all_axes_homed();
 
-void gcode_reset_stepper_timeout();
-
 } // namespace MMU2

--- a/Firmware/mmu2_marlin1.cpp
+++ b/Firmware/mmu2_marlin1.cpp
@@ -133,10 +133,6 @@ void safe_delay_keep_alive(uint16_t t) {
     delay_keep_alive(t);
 }
 
-void gcode_reset_stepper_timeout(){
-    // empty
-}
-
 void Enable_E0(){ enable_e0(); }
 void Disable_E0(){ disable_e0(); }
 


### PR DESCRIPTION
This function was removed on the 32-bit side.
On the 8-bit the function was empty so it is safe
remove it.