### PR TITLE
PFW-1204: M600 - Show filament name at the Insert filament prompt

### DIFF
--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -451,10 +451,10 @@ void gcode_M701(float fastLoadLength, uint8_t mmuSlotIndex);
 #define UVLO !(PINE & (1<<4))
 
 
-void M600_load_filament();
-void M600_load_filament_movements();
+void M600_load_filament(const char* filament_name);
+void M600_load_filament_movements(const char* filament_name);
 void M600_wait_for_user();
-bool M600_check_state_and_repeat();
+bool M600_check_state_and_repeat(const char* filament_name);
 void load_filament_final_feed();
 void marlin_wait_for_click();
 float raise_z(float delta);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2141,16 +2141,21 @@ static void lcd_unLoadFilament()
      preheat_or_continue(FilamentAction::UnLoad);
 }
 
-void lcd_wait_interact() {
+void lcd_wait_interact(const char* filament_name) {
 
   lcd_clear();
 
   lcd_puts_at_P(0, 0, _T(MSG_INSERT_FILAMENT));
+  lcd_set_cursor(0, 1);
+  if (filament_name[0]) {
+      lcd_print(filament_name);
+      lcd_set_cursor(0, 2);
+  }
 #ifdef FILAMENT_SENSOR
   if (!fsensor.getAutoLoadEnabled())
 #endif //FILAMENT_SENSOR
   {
-    lcd_puts_at_P(0, 1, _T(MSG_PRESS));
+    lcd_puts_P(_T(MSG_PRESS));
   }
 }
 
@@ -2187,12 +2192,15 @@ void lcd_loading_color() {
 }
 
 
-void lcd_loading_filament() {
-
+void lcd_loading_filament(const char* filament_name) {
 
   lcd_clear();
 
   lcd_puts_at_P(0, 0, _T(MSG_LOADING_FILAMENT));
+  if (filament_name[0]) {
+      lcd_set_cursor(0, 1);
+      lcd_print(filament_name);
+  }
   lcd_puts_at_P(0, 2, _T(MSG_PLEASE_WAIT));
   uint16_t slow_seq_time = (FILAMENTCHANGE_FINALFEED * 1000ul) / FILAMENTCHANGE_EFEED_FINAL;
   uint16_t fast_seq_time = (FILAMENTCHANGE_FIRSTFEED * 1000ul) / FILAMENTCHANGE_EFEED_FIRST;

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -49,8 +49,8 @@ void lcd_reset_alert_level();
 
 uint8_t lcd_alright();
 void show_preheat_nozzle_warning();
-void lcd_wait_interact();
-void lcd_loading_filament();
+void lcd_wait_interact(const char* filament_name);
+void lcd_loading_filament(const char* filament_name);
 void lcd_change_success();
 void lcd_loading_color();
 void lcd_sdcard_stop();


### PR DESCRIPTION
This PR is an upgraded version of the https://github.com/prusa3d/Prusa-Firmware/pull/2380.

It introduces the C parameter that defines the filament name to be displayed at the Insert filament and Loading filament messages. The filament name must be enclosed in double quotes.

The new syntax is:
`M600 X[pos] Y[pos] Z[relative lift] E[initial retract] L[later retract distance for removal] C"[filament name to show during loading]"`

For example, the command:
`M600 C"Electric Blue"`

will show the message:
```
Insert filament
Electric Blue
and press the knob
```
and afterwards:
```
Loading filament
Electric Blue
Please wait
....
```
