### PR TITLE
optimisation: Simplify saving linearity correction

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -4495,20 +4495,17 @@ static void lcd_settings_menu()
 
 #ifdef TMC2130
 static void lcd_settings_linearity_correction_menu_save() {
-    bool changed = false;
     for (uint8_t axis = 0; axis < NUM_AXIS; axis++) {
-        // Constrain the value
-        if (tmc2130_wave_fac[axis] < TMC2130_WAVE_FAC1000_MIN) tmc2130_wave_fac[axis] = 0;
 
-        // Has the value changed?
-        changed |= (eeprom_read_byte((uint8_t*)EEPROM_TMC2130_WAVE_X_FAC - axis) != tmc2130_wave_fac[axis]);
+        if (tmc2130_wave_fac[axis] < TMC2130_WAVE_FAC1000_MIN) {
+            tmc2130_wave_fac[axis] = 0;
+        }
 
-        // If the value is changed, then write to EEPROM
         eeprom_update_byte_notify((uint8_t*)EEPROM_TMC2130_WAVE_X_FAC - axis, tmc2130_wave_fac[axis]);
     }
 
-    // If any of the values changed, then re-init the TMC2130 driver
-    if (changed) tmc2130_init(TMCInitParams(false, FarmOrUserECool()));
+    // Re-init the TMC2130 driver to apply changes, if any
+    tmc2130_init(TMCInitParams(false, FarmOrUserECool()));
 }
 #endif //TMC2130
 

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -4494,28 +4494,20 @@ static void lcd_settings_menu()
 }
 
 #ifdef TMC2130
-static void lcd_ustep_linearity_menu_save()
-{
-    eeprom_update_byte_notify((uint8_t*)EEPROM_TMC2130_WAVE_X_FAC, tmc2130_wave_fac[X_AXIS]);
-    eeprom_update_byte_notify((uint8_t*)EEPROM_TMC2130_WAVE_Y_FAC, tmc2130_wave_fac[Y_AXIS]);
-    eeprom_update_byte_notify((uint8_t*)EEPROM_TMC2130_WAVE_Z_FAC, tmc2130_wave_fac[Z_AXIS]);
-    eeprom_update_byte_notify((uint8_t*)EEPROM_TMC2130_WAVE_E_FAC, tmc2130_wave_fac[E_AXIS]);
-}
-#endif //TMC2130
-
-#ifdef TMC2130
-static void lcd_settings_linearity_correction_menu_save()
-{
+static void lcd_settings_linearity_correction_menu_save() {
     bool changed = false;
-    if (tmc2130_wave_fac[X_AXIS] < TMC2130_WAVE_FAC1000_MIN) tmc2130_wave_fac[X_AXIS] = 0;
-    if (tmc2130_wave_fac[Y_AXIS] < TMC2130_WAVE_FAC1000_MIN) tmc2130_wave_fac[Y_AXIS] = 0;
-    if (tmc2130_wave_fac[Z_AXIS] < TMC2130_WAVE_FAC1000_MIN) tmc2130_wave_fac[Z_AXIS] = 0;
-    if (tmc2130_wave_fac[E_AXIS] < TMC2130_WAVE_FAC1000_MIN) tmc2130_wave_fac[E_AXIS] = 0;
-    changed |= (eeprom_read_byte((uint8_t*)EEPROM_TMC2130_WAVE_X_FAC) != tmc2130_wave_fac[X_AXIS]);
-    changed |= (eeprom_read_byte((uint8_t*)EEPROM_TMC2130_WAVE_Y_FAC) != tmc2130_wave_fac[Y_AXIS]);
-    changed |= (eeprom_read_byte((uint8_t*)EEPROM_TMC2130_WAVE_Z_FAC) != tmc2130_wave_fac[Z_AXIS]);
-    changed |= (eeprom_read_byte((uint8_t*)EEPROM_TMC2130_WAVE_E_FAC) != tmc2130_wave_fac[E_AXIS]);
-    lcd_ustep_linearity_menu_save();
+    for (uint8_t axis = 0; axis < NUM_AXIS; axis++) {
+        // Constrain the value
+        if (tmc2130_wave_fac[axis] < TMC2130_WAVE_FAC1000_MIN) tmc2130_wave_fac[axis] = 0;
+
+        // Has the value changed?
+        changed |= (eeprom_read_byte((uint8_t*)EEPROM_TMC2130_WAVE_X_FAC - axis) != tmc2130_wave_fac[axis]);
+
+        // If the value is changed, then write to EEPROM
+        eeprom_update_byte_notify((uint8_t*)EEPROM_TMC2130_WAVE_X_FAC - axis, tmc2130_wave_fac[axis]);
+    }
+
+    // If any of the values changed, then re-init the TMC2130 driver
     if (changed) tmc2130_init(TMCInitParams(false, FarmOrUserECool()));
 }
 #endif //TMC2130


### PR DESCRIPTION
Found this optimisation when cleaning up my fork. It looks like it's still relevant.

----

Keep in mind that the EEPROM addresses are in descending order. This means we can't use eeprom_read_block() or eeprom_update_block()

Address --> Axis
3831 --> X-axis
3830 --> Y-axis
3829 --> Z-axis
3828 --> E-axis

Change in memory:
Flash: -140 bytes
SRAM: 0 bytes