### PR TITLE
Use M70 to set label for the filament to load at the M600 Insert filament screen

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3528,6 +3528,8 @@ static void gcode_M600(const bool automatic, const float x_position, const float
     }
     while (repeat);
 
+    lcd_clear_generic_use_text();
+
     lcd_update_enable(true);
 
     // Not let's go back to print
@@ -5930,6 +5932,17 @@ Sigma_Exit:
 	}
 #endif		// Z_PROBE_REPEATABILITY_TEST
 #endif		// ENABLE_AUTO_BED_LEVELING
+
+    /*!
+    ### M70 - Display Message <a href="https://reprap.org/wiki/G-code#M70:_Display_message">M70: Store Message</a>
+    */
+    case 70: 
+    {
+        const char *src = strchr_pointer + 3;
+        while (*src == ' ') src++;
+        lcd_set_generic_use_text(src);
+    }
+    break;
 
     /*!
     ### M72 - Set/get Printer State <a href="https://reprap.org/wiki/G-code#M72:_Set.2FGet_Printer_State">M72: Set/get Printer State</a>

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -81,6 +81,9 @@ static uint8_t lcd_status_message_level;
 static uint8_t lcd_status_message_idx = 0;
 static char lcd_status_message[LCD_WIDTH + 1];
 
+/* Buffer for a generic LCD text */
+static char lcd_generic_use_text[LCD_WIDTH + 1];
+
 /* !Configuration settings */
 
 static uint8_t lay1cal_filament = 0;
@@ -2156,11 +2159,17 @@ void lcd_wait_interact() {
   lcd_clear();
 
   lcd_puts_at_P(0, 0, _T(MSG_INSERT_FILAMENT));
+  lcd_set_cursor(0, 1);
+  if (lcd_generic_use_text[0]) {
+    lcd_print(lcd_generic_use_text);
+    lcd_set_cursor(0, 2);
+  }
+
 #ifdef FILAMENT_SENSOR
   if (!fsensor.getAutoLoadEnabled())
 #endif //FILAMENT_SENSOR
   {
-    lcd_puts_at_P(0, 1, _T(MSG_PRESS));
+    lcd_puts_P(_T(MSG_PRESS));
   }
 }
 
@@ -7310,6 +7319,17 @@ void lcd_reset_alert_level()
 uint8_t get_message_level()
 {
 	return lcd_status_message_level;
+}
+
+void lcd_set_generic_use_text(const char *text)
+{
+    strncpy(lcd_generic_use_text, text, LCD_WIDTH);
+    lcd_generic_use_text[LCD_WIDTH] = 0;
+}
+
+void lcd_clear_generic_use_text()
+{
+    lcd_generic_use_text[0] = 0;
 }
 
 void menu_lcd_longpress_func(void)

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -43,6 +43,10 @@ void lcd_reset_status_message_timeout();
 void lcd_setalertstatus(const char* message, uint8_t severity = LCD_STATUS_ALERT);
 void lcd_setalertstatuspgm(const char* message, uint8_t severity = LCD_STATUS_ALERT);
 
+// Manage the generic use text content
+void lcd_set_generic_use_text(const char *message);
+void lcd_clear_generic_use_text();
+
 //! Get/reset the current alert level
 uint8_t get_message_level();
 void lcd_reset_alert_level();


### PR DESCRIPTION
A variation of the https://github.com/prusa3d/Prusa-Firmware/pull/4548. It repurposes the unused M70 command in the Prusa firmware to store a custom message, which is displayed by the M600 command on the load filament screen.

```
M70 Deep Blue
M600
```
The Insert filament screen will then show the custom text defined with the M70 command:
```
Insert filament
Deep Blue
and press the knob
```
