### PR TITLE
Steel sheet alert before start the print 

### DIFF
--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -240,6 +240,7 @@ extern bool axis_known_position[3];
 extern uint8_t fanSpeed; //!< Print fan speed, ranges from 0 to 255
 extern uint8_t newFanSpeed;
 extern float default_retraction;
+extern bool sheet_alert_enabled;
 
 void get_coordinates();
 void prepare_move(uint16_t start_segment_idx = 0);

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -146,6 +146,8 @@
 //===========================================================================
 //=============================public variables=============================
 //===========================================================================
+bool sheet_alert_enabled = true;
+
 #ifdef SDSUPPORT
 CardReader card;
 #endif
@@ -437,6 +439,10 @@ void serialprintlnPGM(const char *str) {
     }
   }
 #endif //!SDSUPPORT
+
+void SetSheetAlert() {
+	sheet_alert_enabled = eeprom_read_byte((uint8_t *)EEPROM_ED_SHEET_ALERT);
+}
 
 void setup_killpin()
 {
@@ -1608,6 +1614,7 @@ void setup()
 #endif //UVLO_SUPPORT
 
   fCheckModeInit();
+  SetSheetAlert();
   KEEPALIVE_STATE(NOT_BUSY);
 #ifdef WATCHDOG
   wdt_enable(WDTO_4S);
@@ -6488,6 +6495,10 @@ Sigma_Exit:
 	- U - Firmware version provided by G-code to be compared to current one.  
 	*/
 	case 115: // M115
+      if (IS_SD_PRINTING && sheet_alert_enabled)
+      {
+        steel_sheet_check();
+      }
       if (code_seen('V')) {
           // Report the Prusa version number.
           SERIAL_PROTOCOLLNRPGM(FW_VERSION_STR_P());

--- a/Firmware/eeprom.h
+++ b/Firmware/eeprom.h
@@ -382,6 +382,7 @@ static_assert(sizeof(Sheets) == EEPROM_SHEETS_SIZEOF, "Sizeof(Sheets) is not EEP
 | 0x0C94 3220 | uint8   | EEPROM_KILL_PENDING_FLAG              | 42h, ffh     | ffh                   | Kill pending flag (0x42 magic value)              | kill()       | D3 Ax0c94 C1
 | 0x0C91 3217 | char[3] | EEPROM_FILENAME_EXTENSION             | ???          | ffffffffh             | DOS 8.3 filename extension                        | Power Panic  | D3 Ax0c91 C1
 | 0x0C80 3200 | char[17]| EEPROM_CUSTOM_MENDEL_NAME             | Prusa i3 MK3S| ffffffffffffffffff... | Custom Printer Name                               |              | D3 Ax0c80 C17
+| 0x0C7F 3199 | uint8_t | EEPROM_ED_SHEET_ALERT					| 00h 0		   | ffh 255			   | Disable sheet alert: __off__					   | LCD menu     | D3 Ax0d03 C1
 
 |Address begin|Bit/Type | Name                                  | Valid values | Default/FactoryReset  | Description                                       |Gcode/Function| Debug code
 | :--:        | :--:    | :--:                                  | :--:         | :--:                  | :--:                                              | :--:         | :--:
@@ -621,9 +622,10 @@ static Sheets * const EEPROM_Sheets_base = (Sheets*)(EEPROM_SHEETS_BASE);
 #define EEPROM_KILL_PENDING_FLAG (EEPROM_KILL_MESSAGE-1) //uint8
 #define EEPROM_FILENAME_EXTENSION (EEPROM_KILL_PENDING_FLAG - 3) // 3 x char
 #define EEPROM_CUSTOM_MENDEL_NAME (EEPROM_FILENAME_EXTENSION-17) //char[17]
+#define EEPROM_ED_SHEET_ALERT (EEPROM_CUSTOM_MENDEL_NAME - 1) //uint8
 
 //This is supposed to point to last item to allow EEPROM overrun check. Please update when adding new items.
-#define EEPROM_LAST_ITEM EEPROM_FILENAME_EXTENSION
+#define EEPROM_LAST_ITEM EEPROM_ED_SHEET_ALERT
 // !!!!!
 // !!!!! this is end of EEPROM section ... all updates MUST BE inserted before this mark !!!!!
 // !!!!!

--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -191,6 +191,8 @@ extern const char MSG_NOZZLE_CNG_MENU [] PROGMEM_I1 = ISTR("Nozzle change");////
 extern const char MSG_NOZZLE_CNG_READ_HELP [] PROGMEM_I1 = ISTR("For a Nozzle change please read\nprusa.io/nozzle-mk3s");////MSG_NOZZLE_CNG_READ_HELP c=20 r=4
 extern const char MSG_NOZZLE_CNG_CHANGED [] PROGMEM_I1 = ISTR("Hotend at 280C! Nozzle changed and tightened to specs?");////MSG_NOZZLE_CNG_CHANGED c=20 r=6
 extern const char MSG_REPRINT [] PROGMEM_I1 = ISTR("Reprint"); ////MSG_REPRINT c=18
+extern const char MSG_SHEET_ALERT[] PROGMEM_I1 = ISTR("Sheet alert"); ////c=18
+extern const char MSG_CHECK_STEEL_SHEET[] PROGMEM_I1 = ISTR("Check the selected steel sheet:"); ////c=31
 //not internationalized messages
 #if 0
 const char MSG_FW_VERSION_BETA[] PROGMEM_N1 = "You are using a BETA firmware version! It is in a development state! Use this version with CAUTION as it may DAMAGE the printer!"; ////MSG_FW_VERSION_BETA c=20 r=8

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -192,6 +192,8 @@ extern const char MSG_NOZZLE_CNG_MENU [];
 extern const char MSG_NOZZLE_CNG_READ_HELP [];
 extern const char MSG_NOZZLE_CNG_CHANGED [];
 extern const char MSG_REPRINT [];
+extern const char MSG_SHEET_ALERT [];
+extern const char MSG_CHECK_STEEL_SHEET[];
 
 //not internationalized messages
 #if 0

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -4604,7 +4604,7 @@ static void lcd_calibration_menu()
 uint8_t choose_menu_P(const char *header, const char *item, const char *last_item)
 {
     //following code should handle 3 to 127 number of items well
-    const int8_t items_no = last_item?(MMU2::mmu2.Enabled()?11:10):(MMU2::mmu2.Enabled()?10:9);
+    const int8_t items_no = last_item?(MMU2::mmu2.Enabled()?6:5):(MMU2::mmu2.Enabled()?5:4);
     const uint8_t item_len = item?strlen_P(item):0;
 	int8_t first = 0;
 	int8_t cursor_pos = 1;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -4601,7 +4601,7 @@ static void lcd_calibration_menu()
 uint8_t choose_menu_P(const char *header, const char *item, const char *last_item)
 {
     //following code should handle 3 to 127 number of items well
-    const int8_t items_no = last_item?(MMU2::mmu2.Enabled()?6:5):(MMU2::mmu2.Enabled()?5:4);
+    const int8_t items_no = last_item?(MMU2::mmu2.Enabled()?11:10):(MMU2::mmu2.Enabled()?10:9);
     const uint8_t item_len = item?strlen_P(item):0;
 	int8_t first = 0;
 	int8_t cursor_pos = 1;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -240,6 +240,8 @@ static void menu_action_sddirectory(const char* filename);
 
 static void lcd_rehome_xy();
 
+static void lcd_set_sheet_alert();
+
 #define ENCODER_FEEDRATE_DEADZONE 10
 
 #define STATE_NA 255
@@ -4460,6 +4462,7 @@ static void lcd_settings_menu()
 
     SETTINGS_FANS_CHECK();
     SETTINGS_SILENT_MODE();
+    MENU_ITEM_TOGGLE_P(_T(MSG_SHEET_ALERT), sheet_alert_enabled ? _T(MSG_ON) : _T(MSG_OFF), lcd_set_sheet_alert);
 
     if(!farm_mode)
     {
@@ -7488,4 +7491,9 @@ void lcd_send_action_start()
 {
     SERIAL_PROTOCOLLNRPGM(MSG_OCTOPRINT_START);
     lcd_return_to_status();
+}
+
+void lcd_set_sheet_alert() {
+	sheet_alert_enabled = !sheet_alert_enabled;
+	eeprom_update_byte((uint8_t *)EEPROM_ED_SHEET_ALERT, sheet_alert_enabled);
 }

--- a/Firmware/util.cpp
+++ b/Firmware/util.cpp
@@ -447,3 +447,22 @@ void calibration_status_clear(CalibrationStatus components)
     status &= ~components;
     eeprom_update_byte((uint8_t*)EEPROM_CALIBRATION_STATUS_V2, status);
 }
+
+void steel_sheet_check()
+{
+     const int8_t sheetNR = eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet));
+     const int8_t nextSheet = eeprom_next_initialized_sheet(sheetNR);
+     if ((nextSheet >= 0) && (sheetNR != nextSheet))
+     {
+          char sheet[8];
+          eeprom_read_block(sheet, EEPROM_Sheets_base->s[sheetNR].name, 7);
+          sheet[7] = '\0';
+          lcd_display_message_fullscreen_P(_T(MSG_CHECK_STEEL_SHEET));
+          lcd_set_cursor(0, 2);
+          lcd_printf_P(PSTR("%-7s"), sheet);
+          Sound_MakeSound(e_SOUND_TYPE_StandardPrompt);
+          if (!lcd_wait_for_click_delay(30))
+               lcd_print_stop();
+          lcd_update_enable(true);
+     }
+} 

--- a/Firmware/util.h
+++ b/Firmware/util.h
@@ -139,6 +139,7 @@ void printer_model_check(uint16_t nPrinterModel, uint16_t actualPrinterModel);
 void printer_smodel_check(const char *pStrPos, const char *actualPrinterSModel);
 void fw_version_check(const char *pVersion);
 void gcode_level_check(uint16_t nGcodeLevel);
+void steel_sheet_check();
 
 uint16_t nPrinterType(bool bMMu);
 const char *sPrinterType(bool bMMu);

--- a/Firmware/variants/MK3S.h
+++ b/Firmware/variants/MK3S.h
@@ -642,7 +642,7 @@
 //#define SUPPORT_VERBOSITY
 
 #define MMU_CONFIG_FILE "mmu2/variants/config_MMU2S.h"
-#define MMU_FILAMENT_COUNT 5
+#define MMU_FILAMENT_COUNT 10
 //#define MMU_FORCE_STEALTH_MODE
 #define MMU_HWRESET
 #define MMU_DEBUG //print communication between MMU and printer on serial

--- a/Firmware/variants/MK3S.h
+++ b/Firmware/variants/MK3S.h
@@ -642,7 +642,7 @@
 //#define SUPPORT_VERBOSITY
 
 #define MMU_CONFIG_FILE "mmu2/variants/config_MMU2S.h"
-#define MMU_FILAMENT_COUNT 10
+#define MMU_FILAMENT_COUNT 5
 //#define MMU_FORCE_STEALTH_MODE
 #define MMU_HWRESET
 #define MMU_DEBUG //print communication between MMU and printer on serial


### PR DESCRIPTION
One of the usual problems with the MK3S and the different steel sheets is to forget to change the sheet selection resulting  on a PEI damage. So as I have been dealing with that issue I developed this alert. 
In my case I extended the **M115** G-Code in order to perform the check before to start the print and print a message on the LCD alerting the selected sheet, raise a beep and wait for the user input.
The check will work only if the check is enabled in the settings menu which use a eeprom variable, if the printer has more than one steel sheet registered and if is a local print.