### PR TITLE
Add Eject Option To Filament Load Message

### DIFF
--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -18,6 +18,7 @@ const char MSG_BED_HEATING[] PROGMEM_I1 = ISTR("Bed Heating"); ////MSG_BED_HEATI
 const char MSG_BED_LEVELING_FAILED_POINT_LOW[] PROGMEM_I1 = ISTR("Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for reset."); ////MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
 const char MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED[] PROGMEM_I1 = ISTR("XYZ calibration failed. Please consult the manual."); ////MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
 const char MSG_BELT_STATUS[] PROGMEM_I1 = ISTR("Belt status");////MSG_BELT_STATUS c=18
+const char MSG_EJECT[] PROGMEM_I1 = ISTR("Eject"); ////MSG_EJECT c=8
 const char MSG_CANCEL[] PROGMEM_I1 = ISTR(">Cancel");////MSG_CANCEL c=10
 const char MSG_CALIBRATE_Z_AUTO[] PROGMEM_I1 = ISTR("Calibrating Z"); ////MSG_CALIBRATE_Z_AUTO c=20 r=2
 const char MSG_CARD_MENU[] PROGMEM_I1 = ISTR("Print from SD"); ////MSG_CARD_MENU c=18

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -21,6 +21,7 @@ extern const char MSG_BED_HEATING[];
 extern const char MSG_BED_LEVELING_FAILED_POINT_LOW[];
 extern const char MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED[];
 extern const char MSG_BELT_STATUS[];
+extern const char MSG_EJECT[];
 extern const char MSG_CANCEL[];
 extern const char MSG_CALIBRATE_Z_AUTO[];
 extern const char MSG_CARD_MENU[];

--- a/Firmware/mmu2/errors_list.h
+++ b/Firmware/mmu2/errors_list.h
@@ -355,7 +355,7 @@ static const char MSG_BTN_RETRY[] PROGMEM_I1 = ISTR("Retry"); ////MSG_BTN_RETRY 
 static const char MSG_BTN_RESET_MMU[] PROGMEM_I1 = ISTR("ResetMMU"); ////MSG_BTN_RESET_MMU c=8
 static const char MSG_BTN_UNLOAD[] PROGMEM_I1 = ISTR("Unload"); ////MSG_BTN_UNLOAD c=8
 static const char MSG_BTN_LOAD[] PROGMEM_I1 = ISTR("Load"); ////MSG_BTN_LOAD c=8
-static const char MSG_BTN_EJECT[] PROGMEM_I1 = ISTR("Eject"); ////MSG_BTN_EJECT c=8
+//static const char MSG_BTN_EJECT[] PROGMEM_I1 = ISTR("Eject"); //Reuse MSG_EJECT c=8
 //static const char MSG_BTN_TUNE_MMU[] PROGMEM_I1 = ISTR("Tune"); //Reuse MSG_TUNE c=8
 static const char MSG_BTN_STOP[] PROGMEM_I1 = ISTR("Stop"); ////MSG_BTN_STOP c=8
 static const char MSG_BTN_DISABLE_MMU[] PROGMEM_I1 = ISTR("Disable"); ////MSG_BTN_DISABLE_MMU c=8
@@ -368,7 +368,7 @@ static const char * const btnOperation[] PROGMEM = {
     _R(MSG_BTN_RESET_MMU),
     _R(MSG_BTN_UNLOAD),
     _R(MSG_BTN_LOAD),
-    _R(MSG_BTN_EJECT),
+    _R(MSG_EJECT),
     _R(MSG_TUNE),
     _R(MSG_BTN_STOP),
     _R(MSG_BTN_DISABLE_MMU),

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2258,12 +2258,15 @@ void show_preheat_nozzle_warning()
 
 void lcd_load_filament_color_check()
 {
-	uint8_t clean = lcd_show_multiscreen_message_yes_no_and_wait_P(_T(MSG_FILAMENT_CLEAN), false, LCD_LEFT_BUTTON_CHOICE);
-	while (clean == LCD_MIDDLE_BUTTON_CHOICE) {
-		load_filament_final_feed();
-		st_synchronize();
-		clean = lcd_show_multiscreen_message_yes_no_and_wait_P(_T(MSG_FILAMENT_CLEAN), false, LCD_LEFT_BUTTON_CHOICE);
-	}
+    uint8_t clean = lcd_show_multiscreen_message_with_choices_and_wait_P(_T(MSG_FILAMENT_CLEAN), false, LCD_LEFT_BUTTON_CHOICE, _T(MSG_YES), _T(MSG_NO), _T(MSG_EJECT), 8);
+    while (clean == LCD_MIDDLE_BUTTON_CHOICE) {
+        load_filament_final_feed();
+        st_synchronize();
+        clean = lcd_show_multiscreen_message_with_choices_and_wait_P(_T(MSG_FILAMENT_CLEAN), false, LCD_LEFT_BUTTON_CHOICE, _T(MSG_YES), _T(MSG_NO), _T(MSG_EJECT), 8);
+    }
+    if (clean == LCD_RIGHT_BUTTON_CHOICE) {
+        unload_filament(FILAMENTCHANGE_FINALRETRACT);
+    }
 }
 
 #ifdef FILAMENT_SENSOR
@@ -3041,7 +3044,13 @@ void lcd_show_choices_prompt_P(uint8_t selected, const char *first_choice, const
     lcd_putc_at(second_col, 3, selected == LCD_MIDDLE_BUTTON_CHOICE ? '>': ' ');
     lcd_puts_P(second_choice);
     if (third_choice) {
-        lcd_putc_at(18, 3, selected == LCD_RIGHT_BUTTON_CHOICE ? '>': ' ');
+        ////get size of third_choice, offset to the left. Make sure it doesn't overlap second_choice.
+        size_t third_choice_len = strlen_P(third_choice);
+        uint8_t second_col_end = second_col + strlen_P(second_choice) + 2;
+        uint8_t third_col;
+        if (uint8_t pos = 19 - third_choice_len; pos > second_col_end) {third_col = pos;} else {third_col = second_col_end;}
+        if (third_col > 18) {third_col = 18;} //backwards compatability - make sure at least one character of the third selection is shown
+        lcd_putc_at(third_col, 3, selected == LCD_RIGHT_BUTTON_CHOICE ? '>': ' ');
         lcd_puts_P(third_choice);
     }
 }


### PR DESCRIPTION
Add a third option ("eject") to the "Filament extruding & with correct color?" message.

Closes https://github.com/prusa3d/Prusa-Firmware/issues/4643


The third_choice text was rendered incorrectly. (Only showed the first letter of the text because the position was hardcoded.)
I made sure the third_choice text will be offset to the left, but not overlap with the second_choice text.

This uses quite a lot of mem, any help in optimizing is appreciated 😸 