### PR TITLE
Fix an issue in manual fan check where prior knob clicks are not consumed

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -6883,6 +6883,7 @@ static bool lcd_selftest_manual_fan_check(const uint8_t _fan, const bool check_o
 	lcd_encoder = _default;
 
 	KEEPALIVE_STATE(PAUSED_FOR_USER);
+	lcd_consume_click();
 
 	do
 	{


### PR DESCRIPTION
The issue can appear when the knob is clicked at the "Self test start" screen which is hardcoded to stay on the screen for 2 seconds. Any knob clicks during this interval will go unconsumed.

Issue was introduced in 3.13.0, likely by https://github.com/prusa3d/Prusa-Firmware/commit/a7e9ccfb57e436311cb28b5636b8f66fe7982909

Issue mainly affects MK2.5S.

Steps to reproduce:
1. Run selftest
2. When you see “Self test start” on the LCD, click the knob. 
3. Wait for fan self test to run
4. Observe error: The printer doesnt give any choice to select whether the fan is spinning or not. 