### PR TITLE
Fix regression introduced in 3.13.0 where `mFilamentPrompt` menu times out after 30 seconds

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1815,6 +1815,7 @@ void lcd_print_target_temps_first_line() {
 
 static void mFilamentPrompt()
 {
+    lcd_timeoutToStatus.stop();
 lcd_print_target_temps_first_line();
 lcd_puts_at_P(0,1, _T(MSG_PRESS_KNOB));
 lcd_set_cursor(0,2);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1813,61 +1813,59 @@ void lcd_print_target_temps_first_line() {
     }
 }
 
-static void mFilamentPrompt()
-{
+static void mFilamentPrompt() {
     lcd_timeoutToStatus.stop();
-lcd_print_target_temps_first_line();
-lcd_puts_at_P(0,1, _T(MSG_PRESS_KNOB));
-lcd_set_cursor(0,2);
-switch(eFilamentAction)
-     {
-     case FilamentAction::Load:
-     case FilamentAction::AutoLoad:
-     case FilamentAction::MmuLoad:
-     case FilamentAction::MmuLoadingTest:
-          lcd_puts_P(_T(MSG_TO_LOAD_FIL));
-          break;
-     case FilamentAction::UnLoad:
-     case FilamentAction::MmuUnLoad:
-          lcd_puts_P(_T(MSG_TO_UNLOAD_FIL));
-          break;
-     case FilamentAction::MmuEject:
-     case FilamentAction::MmuCut:
-     case FilamentAction::None:
-     case FilamentAction::Preheat:
-     case FilamentAction::Lay1Cal:
-          break;
-     }
+    lcd_print_target_temps_first_line();
+    lcd_puts_at_P(0,1, _T(MSG_PRESS_KNOB));
+    lcd_set_cursor(0,2);
+    switch(eFilamentAction) {
+        case FilamentAction::Load:
+        case FilamentAction::AutoLoad:
+        case FilamentAction::MmuLoad:
+        case FilamentAction::MmuLoadingTest:
+            lcd_puts_P(_T(MSG_TO_LOAD_FIL));
+            break;
+        case FilamentAction::UnLoad:
+        case FilamentAction::MmuUnLoad:
+            lcd_puts_P(_T(MSG_TO_UNLOAD_FIL));
+            break;
+        case FilamentAction::MmuEject:
+        case FilamentAction::MmuCut:
+        case FilamentAction::None:
+        case FilamentAction::Preheat:
+        case FilamentAction::Lay1Cal:
+            break;
+    }
+
     if(lcd_clicked()
 #ifdef FILAMENT_SENSOR
 /// @todo leptun - add this as a specific retest item
         || (((eFilamentAction == FilamentAction::Load) || (eFilamentAction == FilamentAction::AutoLoad)) && fsensor.getFilamentLoadEvent())
 #endif //FILAMENT_SENSOR
     ) {
-     menu_back(bFilamentPreheatState ? 2 : 3);
-     switch(eFilamentAction)
-          {
-          case FilamentAction::AutoLoad:
-               // loading no longer cancellable
-               eFilamentAction = FilamentAction::Load;
-               // FALLTHRU
-          case FilamentAction::Load:
-               enquecommand_P(MSG_M701);      // load filament
-               break;
-          case FilamentAction::UnLoad:
-               enquecommand_P(MSG_M702);      // unload filament
-               break;
-          case FilamentAction::MmuLoad:
-          case FilamentAction::MmuLoadingTest:
-          case FilamentAction::MmuUnLoad:
-          case FilamentAction::MmuEject:
-          case FilamentAction::MmuCut:
-          case FilamentAction::None:
-          case FilamentAction::Preheat:
-          case FilamentAction::Lay1Cal:
-               break;
-          }
-     }
+        menu_back(bFilamentPreheatState ? 2 : 3);
+        switch(eFilamentAction) {
+            case FilamentAction::AutoLoad:
+                // loading no longer cancellable
+                eFilamentAction = FilamentAction::Load;
+                [[fallthrough]];
+            case FilamentAction::Load:
+                enquecommand_P(MSG_M701);      // load filament
+                break;
+            case FilamentAction::UnLoad:
+                enquecommand_P(MSG_M702);      // unload filament
+                break;
+            case FilamentAction::MmuLoad:
+            case FilamentAction::MmuLoadingTest:
+            case FilamentAction::MmuUnLoad:
+            case FilamentAction::MmuEject:
+            case FilamentAction::MmuCut:
+            case FilamentAction::None:
+            case FilamentAction::Preheat:
+            case FilamentAction::Lay1Cal:
+                break;
+        }
+    }
 }
 
 static void setFilamentAction(FilamentAction action) {


### PR DESCRIPTION
Fixes https://github.com/prusa3d/Prusa-Firmware/issues/4718

This PR fixes a regression introduced in 3.13.0 here: https://github.com/prusa3d/Prusa-Firmware/commit/a7e9ccfb57e436311cb28b5636b8f66fe7982909#diff-5fbfdca43c192573e31d8e78d255c510fb6e213b118cf38173277ec2a2163880R7462

Before 3.13.0, the menu never timed out until the safety timer turned off the heaters
After 3.13.0, the menu times out after 30 seconds.

