### PR TITLE
TMC Restore default XY currents after homing

### DIFF
--- a/Firmware/tmc2130.cpp
+++ b/Firmware/tmc2130.cpp
@@ -439,6 +439,9 @@ void tmc2130_home_exit()
 		{
 			if (tmc2130_sg_homing_axes_mask & mask) {
 				tmc2130_XYZ_reg_init(axis);
+				currents[axis].setiRun(tmc2130_current_r[axis]);
+				currents[axis].setiHold(tmc2130_current_h[axis]);
+				tmc2130_setup_chopper(axis, tmc2130_mres[axis]);
 			}
 		}
 		tmc2130_sg_homing_axes_mask = 0x00;

--- a/Firmware/tmc2130.cpp
+++ b/Firmware/tmc2130.cpp
@@ -30,18 +30,25 @@ static constexpr uint8_t default_dedge_bit = 0;
 
 //mode
 uint8_t tmc2130_mode = TMC2130_MODE_NORMAL;
-uint8_t tmc2130_current_h[4] = TMC2130_CURRENTS_H;
-//running currents
-uint8_t tmc2130_current_r[4] = TMC2130_CURRENTS_R;
 
+static constexpr uint8_t tmc2130_default_current_h[4] = TMC2130_CURRENTS_H;
+//running currents
+static constexpr uint8_t tmc2130_default_current_r[4] = TMC2130_CURRENTS_R;
 //running currents for homing
-static uint8_t tmc2130_current_r_home[4] = TMC2130_CURRENTS_R_HOME;
+static constexpr uint8_t tmc2130_current_r_home[4] = TMC2130_CURRENTS_R_HOME;
+
+static constexpr MotorCurrents homing_currents_P[NUM_AXIS] PROGMEM = {
+	MotorCurrents(tmc2130_current_r_home[0], tmc2130_current_r_home[0]),
+	MotorCurrents(tmc2130_current_r_home[1], tmc2130_current_r_home[1]),
+	MotorCurrents(tmc2130_current_r_home[2], tmc2130_current_r_home[2]),
+	MotorCurrents(tmc2130_current_r_home[3], tmc2130_current_r_home[3])
+};
 
 MotorCurrents currents[NUM_AXIS] = {
-	MotorCurrents(tmc2130_current_r[0], tmc2130_current_h[0]),
-	MotorCurrents(tmc2130_current_r[1], tmc2130_current_h[1]),
-	MotorCurrents(tmc2130_current_r[2], tmc2130_current_h[2]),
-	MotorCurrents(tmc2130_current_r[3], tmc2130_current_h[3])
+	MotorCurrents(tmc2130_default_current_r[0], tmc2130_default_current_h[0]),
+	MotorCurrents(tmc2130_default_current_r[1], tmc2130_default_current_h[1]),
+	MotorCurrents(tmc2130_default_current_r[2], tmc2130_default_current_h[2]),
+	MotorCurrents(tmc2130_default_current_r[3], tmc2130_default_current_h[3])
 };
 
 union ChopConfU {
@@ -419,8 +426,8 @@ void tmc2130_home_enter(uint8_t axes_mask)
 			tmc2130_wr(axis, TMC2130_REG_GCONF, TMC2130_GCONF_NORMAL);
 			tmc2130_wr(axis, TMC2130_REG_COOLCONF, (((uint32_t)tmc2130_sg_thr_home[axis]) << 16));
 			tmc2130_wr(axis, TMC2130_REG_TCOOLTHRS, __tcoolthrs(axis));
-			currents[axis].setiRun(tmc2130_current_r_home[axis]);
-			tmc2130_setup_chopper(axis, tmc2130_mres[axis]);
+			MotorCurrents curr(homing_currents_P[axis]);
+			tmc2130_setup_chopper(axis, tmc2130_mres[axis], &curr);
 			tmc2130_wr(axis, TMC2130_REG_GCONF, TMC2130_GCONF_SGSENS); //stallguard output DIAG1, DIAG1 = pushpull
 		}
 	}
@@ -439,9 +446,6 @@ void tmc2130_home_exit()
 		{
 			if (tmc2130_sg_homing_axes_mask & mask) {
 				tmc2130_XYZ_reg_init(axis);
-				currents[axis].setiRun(tmc2130_current_r[axis]);
-				currents[axis].setiHold(tmc2130_current_h[axis]);
-				tmc2130_setup_chopper(axis, tmc2130_mres[axis]);
 			}
 		}
 		tmc2130_sg_homing_axes_mask = 0x00;
@@ -519,17 +523,12 @@ static constexpr bool getIntpolBit([[maybe_unused]]const uint8_t axis, const uin
     return (mres != 0); // intpol to 256 only if microsteps aren't 256
 }
 
-static void SetCurrents(const uint8_t axis) {
-    uint8_t iHold = currents[axis].getiHold();
-    const uint8_t iRun = currents[axis].getiRun();
+static void SetCurrents(const uint8_t axis, const MotorCurrents &curr) {
+    uint8_t iHold = curr.getiHold();
+    const uint8_t iRun = curr.getiRun();
 
     // Make sure iHold never exceeds iRun at runtime
-    if (iHold > iRun) {
-        iHold = iRun;
-
-        // Update global array such that M913 reports correct values
-        currents[axis].setiHold(iRun);
-
+    if (curr.iHoldIsClamped()) {
         // Let user know firmware modified the value
         SERIAL_ECHO_START;
         SERIAL_ECHOLNRPGM(_n("Hold current truncated to Run current"));
@@ -555,7 +554,7 @@ static void SetCurrents(const uint8_t axis) {
     tmc2130_wr(axis, TMC2130_REG_IHOLD_IRUN, ihold_irun.dw);
 }
 
-void tmc2130_setup_chopper(uint8_t axis, uint8_t mres)
+void tmc2130_setup_chopper(uint8_t axis, uint8_t mres, const MotorCurrents *curr /* = nullptr */)
 {
 	// Initialise the chopper configuration
 	ChopConfU chopconf = ChopConfU(currents[axis].getvSense(), mres);
@@ -567,21 +566,10 @@ void tmc2130_setup_chopper(uint8_t axis, uint8_t mres)
 	chopconf.s.tbl = tmc2130_chopper_config[axis].tbl; //blanking time, original value = 2
 
 	tmc2130_wr(axis, TMC2130_REG_CHOPCONF, chopconf.dw);
-	SetCurrents(axis);
-}
-
-void tmc2130_set_current_h(uint8_t axis, uint8_t current)
-{
-//	DBG(_n("tmc2130_set_current_h(axis=%d, current=%d\n"), axis, current);
-	currents[axis].setiHold(current);
-	tmc2130_setup_chopper(axis, tmc2130_mres[axis]);
-}
-
-void tmc2130_set_current_r(uint8_t axis, uint8_t current)
-{
-//	DBG(_n("tmc2130_set_current_r(axis=%d, current=%d\n"), axis, current);
-	currents[axis].setiRun(current);
-	tmc2130_setup_chopper(axis, tmc2130_mres[axis]);
+	if (curr == nullptr) {
+		curr = &currents[axis];
+	}
+	SetCurrents(axis, *curr);
 }
 
 void tmc2130_print_currents()

--- a/Firmware/tmc2130.h
+++ b/Firmware/tmc2130.h
@@ -95,13 +95,17 @@ struct MotorCurrents {
         }
     }
 
+    // PROGMEM initializer
+    inline __attribute__((always_inline)) MotorCurrents(const MotorCurrents &curr_P) { memcpy_P(this, &curr_P, sizeof(*this)); }
+
     constexpr inline __attribute__((always_inline)) MotorCurrents(uint8_t ir, uint8_t ih)
         : vSense((ir < 32) ? 1 : 0)
         , iRun((ir < 32) ? ir : (ir >> 1))
         , iHold((ir < 32) ? ih : (ih >> 1)) {}
 
     inline uint8_t getiRun() const { return iRun; }
-    inline uint8_t getiHold() const { return iHold; }
+    inline uint8_t getiHold() const { return min(iHold, iRun); }
+    inline bool iHoldIsClamped() const { return iHold > iRun; }
     inline uint8_t getvSense() const { return vSense; }
 
     void __attribute__((noinline)) setiRun(uint8_t ir) {
@@ -162,12 +166,11 @@ extern void tmc2130_sg_measure_start(uint8_t axis);
 //stop current stallguard measuring and report result
 extern uint16_t tmc2130_sg_measure_stop();
 
-extern void tmc2130_setup_chopper(uint8_t axis, uint8_t mres);
+// Enable or Disable crash detection according to EEPROM
+void crashdet_use_eeprom_setting();
 
-//set holding current for any axis (M911)
-extern void tmc2130_set_current_h(uint8_t axis, uint8_t current);
-//set running current for any axis (M912)
-extern void tmc2130_set_current_r(uint8_t axis, uint8_t current);
+extern void tmc2130_setup_chopper(uint8_t axis, uint8_t mres, const MotorCurrents *curr = nullptr);
+
 //print currents (M913)
 extern void tmc2130_print_currents();
 


### PR DESCRIPTION
The currents were not properly restored at the end of homing, so the XY axes would remain with the lower homing current, resulting in more skipped steps on the Y axis and worse crash detection.

@3d-gussner please test.

- [x] Create a new branch MK3_3.13.3 based on v3.13.2
- [x] Create PR to MK3_3.13.3
- [x] Create PR with a cherry-pick to MK3 branch
  - [ ] Create tag v3.13.3
  - [ ] Ask for PrusaSlicer-settings PR