### PR TITLE
Change Reprint action message to comply with OctoPrint actions

### DIFF
--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -232,7 +232,7 @@ const char MSG_OCTOPRINT_RESUMED[] PROGMEM_N1 = "// action:resumed"; ////
 const char MSG_OCTOPRINT_CANCEL[] PROGMEM_N1 = "// action:cancel"; ////
 const char MSG_OCTOPRINT_READY[] PROGMEM_N1 = "// action:ready"; ////
 const char MSG_OCTOPRINT_NOT_READY[] PROGMEM_N1 = "// action:not_ready"; ////
-const char MSG_OCTOPRINT_REPRINT[] PROGMEM_N1 = "// action:reprint"; ////
+const char MSG_OCTOPRINT_START[] PROGMEM_N1 = "// action:start"; ////
 const char MSG_FANCHECK_HOTEND[] PROGMEM_N1 = "Err:HOTEND FAN ERROR"; ////c=20
 const char MSG_FANCHECK_PRINT[] PROGMEM_N1 = "Err:PRINT FAN ERROR"; ////c=20
 const char MSG_M112_KILL[] PROGMEM_N1 = "M112 called. Emergency Stop."; ////c=20

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -236,7 +236,7 @@ extern const char MSG_OCTOPRINT_RESUMED[];
 extern const char MSG_OCTOPRINT_CANCEL[];
 extern const char MSG_OCTOPRINT_READY[];
 extern const char MSG_OCTOPRINT_NOT_READY[];
-extern const char MSG_OCTOPRINT_REPRINT[];
+extern const char MSG_OCTOPRINT_START[];
 extern const char MSG_FANCHECK_HOTEND[];
 extern const char MSG_FANCHECK_PRINT[];
 extern const char MSG_M112_KILL[];

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5197,7 +5197,7 @@ static void lcd_main_menu()
     if(!printer_active() && (heating_status == HeatingStatus::NO_HEATING)) {
         if ((GetPrinterState() == PrinterState::SDPrintingFinished) && card.cardOK) {
             MENU_ITEM_SUBMENU_P(_T(MSG_REPRINT), reprint_from_eeprom);
-        } else if (GetPrinterState() == PrinterState::HostPrintingFinished) {
+        } else if ((GetPrinterState() == PrinterState::HostPrintingFinished) && M79_timer_get_status()) {
             MENU_ITEM_SUBMENU_P(_T(MSG_REPRINT), lcd_reprint_usb_print);
         }
     }
@@ -7507,6 +7507,6 @@ void reprint_from_eeprom() {
 //! @brief Send host action "reprint"
 void lcd_reprint_usb_print()
 {
-    SERIAL_PROTOCOLLNRPGM(MSG_OCTOPRINT_REPRINT);
+    SERIAL_PROTOCOLLNRPGM(MSG_OCTOPRINT_START);
     lcd_return_to_status();
 }


### PR DESCRIPTION
Changing the Reprint action message to `// action:start` complies with the OctoPrint [action](https://docs.octoprint.org/en/master/features/action_commands.html) to restart (Reprint)  a selected file.

The `Reprint` menu is now only shown when the host "pings` the printer using `M79` to ensure a host is listening to the serial output.

So to enable `Reprint` for a OctoPrint print it has to send `M79` within 30 seconds between two to keep the host-is-alive-timer going.

Adding `M79 S"OP"` to OctoPrint --> Settings --> GCODE scripts -> After serial connection to printer is established starts the timer and sets the short name of the host `O`cto`P`rint

An OctoPrint plugin would be necessary to "ping" the MK3S printers every few seconds.
Alternative to active the `Reprint` LCD menu would be to send `M79` from OctoPrint but at the same time it doesn't makes sense as the user easily can press the Start button

@jfestrada Please also review this PR  
 