### PR TITLE
Remove recursion workaround in Nozzle Change

### DIFF
--- a/Firmware/lcd.h
+++ b/Firmware/lcd.h
@@ -111,18 +111,18 @@ extern void lcd_buttons_update(void);
 //! When constructed (on stack), original state state of lcd_update_enabled is stored
 //! and LCD updates are disabled.
 //! When destroyed (gone out of scope), original state of LCD update is restored.
-//! It has zero overhead compared to storing bool saved = lcd_update_enabled
-//! and calling lcd_update_enable(false) and lcd_update_enable(saved).
+//! Do not call lcd_update_enable() to prevent calling lcd_update() in sensitive code.
+//! in certain scenarios it will cause recursion e.g. in the menus.
 class LcdUpdateDisabler
 {
 public:
     LcdUpdateDisabler(): m_updateEnabled(lcd_update_enabled)
     {
-        lcd_update_enable(false);
+        lcd_update_enabled = false;
     }
     ~LcdUpdateDisabler()
     {
-        lcd_update_enable(m_updateEnabled);
+        lcd_update_enabled = m_updateEnabled;
     }
 
 private:

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -984,10 +984,7 @@ void lcd_commands()
                 break;
             case 3:
 #ifndef QUICK_NOZZLE_CHANGE
-                lcd_update_enabled = false; //hack to avoid lcd_update recursion.
                 lcd_show_fullscreen_message_and_wait_P(_T(MSG_NOZZLE_CNG_READ_HELP));
-                lcd_update_enabled = true;
-                lcd_draw_update = 2; //force lcd clear and update after the stack unwinds.
                 enquecommand_P(G28W);
                 enquecommand_P(PSTR("G1 X125 Z200 F1000"));
                 enquecommand_P(PSTR("M109 S280"));
@@ -1000,14 +997,9 @@ void lcd_commands()
                     fanSpeed = 255; //turn on fan
                     disable_heater();
                     uint8_t choice = lcd_show_multiscreen_message_yes_no_and_wait_P(_T(MSG_NOZZLE_CNG_COOLDOWN), true, LCD_LEFT_BUTTON_CHOICE);
-                    lcd_update_enabled = false; //hack to avoid lcd_update recursion.
                     if (choice == LCD_MIDDLE_BUTTON_CHOICE) {
-                        lcd_update_enabled = true;
-                        lcd_draw_update = 2; //force lcd clear and update after the stack unwinds.
                         break;
                     }
-                    lcd_update_enabled = true;
-                    lcd_draw_update = 2; //force lcd clear and update after the stack unwinds.
                 }
                 enquecommand_P(G28W); //home
                 enquecommand_P(PSTR("G1 X125 Z200 F1000")); //move to top center
@@ -1016,7 +1008,6 @@ void lcd_commands()
                 break;
             case 2:
                 enquecommand_P(PSTR("M84 XY"));
-                lcd_update_enabled = false; //hack to avoid lcd_update recursion.
                 if (lcd_show_multiscreen_message_yes_no_and_wait_P(_T(MSG_NOZZLE_CNG_CHANGED), false) == LCD_LEFT_BUTTON_CHOICE) {
 #ifndef QUICK_NOZZLE_CHANGE
                     setTargetHotend(0);
@@ -1028,7 +1019,6 @@ void lcd_commands()
 #endif //QUICK_NOZZLE_CHANGE
                     lcd_commands_step = 1;
                 }
-                lcd_update_enabled = true;
                 break;
             case 1:
                 lcd_commands_step = 0;


### PR DESCRIPTION
This workaround isn't needed today. At the time this workaround was added, `lcd_show_multiscreen_message_yes_no_and_wait_P` was calling `lcd_update()` via `lcd_update_enable(true)` which caused all sorts of problems like first layer calibration being inaccessible.

When testing this PR, I found one more place where `lcd_update()` was being called: [7b70f6a](https://github.com/prusa3d/Prusa-Firmware/pull/4736/commits/7b70f6a5922fca082dd6dcf61a32e766fd3e2e15) which has now been eliminated. This change is required to fully remove the workaround.

Steps to test:

1. Power on printer
2. Run Nozzle Change from Hardware setup menu
3. **Test:** at no point does the LCD seem to _freeze_ or become _unresponsive_.