### PR TITLE
:construction: WIP: MMU: Allow reading/writing registers while handling a non-idle error

### DIFF
--- a/Firmware/mmu2.h
+++ b/Firmware/mmu2.h
@@ -259,7 +259,12 @@ private:
     /// Along with the mmu_loop method, this loops until a response from the MMU is received and acts upon.
     /// In case of an error, it parks the print head and turns off nozzle heating
     /// @returns false if the command could not have been completed (MMU interrupted)
-    [[nodiscard]] bool manage_response(const bool move_axes, const bool turn_off_nozzle);
+    [[nodiscard]] bool manage_response(const bool move_axes, const bool turn_off_nozzle, RequestMsg * msg = nullptr);
+
+    /// Check whether a nested request has a received a response
+    /// @param msg Message which the Response must match
+    /// @return true if the response matches the request
+    bool check_nested_response(RequestMsg * msg);
 
     /// The inner private implementation of mmu_loop()
     /// which is NOT (!!!) recursion-guarded. Use caution - but we do need it during waiting for hotend resume to keep comms alive!


### PR DESCRIPTION
Draft for now... this uses a bit more Flash than I'd hoped.

Fixes #4558

Steps to reproduce a problem:

1. Send toolchange command to the printer e.g. T0
2. Hold the Idler in place until you get a "Idler cannot home" error.
3. Select 'Tune' button
4. Select 'Done' button (you need to click it 3 times to exit the menu)
5. Printer is in a 'frozen' state.

Change in memory:
Flash: +136 bytes
SRAM: +1 byte