### PR TITLE
Fix M600 initial loading showing status screen

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -11096,11 +11096,11 @@ void M600_load_filament() {
 	}
 	KEEPALIVE_STATE(IN_HANDLER);
 
-	M600_load_filament_movements();
+	lcd_update_enable(false);
+
+    M600_load_filament_movements();
 
 	Sound_MakeCustom(50,1000,false);
-
-	lcd_update_enable(false);
 }
 
 


### PR DESCRIPTION
At the M600 sequence, after unloading the filament and selecting to start the next filament loading, only for the first time, instead of showing the message "loading filament" the status screen is shown and the progress bar at the bottom.

This PR fixes the wrong behavior.