### PR TITLE
Update stale action to v9 as Node.js 16 are deprecated.

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/stale@v8
+    - uses: actions/stale@v9
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         # Don't ever mark PRs as stale.


### PR DESCRIPTION
See https://github.com/actions/stale/releases/tag/v9.0.0