### PR TITLE
Remove redundant ` cancel_heatup` assignment

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -6164,8 +6164,6 @@ Sigma_Exit:
       /* See if we are heating up or cooling down */
       target_direction = isHeatingHotend(active_extruder); // true if heating, false if cooling
 
-      cancel_heatup = false;
-
       wait_for_heater(codenum, active_extruder); //loops until target temperature is reached
 
         LCD_MESSAGERPGM(_T(MSG_HEATING_COMPLETE));


### PR DESCRIPTION
`cancel_heatup` is set to `false` inside `wait_for_heater()` there is no need to do it before the function call

See: https://github.com/prusa3d/Prusa-Firmware/blob/c999c2948e39bc52d20d558b1686f5ab1f1b4f32/Firmware/Marlin_main.cpp#L10009

Change in memory:
Flash: -4 bytes
SRAM: 0 bytes