### PR TITLE
PFW-1307: Add commit number and hash to `M115`

### DIFF
--- a/Firmware/Configuration.h
+++ b/Firmware/Configuration.h
@@ -34,7 +34,7 @@ extern const char _sPrinterMmuName[] PROGMEM;
     // Construct the TWEAK value as it is expected from the enum.
     #define FW_TWEAK (CONCAT(FIRMWARE_REVISION_,FW_FLAVOR) + FW_FLAVERSION)
     #define FW_VERSION STR(FW_MAJOR) "." STR(FW_MINOR) "." STR(FW_REVISION) "-" STR(FW_FLAVOR) "" STR(FW_FLAVERSION)
-    #define FW_VERSION_FULL STR(FW_MAJOR) "." STR(FW_MINOR) "." STR(FW_REVISION) "-" STR(FW_FLAVOR) "" STR(FW_FLAVERSION) "-" STR(FW_COMMITNR)
+    #define FW_VERSION_FULL STR(FW_MAJOR) "." STR(FW_MINOR) "." STR(FW_REVISION) "-" STR(FW_FLAVOR) "" STR(FW_FLAVERSION) "+" STR(FW_COMMITNR)
 #endif
 
 // The full version string and repository source are set via cmake
@@ -70,7 +70,7 @@ extern const char _sPrinterMmuName[] PROGMEM;
 // build by the user have been successfully uploaded into firmware.
 
 #define STRING_VERSION_CONFIG_H SOURCE_DATE_EPOCH " " SOURCE_TIME_EPOCH // build date and time
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR FW_REPOSITORY // Who made the changes.
 
 // SERIAL_PORT selects which serial port should be used for communication with the host.
 // This allows the connection of wireless adapters (for instance) to non-default port pins.

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1121,7 +1121,7 @@ void setup()
 		SERIAL_PROTOCOLLNPGM("start");
 #endif
 	SERIAL_ECHO_START;
-	puts_P(PSTR(" " FW_VERSION_FULL));
+	puts_P(PSTR(" " FW_VERSION_FULL "_" FW_COMMIT_HASH));
 
 	// by default the MMU shall remain disabled - PFW-1418
 	if (eeprom_init_default_byte((uint8_t *)EEPROM_MMU_ENABLED, 0)) {
@@ -6511,13 +6511,19 @@ Sigma_Exit:
           eeprom_read_block(custom_mendel_name,(char*)EEPROM_CUSTOM_MENDEL_NAME,MAX_CUSTOM_MENDEL_NAME_LENGTH);
           SERIAL_ECHOPGM("FIRMWARE_NAME:Prusa-Firmware ");
           SERIAL_ECHORPGM(FW_VERSION_STR_P());
+          SERIAL_ECHOPGM("+");
+          SERIAL_ECHOPGM(STR(FW_COMMITNR));
+          SERIAL_ECHOPGM("_");
+          SERIAL_ECHOPGM(FW_COMMIT_HASH);
           SERIAL_ECHOPGM(" based on Marlin FIRMWARE_URL:https://github.com/prusa3d/Prusa-Firmware PROTOCOL_VERSION:");
           SERIAL_ECHOPGM(PROTOCOL_VERSION);
           SERIAL_ECHOPGM(" MACHINE_TYPE:");
           SERIAL_PROTOCOL(custom_mendel_name);
           SERIAL_ECHOPGM(" EXTRUDER_COUNT:" STRINGIFY(EXTRUDERS));
+#ifdef MACHINE_UUID
           SERIAL_ECHOPGM(" UUID:");
           SERIAL_ECHOLNPGM(MACHINE_UUID);
+#endif //MACHINE_UUID
 #ifdef EXTENDED_CAPABILITIES_REPORT
           extended_capabilities_report();
 #endif //EXTENDED_CAPABILITIES_REPORT

--- a/Firmware/language.h
+++ b/Firmware/language.h
@@ -13,10 +13,6 @@
 
 #define PROTOCOL_VERSION "1.0"
 
-#ifndef MACHINE_UUID
-   #define MACHINE_UUID "00000000-0000-0000-0000-000000000000"
-#endif
-
 #if (LANG_MODE == 0) //primary language only
 #define PROGMEM_I2 __attribute__((section(".progmem0")))
 #define PROGMEM_I1 __attribute__((section(".progmem1")))


### PR DESCRIPTION
Show UUID only if defined

Tested
- [X] simple serial terminal
- [X] PrusaLink/PrusaConnect
- [X] Octoprint


Boot message:
Before
```
start
echo: 3.14.0-BETA1-7984
MMU is Off
SpoolJoin is On
PowerUp
echo: Last Updated: 2024-01-22 09:11:19 | Author: (none, default config)
echo: Free Memory: 2507  PlannerBufferBytes: 1760
echo:Stored settings retrieved
```
After:
```
start
echo: 3.14.0-BETA1+7984_b80965731
MMU is Off
SpoolJoin is On
echo: Last Updated: 2024-01-22 09:11:19 | Author: 3d-gussner
echo: Free Memory: 2507  PlannerBufferBytes: 1760
echo:Stored settings retrieved
```

`M115` message:
Before: `FIRMWARE_NAME:Prusa-Firmware 3.14.0-BETA1 based on Marlin FIRMWARE_URL:https://github.com/prusa3d/Prusa-Firmware PROTOCOL_VERSION:1.0 MACHINE_TYPE:Prusa i3 MK3S EXTRUDER_COUNT:1 UUID:00000000-0000-0000-0000-000000000000`
After: `FIRMWARE_NAME:Prusa-Firmware 3.14.0-BETA1+7984_b80965731 based on Marlin FIRMWARE_URL:https://github.com/prusa3d/Prusa-Firmware PROTOCOL_VERSION:1.0 MACHINE_TYPE:Prusa i3 MK3S EXTRUDER_COUNT:1`
