### PR TITLE
PFW-1553 fix regression where SD card file is not closed when stopping paused print

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5709,7 +5709,7 @@ void print_stop(bool interactive)
     // called by the main loop one iteration later.
     UnconditionalStop();
 
-    if (card.sdprinting) {
+    if (card.mounted) {
         // Reset the sd status
         card.sdprinting = false;
         card.closefile();


### PR DESCRIPTION
When a print is paused, `card.sdprinting` is set to false. Instead we can check if the SD card has been mounted and try to close the file.

The `closefile()` method will check internally whether or not the file is open.

Regression seems to have been introduced here: 3ad40f02064f1870cdec7fe4d9ce1bd7a2ff6ec0

**Steps to reproduce:**
1. Start a print
2. Pause the print
3. Stop the print
4. Try to find "Print from SD" menu (it's gone now)