### PR TITLE
Beep on M601 pause

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -7972,6 +7972,8 @@ Sigma_Exit:
             cmdqueue_pop_front(); //trick because we want skip this command (M601) after restore
             lcd_pause_print();
         }
+
+        Sound_MakeSound(e_SOUND_TYPE_StandardPrompt);
     }
     break;
 


### PR DESCRIPTION
Make some noise when pausing a print so the user knows the printer is waiting for them.

(Tested on MK3S only)