### PR TITLE
Add load filament option if autoload is disabled

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5363,6 +5363,7 @@ static void lcd_main_menu()
                             MENU_ITEM_SUBMENU_P(_T(MSG_AUTOLOAD_FILAMENT), lcd_menu_AutoLoadFilament);
                         } else {
                             MENU_ITEM_SUBMENU_P(_T(MSG_LOAD_FILAMENT), lcd_LoadFilament);
+                            MENU_ITEM_SUBMENU_P(_T(MSG_UNLOAD_FILAMENT), lcd_unLoadFilament);
                         }
                     } else {
                         MENU_ITEM_SUBMENU_P(_T(MSG_UNLOAD_FILAMENT), lcd_unLoadFilament);


### PR DESCRIPTION
~~Adds "Load filament" menu entry when autoload is disabled. Originally it was hidden as soon as you feed filament into the sensor. It is still hidden if autoload is enabled.~~