### PR TITLE
bootstrap.py: add option '--break-system-packages' to pip3 arguments to mitigate PEP 668

### DIFF
--- a/utils/bootstrap.py
+++ b/utils/bootstrap.py
@@ -193,7 +193,7 @@ def main() -> int:
             continue
         print('Installing Python package %s' % package)
         run(sys.executable, '-m', 'pip', 'install', package,
-            '--disable-pip-version-check')
+            '--disable-pip-version-check', '--break-system-packages')
 
     return 0
 


### PR DESCRIPTION
See [PEP 668](https://peps.python.org/pep-0668/) for the detailed specification.

This PR mitigates the issue that pip3 under Debian 12 will refuse to install packages and thus breaks `bootstrap.py`:

```text
$ ./utils/bootstrap.py 
Downloading ninja-1.10.2
Extracting ninja-1.10.2
Downloading cmake-3.22.5
Extracting cmake-3.22.5
Downloading avr-gcc-7.3.0
Extracting avr-gcc-7.3.0
Downloading prusa3dboards-1.0.6
Extracting prusa3dboards-1.0.6
Installing Python package pyelftools
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
    
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
    
    See /usr/share/doc/python3.11/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
Traceback (most recent call last):
  File "/home/user/Prusa-Firmware/./utils/bootstrap.py", line 202, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/user/Prusa-Firmware/./utils/bootstrap.py", line 195, in main
    run(sys.executable, '-m', 'pip', 'install', package,
  File "/home/user/Prusa-Firmware/./utils/bootstrap.py", line 103, in run
    process = subprocess.run([str(a) for a in cmd],
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['/usr/bin/python3', '-m', 'pip', 'install', 'pyelftools', '--disable-pip-version-check']' returned non-zero exit status 1.
```

running again with the change of this PR:

```text
$ ./utils/bootstrap.py 
Installing Python package pyelftools
Installing Python package polib
Installing Python package regex
```