### PR TITLE
Remove lcd_menu_AutoLoadFilament

### DIFF
--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -253,7 +253,9 @@ extern const char MSG_LOADING_COLOR [] PROGMEM_I1 = ISTR("Loading color"); ////M
 extern const char MSG_CORRECTLY [] PROGMEM_I1 = ISTR("Changed correctly"); ////MSG_CORRECTLY c=19
 extern const char MSG_NOT_LOADED [] PROGMEM_I1 = ISTR("Filament not loaded"); ////MSG_NOT_LOADED c=19
 extern const char MSG_NOT_COLOR [] PROGMEM_I1 = ISTR("Color not correct"); ////MSG_NOT_COLOR c=19
+#ifndef REMOVE_AUTOLOAD_FILAMENT_MENU_ENTRY
 extern const char MSG_AUTOLOADING_ENABLED [] PROGMEM_I1 = ISTR("Autoloading filament is active, just press the knob and insert filament..."); ////MSG_AUTOLOADING_ENABLED c=20 r=4
+#endif //REMOVE_AUTOLOAD_FILAMENT_MENU_ENTRY
 extern const char MSG_FILAMENT_USED [] PROGMEM_I1 = ISTR("Filament used"); ////MSG_FILAMENT_USED c=19
 extern const char MSG_PRINT_TIME [] PROGMEM_I1 = ISTR("Print time"); ////MSG_PRINT_TIME c=19
 extern const char MSG_TOTAL_FILAMENT [] PROGMEM_I1 = ISTR("Total filament"); ////MSG_TOTAL_FILAMENT c=19

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -252,7 +252,9 @@ extern const char MSG_LOADING_COLOR [];
 extern const char MSG_CORRECTLY [];
 extern const char MSG_NOT_LOADED [];
 extern const char MSG_NOT_COLOR [];
+#ifndef REMOVE_AUTOLOAD_FILAMENT_MENU_ENTRY
 extern const char MSG_AUTOLOADING_ENABLED [];
+#endif //REMOVE_AUTOLOAD_FILAMENT_MENU_ENTRY
 extern const char MSG_FILAMENT_USED [];
 extern const char MSG_PRINT_TIME [];
 extern const char MSG_TOTAL_FILAMENT [];

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2296,13 +2296,13 @@ void lcd_load_filament_color_check()
     }
 }
 
-#ifdef FILAMENT_SENSOR
+#if defined(FILAMENT_SENSOR) && !defined(REMOVE_AUTOLOAD_FILAMENT_MENU_ENTRY)
 static void lcd_menu_AutoLoadFilament()
 {
     lcd_display_message_fullscreen_nonBlocking_P(_T(MSG_AUTOLOADING_ENABLED));
     menu_back_if_clicked();
 }
-#endif //FILAMENT_SENSOR
+#endif //FILAMENT_SENSOR && REMOVE_AUTOLOAD_FILAMENT_MENU_ENTRY
 
 static void preheat_or_continue(FilamentAction action) {
 
@@ -5351,13 +5351,16 @@ static void lcd_main_menu()
                     if (!fsensor.getAutoLoadEnabled()) {
                         MENU_ITEM_SUBMENU_P(_T(MSG_LOAD_FILAMENT), lcd_LoadFilament);
                     }
-                    if (!fsensor.getFilamentPresent()) {
-                        if (fsensor.getAutoLoadEnabled()) {
-                            MENU_ITEM_SUBMENU_P(_T(MSG_AUTOLOAD_FILAMENT), lcd_menu_AutoLoadFilament);
-                        }
-                    } else {
+                    if (fsensor.getFilamentPresent()) {
                         MENU_ITEM_SUBMENU_P(_T(MSG_UNLOAD_FILAMENT), lcd_unLoadFilament);
                     }
+#ifndef REMOVE_AUTOLOAD_FILAMENT_MENU_ENTRY
+                    else {
+                        if (fsensor.getAutoLoadEnabled()) {
+                            MENU_ITEM_SUBMENU_P(_T(MSG_AUTOLOAD_FILAMENT), lcd_menu_AutoLoadFilament);
+                        }                        
+                    }
+#endif //REMOVE_AUTOLOAD_FILAMENT_MENU_ENTRY 
                 } else {
 #endif //FILAMENT_SENSOR
                     MENU_ITEM_SUBMENU_P(_T(MSG_LOAD_FILAMENT), lcd_LoadFilament);

--- a/Firmware/variants/MK25-RAMBo10a.h
+++ b/Firmware/variants/MK25-RAMBo10a.h
@@ -527,4 +527,7 @@
 //Show filename instead of print time after SD card print finished
 //#define SHOW_FILENAME_AFTER_FINISH
 
+//Remove the "AutoLoad filament" LCD menu entry if autoload is enabled.
+//#define REMOVE_AUTOLOAD_FILAMENT_MENU_ENTRY
+
 #endif //__CONFIGURATION_PRUSA_H

--- a/Firmware/variants/MK25-RAMBo13a.h
+++ b/Firmware/variants/MK25-RAMBo13a.h
@@ -531,4 +531,7 @@
 //Show filename instead of print time after SD card print finished
 //#define SHOW_FILENAME_AFTER_FINISH
 
+//Remove the "AutoLoad filament" LCD menu entry if autoload is enabled.
+//#define REMOVE_AUTOLOAD_FILAMENT_MENU_ENTRY
+
 #endif //__CONFIGURATION_PRUSA_H

--- a/Firmware/variants/MK25S-RAMBo10a.h
+++ b/Firmware/variants/MK25S-RAMBo10a.h
@@ -535,4 +535,7 @@
 //Show filename instead of print time after SD card print finished
 //#define SHOW_FILENAME_AFTER_FINISH
 
+//Remove the "AutoLoad filament" LCD menu entry if autoload is enabled.
+//#define REMOVE_AUTOLOAD_FILAMENT_MENU_ENTRY
+
 #endif //__CONFIGURATION_PRUSA_H

--- a/Firmware/variants/MK25S-RAMBo13a.h
+++ b/Firmware/variants/MK25S-RAMBo13a.h
@@ -536,4 +536,7 @@
 //Show filename instead of print time after SD card print finished
 //#define SHOW_FILENAME_AFTER_FINISH
 
+//Remove the "AutoLoad filament" LCD menu entry if autoload is enabled.
+//#define REMOVE_AUTOLOAD_FILAMENT_MENU_ENTRY
+
 #endif //__CONFIGURATION_PRUSA_H

--- a/Firmware/variants/MK3-E3DREVO.h
+++ b/Firmware/variants/MK3-E3DREVO.h
@@ -694,4 +694,7 @@
 //Show filename instead of print time after SD card print finished
 //#define SHOW_FILENAME_AFTER_FINISH
 
+//Remove the "AutoLoad filament" LCD menu entry if autoload is enabled.
+//#define REMOVE_AUTOLOAD_FILAMENT_MENU_ENTRY
+
 #endif //__CONFIGURATION_PRUSA_H

--- a/Firmware/variants/MK3-E3DREVO_HF_60W.h
+++ b/Firmware/variants/MK3-E3DREVO_HF_60W.h
@@ -695,4 +695,7 @@
 //Show filename instead of print time after SD card print finished
 //#define SHOW_FILENAME_AFTER_FINISH
 
+//Remove the "AutoLoad filament" LCD menu entry if autoload is enabled.
+//#define REMOVE_AUTOLOAD_FILAMENT_MENU_ENTRY
+
 #endif //__CONFIGURATION_PRUSA_H

--- a/Firmware/variants/MK3.h
+++ b/Firmware/variants/MK3.h
@@ -697,4 +697,7 @@
 //Show filename instead of print time after SD card print finished
 //#define SHOW_FILENAME_AFTER_FINISH
 
+//Remove the "AutoLoad filament" LCD menu entry if autoload is enabled.
+//#define REMOVE_AUTOLOAD_FILAMENT_MENU_ENTRY
+
 #endif //__CONFIGURATION_PRUSA_H

--- a/Firmware/variants/MK3S-E3DREVO.h
+++ b/Firmware/variants/MK3S-E3DREVO.h
@@ -706,4 +706,7 @@
 //Show filename instead of print time after SD card print finished
 //#define SHOW_FILENAME_AFTER_FINISH
 
+//Remove the "AutoLoad filament" LCD menu entry if autoload is enabled.
+//#define REMOVE_AUTOLOAD_FILAMENT_MENU_ENTRY
+
 #endif //__CONFIGURATION_PRUSA_H

--- a/Firmware/variants/MK3S-E3DREVO_HF_60W.h
+++ b/Firmware/variants/MK3S-E3DREVO_HF_60W.h
@@ -707,4 +707,7 @@
 //Show filename instead of print time after SD card print finished
 //#define SHOW_FILENAME_AFTER_FINISH
 
+//Remove the "AutoLoad filament" LCD menu entry if autoload is enabled.
+//#define REMOVE_AUTOLOAD_FILAMENT_MENU_ENTRY
+
 #endif //__CONFIGURATION_PRUSA_H

--- a/Firmware/variants/MK3S.h
+++ b/Firmware/variants/MK3S.h
@@ -709,4 +709,7 @@
 //Show filename instead of print time after SD card print finished
 //#define SHOW_FILENAME_AFTER_FINISH
 
+//Remove the "AutoLoad filament" LCD menu entry if autoload is enabled.
+//#define REMOVE_AUTOLOAD_FILAMENT_MENU_ENTRY
+
 #endif //__CONFIGURATION_PRUSA_H

--- a/Firmware/variants/obsolete/1_75mm_MK2-RAMBo10a-E3Dv6full.h
+++ b/Firmware/variants/obsolete/1_75mm_MK2-RAMBo10a-E3Dv6full.h
@@ -437,4 +437,7 @@ THERMISTORS SETTINGS
 //Show filename instead of print time after SD card print finished
 //#define SHOW_FILENAME_AFTER_FINISH
 
+//Remove the "AutoLoad filament" LCD menu entry if autoload is enabled.
+//#define REMOVE_AUTOLOAD_FILAMENT_MENU_ENTRY
+
 #endif //__CONFIGURATION_PRUSA_H

--- a/Firmware/variants/obsolete/1_75mm_MK2-RAMBo13a-E3Dv6full.h
+++ b/Firmware/variants/obsolete/1_75mm_MK2-RAMBo13a-E3Dv6full.h
@@ -436,4 +436,7 @@ THERMISTORS SETTINGS
 //Show filename instead of print time after SD card print finished
 //#define SHOW_FILENAME_AFTER_FINISH
 
+//Remove the "AutoLoad filament" LCD menu entry if autoload is enabled.
+//#define REMOVE_AUTOLOAD_FILAMENT_MENU_ENTRY
+
 #endif //__CONFIGURATION_PRUSA_H


### PR DESCRIPTION
Added option to remove the "AutoLoad filament" LCD menu entry if autoload is enabled.
(#define REMOVE_AUTOLOAD_FILAMENT_MENU_ENTRY)

Saves 156 bytes of flash memory if enabled.

~~This will conflict with #4821. (I used the same "COMMUNITY FEATURES" header)
I will resolve the conflict after #4821 has been merged.~~