### PR TITLE
Bump up version to 3.14.0-BETA1

### DIFF
--- a/Firmware/Configuration.h
+++ b/Firmware/Configuration.h
@@ -19,10 +19,10 @@ extern const char _sPrinterMmuName[] PROGMEM;
 // Otherwise the repository information takes precedence.
 #ifndef CMAKE_CONTROL
 #define FW_MAJOR 3
-#define FW_MINOR 13
+#define FW_MINOR 14
 #define FW_REVISION 0
-#define FW_COMMITNR 6853
-#define FW_FLAVOR RC      //uncomment if DEV, ALPHA, BETA or RC
+#define FW_COMMITNR 7943
+#define FW_FLAVOR BETA      //uncomment if DEV, ALPHA, BETA or RC
 #define FW_FLAVERSION 1     //uncomment if FW_FLAVOR is defined and versioning is needed. Limited to max 8.
 #endif
 


### PR DESCRIPTION
Pre-bump up to version 3.14.0-BETA1 for testing with PrusaLink 0.7.x