### PR TITLE
Power Panic and LCD menu

### DIFF
--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -313,6 +313,11 @@ extern LongTimer safetyTimer;
 // the print is paused, that still counts as a "running" print.
 bool printJobOngoing();
 
+// Make debug_printer_states available everywhere
+#ifdef DEBUG_PRINTER_STATES
+void debug_printer_states();
+#endif //DEBUG_PRINTER_STATES
+
 // Printing is paused according to SD or host indicators
 bool printingIsPaused();
 

--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -318,6 +318,8 @@ bool printingIsPaused();
 
 bool printer_active();
 
+bool printer_recovering();
+
 //! Beware - mcode_in_progress is set as soon as the command gets really processed,
 //! which is not the same as posting the M600 command into the command queue
 //! There can be a considerable lag between posting M600 and its real processing which might result

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -312,7 +312,7 @@ static bool chdkActive = false;
 //! @{
 bool saved_printing = false; //!< Print is paused and saved in RAM
 uint32_t saved_sdpos = 0; //!< SD card position, or line number in case of USB printing
-uint8_t saved_printing_type = PowerPanic::PRINT_TYPE_SD;
+uint8_t saved_printing_type = PowerPanic::PRINT_TYPE_NONE;
 float saved_pos[NUM_AXIS] = { X_COORD_INVALID, 0, 0, 0 };
 uint16_t saved_feedrate2 = 0; //!< Default feedrate (truncated from float)
 static int saved_feedmultiply2 = 0;

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -4171,62 +4171,52 @@ void process_commands()
         if (farm_prusa_code_seen()) {}
         else if(code_seen_P(PSTR("FANPINTST"))) {
             gcode_PRUSA_BadRAMBoFanTest();
-        }
-        else if (code_seen_P(PSTR("FAN"))) { // PRUSA FAN
+        } else if (code_seen_P(PSTR("FAN"))) { // PRUSA FAN
             printf_P(_N("E0:%d RPM\nPRN0:%d RPM\n"), 60*fan_speed[0], 60*fan_speed[1]);
-        }
-        else if (code_seen_P(PSTR("uvlo"))) // PRUSA uvlo
-        {
-            if (eeprom_read_byte((uint8_t*)EEPROM_UVLO_PRINT_TYPE) == PowerPanic::PRINT_TYPE_SD)
-            {
+        } else if (code_seen_P(PSTR("uvlo"))) { // PRUSA uvlo
+            if (eeprom_read_byte((uint8_t*)EEPROM_UVLO_PRINT_TYPE) == PowerPanic::PRINT_TYPE_SD) {
                 // M24 - Start SD print
                 enquecommand_P(MSG_M24);
 
                 // Print is recovered, clear the recovery flag
                 eeprom_update_byte_notify((uint8_t*)EEPROM_UVLO, PowerPanic::NO_PENDING_RECOVERY);
-            }
-            else if (eeprom_read_byte((uint8_t*)EEPROM_UVLO_PRINT_TYPE) == PowerPanic::PRINT_TYPE_HOST)
-            {
+            } else if (eeprom_read_byte((uint8_t*)EEPROM_UVLO_PRINT_TYPE) == PowerPanic::PRINT_TYPE_HOST) {
                 // For Host prints we need to start the timer so that the pause has any effect
                 // this will allow g-codes to be processed while in the paused state
                 // For SD prints, M24 starts the timer
                 print_job_timer.start();
+                usb_timer.start();
 
                 // Park the extruder to the side and don't resume the print
                 // we must assume that the host as not fully booted up at this point
                 lcd_pause_print();
             }
-        }
-		else if (code_seen_P(PSTR("MMURES"))) // PRUSA MMURES
-		{
-			MMU2::mmu2.Reset(MMU2::MMU2::Software);
-		}
-		else if (code_seen_P(PSTR("RESET"))) { // PRUSA RESET
+        } else if (code_seen_P(PSTR("MMURES"))) { // PRUSA MMURES
+            MMU2::mmu2.Reset(MMU2::MMU2::Software);
+        } else if (code_seen_P(PSTR("RESET"))) { // PRUSA RESET
 #if defined(XFLASH) && defined(BOOTAPP)
             boot_app_magic = 0;
 #endif //defined(XFLASH) && defined(BOOTAPP)
             softReset();
-    }
-    else if (code_seen_P(PSTR("SN"))) { // PRUSA SN
-        char SN[20];
-        eeprom_read_block(SN, (uint8_t*)EEPROM_PRUSA_SN, 20);
-        if (SN[19])
-            puts_P(PSTR("SN invalid"));
-        else
-            puts(SN);
-    }
-    else if(code_seen_P(PSTR("Fir"))){ // PRUSA Fir
+        } else if (code_seen_P(PSTR("SN"))) { // PRUSA SN
+            char SN[20];
+            eeprom_read_block(SN, (uint8_t*)EEPROM_PRUSA_SN, 20);
+            if (SN[19])
+                puts_P(PSTR("SN invalid"));
+            else
+                puts(SN);
+        } else if(code_seen_P(PSTR("Fir"))){ // PRUSA Fir
 
-      SERIAL_PROTOCOLLNPGM(FW_VERSION_FULL);
+            SERIAL_PROTOCOLLNPGM(FW_VERSION_FULL);
 
     } else if(code_seen_P(PSTR("Rev"))){ // PRUSA Rev
 
       SERIAL_PROTOCOLLNPGM(FILAMENT_SIZE "-" ELECTRONICS "-" NOZZLE_TYPE );
 
     } else if(code_seen_P(PSTR("Lang"))) { // PRUSA Lang
-	  lang_reset();
+        lang_reset();
 
-	} else if(code_seen_P(PSTR("Lz"))) { // PRUSA Lz
+    } else if(code_seen_P(PSTR("Lz"))) { // PRUSA Lz
       eeprom_update_word_notify(reinterpret_cast<uint16_t *>(&(EEPROM_Sheets_base->s[(eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet)))].z_offset)),0);
 
     } else if(code_seen_P(PSTR("FR"))) { // PRUSA FR
@@ -4244,21 +4234,17 @@ void process_commands()
             }
         }
     } else if (code_seen_P(PSTR("nozzle"))) { // PRUSA nozzle
-          uint16_t nDiameter;
-          if(code_seen('D'))
-               {
-               nDiameter=(uint16_t)(code_value()*1000.0+0.5); // [,um]
-               nozzle_diameter_check(nDiameter);
-               }
-          else if(code_seen_P(PSTR("set")) && farm_mode)
-               {
-               strchr_pointer++;                  // skip 1st char (~ 's')
-               strchr_pointer++;                  // skip 2nd char (~ 'e')
-               nDiameter=(uint16_t)(code_value()*1000.0+0.5); // [,um]
-               eeprom_update_byte_notify((uint8_t*)EEPROM_NOZZLE_DIAMETER,(uint8_t)ClNozzleDiameter::_Diameter_Undef); // for correct synchronization after farm-mode exiting
-               eeprom_update_word_notify((uint16_t*)EEPROM_NOZZLE_DIAMETER_uM,nDiameter);
-               }
-          else SERIAL_PROTOCOLLN((float)eeprom_read_word((uint16_t*)EEPROM_NOZZLE_DIAMETER_uM)/1000.0);
+            uint16_t nDiameter;
+            if(code_seen('D')) {
+                nDiameter=(uint16_t)(code_value()*1000.0+0.5); // [,um]
+                nozzle_diameter_check(nDiameter);
+            } else if(code_seen_P(PSTR("set")) && farm_mode) {
+                strchr_pointer++;                  // skip 1st char (~ 's')
+                strchr_pointer++;                  // skip 2nd char (~ 'e')
+                nDiameter=(uint16_t)(code_value()*1000.0+0.5); // [,um]
+                eeprom_update_byte_notify((uint8_t*)EEPROM_NOZZLE_DIAMETER,(uint8_t)ClNozzleDiameter::_Diameter_Undef); // for correct synchronization after farm-mode exiting
+                eeprom_update_word_notify((uint16_t*)EEPROM_NOZZLE_DIAMETER_uM,nDiameter);
+            } else SERIAL_PROTOCOLLN((float)eeprom_read_word((uint16_t*)EEPROM_NOZZLE_DIAMETER_uM)/1000.0);
     }
   }
   else if(*CMDBUFFER_CURRENT_STRING == 'G')

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1658,7 +1658,7 @@ void setup()
               if ( btn == LCD_LEFT_BUTTON_CHOICE) {
                   recover_print(0);
             } else { // LCD_MIDDLE_BUTTON_CHOICE
-                  eeprom_update_byte_notify((uint8_t*)EEPROM_UVLO, PowerPanic::NO_PENDING_RECOVERY);
+                  cancel_saved_printing();
             }
           }
       }

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -4182,7 +4182,8 @@ void process_commands()
                 enquecommand_P(MSG_M24);
 
                 // Print is recovered, clear the recovery flag
-                reset_uvlo();
+                eeprom_update_byte_notify((uint8_t*)EEPROM_UVLO, PowerPanic::NO_PENDING_RECOVERY);
+                eeprom_update_byte_notify((uint8_t*)EEPROM_UVLO_Z_LIFTED, 0);
             } else if (eeprom_read_byte((uint8_t*)EEPROM_UVLO_PRINT_TYPE) == PowerPanic::PRINT_TYPE_HOST) {
                 // For Host prints we need to start the timer so that the pause has any effect
                 // this will allow g-codes to be processed while in the paused state
@@ -11070,7 +11071,8 @@ void restore_print_from_ram_and_continue(float e_move)
 	set_destination_to_current();
 
     restore_print_file_state();
-    reset_uvlo();
+    eeprom_update_byte_notify((uint8_t*)EEPROM_UVLO, PowerPanic::NO_PENDING_RECOVERY);
+    eeprom_update_byte_notify((uint8_t*)EEPROM_UVLO_Z_LIFTED, 0);
 	lcd_setstatuspgm(MSG_WELCOME);
     saved_printing_type = PowerPanic::PRINT_TYPE_NONE;
 	saved_printing = false;
@@ -11080,7 +11082,8 @@ void restore_print_from_ram_and_continue(float e_move)
 // Cancel the state related to a currently saved print
 void cancel_saved_printing()
 {
-    reset_uvlo();
+    eeprom_update_byte_notify((uint8_t*)EEPROM_UVLO, PowerPanic::NO_PENDING_RECOVERY);
+    eeprom_update_byte_notify((uint8_t*)EEPROM_UVLO_Z_LIFTED, 0);
     saved_start_position[0] = SAVED_START_POSITION_UNSET;
     saved_printing_type = PowerPanic::PRINT_TYPE_NONE;
     saved_printing = false;

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1516,6 +1516,7 @@ void setup()
 		eeprom_update_byte_notify((uint8_t*)EEPROM_TEMP_CAL_ACTIVE, 0);
 	}
 	eeprom_init_default_byte((uint8_t*)EEPROM_UVLO, PowerPanic::NO_PENDING_RECOVERY);
+	eeprom_init_default_byte((uint8_t*)EEPROM_UVLO_Z_LIFTED, 0);
 	eeprom_init_default_byte((uint8_t*)EEPROM_SD_SORT, 0);
 
 	//mbl_mode_init();
@@ -4181,7 +4182,7 @@ void process_commands()
                 enquecommand_P(MSG_M24);
 
                 // Print is recovered, clear the recovery flag
-                eeprom_update_byte_notify((uint8_t*)EEPROM_UVLO, PowerPanic::NO_PENDING_RECOVERY);
+                reset_uvlo();
             } else if (eeprom_read_byte((uint8_t*)EEPROM_UVLO_PRINT_TYPE) == PowerPanic::PRINT_TYPE_HOST) {
                 // For Host prints we need to start the timer so that the pause has any effect
                 // this will allow g-codes to be processed while in the paused state
@@ -11069,7 +11070,7 @@ void restore_print_from_ram_and_continue(float e_move)
 	set_destination_to_current();
 
     restore_print_file_state();
-    eeprom_update_byte((uint8_t*)EEPROM_UVLO, PowerPanic::NO_PENDING_RECOVERY);
+    reset_uvlo();
 	lcd_setstatuspgm(MSG_WELCOME);
     saved_printing_type = PowerPanic::PRINT_TYPE_NONE;
 	saved_printing = false;
@@ -11079,7 +11080,7 @@ void restore_print_from_ram_and_continue(float e_move)
 // Cancel the state related to a currently saved print
 void cancel_saved_printing()
 {
-    eeprom_update_byte_notify((uint8_t*)EEPROM_UVLO, PowerPanic::NO_PENDING_RECOVERY);
+    reset_uvlo();
     saved_start_position[0] = SAVED_START_POSITION_UNSET;
     saved_printing_type = PowerPanic::PRINT_TYPE_NONE;
     saved_printing = false;

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1651,7 +1651,7 @@ void setup()
           #ifdef DEBUG_UVLO_AUTOMATIC_RECOVER 
         puts_P(_N("Normal recovery!")); 
           #endif
-          if (eeprom_read_byte((uint8_t*)EEPROM_UVLO) == PowerPanic::PRINT_TYPE_HOST) {
+          if (eeprom_read_byte((uint8_t*)EEPROM_UVLO_PRINT_TYPE) == PowerPanic::PRINT_TYPE_HOST) {
             recover_print(0);
           } else {
               const uint8_t btn = lcd_show_fullscreen_message_yes_no_and_wait_P(_T(MSG_RECOVER_PRINT), false);

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1642,13 +1642,17 @@ void setup()
       saved_printing_type = eeprom_read_byte((uint8_t*)EEPROM_UVLO_PRINT_TYPE);
 #ifdef DEBUG_UVLO_AUTOMATIC_RECOVER
       printf_P(_N("Power panic detected!\nCurrent bed temp:%d\nSaved bed temp:%d\n"), (int)degBed(), eeprom_read_byte((uint8_t*)EEPROM_UVLO_TARGET_BED));
+#endif //DEBUG_UVLO_AUTOMATIC_RECOVER
       uvlo_auto_recovery_ready = (degBed() > ( (float)eeprom_read_byte((uint8_t*)EEPROM_UVLO_TARGET_BED) - AUTOMATIC_UVLO_BED_TEMP_OFFSET));
       if (uvlo_auto_recovery_ready){
+#ifdef DEBUG_UVLO_AUTOMATIC_RECOVER
         puts_P(_N("Automatic recovery!")); 
+#endif //DEBUG_UVLO_AUTOMATIC_RECOVER
         recover_print(1);
       } else {
-#endif //DEBUG_UVLO_AUTOMATIC_RECOVER
+#ifdef DEBUG_UVLO_AUTOMATIC_RECOVER
         puts_P(_N("Normal recovery!")); 
+#endif //DEBUG_UVLO_AUTOMATIC_RECOVER
         if (saved_printing_type == PowerPanic::PRINT_TYPE_HOST) {
           recover_print(0);
         } else {
@@ -1659,9 +1663,7 @@ void setup()
             cancel_saved_printing();
           }
         }
-#ifdef DEBUG_UVLO_AUTOMATIC_RECOVER
       }
-#endif //DEBUG_UVLO_AUTOMATIC_RECOVER
   }
 
   // Only arm the uvlo interrupt _after_ a recovering print has been initialized and

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -527,6 +527,56 @@ bool __attribute__((noinline)) printer_active() {
         || (eeprom_read_byte((uint8_t*)EEPROM_UVLO) != PowerPanic::NO_PENDING_RECOVERY);
 }
 
+#ifdef DEBUG_PRINTER_STATES
+//! @brief debug printer states
+//!
+//! This outputs a lot over serial and should be only used
+//! - when debugging LCD menus
+//! - or other functions related to these states
+//! To reduce the output feel free to comment out the lines you
+//! aren't troubleshooting.
+
+void debug_printer_states()
+{
+    printf_P(PSTR("DBG:printJobOngoing() = %d\n"), (int)printJobOngoing());
+    printf_P(PSTR("DBG:IS_SD_PRINTING = %d\n"), (int)IS_SD_PRINTING);
+    printf_P(PSTR("DBG:printer_recovering() = %d\n"), (int)printer_recovering());
+    printf_P(PSTR("DBG:heating_status = %d\n"), (int)heating_status);
+    printf_P(PSTR("DBG:GetPrinterState() = %d\n"), (int)GetPrinterState());
+    printf_P(PSTR("DBG:babystep_allowed_strict() = %d\n"), (int)babystep_allowed_strict());
+    printf_P(PSTR("DBG:lcd_commands_type = %d\n"), (int)lcd_commands_type);
+    printf_P(PSTR("DBG:farm_mode = %d\n"), (int)farm_mode);
+    printf_P(PSTR("DBG:moves_planned() = %d\n"), (int)moves_planned());
+    printf_P(PSTR("DBG:Stopped = %d\n"), (int)Stopped);
+    printf_P(PSTR("DBG:usb_timer.running() = %d\n"), (int)usb_timer.running());
+    printf_P(PSTR("DBG:M79_timer_get_status() = %d\n"), (int)M79_timer_get_status());
+    printf_P(PSTR("DBG:print_job_timer.isRunning() = %d\n"), (int)print_job_timer.isRunning());
+    printf_P(PSTR("DBG:printingIsPaused() = %d\n"), (int)printingIsPaused());
+    printf_P(PSTR("DBG:did_pause_print = %d\n"), (int)did_pause_print);
+    printf_P(PSTR("DBG:print_job_timer.isPaused() = %d\n"), (int)print_job_timer.isPaused());
+    printf_P(PSTR("DBG:saved_printing = %d\n"), (int)saved_printing);
+    printf_P(PSTR("DBG:saved_printing_type = %d\n"), (int)saved_printing_type);
+    printf_P(PSTR("DBG:homing_flag = %d\n"), (int)homing_flag);
+    printf_P(PSTR("DBG:mesh_bed_leveling_flag = %d\n"), (int)mesh_bed_leveling_flag);
+    printf_P(PSTR("DBG:get_temp_error() = %d\n"), (int)get_temp_error());
+    printf_P(PSTR("DBG:card.mounted = %d\n"), (int)card.mounted);
+    printf_P(PSTR("DBG:card.isFileOpen() = %d\n"), (int)card.isFileOpen());
+    printf_P(PSTR("DBG:fan_check_error = %d\n"), (int)fan_check_error);
+    printf_P(PSTR("DBG:processing_tcode = %d\n"), (int)processing_tcode);
+    printf_P(PSTR("DBG:nextSheet = %d\n"), (int)eeprom_next_initialized_sheet(eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet))));
+    printf_P(PSTR("DBG:eFilamentAction = %d\n"), (int)eFilamentAction);
+    printf_P(PSTR("DBG:MMU2::mmu2.Enabled() = %d\n"), (int)MMU2::mmu2.Enabled());
+    printf_P(PSTR("DBG:MMU2::mmu2.MMU_PRINT_SAVED() = %d\n"), (int)MMU2::mmu2.MMU_PRINT_SAVED());
+    printf_P(PSTR("DBG:MMU2::mmu2.FindaDetectsFilament() = %d\n"), (int)MMU2::mmu2.FindaDetectsFilament());
+    printf_P(PSTR("DBG:fsensor.getFilamentPresent() = %d\n"), (int)fsensor.getFilamentPresent());
+    printf_P(PSTR("DBG:MMU CUTTER ENABLED = %d\n"), (int)eeprom_read_byte((uint8_t*)EEPROM_MMU_CUTTER_ENABLED));
+    printf_P(PSTR("DBG:fsensor.isEnabled() = %d\n"), (int)fsensor.isEnabled());
+    printf_P(PSTR("DBG:fsensor.getAutoLoadEnabled() = %d\n"), (int)fsensor.getAutoLoadEnabled());
+    printf_P(PSTR("DBG:custom_message_type = %d\n"), (int)custom_message_type);
+    SERIAL_ECHOLN("");
+}
+#endif //End DEBUG_PRINTER_STATES
+
 // Currently only used in one place, allowed to be inlined
 bool check_fsensor() {
     return printJobOngoing()

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -572,6 +572,7 @@ void debug_printer_states()
     printf_P(PSTR("DBG:fsensor.isEnabled() = %d\n"), (int)fsensor.isEnabled());
     printf_P(PSTR("DBG:fsensor.getAutoLoadEnabled() = %d\n"), (int)fsensor.getAutoLoadEnabled());
     printf_P(PSTR("DBG:custom_message_type = %d\n"), (int)custom_message_type);
+    printf_P(PSTR("DBG:uvlo_auto_recovery_ready = %d\n"), (int)uvlo_auto_recovery_ready);
     SERIAL_ECHOLN("");
 }
 #endif //End DEBUG_PRINTER_STATES
@@ -6053,6 +6054,9 @@ Sigma_Exit:
                 SetHostStatusScreenName(str.GetUnquotedString());
             }
         }
+#ifdef DEBUG_PRINTER_STATES
+        debug_printer_states();
+#endif //DEBUG_PRINTER_STATES
 
         if (eeprom_read_byte((uint8_t*)EEPROM_UVLO_PRINT_TYPE) == PowerPanic::PRINT_TYPE_HOST
            && printer_recovering()

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -11067,7 +11067,7 @@ void restore_print_from_ram_and_continue(float e_move)
 	set_destination_to_current();
 
     restore_print_file_state();
-
+    eeprom_update_byte((uint8_t*)EEPROM_UVLO, PowerPanic::NO_PENDING_RECOVERY);
 	lcd_setstatuspgm(MSG_WELCOME);
     saved_printing_type = PowerPanic::PRINT_TYPE_NONE;
 	saved_printing = false;

--- a/Firmware/eeprom.h
+++ b/Firmware/eeprom.h
@@ -83,7 +83,7 @@ static_assert(sizeof(Sheets) == EEPROM_SHEETS_SIZEOF, "Sizeof(Sheets) is not EEP
 
   To convert hex to dec         https://www.rapidtables.com/convert/number/hex-to-decimal.html
 
-  Version: 1.0.2
+  Version: 3.14.0
 
   ---------------------------------------------------------------------------------
 
@@ -382,6 +382,8 @@ static_assert(sizeof(Sheets) == EEPROM_SHEETS_SIZEOF, "Sizeof(Sheets) is not EEP
 | 0x0C94 3220 | uint8   | EEPROM_KILL_PENDING_FLAG              | 42h, ffh     | ffh                   | Kill pending flag (0x42 magic value)              | kill()       | D3 Ax0c94 C1
 | 0x0C91 3217 | char[3] | EEPROM_FILENAME_EXTENSION             | ???          | ffffffffh             | DOS 8.3 filename extension                        | Power Panic  | D3 Ax0c91 C1
 | 0x0C80 3200 | char[17]| EEPROM_CUSTOM_MENDEL_NAME             | Prusa i3 MK3S| ffffffffffffffffff... | Custom Printer Name                               |              | D3 Ax0c80 C17
+| 0x0C7F 3199 | bool    | EEPROM_UVLO_Z_LIFTED                  | 00h 0        | 00h                   | Power Panic Z axis NOT lifted                     | Power Panic  | D3 Ax0c7f C1
+| ^           | ^       | ^                                     | 01h 1        | 01h                   | Power Panic Z axis lifted                         | ^            | ^
 
 |Address begin|Bit/Type | Name                                  | Valid values | Default/FactoryReset  | Description                                       |Gcode/Function| Debug code
 | :--:        | :--:    | :--:                                  | :--:         | :--:                  | :--:                                              | :--:         | :--:
@@ -621,9 +623,10 @@ static Sheets * const EEPROM_Sheets_base = (Sheets*)(EEPROM_SHEETS_BASE);
 #define EEPROM_KILL_PENDING_FLAG (EEPROM_KILL_MESSAGE-1) //uint8
 #define EEPROM_FILENAME_EXTENSION (EEPROM_KILL_PENDING_FLAG - 3) // 3 x char
 #define EEPROM_CUSTOM_MENDEL_NAME (EEPROM_FILENAME_EXTENSION-17) //char[17]
+#define EEPROM_UVLO_Z_LIFTED (EEPROM_CUSTOM_MENDEL_NAME-1) //bool
 
 //This is supposed to point to last item to allow EEPROM overrun check. Please update when adding new items.
-#define EEPROM_LAST_ITEM EEPROM_FILENAME_EXTENSION
+#define EEPROM_LAST_ITEM EEPROM_UVLO_Z_LIFTED
 // !!!!!
 // !!!!! this is end of EEPROM section ... all updates MUST BE inserted before this mark !!!!!
 // !!!!!

--- a/Firmware/power_panic.cpp
+++ b/Firmware/power_panic.cpp
@@ -315,8 +315,13 @@ void recover_print(uint8_t automatic) {
     // Recover position, temperatures and extrude_multipliers
     bool mbl_was_active = recover_machine_state_after_power_panic();
 
-    // Lift the print head 20mm, first to avoid collisions with oozed material with the print,
-    // and second also so one may remove the excess priming material.
+    // Undo PP Z Lift by setting current Z pos to + Z_PAUSE_LIFT
+    // After a reboot the printer doesn't know the Z height and we have to set its previous value
+    if(eeprom_read_byte((uint8_t*)EEPROM_UVLO) == PowerPanic::PENDING_RECOVERY_RETRY) {
+        current_position[Z_AXIS] += Z_PAUSE_LIFT;
+    }
+
+    // Lift the print head ONCE plus Z_PAUSE_LIFT first to avoid collisions with oozed material with the print,
     if(eeprom_read_byte((uint8_t*)EEPROM_UVLO) == PowerPanic::PENDING_RECOVERY)
     {
         enquecommandf_P(PSTR("G1 Z%.3f F800"), current_position[Z_AXIS] + Z_PAUSE_LIFT);

--- a/Firmware/power_panic.cpp
+++ b/Firmware/power_panic.cpp
@@ -315,11 +315,12 @@ void recover_print(uint8_t automatic) {
     // Recover position, temperatures and extrude_multipliers
     bool mbl_was_active = recover_machine_state_after_power_panic();
 
-    // Lift the print head 25mm, first to avoid collisions with oozed material with the print,
+    // Lift the print head 20mm, first to avoid collisions with oozed material with the print,
     // and second also so one may remove the excess priming material.
     if(eeprom_read_byte((uint8_t*)EEPROM_UVLO) == PowerPanic::PENDING_RECOVERY)
     {
-        enquecommandf_P(PSTR("G1 Z%.3f F800"), current_position[Z_AXIS] + 25);
+        enquecommandf_P(PSTR("G1 Z%.3f F800"), current_position[Z_AXIS] + Z_PAUSE_LIFT);
+        eeprom_update_byte((uint8_t*)EEPROM_UVLO, PowerPanic::PENDING_RECOVERY_RETRY);
     }
 
     // Home X and Y axes. Homing just X and Y shall not touch the babystep and the world2machine

--- a/Firmware/power_panic.cpp
+++ b/Firmware/power_panic.cpp
@@ -286,7 +286,7 @@ void setup_uvlo_interrupt() {
     EIMSK |= (1 << 4);
 
     // check if power was lost before we armed the interrupt
-    if(!(PINE & (1 << 4)) && eeprom_read_byte((uint8_t*)EEPROM_UVLO) != PowerPanic::NO_PENDING_RECOVERY)
+    if(!(PINE & (1 << 4)) && printer_recovering())
     {
         SERIAL_ECHOLNRPGM(MSG_INT4);
         uvlo_drain_reset();

--- a/Firmware/power_panic.cpp
+++ b/Firmware/power_panic.cpp
@@ -427,7 +427,7 @@ void restore_print_from_eeprom(bool mbl_was_active) {
     SERIAL_ECHOPGM(", feedmultiply:");
     MYSERIAL.println(feedmultiply_rec);
 
-    if (eeprom_read_byte((uint8_t*)EEPROM_UVLO_PRINT_TYPE) == PowerPanic::PRINT_TYPE_SD)
+    if (saved_printing_type == PowerPanic::PRINT_TYPE_SD)
     { // M23
         restore_file_from_sd();
     }
@@ -469,12 +469,12 @@ void restore_print_from_eeprom(bool mbl_was_active) {
 
     // SD: Position in file, USB: g-code line number
     uint32_t position = eeprom_read_dword((uint32_t*)(EEPROM_FILE_POSITION));
-    if (eeprom_read_byte((uint8_t*)EEPROM_UVLO_PRINT_TYPE) == PowerPanic::PRINT_TYPE_SD)
+    if (saved_printing_type == PowerPanic::PRINT_TYPE_SD)
     {
         // Set a position in the file.
         enquecommandf_P(PSTR("M26 S%lu"), position);
     }
-    else if (eeprom_read_byte((uint8_t*)EEPROM_UVLO_PRINT_TYPE) == PowerPanic::PRINT_TYPE_HOST)
+    else if (saved_printing_type == PowerPanic::PRINT_TYPE_HOST)
     {
         // Set line number
         enquecommandf_P(PSTR("M110 N%lu"), position);

--- a/Firmware/power_panic.cpp
+++ b/Firmware/power_panic.cpp
@@ -320,7 +320,7 @@ void recover_print(uint8_t automatic) {
     if(eeprom_read_byte((uint8_t*)EEPROM_UVLO) == PowerPanic::PENDING_RECOVERY)
     {
         enquecommandf_P(PSTR("G1 Z%.3f F800"), current_position[Z_AXIS] + Z_PAUSE_LIFT);
-        eeprom_update_byte((uint8_t*)EEPROM_UVLO, PowerPanic::PENDING_RECOVERY_RETRY);
+        eeprom_update_byte_notify((uint8_t*)EEPROM_UVLO, PowerPanic::PENDING_RECOVERY_RETRY);
     }
 
     // Home X and Y axes. Homing just X and Y shall not touch the babystep and the world2machine

--- a/Firmware/power_panic.cpp
+++ b/Firmware/power_panic.cpp
@@ -495,8 +495,4 @@ void restore_print_from_eeprom(bool mbl_was_active) {
     enquecommand_P(PSTR("PRUSA uvlo"));
 }
 
-void reset_uvlo() {
-    eeprom_update_byte_notify((uint8_t*)EEPROM_UVLO, PowerPanic::NO_PENDING_RECOVERY);
-    eeprom_update_byte_notify((uint8_t*)EEPROM_UVLO_Z_LIFTED, 0);
-}
 #endif //UVLO_SUPPORT

--- a/Firmware/power_panic.cpp
+++ b/Firmware/power_panic.cpp
@@ -41,7 +41,7 @@ void uvlo_() {
     unsigned long time_start = _millis();
 
     // True if a print is already saved to RAM
-    const bool sd_print_saved_in_ram = saved_printing && (saved_printing_type == PowerPanic::PRINT_TYPE_SD);
+    const bool print_saved_in_ram = saved_printing && (saved_printing_type == PowerPanic::PRINT_TYPE_SD);
     const bool pos_invalid = mesh_bed_leveling_flag || homing_flag;
 
     // Conserve as much power as soon as possible
@@ -66,7 +66,7 @@ void uvlo_() {
     tmc2130_setup_chopper(E_AXIS, tmc2130_mres[E_AXIS]);
 #endif //TMC2130
 
-    if (!sd_print_saved_in_ram && !isPartialBackupAvailable)
+    if (!print_saved_in_ram && !isPartialBackupAvailable)
     {
         saved_bed_temperature = target_temperature_bed;
         saved_extruder_temperature = target_temperature[active_extruder];
@@ -78,7 +78,7 @@ void uvlo_() {
     disable_heater();
 
     // Fetch data not included in a partial back-up
-    if (!sd_print_saved_in_ram) {
+    if (!print_saved_in_ram) {
         // Calculate the file position, from which to resume this print.
         save_print_file_state();
 
@@ -99,7 +99,7 @@ void uvlo_() {
 
     // When there is no position already saved, then we must grab whatever the current position is.
     // This is most likely a position where the printer is in the middle of a G-code move
-    if (!sd_print_saved_in_ram && !isPartialBackupAvailable)
+    if (!print_saved_in_ram && !isPartialBackupAvailable)
     {
         memcpy(saved_pos, current_position, sizeof(saved_pos));
         if (pos_invalid) saved_pos[X_AXIS] = X_COORD_INVALID;

--- a/Firmware/power_panic.cpp
+++ b/Firmware/power_panic.cpp
@@ -41,7 +41,7 @@ void uvlo_() {
     unsigned long time_start = _millis();
 
     // True if a print is already saved to RAM
-    const bool print_saved_in_ram = saved_printing && (saved_printing_type == PowerPanic::PRINT_TYPE_SD);
+    const bool print_saved_in_ram = saved_printing && (saved_printing_type != PowerPanic::PRINT_TYPE_NONE);
     const bool pos_invalid = mesh_bed_leveling_flag || homing_flag;
 
     // Conserve as much power as soon as possible

--- a/Firmware/power_panic.h
+++ b/Firmware/power_panic.h
@@ -18,3 +18,4 @@ enum PrintType : uint8_t {
 void uvlo_();
 void recover_print(uint8_t automatic); 
 void setup_uvlo_interrupt();
+void reset_uvlo();

--- a/Firmware/power_panic.h
+++ b/Firmware/power_panic.h
@@ -18,4 +18,3 @@ enum PrintType : uint8_t {
 void uvlo_();
 void recover_print(uint8_t automatic); 
 void setup_uvlo_interrupt();
-void reset_uvlo();

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5238,30 +5238,23 @@ static void lcd_main_menu()
 #endif //TMC2130_DEBUG
 
     // Menu item for reprint
-    if (!printer_active()
-        && !printer_recovering()
-        && (heating_status == HeatingStatus::NO_HEATING)) {
-        if ((GetPrinterState() == PrinterState::SDPrintingFinished)
-            && card.mounted) {
+    if (!printer_active() && !printer_recovering() && (heating_status == HeatingStatus::NO_HEATING)) {
+        if ((GetPrinterState() == PrinterState::SDPrintingFinished) && card.mounted) {
             MENU_ITEM_FUNCTION_P(_T(MSG_REPRINT), lcd_reprint_from_eeprom);
-        } else if ((GetPrinterState() == PrinterState::HostPrintingFinished)
-                    && M79_timer_get_status()) {
+        } else if ((GetPrinterState() == PrinterState::HostPrintingFinished) && M79_timer_get_status()) {
             MENU_ITEM_FUNCTION_P(_T(MSG_REPRINT), lcd_send_action_start);
         }
     }
 
     // Menu is never shown when idle
-    if (babystep_allowed_strict()
-        && (printJobOngoing()
-        || lcd_commands_type == LcdCommands::Layer1Cal))
+    if (babystep_allowed_strict() && (printJobOngoing() || lcd_commands_type == LcdCommands::Layer1Cal))
         MENU_ITEM_SUBMENU_P(_T(MSG_BABYSTEP_Z), lcd_babystep_z);//8
 
     if (farm_mode)
         MENU_ITEM_FUNCTION_P(_T(MSG_FILAMENTCHANGE), lcd_colorprint_change);//8
 
     if (!printer_recovering()) {
-        if ( moves_planned()
-            || printer_active()) {
+        if ( moves_planned() || printer_active()) {
             MENU_ITEM_SUBMENU_P(_T(MSG_TUNE), lcd_tune_menu);
         } else if (!Stopped) {
             MENU_ITEM_SUBMENU_P(_i("Preheat"), lcd_preheat_menu);////MSG_PREHEAT c=18
@@ -5273,10 +5266,7 @@ static void lcd_main_menu()
                 }
             }
         }
-        if (mesh_bed_leveling_flag == false
-            && homing_flag == false
-            && !printingIsPaused()
-            && !processing_tcode) {
+        if (mesh_bed_leveling_flag == false && homing_flag == false && !printingIsPaused() && !processing_tcode) {
             if (usb_timer.running()) {
                 MENU_ITEM_FUNCTION_P(_T(MSG_PAUSE_PRINT), lcd_pause_usb_print);
             } else if (IS_SD_PRINTING) {
@@ -5290,21 +5280,16 @@ static void lcd_main_menu()
 #ifdef FANCHECK
         && fan_check_error != EFCE_REPORTED
 #endif //FANCHECK
-        && (saved_printing_type != PowerPanic::PRINT_TYPE_NONE
-           || saved_printing)
+        && (saved_printing_type != PowerPanic::PRINT_TYPE_NONE || saved_printing)
         && custom_message_type != CustomMsg::Resuming) {
         if (saved_printing_type == PowerPanic::PRINT_TYPE_SD) {
                 MENU_ITEM_SUBMENU_P(_T(MSG_RESUME_PRINT), lcd_resume_print);
-        } else if ((saved_printing_type == PowerPanic::PRINT_TYPE_HOST)
-                    && (M79_timer_get_status())) {
+        } else if ((saved_printing_type == PowerPanic::PRINT_TYPE_HOST) && (M79_timer_get_status())) {
                 MENU_ITEM_SUBMENU_P(_T(MSG_RESUME_PRINT), lcd_resume_usb_print);
         }
     }
-    if((printJobOngoing()
-        || printingIsPaused()
-        || (printer_recovering()))
-        && (custom_message_type != CustomMsg::MeshBedLeveling)
-        && !processing_tcode) {
+    if((printJobOngoing() || printingIsPaused() || (printer_recovering()))
+        && (custom_message_type != CustomMsg::MeshBedLeveling) && !processing_tcode) {
         MENU_ITEM_SUBMENU_P(_T(MSG_STOP_PRINT), lcd_sdcard_stop);
     }
 #ifdef THERMAL_MODEL
@@ -5314,9 +5299,7 @@ static void lcd_main_menu()
 #endif
 
     // only allow starting SD print if hardware errors (temperature or fan) are cleared
-    if (!printer_recovering()
-        && !printer_active()
-        && !get_temp_error()
+    if (!printer_recovering() && !printer_active() && !get_temp_error()
 #ifdef FANCHECK
         && fan_check_error != EFCE_REPORTED
 #endif //FANCHECK
@@ -5325,8 +5308,7 @@ static void lcd_main_menu()
             if (card.mounted
                 || lcd_commands_type != LcdCommands::Idle) {
                 if (!card.isFileOpen()) {
-                    if (!usb_timer.running()
-                        && (lcd_commands_type == LcdCommands::Idle)) {
+                    if (!usb_timer.running() && (lcd_commands_type == LcdCommands::Idle)) {
                         bMain=true;               // flag ('fake parameter') for 'lcd_sdcard_menu()' function
                         MENU_ITEM_SUBMENU_P(_T(MSG_CARD_MENU), lcd_sdcard_menu);
                     }
@@ -5342,12 +5324,10 @@ static void lcd_main_menu()
 #endif //SDCARDDETECT
          }
 #endif //SDSUPPORT
-        if(!printer_active()
-            && !farm_mode) {
+        if(!printer_active() && !farm_mode) {
             const int8_t sheet = eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet));
             const int8_t nextSheet = eeprom_next_initialized_sheet(sheet);
-            if ((nextSheet >= 0)
-                && (sheet != nextSheet)) { // show menu only if we have 2 or more sheets initialized
+            if ((nextSheet >= 0) && (sheet != nextSheet)) { // show menu only if we have 2 or more sheets initialized
                 MENU_ITEM_FUNCTION_E(EEPROM_Sheets_base->s[sheet], eeprom_switch_to_next_sheet);
             }
 #ifdef QUICK_NOZZLE_CHANGE
@@ -5356,12 +5336,9 @@ static void lcd_main_menu()
 
         }
 
-        if (!( printer_active()
-                || (eFilamentAction != FilamentAction::None)
-                || Stopped )) {
+        if (!( printer_active() || (eFilamentAction != FilamentAction::None) || Stopped )) {
             if (MMU2::mmu2.Enabled()) {
-                if(!MMU2::mmu2.FindaDetectsFilament()
-                    && !fsensor.getFilamentPresent()) {
+                if(!MMU2::mmu2.FindaDetectsFilament() && !fsensor.getFilamentPresent()) {
                     // The MMU 'Load filament' state machine will reject the command if any
                     // filament sensor is reporting a detected filament
                     MENU_ITEM_SUBMENU_P(_T(MSG_PRELOAD_TO_MMU), mmu_preload_filament_menu);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5289,7 +5289,7 @@ static void lcd_main_menu()
     }
     if((printJobOngoing()
         || printingIsPaused()
-        || (eeprom_read_byte((uint8_t*)EEPROM_UVLO) != PowerPanic::NO_PENDING_RECOVERY))
+        || (printer_recovering()))
         && (custom_message_type != CustomMsg::MeshBedLeveling)
         && !processing_tcode) {
         MENU_ITEM_SUBMENU_P(_T(MSG_STOP_PRINT), lcd_sdcard_stop);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5324,7 +5324,7 @@ static void lcd_main_menu()
 #endif //SDCARDDETECT
          }
 #endif //SDSUPPORT
-        if(!printer_active() && !farm_mode) {
+        if(!farm_mode) {
             const int8_t sheet = eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet));
             const int8_t nextSheet = eeprom_next_initialized_sheet(sheet);
             if ((nextSheet >= 0) && (sheet != nextSheet)) { // show menu only if we have 2 or more sheets initialized
@@ -5336,7 +5336,7 @@ static void lcd_main_menu()
 
         }
 
-        if (!( printer_active() || (eFilamentAction != FilamentAction::None) || Stopped )) {
+        if (!((eFilamentAction != FilamentAction::None) || Stopped )) {
             if (MMU2::mmu2.Enabled()) {
                 if(!MMU2::mmu2.FindaDetectsFilament() && !fsensor.getFilamentPresent()) {
                     // The MMU 'Load filament' state machine will reject the command if any
@@ -5372,7 +5372,7 @@ static void lcd_main_menu()
 #endif //FILAMENT_SENSOR
             }
             MENU_ITEM_SUBMENU_P(_T(MSG_SETTINGS), lcd_settings_menu);
-            if(!printingIsPaused()) MENU_ITEM_SUBMENU_P(_T(MSG_CALIBRATION), lcd_calibration_menu);
+            MENU_ITEM_SUBMENU_P(_T(MSG_CALIBRATION), lcd_calibration_menu);
         }
     }
 

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5317,7 +5317,6 @@ static void lcd_main_menu()
     if (!printer_recovering()
         && !printer_active()
         && !get_temp_error()
-        && !printer_active()
 #ifdef FANCHECK
         && fan_check_error != EFCE_REPORTED
 #endif //FANCHECK

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5238,7 +5238,7 @@ static void lcd_main_menu()
 #endif //TMC2130_DEBUG
 
     // Menu item for reprint
-    if(!printer_active() && (heating_status == HeatingStatus::NO_HEATING)) {
+    if(!printer_active() && !printer_recovering() && (heating_status == HeatingStatus::NO_HEATING)) {
         if ((GetPrinterState() == PrinterState::SDPrintingFinished) && card.mounted) {
             MENU_ITEM_FUNCTION_P(_T(MSG_REPRINT), lcd_reprint_from_eeprom);
         } else if ((GetPrinterState() == PrinterState::HostPrintingFinished) && M79_timer_get_status()) {

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5228,6 +5228,10 @@ static void lcd_main_menu()
         MENU_ITEM_FUNCTION_P(PSTR("tst - Restore"), lcd_menu_test_restore);
 #endif //RESUME_DEBUG
 
+#ifdef DEBUG_PRINTER_STATES
+    debug_printer_states();
+#endif //End DEBUG_PRINTER_STATES
+
 #ifdef TMC2130_DEBUG
     MENU_ITEM_FUNCTION_P(PSTR("recover print"), recover_print);
     MENU_ITEM_FUNCTION_P(PSTR("power panic"), uvlo_);

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -136,16 +136,16 @@ extern LcdCommands lcd_commands_type;
 
 enum class CustomMsg : uint_least8_t
 {
-    Status,          //!< status message from lcd_status_message variable
-    MeshBedLeveling, //!< Mesh bed leveling in progress
-    FilamentLoading, //!< Loading filament in progress
-    PidCal,          //!< PID tuning in progress
-    TempCal,         //!< PINDA temperature calibration
-    TempCompPreheat, //!< Temperature compensation preheat
-    M0Wait,          //!< M0/M1 Wait command working even from SD
-    M117,            //!< M117 Set the status line message on the LCD
-    Resuming,        //!< Resuming message
-    MMUProgress,     ///< MMU progress message
+    Status,          //!< 0 status message from lcd_status_message variable
+    MeshBedLeveling, //!< 1 Mesh bed leveling in progress
+    FilamentLoading, //!< 2 Loading filament in progress
+    PidCal,          //!< 3 PID tuning in progress
+    TempCal,         //!< 4 PINDA temperature calibration
+    TempCompPreheat, //!< 5 Temperature compensation preheat
+    M0Wait,          //!< 6 M0/M1 Wait command working even from SD
+    M117,            //!< 7 M117 Set the status line message on the LCD
+    Resuming,        //!< 8 Resuming message
+    MMUProgress,     ///< 9 MMU progress message
 };
 
 extern CustomMsg custom_message_type;

--- a/Firmware/variants/MK25-RAMBo10a.h
+++ b/Firmware/variants/MK25-RAMBo10a.h
@@ -125,6 +125,7 @@
 
 #define DEBUG_DCODE2
 #define DEBUG_DCODE3
+//#define DEBUG_PRINTER_STATES
 
 //#define DEBUG_EEPROM_CHANGES //Uses +1188 bytes Flash +6 bytes SRAM
 //#define DEBUG_BUILD

--- a/Firmware/variants/MK25-RAMBo13a.h
+++ b/Firmware/variants/MK25-RAMBo13a.h
@@ -126,6 +126,7 @@
 
 #define DEBUG_DCODE2
 #define DEBUG_DCODE3
+//#define DEBUG_PRINTER_STATES
 
 //#define DEBUG_EEPROM_CHANGES //Uses +1188 bytes Flash +6 bytes SRAM
 //#define DEBUG_BUILD

--- a/Firmware/variants/MK25S-RAMBo10a.h
+++ b/Firmware/variants/MK25S-RAMBo10a.h
@@ -125,6 +125,7 @@
 
 #define DEBUG_DCODE2
 #define DEBUG_DCODE3
+//#define DEBUG_PRINTER_STATES
 
 //#define DEBUG_EEPROM_CHANGES //Uses +1188 bytes Flash +6 bytes SRAM
 //#define DEBUG_BUILD

--- a/Firmware/variants/MK25S-RAMBo13a.h
+++ b/Firmware/variants/MK25S-RAMBo13a.h
@@ -126,6 +126,7 @@
 
 #define DEBUG_DCODE2
 #define DEBUG_DCODE3
+//#define DEBUG_PRINTER_STATES
 
 //#define DEBUG_EEPROM_CHANGES //Uses +1188 bytes Flash +6 bytes SRAM
 //#define DEBUG_BUILD

--- a/Firmware/variants/MK3-E3DREVO.h
+++ b/Firmware/variants/MK3-E3DREVO.h
@@ -164,6 +164,7 @@
 #define DEBUG_DCODE6
 
 //#define DEBUG_PULLUP_CRASH //Test Pullup crash
+//#define DEBUG_PRINTER_STATES
 
 //#define DEBUG_EEPROM_CHANGES //Uses +1188 bytes Flash +6 bytes SRAM
 //#define DEBUG_BUILD

--- a/Firmware/variants/MK3-E3DREVO_HF_60W.h
+++ b/Firmware/variants/MK3-E3DREVO_HF_60W.h
@@ -164,6 +164,7 @@
 #define DEBUG_DCODE6
 
 //#define DEBUG_PULLUP_CRASH //Test Pullup crash
+//#define DEBUG_PRINTER_STATES
 
 //#define DEBUG_EEPROM_CHANGES //Uses +1188 bytes Flash +6 bytes SRAM
 //#define DEBUG_BUILD

--- a/Firmware/variants/MK3.h
+++ b/Firmware/variants/MK3.h
@@ -164,6 +164,7 @@
 #define DEBUG_DCODE6
 
 //#define DEBUG_PULLUP_CRASH //Test Pullup crash
+//#define DEBUG_PRINTER_STATES
 
 //#define DEBUG_EEPROM_CHANGES //Uses +1188 bytes Flash +6 bytes SRAM
 //#define DEBUG_BUILD

--- a/Firmware/variants/MK3S-E3DREVO.h
+++ b/Firmware/variants/MK3S-E3DREVO.h
@@ -166,6 +166,7 @@
 #define DEBUG_DCODE6
 
 //#define DEBUG_PULLUP_CRASH //Test Pullup crash
+//#define DEBUG_PRINTER_STATES
 
 //#define DEBUG_EEPROM_CHANGES //Uses +1188 bytes Flash +6 bytes SRAM
 //#define DEBUG_BUILD

--- a/Firmware/variants/MK3S-E3DREVO_HF_60W.h
+++ b/Firmware/variants/MK3S-E3DREVO_HF_60W.h
@@ -166,6 +166,7 @@
 #define DEBUG_DCODE6
 
 //#define DEBUG_PULLUP_CRASH //Test Pullup crash
+//#define DEBUG_PRINTER_STATES
 
 //#define DEBUG_EEPROM_CHANGES //Uses +1188 bytes Flash +6 bytes SRAM
 //#define DEBUG_BUILD

--- a/Firmware/variants/MK3S.h
+++ b/Firmware/variants/MK3S.h
@@ -166,6 +166,7 @@
 #define DEBUG_DCODE6
 
 //#define DEBUG_PULLUP_CRASH //Test Pullup crash
+//#define DEBUG_PRINTER_STATES
 
 //#define DEBUG_EEPROM_CHANGES //Uses +1188 bytes Flash +6 bytes SRAM
 //#define DEBUG_BUILD


### PR DESCRIPTION
Improved Power Panic
- Added Debug for printer states
- SD power panic
  - Recovers from multiple power panic and even resets (as long it is in recovering)
- Host power panic
- LCD menu
  - During recovering all menus are hidden except
    - Stop print (to be able to exit)
    - Statistics
    - Fail Stats
    - Support   
  - Reprint hidden
    - Host reprint only shown when host sends `M79` to ensure that the host is ready to reprint
    - SD Reprint only shown when previous print was finished successfully.
      - ToDo for next release: Don't show Reprint when SD card has been changed
  - Resume hidden
    - When resuming
    - With host prints until host sends `M79`
  - `Autoload filament` menu only shown with active FSensor and NO filament detected
  - `Load filament` menu only shown with active FSensor and NO filament detected OR FSensor disabled
  - `Unload filament` menu only shown with active FSensor and filament detected OR FSensor disabled
 
 
This Firmware doesn't recover correctly with Prusa Link 0.8.0-alpha4 at this moment.
I was able to recover host prints with a modified OctoPrint + two Plugins and additional code (which isn't in this PR as this code is a workaround of existing OctoPrint+Plugins)

Update 27-03-2024

Added `EEPROM_UVLO_Z_LIFTED` to prevent multiple Z lifts in case of a power panic while the print is paused.
A host print recovery it doesn't wait for hotend temp to be stable as it will go into pause state anyway and the hotend will be disabled while paused anyway. 

Tested with MK404

- [X] SD print + power panic
  - For some unknown reason it doesn't recover correctly SD print + power panic + reset while recovering, while a double power panic does recover correctly even with a reset.   
- [X] SD print + power panic and while lifting Z another power panic
- [X] SD print + power panic and while lifting Z another power panic + reset while recovering
- [X] SD print + pause + power panic
- [X] SD print + pause + power panic and while lifting Z another power panic
- [X] SD print + pause + power panic and while lifting Z another power panic + reset while recovering
- [X] Host print same as above for SD

Difference between SD and Host print power panic:
- SD recovers automatically when bed temp isn't lower than 5°C to target bed temperature
- Host recovers the print settings and goes to pause state.
  - Then it waits for the host sending "M79" before showing Resume to ensure that the host is "there" to receive any messages from the printer.  
   
The print can't be recovered if a reset happens at the last step of the recovery as at this moment the power panic recovery is "completed" and the printer is back in normal mode.

