### PR TITLE
Replace hardcoded values

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -2235,12 +2235,7 @@ bool calibrate_z_auto()
 	plan_buffer_line_destinationXYZE(feedrate / 60);
 	st_synchronize();
 	enable_endstops(endstops_enabled);
-	if (PRINTER_TYPE == PRINTER_MK3) {
-		current_position[Z_AXIS] = Z_MAX_POS + 2.0;
-	}
-	else {
-		current_position[Z_AXIS] = Z_MAX_POS + 9.0;
-	}
+	current_position[Z_AXIS] = Z_MAX_POS + Z_MAX_POS_XYZ_CALIBRATION_CORRECTION;
 	plan_set_position_curposXYZE();
 	return true;
 }

--- a/Firmware/variants/MK3-E3DREVO.h
+++ b/Firmware/variants/MK3-E3DREVO.h
@@ -64,6 +64,9 @@
 #define Z_MAX_POS 210
 #define Z_MIN_POS 0.15
 
+// Z height correction value
+#define Z_MAX_POS_XYZ_CALIBRATION_CORRECTION 2
+
 // Canceled home position
 #define X_CANCEL_POS 50
 #define Y_CANCEL_POS 190

--- a/Firmware/variants/MK3-E3DREVO_HF_60W.h
+++ b/Firmware/variants/MK3-E3DREVO_HF_60W.h
@@ -64,6 +64,9 @@
 #define Z_MAX_POS 210
 #define Z_MIN_POS 0.15
 
+// Z height correction value
+#define Z_MAX_POS_XYZ_CALIBRATION_CORRECTION 2
+
 // Canceled home position
 #define X_CANCEL_POS 50
 #define Y_CANCEL_POS 190

--- a/Firmware/variants/MK3.h
+++ b/Firmware/variants/MK3.h
@@ -64,6 +64,9 @@
 #define Z_MAX_POS 210
 #define Z_MIN_POS 0.15
 
+// Z height correction value
+#define Z_MAX_POS_XYZ_CALIBRATION_CORRECTION 2
+
 // Canceled home position
 #define X_CANCEL_POS 50
 #define Y_CANCEL_POS 190

--- a/Firmware/variants/MK3S-E3DREVO.h
+++ b/Firmware/variants/MK3S-E3DREVO.h
@@ -66,6 +66,9 @@
 #define Z_MAX_POS 210
 #define Z_MIN_POS 0.15
 
+// Z height correction value
+#define Z_MAX_POS_XYZ_CALIBRATION_CORRECTION 9
+
 // Canceled home position
 #define X_CANCEL_POS 50
 #define Y_CANCEL_POS 190

--- a/Firmware/variants/MK3S-E3DREVO_HF_60W.h
+++ b/Firmware/variants/MK3S-E3DREVO_HF_60W.h
@@ -66,6 +66,9 @@
 #define Z_MAX_POS 210
 #define Z_MIN_POS 0.15
 
+// Z height correction value
+#define Z_MAX_POS_XYZ_CALIBRATION_CORRECTION 9
+
 // Canceled home position
 #define X_CANCEL_POS 50
 #define Y_CANCEL_POS 190

--- a/Firmware/variants/MK3S.h
+++ b/Firmware/variants/MK3S.h
@@ -66,6 +66,9 @@
 #define Z_MAX_POS 210
 #define Z_MIN_POS 0.15
 
+// Z height correction value
+#define Z_MAX_POS_XYZ_CALIBRATION_CORRECTION 9
+
 // Canceled home position
 #define X_CANCEL_POS 50
 #define Y_CANCEL_POS 190


### PR DESCRIPTION
- [X] XYZ height correction hardcoded value replaced with Z_MAX_POS_XYZ_CALIBRATION_CORRECTION Thanks to @ruedli and his PR https://github.com/prusa3d/Prusa-Firmware/pull/1719.
  - Bondtech and other community extruders can now be defined via a variant file variable. 