### PR TITLE
Add "load filament" if autoload is disabled

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5383,11 +5383,12 @@ static void lcd_main_menu()
             } else {
 #ifdef FILAMENT_SENSOR
                 if (fsensor.isEnabled()) {
+                    if (!fsensor.getAutoLoadEnabled()) {
+                        MENU_ITEM_SUBMENU_P(_T(MSG_LOAD_FILAMENT), lcd_LoadFilament);
+                    }
                     if (!fsensor.getFilamentPresent()) {
                         if (fsensor.getAutoLoadEnabled()) {
                             MENU_ITEM_SUBMENU_P(_T(MSG_AUTOLOAD_FILAMENT), lcd_menu_AutoLoadFilament);
-                        } else {
-                            MENU_ITEM_SUBMENU_P(_T(MSG_LOAD_FILAMENT), lcd_LoadFilament);
                         }
                     } else {
                         MENU_ITEM_SUBMENU_P(_T(MSG_UNLOAD_FILAMENT), lcd_unLoadFilament);


### PR DESCRIPTION
Adds "Load filament" menu entry when autoload is disabled. Originally it was hidden as soon as you feed filament into the sensor. It is still hidden if autoload is enabled.

Fixes https://github.com/prusa3d/Prusa-Firmware/issues/4752