### PR TITLE
CI: Add sudo apt-get update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ jobs:
     # setup base required dependencies
     - name: Setup dependencies
       run: |
+          sudo apt-get update
           sudo apt-get install cmake ninja-build python3-pyelftools python3-regex python3-polib
 
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -72,6 +73,7 @@ jobs:
     # setup base required dependencies
     - name: Setup dependencies
       run: |
+          sudo apt-get update
           sudo apt-get install gcc-11 g++11 lcov cmake ninja-build python3-pyelftools python3-regex python3-polib
 
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -119,6 +121,7 @@ jobs:
     # setup base required dependencies
     - name: Setup dependencies
       run: |
+          sudo apt-get update
           sudo apt-get install gcc-11 g++11 lcov cmake ninja-build python3-pyelftools python3-regex python3-polib
 
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -18,6 +18,7 @@ jobs:
     # setup base required dependencies
     - name: Setup dependencies
       run: |
+          sudo apt-get update
           sudo apt-get install cmake ninja-build python3-pyelftools python3-regex python3-polib
 
     # build the base branch


### PR DESCRIPTION
See: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/customizing-github-hosted-runners#installing-software-on-ubuntu-runners

> Note: Always run `sudo apt-get update` before installing a package. In case the `apt` index is stale, this command fetches and re-indexes any available packages, which helps prevent package installation failures.

Omitting this line was causing jobs to fail in another PR of mine: https://github.com/prusa3d/Prusa-Firmware/pull/4613