### PR TITLE
M850 shows active sheet

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -7880,7 +7880,7 @@ Sigma_Exit:
     Get and Set Sheet parameters
     #### Usage
 
-         M25 [ S | Z | L | B | P | A ]
+         M850 [ S | Z | L | B | P | A ]
 
     #### Parameters
      - `S` - Sheet id [0-7]
@@ -7910,7 +7910,7 @@ Sigma_Exit:
 			break; // invalid sheet ID
 		}	
 	} else {
-		break;
+		iSel = eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet));
 	}
 	
 	if (code_seen('Z')){
@@ -7967,7 +7967,11 @@ Sigma_Exit:
 	if (code_seen('A'))
 	{
 		bIsActive |= code_value_uint8() || (eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet)) == iSel);
-		if(bIsActive) eeprom_update_byte(&EEPROM_Sheets_base->active_sheet, iSel);
+		if(bIsActive && eeprom_is_sheet_initialized(iSel)) {
+            eeprom_update_byte(&EEPROM_Sheets_base->active_sheet, iSel);
+        } else {
+            bIsActive = 0;
+        }
 	}
 	else
 	{


### PR DESCRIPTION
Prevent sheet being active if not initialized

Replaces #3947 and #3948

Show active sheet using `M850`
```
Send: M850
Recv: Sheet 0 Z-0.5125 R-205 LSmooth1 B0 P25 A1
```
Prevent not initialized sheet set active
```
Send: M850 S1 A1
Recv: Sheet 1 NOT INITIALIZED
Recv:  Z-0.0025 R-1 LSmooth2 B255 P255 A0
```