### PR TITLE
🚧 Don't show  "Set ready" & "Set not ready" if host is not PrusaLink

### DIFF
--- a/Firmware/host.cpp
+++ b/Firmware/host.cpp
@@ -30,3 +30,10 @@ bool M79_timer_get_status() {
 void M79_timer_update_status() {
     M79_timer.expired(M79_TIMEOUT);
 }
+
+bool M79_is_host_name_pl() {
+    if(strcmp(GetHostStatusScreenName(), "PL") == 0) {
+        return true;
+    }
+    return false;
+}

--- a/Firmware/host.h
+++ b/Firmware/host.h
@@ -20,3 +20,7 @@ bool M79_timer_get_status();
 /// Checks if the timer period has expired. If the timer
 /// has expired, the timer is stopped
 void M79_timer_update_status();
+
+// Check if set host name is PrusaLink
+/// @returns true if the set hostname is PrusaLink ("PL"), false otherwise
+bool M79_is_host_name_pl();

--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -104,6 +104,7 @@ const char MSG_SELFTEST_WIRINGERROR[] PROGMEM_I1 = ISTR("Wiring error"); ////MSG
 const char MSG_SETTINGS[] PROGMEM_I1 = ISTR("Settings"); ////MSG_SETTINGS c=18
 const char MSG_SET_READY[] PROGMEM_I1 = ISTR("Set Ready"); ////MSG_SET_READY c=18
 const char MSG_SET_NOT_READY[] PROGMEM_I1 = ISTR("Set not Ready"); ////MSG_SET_NOT_READY c=18
+const char MSG_PRINT_FROM_HOST[] PROGMEM_I1 = ISTR("Print from host"); ////MSG_PRINT_FROM_HOST c=18
 const char MSG_SELECT_LANGUAGE[] PROGMEM_I1 = ISTR("Select language"); ////MSG_SELECT_LANGUAGE c=18
 const char MSG_SORTING_FILES[] PROGMEM_I1 = ISTR("Sorting files"); ////MSG_SORTING_FILES c=20
 const char MSG_TOTAL[] PROGMEM_I1 = ISTR("Total"); ////MSG_TOTAL c=6

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -106,6 +106,7 @@ extern const char MSG_SELFTEST_WIRINGERROR[];
 extern const char MSG_SETTINGS[];
 extern const char MSG_SET_READY[];
 extern const char MSG_SET_NOT_READY[];
+extern const char MSG_PRINT_FROM_HOST[];
 extern const char MSG_SELECT_LANGUAGE[];
 extern const char MSG_SORTING_FILES[];
 extern const char MSG_TOTAL[];

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5214,7 +5214,7 @@ static void lcd_main_menu()
     } else if (!Stopped) {
         MENU_ITEM_SUBMENU_P(_i("Preheat"), lcd_preheat_menu);////MSG_PREHEAT c=18
     }
-    if (GetPrinterState() < PrinterState::IsSDPrinting && M79_timer_get_status()) {
+    if (GetPrinterState() < PrinterState::IsSDPrinting && M79_timer_get_status() && M79_is_host_name_pl()) {
         if(GetPrinterState() == PrinterState::IsReady) {
             MENU_ITEM_FUNCTION_P(_T(MSG_SET_NOT_READY), lcd_printer_ready_state_toggle);
         } else {

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5214,11 +5214,15 @@ static void lcd_main_menu()
     } else if (!Stopped) {
         MENU_ITEM_SUBMENU_P(_i("Preheat"), lcd_preheat_menu);////MSG_PREHEAT c=18
     }
-    if (GetPrinterState() < PrinterState::IsSDPrinting && M79_timer_get_status() && M79_is_host_name_pl()) {
-        if(GetPrinterState() == PrinterState::IsReady) {
-            MENU_ITEM_FUNCTION_P(_T(MSG_SET_NOT_READY), lcd_printer_ready_state_toggle);
-        } else {
-            MENU_ITEM_FUNCTION_P(_T(MSG_SET_READY), lcd_printer_ready_state_toggle);
+    if (GetPrinterState() < PrinterState::IsSDPrinting && M79_timer_get_status()) {
+        if(M79_is_host_name_pl()) {
+            if(GetPrinterState() == PrinterState::IsReady) {
+                MENU_ITEM_FUNCTION_P(_T(MSG_SET_NOT_READY), lcd_printer_ready_state_toggle);
+            } else {
+                MENU_ITEM_FUNCTION_P(_T(MSG_SET_READY), lcd_printer_ready_state_toggle);
+            }
+        } else{
+            MENU_ITEM_FUNCTION_P(_T(MSG_PRINT_FROM_HOST), lcd_reprint_usb_print); ////MSG_PRINT_FROM_HOST c=18
         }
     }
     if (mesh_bed_leveling_flag == false && homing_flag == false && !print_job_timer.isPaused() && !processing_tcode) {


### PR DESCRIPTION
I believe the LCD menus "Set ready" & "Set not ready" are only intended for PrusaLink and not OctoPrint. (Maybe I'm wrong?)

So I added a function (M79_is_host_name_pl()) to check if M79 was set with S"PL".
If not, it will replace the menu entry "Set ready" & "Set not ready" with "Print from host" wich sends an action:start to the host.

ToDo: Translations for "Print from host"