### PR TITLE
PFW-1559 Add filament presence check at start of print

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3376,7 +3376,7 @@ static void mmu_M600_load_filament(bool automatic) {
         slot = SpoolJoin::spooljoin.nextSlot();
     } else {
         // Only ask for the slot if automatic/SpoolJoin is off
-        slot = choose_menu_P(_T(MSG_SELECT_FILAMENT), _T(MSG_FILAMENT));
+        slot = choose_menu_P(_T(MSG_SELECT_FILAMENT), MSG_FILAMENT);
     }
 
     setTargetHotend(saved_extruder_temperature);

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -5224,17 +5224,10 @@ void process_commands()
       lcd_resume_print();
     else
     {
-        if (!MMU2::mmu2.Enabled()) {
-            // Check if the filament is present before starting a print.
-            // When MMU is enabled, this is not necessary and the G-code file
-            // should always tell the MMU which filament to load.
-            filament_presence_check();
-
-            if (lcd_commands_type == LcdCommands::StopPrint) {
-                // Print job was canceled
-                break;
-            }
-        }
+      if (!filament_presence_check()) {
+        // Print was aborted
+        break;
+      }
 
       if (!card.get_sdpos())
       {
@@ -5866,16 +5859,9 @@ Sigma_Exit:
     */
     case 75:
     {
-        if (!MMU2::mmu2.Enabled()) {
-            // Check if the filament is present before starting a host print.
-            // When MMU is enabled, this is not necessary and the G-code file
-            // should always tell the MMU which filament to load.
-            filament_presence_check();
-
-            if (lcd_commands_type == LcdCommands::StopPrint) {
-                // Print job was canceled
-                break;
-            }
+        if (!filament_presence_check()) {
+          // Print was aborted
+          break;
         }
 
         print_job_timer.start();

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -5224,6 +5224,18 @@ void process_commands()
       lcd_resume_print();
     else
     {
+        if (!MMU2::mmu2.Enabled()) {
+            // Check if the filament is present before starting a print.
+            // When MMU is enabled, this is not necessary and the G-code file
+            // should always tell the MMU which filament to load.
+            filament_presence_check();
+
+            if (lcd_commands_type == LcdCommands::StopPrint) {
+                // Print job was canceled
+                break;
+            }
+        }
+
       if (!card.get_sdpos())
       {
               // A new print has started from scratch, reset stats
@@ -5854,6 +5866,18 @@ Sigma_Exit:
     */
     case 75:
     {
+        if (!MMU2::mmu2.Enabled()) {
+            // Check if the filament is present before starting a host print.
+            // When MMU is enabled, this is not necessary and the G-code file
+            // should always tell the MMU which filament to load.
+            filament_presence_check();
+
+            if (lcd_commands_type == LcdCommands::StopPrint) {
+                // Print job was canceled
+                break;
+            }
+        }
+
         print_job_timer.start();
         break;
     }

--- a/Firmware/Tcodes.cpp
+++ b/Firmware/Tcodes.cpp
@@ -31,7 +31,7 @@ void TCodes(char *const strchr_pointer, const uint8_t codeValue) {
     } else if (strchr_pointer[index] == 'x' || strchr_pointer[index] == '?'){
         // load to extruder gears; if mmu is not present do nothing
         if (MMU2::mmu2.Enabled()) {
-            MMU2::mmu2.tool_change(strchr_pointer[index], choose_menu_P(_T(MSG_SELECT_FILAMENT), _T(MSG_FILAMENT)));
+            MMU2::mmu2.tool_change(strchr_pointer[index], choose_menu_P(_T(MSG_SELECT_FILAMENT), MSG_FILAMENT));
         }
     } else if (strchr_pointer[index] == 'c'){
         // load from extruder gears to nozzle (nozzle should be preheated)

--- a/Firmware/eeprom.h
+++ b/Firmware/eeprom.h
@@ -246,9 +246,7 @@ static_assert(sizeof(Sheets) == EEPROM_SHEETS_SIZEOF, "Sizeof(Sheets) is not EEP
 | ^           | ^       | ^                                     | 01h 1        | ^                     | MMU cutter: __enabled__                           | ^            | ^
 | ^           | ^       | ^                                     | 02h 2        | ^                     | MMU cutter: __always__                            | ^            | ^
 | 0x0DAE 3502 | uint16  | EEPROM_UVLO_MESH_BED_LEVELING_FULL    | ???          | ff ffh 65535          | Saved MBL points                                  | Power Panic  | D3 Ax0dae C288
-| 0x0DAD 3501 | uint8   | EEPROM_CHECK_FILAMENT                 | 01h 1        | ffh 255               | Check mode for filament is: __warn__              | LCD menu     | D3 Ax0dad C1
-| ^           | ^       | ^                                     | 02h 2        | ^                     | Check mode for filament is: __strict__            | ^            | ^
-| ^           | ^       | ^                                     | 00h 0        | ^                     | Check mode for filament is: __none__              | ^            | ^
+| 0x0DAD 3501 | uint8   | _EEPROM_FREE_NR9_                     | ???          | ffh 255               | _Free EEPROM space_                               | _free space_ | D3 Ax0dad C1
 | 0x0DAC 3500 | bool    | EEPROM_MBL_MAGNET_ELIMINATION         | 01h 1        | ffh 255               | Mesh bed leveling does: __ignores__ magnets       | LCD menu     | D3 Ax0dac C1
 | ^           | ^       | ^                                     | 00h 0        | ^                     | Mesh bed leveling does: __NOT ignores__ magnets   | ^            | ^
 | 0x0DAB 3499 | uint8   | EEPROM_MBL_POINTS_NR                  | 03h 3        | ffh 255               | Mesh bed leveling points: __3x3__                 | LCD menu     | D3 Ax0dab C1
@@ -416,6 +414,9 @@ static_assert(sizeof(Sheets) == EEPROM_SHEETS_SIZEOF, "Sizeof(Sheets) is not EEP
 | ^           | ^       | ^                                     | ???          | ^                     | Z-axis                                            | ^            | D3 Ax0d29 C4
 | ^           | ^       | ^                                     | ???          | ^                     | Y-axis                                            | ^            | D3 Ax0d25 C4
 | ^           | ^       | ^                                     | ???          | ^                     | X-axis                                            | ^            | D3 Ax0c21 C4
+| 0x0C11 3089 | uint8   | EEPROM_CHECK_FILAMENT                 | 01h 1        | ffh 255               | Check mode for filament is: __warn__              | LCD menu     | D3 Ax0c11 C1
+| ^           | ^       | ^                                     | 02h 2        | ^                     | Check mode for filament is: __strict__            | ^            | ^
+| ^           | ^       | ^                                     | 00h 0        | ^                     | Check mode for filament is: __none__              | ^            | ^
 
 
 |Address begin|Bit/Type | Name                                  | Valid values | Default/FactoryReset  | Description                                       |Gcode/Function| Debug code
@@ -587,9 +588,9 @@ static_assert(sizeof(Sheets) == EEPROM_SHEETS_SIZEOF, "Sizeof(Sheets) is not EEP
 #define EEPROM_MMU_CUTTER_ENABLED (EEPROM_MMU_LOAD_FAIL - 1) // bool
 #define EEPROM_UVLO_MESH_BED_LEVELING_FULL     (EEPROM_MMU_CUTTER_ENABLED - 12*12*2) //allow 12 calibration points for future expansion
 
-#define EEPROM_CHECK_FILAMENT (EEPROM_UVLO_MESH_BED_LEVELING_FULL-1) // uint8_t
+#define _EEPROM_FREE_NR9_ (EEPROM_UVLO_MESH_BED_LEVELING_FULL-1) // uint8_t
 
-#define EEPROM_MBL_MAGNET_ELIMINATION (EEPROM_CHECK_FILAMENT - 1)
+#define EEPROM_MBL_MAGNET_ELIMINATION (_EEPROM_FREE_NR9_ - 1)
 #define EEPROM_MBL_POINTS_NR (EEPROM_MBL_MAGNET_ELIMINATION -1) //uint8_t number of points in one exis for mesh bed leveling
 #define EEPROM_MBL_PROBE_NR (EEPROM_MBL_POINTS_NR-1) //number of measurements for each point
 
@@ -666,8 +667,9 @@ static Sheets * const EEPROM_Sheets_base = (Sheets*)(EEPROM_SHEETS_BASE);
 #define EEPROM_UVLO_MIN_TRAVEL_FEEDRATE (EEPROM_UVLO_MIN_FEEDRATE-4) //float
 #define EEPROM_UVLO_MIN_SEGMENT_TIME_US (EEPROM_UVLO_MIN_TRAVEL_FEEDRATE-4) //uint32_t
 #define EEPROM_UVLO_MAX_JERK (EEPROM_UVLO_MIN_SEGMENT_TIME_US-4*4) // 4 x float
+#define EEPROM_CHECK_FILAMENT (EEPROM_UVLO_MAX_JERK-1) // uint8_t
 //This is supposed to point to last item to allow EEPROM overrun check. Please update when adding new items.
-#define EEPROM_LAST_ITEM EEPROM_UVLO_MAX_JERK
+#define EEPROM_LAST_ITEM EEPROM_CHECK_FILAMENT
 // !!!!!
 // !!!!! this is end of EEPROM section ... all updates MUST BE inserted before this mark !!!!!
 // !!!!!

--- a/Firmware/eeprom.h
+++ b/Firmware/eeprom.h
@@ -246,7 +246,9 @@ static_assert(sizeof(Sheets) == EEPROM_SHEETS_SIZEOF, "Sizeof(Sheets) is not EEP
 | ^           | ^       | ^                                     | 01h 1        | ^                     | MMU cutter: __enabled__                           | ^            | ^
 | ^           | ^       | ^                                     | 02h 2        | ^                     | MMU cutter: __always__                            | ^            | ^
 | 0x0DAE 3502 | uint16  | EEPROM_UVLO_MESH_BED_LEVELING_FULL    | ???          | ff ffh 65535          | Saved MBL points                                  | Power Panic  | D3 Ax0dae C288
-| 0x0DAD 3501 | uint8   | _EEPROM_FREE_NR9_                     | ???          | ffh 255               | _Free EEPROM space_                               | _free space_ | D3 Ax0dad C1
+| 0x0DAD 3501 | uint8   | EEPROM_CHECK_FILAMENT                 | 01h 1        | ffh 255               | Check mode for filament is: __warn__              | LCD menu     | D3 Ax0dad C1
+| ^           | ^       | ^                                     | 02h 2        | ^                     | Check mode for filament is: __strict__            | ^            | ^
+| ^           | ^       | ^                                     | 00h 0        | ^                     | Check mode for filament is: __none__              | ^            | ^
 | 0x0DAC 3500 | bool    | EEPROM_MBL_MAGNET_ELIMINATION         | 01h 1        | ffh 255               | Mesh bed leveling does: __ignores__ magnets       | LCD menu     | D3 Ax0dac C1
 | ^           | ^       | ^                                     | 00h 0        | ^                     | Mesh bed leveling does: __NOT ignores__ magnets   | ^            | ^
 | 0x0DAB 3499 | uint8   | EEPROM_MBL_POINTS_NR                  | 03h 3        | ffh 255               | Mesh bed leveling points: __3x3__                 | LCD menu     | D3 Ax0dab C1
@@ -585,9 +587,9 @@ static_assert(sizeof(Sheets) == EEPROM_SHEETS_SIZEOF, "Sizeof(Sheets) is not EEP
 #define EEPROM_MMU_CUTTER_ENABLED (EEPROM_MMU_LOAD_FAIL - 1) // bool
 #define EEPROM_UVLO_MESH_BED_LEVELING_FULL     (EEPROM_MMU_CUTTER_ENABLED - 12*12*2) //allow 12 calibration points for future expansion
 
-#define _EEPROM_FREE_NR9_ (EEPROM_UVLO_MESH_BED_LEVELING_FULL-1) // uint8_t
+#define EEPROM_CHECK_FILAMENT (EEPROM_UVLO_MESH_BED_LEVELING_FULL-1) // uint8_t
 
-#define EEPROM_MBL_MAGNET_ELIMINATION (_EEPROM_FREE_NR9_ - 1)
+#define EEPROM_MBL_MAGNET_ELIMINATION (EEPROM_CHECK_FILAMENT - 1)
 #define EEPROM_MBL_POINTS_NR (EEPROM_MBL_MAGNET_ELIMINATION -1) //uint8_t number of points in one exis for mesh bed leveling
 #define EEPROM_MBL_PROBE_NR (EEPROM_MBL_POINTS_NR-1) //number of measurements for each point
 

--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -35,7 +35,6 @@ const char MSG_ERROR[] PROGMEM_I1 = ISTR("ERROR:"); ////MSG_ERROR c=10
 const char MSG_EXTRUDER[] PROGMEM_I1 = ISTR("Extruder"); ////MSG_EXTRUDER c=17
 const char MSG_FANS_CHECK[] PROGMEM_I1 = ISTR("Fans check"); ////MSG_FANS_CHECK c=13
 const char MSG_FIL_RUNOUTS[] PROGMEM_I1 = ISTR("Fil. runouts"); ////MSG_FIL_RUNOUTS c=15
-const char MSG_FILAMENT[] PROGMEM_I1 = ISTR("Filament"); ////MSG_FILAMENT c=17
 const char MSG_FAN_SPEED[] PROGMEM_I1 = ISTR("Fan speed"); ////MSG_FAN_SPEED c=14
 const char MSG_HOTEND_FAN_SPEED[] PROGMEM_I1 = ISTR("Hotend fan:");////MSG_HOTEND_FAN_SPEED c=15
 const char MSG_PRINT_FAN_SPEED[] PROGMEM_I1 = ISTR("Print fan:"); ////MSG_PRINT_FAN_SPEED c=15
@@ -380,6 +379,7 @@ extern const char MSG_FW_MK3_DETECTED [] PROGMEM_I1 = ISTR(PRINTER_NAME " firmwa
 //not internationalized messages
 const char MSG_SPOOL_JOIN[] PROGMEM_N1 = "SpoolJoin"; ////MSG_SPOOL_JOIN c=13
 const char MSG_FIRMWARE[] PROGMEM_N1 = "Firmware"; ////MSG_FIRMWARE c=8
+const char MSG_FILAMENT[] PROGMEM_N1 = "Filament"; ////MSG_FILAMENT c=8
 const char MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY[] PROGMEM_N1 = "FlashAir"; ////MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY c=8
 const char MSG_PINDA[] PROGMEM_N1 = "PINDA"; ////MSG_PINDA c=5
 const char MSG_WELCOME[] PROGMEM_N1 = WELCOME_MSG;

--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -155,6 +155,8 @@ const char MSG_GCODE_NEWER_FIRMWARE_CONTINUE[] PROGMEM_I1 = ISTR("G-code sliced 
 const char MSG_GCODE_NEWER_FIRMWARE_CANCELLED[] PROGMEM_I1 = ISTR("G-code sliced for a newer firmware. Please update the firmware. Print cancelled."); ////MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
 const char MSG_GCODE_DIFF_CONTINUE[] PROGMEM_I1 = ISTR("G-code sliced for a different level. Continue?"); ////MSG_GCODE_DIFF_CONTINUE c=20 r=3
 const char MSG_GCODE_DIFF_CANCELLED[] PROGMEM_I1 = ISTR("G-code sliced for a different level. Please re-slice the model again. Print cancelled."); ////MSG_GCODE_DIFF_CANCELLED c=20 r=8
+const char MSG_MISSING_FILAMENT_CONTINUE[] PROGMEM_I1 = ISTR("There is no filament loaded. Continue?"); ////MSG_MISSING_FILAMENT_CONTINUE c=20 r=3;
+const char MSG_MISSING_FILAMENT_CANCELLED[] PROGMEM_I1 = ISTR("There is no filament loaded. Print cancelled."); ////MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
 const char MSG_NOZZLE_DIFFERS_CONTINUE[] PROGMEM_I1 = ISTR("Nozzle diameter differs from the G-code. Continue?"); ////MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
 const char MSG_NOZZLE_DIFFERS_CANCELLED[] PROGMEM_I1 = ISTR("Nozzle diameter differs from the G-code. Please check the value in settings. Print cancelled."); ////MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
 const char MSG_NOZZLE_DIAMETER[] PROGMEM_I1 = ISTR("Nozzle d."); ////MSG_NOZZLE_DIAMETER c=10

--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -154,7 +154,7 @@ const char MSG_GCODE_NEWER_FIRMWARE_CONTINUE[] PROGMEM_I1 = ISTR("G-code sliced 
 const char MSG_GCODE_NEWER_FIRMWARE_CANCELLED[] PROGMEM_I1 = ISTR("G-code sliced for a newer firmware. Please update the firmware. Print cancelled."); ////MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
 const char MSG_GCODE_DIFF_CONTINUE[] PROGMEM_I1 = ISTR("G-code sliced for a different level. Continue?"); ////MSG_GCODE_DIFF_CONTINUE c=20 r=3
 const char MSG_GCODE_DIFF_CANCELLED[] PROGMEM_I1 = ISTR("G-code sliced for a different level. Please re-slice the model again. Print cancelled."); ////MSG_GCODE_DIFF_CANCELLED c=20 r=8
-const char MSG_MISSING_FILAMENT_CONTINUE[] PROGMEM_I1 = ISTR("There is no filament loaded. Continue?"); ////MSG_MISSING_FILAMENT_CONTINUE c=20 r=3;
+const char MSG_MISSING_FILAMENT_CONTINUE[] PROGMEM_I1 = ISTR("There is no filament loaded. Continue?"); ////MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
 const char MSG_MISSING_FILAMENT_CANCELLED[] PROGMEM_I1 = ISTR("There is no filament loaded. Print cancelled."); ////MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
 const char MSG_NOZZLE_DIFFERS_CONTINUE[] PROGMEM_I1 = ISTR("Nozzle diameter differs from the G-code. Continue?"); ////MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
 const char MSG_NOZZLE_DIFFERS_CANCELLED[] PROGMEM_I1 = ISTR("Nozzle diameter differs from the G-code. Please check the value in settings. Print cancelled."); ////MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -157,6 +157,8 @@ extern const char MSG_GCODE_NEWER_FIRMWARE_CONTINUE[];
 extern const char MSG_GCODE_NEWER_FIRMWARE_CANCELLED[];
 extern const char MSG_GCODE_DIFF_CONTINUE[];
 extern const char MSG_GCODE_DIFF_CANCELLED[];
+extern const char MSG_MISSING_FILAMENT_CONTINUE[];
+extern const char MSG_MISSING_FILAMENT_CANCELLED[];
 extern const char MSG_NOZZLE_DIFFERS_CONTINUE[];
 extern const char MSG_NOZZLE_DIFFERS_CANCELLED[];
 extern const char MSG_NOZZLE_DIAMETER[];

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -38,7 +38,6 @@ extern const char MSG_ERROR[];
 extern const char MSG_EXTRUDER[];
 extern const char MSG_FANS_CHECK[];
 extern const char MSG_FIL_RUNOUTS[];
-extern const char MSG_FILAMENT[];
 extern const char MSG_FAN_SPEED[];
 extern const char MSG_HOTEND_FAN_SPEED[];
 extern const char MSG_PRINT_FAN_SPEED[];
@@ -380,6 +379,7 @@ extern const char MSG_FW_MK3_DETECTED [];
 //not internationalized messages
 extern const char MSG_SPOOL_JOIN[];
 extern const char MSG_FIRMWARE[];
+extern const char MSG_FILAMENT[];
 extern const char MSG_TOSHIBA_FLASH_AIR_COMPATIBILITY[];
 extern const char MSG_PINDA[];
 extern const char MSG_WELCOME[];

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3620,7 +3620,7 @@ void lcd_v2_calibration() {
 	if (MMU2::mmu2.Enabled()) {
 		const uint8_t filament = choose_menu_P(
 			_T(MSG_SELECT_FILAMENT),
-			_T(MSG_FILAMENT),(_T(MSG_CANCEL)+1)); //Hack to reuse MSG but strip 1st char off
+			MSG_FILAMENT,(_T(MSG_CANCEL)+1)); //Hack to reuse MSG but strip 1st char off
 		if (filament < MMU_FILAMENT_COUNT) {
 			lay1cal_filament = filament;
 		} else {
@@ -6787,7 +6787,7 @@ static bool lcd_selftest_fsensor(void)
 static bool selftest_irsensor()
 {
     // Ask user which slot to load filament from
-    uint8_t slot = choose_menu_P(_T(MSG_SELECT_FILAMENT), _T(MSG_FILAMENT));
+    uint8_t slot = choose_menu_P(_T(MSG_SELECT_FILAMENT), MSG_FILAMENT);
 
     // Render self-test screen
     lcd_selftest_screen(TestScreen::Fsensor, 0, 1, true, 0);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -4233,26 +4233,6 @@ switch(oCheckMode)
 eeprom_update_byte_notify((uint8_t*)EEPROM_CHECK_MODE,(uint8_t)oCheckMode);
 }
 
-#define SETTINGS_MODE \
-do\
-{\
-    switch(oCheckMode)\
-         {\
-         case ClCheckMode::_None:\
-              MENU_ITEM_TOGGLE_P(_T(MSG_NOZZLE), _T(MSG_NONE), lcd_check_mode_set);\
-              break;\
-         case ClCheckMode::_Warn:\
-              MENU_ITEM_TOGGLE_P(_T(MSG_NOZZLE), _T(MSG_WARN), lcd_check_mode_set);\
-              break;\
-         case ClCheckMode::_Strict:\
-              MENU_ITEM_TOGGLE_P(_T(MSG_NOZZLE), _T(MSG_STRICT), lcd_check_mode_set);\
-              break;\
-         default:\
-              MENU_ITEM_TOGGLE_P(_T(MSG_NOZZLE), _T(MSG_NONE), lcd_check_mode_set);\
-         }\
-}\
-while (0)
-
 static void lcd_nozzle_diameter_cycle(void) {
     uint16_t nDiameter;
     switch(oNozzleDiameter){
@@ -4298,127 +4278,83 @@ static void lcd_check_model_set(void)
 {
 switch(oCheckModel)
      {
-     case ClCheckModel::_None:
-          oCheckModel=ClCheckModel::_Warn;
+     case ClCheckMode::_None:
+          oCheckModel=ClCheckMode::_Warn;
           break;
-     case ClCheckModel::_Warn:
-          oCheckModel=ClCheckModel::_Strict;
+     case ClCheckMode::_Warn:
+          oCheckModel=ClCheckMode::_Strict;
           break;
-     case ClCheckModel::_Strict:
-          oCheckModel=ClCheckModel::_None;
+     case ClCheckMode::_Strict:
+          oCheckModel=ClCheckMode::_None;
           break;
      default:
-          oCheckModel=ClCheckModel::_None;
+          oCheckModel=ClCheckMode::_None;
      }
 eeprom_update_byte_notify((uint8_t*)EEPROM_CHECK_MODEL,(uint8_t)oCheckModel);
 }
-
-#define SETTINGS_MODEL \
-do\
-{\
-    switch(oCheckModel)\
-         {\
-         case ClCheckModel::_None:\
-              MENU_ITEM_TOGGLE_P(_T(MSG_MODEL), _T(MSG_NONE), lcd_check_model_set);\
-              break;\
-         case ClCheckModel::_Warn:\
-              MENU_ITEM_TOGGLE_P(_T(MSG_MODEL), _T(MSG_WARN), lcd_check_model_set);\
-              break;\
-         case ClCheckModel::_Strict:\
-              MENU_ITEM_TOGGLE_P(_T(MSG_MODEL), _T(MSG_STRICT), lcd_check_model_set);\
-              break;\
-         default:\
-              MENU_ITEM_TOGGLE_P(_T(MSG_MODEL), _T(MSG_NONE), lcd_check_model_set);\
-         }\
-}\
-while (0)
 
 static void lcd_check_version_set(void)
 {
 switch(oCheckVersion)
      {
-     case ClCheckVersion::_None:
-          oCheckVersion=ClCheckVersion::_Warn;
+     case ClCheckMode::_None:
+          oCheckVersion=ClCheckMode::_Warn;
           break;
-     case ClCheckVersion::_Warn:
-          oCheckVersion=ClCheckVersion::_Strict;
+     case ClCheckMode::_Warn:
+          oCheckVersion=ClCheckMode::_Strict;
           break;
-     case ClCheckVersion::_Strict:
-          oCheckVersion=ClCheckVersion::_None;
+     case ClCheckMode::_Strict:
+          oCheckVersion=ClCheckMode::_None;
           break;
      default:
-          oCheckVersion=ClCheckVersion::_None;
+          oCheckVersion=ClCheckMode::_None;
      }
 eeprom_update_byte_notify((uint8_t*)EEPROM_CHECK_VERSION,(uint8_t)oCheckVersion);
 }
-
-#define SETTINGS_VERSION \
-do\
-{\
-    switch(oCheckVersion)\
-         {\
-         case ClCheckVersion::_None:\
-              MENU_ITEM_TOGGLE_P(MSG_FIRMWARE, _T(MSG_NONE), lcd_check_version_set);\
-              break;\
-         case ClCheckVersion::_Warn:\
-              MENU_ITEM_TOGGLE_P(MSG_FIRMWARE, _T(MSG_WARN), lcd_check_version_set);\
-              break;\
-         case ClCheckVersion::_Strict:\
-              MENU_ITEM_TOGGLE_P(MSG_FIRMWARE, _T(MSG_STRICT), lcd_check_version_set);\
-              break;\
-         default:\
-              MENU_ITEM_TOGGLE_P(MSG_FIRMWARE, _T(MSG_NONE), lcd_check_version_set);\
-         }\
-}\
-while (0)
 
 static void lcd_check_filament_set(void)
 {
 switch(oCheckFilament)
      {
-     case ClCheckFilament::_None:
-          oCheckFilament=ClCheckFilament::_Warn;
+     case ClCheckMode::_None:
+          oCheckFilament=ClCheckMode::_Warn;
           break;
-     case ClCheckFilament::_Warn:
-          oCheckFilament=ClCheckFilament::_Strict;
+     case ClCheckMode::_Warn:
+          oCheckFilament=ClCheckMode::_Strict;
           break;
-     case ClCheckFilament::_Strict:
-          oCheckFilament=ClCheckFilament::_None;
+     case ClCheckMode::_Strict:
+          oCheckFilament=ClCheckMode::_None;
           break;
      default:
-          oCheckFilament=ClCheckFilament::_None;
+          oCheckFilament=ClCheckMode::_None;
      }
 eeprom_update_byte_notify((uint8_t*)EEPROM_CHECK_FILAMENT,(uint8_t)oCheckFilament);
 }
 
-#define SETTINGS_CHECK_FILAMENT \
-do\
-{\
-    switch(oCheckFilament)\
-         {\
-         case ClCheckFilament::_None:\
-              MENU_ITEM_TOGGLE_P(MSG_FILAMENT, _T(MSG_NONE), lcd_check_filament_set);\
-              break;\
-         case ClCheckFilament::_Warn:\
-              MENU_ITEM_TOGGLE_P(MSG_FILAMENT, _T(MSG_WARN), lcd_check_filament_set);\
-              break;\
-         case ClCheckFilament::_Strict:\
-              MENU_ITEM_TOGGLE_P(MSG_FILAMENT, _T(MSG_STRICT), lcd_check_filament_set);\
-              break;\
-         default:\
-              MENU_ITEM_TOGGLE_P(MSG_FILAMENT, _T(MSG_NONE), lcd_check_filament_set);\
-         }\
-}\
-while (0)
+static void settings_check_toggle(ClCheckMode oCheckSetting, const char* msg, void (*func)(void)) {
+    switch(oCheckSetting) {
+        case ClCheckMode::_None:
+            MENU_ITEM_TOGGLE_P(msg, _T(MSG_NONE), func);
+            break;
+        case ClCheckMode::_Warn:
+            MENU_ITEM_TOGGLE_P(msg, _T(MSG_WARN), func);
+            break;
+        case ClCheckMode::_Strict:
+            MENU_ITEM_TOGGLE_P(msg, _T(MSG_STRICT), func);
+            break;
+        default:
+            MENU_ITEM_TOGGLE_P(msg, _T(MSG_NONE), func);
+    }
+}
 
 static void lcd_checking_menu(void)
 {
     MENU_BEGIN();
     MENU_ITEM_BACK_P(_T(MSG_HW_SETUP));
-    SETTINGS_MODE;
-    SETTINGS_MODEL;
-    SETTINGS_VERSION;
-    SETTINGS_CHECK_FILAMENT;
+    settings_check_toggle(oCheckMode, _T(MSG_NOZZLE), lcd_check_mode_set);
+    settings_check_toggle(oCheckModel, _T(MSG_MODEL), lcd_check_model_set);
+    settings_check_toggle(oCheckVersion, MSG_FIRMWARE, lcd_check_version_set);
+    settings_check_toggle(oCheckFilament, MSG_FILAMENT, lcd_check_filament_set);
     MENU_END();
 }
 

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -4372,6 +4372,45 @@ do\
 }\
 while (0)
 
+static void lcd_check_filament_set(void)
+{
+switch(oCheckFilament)
+     {
+     case ClCheckFilament::_None:
+          oCheckFilament=ClCheckFilament::_Warn;
+          break;
+     case ClCheckFilament::_Warn:
+          oCheckFilament=ClCheckFilament::_Strict;
+          break;
+     case ClCheckFilament::_Strict:
+          oCheckFilament=ClCheckFilament::_None;
+          break;
+     default:
+          oCheckFilament=ClCheckFilament::_None;
+     }
+eeprom_update_byte_notify((uint8_t*)EEPROM_CHECK_FILAMENT,(uint8_t)oCheckFilament);
+}
+
+#define SETTINGS_CHECK_FILAMENT \
+do\
+{\
+    switch(oCheckFilament)\
+         {\
+         case ClCheckFilament::_None:\
+              MENU_ITEM_TOGGLE_P(MSG_FILAMENT, _T(MSG_NONE), lcd_check_filament_set);\
+              break;\
+         case ClCheckFilament::_Warn:\
+              MENU_ITEM_TOGGLE_P(MSG_FILAMENT, _T(MSG_WARN), lcd_check_filament_set);\
+              break;\
+         case ClCheckFilament::_Strict:\
+              MENU_ITEM_TOGGLE_P(MSG_FILAMENT, _T(MSG_STRICT), lcd_check_filament_set);\
+              break;\
+         default:\
+              MENU_ITEM_TOGGLE_P(MSG_FILAMENT, _T(MSG_NONE), lcd_check_filament_set);\
+         }\
+}\
+while (0)
+
 static void lcd_checking_menu(void)
 {
     MENU_BEGIN();
@@ -4379,6 +4418,7 @@ static void lcd_checking_menu(void)
     SETTINGS_MODE;
     SETTINGS_MODEL;
     SETTINGS_VERSION;
+    SETTINGS_CHECK_FILAMENT;
     MENU_END();
 }
 

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -4214,25 +4214,6 @@ do\
 }\
 while (0)
 
-static void lcd_check_mode_set(void)
-{
-switch(oCheckMode)
-     {
-     case ClCheckMode::_None:
-          oCheckMode=ClCheckMode::_Warn;
-          break;
-     case ClCheckMode::_Warn:
-          oCheckMode=ClCheckMode::_Strict;
-          break;
-     case ClCheckMode::_Strict:
-          oCheckMode=ClCheckMode::_None;
-          break;
-     default:
-          oCheckMode=ClCheckMode::_None;
-     }
-eeprom_update_byte_notify((uint8_t*)EEPROM_CHECK_MODE,(uint8_t)oCheckMode);
-}
-
 static void lcd_nozzle_diameter_cycle(void) {
     uint16_t nDiameter;
     switch(oNozzleDiameter){
@@ -4274,65 +4255,44 @@ do\
 }\
 while (0)
 
-static void lcd_check_model_set(void)
-{
-switch(oCheckModel)
-     {
-     case ClCheckMode::_None:
-          oCheckModel=ClCheckMode::_Warn;
-          break;
-     case ClCheckMode::_Warn:
-          oCheckModel=ClCheckMode::_Strict;
-          break;
-     case ClCheckMode::_Strict:
-          oCheckModel=ClCheckMode::_None;
-          break;
-     default:
-          oCheckModel=ClCheckMode::_None;
-     }
-eeprom_update_byte_notify((uint8_t*)EEPROM_CHECK_MODEL,(uint8_t)oCheckModel);
+static void lcd_check_update_RAM(ClCheckMode * oCheckSetting) {
+    switch(*oCheckSetting) {
+        case ClCheckMode::_None:
+            *oCheckSetting = ClCheckMode::_Warn;
+            break;
+        case ClCheckMode::_Warn:
+            *oCheckSetting = ClCheckMode::_Strict;
+            break;
+        case ClCheckMode::_Strict:
+            *oCheckSetting = ClCheckMode::_None;
+            break;
+        default:
+            *oCheckSetting = ClCheckMode::_None;
+    }
 }
 
-static void lcd_check_version_set(void)
-{
-switch(oCheckVersion)
-     {
-     case ClCheckMode::_None:
-          oCheckVersion=ClCheckMode::_Warn;
-          break;
-     case ClCheckMode::_Warn:
-          oCheckVersion=ClCheckMode::_Strict;
-          break;
-     case ClCheckMode::_Strict:
-          oCheckVersion=ClCheckMode::_None;
-          break;
-     default:
-          oCheckVersion=ClCheckMode::_None;
-     }
-eeprom_update_byte_notify((uint8_t*)EEPROM_CHECK_VERSION,(uint8_t)oCheckVersion);
+static void lcd_check_mode_set() {
+    lcd_check_update_RAM(&oCheckMode);
+    eeprom_update_byte_notify((uint8_t*)EEPROM_CHECK_MODE,(uint8_t)oCheckMode);
 }
 
-static void lcd_check_filament_set(void)
-{
-switch(oCheckFilament)
-     {
-     case ClCheckMode::_None:
-          oCheckFilament=ClCheckMode::_Warn;
-          break;
-     case ClCheckMode::_Warn:
-          oCheckFilament=ClCheckMode::_Strict;
-          break;
-     case ClCheckMode::_Strict:
-          oCheckFilament=ClCheckMode::_None;
-          break;
-     default:
-          oCheckFilament=ClCheckMode::_None;
-     }
-eeprom_update_byte_notify((uint8_t*)EEPROM_CHECK_FILAMENT,(uint8_t)oCheckFilament);
+static void lcd_check_model_set() {
+    lcd_check_update_RAM(&oCheckModel);
+    eeprom_update_byte_notify((uint8_t*)EEPROM_CHECK_MODEL,(uint8_t)oCheckModel);
 }
 
-static void settings_check_toggle(ClCheckMode oCheckSetting, const char* msg, void (*func)(void)) {
-    switch(oCheckSetting) {
+static void lcd_check_version_set() {
+    lcd_check_update_RAM(&oCheckVersion);
+    eeprom_update_byte_notify((uint8_t*)EEPROM_CHECK_VERSION,(uint8_t)oCheckVersion);
+}
+
+static void lcd_check_filament_set() {
+    lcd_check_update_RAM(&oCheckFilament);
+    eeprom_update_byte_notify((uint8_t*)EEPROM_CHECK_FILAMENT,(uint8_t)oCheckFilament);
+}
+
+static void settings_check_toggle(ClCheckMode * oCheckSetting, const char* msg, void (*func)(void)) {
+    switch(*oCheckSetting) {
         case ClCheckMode::_None:
             MENU_ITEM_TOGGLE_P(msg, _T(MSG_NONE), func);
             break;
@@ -4351,10 +4311,10 @@ static void lcd_checking_menu(void)
 {
     MENU_BEGIN();
     MENU_ITEM_BACK_P(_T(MSG_HW_SETUP));
-    settings_check_toggle(oCheckMode, _T(MSG_NOZZLE), lcd_check_mode_set);
-    settings_check_toggle(oCheckModel, _T(MSG_MODEL), lcd_check_model_set);
-    settings_check_toggle(oCheckVersion, MSG_FIRMWARE, lcd_check_version_set);
-    settings_check_toggle(oCheckFilament, MSG_FILAMENT, lcd_check_filament_set);
+    settings_check_toggle(&oCheckMode, _T(MSG_NOZZLE), lcd_check_mode_set);
+    settings_check_toggle(&oCheckModel, _T(MSG_MODEL), lcd_check_model_set);
+    settings_check_toggle(&oCheckVersion, MSG_FIRMWARE, lcd_check_version_set);
+    settings_check_toggle(&oCheckFilament, MSG_FILAMENT, lcd_check_filament_set);
     MENU_END();
 }
 

--- a/Firmware/util.cpp
+++ b/Firmware/util.cpp
@@ -202,7 +202,7 @@ bool eeprom_fw_version_older_than_p(const uint16_t (&ver_req)[4])
 
 bool show_upgrade_dialog_if_version_newer(const char *version_string)
 {
-    if(oCheckVersion == ClCheckVersion::_None)
+    if(oCheckVersion == ClCheckMode::_None)
         return false;
 
     int8_t upgrade = is_provided_version_newer(version_string);
@@ -242,10 +242,10 @@ void update_current_firmware_version_to_eeprom()
 
 ClNozzleDiameter oNozzleDiameter;
 ClCheckMode oCheckMode;
-ClCheckModel oCheckModel;
-ClCheckVersion oCheckVersion;
-ClCheckGcode oCheckGcode;
-ClCheckFilament oCheckFilament;
+ClCheckMode oCheckModel;
+ClCheckMode oCheckVersion;
+ClCheckMode oCheckGcode;
+ClCheckMode oCheckFilament;
 
 void fCheckModeInit() {
     oCheckMode = (ClCheckMode)eeprom_init_default_byte((uint8_t *)EEPROM_CHECK_MODE, (uint8_t)ClCheckMode::_Warn);
@@ -258,10 +258,10 @@ void fCheckModeInit() {
     oNozzleDiameter = (ClNozzleDiameter)eeprom_init_default_byte((uint8_t *)EEPROM_NOZZLE_DIAMETER, (uint8_t)ClNozzleDiameter::_Diameter_400);
     eeprom_init_default_word((uint16_t *)EEPROM_NOZZLE_DIAMETER_uM, EEPROM_NOZZLE_DIAMETER_uM_DEFAULT);
 
-    oCheckModel = (ClCheckModel)eeprom_init_default_byte((uint8_t *)EEPROM_CHECK_MODEL, (uint8_t)ClCheckModel::_Warn);
-    oCheckVersion = (ClCheckVersion)eeprom_init_default_byte((uint8_t *)EEPROM_CHECK_VERSION, (uint8_t)ClCheckVersion::_Warn);
-    oCheckGcode = (ClCheckGcode)eeprom_init_default_byte((uint8_t *)EEPROM_CHECK_GCODE, (uint8_t)ClCheckGcode::_Warn);
-    oCheckFilament = (ClCheckFilament)eeprom_init_default_byte((uint8_t *)EEPROM_CHECK_FILAMENT, (uint8_t)ClCheckFilament::_Warn);
+    oCheckModel = (ClCheckMode)eeprom_init_default_byte((uint8_t *)EEPROM_CHECK_MODEL, (uint8_t)ClCheckMode::_Warn);
+    oCheckVersion = (ClCheckMode)eeprom_init_default_byte((uint8_t *)EEPROM_CHECK_VERSION, (uint8_t)ClCheckMode::_Warn);
+    oCheckGcode = (ClCheckMode)eeprom_init_default_byte((uint8_t *)EEPROM_CHECK_GCODE, (uint8_t)ClCheckMode::_Warn);
+    oCheckFilament = (ClCheckMode)eeprom_init_default_byte((uint8_t *)EEPROM_CHECK_FILAMENT, (uint8_t)ClCheckMode::_Warn);
 }
 
 static void render_M862_warnings(const char* warning, const char* strict, uint8_t check)
@@ -304,7 +304,7 @@ void nozzle_diameter_check(uint16_t nDiameter) {
 }
 
 void printer_model_check(uint16_t nPrinterModel, uint16_t actualPrinterModel) {
-    if (oCheckModel == ClCheckModel::_None)
+    if (oCheckModel == ClCheckMode::_None)
         return;
     if (nPrinterModel == actualPrinterModel)
         return;
@@ -330,7 +330,7 @@ uint8_t mCompareValue(uint16_t nX, uint16_t nY) {
 }
 
 void fw_version_check(const char *pVersion) {
-    if (oCheckVersion == ClCheckVersion::_None)
+    if (oCheckVersion == ClCheckMode::_None)
         return;
 
     uint16_t aVersion[4];
@@ -374,7 +374,7 @@ void fw_version_check(const char *pVersion) {
 void filament_presence_check() {
     if (fsensor.isEnabled() && !fsensor.getFilamentPresent())
     {
-        if (oCheckFilament == ClCheckFilament::_None)
+        if (oCheckFilament == ClCheckMode::_None)
             return;
 
         render_M862_warnings(
@@ -387,7 +387,7 @@ void filament_presence_check() {
 }
 
 void gcode_level_check(uint16_t nGcodeLevel) {
-    if (oCheckGcode == ClCheckGcode::_None)
+    if (oCheckGcode == ClCheckMode::_None)
         return;
     if (nGcodeLevel <= (uint16_t)GCODE_LEVEL)
         return;

--- a/Firmware/util.cpp
+++ b/Firmware/util.cpp
@@ -374,7 +374,7 @@ void fw_version_check(const char *pVersion) {
 bool filament_presence_check() {
     // When MMU is enabled, this is not necessary and the G-code file
     // should always tell the MMU which filament to load.
-    if (MMU2::mmu2.Enabled()) {
+    if (eeprom_read_byte((uint8_t *)EEPROM_MMU_ENABLED)) {
         goto done;
     }
 

--- a/Firmware/util.cpp
+++ b/Firmware/util.cpp
@@ -3,6 +3,7 @@
 #include <stdio.h> // for sprintf_P
 
 #include "Configuration.h"
+#include "Filament_sensor.h"
 #include "language.h"
 #include "lcd.h"
 #include "Marlin.h" // delay_keep_alive

--- a/Firmware/util.cpp
+++ b/Firmware/util.cpp
@@ -245,6 +245,7 @@ ClCheckMode oCheckMode;
 ClCheckModel oCheckModel;
 ClCheckVersion oCheckVersion;
 ClCheckGcode oCheckGcode;
+ClCheckFilament oCheckFilament;
 
 void fCheckModeInit() {
     oCheckMode = (ClCheckMode)eeprom_init_default_byte((uint8_t *)EEPROM_CHECK_MODE, (uint8_t)ClCheckMode::_Warn);
@@ -260,6 +261,7 @@ void fCheckModeInit() {
     oCheckModel = (ClCheckModel)eeprom_init_default_byte((uint8_t *)EEPROM_CHECK_MODEL, (uint8_t)ClCheckModel::_Warn);
     oCheckVersion = (ClCheckVersion)eeprom_init_default_byte((uint8_t *)EEPROM_CHECK_VERSION, (uint8_t)ClCheckVersion::_Warn);
     oCheckGcode = (ClCheckGcode)eeprom_init_default_byte((uint8_t *)EEPROM_CHECK_GCODE, (uint8_t)ClCheckGcode::_Warn);
+    oCheckFilament = (ClCheckFilament)eeprom_init_default_byte((uint8_t *)EEPROM_CHECK_FILAMENT, (uint8_t)ClCheckFilament::_Warn);
 }
 
 static void render_M862_warnings(const char* warning, const char* strict, uint8_t check)
@@ -367,6 +369,21 @@ void fw_version_check(const char *pVersion) {
         ,_T(MSG_GCODE_NEWER_FIRMWARE_CANCELLED)
         ,(uint8_t)oCheckVersion
     );
+}
+
+void filament_presence_check() {
+    if (fsensor.isEnabled() && !fsensor.getFilamentPresent())
+    {
+        if (oCheckFilament == ClCheckFilament::_None)
+            return;
+
+        render_M862_warnings(
+            _T(MSG_MISSING_FILAMENT_CONTINUE)
+            ,_T(MSG_MISSING_FILAMENT_CANCELLED)
+            ,(uint8_t)oCheckFilament
+        );
+    }
+    
 }
 
 void gcode_level_check(uint16_t nGcodeLevel) {

--- a/Firmware/util.h
+++ b/Firmware/util.h
@@ -115,8 +115,21 @@ void nozzle_diameter_check(uint16_t nDiameter);
 void printer_model_check(uint16_t nPrinterModel, uint16_t actualPrinterModel);
 void printer_smodel_check(const char *pStrPos, const char *actualPrinterSModel);
 void fw_version_check(const char *pVersion);
-void filament_presence_check();
 void gcode_level_check(uint16_t nGcodeLevel);
+
+/// Check if the filament is present before starting a print job.
+/// Depending on the check level set in the menus the printer will:
+///   - None: not issue any warning about missing filament
+///   - Warning (default): The user is warned about missing filament
+///     and is prompted to continue with Yes/No. If No is selected,
+///     the print is aborted. If no user input is given (e.g. from
+///     host printing) then the warning will expire in 30 seconds and
+///     the printer assumes the Yes option was selected.
+///   - Strict: If the filament is not detected when a print is started,
+///     it is immediately canceled with a message saying the filament is
+///     missing.
+/// @returns false if the print is canceled, true otherwise
+bool filament_presence_check();
 
 uint16_t nPrinterType(bool bMMu);
 const char *sPrinterType(bool bMMu);

--- a/Firmware/util.h
+++ b/Firmware/util.h
@@ -55,38 +55,6 @@ enum class ClCheckMode:uint_least8_t
     _Undef=EEPROM_EMPTY_VALUE
 };
 
-enum class ClCheckModel:uint_least8_t
-{
-    _None,
-    _Warn,
-    _Strict,
-    _Undef=EEPROM_EMPTY_VALUE
-};
-
-enum class ClCheckVersion:uint_least8_t
-{
-    _None,
-    _Warn,
-    _Strict,
-    _Undef=EEPROM_EMPTY_VALUE
-};
-
-enum class ClCheckGcode:uint_least8_t
-{
-    _None,
-    _Warn,
-    _Strict,
-    _Undef=EEPROM_EMPTY_VALUE
-};
-
-enum class ClCheckFilament:uint_least8_t
-{
-    _None,
-    _Warn,
-    _Strict,
-    _Undef=EEPROM_EMPTY_VALUE
-};
-
 #define COMPARE_VALUE_EQUAL (((uint8_t)ClCompareValue::_Equal<<6)+((uint8_t)ClCompareValue::_Equal<<4)+((uint8_t)ClCompareValue::_Equal<<2)+((uint8_t)ClCompareValue::_Equal))
 enum class ClCompareValue:uint_least8_t
 {
@@ -137,10 +105,10 @@ private:
 
 extern ClNozzleDiameter oNozzleDiameter;
 extern ClCheckMode oCheckMode;
-extern ClCheckModel oCheckModel;
-extern ClCheckVersion oCheckVersion;
-extern ClCheckGcode oCheckGcode;
-extern ClCheckFilament oCheckFilament;
+extern ClCheckMode oCheckModel;
+extern ClCheckMode oCheckVersion;
+extern ClCheckMode oCheckGcode;
+extern ClCheckMode oCheckFilament;
 
 void fCheckModeInit();
 void nozzle_diameter_check(uint16_t nDiameter);

--- a/Firmware/util.h
+++ b/Firmware/util.h
@@ -79,6 +79,14 @@ enum class ClCheckGcode:uint_least8_t
     _Undef=EEPROM_EMPTY_VALUE
 };
 
+enum class ClCheckFilament:uint_least8_t
+{
+    _None,
+    _Warn,
+    _Strict,
+    _Undef=EEPROM_EMPTY_VALUE
+};
+
 #define COMPARE_VALUE_EQUAL (((uint8_t)ClCompareValue::_Equal<<6)+((uint8_t)ClCompareValue::_Equal<<4)+((uint8_t)ClCompareValue::_Equal<<2)+((uint8_t)ClCompareValue::_Equal))
 enum class ClCompareValue:uint_least8_t
 {
@@ -132,12 +140,14 @@ extern ClCheckMode oCheckMode;
 extern ClCheckModel oCheckModel;
 extern ClCheckVersion oCheckVersion;
 extern ClCheckGcode oCheckGcode;
+extern ClCheckFilament oCheckFilament;
 
 void fCheckModeInit();
 void nozzle_diameter_check(uint16_t nDiameter);
 void printer_model_check(uint16_t nPrinterModel, uint16_t actualPrinterModel);
 void printer_smodel_check(const char *pStrPos, const char *actualPrinterSModel);
 void fw_version_check(const char *pVersion);
+void filament_presence_check();
 void gcode_level_check(uint16_t nGcodeLevel);
 
 uint16_t nPrinterType(bool bMMu);

--- a/lang/Community_made_translations.md
+++ b/lang/Community_made_translations.md
@@ -8,8 +8,8 @@
   - [X] **Maintained**  since September 2019
 
 - **Romanian / Română**
-  - Maintainers: **@leptun** and **@Hauzman**
-  - Co-maintainers: **@QuantumRoboticsFTC**
+  - Maintainers: **@leptun**
+  - Co-maintainers: **@Hauzman**
   - Contributors:
   - [X] **Active**      since January 2022
   - [X] **Maintained**  since January 2022
@@ -22,11 +22,11 @@
   - [X] **Maintained**  since January 2022
 
 - **Croatian / Hrvatski**
-  - Maintainers: **@Prime1910**
-  - Co-maintainers: **@PRPA041**
+  - Maintainers:
+  - Co-maintainers:
   - Contributors:
-  - [X] **Active**      since January 2022
-  - [X] **Maintained**  since January 2022
+  - [ ] **Active**      started January 2022, inactive September 2024
+  - [ ] **Maintained**  started January 2022, inactive September 2024
 
 - **Slovak / Slovencina**
   - Maintainers: **@ingbrzy**
@@ -36,15 +36,15 @@
   - [X] **Maintained**  since June 2021
 
 - **Swedish / Svenska**
-  - Maintainers: **@Painkiller56**
-  - Co-maintainers:**@pkg2000**
+  - Maintainers:
+  - Co-maintainers:
   - Contributors:
-  - [X] **Active**      since March 2022
-  - [X] **Maintained**  since January 2022
+  - [ ] **Active**      started March 2022, inactive September 2024
+  - [ ] **Maintained**  started January 2022
 
 - **Norwegian / Norsk**
-  - Maintainers: **@OS-kar** and **@pkg2000**
-  - Co-maintainers: **@trondkla**
+  - Maintainers:
+  - Co-maintainers:
   - Contributors:
-  - [X] **Active**      since May 2022
-  - [X] **Maintained**  since February 2022
+  - [ ] **Active**      started May 2022, inactive September 2024
+  - [ ] **Maintained**  started February 2022

--- a/lang/po/Firmware.pot
+++ b/lang/po/Firmware.pot
@@ -2182,6 +2182,16 @@ msgid ""
 "chapter)."
 msgstr ""
 
+#. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
+#: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:388
+msgid "There is no filament loaded. Continue?"
+msgstr ""
+
+#. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
+#: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:389
+msgid "There is no filament loaded. Print cancelled."
+msgstr ""
+
 #. MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=8
 #: ../../Firmware/Marlin_main.cpp:1606 ../../Firmware/messages.cpp:47
 msgid ""

--- a/lang/po/Firmware.pot
+++ b/lang/po/Firmware.pot
@@ -674,13 +674,6 @@ msgstr ""
 msgid "Fil. sensor"
 msgstr ""
 
-#. MSG_FILAMENT c=17
-#: ../../Firmware/Marlin_main.cpp:3453 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:3613
-#: ../../Firmware/ultralcd.cpp:6822
-msgid "Filament"
-msgstr ""
-
 #. MSG_DESC_UNLOAD_MANUALLY c=20 r=8
 #: ../../Firmware/mmu2/errors_list.h:284 ../../Firmware/mmu2/errors_list.h:339
 msgid ""

--- a/lang/po/Firmware_cs.po
+++ b/lang/po/Firmware_cs.po
@@ -680,13 +680,6 @@ msgstr "Výpadky filam."
 msgid "Fil. sensor"
 msgstr "Fil. senzor"
 
-#. MSG_FILAMENT c=17
-#: ../../Firmware/Marlin_main.cpp:3453 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:3613
-#: ../../Firmware/ultralcd.cpp:6822
-msgid "Filament"
-msgstr "Filament"
-
 #. MSG_FILAMENT_CLEAN c=20 r=3
 #: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2261
 #: ../../Firmware/ultralcd.cpp:2265

--- a/lang/po/Firmware_cs.po
+++ b/lang/po/Firmware_cs.po
@@ -2595,12 +2595,12 @@ msgstr "Vyměnili jste trysku?"
 #. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:388
 msgid "There is no filament loaded. Continue?"
-msgstr "Není vloženo žádné vlákno. Pokračovat?"
+msgstr "Není vložen filament. Pokračovat?"
 
 #. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:389
 msgid "There is no filament loaded. Print cancelled."
-msgstr "Není vloženo žádné vlákno. Tisk zrušen."
+msgstr "Není vložen filament. Tisk zrušen."
 
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Vyjmete stary filament a stisknete tlacitko pro zavedeni noveho."

--- a/lang/po/Firmware_cs.po
+++ b/lang/po/Firmware_cs.po
@@ -2592,6 +2592,16 @@ msgstr "Tryska je horká! Počkejte na vychladnutí."
 msgid "Nozzle changed?"
 msgstr "Vyměnili jste trysku?"
 
+#. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
+#: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:388
+msgid "There is no filament loaded. Continue?"
+msgstr "Není vloženo žádné vlákno. Pokračovat?"
+
+#. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
+#: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:389
+msgid "There is no filament loaded. Print cancelled."
+msgstr "Není vloženo žádné vlákno. Tisk zrušen."
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Vyjmete stary filament a stisknete tlacitko pro zavedeni noveho."
 

--- a/lang/po/Firmware_de.po
+++ b/lang/po/Firmware_de.po
@@ -682,13 +682,6 @@ msgstr "Fil. Mängel"
 msgid "Fil. sensor"
 msgstr "Fil. Sensor"
 
-#. MSG_FILAMENT c=17
-#: ../../Firmware/Marlin_main.cpp:3453 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:3613
-#: ../../Firmware/ultralcd.cpp:6822
-msgid "Filament"
-msgstr "Filament"
-
 #. MSG_FILAMENT_CLEAN c=20 r=3
 #: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2261
 #: ../../Firmware/ultralcd.cpp:2265

--- a/lang/po/Firmware_de.po
+++ b/lang/po/Firmware_de.po
@@ -2620,6 +2620,16 @@ msgstr "Die Düse ist heiß! Auf Abkühlung warten."
 msgid "Nozzle changed?"
 msgstr "Düse gewechselt?"
 
+#. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
+#: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:388
+msgid "There is no filament loaded. Continue?"
+msgstr "Kein Filament geladen. Fortfahren?"
+
+#. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
+#: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:389
+msgid "There is no filament loaded. Print cancelled."
+msgstr "Kein Filament geladen. Druck abgebrochen."
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Entferne das alte Fil. und drücke den Knopf, um das neue zu laden."
 

--- a/lang/po/Firmware_es.po
+++ b/lang/po/Firmware_es.po
@@ -686,13 +686,6 @@ msgstr "Fil. acabado"
 msgid "Fil. sensor"
 msgstr "Sensor Fil."
 
-#. MSG_FILAMENT c=17
-#: ../../Firmware/Marlin_main.cpp:3453 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:3613
-#: ../../Firmware/ultralcd.cpp:6822
-msgid "Filament"
-msgstr "Filamento"
-
 #. MSG_FILAMENT_CLEAN c=20 r=3
 #: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2261
 #: ../../Firmware/ultralcd.cpp:2265

--- a/lang/po/Firmware_es.po
+++ b/lang/po/Firmware_es.po
@@ -2615,6 +2615,16 @@ msgstr "La boquilla está caliente! Espere a que se enfríe."
 msgid "Nozzle changed?"
 msgstr "Cambió la boquilla?"
 
+#. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
+#: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:388
+msgid "There is no filament loaded. Continue?"
+msgstr "No hay ningún filamento cargado. ¿Continuar?"
+
+#. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
+#: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:389
+msgid "There is no filament loaded. Print cancelled."
+msgstr "No hay ningún filamento cargado. Impresión cancelada."
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr ""
 #~ "Retira el fil. viejo y presiona el dial para comenzar a cargar el nuevo."

--- a/lang/po/Firmware_fr.po
+++ b/lang/po/Firmware_fr.po
@@ -2627,6 +2627,16 @@ msgstr "La buse est chaude! Attendre le refroidissement."
 msgid "Nozzle changed?"
 msgstr "La buse a été changée?"
 
+#. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
+#: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:388
+msgid "There is no filament loaded. Continue?"
+msgstr "Il n'y a pas de filament chargé. Continuer?"
+
+#. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
+#: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:389
+msgid "There is no filament loaded. Print cancelled."
+msgstr "Il n'y a pas de filament chargé. Impression annulée."
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr ""
 #~ "Retirez l'ancien fil. puis appuyez sur le bouton pour charger le nouveau."

--- a/lang/po/Firmware_fr.po
+++ b/lang/po/Firmware_fr.po
@@ -690,13 +690,6 @@ msgstr "Fins filament"
 msgid "Fil. sensor"
 msgstr "Capteur Fil."
 
-#. MSG_FILAMENT c=17
-#: ../../Firmware/Marlin_main.cpp:3453 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:3613
-#: ../../Firmware/ultralcd.cpp:6822
-msgid "Filament"
-msgstr "Filament"
-
 #. MSG_FILAMENT_CLEAN c=20 r=3
 #: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2261
 #: ../../Firmware/ultralcd.cpp:2265

--- a/lang/po/Firmware_hr.po
+++ b/lang/po/Firmware_hr.po
@@ -684,13 +684,6 @@ msgstr "Bez filmaneta"
 msgid "Fil. sensor"
 msgstr "Fil. senzor"
 
-#. MSG_FILAMENT c=17
-#: ../../Firmware/Marlin_main.cpp:3453 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:3613
-#: ../../Firmware/ultralcd.cpp:6822
-msgid "Filament"
-msgstr "Filament"
-
 #. MSG_FILAMENT_CLEAN c=20 r=3
 #: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2261
 #: ../../Firmware/ultralcd.cpp:2265

--- a/lang/po/Firmware_hr.po
+++ b/lang/po/Firmware_hr.po
@@ -2609,6 +2609,16 @@ msgstr "Mlaznica je vruća! Pričekajte hlađenje."
 msgid "Nozzle changed?"
 msgstr "Mlaznica se promijenila?"
 
+#. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
+#: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:388
+msgid "There is no filament loaded. Continue?"
+msgstr "Nema umetnute niti. Nastavite?"
+
+#. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
+#: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:389
+msgid "There is no filament loaded. Print cancelled."
+msgstr "Nema umetnute niti. Print je otkazan."
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Uklonite stari fil. i pritisnite gumb za pocetak stavljanja novog."
 

--- a/lang/po/Firmware_hu.po
+++ b/lang/po/Firmware_hu.po
@@ -687,13 +687,6 @@ msgstr "Fil. kifutasok"
 msgid "Fil. sensor"
 msgstr "Fil. szenzor"
 
-#. MSG_FILAMENT c=17
-#: ../../Firmware/Marlin_main.cpp:3453 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:3613
-#: ../../Firmware/ultralcd.cpp:6822
-msgid "Filament"
-msgstr "Filament"
-
 #. MSG_FILAMENT_CLEAN c=20 r=3
 #: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2261
 #: ../../Firmware/ultralcd.cpp:2265

--- a/lang/po/Firmware_hu.po
+++ b/lang/po/Firmware_hu.po
@@ -2617,12 +2617,12 @@ msgstr "Fúvóka cserélve?"
 #. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:388
 msgid "There is no filament loaded. Continue?"
-msgstr "Nincs betöltött izzószál. Folytasasm?"
+msgstr "Nincs befűzve filament. Folytassam?"
 
 #. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:389
 msgid "There is no filament loaded. Print cancelled."
-msgstr "Nincs betöltött izzószál. Nyomtatas megallitva."
+msgstr "Nincs befűzve filament. Nyomtatás megállítva."
 
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Vedd ki a regi fil., majd nyomd meg a gombot az uj fil. betoltesehez."

--- a/lang/po/Firmware_hu.po
+++ b/lang/po/Firmware_hu.po
@@ -2614,6 +2614,16 @@ msgstr "A fúvóka forró! Várja meg a lehűlést."
 msgid "Nozzle changed?"
 msgstr "Fúvóka cserélve?"
 
+#. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
+#: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:388
+msgid "There is no filament loaded. Continue?"
+msgstr "Nincs betöltött izzószál. Folytasasm?"
+
+#. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
+#: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:389
+msgid "There is no filament loaded. Print cancelled."
+msgstr "Nincs betöltött izzószál. Nyomtatas megallitva."
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Vedd ki a regi fil., majd nyomd meg a gombot az uj fil. betoltesehez."
 

--- a/lang/po/Firmware_it.po
+++ b/lang/po/Firmware_it.po
@@ -2615,6 +2615,16 @@ msgstr "L'ugello è caldo! Attendere il raffreddamento."
 msgid "Nozzle changed?"
 msgstr "L'ugello è cambiato?"
 
+#. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
+#: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:388
+msgid "There is no filament loaded. Continue?"
+msgstr "Non è caricato alcun filamento. Continuare?"
+
+#. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
+#: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:389
+msgid "There is no filament loaded. Print cancelled."
+msgstr "Non è caricato alcun filamento. Stampa annullata."
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Rimuovi il fil. precedente e premi la manopola per caricare il nuovo."
 

--- a/lang/po/Firmware_it.po
+++ b/lang/po/Firmware_it.po
@@ -2618,12 +2618,12 @@ msgstr "L'ugello è cambiato?"
 #. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:388
 msgid "There is no filament loaded. Continue?"
-msgstr "Non è caricato alcun filamento. Continuare?"
+msgstr "Nessun filamento caricato. Continuare?"
 
 #. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:389
 msgid "There is no filament loaded. Print cancelled."
-msgstr "Non è caricato alcun filamento. Stampa annullata."
+msgstr "Nessun filamento caricato. Stampa annullata."
 
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Rimuovi il fil. precedente e premi la manopola per caricare il nuovo."

--- a/lang/po/Firmware_it.po
+++ b/lang/po/Firmware_it.po
@@ -688,13 +688,6 @@ msgstr "Fil. esauriti"
 msgid "Fil. sensor"
 msgstr "Sensore fil."
 
-#. MSG_FILAMENT c=17
-#: ../../Firmware/Marlin_main.cpp:3453 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:3613
-#: ../../Firmware/ultralcd.cpp:6822
-msgid "Filament"
-msgstr "Filamento"
-
 #. MSG_FILAMENT_CLEAN c=20 r=3
 #: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2261
 #: ../../Firmware/ultralcd.cpp:2265

--- a/lang/po/Firmware_nl.po
+++ b/lang/po/Firmware_nl.po
@@ -2617,6 +2617,16 @@ msgstr "Mondstuk is heet! Wacht op afkoeling."
 msgid "Nozzle changed?"
 msgstr "Mondstuk veranderd?"
 
+#. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
+#: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:388
+msgid "There is no filament loaded. Continue?"
+msgstr "Geen filament geladen. Doorgaan?"
+
+#. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
+#: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:389
+msgid "There is no filament loaded. Print cancelled."
+msgstr "Geen filament geladen. Afdrukken geannuleerd."
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr ""
 #~ "Verwijder de oude filament en druk op de knop om nieuwe filament te laden."

--- a/lang/po/Firmware_nl.po
+++ b/lang/po/Firmware_nl.po
@@ -689,13 +689,6 @@ msgstr "Fil. fouten"
 msgid "Fil. sensor"
 msgstr "Fil. sensor"
 
-#. MSG_FILAMENT c=17
-#: ../../Firmware/Marlin_main.cpp:3453 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:3613
-#: ../../Firmware/ultralcd.cpp:6822
-msgid "Filament"
-msgstr "Filament"
-
 #. MSG_FILAMENT_CLEAN c=20 r=3
 #: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2261
 #: ../../Firmware/ultralcd.cpp:2265

--- a/lang/po/Firmware_nl.po
+++ b/lang/po/Firmware_nl.po
@@ -1702,7 +1702,7 @@ msgid ""
 " Print cancelled."
 msgstr ""
 "De diameter van de tuit van de printer verschilt van de G-code. Controleer "
-"de waarde in de instellingen. Afdrukken geannuleerd."
+"de waarde in de instellingen. Printen geannuleerd."
 
 #. MSG_DESC_PULLEY_CANNOT_MOVE c=20 r=8
 #: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302

--- a/lang/po/Firmware_nl.po
+++ b/lang/po/Firmware_nl.po
@@ -2625,7 +2625,7 @@ msgstr "Geen filament geladen. Doorgaan?"
 #. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:389
 msgid "There is no filament loaded. Print cancelled."
-msgstr "Geen filament geladen. Afdrukken geannuleerd."
+msgstr "Geen filament geladen. Printen geannuleerd."
 
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr ""

--- a/lang/po/Firmware_no.po
+++ b/lang/po/Firmware_no.po
@@ -2591,6 +2591,16 @@ msgstr "Dysen er varm! Vent på nedkjøling."
 msgid "Nozzle changed?"
 msgstr "Har du byttet dyse?"
 
+#. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
+#: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:388
+msgid "There is no filament loaded. Continue?"
+msgstr "Det er ingen filament lastet. Fortsette?"
+
+#. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
+#: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:389
+msgid "There is no filament loaded. Print cancelled."
+msgstr "Det er ingen filament lastet. Print avbrutt."
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Ta bort det gamle filamentet og trykk valghjulet for å laste et nytt."
 

--- a/lang/po/Firmware_no.po
+++ b/lang/po/Firmware_no.po
@@ -687,13 +687,6 @@ msgstr "Tomt filament"
 msgid "Fil. sensor"
 msgstr "Fil. Sensor"
 
-#. MSG_FILAMENT c=17
-#: ../../Firmware/Marlin_main.cpp:3453 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:3613
-#: ../../Firmware/ultralcd.cpp:6822
-msgid "Filament"
-msgstr "Filament"
-
 #. MSG_FILAMENT_CLEAN c=20 r=3
 #: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2261
 #: ../../Firmware/ultralcd.cpp:2265

--- a/lang/po/Firmware_pl.po
+++ b/lang/po/Firmware_pl.po
@@ -2607,6 +2607,16 @@ msgstr "Dysza jest gorąca! Poczekaj na schłodzenie."
 msgid "Nozzle changed?"
 msgstr "Dysza została zmieniona?"
 
+#. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
+#: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:388
+msgid "There is no filament loaded. Continue?"
+msgstr "Nie ma załadowanego filamentu. Kontynuować?"
+
+#. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
+#: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:389
+msgid "There is no filament loaded. Print cancelled."
+msgstr "Nie ma załadowanego filamentu. Druk anulowany."
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Wyciągnij poprzedni filament i naciśnij pokrętło aby załadować nowy."
 

--- a/lang/po/Firmware_pl.po
+++ b/lang/po/Firmware_pl.po
@@ -689,13 +689,6 @@ msgstr "Końc. filamentu"
 msgid "Fil. sensor"
 msgstr "Czuj. filam."
 
-#. MSG_FILAMENT c=17
-#: ../../Firmware/Marlin_main.cpp:3453 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:3613
-#: ../../Firmware/ultralcd.cpp:6822
-msgid "Filament"
-msgstr "Filament"
-
 #. MSG_FILAMENT_CLEAN c=20 r=3
 #: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2261
 #: ../../Firmware/ultralcd.cpp:2265

--- a/lang/po/Firmware_ro.po
+++ b/lang/po/Firmware_ro.po
@@ -689,13 +689,6 @@ msgstr "Epuizări Fil."
 msgid "Fil. sensor"
 msgstr "Senzor Fil."
 
-#. MSG_FILAMENT c=17
-#: ../../Firmware/Marlin_main.cpp:3453 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:3613
-#: ../../Firmware/ultralcd.cpp:6822
-msgid "Filament"
-msgstr "Filament"
-
 #. MSG_FILAMENT_CLEAN c=20 r=3
 #: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2261
 #: ../../Firmware/ultralcd.cpp:2265

--- a/lang/po/Firmware_ro.po
+++ b/lang/po/Firmware_ro.po
@@ -2616,6 +2616,16 @@ msgstr "Duza este fierbinte! Așteptați să se răcească."
 msgid "Nozzle changed?"
 msgstr "S-a schimbat duza?"
 
+#. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
+#: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:388
+msgid "There is no filament loaded. Continue?"
+msgstr "Nu există filament încărcat. Continuați?"
+
+#. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
+#: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:389
+msgid "There is no filament loaded. Print cancelled."
+msgstr "Nu există filament încărcat. Print anulat."
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Scoateți fil. vechi și apăsați butonul pentru a încărca unul nou."
 

--- a/lang/po/Firmware_ro.po
+++ b/lang/po/Firmware_ro.po
@@ -2619,12 +2619,12 @@ msgstr "S-a schimbat duza?"
 #. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:388
 msgid "There is no filament loaded. Continue?"
-msgstr "Nu există filament încărcat. Continuați?"
+msgstr "Filamentul nu este detectat. Continuați?"
 
 #. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:389
 msgid "There is no filament loaded. Print cancelled."
-msgstr "Nu există filament încărcat. Print anulat."
+msgstr "Filamentul nu este detectat. Print anulat."
 
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Scoateți fil. vechi și apăsați butonul pentru a încărca unul nou."

--- a/lang/po/Firmware_sk.po
+++ b/lang/po/Firmware_sk.po
@@ -686,13 +686,6 @@ msgstr "Výpadky filam."
 msgid "Fil. sensor"
 msgstr "Fil. senzor"
 
-#. MSG_FILAMENT c=17
-#: ../../Firmware/Marlin_main.cpp:3453 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:3613
-#: ../../Firmware/ultralcd.cpp:6822
-msgid "Filament"
-msgstr "Filament"
-
 #. MSG_FILAMENT_CLEAN c=20 r=3
 #: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2261
 #: ../../Firmware/ultralcd.cpp:2265

--- a/lang/po/Firmware_sk.po
+++ b/lang/po/Firmware_sk.po
@@ -2600,12 +2600,12 @@ msgstr "Vymenili ste trysku?"
 #. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:388
 msgid "There is no filament loaded. Continue?"
-msgstr "Nie je vložené žiadne vlákno. Pokračovať?"
+msgstr "Nie je zavedený žiaden filament. Pokračovať?"
 
 #. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:389
 msgid "There is no filament loaded. Print cancelled."
-msgstr "Nie je vložené žiadne vlákno. Tlač zrušená."
+msgstr "Nie je zavedený žiaden filament. Tlač zrušená."
 
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Vyberte starý filament a stlačte tlačidlo pre zavedenie nového."

--- a/lang/po/Firmware_sk.po
+++ b/lang/po/Firmware_sk.po
@@ -2597,6 +2597,16 @@ msgstr "Tryska je horúca! Počkajte na vychladnutie."
 msgid "Nozzle changed?"
 msgstr "Vymenili ste trysku?"
 
+#. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
+#: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:388
+msgid "There is no filament loaded. Continue?"
+msgstr "Nie je vložené žiadne vlákno. Pokračovať?"
+
+#. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
+#: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:389
+msgid "There is no filament loaded. Print cancelled."
+msgstr "Nie je vložené žiadne vlákno. Tlač zrušená."
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Vyberte starý filament a stlačte tlačidlo pre zavedenie nového."
 

--- a/lang/po/Firmware_sv.po
+++ b/lang/po/Firmware_sv.po
@@ -2604,6 +2604,16 @@ msgstr "Munstycket är varmt! Vänta på nedkylning."
 msgid "Nozzle changed?"
 msgstr "Har munstycket ändrats?"
 
+#. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
+#: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:388
+msgid "There is no filament loaded. Continue?"
+msgstr "Det finns ingen filament laddad. Fortsätta?"
+
+#. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
+#: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:389
+msgid "There is no filament loaded. Print cancelled."
+msgstr "Det finns ingen filament laddad. Utskriften avbröts."
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Ta bort det gamla fil. och tryck på knappen för att börja ladda nytt."
 

--- a/lang/po/Firmware_sv.po
+++ b/lang/po/Firmware_sv.po
@@ -687,13 +687,6 @@ msgstr "Fil. avbrott"
 msgid "Fil. sensor"
 msgstr "Fil. sensor"
 
-#. MSG_FILAMENT c=17
-#: ../../Firmware/Marlin_main.cpp:3453 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:3613
-#: ../../Firmware/ultralcd.cpp:6822
-msgid "Filament"
-msgstr "Filament"
-
 #. MSG_FILAMENT_CLEAN c=20 r=3
 #: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2261
 #: ../../Firmware/ultralcd.cpp:2265


### PR DESCRIPTION
Add filament presence check at start of print job. This PR aims to resolve issues where a user starts a print with no filament loaded. The idea is to use the M862 warning dialogs instead of relying on filament sensor runout. Relying on filament runout will require some fragile logic which may not be very reliable and risks adding new issues.

A new menu setting is added to configure how strict the check should be.

- None: No check is performed
- Warning **(default)**: The user is warned about missing filament and is prompted to continue with `Yes`/`No`. If `No` is selected, the print is aborted. If no user input is given (e.g. from host printing) then the warning will expire in 30 seconds and the printer assumes the `Yes` option was selected.
- Strict: If the filament is not detected when a print is started, it is immediately canceled with a message saying the filament is missing.

The check is currently performed on G-codes: M24 and M75. Starting a SD print and Host print respectively.