### PR TITLE
Cleanup LCD menu

### DIFF
--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -76,7 +76,7 @@ const char MSG_NO[] PROGMEM_I1 = ISTR("No"); ////MSG_NO c=4
 const char MSG_NOZZLE[] PROGMEM_I1 = ISTR("Nozzle"); ////MSG_NOZZLE c=10
 const char MSG_PAPER[] PROGMEM_I1 = ISTR("Place a sheet of paper under the nozzle during the calibration of first 4 points. If the nozzle catches the paper, power off the printer immediately."); ////MSG_PAPER c=20 r=8
 const char MSG_PAUSE_PRINT[] PROGMEM_I1 = ISTR("Pause print");////MSG_PAUSE_PRINT c=18
-const char MSG_PRINT_PAUSED[] PROGMEM_I1 = ISTR("Print paused");////MSG_PAUSE_PRINT c=20
+const char MSG_PRINT_PAUSED[] PROGMEM_I1 = ISTR("Print paused");////MSG_PRINT_PAUSED c=20
 const char MSG_PLACE_STEEL_SHEET[] PROGMEM_I1 = ISTR("Please place steel sheet on heatbed."); ////MSG_PLACE_STEEL_SHEET c=20 r=4
 const char MSG_PLEASE_WAIT[] PROGMEM_I1 = ISTR("Please wait"); ////MSG_PLEASE_WAIT c=20
 const char MSG_POWER_FAILURES[] PROGMEM_I1 = ISTR("Power failures"); ////MSG_POWER_FAILURES c=15

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5196,7 +5196,7 @@ static void lcd_main_menu()
     // Menu item for reprint
     if(!printer_active() && (heating_status == HeatingStatus::NO_HEATING)) {
         if ((GetPrinterState() == PrinterState::SDPrintingFinished) && card.cardOK) {
-            MENU_ITEM_SUBMENU_P(_T(MSG_REPRINT), reprint_from_eeprom);
+            MENU_ITEM_SUBMENU_P(_T(MSG_REPRINT), lcd_reprint_from_eeprom);
         } else if ((GetPrinterState() == PrinterState::HostPrintingFinished) && M79_timer_get_status()) {
             MENU_ITEM_SUBMENU_P(_T(MSG_REPRINT), lcd_reprint_usb_print);
         }
@@ -7444,7 +7444,7 @@ void lcd_heat_bed_on_load_toggle()
     eeprom_update_byte((uint8_t*)EEPROM_HEAT_BED_ON_LOAD_FILAMENT, value);
 }
 
-void reprint_from_eeprom() {
+void lcd_reprint_from_eeprom() {
 	char filename[13];
 	char altfilename[13];
 	uint8_t depth = 0;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5198,7 +5198,7 @@ static void lcd_main_menu()
         if ((GetPrinterState() == PrinterState::SDPrintingFinished) && card.cardOK) {
             MENU_ITEM_SUBMENU_P(_T(MSG_REPRINT), lcd_reprint_from_eeprom);
         } else if ((GetPrinterState() == PrinterState::HostPrintingFinished) && M79_timer_get_status()) {
-            MENU_ITEM_SUBMENU_P(_T(MSG_REPRINT), lcd_reprint_usb_print);
+            MENU_ITEM_SUBMENU_P(_T(MSG_REPRINT), lcd_send_action_start);
         }
     }
 
@@ -7484,8 +7484,8 @@ void lcd_reprint_from_eeprom() {
     lcd_return_to_status();
 }
 
-//! @brief Send host action "reprint"
-void lcd_reprint_usb_print()
+//! @brief Send host action "start"
+void lcd_send_action_start()
 {
     SERIAL_PROTOCOLLNRPGM(MSG_OCTOPRINT_START);
     lcd_return_to_status();

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5196,9 +5196,9 @@ static void lcd_main_menu()
     // Menu item for reprint
     if(!printer_active() && (heating_status == HeatingStatus::NO_HEATING)) {
         if ((GetPrinterState() == PrinterState::SDPrintingFinished) && card.cardOK) {
-            MENU_ITEM_SUBMENU_P(_T(MSG_REPRINT), lcd_reprint_from_eeprom);
+            MENU_ITEM_FUNCTION_P(_T(MSG_REPRINT), lcd_reprint_from_eeprom);
         } else if ((GetPrinterState() == PrinterState::HostPrintingFinished) && M79_timer_get_status()) {
-            MENU_ITEM_SUBMENU_P(_T(MSG_REPRINT), lcd_send_action_start);
+            MENU_ITEM_FUNCTION_P(_T(MSG_REPRINT), lcd_send_action_start);
         }
     }
 

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -20,7 +20,7 @@ void ultralcd_init();
 #define LCD_STATUS_DELAYED_TIMEOUT 4000
 
 // Reprint
-void reprint_from_eeprom();
+void lcd_reprint_from_eeprom();
 
 // Set the current status message (equivalent to LCD_STATUS_NONE)
 void lcdui_print_status_line(void);

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -57,7 +57,7 @@ void lcd_loading_color();
 void lcd_sdcard_stop();
 void lcd_pause_print();
 void lcd_pause_usb_print();
-void lcd_reprint_usb_print();
+void lcd_send_action_start();
 void lcd_resume_print();
 void lcd_print_stop(); // interactive print stop
 void print_stop(bool interactive=false);


### PR DESCRIPTION
Some small changes:

1. Rename reprint_from_eeprom() to lcd_reprint_from_eeprom()
-> The function sets the lcd_return_to_status() at the end, so naming should be consistent witch the other lcd functions
2. Rename lcd_reprint_usb_print() to lcd_send_action_start()
-> Sending action start can not only be used for reprints
3. Change reprint MENU_ITEM_SUBMENU_P to MENU_ITEM_FUNCTION_P
-> There's no submenu, don't show the arrow at the end of the entry
4. Fix MSG_PRINT_PAUSED
->MSG_PRINT_PAUSED used the lang declaration MSG_PAUSE_PRINT instead of MSG_PRINT_PAUSED
