### PR TITLE
MMU2: enlarge the Idler's SG_thrs range in Tune menu

### DIFF
--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -412,7 +412,7 @@ struct TuneItem {
 
 static const TuneItem TuneItems[] PROGMEM = {
   { (uint8_t)Register::Selector_sg_thrs_R, 1, 4},
-  { (uint8_t)Register::Idler_sg_thrs_R, 4, 7},
+  { (uint8_t)Register::Idler_sg_thrs_R, 2, 10},
 };
 
 static_assert(sizeof(TuneItems)/sizeof(TuneItem) == 2);


### PR DESCRIPTION
Based on experience of mibehaving MMU2S units, a broader range seems to help more people in getting their unit to home properly.

Related to issue #4285

PFW-1548