### PR TITLE
Send host actions on filament runout

### DIFF
--- a/Firmware/Filament_sensor.cpp
+++ b/Firmware/Filament_sensor.cpp
@@ -149,6 +149,7 @@ void Filament_sensor::triggerFilamentRemoved() {
 
 void Filament_sensor::filRunout() {
 //    SERIAL_ECHOLNPGM("filRunout");
+    sendHostNotification_P(MSG_FILAMENT_RUNOUT_DETECTED);
     runoutEnabled = false;
     autoLoadEnabled = false;
     stop_and_save_print_to_ram(0, 0);

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3406,6 +3406,7 @@ static void gcode_M600(const bool automatic, const float x_position, const float
       current_position[E_AXIS] += e_shift;
       plan_buffer_line_curposXYZE(FILAMENTCHANGE_RFEED);
       st_synchronize();
+      SERIAL_ECHOLNRPGM(MSG_HOST_ACTION_PAUSED);
     } else {
         // Print is paused and the extruder may be cold
         // Filament change can be issued via the Tune menu
@@ -3505,8 +3506,13 @@ static void gcode_M600(const bool automatic, const float x_position, const float
     feedmultiply = saved_feedmultiply2;
     enquecommandf_P(MSG_M220, saved_feedmultiply2);
 
-    if (printingIsPaused()) lcd_setstatuspgm(_T(MSG_PRINT_PAUSED));
-    else lcd_setstatuspgm(MSG_WELCOME);
+    if (printingIsPaused()) {
+      lcd_setstatuspgm(_T(MSG_PRINT_PAUSED));
+    }
+    else {
+      lcd_setstatuspgm(MSG_WELCOME);
+      SERIAL_ECHOLNRPGM(MSG_HOST_ACTION_RESUMED);
+    }
     custom_message_type = CustomMsg::Status;
 }
 

--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -410,6 +410,7 @@ const char MSG_HOST_ACTION_NOT_READY[] PROGMEM_N1 = "//action:not_ready"; ////
 const char MSG_HOST_ACTION_START[] PROGMEM_N1 = "//action:start"; ////
 const char MSG_HOST_ACTION_UVLO_RECOVERY_READY[] PROGMEM_N1 = "//action:uvlo_recovery_ready"; ////
 const char MSG_HOST_ACTION_UVLO_AUTO_RECOVERY_READY[] PROGMEM_N1 = "//action:uvlo_auto_recovery_ready"; ////
+const char MSG_HOST_ACTION_NOTIFICATION[] PROGMEM_N1 = "//action:notification %S\n"; ////
 #ifdef HOST_SHUTDOWN
 const char MSG_HOST_ACTION_SHUTDOWN[] PROGMEM_N1 = "//action:shutdown"; ////
 #endif //HOST_SHUTOWN
@@ -420,6 +421,7 @@ const char MSG_ADVANCE_K[] PROGMEM_N1 = "Advance K:"; ////c=13
 const char MSG_POWERPANIC_DETECTED[] PROGMEM_N1 = "POWER PANIC DETECTED"; ////c=20
 const char MSG_LCD_STATUS_CHANGED[] PROGMEM_N1 = "LCD status changed";
 const char MSG_UNKNOWN_CODE[] PROGMEM_N1 = "Unknown %c code: %s\n";
+const char MSG_FILAMENT_RUNOUT_DETECTED[] PROGMEM_N1 = "Filament runout detected!"; ////c=20 r=2
 
 // Common G-gcodes
 const char G1_E_F2700[] PROGMEM_N1 = "G1 E%-.3f F2700";

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -412,6 +412,7 @@ extern const char MSG_HOST_ACTION_NOT_READY[];
 extern const char MSG_HOST_ACTION_START[];
 extern const char MSG_HOST_ACTION_UVLO_RECOVERY_READY[];
 extern const char MSG_HOST_ACTION_UVLO_AUTO_RECOVERY_READY[];
+extern const char MSG_HOST_ACTION_NOTIFICATION[];
 #ifdef HOST_SHUTDOWN
 extern const char MSG_HOST_ACTION_SHUTDOWN[];
 #endif //HOST_SHUTOWN
@@ -422,6 +423,7 @@ extern const char MSG_ADVANCE_K[];
 extern const char MSG_POWERPANIC_DETECTED[];
 extern const char MSG_LCD_STATUS_CHANGED[];
 extern const char MSG_UNKNOWN_CODE[];
+extern const char MSG_FILAMENT_RUNOUT_DETECTED[];
 
 // Common G-gcodes
 extern const char G1_E_F2700[];

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5067,7 +5067,11 @@ static void change_sheet()
     menu_back(3);
 }
 
-
+//! @brief Send a notification to the host. Param 'message' must reside in program memory!
+void sendHostNotification_P(const char* message)
+{
+    printf_P(MSG_HOST_ACTION_NOTIFICATION, message);
+}
 
 static void lcd_rename_sheet_menu()
 {

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -260,4 +260,6 @@ extern void lcd_heat_bed_on_load_toggle();
 extern void retract_for_ooze_prevention();
 #endif //COMMUNITY_PREVENT_OOZE
 
+extern void sendHostNotification_P(const char* message);
+
 #endif //ULTRALCD_H


### PR DESCRIPTION
- Sends `//action:notification Filament runout detected!` to the host in case of filament runout.
- Adds `action:paused` & `action:resumed` to M600.

Resolves #805