### PR TITLE
ultralcd: merge two functions into one as cleanup

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1657,7 +1657,7 @@ void setup()
         if (saved_printing_type == PowerPanic::PRINT_TYPE_HOST) {
           recover_print(0);
         } else {
-          const uint8_t btn = lcd_show_fullscreen_message_yes_no_and_wait_P(_T(MSG_RECOVER_PRINT), false);
+          const uint8_t btn = lcd_show_multiscreen_message_yes_no_and_wait_P(_T(MSG_RECOVER_PRINT), false);
           if ( btn == LCD_LEFT_BUTTON_CHOICE) {
             recover_print(0);
           } else { // LCD_MIDDLE_BUTTON_CHOICE
@@ -3235,7 +3235,7 @@ bool gcode_M45(bool onlyZ, int8_t verbosity_level)
 		{
 			KEEPALIVE_STATE(PAUSED_FOR_USER);
 			#ifdef STEEL_SHEET
-			uint8_t result = lcd_show_fullscreen_message_yes_no_and_wait_P(_T(MSG_STEEL_SHEET_CHECK), false);
+			uint8_t result = lcd_show_multiscreen_message_yes_no_and_wait_P(_T(MSG_STEEL_SHEET_CHECK), false);
 			if(result == LCD_LEFT_BUTTON_CHOICE) {
 				lcd_show_fullscreen_message_and_wait_P(_T(MSG_REMOVE_STEEL_SHEET));
 			}
@@ -3514,7 +3514,7 @@ static void gcode_M600(const bool automatic, const float x_position, const float
         {
             KEEPALIVE_STATE(PAUSED_FOR_USER);
             uint8_t choice =
-                lcd_show_fullscreen_message_yes_no_and_wait_P(_T(MSG_UNLOAD_SUCCESSFUL), false, LCD_LEFT_BUTTON_CHOICE);
+                lcd_show_multiscreen_message_yes_no_and_wait_P(_T(MSG_UNLOAD_SUCCESSFUL), false, LCD_LEFT_BUTTON_CHOICE);
             lcd_update_enable(false);
             if (choice == LCD_MIDDLE_BUTTON_CHOICE) {
                 lcd_clear();
@@ -4742,7 +4742,7 @@ void process_commands()
             break;
         }
         lcd_show_fullscreen_message_and_wait_P(_T(MSG_TEMP_CAL_WARNING));
-        uint8_t result = lcd_show_fullscreen_message_yes_no_and_wait_P(_T(MSG_STEEL_SHEET_CHECK), false);
+        uint8_t result = lcd_show_multiscreen_message_yes_no_and_wait_P(_T(MSG_STEEL_SHEET_CHECK), false);
 
         if (result == LCD_LEFT_BUTTON_CHOICE)
         {

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1002,7 +1002,7 @@ void lcd_commands()
                 //| Yes     No
                 enquecommand_P(PSTR("M84 XY"));
                 lcd_update_enabled = false; //hack to avoid lcd_update recursion.
-                if (lcd_show_fullscreen_message_yes_no_and_wait_P(_T(MSG_NOZZLE_CNG_CHANGED), false) == LCD_LEFT_BUTTON_CHOICE) {
+                if (lcd_show_multiscreen_message_yes_no_and_wait_P(_T(MSG_NOZZLE_CNG_CHANGED), false) == LCD_LEFT_BUTTON_CHOICE) {
                     setTargetHotend(0);
 #ifdef THERMAL_MODEL
                     thermal_model_set_enabled(was_enabled);
@@ -2258,11 +2258,11 @@ void show_preheat_nozzle_warning()
 
 void lcd_load_filament_color_check()
 {
-	uint8_t clean = lcd_show_fullscreen_message_yes_no_and_wait_P(_T(MSG_FILAMENT_CLEAN), false, LCD_LEFT_BUTTON_CHOICE);
+	uint8_t clean = lcd_show_multiscreen_message_yes_no_and_wait_P(_T(MSG_FILAMENT_CLEAN), false, LCD_LEFT_BUTTON_CHOICE);
 	while (clean == LCD_MIDDLE_BUTTON_CHOICE) {
 		load_filament_final_feed();
 		st_synchronize();
-		clean = lcd_show_fullscreen_message_yes_no_and_wait_P(_T(MSG_FILAMENT_CLEAN), false, LCD_LEFT_BUTTON_CHOICE);
+		clean = lcd_show_multiscreen_message_yes_no_and_wait_P(_T(MSG_FILAMENT_CLEAN), false, LCD_LEFT_BUTTON_CHOICE);
 	}
 }
 
@@ -2845,7 +2845,7 @@ bool lcd_calibrate_z_end_stop_manual(bool only_z)
             }
         }
         // Let the user confirm, that the Z carriage is at the top end stoppers.
-        uint8_t result = lcd_show_fullscreen_message_yes_no_and_wait_P(_T(MSG_CONFIRM_CARRIAGE_AT_THE_TOP), false);
+        uint8_t result = lcd_show_multiscreen_message_yes_no_and_wait_P(_T(MSG_CONFIRM_CARRIAGE_AT_THE_TOP), false);
         if (result == LCD_BUTTON_TIMEOUT)
             goto canceled;
         else if (result == LCD_LEFT_BUTTON_CHOICE)
@@ -3147,19 +3147,6 @@ uint8_t lcd_show_yes_no_and_wait(bool allow_timeouting, uint8_t default_selectio
     return lcd_show_multiscreen_message_yes_no_and_wait_P(NULL, allow_timeouting, default_selection);
 }
 
-//! @brief Show single screen message with yes and no possible choices and wait with possible timeout
-//! @param msg Message to show. If NULL, do not clear the screen and handle choice selection only.
-//! @param allow_timeouting if true, allows time outing of the screen
-//! @param default_selection if 0, 'Yes' choice is selected by default, otherwise 'No' choice is preselected
-//! @retval 0 yes choice selected by user
-//! @retval 1 no choice selected by user
-//! @retval 0xFF button timeout (only possible if allow_timeouting is true)
-//! @relates lcd_show_yes_no_and_wait
-uint8_t lcd_show_fullscreen_message_yes_no_and_wait_P(const char *msg, bool allow_timeouting, uint8_t default_selection)
-{
-    return lcd_show_multiscreen_message_yes_no_and_wait_P(msg, allow_timeouting, default_selection);
-}
-
 void lcd_bed_calibration_show_result(BedSkewOffsetDetectionResultType result, uint8_t point_too_far_mask)
 {
     const char *msg = NULL;
@@ -3447,7 +3434,7 @@ static void menu_setlang(uint8_t lang)
 {
 	if (!lang_select(lang))
 	{
-		if (lcd_show_fullscreen_message_yes_no_and_wait_P(_T(MSG_COPY_SEL_LANG), false, LCD_LEFT_BUTTON_CHOICE) == LCD_LEFT_BUTTON_CHOICE)
+		if (lcd_show_multiscreen_message_yes_no_and_wait_P(_T(MSG_COPY_SEL_LANG), false, LCD_LEFT_BUTTON_CHOICE) == LCD_LEFT_BUTTON_CHOICE)
 			lang_boot_update_start(lang);
 		lcd_update_enable(true);
 		menu_goto(lcd_language_menu, 0, true, true);
@@ -3625,7 +3612,7 @@ void lcd_v2_calibration() {
 		if (fsensor.isReady()) {
 			loaded = fsensor.getFilamentPresent();
 		} else {
-			loaded = !lcd_show_fullscreen_message_yes_no_and_wait_P(_T(MSG_FILAMENT_LOADED), false, LCD_MIDDLE_BUTTON_CHOICE);
+			loaded = !lcd_show_multiscreen_message_yes_no_and_wait_P(_T(MSG_FILAMENT_LOADED), false, LCD_MIDDLE_BUTTON_CHOICE);
 			lcd_update_enabled = true;
 		}
 
@@ -3855,7 +3842,7 @@ void lcd_wizard(WizState state)
 		case S::Z:
 			lcd_show_fullscreen_message_and_wait_P(_T(MSG_REMOVE_SHIPPING_HELPERS));
 			lcd_show_fullscreen_message_and_wait_P(_T(MSG_REMOVE_TEST_PRINT));
-			wizard_event = lcd_show_fullscreen_message_yes_no_and_wait_P(_T(MSG_STEEL_SHEET_CHECK), false);
+			wizard_event = lcd_show_multiscreen_message_yes_no_and_wait_P(_T(MSG_STEEL_SHEET_CHECK), false);
 			if (wizard_event == LCD_MIDDLE_BUTTON_CHOICE) {
 				lcd_show_fullscreen_message_and_wait_P(_T(MSG_PLACE_STEEL_SHEET));
 			}
@@ -3887,7 +3874,7 @@ void lcd_wizard(WizState state)
 		    //start to preheat nozzle and bed to save some time later
 			setTargetHotend(PLA_PREHEAT_HOTEND_TEMP);
 			setTargetBed(PLA_PREHEAT_HPB_TEMP);
-			wizard_event = lcd_show_fullscreen_message_yes_no_and_wait_P(_T(MSG_FILAMENT_LOADED), false, LCD_MIDDLE_BUTTON_CHOICE);
+			wizard_event = lcd_show_multiscreen_message_yes_no_and_wait_P(_T(MSG_FILAMENT_LOADED), false, LCD_MIDDLE_BUTTON_CHOICE);
 			if (wizard_event == LCD_LEFT_BUTTON_CHOICE) {
 				state = S::Lay1CalCold;
 			} else { // MIDDLE_BUTTON_CHOICE
@@ -4767,7 +4754,7 @@ char reset_menu() {
 
 static void lcd_disable_farm_mode()
 {
-	uint8_t disable = lcd_show_fullscreen_message_yes_no_and_wait_P(PSTR("Disable farm mode?"), true); //allow timeouting, default no
+	uint8_t disable = lcd_show_multiscreen_message_yes_no_and_wait_P(PSTR("Disable farm mode?"), true); //allow timeouting, default no
 	if (disable == LCD_LEFT_BUTTON_CHOICE)
 	{
 		enquecommand_P(PSTR("G99"));
@@ -7136,7 +7123,7 @@ static void menu_action_sdfile(const char* filename)
     }
 
   if (!check_file(selected_filename)) {
-      result = !lcd_show_fullscreen_message_yes_no_and_wait_P(_T(MSG_FILE_INCOMPLETE), false);
+      result = !lcd_show_multiscreen_message_yes_no_and_wait_P(_T(MSG_FILE_INCOMPLETE), false);
       lcd_update_enable(true);
   }
   if (result) {

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -94,7 +94,6 @@ extern bool lcd_wait_for_click_delay(uint16_t nDelay);
 void lcd_show_choices_prompt_P(uint8_t selected, const char *first_choice, const char *second_choice, uint8_t second_col, const char *third_choice = nullptr);
 extern void lcd_show_fullscreen_message_and_wait_P(const char *msg);
 extern uint8_t lcd_show_yes_no_and_wait(bool allow_timeouting = true, uint8_t default_selection = LCD_MIDDLE_BUTTON_CHOICE);
-extern uint8_t lcd_show_fullscreen_message_yes_no_and_wait_P(const char *msg, bool allow_timeouting = true, uint8_t default_selection = LCD_MIDDLE_BUTTON_CHOICE);
 extern uint8_t lcd_show_multiscreen_message_with_choices_and_wait_P(
     const char * const msg, bool allow_timeouting, uint8_t default_selection,
     const char * const first_choice, const char * const second_choice, const char * const third_choice = nullptr,

--- a/Firmware/util.cpp
+++ b/Firmware/util.cpp
@@ -261,7 +261,7 @@ void fCheckModeInit() {
 static void render_M862_warnings(const char* warning, const char* strict, uint8_t check)
 {
     if (check == 1) { // Warning, stop print if user selects 'No'
-        if (lcd_show_fullscreen_message_yes_no_and_wait_P(warning, true, LCD_LEFT_BUTTON_CHOICE) == LCD_MIDDLE_BUTTON_CHOICE) {
+        if (lcd_show_multiscreen_message_yes_no_and_wait_P(warning, true, LCD_LEFT_BUTTON_CHOICE) == LCD_MIDDLE_BUTTON_CHOICE) {
             lcd_print_stop();
         }
     } else if (check == 2) { // Strict, always stop print


### PR DESCRIPTION
`lcd_show_fullscreen_message_yes_no_and_wait_P` and `lcd_show_multiscreen_message_yes_no_and_wait_P` are the same function. Let's drop one of them so we only have one symbol for the function.

Noticed this when reviewing https://github.com/prusa3d/Prusa-Firmware/pull/4644

No change in memory