### PR TITLE
:construction: WIP cmake: enable `-mcall-prologues`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -339,6 +339,9 @@ if(CMAKE_CROSSCOMPILING)
   add_compile_options(-flto -fno-fat-lto-objects)
   add_link_options(-flto)
 
+  # Call Prologues/Epilogues to reduce code size
+  add_compile_options(-mcall-prologues)
+
   # Create this target before we apply the GC options
   add_library(avr_core STATIC ${AVR_SOURCES})
   set_reproducible_target(avr_core)


### PR DESCRIPTION
Idea to reduce flash memory usage by ~5KB. There is some performance impact due to calling two routines, needs to be scoped/investigated. If we run out flash memory, then this could be a good way to free some of it.
