### PR TITLE
PFW-762 ambient shutdown at 80 C

### DIFF
--- a/Firmware/variants/MK3-E3DREVO.h
+++ b/Firmware/variants/MK3-E3DREVO.h
@@ -319,7 +319,7 @@
 #define HEATER_0_MAXTEMP 305
 #endif
 #define BED_MAXTEMP 125
-#define AMBIENT_MAXTEMP 100
+#define AMBIENT_MAXTEMP 80
 
 #if defined(E3D_PT100_EXTRUDER_WITH_AMP) || defined(E3D_PT100_EXTRUDER_NO_AMP)
 // Define PID constants for extruder with PT100

--- a/Firmware/variants/MK3-E3DREVO_HF_60W.h
+++ b/Firmware/variants/MK3-E3DREVO_HF_60W.h
@@ -319,7 +319,7 @@
 #define HEATER_0_MAXTEMP 305
 #endif
 #define BED_MAXTEMP 125
-#define AMBIENT_MAXTEMP 100
+#define AMBIENT_MAXTEMP 80
 
 #if defined(E3D_PT100_EXTRUDER_WITH_AMP) || defined(E3D_PT100_EXTRUDER_NO_AMP)
 // Define PID constants for extruder with PT100

--- a/Firmware/variants/MK3.h
+++ b/Firmware/variants/MK3.h
@@ -319,7 +319,7 @@
 #define HEATER_0_MAXTEMP 305
 #endif
 #define BED_MAXTEMP 125
-#define AMBIENT_MAXTEMP 100
+#define AMBIENT_MAXTEMP 80
 
 #if defined(E3D_PT100_EXTRUDER_WITH_AMP) || defined(E3D_PT100_EXTRUDER_NO_AMP)
 // Define PID constants for extruder with PT100

--- a/Firmware/variants/MK3S-E3DREVO.h
+++ b/Firmware/variants/MK3S-E3DREVO.h
@@ -321,7 +321,7 @@
 #define HEATER_0_MAXTEMP 305
 #endif
 #define BED_MAXTEMP 125
-#define AMBIENT_MAXTEMP 100
+#define AMBIENT_MAXTEMP 80
 
 #if defined(E3D_PT100_EXTRUDER_WITH_AMP) || defined(E3D_PT100_EXTRUDER_NO_AMP)
 // Define PID constants for extruder with PT100

--- a/Firmware/variants/MK3S-E3DREVO_HF_60W.h
+++ b/Firmware/variants/MK3S-E3DREVO_HF_60W.h
@@ -321,7 +321,7 @@
 #define HEATER_0_MAXTEMP 305
 #endif
 #define BED_MAXTEMP 125
-#define AMBIENT_MAXTEMP 100
+#define AMBIENT_MAXTEMP 80
 
 #if defined(E3D_PT100_EXTRUDER_WITH_AMP) || defined(E3D_PT100_EXTRUDER_NO_AMP)
 // Define PID constants for extruder with PT100

--- a/Firmware/variants/MK3S.h
+++ b/Firmware/variants/MK3S.h
@@ -321,7 +321,7 @@
 #define HEATER_0_MAXTEMP 305
 #endif
 #define BED_MAXTEMP 125
-#define AMBIENT_MAXTEMP 100
+#define AMBIENT_MAXTEMP 80
 
 #if defined(E3D_PT100_EXTRUDER_WITH_AMP) || defined(E3D_PT100_EXTRUDER_NO_AMP)
 // Define PID constants for extruder with PT100


### PR DESCRIPTION
Goal of this PR is to prevent more heating up in einsy printed box mainly in case the terminals are not securely screwed.
The Ambient thermistor on the EINSY is close to the PWR and BED IN see here
![image](https://github.com/prusa3d/Prusa-Firmware/assets/25530011/8fba325a-9203-4bd3-a678-7fa97147d1c7)

We have some real data from an enclosed MK3S that the Ambient temp is way below the 80°C in this PR.
See [here](https://github.com/prusa3d/Prusa-Firmware/issues/4431#issuecomment-1880523940)