### PR TITLE
Prevent oozing after filament load

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3545,7 +3545,10 @@ void gcode_M701(float fastLoadLength, uint8_t mmuSlotIndex){
             lcd_load_filament_color_check();
         }
 
-        retract_for_ooze_prevention(); // Retract a little of filament to prevent oozing
+        #ifdef COMMUNITY_PREVENT_OOZE
+        // Retract filament to prevent oozing
+        retract_for_ooze_prevention();
+        #endif //COMMUNITY_PREVENT_OOZE
 
         lcd_update_enable(true);
         lcd_update(2);

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3544,6 +3544,9 @@ void gcode_M701(float fastLoadLength, uint8_t mmuSlotIndex){
         if (!farm_mode && (eFilamentAction != FilamentAction::None)) {
             lcd_load_filament_color_check();
         }
+
+        retract_for_ooze_prevention(); // Retract a little of filament to prevent oozing
+
         lcd_update_enable(true);
         lcd_update(2);
         lcd_setstatuspgm(MSG_WELCOME);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5603,6 +5603,15 @@ static void lcd_sd_updir()
   menu_data_reset(); //Forces reloading of cached variables.
 }
 
+/// @brief retract a little of filament to prevent oozing
+void retract_for_ooze_prevention() {
+        current_position[E_AXIS] += FILAMENTCHANGE_ROOZEFEED;
+        plan_buffer_line_curposXYZE(FILAMENTCHANGE_RFEED);
+        current_position[E_AXIS] += FILAMENTCHANGE_EOOZEFEED;
+        plan_buffer_line_curposXYZE(FILAMENTCHANGE_EFEED_FIRST);
+        st_synchronize();
+}
+
 // continue stopping the print from the main loop after lcd_print_stop() is called
 void lcd_print_stop_finish()
 {
@@ -5617,8 +5626,10 @@ void lcd_print_stop_finish()
         current_position[Y_AXIS] = Y_CANCEL_POS;
         plan_buffer_line_curposXYZE(manual_feedrate[0] / 60);
     }
-    st_synchronize();
 
+    // Retract a little of filament to prevent oozing
+    retract_for_ooze_prevention();
+    
     // did we come here from a thermal error?
     if(get_temp_error()) {
         // time to stop the error beep

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5603,14 +5603,16 @@ static void lcd_sd_updir()
   menu_data_reset(); //Forces reloading of cached variables.
 }
 
-/// @brief retract a little of filament to prevent oozing
+#ifdef COMMUNITY_PREVENT_OOZE
+/// @brief Retract filament to prevent oozing
 void retract_for_ooze_prevention() {
-        current_position[E_AXIS] += FILAMENTCHANGE_ROOZEFEED;
-        plan_buffer_line_curposXYZE(FILAMENTCHANGE_RFEED);
-        current_position[E_AXIS] += FILAMENTCHANGE_EOOZEFEED;
-        plan_buffer_line_curposXYZE(FILAMENTCHANGE_EFEED_FIRST);
-        st_synchronize();
+    current_position[E_AXIS] += FILAMENTCHANGE_COMMUNITY_ROOZEFEED;
+    plan_buffer_line_curposXYZE(FILAMENTCHANGE_RFEED);
+    current_position[E_AXIS] += FILAMENTCHANGE_COMMUNITY_EOOZEFEED;
+    plan_buffer_line_curposXYZE(FILAMENTCHANGE_EFEED_FIRST);
+    st_synchronize();
 }
+#endif //COMMUNITY_PREVENT_OOZE
 
 // continue stopping the print from the main loop after lcd_print_stop() is called
 void lcd_print_stop_finish()
@@ -5626,10 +5628,13 @@ void lcd_print_stop_finish()
         current_position[Y_AXIS] = Y_CANCEL_POS;
         plan_buffer_line_curposXYZE(manual_feedrate[0] / 60);
     }
+    st_synchronize();
 
-    // Retract a little of filament to prevent oozing
+    #ifdef COMMUNITY_PREVENT_OOZE
+    // Retract filament to prevent oozing
     retract_for_ooze_prevention();
-    
+    #endif //COMMUNITY_PREVENT_OOZE
+
     // did we come here from a thermal error?
     if(get_temp_error()) {
         // time to stop the error beep

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -253,5 +253,6 @@ extern void lcd_pinda_temp_compensation_toggle();
 #endif //PINDA_TEMP_COMP
 
 extern void lcd_heat_bed_on_load_toggle();
+extern void retract_for_ooze_prevention();
 
 #endif //ULTRALCD_H

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -253,6 +253,9 @@ extern void lcd_pinda_temp_compensation_toggle();
 #endif //PINDA_TEMP_COMP
 
 extern void lcd_heat_bed_on_load_toggle();
+
+#ifdef COMMUNITY_PREVENT_OOZE
 extern void retract_for_ooze_prevention();
+#endif //COMMUNITY_PREVENT_OOZE
 
 #endif //ULTRALCD_H

--- a/Firmware/variants/MK25-RAMBo10a.h
+++ b/Firmware/variants/MK25-RAMBo10a.h
@@ -232,8 +232,15 @@
 #define FILAMENTCHANGE_RFEED 7000 / 60
 #define FILAMENTCHANGE_EXFEED 2
 #define FILAMENTCHANGE_ZFEED 15
-#define FILAMENTCHANGE_ROOZEFEED -10 //E retract distance in mm for ooze prevention
-#define FILAMENTCHANGE_EOOZEFEED 4 //E extrude distance in mm for ooze prevention
+
+//Retract and then extrude some filament to prevent oozing.
+//After the loading sequence and after a print is canceled, the filament is retracted to get it out of the heat zone of the nozzle.
+//Then a small extrusion is performed to make sure the filament is close enough for the next print without oozing.
+//#define COMMUNITY_PREVENT_OOZE
+#ifdef COMMUNITY_PREVENT_OOZE
+#define FILAMENTCHANGE_COMMUNITY_ROOZEFEED -10 //E retract distance in mm for ooze prevention
+#define FILAMENTCHANGE_COMMUNITY_EOOZEFEED 4 //E extrude distance in mm for ooze prevention
+#endif //End COMMUNITY_PREVENT_OOZE
 
 #endif
 

--- a/Firmware/variants/MK25-RAMBo10a.h
+++ b/Firmware/variants/MK25-RAMBo10a.h
@@ -232,6 +232,8 @@
 #define FILAMENTCHANGE_RFEED 7000 / 60
 #define FILAMENTCHANGE_EXFEED 2
 #define FILAMENTCHANGE_ZFEED 15
+#define FILAMENTCHANGE_ROOZEFEED -10 //E retract distance in mm for ooze prevention
+#define FILAMENTCHANGE_EOOZEFEED 4 //E extrude distance in mm for ooze prevention
 
 #endif
 

--- a/Firmware/variants/MK25-RAMBo13a.h
+++ b/Firmware/variants/MK25-RAMBo13a.h
@@ -233,8 +233,15 @@
 #define FILAMENTCHANGE_RFEED 7000 / 60
 #define FILAMENTCHANGE_EXFEED 2
 #define FILAMENTCHANGE_ZFEED 15
-#define FILAMENTCHANGE_ROOZEFEED -10 //E retract distance in mm for ooze prevention
-#define FILAMENTCHANGE_EOOZEFEED 4 //E extrude distance in mm for ooze prevention
+
+//Retract and then extrude some filament to prevent oozing.
+//After the loading sequence and after a print is canceled, the filament is retracted to get it out of the heat zone of the nozzle.
+//Then a small extrusion is performed to make sure the filament is close enough for the next print without oozing.
+//#define COMMUNITY_PREVENT_OOZE
+#ifdef COMMUNITY_PREVENT_OOZE
+#define FILAMENTCHANGE_COMMUNITY_ROOZEFEED -10 //E retract distance in mm for ooze prevention
+#define FILAMENTCHANGE_COMMUNITY_EOOZEFEED 4 //E extrude distance in mm for ooze prevention
+#endif //End COMMUNITY_PREVENT_OOZE
 
 #endif
 

--- a/Firmware/variants/MK25-RAMBo13a.h
+++ b/Firmware/variants/MK25-RAMBo13a.h
@@ -233,6 +233,8 @@
 #define FILAMENTCHANGE_RFEED 7000 / 60
 #define FILAMENTCHANGE_EXFEED 2
 #define FILAMENTCHANGE_ZFEED 15
+#define FILAMENTCHANGE_ROOZEFEED -10 //E retract distance in mm for ooze prevention
+#define FILAMENTCHANGE_EOOZEFEED 4 //E extrude distance in mm for ooze prevention
 
 #endif
 

--- a/Firmware/variants/MK25S-RAMBo10a.h
+++ b/Firmware/variants/MK25S-RAMBo10a.h
@@ -232,8 +232,15 @@
 #define FILAMENTCHANGE_RFEED 7000 / 60
 #define FILAMENTCHANGE_EXFEED 2
 #define FILAMENTCHANGE_ZFEED 15
-#define FILAMENTCHANGE_ROOZEFEED -10 //E retract distance in mm for ooze prevention
-#define FILAMENTCHANGE_EOOZEFEED 4 //E extrude distance in mm for ooze prevention
+
+//Retract and then extrude some filament to prevent oozing.
+//After the loading sequence and after a print is canceled, the filament is retracted to get it out of the heat zone of the nozzle.
+//Then a small extrusion is performed to make sure the filament is close enough for the next print without oozing.
+//#define COMMUNITY_PREVENT_OOZE
+#ifdef COMMUNITY_PREVENT_OOZE
+#define FILAMENTCHANGE_COMMUNITY_ROOZEFEED -10 //E retract distance in mm for ooze prevention
+#define FILAMENTCHANGE_COMMUNITY_EOOZEFEED 4 //E extrude distance in mm for ooze prevention
+#endif //End COMMUNITY_PREVENT_OOZE
 
 #endif
 

--- a/Firmware/variants/MK25S-RAMBo10a.h
+++ b/Firmware/variants/MK25S-RAMBo10a.h
@@ -232,6 +232,8 @@
 #define FILAMENTCHANGE_RFEED 7000 / 60
 #define FILAMENTCHANGE_EXFEED 2
 #define FILAMENTCHANGE_ZFEED 15
+#define FILAMENTCHANGE_ROOZEFEED -10 //E retract distance in mm for ooze prevention
+#define FILAMENTCHANGE_EOOZEFEED 4 //E extrude distance in mm for ooze prevention
 
 #endif
 

--- a/Firmware/variants/MK25S-RAMBo13a.h
+++ b/Firmware/variants/MK25S-RAMBo13a.h
@@ -233,8 +233,15 @@
 #define FILAMENTCHANGE_RFEED 7000 / 60
 #define FILAMENTCHANGE_EXFEED 2
 #define FILAMENTCHANGE_ZFEED 15
-#define FILAMENTCHANGE_ROOZEFEED -10 //E retract distance in mm for ooze prevention
-#define FILAMENTCHANGE_EOOZEFEED 4 //E extrude distance in mm for ooze prevention
+
+//Retract and then extrude some filament to prevent oozing.
+//After the loading sequence and after a print is canceled, the filament is retracted to get it out of the heat zone of the nozzle.
+//Then a small extrusion is performed to make sure the filament is close enough for the next print without oozing.
+//#define COMMUNITY_PREVENT_OOZE
+#ifdef COMMUNITY_PREVENT_OOZE
+#define FILAMENTCHANGE_COMMUNITY_ROOZEFEED -10 //E retract distance in mm for ooze prevention
+#define FILAMENTCHANGE_COMMUNITY_EOOZEFEED 4 //E extrude distance in mm for ooze prevention
+#endif //End COMMUNITY_PREVENT_OOZE
 
 #endif
 

--- a/Firmware/variants/MK25S-RAMBo13a.h
+++ b/Firmware/variants/MK25S-RAMBo13a.h
@@ -233,6 +233,8 @@
 #define FILAMENTCHANGE_RFEED 7000 / 60
 #define FILAMENTCHANGE_EXFEED 2
 #define FILAMENTCHANGE_ZFEED 15
+#define FILAMENTCHANGE_ROOZEFEED -10 //E retract distance in mm for ooze prevention
+#define FILAMENTCHANGE_EOOZEFEED 4 //E extrude distance in mm for ooze prevention
 
 #endif
 

--- a/Firmware/variants/MK3-E3DREVO.h
+++ b/Firmware/variants/MK3-E3DREVO.h
@@ -366,6 +366,8 @@
 #define FILAMENTCHANGE_RFEED 7000 / 60
 #define FILAMENTCHANGE_EXFEED 2
 #define FILAMENTCHANGE_ZFEED 15
+#define FILAMENTCHANGE_ROOZEFEED -10 //E retract distance in mm for ooze prevention
+#define FILAMENTCHANGE_EOOZEFEED 4 //E extrude distance in mm for ooze prevention
 
 #endif
 

--- a/Firmware/variants/MK3-E3DREVO.h
+++ b/Firmware/variants/MK3-E3DREVO.h
@@ -366,8 +366,15 @@
 #define FILAMENTCHANGE_RFEED 7000 / 60
 #define FILAMENTCHANGE_EXFEED 2
 #define FILAMENTCHANGE_ZFEED 15
-#define FILAMENTCHANGE_ROOZEFEED -10 //E retract distance in mm for ooze prevention
-#define FILAMENTCHANGE_EOOZEFEED 4 //E extrude distance in mm for ooze prevention
+
+//Retract and then extrude some filament to prevent oozing.
+//After the loading sequence and after a print is canceled, the filament is retracted to get it out of the heat zone of the nozzle.
+//Then a small extrusion is performed to make sure the filament is close enough for the next print without oozing.
+//#define COMMUNITY_PREVENT_OOZE
+#ifdef COMMUNITY_PREVENT_OOZE
+#define FILAMENTCHANGE_COMMUNITY_ROOZEFEED -10 //E retract distance in mm for ooze prevention
+#define FILAMENTCHANGE_COMMUNITY_EOOZEFEED 4 //E extrude distance in mm for ooze prevention
+#endif //End COMMUNITY_PREVENT_OOZE
 
 #endif
 

--- a/Firmware/variants/MK3-E3DREVO_HF_60W.h
+++ b/Firmware/variants/MK3-E3DREVO_HF_60W.h
@@ -367,6 +367,8 @@
 #define FILAMENTCHANGE_RFEED 7000 / 60
 #define FILAMENTCHANGE_EXFEED 2
 #define FILAMENTCHANGE_ZFEED 15
+#define FILAMENTCHANGE_ROOZEFEED -10 //E retract distance in mm for ooze prevention
+#define FILAMENTCHANGE_EOOZEFEED 4 //E extrude distance in mm for ooze prevention
 
 #endif
 

--- a/Firmware/variants/MK3-E3DREVO_HF_60W.h
+++ b/Firmware/variants/MK3-E3DREVO_HF_60W.h
@@ -367,8 +367,15 @@
 #define FILAMENTCHANGE_RFEED 7000 / 60
 #define FILAMENTCHANGE_EXFEED 2
 #define FILAMENTCHANGE_ZFEED 15
-#define FILAMENTCHANGE_ROOZEFEED -10 //E retract distance in mm for ooze prevention
-#define FILAMENTCHANGE_EOOZEFEED 4 //E extrude distance in mm for ooze prevention
+
+//Retract and then extrude some filament to prevent oozing.
+//After the loading sequence and after a print is canceled, the filament is retracted to get it out of the heat zone of the nozzle.
+//Then a small extrusion is performed to make sure the filament is close enough for the next print without oozing.
+//#define COMMUNITY_PREVENT_OOZE
+#ifdef COMMUNITY_PREVENT_OOZE
+#define FILAMENTCHANGE_COMMUNITY_ROOZEFEED -10 //E retract distance in mm for ooze prevention
+#define FILAMENTCHANGE_COMMUNITY_EOOZEFEED 4 //E extrude distance in mm for ooze prevention
+#endif //End COMMUNITY_PREVENT_OOZE
 
 #endif
 

--- a/Firmware/variants/MK3.h
+++ b/Firmware/variants/MK3.h
@@ -369,6 +369,8 @@
 #define FILAMENTCHANGE_RFEED 7000 / 60
 #define FILAMENTCHANGE_EXFEED 2
 #define FILAMENTCHANGE_ZFEED 15
+#define FILAMENTCHANGE_ROOZEFEED -10 //E retract distance in mm for ooze prevention
+#define FILAMENTCHANGE_EOOZEFEED 4 //E extrude distance in mm for ooze prevention
 
 #endif
 

--- a/Firmware/variants/MK3.h
+++ b/Firmware/variants/MK3.h
@@ -369,8 +369,15 @@
 #define FILAMENTCHANGE_RFEED 7000 / 60
 #define FILAMENTCHANGE_EXFEED 2
 #define FILAMENTCHANGE_ZFEED 15
-#define FILAMENTCHANGE_ROOZEFEED -10 //E retract distance in mm for ooze prevention
-#define FILAMENTCHANGE_EOOZEFEED 4 //E extrude distance in mm for ooze prevention
+
+//Retract and then extrude some filament to prevent oozing.
+//After the loading sequence and after a print is canceled, the filament is retracted to get it out of the heat zone of the nozzle.
+//Then a small extrusion is performed to make sure the filament is close enough for the next print without oozing.
+//#define COMMUNITY_PREVENT_OOZE
+#ifdef COMMUNITY_PREVENT_OOZE
+#define FILAMENTCHANGE_COMMUNITY_ROOZEFEED -10 //E retract distance in mm for ooze prevention
+#define FILAMENTCHANGE_COMMUNITY_EOOZEFEED 4 //E extrude distance in mm for ooze prevention
+#endif //End COMMUNITY_PREVENT_OOZE
 
 #endif
 

--- a/Firmware/variants/MK3S-E3DREVO.h
+++ b/Firmware/variants/MK3S-E3DREVO.h
@@ -370,6 +370,8 @@
 #define FILAMENTCHANGE_RFEED 7000 / 60
 #define FILAMENTCHANGE_EXFEED 2
 #define FILAMENTCHANGE_ZFEED 15
+#define FILAMENTCHANGE_ROOZEFEED -10 //E retract distance in mm for ooze prevention
+#define FILAMENTCHANGE_EOOZEFEED 4 //E extrude distance in mm for ooze prevention
 
 #endif
 

--- a/Firmware/variants/MK3S-E3DREVO.h
+++ b/Firmware/variants/MK3S-E3DREVO.h
@@ -370,8 +370,15 @@
 #define FILAMENTCHANGE_RFEED 7000 / 60
 #define FILAMENTCHANGE_EXFEED 2
 #define FILAMENTCHANGE_ZFEED 15
-#define FILAMENTCHANGE_ROOZEFEED -10 //E retract distance in mm for ooze prevention
-#define FILAMENTCHANGE_EOOZEFEED 4 //E extrude distance in mm for ooze prevention
+
+//Retract and then extrude some filament to prevent oozing.
+//After the loading sequence and after a print is canceled, the filament is retracted to get it out of the heat zone of the nozzle.
+//Then a small extrusion is performed to make sure the filament is close enough for the next print without oozing.
+//#define COMMUNITY_PREVENT_OOZE
+#ifdef COMMUNITY_PREVENT_OOZE
+#define FILAMENTCHANGE_COMMUNITY_ROOZEFEED -10 //E retract distance in mm for ooze prevention
+#define FILAMENTCHANGE_COMMUNITY_EOOZEFEED 4 //E extrude distance in mm for ooze prevention
+#endif //End COMMUNITY_PREVENT_OOZE
 
 #endif
 

--- a/Firmware/variants/MK3S-E3DREVO_HF_60W.h
+++ b/Firmware/variants/MK3S-E3DREVO_HF_60W.h
@@ -371,8 +371,15 @@
 #define FILAMENTCHANGE_RFEED 7000 / 60
 #define FILAMENTCHANGE_EXFEED 2
 #define FILAMENTCHANGE_ZFEED 15
-#define FILAMENTCHANGE_ROOZEFEED -10 //E retract distance in mm for ooze prevention
-#define FILAMENTCHANGE_EOOZEFEED 4 //E extrude distance in mm for ooze prevention
+
+//Retract and then extrude some filament to prevent oozing.
+//After the loading sequence and after a print is canceled, the filament is retracted to get it out of the heat zone of the nozzle.
+//Then a small extrusion is performed to make sure the filament is close enough for the next print without oozing.
+//#define COMMUNITY_PREVENT_OOZE
+#ifdef COMMUNITY_PREVENT_OOZE
+#define FILAMENTCHANGE_COMMUNITY_ROOZEFEED -10 //E retract distance in mm for ooze prevention
+#define FILAMENTCHANGE_COMMUNITY_EOOZEFEED 4 //E extrude distance in mm for ooze prevention
+#endif //End COMMUNITY_PREVENT_OOZE
 
 #endif
 

--- a/Firmware/variants/MK3S-E3DREVO_HF_60W.h
+++ b/Firmware/variants/MK3S-E3DREVO_HF_60W.h
@@ -371,6 +371,8 @@
 #define FILAMENTCHANGE_RFEED 7000 / 60
 #define FILAMENTCHANGE_EXFEED 2
 #define FILAMENTCHANGE_ZFEED 15
+#define FILAMENTCHANGE_ROOZEFEED -10 //E retract distance in mm for ooze prevention
+#define FILAMENTCHANGE_EOOZEFEED 4 //E extrude distance in mm for ooze prevention
 
 #endif
 

--- a/Firmware/variants/MK3S.h
+++ b/Firmware/variants/MK3S.h
@@ -373,8 +373,15 @@
 #define FILAMENTCHANGE_RFEED 7000 / 60
 #define FILAMENTCHANGE_EXFEED 2
 #define FILAMENTCHANGE_ZFEED 15
-#define FILAMENTCHANGE_ROOZEFEED -10 //E retract distance in mm for ooze prevention
-#define FILAMENTCHANGE_EOOZEFEED 4 //E extrude distance in mm for ooze prevention
+
+//Retract and then extrude some filament to prevent oozing.
+//After the loading sequence and after a print is canceled, the filament is retracted to get it out of the heat zone of the nozzle.
+//Then a small extrusion is performed to make sure the filament is close enough for the next print without oozing.
+//#define COMMUNITY_PREVENT_OOZE
+#ifdef COMMUNITY_PREVENT_OOZE
+#define FILAMENTCHANGE_COMMUNITY_ROOZEFEED -10 //E retract distance in mm for ooze prevention
+#define FILAMENTCHANGE_COMMUNITY_EOOZEFEED 4 //E extrude distance in mm for ooze prevention
+#endif //End COMMUNITY_PREVENT_OOZE
 
 #endif
 

--- a/Firmware/variants/MK3S.h
+++ b/Firmware/variants/MK3S.h
@@ -373,6 +373,8 @@
 #define FILAMENTCHANGE_RFEED 7000 / 60
 #define FILAMENTCHANGE_EXFEED 2
 #define FILAMENTCHANGE_ZFEED 15
+#define FILAMENTCHANGE_ROOZEFEED -10 //E retract distance in mm for ooze prevention
+#define FILAMENTCHANGE_EOOZEFEED 4 //E extrude distance in mm for ooze prevention
 
 #endif
 

--- a/Firmware/variants/obsolete/1_75mm_MK2-RAMBo10a-E3Dv6full.h
+++ b/Firmware/variants/obsolete/1_75mm_MK2-RAMBo10a-E3Dv6full.h
@@ -161,6 +161,8 @@ CHANGE FILAMENT SETTINGS
 #define FILAMENTCHANGE_RFEED 400
 #define FILAMENTCHANGE_EXFEED 2
 #define FILAMENTCHANGE_ZFEED 15
+#define FILAMENTCHANGE_ROOZEFEED -10 //E retract distance in mm for ooze prevention
+#define FILAMENTCHANGE_EOOZEFEED 4 //E extrude distance in mm for ooze prevention
 
 #endif
 

--- a/Firmware/variants/obsolete/1_75mm_MK2-RAMBo10a-E3Dv6full.h
+++ b/Firmware/variants/obsolete/1_75mm_MK2-RAMBo10a-E3Dv6full.h
@@ -161,8 +161,15 @@ CHANGE FILAMENT SETTINGS
 #define FILAMENTCHANGE_RFEED 400
 #define FILAMENTCHANGE_EXFEED 2
 #define FILAMENTCHANGE_ZFEED 15
-#define FILAMENTCHANGE_ROOZEFEED -10 //E retract distance in mm for ooze prevention
-#define FILAMENTCHANGE_EOOZEFEED 4 //E extrude distance in mm for ooze prevention
+
+//Retract and then extrude some filament to prevent oozing.
+//After the loading sequence and after a print is canceled, the filament is retracted to get it out of the heat zone of the nozzle.
+//Then a small extrusion is performed to make sure the filament is close enough for the next print without oozing.
+//#define COMMUNITY_PREVENT_OOZE
+#ifdef COMMUNITY_PREVENT_OOZE
+#define FILAMENTCHANGE_COMMUNITY_ROOZEFEED -10 //E retract distance in mm for ooze prevention
+#define FILAMENTCHANGE_COMMUNITY_EOOZEFEED 4 //E extrude distance in mm for ooze prevention
+#endif //End COMMUNITY_PREVENT_OOZE
 
 #endif
 

--- a/Firmware/variants/obsolete/1_75mm_MK2-RAMBo13a-E3Dv6full.h
+++ b/Firmware/variants/obsolete/1_75mm_MK2-RAMBo13a-E3Dv6full.h
@@ -160,6 +160,8 @@ CHANGE FILAMENT SETTINGS
 #define FILAMENTCHANGE_RFEED 400
 #define FILAMENTCHANGE_EXFEED 2
 #define FILAMENTCHANGE_ZFEED 15
+#define FILAMENTCHANGE_ROOZEFEED -10 //E retract distance in mm for ooze prevention
+#define FILAMENTCHANGE_EOOZEFEED 4 //E extrude distance in mm for ooze prevention
 
 #endif
 

--- a/Firmware/variants/obsolete/1_75mm_MK2-RAMBo13a-E3Dv6full.h
+++ b/Firmware/variants/obsolete/1_75mm_MK2-RAMBo13a-E3Dv6full.h
@@ -160,8 +160,15 @@ CHANGE FILAMENT SETTINGS
 #define FILAMENTCHANGE_RFEED 400
 #define FILAMENTCHANGE_EXFEED 2
 #define FILAMENTCHANGE_ZFEED 15
-#define FILAMENTCHANGE_ROOZEFEED -10 //E retract distance in mm for ooze prevention
-#define FILAMENTCHANGE_EOOZEFEED 4 //E extrude distance in mm for ooze prevention
+
+//Retract and then extrude some filament to prevent oozing.
+//After the loading sequence and after a print is canceled, the filament is retracted to get it out of the heat zone of the nozzle.
+//Then a small extrusion is performed to make sure the filament is close enough for the next print without oozing.
+//#define COMMUNITY_PREVENT_OOZE
+#ifdef COMMUNITY_PREVENT_OOZE
+#define FILAMENTCHANGE_COMMUNITY_ROOZEFEED -10 //E retract distance in mm for ooze prevention
+#define FILAMENTCHANGE_COMMUNITY_EOOZEFEED 4 //E extrude distance in mm for ooze prevention
+#endif //End COMMUNITY_PREVENT_OOZE
 
 #endif
 


### PR DESCRIPTION
This is my attempt to fix leaking filament issues like it's described in #4531.

After a filament load & canceled/ended prints, the filament tends to leak extensively, which will mess up the first layer of a new print if not properly cleaned.

By retracting the filament by 10mm & then extracting 2mm (to make sure it's close enough to do a successful "prime line"). I eliminated this problem on my printer completely. I use this modification for at least a year and never had any issues.
(It tends to still leak a bit when I just do a single 8mm retraction...)

This results in the same behaviour like leaving the printer preheated for about 10min. after loading filament. -> The "prime line" is not printed 100% but it starts after about 1/3 of the total distance.

I did't touch M600, so filament change during print is not affected.

This change combined with adding
```
G1 E-10
G1 E2
```
to the start of my "end G-code" in the slicer, fixed the issue for me and I don't have to hover over my printer with tweezers at the beginning of every print anymore.