### PR TITLE
Reduce `_lcd_move()` code size

### DIFF
--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -232,8 +232,6 @@ extern int extrudemultiply; // Sets extrude multiply factor (in percent) for all
 extern float extruder_multiplier[EXTRUDERS]; // reciprocal of cross-sectional area of filament (in square millimeters), stored this way to reduce computational burden in planner
 extern float current_position[NUM_AXIS] ;
 extern float destination[NUM_AXIS] ;
-extern float min_pos[3];
-extern float max_pos[3];
 extern bool axis_known_position[3];
 extern uint8_t fanSpeed; //!< Print fan speed, ranges from 0 to 255
 extern uint8_t newFanSpeed;

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -193,8 +193,8 @@ float current_position[NUM_AXIS] = { 0.0, 0.0, 0.0, 0.0 };
 #define _z current_position[Z_AXIS]
 #define _e current_position[E_AXIS]
 
-float min_pos[3] = { X_MIN_POS, Y_MIN_POS, Z_MIN_POS };
-float max_pos[3] = { X_MAX_POS, Y_MAX_POS, Z_MAX_POS };
+static float min_pos[3] = { X_MIN_POS, Y_MIN_POS, Z_MIN_POS };
+static float max_pos[3] = { X_MAX_POS, Y_MAX_POS, Z_MAX_POS };
 bool axis_known_position[3] = {false, false, false};
 
 static float pause_position[3] = { X_PAUSE_POS, Y_PAUSE_POS, Z_PAUSE_LIFT };

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2390,7 +2390,7 @@ void lcd_menu_statistics()
 }
 
 
-static void _lcd_move(const char *name, uint8_t axis, int min, int max)
+static void _lcd_move(const char *name, const uint8_t axis)
 {
     if (homing_flag || mesh_bed_leveling_flag)
     {
@@ -2417,10 +2417,8 @@ static void _lcd_move(const char *name, uint8_t axis, int min, int max)
 		if (! planner_queue_full())
 		{
 			current_position[axis] += lcd_encoder;
-			if (min_software_endstops && current_position[axis] < min) current_position[axis] = min;
-			if (max_software_endstops && current_position[axis] > max) current_position[axis] = max;
 			lcd_encoder = 0;
-			world2machine_clamp(current_position[X_AXIS], current_position[Y_AXIS]);
+			clamp_to_software_endstops(current_position);
 			plan_buffer_line_curposXYZE(get_feedrate_mm_s(manual_feedrate[axis]));
 			lcd_draw_update = 1;
 		}
@@ -2573,13 +2571,13 @@ static void lcd_menu_xyz_offset()
 // Note: the colon behind the text (X, Y, Z) is necessary to greatly shorten
 // the implementation of menu_draw_float31
 static void lcd_move_x() {
-  _lcd_move(PSTR("X:"), X_AXIS, X_MIN_POS, X_MAX_POS);
+  _lcd_move(PSTR("X:"), X_AXIS);
 }
 static void lcd_move_y() {
-  _lcd_move(PSTR("Y:"), Y_AXIS, Y_MIN_POS, Y_MAX_POS);
+  _lcd_move(PSTR("Y:"), Y_AXIS);
 }
 static void lcd_move_z() {
-  _lcd_move(PSTR("Z:"), Z_AXIS, Z_MIN_POS, Z_MAX_POS);
+  _lcd_move(PSTR("Z:"), Z_AXIS);
 }
 
 

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2420,7 +2420,6 @@ static void _lcd_move(const char *name, const uint8_t axis)
 			lcd_encoder = 0;
 			clamp_to_software_endstops(current_position);
 			plan_buffer_line_curposXYZE(get_feedrate_mm_s(manual_feedrate[axis]));
-			lcd_draw_update = 1;
 		}
 	}
 	if (lcd_draw_update)
@@ -2445,7 +2444,6 @@ void lcd_move_e()
 				current_position[E_AXIS] += lcd_encoder;
 				lcd_encoder = 0;
 				plan_buffer_line_curposXYZE(manual_feedrate[E_AXIS] / 60);
-				lcd_draw_update = 1;
 			}
 		}
 		if (lcd_draw_update)


### PR DESCRIPTION
Reuse `clamp_to_software_endstops()` to avoid code duplication. The code should be functionally equivalent.

Change in memory:
Flash: -204 bytes
SRAM: 0 bytes