### PR TITLE
Adjust Nozzle Change Menu For Quick Change Nozzles

### DIFF
--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -192,7 +192,12 @@ extern const char MSG_TM_ACK_ERROR[] PROGMEM_I1 = ISTR("Clear TM error");////MSG
 extern const char MSG_LOAD_ALL[] PROGMEM_I1 = ISTR("Load All"); ////MSG_LOAD_ALL c=18
 extern const char MSG_NOZZLE_CNG_MENU [] PROGMEM_I1 = ISTR("Nozzle change");////MSG_NOZZLE_CNG_MENU c=18
 extern const char MSG_NOZZLE_CNG_READ_HELP [] PROGMEM_I1 = ISTR("For a Nozzle change please read\nprusa.io/nozzle-mk3s");////MSG_NOZZLE_CNG_READ_HELP c=20 r=4
+#ifdef QUICK_NOZZLE_CHANGE
+extern const char MSG_NOZZLE_CNG_COOLDOWN [] PROGMEM_I1 = ISTR("Nozzle is hot! Wait for cooldown.");////MSG_NOZZLE_CNG_COOLDOWN c=20 r=3
+extern const char MSG_NOZZLE_CNG_CHANGED [] PROGMEM_I1 = ISTR("Nozzle changed?");////MSG_NOZZLE_CNG_CHANGED_QUICK c=20 r=3
+#else
 extern const char MSG_NOZZLE_CNG_CHANGED [] PROGMEM_I1 = ISTR("Hotend at 280C! Nozzle changed and tightened to specs?");////MSG_NOZZLE_CNG_CHANGED c=20 r=6
+#endif //QUICK_NOZZLE_CHANGE
 extern const char MSG_REPRINT [] PROGMEM_I1 = ISTR("Reprint"); ////MSG_REPRINT c=18
 extern const char MSG_FILE_CNT [] PROGMEM_I1 = ISTR("Some files will not be sorted. Max. No. of files in 1 folder for sorting is 100."); ////MSG_FILE_CNT c=20 r=6
 extern const char MSG_CHANGED_MOTHERBOARD [] PROGMEM_I1 = ISTR("Warning: motherboard type changed."); ////MSG_CHANGED_MOTHERBOARD c=20 r=4

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -194,6 +194,9 @@ extern const char MSG_LOAD_ALL[];
 extern const char MSG_NOZZLE_CNG_MENU [];
 extern const char MSG_NOZZLE_CNG_READ_HELP [];
 extern const char MSG_NOZZLE_CNG_CHANGED [];
+#ifdef QUICK_NOZZLE_CHANGE
+extern const char MSG_NOZZLE_CNG_COOLDOWN [];
+#endif //QUICK_NOZZLE_CHANGE
 extern const char MSG_REPRINT [];
 extern const char MSG_FILE_CNT [];
 extern const char MSG_CHANGED_MOTHERBOARD [];

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -972,15 +972,18 @@ void lcd_commands()
 	{
         if (!blocks_queued() && cmd_buffer_empty() && !saved_printing)
         {
+#ifndef QUICK_NOZZLE_CHANGE //thermal model can be ignored if a quickchange nozzle is in use, no heatup necessary
 #ifdef THERMAL_MODEL
             static bool was_enabled;
 #endif //THERMAL_MODEL
+#endif //QUICK_NOZZLE_CHANGE
             switch(lcd_commands_step)
             {
             case 0:
                 lcd_commands_step = 3;
                 break;
             case 3:
+#ifndef QUICK_NOZZLE_CHANGE
                 lcd_update_enabled = false; //hack to avoid lcd_update recursion.
                 lcd_show_fullscreen_message_and_wait_P(_T(MSG_NOZZLE_CNG_READ_HELP));
                 lcd_update_enabled = true;
@@ -992,30 +995,47 @@ void lcd_commands()
                 was_enabled = thermal_model_enabled();
                 thermal_model_set_enabled(false);
 #endif //THERMAL_MODEL
+#else //nozzle change without heating
+                while((int)degHotend(active_extruder)>40) { //check temp
+                    fanSpeed = 255; //turn on fan
+                    disable_heater();
+                    uint8_t choice = lcd_show_multiscreen_message_yes_no_and_wait_P(_T(MSG_NOZZLE_CNG_COOLDOWN), true, LCD_LEFT_BUTTON_CHOICE);
+                    lcd_update_enabled = false; //hack to avoid lcd_update recursion.
+                    if (choice == LCD_MIDDLE_BUTTON_CHOICE) {
+                        lcd_update_enabled = true;
+                        lcd_draw_update = 2; //force lcd clear and update after the stack unwinds.
+                        break;
+                    }
+                    lcd_update_enabled = true;
+                    lcd_draw_update = 2; //force lcd clear and update after the stack unwinds.
+                }
+                enquecommand_P(G28W); //home
+                enquecommand_P(PSTR("G1 X125 Z200 F1000")); //move to top center
+#endif //QUICK_NOZZLE_CHANGE
                 lcd_commands_step = 2;
                 break;
             case 2:
-                //|0123456789012456789|
-                //|Hotend at 280C!
-                //|Nozzle changed and
-                //|tightend to specs?
-                //| Yes     No
                 enquecommand_P(PSTR("M84 XY"));
                 lcd_update_enabled = false; //hack to avoid lcd_update recursion.
                 if (lcd_show_multiscreen_message_yes_no_and_wait_P(_T(MSG_NOZZLE_CNG_CHANGED), false) == LCD_LEFT_BUTTON_CHOICE) {
+#ifndef QUICK_NOZZLE_CHANGE
                     setTargetHotend(0);
 #ifdef THERMAL_MODEL
                     thermal_model_set_enabled(was_enabled);
 #endif //THERMAL_MODEL
+#else
+                    fanSpeed = 0; //turn off fan
+#endif //QUICK_NOZZLE_CHANGE
                     lcd_commands_step = 1;
                 }
                 lcd_update_enabled = true;
                 break;
             case 1:
-                lcd_setstatuspgm(MSG_WELCOME);
                 lcd_commands_step = 0;
                 lcd_commands_type = LcdCommands::Idle;
                 SetPrinterState(PrinterState::Idle);
+                menu_goto(lcd_hw_setup_menu, 2, true);
+                menu_depth = 3;
                 break;
             }
         }

--- a/lang/po/Firmware.pot
+++ b/lang/po/Firmware.pot
@@ -1390,6 +1390,16 @@ msgid ""
 " Print cancelled."
 msgstr ""
 
+#. MSG_NOZZLE_CNG_COOLDOWN c=20 r=3
+#: ../../Firmware/messages.cpp:198 ../../Firmware/ultralcd.cpp:1002
+msgid "Nozzle is hot! Wait for cooldown."
+msgstr ""
+
+#. MSG_NOZZLE_CNG_CHANGED_QUICK c=20 r=3
+#: ../../Firmware/messages.cpp:199
+msgid "Nozzle changed?"
+msgstr ""
+
 #. MSG_PROGRESS_OK c=4
 #: ../../Firmware/mmu2_progress_converter.cpp:8
 #: ../../Firmware/mmu2_progress_converter.cpp:34

--- a/lang/po/Firmware_cs.po
+++ b/lang/po/Firmware_cs.po
@@ -2584,6 +2584,16 @@ msgstr "Tisk. znovu"
 msgid "Shutdown host"
 msgstr "Vypnutí hostitele"
 
+#. MSG_NOZZLE_CNG_COOLDOWN c=20 r=3
+#: ../../Firmware/messages.cpp:198 ../../Firmware/ultralcd.cpp:1002
+msgid "Nozzle is hot! Wait for cooldown."
+msgstr "Tryska je horká! Počkejte na vychladnutí."
+
+#. MSG_NOZZLE_CNG_CHANGED_QUICK c=20 r=3
+#: ../../Firmware/messages.cpp:199
+msgid "Nozzle changed?"
+msgstr "Vyměnili jste trysku?"
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Vyjmete stary filament a stisknete tlacitko pro zavedeni noveho."
 

--- a/lang/po/Firmware_de.po
+++ b/lang/po/Firmware_de.po
@@ -2612,6 +2612,16 @@ msgstr "Druck wiederholen"
 msgid "Shutdown host"
 msgstr "Host runterfahren"
 
+#. MSG_NOZZLE_CNG_COOLDOWN c=20 r=3
+#: ../../Firmware/messages.cpp:198 ../../Firmware/ultralcd.cpp:1002
+msgid "Nozzle is hot! Wait for cooldown."
+msgstr "Die Düse ist heiß! Auf Abkühlung warten."
+
+#. MSG_NOZZLE_CNG_CHANGED_QUICK c=20 r=3
+#: ../../Firmware/messages.cpp:199
+msgid "Nozzle changed?"
+msgstr "Düse gewechselt?"
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Entferne das alte Fil. und drücke den Knopf, um das neue zu laden."
 

--- a/lang/po/Firmware_es.po
+++ b/lang/po/Firmware_es.po
@@ -2607,6 +2607,16 @@ msgstr "Volver a imprimir"
 msgid "Shutdown host"
 msgstr "Apagar host"
 
+#. MSG_NOZZLE_CNG_COOLDOWN c=20 r=3
+#: ../../Firmware/messages.cpp:198 ../../Firmware/ultralcd.cpp:1002
+msgid "Nozzle is hot! Wait for cooldown."
+msgstr "La boquilla está caliente! Espere a que se enfríe."
+
+#. MSG_NOZZLE_CNG_CHANGED_QUICK c=20 r=3
+#: ../../Firmware/messages.cpp:199
+msgid "Nozzle changed?"
+msgstr "Cambió la boquilla?"
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr ""
 #~ "Retira el fil. viejo y presiona el dial para comenzar a cargar el nuevo."

--- a/lang/po/Firmware_fr.po
+++ b/lang/po/Firmware_fr.po
@@ -2619,6 +2619,16 @@ msgstr "Ré-imprimer"
 msgid "Shutdown host"
 msgstr "Arrêter l'hôte"
 
+#. MSG_NOZZLE_CNG_COOLDOWN c=20 r=3
+#: ../../Firmware/messages.cpp:198 ../../Firmware/ultralcd.cpp:1002
+msgid "Nozzle is hot! Wait for cooldown."
+msgstr "La buse est chaude! Attendre le refroidissement."
+
+#. MSG_NOZZLE_CNG_CHANGED_QUICK c=20 r=3
+#: ../../Firmware/messages.cpp:199
+msgid "Nozzle changed?"
+msgstr "La buse a été changée?"
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr ""
 #~ "Retirez l'ancien fil. puis appuyez sur le bouton pour charger le nouveau."

--- a/lang/po/Firmware_hr.po
+++ b/lang/po/Firmware_hr.po
@@ -2601,6 +2601,16 @@ msgstr "Ponovno tiskanje"
 msgid "Shutdown host"
 msgstr "Iskljuciti host"
 
+#. MSG_NOZZLE_CNG_COOLDOWN c=20 r=3
+#: ../../Firmware/messages.cpp:198 ../../Firmware/ultralcd.cpp:1002
+msgid "Nozzle is hot! Wait for cooldown."
+msgstr "Mlaznica je vruća! Pričekajte hlađenje."
+
+#. MSG_NOZZLE_CNG_CHANGED_QUICK c=20 r=3
+#: ../../Firmware/messages.cpp:199
+msgid "Nozzle changed?"
+msgstr "Mlaznica se promijenila?"
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Uklonite stari fil. i pritisnite gumb za pocetak stavljanja novog."
 

--- a/lang/po/Firmware_hu.po
+++ b/lang/po/Firmware_hu.po
@@ -2606,6 +2606,16 @@ msgstr "Újranyomtatás"
 msgid "Shutdown host"
 msgstr "Gazdagép leállítás"
 
+#. MSG_NOZZLE_CNG_COOLDOWN c=20 r=3
+#: ../../Firmware/messages.cpp:198 ../../Firmware/ultralcd.cpp:1002
+msgid "Nozzle is hot! Wait for cooldown."
+msgstr "A fúvóka forró! Várja meg a lehűlést."
+
+#. MSG_NOZZLE_CNG_CHANGED_QUICK c=20 r=3
+#: ../../Firmware/messages.cpp:199
+msgid "Nozzle changed?"
+msgstr "Fúvóka cserélve?"
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Vedd ki a regi fil., majd nyomd meg a gombot az uj fil. betoltesehez."
 

--- a/lang/po/Firmware_it.po
+++ b/lang/po/Firmware_it.po
@@ -2607,6 +2607,16 @@ msgstr "Ristampa"
 msgid "Shutdown host"
 msgstr "Spegnere l'host"
 
+#. MSG_NOZZLE_CNG_COOLDOWN c=20 r=3
+#: ../../Firmware/messages.cpp:198 ../../Firmware/ultralcd.cpp:1002
+msgid "Nozzle is hot! Wait for cooldown."
+msgstr "L'ugello è caldo! Attendere il raffreddamento."
+
+#. MSG_NOZZLE_CNG_CHANGED_QUICK c=20 r=3
+#: ../../Firmware/messages.cpp:199
+msgid "Nozzle changed?"
+msgstr "L'ugello è cambiato?"
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Rimuovi il fil. precedente e premi la manopola per caricare il nuovo."
 

--- a/lang/po/Firmware_nl.po
+++ b/lang/po/Firmware_nl.po
@@ -2609,6 +2609,16 @@ msgstr "Herhaal druk"
 msgid "Shutdown host"
 msgstr "Host uitschakelen"
 
+#. MSG_NOZZLE_CNG_COOLDOWN c=20 r=3
+#: ../../Firmware/messages.cpp:198 ../../Firmware/ultralcd.cpp:1002
+msgid "Nozzle is hot! Wait for cooldown."
+msgstr "Mondstuk is heet! Wacht op afkoeling."
+
+#. MSG_NOZZLE_CNG_CHANGED_QUICK c=20 r=3
+#: ../../Firmware/messages.cpp:199
+msgid "Nozzle changed?"
+msgstr "Mondstuk veranderd?"
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr ""
 #~ "Verwijder de oude filament en druk op de knop om nieuwe filament te laden."

--- a/lang/po/Firmware_no.po
+++ b/lang/po/Firmware_no.po
@@ -2583,6 +2583,16 @@ msgstr "Gjenta print"
 msgid "Shutdown host"
 msgstr "Slå av vert"
 
+#. MSG_NOZZLE_CNG_COOLDOWN c=20 r=3
+#: ../../Firmware/messages.cpp:198 ../../Firmware/ultralcd.cpp:1002
+msgid "Nozzle is hot! Wait for cooldown."
+msgstr "Dysen er varm! Vent på nedkjøling."
+
+#. MSG_NOZZLE_CNG_CHANGED_QUICK c=20 r=3
+#: ../../Firmware/messages.cpp:199
+msgid "Nozzle changed?"
+msgstr "Har du byttet dyse?"
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Ta bort det gamle filamentet og trykk valghjulet for å laste et nytt."
 

--- a/lang/po/Firmware_pl.po
+++ b/lang/po/Firmware_pl.po
@@ -2599,6 +2599,16 @@ msgstr "Przedruk"
 msgid "Shutdown host"
 msgstr "Zamknięcie hosta"
 
+#. MSG_NOZZLE_CNG_COOLDOWN c=20 r=3
+#: ../../Firmware/messages.cpp:198 ../../Firmware/ultralcd.cpp:1002
+msgid "Nozzle is hot! Wait for cooldown."
+msgstr "Dysza jest gorąca! Poczekaj na schłodzenie."
+
+#. MSG_NOZZLE_CNG_CHANGED_QUICK c=20 r=3
+#: ../../Firmware/messages.cpp:199
+msgid "Nozzle changed?"
+msgstr "Dysza została zmieniona?"
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Wyciągnij poprzedni filament i naciśnij pokrętło aby załadować nowy."
 

--- a/lang/po/Firmware_ro.po
+++ b/lang/po/Firmware_ro.po
@@ -2608,6 +2608,16 @@ msgstr "Repetă print"
 msgid "Shutdown host"
 msgstr "Oprește gazda"
 
+#. MSG_NOZZLE_CNG_COOLDOWN c=20 r=3
+#: ../../Firmware/messages.cpp:198 ../../Firmware/ultralcd.cpp:1002
+msgid "Nozzle is hot! Wait for cooldown."
+msgstr "Duza este fierbinte! Așteptați să se răcească."
+
+#. MSG_NOZZLE_CNG_CHANGED_QUICK c=20 r=3
+#: ../../Firmware/messages.cpp:199
+msgid "Nozzle changed?"
+msgstr "S-a schimbat duza?"
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Scoateți fil. vechi și apăsați butonul pentru a încărca unul nou."
 

--- a/lang/po/Firmware_sk.po
+++ b/lang/po/Firmware_sk.po
@@ -2589,6 +2589,16 @@ msgstr "Vytlačiť znova"
 msgid "Shutdown host"
 msgstr "Vypnutie hostiteľa"
 
+#. MSG_NOZZLE_CNG_COOLDOWN c=20 r=3
+#: ../../Firmware/messages.cpp:198 ../../Firmware/ultralcd.cpp:1002
+msgid "Nozzle is hot! Wait for cooldown."
+msgstr "Tryska je horúca! Počkajte na vychladnutie."
+
+#. MSG_NOZZLE_CNG_CHANGED_QUICK c=20 r=3
+#: ../../Firmware/messages.cpp:199
+msgid "Nozzle changed?"
+msgstr "Vymenili ste trysku?"
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Vyberte starý filament a stlačte tlačidlo pre zavedenie nového."
 

--- a/lang/po/Firmware_sv.po
+++ b/lang/po/Firmware_sv.po
@@ -2596,6 +2596,16 @@ msgstr "Upprepa trycket"
 msgid "Shutdown host"
 msgstr "Stänga av värd"
 
+#. MSG_NOZZLE_CNG_COOLDOWN c=20 r=3
+#: ../../Firmware/messages.cpp:198 ../../Firmware/ultralcd.cpp:1002
+msgid "Nozzle is hot! Wait for cooldown."
+msgstr "Munstycket är varmt! Vänta på nedkylning."
+
+#. MSG_NOZZLE_CNG_CHANGED_QUICK c=20 r=3
+#: ../../Firmware/messages.cpp:199
+msgid "Nozzle changed?"
+msgstr "Har munstycket ändrats?"
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Ta bort det gamla fil. och tryck på knappen för att börja ladda nytt."
 


### PR DESCRIPTION
Changes the nozzle change procedure for variants that have QUICK_NOZZLE_CHANGE defined.
Resolves https://github.com/prusa3d/Prusa-Firmware/issues/4595

If extruder temp is > 40°C
1) Show warning that extruder is hot.
2) Turn on fan, home, move to top center, wait for extruder to cooldown to 40°C.
3) Show msg that nozzle is ready to be changed, if confirmed turn off fan.
4) Switch to the nozzle diameter selection after nozzle change has been confirmed. (This change affects all variants)

If extruder temp is < 40°C
1) Home and move to top center
2) Show msg that nozzle is ready to be changed
4) Switch to the nozzle diameter selection after nozzle change has been confirmed. (This change affects all variants)