### PR TITLE
Add Extrude mintemp save and restore during power panic

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -7449,7 +7449,7 @@ Sigma_Exit:
       set_extrude_min_temp(temp);
     }
     break;
-	#endif
+	#endif //PREVENT_DANGEROUS_EXTRUDE
 
     /*!
 	### M303 - PID autotune <a href="https://reprap.org/wiki/G-code#M303:_Run_PID_tuning">M303: Run PID tuning</a>

--- a/Firmware/eeprom.h
+++ b/Firmware/eeprom.h
@@ -83,7 +83,7 @@ static_assert(sizeof(Sheets) == EEPROM_SHEETS_SIZEOF, "Sizeof(Sheets) is not EEP
 
   To convert hex to dec         https://www.rapidtables.com/convert/number/hex-to-decimal.html
 
-  Version: 3.14.0
+  Version: 3.14.1
 
   ---------------------------------------------------------------------------------
 
@@ -384,6 +384,7 @@ static_assert(sizeof(Sheets) == EEPROM_SHEETS_SIZEOF, "Sizeof(Sheets) is not EEP
 | 0x0C80 3200 | char[17]| EEPROM_CUSTOM_MENDEL_NAME             | Prusa i3 MK3S| ffffffffffffffffff... | Custom Printer Name                               |              | D3 Ax0c80 C17
 | 0x0C7F 3199 | bool    | EEPROM_UVLO_Z_LIFTED                  | 00h 0        | 00h                   | Power Panic Z axis NOT lifted                     | Power Panic  | D3 Ax0c7f C1
 | ^           | ^       | ^                                     | 01h 1        | 01h                   | Power Panic Z axis lifted                         | ^            | ^
+| 0x0C7d 3197 | uint16  | EEPROM_UVLO_EXTRUDE_MINTEMP           | 0-305        | afh 175               | Power Panic Extrude mintemp                       | Power Panic  | D3 Ax0c7d C2
 
 |Address begin|Bit/Type | Name                                  | Valid values | Default/FactoryReset  | Description                                       |Gcode/Function| Debug code
 | :--:        | :--:    | :--:                                  | :--:         | :--:                  | :--:                                              | :--:         | :--:
@@ -624,9 +625,10 @@ static Sheets * const EEPROM_Sheets_base = (Sheets*)(EEPROM_SHEETS_BASE);
 #define EEPROM_FILENAME_EXTENSION (EEPROM_KILL_PENDING_FLAG - 3) // 3 x char
 #define EEPROM_CUSTOM_MENDEL_NAME (EEPROM_FILENAME_EXTENSION-17) //char[17]
 #define EEPROM_UVLO_Z_LIFTED (EEPROM_CUSTOM_MENDEL_NAME-1) //bool
+#define EEPROM_UVLO_EXTRUDE_MINTEMP (EEPROM_UVLO_Z_LIFTED-2) //uint16_t
 
 //This is supposed to point to last item to allow EEPROM overrun check. Please update when adding new items.
-#define EEPROM_LAST_ITEM EEPROM_UVLO_Z_LIFTED
+#define EEPROM_LAST_ITEM EEPROM_UVLO_EXTRUDE_MINTEMP
 // !!!!!
 // !!!!! this is end of EEPROM section ... all updates MUST BE inserted before this mark !!!!!
 // !!!!!

--- a/Firmware/planner.cpp
+++ b/Firmware/planner.cpp
@@ -123,7 +123,7 @@ static uint8_t g_cntr_planner_queue_min = 0;
 //===========================================================================
 #ifdef PREVENT_DANGEROUS_EXTRUDE
 int extrude_min_temp = EXTRUDE_MINTEMP;
-#endif
+#endif //PREVENT_DANGEROUS_EXTRUDE
 
 #ifdef LIN_ADVANCE
 float extruder_advance_K = LA_K_DEF;
@@ -856,7 +856,7 @@ void plan_buffer_line(float x, float y, float z, const float &e, float feed_rate
     }
     #endif
   }
-  #endif
+  #endif //PREVENT_DANGEROUS_EXTRUDE
 
   // Number of steps for each axis
 #ifndef COREXY
@@ -1364,7 +1364,7 @@ void set_extrude_min_temp(int temp)
 {
   extrude_min_temp = temp;
 }
-#endif
+#endif //PREVENT_DANGEROUS_EXTRUDE
 
 // Calculate the steps/s^2 acceleration rates, based on the mm/s^s
 void reset_acceleration_rates()

--- a/Firmware/planner.h
+++ b/Firmware/planner.h
@@ -266,7 +266,7 @@ extern bool planner_aborted;
 #ifdef PREVENT_DANGEROUS_EXTRUDE
 extern int extrude_min_temp;
 void set_extrude_min_temp(int temp);
-#endif
+#endif //PREVENT_DANGEROUS_EXTRUDE
 
 void reset_acceleration_rates();
 #endif

--- a/Firmware/power_panic.cpp
+++ b/Firmware/power_panic.cpp
@@ -195,6 +195,9 @@ void uvlo_() {
     if (did_pause_print) {
         eeprom_update_byte_notify((uint8_t*)EEPROM_UVLO_Z_LIFTED, 1);
     }
+#ifdef PREVENT_DANGEROUS_EXTRUDE
+    eeprom_update_word_notify((uint16_t*)EEPROM_UVLO_EXTRUDE_MINTEMP, extrude_min_temp);
+#endif //PREVENT_DANGEROUS_EXTRUDE
     eeprom_update_byte_notify((uint8_t*)EEPROM_UVLO, PowerPanic::PENDING_RECOVERY);
 
     // Increment power failure counter
@@ -422,6 +425,9 @@ bool recover_machine_state_after_power_panic() {
     extruder_advance_K = eeprom_read_float((float*)EEPROM_UVLO_LA_K);
 #endif
 
+#ifdef PREVENT_DANGEROUS_EXTRUDE
+    extrude_min_temp = eeprom_read_word((uint16_t*)EEPROM_UVLO_EXTRUDE_MINTEMP);
+#endif //PREVENT_DANGEROUS_EXTRUDE
      return mbl_was_active;
 }
 


### PR DESCRIPTION
Thanks to @wavexx in #3008
Minor documentation changes
Tested with MK404
- Set `M302 S150`
- Start print at 155°C
- PowerPanic during print
- Let it recover
- Check `D3 Ax0c7d C2` that the correct value has been saved to EEPROM during PP
- Set temp to 155°C which is below the default of 175°C
- Verify that no ` cold extrusion prevented` is shown