### PR TITLE
planner/stepper: simplify `ultralcd.h` include into `lcd.h`

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -8319,10 +8319,8 @@ Sigma_Exit:
     }
     else if (code_seen('P'))
     {
-        uint8_t newMenuMode = (mcode_in_progress==914) ? SILENT_MODE_NORMAL : SILENT_MODE_STEALTH;
-
         // Update both EEPROM value and cached value in RAM
-        st_update_stepper_mode(newMenuMode);
+        st_update_stepper_mode(newMode);
         //printf_P(_n("tmc2130mode/smm/eep: %d %d %d %d"),stepper_cached_mode,stepper_cached_mode,eeprom_read_byte((uint8_t*)EEPROM_SILENT), bEnableForce_z);
     }
     else if (code_seen('Q'))

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1084,7 +1084,7 @@ void setup()
     farm_mode_init();
 
 #ifdef TMC2130
-    if(FarmOrUserECool()) {
+    if(UserECoolEnabled()) {
         //increased extruder current (PFW363)
         currents[E_AXIS].setiRun(TMC2130_CURRENTS_FARM);
         currents[E_AXIS].setiHold(TMC2130_CURRENTS_FARM);
@@ -1314,7 +1314,7 @@ void setup()
 #ifdef TMC2130
 	tmc2130_mode = silentMode?TMC2130_MODE_SILENT:TMC2130_MODE_NORMAL;
 	update_mode_profile();
-	tmc2130_init(TMCInitParams(false, FarmOrUserECool() ));
+	tmc2130_init(TMCInitParams(false, UserECoolEnabled() ));
 #endif //TMC2130
 #ifdef PSU_Delta
      init_force_z();                              // ! important for correct Z-axis initialization
@@ -2406,7 +2406,7 @@ void change_power_mode_live(uint8_t mode)
 		cli();
 		tmc2130_mode = mode;
 		update_mode_profile();
-		tmc2130_init(TMCInitParams(FarmOrUserECool()));
+		tmc2130_init(TMCInitParams(UserECoolEnabled()));
     // We may have missed a stepper timer interrupt due to the time spent in the tmc2130_init() routine.
     // Be safe than sorry, reset the stepper timer before re-enabling interrupts.
     st_reset_timer();
@@ -8161,7 +8161,7 @@ Sigma_Exit:
         // See tmc2130_cur2val() for translation to 0 .. 63 range
         for (uint_least8_t i = 0; i < NUM_AXIS; i++){
             if(code_seen(axis_codes[i])){
-                if( i == E_AXIS && FarmOrUserECool() ){
+                if( i == E_AXIS && UserECoolEnabled() ){
                     SERIAL_ECHORPGM(eMotorCurrentScalingEnabled);
                     SERIAL_ECHOLNPGM(", M907 E ignored");
                     continue;
@@ -8223,7 +8223,7 @@ Sigma_Exit:
     */
 	case 910:
     {
-		tmc2130_init(TMCInitParams(false, FarmOrUserECool()));
+		tmc2130_init(TMCInitParams(false, UserECoolEnabled()));
     }
     break;
 
@@ -11075,7 +11075,7 @@ void disable_force_z()
 #ifdef TMC2130
     tmc2130_mode=TMC2130_MODE_SILENT;
     update_mode_profile();
-    tmc2130_init(TMCInitParams(true, FarmOrUserECool()));
+    tmc2130_init(TMCInitParams(true, UserECoolEnabled()));
 #endif // TMC2130
 }
 
@@ -11089,7 +11089,7 @@ bEnableForce_z=true;
 #ifdef TMC2130
 tmc2130_mode=eeprom_read_byte((uint8_t*)EEPROM_SILENT)?TMC2130_MODE_SILENT:TMC2130_MODE_NORMAL;
 update_mode_profile();
-tmc2130_init(TMCInitParams(true, FarmOrUserECool()));
+tmc2130_init(TMCInitParams(true, UserECoolEnabled()));
 #endif // TMC2130
 
 WRITE(Z_ENABLE_PIN,Z_ENABLE_ON);                  // slightly redundant ;-p

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -8321,7 +8321,7 @@ Sigma_Exit:
     {
         uint8_t newMenuMode = (mcode_in_progress==914) ? SILENT_MODE_NORMAL : SILENT_MODE_STEALTH;
 
-        // Update both EEPROM value an cached value in RAM
+        // Update both EEPROM value and cached value in RAM
         st_update_stepper_mode(newMenuMode);
         //printf_P(_n("tmc2130mode/smm/eep: %d %d %d %d"),stepper_cached_mode,stepper_cached_mode,eeprom_read_byte((uint8_t*)EEPROM_SILENT), bEnableForce_z);
     }

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1267,14 +1267,10 @@ void setup()
 
 	factory_reset();
 
-  eeprom_init_default_byte((uint8_t*)EEPROM_SILENT, SILENT_MODE_OFF);
+  stepper_cached_mode = eeprom_init_default_byte((uint8_t*)EEPROM_SILENT, SILENT_MODE_OFF);
   eeprom_init_default_byte((uint8_t*)EEPROM_WIZARD_ACTIVE, 1); //run wizard if uninitialized
 
 #ifdef TMC2130
-	uint8_t silentMode = eeprom_read_byte((uint8_t*)EEPROM_SILENT);
-	if (silentMode == 0xff) silentMode = 0;
-	tmc2130_mode = TMC2130_MODE_NORMAL;
-
   tmc2130_sg_stop_on_crash = eeprom_init_default_byte((uint8_t*)EEPROM_CRASH_DET, farm_mode ? false : true);
 
 	if (tmc2130_sg_stop_on_crash) {
@@ -1312,7 +1308,6 @@ void setup()
 	st_init();    // Initialize stepper, this enables interrupts!
 
 #ifdef TMC2130
-	tmc2130_mode = silentMode?TMC2130_MODE_SILENT:TMC2130_MODE_NORMAL;
 	update_mode_profile();
 	tmc2130_init(TMCInitParams(false, UserECoolEnabled() ));
 #endif //TMC2130
@@ -2404,7 +2399,9 @@ void change_power_mode_live(uint8_t mode)
   // Wait for the planner queue to drain and for the stepper timer routine to reach an idle state.
 		st_synchronize();
 		cli();
-		tmc2130_mode = mode;
+
+    // EEPROM is intentionally not updated here, see M914/M915
+    stepper_cached_mode = mode;
 		update_mode_profile();
 		tmc2130_init(TMCInitParams(UserECoolEnabled()));
     // We may have missed a stepper timer interrupt due to the time spent in the tmc2130_init() routine.
@@ -2417,9 +2414,7 @@ void force_high_power_mode(bool start_high_power_section) {
 #ifdef PSU_Delta
 	if (start_high_power_section == true) enable_force_z();
 #endif //PSU_Delta
-	uint8_t silent;
-	silent = eeprom_read_byte((uint8_t*)EEPROM_SILENT);
-	if (silent == 1 || tmc2130_mode == TMC2130_MODE_SILENT) {
+	if (stepper_cached_mode == TMC2130_MODE_SILENT) {
 		//we are in silent mode, set to normal mode to enable crash detection
     change_power_mode_live((start_high_power_section == true) ? TMC2130_MODE_NORMAL : TMC2130_MODE_SILENT);
 	}
@@ -8317,27 +8312,28 @@ Sigma_Exit:
     case 915:
     {
     uint8_t newMode = (mcode_in_progress==914) ? TMC2130_MODE_NORMAL : TMC2130_MODE_SILENT;
-    //printf_P(_n("tmc2130mode/smm/eep: %d %d %d %d"),tmc2130_mode,SilentModeMenu,eeprom_read_byte((uint8_t*)EEPROM_SILENT), bEnableForce_z);
+    //printf_P(_n("tmc2130mode/smm/eep: %d %d %d %d"),stepper_cached_mode,newMode,eeprom_read_byte((uint8_t*)EEPROM_SILENT), bEnableForce_z);
     if (code_seen('R'))
     {
-        newMode = eeprom_read_byte((uint8_t*)EEPROM_SILENT);
+        newMode = stepper_cached_mode;
     }
     else if (code_seen('P'))
     {
         uint8_t newMenuMode = (mcode_in_progress==914) ? SILENT_MODE_NORMAL : SILENT_MODE_STEALTH;
-        eeprom_update_byte_notify((unsigned char *)EEPROM_SILENT, newMenuMode);
-        SilentModeMenu = newMenuMode;
-        //printf_P(_n("tmc2130mode/smm/eep: %d %d %d %d"),tmc2130_mode,SilentModeMenu,eeprom_read_byte((uint8_t*)EEPROM_SILENT), bEnableForce_z);
+
+        // Update both EEPROM value an cached value in RAM
+        st_update_stepper_mode(newMenuMode);
+        //printf_P(_n("tmc2130mode/smm/eep: %d %d %d %d"),stepper_cached_mode,stepper_cached_mode,eeprom_read_byte((uint8_t*)EEPROM_SILENT), bEnableForce_z);
     }
     else if (code_seen('Q'))
     {
         printf_P(PSTR("%S: %S\n"), _O(MSG_MODE),
-            tmc2130_mode == TMC2130_MODE_NORMAL ?
+            stepper_cached_mode == TMC2130_MODE_NORMAL ?
             _O(MSG_NORMAL) : _O(MSG_SILENT)
         );
 
     }
-      if (tmc2130_mode != newMode
+      if (stepper_cached_mode != newMode
 #ifdef PSU_Delta
           || !bEnableForce_z
 #endif
@@ -9301,7 +9297,7 @@ void get_coordinates() {
       if (relative)
         destination[i] += current_position[i];
 #if MOTHERBOARD == BOARD_RAMBO_MINI_1_0 || MOTHERBOARD == BOARD_RAMBO_MINI_1_3
-	  if (i == Z_AXIS && SilentModeMenu == SILENT_MODE_AUTO) update_currents();
+	  if (i == Z_AXIS && stepper_cached_mode == SILENT_MODE_AUTO) update_currents();
 #endif //MOTHERBOARD == BOARD_RAMBO_MINI_1_0 || MOTHERBOARD == BOARD_RAMBO_MINI_1_3
     }
     else destination[i] = current_position[i]; //Are these else lines really needed?
@@ -10860,7 +10856,7 @@ uint8_t calc_percent_done()
     //in case that we have information from M73 gcode return percentage counted by slicer, else return percentage counted as byte_printed/filesize
     uint8_t percent_done = 0;
 #ifdef TMC2130
-    if (SilentModeMenu == SILENT_MODE_OFF && print_percent_done_normal <= 100)
+    if (stepper_cached_mode == SILENT_MODE_OFF && print_percent_done_normal <= 100)
     {
         percent_done = print_percent_done_normal;
     }
@@ -11073,7 +11069,7 @@ void disable_force_z()
 
     // switching to silent mode
 #ifdef TMC2130
-    tmc2130_mode=TMC2130_MODE_SILENT;
+    st_update_stepper_mode(TMC2130_MODE_SILENT)
     update_mode_profile();
     tmc2130_init(TMCInitParams(true, UserECoolEnabled()));
 #endif // TMC2130
@@ -11087,7 +11083,6 @@ bEnableForce_z=true;
 
 // mode recovering
 #ifdef TMC2130
-tmc2130_mode=eeprom_read_byte((uint8_t*)EEPROM_SILENT)?TMC2130_MODE_SILENT:TMC2130_MODE_NORMAL;
 update_mode_profile();
 tmc2130_init(TMCInitParams(true, UserECoolEnabled()));
 #endif // TMC2130

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -8315,7 +8315,7 @@ Sigma_Exit:
     //printf_P(_n("tmc2130mode/smm/eep: %d %d %d %d"),stepper_cached_mode,newMode,eeprom_read_byte((uint8_t*)EEPROM_SILENT), bEnableForce_z);
     if (code_seen('R'))
     {
-        newMode = stepper_cached_mode;
+        newMode = eeprom_read_byte((uint8_t*)EEPROM_SILENT);
     }
     else if (code_seen('P'))
     {

--- a/Firmware/Prusa_farm.cpp
+++ b/Firmware/Prusa_farm.cpp
@@ -9,6 +9,7 @@
 #include "Filament_sensor.h"
 #include "language.h"
 #include "stopwatch.h"
+#include "stepper.h"
 
 #ifdef PRUSA_FARM
 uint8_t farm_mode = 0;
@@ -448,8 +449,7 @@ bool farm_prusa_code_seen() {
 void farm_gcode_g98() {
     farm_mode = 1;
     eeprom_update_byte_notify((unsigned char *)EEPROM_FARM_MODE, farm_mode);
-    SilentModeMenu = SILENT_MODE_OFF;
-    eeprom_update_byte_notify((unsigned char *)EEPROM_SILENT, SilentModeMenu);
+    st_update_stepper_mode(SILENT_MODE_OFF);
     fCheckModeInit(); // alternatively invoke printer reset
 }
 

--- a/Firmware/eeprom.cpp
+++ b/Firmware/eeprom.cpp
@@ -73,6 +73,21 @@ void eeprom_adjust_bed_reset() {
     eeprom_update_byte_notify((uint8_t*)EEPROM_BED_CORRECTION_REAR, 0);
 }
 
+/// Enable experimental support for cooler operation of the extruder motor
+/// Beware - REQUIRES original Prusa MK3/S/+ extruder motor with adequate maximal current
+/// Therefore we don't want to allow general usage of this feature in public as the community likes to
+/// change motors for various reasons and unless the motor is rotating, we cannot verify its properties
+/// (which would be obviously too late for an improperly sized motor)
+/// For farm printing, the cooler E-motor is enabled by default.
+bool UserECoolEnabled() {
+    // We enable E-cool mode for non-farm prints IFF the experimental menu is visible AND the EEPROM_ECOOL variable has
+    // a value of the universal answer to all problems of the universe
+    return eeprom_read_byte((uint8_t*)EEPROM_FARM_MODE) || (
+        ( eeprom_read_byte((uint8_t *)EEPROM_ECOOL_ENABLE) == EEPROM_ECOOL_MAGIC_NUMBER )
+        && ( eeprom_read_byte((uint8_t *)EEPROM_EXPERIMENTAL_VISIBILITY) == 1 )
+    );
+}
+
 //! @brief Get default sheet name for index
 //!
 //! | index | sheetName |

--- a/Firmware/eeprom.h
+++ b/Firmware/eeprom.h
@@ -698,6 +698,8 @@ enum
 #ifdef __cplusplus
 void eeprom_init();
 void eeprom_adjust_bed_reset();
+bool UserECoolEnabled();
+
 struct SheetName
 {
     char c[sizeof(Sheet::name) + 1];

--- a/Firmware/mesh_bed_calibration.cpp
+++ b/Firmware/mesh_bed_calibration.cpp
@@ -937,7 +937,7 @@ bool find_bed_induction_sensor_point_z(float minimum_z, uint8_t n_iter, int
     bedPWMDisabled = 1;
 #ifdef TMC2130
     bool bHighPowerForced = false;
-	if (tmc2130_mode == TMC2130_MODE_SILENT)
+	if (stepper_cached_mode == TMC2130_MODE_SILENT)
     {
         FORCE_HIGH_POWER_START;
         bHighPowerForced = true;

--- a/Firmware/planner.cpp
+++ b/Firmware/planner.cpp
@@ -56,7 +56,7 @@
 #include "stepper.h"
 #include "temperature.h"
 #include "fancheck.h"
-#include "ultralcd.h"
+#include "lcd.h"
 #include "language.h"
 #include "ConfigurationStore.h"
 

--- a/Firmware/planner.cpp
+++ b/Firmware/planner.cpp
@@ -1335,12 +1335,12 @@ void reset_acceleration_rates()
 #ifdef TMC2130
 void update_mode_profile()
 {
-	if (tmc2130_mode == TMC2130_MODE_NORMAL)
+	if (stepper_cached_mode == TMC2130_MODE_NORMAL)
 	{
 		max_feedrate = cs.max_feedrate_normal;
 		max_acceleration_mm_per_s2 = cs.max_acceleration_mm_per_s2_normal;
 	}
-	else if (tmc2130_mode == TMC2130_MODE_SILENT)
+	else if (stepper_cached_mode == TMC2130_MODE_SILENT)
 	{
 		max_feedrate = cs.max_feedrate_silent;
 		max_acceleration_mm_per_s2 = cs.max_acceleration_mm_per_s2_silent;

--- a/Firmware/stepper.cpp
+++ b/Firmware/stepper.cpp
@@ -119,6 +119,13 @@ static uint8_t  step_loops;
 static uint16_t OCR1A_nominal;
 static uint8_t  step_loops_nominal;
 
+uint8_t stepper_cached_mode = 0;
+
+void st_update_stepper_mode(uint8_t mode) {
+  stepper_cached_mode = mode;
+  eeprom_update_byte_notify((uint8_t *)EEPROM_SILENT, mode);
+}
+
 #ifdef VERBOSE_CHECK_HIT_ENDSTOPS
 volatile long endstops_trigsteps[3]={0,0,0};
 #endif //VERBOSE_CHECK_HIT_ENDSTOPS
@@ -558,7 +565,7 @@ FORCE_INLINE void stepper_check_endstops()
         #ifdef TMC2130_SG_HOMING
           // Stall guard homing turned on
 #ifdef TMC2130_STEALTH_Z
-          if ((tmc2130_mode == TMC2130_MODE_SILENT) && !(tmc2130_sg_homing_axes_mask & 0x04))
+          if ((stepper_cached_mode == TMC2130_MODE_SILENT) && !(tmc2130_sg_homing_axes_mask & 0x04))
             SET_BIT_TO(_endstop, Z_AXIS, (READ(Z_MIN_PIN) != Z_MIN_ENDSTOP_INVERTING));
           else
 #endif //TMC2130_STEALTH_Z
@@ -580,7 +587,7 @@ FORCE_INLINE void stepper_check_endstops()
         #ifdef TMC2130_SG_HOMING
         // Stall guard homing turned on
 #ifdef TMC2130_STEALTH_Z
-        if ((tmc2130_mode == TMC2130_MODE_SILENT) && !(tmc2130_sg_homing_axes_mask & 0x04))
+        if ((stepper_cached_mode == TMC2130_MODE_SILENT) && !(tmc2130_sg_homing_axes_mask & 0x04))
           SET_BIT_TO(_endstop, Z_AXIS + 4, 0);
         else
 #endif //TMC2130_STEALTH_Z
@@ -613,7 +620,7 @@ FORCE_INLINE void stepper_check_endstops()
       #ifdef TMC2130_SG_HOMING
       // Stall guard homing turned on
 #ifdef TMC2130_STEALTH_Z
-      if ((tmc2130_mode == TMC2130_MODE_SILENT) && !(tmc2130_sg_homing_axes_mask & 0x04))
+      if ((stepper_cached_mode == TMC2130_MODE_SILENT) && !(tmc2130_sg_homing_axes_mask & 0x04))
         SET_BIT_TO(_endstop, Z_AXIS, (READ(Z_MIN_PIN) != Z_MIN_ENDSTOP_INVERTING));
       else
 #endif //TMC2130_STEALTH_Z
@@ -1481,12 +1488,10 @@ void digitalPotWrite(int address, int value) // From Arduino DigitalPotControl e
 void st_current_init() //Initialize Digipot Motor Current
 {
 #ifdef MOTOR_CURRENT_PWM_XY_PIN
-  uint8_t SilentMode = eeprom_read_byte((uint8_t*)EEPROM_SILENT);
-  SilentModeMenu = SilentMode;
     SET_OUTPUT(MOTOR_CURRENT_PWM_XY_PIN);
     SET_OUTPUT(MOTOR_CURRENT_PWM_Z_PIN);
     SET_OUTPUT(MOTOR_CURRENT_PWM_E_PIN);
-    if((SilentMode == SILENT_MODE_OFF) || (farm_mode) ){
+    if((stepper_cached_mode == SILENT_MODE_OFF) || (farm_mode) ){
 
      motor_current_setting[0] = motor_current_setting_loud[0];
      motor_current_setting[1] = motor_current_setting_loud[1];

--- a/Firmware/stepper.cpp
+++ b/Firmware/stepper.cpp
@@ -25,7 +25,7 @@
 #include "stepper.h"
 #include "planner.h"
 #include "temperature.h"
-#include "ultralcd.h"
+#include "lcd.h"
 #include "cardreader.h"
 #include "speed_lookuptable.h"
 #if defined(DIGIPOTSS_PIN) && DIGIPOTSS_PIN > -1
@@ -1063,7 +1063,7 @@ FORCE_INLINE void advance_isr_scheduler() {
 void st_init()
 {
 #ifdef TMC2130
-	tmc2130_init(TMCInitParams(false, FarmOrUserECool()));
+	tmc2130_init(TMCInitParams(false, UserECoolEnabled()));
 #else
   st_current_init(); //Initialize Digipot Motor Current
   microstep_init(); //Initialize Microstepping Pins

--- a/Firmware/stepper.h
+++ b/Firmware/stepper.h
@@ -30,6 +30,20 @@
 extern bool abort_on_endstop_hit;
 #endif
 
+extern uint8_t stepper_cached_mode;
+void st_update_stepper_mode(uint8_t mode);
+
+#ifdef TMC2130
+#define SILENT_MODE_NORMAL 0
+#define SILENT_MODE_STEALTH 1
+#define SILENT_MODE_OFF SILENT_MODE_NORMAL
+#else
+#define SILENT_MODE_POWER 0
+#define SILENT_MODE_SILENT 1
+#define SILENT_MODE_AUTO 2
+#define SILENT_MODE_OFF SILENT_MODE_POWER
+#endif
+
 // Initialize and start the stepper motor subsystem
 void st_init();
 

--- a/Firmware/tmc2130.h
+++ b/Firmware/tmc2130.h
@@ -4,8 +4,6 @@
 #include <stdint.h>
 #include "Configuration_var.h"
 
-//mode
-extern uint8_t tmc2130_mode;
 //microstep resolution (0 means 256usteps, 8 means 1ustep
 extern uint8_t tmc2130_mres[4];
 

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -4122,7 +4122,7 @@ static void SETTINGS_SILENT_MODE()
     { // dont show in menu if we are in farm mode
 #ifdef TMC2130
         uint8_t eeprom_mode = eeprom_read_byte((uint8_t*)EEPROM_SILENT);
-        bool bDesync = stepper_cached_mode ^eeprom_mode;
+        bool bDesync = stepper_cached_mode ^ eeprom_mode;
         if (stepper_cached_mode == SILENT_MODE_NORMAL)
         {
             if (bDesync)

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3421,7 +3421,7 @@ static void lcd_silent_mode_set() {
   cli();
   tmc2130_mode = (SilentModeMenu != SILENT_MODE_NORMAL)?TMC2130_MODE_SILENT:TMC2130_MODE_NORMAL;
   update_mode_profile();
-  tmc2130_init(TMCInitParams(false, FarmOrUserECool()));
+  tmc2130_init(TMCInitParams(false, UserECoolEnabled()));
   // We may have missed a stepper timer interrupt due to the time spent in tmc2130_init.
   // Be safe than sorry, reset the stepper timer before re-enabling interrupts.
   st_reset_timer();
@@ -4565,7 +4565,7 @@ static void lcd_settings_linearity_correction_menu_save()
     changed |= (eeprom_read_byte((uint8_t*)EEPROM_TMC2130_WAVE_Z_FAC) != tmc2130_wave_fac[Z_AXIS]);
     changed |= (eeprom_read_byte((uint8_t*)EEPROM_TMC2130_WAVE_E_FAC) != tmc2130_wave_fac[E_AXIS]);
     lcd_ustep_linearity_menu_save();
-    if (changed) tmc2130_init(TMCInitParams(false, FarmOrUserECool()));
+    if (changed) tmc2130_init(TMCInitParams(false, UserECoolEnabled()));
 }
 #endif //TMC2130
 
@@ -7459,23 +7459,6 @@ void UserECool_toggle(){
     tmc2130_init(TMCInitParams(enable));
 }
 #endif
-
-/// Enable experimental support for cooler operation of the extruder motor
-/// Beware - REQUIRES original Prusa MK3/S/+ extruder motor with adequate maximal current
-/// Therefore we don't want to allow general usage of this feature in public as the community likes to
-/// change motors for various reasons and unless the motor is rotating, we cannot verify its properties
-/// (which would be obviously too late for an improperly sized motor)
-/// For farm printing, the cooler E-motor is enabled by default.
-bool UserECoolEnabled(){
-    // We enable E-cool mode for non-farm prints IFF the experimental menu is visible AND the EEPROM_ECOOL variable has
-    // a value of the universal answer to all problems of the universe
-    return ( eeprom_read_byte((uint8_t *)EEPROM_ECOOL_ENABLE) == EEPROM_ECOOL_MAGIC_NUMBER )
-        && ( eeprom_read_byte((uint8_t *)EEPROM_EXPERIMENTAL_VISIBILITY) == 1 );
-}
-
-bool FarmOrUserECool(){
-    return farm_mode || UserECoolEnabled();
-}
 
 #ifdef PRUSA_SN_SUPPORT
 void WorkaroundPrusaSN() {

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -61,8 +61,6 @@ static bool bFilamentSkipPreheat; // True if waiting for preheat is not required
 int8_t ReInitLCD = 0;
 uint8_t scrollstuff = 0;
 
-int8_t SilentModeMenu = SILENT_MODE_OFF;
-
 LcdCommands lcd_commands_type = LcdCommands::Idle;
 static uint8_t lcd_commands_step = 0;
 static bool extraPurgeNeeded = false; ///< lcd_commands - detect if extra purge after MMU-toolchange is necessary or not
@@ -451,7 +449,7 @@ void lcdui_print_time(void)
         char suff_doubt = ' ';
 
 #ifdef TMC2130
-        if (SilentModeMenu != SILENT_MODE_OFF) {
+        if (stepper_cached_mode != SILENT_MODE_OFF) {
             if (print_time_remaining_silent != PRINT_TIME_REMAINING_INIT)
                 print_tr = print_time_remaining_silent;
 //#ifdef CLOCK_INTERVAL_TIME
@@ -3396,19 +3394,20 @@ static void lcd_mmu_mode_toggle() {
 #endif //MMU_FORCE_STEALTH_MODE
 
 static void lcd_silent_mode_set() {
-	switch (SilentModeMenu) {
+	switch (stepper_cached_mode) {
 #ifdef TMC2130
-	case SILENT_MODE_NORMAL: SilentModeMenu = SILENT_MODE_STEALTH; break;
-	case SILENT_MODE_STEALTH: SilentModeMenu = SILENT_MODE_NORMAL; break;
-	default: SilentModeMenu = SILENT_MODE_NORMAL; break; // (probably) not needed
+	case SILENT_MODE_NORMAL: stepper_cached_mode = SILENT_MODE_STEALTH; break;
+	case SILENT_MODE_STEALTH: stepper_cached_mode = SILENT_MODE_NORMAL; break;
+	default: stepper_cached_mode = SILENT_MODE_NORMAL; break; // (probably) not needed
 #else
-	case SILENT_MODE_POWER: SilentModeMenu = SILENT_MODE_SILENT; break;
-	case SILENT_MODE_SILENT: SilentModeMenu = SILENT_MODE_AUTO; break;
-	case SILENT_MODE_AUTO: SilentModeMenu = SILENT_MODE_POWER; break;
-	default: SilentModeMenu = SILENT_MODE_POWER; break; // (probably) not needed
+	case SILENT_MODE_POWER: stepper_cached_mode = SILENT_MODE_SILENT; break;
+	case SILENT_MODE_SILENT: stepper_cached_mode = SILENT_MODE_AUTO; break;
+	case SILENT_MODE_AUTO: stepper_cached_mode = SILENT_MODE_POWER; break;
+	default: stepper_cached_mode = SILENT_MODE_POWER; break; // (probably) not needed
 #endif //TMC2130
 	}
-  eeprom_update_byte_notify((unsigned char *)EEPROM_SILENT, SilentModeMenu);
+
+  eeprom_update_byte_notify((uint8_t *)EEPROM_SILENT, stepper_cached_mode);
 #ifdef TMC2130
   if (blocks_queued())
   {
@@ -3419,7 +3418,6 @@ static void lcd_silent_mode_set() {
   }
   tmc2130_wait_standstill_xy(1000);
   cli();
-  tmc2130_mode = (SilentModeMenu != SILENT_MODE_NORMAL)?TMC2130_MODE_SILENT:TMC2130_MODE_NORMAL;
   update_mode_profile();
   tmc2130_init(TMCInitParams(false, UserECoolEnabled()));
   // We may have missed a stepper timer interrupt due to the time spent in tmc2130_init.
@@ -3431,7 +3429,7 @@ static void lcd_silent_mode_set() {
 #endif //TMC2130
 
 #ifdef TMC2130
-  if (eeprom_read_byte((uint8_t*)EEPROM_CRASH_DET) && (SilentModeMenu != SILENT_MODE_NORMAL))
+  if (eeprom_read_byte((uint8_t*)EEPROM_CRASH_DET) && (stepper_cached_mode != SILENT_MODE_NORMAL))
 	  menu_submenu(lcd_crash_mode_info2);
 #endif //TMC2130
 }
@@ -4124,14 +4122,14 @@ static void SETTINGS_SILENT_MODE()
     { // dont show in menu if we are in farm mode
 #ifdef TMC2130
         uint8_t eeprom_mode = eeprom_read_byte((uint8_t*)EEPROM_SILENT);
-		bool bDesync = tmc2130_mode ^ eeprom_mode;
-        if (eeprom_mode == SILENT_MODE_NORMAL)
+        bool bDesync = stepper_cached_mode ^eeprom_mode;
+        if (stepper_cached_mode == SILENT_MODE_NORMAL)
         {
             if (bDesync)
             {
                 MENU_ITEM_TOGGLE_P(_T(MSG_MODE), PSTR("M915"), lcd_silent_mode_set);
             }
-			else
+            else
             {
                 MENU_ITEM_TOGGLE_P(_T(MSG_MODE), _T(MSG_NORMAL), lcd_silent_mode_set);
             }
@@ -4143,7 +4141,7 @@ static void SETTINGS_SILENT_MODE()
             {
                 MENU_ITEM_TOGGLE_P(_T(MSG_MODE), PSTR("M914") , lcd_silent_mode_set);
             }
-			else
+            else
             {
                 MENU_ITEM_TOGGLE_P(_T(MSG_MODE), _T(MSG_STEALTH), lcd_silent_mode_set);
             }
@@ -4452,7 +4450,6 @@ void lcd_hw_setup_menu(void)                      // can not be "static"
 
 static void lcd_settings_menu()
 {
-	SilentModeMenu = eeprom_read_byte((uint8_t*) EEPROM_SILENT);
 	MENU_BEGIN();
 	MENU_ITEM_BACK_P(_T(MSG_MAIN));
 
@@ -5510,8 +5507,6 @@ static void lcd_tune_menu()
 		calculate_extruder_multipliers();
 	}
 
-	SilentModeMenu = eeprom_read_byte((uint8_t*) EEPROM_SILENT);
-
 	MENU_BEGIN();
 	ON_MENU_LEAVE(
 		refresh_saved_feedrate_multiplier_in_ram();
@@ -6536,7 +6531,7 @@ static bool lcd_selfcheck_pulleys(int axis)
 		st_current_set(0, 850); //set motor current higher
 		plan_buffer_line_curposXYZE(200);
 		st_synchronize();
-          if (SilentModeMenu != SILENT_MODE_OFF) st_current_set(0, tmp_motor[0]); //set back to normal operation currents
+          if (stepper_cached_mode != SILENT_MODE_OFF) st_current_set(0, tmp_motor[0]); //set back to normal operation currents
 		else st_current_set(0, tmp_motor_loud[0]); //set motor current back
 		current_position[axis] = current_position[axis] - move;
 		plan_buffer_line_curposXYZE(50);

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -149,22 +149,9 @@ enum class CustomMsg : uint_least8_t
 extern CustomMsg custom_message_type;
 extern uint8_t custom_message_state;
 
-#ifdef TMC2130
-#define SILENT_MODE_NORMAL 0
-#define SILENT_MODE_STEALTH 1
-#define SILENT_MODE_OFF SILENT_MODE_NORMAL
-#else
-#define SILENT_MODE_POWER 0
-#define SILENT_MODE_SILENT 1
-#define SILENT_MODE_AUTO 2
-#define SILENT_MODE_OFF SILENT_MODE_POWER
-#endif
-
 #if defined(FILAMENT_SENSOR) && (FILAMENT_SENSOR_TYPE == FSENSOR_IR_ANALOG)
 void printf_IRSensorAnalogBoardChange();
 #endif //defined(FILAMENT_SENSOR) && (FILAMENT_SENSOR_TYPE == FSENSOR_IR_ANALOG)
-
-extern int8_t SilentModeMenu;
 
 extern uint8_t scrollstuff;
 

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -149,9 +149,6 @@ enum class CustomMsg : uint_least8_t
 extern CustomMsg custom_message_type;
 extern uint8_t custom_message_state;
 
-extern bool UserECoolEnabled();
-extern bool FarmOrUserECool();
-
 #ifdef TMC2130
 #define SILENT_MODE_NORMAL 0
 #define SILENT_MODE_STEALTH 1


### PR DESCRIPTION
Move `UserECoolEnabled()` from `ultralcd.cpp` into `eeprom.cpp` since this function has nothing to do with LCD specifically.
To avoid including `Prusa_farm.h` into `epprom.cpp`, simply replace `farm_mode` variable by reading the farm mode from EEPROM directly. This change allows us to remove `FarmOrUserECool()` function.

The goal is to avoid including `ultralcd.h` in general since it is a nightmare to unit test as is. Including `lcd.h` is less of a problem than `ultralcd.h` 


----

TODO:

- [ ] Unify `SILENT_MODE_*` and `TMC2130_MODE_*` preprocessor symbols. From EEPROM perspective these are the same.

Something like this:

```cpp
// On TMC2130 printers we have either Normal or Stealth mode.
// On non-TMC2130 printers we have Normal (Power), Stealth (Silent), and Auto mode.
enum StepperMode : uint8_t {
  NORMAL = 0,
  STEALTH = 1,
  AUTO = 2,
};
```