### PR TITLE
PR 4739 follow-up (two things were missed)

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -726,12 +726,6 @@ void softReset(void) {
     while(1);
 }
 
-
-#ifdef MESH_BED_LEVELING
-   enum MeshLevelingState { MeshReport, MeshStart, MeshNext, MeshSet };
-#endif
-
-
 static void factory_reset_stats(){
     eeprom_update_dword_notify((uint32_t *)EEPROM_TOTALTIME, 0);
     eeprom_update_dword_notify((uint32_t *)EEPROM_FILAMENTUSED, 0);

--- a/Firmware/eeprom.h
+++ b/Firmware/eeprom.h
@@ -106,7 +106,7 @@ static_assert(sizeof(Sheets) == EEPROM_SHEETS_SIZEOF, "Sizeof(Sheets) is not EEP
 | ^           | ^       | ^                                     | f0h 240      | ^               __P__ | needs Z calibration                               | ^            | ^
 | ^           | ^       | ^                                     | fah 250      | ^                     | needs XYZ calibration                             | ^            | ^
 | ^           | ^       | ^                                     | 00h 0        | ^                     | Unknown (legacy)                                  | ^            | ^
-| 0x0FF5 4085 | uint16  | EEPROM_BABYSTEP_Z0                    | ???          | ff ffh 65535          | Babystep for Z ???                                | ???          | D3 Ax0ff5 C2
+| 0x0FF5 4085 | uint16  | _EEPROM_FREE_NR12_                    | ???          | ff ffh 65535          | _Free EEPROM space_                               | _free space_ | D3 Ax0ff5 C2
 | 0x0FF1 4081 | uint32  | EEPROM_FILAMENTUSED                   | ???          | 00 00 00 00h 0 __S/P__| Filament used in meters                           | ???          | D3 Ax0ff1 C4
 | 0x0FED 4077 | uint32  | EEPROM_TOTALTIME                      | ???          | 00 00 00 00h 0 __S/P__| Total print time in minutes                       | ???          | D3 Ax0fed C4
 | 0x0FE5 4069 | float   | EEPROM_BED_CALIBRATION_CENTER         | ???          | ff ff ff ffh          | ???                                               | ???          | D3 Ax0fe5 C8
@@ -437,7 +437,7 @@ static_assert(sizeof(Sheets) == EEPROM_SHEETS_SIZEOF, "Sizeof(Sheets) is not EEP
 #define _EEPROM_FREE_NR11_ 4090 // uint16_t
 #define EEPROM_BABYSTEP_Z 4088 //legacy, multiple values stored now in EEPROM_Sheets_base
 #define EEPROM_CALIBRATION_STATUS_V1 4087 // legacy, used up to v3.11
-#define EEPROM_BABYSTEP_Z0 4085
+#define _EEPROM_FREE_NR12_ (EEPROM_CALIBRATION_STATUS_V1 - 2) // uint16_t
 #define EEPROM_FILAMENTUSED 4081
 // uint32_t
 #define EEPROM_TOTALTIME 4077

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -47,7 +47,6 @@ void lcd_setalertstatuspgm(const char* message, uint8_t severity = LCD_STATUS_AL
 uint8_t get_message_level();
 void lcd_reset_alert_level();
 
-void lcd_pick_babystep();
 uint8_t lcd_alright();
 void show_preheat_nozzle_warning();
 void lcd_wait_interact();


### PR DESCRIPTION
Follow up to https://github.com/prusa3d/Prusa-Firmware/pull/4739

I spotted two minor things I missed

1. `EEPROM_BABYSTEP_Z0` is no longer used anywhere (this was used in `G83` which is now removed)
2. `lcd_pick_babystep` function isn't defined anywhere or used. (this was used in `G85` which is now removed)