### PR TITLE
PFW-1552 Fix a regression introduced in f022567

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -9776,6 +9776,15 @@ void ConditionalStop()
 {
     CRITICAL_SECTION_START;
 
+    // Don't disable the heaters! lcd_print_stop_finish() will do it later via lcd_cooldown()
+    //
+    // However, the firmware must take into account the edge case when the firmware
+    // is running M109 or M190 G-codes. These G-codes execute a blocking while loop
+    // which waits for the bed or nozzle to reach their target temperature.
+    // To exit the loop, the firmware must set cancel_heatup to true.
+    cancel_heatup = true;
+    heating_status = HeatingStatus::NO_HEATING;
+
     // Clear any saved printing state
     cancel_saved_printing();
 


### PR DESCRIPTION
Kudos to @3d-gussner for spotting the issue :) 

I have re-tested the items here: https://github.com/prusa3d/Prusa-Firmware/pull/4582#issuecomment-1913586179 and they are all behaving as expected.

With this PR, now the heaters are disabled correctly if the print is stopped before heating is completed.

Steps to reproduce issue:
1. Start a print
2. While heating, stop the print
3. Observe issue: Hotend/Bed continue to heat up to the target temperature
4. Expected result: The Hotend/Bed should stop heating