### PR TITLE
Fix pause indicator when print job timer is not used

### DIFF
--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -279,6 +279,7 @@ extern int fan_speed[2];
 #define active_extruder 0
 
 extern bool mesh_bed_leveling_flag;
+extern bool did_pause_print;
 
 // save/restore printing
 extern bool saved_printing;
@@ -309,6 +310,9 @@ extern LongTimer safetyTimer;
 // Returns true if there is a print running. It does not matter if
 // the print is paused, that still counts as a "running" print.
 bool printJobOngoing();
+
+// Printing is paused according to SD or host indicators
+bool printingIsPaused();
 
 bool printer_active();
 

--- a/Firmware/Prusa_farm.cpp
+++ b/Firmware/Prusa_farm.cpp
@@ -238,7 +238,7 @@ void prusa_statistics(uint8_t _message) {
         if (busy_state == PAUSED_FOR_USER) {
             prusa_statistics_case0(15);
         }
-        else if (print_job_timer.isPaused()) {
+        else if (printingIsPaused()) {
             prusa_statistics_case0(14);
         }
         else if (IS_SD_PRINTING || (eFilamentAction != FilamentAction::None)) {

--- a/Firmware/cardreader.cpp
+++ b/Firmware/cardreader.cpp
@@ -558,7 +558,7 @@ uint32_t CardReader::getFileSize()
 
 void CardReader::getStatus(bool arg_P)
 {
-    if (print_job_timer.isPaused())
+    if (printingIsPaused())
     {
         if (saved_printing && (saved_printing_type == PowerPanic::PRINT_TYPE_SD))
             SERIAL_PROTOCOLLNPGM("SD print paused");

--- a/Firmware/cmdqueue.cpp
+++ b/Firmware/cmdqueue.cpp
@@ -368,7 +368,7 @@ void get_command()
 	}
 
   // start of serial line processing loop
-  while (((MYSERIAL.available() > 0 && !saved_printing) || (MYSERIAL.available() > 0 && print_job_timer.isPaused())) && !cmdqueue_serial_disabled) {  //is print is saved (crash detection or filament detection), dont process data from serial line
+  while (((MYSERIAL.available() > 0 && !saved_printing) || (MYSERIAL.available() > 0 && printingIsPaused())) && !cmdqueue_serial_disabled) {  //is print is saved (crash detection or filament detection), dont process data from serial line
 	
 #ifdef ENABLE_MEATPACK
     // MeatPack Changes

--- a/Firmware/fancheck.cpp
+++ b/Firmware/fancheck.cpp
@@ -94,7 +94,7 @@ void fanSpeedError(unsigned char _fan) {
 
     if (printJobOngoing()) {
         // A print is ongoing, pause the print normally
-        if(!print_job_timer.isPaused()) {
+        if(!printingIsPaused()) {
             if (usb_timer.running())
                 lcd_pause_usb_print();
             else


### PR DESCRIPTION
Fixes #4554

Kudos goes to Marlin 2.1, `printingIsPaused()` and `did_pause_print` are copied from there :)

Change in memory:
Flash: +50 bytes
SRAM: +1 byte