### PR TITLE
Fix compiler warning and add missing includes in unit test environment

### DIFF
--- a/Firmware/Configuration.h
+++ b/Firmware/Configuration.h
@@ -1,6 +1,7 @@
 #ifndef CONFIGURATION_H
 #define CONFIGURATION_H
 
+#include <stdint.h>
 #include "boards.h"
 
 #define STR_HELPER(x) #x

--- a/Firmware/Filament_sensor.cpp
+++ b/Firmware/Filament_sensor.cpp
@@ -8,6 +8,7 @@
 #include "language.h"
 #include "menu.h"
 #include "messages.h"
+#include "mmu2.h"
 #include "planner.h"
 #include "temperature.h"
 #include "ultralcd.h"

--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -63,8 +63,6 @@
   #define MYSERIAL MSerial
 #endif
 
-#include "lcd.h"
-
 #define SERIAL_PROTOCOL(x) (MYSERIAL.print(x))
 #define SERIAL_PROTOCOL_F(x,y) (MYSERIAL.print(x,y))
 #define SERIAL_PROTOCOLPGM(x) (serialprintPGM(PSTR(x)))

--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -21,7 +21,6 @@
 #include "Configuration.h"
 #include "pins.h"
 #include "Timer.h"
-#include "mmu2.h"
 #include "printer_state.h"
 
 #ifndef AT90USB

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -76,6 +76,7 @@
 #include "cardreader.h"
 #include "ConfigurationStore.h"
 #include "language.h"
+#include "lcd.h"
 #include "math.h"
 #include "util.h"
 #include "Timer.h"

--- a/Firmware/Prusa_farm.cpp
+++ b/Firmware/Prusa_farm.cpp
@@ -8,6 +8,7 @@
 #include "ultralcd.h"
 #include "Filament_sensor.h"
 #include "language.h"
+#include "lcd.h"
 #include "stopwatch.h"
 
 #ifdef PRUSA_FARM

--- a/Firmware/eeprom.h
+++ b/Firmware/eeprom.h
@@ -12,6 +12,7 @@
 #define EEPROM_H
 
 #include <stdint.h>
+#include <stddef.h>
 #include "Configuration_var.h"
 
 // Custom Mendel Name

--- a/Firmware/mesh_bed_calibration.cpp
+++ b/Firmware/mesh_bed_calibration.cpp
@@ -2,6 +2,7 @@
 #include "ConfigurationStore.h"
 #include "util.h"
 #include "language.h"
+#include "lcd.h"
 #include "mesh_bed_calibration.h"
 #include "mesh_bed_leveling.h"
 #include "stepper.h"

--- a/Firmware/mesh_bed_calibration.h
+++ b/Firmware/mesh_bed_calibration.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Marlin.h"
+#include <avr/pgmspace.h>
 
 #define BED_ZERO_REF_X (- 22.f + X_PROBE_OFFSET_FROM_EXTRUDER) // -22 + 23 = 1
 #define BED_ZERO_REF_Y (- 0.6f + Y_PROBE_OFFSET_FROM_EXTRUDER + 4.f) // -0.6 + 5 + 4 = 8.4

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -11,6 +11,7 @@
 #include "ultralcd.h"
 #include "Filament_sensor.h"
 #include "language.h"
+#include "lcd.h"
 #include "temperature.h"
 #include "sound.h"
 

--- a/Firmware/planner.cpp
+++ b/Firmware/planner.cpp
@@ -57,6 +57,7 @@
 #include "temperature.h"
 #include "fancheck.h"
 #include "ultralcd.h"
+#include "lcd.h"
 #include "language.h"
 #include "ConfigurationStore.h"
 

--- a/Firmware/stepper.cpp
+++ b/Firmware/stepper.cpp
@@ -26,6 +26,7 @@
 #include "planner.h"
 #include "temperature.h"
 #include "ultralcd.h"
+#include "lcd.h"
 #include "cardreader.h"
 #include "speed_lookuptable.h"
 #if defined(DIGIPOTSS_PIN) && DIGIPOTSS_PIN > -1

--- a/Firmware/temperature.cpp
+++ b/Firmware/temperature.cpp
@@ -36,6 +36,7 @@
 #include "fancheck.h"
 #include "messages.h"
 #include "language.h"
+#include "lcd.h"
 
 #include "SdFatUtil.h"
 

--- a/Firmware/util.cpp
+++ b/Firmware/util.cpp
@@ -5,6 +5,7 @@
 #include "sound.h"
 #include "language.h"
 #include "util.h"
+#include <avr/eeprom.h>
 #include <avr/pgmspace.h>
 #include "Prusa_farm.h"
 

--- a/Firmware/util.cpp
+++ b/Firmware/util.cpp
@@ -4,6 +4,8 @@
 
 #include "Configuration.h"
 #include "language.h"
+#include "lcd.h"
+#include "Marlin.h" // delay_keep_alive
 #include "menu.h"
 #include "Prusa_farm.h"
 #include "sound.h"

--- a/Firmware/util.cpp
+++ b/Firmware/util.cpp
@@ -1,5 +1,6 @@
 #include <avr/eeprom.h>
 #include <avr/pgmspace.h>
+#include <stdio.h> // for sprintf_P
 
 #include "Configuration.h"
 #include "language.h"

--- a/Firmware/util.cpp
+++ b/Firmware/util.cpp
@@ -1,13 +1,13 @@
-#include "Configuration.h"
-
-#include "ultralcd.h"
-#include "menu.h"
-#include "sound.h"
-#include "language.h"
-#include "util.h"
 #include <avr/eeprom.h>
 #include <avr/pgmspace.h>
+
+#include "Configuration.h"
+#include "language.h"
+#include "menu.h"
 #include "Prusa_farm.h"
+#include "sound.h"
+#include "ultralcd.h"
+#include "util.h"
 
 // Allocate the version string in the program memory. Otherwise the string lands either on the stack or in the global RAM.
 static const char FW_VERSION_STR[] PROGMEM = FW_VERSION;

--- a/Firmware/util.h
+++ b/Firmware/util.h
@@ -96,7 +96,7 @@ public:
     : len(0)
     , found(false)
     {
-        char * pStrEnd = NULL;
+        const char * pStrEnd = NULL;
 
         // Start of the string
         this->ptr = strchr(pStr, '"');

--- a/Firmware/xyzcal.cpp
+++ b/Firmware/xyzcal.cpp
@@ -5,6 +5,7 @@
 
 #include "xyzcal.h"
 #include <avr/wdt.h>
+#include "lcd.h"
 #include "stepper.h"
 #include "temperature.h"
 #include "sm4.h"


### PR DESCRIPTION
This PR fixes a few issues I noticed when attempting to create unit test for printer model checks in `util.cpp/h`.