### PR TITLE
Lower MIN_Z_FOR_UNLOAD

### DIFF
--- a/Firmware/Configuration.h
+++ b/Firmware/Configuration.h
@@ -487,7 +487,7 @@ your extruder heater takes 2 minutes to hit the target on heating.
 // Try to maintain a minimum distance from the bed even when Z is
 // unknown when doing the following operations
 #define MIN_Z_FOR_LOAD    50 // lcd filament loading or autoload
-#define MIN_Z_FOR_UNLOAD  50 // lcd filament unloading
+#define MIN_Z_FOR_UNLOAD  20 // lcd filament unloading
 #define MIN_Z_FOR_SWAP    27 // filament change (including M600)
 #define MIN_Z_FOR_PREHEAT 10 // lcd preheat
 


### PR DESCRIPTION
Lower the amount of Z lift on filament unload from 50mm to ~~10mm~~ 20mm.

This does not alter the behavior of M600. (M600 uses MIN_Z_FOR_SWAP)

Resolves #4700