### PR TITLE
Raise `END_FILE_SECTION` from 20000 to 30720

### DIFF
--- a/Firmware/variants/MK25-RAMBo10a.h
+++ b/Firmware/variants/MK25-RAMBo10a.h
@@ -98,7 +98,7 @@
 #define MANUAL_FEEDRATE {2700, 2700, 1000, 100}   // set the speeds for manual moves (mm/min)
 
 //number of bytes from end of the file to start check
-#define END_FILE_SECTION 20000
+#define END_FILE_SECTION 30720
 
 #define Z_AXIS_ALWAYS_ON 1
 

--- a/Firmware/variants/MK25-RAMBo13a.h
+++ b/Firmware/variants/MK25-RAMBo13a.h
@@ -99,7 +99,7 @@
 #define MANUAL_FEEDRATE {2700, 2700, 1000, 100}   // set the speeds for manual moves (mm/min)
 
 //number of bytes from end of the file to start check
-#define END_FILE_SECTION 20000
+#define END_FILE_SECTION 30720
 
 #define Z_AXIS_ALWAYS_ON 1
 

--- a/Firmware/variants/MK25S-RAMBo10a.h
+++ b/Firmware/variants/MK25S-RAMBo10a.h
@@ -98,7 +98,7 @@
 #define MANUAL_FEEDRATE {2700, 2700, 1000, 100}   // set the speeds for manual moves (mm/min)
 
 //number of bytes from end of the file to start check
-#define END_FILE_SECTION 20000
+#define END_FILE_SECTION 30720
 
 #define Z_AXIS_ALWAYS_ON 1
 

--- a/Firmware/variants/MK25S-RAMBo13a.h
+++ b/Firmware/variants/MK25S-RAMBo13a.h
@@ -99,7 +99,7 @@
 #define MANUAL_FEEDRATE {2700, 2700, 1000, 100}   // set the speeds for manual moves (mm/min)
 
 //number of bytes from end of the file to start check
-#define END_FILE_SECTION 20000
+#define END_FILE_SECTION 30720
 
 #define Z_AXIS_ALWAYS_ON 1
 

--- a/Firmware/variants/MK3-E3DREVO.h
+++ b/Firmware/variants/MK3-E3DREVO.h
@@ -109,7 +109,7 @@
 #define NORMAL_MAX_FEEDRATE_XY   200  // max feedrate in mm/s
 
 //number of bytes from end of the file to start check
-#define END_FILE_SECTION 20000
+#define END_FILE_SECTION 30720
 
 #define Z_AXIS_ALWAYS_ON 1
 

--- a/Firmware/variants/MK3-E3DREVO_HF_60W.h
+++ b/Firmware/variants/MK3-E3DREVO_HF_60W.h
@@ -109,7 +109,7 @@
 #define NORMAL_MAX_FEEDRATE_XY   200  // max feedrate in mm/s
 
 //number of bytes from end of the file to start check
-#define END_FILE_SECTION 20000
+#define END_FILE_SECTION 30720
 
 #define Z_AXIS_ALWAYS_ON 1
 

--- a/Firmware/variants/MK3.h
+++ b/Firmware/variants/MK3.h
@@ -109,7 +109,7 @@
 #define NORMAL_MAX_FEEDRATE_XY   200  // max feedrate in mm/s
 
 //number of bytes from end of the file to start check
-#define END_FILE_SECTION 20000
+#define END_FILE_SECTION 30720
 
 #define Z_AXIS_ALWAYS_ON 1
 

--- a/Firmware/variants/MK3S-E3DREVO.h
+++ b/Firmware/variants/MK3S-E3DREVO.h
@@ -111,7 +111,7 @@
 #define NORMAL_MAX_FEEDRATE_XY   200  // max feedrate in mm/s
 
 //number of bytes from end of the file to start check
-#define END_FILE_SECTION 20000
+#define END_FILE_SECTION 30720
 
 #define Z_AXIS_ALWAYS_ON 1
 

--- a/Firmware/variants/MK3S-E3DREVO_HF_60W.h
+++ b/Firmware/variants/MK3S-E3DREVO_HF_60W.h
@@ -111,7 +111,7 @@
 #define NORMAL_MAX_FEEDRATE_XY   200  // max feedrate in mm/s
 
 //number of bytes from end of the file to start check
-#define END_FILE_SECTION 20000
+#define END_FILE_SECTION 30720
 
 #define Z_AXIS_ALWAYS_ON 1
 

--- a/Firmware/variants/MK3S.h
+++ b/Firmware/variants/MK3S.h
@@ -111,7 +111,7 @@
 #define NORMAL_MAX_FEEDRATE_XY   200  // max feedrate in mm/s
 
 //number of bytes from end of the file to start check
-#define END_FILE_SECTION 20000
+#define END_FILE_SECTION 30720
 
 #define Z_AXIS_ALWAYS_ON 1
 

--- a/Firmware/variants/obsolete/1_75mm_MK2-RAMBo10a-E3Dv6full.h
+++ b/Firmware/variants/obsolete/1_75mm_MK2-RAMBo10a-E3Dv6full.h
@@ -389,7 +389,7 @@ THERMISTORS SETTINGS
 
 #define DEFAULT_PID_TEMP 210
 
-#define END_FILE_SECTION 20000 //number of bytes from end of file used for checking if file is complete
+#define END_FILE_SECTION 30720 //number of bytes from end of file used for checking if file is complete
 
 // Safety timer
 #define SAFETYTIMER

--- a/Firmware/variants/obsolete/1_75mm_MK2-RAMBo13a-E3Dv6full.h
+++ b/Firmware/variants/obsolete/1_75mm_MK2-RAMBo13a-E3Dv6full.h
@@ -388,7 +388,7 @@ THERMISTORS SETTINGS
 
 #define DEFAULT_PID_TEMP 210
 
-#define END_FILE_SECTION 20000 //number of bytes from end of file used for checking if file is complete
+#define END_FILE_SECTION 30720 //number of bytes from end of file used for checking if file is complete
 
 // Safety timer
 #define SAFETYTIMER


### PR DESCRIPTION
 to prevent false positive `File incomplete. Continue Anyway?` messages.

This is a cherry-pick of #4507 and has been approved and tested.