### PR TITLE
Add nozzle diameter change to main menu for REVO builds

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -497,7 +497,7 @@ void lcdui_print_time(void)
             chars = lcd_printf_P(_N(LCD_STR_CLOCK "%3uh %c%c"), print_t / 60, suff, suff_doubt);
     } else {
 #ifdef QUICK_NOZZLE_CHANGE
-        chars = lcd_printf_P(PSTR("Nd. %4.2f"),(float)eeprom_read_word((uint16_t*)EEPROM_NOZZLE_DIAMETER_uM)/1000.0);
+        chars = lcd_printf_P(PSTR("Nd %4.2f "),(float)eeprom_read_word((uint16_t*)EEPROM_NOZZLE_DIAMETER_uM)/1000.0);
 #else
         chars = lcd_printf_P(_N(LCD_STR_CLOCK "--:--  "));
 #endif //QUICK_NOZZLE_CHANGE
@@ -633,7 +633,7 @@ void lcdui_print_status_line(void) {
 //!
 //! |Smooth1 F?  t--:--  | // Idle + Muliple sheets + MMU3
 //!
-//! |Smooth1     Nd. 0.40| // Idle + Muliple sheets + QUICK_NOZZLE_CHANGE
+//! |Smooth1     Nd 0.40 | // Idle + Muliple sheets + QUICK_NOZZLE_CHANGE
 //!
 //! | SD 99% F1  t00:17R | // SD print + MMU3
 //!

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -495,9 +495,13 @@ void lcdui_print_time(void)
             chars = lcd_printf_P(_N(LCD_STR_CLOCK "%02u:%02u%c%c"), print_t / 60, print_t % 60, suff, suff_doubt);
         else //time>=100h
             chars = lcd_printf_P(_N(LCD_STR_CLOCK "%3uh %c%c"), print_t / 60, suff, suff_doubt);
-    }
-    else
+    } else {
+#ifdef QUICK_NOZZLE_CHANGE
+        chars = lcd_printf_P(PSTR("Nd. %4.2f"),(float)eeprom_read_word((uint16_t*)EEPROM_NOZZLE_DIAMETER_uM)/1000.0);
+#else
         chars = lcd_printf_P(_N(LCD_STR_CLOCK "--:--  "));
+#endif //QUICK_NOZZLE_CHANGE
+    }
     lcd_space(8 - chars);
 }
 
@@ -619,9 +623,20 @@ void lcdui_print_status_line(void) {
 //!
 //! @code{.unparsed}
 //! |01234567890123456789|
-//! |N 000/000D  Z000.0  |
-//! |B 000/000D  F100%   |
-//! |USB100% T0  t--:--  |
+//! |N000/000D   Z000.00 |
+//! |B000/000D   F100%   |
+//! |   ---%     t--:--  | // Idle
+//!
+//! |   ---% F?  t--:--  | // Idle + MMU3
+//!
+//! |Smooth1     t--:--  | // Idle + Muliple sheets
+//!
+//! |Smooth1 F?  t--:--  | // Idle + Muliple sheets + MMU3
+//!
+//! |Smooth1     Nd. 0.40| // Idle + Muliple sheets + QUICK_NOZZLE_CHANGE
+//!
+//! | SD 99% F1  t00:17R | // SD print + MMU3
+//!
 //! |Status line.........|
 //! ----------------------
 //! N - nozzle temp symbol	LCD_STR_THERMOMETER
@@ -5166,7 +5181,12 @@ static void lcd_shutdown_menu()
 //! | Preheat            | not printing + not paused
 //! | Print from SD      | not printing or paused
 //!
-//! | Switch sheet       | farm mode
+//! | Switch sheet       | NOT farm mode
+//!                        AND multiple sheets calibrated AND not active
+//!
+//! | Nozzle diameter    | NOT farm mode
+//!                        AND multiple sheets calibrated AND not active
+//!                        AND QUICK_NOZZLE_CHANGE defined
 //!
 //! | AutoLoad filament  | not printing + not mmu or paused
 //! | Load filament      | not printing + mmu or paused
@@ -5296,6 +5316,10 @@ static void lcd_main_menu()
         if ((nextSheet >= 0) && (sheet != nextSheet)) { // show menu only if we have 2 or more sheets initialized
             MENU_ITEM_FUNCTION_E(EEPROM_Sheets_base->s[sheet], eeprom_switch_to_next_sheet);
         }
+#ifdef QUICK_NOZZLE_CHANGE
+        SETTINGS_NOZZLE;
+#endif //QUICK_NOZZLE_CHANGE
+
     }
 
     if ( ! ( printer_active() || (eFilamentAction != FilamentAction::None) || Stopped ) ) {

--- a/Firmware/variants/MK25-RAMBo10a.h
+++ b/Firmware/variants/MK25-RAMBo10a.h
@@ -200,6 +200,9 @@
 // Extrude mintemp
 #define EXTRUDE_MINTEMP 175
 
+// Quick nozzle change supported
+//#define QUICK_NOZZLE_CHANGE
+
 // Extruder cooling fans
 #define EXTRUDER_0_AUTO_FAN_PIN   8
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50

--- a/Firmware/variants/MK25-RAMBo13a.h
+++ b/Firmware/variants/MK25-RAMBo13a.h
@@ -201,6 +201,9 @@
 // Extrude mintemp
 #define EXTRUDE_MINTEMP 175
 
+// Quick nozzle change supported
+//#define QUICK_NOZZLE_CHANGE
+
 // Extruder cooling fans
 #define EXTRUDER_0_AUTO_FAN_PIN   8
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50

--- a/Firmware/variants/MK25S-RAMBo10a.h
+++ b/Firmware/variants/MK25S-RAMBo10a.h
@@ -200,6 +200,9 @@
 // Extrude mintemp
 #define EXTRUDE_MINTEMP 175
 
+// Quick nozzle change supported
+//#define QUICK_NOZZLE_CHANGE
+
 // Extruder cooling fans
 #define EXTRUDER_0_AUTO_FAN_PIN   8
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50

--- a/Firmware/variants/MK25S-RAMBo13a.h
+++ b/Firmware/variants/MK25S-RAMBo13a.h
@@ -201,6 +201,9 @@
 // Extrude mintemp
 #define EXTRUDE_MINTEMP 175
 
+// Quick nozzle change supported
+//#define QUICK_NOZZLE_CHANGE
+
 // Extruder cooling fans
 #define EXTRUDER_0_AUTO_FAN_PIN   8
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50

--- a/Firmware/variants/MK3-E3DREVO.h
+++ b/Firmware/variants/MK3-E3DREVO.h
@@ -334,6 +334,9 @@
 // Extrude mintemp
 #define EXTRUDE_MINTEMP 175
 
+// Quick nozzle change supported
+#define QUICK_NOZZLE_CHANGE
+
 // Extruder cooling fans
 #define EXTRUDER_0_AUTO_FAN_PIN   8
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50

--- a/Firmware/variants/MK3-E3DREVO_HF_60W.h
+++ b/Firmware/variants/MK3-E3DREVO_HF_60W.h
@@ -335,6 +335,9 @@
 // Extrude mintemp
 #define EXTRUDE_MINTEMP 175
 
+// Quick nozzle change supported
+#define QUICK_NOZZLE_CHANGE
+
 // Extruder cooling fans
 #define EXTRUDER_0_AUTO_FAN_PIN   8
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50

--- a/Firmware/variants/MK3.h
+++ b/Firmware/variants/MK3.h
@@ -337,6 +337,9 @@
 // Extrude mintemp
 #define EXTRUDE_MINTEMP 175
 
+// Quick nozzle change supported
+//#define QUICK_NOZZLE_CHANGE
+
 // Extruder cooling fans
 #define EXTRUDER_0_AUTO_FAN_PIN   8
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50

--- a/Firmware/variants/MK3S-E3DREVO.h
+++ b/Firmware/variants/MK3S-E3DREVO.h
@@ -336,6 +336,9 @@
 // Extrude mintemp
 #define EXTRUDE_MINTEMP 175
 
+// Quick nozzle change supported
+#define QUICK_NOZZLE_CHANGE
+
 // Extruder cooling fans
 #define EXTRUDER_0_AUTO_FAN_PIN   8
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50

--- a/Firmware/variants/MK3S-E3DREVO.h
+++ b/Firmware/variants/MK3S-E3DREVO.h
@@ -17,7 +17,7 @@
 #define NOZZLE_TYPE "E3DREVO"
 
 // Printer name
-#define CUSTOM_MENDEL_NAME "Prusa i3 MK3S-R"
+#define CUSTOM_MENDEL_NAME "Prusa i3 MK3S+R"
 
 // Electronics
 #define MOTHERBOARD BOARD_EINSY_1_0a

--- a/Firmware/variants/MK3S-E3DREVO_HF_60W.h
+++ b/Firmware/variants/MK3S-E3DREVO_HF_60W.h
@@ -337,6 +337,9 @@
 // Extrude mintemp
 #define EXTRUDE_MINTEMP 175
 
+// Quick nozzle change supported
+#define QUICK_NOZZLE_CHANGE
+
 // Extruder cooling fans
 #define EXTRUDER_0_AUTO_FAN_PIN   8
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50

--- a/Firmware/variants/MK3S-E3DREVO_HF_60W.h
+++ b/Firmware/variants/MK3S-E3DREVO_HF_60W.h
@@ -17,7 +17,7 @@
 #define NOZZLE_TYPE "E3DREVO_HF_60W"
 
 // Printer name
-#define CUSTOM_MENDEL_NAME "Prusa MK3S-RHF60"
+#define CUSTOM_MENDEL_NAME "Prusa MK3S+RHF60"
 
 // Electronics
 #define MOTHERBOARD BOARD_EINSY_1_0a

--- a/Firmware/variants/MK3S.h
+++ b/Firmware/variants/MK3S.h
@@ -339,6 +339,9 @@
 // Extrude mintemp
 #define EXTRUDE_MINTEMP 175
 
+// Quick nozzle change supported
+//#define QUICK_NOZZLE_CHANGE
+
 // Extruder cooling fans
 #define EXTRUDER_0_AUTO_FAN_PIN   8
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50

--- a/Firmware/variants/obsolete/1_75mm_MK2-RAMBo10a-E3Dv6full.h
+++ b/Firmware/variants/obsolete/1_75mm_MK2-RAMBo10a-E3Dv6full.h
@@ -132,6 +132,9 @@ EXTRUDER SETTINGS
 // Extrude mintemp
 #define EXTRUDE_MINTEMP 175
 
+// Quick nozzle change supported
+//#define QUICK_NOZZLE_CHANGE
+
 // Extruder cooling fans
 #define EXTRUDER_0_AUTO_FAN_PIN   8
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50

--- a/Firmware/variants/obsolete/1_75mm_MK2-RAMBo13a-E3Dv6full.h
+++ b/Firmware/variants/obsolete/1_75mm_MK2-RAMBo13a-E3Dv6full.h
@@ -131,6 +131,9 @@ EXTRUDER SETTINGS
 // Extrude mintemp
 #define EXTRUDE_MINTEMP 175
 
+// Quick nozzle change supported
+//#define QUICK_NOZZLE_CHANGE
+
 // Extruder cooling fans
 #define EXTRUDER_0_AUTO_FAN_PIN   8
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50


### PR DESCRIPTION
Add Nozzle diameter to Info screen when printer inactive and QUICK_NOZZLE_CHANGE defined

Solves #4488

Only active by default on REVO builds
Info screen idle 
![Info_screen_idle_with_Nozzle_diameter](https://github.com/prusa3d/Prusa-Firmware/assets/25530011/22d8d9cf-dbdf-47eb-9f99-50b828f9796b)

Main menu 
![Main_menu_Nozzle_diameter](https://github.com/prusa3d/Prusa-Firmware/assets/25530011/136acabd-1862-4cfb-b461-c4f0756ea0e1)
