### PR TITLE
tests: test_run_all target must depend on tests executable

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,4 +39,5 @@ add_custom_target(
   COMMAND ${CMAKE_COMMAND} -E touch .ctest-finished || exit 0
   BYPRODUCTS ${PROJECT_BINARY_DIR}/.ctest-finished
   WORKING_DIRECTORY "${PROJECT_BINARY_DIR}"
+  DEPENDS tests
   )


### PR DESCRIPTION
Otherwise the tests and Catch2 isn't built