### PR TITLE
MMU: Add workaround for broken Tune button

### DIFF
--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -464,6 +464,15 @@ void tuneIdlerStallguardThresholdMenu() {
 }
 
 void tuneIdlerStallguardThreshold() {
+    if ((CommandInProgress)mmu2.GetCommandInProgress() != NoCommand)
+    {
+        // Workaround to mitigate an issue where the Tune menu doesn't
+        // work if the MMU is running a command. For example the Idler
+        // homing fails during toolchange.
+        // To save the print, make the Tune button unresponsive for now.
+        return;
+    }
+    
     putErrorScreenToSleep = true;
     menu_submenu(tuneIdlerStallguardThresholdMenu);
 }


### PR DESCRIPTION
If the MMU is processing a command, the Tune button can't be executed and will put the printer into an unrecoverable state.

Mitigate the issue by ignoring the Tune button if the MMU is processing a command. In 99.9% of cases this will only happen when printing. The Tune button is still useful for the particular use case scenario it was added into the firmware in the first place, which is to allow the user to tune the idler stallguard threshold immediately after the printer boots up.

Fixes https://github.com/prusa3d/Prusa-Firmware/issues/4558

For anyone interested, a proper fix may look like this: https://github.com/prusa3d/Prusa-Firmware/pull/4561 but for now it is better to at least mitigate the issue instead of leaving it open in the firmware.

Steps to reproduce a problem:

1. Send toolchange command to the printer e.g. T0
2. Hold the Idler in place until you get a "Idler cannot home" error.
3. Select 'Tune' button
4. Select 'Done' button (you need to click it 3 times to exit the menu)
5. Printer is in a 'frozen' state.

Change in memory:
Flash: +16 bytes
SRAM: 0 bytes