### PR TITLE
reprint: reduce duplicate code

### DIFF
--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -380,6 +380,7 @@ void refresh_print_state_in_ram();
 void refresh_saved_feedrate_multiplier_in_ram();
 void clear_print_state_in_ram();
 extern void stop_and_save_print_to_ram(float z_move, float e_move);
+void restore_file_from_sd();
 void restore_extruder_temperature_from_ram();
 extern void restore_print_from_ram_and_continue(float e_move);
 extern void cancel_saved_printing();

--- a/Firmware/power_panic.cpp
+++ b/Firmware/power_panic.cpp
@@ -413,36 +413,6 @@ bool recover_machine_state_after_power_panic() {
      return mbl_was_active;
 }
 
-/// @brief Read saved filename from EEPROM and send g-code command: M23 <filename>
-void restore_file_from_sd()
-{
-    char filename[FILENAME_LENGTH];
-    char dir_name[9];
-    char extension_ptr[5];
-    uint8_t depth = eeprom_read_byte((uint8_t*)EEPROM_DIR_DEPTH);
-
-    for (uint8_t i = 0; i < depth; i++) {
-        eeprom_read_block(dir_name, (const char *)EEPROM_DIRS + 8 * i, 8);
-        dir_name[8] = '\0';
-        card.chdir(dir_name, false);
-    }
-
-    // Recover DOS 8.3 filename without extension.
-    // Short filenames are always null terminated.
-    eeprom_read_block(filename, (const char *)EEPROM_FILENAME, 8);
-
-    // Add null delimiter in case all 8 characters were not NULL
-    filename[8] = '\0';
-
-    // Add extension to complete the DOS 8.3 filename e.g. ".gco" or ".g"
-    extension_ptr[0] = '.';
-    eeprom_read_block(&extension_ptr[1], (const char *)EEPROM_FILENAME_EXTENSION, 3);
-    extension_ptr[4] = '\0';
-    strcat(filename, extension_ptr);
-
-    enquecommandf_P(MSG_M23, filename);
-}
-
 void restore_print_from_eeprom(bool mbl_was_active) {
     int feedrate_rec;
     int feedmultiply_rec;

--- a/Firmware/power_panic.h
+++ b/Firmware/power_panic.h
@@ -18,3 +18,4 @@ enum PrintType : uint8_t {
 void uvlo_();
 void recover_print(uint8_t automatic); 
 void setup_uvlo_interrupt();
+void restore_file_from_sd();

--- a/Firmware/power_panic.h
+++ b/Firmware/power_panic.h
@@ -18,4 +18,3 @@ enum PrintType : uint8_t {
 void uvlo_();
 void recover_print(uint8_t automatic); 
 void setup_uvlo_interrupt();
-void restore_file_from_sd();

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -11,7 +11,6 @@
 #include "fancheck.h"
 #include "stepper.h"
 #include "ConfigurationStore.h"
-#include "power_panic.h"
 #include "printers.h"
 #include <string.h>
 #include "stopwatch.h"

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -11,6 +11,7 @@
 #include "fancheck.h"
 #include "stepper.h"
 #include "ConfigurationStore.h"
+#include "power_panic.h"
 #include "printers.h"
 #include <string.h>
 #include "stopwatch.h"
@@ -7465,40 +7466,8 @@ void lcd_heat_bed_on_load_toggle()
 }
 
 void lcd_reprint_from_eeprom() {
-	char filename[13];
-	char altfilename[13];
-	uint8_t depth = 0;
-	char dir_name[9];
+    restore_file_from_sd();
 
-	depth = eeprom_read_byte((uint8_t*)EEPROM_DIR_DEPTH);
-
-	for (int i = 0; i < depth; i++) {
-		for (int j = 0; j < 8; j++) {
-			dir_name[j] = eeprom_read_byte((uint8_t*)EEPROM_DIRS + j + 8 * i);
-		}
-		dir_name[8] = '\0';
-		card.chdir(dir_name, false);
-	}
-
-	for (int i = 0; i < 8; i++) {
-		filename[i] = eeprom_read_byte((uint8_t*)EEPROM_FILENAME + i);
-	}
-	filename[8] = '\0';
-
-	strcpy(altfilename,filename);
-	if (!card.FileExists(altfilename))
-	{
-		strcat_P(filename, PSTR(".gco"));
-		if (card.FileExists(filename))
-		{
-			strcpy(altfilename,filename);
-		}else
-		{
-			strcat_P(altfilename, PSTR(".g"));
-		}
-	}
-    // M23: Select SD file
-    enquecommandf_P(MSG_M23, altfilename);
     // M24: Start/resume SD print
     enquecommand_P(MSG_M24);
     lcd_return_to_status();


### PR DESCRIPTION
`restore_file_from_sd` function now supports any filename extension. This was not the case when the reprint feature was merged.

If a print was finished (to allow reprinting) then the EEPROM filename and extension should always be valid.

Change in memory:
Flash: -312 bytes
SRAM: 0 bytes