### PR TITLE
Bugfix: Resume print after M601 pause (Octoprint)

### DIFF
--- a/Firmware/stopwatch.cpp
+++ b/Firmware/stopwatch.cpp
@@ -35,7 +35,11 @@ uint32_t Stopwatch::accumulator;
 uint32_t Stopwatch::startTimestamp;
 uint32_t Stopwatch::stopTimestamp;
 
-bool Stopwatch::stop() {
+bool Stopwatch::stop(bool forceStateOnly) {
+  if (forceStateOnly) {
+    state = STOPPED;
+    return true;
+  }
   if (isRunning() || isPaused()) {
     state = STOPPED;
     stopTimestamp = _millis();
@@ -44,7 +48,11 @@ bool Stopwatch::stop() {
   else return false;
 }
 
-bool Stopwatch::pause() {
+bool Stopwatch::pause(bool forceStateOnly) {
+  if (forceStateOnly) {
+    state = PAUSED;
+    return true;
+  }
   if (isRunning()) {
     state = PAUSED;
     stopTimestamp = _millis();

--- a/Firmware/stopwatch.h
+++ b/Firmware/stopwatch.h
@@ -53,7 +53,7 @@ class Stopwatch {
      *          no timer is currently running.
      * @return true on success
      */
-    static bool stop();
+    static bool stop(bool forceStateOnly = false);
     static bool abort() { return stop(); } // Alias by default
 
     /**
@@ -62,7 +62,7 @@ class Stopwatch {
      *          no timer is currently running.
      * @return true on success
      */
-    static bool pause();
+    static bool pause(bool forceStateOnly = false);
 
     /**
      * @brief Start the stopwatch

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1022,7 +1022,7 @@ void lcd_pause_print()
 
     SERIAL_ECHOLNRPGM(MSG_OCTOPRINT_PAUSED);
 
-    print_job_timer.pause();
+    print_job_timer.pause(true);
 
     // return to status is required to continue processing in the main loop!
     lcd_commands_type = LcdCommands::LongPause;
@@ -5010,7 +5010,12 @@ void lcd_resume_print()
     Stopped = false;
 
     restore_print_from_ram_and_continue(default_retraction);
-    print_job_timer.start();
+    if (usb_timer.running()) {
+        print_job_timer.stop(true);
+    }
+    else {
+        print_job_timer.start();
+    }
     refresh_cmd_timeout();
     SERIAL_PROTOCOLLNRPGM(MSG_OCTOPRINT_RESUMED); //resume octoprint
     custom_message_type = CustomMsg::Status;


### PR DESCRIPTION
Add a forced state change to print_job_timer, to restore original behaviour.
This will ignore previous states and not update timers.

Fixes https://github.com/prusa3d/Prusa-Firmware/issues/4554