### PR TITLE
Prepare FW 3.14.1 for testing

### DIFF
--- a/Firmware/Configuration.h
+++ b/Firmware/Configuration.h
@@ -21,9 +21,9 @@ extern const char _sPrinterMmuName[] PROGMEM;
 #ifndef CMAKE_CONTROL
 #define FW_MAJOR 3
 #define FW_MINOR 14
-#define FW_REVISION 0
-#define FW_COMMITNR 7945
-#define FW_FLAVOR BETA      //uncomment if DEV, ALPHA, BETA or RC
+#define FW_REVISION 1
+#define FW_COMMITNR 8225
+#define FW_FLAVOR RC      //uncomment if DEV, ALPHA, BETA or RC
 #define FW_FLAVERSION 1     //uncomment if FW_FLAVOR is defined and versioning is needed. Limited to max 8.
 #endif
 

--- a/lang/po/Firmware.pot
+++ b/lang/po/Firmware.pot
@@ -7,91 +7,91 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. MSG_IR_03_OR_OLDER c=18
-#: ../../Firmware/Filament_sensor.cpp:280
-#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:183
+#: ../../Firmware/Filament_sensor.cpp:282
+#: ../../Firmware/Filament_sensor.cpp:344 ../../Firmware/messages.cpp:190
 msgid " 0.3 or older"
 msgstr ""
 
 #. MSG_IR_04_OR_NEWER c=18
-#: ../../Firmware/Filament_sensor.cpp:282
-#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:182
+#: ../../Firmware/Filament_sensor.cpp:284
+#: ../../Firmware/Filament_sensor.cpp:347 ../../Firmware/messages.cpp:189
 msgid " 0.4 or newer"
 msgstr ""
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/messages.cpp:356 ../../Firmware/ultralcd.cpp:6773
+#: ../../Firmware/messages.cpp:368 ../../Firmware/ultralcd.cpp:6749
 msgid "%s level expected"
 msgstr ""
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:1978
-#: ../../Firmware/ultralcd.cpp:3613
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:1986
+#: ../../Firmware/ultralcd.cpp:3623
 msgid ">Cancel"
 msgstr ""
 
 #. MSG_BABYSTEPPING_Z c=13
-#: ../../Firmware/messages.cpp:257 ../../Firmware/ultralcd.cpp:2635
+#: ../../Firmware/messages.cpp:269 ../../Firmware/ultralcd.cpp:2652
 msgid "Adjusting Z"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/messages.cpp:360 ../../Firmware/ultralcd.cpp:6983
+#: ../../Firmware/messages.cpp:372 ../../Firmware/ultralcd.cpp:6960
 msgid "All correct"
 msgstr ""
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:3955
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:3979
 msgid "All is done. Happy printing!"
 msgstr ""
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4482
 msgid "Alphabet"
 msgstr ""
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4086
+#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4110
 msgid "Always"
 msgstr ""
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/messages.cpp:221 ../../Firmware/ultralcd.cpp:1393
+#: ../../Firmware/messages.cpp:233 ../../Firmware/ultralcd.cpp:1403
 msgid "Ambient"
 msgstr ""
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=3
-#: ../../Firmware/messages.cpp:267 ../../Firmware/ultralcd.cpp:2848
+#: ../../Firmware/messages.cpp:279 ../../Firmware/ultralcd.cpp:2865
 msgid "Are left and right Z-carriages all up?"
 msgstr ""
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4197
+#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:4221
 msgid "Assist"
 msgstr ""
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:179 ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/messages.cpp:186 ../../Firmware/ultralcd.cpp:5594
 msgid "Auto"
 msgstr ""
 
 #. MSG_AUTO_HOME c=18
-#: ../../Firmware/Marlin_main.cpp:3198 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:4577 ../../Firmware/ultralcd.cpp:5529
+#: ../../Firmware/Marlin_main.cpp:2942 ../../Firmware/messages.cpp:12
+#: ../../Firmware/ultralcd.cpp:4533 ../../Firmware/ultralcd.cpp:5496
 msgid "Auto home"
 msgstr ""
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4182
 msgid "Auto power"
 msgstr ""
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:328 ../../Firmware/ultralcd.cpp:5359
+#: ../../Firmware/messages.cpp:340 ../../Firmware/ultralcd.cpp:5328
 msgid "AutoLoad filament"
 msgstr ""
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/messages.cpp:245 ../../Firmware/ultralcd.cpp:2272
+#: ../../Firmware/messages.cpp:257 ../../Firmware/ultralcd.cpp:2289
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
@@ -103,85 +103,84 @@ msgid "Avoiding grind"
 msgstr ""
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/messages.cpp:352 ../../Firmware/ultralcd.cpp:6752
+#: ../../Firmware/messages.cpp:364 ../../Firmware/ultralcd.cpp:6728
 msgid "Axis"
 msgstr ""
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/messages.cpp:351 ../../Firmware/ultralcd.cpp:6751
+#: ../../Firmware/messages.cpp:363 ../../Firmware/ultralcd.cpp:6727
 msgid "Axis length"
 msgstr ""
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2708
-#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:5618
-#: ../../Firmware/ultralcd.cpp:7484
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2725
+#: ../../Firmware/ultralcd.cpp:4061 ../../Firmware/ultralcd.cpp:5591
+#: ../../Firmware/ultralcd.cpp:7461
 msgid "Back"
 msgstr ""
 
 #. MSG_BED c=13
-#: ../../Firmware/Marlin_main.cpp:2081 ../../Firmware/Marlin_main.cpp:4627
-#: ../../Firmware/Marlin_main.cpp:4678 ../../Firmware/messages.cpp:15
-#: ../../Firmware/ultralcd.cpp:1391 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/Marlin_main.cpp:4247 ../../Firmware/messages.cpp:15
+#: ../../Firmware/ultralcd.cpp:1401 ../../Firmware/ultralcd.cpp:4197
 msgid "Bed"
 msgstr ""
 
 #. MSG_BED_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6240 ../../Firmware/messages.cpp:17
+#: ../../Firmware/Marlin_main.cpp:5470 ../../Firmware/messages.cpp:17
 #: ../../Firmware/ultralcd.cpp:534
 msgid "Bed Heating"
 msgstr ""
 
 #. MSG_BED_DONE c=20
-#: ../../Firmware/Marlin_main.cpp:6277 ../../Firmware/messages.cpp:16
+#: ../../Firmware/Marlin_main.cpp:5507 ../../Firmware/messages.cpp:16
 #: ../../Firmware/ultralcd.cpp:537
 msgid "Bed done"
 msgstr ""
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/messages.cpp:317 ../../Firmware/ultralcd.cpp:4589
+#: ../../Firmware/messages.cpp:329 ../../Firmware/ultralcd.cpp:4545
 msgid "Bed level correct"
 msgstr ""
 
 #. MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:2262 ../../Firmware/Marlin_main.cpp:2999
-#: ../../Firmware/Marlin_main.cpp:3008
-#: ../../Firmware/mesh_bed_calibration.cpp:2878
-#: ../../Firmware/mesh_bed_calibration.cpp:2903 ../../Firmware/messages.cpp:18
+#: ../../Firmware/Marlin_main.cpp:2048 ../../Firmware/Marlin_main.cpp:2736
+#: ../../Firmware/Marlin_main.cpp:2745
+#: ../../Firmware/mesh_bed_calibration.cpp:2863
+#: ../../Firmware/mesh_bed_calibration.cpp:2888 ../../Firmware/messages.cpp:18
 msgid ""
 "Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for "
 "reset."
 msgstr ""
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/messages.cpp:346 ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/messages.cpp:358 ../../Firmware/ultralcd.cpp:6685
 msgid "Bed/Heater"
 msgstr ""
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1444
-#: ../../Firmware/ultralcd.cpp:1704
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1454
+#: ../../Firmware/ultralcd.cpp:1714
 msgid "Belt status"
 msgstr ""
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/messages.cpp:314 ../../Firmware/ultralcd.cpp:4579
+#: ../../Firmware/messages.cpp:326 ../../Firmware/ultralcd.cpp:4535
 msgid "Belt test"
 msgstr ""
 
 #. MSG_RECOVER_PRINT c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:1660 ../../Firmware/messages.cpp:87
+#: ../../Firmware/Marlin_main.cpp:1587 ../../Firmware/messages.cpp:87
 msgid "Blackout occurred. Recover print?"
 msgstr ""
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:177 ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:5594
 msgid "Bright"
 msgstr ""
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:4526
-#: ../../Firmware/ultralcd.cpp:5546
+#: ../../Firmware/messages.cpp:180 ../../Firmware/ultralcd.cpp:4493
+#: ../../Firmware/ultralcd.cpp:5513
 msgid "Brightness"
 msgstr ""
 
@@ -191,47 +190,47 @@ msgid "COMMUNICATION ERROR"
 msgstr ""
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/messages.cpp:316 ../../Firmware/ultralcd.cpp:4583
+#: ../../Firmware/messages.cpp:328 ../../Firmware/ultralcd.cpp:4539
 msgid "Calibrate XYZ"
 msgstr ""
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4585
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4541
 msgid "Calibrate Z"
 msgstr ""
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/messages.cpp:266 ../../Firmware/ultralcd.cpp:2813
+#: ../../Firmware/messages.cpp:278 ../../Firmware/ultralcd.cpp:2830
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
 msgstr ""
 
 #. MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: ../../Firmware/Marlin_main.cpp:2218 ../../Firmware/messages.cpp:22
+#: ../../Firmware/Marlin_main.cpp:2009 ../../Firmware/messages.cpp:23
 #: ../../Firmware/ultralcd.cpp:582
 msgid "Calibrating Z"
 msgstr ""
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/messages.cpp:265 ../../Firmware/ultralcd.cpp:2812
+#: ../../Firmware/messages.cpp:277 ../../Firmware/ultralcd.cpp:2829
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
 msgstr ""
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/messages.cpp:361 ../../Firmware/ultralcd.cpp:6985
+#: ../../Firmware/messages.cpp:373 ../../Firmware/ultralcd.cpp:6962
 msgid "Calibrating home"
 msgstr ""
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5375
+#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5342
 msgid "Calibration"
 msgstr ""
 
 #. MSG_HOMEYZ_DONE c=20
-#: ../../Firmware/messages.cpp:217 ../../Firmware/ultralcd.cpp:593
+#: ../../Firmware/messages.cpp:229 ../../Firmware/ultralcd.cpp:593
 msgid "Calibration done"
 msgstr ""
 
@@ -248,128 +247,128 @@ msgid ""
 msgstr ""
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/messages.cpp:364 ../../Firmware/ultralcd.cpp:7405
+#: ../../Firmware/messages.cpp:376 ../../Firmware/ultralcd.cpp:7382
 msgid "Card removed"
 msgstr ""
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/messages.cpp:324 ../../Firmware/ultralcd.cpp:5316
+#: ../../Firmware/messages.cpp:336 ../../Firmware/ultralcd.cpp:5282
 msgid "Change SD card"
 msgstr ""
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5254
-#: ../../Firmware/ultralcd.cpp:5526
+#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5216
+#: ../../Firmware/ultralcd.cpp:5493
 msgid "Change filament"
 msgstr ""
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/messages.cpp:240 ../../Firmware/ultralcd.cpp:2156
+#: ../../Firmware/messages.cpp:252 ../../Firmware/ultralcd.cpp:2167
 msgid "Change success!"
 msgstr ""
 
 #. MSG_CORRECTLY c=19
-#: ../../Firmware/messages.cpp:242 ../../Firmware/ultralcd.cpp:2203
+#: ../../Firmware/messages.cpp:254 ../../Firmware/ultralcd.cpp:2217
 msgid "Changed correctly"
 msgstr ""
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5951
-#: ../../Firmware/ultralcd.cpp:6975
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5927
+#: ../../Firmware/ultralcd.cpp:6952
 msgid "Checking X axis"
 msgstr ""
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5961
-#: ../../Firmware/ultralcd.cpp:6976
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:5937
+#: ../../Firmware/ultralcd.cpp:6953
 msgid "Checking Y axis"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/messages.cpp:358 ../../Firmware/ultralcd.cpp:6977
+#: ../../Firmware/messages.cpp:370 ../../Firmware/ultralcd.cpp:6954
 msgid "Checking Z axis"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6978
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6955
 msgid "Checking bed"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/messages.cpp:357 ../../Firmware/ultralcd.cpp:6974
+#: ../../Firmware/messages.cpp:369 ../../Firmware/ultralcd.cpp:6951
 msgid "Checking endstops"
 msgstr ""
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/messages.cpp:362 ../../Firmware/ultralcd.cpp:7070
+#: ../../Firmware/messages.cpp:374 ../../Firmware/ultralcd.cpp:7047
 msgid "Checking file"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/messages.cpp:359 ../../Firmware/ultralcd.cpp:6980
+#: ../../Firmware/messages.cpp:371 ../../Firmware/ultralcd.cpp:6957
 msgid "Checking hotend"
 msgstr ""
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6981
-#: ../../Firmware/ultralcd.cpp:6982
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6958
+#: ../../Firmware/ultralcd.cpp:6959
 msgid "Checking sensors"
 msgstr ""
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/messages.cpp:308 ../../Firmware/ultralcd.cpp:4424
+#: ../../Firmware/messages.cpp:320 ../../Firmware/ultralcd.cpp:4391
 msgid "Checks"
 msgstr ""
 
 #. MSG_TM_ACK_ERROR c=18
-#: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5297
+#: ../../Firmware/messages.cpp:197 ../../Firmware/ultralcd.cpp:5263
 msgid "Clear TM error"
 msgstr ""
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/messages.cpp:244 ../../Firmware/ultralcd.cpp:2205
+#: ../../Firmware/messages.cpp:256 ../../Firmware/ultralcd.cpp:2219
 msgid "Color not correct"
 msgstr ""
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:3508
+#: ../../Firmware/messages.cpp:27 ../../Firmware/ultralcd.cpp:3518
 msgid "Community made"
 msgstr ""
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:4059
+#: ../../Firmware/messages.cpp:178 ../../Firmware/ultralcd.cpp:4083
 msgid "Cont."
 msgstr ""
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:2129
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2135
 msgid "Cooldown"
 msgstr ""
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/messages.cpp:283 ../../Firmware/ultralcd.cpp:3450
+#: ../../Firmware/messages.cpp:295 ../../Firmware/ultralcd.cpp:3460
 msgid "Copy selected language?"
 msgstr ""
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:1234
-#: ../../Firmware/ultralcd.cpp:1263
+#: ../../Firmware/messages.cpp:30 ../../Firmware/ultralcd.cpp:1244
+#: ../../Firmware/ultralcd.cpp:1273
 msgid "Crash"
 msgstr ""
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4146
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/ultralcd.cpp:4170
 msgid "Crash det."
 msgstr ""
 
 #. MSG_CRASH_DETECTED c=20
-#: ../../Firmware/Marlin_main.cpp:630 ../../Firmware/messages.cpp:30
+#: ../../Firmware/Marlin_main.cpp:595 ../../Firmware/messages.cpp:31
 msgid "Crash detected."
 msgstr ""
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/messages.cpp:280 ../../Firmware/ultralcd.cpp:3374
+#: ../../Firmware/messages.cpp:292 ../../Firmware/ultralcd.cpp:3384
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -377,24 +376,24 @@ msgid ""
 msgstr ""
 
 #. MSG_CUT_FILAMENT c=16
-#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:380
-#: ../../Firmware/ultralcd.cpp:4854 ../../Firmware/ultralcd.cpp:5351
+#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:381
+#: ../../Firmware/ultralcd.cpp:4810 ../../Firmware/ultralcd.cpp:5317
 msgid "Cut filament"
 msgstr ""
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4081
-#: ../../Firmware/ultralcd.cpp:4086 ../../Firmware/ultralcd.cpp:4091
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:4105
+#: ../../Firmware/ultralcd.cpp:4110 ../../Firmware/ultralcd.cpp:4115
 msgid "Cutter"
 msgstr ""
 
 #. MSG_DATE c=17
-#: ../../Firmware/messages.cpp:222 ../../Firmware/ultralcd.cpp:1645
+#: ../../Firmware/messages.cpp:234 ../../Firmware/ultralcd.cpp:1655
 msgid "Date:"
 msgstr ""
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:178 ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/messages.cpp:185 ../../Firmware/ultralcd.cpp:5594
 msgid "Dim"
 msgstr ""
 
@@ -404,7 +403,7 @@ msgid "Disable"
 msgstr ""
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/messages.cpp:311 ../../Firmware/ultralcd.cpp:4460
+#: ../../Firmware/messages.cpp:323 ../../Firmware/ultralcd.cpp:4427
 msgid "Disable steppers"
 msgstr ""
 
@@ -416,7 +415,7 @@ msgid "Disengaging idler"
 msgstr ""
 
 #. MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: ../../Firmware/Marlin_main.cpp:1610 ../../Firmware/Marlin_main.cpp:3334
+#: ../../Firmware/Marlin_main.cpp:1537 ../../Firmware/Marlin_main.cpp:3073
 #: ../../Firmware/messages.cpp:14
 msgid ""
 "Distance between tip of the nozzle and the bed surface has not been set yet."
@@ -425,20 +424,20 @@ msgid ""
 msgstr ""
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/messages.cpp:301 ../../Firmware/ultralcd.cpp:3923
+#: ../../Firmware/messages.cpp:313 ../../Firmware/ultralcd.cpp:3947
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
 msgstr ""
 
 #. MSG_DONE c=8
-#: ../../Firmware/messages.cpp:32 ../../Firmware/mmu2/errors_list.h:367
-#: ../../Firmware/mmu2_reporting.cpp:456
+#: ../../Firmware/messages.cpp:33 ../../Firmware/mmu2/errors_list.h:367
+#: ../../Firmware/mmu2_reporting.cpp:457
 msgid "Done"
 msgstr ""
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/messages.cpp:307 ../../Firmware/ultralcd.cpp:3990
+#: ../../Firmware/messages.cpp:319 ../../Firmware/ultralcd.cpp:4014
 msgid "E-correct"
 msgstr ""
 
@@ -467,18 +466,19 @@ msgid "ERR Wait for User"
 msgstr ""
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:2253
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:2267
 msgid "ERROR:"
 msgstr ""
 
-#. MSG_BTN_EJECT c=8
-#: ../../Firmware/mmu2/errors_list.h:358 ../../Firmware/mmu2/errors_list.h:371
+#. MSG_EJECT c=8
+#: ../../Firmware/messages.cpp:21 ../../Firmware/mmu2/errors_list.h:371
+#: ../../Firmware/ultralcd.cpp:2275 ../../Firmware/ultralcd.cpp:2279
 msgid "Eject"
 msgstr ""
 
 #. MSG_EJECT_FROM_MMU c=16
-#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:384
-#: ../../Firmware/ultralcd.cpp:4845 ../../Firmware/ultralcd.cpp:5348
+#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:385
+#: ../../Firmware/ultralcd.cpp:4801 ../../Firmware/ultralcd.cpp:5314
 msgid "Eject from MMU"
 msgstr ""
 
@@ -490,17 +490,17 @@ msgid "Ejecting filament"
 msgstr ""
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/messages.cpp:348 ../../Firmware/ultralcd.cpp:6722
+#: ../../Firmware/messages.cpp:360 ../../Firmware/ultralcd.cpp:6698
 msgid "Endstop"
 msgstr ""
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/messages.cpp:349 ../../Firmware/ultralcd.cpp:6727
+#: ../../Firmware/messages.cpp:361 ../../Firmware/ultralcd.cpp:6703
 msgid "Endstop not hit"
 msgstr ""
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/messages.cpp:347 ../../Firmware/ultralcd.cpp:6713
+#: ../../Firmware/messages.cpp:359 ../../Firmware/ultralcd.cpp:6689
 msgid "Endstops"
 msgstr ""
 
@@ -512,30 +512,30 @@ msgid "Engaging idler"
 msgstr ""
 
 #. MSG_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:3352
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:3362
 msgid "Extruder"
 msgstr ""
 
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/messages.cpp:227 ../../Firmware/ultralcd.cpp:1700
+#: ../../Firmware/messages.cpp:239 ../../Firmware/ultralcd.cpp:1710
 msgid "Extruder info"
 msgstr ""
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4044
-#: ../../Firmware/ultralcd.cpp:4051
+#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4068
+#: ../../Firmware/ultralcd.cpp:4075
 msgid "F. autoload"
 msgstr ""
 
 #. MSG_FSENSOR_JAM_DETECTION c=13
-#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4046
-#: ../../Firmware/ultralcd.cpp:4053
+#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4070
+#: ../../Firmware/ultralcd.cpp:4077
 msgid "F. jam detect"
 msgstr ""
 
 #. MSG_FSENSOR_RUNOUT c=13
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4074
 msgid "F. runout"
 msgstr ""
 
@@ -579,8 +579,8 @@ msgid ""
 msgstr ""
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:4059
-#: ../../Firmware/ultralcd.cpp:4062
+#: ../../Firmware/messages.cpp:177 ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/ultralcd.cpp:4086
 msgid "FS Action"
 msgstr ""
 
@@ -605,34 +605,34 @@ msgid "FW RUNTIME ERROR"
 msgstr ""
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/messages.cpp:330 ../../Firmware/ultralcd.cpp:5382
+#: ../../Firmware/messages.cpp:342 ../../Firmware/ultralcd.cpp:5349
 msgid "Fail stats"
 msgstr ""
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/messages.cpp:331 ../../Firmware/ultralcd.cpp:5385
+#: ../../Firmware/messages.cpp:343 ../../Firmware/ultralcd.cpp:5352
 msgid "Fail stats MMU"
 msgstr ""
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/messages.cpp:355 ../../Firmware/ultralcd.cpp:6768
+#: ../../Firmware/messages.cpp:367 ../../Firmware/ultralcd.cpp:6744
 msgid "False triggering"
 msgstr ""
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4175
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4199
 msgid "Fan speed"
 msgstr ""
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6844
-#: ../../Firmware/ultralcd.cpp:6971 ../../Firmware/ultralcd.cpp:6972
-#: ../../Firmware/ultralcd.cpp:6973
+#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6820
+#: ../../Firmware/ultralcd.cpp:6948 ../../Firmware/ultralcd.cpp:6949
+#: ../../Firmware/ultralcd.cpp:6950
 msgid "Fan test"
 msgstr ""
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:4179
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:4203
 msgid "Fans check"
 msgstr ""
 
@@ -661,16 +661,16 @@ msgid "Feeding to nozzle"
 msgstr ""
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1233
-#: ../../Firmware/ultralcd.cpp:1262 ../../Firmware/ultralcd.cpp:1316
-#: ../../Firmware/ultralcd.cpp:1318
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:1243
+#: ../../Firmware/ultralcd.cpp:1272 ../../Firmware/ultralcd.cpp:1326
+#: ../../Firmware/ultralcd.cpp:1328
 msgid "Fil. runouts"
 msgstr ""
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3313
-#: ../../Firmware/ultralcd.cpp:4039 ../../Firmware/ultralcd.cpp:4464
-#: ../../Firmware/ultralcd.cpp:5532
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3323
+#: ../../Firmware/ultralcd.cpp:4063 ../../Firmware/ultralcd.cpp:4431
+#: ../../Firmware/ultralcd.cpp:5499
 msgid "Fil. sensor"
 msgstr ""
 
@@ -682,20 +682,20 @@ msgid ""
 msgstr ""
 
 #. MSG_FILAMENT_CLEAN c=20 r=3
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2261
-#: ../../Firmware/ultralcd.cpp:2265
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2275
+#: ../../Firmware/ultralcd.cpp:2279
 msgid "Filament extruding & with correct color?"
 msgstr ""
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/messages.cpp:243 ../../Firmware/ultralcd.cpp:2204
+#: ../../Firmware/messages.cpp:255 ../../Firmware/ultralcd.cpp:2218
 msgid "Filament not loaded"
 msgstr ""
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6763
-#: ../../Firmware/ultralcd.cpp:6767 ../../Firmware/ultralcd.cpp:6771
-#: ../../Firmware/ultralcd.cpp:7000
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6739
+#: ../../Firmware/ultralcd.cpp:6743 ../../Firmware/ultralcd.cpp:6747
+#: ../../Firmware/ultralcd.cpp:6977
 msgid "Filament sensor"
 msgstr ""
 
@@ -721,129 +721,129 @@ msgid ""
 msgstr ""
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/messages.cpp:246 ../../Firmware/ultralcd.cpp:2347
+#: ../../Firmware/messages.cpp:258 ../../Firmware/ultralcd.cpp:2364
 msgid "Filament used"
 msgstr ""
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/messages.cpp:363 ../../Firmware/ultralcd.cpp:7139
+#: ../../Firmware/messages.cpp:375 ../../Firmware/ultralcd.cpp:7116
 msgid "File incomplete. Continue anyway?"
 msgstr ""
 
 #. MSG_FINISHING_MOVEMENTS c=20
 #: ../../Firmware/messages.cpp:45
 #: ../../Firmware/mmu2_progress_converter.cpp:43
-#: ../../Firmware/ultralcd.cpp:5021 ../../Firmware/ultralcd.cpp:5425
+#: ../../Firmware/ultralcd.cpp:4977 ../../Firmware/ultralcd.cpp:5392
 msgid "Finishing movements"
 msgstr ""
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4575
-#: ../../Firmware/ultralcd.cpp:5141
+#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4531
+#: ../../Firmware/ultralcd.cpp:5101
 msgid "First layer cal."
 msgstr ""
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/messages.cpp:293 ../../Firmware/ultralcd.cpp:3846
+#: ../../Firmware/messages.cpp:305 ../../Firmware/ultralcd.cpp:3872
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 
 #. MSG_FLOW c=15
-#: ../../Firmware/messages.cpp:334 ../../Firmware/ultralcd.cpp:5520
+#: ../../Firmware/messages.cpp:346 ../../Firmware/ultralcd.cpp:5487
 msgid "Flow"
 msgstr ""
 
 #. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
-#: ../../Firmware/messages.cpp:194 ../../Firmware/ultralcd.cpp:985
+#: ../../Firmware/messages.cpp:201 ../../Firmware/ultralcd.cpp:987
 msgid ""
 "For a Nozzle change please read\n"
 "prusa.io/nozzle-mk3s"
 msgstr ""
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6733
-#: ../../Firmware/ultralcd.cpp:6850 ../../Firmware/ultralcd.cpp:6855
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/ultralcd.cpp:6826 ../../Firmware/ultralcd.cpp:6831
 msgid "Front print fan?"
 msgstr ""
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/messages.cpp:260 ../../Firmware/ultralcd.cpp:2711
+#: ../../Firmware/messages.cpp:272 ../../Firmware/ultralcd.cpp:2728
 msgid "Front side[µm]"
 msgstr ""
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/messages.cpp:353 ../../Firmware/ultralcd.cpp:6757
+#: ../../Firmware/messages.cpp:365 ../../Firmware/ultralcd.cpp:6733
 msgid "Front/left fans"
 msgstr ""
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:151 ../../Firmware/util.cpp:382
+#: ../../Firmware/messages.cpp:156 ../../Firmware/util.cpp:417
 msgid "G-code sliced for a different level. Continue?"
 msgstr ""
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:152 ../../Firmware/util.cpp:383
+#: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:418
 msgid ""
 "G-code sliced for a different level. Please re-slice the model again. Print "
 "cancelled."
 msgstr ""
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:147 ../../Firmware/util.cpp:312
-#: ../../Firmware/util.cpp:401
+#: ../../Firmware/messages.cpp:152 ../../Firmware/util.cpp:319
+#: ../../Firmware/util.cpp:436
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr ""
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:148 ../../Firmware/util.cpp:313
-#: ../../Firmware/util.cpp:402
+#: ../../Firmware/messages.cpp:153 ../../Firmware/util.cpp:320
+#: ../../Firmware/util.cpp:437
 msgid ""
 "G-code sliced for a different printer type. Please re-slice the model again."
 " Print cancelled."
 msgstr ""
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:149 ../../Firmware/util.cpp:362
+#: ../../Firmware/messages.cpp:154 ../../Firmware/util.cpp:369
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr ""
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:150 ../../Firmware/util.cpp:363
+#: ../../Firmware/messages.cpp:155 ../../Firmware/util.cpp:370
 msgid ""
 "G-code sliced for a newer firmware. Please update the firmware. Print "
 "cancelled."
 msgstr ""
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4366
-#: ../../Firmware/ultralcd.cpp:4383 ../../Firmware/ultralcd.cpp:4485
+#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4325
+#: ../../Firmware/ultralcd.cpp:4343 ../../Firmware/ultralcd.cpp:4452
 msgid "HW Setup"
 msgstr ""
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/messages.cpp:344 ../../Firmware/ultralcd.cpp:6705
+#: ../../Firmware/messages.cpp:356 ../../Firmware/ultralcd.cpp:6681
 msgid "Heater/Thermistor"
 msgstr ""
 
 #. MSG_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6184 ../../Firmware/messages.cpp:52
+#: ../../Firmware/Marlin_main.cpp:5416 ../../Firmware/messages.cpp:52
 #: ../../Firmware/ultralcd.cpp:526
 msgid "Heating"
 msgstr ""
 
 #. MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:9647 ../../Firmware/messages.cpp:211
+#: ../../Firmware/Marlin_main.cpp:8807 ../../Firmware/messages.cpp:223
 msgid "Heating disabled by safety timer."
 msgstr ""
 
 #. MSG_HEATING_COMPLETE c=20
-#: ../../Firmware/Marlin_main.cpp:6215 ../../Firmware/messages.cpp:53
+#: ../../Firmware/Marlin_main.cpp:5445 ../../Firmware/messages.cpp:53
 #: ../../Firmware/ultralcd.cpp:529
 msgid "Heating done."
 msgstr ""
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=12
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:3806
+#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:3832
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -851,15 +851,15 @@ msgid ""
 msgstr ""
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:3810
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:3836
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
 msgstr ""
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4152
-#: ../../Firmware/ultralcd.cpp:4161
+#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:4176
+#: ../../Firmware/ultralcd.cpp:4185
 msgid "High power"
 msgstr ""
 
@@ -870,23 +870,23 @@ msgid "Homing"
 msgstr ""
 
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
-#: ../../Firmware/messages.cpp:195 ../../Firmware/ultralcd.cpp:1005
+#: ../../Firmware/messages.cpp:206 ../../Firmware/ultralcd.cpp:1011
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr ""
 
 #. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1106
-#: ../../Firmware/ultralcd.cpp:6991
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1116
+#: ../../Firmware/ultralcd.cpp:6968
 msgid "Hotend fan:"
 msgstr ""
 
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/messages.cpp:294 ../../Firmware/ultralcd.cpp:3851
+#: ../../Firmware/messages.cpp:306 ../../Firmware/ultralcd.cpp:3877
 msgid "I will run xyz calibration now. It will take up to 24 mins."
 msgstr ""
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/messages.cpp:297 ../../Firmware/ultralcd.cpp:3862
+#: ../../Firmware/messages.cpp:309 ../../Firmware/ultralcd.cpp:3884
 msgid "I will run z calibration now."
 msgstr ""
 
@@ -911,35 +911,35 @@ msgid "INVALID TOOL"
 msgstr ""
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=8
-#: ../../Firmware/messages.cpp:303 ../../Firmware/ultralcd.cpp:3931
+#: ../../Firmware/messages.cpp:315 ../../Firmware/ultralcd.cpp:3955
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
 msgstr ""
 
 #. MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2540
-#: ../../Firmware/messages.cpp:213
+#: ../../Firmware/mesh_bed_calibration.cpp:2525
+#: ../../Firmware/messages.cpp:225
 msgid "Improving bed calibration point"
 msgstr ""
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:5222
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:5184
 msgid "Info screen"
 msgstr ""
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/messages.cpp:326 ../../Firmware/ultralcd.cpp:5323
+#: ../../Firmware/messages.cpp:338 ../../Firmware/ultralcd.cpp:5289
 msgid "Init. SD card"
 msgstr ""
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/messages.cpp:238 ../../Firmware/ultralcd.cpp:2142
+#: ../../Firmware/messages.cpp:250 ../../Firmware/ultralcd.cpp:2148
 msgid "Insert filament"
 msgstr ""
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/messages.cpp:335 ../../Firmware/ultralcd.cpp:5998
+#: ../../Firmware/messages.cpp:347 ../../Firmware/ultralcd.cpp:5974
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
@@ -952,19 +952,19 @@ msgid ""
 msgstr ""
 
 #. MSG_FILAMENT_LOADED c=20 r=3
-#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3628
-#: ../../Firmware/ultralcd.cpp:3890
+#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3638
+#: ../../Firmware/ultralcd.cpp:3914
 msgid "Is filament loaded?"
 msgstr ""
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3238 ../../Firmware/Marlin_main.cpp:4745
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:3858
+#: ../../Firmware/Marlin_main.cpp:4314 ../../Firmware/messages.cpp:127
+#: ../../Firmware/ultralcd.cpp:3760
 msgid "Is steel sheet on heatbed?"
 msgstr ""
 
 #. MSG_ITERATION c=12
-#: ../../Firmware/mesh_bed_calibration.cpp:2265 ../../Firmware/messages.cpp:55
+#: ../../Firmware/mesh_bed_calibration.cpp:2250 ../../Firmware/messages.cpp:55
 msgid "Iteration"
 msgstr ""
 
@@ -974,51 +974,51 @@ msgid "LOAD TO EXTR. FAILED"
 msgstr ""
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1128
-#: ../../Firmware/ultralcd.cpp:1286
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1138
+#: ../../Firmware/ultralcd.cpp:1296
 msgid "Last print"
 msgstr ""
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1152
-#: ../../Firmware/ultralcd.cpp:1260 ../../Firmware/ultralcd.cpp:1315
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1162
+#: ../../Firmware/ultralcd.cpp:1270 ../../Firmware/ultralcd.cpp:1325
 msgid "Last print failures"
 msgstr ""
 
 #. MSG_LEFT c=10
-#: ../../Firmware/messages.cpp:251 ../../Firmware/ultralcd.cpp:2478
+#: ../../Firmware/messages.cpp:263 ../../Firmware/ultralcd.cpp:2495
 msgid "Left"
 msgstr ""
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6739
-#: ../../Firmware/ultralcd.cpp:6850 ../../Firmware/ultralcd.cpp:6855
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6715
+#: ../../Firmware/ultralcd.cpp:6826 ../../Firmware/ultralcd.cpp:6831
 msgid "Left hotend fan?"
 msgstr ""
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/messages.cpp:258 ../../Firmware/ultralcd.cpp:2709
+#: ../../Firmware/messages.cpp:270 ../../Firmware/ultralcd.cpp:2726
 msgid "Left side [µm]"
 msgstr ""
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:5619
+#: ../../Firmware/messages.cpp:181 ../../Firmware/ultralcd.cpp:5592
 msgid "Level Bright"
 msgstr ""
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:175 ../../Firmware/ultralcd.cpp:5620
+#: ../../Firmware/messages.cpp:182 ../../Firmware/ultralcd.cpp:5593
 msgid "Level Dimmed"
 msgstr ""
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/messages.cpp:312 ../../Firmware/ultralcd.cpp:4491
+#: ../../Firmware/messages.cpp:324 ../../Firmware/ultralcd.cpp:4458
 msgid "Lin. correction"
 msgstr ""
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4501
-#: ../../Firmware/ultralcd.cpp:5251
+#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4468
+#: ../../Firmware/ultralcd.cpp:5213
 msgid "Live adjust Z"
 msgstr ""
 
@@ -1028,38 +1028,38 @@ msgid "Load"
 msgstr ""
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/messages.cpp:192 ../../Firmware/ultralcd.cpp:4794
-#: ../../Firmware/ultralcd.cpp:4880
+#: ../../Firmware/messages.cpp:199 ../../Firmware/ultralcd.cpp:4750
+#: ../../Firmware/ultralcd.cpp:4836
 msgid "Load All"
 msgstr ""
 
 #. MSG_LOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4796
-#: ../../Firmware/ultralcd.cpp:4833 ../../Firmware/ultralcd.cpp:4882
-#: ../../Firmware/ultralcd.cpp:5361 ../../Firmware/ultralcd.cpp:5368
+#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4752
+#: ../../Firmware/ultralcd.cpp:4789 ../../Firmware/ultralcd.cpp:4838
+#: ../../Firmware/ultralcd.cpp:5324 ../../Firmware/ultralcd.cpp:5335
 msgid "Load filament"
 msgstr ""
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/messages.cpp:327 ../../Firmware/ultralcd.cpp:5346
+#: ../../Firmware/messages.cpp:339 ../../Firmware/ultralcd.cpp:5312
 msgid "Load to nozzle"
 msgstr ""
 
 #. MSG_LOADING_TEST c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4476
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4443
 msgid "Loading Test"
 msgstr ""
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/messages.cpp:241 ../../Firmware/ultralcd.cpp:2178
+#: ../../Firmware/messages.cpp:253 ../../Firmware/ultralcd.cpp:2189
 msgid "Loading color"
 msgstr ""
 
 #. MSG_LOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3598 ../../Firmware/messages.cpp:62
+#: ../../Firmware/Marlin_main.cpp:3343 ../../Firmware/messages.cpp:62
 #: ../../Firmware/mmu2_progress_converter.cpp:51
-#: ../../Firmware/mmu2_reporting.cpp:392 ../../Firmware/ultralcd.cpp:2189
-#: ../../Firmware/ultralcd.cpp:3715
+#: ../../Firmware/mmu2_reporting.cpp:393 ../../Firmware/ultralcd.cpp:2199
+#: ../../Firmware/ultralcd.cpp:3725
 msgid "Loading filament"
 msgstr ""
 
@@ -1071,13 +1071,13 @@ msgid ""
 msgstr ""
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/messages.cpp:350 ../../Firmware/ultralcd.cpp:6745
+#: ../../Firmware/messages.cpp:362 ../../Firmware/ultralcd.cpp:6721
 msgid "Loose pulley"
 msgstr ""
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4188
-#: ../../Firmware/ultralcd.cpp:4200
+#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4224
 msgid "Loud"
 msgstr ""
 
@@ -1108,7 +1108,7 @@ msgid "MMU MCU ERROR"
 msgstr ""
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:4096
+#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4120
 msgid "MMU Mode"
 msgstr ""
 
@@ -1118,7 +1118,7 @@ msgid "MMU NOT RESPONDING"
 msgstr ""
 
 #. MSG_MMU_RESTORE_TEMP c=20 r=4
-#: ../../Firmware/messages.cpp:214 ../../Firmware/mmu2_reporting.cpp:396
+#: ../../Firmware/messages.cpp:226 ../../Firmware/mmu2_reporting.cpp:397
 msgid "MMU Retry: Restoring temperature..."
 msgstr ""
 
@@ -1129,19 +1129,19 @@ msgid "MMU SELFTEST FAILED"
 msgstr ""
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/messages.cpp:223 ../../Firmware/ultralcd.cpp:1657
+#: ../../Firmware/messages.cpp:235 ../../Firmware/ultralcd.cpp:1667
 msgid "MMU connected"
 msgstr ""
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1153
-#: ../../Firmware/ultralcd.cpp:1178
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1163
+#: ../../Firmware/ultralcd.cpp:1188
 msgid "MMU fails"
 msgstr ""
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1154
-#: ../../Firmware/ultralcd.cpp:1179
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1164
+#: ../../Firmware/ultralcd.cpp:1189
 msgid "MMU load fails"
 msgstr ""
 
@@ -1156,77 +1156,75 @@ msgid "MMU not responding. Check the wiring and connectors."
 msgstr ""
 
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1180
+#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1190
 msgid "MMU power fails"
 msgstr ""
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/messages.cpp:176 ../../Firmware/ultralcd.cpp:5567
 msgid "Magnets comp."
 msgstr ""
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1127
-#: ../../Firmware/ultralcd.cpp:1285 ../../Firmware/ultralcd.cpp:1327
-#: ../../Firmware/ultralcd.cpp:1631 ../../Firmware/ultralcd.cpp:4453
-#: ../../Firmware/ultralcd.cpp:4571 ../../Firmware/ultralcd.cpp:4793
-#: ../../Firmware/ultralcd.cpp:4826 ../../Firmware/ultralcd.cpp:4879
-#: ../../Firmware/ultralcd.cpp:5515
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1137
+#: ../../Firmware/ultralcd.cpp:1295 ../../Firmware/ultralcd.cpp:1337
+#: ../../Firmware/ultralcd.cpp:1641 ../../Firmware/ultralcd.cpp:4420
+#: ../../Firmware/ultralcd.cpp:4527 ../../Firmware/ultralcd.cpp:4749
+#: ../../Firmware/ultralcd.cpp:4782 ../../Firmware/ultralcd.cpp:4835
+#: ../../Firmware/ultralcd.cpp:5482
 msgid "Main"
 msgstr ""
 
 #. MSG_MATERIAL_CHANGES c=18
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:1130
-#: ../../Firmware/ultralcd.cpp:1204
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:1140
+#: ../../Firmware/ultralcd.cpp:1214
 msgid "Material changes"
 msgstr ""
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/messages.cpp:253 ../../Firmware/ultralcd.cpp:2519
+#: ../../Firmware/messages.cpp:265 ../../Firmware/ultralcd.cpp:2536
 msgid "Measured skew"
 msgstr ""
 
 #. MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3219
-#: ../../Firmware/mesh_bed_calibration.cpp:2852 ../../Firmware/messages.cpp:70
+#: ../../Firmware/Marlin_main.cpp:2963
+#: ../../Firmware/mesh_bed_calibration.cpp:2837 ../../Firmware/messages.cpp:70
 msgid "Measuring reference height of calibration point"
 msgstr ""
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:5590
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:5563
 msgid "Mesh"
 msgstr ""
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4488
-#: ../../Firmware/ultralcd.cpp:4587
+#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:4455
+#: ../../Firmware/ultralcd.cpp:4543
 msgid "Mesh Bed Leveling"
 msgstr ""
 
 #. MSG_MBL_FAILED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3038 ../../Firmware/messages.cpp:203
+#: ../../Firmware/Marlin_main.cpp:2776 ../../Firmware/messages.cpp:215
 msgid "Mesh bed leveling failed. Print canceled."
 msgstr ""
 
 #. MSG_MODE c=6
-#: ../../Firmware/Marlin_main.cpp:8495 ../../Firmware/messages.cpp:117
-#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4132
-#: ../../Firmware/ultralcd.cpp:4140 ../../Firmware/ultralcd.cpp:4144
-#: ../../Firmware/ultralcd.cpp:4152 ../../Firmware/ultralcd.cpp:4155
-#: ../../Firmware/ultralcd.cpp:4158 ../../Firmware/ultralcd.cpp:4161
-#: ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/Marlin_main.cpp:7666 ../../Firmware/messages.cpp:121
+#: ../../Firmware/ultralcd.cpp:4152 ../../Firmware/ultralcd.cpp:4156
+#: ../../Firmware/ultralcd.cpp:4164 ../../Firmware/ultralcd.cpp:4168
+#: ../../Firmware/ultralcd.cpp:4176 ../../Firmware/ultralcd.cpp:4179
+#: ../../Firmware/ultralcd.cpp:4182 ../../Firmware/ultralcd.cpp:4185
+#: ../../Firmware/ultralcd.cpp:5594
 msgid "Mode"
 msgstr ""
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/messages.cpp:282 ../../Firmware/ultralcd.cpp:3413
+#: ../../Firmware/messages.cpp:294 ../../Firmware/ultralcd.cpp:3423
 msgid "Mode change in progress..."
 msgstr ""
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:4310
-#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4316
-#: ../../Firmware/ultralcd.cpp:4319
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4327
 msgid "Model"
 msgstr ""
 
@@ -1247,28 +1245,28 @@ msgid "More details online."
 msgstr ""
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6719
-#: ../../Firmware/ultralcd.cpp:6728 ../../Firmware/ultralcd.cpp:6746
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6695
+#: ../../Firmware/ultralcd.cpp:6704 ../../Firmware/ultralcd.cpp:6722
 msgid "Motor"
 msgstr ""
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/messages.cpp:277 ../../Firmware/ultralcd.cpp:3349
+#: ../../Firmware/messages.cpp:289 ../../Firmware/ultralcd.cpp:3359
 msgid "Move X"
 msgstr ""
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/messages.cpp:278 ../../Firmware/ultralcd.cpp:3350
+#: ../../Firmware/messages.cpp:290 ../../Firmware/ultralcd.cpp:3360
 msgid "Move Y"
 msgstr ""
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/messages.cpp:279 ../../Firmware/ultralcd.cpp:3351
+#: ../../Firmware/messages.cpp:291 ../../Firmware/ultralcd.cpp:3361
 msgid "Move Z"
 msgstr ""
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/messages.cpp:310 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:322 ../../Firmware/ultralcd.cpp:4426
 msgid "Move axis"
 msgstr ""
 
@@ -1279,118 +1277,115 @@ msgid "Moving selector"
 msgstr ""
 
 #. MSG_NA c=3
-#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:141
-#: ../../Firmware/ultralcd.cpp:2484 ../../Firmware/ultralcd.cpp:2528
-#: ../../Firmware/ultralcd.cpp:3279 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:4044 ../../Firmware/ultralcd.cpp:4046
-#: ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:146
+#: ../../Firmware/ultralcd.cpp:2501 ../../Firmware/ultralcd.cpp:2545
+#: ../../Firmware/ultralcd.cpp:3289 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4068 ../../Firmware/ultralcd.cpp:4070
+#: ../../Firmware/ultralcd.cpp:5567
 msgid "N/A"
 msgstr ""
 
 #. MSG_NEW_FIRMWARE_AVAILABLE c=20 r=2
-#: ../../Firmware/messages.cpp:365 ../../Firmware/util.cpp:209
+#: ../../Firmware/messages.cpp:377 ../../Firmware/util.cpp:214
 msgid "New firmware version available:"
 msgstr ""
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:3029
-#: ../../Firmware/ultralcd.cpp:4443 ../../Firmware/ultralcd.cpp:4531
-#: ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:2275
+#: ../../Firmware/ultralcd.cpp:2279 ../../Firmware/ultralcd.cpp:3046
+#: ../../Firmware/ultralcd.cpp:4410 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/ultralcd.cpp:5765
 msgid "No"
 msgstr ""
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/messages.cpp:325 ../../Firmware/ultralcd.cpp:5321
+#: ../../Firmware/messages.cpp:337 ../../Firmware/ultralcd.cpp:5287
 msgid "No SD card"
 msgstr ""
 
 #. MSG_NO_MOVE c=20
-#: ../../Firmware/Marlin_main.cpp:5271 ../../Firmware/messages.cpp:210
+#: ../../Firmware/Marlin_main.cpp:4778 ../../Firmware/messages.cpp:222
 msgid "No move."
 msgstr ""
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4239 ../../Firmware/ultralcd.cpp:4310
-#: ../../Firmware/ultralcd.cpp:4319 ../../Firmware/ultralcd.cpp:4349
-#: ../../Firmware/ultralcd.cpp:4358 ../../Firmware/ultralcd.cpp:4516
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4309
+#: ../../Firmware/ultralcd.cpp:4318 ../../Firmware/ultralcd.cpp:4483
 msgid "None"
 msgstr ""
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/Marlin_main.cpp:8497 ../../Firmware/messages.cpp:121
-#: ../../Firmware/ultralcd.cpp:4096 ../../Firmware/ultralcd.cpp:4132
-#: ../../Firmware/ultralcd.cpp:4511
+#: ../../Firmware/Marlin_main.cpp:7668 ../../Firmware/messages.cpp:125
+#: ../../Firmware/ultralcd.cpp:4120 ../../Firmware/ultralcd.cpp:4156
+#: ../../Firmware/ultralcd.cpp:4478
 msgid "Normal"
 msgstr ""
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/messages.cpp:345 ../../Firmware/ultralcd.cpp:6706
+#: ../../Firmware/messages.cpp:357 ../../Firmware/ultralcd.cpp:6682
 msgid "Not connected"
 msgstr ""
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6863
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6839
 msgid "Not spinning"
 msgstr ""
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/messages.cpp:289 ../../Firmware/ultralcd.cpp:3726
+#: ../../Firmware/messages.cpp:301 ../../Firmware/ultralcd.cpp:3736
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr ""
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/messages.cpp:298 ../../Firmware/ultralcd.cpp:3871
+#: ../../Firmware/messages.cpp:310 ../../Firmware/ultralcd.cpp:3894
 msgid "Now I will preheat nozzle for PLA."
 msgstr ""
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/messages.cpp:296 ../../Firmware/ultralcd.cpp:3857
+#: ../../Firmware/messages.cpp:308 ../../Firmware/ultralcd.cpp:3883
 msgid "Now remove the test print from steel sheet."
 msgstr ""
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1390
-#: ../../Firmware/ultralcd.cpp:4170 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4233 ../../Firmware/ultralcd.cpp:4236
-#: ../../Firmware/ultralcd.cpp:4239
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1400
+#: ../../Firmware/ultralcd.cpp:4194 ../../Firmware/ultralcd.cpp:4326
 msgid "Nozzle"
 msgstr ""
 
 #. MSG_NOZZLE_CNG_MENU c=18
-#: ../../Firmware/messages.cpp:193 ../../Firmware/ultralcd.cpp:4423
-#: ../../Firmware/ultralcd.cpp:4486
+#: ../../Firmware/messages.cpp:200 ../../Firmware/ultralcd.cpp:4390
+#: ../../Firmware/ultralcd.cpp:4453
 msgid "Nozzle change"
 msgstr ""
 
+#. MSG_NOZZLE_CNG_CHANGED_QUICK c=20 r=3
+#: ../../Firmware/messages.cpp:204
+msgid "Nozzle changed?"
+msgstr ""
+
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4276
-#: ../../Firmware/ultralcd.cpp:4278 ../../Firmware/ultralcd.cpp:4279
-#: ../../Firmware/ultralcd.cpp:4280
+#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4261
+#: ../../Firmware/ultralcd.cpp:4263 ../../Firmware/ultralcd.cpp:4264
+#: ../../Firmware/ultralcd.cpp:4265
 msgid "Nozzle d."
 msgstr ""
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:153 ../../Firmware/util.cpp:289
+#: ../../Firmware/messages.cpp:160 ../../Firmware/util.cpp:296
 msgid "Nozzle diameter differs from the G-code. Continue?"
 msgstr ""
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:154 ../../Firmware/util.cpp:290
+#: ../../Firmware/messages.cpp:161 ../../Firmware/util.cpp:297
 msgid ""
 "Nozzle diameter differs from the G-code. Please check the value in settings."
 " Print cancelled."
 msgstr ""
 
 #. MSG_NOZZLE_CNG_COOLDOWN c=20 r=3
-#: ../../Firmware/messages.cpp:198 ../../Firmware/ultralcd.cpp:1002
+#: ../../Firmware/messages.cpp:203 ../../Firmware/ultralcd.cpp:999
 msgid "Nozzle is hot! Wait for cooldown."
-msgstr ""
-
-#. MSG_NOZZLE_CNG_CHANGED_QUICK c=20 r=3
-#: ../../Firmware/messages.cpp:199
-msgid "Nozzle changed?"
 msgstr ""
 
 #. MSG_PROGRESS_OK c=4
@@ -1400,81 +1395,81 @@ msgid "OK"
 msgstr ""
 
 #. MSG_OFF c=3
-#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:139
-#: ../../Firmware/mmu2.cpp:65 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4050 ../../Firmware/ultralcd.cpp:4051
-#: ../../Firmware/ultralcd.cpp:4053 ../../Firmware/ultralcd.cpp:4076
-#: ../../Firmware/ultralcd.cpp:4091 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4179 ../../Firmware/ultralcd.cpp:4467
-#: ../../Firmware/ultralcd.cpp:4495 ../../Firmware/ultralcd.cpp:4498
-#: ../../Firmware/ultralcd.cpp:5439 ../../Firmware/ultralcd.cpp:5594
-#: ../../Firmware/ultralcd.cpp:7487 ../../Firmware/ultralcd.cpp:7491
+#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:144
+#: ../../Firmware/mmu2.cpp:65 ../../Firmware/ultralcd.cpp:4063
+#: ../../Firmware/ultralcd.cpp:4074 ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4077 ../../Firmware/ultralcd.cpp:4100
+#: ../../Firmware/ultralcd.cpp:4115 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/ultralcd.cpp:4203 ../../Firmware/ultralcd.cpp:4434
+#: ../../Firmware/ultralcd.cpp:4462 ../../Firmware/ultralcd.cpp:4465
+#: ../../Firmware/ultralcd.cpp:5406 ../../Firmware/ultralcd.cpp:5567
+#: ../../Firmware/ultralcd.cpp:7464 ../../Firmware/ultralcd.cpp:7468
 msgid "Off"
 msgstr ""
 
 #. MSG_DEFAULT_SETTINGS_LOADED c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:1562 ../../Firmware/messages.cpp:201
+#: ../../Firmware/Marlin_main.cpp:1489 ../../Firmware/messages.cpp:213
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr ""
 
 #. MSG_ON c=3
-#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:140
-#: ../../Firmware/mmu2.cpp:63 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4050 ../../Firmware/ultralcd.cpp:4051
-#: ../../Firmware/ultralcd.cpp:4053 ../../Firmware/ultralcd.cpp:4076
-#: ../../Firmware/ultralcd.cpp:4081 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4179 ../../Firmware/ultralcd.cpp:4467
-#: ../../Firmware/ultralcd.cpp:4495 ../../Firmware/ultralcd.cpp:4498
-#: ../../Firmware/ultralcd.cpp:5594 ../../Firmware/ultralcd.cpp:7487
-#: ../../Firmware/ultralcd.cpp:7491
+#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:145
+#: ../../Firmware/mmu2.cpp:63 ../../Firmware/ultralcd.cpp:4063
+#: ../../Firmware/ultralcd.cpp:4074 ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4077 ../../Firmware/ultralcd.cpp:4100
+#: ../../Firmware/ultralcd.cpp:4105 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/ultralcd.cpp:4203 ../../Firmware/ultralcd.cpp:4434
+#: ../../Firmware/ultralcd.cpp:4462 ../../Firmware/ultralcd.cpp:4465
+#: ../../Firmware/ultralcd.cpp:5567 ../../Firmware/ultralcd.cpp:7464
+#: ../../Firmware/ultralcd.cpp:7468
 msgid "On"
 msgstr ""
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4191
+#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:4215
 msgid "Once"
 msgstr ""
 
 #. MSG_PAUSED_THERMAL_ERROR c=20
-#: ../../Firmware/Marlin_main.cpp:9861 ../../Firmware/messages.cpp:186
+#: ../../Firmware/Marlin_main.cpp:9021 ../../Firmware/messages.cpp:193
 msgid "PAUSED THERMAL ERROR"
 msgstr ""
 
 #. MSG_PID_RUNNING c=20
-#: ../../Firmware/messages.cpp:219 ../../Firmware/ultralcd.cpp:897
+#: ../../Firmware/messages.cpp:231 ../../Firmware/ultralcd.cpp:897
 msgid "PID cal."
 msgstr ""
 
 #. MSG_PID_FINISHED c=20
-#: ../../Firmware/messages.cpp:220 ../../Firmware/ultralcd.cpp:902
+#: ../../Firmware/messages.cpp:232 ../../Firmware/ultralcd.cpp:902
 msgid "PID cal. finished"
 msgstr ""
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:318 ../../Firmware/ultralcd.cpp:4590
+#: ../../Firmware/messages.cpp:330 ../../Firmware/ultralcd.cpp:4546
 msgid "PID calibration"
 msgstr ""
 
 #. MSG_PINDA_PREHEAT c=20
-#: ../../Firmware/messages.cpp:218 ../../Firmware/ultralcd.cpp:610
+#: ../../Firmware/messages.cpp:230 ../../Firmware/ultralcd.cpp:610
 msgid "PINDA Heating"
 msgstr ""
 
 #. MSG_PINDA_CALIBRATION c=13
-#: ../../Firmware/Marlin_main.cpp:4790 ../../Firmware/Marlin_main.cpp:4892
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:607
-#: ../../Firmware/ultralcd.cpp:4495 ../../Firmware/ultralcd.cpp:4597
+#: ../../Firmware/Marlin_main.cpp:4359 ../../Firmware/Marlin_main.cpp:4461
+#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:607
+#: ../../Firmware/ultralcd.cpp:4462 ../../Firmware/ultralcd.cpp:4553
 msgid "PINDA cal."
 msgstr ""
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/messages.cpp:276 ../../Firmware/ultralcd.cpp:3233
+#: ../../Firmware/messages.cpp:288 ../../Firmware/ultralcd.cpp:3243
 msgid "PINDA calibration failed"
 msgstr ""
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:4967 ../../Firmware/messages.cpp:127
-#: ../../Firmware/ultralcd.cpp:3230
+#: ../../Firmware/Marlin_main.cpp:4536 ../../Firmware/messages.cpp:132
+#: ../../Firmware/ultralcd.cpp:3240
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1492,13 +1487,13 @@ msgid "Parking selector"
 msgstr ""
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:4062
+#: ../../Firmware/messages.cpp:179 ../../Firmware/ultralcd.cpp:4086
 msgid "Pause"
 msgstr ""
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5271
-#: ../../Firmware/ultralcd.cpp:5273
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5237
+#: ../../Firmware/ultralcd.cpp:5239
 msgid "Pause print"
 msgstr ""
 
@@ -1509,156 +1504,155 @@ msgid "Performing cut"
 msgstr ""
 
 #. MSG_PAPER c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3243 ../../Firmware/messages.cpp:77
+#: ../../Firmware/Marlin_main.cpp:2982 ../../Firmware/messages.cpp:77
 msgid ""
 "Place a sheet of paper under the nozzle during the calibration of first 4 "
 "points. If the nozzle catches the paper, power off the printer immediately."
 msgstr ""
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:3963
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:3987
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
 msgstr ""
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/messages.cpp:337 ../../Firmware/ultralcd.cpp:6023
+#: ../../Firmware/messages.cpp:349 ../../Firmware/ultralcd.cpp:5999
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr ""
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/messages.cpp:343 ../../Firmware/ultralcd.cpp:6700
+#: ../../Firmware/messages.cpp:355 ../../Firmware/ultralcd.cpp:6676
 msgid "Please check:"
 msgstr ""
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/messages.cpp:302 ../../Firmware/ultralcd.cpp:3926
+#: ../../Firmware/messages.cpp:314 ../../Firmware/ultralcd.cpp:3950
 msgid "Please clean heatbed and then press the knob."
 msgstr ""
 
 #. MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3217 ../../Firmware/messages.cpp:27
+#: ../../Firmware/Marlin_main.cpp:2960 ../../Firmware/messages.cpp:28
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr ""
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/messages.cpp:288 ../../Firmware/ultralcd.cpp:3712
+#: ../../Firmware/messages.cpp:300 ../../Firmware/ultralcd.cpp:3722
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr ""
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/messages.cpp:287 ../../Firmware/ultralcd.cpp:3705
+#: ../../Firmware/messages.cpp:299 ../../Firmware/ultralcd.cpp:3715
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
 msgstr ""
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/messages.cpp:285 ../../Firmware/ultralcd.cpp:3633
+#: ../../Firmware/messages.cpp:297 ../../Firmware/ultralcd.cpp:3643
 msgid "Please load filament first."
 msgstr ""
 
 #. MSG_CHECK_IDLER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3525 ../../Firmware/messages.cpp:206
+#: ../../Firmware/Marlin_main.cpp:3265 ../../Firmware/messages.cpp:218
 msgid "Please open idler and remove filament manually."
 msgstr ""
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2806 ../../Firmware/messages.cpp:80
-#: ../../Firmware/ultralcd.cpp:3860
+#: ../../Firmware/mesh_bed_calibration.cpp:2791 ../../Firmware/messages.cpp:80
 msgid "Please place steel sheet on heatbed."
 msgstr ""
 
 #. MSG_PRESS_TO_UNLOAD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:11215 ../../Firmware/Marlin_main.cpp:11245
+#: ../../Firmware/Marlin_main.cpp:10287 ../../Firmware/Marlin_main.cpp:10317
 #: ../../Firmware/messages.cpp:84
 msgid "Please press the knob to unload filament"
 msgstr ""
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:4932
+#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:4888
 msgid "Please pull out filament immediately"
 msgstr ""
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/messages.cpp:295 ../../Firmware/ultralcd.cpp:3856
+#: ../../Firmware/messages.cpp:307 ../../Firmware/ultralcd.cpp:3882
 msgid "Please remove shipping helpers first."
 msgstr ""
 
 #. MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3240 ../../Firmware/Marlin_main.cpp:4755
-#: ../../Firmware/messages.cpp:89
+#: ../../Firmware/Marlin_main.cpp:4324 ../../Firmware/messages.cpp:89
 msgid "Please remove steel sheet from heatbed."
 msgstr ""
 
 #. MSG_RUN_XYZ c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4731 ../../Firmware/messages.cpp:207
+#: ../../Firmware/Marlin_main.cpp:4300 ../../Firmware/messages.cpp:219
 msgid "Please run XYZ calibration first."
 msgstr ""
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/messages.cpp:336 ../../Firmware/ultralcd.cpp:6020
+#: ../../Firmware/messages.cpp:348 ../../Firmware/ultralcd.cpp:4359
+#: ../../Firmware/ultralcd.cpp:5996
 msgid "Please unload the filament first, then repeat this action."
 msgstr ""
 
 #. MSG_NEW_FIRMWARE_PLEASE_UPGRADE c=20
-#: ../../Firmware/messages.cpp:366 ../../Firmware/util.cpp:213
+#: ../../Firmware/messages.cpp:378 ../../Firmware/util.cpp:218
 msgid "Please upgrade."
 msgstr ""
 
 #. MSG_PLEASE_WAIT c=20
-#: ../../Firmware/Marlin_main.cpp:3521 ../../Firmware/Marlin_main.cpp:8090
-#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:2179
-#: ../../Firmware/ultralcd.cpp:2190
+#: ../../Firmware/Marlin_main.cpp:3261 ../../Firmware/Marlin_main.cpp:7262
+#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:2190
+#: ../../Firmware/ultralcd.cpp:2204
 msgid "Please wait"
 msgstr ""
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:1232
-#: ../../Firmware/ultralcd.cpp:1261
+#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:1242
+#: ../../Firmware/ultralcd.cpp:1271
 msgid "Power failures"
 msgstr ""
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/messages.cpp:323 ../../Firmware/ultralcd.cpp:5260
+#: ../../Firmware/messages.cpp:335 ../../Firmware/ultralcd.cpp:5222
 msgid "Preheat"
 msgstr ""
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:2254
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:2268
 msgid "Preheat the nozzle!"
 msgstr ""
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:2771
-#: ../../Firmware/ultralcd.cpp:3690 ../../Firmware/ultralcd.cpp:3692
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:2788
+#: ../../Firmware/ultralcd.cpp:3700 ../../Firmware/ultralcd.cpp:3702
 msgid "Preheating nozzle. Please wait."
 msgstr ""
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/messages.cpp:237 ../../Firmware/ultralcd.cpp:1999
+#: ../../Firmware/messages.cpp:249 ../../Firmware/ultralcd.cpp:2005
 msgid "Preheating to cut"
 msgstr ""
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/messages.cpp:236 ../../Firmware/ultralcd.cpp:1996
+#: ../../Firmware/messages.cpp:248 ../../Firmware/ultralcd.cpp:2002
 msgid "Preheating to eject"
 msgstr ""
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/messages.cpp:234 ../../Firmware/ultralcd.cpp:1987
+#: ../../Firmware/messages.cpp:246 ../../Firmware/ultralcd.cpp:1995
 msgid "Preheating to load"
 msgstr ""
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/messages.cpp:235 ../../Firmware/ultralcd.cpp:1992
+#: ../../Firmware/messages.cpp:247 ../../Firmware/ultralcd.cpp:1999
 msgid "Preheating to unload"
 msgstr ""
 
 #. MSG_PRELOAD_TO_MMU c=17
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5344
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5310
 msgid "Preload to MMU"
 msgstr ""
 
@@ -1669,12 +1663,12 @@ msgid "Preparing blade"
 msgstr ""
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/messages.cpp:231 ../../Firmware/ultralcd.cpp:1799
+#: ../../Firmware/messages.cpp:243 ../../Firmware/ultralcd.cpp:1809
 msgid "Press the knob"
 msgstr ""
 
 #. MSG_PRESS_TO_PREHEAT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:11227 ../../Firmware/messages.cpp:212
+#: ../../Firmware/Marlin_main.cpp:10299 ../../Firmware/messages.cpp:224
 msgid "Press the knob to preheat nozzle and continue."
 msgstr ""
 
@@ -1684,34 +1678,39 @@ msgid "Print aborted"
 msgstr ""
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1106
-#: ../../Firmware/ultralcd.cpp:6994
+#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1116
+#: ../../Firmware/ultralcd.cpp:6971
 msgid "Print fan:"
 msgstr ""
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:5313
+#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5279
 msgid "Print from SD"
 msgstr ""
 
+#. MSG_HOSTPRINT c=18
+#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:5231
+msgid "Print from host"
+msgstr ""
+
 #. MSG_PRINT_PAUSED c=20
-#: ../../Firmware/Marlin_main.cpp:3582 ../../Firmware/messages.cpp:79
+#: ../../Firmware/Marlin_main.cpp:3323 ../../Firmware/messages.cpp:79
 #: ../../Firmware/ultralcd.cpp:814
 msgid "Print paused"
 msgstr ""
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/messages.cpp:247 ../../Firmware/ultralcd.cpp:2348
+#: ../../Firmware/messages.cpp:259 ../../Firmware/ultralcd.cpp:2365
 msgid "Print time"
 msgstr ""
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/messages.cpp:225 ../../Firmware/ultralcd.cpp:1689
+#: ../../Firmware/messages.cpp:237 ../../Firmware/ultralcd.cpp:1699
 msgid "Printer IP Addr:"
 msgstr ""
 
 #. MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1602 ../../Firmware/messages.cpp:46
+#: ../../Firmware/Marlin_main.cpp:1529 ../../Firmware/messages.cpp:46
 msgid ""
 "Printer has not been calibrated yet. Please follow the manual, chapter First"
 " steps, section Calibration flow."
@@ -1734,17 +1733,17 @@ msgid "QUEUE FULL"
 msgstr ""
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:4465
 msgid "RPi port"
 msgstr ""
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/messages.cpp:261 ../../Firmware/ultralcd.cpp:2712
+#: ../../Firmware/messages.cpp:273 ../../Firmware/ultralcd.cpp:2729
 msgid "Rear side [µm]"
 msgstr ""
 
 #. MSG_RECOVERING_PRINT c=20
-#: ../../Firmware/messages.cpp:216 ../../Firmware/power_panic.cpp:316
+#: ../../Firmware/messages.cpp:228 ../../Firmware/power_panic.cpp:328
 msgid "Recovering print"
 msgstr ""
 
@@ -1754,13 +1753,13 @@ msgid "Remove the ejected filament from the front of the MMU."
 msgstr ""
 
 #. MSG_RENAME c=18
-#: ../../Firmware/messages.cpp:322 ../../Firmware/ultralcd.cpp:5143
+#: ../../Firmware/messages.cpp:334 ../../Firmware/ultralcd.cpp:5103
 msgid "Rename"
 msgstr ""
 
 #. MSG_REPRINT c=18
-#: ../../Firmware/messages.cpp:196 ../../Firmware/ultralcd.cpp:5243
-#: ../../Firmware/ultralcd.cpp:5245
+#: ../../Firmware/messages.cpp:208 ../../Firmware/ultralcd.cpp:5205
+#: ../../Firmware/ultralcd.cpp:5207
 msgid "Reprint"
 msgstr ""
 
@@ -1772,13 +1771,13 @@ msgid ""
 msgstr ""
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:2713
-#: ../../Firmware/ultralcd.cpp:5144
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:2730
+#: ../../Firmware/ultralcd.cpp:5104
 msgid "Reset"
 msgstr ""
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/messages.cpp:320 ../../Firmware/ultralcd.cpp:4594
+#: ../../Firmware/messages.cpp:332 ../../Firmware/ultralcd.cpp:4550
 msgid "Reset XYZ calibr."
 msgstr ""
 
@@ -1788,8 +1787,8 @@ msgid "ResetMMU"
 msgstr ""
 
 #. MSG_RESUME_PRINT c=18
-#: ../../Firmware/Marlin_main.cpp:680 ../../Firmware/messages.cpp:91
-#: ../../Firmware/ultralcd.cpp:5286 ../../Firmware/ultralcd.cpp:5288
+#: ../../Firmware/Marlin_main.cpp:645 ../../Firmware/messages.cpp:91
+#: ../../Firmware/ultralcd.cpp:5252 ../../Firmware/ultralcd.cpp:5254
 msgid "Resume print"
 msgstr ""
 
@@ -1816,25 +1815,25 @@ msgid "Returning selector"
 msgstr ""
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/messages.cpp:252 ../../Firmware/ultralcd.cpp:2479
+#: ../../Firmware/messages.cpp:264 ../../Firmware/ultralcd.cpp:2496
 msgid "Right"
 msgstr ""
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/messages.cpp:259 ../../Firmware/ultralcd.cpp:2710
+#: ../../Firmware/messages.cpp:271 ../../Firmware/ultralcd.cpp:2727
 msgid "Right side[µm]"
 msgstr ""
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/messages.cpp:286 ../../Firmware/ultralcd.cpp:3656
+#: ../../Firmware/messages.cpp:298 ../../Firmware/ultralcd.cpp:3666
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
 msgstr ""
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4509
-#: ../../Firmware/ultralcd.cpp:4511
+#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4476
+#: ../../Firmware/ultralcd.cpp:4478
 msgid "SD card"
 msgstr ""
 
@@ -1849,48 +1848,48 @@ msgid "SELECTOR CANNOT MOVE"
 msgstr ""
 
 #. MSG_STOPPED c=20
-#: ../../Firmware/Marlin_main.cpp:9887 ../../Firmware/messages.cpp:125
+#: ../../Firmware/Marlin_main.cpp:9047 ../../Firmware/messages.cpp:130
 msgid "STOPPED."
 msgstr ""
 
 #. MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3223 ../../Firmware/Marlin_main.cpp:3245
-#: ../../Firmware/mesh_bed_calibration.cpp:2246 ../../Firmware/messages.cpp:44
+#: ../../Firmware/Marlin_main.cpp:2967 ../../Firmware/Marlin_main.cpp:2984
+#: ../../Firmware/mesh_bed_calibration.cpp:2231 ../../Firmware/messages.cpp:44
 msgid "Searching bed calibration point"
 msgstr ""
 
 #. MSG_SELECT c=18
-#: ../../Firmware/messages.cpp:321 ../../Firmware/ultralcd.cpp:5136
+#: ../../Firmware/messages.cpp:333 ../../Firmware/ultralcd.cpp:5096
 msgid "Select"
 msgstr ""
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/messages.cpp:290 ../../Firmware/ultralcd.cpp:3730
+#: ../../Firmware/messages.cpp:302 ../../Firmware/ultralcd.cpp:3740
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
 msgstr ""
 
 #. MSG_SELECT_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3453 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3612
-#: ../../Firmware/ultralcd.cpp:6822
+#: ../../Firmware/Marlin_main.cpp:3192 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3622
+#: ../../Firmware/ultralcd.cpp:6798
 msgid "Select filament:"
 msgstr ""
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:110 ../../Firmware/ultralcd.cpp:3464
-#: ../../Firmware/ultralcd.cpp:4504
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:3474
+#: ../../Firmware/ultralcd.cpp:4471
 msgid "Select language"
 msgstr ""
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/messages.cpp:300 ../../Firmware/ultralcd.cpp:3900
+#: ../../Firmware/messages.cpp:312 ../../Firmware/ultralcd.cpp:3924
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr ""
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/messages.cpp:291 ../../Firmware/ultralcd.cpp:3735
+#: ../../Firmware/messages.cpp:303 ../../Firmware/ultralcd.cpp:3745
 msgid "Select temperature which matches your material."
 msgstr ""
 
@@ -1908,81 +1907,76 @@ msgid ""
 msgstr ""
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/messages.cpp:315 ../../Firmware/ultralcd.cpp:4581
+#: ../../Firmware/messages.cpp:327 ../../Firmware/ultralcd.cpp:4537
 msgid "Selftest"
 msgstr ""
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/messages.cpp:341 ../../Firmware/ultralcd.cpp:6274
+#: ../../Firmware/messages.cpp:353 ../../Firmware/ultralcd.cpp:6250
 msgid "Selftest OK"
 msgstr ""
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/messages.cpp:342 ../../Firmware/ultralcd.cpp:6699
+#: ../../Firmware/messages.cpp:354 ../../Firmware/ultralcd.cpp:6675
 msgid "Selftest error!"
 msgstr ""
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6279
-#: ../../Firmware/ultralcd.cpp:6786 ../../Firmware/ultralcd.cpp:6984
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6255
+#: ../../Firmware/ultralcd.cpp:6762 ../../Firmware/ultralcd.cpp:6961
 msgid "Selftest failed"
 msgstr ""
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/messages.cpp:340 ../../Firmware/ultralcd.cpp:6057
+#: ../../Firmware/messages.cpp:352 ../../Firmware/ultralcd.cpp:6033
 msgid "Selftest start"
 msgstr ""
 
 #. MSG_FORCE_SELFTEST c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1577 ../../Firmware/messages.cpp:202
+#: ../../Firmware/Marlin_main.cpp:1504 ../../Firmware/messages.cpp:214
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr ""
 
 #. MSG_MMU_SENSITIVITY c=18
-#: ../../Firmware/messages.cpp:215 ../../Firmware/mmu2_reporting.cpp:458
+#: ../../Firmware/messages.cpp:227 ../../Firmware/mmu2_reporting.cpp:459
 msgid "Sensitivity"
 msgstr ""
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/messages.cpp:228 ../../Firmware/ultralcd.cpp:1701
+#: ../../Firmware/messages.cpp:240 ../../Firmware/ultralcd.cpp:1711
 msgid "Sensor info"
 msgstr ""
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/messages.cpp:338 ../../Firmware/ultralcd.cpp:6027
+#: ../../Firmware/messages.cpp:350 ../../Firmware/ultralcd.cpp:6003
 msgid "Sensor verified, remove the filament now."
 msgstr ""
 
 #. MSG_SET_READY c=18
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:5265
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:5228
 msgid "Set Ready"
 msgstr ""
 
 #. MSG_SET_NOT_READY c=18
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:5263
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5226
 msgid "Set not Ready"
 msgstr ""
 
-#. MSG_HOSTPRINT c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5285
-msgid "Print from host"
-msgstr ""
-
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/messages.cpp:262 ../../Firmware/ultralcd.cpp:2730
+#: ../../Firmware/messages.cpp:274 ../../Firmware/ultralcd.cpp:2747
 msgid "Set temperature:"
 msgstr ""
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3348
-#: ../../Firmware/ultralcd.cpp:3479 ../../Firmware/ultralcd.cpp:3984
-#: ../../Firmware/ultralcd.cpp:5374 ../../Firmware/ultralcd.cpp:5585
-#: ../../Firmware/ultralcd.cpp:5631
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3358
+#: ../../Firmware/ultralcd.cpp:3489 ../../Firmware/ultralcd.cpp:4008
+#: ../../Firmware/ultralcd.cpp:5341 ../../Firmware/ultralcd.cpp:5558
+#: ../../Firmware/ultralcd.cpp:5604
 msgid "Settings"
 msgstr ""
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/messages.cpp:255 ../../Firmware/ultralcd.cpp:2522
+#: ../../Firmware/messages.cpp:267 ../../Firmware/ultralcd.cpp:2539
 msgid "Severe skew"
 msgstr ""
 
@@ -1993,7 +1987,7 @@ msgid "Sheet"
 msgstr ""
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/messages.cpp:284 ../../Firmware/ultralcd.cpp:3604
+#: ../../Firmware/messages.cpp:296 ../../Firmware/ultralcd.cpp:3614
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -2002,86 +1996,86 @@ msgid ""
 msgstr ""
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/messages.cpp:319 ../../Firmware/ultralcd.cpp:4592
+#: ../../Firmware/messages.cpp:331 ../../Firmware/ultralcd.cpp:4548
 msgid "Show end stops"
 msgstr ""
 
 #. MSG_SHUTDOWN_HOST c=18
-#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:5390
+#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:5357
 msgid "Shutdown host"
 msgstr ""
 
 #. MSG_SILENT c=7
-#: ../../Firmware/Marlin_main.cpp:8497 ../../Firmware/messages.cpp:120
-#: ../../Firmware/ultralcd.cpp:4155 ../../Firmware/ultralcd.cpp:4194
+#: ../../Firmware/Marlin_main.cpp:7668 ../../Firmware/messages.cpp:124
+#: ../../Firmware/ultralcd.cpp:4179 ../../Firmware/ultralcd.cpp:4218
 msgid "Silent"
 msgstr ""
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/messages.cpp:254 ../../Firmware/ultralcd.cpp:2521
+#: ../../Firmware/messages.cpp:266 ../../Firmware/ultralcd.cpp:2538
 msgid "Slight skew"
 msgstr ""
 
 #. MSG_FILE_CNT c=20 r=6
-#: ../../Firmware/cardreader.cpp:805 ../../Firmware/messages.cpp:197
+#: ../../Firmware/cardreader.cpp:805 ../../Firmware/messages.cpp:209
 msgid ""
 "Some files will not be sorted. Max. No. of files in 1 folder for sorting is "
 "100."
 msgstr ""
 
 #. MSG_ZLEVELING_ENFORCED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3043 ../../Firmware/messages.cpp:204
+#: ../../Firmware/Marlin_main.cpp:2783 ../../Firmware/messages.cpp:216
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr ""
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:4514
-#: ../../Firmware/ultralcd.cpp:4515 ../../Firmware/ultralcd.cpp:4516
+#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4481
+#: ../../Firmware/ultralcd.cpp:4482 ../../Firmware/ultralcd.cpp:4483
 msgid "Sort"
 msgstr ""
 
 #. MSG_SORTING_FILES c=20
 #: ../../Firmware/cardreader.cpp:849 ../../Firmware/cardreader.cpp:916
-#: ../../Firmware/messages.cpp:111
+#: ../../Firmware/messages.cpp:115
 msgid "Sorting files"
 msgstr ""
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4188
-#: ../../Firmware/ultralcd.cpp:4191 ../../Firmware/ultralcd.cpp:4194
-#: ../../Firmware/ultralcd.cpp:4197 ../../Firmware/ultralcd.cpp:4200
+#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4215 ../../Firmware/ultralcd.cpp:4218
+#: ../../Firmware/ultralcd.cpp:4221 ../../Firmware/ultralcd.cpp:4224
 msgid "Sound"
 msgstr ""
 
 #. MSG_SPEED c=15
-#: ../../Firmware/messages.cpp:333 ../../Firmware/ultralcd.cpp:5516
+#: ../../Firmware/messages.cpp:345 ../../Firmware/ultralcd.cpp:5483
 msgid "Speed"
 msgstr ""
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6861
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6837
 msgid "Spinning"
 msgstr ""
 
 #. MSG_TEMP_CAL_WARNING c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4744 ../../Firmware/messages.cpp:208
+#: ../../Firmware/Marlin_main.cpp:4313 ../../Firmware/messages.cpp:220
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr ""
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/messages.cpp:329 ../../Firmware/ultralcd.cpp:5379
+#: ../../Firmware/messages.cpp:341 ../../Firmware/ultralcd.cpp:5346
 msgid "Statistics"
 msgstr ""
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:4096
-#: ../../Firmware/ultralcd.cpp:4144
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4120
+#: ../../Firmware/ultralcd.cpp:4168
 msgid "Stealth"
 msgstr ""
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4421
-#: ../../Firmware/ultralcd.cpp:5133
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4388
+#: ../../Firmware/ultralcd.cpp:5093
 msgid "Steel sheets"
 msgstr ""
 
@@ -2091,29 +2085,28 @@ msgid "Stop"
 msgstr ""
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:5293
-#: ../../Firmware/ultralcd.cpp:5781
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:5259
+#: ../../Firmware/ultralcd.cpp:5757
 msgid "Stop print"
 msgstr ""
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4236
-#: ../../Firmware/ultralcd.cpp:4316 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4315
 msgid "Strict"
 msgstr ""
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/messages.cpp:332 ../../Firmware/ultralcd.cpp:5394
+#: ../../Firmware/messages.cpp:344 ../../Firmware/ultralcd.cpp:5361
 msgid "Support"
 msgstr ""
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/messages.cpp:354 ../../Firmware/ultralcd.cpp:6758
+#: ../../Firmware/messages.cpp:366 ../../Firmware/ultralcd.cpp:6734
 msgid "Swapped"
 msgstr ""
 
 #. MSG_THERMAL_ANOMALY c=20
-#: ../../Firmware/messages.cpp:188 ../../Firmware/temperature.cpp:2223
+#: ../../Firmware/messages.cpp:195 ../../Firmware/temperature.cpp:2197
 msgid "THERMAL ANOMALY"
 msgstr ""
 
@@ -2148,17 +2141,17 @@ msgid "TMC UNDERVOLTAGE ERR"
 msgstr ""
 
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/messages.cpp:309 ../../Firmware/ultralcd.cpp:4455
+#: ../../Firmware/messages.cpp:321 ../../Firmware/ultralcd.cpp:4422
 msgid "Temperature"
 msgstr ""
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/messages.cpp:229 ../../Firmware/ultralcd.cpp:1707
+#: ../../Firmware/messages.cpp:241 ../../Firmware/ultralcd.cpp:1717
 msgid "Temperatures"
 msgstr ""
 
 #. MSG_TESTING_FILAMENT c=20
-#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:388
+#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:389
 msgid "Testing filament"
 msgstr ""
 
@@ -2175,7 +2168,7 @@ msgid ""
 msgstr ""
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/messages.cpp:292 ../../Firmware/ultralcd.cpp:3738
+#: ../../Firmware/messages.cpp:304 ../../Firmware/ultralcd.cpp:3748
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -2183,69 +2176,69 @@ msgid ""
 msgstr ""
 
 #. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:388
+#: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:388
 msgid "There is no filament loaded. Continue?"
 msgstr ""
 
 #. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:389
+#: ../../Firmware/messages.cpp:159 ../../Firmware/util.cpp:389
 msgid "There is no filament loaded. Print cancelled."
 msgstr ""
 
 #. MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1606 ../../Firmware/messages.cpp:47
+#: ../../Firmware/Marlin_main.cpp:1533 ../../Firmware/messages.cpp:47
 msgid ""
 "There is still a need to make Z calibration. Please follow the manual, "
 "chapter First steps, section Calibration flow."
 msgstr ""
 
 #. MSG_TM_CAL c=20 r=4
-#: ../../Firmware/messages.cpp:299 ../../Firmware/ultralcd.cpp:3881
+#: ../../Firmware/messages.cpp:311 ../../Firmware/ultralcd.cpp:3905
 msgid ""
 "Thermal model cal. takes approx. 12 mins. See\n"
 "prusa.io/tm-cal"
 msgstr ""
 
 #. MSG_TM_NOT_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1613 ../../Firmware/messages.cpp:189
+#: ../../Firmware/Marlin_main.cpp:1540 ../../Firmware/messages.cpp:196
 msgid "Thermal model not calibrated yet."
 msgstr ""
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:4514
+#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:4481
 msgid "Time"
 msgstr ""
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:176 ../../Firmware/ultralcd.cpp:5622
+#: ../../Firmware/messages.cpp:183 ../../Firmware/ultralcd.cpp:5595
 msgid "Timeout"
 msgstr ""
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:1129
-#: ../../Firmware/ultralcd.cpp:1287
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:1139
+#: ../../Firmware/ultralcd.cpp:1297
 msgid "Total"
 msgstr ""
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:1177
-#: ../../Firmware/ultralcd.cpp:1231 ../../Firmware/ultralcd.cpp:1317
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:1187
+#: ../../Firmware/ultralcd.cpp:1241 ../../Firmware/ultralcd.cpp:1327
 msgid "Total failures"
 msgstr ""
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/messages.cpp:248 ../../Firmware/ultralcd.cpp:2369
+#: ../../Firmware/messages.cpp:260 ../../Firmware/ultralcd.cpp:2386
 msgid "Total filament"
 msgstr ""
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/messages.cpp:249 ../../Firmware/ultralcd.cpp:2370
+#: ../../Firmware/messages.cpp:261 ../../Firmware/ultralcd.cpp:2387
 msgid "Total print time"
 msgstr ""
 
 #. MSG_TUNE c=8
-#: ../../Firmware/messages.cpp:116 ../../Firmware/mmu2/errors_list.h:372
-#: ../../Firmware/ultralcd.cpp:5258
+#: ../../Firmware/messages.cpp:120 ../../Firmware/mmu2/errors_list.h:372
+#: ../../Firmware/ultralcd.cpp:5220
 msgid "Tune"
 msgstr ""
 
@@ -2270,16 +2263,16 @@ msgid "Unload"
 msgstr ""
 
 #. MSG_UNLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:2206
-#: ../../Firmware/ultralcd.cpp:5347 ../../Firmware/ultralcd.cpp:5364
-#: ../../Firmware/ultralcd.cpp:5369
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:2220
+#: ../../Firmware/ultralcd.cpp:5313 ../../Firmware/ultralcd.cpp:5331
+#: ../../Firmware/ultralcd.cpp:5336
 msgid "Unload filament"
 msgstr ""
 
 #. MSG_UNLOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3436 ../../Firmware/messages.cpp:129
+#: ../../Firmware/Marlin_main.cpp:3175 ../../Firmware/messages.cpp:134
 #: ../../Firmware/mmu2_progress_converter.cpp:50
-#: ../../Firmware/ultralcd.cpp:4911
+#: ../../Firmware/ultralcd.cpp:4867
 msgid "Unloading filament"
 msgstr ""
 
@@ -2296,12 +2289,12 @@ msgid "Unloading to pulley"
 msgstr ""
 
 #. MSG_FIL_FAILED c=20 r=4
-#: ../../Firmware/messages.cpp:339 ../../Firmware/ultralcd.cpp:6030
+#: ../../Firmware/messages.cpp:351 ../../Firmware/ultralcd.cpp:6006
 msgid "Verification failed, remove the filament and try again."
 msgstr ""
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/messages.cpp:230 ../../Firmware/ultralcd.cpp:1710
+#: ../../Firmware/messages.cpp:242 ../../Firmware/ultralcd.cpp:1720
 msgid "Voltages"
 msgstr ""
 
@@ -2312,7 +2305,7 @@ msgid "WARNING TMC TOO HOT"
 msgstr ""
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/messages.cpp:281 ../../Firmware/ultralcd.cpp:3381
+#: ../../Firmware/messages.cpp:293 ../../Firmware/ultralcd.cpp:3391
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -2321,134 +2314,134 @@ msgid ""
 msgstr ""
 
 #. MSG_USERWAIT c=20
-#: ../../Firmware/Marlin_main.cpp:5240 ../../Firmware/messages.cpp:209
+#: ../../Firmware/Marlin_main.cpp:4747 ../../Firmware/messages.cpp:221
 msgid "Wait for user..."
 msgstr ""
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/messages.cpp:263 ../../Firmware/ultralcd.cpp:2753
+#: ../../Firmware/messages.cpp:275 ../../Firmware/ultralcd.cpp:2770
 msgid "Waiting for PINDA probe cooling"
 msgstr ""
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/messages.cpp:264 ../../Firmware/ultralcd.cpp:2782
+#: ../../Firmware/messages.cpp:276 ../../Firmware/ultralcd.cpp:2799
 msgid "Waiting for nozzle and bed cooling"
 msgstr ""
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:4233
-#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4352
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4312
 msgid "Warn"
 msgstr ""
 
 #. MSG_CHANGED_BOTH c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1554 ../../Firmware/messages.cpp:200
+#: ../../Firmware/Marlin_main.cpp:1481 ../../Firmware/messages.cpp:212
 msgid "Warning: both printer type and motherboard type changed."
 msgstr ""
 
 #. MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1546 ../../Firmware/messages.cpp:198
+#: ../../Firmware/Marlin_main.cpp:1473 ../../Firmware/messages.cpp:210
 msgid "Warning: motherboard type changed."
 msgstr ""
 
 #. MSG_CHANGED_PRINTER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1550 ../../Firmware/messages.cpp:199
+#: ../../Firmware/Marlin_main.cpp:1477 ../../Firmware/messages.cpp:211
 msgid "Warning: printer type changed."
 msgstr ""
 
 #. MSG_UNLOAD_SUCCESSFUL c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3517 ../../Firmware/messages.cpp:205
+#: ../../Firmware/Marlin_main.cpp:3257 ../../Firmware/messages.cpp:217
 msgid "Was filament unload successful?"
 msgstr ""
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:6710
-#: ../../Firmware/ultralcd.cpp:6714 ../../Firmware/ultralcd.cpp:6734
-#: ../../Firmware/ultralcd.cpp:6740 ../../Firmware/ultralcd.cpp:6764
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:6686
+#: ../../Firmware/ultralcd.cpp:6690 ../../Firmware/ultralcd.cpp:6710
+#: ../../Firmware/ultralcd.cpp:6716 ../../Firmware/ultralcd.cpp:6740
 msgid "Wiring error"
 msgstr ""
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/messages.cpp:313 ../../Firmware/ultralcd.cpp:4572
+#: ../../Firmware/messages.cpp:325 ../../Firmware/ultralcd.cpp:4528
 msgid "Wizard"
 msgstr ""
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/messages.cpp:304 ../../Firmware/ultralcd.cpp:3986
+#: ../../Firmware/messages.cpp:316 ../../Firmware/ultralcd.cpp:4010
 msgid "X-correct"
 msgstr ""
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/messages.cpp:226 ../../Firmware/ultralcd.cpp:1699
+#: ../../Firmware/messages.cpp:238 ../../Firmware/ultralcd.cpp:1709
 msgid "XYZ cal. details"
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/messages.cpp:275 ../../Firmware/ultralcd.cpp:3207
+#: ../../Firmware/messages.cpp:287 ../../Firmware/ultralcd.cpp:3217
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/messages.cpp:274 ../../Firmware/ultralcd.cpp:3204
+#: ../../Firmware/messages.cpp:286 ../../Firmware/ultralcd.cpp:3214
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/messages.cpp:271 ../../Firmware/ultralcd.cpp:3185
+#: ../../Firmware/messages.cpp:283 ../../Firmware/ultralcd.cpp:3195
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/messages.cpp:272 ../../Firmware/ultralcd.cpp:3188
+#: ../../Firmware/messages.cpp:284 ../../Firmware/ultralcd.cpp:3198
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/messages.cpp:268 ../../Firmware/ultralcd.cpp:3167
+#: ../../Firmware/messages.cpp:280 ../../Firmware/ultralcd.cpp:3177
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/messages.cpp:269 ../../Firmware/ultralcd.cpp:3173
+#: ../../Firmware/messages.cpp:281 ../../Firmware/ultralcd.cpp:3183
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3170
-#: ../../Firmware/ultralcd.cpp:3198
+#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3180
+#: ../../Firmware/ultralcd.cpp:3208
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/messages.cpp:270 ../../Firmware/ultralcd.cpp:3176
+#: ../../Firmware/messages.cpp:282 ../../Firmware/ultralcd.cpp:3186
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr ""
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/messages.cpp:273 ../../Firmware/ultralcd.cpp:3201
+#: ../../Firmware/messages.cpp:285 ../../Firmware/ultralcd.cpp:3211
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr ""
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/messages.cpp:250 ../../Firmware/ultralcd.cpp:2476
+#: ../../Firmware/messages.cpp:262 ../../Firmware/ultralcd.cpp:2493
 msgid "Y distance from min"
 msgstr ""
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/messages.cpp:305 ../../Firmware/ultralcd.cpp:3987
+#: ../../Firmware/messages.cpp:317 ../../Firmware/ultralcd.cpp:4011
 msgid "Y-correct"
 msgstr ""
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:3029
-#: ../../Firmware/ultralcd.cpp:4443 ../../Firmware/ultralcd.cpp:4531
-#: ../../Firmware/ultralcd.cpp:5790
+#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:2275
+#: ../../Firmware/ultralcd.cpp:2279 ../../Firmware/ultralcd.cpp:3046
+#: ../../Firmware/ultralcd.cpp:4410 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/ultralcd.cpp:5766
 msgid "Yes"
 msgstr ""
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:3950
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:3974
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr ""
 
@@ -2458,57 +2451,57 @@ msgid "Z calibration recommended. Run it now?"
 msgstr ""
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/messages.cpp:306 ../../Firmware/ultralcd.cpp:3988
+#: ../../Firmware/messages.cpp:318 ../../Firmware/ultralcd.cpp:4012
 msgid "Z-correct"
 msgstr ""
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5593
+#: ../../Firmware/messages.cpp:175 ../../Firmware/ultralcd.cpp:5566
 msgid "Z-probe nr."
 msgstr ""
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/messages.cpp:256 ../../Firmware/ultralcd.cpp:2546
+#: ../../Firmware/messages.cpp:268 ../../Firmware/ultralcd.cpp:2563
 msgid "[0;0] point offset"
 msgstr ""
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/messages.cpp:239 ../../Firmware/ultralcd.cpp:2147
+#: ../../Firmware/messages.cpp:251 ../../Firmware/ultralcd.cpp:2158
 msgid "and press the knob"
 msgstr ""
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/messages.cpp:232 ../../Firmware/ultralcd.cpp:1807
+#: ../../Firmware/messages.cpp:244 ../../Firmware/ultralcd.cpp:1816
 msgid "to load filament"
 msgstr ""
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/messages.cpp:233 ../../Firmware/ultralcd.cpp:1811
+#: ../../Firmware/messages.cpp:245 ../../Firmware/ultralcd.cpp:1820
 msgid "to unload filament"
 msgstr ""
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/messages.cpp:224 ../../Firmware/ultralcd.cpp:1666
+#: ../../Firmware/messages.cpp:236 ../../Firmware/ultralcd.cpp:1676
 msgid "unknown"
 msgstr ""
 
 #. MSG_IR_UNKNOWN c=18
-#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:184
+#: ../../Firmware/Filament_sensor.cpp:286 ../../Firmware/messages.cpp:191
 msgid "unknown state"
 msgstr ""
 
 #. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:5858
-#: ../../Firmware/ultralcd.cpp:5861
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:5834
+#: ../../Firmware/ultralcd.cpp:5837
 msgid "🔃Refresh"
 msgstr ""
 
 #. MSG_FW_MK3S_DETECTED c=20 r=4
-#: ../../Firmware/messages.cpp:367 ../../Firmware/Marlin_main.cpp:920
+#: ../../Firmware/messages.cpp:379 ../../Firmware/Marlin_main.cpp:854
 msgid "MK3S firmware detected on MK3 printer"
 msgstr ""
 
 #. MSG_FW_MK3_DETECTED c=20 r=4
-#: ../../Firmware/messages.cpp:367 ../../Firmware/Marlin_main.cpp:920
+#: ../../Firmware/messages.cpp:379 ../../Firmware/Marlin_main.cpp:854
 msgid "MK3 firmware detected on MK3S printer"
 msgstr ""

--- a/lang/po/Firmware_cs.po
+++ b/lang/po/Firmware_cs.po
@@ -16,91 +16,91 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 
 #. MSG_IR_03_OR_OLDER c=18
-#: ../../Firmware/Filament_sensor.cpp:280
-#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:183
+#: ../../Firmware/Filament_sensor.cpp:282
+#: ../../Firmware/Filament_sensor.cpp:344 ../../Firmware/messages.cpp:190
 msgid " 0.3 or older"
 msgstr " 0.3 nebo starší"
 
 #. MSG_IR_04_OR_NEWER c=18
-#: ../../Firmware/Filament_sensor.cpp:282
-#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:182
+#: ../../Firmware/Filament_sensor.cpp:284
+#: ../../Firmware/Filament_sensor.cpp:347 ../../Firmware/messages.cpp:189
 msgid " 0.4 or newer"
 msgstr " 0.4 nebo novější"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/messages.cpp:356 ../../Firmware/ultralcd.cpp:6773
+#: ../../Firmware/messages.cpp:368 ../../Firmware/ultralcd.cpp:6749
 msgid "%s level expected"
 msgstr "%s očekávaná verze"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:1978
-#: ../../Firmware/ultralcd.cpp:3613
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:1986
+#: ../../Firmware/ultralcd.cpp:3623
 msgid ">Cancel"
 msgstr ">Zrušit"
 
 #. MSG_BABYSTEPPING_Z c=13
-#: ../../Firmware/messages.cpp:257 ../../Firmware/ultralcd.cpp:2635
+#: ../../Firmware/messages.cpp:269 ../../Firmware/ultralcd.cpp:2652
 msgid "Adjusting Z"
 msgstr "Doladění Z"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/messages.cpp:360 ../../Firmware/ultralcd.cpp:6983
+#: ../../Firmware/messages.cpp:372 ../../Firmware/ultralcd.cpp:6960
 msgid "All correct"
 msgstr "Vše OK"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:3955
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:3979
 msgid "All is done. Happy printing!"
 msgstr "Vše je hotovo. Tisku zdar!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4482
 msgid "Alphabet"
 msgstr "Abeceda"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4086
+#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4110
 msgid "Always"
 msgstr "Vždy"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/messages.cpp:221 ../../Firmware/ultralcd.cpp:1393
+#: ../../Firmware/messages.cpp:233 ../../Firmware/ultralcd.cpp:1403
 msgid "Ambient"
 msgstr "Okolí"
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=3
-#: ../../Firmware/messages.cpp:267 ../../Firmware/ultralcd.cpp:2848
+#: ../../Firmware/messages.cpp:279 ../../Firmware/ultralcd.cpp:2865
 msgid "Are left and right Z-carriages all up?"
 msgstr "Dojely oba Z vozíky k-hornímu dorazu?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4197
+#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:4221
 msgid "Assist"
 msgstr "Asist."
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:179 ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/messages.cpp:186 ../../Firmware/ultralcd.cpp:5594
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
-#: ../../Firmware/Marlin_main.cpp:3198 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:4577 ../../Firmware/ultralcd.cpp:5529
+#: ../../Firmware/Marlin_main.cpp:2942 ../../Firmware/messages.cpp:12
+#: ../../Firmware/ultralcd.cpp:4533 ../../Firmware/ultralcd.cpp:5496
 msgid "Auto home"
 msgstr "Auto home"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4182
 msgid "Auto power"
 msgstr "Automat."
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:328 ../../Firmware/ultralcd.cpp:5359
+#: ../../Firmware/messages.cpp:340 ../../Firmware/ultralcd.cpp:5328
 msgid "AutoLoad filament"
 msgstr "AutoZavedení fil."
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/messages.cpp:245 ../../Firmware/ultralcd.cpp:2272
+#: ../../Firmware/messages.cpp:257 ../../Firmware/ultralcd.cpp:2289
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
@@ -114,51 +114,50 @@ msgid "Avoiding grind"
 msgstr "Eliminace obroušení"
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/messages.cpp:352 ../../Firmware/ultralcd.cpp:6752
+#: ../../Firmware/messages.cpp:364 ../../Firmware/ultralcd.cpp:6728
 msgid "Axis"
 msgstr "Osa"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/messages.cpp:351 ../../Firmware/ultralcd.cpp:6751
+#: ../../Firmware/messages.cpp:363 ../../Firmware/ultralcd.cpp:6727
 msgid "Axis length"
 msgstr "Délka osy"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2708
-#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:5618
-#: ../../Firmware/ultralcd.cpp:7484
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2725
+#: ../../Firmware/ultralcd.cpp:4061 ../../Firmware/ultralcd.cpp:5591
+#: ../../Firmware/ultralcd.cpp:7461
 msgid "Back"
 msgstr "Zpět"
 
 #. MSG_BED c=13
-#: ../../Firmware/Marlin_main.cpp:2081 ../../Firmware/Marlin_main.cpp:4627
-#: ../../Firmware/Marlin_main.cpp:4678 ../../Firmware/messages.cpp:15
-#: ../../Firmware/ultralcd.cpp:1391 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/Marlin_main.cpp:4247 ../../Firmware/messages.cpp:15
+#: ../../Firmware/ultralcd.cpp:1401 ../../Firmware/ultralcd.cpp:4197
 msgid "Bed"
 msgstr "Podložka"
 
 #. MSG_BED_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6240 ../../Firmware/messages.cpp:17
+#: ../../Firmware/Marlin_main.cpp:5470 ../../Firmware/messages.cpp:17
 #: ../../Firmware/ultralcd.cpp:534
 msgid "Bed Heating"
 msgstr "Zahřívání bedu"
 
 #. MSG_BED_DONE c=20
-#: ../../Firmware/Marlin_main.cpp:6277 ../../Firmware/messages.cpp:16
+#: ../../Firmware/Marlin_main.cpp:5507 ../../Firmware/messages.cpp:16
 #: ../../Firmware/ultralcd.cpp:537
 msgid "Bed done"
 msgstr "Bed OK."
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/messages.cpp:317 ../../Firmware/ultralcd.cpp:4589
+#: ../../Firmware/messages.cpp:329 ../../Firmware/ultralcd.cpp:4545
 msgid "Bed level correct"
 msgstr "Korekce podložky"
 
 #. MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:2262 ../../Firmware/Marlin_main.cpp:2999
-#: ../../Firmware/Marlin_main.cpp:3008
-#: ../../Firmware/mesh_bed_calibration.cpp:2878
-#: ../../Firmware/mesh_bed_calibration.cpp:2903 ../../Firmware/messages.cpp:18
+#: ../../Firmware/Marlin_main.cpp:2048 ../../Firmware/Marlin_main.cpp:2736
+#: ../../Firmware/Marlin_main.cpp:2745
+#: ../../Firmware/mesh_bed_calibration.cpp:2863
+#: ../../Firmware/mesh_bed_calibration.cpp:2888 ../../Firmware/messages.cpp:18
 msgid ""
 "Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for "
 "reset."
@@ -166,34 +165,34 @@ msgstr ""
 "Kalibrace Z selhala. Sensor nesepnul. Znečištená tryska? Čekám na reset."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/messages.cpp:346 ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/messages.cpp:358 ../../Firmware/ultralcd.cpp:6685
 msgid "Bed/Heater"
 msgstr "Podložka/Topení"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1444
-#: ../../Firmware/ultralcd.cpp:1704
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1454
+#: ../../Firmware/ultralcd.cpp:1714
 msgid "Belt status"
 msgstr "Stav řemenu"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/messages.cpp:314 ../../Firmware/ultralcd.cpp:4579
+#: ../../Firmware/messages.cpp:326 ../../Firmware/ultralcd.cpp:4535
 msgid "Belt test"
 msgstr "Test řemenu"
 
 #. MSG_RECOVER_PRINT c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:1660 ../../Firmware/messages.cpp:87
+#: ../../Firmware/Marlin_main.cpp:1587 ../../Firmware/messages.cpp:87
 msgid "Blackout occurred. Recover print?"
 msgstr "Detekován výpadek proudu. Obnovit tisk?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:177 ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:5594
 msgid "Bright"
 msgstr "Jasný"
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:4526
-#: ../../Firmware/ultralcd.cpp:5546
+#: ../../Firmware/messages.cpp:180 ../../Firmware/ultralcd.cpp:4493
+#: ../../Firmware/ultralcd.cpp:5513
 msgid "Brightness"
 msgstr "Podsvícení"
 
@@ -203,17 +202,17 @@ msgid "COMMUNICATION ERROR"
 msgstr "CHYBA KOMUNIKACE"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/messages.cpp:316 ../../Firmware/ultralcd.cpp:4583
+#: ../../Firmware/messages.cpp:328 ../../Firmware/ultralcd.cpp:4539
 msgid "Calibrate XYZ"
 msgstr "Kalibrace XYZ"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4585
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4541
 msgid "Calibrate Z"
 msgstr "Kalibrovat Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/messages.cpp:266 ../../Firmware/ultralcd.cpp:2813
+#: ../../Firmware/messages.cpp:278 ../../Firmware/ultralcd.cpp:2830
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -222,13 +221,13 @@ msgstr ""
 " tlačítkem."
 
 #. MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: ../../Firmware/Marlin_main.cpp:2218 ../../Firmware/messages.cpp:22
+#: ../../Firmware/Marlin_main.cpp:2009 ../../Firmware/messages.cpp:23
 #: ../../Firmware/ultralcd.cpp:582
 msgid "Calibrating Z"
 msgstr "Kalibruji Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/messages.cpp:265 ../../Firmware/ultralcd.cpp:2812
+#: ../../Firmware/messages.cpp:277 ../../Firmware/ultralcd.cpp:2829
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -237,17 +236,17 @@ msgstr ""
 "tlacitkem."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/messages.cpp:361 ../../Firmware/ultralcd.cpp:6985
+#: ../../Firmware/messages.cpp:373 ../../Firmware/ultralcd.cpp:6962
 msgid "Calibrating home"
 msgstr "Kalibruji výchozí p."
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5375
+#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5342
 msgid "Calibration"
 msgstr "Kalibrace"
 
 #. MSG_HOMEYZ_DONE c=20
-#: ../../Firmware/messages.cpp:217 ../../Firmware/ultralcd.cpp:593
+#: ../../Firmware/messages.cpp:229 ../../Firmware/ultralcd.cpp:593
 msgid "Calibration done"
 msgstr "Kalibrace OK"
 
@@ -264,128 +263,128 @@ msgid ""
 msgstr "Nelze provést akci, filament je zaveden. Nejprve jej vyjměte."
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/messages.cpp:364 ../../Firmware/ultralcd.cpp:7405
+#: ../../Firmware/messages.cpp:376 ../../Firmware/ultralcd.cpp:7382
 msgid "Card removed"
 msgstr "Karta vyjmuta"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/messages.cpp:324 ../../Firmware/ultralcd.cpp:5316
+#: ../../Firmware/messages.cpp:336 ../../Firmware/ultralcd.cpp:5282
 msgid "Change SD card"
 msgstr "Vyměňte SD kartu"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5254
-#: ../../Firmware/ultralcd.cpp:5526
+#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5216
+#: ../../Firmware/ultralcd.cpp:5493
 msgid "Change filament"
 msgstr "Vyměnit filament"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/messages.cpp:240 ../../Firmware/ultralcd.cpp:2156
+#: ../../Firmware/messages.cpp:252 ../../Firmware/ultralcd.cpp:2167
 msgid "Change success!"
 msgstr "Změna úspěšná!"
 
 #. MSG_CORRECTLY c=19
-#: ../../Firmware/messages.cpp:242 ../../Firmware/ultralcd.cpp:2203
+#: ../../Firmware/messages.cpp:254 ../../Firmware/ultralcd.cpp:2217
 msgid "Changed correctly"
 msgstr "Výměna ok"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5951
-#: ../../Firmware/ultralcd.cpp:6975
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5927
+#: ../../Firmware/ultralcd.cpp:6952
 msgid "Checking X axis"
 msgstr "Kontrola osy X"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5961
-#: ../../Firmware/ultralcd.cpp:6976
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:5937
+#: ../../Firmware/ultralcd.cpp:6953
 msgid "Checking Y axis"
 msgstr "Kontrola osy Y"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/messages.cpp:358 ../../Firmware/ultralcd.cpp:6977
+#: ../../Firmware/messages.cpp:370 ../../Firmware/ultralcd.cpp:6954
 msgid "Checking Z axis"
 msgstr "Kontrola osy Z"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6978
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6955
 msgid "Checking bed"
 msgstr "Kontrola podložky"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/messages.cpp:357 ../../Firmware/ultralcd.cpp:6974
+#: ../../Firmware/messages.cpp:369 ../../Firmware/ultralcd.cpp:6951
 msgid "Checking endstops"
 msgstr "Kontrola endstopů"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/messages.cpp:362 ../../Firmware/ultralcd.cpp:7070
+#: ../../Firmware/messages.cpp:374 ../../Firmware/ultralcd.cpp:7047
 msgid "Checking file"
 msgstr "Kontroluji soubor"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/messages.cpp:359 ../../Firmware/ultralcd.cpp:6980
+#: ../../Firmware/messages.cpp:371 ../../Firmware/ultralcd.cpp:6957
 msgid "Checking hotend"
 msgstr "Kontrola hotend"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6981
-#: ../../Firmware/ultralcd.cpp:6982
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6958
+#: ../../Firmware/ultralcd.cpp:6959
 msgid "Checking sensors"
 msgstr "Kontrola senzorů"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/messages.cpp:308 ../../Firmware/ultralcd.cpp:4424
+#: ../../Firmware/messages.cpp:320 ../../Firmware/ultralcd.cpp:4391
 msgid "Checks"
 msgstr "Kontrola"
 
 #. MSG_TM_ACK_ERROR c=18
-#: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5297
+#: ../../Firmware/messages.cpp:197 ../../Firmware/ultralcd.cpp:5263
 msgid "Clear TM error"
 msgstr "Vymazat chybu TM"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/messages.cpp:244 ../../Firmware/ultralcd.cpp:2205
+#: ../../Firmware/messages.cpp:256 ../../Firmware/ultralcd.cpp:2219
 msgid "Color not correct"
 msgstr "Barva není čistá"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:3508
+#: ../../Firmware/messages.cpp:27 ../../Firmware/ultralcd.cpp:3518
 msgid "Community made"
 msgstr "Komunitní překl."
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:4059
+#: ../../Firmware/messages.cpp:178 ../../Firmware/ultralcd.cpp:4083
 msgid "Cont."
 msgstr "Pokr."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:2129
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2135
 msgid "Cooldown"
 msgstr "Zchladit"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/messages.cpp:283 ../../Firmware/ultralcd.cpp:3450
+#: ../../Firmware/messages.cpp:295 ../../Firmware/ultralcd.cpp:3460
 msgid "Copy selected language?"
 msgstr "Kopírovat vybraný jazyk?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:1234
-#: ../../Firmware/ultralcd.cpp:1263
+#: ../../Firmware/messages.cpp:30 ../../Firmware/ultralcd.cpp:1244
+#: ../../Firmware/ultralcd.cpp:1273
 msgid "Crash"
 msgstr "Náraz"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4146
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/ultralcd.cpp:4170
 msgid "Crash det."
 msgstr "Det. nárazu"
 
 #. MSG_CRASH_DETECTED c=20
-#: ../../Firmware/Marlin_main.cpp:630 ../../Firmware/messages.cpp:30
+#: ../../Firmware/Marlin_main.cpp:595 ../../Firmware/messages.cpp:31
 msgid "Crash detected."
 msgstr "Detekován náraz."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/messages.cpp:280 ../../Firmware/ultralcd.cpp:3374
+#: ../../Firmware/messages.cpp:292 ../../Firmware/ultralcd.cpp:3384
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -396,24 +395,24 @@ msgstr ""
 "Normal módu"
 
 #. MSG_CUT_FILAMENT c=16
-#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:380
-#: ../../Firmware/ultralcd.cpp:4854 ../../Firmware/ultralcd.cpp:5351
+#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:381
+#: ../../Firmware/ultralcd.cpp:4810 ../../Firmware/ultralcd.cpp:5317
 msgid "Cut filament"
 msgstr "Ustřihnout"
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4081
-#: ../../Firmware/ultralcd.cpp:4086 ../../Firmware/ultralcd.cpp:4091
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:4105
+#: ../../Firmware/ultralcd.cpp:4110 ../../Firmware/ultralcd.cpp:4115
 msgid "Cutter"
 msgstr "Stříhání"
 
 #. MSG_DATE c=17
-#: ../../Firmware/messages.cpp:222 ../../Firmware/ultralcd.cpp:1645
+#: ../../Firmware/messages.cpp:234 ../../Firmware/ultralcd.cpp:1655
 msgid "Date:"
 msgstr "Datum:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:178 ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/messages.cpp:185 ../../Firmware/ultralcd.cpp:5594
 msgid "Dim"
 msgstr "Temný"
 
@@ -423,7 +422,7 @@ msgid "Disable"
 msgstr "Vypnout"
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/messages.cpp:311 ../../Firmware/ultralcd.cpp:4460
+#: ../../Firmware/messages.cpp:323 ../../Firmware/ultralcd.cpp:4427
 msgid "Disable steppers"
 msgstr "Vypnout motory"
 
@@ -435,7 +434,7 @@ msgid "Disengaging idler"
 msgstr "Odpojuji idler"
 
 #. MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: ../../Firmware/Marlin_main.cpp:1610 ../../Firmware/Marlin_main.cpp:3334
+#: ../../Firmware/Marlin_main.cpp:1537 ../../Firmware/Marlin_main.cpp:3073
 #: ../../Firmware/messages.cpp:14
 msgid ""
 "Distance between tip of the nozzle and the bed surface has not been set yet."
@@ -446,7 +445,7 @@ msgstr ""
 "manuálu, kapitola Začínáme."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/messages.cpp:301 ../../Firmware/ultralcd.cpp:3923
+#: ../../Firmware/messages.cpp:313 ../../Firmware/ultralcd.cpp:3947
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -455,13 +454,13 @@ msgstr ""
 "podložkou?"
 
 #. MSG_DONE c=8
-#: ../../Firmware/messages.cpp:32 ../../Firmware/mmu2/errors_list.h:367
-#: ../../Firmware/mmu2_reporting.cpp:456
+#: ../../Firmware/messages.cpp:33 ../../Firmware/mmu2/errors_list.h:367
+#: ../../Firmware/mmu2_reporting.cpp:457
 msgid "Done"
 msgstr "Konec"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/messages.cpp:307 ../../Firmware/ultralcd.cpp:3990
+#: ../../Firmware/messages.cpp:319 ../../Firmware/ultralcd.cpp:4014
 msgid "E-correct"
 msgstr "Korekce E"
 
@@ -490,7 +489,7 @@ msgid "ERR Wait for User"
 msgstr "ERR: Čekám na uživ."
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:2253
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:2267
 msgid "ERROR:"
 msgstr "CHYBA:"
 
@@ -502,17 +501,17 @@ msgid "Ejecting filament"
 msgstr "Vysouvám filament"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/messages.cpp:348 ../../Firmware/ultralcd.cpp:6722
+#: ../../Firmware/messages.cpp:360 ../../Firmware/ultralcd.cpp:6698
 msgid "Endstop"
 msgstr "Koncový spínač"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/messages.cpp:349 ../../Firmware/ultralcd.cpp:6727
+#: ../../Firmware/messages.cpp:361 ../../Firmware/ultralcd.cpp:6703
 msgid "Endstop not hit"
 msgstr "Kon. spínač nesepnut"
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/messages.cpp:347 ../../Firmware/ultralcd.cpp:6713
+#: ../../Firmware/messages.cpp:359 ../../Firmware/ultralcd.cpp:6689
 msgid "Endstops"
 msgstr "Konc. spínače"
 
@@ -524,30 +523,30 @@ msgid "Engaging idler"
 msgstr "Zapínání idleru"
 
 #. MSG_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:3352
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:3362
 msgid "Extruder"
 msgstr "Extruder"
 
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/messages.cpp:227 ../../Firmware/ultralcd.cpp:1700
+#: ../../Firmware/messages.cpp:239 ../../Firmware/ultralcd.cpp:1710
 msgid "Extruder info"
 msgstr "Extruder - info"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4044
-#: ../../Firmware/ultralcd.cpp:4051
+#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4068
+#: ../../Firmware/ultralcd.cpp:4075
 msgid "F. autoload"
 msgstr "F. autozav."
 
 #. MSG_FSENSOR_JAM_DETECTION c=13
-#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4046
-#: ../../Firmware/ultralcd.cpp:4053
+#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4070
+#: ../../Firmware/ultralcd.cpp:4077
 msgid "F. jam detect"
 msgstr "Det. záseku"
 
 #. MSG_FSENSOR_RUNOUT c=13
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4074
 msgid "F. runout"
 msgstr "F. runout"
 
@@ -585,8 +584,8 @@ msgid "FINDA FILAM. STUCK"
 msgstr "FINDA ZASEK. FILAM."
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:4059
-#: ../../Firmware/ultralcd.cpp:4062
+#: ../../Firmware/messages.cpp:177 ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/ultralcd.cpp:4086
 msgid "FS Action"
 msgstr "FS reakce"
 
@@ -611,34 +610,34 @@ msgid "FW RUNTIME ERROR"
 msgstr "FW RUNTIME CHYBA"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/messages.cpp:330 ../../Firmware/ultralcd.cpp:5382
+#: ../../Firmware/messages.cpp:342 ../../Firmware/ultralcd.cpp:5349
 msgid "Fail stats"
 msgstr "Selhání"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/messages.cpp:331 ../../Firmware/ultralcd.cpp:5385
+#: ../../Firmware/messages.cpp:343 ../../Firmware/ultralcd.cpp:5352
 msgid "Fail stats MMU"
 msgstr "Selhání MMU"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/messages.cpp:355 ../../Firmware/ultralcd.cpp:6768
+#: ../../Firmware/messages.cpp:367 ../../Firmware/ultralcd.cpp:6744
 msgid "False triggering"
 msgstr "Falešné spuštění"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4175
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4199
 msgid "Fan speed"
 msgstr "Rychlost vent."
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6844
-#: ../../Firmware/ultralcd.cpp:6971 ../../Firmware/ultralcd.cpp:6972
-#: ../../Firmware/ultralcd.cpp:6973
+#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6820
+#: ../../Firmware/ultralcd.cpp:6948 ../../Firmware/ultralcd.cpp:6949
+#: ../../Firmware/ultralcd.cpp:6950
 msgid "Fan test"
 msgstr "Test ventilátoru"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:4179
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:4203
 msgid "Fans check"
 msgstr "Kontr. vent."
 
@@ -667,34 +666,34 @@ msgid "Feeding to nozzle"
 msgstr "Zavádím do trysky"
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1233
-#: ../../Firmware/ultralcd.cpp:1262 ../../Firmware/ultralcd.cpp:1316
-#: ../../Firmware/ultralcd.cpp:1318
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:1243
+#: ../../Firmware/ultralcd.cpp:1272 ../../Firmware/ultralcd.cpp:1326
+#: ../../Firmware/ultralcd.cpp:1328
 msgid "Fil. runouts"
 msgstr "Výpadky filam."
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3313
-#: ../../Firmware/ultralcd.cpp:4039 ../../Firmware/ultralcd.cpp:4464
-#: ../../Firmware/ultralcd.cpp:5532
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3323
+#: ../../Firmware/ultralcd.cpp:4063 ../../Firmware/ultralcd.cpp:4431
+#: ../../Firmware/ultralcd.cpp:5499
 msgid "Fil. sensor"
 msgstr "Fil. senzor"
 
 #. MSG_FILAMENT_CLEAN c=20 r=3
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2261
-#: ../../Firmware/ultralcd.cpp:2265
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2275
+#: ../../Firmware/ultralcd.cpp:2279
 msgid "Filament extruding & with correct color?"
 msgstr "Filament vytlačen a správné barvy?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/messages.cpp:243 ../../Firmware/ultralcd.cpp:2204
+#: ../../Firmware/messages.cpp:255 ../../Firmware/ultralcd.cpp:2218
 msgid "Filament not loaded"
 msgstr "Filament nezaveden"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6763
-#: ../../Firmware/ultralcd.cpp:6767 ../../Firmware/ultralcd.cpp:6771
-#: ../../Firmware/ultralcd.cpp:7000
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6739
+#: ../../Firmware/ultralcd.cpp:6743 ../../Firmware/ultralcd.cpp:6747
+#: ../../Firmware/ultralcd.cpp:6977
 msgid "Filament sensor"
 msgstr "Senzor filamentu"
 
@@ -726,42 +725,42 @@ msgstr ""
 "nejsou nečistoty. Ujistěte se, že senzor funguje správně."
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/messages.cpp:246 ../../Firmware/ultralcd.cpp:2347
+#: ../../Firmware/messages.cpp:258 ../../Firmware/ultralcd.cpp:2364
 msgid "Filament used"
 msgstr "Spotřebováno filam."
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/messages.cpp:363 ../../Firmware/ultralcd.cpp:7139
+#: ../../Firmware/messages.cpp:375 ../../Firmware/ultralcd.cpp:7116
 msgid "File incomplete. Continue anyway?"
 msgstr "Soubor nekompletní. Pokračovat?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
 #: ../../Firmware/messages.cpp:45
 #: ../../Firmware/mmu2_progress_converter.cpp:43
-#: ../../Firmware/ultralcd.cpp:5021 ../../Firmware/ultralcd.cpp:5425
+#: ../../Firmware/ultralcd.cpp:4977 ../../Firmware/ultralcd.cpp:5392
 msgid "Finishing movements"
 msgstr "Dokončování pohybů"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4575
-#: ../../Firmware/ultralcd.cpp:5141
+#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4531
+#: ../../Firmware/ultralcd.cpp:5101
 msgid "First layer cal."
 msgstr "Kal. první vrstvy"
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/messages.cpp:293 ../../Firmware/ultralcd.cpp:3846
+#: ../../Firmware/messages.cpp:305 ../../Firmware/ultralcd.cpp:3872
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Nejdřív pomocí selftestu zkontoluji nejčastější chyby vznikající při "
 "sestavení tiskárny."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/messages.cpp:334 ../../Firmware/ultralcd.cpp:5520
+#: ../../Firmware/messages.cpp:346 ../../Firmware/ultralcd.cpp:5487
 msgid "Flow"
 msgstr "Průtok"
 
 #. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
-#: ../../Firmware/messages.cpp:194 ../../Firmware/ultralcd.cpp:985
+#: ../../Firmware/messages.cpp:201 ../../Firmware/ultralcd.cpp:987
 msgid ""
 "For a Nozzle change please read\n"
 "prusa.io/nozzle-mk3s"
@@ -770,28 +769,28 @@ msgstr ""
 "prusa.io/nozzle-mk3s"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6733
-#: ../../Firmware/ultralcd.cpp:6850 ../../Firmware/ultralcd.cpp:6855
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/ultralcd.cpp:6826 ../../Firmware/ultralcd.cpp:6831
 msgid "Front print fan?"
 msgstr "Přední tiskový vent?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/messages.cpp:260 ../../Firmware/ultralcd.cpp:2711
+#: ../../Firmware/messages.cpp:272 ../../Firmware/ultralcd.cpp:2728
 msgid "Front side[µm]"
 msgstr "Vpředu [µm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/messages.cpp:353 ../../Firmware/ultralcd.cpp:6757
+#: ../../Firmware/messages.cpp:365 ../../Firmware/ultralcd.cpp:6733
 msgid "Front/left fans"
 msgstr "Přední/levý vent."
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:151 ../../Firmware/util.cpp:382
+#: ../../Firmware/messages.cpp:156 ../../Firmware/util.cpp:417
 msgid "G-code sliced for a different level. Continue?"
 msgstr "G-code je připraven pro jinou verzi. Pokračovat?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:152 ../../Firmware/util.cpp:383
+#: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:418
 msgid ""
 "G-code sliced for a different level. Please re-slice the model again. Print "
 "cancelled."
@@ -799,14 +798,14 @@ msgstr ""
 "G-code je připraven pro jinou verzi. Vyslicujte model znovu. Tisk zrušen."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:147 ../../Firmware/util.cpp:312
-#: ../../Firmware/util.cpp:401
+#: ../../Firmware/messages.cpp:152 ../../Firmware/util.cpp:319
+#: ../../Firmware/util.cpp:436
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr "G-code je připraven pro jiný typ tiskárny.Pokračovat?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:148 ../../Firmware/util.cpp:313
-#: ../../Firmware/util.cpp:402
+#: ../../Firmware/messages.cpp:153 ../../Firmware/util.cpp:320
+#: ../../Firmware/util.cpp:437
 msgid ""
 "G-code sliced for a different printer type. Please re-slice the model again."
 " Print cancelled."
@@ -815,47 +814,47 @@ msgstr ""
 "zrušen."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:149 ../../Firmware/util.cpp:362
+#: ../../Firmware/messages.cpp:154 ../../Firmware/util.cpp:369
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "G-code je pripraven pro novější FW. Pokračovat?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:150 ../../Firmware/util.cpp:363
+#: ../../Firmware/messages.cpp:155 ../../Firmware/util.cpp:370
 msgid ""
 "G-code sliced for a newer firmware. Please update the firmware. Print "
 "cancelled."
 msgstr "G-code je připraven pro novější FW. Aktualizujte FW. Tisk zrušen."
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4366
-#: ../../Firmware/ultralcd.cpp:4383 ../../Firmware/ultralcd.cpp:4485
+#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4325
+#: ../../Firmware/ultralcd.cpp:4343 ../../Firmware/ultralcd.cpp:4452
 msgid "HW Setup"
 msgstr "HW nastavení"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/messages.cpp:344 ../../Firmware/ultralcd.cpp:6705
+#: ../../Firmware/messages.cpp:356 ../../Firmware/ultralcd.cpp:6681
 msgid "Heater/Thermistor"
 msgstr "Topení/Termistor"
 
 #. MSG_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6184 ../../Firmware/messages.cpp:52
+#: ../../Firmware/Marlin_main.cpp:5416 ../../Firmware/messages.cpp:52
 #: ../../Firmware/ultralcd.cpp:526
 msgid "Heating"
 msgstr "Zahřívání"
 
 #. MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:9647 ../../Firmware/messages.cpp:211
+#: ../../Firmware/Marlin_main.cpp:8807 ../../Firmware/messages.cpp:223
 msgid "Heating disabled by safety timer."
 msgstr "Zahřívání přerušeno bezpečnostním časovačem."
 
 #. MSG_HEATING_COMPLETE c=20
-#: ../../Firmware/Marlin_main.cpp:6215 ../../Firmware/messages.cpp:53
+#: ../../Firmware/Marlin_main.cpp:5445 ../../Firmware/messages.cpp:53
 #: ../../Firmware/ultralcd.cpp:529
 msgid "Heating done."
 msgstr "Zahřívání OK."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=12
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:3806
+#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:3832
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -865,7 +864,7 @@ msgstr ""
 "nastavení, ve kterém zkalibrujeme osu Z. Pak budete moct začít tisknout."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:3810
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:3836
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -874,8 +873,8 @@ msgstr ""
 "kalibračním procesem?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4152
-#: ../../Firmware/ultralcd.cpp:4161
+#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:4176
+#: ../../Firmware/ultralcd.cpp:4185
 msgid "High power"
 msgstr "Vys. výkon"
 
@@ -886,23 +885,23 @@ msgid "Homing"
 msgstr "Homing"
 
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
-#: ../../Firmware/messages.cpp:195 ../../Firmware/ultralcd.cpp:1005
+#: ../../Firmware/messages.cpp:206 ../../Firmware/ultralcd.cpp:1011
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr "Hotend má 280C! Tryska vyměněna a dotažena dle instrukcí?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1106
-#: ../../Firmware/ultralcd.cpp:6991
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1116
+#: ../../Firmware/ultralcd.cpp:6968
 msgid "Hotend fan:"
 msgstr "Vent. hotendu:"
 
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/messages.cpp:294 ../../Firmware/ultralcd.cpp:3851
+#: ../../Firmware/messages.cpp:306 ../../Firmware/ultralcd.cpp:3877
 msgid "I will run xyz calibration now. It will take up to 24 mins."
 msgstr "Nyní provedu xyz kalibraci. Zabere to až 24 min."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/messages.cpp:297 ../../Firmware/ultralcd.cpp:3862
+#: ../../Firmware/messages.cpp:309 ../../Firmware/ultralcd.cpp:3884
 msgid "I will run z calibration now."
 msgstr "Nyní provedu z kalibraci."
 
@@ -927,7 +926,7 @@ msgid "INVALID TOOL"
 msgstr "NEPLATNÝ NÁSTROJ"
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=8
-#: ../../Firmware/messages.cpp:303 ../../Firmware/ultralcd.cpp:3931
+#: ../../Firmware/messages.cpp:315 ../../Firmware/ultralcd.cpp:3955
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -936,28 +935,28 @@ msgstr ""
 "Tiskové pláty"
 
 #. MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2540
-#: ../../Firmware/messages.cpp:213
+#: ../../Firmware/mesh_bed_calibration.cpp:2525
+#: ../../Firmware/messages.cpp:225
 msgid "Improving bed calibration point"
 msgstr "Upřesňování kalibračního bodu"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:5222
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:5184
 msgid "Info screen"
 msgstr "Informace"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/messages.cpp:326 ../../Firmware/ultralcd.cpp:5323
+#: ../../Firmware/messages.cpp:338 ../../Firmware/ultralcd.cpp:5289
 msgid "Init. SD card"
 msgstr "Zav. SD karty"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/messages.cpp:238 ../../Firmware/ultralcd.cpp:2142
+#: ../../Firmware/messages.cpp:250 ../../Firmware/ultralcd.cpp:2148
 msgid "Insert filament"
 msgstr "Vložte filament"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/messages.cpp:335 ../../Firmware/ultralcd.cpp:5998
+#: ../../Firmware/messages.cpp:347 ../../Firmware/ultralcd.cpp:5974
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
@@ -970,115 +969,115 @@ msgid ""
 msgstr "Interní chyba. Zkuste resetovat MMU či aktualizujte FW."
 
 #. MSG_FILAMENT_LOADED c=20 r=3
-#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3628
-#: ../../Firmware/ultralcd.cpp:3890
+#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3638
+#: ../../Firmware/ultralcd.cpp:3914
 msgid "Is filament loaded?"
 msgstr "Je filament zaveden?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3238 ../../Firmware/Marlin_main.cpp:4745
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:3858
+#: ../../Firmware/Marlin_main.cpp:4314 ../../Firmware/messages.cpp:127
+#: ../../Firmware/ultralcd.cpp:3760
 msgid "Is steel sheet on heatbed?"
 msgstr "Je tiskový plát na podložce?"
 
 #. MSG_ITERATION c=12
-#: ../../Firmware/mesh_bed_calibration.cpp:2265 ../../Firmware/messages.cpp:55
+#: ../../Firmware/mesh_bed_calibration.cpp:2250 ../../Firmware/messages.cpp:55
 msgid "Iteration"
 msgstr "Opakování"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1128
-#: ../../Firmware/ultralcd.cpp:1286
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1138
+#: ../../Firmware/ultralcd.cpp:1296
 msgid "Last print"
 msgstr "Poslední tisk"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1152
-#: ../../Firmware/ultralcd.cpp:1260 ../../Firmware/ultralcd.cpp:1315
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1162
+#: ../../Firmware/ultralcd.cpp:1270 ../../Firmware/ultralcd.cpp:1325
 msgid "Last print failures"
 msgstr "Selhání posl. tisku"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/messages.cpp:251 ../../Firmware/ultralcd.cpp:2478
+#: ../../Firmware/messages.cpp:263 ../../Firmware/ultralcd.cpp:2495
 msgid "Left"
 msgstr "Vlevo"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6739
-#: ../../Firmware/ultralcd.cpp:6850 ../../Firmware/ultralcd.cpp:6855
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6715
+#: ../../Firmware/ultralcd.cpp:6826 ../../Firmware/ultralcd.cpp:6831
 msgid "Left hotend fan?"
 msgstr "Levý vent na trysce?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/messages.cpp:258 ../../Firmware/ultralcd.cpp:2709
+#: ../../Firmware/messages.cpp:270 ../../Firmware/ultralcd.cpp:2726
 msgid "Left side [µm]"
 msgstr "Vlevo [µm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:5619
+#: ../../Firmware/messages.cpp:181 ../../Firmware/ultralcd.cpp:5592
 msgid "Level Bright"
 msgstr "Normální"
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:175 ../../Firmware/ultralcd.cpp:5620
+#: ../../Firmware/messages.cpp:182 ../../Firmware/ultralcd.cpp:5593
 msgid "Level Dimmed"
 msgstr "Ztlumený"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/messages.cpp:312 ../../Firmware/ultralcd.cpp:4491
+#: ../../Firmware/messages.cpp:324 ../../Firmware/ultralcd.cpp:4458
 msgid "Lin. correction"
 msgstr "Korekce lin."
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4501
-#: ../../Firmware/ultralcd.cpp:5251
+#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4468
+#: ../../Firmware/ultralcd.cpp:5213
 msgid "Live adjust Z"
 msgstr "Doladění osy Z"
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/messages.cpp:192 ../../Firmware/ultralcd.cpp:4794
-#: ../../Firmware/ultralcd.cpp:4880
+#: ../../Firmware/messages.cpp:199 ../../Firmware/ultralcd.cpp:4750
+#: ../../Firmware/ultralcd.cpp:4836
 msgid "Load All"
 msgstr "Načíst vše"
 
 #. MSG_LOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4796
-#: ../../Firmware/ultralcd.cpp:4833 ../../Firmware/ultralcd.cpp:4882
-#: ../../Firmware/ultralcd.cpp:5361 ../../Firmware/ultralcd.cpp:5368
+#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4752
+#: ../../Firmware/ultralcd.cpp:4789 ../../Firmware/ultralcd.cpp:4838
+#: ../../Firmware/ultralcd.cpp:5324 ../../Firmware/ultralcd.cpp:5335
 msgid "Load filament"
 msgstr "Zavést filament"
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/messages.cpp:327 ../../Firmware/ultralcd.cpp:5346
+#: ../../Firmware/messages.cpp:339 ../../Firmware/ultralcd.cpp:5312
 msgid "Load to nozzle"
 msgstr "Zavést do trysky"
 
 #. MSG_LOADING_TEST c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4476
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4443
 msgid "Loading Test"
 msgstr "Zatěžovací test"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/messages.cpp:241 ../../Firmware/ultralcd.cpp:2178
+#: ../../Firmware/messages.cpp:253 ../../Firmware/ultralcd.cpp:2189
 msgid "Loading color"
 msgstr "Čištění barvy"
 
 #. MSG_LOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3598 ../../Firmware/messages.cpp:62
+#: ../../Firmware/Marlin_main.cpp:3343 ../../Firmware/messages.cpp:62
 #: ../../Firmware/mmu2_progress_converter.cpp:51
-#: ../../Firmware/mmu2_reporting.cpp:392 ../../Firmware/ultralcd.cpp:2189
-#: ../../Firmware/ultralcd.cpp:3715
+#: ../../Firmware/mmu2_reporting.cpp:393 ../../Firmware/ultralcd.cpp:2199
+#: ../../Firmware/ultralcd.cpp:3725
 msgid "Loading filament"
 msgstr "Zavádění filamentu"
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/messages.cpp:350 ../../Firmware/ultralcd.cpp:6745
+#: ../../Firmware/messages.cpp:362 ../../Firmware/ultralcd.cpp:6721
 msgid "Loose pulley"
 msgstr "Uvolněná řemenička"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4188
-#: ../../Firmware/ultralcd.cpp:4200
+#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4224
 msgid "Loud"
 msgstr "Hlasitý"
 
@@ -1093,7 +1092,7 @@ msgid "MMU Firmware internal error, please reset the MMU."
 msgstr "Interní chyba MMU FW, resetujte MMU"
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:4096
+#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4120
 msgid "MMU Mode"
 msgstr "MMU mód"
 
@@ -1103,7 +1102,7 @@ msgid "MMU NOT RESPONDING"
 msgstr "MMU NEODPOVÍDÁ"
 
 #. MSG_MMU_RESTORE_TEMP c=20 r=4
-#: ../../Firmware/messages.cpp:214 ../../Firmware/mmu2_reporting.cpp:396
+#: ../../Firmware/messages.cpp:226 ../../Firmware/mmu2_reporting.cpp:397
 msgid "MMU Retry: Restoring temperature..."
 msgstr "MMU opakování: Obnova teploty..."
 
@@ -1114,14 +1113,14 @@ msgid "MMU SELFTEST FAILED"
 msgstr "MMU SELFTEST SELHAL"
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1153
-#: ../../Firmware/ultralcd.cpp:1178
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1163
+#: ../../Firmware/ultralcd.cpp:1188
 msgid "MMU fails"
 msgstr "Selhání MMU"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1154
-#: ../../Firmware/ultralcd.cpp:1179
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1164
+#: ../../Firmware/ultralcd.cpp:1189
 msgid "MMU load fails"
 msgstr "MMU selhání zav"
 
@@ -1136,66 +1135,64 @@ msgid "MMU not responding. Check the wiring and connectors."
 msgstr "MMU neodpovídá. Zkontrolujte kabely a jejich zapojení."
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/messages.cpp:223 ../../Firmware/ultralcd.cpp:1657
+#: ../../Firmware/messages.cpp:235 ../../Firmware/ultralcd.cpp:1667
 msgid "MMU connected"
 msgstr "MMU připojeno"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/messages.cpp:176 ../../Firmware/ultralcd.cpp:5567
 msgid "Magnets comp."
 msgstr "Komp. magnetu"
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1127
-#: ../../Firmware/ultralcd.cpp:1285 ../../Firmware/ultralcd.cpp:1327
-#: ../../Firmware/ultralcd.cpp:1631 ../../Firmware/ultralcd.cpp:4453
-#: ../../Firmware/ultralcd.cpp:4571 ../../Firmware/ultralcd.cpp:4793
-#: ../../Firmware/ultralcd.cpp:4826 ../../Firmware/ultralcd.cpp:4879
-#: ../../Firmware/ultralcd.cpp:5515
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1137
+#: ../../Firmware/ultralcd.cpp:1295 ../../Firmware/ultralcd.cpp:1337
+#: ../../Firmware/ultralcd.cpp:1641 ../../Firmware/ultralcd.cpp:4420
+#: ../../Firmware/ultralcd.cpp:4527 ../../Firmware/ultralcd.cpp:4749
+#: ../../Firmware/ultralcd.cpp:4782 ../../Firmware/ultralcd.cpp:4835
+#: ../../Firmware/ultralcd.cpp:5482
 msgid "Main"
 msgstr "Hlavní nabídka"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/messages.cpp:253 ../../Firmware/ultralcd.cpp:2519
+#: ../../Firmware/messages.cpp:265 ../../Firmware/ultralcd.cpp:2536
 msgid "Measured skew"
 msgstr "Meřené zkos."
 
 #. MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3219
-#: ../../Firmware/mesh_bed_calibration.cpp:2852 ../../Firmware/messages.cpp:70
+#: ../../Firmware/Marlin_main.cpp:2963
+#: ../../Firmware/mesh_bed_calibration.cpp:2837 ../../Firmware/messages.cpp:70
 msgid "Measuring reference height of calibration point"
 msgstr "Meřím referenční výšku kalibračního bodu"
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:5590
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:5563
 msgid "Mesh"
 msgstr "Mesh"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4488
-#: ../../Firmware/ultralcd.cpp:4587
+#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:4455
+#: ../../Firmware/ultralcd.cpp:4543
 msgid "Mesh Bed Leveling"
 msgstr "Mesh Bed Leveling"
 
 #. MSG_MODE c=6
-#: ../../Firmware/Marlin_main.cpp:8495 ../../Firmware/messages.cpp:117
-#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4132
-#: ../../Firmware/ultralcd.cpp:4140 ../../Firmware/ultralcd.cpp:4144
-#: ../../Firmware/ultralcd.cpp:4152 ../../Firmware/ultralcd.cpp:4155
-#: ../../Firmware/ultralcd.cpp:4158 ../../Firmware/ultralcd.cpp:4161
-#: ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/Marlin_main.cpp:7666 ../../Firmware/messages.cpp:121
+#: ../../Firmware/ultralcd.cpp:4152 ../../Firmware/ultralcd.cpp:4156
+#: ../../Firmware/ultralcd.cpp:4164 ../../Firmware/ultralcd.cpp:4168
+#: ../../Firmware/ultralcd.cpp:4176 ../../Firmware/ultralcd.cpp:4179
+#: ../../Firmware/ultralcd.cpp:4182 ../../Firmware/ultralcd.cpp:4185
+#: ../../Firmware/ultralcd.cpp:5594
 msgid "Mode"
 msgstr "Mód"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/messages.cpp:282 ../../Firmware/ultralcd.cpp:3413
+#: ../../Firmware/messages.cpp:294 ../../Firmware/ultralcd.cpp:3423
 msgid "Mode change in progress..."
 msgstr "Probíhá změna modu..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:4310
-#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4316
-#: ../../Firmware/ultralcd.cpp:4319
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4327
 msgid "Model"
 msgstr "Model"
 
@@ -1216,28 +1213,28 @@ msgid "More details online."
 msgstr "Více info na webu"
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6719
-#: ../../Firmware/ultralcd.cpp:6728 ../../Firmware/ultralcd.cpp:6746
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6695
+#: ../../Firmware/ultralcd.cpp:6704 ../../Firmware/ultralcd.cpp:6722
 msgid "Motor"
 msgstr "Motor"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/messages.cpp:277 ../../Firmware/ultralcd.cpp:3349
+#: ../../Firmware/messages.cpp:289 ../../Firmware/ultralcd.cpp:3359
 msgid "Move X"
 msgstr "Posunout X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/messages.cpp:278 ../../Firmware/ultralcd.cpp:3350
+#: ../../Firmware/messages.cpp:290 ../../Firmware/ultralcd.cpp:3360
 msgid "Move Y"
 msgstr "Posunout Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/messages.cpp:279 ../../Firmware/ultralcd.cpp:3351
+#: ../../Firmware/messages.cpp:291 ../../Firmware/ultralcd.cpp:3361
 msgid "Move Z"
 msgstr "Posunout Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/messages.cpp:310 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:322 ../../Firmware/ultralcd.cpp:4426
 msgid "Move axis"
 msgstr "Posunout osu"
 
@@ -1248,95 +1245,92 @@ msgid "Moving selector"
 msgstr "Přesun selektoru"
 
 #. MSG_NA c=3
-#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:141
-#: ../../Firmware/ultralcd.cpp:2484 ../../Firmware/ultralcd.cpp:2528
-#: ../../Firmware/ultralcd.cpp:3279 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:4044 ../../Firmware/ultralcd.cpp:4046
-#: ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:146
+#: ../../Firmware/ultralcd.cpp:2501 ../../Firmware/ultralcd.cpp:2545
+#: ../../Firmware/ultralcd.cpp:3289 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4068 ../../Firmware/ultralcd.cpp:4070
+#: ../../Firmware/ultralcd.cpp:5567
 msgid "N/A"
 msgstr "N/A"
 
 #. MSG_NEW_FIRMWARE_AVAILABLE c=20 r=2
-#: ../../Firmware/messages.cpp:365 ../../Firmware/util.cpp:209
+#: ../../Firmware/messages.cpp:377 ../../Firmware/util.cpp:214
 msgid "New firmware version available:"
 msgstr "Vyšla nová verze FW:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:3029
-#: ../../Firmware/ultralcd.cpp:4443 ../../Firmware/ultralcd.cpp:4531
-#: ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:2275
+#: ../../Firmware/ultralcd.cpp:2279 ../../Firmware/ultralcd.cpp:3046
+#: ../../Firmware/ultralcd.cpp:4410 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/ultralcd.cpp:5765
 msgid "No"
 msgstr "Ne"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/messages.cpp:325 ../../Firmware/ultralcd.cpp:5321
+#: ../../Firmware/messages.cpp:337 ../../Firmware/ultralcd.cpp:5287
 msgid "No SD card"
 msgstr "Žádná SD karta"
 
 #. MSG_NO_MOVE c=20
-#: ../../Firmware/Marlin_main.cpp:5271 ../../Firmware/messages.cpp:210
+#: ../../Firmware/Marlin_main.cpp:4778 ../../Firmware/messages.cpp:222
 msgid "No move."
 msgstr "Bez pohybu."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4239 ../../Firmware/ultralcd.cpp:4310
-#: ../../Firmware/ultralcd.cpp:4319 ../../Firmware/ultralcd.cpp:4349
-#: ../../Firmware/ultralcd.cpp:4358 ../../Firmware/ultralcd.cpp:4516
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4309
+#: ../../Firmware/ultralcd.cpp:4318 ../../Firmware/ultralcd.cpp:4483
 msgid "None"
 msgstr "Žádné"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/Marlin_main.cpp:8497 ../../Firmware/messages.cpp:121
-#: ../../Firmware/ultralcd.cpp:4096 ../../Firmware/ultralcd.cpp:4132
-#: ../../Firmware/ultralcd.cpp:4511
+#: ../../Firmware/Marlin_main.cpp:7668 ../../Firmware/messages.cpp:125
+#: ../../Firmware/ultralcd.cpp:4120 ../../Firmware/ultralcd.cpp:4156
+#: ../../Firmware/ultralcd.cpp:4478
 msgid "Normal"
 msgstr "Normal"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/messages.cpp:345 ../../Firmware/ultralcd.cpp:6706
+#: ../../Firmware/messages.cpp:357 ../../Firmware/ultralcd.cpp:6682
 msgid "Not connected"
 msgstr "Nezapojeno"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6863
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6839
 msgid "Not spinning"
 msgstr "Netočí se"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/messages.cpp:289 ../../Firmware/ultralcd.cpp:3726
+#: ../../Firmware/messages.cpp:301 ../../Firmware/ultralcd.cpp:3736
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr "Nyní zkalibruji vzdálenost mezi koncem trysky a povrchem podložky."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/messages.cpp:298 ../../Firmware/ultralcd.cpp:3871
+#: ../../Firmware/messages.cpp:310 ../../Firmware/ultralcd.cpp:3894
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Nyní předehřeji trysku pro PLA."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/messages.cpp:296 ../../Firmware/ultralcd.cpp:3857
+#: ../../Firmware/messages.cpp:308 ../../Firmware/ultralcd.cpp:3883
 msgid "Now remove the test print from steel sheet."
 msgstr "Nyní odstraňte testovací výtisk z tiskového plátu."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1390
-#: ../../Firmware/ultralcd.cpp:4170 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4233 ../../Firmware/ultralcd.cpp:4236
-#: ../../Firmware/ultralcd.cpp:4239
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1400
+#: ../../Firmware/ultralcd.cpp:4194 ../../Firmware/ultralcd.cpp:4326
 msgid "Nozzle"
 msgstr "Tryska"
 
 #. MSG_NOZZLE_CNG_MENU c=18
-#: ../../Firmware/messages.cpp:193 ../../Firmware/ultralcd.cpp:4423
-#: ../../Firmware/ultralcd.cpp:4486
+#: ../../Firmware/messages.cpp:200 ../../Firmware/ultralcd.cpp:4390
+#: ../../Firmware/ultralcd.cpp:4453
 msgid "Nozzle change"
 msgstr "Výměna trysek"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4276
-#: ../../Firmware/ultralcd.cpp:4278 ../../Firmware/ultralcd.cpp:4279
-#: ../../Firmware/ultralcd.cpp:4280
+#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4261
+#: ../../Firmware/ultralcd.cpp:4263 ../../Firmware/ultralcd.cpp:4264
+#: ../../Firmware/ultralcd.cpp:4265
 msgid "Nozzle d."
 msgstr "Tryska"
 
@@ -1347,81 +1341,81 @@ msgid "OK"
 msgstr "OK"
 
 #. MSG_OFF c=3
-#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:139
-#: ../../Firmware/mmu2.cpp:65 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4050 ../../Firmware/ultralcd.cpp:4051
-#: ../../Firmware/ultralcd.cpp:4053 ../../Firmware/ultralcd.cpp:4076
-#: ../../Firmware/ultralcd.cpp:4091 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4179 ../../Firmware/ultralcd.cpp:4467
-#: ../../Firmware/ultralcd.cpp:4495 ../../Firmware/ultralcd.cpp:4498
-#: ../../Firmware/ultralcd.cpp:5439 ../../Firmware/ultralcd.cpp:5594
-#: ../../Firmware/ultralcd.cpp:7487 ../../Firmware/ultralcd.cpp:7491
+#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:144
+#: ../../Firmware/mmu2.cpp:65 ../../Firmware/ultralcd.cpp:4063
+#: ../../Firmware/ultralcd.cpp:4074 ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4077 ../../Firmware/ultralcd.cpp:4100
+#: ../../Firmware/ultralcd.cpp:4115 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/ultralcd.cpp:4203 ../../Firmware/ultralcd.cpp:4434
+#: ../../Firmware/ultralcd.cpp:4462 ../../Firmware/ultralcd.cpp:4465
+#: ../../Firmware/ultralcd.cpp:5406 ../../Firmware/ultralcd.cpp:5567
+#: ../../Firmware/ultralcd.cpp:7464 ../../Firmware/ultralcd.cpp:7468
 msgid "Off"
 msgstr "Vyp"
 
 #. MSG_DEFAULT_SETTINGS_LOADED c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:1562 ../../Firmware/messages.cpp:201
+#: ../../Firmware/Marlin_main.cpp:1489 ../../Firmware/messages.cpp:213
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr "Neplatné hodnoty nastavení. Bude použito výchozí PID, Esteps atd."
 
 #. MSG_ON c=3
-#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:140
-#: ../../Firmware/mmu2.cpp:63 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4050 ../../Firmware/ultralcd.cpp:4051
-#: ../../Firmware/ultralcd.cpp:4053 ../../Firmware/ultralcd.cpp:4076
-#: ../../Firmware/ultralcd.cpp:4081 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4179 ../../Firmware/ultralcd.cpp:4467
-#: ../../Firmware/ultralcd.cpp:4495 ../../Firmware/ultralcd.cpp:4498
-#: ../../Firmware/ultralcd.cpp:5594 ../../Firmware/ultralcd.cpp:7487
-#: ../../Firmware/ultralcd.cpp:7491
+#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:145
+#: ../../Firmware/mmu2.cpp:63 ../../Firmware/ultralcd.cpp:4063
+#: ../../Firmware/ultralcd.cpp:4074 ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4077 ../../Firmware/ultralcd.cpp:4100
+#: ../../Firmware/ultralcd.cpp:4105 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/ultralcd.cpp:4203 ../../Firmware/ultralcd.cpp:4434
+#: ../../Firmware/ultralcd.cpp:4462 ../../Firmware/ultralcd.cpp:4465
+#: ../../Firmware/ultralcd.cpp:5567 ../../Firmware/ultralcd.cpp:7464
+#: ../../Firmware/ultralcd.cpp:7468
 msgid "On"
 msgstr "Zap"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4191
+#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:4215
 msgid "Once"
 msgstr "Jednou"
 
 #. MSG_PAUSED_THERMAL_ERROR c=20
-#: ../../Firmware/Marlin_main.cpp:9861 ../../Firmware/messages.cpp:186
+#: ../../Firmware/Marlin_main.cpp:9021 ../../Firmware/messages.cpp:193
 msgid "PAUSED THERMAL ERROR"
 msgstr "STOP: CHYBA TEPLOTY"
 
 #. MSG_PID_RUNNING c=20
-#: ../../Firmware/messages.cpp:219 ../../Firmware/ultralcd.cpp:897
+#: ../../Firmware/messages.cpp:231 ../../Firmware/ultralcd.cpp:897
 msgid "PID cal."
 msgstr "PID kal."
 
 #. MSG_PID_FINISHED c=20
-#: ../../Firmware/messages.cpp:220 ../../Firmware/ultralcd.cpp:902
+#: ../../Firmware/messages.cpp:232 ../../Firmware/ultralcd.cpp:902
 msgid "PID cal. finished"
 msgstr "PID kal. ukončena"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:318 ../../Firmware/ultralcd.cpp:4590
+#: ../../Firmware/messages.cpp:330 ../../Firmware/ultralcd.cpp:4546
 msgid "PID calibration"
 msgstr "PID kalibrace"
 
 #. MSG_PINDA_PREHEAT c=20
-#: ../../Firmware/messages.cpp:218 ../../Firmware/ultralcd.cpp:610
+#: ../../Firmware/messages.cpp:230 ../../Firmware/ultralcd.cpp:610
 msgid "PINDA Heating"
 msgstr "Nahřívání PINDA"
 
 #. MSG_PINDA_CALIBRATION c=13
-#: ../../Firmware/Marlin_main.cpp:4790 ../../Firmware/Marlin_main.cpp:4892
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:607
-#: ../../Firmware/ultralcd.cpp:4495 ../../Firmware/ultralcd.cpp:4597
+#: ../../Firmware/Marlin_main.cpp:4359 ../../Firmware/Marlin_main.cpp:4461
+#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:607
+#: ../../Firmware/ultralcd.cpp:4462 ../../Firmware/ultralcd.cpp:4553
 msgid "PINDA cal."
 msgstr "PINDA kal."
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/messages.cpp:276 ../../Firmware/ultralcd.cpp:3233
+#: ../../Firmware/messages.cpp:288 ../../Firmware/ultralcd.cpp:3243
 msgid "PINDA calibration failed"
 msgstr "PINDA kalibrace selhala"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:4967 ../../Firmware/messages.cpp:127
-#: ../../Firmware/ultralcd.cpp:3230
+#: ../../Firmware/Marlin_main.cpp:4536 ../../Firmware/messages.cpp:132
+#: ../../Firmware/ultralcd.cpp:3240
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1441,13 +1435,13 @@ msgid "Parking selector"
 msgstr "KLADKA SE NEOTÁČÍ"
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:4062
+#: ../../Firmware/messages.cpp:179 ../../Firmware/ultralcd.cpp:4086
 msgid "Pause"
 msgstr "Pauza"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5271
-#: ../../Firmware/ultralcd.cpp:5273
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5237
+#: ../../Firmware/ultralcd.cpp:5239
 msgid "Pause print"
 msgstr "Pozastavit tisk"
 
@@ -1458,7 +1452,7 @@ msgid "Performing cut"
 msgstr "Provádím řez"
 
 #. MSG_PAPER c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3243 ../../Firmware/messages.cpp:77
+#: ../../Firmware/Marlin_main.cpp:2982 ../../Firmware/messages.cpp:77
 msgid ""
 "Place a sheet of paper under the nozzle during the calibration of first 4 "
 "points. If the nozzle catches the paper, power off the printer immediately."
@@ -1467,7 +1461,7 @@ msgstr ""
 "prvních 4 bodů. Pokud tryska zachyti papír, okamžitě vypněte tiskárnu."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:3963
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:3987
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1476,33 +1470,33 @@ msgstr ""
 "restartováním tiskárny."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/messages.cpp:337 ../../Firmware/ultralcd.cpp:6023
+#: ../../Firmware/messages.cpp:349 ../../Firmware/ultralcd.cpp:5999
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "Zkontrolujte zapojení IR senzoru a vyjmutý filament"
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/messages.cpp:343 ../../Firmware/ultralcd.cpp:6700
+#: ../../Firmware/messages.cpp:355 ../../Firmware/ultralcd.cpp:6676
 msgid "Please check:"
 msgstr "Zkontrolujte:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/messages.cpp:302 ../../Firmware/ultralcd.cpp:3926
+#: ../../Firmware/messages.cpp:314 ../../Firmware/ultralcd.cpp:3950
 msgid "Please clean heatbed and then press the knob."
 msgstr "Očistěte podložku a stiskněte tlačítko."
 
 #. MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3217 ../../Firmware/messages.cpp:27
+#: ../../Firmware/Marlin_main.cpp:2960 ../../Firmware/messages.cpp:28
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Pro úspěšnou kalibraci očistete trysku. Potvrďte tlačítkem."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/messages.cpp:288 ../../Firmware/ultralcd.cpp:3712
+#: ../../Firmware/messages.cpp:300 ../../Firmware/ultralcd.cpp:3722
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr "Vložte filament do extruderu a stiskem tlačítka jej zavedete."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/messages.cpp:287 ../../Firmware/ultralcd.cpp:3705
+#: ../../Firmware/messages.cpp:299 ../../Firmware/ultralcd.cpp:3715
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1510,104 +1504,103 @@ msgstr ""
 "Vložte filament do první trubičky MMU a stiskněte tlačítko k jeho zavedení."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/messages.cpp:285 ../../Firmware/ultralcd.cpp:3633
+#: ../../Firmware/messages.cpp:297 ../../Firmware/ultralcd.cpp:3643
 msgid "Please load filament first."
 msgstr "Nejdřív zaveďte filament"
 
 #. MSG_CHECK_IDLER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3525 ../../Firmware/messages.cpp:206
+#: ../../Firmware/Marlin_main.cpp:3265 ../../Firmware/messages.cpp:218
 msgid "Please open idler and remove filament manually."
 msgstr "Otevřete idler a manuálně odstraňte filament."
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2806 ../../Firmware/messages.cpp:80
-#: ../../Firmware/ultralcd.cpp:3860
+#: ../../Firmware/mesh_bed_calibration.cpp:2791 ../../Firmware/messages.cpp:80
 msgid "Please place steel sheet on heatbed."
 msgstr "Umistěte tiskový plát na podložku"
 
 #. MSG_PRESS_TO_UNLOAD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:11215 ../../Firmware/Marlin_main.cpp:11245
+#: ../../Firmware/Marlin_main.cpp:10287 ../../Firmware/Marlin_main.cpp:10317
 #: ../../Firmware/messages.cpp:84
 msgid "Please press the knob to unload filament"
 msgstr "Pro vysunutí filamentu stiskněte tlačítko"
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:4932
+#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:4888
 msgid "Please pull out filament immediately"
 msgstr "Vyjměte urychleně filament"
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/messages.cpp:295 ../../Firmware/ultralcd.cpp:3856
+#: ../../Firmware/messages.cpp:307 ../../Firmware/ultralcd.cpp:3882
 msgid "Please remove shipping helpers first."
 msgstr "Nejprve sundejte transportní součástky."
 
 #. MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3240 ../../Firmware/Marlin_main.cpp:4755
-#: ../../Firmware/messages.cpp:89
+#: ../../Firmware/Marlin_main.cpp:4324 ../../Firmware/messages.cpp:89
 msgid "Please remove steel sheet from heatbed."
 msgstr "Odstraňte tiskový plát z podložky."
 
 #. MSG_RUN_XYZ c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4731 ../../Firmware/messages.cpp:207
+#: ../../Firmware/Marlin_main.cpp:4300 ../../Firmware/messages.cpp:219
 msgid "Please run XYZ calibration first."
 msgstr "Nejprve spusťte kalibraci XYZ."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/messages.cpp:336 ../../Firmware/ultralcd.cpp:6020
+#: ../../Firmware/messages.cpp:348 ../../Firmware/ultralcd.cpp:4359
+#: ../../Firmware/ultralcd.cpp:5996
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Vyjměte filament a zopakujte tuto akci"
 
 #. MSG_NEW_FIRMWARE_PLEASE_UPGRADE c=20
-#: ../../Firmware/messages.cpp:366 ../../Firmware/util.cpp:213
+#: ../../Firmware/messages.cpp:378 ../../Firmware/util.cpp:218
 msgid "Please upgrade."
 msgstr "Prosím aktualizujte."
 
 #. MSG_PLEASE_WAIT c=20
-#: ../../Firmware/Marlin_main.cpp:3521 ../../Firmware/Marlin_main.cpp:8090
-#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:2179
-#: ../../Firmware/ultralcd.cpp:2190
+#: ../../Firmware/Marlin_main.cpp:3261 ../../Firmware/Marlin_main.cpp:7262
+#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:2190
+#: ../../Firmware/ultralcd.cpp:2204
 msgid "Please wait"
 msgstr "Čekejte"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:1232
-#: ../../Firmware/ultralcd.cpp:1261
+#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:1242
+#: ../../Firmware/ultralcd.cpp:1271
 msgid "Power failures"
 msgstr "Výpadky proudu"
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/messages.cpp:323 ../../Firmware/ultralcd.cpp:5260
+#: ../../Firmware/messages.cpp:335 ../../Firmware/ultralcd.cpp:5222
 msgid "Preheat"
 msgstr "Předehřev"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:2254
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:2268
 msgid "Preheat the nozzle!"
 msgstr "Předehřejte trysku!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:2771
-#: ../../Firmware/ultralcd.cpp:3690 ../../Firmware/ultralcd.cpp:3692
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:2788
+#: ../../Firmware/ultralcd.cpp:3700 ../../Firmware/ultralcd.cpp:3702
 msgid "Preheating nozzle. Please wait."
 msgstr "Předehřev trysky. Vyčkejte."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/messages.cpp:237 ../../Firmware/ultralcd.cpp:1999
+#: ../../Firmware/messages.cpp:249 ../../Firmware/ultralcd.cpp:2005
 msgid "Preheating to cut"
 msgstr "Předehřev ke střihu"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/messages.cpp:236 ../../Firmware/ultralcd.cpp:1996
+#: ../../Firmware/messages.cpp:248 ../../Firmware/ultralcd.cpp:2002
 msgid "Preheating to eject"
 msgstr "Předehřev k vysunutí"
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/messages.cpp:234 ../../Firmware/ultralcd.cpp:1987
+#: ../../Firmware/messages.cpp:246 ../../Firmware/ultralcd.cpp:1995
 msgid "Preheating to load"
 msgstr "Předehřev k zavedení"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/messages.cpp:235 ../../Firmware/ultralcd.cpp:1992
+#: ../../Firmware/messages.cpp:247 ../../Firmware/ultralcd.cpp:1999
 msgid "Preheating to unload"
 msgstr "Předehřev k vyjmutí"
 
@@ -1618,12 +1611,12 @@ msgid "Preparing blade"
 msgstr "Připravuji čepel"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/messages.cpp:231 ../../Firmware/ultralcd.cpp:1799
+#: ../../Firmware/messages.cpp:243 ../../Firmware/ultralcd.cpp:1809
 msgid "Press the knob"
 msgstr "Stiskněte tlačítko"
 
 #. MSG_PRESS_TO_PREHEAT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:11227 ../../Firmware/messages.cpp:212
+#: ../../Firmware/Marlin_main.cpp:10299 ../../Firmware/messages.cpp:224
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Pro nahřátí trysky a pokračování stiskněte tlačítko."
 
@@ -1633,34 +1626,34 @@ msgid "Print aborted"
 msgstr "Tisk přerušen"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1106
-#: ../../Firmware/ultralcd.cpp:6994
+#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1116
+#: ../../Firmware/ultralcd.cpp:6971
 msgid "Print fan:"
 msgstr "Tiskový vent.:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:5313
+#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5279
 msgid "Print from SD"
 msgstr "Tisk z SD"
 
 #. MSG_PRINT_PAUSED c=20
-#: ../../Firmware/Marlin_main.cpp:3582 ../../Firmware/messages.cpp:79
+#: ../../Firmware/Marlin_main.cpp:3323 ../../Firmware/messages.cpp:79
 #: ../../Firmware/ultralcd.cpp:814
 msgid "Print paused"
 msgstr "Tisk pozastaven"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/messages.cpp:247 ../../Firmware/ultralcd.cpp:2348
+#: ../../Firmware/messages.cpp:259 ../../Firmware/ultralcd.cpp:2365
 msgid "Print time"
 msgstr "Čas tisku"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/messages.cpp:225 ../../Firmware/ultralcd.cpp:1689
+#: ../../Firmware/messages.cpp:237 ../../Firmware/ultralcd.cpp:1699
 msgid "Printer IP Addr:"
 msgstr "IP adr. tiskárny:"
 
 #. MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1602 ../../Firmware/messages.cpp:46
+#: ../../Firmware/Marlin_main.cpp:1529 ../../Firmware/messages.cpp:46
 msgid ""
 "Printer has not been calibrated yet. Please follow the manual, chapter First"
 " steps, section Calibration flow."
@@ -1669,12 +1662,12 @@ msgstr ""
 "Začínáme."
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:153 ../../Firmware/util.cpp:289
+#: ../../Firmware/messages.cpp:160 ../../Firmware/util.cpp:296
 msgid "Nozzle diameter differs from the G-code. Continue?"
 msgstr "Průměr trysky tiskárny se liší od G-code. Pokračovat?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:154 ../../Firmware/util.cpp:290
+#: ../../Firmware/messages.cpp:161 ../../Firmware/util.cpp:297
 msgid ""
 "Nozzle diameter differs from the G-code. Please check the value in settings."
 " Print cancelled."
@@ -1701,22 +1694,22 @@ msgid "QUEUE FULL"
 msgstr "FRONTA PLNA"
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:4465
 msgid "RPi port"
 msgstr "RPi port"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/messages.cpp:261 ../../Firmware/ultralcd.cpp:2712
+#: ../../Firmware/messages.cpp:273 ../../Firmware/ultralcd.cpp:2729
 msgid "Rear side [µm]"
 msgstr "Vzadu [µm]"
 
 #. MSG_RECOVERING_PRINT c=20
-#: ../../Firmware/messages.cpp:216 ../../Firmware/power_panic.cpp:316
+#: ../../Firmware/messages.cpp:228 ../../Firmware/power_panic.cpp:328
 msgid "Recovering print"
 msgstr "Obnovování tisku"
 
 #. MSG_RENAME c=18
-#: ../../Firmware/messages.cpp:322 ../../Firmware/ultralcd.cpp:5143
+#: ../../Firmware/messages.cpp:334 ../../Firmware/ultralcd.cpp:5103
 msgid "Rename"
 msgstr "Přejmenovat"
 
@@ -1730,19 +1723,19 @@ msgstr ""
 "nástrojový index mimo rozsah (T0-T4)."
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:2713
-#: ../../Firmware/ultralcd.cpp:5144
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:2730
+#: ../../Firmware/ultralcd.cpp:5104
 msgid "Reset"
 msgstr "Reset"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/messages.cpp:320 ../../Firmware/ultralcd.cpp:4594
+#: ../../Firmware/messages.cpp:332 ../../Firmware/ultralcd.cpp:4550
 msgid "Reset XYZ calibr."
 msgstr "Reset XYZ kalibr."
 
 #. MSG_RESUME_PRINT c=18
-#: ../../Firmware/Marlin_main.cpp:680 ../../Firmware/messages.cpp:91
-#: ../../Firmware/ultralcd.cpp:5286 ../../Firmware/ultralcd.cpp:5288
+#: ../../Firmware/Marlin_main.cpp:645 ../../Firmware/messages.cpp:91
+#: ../../Firmware/ultralcd.cpp:5252 ../../Firmware/ultralcd.cpp:5254
 msgid "Resume print"
 msgstr "Pokračovat"
 
@@ -1769,17 +1762,17 @@ msgid "Returning selector"
 msgstr "Vracím selektor"
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/messages.cpp:252 ../../Firmware/ultralcd.cpp:2479
+#: ../../Firmware/messages.cpp:264 ../../Firmware/ultralcd.cpp:2496
 msgid "Right"
 msgstr "Vpravo"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/messages.cpp:259 ../../Firmware/ultralcd.cpp:2710
+#: ../../Firmware/messages.cpp:271 ../../Firmware/ultralcd.cpp:2727
 msgid "Right side[µm]"
 msgstr "Vpravo [µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/messages.cpp:286 ../../Firmware/ultralcd.cpp:3656
+#: ../../Firmware/messages.cpp:298 ../../Firmware/ultralcd.cpp:3666
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1788,8 +1781,8 @@ msgstr ""
 "kalibrační proces od začátku. Pokračovat?"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4509
-#: ../../Firmware/ultralcd.cpp:4511
+#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4476
+#: ../../Firmware/ultralcd.cpp:4478
 msgid "SD card"
 msgstr "SD karta"
 
@@ -1804,48 +1797,48 @@ msgid "SELECTOR CANNOT MOVE"
 msgstr "SELEKTOR SE NEHÝBE"
 
 #. MSG_STOPPED c=20
-#: ../../Firmware/Marlin_main.cpp:9887 ../../Firmware/messages.cpp:125
+#: ../../Firmware/Marlin_main.cpp:9047 ../../Firmware/messages.cpp:130
 msgid "STOPPED."
 msgstr "ZASTAVENO."
 
 #. MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3223 ../../Firmware/Marlin_main.cpp:3245
-#: ../../Firmware/mesh_bed_calibration.cpp:2246 ../../Firmware/messages.cpp:44
+#: ../../Firmware/Marlin_main.cpp:2967 ../../Firmware/Marlin_main.cpp:2984
+#: ../../Firmware/mesh_bed_calibration.cpp:2231 ../../Firmware/messages.cpp:44
 msgid "Searching bed calibration point"
 msgstr "Hledám kalibrační bod podložky"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/messages.cpp:321 ../../Firmware/ultralcd.cpp:5136
+#: ../../Firmware/messages.cpp:333 ../../Firmware/ultralcd.cpp:5096
 msgid "Select"
 msgstr "Vybrat"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/messages.cpp:290 ../../Firmware/ultralcd.cpp:3730
+#: ../../Firmware/messages.cpp:302 ../../Firmware/ultralcd.cpp:3740
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
 msgstr "Zvolte filament pro kalibraci první vrstvy z následujícího menu"
 
 #. MSG_SELECT_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3453 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3612
-#: ../../Firmware/ultralcd.cpp:6822
+#: ../../Firmware/Marlin_main.cpp:3192 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3622
+#: ../../Firmware/ultralcd.cpp:6798
 msgid "Select filament:"
 msgstr "Zvolte filament:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:110 ../../Firmware/ultralcd.cpp:3464
-#: ../../Firmware/ultralcd.cpp:4504
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:3474
+#: ../../Firmware/ultralcd.cpp:4471
 msgid "Select language"
 msgstr "Výběr jazyka"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/messages.cpp:300 ../../Firmware/ultralcd.cpp:3900
+#: ../../Firmware/messages.cpp:312 ../../Firmware/ultralcd.cpp:3924
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr "Vyberte teplotu predehřátí trysky která odpovídá vašemu materiálu."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/messages.cpp:291 ../../Firmware/ultralcd.cpp:3735
+#: ../../Firmware/messages.cpp:303 ../../Firmware/ultralcd.cpp:3745
 msgid "Select temperature which matches your material."
 msgstr "Zvolte teplotu, která odpovídá vašemu materiálu."
 
@@ -1856,61 +1849,61 @@ msgid "Selecting fil. slot"
 msgstr "Výběr fil. slot"
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/messages.cpp:341 ../../Firmware/ultralcd.cpp:6274
+#: ../../Firmware/messages.cpp:353 ../../Firmware/ultralcd.cpp:6250
 msgid "Selftest OK"
 msgstr "Selftest OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/messages.cpp:340 ../../Firmware/ultralcd.cpp:6057
+#: ../../Firmware/messages.cpp:352 ../../Firmware/ultralcd.cpp:6033
 msgid "Selftest start"
 msgstr "Start Selftestu"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/messages.cpp:315 ../../Firmware/ultralcd.cpp:4581
+#: ../../Firmware/messages.cpp:327 ../../Firmware/ultralcd.cpp:4537
 msgid "Selftest"
 msgstr "Selftest"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/messages.cpp:342 ../../Firmware/ultralcd.cpp:6699
+#: ../../Firmware/messages.cpp:354 ../../Firmware/ultralcd.cpp:6675
 msgid "Selftest error!"
 msgstr "Chyba Selftestu!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6279
-#: ../../Firmware/ultralcd.cpp:6786 ../../Firmware/ultralcd.cpp:6984
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6255
+#: ../../Firmware/ultralcd.cpp:6762 ../../Firmware/ultralcd.cpp:6961
 msgid "Selftest failed"
 msgstr "Selftest selhal"
 
 #. MSG_FORCE_SELFTEST c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1577 ../../Firmware/messages.cpp:202
+#: ../../Firmware/Marlin_main.cpp:1504 ../../Firmware/messages.cpp:214
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr "Pro kalibraci přesného rehomování bude nyní spuštěn selftest."
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/messages.cpp:228 ../../Firmware/ultralcd.cpp:1701
+#: ../../Firmware/messages.cpp:240 ../../Firmware/ultralcd.cpp:1711
 msgid "Sensor info"
 msgstr "Senzor info"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/messages.cpp:338 ../../Firmware/ultralcd.cpp:6027
+#: ../../Firmware/messages.cpp:350 ../../Firmware/ultralcd.cpp:6003
 msgid "Sensor verified, remove the filament now."
 msgstr "Senzor ověřen, vyjměte filament."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/messages.cpp:262 ../../Firmware/ultralcd.cpp:2730
+#: ../../Firmware/messages.cpp:274 ../../Firmware/ultralcd.cpp:2747
 msgid "Set temperature:"
 msgstr "Nastavte teplotu:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3348
-#: ../../Firmware/ultralcd.cpp:3479 ../../Firmware/ultralcd.cpp:3984
-#: ../../Firmware/ultralcd.cpp:5374 ../../Firmware/ultralcd.cpp:5585
-#: ../../Firmware/ultralcd.cpp:5631
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3358
+#: ../../Firmware/ultralcd.cpp:3489 ../../Firmware/ultralcd.cpp:4008
+#: ../../Firmware/ultralcd.cpp:5341 ../../Firmware/ultralcd.cpp:5558
+#: ../../Firmware/ultralcd.cpp:5604
 msgid "Settings"
 msgstr "Nastavení"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/messages.cpp:255 ../../Firmware/ultralcd.cpp:2522
+#: ../../Firmware/messages.cpp:267 ../../Firmware/ultralcd.cpp:2539
 msgid "Severe skew"
 msgstr "Težké zkos."
 
@@ -1921,7 +1914,7 @@ msgid "Sheet"
 msgstr "Plát"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/messages.cpp:284 ../../Firmware/ultralcd.cpp:3604
+#: ../../Firmware/messages.cpp:296 ../../Firmware/ultralcd.cpp:3614
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1934,23 +1927,23 @@ msgstr ""
 "%cReset"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/messages.cpp:319 ../../Firmware/ultralcd.cpp:4592
+#: ../../Firmware/messages.cpp:331 ../../Firmware/ultralcd.cpp:4548
 msgid "Show end stops"
 msgstr "Stav konc. spín."
 
 #. MSG_SILENT c=7
-#: ../../Firmware/Marlin_main.cpp:8497 ../../Firmware/messages.cpp:120
-#: ../../Firmware/ultralcd.cpp:4155 ../../Firmware/ultralcd.cpp:4194
+#: ../../Firmware/Marlin_main.cpp:7668 ../../Firmware/messages.cpp:124
+#: ../../Firmware/ultralcd.cpp:4179 ../../Firmware/ultralcd.cpp:4218
 msgid "Silent"
 msgstr "Tichý"
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/messages.cpp:254 ../../Firmware/ultralcd.cpp:2521
+#: ../../Firmware/messages.cpp:266 ../../Firmware/ultralcd.cpp:2538
 msgid "Slight skew"
 msgstr "Lehké zkos."
 
 #. MSG_FILE_CNT c=20 r=6
-#: ../../Firmware/cardreader.cpp:805 ../../Firmware/messages.cpp:197
+#: ../../Firmware/cardreader.cpp:805 ../../Firmware/messages.cpp:209
 msgid ""
 "Some files will not be sorted. Max. No. of files in 1 folder for sorting is "
 "100."
@@ -1959,58 +1952,58 @@ msgstr ""
 "setříděni je 100."
 
 #. MSG_ZLEVELING_ENFORCED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3043 ../../Firmware/messages.cpp:204
+#: ../../Firmware/Marlin_main.cpp:2783 ../../Firmware/messages.cpp:216
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Vyskytl se problém, srovnávám osu Z ..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:4514
-#: ../../Firmware/ultralcd.cpp:4515 ../../Firmware/ultralcd.cpp:4516
+#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4481
+#: ../../Firmware/ultralcd.cpp:4482 ../../Firmware/ultralcd.cpp:4483
 msgid "Sort"
 msgstr "Řazení"
 
 #. MSG_SORTING_FILES c=20
 #: ../../Firmware/cardreader.cpp:849 ../../Firmware/cardreader.cpp:916
-#: ../../Firmware/messages.cpp:111
+#: ../../Firmware/messages.cpp:115
 msgid "Sorting files"
 msgstr "Řazení souborů"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4188
-#: ../../Firmware/ultralcd.cpp:4191 ../../Firmware/ultralcd.cpp:4194
-#: ../../Firmware/ultralcd.cpp:4197 ../../Firmware/ultralcd.cpp:4200
+#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4215 ../../Firmware/ultralcd.cpp:4218
+#: ../../Firmware/ultralcd.cpp:4221 ../../Firmware/ultralcd.cpp:4224
 msgid "Sound"
 msgstr "Zvuk"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/messages.cpp:333 ../../Firmware/ultralcd.cpp:5516
+#: ../../Firmware/messages.cpp:345 ../../Firmware/ultralcd.cpp:5483
 msgid "Speed"
 msgstr "Rychlost"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6861
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6837
 msgid "Spinning"
 msgstr "Točí se"
 
 #. MSG_TEMP_CAL_WARNING c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4744 ../../Firmware/messages.cpp:208
+#: ../../Firmware/Marlin_main.cpp:4313 ../../Firmware/messages.cpp:220
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr "Je vyžadována stabilní pokojová teplota 21-26C a pevná podložka."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/messages.cpp:329 ../../Firmware/ultralcd.cpp:5379
+#: ../../Firmware/messages.cpp:341 ../../Firmware/ultralcd.cpp:5346
 msgid "Statistics"
 msgstr "Statistika"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:4096
-#: ../../Firmware/ultralcd.cpp:4144
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4120
+#: ../../Firmware/ultralcd.cpp:4168
 msgid "Stealth"
 msgstr "Tichý"
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4421
-#: ../../Firmware/ultralcd.cpp:5133
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4388
+#: ../../Firmware/ultralcd.cpp:5093
 msgid "Steel sheets"
 msgstr "Tiskové pláty"
 
@@ -2020,29 +2013,28 @@ msgid "Stop"
 msgstr "Stop"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:5293
-#: ../../Firmware/ultralcd.cpp:5781
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:5259
+#: ../../Firmware/ultralcd.cpp:5757
 msgid "Stop print"
 msgstr "Zastavit tisk"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4236
-#: ../../Firmware/ultralcd.cpp:4316 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4315
 msgid "Strict"
 msgstr "Přísně"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/messages.cpp:332 ../../Firmware/ultralcd.cpp:5394
+#: ../../Firmware/messages.cpp:344 ../../Firmware/ultralcd.cpp:5361
 msgid "Support"
 msgstr "Podpora"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/messages.cpp:354 ../../Firmware/ultralcd.cpp:6758
+#: ../../Firmware/messages.cpp:366 ../../Firmware/ultralcd.cpp:6734
 msgid "Swapped"
 msgstr "Prohozené"
 
 #. MSG_THERMAL_ANOMALY c=20
-#: ../../Firmware/messages.cpp:188 ../../Firmware/temperature.cpp:2223
+#: ../../Firmware/messages.cpp:195 ../../Firmware/temperature.cpp:2197
 msgid "THERMAL ANOMALY"
 msgstr "TEPLOTNÍ VÝJIMKA"
 
@@ -2077,7 +2069,7 @@ msgid "TMC UNDERVOLTAGE ERR"
 msgstr "TMC CHYBA NÍZKÉ NAP."
 
 #. MSG_TM_CAL c=20 r=4
-#: ../../Firmware/messages.cpp:299 ../../Firmware/ultralcd.cpp:3881
+#: ../../Firmware/messages.cpp:311 ../../Firmware/ultralcd.cpp:3905
 msgid ""
 "Thermal model cal. takes approx. 12 mins. See\n"
 "prusa.io/tm-cal"
@@ -2086,22 +2078,22 @@ msgstr ""
 "prusa.io/tm-cal"
 
 #. MSG_TM_NOT_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1613 ../../Firmware/messages.cpp:189
+#: ../../Firmware/Marlin_main.cpp:1540 ../../Firmware/messages.cpp:196
 msgid "Thermal model not calibrated yet."
 msgstr "Termální model zatím nebyl kalibrován."
 
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/messages.cpp:309 ../../Firmware/ultralcd.cpp:4455
+#: ../../Firmware/messages.cpp:321 ../../Firmware/ultralcd.cpp:4422
 msgid "Temperature"
 msgstr "Teplota"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/messages.cpp:229 ../../Firmware/ultralcd.cpp:1707
+#: ../../Firmware/messages.cpp:241 ../../Firmware/ultralcd.cpp:1717
 msgid "Temperatures"
 msgstr "Teploty"
 
 #. MSG_TESTING_FILAMENT c=20
-#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:388
+#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:389
 msgid "Testing filament"
 msgstr "Testování filamentu"
 
@@ -2122,7 +2114,7 @@ msgstr ""
 "pohyb."
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/messages.cpp:292 ../../Firmware/ultralcd.cpp:3738
+#: ../../Firmware/messages.cpp:304 ../../Firmware/ultralcd.cpp:3748
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -2132,7 +2124,7 @@ msgstr ""
 "výšku. Postupujte podle obrázku v handbooku (kapitola Kalibrace)."
 
 #. MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1606 ../../Firmware/messages.cpp:47
+#: ../../Firmware/Marlin_main.cpp:1533 ../../Firmware/messages.cpp:47
 msgid ""
 "There is still a need to make Z calibration. Please follow the manual, "
 "chapter First steps, section Calibration flow."
@@ -2140,40 +2132,40 @@ msgstr ""
 "Je potřeba kalibrovat osu Z. Postupujte dle příručky, kapitola Začíname."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:4514
+#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:4481
 msgid "Time"
 msgstr "Čas"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:176 ../../Firmware/ultralcd.cpp:5622
+#: ../../Firmware/messages.cpp:183 ../../Firmware/ultralcd.cpp:5595
 msgid "Timeout"
 msgstr "Timeout"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:1129
-#: ../../Firmware/ultralcd.cpp:1287
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:1139
+#: ../../Firmware/ultralcd.cpp:1297
 msgid "Total"
 msgstr "Celkem"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:1177
-#: ../../Firmware/ultralcd.cpp:1231 ../../Firmware/ultralcd.cpp:1317
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:1187
+#: ../../Firmware/ultralcd.cpp:1241 ../../Firmware/ultralcd.cpp:1327
 msgid "Total failures"
 msgstr "Celkem selhání"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/messages.cpp:248 ../../Firmware/ultralcd.cpp:2369
+#: ../../Firmware/messages.cpp:260 ../../Firmware/ultralcd.cpp:2386
 msgid "Total filament"
 msgstr "Filament celkem"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/messages.cpp:249 ../../Firmware/ultralcd.cpp:2370
+#: ../../Firmware/messages.cpp:261 ../../Firmware/ultralcd.cpp:2387
 msgid "Total print time"
 msgstr "Celkový čas tisku"
 
 #. MSG_TUNE c=8
-#: ../../Firmware/messages.cpp:116 ../../Firmware/mmu2/errors_list.h:372
-#: ../../Firmware/ultralcd.cpp:5258
+#: ../../Firmware/messages.cpp:120 ../../Firmware/mmu2/errors_list.h:372
+#: ../../Firmware/ultralcd.cpp:5220
 msgid "Tune"
 msgstr "Ladit"
 
@@ -2188,16 +2180,16 @@ msgid "Unload"
 msgstr "Vyjmout"
 
 #. MSG_UNLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:2206
-#: ../../Firmware/ultralcd.cpp:5347 ../../Firmware/ultralcd.cpp:5364
-#: ../../Firmware/ultralcd.cpp:5369
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:2220
+#: ../../Firmware/ultralcd.cpp:5313 ../../Firmware/ultralcd.cpp:5331
+#: ../../Firmware/ultralcd.cpp:5336
 msgid "Unload filament"
 msgstr "Vyjmout filament"
 
 #. MSG_UNLOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3436 ../../Firmware/messages.cpp:129
+#: ../../Firmware/Marlin_main.cpp:3175 ../../Firmware/messages.cpp:134
 #: ../../Firmware/mmu2_progress_converter.cpp:50
-#: ../../Firmware/ultralcd.cpp:4911
+#: ../../Firmware/ultralcd.cpp:4867
 msgid "Unloading filament"
 msgstr "Vysouvám filament"
 
@@ -2214,12 +2206,12 @@ msgid "Unloading to pulley"
 msgstr "Vysunutí ke kladce"
 
 #. MSG_FIL_FAILED c=20 r=4
-#: ../../Firmware/messages.cpp:339 ../../Firmware/ultralcd.cpp:6030
+#: ../../Firmware/messages.cpp:351 ../../Firmware/ultralcd.cpp:6006
 msgid "Verification failed, remove the filament and try again."
 msgstr "Ověření selhalo, vyjměte filament a zkuste znovu."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/messages.cpp:230 ../../Firmware/ultralcd.cpp:1710
+#: ../../Firmware/messages.cpp:242 ../../Firmware/ultralcd.cpp:1720
 msgid "Voltages"
 msgstr "Napětí"
 
@@ -2230,7 +2222,7 @@ msgid "WARNING TMC TOO HOT"
 msgstr "TMC: VYSOKA TEPLOTA!"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/messages.cpp:281 ../../Firmware/ultralcd.cpp:3381
+#: ../../Firmware/messages.cpp:293 ../../Firmware/ultralcd.cpp:3391
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -2243,195 +2235,195 @@ msgstr ""
 "Stealth módu"
 
 #. MSG_USERWAIT c=20
-#: ../../Firmware/Marlin_main.cpp:5240 ../../Firmware/messages.cpp:209
+#: ../../Firmware/Marlin_main.cpp:4747 ../../Firmware/messages.cpp:221
 msgid "Wait for user..."
 msgstr "Čeká se na uživatele"
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/messages.cpp:263 ../../Firmware/ultralcd.cpp:2753
+#: ../../Firmware/messages.cpp:275 ../../Firmware/ultralcd.cpp:2770
 msgid "Waiting for PINDA probe cooling"
 msgstr "Čekání na zchladnutí PINDA"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/messages.cpp:264 ../../Firmware/ultralcd.cpp:2782
+#: ../../Firmware/messages.cpp:276 ../../Firmware/ultralcd.cpp:2799
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Čekání na zchladnutí trysky a podložky."
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:4233
-#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4352
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4312
 msgid "Warn"
 msgstr "Varovat"
 
 #. MSG_CHANGED_BOTH c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1554 ../../Firmware/messages.cpp:200
+#: ../../Firmware/Marlin_main.cpp:1481 ../../Firmware/messages.cpp:212
 msgid "Warning: both printer type and motherboard type changed."
 msgstr "Varování: došlo ke změně typu tiskárny a motherboardu."
 
 #. MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1546 ../../Firmware/messages.cpp:198
+#: ../../Firmware/Marlin_main.cpp:1473 ../../Firmware/messages.cpp:210
 msgid "Warning: motherboard type changed."
 msgstr "Varování: došlo ke změně typu motherboardu."
 
 #. MSG_CHANGED_PRINTER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1550 ../../Firmware/messages.cpp:199
+#: ../../Firmware/Marlin_main.cpp:1477 ../../Firmware/messages.cpp:211
 msgid "Warning: printer type changed."
 msgstr "Varování: došlo ke změně typu tiskárny."
 
 #. MSG_UNLOAD_SUCCESSFUL c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3517 ../../Firmware/messages.cpp:205
+#: ../../Firmware/Marlin_main.cpp:3257 ../../Firmware/messages.cpp:217
 msgid "Was filament unload successful?"
 msgstr "Bylo vysunutí filamentu úspěšné?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:6710
-#: ../../Firmware/ultralcd.cpp:6714 ../../Firmware/ultralcd.cpp:6734
-#: ../../Firmware/ultralcd.cpp:6740 ../../Firmware/ultralcd.cpp:6764
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:6686
+#: ../../Firmware/ultralcd.cpp:6690 ../../Firmware/ultralcd.cpp:6710
+#: ../../Firmware/ultralcd.cpp:6716 ../../Firmware/ultralcd.cpp:6740
 msgid "Wiring error"
 msgstr "Chyba zapojení"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/messages.cpp:313 ../../Firmware/ultralcd.cpp:4572
+#: ../../Firmware/messages.cpp:325 ../../Firmware/ultralcd.cpp:4528
 msgid "Wizard"
 msgstr "Průvodce"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/messages.cpp:304 ../../Firmware/ultralcd.cpp:3986
+#: ../../Firmware/messages.cpp:316 ../../Firmware/ultralcd.cpp:4010
 msgid "X-correct"
 msgstr "Korekce X"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/messages.cpp:226 ../../Firmware/ultralcd.cpp:1699
+#: ../../Firmware/messages.cpp:238 ../../Firmware/ultralcd.cpp:1709
 msgid "XYZ cal. details"
 msgstr "Detaily XYZ kal."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/messages.cpp:275 ../../Firmware/ultralcd.cpp:3207
+#: ../../Firmware/messages.cpp:287 ../../Firmware/ultralcd.cpp:3217
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr ""
 "Kalibrace XYZ v pořádku. Zkosení bude automaticky vyrovnáno při tisku."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/messages.cpp:274 ../../Firmware/ultralcd.cpp:3204
+#: ../../Firmware/messages.cpp:286 ../../Firmware/ultralcd.cpp:3214
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr "Kalibrace XYZ v pořádku. X/Y osy mírně zkosené. Dobrá práce!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/messages.cpp:271 ../../Firmware/ultralcd.cpp:3185
+#: ../../Firmware/messages.cpp:283 ../../Firmware/ultralcd.cpp:3195
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr "Kalibrace XYZ nepřesná. Přední kalibrační body moc vpředu."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/messages.cpp:272 ../../Firmware/ultralcd.cpp:3188
+#: ../../Firmware/messages.cpp:284 ../../Firmware/ultralcd.cpp:3198
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr "Kalibrace XYZ nepřesná. Pravý přední bod moc vpředu."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/messages.cpp:268 ../../Firmware/ultralcd.cpp:3167
+#: ../../Firmware/messages.cpp:280 ../../Firmware/ultralcd.cpp:3177
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr "Kalibrace XYZ selhala. Kalibrační bod podložky nenalezen."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/messages.cpp:269 ../../Firmware/ultralcd.cpp:3173
+#: ../../Firmware/messages.cpp:281 ../../Firmware/ultralcd.cpp:3183
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr ""
 "Kalibrace XYZ selhala. Přední kalibrační body moc vpředu. Srovnejte "
 "tiskárnu."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3170
-#: ../../Firmware/ultralcd.cpp:3198
+#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3180
+#: ../../Firmware/ultralcd.cpp:3208
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "Kalibrace XYZ selhala. Nahlédněte do manuálu."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/messages.cpp:270 ../../Firmware/ultralcd.cpp:3176
+#: ../../Firmware/messages.cpp:282 ../../Firmware/ultralcd.cpp:3186
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr ""
 "Kalibrace XYZ selhala. Pravý přední bod moc vpředu. Srovnejte tiskárnu."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/messages.cpp:273 ../../Firmware/ultralcd.cpp:3201
+#: ../../Firmware/messages.cpp:285 ../../Firmware/ultralcd.cpp:3211
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "Kalibrace XYZ v pořádku. X/Y osy jsou kolmé. Gratuluji!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/messages.cpp:250 ../../Firmware/ultralcd.cpp:2476
+#: ../../Firmware/messages.cpp:262 ../../Firmware/ultralcd.cpp:2493
 msgid "Y distance from min"
 msgstr "Y vzdálenost od min"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/messages.cpp:305 ../../Firmware/ultralcd.cpp:3987
+#: ../../Firmware/messages.cpp:317 ../../Firmware/ultralcd.cpp:4011
 msgid "Y-correct"
 msgstr "Korekce Y"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:3029
-#: ../../Firmware/ultralcd.cpp:4443 ../../Firmware/ultralcd.cpp:4531
-#: ../../Firmware/ultralcd.cpp:5790
+#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:2275
+#: ../../Firmware/ultralcd.cpp:2279 ../../Firmware/ultralcd.cpp:3046
+#: ../../Firmware/ultralcd.cpp:4410 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/ultralcd.cpp:5766
 msgid "Yes"
 msgstr "Ano"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:3950
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:3974
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr "Průvodce můžete znovu spustit z menu Kalibrace -> Průvodce."
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/messages.cpp:306 ../../Firmware/ultralcd.cpp:3988
+#: ../../Firmware/messages.cpp:318 ../../Firmware/ultralcd.cpp:4012
 msgid "Z-correct"
 msgstr "Korekce Z"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5593
+#: ../../Firmware/messages.cpp:175 ../../Firmware/ultralcd.cpp:5566
 msgid "Z-probe nr."
 msgstr "Počet měření Z"
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/messages.cpp:256 ../../Firmware/ultralcd.cpp:2546
+#: ../../Firmware/messages.cpp:268 ../../Firmware/ultralcd.cpp:2563
 msgid "[0;0] point offset"
 msgstr "[0;0] odsazení bodu"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/messages.cpp:239 ../../Firmware/ultralcd.cpp:2147
+#: ../../Firmware/messages.cpp:251 ../../Firmware/ultralcd.cpp:2158
 msgid "and press the knob"
 msgstr "a stiskněte tlačítko"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/messages.cpp:232 ../../Firmware/ultralcd.cpp:1807
+#: ../../Firmware/messages.cpp:244 ../../Firmware/ultralcd.cpp:1816
 msgid "to load filament"
 msgstr "k zavedení filamentu"
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/messages.cpp:233 ../../Firmware/ultralcd.cpp:1811
+#: ../../Firmware/messages.cpp:245 ../../Firmware/ultralcd.cpp:1820
 msgid "to unload filament"
 msgstr "k vyjmutí filamentu"
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/messages.cpp:224 ../../Firmware/ultralcd.cpp:1666
+#: ../../Firmware/messages.cpp:236 ../../Firmware/ultralcd.cpp:1676
 msgid "unknown"
 msgstr "neznámý"
 
 #. MSG_IR_UNKNOWN c=18
-#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:184
+#: ../../Firmware/Filament_sensor.cpp:286 ../../Firmware/messages.cpp:191
 msgid "unknown state"
 msgstr "neznámý stav"
 
 #. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:5858
-#: ../../Firmware/ultralcd.cpp:5861
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:5834
+#: ../../Firmware/ultralcd.cpp:5837
 msgid "🔃Refresh"
 msgstr "🔃Obnovit"
 
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1180
+#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1190
 msgid "MMU power fails"
 msgstr "MMU vyp. proudu"
 
 #. MSG_EJECT_FROM_MMU c=16
-#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:384
-#: ../../Firmware/ultralcd.cpp:4845 ../../Firmware/ultralcd.cpp:5348
+#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:385
+#: ../../Firmware/ultralcd.cpp:4801 ../../Firmware/ultralcd.cpp:5314
 msgid "Eject from MMU"
 msgstr "Vysunutí z MMU"
 
@@ -2469,8 +2461,8 @@ msgid "MMU MCU ERROR"
 msgstr "MMU MCU CHYBA"
 
 #. MSG_MATERIAL_CHANGES c=18
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:1130
-#: ../../Firmware/ultralcd.cpp:1204
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:1140
+#: ../../Firmware/ultralcd.cpp:1214
 msgid "Material changes"
 msgstr "Výměn materiálů"
 
@@ -2502,17 +2494,17 @@ msgstr ""
 "3.0.3."
 
 #. MSG_PRELOAD_TO_MMU c=17
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5344
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5310
 msgid "Preload to MMU"
 msgstr "Zavést do MMU"
 
 #. MSG_FW_MK3_DETECTED c=20 r=4
-#: ../../Firmware/messages.cpp:367 ../../Firmware/Marlin_main.cpp:920
+#: ../../Firmware/messages.cpp:379 ../../Firmware/Marlin_main.cpp:854
 msgid "MK3 firmware detected on MK3S printer"
 msgstr "MK3 firmware detekován na MK3S tiskarně"
 
 #. MSG_FW_MK3S_DETECTED c=20 r=4
-#: ../../Firmware/messages.cpp:367 ../../Firmware/Marlin_main.cpp:920
+#: ../../Firmware/messages.cpp:379 ../../Firmware/Marlin_main.cpp:854
 msgid "MK3S firmware detected on MK3 printer"
 msgstr "MK3S firmware detekován na tiskarně MK3"
 
@@ -2526,8 +2518,9 @@ msgstr "NEZNÁMÁ CHYBA"
 msgid "Unexpected error occurred."
 msgstr "Došlo k neočekávané chybě."
 
-#. MSG_BTN_EJECT c=8
-#: ../../Firmware/mmu2/errors_list.h:358 ../../Firmware/mmu2/errors_list.h:371
+#. MSG_EJECT c=8
+#: ../../Firmware/messages.cpp:21 ../../Firmware/mmu2/errors_list.h:371
+#: ../../Firmware/ultralcd.cpp:2275 ../../Firmware/ultralcd.cpp:2279
 msgid "Eject"
 msgstr "Vysunout"
 
@@ -2547,58 +2540,58 @@ msgid "M600 Filament Change. Load a new filament or eject the old one."
 msgstr "Výměna filamentu M600. Vložte nový filament nebo vysuňte starý."
 
 #. MSG_MMU_SENSITIVITY c=18
-#: ../../Firmware/messages.cpp:215 ../../Firmware/mmu2_reporting.cpp:458
+#: ../../Firmware/messages.cpp:227 ../../Firmware/mmu2_reporting.cpp:459
 msgid "Sensitivity"
 msgstr "Citlivost"
 
 #. MSG_MBL_FAILED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3038 ../../Firmware/messages.cpp:203
+#: ../../Firmware/Marlin_main.cpp:2776 ../../Firmware/messages.cpp:215
 msgid "Mesh bed leveling failed. Print canceled."
 msgstr "Mesh Bed Leveling selhal. Tisk zrušen."
 
 #. MSG_SET_READY c=18
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:5265
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:5228
 msgid "Set Ready"
 msgstr "Připravit"
 
 #. MSG_SET_NOT_READY c=18
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:5263
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5226
 msgid "Set not Ready"
 msgstr "Zrušit Připravena"
 
 #. MSG_HOSTPRINT c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5285
+#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:5231
 msgid "Print from host"
 msgstr "Tisk z hosta"
 
 #. MSG_REPRINT c=18
-#: ../../Firmware/messages.cpp:196 ../../Firmware/ultralcd.cpp:5243
-#: ../../Firmware/ultralcd.cpp:5245
+#: ../../Firmware/messages.cpp:208 ../../Firmware/ultralcd.cpp:5205
+#: ../../Firmware/ultralcd.cpp:5207
 msgid "Reprint"
 msgstr "Tisk. znovu"
 
 #. MSG_SHUTDOWN_HOST c=18
-#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:5390
+#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:5357
 msgid "Shutdown host"
 msgstr "Vypnutí hostitele"
 
 #. MSG_NOZZLE_CNG_COOLDOWN c=20 r=3
-#: ../../Firmware/messages.cpp:198 ../../Firmware/ultralcd.cpp:1002
+#: ../../Firmware/messages.cpp:203 ../../Firmware/ultralcd.cpp:999
 msgid "Nozzle is hot! Wait for cooldown."
 msgstr "Tryska je horká! Počkejte na vychladnutí."
 
 #. MSG_NOZZLE_CNG_CHANGED_QUICK c=20 r=3
-#: ../../Firmware/messages.cpp:199
+#: ../../Firmware/messages.cpp:204
 msgid "Nozzle changed?"
 msgstr "Vyměnili jste trysku?"
 
 #. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:388
+#: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:388
 msgid "There is no filament loaded. Continue?"
 msgstr "Není vložen filament. Pokračovat?"
 
 #. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:389
+#: ../../Firmware/messages.cpp:159 ../../Firmware/util.cpp:389
 msgid "There is no filament loaded. Print cancelled."
 msgstr "Není vložen filament. Tisk zrušen."
 

--- a/lang/po/Firmware_de.po
+++ b/lang/po/Firmware_de.po
@@ -16,91 +16,91 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 
 #. MSG_IR_03_OR_OLDER c=18
-#: ../../Firmware/Filament_sensor.cpp:280
-#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:183
+#: ../../Firmware/Filament_sensor.cpp:282
+#: ../../Firmware/Filament_sensor.cpp:344 ../../Firmware/messages.cpp:190
 msgid " 0.3 or older"
 msgstr " 0.3 oder älter"
 
 #. MSG_IR_04_OR_NEWER c=18
-#: ../../Firmware/Filament_sensor.cpp:282
-#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:182
+#: ../../Firmware/Filament_sensor.cpp:284
+#: ../../Firmware/Filament_sensor.cpp:347 ../../Firmware/messages.cpp:189
 msgid " 0.4 or newer"
 msgstr " 0.4 oder neuer"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/messages.cpp:356 ../../Firmware/ultralcd.cpp:6773
+#: ../../Firmware/messages.cpp:368 ../../Firmware/ultralcd.cpp:6749
 msgid "%s level expected"
 msgstr "%s Level erwartet"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:1978
-#: ../../Firmware/ultralcd.cpp:3613
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:1986
+#: ../../Firmware/ultralcd.cpp:3623
 msgid ">Cancel"
 msgstr ">Abbruch"
 
 #. MSG_BABYSTEPPING_Z c=13
-#: ../../Firmware/messages.cpp:257 ../../Firmware/ultralcd.cpp:2635
+#: ../../Firmware/messages.cpp:269 ../../Firmware/ultralcd.cpp:2652
 msgid "Adjusting Z"
 msgstr "Z Anpassen"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/messages.cpp:360 ../../Firmware/ultralcd.cpp:6983
+#: ../../Firmware/messages.cpp:372 ../../Firmware/ultralcd.cpp:6960
 msgid "All correct"
 msgstr "Alles richtig"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:3955
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:3979
 msgid "All is done. Happy printing!"
 msgstr "Alles abgeschlossen. Viel Spaß beim Drucken!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4482
 msgid "Alphabet"
 msgstr "Alphabet"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4086
+#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4110
 msgid "Always"
 msgstr "Immer"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/messages.cpp:221 ../../Firmware/ultralcd.cpp:1393
+#: ../../Firmware/messages.cpp:233 ../../Firmware/ultralcd.cpp:1403
 msgid "Ambient"
 msgstr "Raumtemp."
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=3
-#: ../../Firmware/messages.cpp:267 ../../Firmware/ultralcd.cpp:2848
+#: ../../Firmware/messages.cpp:279 ../../Firmware/ultralcd.cpp:2865
 msgid "Are left and right Z-carriages all up?"
 msgstr "Sind linker+rechter Z-Schlitten ganz oben?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4197
+#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:4221
 msgid "Assist"
 msgstr "Assist."
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:179 ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/messages.cpp:186 ../../Firmware/ultralcd.cpp:5594
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
-#: ../../Firmware/Marlin_main.cpp:3198 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:4577 ../../Firmware/ultralcd.cpp:5529
+#: ../../Firmware/Marlin_main.cpp:2942 ../../Firmware/messages.cpp:12
+#: ../../Firmware/ultralcd.cpp:4533 ../../Firmware/ultralcd.cpp:5496
 msgid "Auto home"
 msgstr "Startposition"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4182
 msgid "Auto power"
 msgstr "Auto Leist"
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:328 ../../Firmware/ultralcd.cpp:5359
+#: ../../Firmware/messages.cpp:340 ../../Firmware/ultralcd.cpp:5328
 msgid "AutoLoad filament"
 msgstr "AutoLaden Filament"
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/messages.cpp:245 ../../Firmware/ultralcd.cpp:2272
+#: ../../Firmware/messages.cpp:257 ../../Firmware/ultralcd.cpp:2289
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
@@ -114,51 +114,50 @@ msgid "Avoiding grind"
 msgstr "Vermeide schleifen"
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/messages.cpp:352 ../../Firmware/ultralcd.cpp:6752
+#: ../../Firmware/messages.cpp:364 ../../Firmware/ultralcd.cpp:6728
 msgid "Axis"
 msgstr "Achse"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/messages.cpp:351 ../../Firmware/ultralcd.cpp:6751
+#: ../../Firmware/messages.cpp:363 ../../Firmware/ultralcd.cpp:6727
 msgid "Axis length"
 msgstr "Achsenlänge"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2708
-#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:5618
-#: ../../Firmware/ultralcd.cpp:7484
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2725
+#: ../../Firmware/ultralcd.cpp:4061 ../../Firmware/ultralcd.cpp:5591
+#: ../../Firmware/ultralcd.cpp:7461
 msgid "Back"
 msgstr "Zurück"
 
 #. MSG_BED c=13
-#: ../../Firmware/Marlin_main.cpp:2081 ../../Firmware/Marlin_main.cpp:4627
-#: ../../Firmware/Marlin_main.cpp:4678 ../../Firmware/messages.cpp:15
-#: ../../Firmware/ultralcd.cpp:1391 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/Marlin_main.cpp:4247 ../../Firmware/messages.cpp:15
+#: ../../Firmware/ultralcd.cpp:1401 ../../Firmware/ultralcd.cpp:4197
 msgid "Bed"
 msgstr "Bett"
 
 #. MSG_BED_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6240 ../../Firmware/messages.cpp:17
+#: ../../Firmware/Marlin_main.cpp:5470 ../../Firmware/messages.cpp:17
 #: ../../Firmware/ultralcd.cpp:534
 msgid "Bed Heating"
 msgstr "Bett aufwärmen"
 
 #. MSG_BED_DONE c=20
-#: ../../Firmware/Marlin_main.cpp:6277 ../../Firmware/messages.cpp:16
+#: ../../Firmware/Marlin_main.cpp:5507 ../../Firmware/messages.cpp:16
 #: ../../Firmware/ultralcd.cpp:537
 msgid "Bed done"
 msgstr "Bett OK"
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/messages.cpp:317 ../../Firmware/ultralcd.cpp:4589
+#: ../../Firmware/messages.cpp:329 ../../Firmware/ultralcd.cpp:4545
 msgid "Bed level correct"
 msgstr "Bett Level Korr."
 
 #. MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:2262 ../../Firmware/Marlin_main.cpp:2999
-#: ../../Firmware/Marlin_main.cpp:3008
-#: ../../Firmware/mesh_bed_calibration.cpp:2878
-#: ../../Firmware/mesh_bed_calibration.cpp:2903 ../../Firmware/messages.cpp:18
+#: ../../Firmware/Marlin_main.cpp:2048 ../../Firmware/Marlin_main.cpp:2736
+#: ../../Firmware/Marlin_main.cpp:2745
+#: ../../Firmware/mesh_bed_calibration.cpp:2863
+#: ../../Firmware/mesh_bed_calibration.cpp:2888 ../../Firmware/messages.cpp:18
 msgid ""
 "Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for "
 "reset."
@@ -167,34 +166,34 @@ msgstr ""
 "Reset."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/messages.cpp:346 ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/messages.cpp:358 ../../Firmware/ultralcd.cpp:6685
 msgid "Bed/Heater"
 msgstr "Bett/Heizung"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1444
-#: ../../Firmware/ultralcd.cpp:1704
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1454
+#: ../../Firmware/ultralcd.cpp:1714
 msgid "Belt status"
 msgstr "Gurtstatus"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/messages.cpp:314 ../../Firmware/ultralcd.cpp:4579
+#: ../../Firmware/messages.cpp:326 ../../Firmware/ultralcd.cpp:4535
 msgid "Belt test"
 msgstr "Riementest"
 
 #. MSG_RECOVER_PRINT c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:1660 ../../Firmware/messages.cpp:87
+#: ../../Firmware/Marlin_main.cpp:1587 ../../Firmware/messages.cpp:87
 msgid "Blackout occurred. Recover print?"
 msgstr "Stromausfall! Druck wiederherstellen?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:177 ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:5594
 msgid "Bright"
 msgstr "Hell"
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:4526
-#: ../../Firmware/ultralcd.cpp:5546
+#: ../../Firmware/messages.cpp:180 ../../Firmware/ultralcd.cpp:4493
+#: ../../Firmware/ultralcd.cpp:5513
 msgid "Brightness"
 msgstr "Helligkeit"
 
@@ -204,17 +203,17 @@ msgid "COMMUNICATION ERROR"
 msgstr "KOMMUNIKATIONSFEHLER"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/messages.cpp:316 ../../Firmware/ultralcd.cpp:4583
+#: ../../Firmware/messages.cpp:328 ../../Firmware/ultralcd.cpp:4539
 msgid "Calibrate XYZ"
 msgstr "XYZ Kalibrierung"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4585
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4541
 msgid "Calibrate Z"
 msgstr "Z Kalibrierung"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/messages.cpp:266 ../../Firmware/ultralcd.cpp:2813
+#: ../../Firmware/messages.cpp:278 ../../Firmware/ultralcd.cpp:2830
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -223,13 +222,13 @@ msgstr ""
 "Anschliessend den Knopf drücken."
 
 #. MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: ../../Firmware/Marlin_main.cpp:2218 ../../Firmware/messages.cpp:22
+#: ../../Firmware/Marlin_main.cpp:2009 ../../Firmware/messages.cpp:23
 #: ../../Firmware/ultralcd.cpp:582
 msgid "Calibrating Z"
 msgstr "Kalibriere Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/messages.cpp:265 ../../Firmware/ultralcd.cpp:2812
+#: ../../Firmware/messages.cpp:277 ../../Firmware/ultralcd.cpp:2829
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -238,17 +237,17 @@ msgstr ""
 "Anschliessend den Knopf drücken."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/messages.cpp:361 ../../Firmware/ultralcd.cpp:6985
+#: ../../Firmware/messages.cpp:373 ../../Firmware/ultralcd.cpp:6962
 msgid "Calibrating home"
 msgstr "Kalibriere Start"
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5375
+#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5342
 msgid "Calibration"
 msgstr "Kalibrierung"
 
 #. MSG_HOMEYZ_DONE c=20
-#: ../../Firmware/messages.cpp:217 ../../Firmware/ultralcd.cpp:593
+#: ../../Firmware/messages.cpp:229 ../../Firmware/ultralcd.cpp:593
 msgid "Calibration done"
 msgstr "Kalibrierung OK"
 
@@ -267,128 +266,128 @@ msgstr ""
 "Entladen Sie es zuerst."
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/messages.cpp:364 ../../Firmware/ultralcd.cpp:7405
+#: ../../Firmware/messages.cpp:376 ../../Firmware/ultralcd.cpp:7382
 msgid "Card removed"
 msgstr "SD Karte entfernt"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/messages.cpp:324 ../../Firmware/ultralcd.cpp:5316
+#: ../../Firmware/messages.cpp:336 ../../Firmware/ultralcd.cpp:5282
 msgid "Change SD card"
 msgstr "Wechsel SD Karte"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5254
-#: ../../Firmware/ultralcd.cpp:5526
+#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5216
+#: ../../Firmware/ultralcd.cpp:5493
 msgid "Change filament"
 msgstr "Filament-Wechsel"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/messages.cpp:240 ../../Firmware/ultralcd.cpp:2156
+#: ../../Firmware/messages.cpp:252 ../../Firmware/ultralcd.cpp:2167
 msgid "Change success!"
 msgstr "Wechsel erfolgreich!"
 
 #. MSG_CORRECTLY c=19
-#: ../../Firmware/messages.cpp:242 ../../Firmware/ultralcd.cpp:2203
+#: ../../Firmware/messages.cpp:254 ../../Firmware/ultralcd.cpp:2217
 msgid "Changed correctly"
 msgstr "Wechsel ok"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5951
-#: ../../Firmware/ultralcd.cpp:6975
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5927
+#: ../../Firmware/ultralcd.cpp:6952
 msgid "Checking X axis"
 msgstr "Prüfe X Achse"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5961
-#: ../../Firmware/ultralcd.cpp:6976
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:5937
+#: ../../Firmware/ultralcd.cpp:6953
 msgid "Checking Y axis"
 msgstr "Prüfe Y Achse"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/messages.cpp:358 ../../Firmware/ultralcd.cpp:6977
+#: ../../Firmware/messages.cpp:370 ../../Firmware/ultralcd.cpp:6954
 msgid "Checking Z axis"
 msgstr "Prüfe Z Achse"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6978
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6955
 msgid "Checking bed"
 msgstr "Prüfe Bett"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/messages.cpp:357 ../../Firmware/ultralcd.cpp:6974
+#: ../../Firmware/messages.cpp:369 ../../Firmware/ultralcd.cpp:6951
 msgid "Checking endstops"
 msgstr "Prüfe Endschalter"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/messages.cpp:362 ../../Firmware/ultralcd.cpp:7070
+#: ../../Firmware/messages.cpp:374 ../../Firmware/ultralcd.cpp:7047
 msgid "Checking file"
 msgstr "Überprüfe Datei"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/messages.cpp:359 ../../Firmware/ultralcd.cpp:6980
+#: ../../Firmware/messages.cpp:371 ../../Firmware/ultralcd.cpp:6957
 msgid "Checking hotend"
 msgstr "Prüfe Düse"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6981
-#: ../../Firmware/ultralcd.cpp:6982
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6958
+#: ../../Firmware/ultralcd.cpp:6959
 msgid "Checking sensors"
 msgstr "Prüfe Sensoren"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/messages.cpp:308 ../../Firmware/ultralcd.cpp:4424
+#: ../../Firmware/messages.cpp:320 ../../Firmware/ultralcd.cpp:4391
 msgid "Checks"
 msgstr "Kontrolle"
 
 #. MSG_TM_ACK_ERROR c=18
-#: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5297
+#: ../../Firmware/messages.cpp:197 ../../Firmware/ultralcd.cpp:5263
 msgid "Clear TM error"
 msgstr "TM Fehler löschen"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/messages.cpp:244 ../../Firmware/ultralcd.cpp:2205
+#: ../../Firmware/messages.cpp:256 ../../Firmware/ultralcd.cpp:2219
 msgid "Color not correct"
 msgstr "Falsche Farbe"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:3508
+#: ../../Firmware/messages.cpp:27 ../../Firmware/ultralcd.cpp:3518
 msgid "Community made"
 msgstr "Von der Community"
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:4059
+#: ../../Firmware/messages.cpp:178 ../../Firmware/ultralcd.cpp:4083
 msgid "Cont."
 msgstr "Weit."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:2129
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2135
 msgid "Cooldown"
 msgstr "Abkühlen"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/messages.cpp:283 ../../Firmware/ultralcd.cpp:3450
+#: ../../Firmware/messages.cpp:295 ../../Firmware/ultralcd.cpp:3460
 msgid "Copy selected language?"
 msgstr "Gewählte Sprache kopieren?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:1234
-#: ../../Firmware/ultralcd.cpp:1263
+#: ../../Firmware/messages.cpp:30 ../../Firmware/ultralcd.cpp:1244
+#: ../../Firmware/ultralcd.cpp:1273
 msgid "Crash"
 msgstr "Crash"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4146
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/ultralcd.cpp:4170
 msgid "Crash det."
 msgstr "Crash Erk."
 
 #. MSG_CRASH_DETECTED c=20
-#: ../../Firmware/Marlin_main.cpp:630 ../../Firmware/messages.cpp:30
+#: ../../Firmware/Marlin_main.cpp:595 ../../Firmware/messages.cpp:31
 msgid "Crash detected."
 msgstr "Crash erkannt."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/messages.cpp:280 ../../Firmware/ultralcd.cpp:3374
+#: ../../Firmware/messages.cpp:292 ../../Firmware/ultralcd.cpp:3384
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -399,24 +398,24 @@ msgstr ""
 "genutzt werden"
 
 #. MSG_CUT_FILAMENT c=16
-#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:380
-#: ../../Firmware/ultralcd.cpp:4854 ../../Firmware/ultralcd.cpp:5351
+#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:381
+#: ../../Firmware/ultralcd.cpp:4810 ../../Firmware/ultralcd.cpp:5317
 msgid "Cut filament"
 msgstr "Fil. schneiden"
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4081
-#: ../../Firmware/ultralcd.cpp:4086 ../../Firmware/ultralcd.cpp:4091
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:4105
+#: ../../Firmware/ultralcd.cpp:4110 ../../Firmware/ultralcd.cpp:4115
 msgid "Cutter"
 msgstr "Messer"
 
 #. MSG_DATE c=17
-#: ../../Firmware/messages.cpp:222 ../../Firmware/ultralcd.cpp:1645
+#: ../../Firmware/messages.cpp:234 ../../Firmware/ultralcd.cpp:1655
 msgid "Date:"
 msgstr "Datum:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:178 ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/messages.cpp:185 ../../Firmware/ultralcd.cpp:5594
 msgid "Dim"
 msgstr "Dimm"
 
@@ -426,7 +425,7 @@ msgid "Disable"
 msgstr "Deaktiv."
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/messages.cpp:311 ../../Firmware/ultralcd.cpp:4460
+#: ../../Firmware/messages.cpp:323 ../../Firmware/ultralcd.cpp:4427
 msgid "Disable steppers"
 msgstr "Motoren aus"
 
@@ -438,7 +437,7 @@ msgid "Disengaging idler"
 msgstr "Spannrol. auskuppeln"
 
 #. MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: ../../Firmware/Marlin_main.cpp:1610 ../../Firmware/Marlin_main.cpp:3334
+#: ../../Firmware/Marlin_main.cpp:1537 ../../Firmware/Marlin_main.cpp:3073
 #: ../../Firmware/messages.cpp:14
 msgid ""
 "Distance between tip of the nozzle and the bed surface has not been set yet."
@@ -449,7 +448,7 @@ msgstr ""
 "eingestellt. Folgen Sie dem Handbuch, Kapitel Erste Schritte."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/messages.cpp:301 ../../Firmware/ultralcd.cpp:3923
+#: ../../Firmware/messages.cpp:313 ../../Firmware/ultralcd.cpp:3947
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -457,13 +456,13 @@ msgstr ""
 "Willst du den letzten Schritt wiederholen, um den Abstand neu einzustellen?"
 
 #. MSG_DONE c=8
-#: ../../Firmware/messages.cpp:32 ../../Firmware/mmu2/errors_list.h:367
-#: ../../Firmware/mmu2_reporting.cpp:456
+#: ../../Firmware/messages.cpp:33 ../../Firmware/mmu2/errors_list.h:367
+#: ../../Firmware/mmu2_reporting.cpp:457
 msgid "Done"
 msgstr "Klar"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/messages.cpp:307 ../../Firmware/ultralcd.cpp:3990
+#: ../../Firmware/messages.cpp:319 ../../Firmware/ultralcd.cpp:4014
 msgid "E-correct"
 msgstr "E-Korrektur"
 
@@ -492,7 +491,7 @@ msgid "ERR Wait for User"
 msgstr "FEHL. Warte Benutzer"
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:2253
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:2267
 msgid "ERROR:"
 msgstr "FEHLER:"
 
@@ -504,17 +503,17 @@ msgid "Ejecting filament"
 msgstr "Werfe Filament aus"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/messages.cpp:348 ../../Firmware/ultralcd.cpp:6722
+#: ../../Firmware/messages.cpp:360 ../../Firmware/ultralcd.cpp:6698
 msgid "Endstop"
 msgstr "Endschalter"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/messages.cpp:349 ../../Firmware/ultralcd.cpp:6727
+#: ../../Firmware/messages.cpp:361 ../../Firmware/ultralcd.cpp:6703
 msgid "Endstop not hit"
 msgstr "Ende nicht getroffen"
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/messages.cpp:347 ../../Firmware/ultralcd.cpp:6713
+#: ../../Firmware/messages.cpp:359 ../../Firmware/ultralcd.cpp:6689
 msgid "Endstops"
 msgstr "Endschalter"
 
@@ -526,30 +525,30 @@ msgid "Engaging idler"
 msgstr "Spannrol. einkuppeln"
 
 #. MSG_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:3352
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:3362
 msgid "Extruder"
 msgstr "Extruder"
 
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/messages.cpp:227 ../../Firmware/ultralcd.cpp:1700
+#: ../../Firmware/messages.cpp:239 ../../Firmware/ultralcd.cpp:1710
 msgid "Extruder info"
 msgstr "Extruder Info"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4044
-#: ../../Firmware/ultralcd.cpp:4051
+#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4068
+#: ../../Firmware/ultralcd.cpp:4075
 msgid "F. autoload"
 msgstr "F. autoladen"
 
 #. MSG_FSENSOR_JAM_DETECTION c=13
-#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4046
-#: ../../Firmware/ultralcd.cpp:4053
+#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4070
+#: ../../Firmware/ultralcd.cpp:4077
 msgid "F. jam detect"
 msgstr "F. Stau entd."
 
 #. MSG_FSENSOR_RUNOUT c=13
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4074
 msgid "F. runout"
 msgstr "FS. Auslauf"
 
@@ -587,8 +586,8 @@ msgid "FINDA FILAM. STUCK"
 msgstr "FINDA NICHT FIL.FREI"
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:4059
-#: ../../Firmware/ultralcd.cpp:4062
+#: ../../Firmware/messages.cpp:177 ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/ultralcd.cpp:4086
 msgid "FS Action"
 msgstr "FS Aktion"
 
@@ -613,34 +612,34 @@ msgid "FW RUNTIME ERROR"
 msgstr "FW-LAUFZEITFEHLER"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/messages.cpp:330 ../../Firmware/ultralcd.cpp:5382
+#: ../../Firmware/messages.cpp:342 ../../Firmware/ultralcd.cpp:5349
 msgid "Fail stats"
 msgstr "Fehlerstatistik"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/messages.cpp:331 ../../Firmware/ultralcd.cpp:5385
+#: ../../Firmware/messages.cpp:343 ../../Firmware/ultralcd.cpp:5352
 msgid "Fail stats MMU"
 msgstr "MMU-Fehler"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/messages.cpp:355 ../../Firmware/ultralcd.cpp:6768
+#: ../../Firmware/messages.cpp:367 ../../Firmware/ultralcd.cpp:6744
 msgid "False triggering"
 msgstr "Fehlauslösung"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4175
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4199
 msgid "Fan speed"
 msgstr "Lüfter-Tempo"
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6844
-#: ../../Firmware/ultralcd.cpp:6971 ../../Firmware/ultralcd.cpp:6972
-#: ../../Firmware/ultralcd.cpp:6973
+#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6820
+#: ../../Firmware/ultralcd.cpp:6948 ../../Firmware/ultralcd.cpp:6949
+#: ../../Firmware/ultralcd.cpp:6950
 msgid "Fan test"
 msgstr "Lüftertest"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:4179
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:4203
 msgid "Fans check"
 msgstr "Lüfter Check"
 
@@ -669,34 +668,34 @@ msgid "Feeding to nozzle"
 msgstr "Zufuhr zur Düse"
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1233
-#: ../../Firmware/ultralcd.cpp:1262 ../../Firmware/ultralcd.cpp:1316
-#: ../../Firmware/ultralcd.cpp:1318
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:1243
+#: ../../Firmware/ultralcd.cpp:1272 ../../Firmware/ultralcd.cpp:1326
+#: ../../Firmware/ultralcd.cpp:1328
 msgid "Fil. runouts"
 msgstr "Fil. Mängel"
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3313
-#: ../../Firmware/ultralcd.cpp:4039 ../../Firmware/ultralcd.cpp:4464
-#: ../../Firmware/ultralcd.cpp:5532
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3323
+#: ../../Firmware/ultralcd.cpp:4063 ../../Firmware/ultralcd.cpp:4431
+#: ../../Firmware/ultralcd.cpp:5499
 msgid "Fil. sensor"
 msgstr "Fil. Sensor"
 
 #. MSG_FILAMENT_CLEAN c=20 r=3
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2261
-#: ../../Firmware/ultralcd.cpp:2265
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2275
+#: ../../Firmware/ultralcd.cpp:2279
 msgid "Filament extruding & with correct color?"
 msgstr "Filament extrudiert mit richtiger Farbe?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/messages.cpp:243 ../../Firmware/ultralcd.cpp:2204
+#: ../../Firmware/messages.cpp:255 ../../Firmware/ultralcd.cpp:2218
 msgid "Filament not loaded"
 msgstr "Fil. nicht geladen"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6763
-#: ../../Firmware/ultralcd.cpp:6767 ../../Firmware/ultralcd.cpp:6771
-#: ../../Firmware/ultralcd.cpp:7000
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6739
+#: ../../Firmware/ultralcd.cpp:6743 ../../Firmware/ultralcd.cpp:6747
+#: ../../Firmware/ultralcd.cpp:6977
 msgid "Filament sensor"
 msgstr "Filament-Sensor"
 
@@ -729,42 +728,42 @@ msgstr ""
 "dass nichts im PTFE-Schlauch fest- sitzt und der Sensor richtig liest."
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/messages.cpp:246 ../../Firmware/ultralcd.cpp:2347
+#: ../../Firmware/messages.cpp:258 ../../Firmware/ultralcd.cpp:2364
 msgid "Filament used"
 msgstr "Filament benutzt"
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/messages.cpp:363 ../../Firmware/ultralcd.cpp:7139
+#: ../../Firmware/messages.cpp:375 ../../Firmware/ultralcd.cpp:7116
 msgid "File incomplete. Continue anyway?"
 msgstr "Datei unvollständig. Trotzdem fortfahren?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
 #: ../../Firmware/messages.cpp:45
 #: ../../Firmware/mmu2_progress_converter.cpp:43
-#: ../../Firmware/ultralcd.cpp:5021 ../../Firmware/ultralcd.cpp:5425
+#: ../../Firmware/ultralcd.cpp:4977 ../../Firmware/ultralcd.cpp:5392
 msgid "Finishing movements"
 msgstr "Bewegungen beenden"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4575
-#: ../../Firmware/ultralcd.cpp:5141
+#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4531
+#: ../../Firmware/ultralcd.cpp:5101
 msgid "First layer cal."
 msgstr "Erste-Schicht Kal."
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/messages.cpp:293 ../../Firmware/ultralcd.cpp:3846
+#: ../../Firmware/messages.cpp:305 ../../Firmware/ultralcd.cpp:3872
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Zunächst führe ich den Selbsttest durch, um die häufigsten Probleme beim "
 "Zusammenbau zu überprüfen."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/messages.cpp:334 ../../Firmware/ultralcd.cpp:5520
+#: ../../Firmware/messages.cpp:346 ../../Firmware/ultralcd.cpp:5487
 msgid "Flow"
 msgstr "Durchfluss"
 
 #. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
-#: ../../Firmware/messages.cpp:194 ../../Firmware/ultralcd.cpp:985
+#: ../../Firmware/messages.cpp:201 ../../Firmware/ultralcd.cpp:987
 msgid ""
 "For a Nozzle change please read\n"
 "prusa.io/nozzle-mk3s"
@@ -773,28 +772,28 @@ msgstr ""
 "prusa.io/nozzle-mk3s"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6733
-#: ../../Firmware/ultralcd.cpp:6850 ../../Firmware/ultralcd.cpp:6855
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/ultralcd.cpp:6826 ../../Firmware/ultralcd.cpp:6831
 msgid "Front print fan?"
 msgstr "Vorderer Lüfter?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/messages.cpp:260 ../../Firmware/ultralcd.cpp:2711
+#: ../../Firmware/messages.cpp:272 ../../Firmware/ultralcd.cpp:2728
 msgid "Front side[µm]"
 msgstr "Vorne [µm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/messages.cpp:353 ../../Firmware/ultralcd.cpp:6757
+#: ../../Firmware/messages.cpp:365 ../../Firmware/ultralcd.cpp:6733
 msgid "Front/left fans"
 msgstr "Druck/Hotend Lüfter"
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:151 ../../Firmware/util.cpp:382
+#: ../../Firmware/messages.cpp:156 ../../Firmware/util.cpp:417
 msgid "G-code sliced for a different level. Continue?"
 msgstr "G-Code ist für einen anderen Level geslict. Fortfahren?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:152 ../../Firmware/util.cpp:383
+#: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:418
 msgid ""
 "G-code sliced for a different level. Please re-slice the model again. Print "
 "cancelled."
@@ -803,14 +802,14 @@ msgstr ""
 "Druck abgebrochen."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:147 ../../Firmware/util.cpp:312
-#: ../../Firmware/util.cpp:401
+#: ../../Firmware/messages.cpp:152 ../../Firmware/util.cpp:319
+#: ../../Firmware/util.cpp:436
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr "G-Code ist für einen anderen Drucker geslict. Fortfahren?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:148 ../../Firmware/util.cpp:313
-#: ../../Firmware/util.cpp:402
+#: ../../Firmware/messages.cpp:153 ../../Firmware/util.cpp:320
+#: ../../Firmware/util.cpp:437
 msgid ""
 "G-code sliced for a different printer type. Please re-slice the model again."
 " Print cancelled."
@@ -819,12 +818,12 @@ msgstr ""
 "Druck abgebrochen."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:149 ../../Firmware/util.cpp:362
+#: ../../Firmware/messages.cpp:154 ../../Firmware/util.cpp:369
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "G-Code ist für eine neuere Firmware geslict. Fortfahren?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:150 ../../Firmware/util.cpp:363
+#: ../../Firmware/messages.cpp:155 ../../Firmware/util.cpp:370
 msgid ""
 "G-code sliced for a newer firmware. Please update the firmware. Print "
 "cancelled."
@@ -833,35 +832,35 @@ msgstr ""
 "Druck abgebrochen."
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4366
-#: ../../Firmware/ultralcd.cpp:4383 ../../Firmware/ultralcd.cpp:4485
+#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4325
+#: ../../Firmware/ultralcd.cpp:4343 ../../Firmware/ultralcd.cpp:4452
 msgid "HW Setup"
 msgstr "HW Einstellungen"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/messages.cpp:344 ../../Firmware/ultralcd.cpp:6705
+#: ../../Firmware/messages.cpp:356 ../../Firmware/ultralcd.cpp:6681
 msgid "Heater/Thermistor"
 msgstr "Heizung/Thermistor"
 
 #. MSG_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6184 ../../Firmware/messages.cpp:52
+#: ../../Firmware/Marlin_main.cpp:5416 ../../Firmware/messages.cpp:52
 #: ../../Firmware/ultralcd.cpp:526
 msgid "Heating"
 msgstr "Aufwärmen"
 
 #. MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:9647 ../../Firmware/messages.cpp:211
+#: ../../Firmware/Marlin_main.cpp:8807 ../../Firmware/messages.cpp:223
 msgid "Heating disabled by safety timer."
 msgstr "Heizung durch Sicherheitstimer deaktiviert."
 
 #. MSG_HEATING_COMPLETE c=20
-#: ../../Firmware/Marlin_main.cpp:6215 ../../Firmware/messages.cpp:53
+#: ../../Firmware/Marlin_main.cpp:5445 ../../Firmware/messages.cpp:53
 #: ../../Firmware/ultralcd.cpp:529
 msgid "Heating done."
 msgstr "Aufwärmen OK."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=12
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:3806
+#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:3832
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -872,7 +871,7 @@ msgstr ""
 "Danach können Sie drucken."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:3810
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:3836
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -881,8 +880,8 @@ msgstr ""
 "durch den Einricht- ungsablauf führe?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4152
-#: ../../Firmware/ultralcd.cpp:4161
+#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:4176
+#: ../../Firmware/ultralcd.cpp:4185
 msgid "High power"
 msgstr "Hohe Leist"
 
@@ -893,25 +892,25 @@ msgid "Homing"
 msgstr "Startposition"
 
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
-#: ../../Firmware/messages.cpp:195 ../../Firmware/ultralcd.cpp:1005
+#: ../../Firmware/messages.cpp:206 ../../Firmware/ultralcd.cpp:1011
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr "Hotend bei 280C! Düse gewechselt, gemäß Spezifikation angezogen?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1106
-#: ../../Firmware/ultralcd.cpp:6991
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1116
+#: ../../Firmware/ultralcd.cpp:6968
 msgid "Hotend fan:"
 msgstr "Hotend-Lüfter:"
 
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/messages.cpp:294 ../../Firmware/ultralcd.cpp:3851
+#: ../../Firmware/messages.cpp:306 ../../Firmware/ultralcd.cpp:3877
 msgid "I will run xyz calibration now. It will take up to 24 mins."
 msgstr ""
 "Ich werde jetzt die XYZ-Kalibrierung durchführen. Es kan bis zu 24 "
 "Min.dauern."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/messages.cpp:297 ../../Firmware/ultralcd.cpp:3862
+#: ../../Firmware/messages.cpp:309 ../../Firmware/ultralcd.cpp:3884
 msgid "I will run z calibration now."
 msgstr "Ich werde jetzt die Z Kalibrierung durchführen."
 
@@ -936,7 +935,7 @@ msgid "INVALID TOOL"
 msgstr "UNGÜLTIGER FIL.PLATZ"
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=8
-#: ../../Firmware/messages.cpp:303 ../../Firmware/ultralcd.cpp:3931
+#: ../../Firmware/messages.cpp:315 ../../Firmware/ultralcd.cpp:3955
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -945,28 +944,28 @@ msgstr ""
 "stellungen unter Einstellungen - HW Setup - Stahlbleche."
 
 #. MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2540
-#: ../../Firmware/messages.cpp:213
+#: ../../Firmware/mesh_bed_calibration.cpp:2525
+#: ../../Firmware/messages.cpp:225
 msgid "Improving bed calibration point"
 msgstr "Verbesserung des Bettkalibrierungs- punkts"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:5222
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:5184
 msgid "Info screen"
 msgstr "Infoanzeige"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/messages.cpp:326 ../../Firmware/ultralcd.cpp:5323
+#: ../../Firmware/messages.cpp:338 ../../Firmware/ultralcd.cpp:5289
 msgid "Init. SD card"
 msgstr "Init. SD Karte"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/messages.cpp:238 ../../Firmware/ultralcd.cpp:2142
+#: ../../Firmware/messages.cpp:250 ../../Firmware/ultralcd.cpp:2148
 msgid "Insert filament"
 msgstr "Filament einlegen"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/messages.cpp:335 ../../Firmware/ultralcd.cpp:5998
+#: ../../Firmware/messages.cpp:347 ../../Firmware/ultralcd.cpp:5974
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
@@ -982,115 +981,115 @@ msgstr ""
 "Interner Laufzeitfehler. MMU zurücksetzen oder Firmware aktualisieren."
 
 #. MSG_FILAMENT_LOADED c=20 r=3
-#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3628
-#: ../../Firmware/ultralcd.cpp:3890
+#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3638
+#: ../../Firmware/ultralcd.cpp:3914
 msgid "Is filament loaded?"
 msgstr "Ist Filament geladen?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3238 ../../Firmware/Marlin_main.cpp:4745
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:3858
+#: ../../Firmware/Marlin_main.cpp:4314 ../../Firmware/messages.cpp:127
+#: ../../Firmware/ultralcd.cpp:3760
 msgid "Is steel sheet on heatbed?"
 msgstr "Liegt Stahlblech auf dem Heizbett?"
 
 #. MSG_ITERATION c=12
-#: ../../Firmware/mesh_bed_calibration.cpp:2265 ../../Firmware/messages.cpp:55
+#: ../../Firmware/mesh_bed_calibration.cpp:2250 ../../Firmware/messages.cpp:55
 msgid "Iteration"
 msgstr "Wiederholung"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1128
-#: ../../Firmware/ultralcd.cpp:1286
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1138
+#: ../../Firmware/ultralcd.cpp:1296
 msgid "Last print"
 msgstr "Letzter Druck"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1152
-#: ../../Firmware/ultralcd.cpp:1260 ../../Firmware/ultralcd.cpp:1315
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1162
+#: ../../Firmware/ultralcd.cpp:1270 ../../Firmware/ultralcd.cpp:1325
 msgid "Last print failures"
 msgstr "Letzte Druckfehler"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/messages.cpp:251 ../../Firmware/ultralcd.cpp:2478
+#: ../../Firmware/messages.cpp:263 ../../Firmware/ultralcd.cpp:2495
 msgid "Left"
 msgstr "Links"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6739
-#: ../../Firmware/ultralcd.cpp:6850 ../../Firmware/ultralcd.cpp:6855
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6715
+#: ../../Firmware/ultralcd.cpp:6826 ../../Firmware/ultralcd.cpp:6831
 msgid "Left hotend fan?"
 msgstr "Linker Lüfter?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/messages.cpp:258 ../../Firmware/ultralcd.cpp:2709
+#: ../../Firmware/messages.cpp:270 ../../Firmware/ultralcd.cpp:2726
 msgid "Left side [µm]"
 msgstr "Links [µm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:5619
+#: ../../Firmware/messages.cpp:181 ../../Firmware/ultralcd.cpp:5592
 msgid "Level Bright"
 msgstr "Hell.wert"
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:175 ../../Firmware/ultralcd.cpp:5620
+#: ../../Firmware/messages.cpp:182 ../../Firmware/ultralcd.cpp:5593
 msgid "Level Dimmed"
 msgstr "Dimmwert"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/messages.cpp:312 ../../Firmware/ultralcd.cpp:4491
+#: ../../Firmware/messages.cpp:324 ../../Firmware/ultralcd.cpp:4458
 msgid "Lin. correction"
 msgstr "Lineare Korrektur"
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4501
-#: ../../Firmware/ultralcd.cpp:5251
+#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4468
+#: ../../Firmware/ultralcd.cpp:5213
 msgid "Live adjust Z"
 msgstr "Z einstellen"
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/messages.cpp:192 ../../Firmware/ultralcd.cpp:4794
-#: ../../Firmware/ultralcd.cpp:4880
+#: ../../Firmware/messages.cpp:199 ../../Firmware/ultralcd.cpp:4750
+#: ../../Firmware/ultralcd.cpp:4836
 msgid "Load All"
 msgstr "Alle laden"
 
 #. MSG_LOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4796
-#: ../../Firmware/ultralcd.cpp:4833 ../../Firmware/ultralcd.cpp:4882
-#: ../../Firmware/ultralcd.cpp:5361 ../../Firmware/ultralcd.cpp:5368
+#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4752
+#: ../../Firmware/ultralcd.cpp:4789 ../../Firmware/ultralcd.cpp:4838
+#: ../../Firmware/ultralcd.cpp:5324 ../../Firmware/ultralcd.cpp:5335
 msgid "Load filament"
 msgstr "Filament laden"
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/messages.cpp:327 ../../Firmware/ultralcd.cpp:5346
+#: ../../Firmware/messages.cpp:339 ../../Firmware/ultralcd.cpp:5312
 msgid "Load to nozzle"
 msgstr "In Düse laden"
 
 #. MSG_LOADING_TEST c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4476
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4443
 msgid "Loading Test"
 msgstr "Lade Filament Test"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/messages.cpp:241 ../../Firmware/ultralcd.cpp:2178
+#: ../../Firmware/messages.cpp:253 ../../Firmware/ultralcd.cpp:2189
 msgid "Loading color"
 msgstr "Lade Farbe"
 
 #. MSG_LOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3598 ../../Firmware/messages.cpp:62
+#: ../../Firmware/Marlin_main.cpp:3343 ../../Firmware/messages.cpp:62
 #: ../../Firmware/mmu2_progress_converter.cpp:51
-#: ../../Firmware/mmu2_reporting.cpp:392 ../../Firmware/ultralcd.cpp:2189
-#: ../../Firmware/ultralcd.cpp:3715
+#: ../../Firmware/mmu2_reporting.cpp:393 ../../Firmware/ultralcd.cpp:2199
+#: ../../Firmware/ultralcd.cpp:3725
 msgid "Loading filament"
 msgstr "Filament lädt"
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/messages.cpp:350 ../../Firmware/ultralcd.cpp:6745
+#: ../../Firmware/messages.cpp:362 ../../Firmware/ultralcd.cpp:6721
 msgid "Loose pulley"
 msgstr "Lose Riemenscheibe"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4188
-#: ../../Firmware/ultralcd.cpp:4200
+#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4224
 msgid "Loud"
 msgstr "Laut"
 
@@ -1105,7 +1104,7 @@ msgid "MMU Firmware internal error, please reset the MMU."
 msgstr "MMU Firmware Fehler, setzen Sie die MMU zurück."
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:4096
+#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4120
 msgid "MMU Mode"
 msgstr "MMU Mod."
 
@@ -1115,7 +1114,7 @@ msgid "MMU NOT RESPONDING"
 msgstr "MMU REAGIERT NICHT"
 
 #. MSG_MMU_RESTORE_TEMP c=20 r=4
-#: ../../Firmware/messages.cpp:214 ../../Firmware/mmu2_reporting.cpp:396
+#: ../../Firmware/messages.cpp:226 ../../Firmware/mmu2_reporting.cpp:397
 msgid "MMU Retry: Restoring temperature..."
 msgstr "MMU-Neuversuch: Stelle die Tempera- tur wieder her..."
 
@@ -1126,14 +1125,14 @@ msgid "MMU SELFTEST FAILED"
 msgstr "MMU SELBSTTEST FEHL."
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1153
-#: ../../Firmware/ultralcd.cpp:1178
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1163
+#: ../../Firmware/ultralcd.cpp:1188
 msgid "MMU fails"
 msgstr "MMU Fehler"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1154
-#: ../../Firmware/ultralcd.cpp:1179
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1164
+#: ../../Firmware/ultralcd.cpp:1189
 msgid "MMU load fails"
 msgstr "MMU Ladefehler"
 
@@ -1151,66 +1150,64 @@ msgstr ""
 "MMU antwortet nicht. Überprüfen Sie die Verkabelung und die Anschlüsse."
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/messages.cpp:223 ../../Firmware/ultralcd.cpp:1657
+#: ../../Firmware/messages.cpp:235 ../../Firmware/ultralcd.cpp:1667
 msgid "MMU connected"
 msgstr "MMU verbunden"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/messages.cpp:176 ../../Firmware/ultralcd.cpp:5567
 msgid "Magnets comp."
 msgstr "Magnet Komp."
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1127
-#: ../../Firmware/ultralcd.cpp:1285 ../../Firmware/ultralcd.cpp:1327
-#: ../../Firmware/ultralcd.cpp:1631 ../../Firmware/ultralcd.cpp:4453
-#: ../../Firmware/ultralcd.cpp:4571 ../../Firmware/ultralcd.cpp:4793
-#: ../../Firmware/ultralcd.cpp:4826 ../../Firmware/ultralcd.cpp:4879
-#: ../../Firmware/ultralcd.cpp:5515
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1137
+#: ../../Firmware/ultralcd.cpp:1295 ../../Firmware/ultralcd.cpp:1337
+#: ../../Firmware/ultralcd.cpp:1641 ../../Firmware/ultralcd.cpp:4420
+#: ../../Firmware/ultralcd.cpp:4527 ../../Firmware/ultralcd.cpp:4749
+#: ../../Firmware/ultralcd.cpp:4782 ../../Firmware/ultralcd.cpp:4835
+#: ../../Firmware/ultralcd.cpp:5482
 msgid "Main"
 msgstr "Hauptmenü"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/messages.cpp:253 ../../Firmware/ultralcd.cpp:2519
+#: ../../Firmware/messages.cpp:265 ../../Firmware/ultralcd.cpp:2536
 msgid "Measured skew"
 msgstr "Schräglauf"
 
 #. MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3219
-#: ../../Firmware/mesh_bed_calibration.cpp:2852 ../../Firmware/messages.cpp:70
+#: ../../Firmware/Marlin_main.cpp:2963
+#: ../../Firmware/mesh_bed_calibration.cpp:2837 ../../Firmware/messages.cpp:70
 msgid "Measuring reference height of calibration point"
 msgstr "Messen der Referenzhöhe des Kalibrierpunktes"
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:5590
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:5563
 msgid "Mesh"
 msgstr "Gitter"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4488
-#: ../../Firmware/ultralcd.cpp:4587
+#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:4455
+#: ../../Firmware/ultralcd.cpp:4543
 msgid "Mesh Bed Leveling"
 msgstr "MeshBett Ausgleich"
 
 #. MSG_MODE c=6
-#: ../../Firmware/Marlin_main.cpp:8495 ../../Firmware/messages.cpp:117
-#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4132
-#: ../../Firmware/ultralcd.cpp:4140 ../../Firmware/ultralcd.cpp:4144
-#: ../../Firmware/ultralcd.cpp:4152 ../../Firmware/ultralcd.cpp:4155
-#: ../../Firmware/ultralcd.cpp:4158 ../../Firmware/ultralcd.cpp:4161
-#: ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/Marlin_main.cpp:7666 ../../Firmware/messages.cpp:121
+#: ../../Firmware/ultralcd.cpp:4152 ../../Firmware/ultralcd.cpp:4156
+#: ../../Firmware/ultralcd.cpp:4164 ../../Firmware/ultralcd.cpp:4168
+#: ../../Firmware/ultralcd.cpp:4176 ../../Firmware/ultralcd.cpp:4179
+#: ../../Firmware/ultralcd.cpp:4182 ../../Firmware/ultralcd.cpp:4185
+#: ../../Firmware/ultralcd.cpp:5594
 msgid "Mode"
 msgstr "Modus"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/messages.cpp:282 ../../Firmware/ultralcd.cpp:3413
+#: ../../Firmware/messages.cpp:294 ../../Firmware/ultralcd.cpp:3423
 msgid "Mode change in progress..."
 msgstr "Moduswechsel erfolgt..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:4310
-#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4316
-#: ../../Firmware/ultralcd.cpp:4319
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4327
 msgid "Model"
 msgstr "Modell"
 
@@ -1231,28 +1228,28 @@ msgid "More details online."
 msgstr "Weitere Details online."
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6719
-#: ../../Firmware/ultralcd.cpp:6728 ../../Firmware/ultralcd.cpp:6746
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6695
+#: ../../Firmware/ultralcd.cpp:6704 ../../Firmware/ultralcd.cpp:6722
 msgid "Motor"
 msgstr "Motor"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/messages.cpp:277 ../../Firmware/ultralcd.cpp:3349
+#: ../../Firmware/messages.cpp:289 ../../Firmware/ultralcd.cpp:3359
 msgid "Move X"
 msgstr "Bewege X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/messages.cpp:278 ../../Firmware/ultralcd.cpp:3350
+#: ../../Firmware/messages.cpp:290 ../../Firmware/ultralcd.cpp:3360
 msgid "Move Y"
 msgstr "Bewege Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/messages.cpp:279 ../../Firmware/ultralcd.cpp:3351
+#: ../../Firmware/messages.cpp:291 ../../Firmware/ultralcd.cpp:3361
 msgid "Move Z"
 msgstr "Bewege Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/messages.cpp:310 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:322 ../../Firmware/ultralcd.cpp:4426
 msgid "Move axis"
 msgstr "Achse bewegen"
 
@@ -1263,95 +1260,92 @@ msgid "Moving selector"
 msgstr "Bewege Selektor"
 
 #. MSG_NA c=3
-#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:141
-#: ../../Firmware/ultralcd.cpp:2484 ../../Firmware/ultralcd.cpp:2528
-#: ../../Firmware/ultralcd.cpp:3279 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:4044 ../../Firmware/ultralcd.cpp:4046
-#: ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:146
+#: ../../Firmware/ultralcd.cpp:2501 ../../Firmware/ultralcd.cpp:2545
+#: ../../Firmware/ultralcd.cpp:3289 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4068 ../../Firmware/ultralcd.cpp:4070
+#: ../../Firmware/ultralcd.cpp:5567
 msgid "N/A"
 msgstr "N/V"
 
 #. MSG_NEW_FIRMWARE_AVAILABLE c=20 r=2
-#: ../../Firmware/messages.cpp:365 ../../Firmware/util.cpp:209
+#: ../../Firmware/messages.cpp:377 ../../Firmware/util.cpp:214
 msgid "New firmware version available:"
 msgstr "Neue Firmware- Version verfügbar:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:3029
-#: ../../Firmware/ultralcd.cpp:4443 ../../Firmware/ultralcd.cpp:4531
-#: ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:2275
+#: ../../Firmware/ultralcd.cpp:2279 ../../Firmware/ultralcd.cpp:3046
+#: ../../Firmware/ultralcd.cpp:4410 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/ultralcd.cpp:5765
 msgid "No"
 msgstr "Nein"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/messages.cpp:325 ../../Firmware/ultralcd.cpp:5321
+#: ../../Firmware/messages.cpp:337 ../../Firmware/ultralcd.cpp:5287
 msgid "No SD card"
 msgstr "Keine SD Karte"
 
 #. MSG_NO_MOVE c=20
-#: ../../Firmware/Marlin_main.cpp:5271 ../../Firmware/messages.cpp:210
+#: ../../Firmware/Marlin_main.cpp:4778 ../../Firmware/messages.cpp:222
 msgid "No move."
 msgstr "Keine Bewegung."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4239 ../../Firmware/ultralcd.cpp:4310
-#: ../../Firmware/ultralcd.cpp:4319 ../../Firmware/ultralcd.cpp:4349
-#: ../../Firmware/ultralcd.cpp:4358 ../../Firmware/ultralcd.cpp:4516
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4309
+#: ../../Firmware/ultralcd.cpp:4318 ../../Firmware/ultralcd.cpp:4483
 msgid "None"
 msgstr "Ohne"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/Marlin_main.cpp:8497 ../../Firmware/messages.cpp:121
-#: ../../Firmware/ultralcd.cpp:4096 ../../Firmware/ultralcd.cpp:4132
-#: ../../Firmware/ultralcd.cpp:4511
+#: ../../Firmware/Marlin_main.cpp:7668 ../../Firmware/messages.cpp:125
+#: ../../Firmware/ultralcd.cpp:4120 ../../Firmware/ultralcd.cpp:4156
+#: ../../Firmware/ultralcd.cpp:4478
 msgid "Normal"
 msgstr "Normal"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/messages.cpp:345 ../../Firmware/ultralcd.cpp:6706
+#: ../../Firmware/messages.cpp:357 ../../Firmware/ultralcd.cpp:6682
 msgid "Not connected"
 msgstr "Nicht angeschlossen"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6863
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6839
 msgid "Not spinning"
 msgstr "Dreht sich nicht"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/messages.cpp:289 ../../Firmware/ultralcd.cpp:3726
+#: ../../Firmware/messages.cpp:301 ../../Firmware/ultralcd.cpp:3736
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr "Jetzt kalibriere ich den Abstand zwischen Düsenspitze und Druckbett."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/messages.cpp:298 ../../Firmware/ultralcd.cpp:3871
+#: ../../Firmware/messages.cpp:310 ../../Firmware/ultralcd.cpp:3894
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Jetzt werde ich die Düse für PLA vorheizen."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/messages.cpp:296 ../../Firmware/ultralcd.cpp:3857
+#: ../../Firmware/messages.cpp:308 ../../Firmware/ultralcd.cpp:3883
 msgid "Now remove the test print from steel sheet."
 msgstr "Testdruck jetzt vom Stahlblech entfernen."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1390
-#: ../../Firmware/ultralcd.cpp:4170 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4233 ../../Firmware/ultralcd.cpp:4236
-#: ../../Firmware/ultralcd.cpp:4239
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1400
+#: ../../Firmware/ultralcd.cpp:4194 ../../Firmware/ultralcd.cpp:4326
 msgid "Nozzle"
 msgstr "Düse"
 
 #. MSG_NOZZLE_CNG_MENU c=18
-#: ../../Firmware/messages.cpp:193 ../../Firmware/ultralcd.cpp:4423
-#: ../../Firmware/ultralcd.cpp:4486
+#: ../../Firmware/messages.cpp:200 ../../Firmware/ultralcd.cpp:4390
+#: ../../Firmware/ultralcd.cpp:4453
 msgid "Nozzle change"
 msgstr "Düsenwechsel"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4276
-#: ../../Firmware/ultralcd.cpp:4278 ../../Firmware/ultralcd.cpp:4279
-#: ../../Firmware/ultralcd.cpp:4280
+#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4261
+#: ../../Firmware/ultralcd.cpp:4263 ../../Firmware/ultralcd.cpp:4264
+#: ../../Firmware/ultralcd.cpp:4265
 msgid "Nozzle d."
 msgstr "Düsen Dia."
 
@@ -1362,82 +1356,82 @@ msgid "OK"
 msgstr "OK"
 
 #. MSG_OFF c=3
-#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:139
-#: ../../Firmware/mmu2.cpp:65 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4050 ../../Firmware/ultralcd.cpp:4051
-#: ../../Firmware/ultralcd.cpp:4053 ../../Firmware/ultralcd.cpp:4076
-#: ../../Firmware/ultralcd.cpp:4091 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4179 ../../Firmware/ultralcd.cpp:4467
-#: ../../Firmware/ultralcd.cpp:4495 ../../Firmware/ultralcd.cpp:4498
-#: ../../Firmware/ultralcd.cpp:5439 ../../Firmware/ultralcd.cpp:5594
-#: ../../Firmware/ultralcd.cpp:7487 ../../Firmware/ultralcd.cpp:7491
+#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:144
+#: ../../Firmware/mmu2.cpp:65 ../../Firmware/ultralcd.cpp:4063
+#: ../../Firmware/ultralcd.cpp:4074 ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4077 ../../Firmware/ultralcd.cpp:4100
+#: ../../Firmware/ultralcd.cpp:4115 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/ultralcd.cpp:4203 ../../Firmware/ultralcd.cpp:4434
+#: ../../Firmware/ultralcd.cpp:4462 ../../Firmware/ultralcd.cpp:4465
+#: ../../Firmware/ultralcd.cpp:5406 ../../Firmware/ultralcd.cpp:5567
+#: ../../Firmware/ultralcd.cpp:7464 ../../Firmware/ultralcd.cpp:7468
 msgid "Off"
 msgstr "Aus"
 
 #. MSG_DEFAULT_SETTINGS_LOADED c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:1562 ../../Firmware/messages.cpp:201
+#: ../../Firmware/Marlin_main.cpp:1489 ../../Firmware/messages.cpp:213
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr ""
 "Alte Einstellungen gefunden. Standard PID, E-Steps u.s.w. werden gesetzt."
 
 #. MSG_ON c=3
-#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:140
-#: ../../Firmware/mmu2.cpp:63 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4050 ../../Firmware/ultralcd.cpp:4051
-#: ../../Firmware/ultralcd.cpp:4053 ../../Firmware/ultralcd.cpp:4076
-#: ../../Firmware/ultralcd.cpp:4081 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4179 ../../Firmware/ultralcd.cpp:4467
-#: ../../Firmware/ultralcd.cpp:4495 ../../Firmware/ultralcd.cpp:4498
-#: ../../Firmware/ultralcd.cpp:5594 ../../Firmware/ultralcd.cpp:7487
-#: ../../Firmware/ultralcd.cpp:7491
+#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:145
+#: ../../Firmware/mmu2.cpp:63 ../../Firmware/ultralcd.cpp:4063
+#: ../../Firmware/ultralcd.cpp:4074 ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4077 ../../Firmware/ultralcd.cpp:4100
+#: ../../Firmware/ultralcd.cpp:4105 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/ultralcd.cpp:4203 ../../Firmware/ultralcd.cpp:4434
+#: ../../Firmware/ultralcd.cpp:4462 ../../Firmware/ultralcd.cpp:4465
+#: ../../Firmware/ultralcd.cpp:5567 ../../Firmware/ultralcd.cpp:7464
+#: ../../Firmware/ultralcd.cpp:7468
 msgid "On"
 msgstr "An"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4191
+#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:4215
 msgid "Once"
 msgstr "Einmal"
 
 #. MSG_PAUSED_THERMAL_ERROR c=20
-#: ../../Firmware/Marlin_main.cpp:9861 ../../Firmware/messages.cpp:186
+#: ../../Firmware/Marlin_main.cpp:9021 ../../Firmware/messages.cpp:193
 msgid "PAUSED THERMAL ERROR"
 msgstr "PAUSE THERM. FEHLER"
 
 #. MSG_PID_RUNNING c=20
-#: ../../Firmware/messages.cpp:219 ../../Firmware/ultralcd.cpp:897
+#: ../../Firmware/messages.cpp:231 ../../Firmware/ultralcd.cpp:897
 msgid "PID cal."
 msgstr "PID Kal."
 
 #. MSG_PID_FINISHED c=20
-#: ../../Firmware/messages.cpp:220 ../../Firmware/ultralcd.cpp:902
+#: ../../Firmware/messages.cpp:232 ../../Firmware/ultralcd.cpp:902
 msgid "PID cal. finished"
 msgstr "PID Kalib. fertig"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:318 ../../Firmware/ultralcd.cpp:4590
+#: ../../Firmware/messages.cpp:330 ../../Firmware/ultralcd.cpp:4546
 msgid "PID calibration"
 msgstr "PID Kalibrierung"
 
 #. MSG_PINDA_PREHEAT c=20
-#: ../../Firmware/messages.cpp:218 ../../Firmware/ultralcd.cpp:610
+#: ../../Firmware/messages.cpp:230 ../../Firmware/ultralcd.cpp:610
 msgid "PINDA Heating"
 msgstr "PINDA erwärmen"
 
 #. MSG_PINDA_CALIBRATION c=13
-#: ../../Firmware/Marlin_main.cpp:4790 ../../Firmware/Marlin_main.cpp:4892
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:607
-#: ../../Firmware/ultralcd.cpp:4495 ../../Firmware/ultralcd.cpp:4597
+#: ../../Firmware/Marlin_main.cpp:4359 ../../Firmware/Marlin_main.cpp:4461
+#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:607
+#: ../../Firmware/ultralcd.cpp:4462 ../../Firmware/ultralcd.cpp:4553
 msgid "PINDA cal."
 msgstr "PINDA Kal."
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/messages.cpp:276 ../../Firmware/ultralcd.cpp:3233
+#: ../../Firmware/messages.cpp:288 ../../Firmware/ultralcd.cpp:3243
 msgid "PINDA calibration failed"
 msgstr "PINDA-Kalibrierung fehlgeschlagen"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:4967 ../../Firmware/messages.cpp:127
-#: ../../Firmware/ultralcd.cpp:3230
+#: ../../Firmware/Marlin_main.cpp:4536 ../../Firmware/messages.cpp:132
+#: ../../Firmware/ultralcd.cpp:3240
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1457,13 +1451,13 @@ msgid "Parking selector"
 msgstr "Parke Selektor"
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:4062
+#: ../../Firmware/messages.cpp:179 ../../Firmware/ultralcd.cpp:4086
 msgid "Pause"
 msgstr "Pause"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5271
-#: ../../Firmware/ultralcd.cpp:5273
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5237
+#: ../../Firmware/ultralcd.cpp:5239
 msgid "Pause print"
 msgstr "Druck pausieren"
 
@@ -1474,7 +1468,7 @@ msgid "Performing cut"
 msgstr "Führe Schnitt aus"
 
 #. MSG_PAPER c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3243 ../../Firmware/messages.cpp:77
+#: ../../Firmware/Marlin_main.cpp:2982 ../../Firmware/messages.cpp:77
 msgid ""
 "Place a sheet of paper under the nozzle during the calibration of first 4 "
 "points. If the nozzle catches the paper, power off the printer immediately."
@@ -1483,7 +1477,7 @@ msgstr ""
 "ersten 4 Punkte. Drucker sofort aus- schalten, wenn das Papier erfasst wird."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:3963
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:3987
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1492,28 +1486,28 @@ msgstr ""
 "dem Assistenten fort, indem Sie den Drucker neu starten."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/messages.cpp:337 ../../Firmware/ultralcd.cpp:6023
+#: ../../Firmware/messages.cpp:349 ../../Firmware/ultralcd.cpp:5999
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "IR Sensor Verbindungen über- prüfen. Ist Filament entladen?"
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/messages.cpp:343 ../../Firmware/ultralcd.cpp:6700
+#: ../../Firmware/messages.cpp:355 ../../Firmware/ultralcd.cpp:6676
 msgid "Please check:"
 msgstr "Prüfen:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/messages.cpp:302 ../../Firmware/ultralcd.cpp:3926
+#: ../../Firmware/messages.cpp:314 ../../Firmware/ultralcd.cpp:3950
 msgid "Please clean heatbed and then press the knob."
 msgstr "Reinigen Sie das Heizbett und drücken Sie dann den Knopf."
 
 #. MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3217 ../../Firmware/messages.cpp:27
+#: ../../Firmware/Marlin_main.cpp:2960 ../../Firmware/messages.cpp:28
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr ""
 "Entfernen Sie überstehendes Filament von der Düse. Klicken wenn sauber."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/messages.cpp:288 ../../Firmware/ultralcd.cpp:3712
+#: ../../Firmware/messages.cpp:300 ../../Firmware/ultralcd.cpp:3722
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr ""
@@ -1521,7 +1515,7 @@ msgstr ""
 "laden."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/messages.cpp:287 ../../Firmware/ultralcd.cpp:3705
+#: ../../Firmware/messages.cpp:299 ../../Firmware/ultralcd.cpp:3715
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1530,104 +1524,103 @@ msgstr ""
 "den Knopf, um es zu laden."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/messages.cpp:285 ../../Firmware/ultralcd.cpp:3633
+#: ../../Firmware/messages.cpp:297 ../../Firmware/ultralcd.cpp:3643
 msgid "Please load filament first."
 msgstr "Laden Sie zuerst das Filament."
 
 #. MSG_CHECK_IDLER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3525 ../../Firmware/messages.cpp:206
+#: ../../Firmware/Marlin_main.cpp:3265 ../../Firmware/messages.cpp:218
 msgid "Please open idler and remove filament manually."
 msgstr "Spannrolle öffnen und Filament von Hand entfernen"
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2806 ../../Firmware/messages.cpp:80
-#: ../../Firmware/ultralcd.cpp:3860
+#: ../../Firmware/mesh_bed_calibration.cpp:2791 ../../Firmware/messages.cpp:80
 msgid "Please place steel sheet on heatbed."
 msgstr "Legen Sie das Stahlblech auf das Heizbett."
 
 #. MSG_PRESS_TO_UNLOAD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:11215 ../../Firmware/Marlin_main.cpp:11245
+#: ../../Firmware/Marlin_main.cpp:10287 ../../Firmware/Marlin_main.cpp:10317
 #: ../../Firmware/messages.cpp:84
 msgid "Please press the knob to unload filament"
 msgstr "Drücken Sie den Knopf um das Filament zu entladen."
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:4932
+#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:4888
 msgid "Please pull out filament immediately"
 msgstr "Ziehen Sie das Filament sofort heraus"
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/messages.cpp:295 ../../Firmware/ultralcd.cpp:3856
+#: ../../Firmware/messages.cpp:307 ../../Firmware/ultralcd.cpp:3882
 msgid "Please remove shipping helpers first."
 msgstr "Zuerst Transportsicherungen entfernen."
 
 #. MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3240 ../../Firmware/Marlin_main.cpp:4755
-#: ../../Firmware/messages.cpp:89
+#: ../../Firmware/Marlin_main.cpp:4324 ../../Firmware/messages.cpp:89
 msgid "Please remove steel sheet from heatbed."
 msgstr "Entfernen Sie das Stahlblech vom Heizbett."
 
 #. MSG_RUN_XYZ c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4731 ../../Firmware/messages.cpp:207
+#: ../../Firmware/Marlin_main.cpp:4300 ../../Firmware/messages.cpp:219
 msgid "Please run XYZ calibration first."
 msgstr "Zuerst XYZ Kalibrierung ausführen."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/messages.cpp:336 ../../Firmware/ultralcd.cpp:6020
+#: ../../Firmware/messages.cpp:348 ../../Firmware/ultralcd.cpp:4359
+#: ../../Firmware/ultralcd.cpp:5996
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Entladen Sie erst das Filament und versuchen Sie es nochmal."
 
 #. MSG_NEW_FIRMWARE_PLEASE_UPGRADE c=20
-#: ../../Firmware/messages.cpp:366 ../../Firmware/util.cpp:213
+#: ../../Firmware/messages.cpp:378 ../../Firmware/util.cpp:218
 msgid "Please upgrade."
 msgstr "Bitte aktualisieren."
 
 #. MSG_PLEASE_WAIT c=20
-#: ../../Firmware/Marlin_main.cpp:3521 ../../Firmware/Marlin_main.cpp:8090
-#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:2179
-#: ../../Firmware/ultralcd.cpp:2190
+#: ../../Firmware/Marlin_main.cpp:3261 ../../Firmware/Marlin_main.cpp:7262
+#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:2190
+#: ../../Firmware/ultralcd.cpp:2204
 msgid "Please wait"
 msgstr "Warten"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:1232
-#: ../../Firmware/ultralcd.cpp:1261
+#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:1242
+#: ../../Firmware/ultralcd.cpp:1271
 msgid "Power failures"
 msgstr "Netzfehler"
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/messages.cpp:323 ../../Firmware/ultralcd.cpp:5260
+#: ../../Firmware/messages.cpp:335 ../../Firmware/ultralcd.cpp:5222
 msgid "Preheat"
 msgstr "Vorheizen"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:2254
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:2268
 msgid "Preheat the nozzle!"
 msgstr "Düse vorheizen!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:2771
-#: ../../Firmware/ultralcd.cpp:3690 ../../Firmware/ultralcd.cpp:3692
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:2788
+#: ../../Firmware/ultralcd.cpp:3700 ../../Firmware/ultralcd.cpp:3702
 msgid "Preheating nozzle. Please wait."
 msgstr "Vorheizen der Düse. Bitte warten."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/messages.cpp:237 ../../Firmware/ultralcd.cpp:1999
+#: ../../Firmware/messages.cpp:249 ../../Firmware/ultralcd.cpp:2005
 msgid "Preheating to cut"
 msgstr "Heizen zum Schnitt"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/messages.cpp:236 ../../Firmware/ultralcd.cpp:1996
+#: ../../Firmware/messages.cpp:248 ../../Firmware/ultralcd.cpp:2002
 msgid "Preheating to eject"
 msgstr "Heizen zum Auswurf"
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/messages.cpp:234 ../../Firmware/ultralcd.cpp:1987
+#: ../../Firmware/messages.cpp:246 ../../Firmware/ultralcd.cpp:1995
 msgid "Preheating to load"
 msgstr "Heizen zum Laden"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/messages.cpp:235 ../../Firmware/ultralcd.cpp:1992
+#: ../../Firmware/messages.cpp:247 ../../Firmware/ultralcd.cpp:1999
 msgid "Preheating to unload"
 msgstr "Heizen zum Entladen"
 
@@ -1638,12 +1631,12 @@ msgid "Preparing blade"
 msgstr "Bereite Messer vor"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/messages.cpp:231 ../../Firmware/ultralcd.cpp:1799
+#: ../../Firmware/messages.cpp:243 ../../Firmware/ultralcd.cpp:1809
 msgid "Press the knob"
 msgstr "Knopf drücken zum"
 
 #. MSG_PRESS_TO_PREHEAT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:11227 ../../Firmware/messages.cpp:212
+#: ../../Firmware/Marlin_main.cpp:10299 ../../Firmware/messages.cpp:224
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Drücken Sie den Knopf um die Düse vorzuheizen und fortzufahren."
 
@@ -1653,34 +1646,34 @@ msgid "Print aborted"
 msgstr "Druck abgebrochen"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1106
-#: ../../Firmware/ultralcd.cpp:6994
+#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1116
+#: ../../Firmware/ultralcd.cpp:6971
 msgid "Print fan:"
 msgstr "Drucklüfter:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:5313
+#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5279
 msgid "Print from SD"
 msgstr "Drucken von SD"
 
 #. MSG_PRINT_PAUSED c=20
-#: ../../Firmware/Marlin_main.cpp:3582 ../../Firmware/messages.cpp:79
+#: ../../Firmware/Marlin_main.cpp:3323 ../../Firmware/messages.cpp:79
 #: ../../Firmware/ultralcd.cpp:814
 msgid "Print paused"
 msgstr "Druck pausiert"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/messages.cpp:247 ../../Firmware/ultralcd.cpp:2348
+#: ../../Firmware/messages.cpp:259 ../../Firmware/ultralcd.cpp:2365
 msgid "Print time"
 msgstr "Druckzeit"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/messages.cpp:225 ../../Firmware/ultralcd.cpp:1689
+#: ../../Firmware/messages.cpp:237 ../../Firmware/ultralcd.cpp:1699
 msgid "Printer IP Addr:"
 msgstr "Drucker IP Adr.:"
 
 #. MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1602 ../../Firmware/messages.cpp:46
+#: ../../Firmware/Marlin_main.cpp:1529 ../../Firmware/messages.cpp:46
 msgid ""
 "Printer has not been calibrated yet. Please follow the manual, chapter First"
 " steps, section Calibration flow."
@@ -1689,12 +1682,12 @@ msgstr ""
 "Schritte."
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:153 ../../Firmware/util.cpp:289
+#: ../../Firmware/messages.cpp:160 ../../Firmware/util.cpp:296
 msgid "Nozzle diameter differs from the G-code. Continue?"
 msgstr "Düsendurchmesser weicht vom G-Code ab. Fortfahren?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:154 ../../Firmware/util.cpp:290
+#: ../../Firmware/messages.cpp:161 ../../Firmware/util.cpp:297
 msgid ""
 "Nozzle diameter differs from the G-code. Please check the value in settings."
 " Print cancelled."
@@ -1721,22 +1714,22 @@ msgid "QUEUE FULL"
 msgstr "QUEUE VOLL"
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:4465
 msgid "RPi port"
 msgstr "RPi port"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/messages.cpp:261 ../../Firmware/ultralcd.cpp:2712
+#: ../../Firmware/messages.cpp:273 ../../Firmware/ultralcd.cpp:2729
 msgid "Rear side [µm]"
 msgstr "Hinten [µm]"
 
 #. MSG_RECOVERING_PRINT c=20
-#: ../../Firmware/messages.cpp:216 ../../Firmware/power_panic.cpp:316
+#: ../../Firmware/messages.cpp:228 ../../Firmware/power_panic.cpp:328
 msgid "Recovering print"
 msgstr "Druck wiederherstel."
 
 #. MSG_RENAME c=18
-#: ../../Firmware/messages.cpp:322 ../../Firmware/ultralcd.cpp:5143
+#: ../../Firmware/messages.cpp:334 ../../Firmware/ultralcd.cpp:5103
 msgid "Rename"
 msgstr "Umbenennen"
 
@@ -1750,19 +1743,19 @@ msgstr ""
 "Prüfen Sie den G-Code auf Plätze außerhalb des Bereichs (T0-T4)."
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:2713
-#: ../../Firmware/ultralcd.cpp:5144
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:2730
+#: ../../Firmware/ultralcd.cpp:5104
 msgid "Reset"
 msgstr "Reset"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/messages.cpp:320 ../../Firmware/ultralcd.cpp:4594
+#: ../../Firmware/messages.cpp:332 ../../Firmware/ultralcd.cpp:4550
 msgid "Reset XYZ calibr."
 msgstr "Reset XYZ Kalibr."
 
 #. MSG_RESUME_PRINT c=18
-#: ../../Firmware/Marlin_main.cpp:680 ../../Firmware/messages.cpp:91
-#: ../../Firmware/ultralcd.cpp:5286 ../../Firmware/ultralcd.cpp:5288
+#: ../../Firmware/Marlin_main.cpp:645 ../../Firmware/messages.cpp:91
+#: ../../Firmware/ultralcd.cpp:5252 ../../Firmware/ultralcd.cpp:5254
 msgid "Resume print"
 msgstr "Druck fortsetzen"
 
@@ -1789,17 +1782,17 @@ msgid "Returning selector"
 msgstr "Selektor zurückfahr."
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/messages.cpp:252 ../../Firmware/ultralcd.cpp:2479
+#: ../../Firmware/messages.cpp:264 ../../Firmware/ultralcd.cpp:2496
 msgid "Right"
 msgstr "Rechts"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/messages.cpp:259 ../../Firmware/ultralcd.cpp:2710
+#: ../../Firmware/messages.cpp:271 ../../Firmware/ultralcd.cpp:2727
 msgid "Right side[µm]"
 msgstr "Rechts [µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/messages.cpp:286 ../../Firmware/ultralcd.cpp:3656
+#: ../../Firmware/messages.cpp:298 ../../Firmware/ultralcd.cpp:3666
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1808,8 +1801,8 @@ msgstr ""
 "beginnen. Fortfahren?"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4509
-#: ../../Firmware/ultralcd.cpp:4511
+#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4476
+#: ../../Firmware/ultralcd.cpp:4478
 msgid "SD card"
 msgstr "SD Karte"
 
@@ -1824,23 +1817,23 @@ msgid "SELECTOR CANNOT MOVE"
 msgstr "SELEKTOR SITZT FEST"
 
 #. MSG_STOPPED c=20
-#: ../../Firmware/Marlin_main.cpp:9887 ../../Firmware/messages.cpp:125
+#: ../../Firmware/Marlin_main.cpp:9047 ../../Firmware/messages.cpp:130
 msgid "STOPPED."
 msgstr "GESTOPPT."
 
 #. MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3223 ../../Firmware/Marlin_main.cpp:3245
-#: ../../Firmware/mesh_bed_calibration.cpp:2246 ../../Firmware/messages.cpp:44
+#: ../../Firmware/Marlin_main.cpp:2967 ../../Firmware/Marlin_main.cpp:2984
+#: ../../Firmware/mesh_bed_calibration.cpp:2231 ../../Firmware/messages.cpp:44
 msgid "Searching bed calibration point"
 msgstr "Suche Bett Kalibrierpunkt"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/messages.cpp:321 ../../Firmware/ultralcd.cpp:5136
+#: ../../Firmware/messages.cpp:333 ../../Firmware/ultralcd.cpp:5096
 msgid "Select"
 msgstr "Auswahl"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/messages.cpp:290 ../../Firmware/ultralcd.cpp:3730
+#: ../../Firmware/messages.cpp:302 ../../Firmware/ultralcd.cpp:3740
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
@@ -1849,25 +1842,25 @@ msgstr ""
 " im On-Screen-Menü aus."
 
 #. MSG_SELECT_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3453 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3612
-#: ../../Firmware/ultralcd.cpp:6822
+#: ../../Firmware/Marlin_main.cpp:3192 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3622
+#: ../../Firmware/ultralcd.cpp:6798
 msgid "Select filament:"
 msgstr "Wähle filament:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:110 ../../Firmware/ultralcd.cpp:3464
-#: ../../Firmware/ultralcd.cpp:4504
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:3474
+#: ../../Firmware/ultralcd.cpp:4471
 msgid "Select language"
 msgstr "Wähle Sprache"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/messages.cpp:300 ../../Firmware/ultralcd.cpp:3900
+#: ../../Firmware/messages.cpp:312 ../../Firmware/ultralcd.cpp:3924
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr "Vorheiztemperatur auswählen, die Ihrem Material entspricht."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/messages.cpp:291 ../../Firmware/ultralcd.cpp:3735
+#: ../../Firmware/messages.cpp:303 ../../Firmware/ultralcd.cpp:3745
 msgid "Select temperature which matches your material."
 msgstr "Wählen Sie die Temperatur, die zu Ihrem Material passt."
 
@@ -1878,61 +1871,61 @@ msgid "Selecting fil. slot"
 msgstr "Wähle Filament Platz"
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/messages.cpp:341 ../../Firmware/ultralcd.cpp:6274
+#: ../../Firmware/messages.cpp:353 ../../Firmware/ultralcd.cpp:6250
 msgid "Selftest OK"
 msgstr "Selbsttest OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/messages.cpp:340 ../../Firmware/ultralcd.cpp:6057
+#: ../../Firmware/messages.cpp:352 ../../Firmware/ultralcd.cpp:6033
 msgid "Selftest start"
 msgstr "Selbsttest start"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/messages.cpp:315 ../../Firmware/ultralcd.cpp:4581
+#: ../../Firmware/messages.cpp:327 ../../Firmware/ultralcd.cpp:4537
 msgid "Selftest"
 msgstr "Selbsttest"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/messages.cpp:342 ../../Firmware/ultralcd.cpp:6699
+#: ../../Firmware/messages.cpp:354 ../../Firmware/ultralcd.cpp:6675
 msgid "Selftest error!"
 msgstr "Selbsttest Fehler!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6279
-#: ../../Firmware/ultralcd.cpp:6786 ../../Firmware/ultralcd.cpp:6984
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6255
+#: ../../Firmware/ultralcd.cpp:6762 ../../Firmware/ultralcd.cpp:6961
 msgid "Selftest failed"
 msgstr "Selbsttest Error"
 
 #. MSG_FORCE_SELFTEST c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1577 ../../Firmware/messages.cpp:202
+#: ../../Firmware/Marlin_main.cpp:1504 ../../Firmware/messages.cpp:214
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr "Selbsttest wird gestartet, um Startposition zu kalibrieren."
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/messages.cpp:228 ../../Firmware/ultralcd.cpp:1701
+#: ../../Firmware/messages.cpp:240 ../../Firmware/ultralcd.cpp:1711
 msgid "Sensor info"
 msgstr "Sensor Info"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/messages.cpp:338 ../../Firmware/ultralcd.cpp:6027
+#: ../../Firmware/messages.cpp:350 ../../Firmware/ultralcd.cpp:6003
 msgid "Sensor verified, remove the filament now."
 msgstr "FSensor überprüft, entladen Sie jetzt das Filament."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/messages.cpp:262 ../../Firmware/ultralcd.cpp:2730
+#: ../../Firmware/messages.cpp:274 ../../Firmware/ultralcd.cpp:2747
 msgid "Set temperature:"
 msgstr "Temp. einstellen:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3348
-#: ../../Firmware/ultralcd.cpp:3479 ../../Firmware/ultralcd.cpp:3984
-#: ../../Firmware/ultralcd.cpp:5374 ../../Firmware/ultralcd.cpp:5585
-#: ../../Firmware/ultralcd.cpp:5631
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3358
+#: ../../Firmware/ultralcd.cpp:3489 ../../Firmware/ultralcd.cpp:4008
+#: ../../Firmware/ultralcd.cpp:5341 ../../Firmware/ultralcd.cpp:5558
+#: ../../Firmware/ultralcd.cpp:5604
 msgid "Settings"
 msgstr "Einstellungen"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/messages.cpp:255 ../../Firmware/ultralcd.cpp:2522
+#: ../../Firmware/messages.cpp:267 ../../Firmware/ultralcd.cpp:2539
 msgid "Severe skew"
 msgstr "Sehr schräg"
 
@@ -1943,7 +1936,7 @@ msgid "Sheet"
 msgstr "Stahlblech"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/messages.cpp:284 ../../Firmware/ultralcd.cpp:3604
+#: ../../Firmware/messages.cpp:296 ../../Firmware/ultralcd.cpp:3614
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1956,23 +1949,23 @@ msgstr ""
 "%cReset"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/messages.cpp:319 ../../Firmware/ultralcd.cpp:4592
+#: ../../Firmware/messages.cpp:331 ../../Firmware/ultralcd.cpp:4548
 msgid "Show end stops"
 msgstr "Endschalter Status"
 
 #. MSG_SILENT c=7
-#: ../../Firmware/Marlin_main.cpp:8497 ../../Firmware/messages.cpp:120
-#: ../../Firmware/ultralcd.cpp:4155 ../../Firmware/ultralcd.cpp:4194
+#: ../../Firmware/Marlin_main.cpp:7668 ../../Firmware/messages.cpp:124
+#: ../../Firmware/ultralcd.cpp:4179 ../../Firmware/ultralcd.cpp:4218
 msgid "Silent"
 msgstr "Leise"
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/messages.cpp:254 ../../Firmware/ultralcd.cpp:2521
+#: ../../Firmware/messages.cpp:266 ../../Firmware/ultralcd.cpp:2538
 msgid "Slight skew"
 msgstr "Leicht schräg"
 
 #. MSG_FILE_CNT c=20 r=6
-#: ../../Firmware/cardreader.cpp:805 ../../Firmware/messages.cpp:197
+#: ../../Firmware/cardreader.cpp:805 ../../Firmware/messages.cpp:209
 msgid ""
 "Some files will not be sorted. Max. No. of files in 1 folder for sorting is "
 "100."
@@ -1980,59 +1973,59 @@ msgstr ""
 "Einige Dateien wur- den nicht sortiert. Max. Dateien pro Verzeichnis = 100."
 
 #. MSG_ZLEVELING_ENFORCED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3043 ../../Firmware/messages.cpp:204
+#: ../../Firmware/Marlin_main.cpp:2783 ../../Firmware/messages.cpp:216
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Fehler aufgetreten, Z-Kalibrierung erforderlich..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:4514
-#: ../../Firmware/ultralcd.cpp:4515 ../../Firmware/ultralcd.cpp:4516
+#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4481
+#: ../../Firmware/ultralcd.cpp:4482 ../../Firmware/ultralcd.cpp:4483
 msgid "Sort"
 msgstr "Sort."
 
 #. MSG_SORTING_FILES c=20
 #: ../../Firmware/cardreader.cpp:849 ../../Firmware/cardreader.cpp:916
-#: ../../Firmware/messages.cpp:111
+#: ../../Firmware/messages.cpp:115
 msgid "Sorting files"
 msgstr "Sortiere Dateien"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4188
-#: ../../Firmware/ultralcd.cpp:4191 ../../Firmware/ultralcd.cpp:4194
-#: ../../Firmware/ultralcd.cpp:4197 ../../Firmware/ultralcd.cpp:4200
+#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4215 ../../Firmware/ultralcd.cpp:4218
+#: ../../Firmware/ultralcd.cpp:4221 ../../Firmware/ultralcd.cpp:4224
 msgid "Sound"
 msgstr "Ton"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/messages.cpp:333 ../../Firmware/ultralcd.cpp:5516
+#: ../../Firmware/messages.cpp:345 ../../Firmware/ultralcd.cpp:5483
 msgid "Speed"
 msgstr "Tempo"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6861
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6837
 msgid "Spinning"
 msgstr "Dreht sich"
 
 #. MSG_TEMP_CAL_WARNING c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4744 ../../Firmware/messages.cpp:208
+#: ../../Firmware/Marlin_main.cpp:4313 ../../Firmware/messages.cpp:220
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr ""
 "Stabile Umgebungs- temperatur 21-26C und feste Stand- fläche erforderlich."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/messages.cpp:329 ../../Firmware/ultralcd.cpp:5379
+#: ../../Firmware/messages.cpp:341 ../../Firmware/ultralcd.cpp:5346
 msgid "Statistics"
 msgstr "Statistiken"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:4096
-#: ../../Firmware/ultralcd.cpp:4144
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4120
+#: ../../Firmware/ultralcd.cpp:4168
 msgid "Stealth"
 msgstr "Leise"
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4421
-#: ../../Firmware/ultralcd.cpp:5133
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4388
+#: ../../Firmware/ultralcd.cpp:5093
 msgid "Steel sheets"
 msgstr "Stahlbleche"
 
@@ -2042,29 +2035,28 @@ msgid "Stop"
 msgstr "Stop"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:5293
-#: ../../Firmware/ultralcd.cpp:5781
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:5259
+#: ../../Firmware/ultralcd.cpp:5757
 msgid "Stop print"
 msgstr "Druck abbrechen"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4236
-#: ../../Firmware/ultralcd.cpp:4316 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4315
 msgid "Strict"
 msgstr "Strikt"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/messages.cpp:332 ../../Firmware/ultralcd.cpp:5394
+#: ../../Firmware/messages.cpp:344 ../../Firmware/ultralcd.cpp:5361
 msgid "Support"
 msgstr "Support"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/messages.cpp:354 ../../Firmware/ultralcd.cpp:6758
+#: ../../Firmware/messages.cpp:366 ../../Firmware/ultralcd.cpp:6734
 msgid "Swapped"
 msgstr "Ausgetauscht"
 
 #. MSG_THERMAL_ANOMALY c=20
-#: ../../Firmware/messages.cpp:188 ../../Firmware/temperature.cpp:2223
+#: ../../Firmware/messages.cpp:195 ../../Firmware/temperature.cpp:2197
 msgid "THERMAL ANOMALY"
 msgstr "THERMISCHE ANOMALIE"
 
@@ -2099,7 +2091,7 @@ msgid "TMC UNDERVOLTAGE ERR"
 msgstr "TMC UNTERSPANN.FEHL."
 
 #. MSG_TM_CAL c=20 r=4
-#: ../../Firmware/messages.cpp:299 ../../Firmware/ultralcd.cpp:3881
+#: ../../Firmware/messages.cpp:311 ../../Firmware/ultralcd.cpp:3905
 msgid ""
 "Thermal model cal. takes approx. 12 mins. See\n"
 "prusa.io/tm-cal"
@@ -2108,22 +2100,22 @@ msgstr ""
 "prusa.io/tm-cal"
 
 #. MSG_TM_NOT_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1613 ../../Firmware/messages.cpp:189
+#: ../../Firmware/Marlin_main.cpp:1540 ../../Firmware/messages.cpp:196
 msgid "Thermal model not calibrated yet."
 msgstr "Thermomodell noch nicht kalibriert."
 
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/messages.cpp:309 ../../Firmware/ultralcd.cpp:4455
+#: ../../Firmware/messages.cpp:321 ../../Firmware/ultralcd.cpp:4422
 msgid "Temperature"
 msgstr "Temperatur"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/messages.cpp:229 ../../Firmware/ultralcd.cpp:1707
+#: ../../Firmware/messages.cpp:241 ../../Firmware/ultralcd.cpp:1717
 msgid "Temperatures"
 msgstr "Temperaturen"
 
 #. MSG_TESTING_FILAMENT c=20
-#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:388
+#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:389
 msgid "Testing filament"
 msgstr "Teste filament"
 
@@ -2142,7 +2134,7 @@ msgid ""
 msgstr "Selektor erreicht Startpos. nicht. Prüf, ob etwas blockiert."
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/messages.cpp:292 ../../Firmware/ultralcd.cpp:3738
+#: ../../Firmware/messages.cpp:304 ../../Firmware/ultralcd.cpp:3748
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -2153,7 +2145,7 @@ msgstr ""
 "im Handbuch."
 
 #. MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1606 ../../Firmware/messages.cpp:47
+#: ../../Firmware/Marlin_main.cpp:1533 ../../Firmware/messages.cpp:47
 msgid ""
 "There is still a need to make Z calibration. Please follow the manual, "
 "chapter First steps, section Calibration flow."
@@ -2162,40 +2154,40 @@ msgstr ""
 " Schritte."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:4514
+#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:4481
 msgid "Time"
 msgstr "Zeit"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:176 ../../Firmware/ultralcd.cpp:5622
+#: ../../Firmware/messages.cpp:183 ../../Firmware/ultralcd.cpp:5595
 msgid "Timeout"
 msgstr "Timeout"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:1129
-#: ../../Firmware/ultralcd.cpp:1287
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:1139
+#: ../../Firmware/ultralcd.cpp:1297
 msgid "Total"
 msgstr "Gesamt"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:1177
-#: ../../Firmware/ultralcd.cpp:1231 ../../Firmware/ultralcd.cpp:1317
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:1187
+#: ../../Firmware/ultralcd.cpp:1241 ../../Firmware/ultralcd.cpp:1327
 msgid "Total failures"
 msgstr "Gesamte Fehler"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/messages.cpp:248 ../../Firmware/ultralcd.cpp:2369
+#: ../../Firmware/messages.cpp:260 ../../Firmware/ultralcd.cpp:2386
 msgid "Total filament"
 msgstr "Gesamtes Filament"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/messages.cpp:249 ../../Firmware/ultralcd.cpp:2370
+#: ../../Firmware/messages.cpp:261 ../../Firmware/ultralcd.cpp:2387
 msgid "Total print time"
 msgstr "Gesamte Druckzeit"
 
 #. MSG_TUNE c=8
-#: ../../Firmware/messages.cpp:116 ../../Firmware/mmu2/errors_list.h:372
-#: ../../Firmware/ultralcd.cpp:5258
+#: ../../Firmware/messages.cpp:120 ../../Firmware/mmu2/errors_list.h:372
+#: ../../Firmware/ultralcd.cpp:5220
 msgid "Tune"
 msgstr "Anpassen"
 
@@ -2210,16 +2202,16 @@ msgid "Unload"
 msgstr "Entla."
 
 #. MSG_UNLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:2206
-#: ../../Firmware/ultralcd.cpp:5347 ../../Firmware/ultralcd.cpp:5364
-#: ../../Firmware/ultralcd.cpp:5369
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:2220
+#: ../../Firmware/ultralcd.cpp:5313 ../../Firmware/ultralcd.cpp:5331
+#: ../../Firmware/ultralcd.cpp:5336
 msgid "Unload filament"
 msgstr "Fil. entladen"
 
 #. MSG_UNLOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3436 ../../Firmware/messages.cpp:129
+#: ../../Firmware/Marlin_main.cpp:3175 ../../Firmware/messages.cpp:134
 #: ../../Firmware/mmu2_progress_converter.cpp:50
-#: ../../Firmware/ultralcd.cpp:4911
+#: ../../Firmware/ultralcd.cpp:4867
 msgid "Unloading filament"
 msgstr "Filament auswerfen"
 
@@ -2236,14 +2228,14 @@ msgid "Unloading to pulley"
 msgstr "Entlade zur Riemens."
 
 #. MSG_FIL_FAILED c=20 r=4
-#: ../../Firmware/messages.cpp:339 ../../Firmware/ultralcd.cpp:6030
+#: ../../Firmware/messages.cpp:351 ../../Firmware/ultralcd.cpp:6006
 msgid "Verification failed, remove the filament and try again."
 msgstr ""
 "Überprüfung fehl- geschlagen, entladen Sie das Filament und nochmals "
 "versuchen."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/messages.cpp:230 ../../Firmware/ultralcd.cpp:1710
+#: ../../Firmware/messages.cpp:242 ../../Firmware/ultralcd.cpp:1720
 msgid "Voltages"
 msgstr "Spannungen"
 
@@ -2254,7 +2246,7 @@ msgid "WARNING TMC TOO HOT"
 msgstr "WARNUNG TMC ZU HEISS"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/messages.cpp:281 ../../Firmware/ultralcd.cpp:3381
+#: ../../Firmware/messages.cpp:293 ../../Firmware/ultralcd.cpp:3391
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -2267,199 +2259,199 @@ msgstr ""
 "Stealth Modus"
 
 #. MSG_USERWAIT c=20
-#: ../../Firmware/Marlin_main.cpp:5240 ../../Firmware/messages.cpp:209
+#: ../../Firmware/Marlin_main.cpp:4747 ../../Firmware/messages.cpp:221
 msgid "Wait for user..."
 msgstr "Warte auf Benutzer.."
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/messages.cpp:263 ../../Firmware/ultralcd.cpp:2753
+#: ../../Firmware/messages.cpp:275 ../../Firmware/ultralcd.cpp:2770
 msgid "Waiting for PINDA probe cooling"
 msgstr "Warte bis PINDA- Sonde abgekühlt ist"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/messages.cpp:264 ../../Firmware/ultralcd.cpp:2782
+#: ../../Firmware/messages.cpp:276 ../../Firmware/ultralcd.cpp:2799
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Warte bis Heizung und Bett abgekühlt sind"
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:4233
-#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4352
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4312
 msgid "Warn"
 msgstr "Warnen"
 
 #. MSG_CHANGED_BOTH c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1554 ../../Firmware/messages.cpp:200
+#: ../../Firmware/Marlin_main.cpp:1481 ../../Firmware/messages.cpp:212
 msgid "Warning: both printer type and motherboard type changed."
 msgstr "Warnung: Druckertyp und Platinentyp wurden beide geändert."
 
 #. MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1546 ../../Firmware/messages.cpp:198
+#: ../../Firmware/Marlin_main.cpp:1473 ../../Firmware/messages.cpp:210
 msgid "Warning: motherboard type changed."
 msgstr "Warnung: Platinentyp wurde geändert."
 
 #. MSG_CHANGED_PRINTER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1550 ../../Firmware/messages.cpp:199
+#: ../../Firmware/Marlin_main.cpp:1477 ../../Firmware/messages.cpp:211
 msgid "Warning: printer type changed."
 msgstr "Warnung: Druckertyp wurde geändert."
 
 #. MSG_UNLOAD_SUCCESSFUL c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3517 ../../Firmware/messages.cpp:205
+#: ../../Firmware/Marlin_main.cpp:3257 ../../Firmware/messages.cpp:217
 msgid "Was filament unload successful?"
 msgstr "Konnten Sie das Filament entnehmen?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:6710
-#: ../../Firmware/ultralcd.cpp:6714 ../../Firmware/ultralcd.cpp:6734
-#: ../../Firmware/ultralcd.cpp:6740 ../../Firmware/ultralcd.cpp:6764
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:6686
+#: ../../Firmware/ultralcd.cpp:6690 ../../Firmware/ultralcd.cpp:6710
+#: ../../Firmware/ultralcd.cpp:6716 ../../Firmware/ultralcd.cpp:6740
 msgid "Wiring error"
 msgstr "Verdrahtungsfehler"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/messages.cpp:313 ../../Firmware/ultralcd.cpp:4572
+#: ../../Firmware/messages.cpp:325 ../../Firmware/ultralcd.cpp:4528
 msgid "Wizard"
 msgstr "Assistent"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/messages.cpp:304 ../../Firmware/ultralcd.cpp:3986
+#: ../../Firmware/messages.cpp:316 ../../Firmware/ultralcd.cpp:4010
 msgid "X-correct"
 msgstr "X-Korrektur"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/messages.cpp:226 ../../Firmware/ultralcd.cpp:1699
+#: ../../Firmware/messages.cpp:238 ../../Firmware/ultralcd.cpp:1709
 msgid "XYZ cal. details"
 msgstr "XYZ Kal. Details"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/messages.cpp:275 ../../Firmware/ultralcd.cpp:3207
+#: ../../Firmware/messages.cpp:287 ../../Firmware/ultralcd.cpp:3217
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr "XYZ Kalibrierung in Ordnung. Schräglauf wird automatisch korrigiert."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/messages.cpp:274 ../../Firmware/ultralcd.cpp:3204
+#: ../../Firmware/messages.cpp:286 ../../Firmware/ultralcd.cpp:3214
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr ""
 "XYZ Kalibrierung in Ordnung. X/Y Achsen sind etwas schräg. Gut gemacht!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/messages.cpp:271 ../../Firmware/ultralcd.cpp:3185
+#: ../../Firmware/messages.cpp:283 ../../Firmware/ultralcd.cpp:3195
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr ""
 "XYZ-Kalibrierung beeinträchtigt. Vordere Kal.-Punkte nicht erreichbar."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/messages.cpp:272 ../../Firmware/ultralcd.cpp:3188
+#: ../../Firmware/messages.cpp:284 ../../Firmware/ultralcd.cpp:3198
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr ""
 "XYZ-Kalibrierung beeinträchtigt. Kal. -Punkt vorne rechts nicht erreichbar."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/messages.cpp:268 ../../Firmware/ultralcd.cpp:3167
+#: ../../Firmware/messages.cpp:280 ../../Firmware/ultralcd.cpp:3177
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr "XYZ-Kalibrierung fehlgeschlagen. Bett-Kalibrierpunkt nicht gefunden."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/messages.cpp:269 ../../Firmware/ultralcd.cpp:3173
+#: ../../Firmware/messages.cpp:281 ../../Firmware/ultralcd.cpp:3183
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr ""
 "XYZ-Kalibrierung fehlgeschlagen. Vordere Kal.-Punkte nicht erreichbar."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3170
-#: ../../Firmware/ultralcd.cpp:3198
+#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3180
+#: ../../Firmware/ultralcd.cpp:3208
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "XYZ-Kalibrierung fehlgeschlagen - mehr im Handbuch."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/messages.cpp:270 ../../Firmware/ultralcd.cpp:3176
+#: ../../Firmware/messages.cpp:282 ../../Firmware/ultralcd.cpp:3186
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr ""
 "XYZ-Kalibrierung fehlgeschlagen. Kal. -Punkt vorne rechts nicht erreichbar."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/messages.cpp:273 ../../Firmware/ultralcd.cpp:3201
+#: ../../Firmware/messages.cpp:285 ../../Firmware/ultralcd.cpp:3211
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr ""
 "XYZ-Kalibrierung ok. X/Y-Achsen sind senkrecht zueinander Glückwunsch!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/messages.cpp:250 ../../Firmware/ultralcd.cpp:2476
+#: ../../Firmware/messages.cpp:262 ../../Firmware/ultralcd.cpp:2493
 msgid "Y distance from min"
 msgstr "Y Entfernung vom Min"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/messages.cpp:305 ../../Firmware/ultralcd.cpp:3987
+#: ../../Firmware/messages.cpp:317 ../../Firmware/ultralcd.cpp:4011
 msgid "Y-correct"
 msgstr "Y-Korrektur"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:3029
-#: ../../Firmware/ultralcd.cpp:4443 ../../Firmware/ultralcd.cpp:4531
-#: ../../Firmware/ultralcd.cpp:5790
+#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:2275
+#: ../../Firmware/ultralcd.cpp:2279 ../../Firmware/ultralcd.cpp:3046
+#: ../../Firmware/ultralcd.cpp:4410 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/ultralcd.cpp:5766
 msgid "Yes"
 msgstr "Ja"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:3950
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:3974
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr ""
 "Im Menü Kalibrierung -> Assistent können Sie den Assistenten immer neu "
 "starten."
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/messages.cpp:306 ../../Firmware/ultralcd.cpp:3988
+#: ../../Firmware/messages.cpp:318 ../../Firmware/ultralcd.cpp:4012
 msgid "Z-correct"
 msgstr "Z-Korrektur"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5593
+#: ../../Firmware/messages.cpp:175 ../../Firmware/ultralcd.cpp:5566
 msgid "Z-probe nr."
 msgstr "Z-Test Nr."
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/messages.cpp:256 ../../Firmware/ultralcd.cpp:2546
+#: ../../Firmware/messages.cpp:268 ../../Firmware/ultralcd.cpp:2563
 msgid "[0;0] point offset"
 msgstr "[0;0] Punktversatz"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/messages.cpp:239 ../../Firmware/ultralcd.cpp:2147
+#: ../../Firmware/messages.cpp:251 ../../Firmware/ultralcd.cpp:2158
 msgid "and press the knob"
 msgstr "und Knopf drücken"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/messages.cpp:232 ../../Firmware/ultralcd.cpp:1807
+#: ../../Firmware/messages.cpp:244 ../../Firmware/ultralcd.cpp:1816
 msgid "to load filament"
 msgstr "um Filament laden"
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/messages.cpp:233 ../../Firmware/ultralcd.cpp:1811
+#: ../../Firmware/messages.cpp:245 ../../Firmware/ultralcd.cpp:1820
 msgid "to unload filament"
 msgstr "um Filament entladen"
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/messages.cpp:224 ../../Firmware/ultralcd.cpp:1666
+#: ../../Firmware/messages.cpp:236 ../../Firmware/ultralcd.cpp:1676
 msgid "unknown"
 msgstr "unbekannt"
 
 #. MSG_IR_UNKNOWN c=18
-#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:184
+#: ../../Firmware/Filament_sensor.cpp:286 ../../Firmware/messages.cpp:191
 msgid "unknown state"
 msgstr "Status unbekannt"
 
 #. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:5858
-#: ../../Firmware/ultralcd.cpp:5861
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:5834
+#: ../../Firmware/ultralcd.cpp:5837
 msgid "🔃Refresh"
 msgstr "🔃Aktualisiere"
 
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1180
+#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1190
 msgid "MMU power fails"
 msgstr "MMU Netzfehler"
 
 #. MSG_EJECT_FROM_MMU c=16
-#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:384
-#: ../../Firmware/ultralcd.cpp:4845 ../../Firmware/ultralcd.cpp:5348
+#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:385
+#: ../../Firmware/ultralcd.cpp:4801 ../../Firmware/ultralcd.cpp:5314
 msgid "Eject from MMU"
 msgstr "Aus MMU auswerf."
 
@@ -2497,8 +2489,8 @@ msgid "MMU MCU ERROR"
 msgstr "MMU MCU FEHLER"
 
 #. MSG_MATERIAL_CHANGES c=18
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:1130
-#: ../../Firmware/ultralcd.cpp:1204
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:1140
+#: ../../Firmware/ultralcd.cpp:1214
 msgid "Material changes"
 msgstr "Materialwechsel"
 
@@ -2528,17 +2520,17 @@ msgid ""
 msgstr "MMU FW ist inkompatibel mit Drucker FW. Update auf Version 3.0.3."
 
 #. MSG_PRELOAD_TO_MMU c=17
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5344
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5310
 msgid "Preload to MMU"
 msgstr "In MMU laden"
 
 #. MSG_FW_MK3_DETECTED c=20 r=4
-#: ../../Firmware/messages.cpp:367 ../../Firmware/Marlin_main.cpp:920
+#: ../../Firmware/messages.cpp:379 ../../Firmware/Marlin_main.cpp:854
 msgid "MK3 firmware detected on MK3S printer"
 msgstr "MK3-Firmware am MK3S-Drucker erkannt"
 
 #. MSG_FW_MK3S_DETECTED c=20 r=4
-#: ../../Firmware/messages.cpp:367 ../../Firmware/Marlin_main.cpp:920
+#: ../../Firmware/messages.cpp:379 ../../Firmware/Marlin_main.cpp:854
 msgid "MK3S firmware detected on MK3 printer"
 msgstr "MK3S-Firmware auf MK3-Drucker erkannt"
 
@@ -2552,8 +2544,9 @@ msgstr "UNBEKANNTER FEHLER"
 msgid "Unexpected error occurred."
 msgstr "Ein unerwarteter Fehler ist aufgetreten."
 
-#. MSG_BTN_EJECT c=8
-#: ../../Firmware/mmu2/errors_list.h:358 ../../Firmware/mmu2/errors_list.h:371
+#. MSG_EJECT c=8
+#: ../../Firmware/messages.cpp:21 ../../Firmware/mmu2/errors_list.h:371
+#: ../../Firmware/ultralcd.cpp:2275 ../../Firmware/ultralcd.cpp:2279
 msgid "Eject"
 msgstr "Auswerf."
 
@@ -2575,58 +2568,58 @@ msgstr ""
 "aus."
 
 #. MSG_MMU_SENSITIVITY c=18
-#: ../../Firmware/messages.cpp:215 ../../Firmware/mmu2_reporting.cpp:458
+#: ../../Firmware/messages.cpp:227 ../../Firmware/mmu2_reporting.cpp:459
 msgid "Sensitivity"
 msgstr "Sensitivität"
 
 #. MSG_MBL_FAILED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3038 ../../Firmware/messages.cpp:203
+#: ../../Firmware/Marlin_main.cpp:2776 ../../Firmware/messages.cpp:215
 msgid "Mesh bed leveling failed. Print canceled."
 msgstr "MeshBett Ausgleich fehlgeschlagen. Druck abgebrochen."
 
 #. MSG_SET_READY c=18
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:5265
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:5228
 msgid "Set Ready"
 msgstr "Bereit setzen"
 
 #. MSG_SET_NOT_READY c=18
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:5263
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5226
 msgid "Set not Ready"
 msgstr "Nicht breit setzen"
 
 #. MSG_HOSTPRINT c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5285
+#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:5231
 msgid "Print from host"
 msgstr "Drucken vom Host"
 
 #. MSG_REPRINT c=18
-#: ../../Firmware/messages.cpp:196 ../../Firmware/ultralcd.cpp:5243
-#: ../../Firmware/ultralcd.cpp:5245
+#: ../../Firmware/messages.cpp:208 ../../Firmware/ultralcd.cpp:5205
+#: ../../Firmware/ultralcd.cpp:5207
 msgid "Reprint"
 msgstr "Druck wiederholen"
 
 #. MSG_SHUTDOWN_HOST c=18
-#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:5390
+#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:5357
 msgid "Shutdown host"
 msgstr "Host runterfahren"
 
 #. MSG_NOZZLE_CNG_COOLDOWN c=20 r=3
-#: ../../Firmware/messages.cpp:198 ../../Firmware/ultralcd.cpp:1002
+#: ../../Firmware/messages.cpp:203 ../../Firmware/ultralcd.cpp:999
 msgid "Nozzle is hot! Wait for cooldown."
 msgstr "Die Düse ist heiß! Auf Abkühlung warten."
 
 #. MSG_NOZZLE_CNG_CHANGED_QUICK c=20 r=3
-#: ../../Firmware/messages.cpp:199
+#: ../../Firmware/messages.cpp:204
 msgid "Nozzle changed?"
 msgstr "Düse gewechselt?"
 
 #. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:388
+#: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:388
 msgid "There is no filament loaded. Continue?"
 msgstr "Kein Filament geladen. Fortfahren?"
 
 #. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:389
+#: ../../Firmware/messages.cpp:159 ../../Firmware/util.cpp:389
 msgid "There is no filament loaded. Print cancelled."
 msgstr "Kein Filament geladen. Druck abgebrochen."
 

--- a/lang/po/Firmware_es.po
+++ b/lang/po/Firmware_es.po
@@ -16,91 +16,91 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 
 #. MSG_IR_03_OR_OLDER c=18
-#: ../../Firmware/Filament_sensor.cpp:280
-#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:183
+#: ../../Firmware/Filament_sensor.cpp:282
+#: ../../Firmware/Filament_sensor.cpp:344 ../../Firmware/messages.cpp:190
 msgid " 0.3 or older"
 msgstr " 0.3 o mayor"
 
 #. MSG_IR_04_OR_NEWER c=18
-#: ../../Firmware/Filament_sensor.cpp:282
-#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:182
+#: ../../Firmware/Filament_sensor.cpp:284
+#: ../../Firmware/Filament_sensor.cpp:347 ../../Firmware/messages.cpp:189
 msgid " 0.4 or newer"
 msgstr " 0.4 o más nueva"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/messages.cpp:356 ../../Firmware/ultralcd.cpp:6773
+#: ../../Firmware/messages.cpp:368 ../../Firmware/ultralcd.cpp:6749
 msgid "%s level expected"
 msgstr "%s nivel esperado"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:1978
-#: ../../Firmware/ultralcd.cpp:3613
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:1986
+#: ../../Firmware/ultralcd.cpp:3623
 msgid ">Cancel"
 msgstr ">Cancelar"
 
 #. MSG_BABYSTEPPING_Z c=13
-#: ../../Firmware/messages.cpp:257 ../../Firmware/ultralcd.cpp:2635
+#: ../../Firmware/messages.cpp:269 ../../Firmware/ultralcd.cpp:2652
 msgid "Adjusting Z"
 msgstr "Ajustar-Z"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/messages.cpp:360 ../../Firmware/ultralcd.cpp:6983
+#: ../../Firmware/messages.cpp:372 ../../Firmware/ultralcd.cpp:6960
 msgid "All correct"
 msgstr "Todo bien"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:3955
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:3979
 msgid "All is done. Happy printing!"
 msgstr "Terminado. Felices impresiones!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4482
 msgid "Alphabet"
 msgstr "Alfabeto"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4086
+#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4110
 msgid "Always"
 msgstr "Siemp."
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/messages.cpp:221 ../../Firmware/ultralcd.cpp:1393
+#: ../../Firmware/messages.cpp:233 ../../Firmware/ultralcd.cpp:1403
 msgid "Ambient"
 msgstr "Ambiente"
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=3
-#: ../../Firmware/messages.cpp:267 ../../Firmware/ultralcd.cpp:2848
+#: ../../Firmware/messages.cpp:279 ../../Firmware/ultralcd.cpp:2865
 msgid "Are left and right Z-carriages all up?"
 msgstr "¿Carros Z izq./der. están arriba máximo?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4197
+#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:4221
 msgid "Assist"
 msgstr "Asist."
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:179 ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/messages.cpp:186 ../../Firmware/ultralcd.cpp:5594
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
-#: ../../Firmware/Marlin_main.cpp:3198 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:4577 ../../Firmware/ultralcd.cpp:5529
+#: ../../Firmware/Marlin_main.cpp:2942 ../../Firmware/messages.cpp:12
+#: ../../Firmware/ultralcd.cpp:4533 ../../Firmware/ultralcd.cpp:5496
 msgid "Auto home"
 msgstr "Ir al origen"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4182
 msgid "Auto power"
 msgstr "Encendido"
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:328 ../../Firmware/ultralcd.cpp:5359
+#: ../../Firmware/messages.cpp:340 ../../Firmware/ultralcd.cpp:5328
 msgid "AutoLoad filament"
 msgstr "Carga auto. filam."
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/messages.cpp:245 ../../Firmware/ultralcd.cpp:2272
+#: ../../Firmware/messages.cpp:257 ../../Firmware/ultralcd.cpp:2289
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
@@ -113,51 +113,50 @@ msgid "Avoiding grind"
 msgstr "Evita morder"
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/messages.cpp:352 ../../Firmware/ultralcd.cpp:6752
+#: ../../Firmware/messages.cpp:364 ../../Firmware/ultralcd.cpp:6728
 msgid "Axis"
 msgstr "Eje"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/messages.cpp:351 ../../Firmware/ultralcd.cpp:6751
+#: ../../Firmware/messages.cpp:363 ../../Firmware/ultralcd.cpp:6727
 msgid "Axis length"
 msgstr "Longitud del eje"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2708
-#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:5618
-#: ../../Firmware/ultralcd.cpp:7484
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2725
+#: ../../Firmware/ultralcd.cpp:4061 ../../Firmware/ultralcd.cpp:5591
+#: ../../Firmware/ultralcd.cpp:7461
 msgid "Back"
 msgstr "Atrás"
 
 #. MSG_BED c=13
-#: ../../Firmware/Marlin_main.cpp:2081 ../../Firmware/Marlin_main.cpp:4627
-#: ../../Firmware/Marlin_main.cpp:4678 ../../Firmware/messages.cpp:15
-#: ../../Firmware/ultralcd.cpp:1391 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/Marlin_main.cpp:4247 ../../Firmware/messages.cpp:15
+#: ../../Firmware/ultralcd.cpp:1401 ../../Firmware/ultralcd.cpp:4197
 msgid "Bed"
 msgstr "Base"
 
 #. MSG_BED_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6240 ../../Firmware/messages.cpp:17
+#: ../../Firmware/Marlin_main.cpp:5470 ../../Firmware/messages.cpp:17
 #: ../../Firmware/ultralcd.cpp:534
 msgid "Bed Heating"
 msgstr "Calentando Base"
 
 #. MSG_BED_DONE c=20
-#: ../../Firmware/Marlin_main.cpp:6277 ../../Firmware/messages.cpp:16
+#: ../../Firmware/Marlin_main.cpp:5507 ../../Firmware/messages.cpp:16
 #: ../../Firmware/ultralcd.cpp:537
 msgid "Bed done"
 msgstr "Base preparada"
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/messages.cpp:317 ../../Firmware/ultralcd.cpp:4589
+#: ../../Firmware/messages.cpp:329 ../../Firmware/ultralcd.cpp:4545
 msgid "Bed level correct"
 msgstr "Corr. de la cama"
 
 #. MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:2262 ../../Firmware/Marlin_main.cpp:2999
-#: ../../Firmware/Marlin_main.cpp:3008
-#: ../../Firmware/mesh_bed_calibration.cpp:2878
-#: ../../Firmware/mesh_bed_calibration.cpp:2903 ../../Firmware/messages.cpp:18
+#: ../../Firmware/Marlin_main.cpp:2048 ../../Firmware/Marlin_main.cpp:2736
+#: ../../Firmware/Marlin_main.cpp:2745
+#: ../../Firmware/mesh_bed_calibration.cpp:2863
+#: ../../Firmware/mesh_bed_calibration.cpp:2888 ../../Firmware/messages.cpp:18
 msgid ""
 "Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for "
 "reset."
@@ -166,34 +165,34 @@ msgstr ""
 "reset."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/messages.cpp:346 ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/messages.cpp:358 ../../Firmware/ultralcd.cpp:6685
 msgid "Bed/Heater"
 msgstr "Base/Calentador"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1444
-#: ../../Firmware/ultralcd.cpp:1704
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1454
+#: ../../Firmware/ultralcd.cpp:1714
 msgid "Belt status"
 msgstr "Estado de correa"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/messages.cpp:314 ../../Firmware/ultralcd.cpp:4579
+#: ../../Firmware/messages.cpp:326 ../../Firmware/ultralcd.cpp:4535
 msgid "Belt test"
 msgstr "Test correa"
 
 #. MSG_RECOVER_PRINT c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:1660 ../../Firmware/messages.cpp:87
+#: ../../Firmware/Marlin_main.cpp:1587 ../../Firmware/messages.cpp:87
 msgid "Blackout occurred. Recover print?"
 msgstr "Se fue la luz. ¿Re- anudar la impresión?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:177 ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:5594
 msgid "Bright"
 msgstr "Brill."
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:4526
-#: ../../Firmware/ultralcd.cpp:5546
+#: ../../Firmware/messages.cpp:180 ../../Firmware/ultralcd.cpp:4493
+#: ../../Firmware/ultralcd.cpp:5513
 msgid "Brightness"
 msgstr "Brillo"
 
@@ -203,17 +202,17 @@ msgid "COMMUNICATION ERROR"
 msgstr "ERROR COMUNICACIÓN"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/messages.cpp:316 ../../Firmware/ultralcd.cpp:4583
+#: ../../Firmware/messages.cpp:328 ../../Firmware/ultralcd.cpp:4539
 msgid "Calibrate XYZ"
 msgstr "Calibrar XYZ"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4585
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4541
 msgid "Calibrate Z"
 msgstr "Calibrar Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/messages.cpp:266 ../../Firmware/ultralcd.cpp:2813
+#: ../../Firmware/messages.cpp:278 ../../Firmware/ultralcd.cpp:2830
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -222,13 +221,13 @@ msgstr ""
 "superiores. Después haz clic."
 
 #. MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: ../../Firmware/Marlin_main.cpp:2218 ../../Firmware/messages.cpp:22
+#: ../../Firmware/Marlin_main.cpp:2009 ../../Firmware/messages.cpp:23
 #: ../../Firmware/ultralcd.cpp:582
 msgid "Calibrating Z"
 msgstr "Calibrando Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/messages.cpp:265 ../../Firmware/ultralcd.cpp:2812
+#: ../../Firmware/messages.cpp:277 ../../Firmware/ultralcd.cpp:2829
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -237,17 +236,17 @@ msgstr ""
 "superiores. Después haz clic."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/messages.cpp:361 ../../Firmware/ultralcd.cpp:6985
+#: ../../Firmware/messages.cpp:373 ../../Firmware/ultralcd.cpp:6962
 msgid "Calibrating home"
 msgstr "Calibrar pos.inicial"
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5375
+#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5342
 msgid "Calibration"
 msgstr "Calibración"
 
 #. MSG_HOMEYZ_DONE c=20
-#: ../../Firmware/messages.cpp:217 ../../Firmware/ultralcd.cpp:593
+#: ../../Firmware/messages.cpp:229 ../../Firmware/ultralcd.cpp:593
 msgid "Calibration done"
 msgstr "Calibración OK"
 
@@ -265,128 +264,128 @@ msgstr ""
 "No se puede realizar la acción, filamento ya cargado. Primero descarga."
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/messages.cpp:364 ../../Firmware/ultralcd.cpp:7405
+#: ../../Firmware/messages.cpp:376 ../../Firmware/ultralcd.cpp:7382
 msgid "Card removed"
 msgstr "Tarjeta retirada"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/messages.cpp:324 ../../Firmware/ultralcd.cpp:5316
+#: ../../Firmware/messages.cpp:336 ../../Firmware/ultralcd.cpp:5282
 msgid "Change SD card"
 msgstr "Cambiar Tarj. SD"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5254
-#: ../../Firmware/ultralcd.cpp:5526
+#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5216
+#: ../../Firmware/ultralcd.cpp:5493
 msgid "Change filament"
 msgstr "Cambiar filamento"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/messages.cpp:240 ../../Firmware/ultralcd.cpp:2156
+#: ../../Firmware/messages.cpp:252 ../../Firmware/ultralcd.cpp:2167
 msgid "Change success!"
 msgstr "Cambio correcto!"
 
 #. MSG_CORRECTLY c=19
-#: ../../Firmware/messages.cpp:242 ../../Firmware/ultralcd.cpp:2203
+#: ../../Firmware/messages.cpp:254 ../../Firmware/ultralcd.cpp:2217
 msgid "Changed correctly"
 msgstr "Cambio correcto"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5951
-#: ../../Firmware/ultralcd.cpp:6975
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5927
+#: ../../Firmware/ultralcd.cpp:6952
 msgid "Checking X axis"
 msgstr "Control sensor X"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5961
-#: ../../Firmware/ultralcd.cpp:6976
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:5937
+#: ../../Firmware/ultralcd.cpp:6953
 msgid "Checking Y axis"
 msgstr "Control sensor Y"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/messages.cpp:358 ../../Firmware/ultralcd.cpp:6977
+#: ../../Firmware/messages.cpp:370 ../../Firmware/ultralcd.cpp:6954
 msgid "Checking Z axis"
 msgstr "Control sensor Z"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6978
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6955
 msgid "Checking bed"
 msgstr "Control base cal."
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/messages.cpp:357 ../../Firmware/ultralcd.cpp:6974
+#: ../../Firmware/messages.cpp:369 ../../Firmware/ultralcd.cpp:6951
 msgid "Checking endstops"
 msgstr "Control endstops"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/messages.cpp:362 ../../Firmware/ultralcd.cpp:7070
+#: ../../Firmware/messages.cpp:374 ../../Firmware/ultralcd.cpp:7047
 msgid "Checking file"
 msgstr "Verif. archivo"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/messages.cpp:359 ../../Firmware/ultralcd.cpp:6980
+#: ../../Firmware/messages.cpp:371 ../../Firmware/ultralcd.cpp:6957
 msgid "Checking hotend"
 msgstr "Control fusor"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6981
-#: ../../Firmware/ultralcd.cpp:6982
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6958
+#: ../../Firmware/ultralcd.cpp:6959
 msgid "Checking sensors"
 msgstr "Comprobando sensores"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/messages.cpp:308 ../../Firmware/ultralcd.cpp:4424
+#: ../../Firmware/messages.cpp:320 ../../Firmware/ultralcd.cpp:4391
 msgid "Checks"
 msgstr "Comprobaciones"
 
 #. MSG_TM_ACK_ERROR c=18
-#: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5297
+#: ../../Firmware/messages.cpp:197 ../../Firmware/ultralcd.cpp:5263
 msgid "Clear TM error"
 msgstr "Borrar error TM"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/messages.cpp:244 ../../Firmware/ultralcd.cpp:2205
+#: ../../Firmware/messages.cpp:256 ../../Firmware/ultralcd.cpp:2219
 msgid "Color not correct"
 msgstr "Color no homogéneo"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:3508
+#: ../../Firmware/messages.cpp:27 ../../Firmware/ultralcd.cpp:3518
 msgid "Community made"
 msgstr "Desde la comunidad"
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:4059
+#: ../../Firmware/messages.cpp:178 ../../Firmware/ultralcd.cpp:4083
 msgid "Cont."
 msgstr "Cont."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:2129
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2135
 msgid "Cooldown"
 msgstr "Enfriar"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/messages.cpp:283 ../../Firmware/ultralcd.cpp:3450
+#: ../../Firmware/messages.cpp:295 ../../Firmware/ultralcd.cpp:3460
 msgid "Copy selected language?"
 msgstr "¿Copiar idioma seleccionado?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:1234
-#: ../../Firmware/ultralcd.cpp:1263
+#: ../../Firmware/messages.cpp:30 ../../Firmware/ultralcd.cpp:1244
+#: ../../Firmware/ultralcd.cpp:1273
 msgid "Crash"
 msgstr "Choque"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4146
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/ultralcd.cpp:4170
 msgid "Crash det."
 msgstr "Det. choque"
 
 #. MSG_CRASH_DETECTED c=20
-#: ../../Firmware/Marlin_main.cpp:630 ../../Firmware/messages.cpp:30
+#: ../../Firmware/Marlin_main.cpp:595 ../../Firmware/messages.cpp:31
 msgid "Crash detected."
 msgstr "Choque detectado."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/messages.cpp:280 ../../Firmware/ultralcd.cpp:3374
+#: ../../Firmware/messages.cpp:292 ../../Firmware/ultralcd.cpp:3384
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -397,24 +396,24 @@ msgstr ""
 "en modo Normal."
 
 #. MSG_CUT_FILAMENT c=16
-#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:380
-#: ../../Firmware/ultralcd.cpp:4854 ../../Firmware/ultralcd.cpp:5351
+#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:381
+#: ../../Firmware/ultralcd.cpp:4810 ../../Firmware/ultralcd.cpp:5317
 msgid "Cut filament"
 msgstr "Cortar filament"
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4081
-#: ../../Firmware/ultralcd.cpp:4086 ../../Firmware/ultralcd.cpp:4091
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:4105
+#: ../../Firmware/ultralcd.cpp:4110 ../../Firmware/ultralcd.cpp:4115
 msgid "Cutter"
 msgstr "Cuchillo"
 
 #. MSG_DATE c=17
-#: ../../Firmware/messages.cpp:222 ../../Firmware/ultralcd.cpp:1645
+#: ../../Firmware/messages.cpp:234 ../../Firmware/ultralcd.cpp:1655
 msgid "Date:"
 msgstr "Fecha:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:178 ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/messages.cpp:185 ../../Firmware/ultralcd.cpp:5594
 msgid "Dim"
 msgstr "Oscuro"
 
@@ -424,7 +423,7 @@ msgid "Disable"
 msgstr "Desact."
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/messages.cpp:311 ../../Firmware/ultralcd.cpp:4460
+#: ../../Firmware/messages.cpp:323 ../../Firmware/ultralcd.cpp:4427
 msgid "Disable steppers"
 msgstr "Apagar motores"
 
@@ -436,7 +435,7 @@ msgid "Disengaging idler"
 msgstr "Soltando tensor"
 
 #. MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: ../../Firmware/Marlin_main.cpp:1610 ../../Firmware/Marlin_main.cpp:3334
+#: ../../Firmware/Marlin_main.cpp:1537 ../../Firmware/Marlin_main.cpp:3073
 #: ../../Firmware/messages.cpp:14
 msgid ""
 "Distance between tip of the nozzle and the bed surface has not been set yet."
@@ -447,7 +446,7 @@ msgstr ""
 "fijada. Siga el manual, capitulo Primeros Pasos."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/messages.cpp:301 ../../Firmware/ultralcd.cpp:3923
+#: ../../Firmware/messages.cpp:313 ../../Firmware/ultralcd.cpp:3947
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -455,13 +454,13 @@ msgstr ""
 "¿Quieres repetir el último paso para re- ajustar la distancia boquilla-base?"
 
 #. MSG_DONE c=8
-#: ../../Firmware/messages.cpp:32 ../../Firmware/mmu2/errors_list.h:367
-#: ../../Firmware/mmu2_reporting.cpp:456
+#: ../../Firmware/messages.cpp:33 ../../Firmware/mmu2/errors_list.h:367
+#: ../../Firmware/mmu2_reporting.cpp:457
 msgid "Done"
 msgstr "Listo"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/messages.cpp:307 ../../Firmware/ultralcd.cpp:3990
+#: ../../Firmware/messages.cpp:319 ../../Firmware/ultralcd.cpp:4014
 msgid "E-correct"
 msgstr "Corregir-E"
 
@@ -490,13 +489,13 @@ msgid "ERR Wait for User"
 msgstr "ERR Espera usuario"
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:2253
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:2267
 msgid "ERROR:"
 msgstr "ERROR:"
 
 #. MSG_EJECT_FROM_MMU c=16
-#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:384
-#: ../../Firmware/ultralcd.cpp:4845 ../../Firmware/ultralcd.cpp:5348
+#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:385
+#: ../../Firmware/ultralcd.cpp:4801 ../../Firmware/ultralcd.cpp:5314
 msgid "Eject from MMU"
 msgstr "Expulsar de MMU"
 
@@ -508,17 +507,17 @@ msgid "Ejecting filament"
 msgstr "Expulsando filamento"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/messages.cpp:348 ../../Firmware/ultralcd.cpp:6722
+#: ../../Firmware/messages.cpp:360 ../../Firmware/ultralcd.cpp:6698
 msgid "Endstop"
 msgstr "Fin de carrera"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/messages.cpp:349 ../../Firmware/ultralcd.cpp:6727
+#: ../../Firmware/messages.cpp:361 ../../Firmware/ultralcd.cpp:6703
 msgid "Endstop not hit"
 msgstr "Fin no alcanzado"
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/messages.cpp:347 ../../Firmware/ultralcd.cpp:6713
+#: ../../Firmware/messages.cpp:359 ../../Firmware/ultralcd.cpp:6689
 msgid "Endstops"
 msgstr "Finales de carrera"
 
@@ -530,30 +529,30 @@ msgid "Engaging idler"
 msgstr "Enganchando tensor"
 
 #. MSG_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:3352
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:3362
 msgid "Extruder"
 msgstr "Extrusor"
 
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/messages.cpp:227 ../../Firmware/ultralcd.cpp:1700
+#: ../../Firmware/messages.cpp:239 ../../Firmware/ultralcd.cpp:1710
 msgid "Extruder info"
 msgstr "Info. del extrusor"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4044
-#: ../../Firmware/ultralcd.cpp:4051
+#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4068
+#: ../../Firmware/ultralcd.cpp:4075
 msgid "F. autoload"
 msgstr "Autocarg.fil."
 
 #. MSG_FSENSOR_JAM_DETECTION c=13
-#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4046
-#: ../../Firmware/ultralcd.cpp:4053
+#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4070
+#: ../../Firmware/ultralcd.cpp:4077
 msgid "F. jam detect"
 msgstr "Det. atasco f"
 
 #. MSG_FSENSOR_RUNOUT c=13
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4074
 msgid "F. runout"
 msgstr "Fin fil."
 
@@ -591,8 +590,8 @@ msgid "FINDA FILAM. STUCK"
 msgstr "FINDA ATASCO FIL."
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:4059
-#: ../../Firmware/ultralcd.cpp:4062
+#: ../../Firmware/messages.cpp:177 ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/ultralcd.cpp:4086
 msgid "FS Action"
 msgstr "FS acción"
 
@@ -617,34 +616,34 @@ msgid "FW RUNTIME ERROR"
 msgstr "ERROR EJECUCIÓN FW"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/messages.cpp:330 ../../Firmware/ultralcd.cpp:5382
+#: ../../Firmware/messages.cpp:342 ../../Firmware/ultralcd.cpp:5349
 msgid "Fail stats"
 msgstr "Registro de fallos"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/messages.cpp:331 ../../Firmware/ultralcd.cpp:5385
+#: ../../Firmware/messages.cpp:343 ../../Firmware/ultralcd.cpp:5352
 msgid "Fail stats MMU"
 msgstr "Fallos totales MMU"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/messages.cpp:355 ../../Firmware/ultralcd.cpp:6768
+#: ../../Firmware/messages.cpp:367 ../../Firmware/ultralcd.cpp:6744
 msgid "False triggering"
 msgstr "Falsa activación"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4175
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4199
 msgid "Fan speed"
 msgstr "Velocidad Vent"
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6844
-#: ../../Firmware/ultralcd.cpp:6971 ../../Firmware/ultralcd.cpp:6972
-#: ../../Firmware/ultralcd.cpp:6973
+#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6820
+#: ../../Firmware/ultralcd.cpp:6948 ../../Firmware/ultralcd.cpp:6949
+#: ../../Firmware/ultralcd.cpp:6950
 msgid "Fan test"
 msgstr "Test ventiladores"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:4179
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:4203
 msgid "Fans check"
 msgstr "Comprob.vent"
 
@@ -673,34 +672,34 @@ msgid "Feeding to nozzle"
 msgstr "Aliment. a la boq."
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1233
-#: ../../Firmware/ultralcd.cpp:1262 ../../Firmware/ultralcd.cpp:1316
-#: ../../Firmware/ultralcd.cpp:1318
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:1243
+#: ../../Firmware/ultralcd.cpp:1272 ../../Firmware/ultralcd.cpp:1326
+#: ../../Firmware/ultralcd.cpp:1328
 msgid "Fil. runouts"
 msgstr "Fil. acabado"
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3313
-#: ../../Firmware/ultralcd.cpp:4039 ../../Firmware/ultralcd.cpp:4464
-#: ../../Firmware/ultralcd.cpp:5532
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3323
+#: ../../Firmware/ultralcd.cpp:4063 ../../Firmware/ultralcd.cpp:4431
+#: ../../Firmware/ultralcd.cpp:5499
 msgid "Fil. sensor"
 msgstr "Sensor Fil."
 
 #. MSG_FILAMENT_CLEAN c=20 r=3
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2261
-#: ../../Firmware/ultralcd.cpp:2265
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2275
+#: ../../Firmware/ultralcd.cpp:2279
 msgid "Filament extruding & with correct color?"
 msgstr "¿Se extruye filamento y con el color correcto?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/messages.cpp:243 ../../Firmware/ultralcd.cpp:2204
+#: ../../Firmware/messages.cpp:255 ../../Firmware/ultralcd.cpp:2218
 msgid "Filament not loaded"
 msgstr "Fil. no introducido"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6763
-#: ../../Firmware/ultralcd.cpp:6767 ../../Firmware/ultralcd.cpp:6771
-#: ../../Firmware/ultralcd.cpp:7000
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6739
+#: ../../Firmware/ultralcd.cpp:6743 ../../Firmware/ultralcd.cpp:6747
+#: ../../Firmware/ultralcd.cpp:6977
 msgid "Filament sensor"
 msgstr "Sensor de fil."
 
@@ -733,42 +732,42 @@ msgstr ""
 " ok."
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/messages.cpp:246 ../../Firmware/ultralcd.cpp:2347
+#: ../../Firmware/messages.cpp:258 ../../Firmware/ultralcd.cpp:2364
 msgid "Filament used"
 msgstr "Filamento usado"
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/messages.cpp:363 ../../Firmware/ultralcd.cpp:7139
+#: ../../Firmware/messages.cpp:375 ../../Firmware/ultralcd.cpp:7116
 msgid "File incomplete. Continue anyway?"
 msgstr "¿Archivo incompleto. Continuar de todos modos?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
 #: ../../Firmware/messages.cpp:45
 #: ../../Firmware/mmu2_progress_converter.cpp:43
-#: ../../Firmware/ultralcd.cpp:5021 ../../Firmware/ultralcd.cpp:5425
+#: ../../Firmware/ultralcd.cpp:4977 ../../Firmware/ultralcd.cpp:5392
 msgid "Finishing movements"
 msgstr "Term. movimientos"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4575
-#: ../../Firmware/ultralcd.cpp:5141
+#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4531
+#: ../../Firmware/ultralcd.cpp:5101
 msgid "First layer cal."
 msgstr "Cal. primera cap."
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/messages.cpp:293 ../../Firmware/ultralcd.cpp:3846
+#: ../../Firmware/messages.cpp:305 ../../Firmware/ultralcd.cpp:3872
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Primero, hare el Selftest para comprobar los problemas de montaje más "
 "comunes."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/messages.cpp:334 ../../Firmware/ultralcd.cpp:5520
+#: ../../Firmware/messages.cpp:346 ../../Firmware/ultralcd.cpp:5487
 msgid "Flow"
 msgstr "Flujo"
 
 #. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
-#: ../../Firmware/messages.cpp:194 ../../Firmware/ultralcd.cpp:985
+#: ../../Firmware/messages.cpp:201 ../../Firmware/ultralcd.cpp:987
 msgid ""
 "For a Nozzle change please read\n"
 "prusa.io/nozzle-mk3s"
@@ -777,28 +776,28 @@ msgstr ""
 "prusa.io/nozzle-mk3s"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6733
-#: ../../Firmware/ultralcd.cpp:6850 ../../Firmware/ultralcd.cpp:6855
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/ultralcd.cpp:6826 ../../Firmware/ultralcd.cpp:6831
 msgid "Front print fan?"
 msgstr "¿Vent. frontal?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/messages.cpp:260 ../../Firmware/ultralcd.cpp:2711
+#: ../../Firmware/messages.cpp:272 ../../Firmware/ultralcd.cpp:2728
 msgid "Front side[µm]"
 msgstr "Frontal [µm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/messages.cpp:353 ../../Firmware/ultralcd.cpp:6757
+#: ../../Firmware/messages.cpp:365 ../../Firmware/ultralcd.cpp:6733
 msgid "Front/left fans"
 msgstr "Vents. front/izqui."
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:151 ../../Firmware/util.cpp:382
+#: ../../Firmware/messages.cpp:156 ../../Firmware/util.cpp:417
 msgid "G-code sliced for a different level. Continue?"
 msgstr "Código G laminado para un nivel dif. ¿Continuar?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:152 ../../Firmware/util.cpp:383
+#: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:418
 msgid ""
 "G-code sliced for a different level. Please re-slice the model again. Print "
 "cancelled."
@@ -807,14 +806,14 @@ msgstr ""
 "nuevo. Impresión cancelada."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:147 ../../Firmware/util.cpp:312
-#: ../../Firmware/util.cpp:401
+#: ../../Firmware/messages.cpp:152 ../../Firmware/util.cpp:319
+#: ../../Firmware/util.cpp:436
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr "Código G laminado para un tipo de impresora dif.Cont.?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:148 ../../Firmware/util.cpp:313
-#: ../../Firmware/util.cpp:402
+#: ../../Firmware/messages.cpp:153 ../../Firmware/util.cpp:320
+#: ../../Firmware/util.cpp:437
 msgid ""
 "G-code sliced for a different printer type. Please re-slice the model again."
 " Print cancelled."
@@ -823,12 +822,12 @@ msgstr ""
 "de nuevo. Impresión cancelada."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:149 ../../Firmware/util.cpp:362
+#: ../../Firmware/messages.cpp:154 ../../Firmware/util.cpp:369
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "Código G laminado para nuevo firmware. ¿Continuar?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:150 ../../Firmware/util.cpp:363
+#: ../../Firmware/messages.cpp:155 ../../Firmware/util.cpp:370
 msgid ""
 "G-code sliced for a newer firmware. Please update the firmware. Print "
 "cancelled."
@@ -837,35 +836,35 @@ msgstr ""
 "cancelada."
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4366
-#: ../../Firmware/ultralcd.cpp:4383 ../../Firmware/ultralcd.cpp:4485
+#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4325
+#: ../../Firmware/ultralcd.cpp:4343 ../../Firmware/ultralcd.cpp:4452
 msgid "HW Setup"
 msgstr "Configuración HW"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/messages.cpp:344 ../../Firmware/ultralcd.cpp:6705
+#: ../../Firmware/messages.cpp:356 ../../Firmware/ultralcd.cpp:6681
 msgid "Heater/Thermistor"
 msgstr "Calentador/Termistor"
 
 #. MSG_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6184 ../../Firmware/messages.cpp:52
+#: ../../Firmware/Marlin_main.cpp:5416 ../../Firmware/messages.cpp:52
 #: ../../Firmware/ultralcd.cpp:526
 msgid "Heating"
 msgstr "Calentando..."
 
 #. MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:9647 ../../Firmware/messages.cpp:211
+#: ../../Firmware/Marlin_main.cpp:8807 ../../Firmware/messages.cpp:223
 msgid "Heating disabled by safety timer."
 msgstr "Calentadores desactivados por el temporizador de seguridad."
 
 #. MSG_HEATING_COMPLETE c=20
-#: ../../Firmware/Marlin_main.cpp:6215 ../../Firmware/messages.cpp:53
+#: ../../Firmware/Marlin_main.cpp:5445 ../../Firmware/messages.cpp:53
 #: ../../Firmware/ultralcd.cpp:529
 msgid "Heating done."
 msgstr "Calentando acabado."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=12
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:3806
+#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:3832
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -876,7 +875,7 @@ msgstr ""
 "listo para imprimir."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:3810
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:3836
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -885,8 +884,8 @@ msgstr ""
 "la configuración?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4152
-#: ../../Firmware/ultralcd.cpp:4161
+#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:4176
+#: ../../Firmware/ultralcd.cpp:4185
 msgid "High power"
 msgstr "Rend.pleno"
 
@@ -897,23 +896,23 @@ msgid "Homing"
 msgstr "Homing"
 
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
-#: ../../Firmware/messages.cpp:195 ../../Firmware/ultralcd.cpp:1005
+#: ../../Firmware/messages.cpp:206 ../../Firmware/ultralcd.cpp:1011
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr "Fusor a 280C! ¿Boquilla cambiado y ajust. a la medida?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1106
-#: ../../Firmware/ultralcd.cpp:6991
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1116
+#: ../../Firmware/ultralcd.cpp:6968
 msgid "Hotend fan:"
 msgstr "Vent. d. fusor:"
 
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/messages.cpp:294 ../../Firmware/ultralcd.cpp:3851
+#: ../../Firmware/messages.cpp:306 ../../Firmware/ultralcd.cpp:3877
 msgid "I will run xyz calibration now. It will take up to 24 mins."
 msgstr "Haré la calibración XYZ. Puede tardar hasta 24 min."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/messages.cpp:297 ../../Firmware/ultralcd.cpp:3862
+#: ../../Firmware/messages.cpp:309 ../../Firmware/ultralcd.cpp:3884
 msgid "I will run z calibration now."
 msgstr "Voy a hacer Calibración Z ahora."
 
@@ -938,7 +937,7 @@ msgid "INVALID TOOL"
 msgstr "HERR. INVALIDA"
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=8
-#: ../../Firmware/messages.cpp:303 ../../Firmware/ultralcd.cpp:3931
+#: ../../Firmware/messages.cpp:315 ../../Firmware/ultralcd.cpp:3955
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -947,28 +946,28 @@ msgstr ""
 "Ajustes HW - Planchas acero."
 
 #. MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2540
-#: ../../Firmware/messages.cpp:213
+#: ../../Firmware/mesh_bed_calibration.cpp:2525
+#: ../../Firmware/messages.cpp:225
 msgid "Improving bed calibration point"
 msgstr "Mejorando punto calibración base"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:5222
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:5184
 msgid "Info screen"
 msgstr "Monitorizar"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/messages.cpp:326 ../../Firmware/ultralcd.cpp:5323
+#: ../../Firmware/messages.cpp:338 ../../Firmware/ultralcd.cpp:5289
 msgid "Init. SD card"
 msgstr "Init. Tarjeta SD"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/messages.cpp:238 ../../Firmware/ultralcd.cpp:2142
+#: ../../Firmware/messages.cpp:250 ../../Firmware/ultralcd.cpp:2148
 msgid "Insert filament"
 msgstr "Introducir filamento"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/messages.cpp:335 ../../Firmware/ultralcd.cpp:5998
+#: ../../Firmware/messages.cpp:347 ../../Firmware/ultralcd.cpp:5974
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
@@ -982,115 +981,115 @@ msgid ""
 msgstr "Error interno de ejecución. Reinicia la MMU o actualiza el firmware."
 
 #. MSG_FILAMENT_LOADED c=20 r=3
-#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3628
-#: ../../Firmware/ultralcd.cpp:3890
+#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3638
+#: ../../Firmware/ultralcd.cpp:3914
 msgid "Is filament loaded?"
 msgstr "¿Esta el filamento cargado?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3238 ../../Firmware/Marlin_main.cpp:4745
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:3858
+#: ../../Firmware/Marlin_main.cpp:4314 ../../Firmware/messages.cpp:127
+#: ../../Firmware/ultralcd.cpp:3760
 msgid "Is steel sheet on heatbed?"
 msgstr "¿Está la lámina sobre la base?"
 
 #. MSG_ITERATION c=12
-#: ../../Firmware/mesh_bed_calibration.cpp:2265 ../../Firmware/messages.cpp:55
+#: ../../Firmware/mesh_bed_calibration.cpp:2250 ../../Firmware/messages.cpp:55
 msgid "Iteration"
 msgstr "Iteración"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1128
-#: ../../Firmware/ultralcd.cpp:1286
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1138
+#: ../../Firmware/ultralcd.cpp:1296
 msgid "Last print"
 msgstr "Ultima impresión"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1152
-#: ../../Firmware/ultralcd.cpp:1260 ../../Firmware/ultralcd.cpp:1315
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1162
+#: ../../Firmware/ultralcd.cpp:1270 ../../Firmware/ultralcd.cpp:1325
 msgid "Last print failures"
 msgstr "Últimos imp. fallos"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/messages.cpp:251 ../../Firmware/ultralcd.cpp:2478
+#: ../../Firmware/messages.cpp:263 ../../Firmware/ultralcd.cpp:2495
 msgid "Left"
 msgstr "Izquierda"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6739
-#: ../../Firmware/ultralcd.cpp:6850 ../../Firmware/ultralcd.cpp:6855
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6715
+#: ../../Firmware/ultralcd.cpp:6826 ../../Firmware/ultralcd.cpp:6831
 msgid "Left hotend fan?"
 msgstr "¿Vent. izquierdo?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/messages.cpp:258 ../../Firmware/ultralcd.cpp:2709
+#: ../../Firmware/messages.cpp:270 ../../Firmware/ultralcd.cpp:2726
 msgid "Left side [µm]"
 msgstr "Izquierda [µm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:5619
+#: ../../Firmware/messages.cpp:181 ../../Firmware/ultralcd.cpp:5592
 msgid "Level Bright"
 msgstr "Valor brill."
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:175 ../../Firmware/ultralcd.cpp:5620
+#: ../../Firmware/messages.cpp:182 ../../Firmware/ultralcd.cpp:5593
 msgid "Level Dimmed"
 msgstr "Valor oscuro"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/messages.cpp:312 ../../Firmware/ultralcd.cpp:4491
+#: ../../Firmware/messages.cpp:324 ../../Firmware/ultralcd.cpp:4458
 msgid "Lin. correction"
 msgstr "Correc. Linealidad"
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4501
-#: ../../Firmware/ultralcd.cpp:5251
+#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4468
+#: ../../Firmware/ultralcd.cpp:5213
 msgid "Live adjust Z"
 msgstr "Ajuste en vivo Z"
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/messages.cpp:192 ../../Firmware/ultralcd.cpp:4794
-#: ../../Firmware/ultralcd.cpp:4880
+#: ../../Firmware/messages.cpp:199 ../../Firmware/ultralcd.cpp:4750
+#: ../../Firmware/ultralcd.cpp:4836
 msgid "Load All"
 msgstr "Intr. todos fil."
 
 #. MSG_LOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4796
-#: ../../Firmware/ultralcd.cpp:4833 ../../Firmware/ultralcd.cpp:4882
-#: ../../Firmware/ultralcd.cpp:5361 ../../Firmware/ultralcd.cpp:5368
+#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4752
+#: ../../Firmware/ultralcd.cpp:4789 ../../Firmware/ultralcd.cpp:4838
+#: ../../Firmware/ultralcd.cpp:5324 ../../Firmware/ultralcd.cpp:5335
 msgid "Load filament"
 msgstr "Introducir fil."
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/messages.cpp:327 ../../Firmware/ultralcd.cpp:5346
+#: ../../Firmware/messages.cpp:339 ../../Firmware/ultralcd.cpp:5312
 msgid "Load to nozzle"
 msgstr "Cargar a boquilla"
 
 #. MSG_LOADING_TEST c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4476
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4443
 msgid "Loading Test"
 msgstr "Prueba de carga"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/messages.cpp:241 ../../Firmware/ultralcd.cpp:2178
+#: ../../Firmware/messages.cpp:253 ../../Firmware/ultralcd.cpp:2189
 msgid "Loading color"
 msgstr "Cambiando color"
 
 #. MSG_LOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3598 ../../Firmware/messages.cpp:62
+#: ../../Firmware/Marlin_main.cpp:3343 ../../Firmware/messages.cpp:62
 #: ../../Firmware/mmu2_progress_converter.cpp:51
-#: ../../Firmware/mmu2_reporting.cpp:392 ../../Firmware/ultralcd.cpp:2189
-#: ../../Firmware/ultralcd.cpp:3715
+#: ../../Firmware/mmu2_reporting.cpp:393 ../../Firmware/ultralcd.cpp:2199
+#: ../../Firmware/ultralcd.cpp:3725
 msgid "Loading filament"
 msgstr "Introduciendo filam."
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/messages.cpp:350 ../../Firmware/ultralcd.cpp:6745
+#: ../../Firmware/messages.cpp:362 ../../Firmware/ultralcd.cpp:6721
 msgid "Loose pulley"
 msgstr "Polea suelta"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4188
-#: ../../Firmware/ultralcd.cpp:4200
+#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4224
 msgid "Loud"
 msgstr "Alto"
 
@@ -1105,7 +1104,7 @@ msgid "MMU Firmware internal error, please reset the MMU."
 msgstr "Error interno del firmware MMU, reinicia el MMU."
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:4096
+#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4120
 msgid "MMU Mode"
 msgstr "Modo MMU"
 
@@ -1115,7 +1114,7 @@ msgid "MMU NOT RESPONDING"
 msgstr "MMU NO RESPONDE"
 
 #. MSG_MMU_RESTORE_TEMP c=20 r=4
-#: ../../Firmware/messages.cpp:214 ../../Firmware/mmu2_reporting.cpp:396
+#: ../../Firmware/messages.cpp:226 ../../Firmware/mmu2_reporting.cpp:397
 msgid "MMU Retry: Restoring temperature..."
 msgstr "MMU Reintento: Restaurando temperatura..."
 
@@ -1126,14 +1125,14 @@ msgid "MMU SELFTEST FAILED"
 msgstr "MMU SELFTEST FALLO"
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1153
-#: ../../Firmware/ultralcd.cpp:1178
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1163
+#: ../../Firmware/ultralcd.cpp:1188
 msgid "MMU fails"
 msgstr "Fallos MMU"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1154
-#: ../../Firmware/ultralcd.cpp:1179
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1164
+#: ../../Firmware/ultralcd.cpp:1189
 msgid "MMU load fails"
 msgstr "Carga MMU falla"
 
@@ -1148,66 +1147,64 @@ msgid "MMU not responding. Check the wiring and connectors."
 msgstr "La MMU no responde. Revisa los cables y conectores."
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/messages.cpp:223 ../../Firmware/ultralcd.cpp:1657
+#: ../../Firmware/messages.cpp:235 ../../Firmware/ultralcd.cpp:1667
 msgid "MMU connected"
 msgstr "MMU conectado"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/messages.cpp:176 ../../Firmware/ultralcd.cpp:5567
 msgid "Magnets comp."
 msgstr "Comp. imanes"
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1127
-#: ../../Firmware/ultralcd.cpp:1285 ../../Firmware/ultralcd.cpp:1327
-#: ../../Firmware/ultralcd.cpp:1631 ../../Firmware/ultralcd.cpp:4453
-#: ../../Firmware/ultralcd.cpp:4571 ../../Firmware/ultralcd.cpp:4793
-#: ../../Firmware/ultralcd.cpp:4826 ../../Firmware/ultralcd.cpp:4879
-#: ../../Firmware/ultralcd.cpp:5515
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1137
+#: ../../Firmware/ultralcd.cpp:1295 ../../Firmware/ultralcd.cpp:1337
+#: ../../Firmware/ultralcd.cpp:1641 ../../Firmware/ultralcd.cpp:4420
+#: ../../Firmware/ultralcd.cpp:4527 ../../Firmware/ultralcd.cpp:4749
+#: ../../Firmware/ultralcd.cpp:4782 ../../Firmware/ultralcd.cpp:4835
+#: ../../Firmware/ultralcd.cpp:5482
 msgid "Main"
 msgstr "Menu principal"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/messages.cpp:253 ../../Firmware/ultralcd.cpp:2519
+#: ../../Firmware/messages.cpp:265 ../../Firmware/ultralcd.cpp:2536
 msgid "Measured skew"
 msgstr "Desv. medida"
 
 #. MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3219
-#: ../../Firmware/mesh_bed_calibration.cpp:2852 ../../Firmware/messages.cpp:70
+#: ../../Firmware/Marlin_main.cpp:2963
+#: ../../Firmware/mesh_bed_calibration.cpp:2837 ../../Firmware/messages.cpp:70
 msgid "Measuring reference height of calibration point"
 msgstr "Midiendo altura del punto de calibración"
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:5590
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:5563
 msgid "Mesh"
 msgstr "Malla"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4488
-#: ../../Firmware/ultralcd.cpp:4587
+#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:4455
+#: ../../Firmware/ultralcd.cpp:4543
 msgid "Mesh Bed Leveling"
 msgstr "Nivela. Malla Base"
 
 #. MSG_MODE c=6
-#: ../../Firmware/Marlin_main.cpp:8495 ../../Firmware/messages.cpp:117
-#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4132
-#: ../../Firmware/ultralcd.cpp:4140 ../../Firmware/ultralcd.cpp:4144
-#: ../../Firmware/ultralcd.cpp:4152 ../../Firmware/ultralcd.cpp:4155
-#: ../../Firmware/ultralcd.cpp:4158 ../../Firmware/ultralcd.cpp:4161
-#: ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/Marlin_main.cpp:7666 ../../Firmware/messages.cpp:121
+#: ../../Firmware/ultralcd.cpp:4152 ../../Firmware/ultralcd.cpp:4156
+#: ../../Firmware/ultralcd.cpp:4164 ../../Firmware/ultralcd.cpp:4168
+#: ../../Firmware/ultralcd.cpp:4176 ../../Firmware/ultralcd.cpp:4179
+#: ../../Firmware/ultralcd.cpp:4182 ../../Firmware/ultralcd.cpp:4185
+#: ../../Firmware/ultralcd.cpp:5594
 msgid "Mode"
 msgstr "Modo"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/messages.cpp:282 ../../Firmware/ultralcd.cpp:3413
+#: ../../Firmware/messages.cpp:294 ../../Firmware/ultralcd.cpp:3423
 msgid "Mode change in progress..."
 msgstr "Cambio de modo progresando ..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:4310
-#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4316
-#: ../../Firmware/ultralcd.cpp:4319
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4327
 msgid "Model"
 msgstr "Modelo"
 
@@ -1228,28 +1225,28 @@ msgid "More details online."
 msgstr "Más detalles online."
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6719
-#: ../../Firmware/ultralcd.cpp:6728 ../../Firmware/ultralcd.cpp:6746
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6695
+#: ../../Firmware/ultralcd.cpp:6704 ../../Firmware/ultralcd.cpp:6722
 msgid "Motor"
 msgstr "Motor"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/messages.cpp:277 ../../Firmware/ultralcd.cpp:3349
+#: ../../Firmware/messages.cpp:289 ../../Firmware/ultralcd.cpp:3359
 msgid "Move X"
 msgstr "Mover X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/messages.cpp:278 ../../Firmware/ultralcd.cpp:3350
+#: ../../Firmware/messages.cpp:290 ../../Firmware/ultralcd.cpp:3360
 msgid "Move Y"
 msgstr "Mover Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/messages.cpp:279 ../../Firmware/ultralcd.cpp:3351
+#: ../../Firmware/messages.cpp:291 ../../Firmware/ultralcd.cpp:3361
 msgid "Move Z"
 msgstr "Mover Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/messages.cpp:310 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:322 ../../Firmware/ultralcd.cpp:4426
 msgid "Move axis"
 msgstr "Mover ejes"
 
@@ -1260,63 +1257,62 @@ msgid "Moving selector"
 msgstr "Moviendo selector"
 
 #. MSG_NA c=3
-#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:141
-#: ../../Firmware/ultralcd.cpp:2484 ../../Firmware/ultralcd.cpp:2528
-#: ../../Firmware/ultralcd.cpp:3279 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:4044 ../../Firmware/ultralcd.cpp:4046
-#: ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:146
+#: ../../Firmware/ultralcd.cpp:2501 ../../Firmware/ultralcd.cpp:2545
+#: ../../Firmware/ultralcd.cpp:3289 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4068 ../../Firmware/ultralcd.cpp:4070
+#: ../../Firmware/ultralcd.cpp:5567
 msgid "N/A"
 msgstr "N/D"
 
 #. MSG_NEW_FIRMWARE_AVAILABLE c=20 r=2
-#: ../../Firmware/messages.cpp:365 ../../Firmware/util.cpp:209
+#: ../../Firmware/messages.cpp:377 ../../Firmware/util.cpp:214
 msgid "New firmware version available:"
 msgstr "Nuevo firmware disponible:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:3029
-#: ../../Firmware/ultralcd.cpp:4443 ../../Firmware/ultralcd.cpp:4531
-#: ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:2275
+#: ../../Firmware/ultralcd.cpp:2279 ../../Firmware/ultralcd.cpp:3046
+#: ../../Firmware/ultralcd.cpp:4410 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/ultralcd.cpp:5765
 msgid "No"
 msgstr "No"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/messages.cpp:325 ../../Firmware/ultralcd.cpp:5321
+#: ../../Firmware/messages.cpp:337 ../../Firmware/ultralcd.cpp:5287
 msgid "No SD card"
 msgstr "No hay tarjeta SD"
 
 #. MSG_NO_MOVE c=20
-#: ../../Firmware/Marlin_main.cpp:5271 ../../Firmware/messages.cpp:210
+#: ../../Firmware/Marlin_main.cpp:4778 ../../Firmware/messages.cpp:222
 msgid "No move."
 msgstr "Sin movimiento"
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4239 ../../Firmware/ultralcd.cpp:4310
-#: ../../Firmware/ultralcd.cpp:4319 ../../Firmware/ultralcd.cpp:4349
-#: ../../Firmware/ultralcd.cpp:4358 ../../Firmware/ultralcd.cpp:4516
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4309
+#: ../../Firmware/ultralcd.cpp:4318 ../../Firmware/ultralcd.cpp:4483
 msgid "None"
 msgstr "Ninguno"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/Marlin_main.cpp:8497 ../../Firmware/messages.cpp:121
-#: ../../Firmware/ultralcd.cpp:4096 ../../Firmware/ultralcd.cpp:4132
-#: ../../Firmware/ultralcd.cpp:4511
+#: ../../Firmware/Marlin_main.cpp:7668 ../../Firmware/messages.cpp:125
+#: ../../Firmware/ultralcd.cpp:4120 ../../Firmware/ultralcd.cpp:4156
+#: ../../Firmware/ultralcd.cpp:4478
 msgid "Normal"
 msgstr "Normal"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/messages.cpp:345 ../../Firmware/ultralcd.cpp:6706
+#: ../../Firmware/messages.cpp:357 ../../Firmware/ultralcd.cpp:6682
 msgid "Not connected"
 msgstr "No hay conexión"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6863
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6839
 msgid "Not spinning"
 msgstr "Ventilador no gira"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/messages.cpp:289 ../../Firmware/ultralcd.cpp:3726
+#: ../../Firmware/messages.cpp:301 ../../Firmware/ultralcd.cpp:3736
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr ""
@@ -1324,33 +1320,31 @@ msgstr ""
 " la base."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/messages.cpp:298 ../../Firmware/ultralcd.cpp:3871
+#: ../../Firmware/messages.cpp:310 ../../Firmware/ultralcd.cpp:3894
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Ahora precalentaré la boquilla para PLA."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/messages.cpp:296 ../../Firmware/ultralcd.cpp:3857
+#: ../../Firmware/messages.cpp:308 ../../Firmware/ultralcd.cpp:3883
 msgid "Now remove the test print from steel sheet."
 msgstr "Ahora retira la prueba de la lámina de acero."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1390
-#: ../../Firmware/ultralcd.cpp:4170 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4233 ../../Firmware/ultralcd.cpp:4236
-#: ../../Firmware/ultralcd.cpp:4239
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1400
+#: ../../Firmware/ultralcd.cpp:4194 ../../Firmware/ultralcd.cpp:4326
 msgid "Nozzle"
 msgstr "Boquilla"
 
 #. MSG_NOZZLE_CNG_MENU c=18
-#: ../../Firmware/messages.cpp:193 ../../Firmware/ultralcd.cpp:4423
-#: ../../Firmware/ultralcd.cpp:4486
+#: ../../Firmware/messages.cpp:200 ../../Firmware/ultralcd.cpp:4390
+#: ../../Firmware/ultralcd.cpp:4453
 msgid "Nozzle change"
 msgstr "Cambio de boquilla"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4276
-#: ../../Firmware/ultralcd.cpp:4278 ../../Firmware/ultralcd.cpp:4279
-#: ../../Firmware/ultralcd.cpp:4280
+#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4261
+#: ../../Firmware/ultralcd.cpp:4263 ../../Firmware/ultralcd.cpp:4264
+#: ../../Firmware/ultralcd.cpp:4265
 msgid "Nozzle d."
 msgstr "D boquilla"
 
@@ -1361,83 +1355,83 @@ msgid "OK"
 msgstr "OK"
 
 #. MSG_OFF c=3
-#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:139
-#: ../../Firmware/mmu2.cpp:65 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4050 ../../Firmware/ultralcd.cpp:4051
-#: ../../Firmware/ultralcd.cpp:4053 ../../Firmware/ultralcd.cpp:4076
-#: ../../Firmware/ultralcd.cpp:4091 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4179 ../../Firmware/ultralcd.cpp:4467
-#: ../../Firmware/ultralcd.cpp:4495 ../../Firmware/ultralcd.cpp:4498
-#: ../../Firmware/ultralcd.cpp:5439 ../../Firmware/ultralcd.cpp:5594
-#: ../../Firmware/ultralcd.cpp:7487 ../../Firmware/ultralcd.cpp:7491
+#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:144
+#: ../../Firmware/mmu2.cpp:65 ../../Firmware/ultralcd.cpp:4063
+#: ../../Firmware/ultralcd.cpp:4074 ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4077 ../../Firmware/ultralcd.cpp:4100
+#: ../../Firmware/ultralcd.cpp:4115 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/ultralcd.cpp:4203 ../../Firmware/ultralcd.cpp:4434
+#: ../../Firmware/ultralcd.cpp:4462 ../../Firmware/ultralcd.cpp:4465
+#: ../../Firmware/ultralcd.cpp:5406 ../../Firmware/ultralcd.cpp:5567
+#: ../../Firmware/ultralcd.cpp:7464 ../../Firmware/ultralcd.cpp:7468
 msgid "Off"
 msgstr "Ina"
 
 #. MSG_DEFAULT_SETTINGS_LOADED c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:1562 ../../Firmware/messages.cpp:201
+#: ../../Firmware/Marlin_main.cpp:1489 ../../Firmware/messages.cpp:213
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr ""
 "Se han encontrado ajustes anteriores. Se ajustara el PID, los pasos del "
 "extrusor, etc."
 
 #. MSG_ON c=3
-#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:140
-#: ../../Firmware/mmu2.cpp:63 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4050 ../../Firmware/ultralcd.cpp:4051
-#: ../../Firmware/ultralcd.cpp:4053 ../../Firmware/ultralcd.cpp:4076
-#: ../../Firmware/ultralcd.cpp:4081 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4179 ../../Firmware/ultralcd.cpp:4467
-#: ../../Firmware/ultralcd.cpp:4495 ../../Firmware/ultralcd.cpp:4498
-#: ../../Firmware/ultralcd.cpp:5594 ../../Firmware/ultralcd.cpp:7487
-#: ../../Firmware/ultralcd.cpp:7491
+#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:145
+#: ../../Firmware/mmu2.cpp:63 ../../Firmware/ultralcd.cpp:4063
+#: ../../Firmware/ultralcd.cpp:4074 ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4077 ../../Firmware/ultralcd.cpp:4100
+#: ../../Firmware/ultralcd.cpp:4105 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/ultralcd.cpp:4203 ../../Firmware/ultralcd.cpp:4434
+#: ../../Firmware/ultralcd.cpp:4462 ../../Firmware/ultralcd.cpp:4465
+#: ../../Firmware/ultralcd.cpp:5567 ../../Firmware/ultralcd.cpp:7464
+#: ../../Firmware/ultralcd.cpp:7468
 msgid "On"
 msgstr "Act"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4191
+#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:4215
 msgid "Once"
 msgstr "Una vez"
 
 #. MSG_PAUSED_THERMAL_ERROR c=20
-#: ../../Firmware/Marlin_main.cpp:9861 ../../Firmware/messages.cpp:186
+#: ../../Firmware/Marlin_main.cpp:9021 ../../Firmware/messages.cpp:193
 msgid "PAUSED THERMAL ERROR"
 msgstr "PAUSA ERROR TÉRMICO"
 
 #. MSG_PID_RUNNING c=20
-#: ../../Firmware/messages.cpp:219 ../../Firmware/ultralcd.cpp:897
+#: ../../Firmware/messages.cpp:231 ../../Firmware/ultralcd.cpp:897
 msgid "PID cal."
 msgstr "Cal. PID"
 
 #. MSG_PID_FINISHED c=20
-#: ../../Firmware/messages.cpp:220 ../../Firmware/ultralcd.cpp:902
+#: ../../Firmware/messages.cpp:232 ../../Firmware/ultralcd.cpp:902
 msgid "PID cal. finished"
 msgstr "Cal. PID terminada"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:318 ../../Firmware/ultralcd.cpp:4590
+#: ../../Firmware/messages.cpp:330 ../../Firmware/ultralcd.cpp:4546
 msgid "PID calibration"
 msgstr "Calibración PID"
 
 #. MSG_PINDA_PREHEAT c=20
-#: ../../Firmware/messages.cpp:218 ../../Firmware/ultralcd.cpp:610
+#: ../../Firmware/messages.cpp:230 ../../Firmware/ultralcd.cpp:610
 msgid "PINDA Heating"
 msgstr "Calentando PINDA"
 
 #. MSG_PINDA_CALIBRATION c=13
-#: ../../Firmware/Marlin_main.cpp:4790 ../../Firmware/Marlin_main.cpp:4892
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:607
-#: ../../Firmware/ultralcd.cpp:4495 ../../Firmware/ultralcd.cpp:4597
+#: ../../Firmware/Marlin_main.cpp:4359 ../../Firmware/Marlin_main.cpp:4461
+#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:607
+#: ../../Firmware/ultralcd.cpp:4462 ../../Firmware/ultralcd.cpp:4553
 msgid "PINDA cal."
 msgstr "Cal. PINDA"
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/messages.cpp:276 ../../Firmware/ultralcd.cpp:3233
+#: ../../Firmware/messages.cpp:288 ../../Firmware/ultralcd.cpp:3243
 msgid "PINDA calibration failed"
 msgstr "Fallo de la calibración de PINDA"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:4967 ../../Firmware/messages.cpp:127
-#: ../../Firmware/ultralcd.cpp:3230
+#: ../../Firmware/Marlin_main.cpp:4536 ../../Firmware/messages.cpp:132
+#: ../../Firmware/ultralcd.cpp:3240
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1457,13 +1451,13 @@ msgid "Parking selector"
 msgstr "Aparcando selector"
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:4062
+#: ../../Firmware/messages.cpp:179 ../../Firmware/ultralcd.cpp:4086
 msgid "Pause"
 msgstr "Pausa"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5271
-#: ../../Firmware/ultralcd.cpp:5273
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5237
+#: ../../Firmware/ultralcd.cpp:5239
 msgid "Pause print"
 msgstr "Pausar impresión"
 
@@ -1474,7 +1468,7 @@ msgid "Performing cut"
 msgstr "Realizando corte"
 
 #. MSG_PAPER c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3243 ../../Firmware/messages.cpp:77
+#: ../../Firmware/Marlin_main.cpp:2982 ../../Firmware/messages.cpp:77
 msgid ""
 "Place a sheet of paper under the nozzle during the calibration of first 4 "
 "points. If the nozzle catches the paper, power off the printer immediately."
@@ -1483,7 +1477,7 @@ msgstr ""
 "los primeros 4 puntos. Si la boquilla coge el papel, apague inmediatamente."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:3963
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:3987
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1492,34 +1486,34 @@ msgstr ""
 "continua con el Asistente."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/messages.cpp:337 ../../Firmware/ultralcd.cpp:6023
+#: ../../Firmware/messages.cpp:349 ../../Firmware/ultralcd.cpp:5999
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "Comprueba la conexión del IR sensor y filamento está descargado."
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/messages.cpp:343 ../../Firmware/ultralcd.cpp:6700
+#: ../../Firmware/messages.cpp:355 ../../Firmware/ultralcd.cpp:6676
 msgid "Please check:"
 msgstr "Controla:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/messages.cpp:302 ../../Firmware/ultralcd.cpp:3926
+#: ../../Firmware/messages.cpp:314 ../../Firmware/ultralcd.cpp:3950
 msgid "Please clean heatbed and then press the knob."
 msgstr "Limpia la superficie de la base, y luego presiona el dial."
 
 #. MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3217 ../../Firmware/messages.cpp:27
+#: ../../Firmware/Marlin_main.cpp:2960 ../../Firmware/messages.cpp:28
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Limpia boquilla para calibración. Clic cuando acabes."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/messages.cpp:288 ../../Firmware/ultralcd.cpp:3712
+#: ../../Firmware/messages.cpp:300 ../../Firmware/ultralcd.cpp:3722
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr ""
 "Coloca el filamento en el extrusor, luego presiona el dial para cargarlo."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/messages.cpp:287 ../../Firmware/ultralcd.cpp:3705
+#: ../../Firmware/messages.cpp:299 ../../Firmware/ultralcd.cpp:3715
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1528,104 +1522,103 @@ msgstr ""
 " cargarlo."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/messages.cpp:285 ../../Firmware/ultralcd.cpp:3633
+#: ../../Firmware/messages.cpp:297 ../../Firmware/ultralcd.cpp:3643
 msgid "Please load filament first."
 msgstr "Carga primero el filamento."
 
 #. MSG_CHECK_IDLER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3525 ../../Firmware/messages.cpp:206
+#: ../../Firmware/Marlin_main.cpp:3265 ../../Firmware/messages.cpp:218
 msgid "Please open idler and remove filament manually."
 msgstr "Abre el tensor y retira el filamento manualmente."
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2806 ../../Firmware/messages.cpp:80
-#: ../../Firmware/ultralcd.cpp:3860
+#: ../../Firmware/mesh_bed_calibration.cpp:2791 ../../Firmware/messages.cpp:80
 msgid "Please place steel sheet on heatbed."
 msgstr "Coloca la lam. de acero en la base."
 
 #. MSG_PRESS_TO_UNLOAD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:11215 ../../Firmware/Marlin_main.cpp:11245
+#: ../../Firmware/Marlin_main.cpp:10287 ../../Firmware/Marlin_main.cpp:10317
 #: ../../Firmware/messages.cpp:84
 msgid "Please press the knob to unload filament"
 msgstr "Pulsa el dial para descargar el filamento"
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:4932
+#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:4888
 msgid "Please pull out filament immediately"
 msgstr "Retira el filamento de inmediato"
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/messages.cpp:295 ../../Firmware/ultralcd.cpp:3856
+#: ../../Firmware/messages.cpp:307 ../../Firmware/ultralcd.cpp:3882
 msgid "Please remove shipping helpers first."
 msgstr "Retira los soportes de envío primero."
 
 #. MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3240 ../../Firmware/Marlin_main.cpp:4755
-#: ../../Firmware/messages.cpp:89
+#: ../../Firmware/Marlin_main.cpp:4324 ../../Firmware/messages.cpp:89
 msgid "Please remove steel sheet from heatbed."
 msgstr "Retira la lam. de acero de la base."
 
 #. MSG_RUN_XYZ c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4731 ../../Firmware/messages.cpp:207
+#: ../../Firmware/Marlin_main.cpp:4300 ../../Firmware/messages.cpp:219
 msgid "Please run XYZ calibration first."
 msgstr "Realiza la calibración XYZ primero."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/messages.cpp:336 ../../Firmware/ultralcd.cpp:6020
+#: ../../Firmware/messages.cpp:348 ../../Firmware/ultralcd.cpp:4359
+#: ../../Firmware/ultralcd.cpp:5996
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Primero descarga el filamento, luego repite esta acción."
 
 #. MSG_NEW_FIRMWARE_PLEASE_UPGRADE c=20
-#: ../../Firmware/messages.cpp:366 ../../Firmware/util.cpp:213
+#: ../../Firmware/messages.cpp:378 ../../Firmware/util.cpp:218
 msgid "Please upgrade."
 msgstr "Actualiza por favor."
 
 #. MSG_PLEASE_WAIT c=20
-#: ../../Firmware/Marlin_main.cpp:3521 ../../Firmware/Marlin_main.cpp:8090
-#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:2179
-#: ../../Firmware/ultralcd.cpp:2190
+#: ../../Firmware/Marlin_main.cpp:3261 ../../Firmware/Marlin_main.cpp:7262
+#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:2190
+#: ../../Firmware/ultralcd.cpp:2204
 msgid "Please wait"
 msgstr "Por favor espera"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:1232
-#: ../../Firmware/ultralcd.cpp:1261
+#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:1242
+#: ../../Firmware/ultralcd.cpp:1271
 msgid "Power failures"
 msgstr "Fallos energía"
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/messages.cpp:323 ../../Firmware/ultralcd.cpp:5260
+#: ../../Firmware/messages.cpp:335 ../../Firmware/ultralcd.cpp:5222
 msgid "Preheat"
 msgstr "Precalentar"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:2254
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:2268
 msgid "Preheat the nozzle!"
 msgstr "Precalentar boquilla"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:2771
-#: ../../Firmware/ultralcd.cpp:3690 ../../Firmware/ultralcd.cpp:3692
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:2788
+#: ../../Firmware/ultralcd.cpp:3700 ../../Firmware/ultralcd.cpp:3702
 msgid "Preheating nozzle. Please wait."
 msgstr "Precalent. boquilla. Espera por favor."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/messages.cpp:237 ../../Firmware/ultralcd.cpp:1999
+#: ../../Firmware/messages.cpp:249 ../../Firmware/ultralcd.cpp:2005
 msgid "Preheating to cut"
 msgstr "Precalent. cortar"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/messages.cpp:236 ../../Firmware/ultralcd.cpp:1996
+#: ../../Firmware/messages.cpp:248 ../../Firmware/ultralcd.cpp:2002
 msgid "Preheating to eject"
 msgstr "Precalent. expulsar"
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/messages.cpp:234 ../../Firmware/ultralcd.cpp:1987
+#: ../../Firmware/messages.cpp:246 ../../Firmware/ultralcd.cpp:1995
 msgid "Preheating to load"
 msgstr "Precalent. cargar"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/messages.cpp:235 ../../Firmware/ultralcd.cpp:1992
+#: ../../Firmware/messages.cpp:247 ../../Firmware/ultralcd.cpp:1999
 msgid "Preheating to unload"
 msgstr "Precalent. descargar"
 
@@ -1636,12 +1629,12 @@ msgid "Preparing blade"
 msgstr "Preparando cuchilla"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/messages.cpp:231 ../../Firmware/ultralcd.cpp:1799
+#: ../../Firmware/messages.cpp:243 ../../Firmware/ultralcd.cpp:1809
 msgid "Press the knob"
 msgstr "Pulsa el dial"
 
 #. MSG_PRESS_TO_PREHEAT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:11227 ../../Firmware/messages.cpp:212
+#: ../../Firmware/Marlin_main.cpp:10299 ../../Firmware/messages.cpp:224
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Pulsa el dial para precalentar la boquilla y continue."
 
@@ -1651,34 +1644,34 @@ msgid "Print aborted"
 msgstr "Impresión cancelada"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1106
-#: ../../Firmware/ultralcd.cpp:6994
+#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1116
+#: ../../Firmware/ultralcd.cpp:6971
 msgid "Print fan:"
 msgstr "Vent.fusor:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:5313
+#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5279
 msgid "Print from SD"
 msgstr "Menu tarjeta SD"
 
 #. MSG_PRINT_PAUSED c=20
-#: ../../Firmware/Marlin_main.cpp:3582 ../../Firmware/messages.cpp:79
+#: ../../Firmware/Marlin_main.cpp:3323 ../../Firmware/messages.cpp:79
 #: ../../Firmware/ultralcd.cpp:814
 msgid "Print paused"
 msgstr "Impresión en pausa"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/messages.cpp:247 ../../Firmware/ultralcd.cpp:2348
+#: ../../Firmware/messages.cpp:259 ../../Firmware/ultralcd.cpp:2365
 msgid "Print time"
 msgstr "Tiempo de imp."
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/messages.cpp:225 ../../Firmware/ultralcd.cpp:1689
+#: ../../Firmware/messages.cpp:237 ../../Firmware/ultralcd.cpp:1699
 msgid "Printer IP Addr:"
 msgstr "Dir. IP impresora:"
 
 #. MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1602 ../../Firmware/messages.cpp:46
+#: ../../Firmware/Marlin_main.cpp:1529 ../../Firmware/messages.cpp:46
 msgid ""
 "Printer has not been calibrated yet. Please follow the manual, chapter First"
 " steps, section Calibration flow."
@@ -1687,12 +1680,12 @@ msgstr ""
 "Calibración flujo."
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:153 ../../Firmware/util.cpp:289
+#: ../../Firmware/messages.cpp:160 ../../Firmware/util.cpp:296
 msgid "Nozzle diameter differs from the G-code. Continue?"
 msgstr "Diámetro boquilla impresora difiere de cod.G. ¿Continuar?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:154 ../../Firmware/util.cpp:290
+#: ../../Firmware/messages.cpp:161 ../../Firmware/util.cpp:297
 msgid ""
 "Nozzle diameter differs from the G-code. Please check the value in settings."
 " Print cancelled."
@@ -1719,22 +1712,22 @@ msgid "QUEUE FULL"
 msgstr "COLA LLENA"
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:4465
 msgid "RPi port"
 msgstr "Puerto RPi"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/messages.cpp:261 ../../Firmware/ultralcd.cpp:2712
+#: ../../Firmware/messages.cpp:273 ../../Firmware/ultralcd.cpp:2729
 msgid "Rear side [µm]"
 msgstr "Trasera [µm]"
 
 #. MSG_RECOVERING_PRINT c=20
-#: ../../Firmware/messages.cpp:216 ../../Firmware/power_panic.cpp:316
+#: ../../Firmware/messages.cpp:228 ../../Firmware/power_panic.cpp:328
 msgid "Recovering print"
 msgstr "Recuper. impresión"
 
 #. MSG_RENAME c=18
-#: ../../Firmware/messages.cpp:322 ../../Firmware/ultralcd.cpp:5143
+#: ../../Firmware/messages.cpp:334 ../../Firmware/ultralcd.cpp:5103
 msgid "Rename"
 msgstr "Renombrar"
 
@@ -1748,19 +1741,19 @@ msgstr ""
 "para si el índice de herramienta está fuera de rango (T0-T4)."
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:2713
-#: ../../Firmware/ultralcd.cpp:5144
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:2730
+#: ../../Firmware/ultralcd.cpp:5104
 msgid "Reset"
 msgstr "Reset"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/messages.cpp:320 ../../Firmware/ultralcd.cpp:4594
+#: ../../Firmware/messages.cpp:332 ../../Firmware/ultralcd.cpp:4550
 msgid "Reset XYZ calibr."
 msgstr "Reset calibr. XYZ"
 
 #. MSG_RESUME_PRINT c=18
-#: ../../Firmware/Marlin_main.cpp:680 ../../Firmware/messages.cpp:91
-#: ../../Firmware/ultralcd.cpp:5286 ../../Firmware/ultralcd.cpp:5288
+#: ../../Firmware/Marlin_main.cpp:645 ../../Firmware/messages.cpp:91
+#: ../../Firmware/ultralcd.cpp:5252 ../../Firmware/ultralcd.cpp:5254
 msgid "Resume print"
 msgstr "Reanudar impres."
 
@@ -1787,17 +1780,17 @@ msgid "Returning selector"
 msgstr "Selector volviendo"
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/messages.cpp:252 ../../Firmware/ultralcd.cpp:2479
+#: ../../Firmware/messages.cpp:264 ../../Firmware/ultralcd.cpp:2496
 msgid "Right"
 msgstr "Derecha"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/messages.cpp:259 ../../Firmware/ultralcd.cpp:2710
+#: ../../Firmware/messages.cpp:271 ../../Firmware/ultralcd.cpp:2727
 msgid "Right side[µm]"
 msgstr "Derecha [µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/messages.cpp:286 ../../Firmware/ultralcd.cpp:3656
+#: ../../Firmware/messages.cpp:298 ../../Firmware/ultralcd.cpp:3666
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1806,8 +1799,8 @@ msgstr ""
 "comenzará de nuevo. ¿Continuar?"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4509
-#: ../../Firmware/ultralcd.cpp:4511
+#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4476
+#: ../../Firmware/ultralcd.cpp:4478
 msgid "SD card"
 msgstr "Tarj. SD"
 
@@ -1822,23 +1815,23 @@ msgid "SELECTOR CANNOT MOVE"
 msgstr "SELECT. SIN MOVERSE"
 
 #. MSG_STOPPED c=20
-#: ../../Firmware/Marlin_main.cpp:9887 ../../Firmware/messages.cpp:125
+#: ../../Firmware/Marlin_main.cpp:9047 ../../Firmware/messages.cpp:130
 msgid "STOPPED."
 msgstr "PARADA"
 
 #. MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3223 ../../Firmware/Marlin_main.cpp:3245
-#: ../../Firmware/mesh_bed_calibration.cpp:2246 ../../Firmware/messages.cpp:44
+#: ../../Firmware/Marlin_main.cpp:2967 ../../Firmware/Marlin_main.cpp:2984
+#: ../../Firmware/mesh_bed_calibration.cpp:2231 ../../Firmware/messages.cpp:44
 msgid "Searching bed calibration point"
 msgstr "Buscando punto de calibración base"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/messages.cpp:321 ../../Firmware/ultralcd.cpp:5136
+#: ../../Firmware/messages.cpp:333 ../../Firmware/ultralcd.cpp:5096
 msgid "Select"
 msgstr "Seleccionar"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/messages.cpp:290 ../../Firmware/ultralcd.cpp:3730
+#: ../../Firmware/messages.cpp:302 ../../Firmware/ultralcd.cpp:3740
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
@@ -1847,27 +1840,27 @@ msgstr ""
 " el menu en pantalla."
 
 #. MSG_SELECT_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3453 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3612
-#: ../../Firmware/ultralcd.cpp:6822
+#: ../../Firmware/Marlin_main.cpp:3192 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3622
+#: ../../Firmware/ultralcd.cpp:6798
 msgid "Select filament:"
 msgstr "Selecciona filam.:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:110 ../../Firmware/ultralcd.cpp:3464
-#: ../../Firmware/ultralcd.cpp:4504
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:3474
+#: ../../Firmware/ultralcd.cpp:4471
 msgid "Select language"
 msgstr "Cambiar el idioma"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/messages.cpp:300 ../../Firmware/ultralcd.cpp:3900
+#: ../../Firmware/messages.cpp:312 ../../Firmware/ultralcd.cpp:3924
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr ""
 "Selecciona la temperatura para precalentar la boquilla que se ajuste a tu "
 "material."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/messages.cpp:291 ../../Firmware/ultralcd.cpp:3735
+#: ../../Firmware/messages.cpp:303 ../../Firmware/ultralcd.cpp:3745
 msgid "Select temperature which matches your material."
 msgstr "Selecciona la temperatura adecuada a tu material."
 
@@ -1878,63 +1871,63 @@ msgid "Selecting fil. slot"
 msgstr "Eligiendo hueco fil."
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/messages.cpp:341 ../../Firmware/ultralcd.cpp:6274
+#: ../../Firmware/messages.cpp:353 ../../Firmware/ultralcd.cpp:6250
 msgid "Selftest OK"
 msgstr "Selftest OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/messages.cpp:340 ../../Firmware/ultralcd.cpp:6057
+#: ../../Firmware/messages.cpp:352 ../../Firmware/ultralcd.cpp:6033
 msgid "Selftest start"
 msgstr "Iniciar Selftest"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/messages.cpp:315 ../../Firmware/ultralcd.cpp:4581
+#: ../../Firmware/messages.cpp:327 ../../Firmware/ultralcd.cpp:4537
 msgid "Selftest"
 msgstr "Selftest"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/messages.cpp:342 ../../Firmware/ultralcd.cpp:6699
+#: ../../Firmware/messages.cpp:354 ../../Firmware/ultralcd.cpp:6675
 msgid "Selftest error!"
 msgstr "Error Selftest!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6279
-#: ../../Firmware/ultralcd.cpp:6786 ../../Firmware/ultralcd.cpp:6984
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6255
+#: ../../Firmware/ultralcd.cpp:6762 ../../Firmware/ultralcd.cpp:6961
 msgid "Selftest failed"
 msgstr "Fallo Selftest"
 
 #. MSG_FORCE_SELFTEST c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1577 ../../Firmware/messages.cpp:202
+#: ../../Firmware/Marlin_main.cpp:1504 ../../Firmware/messages.cpp:214
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr ""
 "Se realizará el selftest para calibrar con precision la vuelta a la posición"
 " inicial sin sensores."
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/messages.cpp:228 ../../Firmware/ultralcd.cpp:1701
+#: ../../Firmware/messages.cpp:240 ../../Firmware/ultralcd.cpp:1711
 msgid "Sensor info"
 msgstr "Info sensor"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/messages.cpp:338 ../../Firmware/ultralcd.cpp:6027
+#: ../../Firmware/messages.cpp:350 ../../Firmware/ultralcd.cpp:6003
 msgid "Sensor verified, remove the filament now."
 msgstr "Sensor verificado, retira el filamento ahora."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/messages.cpp:262 ../../Firmware/ultralcd.cpp:2730
+#: ../../Firmware/messages.cpp:274 ../../Firmware/ultralcd.cpp:2747
 msgid "Set temperature:"
 msgstr "Establecer temp.:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3348
-#: ../../Firmware/ultralcd.cpp:3479 ../../Firmware/ultralcd.cpp:3984
-#: ../../Firmware/ultralcd.cpp:5374 ../../Firmware/ultralcd.cpp:5585
-#: ../../Firmware/ultralcd.cpp:5631
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3358
+#: ../../Firmware/ultralcd.cpp:3489 ../../Firmware/ultralcd.cpp:4008
+#: ../../Firmware/ultralcd.cpp:5341 ../../Firmware/ultralcd.cpp:5558
+#: ../../Firmware/ultralcd.cpp:5604
 msgid "Settings"
 msgstr "Configuración"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/messages.cpp:255 ../../Firmware/ultralcd.cpp:2522
+#: ../../Firmware/messages.cpp:267 ../../Firmware/ultralcd.cpp:2539
 msgid "Severe skew"
 msgstr "Desv. severa"
 
@@ -1945,7 +1938,7 @@ msgid "Sheet"
 msgstr "Lámina"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/messages.cpp:284 ../../Firmware/ultralcd.cpp:3604
+#: ../../Firmware/messages.cpp:296 ../../Firmware/ultralcd.cpp:3614
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1958,23 +1951,23 @@ msgstr ""
 "%cReset"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/messages.cpp:319 ../../Firmware/ultralcd.cpp:4592
+#: ../../Firmware/messages.cpp:331 ../../Firmware/ultralcd.cpp:4548
 msgid "Show end stops"
 msgstr "Mostrar endstops"
 
 #. MSG_SILENT c=7
-#: ../../Firmware/Marlin_main.cpp:8497 ../../Firmware/messages.cpp:120
-#: ../../Firmware/ultralcd.cpp:4155 ../../Firmware/ultralcd.cpp:4194
+#: ../../Firmware/Marlin_main.cpp:7668 ../../Firmware/messages.cpp:124
+#: ../../Firmware/ultralcd.cpp:4179 ../../Firmware/ultralcd.cpp:4218
 msgid "Silent"
 msgstr "Acallar"
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/messages.cpp:254 ../../Firmware/ultralcd.cpp:2521
+#: ../../Firmware/messages.cpp:266 ../../Firmware/ultralcd.cpp:2538
 msgid "Slight skew"
 msgstr "Desv. ligera"
 
 #. MSG_FILE_CNT c=20 r=6
-#: ../../Firmware/cardreader.cpp:805 ../../Firmware/messages.cpp:197
+#: ../../Firmware/cardreader.cpp:805 ../../Firmware/messages.cpp:209
 msgid ""
 "Some files will not be sorted. Max. No. of files in 1 folder for sorting is "
 "100."
@@ -1983,59 +1976,59 @@ msgstr ""
 "ordenar."
 
 #. MSG_ZLEVELING_ENFORCED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3043 ../../Firmware/messages.cpp:204
+#: ../../Firmware/Marlin_main.cpp:2783 ../../Firmware/messages.cpp:216
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Problema encontrado, nivelación Z forzosa ..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:4514
-#: ../../Firmware/ultralcd.cpp:4515 ../../Firmware/ultralcd.cpp:4516
+#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4481
+#: ../../Firmware/ultralcd.cpp:4482 ../../Firmware/ultralcd.cpp:4483
 msgid "Sort"
 msgstr "Ordenar"
 
 #. MSG_SORTING_FILES c=20
 #: ../../Firmware/cardreader.cpp:849 ../../Firmware/cardreader.cpp:916
-#: ../../Firmware/messages.cpp:111
+#: ../../Firmware/messages.cpp:115
 msgid "Sorting files"
 msgstr "Ordenando archivos"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4188
-#: ../../Firmware/ultralcd.cpp:4191 ../../Firmware/ultralcd.cpp:4194
-#: ../../Firmware/ultralcd.cpp:4197 ../../Firmware/ultralcd.cpp:4200
+#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4215 ../../Firmware/ultralcd.cpp:4218
+#: ../../Firmware/ultralcd.cpp:4221 ../../Firmware/ultralcd.cpp:4224
 msgid "Sound"
 msgstr "Sonido"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/messages.cpp:333 ../../Firmware/ultralcd.cpp:5516
+#: ../../Firmware/messages.cpp:345 ../../Firmware/ultralcd.cpp:5483
 msgid "Speed"
 msgstr "Velocidad"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6861
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6837
 msgid "Spinning"
 msgstr "Ventilador girando"
 
 #. MSG_TEMP_CAL_WARNING c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4744 ../../Firmware/messages.cpp:208
+#: ../../Firmware/Marlin_main.cpp:4313 ../../Firmware/messages.cpp:220
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr ""
 "Se necesita una temperatura ambiente ente 21 y 26C y un soporte rígido."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/messages.cpp:329 ../../Firmware/ultralcd.cpp:5379
+#: ../../Firmware/messages.cpp:341 ../../Firmware/ultralcd.cpp:5346
 msgid "Statistics"
 msgstr "Estadísticas"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:4096
-#: ../../Firmware/ultralcd.cpp:4144
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4120
+#: ../../Firmware/ultralcd.cpp:4168
 msgid "Stealth"
 msgstr "Sigilo"
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4421
-#: ../../Firmware/ultralcd.cpp:5133
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4388
+#: ../../Firmware/ultralcd.cpp:5093
 msgid "Steel sheets"
 msgstr "Lámina de acero"
 
@@ -2045,29 +2038,28 @@ msgid "Stop"
 msgstr "Parar"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:5293
-#: ../../Firmware/ultralcd.cpp:5781
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:5259
+#: ../../Firmware/ultralcd.cpp:5757
 msgid "Stop print"
 msgstr "Detener impresión"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4236
-#: ../../Firmware/ultralcd.cpp:4316 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4315
 msgid "Strict"
 msgstr "Estricto"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/messages.cpp:332 ../../Firmware/ultralcd.cpp:5394
+#: ../../Firmware/messages.cpp:344 ../../Firmware/ultralcd.cpp:5361
 msgid "Support"
 msgstr "Soporte"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/messages.cpp:354 ../../Firmware/ultralcd.cpp:6758
+#: ../../Firmware/messages.cpp:366 ../../Firmware/ultralcd.cpp:6734
 msgid "Swapped"
 msgstr "Intercambiado"
 
 #. MSG_THERMAL_ANOMALY c=20
-#: ../../Firmware/messages.cpp:188 ../../Firmware/temperature.cpp:2223
+#: ../../Firmware/messages.cpp:195 ../../Firmware/temperature.cpp:2197
 msgid "THERMAL ANOMALY"
 msgstr "ANOMALÍA TÉRMICA"
 
@@ -2102,7 +2094,7 @@ msgid "TMC UNDERVOLTAGE ERR"
 msgstr "ERROR SBRVOLTAJE TMC"
 
 #. MSG_TM_CAL c=20 r=4
-#: ../../Firmware/messages.cpp:299 ../../Firmware/ultralcd.cpp:3881
+#: ../../Firmware/messages.cpp:311 ../../Firmware/ultralcd.cpp:3905
 msgid ""
 "Thermal model cal. takes approx. 12 mins. See\n"
 "prusa.io/tm-cal"
@@ -2111,22 +2103,22 @@ msgstr ""
 "prusa.io/tm-cal"
 
 #. MSG_TM_NOT_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1613 ../../Firmware/messages.cpp:189
+#: ../../Firmware/Marlin_main.cpp:1540 ../../Firmware/messages.cpp:196
 msgid "Thermal model not calibrated yet."
 msgstr "Modelo térmico todavía sin cal."
 
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/messages.cpp:309 ../../Firmware/ultralcd.cpp:4455
+#: ../../Firmware/messages.cpp:321 ../../Firmware/ultralcd.cpp:4422
 msgid "Temperature"
 msgstr "Temperatura"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/messages.cpp:229 ../../Firmware/ultralcd.cpp:1707
+#: ../../Firmware/messages.cpp:241 ../../Firmware/ultralcd.cpp:1717
 msgid "Temperatures"
 msgstr "Temperaturas"
 
 #. MSG_TESTING_FILAMENT c=20
-#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:388
+#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:389
 msgid "Testing filament"
 msgstr "Probando filamento"
 
@@ -2147,7 +2139,7 @@ msgstr ""
 "su movimiento."
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/messages.cpp:292 ../../Firmware/ultralcd.cpp:3738
+#: ../../Firmware/messages.cpp:304 ../../Firmware/ultralcd.cpp:3748
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -2158,7 +2150,7 @@ msgstr ""
 "de calibración)."
 
 #. MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1606 ../../Firmware/messages.cpp:47
+#: ../../Firmware/Marlin_main.cpp:1533 ../../Firmware/messages.cpp:47
 msgid ""
 "There is still a need to make Z calibration. Please follow the manual, "
 "chapter First steps, section Calibration flow."
@@ -2167,40 +2159,40 @@ msgstr ""
 "Primeros pasos."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:4514
+#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:4481
 msgid "Time"
 msgstr "Tiempo"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:176 ../../Firmware/ultralcd.cpp:5622
+#: ../../Firmware/messages.cpp:183 ../../Firmware/ultralcd.cpp:5595
 msgid "Timeout"
 msgstr "Expirar"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:1129
-#: ../../Firmware/ultralcd.cpp:1287
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:1139
+#: ../../Firmware/ultralcd.cpp:1297
 msgid "Total"
 msgstr "Total"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:1177
-#: ../../Firmware/ultralcd.cpp:1231 ../../Firmware/ultralcd.cpp:1317
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:1187
+#: ../../Firmware/ultralcd.cpp:1241 ../../Firmware/ultralcd.cpp:1327
 msgid "Total failures"
 msgstr "Fallos totales"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/messages.cpp:248 ../../Firmware/ultralcd.cpp:2369
+#: ../../Firmware/messages.cpp:260 ../../Firmware/ultralcd.cpp:2386
 msgid "Total filament"
 msgstr "Filamento total"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/messages.cpp:249 ../../Firmware/ultralcd.cpp:2370
+#: ../../Firmware/messages.cpp:261 ../../Firmware/ultralcd.cpp:2387
 msgid "Total print time"
 msgstr "Tiempo total imp."
 
 #. MSG_TUNE c=8
-#: ../../Firmware/messages.cpp:116 ../../Firmware/mmu2/errors_list.h:372
-#: ../../Firmware/ultralcd.cpp:5258
+#: ../../Firmware/messages.cpp:120 ../../Firmware/mmu2/errors_list.h:372
+#: ../../Firmware/ultralcd.cpp:5220
 msgid "Tune"
 msgstr "Ajustar"
 
@@ -2215,16 +2207,16 @@ msgid "Unload"
 msgstr "Desc."
 
 #. MSG_UNLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:2206
-#: ../../Firmware/ultralcd.cpp:5347 ../../Firmware/ultralcd.cpp:5364
-#: ../../Firmware/ultralcd.cpp:5369
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:2220
+#: ../../Firmware/ultralcd.cpp:5313 ../../Firmware/ultralcd.cpp:5331
+#: ../../Firmware/ultralcd.cpp:5336
 msgid "Unload filament"
 msgstr "Descarga fil."
 
 #. MSG_UNLOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3436 ../../Firmware/messages.cpp:129
+#: ../../Firmware/Marlin_main.cpp:3175 ../../Firmware/messages.cpp:134
 #: ../../Firmware/mmu2_progress_converter.cpp:50
-#: ../../Firmware/ultralcd.cpp:4911
+#: ../../Firmware/ultralcd.cpp:4867
 msgid "Unloading filament"
 msgstr "Descargando fil."
 
@@ -2241,12 +2233,12 @@ msgid "Unloading to pulley"
 msgstr "Descarg. hasta polea"
 
 #. MSG_FIL_FAILED c=20 r=4
-#: ../../Firmware/messages.cpp:339 ../../Firmware/ultralcd.cpp:6030
+#: ../../Firmware/messages.cpp:351 ../../Firmware/ultralcd.cpp:6006
 msgid "Verification failed, remove the filament and try again."
 msgstr "La verificación falló, retira el filamento e intenta nuevamente."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/messages.cpp:230 ../../Firmware/ultralcd.cpp:1710
+#: ../../Firmware/messages.cpp:242 ../../Firmware/ultralcd.cpp:1720
 msgid "Voltages"
 msgstr "Voltajes"
 
@@ -2257,7 +2249,7 @@ msgid "WARNING TMC TOO HOT"
 msgstr "AVISO TMC DEM. CALOR"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/messages.cpp:281 ../../Firmware/ultralcd.cpp:3381
+#: ../../Firmware/messages.cpp:293 ../../Firmware/ultralcd.cpp:3391
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -2270,189 +2262,189 @@ msgstr ""
 "Modo silencio"
 
 #. MSG_USERWAIT c=20
-#: ../../Firmware/Marlin_main.cpp:5240 ../../Firmware/messages.cpp:209
+#: ../../Firmware/Marlin_main.cpp:4747 ../../Firmware/messages.cpp:221
 msgid "Wait for user..."
 msgstr "Esperando ordenes..."
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/messages.cpp:263 ../../Firmware/ultralcd.cpp:2753
+#: ../../Firmware/messages.cpp:275 ../../Firmware/ultralcd.cpp:2770
 msgid "Waiting for PINDA probe cooling"
 msgstr "Esperando a que se enfríe la sonda PINDA"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/messages.cpp:264 ../../Firmware/ultralcd.cpp:2782
+#: ../../Firmware/messages.cpp:276 ../../Firmware/ultralcd.cpp:2799
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Esperando enfriamiento de la base y boquilla."
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:4233
-#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4352
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4312
 msgid "Warn"
 msgstr "Aviso"
 
 #. MSG_CHANGED_BOTH c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1554 ../../Firmware/messages.cpp:200
+#: ../../Firmware/Marlin_main.cpp:1481 ../../Firmware/messages.cpp:212
 msgid "Warning: both printer type and motherboard type changed."
 msgstr ""
 "Aviso: tanto el tipo de impresora como el tipo de la placa han cambiado."
 
 #. MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1546 ../../Firmware/messages.cpp:198
+#: ../../Firmware/Marlin_main.cpp:1473 ../../Firmware/messages.cpp:210
 msgid "Warning: motherboard type changed."
 msgstr "Aviso: el tipo de placa ha cambiado."
 
 #. MSG_CHANGED_PRINTER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1550 ../../Firmware/messages.cpp:199
+#: ../../Firmware/Marlin_main.cpp:1477 ../../Firmware/messages.cpp:211
 msgid "Warning: printer type changed."
 msgstr "Aviso: ha cambiado el tipo de impresora."
 
 #. MSG_UNLOAD_SUCCESSFUL c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3517 ../../Firmware/messages.cpp:205
+#: ../../Firmware/Marlin_main.cpp:3257 ../../Firmware/messages.cpp:217
 msgid "Was filament unload successful?"
 msgstr "¿Se descargó con éxito el filamento?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:6710
-#: ../../Firmware/ultralcd.cpp:6714 ../../Firmware/ultralcd.cpp:6734
-#: ../../Firmware/ultralcd.cpp:6740 ../../Firmware/ultralcd.cpp:6764
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:6686
+#: ../../Firmware/ultralcd.cpp:6690 ../../Firmware/ultralcd.cpp:6710
+#: ../../Firmware/ultralcd.cpp:6716 ../../Firmware/ultralcd.cpp:6740
 msgid "Wiring error"
 msgstr "Error de conexión"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/messages.cpp:313 ../../Firmware/ultralcd.cpp:4572
+#: ../../Firmware/messages.cpp:325 ../../Firmware/ultralcd.cpp:4528
 msgid "Wizard"
 msgstr "Asistente"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/messages.cpp:304 ../../Firmware/ultralcd.cpp:3986
+#: ../../Firmware/messages.cpp:316 ../../Firmware/ultralcd.cpp:4010
 msgid "X-correct"
 msgstr "Corregir-X"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/messages.cpp:226 ../../Firmware/ultralcd.cpp:1699
+#: ../../Firmware/messages.cpp:238 ../../Firmware/ultralcd.cpp:1709
 msgid "XYZ cal. details"
 msgstr "Detalles cal. XYZ"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/messages.cpp:275 ../../Firmware/ultralcd.cpp:3207
+#: ../../Firmware/messages.cpp:287 ../../Firmware/ultralcd.cpp:3217
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr "Calibración XYZ correcta. La desviación se corregirá automáticamente."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/messages.cpp:274 ../../Firmware/ultralcd.cpp:3204
+#: ../../Firmware/messages.cpp:286 ../../Firmware/ultralcd.cpp:3214
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr ""
 "Calibración XYZ correcta. Los ejes X/Y están ligeramente desviados. Buen "
 "trabajo!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/messages.cpp:271 ../../Firmware/ultralcd.cpp:3185
+#: ../../Firmware/messages.cpp:283 ../../Firmware/ultralcd.cpp:3195
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr "Calibración XYZ comprometida. Puntos frontales no alcanzables."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/messages.cpp:272 ../../Firmware/ultralcd.cpp:3188
+#: ../../Firmware/messages.cpp:284 ../../Firmware/ultralcd.cpp:3198
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr "Calibración XYZ comprometida. Punto frontal derecho no alcanzable."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/messages.cpp:268 ../../Firmware/ultralcd.cpp:3167
+#: ../../Firmware/messages.cpp:280 ../../Firmware/ultralcd.cpp:3177
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr ""
 "Calibración XYZ fallida. Puntos de calibración en la base no encontrados."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/messages.cpp:269 ../../Firmware/ultralcd.cpp:3173
+#: ../../Firmware/messages.cpp:281 ../../Firmware/ultralcd.cpp:3183
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr "Calibración XYZ fallida. Puntos frontales no alcanzables."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3170
-#: ../../Firmware/ultralcd.cpp:3198
+#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3180
+#: ../../Firmware/ultralcd.cpp:3208
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "Calibración XYZ fallida. Consulta el manual."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/messages.cpp:270 ../../Firmware/ultralcd.cpp:3176
+#: ../../Firmware/messages.cpp:282 ../../Firmware/ultralcd.cpp:3186
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr "Calibración XYZ fallad. Punto frontal derecho no alcanzable."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/messages.cpp:273 ../../Firmware/ultralcd.cpp:3201
+#: ../../Firmware/messages.cpp:285 ../../Firmware/ultralcd.cpp:3211
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "Calibración XYZ ok. Ejes X/Y perpendiculares. Enhorabuena!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/messages.cpp:250 ../../Firmware/ultralcd.cpp:2476
+#: ../../Firmware/messages.cpp:262 ../../Firmware/ultralcd.cpp:2493
 msgid "Y distance from min"
 msgstr "Dist. en Y desde min"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/messages.cpp:305 ../../Firmware/ultralcd.cpp:3987
+#: ../../Firmware/messages.cpp:317 ../../Firmware/ultralcd.cpp:4011
 msgid "Y-correct"
 msgstr "Corregir-Y"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:3029
-#: ../../Firmware/ultralcd.cpp:4443 ../../Firmware/ultralcd.cpp:4531
-#: ../../Firmware/ultralcd.cpp:5790
+#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:2275
+#: ../../Firmware/ultralcd.cpp:2279 ../../Firmware/ultralcd.cpp:3046
+#: ../../Firmware/ultralcd.cpp:4410 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/ultralcd.cpp:5766
 msgid "Yes"
 msgstr "Si"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:3950
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:3974
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr "Siempre puedes acceder al asistente desde Calibración -> Asistente"
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/messages.cpp:306 ../../Firmware/ultralcd.cpp:3988
+#: ../../Firmware/messages.cpp:318 ../../Firmware/ultralcd.cpp:4012
 msgid "Z-correct"
 msgstr "Corregir-Z"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5593
+#: ../../Firmware/messages.cpp:175 ../../Firmware/ultralcd.cpp:5566
 msgid "Z-probe nr."
 msgstr "Z-sensor nr."
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/messages.cpp:256 ../../Firmware/ultralcd.cpp:2546
+#: ../../Firmware/messages.cpp:268 ../../Firmware/ultralcd.cpp:2563
 msgid "[0;0] point offset"
 msgstr "[0;0] punto offset"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/messages.cpp:239 ../../Firmware/ultralcd.cpp:2147
+#: ../../Firmware/messages.cpp:251 ../../Firmware/ultralcd.cpp:2158
 msgid "and press the knob"
 msgstr "y presiona el dial"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/messages.cpp:232 ../../Firmware/ultralcd.cpp:1807
+#: ../../Firmware/messages.cpp:244 ../../Firmware/ultralcd.cpp:1816
 msgid "to load filament"
 msgstr "para cargar el fil."
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/messages.cpp:233 ../../Firmware/ultralcd.cpp:1811
+#: ../../Firmware/messages.cpp:245 ../../Firmware/ultralcd.cpp:1820
 msgid "to unload filament"
 msgstr "para descargar fil."
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/messages.cpp:224 ../../Firmware/ultralcd.cpp:1666
+#: ../../Firmware/messages.cpp:236 ../../Firmware/ultralcd.cpp:1676
 msgid "unknown"
 msgstr "desconocido"
 
 #. MSG_IR_UNKNOWN c=18
-#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:184
+#: ../../Firmware/Filament_sensor.cpp:286 ../../Firmware/messages.cpp:191
 msgid "unknown state"
 msgstr "estado desconocido"
 
 #. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:5858
-#: ../../Firmware/ultralcd.cpp:5861
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:5834
+#: ../../Firmware/ultralcd.cpp:5837
 msgid "🔃Refresh"
 msgstr "🔃Actualizar"
 
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1180
+#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1190
 msgid "MMU power fails"
 msgstr "Fallo red MMU"
 
@@ -2490,8 +2482,8 @@ msgid "MMU MCU ERROR"
 msgstr "MMU MCU ERROR"
 
 #. MSG_MATERIAL_CHANGES c=18
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:1130
-#: ../../Firmware/ultralcd.cpp:1204
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:1140
+#: ../../Firmware/ultralcd.cpp:1214
 msgid "Material changes"
 msgstr "Cambios materiales"
 
@@ -2524,17 +2516,17 @@ msgstr ""
 "Actualizar a la versión 3.0.3."
 
 #. MSG_PRELOAD_TO_MMU c=17
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5344
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5310
 msgid "Preload to MMU"
 msgstr "Precarga a MMU"
 
 #. MSG_FW_MK3_DETECTED c=20 r=4
-#: ../../Firmware/messages.cpp:367 ../../Firmware/Marlin_main.cpp:920
+#: ../../Firmware/messages.cpp:379 ../../Firmware/Marlin_main.cpp:854
 msgid "MK3 firmware detected on MK3S printer"
 msgstr "Firmware MK3 detectado en impresora MK3S"
 
 #. MSG_FW_MK3S_DETECTED c=20 r=4
-#: ../../Firmware/messages.cpp:367 ../../Firmware/Marlin_main.cpp:920
+#: ../../Firmware/messages.cpp:379 ../../Firmware/Marlin_main.cpp:854
 msgid "MK3S firmware detected on MK3 printer"
 msgstr "Firmware MK3S detectado en impresora MK3"
 
@@ -2548,8 +2540,9 @@ msgstr "ERROR DESCONOCIDO"
 msgid "Unexpected error occurred."
 msgstr "Ocurrió un error inesperado."
 
-#. MSG_BTN_EJECT c=8
-#: ../../Firmware/mmu2/errors_list.h:358 ../../Firmware/mmu2/errors_list.h:371
+#. MSG_EJECT c=8
+#: ../../Firmware/messages.cpp:21 ../../Firmware/mmu2/errors_list.h:371
+#: ../../Firmware/ultralcd.cpp:2275 ../../Firmware/ultralcd.cpp:2279
 msgid "Eject"
 msgstr "Expulsar"
 
@@ -2570,58 +2563,58 @@ msgstr ""
 "Cambio de filamento M600. Cargue un filamento nuevo o expulse el anterior."
 
 #. MSG_MMU_SENSITIVITY c=18
-#: ../../Firmware/messages.cpp:215 ../../Firmware/mmu2_reporting.cpp:458
+#: ../../Firmware/messages.cpp:227 ../../Firmware/mmu2_reporting.cpp:459
 msgid "Sensitivity"
 msgstr "Sensibilidad"
 
 #. MSG_MBL_FAILED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3038 ../../Firmware/messages.cpp:203
+#: ../../Firmware/Marlin_main.cpp:2776 ../../Firmware/messages.cpp:215
 msgid "Mesh bed leveling failed. Print canceled."
 msgstr "Nivelación fallida. Impresión cancelada."
 
 #. MSG_SET_READY c=18
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:5265
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:5228
 msgid "Set Ready"
 msgstr "Listo"
 
 #. MSG_SET_NOT_READY c=18
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:5263
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5226
 msgid "Set not Ready"
 msgstr "Conjunto no listo"
 
 #. MSG_HOSTPRINT c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5285
+#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:5231
 msgid "Print from host"
 msgstr "Imprimir host"
 
 #. MSG_REPRINT c=18
-#: ../../Firmware/messages.cpp:196 ../../Firmware/ultralcd.cpp:5243
-#: ../../Firmware/ultralcd.cpp:5245
+#: ../../Firmware/messages.cpp:208 ../../Firmware/ultralcd.cpp:5205
+#: ../../Firmware/ultralcd.cpp:5207
 msgid "Reprint"
 msgstr "Volver a imprimir"
 
 #. MSG_SHUTDOWN_HOST c=18
-#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:5390
+#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:5357
 msgid "Shutdown host"
 msgstr "Apagar host"
 
 #. MSG_NOZZLE_CNG_COOLDOWN c=20 r=3
-#: ../../Firmware/messages.cpp:198 ../../Firmware/ultralcd.cpp:1002
+#: ../../Firmware/messages.cpp:203 ../../Firmware/ultralcd.cpp:999
 msgid "Nozzle is hot! Wait for cooldown."
 msgstr "La boquilla está caliente! Espere a que se enfríe."
 
 #. MSG_NOZZLE_CNG_CHANGED_QUICK c=20 r=3
-#: ../../Firmware/messages.cpp:199
+#: ../../Firmware/messages.cpp:204
 msgid "Nozzle changed?"
 msgstr "Cambió la boquilla?"
 
 #. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:388
+#: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:388
 msgid "There is no filament loaded. Continue?"
 msgstr "No hay ningún filamento cargado. ¿Continuar?"
 
 #. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:389
+#: ../../Firmware/messages.cpp:159 ../../Firmware/util.cpp:389
 msgid "There is no filament loaded. Print cancelled."
 msgstr "No hay ningún filamento cargado. Impresión cancelada."
 

--- a/lang/po/Firmware_fr.po
+++ b/lang/po/Firmware_fr.po
@@ -16,91 +16,91 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 
 #. MSG_IR_03_OR_OLDER c=18
-#: ../../Firmware/Filament_sensor.cpp:280
-#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:183
+#: ../../Firmware/Filament_sensor.cpp:282
+#: ../../Firmware/Filament_sensor.cpp:344 ../../Firmware/messages.cpp:190
 msgid " 0.3 or older"
 msgstr " 0.3 ou +ancien"
 
 #. MSG_IR_04_OR_NEWER c=18
-#: ../../Firmware/Filament_sensor.cpp:282
-#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:182
+#: ../../Firmware/Filament_sensor.cpp:284
+#: ../../Firmware/Filament_sensor.cpp:347 ../../Firmware/messages.cpp:189
 msgid " 0.4 or newer"
 msgstr " 0.4 ou +recent"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/messages.cpp:356 ../../Firmware/ultralcd.cpp:6773
+#: ../../Firmware/messages.cpp:368 ../../Firmware/ultralcd.cpp:6749
 msgid "%s level expected"
 msgstr "niveau %s attendu"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:1978
-#: ../../Firmware/ultralcd.cpp:3613
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:1986
+#: ../../Firmware/ultralcd.cpp:3623
 msgid ">Cancel"
 msgstr ">Annuler"
 
 #. MSG_BABYSTEPPING_Z c=13
-#: ../../Firmware/messages.cpp:257 ../../Firmware/ultralcd.cpp:2635
+#: ../../Firmware/messages.cpp:269 ../../Firmware/ultralcd.cpp:2652
 msgid "Adjusting Z"
 msgstr "Ajuster Z"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/messages.cpp:360 ../../Firmware/ultralcd.cpp:6983
+#: ../../Firmware/messages.cpp:372 ../../Firmware/ultralcd.cpp:6960
 msgid "All correct"
 msgstr "Tout est correct"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:3955
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:3979
 msgid "All is done. Happy printing!"
 msgstr "Tout est pret. Bonne impression!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4482
 msgid "Alphabet"
 msgstr "Alphabet"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4086
+#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4110
 msgid "Always"
 msgstr "Tjrs"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/messages.cpp:221 ../../Firmware/ultralcd.cpp:1393
+#: ../../Firmware/messages.cpp:233 ../../Firmware/ultralcd.cpp:1403
 msgid "Ambient"
 msgstr "Ambiant"
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=3
-#: ../../Firmware/messages.cpp:267 ../../Firmware/ultralcd.cpp:2848
+#: ../../Firmware/messages.cpp:279 ../../Firmware/ultralcd.cpp:2865
 msgid "Are left and right Z-carriages all up?"
 msgstr "Z-carriages gauche + droite tout en haut?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4197
+#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:4221
 msgid "Assist"
 msgstr "Assist"
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:179 ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/messages.cpp:186 ../../Firmware/ultralcd.cpp:5594
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
-#: ../../Firmware/Marlin_main.cpp:3198 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:4577 ../../Firmware/ultralcd.cpp:5529
+#: ../../Firmware/Marlin_main.cpp:2942 ../../Firmware/messages.cpp:12
+#: ../../Firmware/ultralcd.cpp:4533 ../../Firmware/ultralcd.cpp:5496
 msgid "Auto home"
 msgstr "Mise a 0 des axes"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4182
 msgid "Auto power"
 msgstr "Puiss.auto"
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:328 ../../Firmware/ultralcd.cpp:5359
+#: ../../Firmware/messages.cpp:340 ../../Firmware/ultralcd.cpp:5328
 msgid "AutoLoad filament"
 msgstr "Autocharge du fil."
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/messages.cpp:245 ../../Firmware/ultralcd.cpp:2272
+#: ../../Firmware/messages.cpp:257 ../../Firmware/ultralcd.cpp:2289
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
@@ -113,51 +113,50 @@ msgid "Avoiding grind"
 msgstr "Éviter broiement"
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/messages.cpp:352 ../../Firmware/ultralcd.cpp:6752
+#: ../../Firmware/messages.cpp:364 ../../Firmware/ultralcd.cpp:6728
 msgid "Axis"
 msgstr "Axe"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/messages.cpp:351 ../../Firmware/ultralcd.cpp:6751
+#: ../../Firmware/messages.cpp:363 ../../Firmware/ultralcd.cpp:6727
 msgid "Axis length"
 msgstr "Longueur de l'axe"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2708
-#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:5618
-#: ../../Firmware/ultralcd.cpp:7484
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2725
+#: ../../Firmware/ultralcd.cpp:4061 ../../Firmware/ultralcd.cpp:5591
+#: ../../Firmware/ultralcd.cpp:7461
 msgid "Back"
 msgstr "Retour"
 
 #. MSG_BED c=13
-#: ../../Firmware/Marlin_main.cpp:2081 ../../Firmware/Marlin_main.cpp:4627
-#: ../../Firmware/Marlin_main.cpp:4678 ../../Firmware/messages.cpp:15
-#: ../../Firmware/ultralcd.cpp:1391 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/Marlin_main.cpp:4247 ../../Firmware/messages.cpp:15
+#: ../../Firmware/ultralcd.cpp:1401 ../../Firmware/ultralcd.cpp:4197
 msgid "Bed"
 msgstr "Lit"
 
 #. MSG_BED_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6240 ../../Firmware/messages.cpp:17
+#: ../../Firmware/Marlin_main.cpp:5470 ../../Firmware/messages.cpp:17
 #: ../../Firmware/ultralcd.cpp:534
 msgid "Bed Heating"
 msgstr "Chauffe du lit"
 
 #. MSG_BED_DONE c=20
-#: ../../Firmware/Marlin_main.cpp:6277 ../../Firmware/messages.cpp:16
+#: ../../Firmware/Marlin_main.cpp:5507 ../../Firmware/messages.cpp:16
 #: ../../Firmware/ultralcd.cpp:537
 msgid "Bed done"
 msgstr "Lit termine"
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/messages.cpp:317 ../../Firmware/ultralcd.cpp:4589
+#: ../../Firmware/messages.cpp:329 ../../Firmware/ultralcd.cpp:4545
 msgid "Bed level correct"
 msgstr "Réglage lit"
 
 #. MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:2262 ../../Firmware/Marlin_main.cpp:2999
-#: ../../Firmware/Marlin_main.cpp:3008
-#: ../../Firmware/mesh_bed_calibration.cpp:2878
-#: ../../Firmware/mesh_bed_calibration.cpp:2903 ../../Firmware/messages.cpp:18
+#: ../../Firmware/Marlin_main.cpp:2048 ../../Firmware/Marlin_main.cpp:2736
+#: ../../Firmware/Marlin_main.cpp:2745
+#: ../../Firmware/mesh_bed_calibration.cpp:2863
+#: ../../Firmware/mesh_bed_calibration.cpp:2888 ../../Firmware/messages.cpp:18
 msgid ""
 "Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for "
 "reset."
@@ -166,34 +165,34 @@ msgstr ""
 "attente d'un reset."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/messages.cpp:346 ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/messages.cpp:358 ../../Firmware/ultralcd.cpp:6685
 msgid "Bed/Heater"
 msgstr "Lit/Chauffage"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1444
-#: ../../Firmware/ultralcd.cpp:1704
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1454
+#: ../../Firmware/ultralcd.cpp:1714
 msgid "Belt status"
 msgstr "Statut courroie"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/messages.cpp:314 ../../Firmware/ultralcd.cpp:4579
+#: ../../Firmware/messages.cpp:326 ../../Firmware/ultralcd.cpp:4535
 msgid "Belt test"
 msgstr "Test de courroie"
 
 #. MSG_RECOVER_PRINT c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:1660 ../../Firmware/messages.cpp:87
+#: ../../Firmware/Marlin_main.cpp:1587 ../../Firmware/messages.cpp:87
 msgid "Blackout occurred. Recover print?"
 msgstr "Coupure détectée. Reprendre impres.?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:177 ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:5594
 msgid "Bright"
 msgstr "Brill."
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:4526
-#: ../../Firmware/ultralcd.cpp:5546
+#: ../../Firmware/messages.cpp:180 ../../Firmware/ultralcd.cpp:4493
+#: ../../Firmware/ultralcd.cpp:5513
 msgid "Brightness"
 msgstr "Luminosité"
 
@@ -203,17 +202,17 @@ msgid "COMMUNICATION ERROR"
 msgstr "ERREUR COMMUNICATION"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/messages.cpp:316 ../../Firmware/ultralcd.cpp:4583
+#: ../../Firmware/messages.cpp:328 ../../Firmware/ultralcd.cpp:4539
 msgid "Calibrate XYZ"
 msgstr "Calibrer XYZ"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4585
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4541
 msgid "Calibrate Z"
 msgstr "Calibrer Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/messages.cpp:266 ../../Firmware/ultralcd.cpp:2813
+#: ../../Firmware/messages.cpp:278 ../../Firmware/ultralcd.cpp:2830
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -222,13 +221,13 @@ msgstr ""
 "l'axe Z jusqu'aux butées. Cliquez une fois fait."
 
 #. MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: ../../Firmware/Marlin_main.cpp:2218 ../../Firmware/messages.cpp:22
+#: ../../Firmware/Marlin_main.cpp:2009 ../../Firmware/messages.cpp:23
 #: ../../Firmware/ultralcd.cpp:582
 msgid "Calibrating Z"
 msgstr "Calibration Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/messages.cpp:265 ../../Firmware/ultralcd.cpp:2812
+#: ../../Firmware/messages.cpp:277 ../../Firmware/ultralcd.cpp:2829
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -237,17 +236,17 @@ msgstr ""
 " Z jusqu'aux butées. Cliquez une fois fait."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/messages.cpp:361 ../../Firmware/ultralcd.cpp:6985
+#: ../../Firmware/messages.cpp:373 ../../Firmware/ultralcd.cpp:6962
 msgid "Calibrating home"
 msgstr "Calib. mise a 0"
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5375
+#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5342
 msgid "Calibration"
 msgstr "Calibration"
 
 #. MSG_HOMEYZ_DONE c=20
-#: ../../Firmware/messages.cpp:217 ../../Firmware/ultralcd.cpp:593
+#: ../../Firmware/messages.cpp:229 ../../Firmware/ultralcd.cpp:593
 msgid "Calibration done"
 msgstr "Calibration terminée"
 
@@ -266,128 +265,128 @@ msgstr ""
 "d'abord."
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/messages.cpp:364 ../../Firmware/ultralcd.cpp:7405
+#: ../../Firmware/messages.cpp:376 ../../Firmware/ultralcd.cpp:7382
 msgid "Card removed"
 msgstr "Carte retiree"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/messages.cpp:324 ../../Firmware/ultralcd.cpp:5316
+#: ../../Firmware/messages.cpp:336 ../../Firmware/ultralcd.cpp:5282
 msgid "Change SD card"
 msgstr "Changez carte SD"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5254
-#: ../../Firmware/ultralcd.cpp:5526
+#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5216
+#: ../../Firmware/ultralcd.cpp:5493
 msgid "Change filament"
 msgstr "Changer filament"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/messages.cpp:240 ../../Firmware/ultralcd.cpp:2156
+#: ../../Firmware/messages.cpp:252 ../../Firmware/ultralcd.cpp:2167
 msgid "Change success!"
 msgstr "Changement réussi!"
 
 #. MSG_CORRECTLY c=19
-#: ../../Firmware/messages.cpp:242 ../../Firmware/ultralcd.cpp:2203
+#: ../../Firmware/messages.cpp:254 ../../Firmware/ultralcd.cpp:2217
 msgid "Changed correctly"
 msgstr "Change correctement"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5951
-#: ../../Firmware/ultralcd.cpp:6975
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5927
+#: ../../Firmware/ultralcd.cpp:6952
 msgid "Checking X axis"
 msgstr "Vérifier axe X"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5961
-#: ../../Firmware/ultralcd.cpp:6976
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:5937
+#: ../../Firmware/ultralcd.cpp:6953
 msgid "Checking Y axis"
 msgstr "Vérifier axe Y"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/messages.cpp:358 ../../Firmware/ultralcd.cpp:6977
+#: ../../Firmware/messages.cpp:370 ../../Firmware/ultralcd.cpp:6954
 msgid "Checking Z axis"
 msgstr "Vérifier axe Z"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6978
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6955
 msgid "Checking bed"
 msgstr "Vérifier lit"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/messages.cpp:357 ../../Firmware/ultralcd.cpp:6974
+#: ../../Firmware/messages.cpp:369 ../../Firmware/ultralcd.cpp:6951
 msgid "Checking endstops"
 msgstr "Vérifier butées"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/messages.cpp:362 ../../Firmware/ultralcd.cpp:7070
+#: ../../Firmware/messages.cpp:374 ../../Firmware/ultralcd.cpp:7047
 msgid "Checking file"
 msgstr "Vérifier fichier"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/messages.cpp:359 ../../Firmware/ultralcd.cpp:6980
+#: ../../Firmware/messages.cpp:371 ../../Firmware/ultralcd.cpp:6957
 msgid "Checking hotend"
 msgstr "Vérifier du hotend"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6981
-#: ../../Firmware/ultralcd.cpp:6982
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6958
+#: ../../Firmware/ultralcd.cpp:6959
 msgid "Checking sensors"
 msgstr "Vérifier capteurs"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/messages.cpp:308 ../../Firmware/ultralcd.cpp:4424
+#: ../../Firmware/messages.cpp:320 ../../Firmware/ultralcd.cpp:4391
 msgid "Checks"
 msgstr "Verifications"
 
 #. MSG_TM_ACK_ERROR c=18
-#: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5297
+#: ../../Firmware/messages.cpp:197 ../../Firmware/ultralcd.cpp:5263
 msgid "Clear TM error"
 msgstr "Effacer l'error TM"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/messages.cpp:244 ../../Firmware/ultralcd.cpp:2205
+#: ../../Firmware/messages.cpp:256 ../../Firmware/ultralcd.cpp:2219
 msgid "Color not correct"
 msgstr "Couleur incorrecte"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:3508
+#: ../../Firmware/messages.cpp:27 ../../Firmware/ultralcd.cpp:3518
 msgid "Community made"
 msgstr "Fait de community"
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:4059
+#: ../../Firmware/messages.cpp:178 ../../Firmware/ultralcd.cpp:4083
 msgid "Cont."
 msgstr "Cont."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:2129
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2135
 msgid "Cooldown"
 msgstr "Refroidissement"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/messages.cpp:283 ../../Firmware/ultralcd.cpp:3450
+#: ../../Firmware/messages.cpp:295 ../../Firmware/ultralcd.cpp:3460
 msgid "Copy selected language?"
 msgstr "Copier la langue choisie?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:1234
-#: ../../Firmware/ultralcd.cpp:1263
+#: ../../Firmware/messages.cpp:30 ../../Firmware/ultralcd.cpp:1244
+#: ../../Firmware/ultralcd.cpp:1273
 msgid "Crash"
 msgstr "Crash"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4146
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/ultralcd.cpp:4170
 msgid "Crash det."
 msgstr "Crash détecté"
 
 #. MSG_CRASH_DETECTED c=20
-#: ../../Firmware/Marlin_main.cpp:630 ../../Firmware/messages.cpp:30
+#: ../../Firmware/Marlin_main.cpp:595 ../../Firmware/messages.cpp:31
 msgid "Crash detected."
 msgstr "Crash détecté."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/messages.cpp:280 ../../Firmware/ultralcd.cpp:3374
+#: ../../Firmware/messages.cpp:292 ../../Firmware/ultralcd.cpp:3384
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -399,24 +398,24 @@ msgstr ""
 "mode Normal"
 
 #. MSG_CUT_FILAMENT c=16
-#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:380
-#: ../../Firmware/ultralcd.cpp:4854 ../../Firmware/ultralcd.cpp:5351
+#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:381
+#: ../../Firmware/ultralcd.cpp:4810 ../../Firmware/ultralcd.cpp:5317
 msgid "Cut filament"
 msgstr "Coupe filament"
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4081
-#: ../../Firmware/ultralcd.cpp:4086 ../../Firmware/ultralcd.cpp:4091
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:4105
+#: ../../Firmware/ultralcd.cpp:4110 ../../Firmware/ultralcd.cpp:4115
 msgid "Cutter"
 msgstr "Coupeur"
 
 #. MSG_DATE c=17
-#: ../../Firmware/messages.cpp:222 ../../Firmware/ultralcd.cpp:1645
+#: ../../Firmware/messages.cpp:234 ../../Firmware/ultralcd.cpp:1655
 msgid "Date:"
 msgstr "Date:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:178 ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/messages.cpp:185 ../../Firmware/ultralcd.cpp:5594
 msgid "Dim"
 msgstr "Sombre"
 
@@ -426,7 +425,7 @@ msgid "Disable"
 msgstr "Désact."
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/messages.cpp:311 ../../Firmware/ultralcd.cpp:4460
+#: ../../Firmware/messages.cpp:323 ../../Firmware/ultralcd.cpp:4427
 msgid "Disable steppers"
 msgstr "Désactiver moteurs"
 
@@ -438,7 +437,7 @@ msgid "Disengaging idler"
 msgstr "Désenga.t de l'idler"
 
 #. MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: ../../Firmware/Marlin_main.cpp:1610 ../../Firmware/Marlin_main.cpp:3334
+#: ../../Firmware/Marlin_main.cpp:1537 ../../Firmware/Marlin_main.cpp:3073
 #: ../../Firmware/messages.cpp:14
 msgid ""
 "Distance between tip of the nozzle and the bed surface has not been set yet."
@@ -449,7 +448,7 @@ msgstr ""
 "manuel, chap. Premiers pas."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/messages.cpp:301 ../../Firmware/ultralcd.cpp:3923
+#: ../../Firmware/messages.cpp:313 ../../Firmware/ultralcd.cpp:3947
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -458,13 +457,13 @@ msgstr ""
 "lit?"
 
 #. MSG_DONE c=8
-#: ../../Firmware/messages.cpp:32 ../../Firmware/mmu2/errors_list.h:367
-#: ../../Firmware/mmu2_reporting.cpp:456
+#: ../../Firmware/messages.cpp:33 ../../Firmware/mmu2/errors_list.h:367
+#: ../../Firmware/mmu2_reporting.cpp:457
 msgid "Done"
 msgstr "Fait"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/messages.cpp:307 ../../Firmware/ultralcd.cpp:3990
+#: ../../Firmware/messages.cpp:319 ../../Firmware/ultralcd.cpp:4014
 msgid "E-correct"
 msgstr "Correct-E"
 
@@ -493,13 +492,13 @@ msgid "ERR Wait for User"
 msgstr "ERR Att. Utilisateur"
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:2253
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:2267
 msgid "ERROR:"
 msgstr "ERREUR:"
 
 #. MSG_EJECT_FROM_MMU c=16
-#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:384
-#: ../../Firmware/ultralcd.cpp:4845 ../../Firmware/ultralcd.cpp:5348
+#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:385
+#: ../../Firmware/ultralcd.cpp:4801 ../../Firmware/ultralcd.cpp:5314
 msgid "Eject from MMU"
 msgstr "Éjecter du MMU"
 
@@ -511,17 +510,17 @@ msgid "Ejecting filament"
 msgstr "Le fil. remonte"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/messages.cpp:348 ../../Firmware/ultralcd.cpp:6722
+#: ../../Firmware/messages.cpp:360 ../../Firmware/ultralcd.cpp:6698
 msgid "Endstop"
 msgstr "Butée"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/messages.cpp:349 ../../Firmware/ultralcd.cpp:6727
+#: ../../Firmware/messages.cpp:361 ../../Firmware/ultralcd.cpp:6703
 msgid "Endstop not hit"
 msgstr "Butée non atteinte"
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/messages.cpp:347 ../../Firmware/ultralcd.cpp:6713
+#: ../../Firmware/messages.cpp:359 ../../Firmware/ultralcd.cpp:6689
 msgid "Endstops"
 msgstr "Butées"
 
@@ -533,30 +532,30 @@ msgid "Engaging idler"
 msgstr "Engagem.t de l'idler"
 
 #. MSG_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:3352
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:3362
 msgid "Extruder"
 msgstr "Extrudeur"
 
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/messages.cpp:227 ../../Firmware/ultralcd.cpp:1700
+#: ../../Firmware/messages.cpp:239 ../../Firmware/ultralcd.cpp:1710
 msgid "Extruder info"
 msgstr "Infos extrudeur"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4044
-#: ../../Firmware/ultralcd.cpp:4051
+#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4068
+#: ../../Firmware/ultralcd.cpp:4075
 msgid "F. autoload"
 msgstr "F. autocharg."
 
 #. MSG_FSENSOR_JAM_DETECTION c=13
-#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4046
-#: ../../Firmware/ultralcd.cpp:4053
+#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4070
+#: ../../Firmware/ultralcd.cpp:4077
 msgid "F. jam detect"
 msgstr "Detect bour F"
 
 #. MSG_FSENSOR_RUNOUT c=13
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4074
 msgid "F. runout"
 msgstr "Fin de F."
 
@@ -595,8 +594,8 @@ msgid "FINDA FILAM. STUCK"
 msgstr "FINDA FILAM. BLOQUE"
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:4059
-#: ../../Firmware/ultralcd.cpp:4062
+#: ../../Firmware/messages.cpp:177 ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/ultralcd.cpp:4086
 msgid "FS Action"
 msgstr "Action FS"
 
@@ -621,34 +620,34 @@ msgid "FW RUNTIME ERROR"
 msgstr "ERREUR EXÉCUTION FW"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/messages.cpp:330 ../../Firmware/ultralcd.cpp:5382
+#: ../../Firmware/messages.cpp:342 ../../Firmware/ultralcd.cpp:5349
 msgid "Fail stats"
 msgstr "Stat. d'échec"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/messages.cpp:331 ../../Firmware/ultralcd.cpp:5385
+#: ../../Firmware/messages.cpp:343 ../../Firmware/ultralcd.cpp:5352
 msgid "Fail stats MMU"
 msgstr "Stat. d'échec MMU"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/messages.cpp:355 ../../Firmware/ultralcd.cpp:6768
+#: ../../Firmware/messages.cpp:367 ../../Firmware/ultralcd.cpp:6744
 msgid "False triggering"
 msgstr "Faux déclenchement"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4175
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4199
 msgid "Fan speed"
 msgstr "Vitesse vent."
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6844
-#: ../../Firmware/ultralcd.cpp:6971 ../../Firmware/ultralcd.cpp:6972
-#: ../../Firmware/ultralcd.cpp:6973
+#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6820
+#: ../../Firmware/ultralcd.cpp:6948 ../../Firmware/ultralcd.cpp:6949
+#: ../../Firmware/ultralcd.cpp:6950
 msgid "Fan test"
 msgstr "Test du ventilateur"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:4179
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:4203
 msgid "Fans check"
 msgstr "Vérif. vent."
 
@@ -677,34 +676,34 @@ msgid "Feeding to nozzle"
 msgstr "Chargement vers buse"
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1233
-#: ../../Firmware/ultralcd.cpp:1262 ../../Firmware/ultralcd.cpp:1316
-#: ../../Firmware/ultralcd.cpp:1318
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:1243
+#: ../../Firmware/ultralcd.cpp:1272 ../../Firmware/ultralcd.cpp:1326
+#: ../../Firmware/ultralcd.cpp:1328
 msgid "Fil. runouts"
 msgstr "Fins filament"
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3313
-#: ../../Firmware/ultralcd.cpp:4039 ../../Firmware/ultralcd.cpp:4464
-#: ../../Firmware/ultralcd.cpp:5532
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3323
+#: ../../Firmware/ultralcd.cpp:4063 ../../Firmware/ultralcd.cpp:4431
+#: ../../Firmware/ultralcd.cpp:5499
 msgid "Fil. sensor"
 msgstr "Capteur Fil."
 
 #. MSG_FILAMENT_CLEAN c=20 r=3
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2261
-#: ../../Firmware/ultralcd.cpp:2265
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2275
+#: ../../Firmware/ultralcd.cpp:2279
 msgid "Filament extruding & with correct color?"
 msgstr "Filament extrude et avec bonne couleur?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/messages.cpp:243 ../../Firmware/ultralcd.cpp:2204
+#: ../../Firmware/messages.cpp:255 ../../Firmware/ultralcd.cpp:2218
 msgid "Filament not loaded"
 msgstr "Filament non charge"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6763
-#: ../../Firmware/ultralcd.cpp:6767 ../../Firmware/ultralcd.cpp:6771
-#: ../../Firmware/ultralcd.cpp:7000
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6739
+#: ../../Firmware/ultralcd.cpp:6743 ../../Firmware/ultralcd.cpp:6747
+#: ../../Firmware/ultralcd.cpp:6977
 msgid "Filament sensor"
 msgstr "Capteur Fil."
 
@@ -736,42 +735,42 @@ msgstr ""
 "Vérifiez le tube PTFE. Vérifiez que le capteur fonctionne."
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/messages.cpp:246 ../../Firmware/ultralcd.cpp:2347
+#: ../../Firmware/messages.cpp:258 ../../Firmware/ultralcd.cpp:2364
 msgid "Filament used"
 msgstr "Filament utilise"
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/messages.cpp:363 ../../Firmware/ultralcd.cpp:7139
+#: ../../Firmware/messages.cpp:375 ../../Firmware/ultralcd.cpp:7116
 msgid "File incomplete. Continue anyway?"
 msgstr "Fichier incomplet. Continuer qd meme?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
 #: ../../Firmware/messages.cpp:45
 #: ../../Firmware/mmu2_progress_converter.cpp:43
-#: ../../Firmware/ultralcd.cpp:5021 ../../Firmware/ultralcd.cpp:5425
+#: ../../Firmware/ultralcd.cpp:4977 ../../Firmware/ultralcd.cpp:5392
 msgid "Finishing movements"
 msgstr "Mouvement final"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4575
-#: ../../Firmware/ultralcd.cpp:5141
+#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4531
+#: ../../Firmware/ultralcd.cpp:5101
 msgid "First layer cal."
 msgstr "Cal. 1ere couche"
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/messages.cpp:293 ../../Firmware/ultralcd.cpp:3846
+#: ../../Firmware/messages.cpp:305 ../../Firmware/ultralcd.cpp:3872
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Je vais lancer le selftest pour verifier les problèmes d'assemblage les plus"
 " communs."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/messages.cpp:334 ../../Firmware/ultralcd.cpp:5520
+#: ../../Firmware/messages.cpp:346 ../../Firmware/ultralcd.cpp:5487
 msgid "Flow"
 msgstr "Flux"
 
 #. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
-#: ../../Firmware/messages.cpp:194 ../../Firmware/ultralcd.cpp:985
+#: ../../Firmware/messages.cpp:201 ../../Firmware/ultralcd.cpp:987
 msgid ""
 "For a Nozzle change please read\n"
 "prusa.io/nozzle-mk3s"
@@ -780,28 +779,28 @@ msgstr ""
 "prusa.io/nozzle-mk3s"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6733
-#: ../../Firmware/ultralcd.cpp:6850 ../../Firmware/ultralcd.cpp:6855
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/ultralcd.cpp:6826 ../../Firmware/ultralcd.cpp:6831
 msgid "Front print fan?"
 msgstr "Ventilo impr avant?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/messages.cpp:260 ../../Firmware/ultralcd.cpp:2711
+#: ../../Firmware/messages.cpp:272 ../../Firmware/ultralcd.cpp:2728
 msgid "Front side[µm]"
 msgstr "Avant [µm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/messages.cpp:353 ../../Firmware/ultralcd.cpp:6757
+#: ../../Firmware/messages.cpp:365 ../../Firmware/ultralcd.cpp:6733
 msgid "Front/left fans"
 msgstr "Ventilos avt/gauche"
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:151 ../../Firmware/util.cpp:382
+#: ../../Firmware/messages.cpp:156 ../../Firmware/util.cpp:417
 msgid "G-code sliced for a different level. Continue?"
 msgstr "G-code a été préparé pour un niveau diff. Continuer?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:152 ../../Firmware/util.cpp:383
+#: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:418
 msgid ""
 "G-code sliced for a different level. Please re-slice the model again. Print "
 "cancelled."
@@ -810,14 +809,14 @@ msgstr ""
 " Impression annulée."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:147 ../../Firmware/util.cpp:312
-#: ../../Firmware/util.cpp:401
+#: ../../Firmware/messages.cpp:152 ../../Firmware/util.cpp:319
+#: ../../Firmware/util.cpp:436
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr "G-code pour un type d'imprimante différent. Continue?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:148 ../../Firmware/util.cpp:313
-#: ../../Firmware/util.cpp:402
+#: ../../Firmware/messages.cpp:153 ../../Firmware/util.cpp:320
+#: ../../Firmware/util.cpp:437
 msgid ""
 "G-code sliced for a different printer type. Please re-slice the model again."
 " Print cancelled."
@@ -826,12 +825,12 @@ msgstr ""
 "Impression annulée."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:149 ../../Firmware/util.cpp:362
+#: ../../Firmware/messages.cpp:154 ../../Firmware/util.cpp:369
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "G-code a été préparé pour un FW plus récent. Cont.?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:150 ../../Firmware/util.cpp:363
+#: ../../Firmware/messages.cpp:155 ../../Firmware/util.cpp:370
 msgid ""
 "G-code sliced for a newer firmware. Please update the firmware. Print "
 "cancelled."
@@ -840,35 +839,35 @@ msgstr ""
 "annulée."
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4366
-#: ../../Firmware/ultralcd.cpp:4383 ../../Firmware/ultralcd.cpp:4485
+#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4325
+#: ../../Firmware/ultralcd.cpp:4343 ../../Firmware/ultralcd.cpp:4452
 msgid "HW Setup"
 msgstr "Config HW"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/messages.cpp:344 ../../Firmware/ultralcd.cpp:6705
+#: ../../Firmware/messages.cpp:356 ../../Firmware/ultralcd.cpp:6681
 msgid "Heater/Thermistor"
 msgstr "Chauffage/Thermistor"
 
 #. MSG_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6184 ../../Firmware/messages.cpp:52
+#: ../../Firmware/Marlin_main.cpp:5416 ../../Firmware/messages.cpp:52
 #: ../../Firmware/ultralcd.cpp:526
 msgid "Heating"
 msgstr "Chauffe"
 
 #. MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:9647 ../../Firmware/messages.cpp:211
+#: ../../Firmware/Marlin_main.cpp:8807 ../../Firmware/messages.cpp:223
 msgid "Heating disabled by safety timer."
 msgstr "Chauffage désactivé par le compteur de sécurité."
 
 #. MSG_HEATING_COMPLETE c=20
-#: ../../Firmware/Marlin_main.cpp:6215 ../../Firmware/messages.cpp:53
+#: ../../Firmware/Marlin_main.cpp:5445 ../../Firmware/messages.cpp:53
 #: ../../Firmware/ultralcd.cpp:529
 msgid "Heating done."
 msgstr "Chauffe terminée."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=12
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:3806
+#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:3832
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -879,7 +878,7 @@ msgstr ""
 "à imprimer."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:3810
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:3836
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -888,8 +887,8 @@ msgstr ""
 "travers le processus d'installation"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4152
-#: ../../Firmware/ultralcd.cpp:4161
+#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:4176
+#: ../../Firmware/ultralcd.cpp:4185
 msgid "High power"
 msgstr "Haut.puiss"
 
@@ -900,25 +899,25 @@ msgid "Homing"
 msgstr "Mise à zéro"
 
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
-#: ../../Firmware/messages.cpp:195 ../../Firmware/ultralcd.cpp:1005
+#: ../../Firmware/messages.cpp:206 ../../Firmware/ultralcd.cpp:1011
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr "Hotend à 280C! Buse changée et resserrée aux spécifications?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1106
-#: ../../Firmware/ultralcd.cpp:6991
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1116
+#: ../../Firmware/ultralcd.cpp:6968
 msgid "Hotend fan:"
 msgstr "Vent. hotend:"
 
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/messages.cpp:294 ../../Firmware/ultralcd.cpp:3851
+#: ../../Firmware/messages.cpp:306 ../../Firmware/ultralcd.cpp:3877
 msgid "I will run xyz calibration now. It will take up to 24 mins."
 msgstr ""
 "Je vais maintenant lancer la calibration XYZ. Cela peut prendre jusqu'à 24 "
 "min."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/messages.cpp:297 ../../Firmware/ultralcd.cpp:3862
+#: ../../Firmware/messages.cpp:309 ../../Firmware/ultralcd.cpp:3884
 msgid "I will run z calibration now."
 msgstr "Je vais maintenant lancer la calibration Z."
 
@@ -943,7 +942,7 @@ msgid "INVALID TOOL"
 msgstr "OUTIL INVALIDE"
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=8
-#: ../../Firmware/messages.cpp:303 ../../Firmware/ultralcd.cpp:3931
+#: ../../Firmware/messages.cpp:315 ../../Firmware/ultralcd.cpp:3955
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -952,28 +951,28 @@ msgstr ""
 "Réglages - Config HW - Plaque en acier."
 
 #. MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2540
-#: ../../Firmware/messages.cpp:213
+#: ../../Firmware/mesh_bed_calibration.cpp:2525
+#: ../../Firmware/messages.cpp:225
 msgid "Improving bed calibration point"
 msgstr "Amelioration du point de calibration du lit"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:5222
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:5184
 msgid "Info screen"
 msgstr "Écran d'info"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/messages.cpp:326 ../../Firmware/ultralcd.cpp:5323
+#: ../../Firmware/messages.cpp:338 ../../Firmware/ultralcd.cpp:5289
 msgid "Init. SD card"
 msgstr "Init. carte SD"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/messages.cpp:238 ../../Firmware/ultralcd.cpp:2142
+#: ../../Firmware/messages.cpp:250 ../../Firmware/ultralcd.cpp:2148
 msgid "Insert filament"
 msgstr "Insérez le filament"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/messages.cpp:335 ../../Firmware/ultralcd.cpp:5998
+#: ../../Firmware/messages.cpp:347 ../../Firmware/ultralcd.cpp:5974
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
@@ -990,115 +989,115 @@ msgstr ""
 " le FW."
 
 #. MSG_FILAMENT_LOADED c=20 r=3
-#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3628
-#: ../../Firmware/ultralcd.cpp:3890
+#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3638
+#: ../../Firmware/ultralcd.cpp:3914
 msgid "Is filament loaded?"
 msgstr "Fil. est-il charge?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3238 ../../Firmware/Marlin_main.cpp:4745
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:3858
+#: ../../Firmware/Marlin_main.cpp:4314 ../../Firmware/messages.cpp:127
+#: ../../Firmware/ultralcd.cpp:3760
 msgid "Is steel sheet on heatbed?"
 msgstr "Plaque sur le lit?"
 
 #. MSG_ITERATION c=12
-#: ../../Firmware/mesh_bed_calibration.cpp:2265 ../../Firmware/messages.cpp:55
+#: ../../Firmware/mesh_bed_calibration.cpp:2250 ../../Firmware/messages.cpp:55
 msgid "Iteration"
 msgstr "Iteration"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1128
-#: ../../Firmware/ultralcd.cpp:1286
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1138
+#: ../../Firmware/ultralcd.cpp:1296
 msgid "Last print"
 msgstr "Dernière impres."
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1152
-#: ../../Firmware/ultralcd.cpp:1260 ../../Firmware/ultralcd.cpp:1315
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1162
+#: ../../Firmware/ultralcd.cpp:1270 ../../Firmware/ultralcd.cpp:1325
 msgid "Last print failures"
 msgstr "Échecs dernière imp."
 
 #. MSG_LEFT c=10
-#: ../../Firmware/messages.cpp:251 ../../Firmware/ultralcd.cpp:2478
+#: ../../Firmware/messages.cpp:263 ../../Firmware/ultralcd.cpp:2495
 msgid "Left"
 msgstr "Gauche"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6739
-#: ../../Firmware/ultralcd.cpp:6850 ../../Firmware/ultralcd.cpp:6855
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6715
+#: ../../Firmware/ultralcd.cpp:6826 ../../Firmware/ultralcd.cpp:6831
 msgid "Left hotend fan?"
 msgstr "Ventilo gauche?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/messages.cpp:258 ../../Firmware/ultralcd.cpp:2709
+#: ../../Firmware/messages.cpp:270 ../../Firmware/ultralcd.cpp:2726
 msgid "Left side [µm]"
 msgstr "Gauche [µm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:5619
+#: ../../Firmware/messages.cpp:181 ../../Firmware/ultralcd.cpp:5592
 msgid "Level Bright"
 msgstr "Niveau brill"
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:175 ../../Firmware/ultralcd.cpp:5620
+#: ../../Firmware/messages.cpp:182 ../../Firmware/ultralcd.cpp:5593
 msgid "Level Dimmed"
 msgstr "Niv. sombre"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/messages.cpp:312 ../../Firmware/ultralcd.cpp:4491
+#: ../../Firmware/messages.cpp:324 ../../Firmware/ultralcd.cpp:4458
 msgid "Lin. correction"
 msgstr "Correction lin."
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4501
-#: ../../Firmware/ultralcd.cpp:5251
+#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4468
+#: ../../Firmware/ultralcd.cpp:5213
 msgid "Live adjust Z"
 msgstr "Ajuster Z en dir."
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/messages.cpp:192 ../../Firmware/ultralcd.cpp:4794
-#: ../../Firmware/ultralcd.cpp:4880
+#: ../../Firmware/messages.cpp:199 ../../Firmware/ultralcd.cpp:4750
+#: ../../Firmware/ultralcd.cpp:4836
 msgid "Load All"
 msgstr "Tout Charger"
 
 #. MSG_LOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4796
-#: ../../Firmware/ultralcd.cpp:4833 ../../Firmware/ultralcd.cpp:4882
-#: ../../Firmware/ultralcd.cpp:5361 ../../Firmware/ultralcd.cpp:5368
+#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4752
+#: ../../Firmware/ultralcd.cpp:4789 ../../Firmware/ultralcd.cpp:4838
+#: ../../Firmware/ultralcd.cpp:5324 ../../Firmware/ultralcd.cpp:5335
 msgid "Load filament"
 msgstr "Charger filament"
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/messages.cpp:327 ../../Firmware/ultralcd.cpp:5346
+#: ../../Firmware/messages.cpp:339 ../../Firmware/ultralcd.cpp:5312
 msgid "Load to nozzle"
 msgstr "Charger la buse"
 
 #. MSG_LOADING_TEST c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4476
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4443
 msgid "Loading Test"
 msgstr "Test de chargmt."
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/messages.cpp:241 ../../Firmware/ultralcd.cpp:2178
+#: ../../Firmware/messages.cpp:253 ../../Firmware/ultralcd.cpp:2189
 msgid "Loading color"
 msgstr "Charg. de la couleur"
 
 #. MSG_LOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3598 ../../Firmware/messages.cpp:62
+#: ../../Firmware/Marlin_main.cpp:3343 ../../Firmware/messages.cpp:62
 #: ../../Firmware/mmu2_progress_converter.cpp:51
-#: ../../Firmware/mmu2_reporting.cpp:392 ../../Firmware/ultralcd.cpp:2189
-#: ../../Firmware/ultralcd.cpp:3715
+#: ../../Firmware/mmu2_reporting.cpp:393 ../../Firmware/ultralcd.cpp:2199
+#: ../../Firmware/ultralcd.cpp:3725
 msgid "Loading filament"
 msgstr "Chargement du fil."
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/messages.cpp:350 ../../Firmware/ultralcd.cpp:6745
+#: ../../Firmware/messages.cpp:362 ../../Firmware/ultralcd.cpp:6721
 msgid "Loose pulley"
 msgstr "Poulie lâche"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4188
-#: ../../Firmware/ultralcd.cpp:4200
+#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4224
 msgid "Loud"
 msgstr "Fort"
 
@@ -1113,7 +1112,7 @@ msgid "MMU Firmware internal error, please reset the MMU."
 msgstr "Erreur interne du FW du MMU, réinitialisez le MMU."
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:4096
+#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4120
 msgid "MMU Mode"
 msgstr "Mode MMU"
 
@@ -1123,7 +1122,7 @@ msgid "MMU NOT RESPONDING"
 msgstr "LE MMU NE RÉPOND PAS"
 
 #. MSG_MMU_RESTORE_TEMP c=20 r=4
-#: ../../Firmware/messages.cpp:214 ../../Firmware/mmu2_reporting.cpp:396
+#: ../../Firmware/messages.cpp:226 ../../Firmware/mmu2_reporting.cpp:397
 msgid "MMU Retry: Restoring temperature..."
 msgstr "Nouvelle tentative MMU: Restauration de la temperature..."
 
@@ -1134,14 +1133,14 @@ msgid "MMU SELFTEST FAILED"
 msgstr "MMU SELF TEST ÉCHEC"
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1153
-#: ../../Firmware/ultralcd.cpp:1178
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1163
+#: ../../Firmware/ultralcd.cpp:1188
 msgid "MMU fails"
 msgstr "Échecs MMU"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1154
-#: ../../Firmware/ultralcd.cpp:1179
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1164
+#: ../../Firmware/ultralcd.cpp:1189
 msgid "MMU load fails"
 msgstr "Def. charg. MMU"
 
@@ -1157,66 +1156,64 @@ msgid "MMU not responding. Check the wiring and connectors."
 msgstr "MMU ne répond pas. Vérifiez le câblage et les connecteurs."
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/messages.cpp:223 ../../Firmware/ultralcd.cpp:1657
+#: ../../Firmware/messages.cpp:235 ../../Firmware/ultralcd.cpp:1667
 msgid "MMU connected"
 msgstr "MMU connecte"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/messages.cpp:176 ../../Firmware/ultralcd.cpp:5567
 msgid "Magnets comp."
 msgstr "Compens. aim."
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1127
-#: ../../Firmware/ultralcd.cpp:1285 ../../Firmware/ultralcd.cpp:1327
-#: ../../Firmware/ultralcd.cpp:1631 ../../Firmware/ultralcd.cpp:4453
-#: ../../Firmware/ultralcd.cpp:4571 ../../Firmware/ultralcd.cpp:4793
-#: ../../Firmware/ultralcd.cpp:4826 ../../Firmware/ultralcd.cpp:4879
-#: ../../Firmware/ultralcd.cpp:5515
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1137
+#: ../../Firmware/ultralcd.cpp:1295 ../../Firmware/ultralcd.cpp:1337
+#: ../../Firmware/ultralcd.cpp:1641 ../../Firmware/ultralcd.cpp:4420
+#: ../../Firmware/ultralcd.cpp:4527 ../../Firmware/ultralcd.cpp:4749
+#: ../../Firmware/ultralcd.cpp:4782 ../../Firmware/ultralcd.cpp:4835
+#: ../../Firmware/ultralcd.cpp:5482
 msgid "Main"
 msgstr "Menu principal"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/messages.cpp:253 ../../Firmware/ultralcd.cpp:2519
+#: ../../Firmware/messages.cpp:265 ../../Firmware/ultralcd.cpp:2536
 msgid "Measured skew"
 msgstr "Var. mesurée"
 
 #. MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3219
-#: ../../Firmware/mesh_bed_calibration.cpp:2852 ../../Firmware/messages.cpp:70
+#: ../../Firmware/Marlin_main.cpp:2963
+#: ../../Firmware/mesh_bed_calibration.cpp:2837 ../../Firmware/messages.cpp:70
 msgid "Measuring reference height of calibration point"
 msgstr "Je mesure la hauteur de reference du point de calibrage"
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:5590
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:5563
 msgid "Mesh"
 msgstr "Mesh"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4488
-#: ../../Firmware/ultralcd.cpp:4587
+#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:4455
+#: ../../Firmware/ultralcd.cpp:4543
 msgid "Mesh Bed Leveling"
 msgstr "Mesh Bed Leveling"
 
 #. MSG_MODE c=6
-#: ../../Firmware/Marlin_main.cpp:8495 ../../Firmware/messages.cpp:117
-#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4132
-#: ../../Firmware/ultralcd.cpp:4140 ../../Firmware/ultralcd.cpp:4144
-#: ../../Firmware/ultralcd.cpp:4152 ../../Firmware/ultralcd.cpp:4155
-#: ../../Firmware/ultralcd.cpp:4158 ../../Firmware/ultralcd.cpp:4161
-#: ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/Marlin_main.cpp:7666 ../../Firmware/messages.cpp:121
+#: ../../Firmware/ultralcd.cpp:4152 ../../Firmware/ultralcd.cpp:4156
+#: ../../Firmware/ultralcd.cpp:4164 ../../Firmware/ultralcd.cpp:4168
+#: ../../Firmware/ultralcd.cpp:4176 ../../Firmware/ultralcd.cpp:4179
+#: ../../Firmware/ultralcd.cpp:4182 ../../Firmware/ultralcd.cpp:4185
+#: ../../Firmware/ultralcd.cpp:5594
 msgid "Mode"
 msgstr "Mode"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/messages.cpp:282 ../../Firmware/ultralcd.cpp:3413
+#: ../../Firmware/messages.cpp:294 ../../Firmware/ultralcd.cpp:3423
 msgid "Mode change in progress..."
 msgstr "Changement de mode en cours..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:4310
-#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4316
-#: ../../Firmware/ultralcd.cpp:4319
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4327
 msgid "Model"
 msgstr "Modèle"
 
@@ -1237,28 +1234,28 @@ msgid "More details online."
 msgstr "Plus de details en ligne."
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6719
-#: ../../Firmware/ultralcd.cpp:6728 ../../Firmware/ultralcd.cpp:6746
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6695
+#: ../../Firmware/ultralcd.cpp:6704 ../../Firmware/ultralcd.cpp:6722
 msgid "Motor"
 msgstr "Moteur"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/messages.cpp:277 ../../Firmware/ultralcd.cpp:3349
+#: ../../Firmware/messages.cpp:289 ../../Firmware/ultralcd.cpp:3359
 msgid "Move X"
 msgstr "Déplacer X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/messages.cpp:278 ../../Firmware/ultralcd.cpp:3350
+#: ../../Firmware/messages.cpp:290 ../../Firmware/ultralcd.cpp:3360
 msgid "Move Y"
 msgstr "Déplacer Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/messages.cpp:279 ../../Firmware/ultralcd.cpp:3351
+#: ../../Firmware/messages.cpp:291 ../../Firmware/ultralcd.cpp:3361
 msgid "Move Z"
 msgstr "Déplacer Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/messages.cpp:310 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:322 ../../Firmware/ultralcd.cpp:4426
 msgid "Move axis"
 msgstr "Déplacer l'axe"
 
@@ -1269,63 +1266,62 @@ msgid "Moving selector"
 msgstr "Déplacement select."
 
 #. MSG_NA c=3
-#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:141
-#: ../../Firmware/ultralcd.cpp:2484 ../../Firmware/ultralcd.cpp:2528
-#: ../../Firmware/ultralcd.cpp:3279 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:4044 ../../Firmware/ultralcd.cpp:4046
-#: ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:146
+#: ../../Firmware/ultralcd.cpp:2501 ../../Firmware/ultralcd.cpp:2545
+#: ../../Firmware/ultralcd.cpp:3289 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4068 ../../Firmware/ultralcd.cpp:4070
+#: ../../Firmware/ultralcd.cpp:5567
 msgid "N/A"
 msgstr "I/D"
 
 #. MSG_NEW_FIRMWARE_AVAILABLE c=20 r=2
-#: ../../Firmware/messages.cpp:365 ../../Firmware/util.cpp:209
+#: ../../Firmware/messages.cpp:377 ../../Firmware/util.cpp:214
 msgid "New firmware version available:"
 msgstr "Nouvelle version de FW disponible:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:3029
-#: ../../Firmware/ultralcd.cpp:4443 ../../Firmware/ultralcd.cpp:4531
-#: ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:2275
+#: ../../Firmware/ultralcd.cpp:2279 ../../Firmware/ultralcd.cpp:3046
+#: ../../Firmware/ultralcd.cpp:4410 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/ultralcd.cpp:5765
 msgid "No"
 msgstr "Non"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/messages.cpp:325 ../../Firmware/ultralcd.cpp:5321
+#: ../../Firmware/messages.cpp:337 ../../Firmware/ultralcd.cpp:5287
 msgid "No SD card"
 msgstr "Pas de carte SD"
 
 #. MSG_NO_MOVE c=20
-#: ../../Firmware/Marlin_main.cpp:5271 ../../Firmware/messages.cpp:210
+#: ../../Firmware/Marlin_main.cpp:4778 ../../Firmware/messages.cpp:222
 msgid "No move."
 msgstr "Pas de mouvement."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4239 ../../Firmware/ultralcd.cpp:4310
-#: ../../Firmware/ultralcd.cpp:4319 ../../Firmware/ultralcd.cpp:4349
-#: ../../Firmware/ultralcd.cpp:4358 ../../Firmware/ultralcd.cpp:4516
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4309
+#: ../../Firmware/ultralcd.cpp:4318 ../../Firmware/ultralcd.cpp:4483
 msgid "None"
 msgstr "Aucun"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/Marlin_main.cpp:8497 ../../Firmware/messages.cpp:121
-#: ../../Firmware/ultralcd.cpp:4096 ../../Firmware/ultralcd.cpp:4132
-#: ../../Firmware/ultralcd.cpp:4511
+#: ../../Firmware/Marlin_main.cpp:7668 ../../Firmware/messages.cpp:125
+#: ../../Firmware/ultralcd.cpp:4120 ../../Firmware/ultralcd.cpp:4156
+#: ../../Firmware/ultralcd.cpp:4478
 msgid "Normal"
 msgstr "Normal"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/messages.cpp:345 ../../Firmware/ultralcd.cpp:6706
+#: ../../Firmware/messages.cpp:357 ../../Firmware/ultralcd.cpp:6682
 msgid "Not connected"
 msgstr "Non connecte"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6863
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6839
 msgid "Not spinning"
 msgstr "Ne tourne pas"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/messages.cpp:289 ../../Firmware/ultralcd.cpp:3726
+#: ../../Firmware/messages.cpp:301 ../../Firmware/ultralcd.cpp:3736
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr ""
@@ -1333,33 +1329,31 @@ msgstr ""
 "lit."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/messages.cpp:298 ../../Firmware/ultralcd.cpp:3871
+#: ../../Firmware/messages.cpp:310 ../../Firmware/ultralcd.cpp:3894
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Maintenant je vais préchauffer la buse pour du PLA."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/messages.cpp:296 ../../Firmware/ultralcd.cpp:3857
+#: ../../Firmware/messages.cpp:308 ../../Firmware/ultralcd.cpp:3883
 msgid "Now remove the test print from steel sheet."
 msgstr "Retirez maintenant l'impression de test de la plaque en acier."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1390
-#: ../../Firmware/ultralcd.cpp:4170 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4233 ../../Firmware/ultralcd.cpp:4236
-#: ../../Firmware/ultralcd.cpp:4239
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1400
+#: ../../Firmware/ultralcd.cpp:4194 ../../Firmware/ultralcd.cpp:4326
 msgid "Nozzle"
 msgstr "Buse"
 
 #. MSG_NOZZLE_CNG_MENU c=18
-#: ../../Firmware/messages.cpp:193 ../../Firmware/ultralcd.cpp:4423
-#: ../../Firmware/ultralcd.cpp:4486
+#: ../../Firmware/messages.cpp:200 ../../Firmware/ultralcd.cpp:4390
+#: ../../Firmware/ultralcd.cpp:4453
 msgid "Nozzle change"
 msgstr "Changement de buse"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4276
-#: ../../Firmware/ultralcd.cpp:4278 ../../Firmware/ultralcd.cpp:4279
-#: ../../Firmware/ultralcd.cpp:4280
+#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4261
+#: ../../Firmware/ultralcd.cpp:4263 ../../Firmware/ultralcd.cpp:4264
+#: ../../Firmware/ultralcd.cpp:4265
 msgid "Nozzle d."
 msgstr "Diam. buse"
 
@@ -1370,82 +1364,82 @@ msgid "OK"
 msgstr "OK"
 
 #. MSG_OFF c=3
-#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:139
-#: ../../Firmware/mmu2.cpp:65 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4050 ../../Firmware/ultralcd.cpp:4051
-#: ../../Firmware/ultralcd.cpp:4053 ../../Firmware/ultralcd.cpp:4076
-#: ../../Firmware/ultralcd.cpp:4091 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4179 ../../Firmware/ultralcd.cpp:4467
-#: ../../Firmware/ultralcd.cpp:4495 ../../Firmware/ultralcd.cpp:4498
-#: ../../Firmware/ultralcd.cpp:5439 ../../Firmware/ultralcd.cpp:5594
-#: ../../Firmware/ultralcd.cpp:7487 ../../Firmware/ultralcd.cpp:7491
+#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:144
+#: ../../Firmware/mmu2.cpp:65 ../../Firmware/ultralcd.cpp:4063
+#: ../../Firmware/ultralcd.cpp:4074 ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4077 ../../Firmware/ultralcd.cpp:4100
+#: ../../Firmware/ultralcd.cpp:4115 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/ultralcd.cpp:4203 ../../Firmware/ultralcd.cpp:4434
+#: ../../Firmware/ultralcd.cpp:4462 ../../Firmware/ultralcd.cpp:4465
+#: ../../Firmware/ultralcd.cpp:5406 ../../Firmware/ultralcd.cpp:5567
+#: ../../Firmware/ultralcd.cpp:7464 ../../Firmware/ultralcd.cpp:7468
 msgid "Off"
 msgstr "Off"
 
 #. MSG_DEFAULT_SETTINGS_LOADED c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:1562 ../../Firmware/messages.cpp:201
+#: ../../Firmware/Marlin_main.cpp:1489 ../../Firmware/messages.cpp:213
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr ""
 "Anciens réglages trouvés. Le PID, les Esteps, etc. par défaut seront réglés."
 
 #. MSG_ON c=3
-#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:140
-#: ../../Firmware/mmu2.cpp:63 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4050 ../../Firmware/ultralcd.cpp:4051
-#: ../../Firmware/ultralcd.cpp:4053 ../../Firmware/ultralcd.cpp:4076
-#: ../../Firmware/ultralcd.cpp:4081 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4179 ../../Firmware/ultralcd.cpp:4467
-#: ../../Firmware/ultralcd.cpp:4495 ../../Firmware/ultralcd.cpp:4498
-#: ../../Firmware/ultralcd.cpp:5594 ../../Firmware/ultralcd.cpp:7487
-#: ../../Firmware/ultralcd.cpp:7491
+#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:145
+#: ../../Firmware/mmu2.cpp:63 ../../Firmware/ultralcd.cpp:4063
+#: ../../Firmware/ultralcd.cpp:4074 ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4077 ../../Firmware/ultralcd.cpp:4100
+#: ../../Firmware/ultralcd.cpp:4105 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/ultralcd.cpp:4203 ../../Firmware/ultralcd.cpp:4434
+#: ../../Firmware/ultralcd.cpp:4462 ../../Firmware/ultralcd.cpp:4465
+#: ../../Firmware/ultralcd.cpp:5567 ../../Firmware/ultralcd.cpp:7464
+#: ../../Firmware/ultralcd.cpp:7468
 msgid "On"
 msgstr "On"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4191
+#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:4215
 msgid "Once"
 msgstr "1 fois"
 
 #. MSG_PAUSED_THERMAL_ERROR c=20
-#: ../../Firmware/Marlin_main.cpp:9861 ../../Firmware/messages.cpp:186
+#: ../../Firmware/Marlin_main.cpp:9021 ../../Firmware/messages.cpp:193
 msgid "PAUSED THERMAL ERROR"
 msgstr "PAUSE ERREUR THERM."
 
 #. MSG_PID_RUNNING c=20
-#: ../../Firmware/messages.cpp:219 ../../Firmware/ultralcd.cpp:897
+#: ../../Firmware/messages.cpp:231 ../../Firmware/ultralcd.cpp:897
 msgid "PID cal."
 msgstr "Calib. PID"
 
 #. MSG_PID_FINISHED c=20
-#: ../../Firmware/messages.cpp:220 ../../Firmware/ultralcd.cpp:902
+#: ../../Firmware/messages.cpp:232 ../../Firmware/ultralcd.cpp:902
 msgid "PID cal. finished"
 msgstr "Calib. PID terminée"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:318 ../../Firmware/ultralcd.cpp:4590
+#: ../../Firmware/messages.cpp:330 ../../Firmware/ultralcd.cpp:4546
 msgid "PID calibration"
 msgstr "Calibration PID"
 
 #. MSG_PINDA_PREHEAT c=20
-#: ../../Firmware/messages.cpp:218 ../../Firmware/ultralcd.cpp:610
+#: ../../Firmware/messages.cpp:230 ../../Firmware/ultralcd.cpp:610
 msgid "PINDA Heating"
 msgstr "Chauffe de la PINDA"
 
 #. MSG_PINDA_CALIBRATION c=13
-#: ../../Firmware/Marlin_main.cpp:4790 ../../Firmware/Marlin_main.cpp:4892
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:607
-#: ../../Firmware/ultralcd.cpp:4495 ../../Firmware/ultralcd.cpp:4597
+#: ../../Firmware/Marlin_main.cpp:4359 ../../Firmware/Marlin_main.cpp:4461
+#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:607
+#: ../../Firmware/ultralcd.cpp:4462 ../../Firmware/ultralcd.cpp:4553
 msgid "PINDA cal."
 msgstr "Calib. PINDA"
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/messages.cpp:276 ../../Firmware/ultralcd.cpp:3233
+#: ../../Firmware/messages.cpp:288 ../../Firmware/ultralcd.cpp:3243
 msgid "PINDA calibration failed"
 msgstr "Échec de la calibration en PINDA"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:4967 ../../Firmware/messages.cpp:127
-#: ../../Firmware/ultralcd.cpp:3230
+#: ../../Firmware/Marlin_main.cpp:4536 ../../Firmware/messages.cpp:132
+#: ../../Firmware/ultralcd.cpp:3240
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1465,13 +1459,13 @@ msgid "Parking selector"
 msgstr "Parquage sélecteur"
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:4062
+#: ../../Firmware/messages.cpp:179 ../../Firmware/ultralcd.cpp:4086
 msgid "Pause"
 msgstr "Pause"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5271
-#: ../../Firmware/ultralcd.cpp:5273
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5237
+#: ../../Firmware/ultralcd.cpp:5239
 msgid "Pause print"
 msgstr "Pause de l'impr."
 
@@ -1482,7 +1476,7 @@ msgid "Performing cut"
 msgstr "Coupe en cours"
 
 #. MSG_PAPER c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3243 ../../Firmware/messages.cpp:77
+#: ../../Firmware/Marlin_main.cpp:2982 ../../Firmware/messages.cpp:77
 msgid ""
 "Place a sheet of paper under the nozzle during the calibration of first 4 "
 "points. If the nozzle catches the paper, power off the printer immediately."
@@ -1491,7 +1485,7 @@ msgstr ""
 "premiers points. Si la buse accroche le papier, éteignez vite l'imprimante."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:3963
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:3987
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1500,27 +1494,27 @@ msgstr ""
 "l'assistant en redémarrant l'imprimante."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/messages.cpp:337 ../../Firmware/ultralcd.cpp:6023
+#: ../../Firmware/messages.cpp:349 ../../Firmware/ultralcd.cpp:5999
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "SVP, vérifiez la connexion du capteur IR et déchargez le filament."
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/messages.cpp:343 ../../Firmware/ultralcd.cpp:6700
+#: ../../Firmware/messages.cpp:355 ../../Firmware/ultralcd.cpp:6676
 msgid "Please check:"
 msgstr "Vérifiez:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/messages.cpp:302 ../../Firmware/ultralcd.cpp:3926
+#: ../../Firmware/messages.cpp:314 ../../Firmware/ultralcd.cpp:3950
 msgid "Please clean heatbed and then press the knob."
 msgstr "Nettoyez la plaque en acier et appuyez sur le bouton."
 
 #. MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3217 ../../Firmware/messages.cpp:27
+#: ../../Firmware/Marlin_main.cpp:2960 ../../Firmware/messages.cpp:28
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Nettoyez la buse pour la calibration. Cliquez une fois fait."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/messages.cpp:288 ../../Firmware/ultralcd.cpp:3712
+#: ../../Firmware/messages.cpp:300 ../../Firmware/ultralcd.cpp:3722
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr ""
@@ -1528,7 +1522,7 @@ msgstr ""
 "pour le charger."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/messages.cpp:287 ../../Firmware/ultralcd.cpp:3705
+#: ../../Firmware/messages.cpp:299 ../../Firmware/ultralcd.cpp:3715
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1537,104 +1531,103 @@ msgstr ""
 "pour le charger."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/messages.cpp:285 ../../Firmware/ultralcd.cpp:3633
+#: ../../Firmware/messages.cpp:297 ../../Firmware/ultralcd.cpp:3643
 msgid "Please load filament first."
 msgstr "Veuillez d'abord charger un filament."
 
 #. MSG_CHECK_IDLER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3525 ../../Firmware/messages.cpp:206
+#: ../../Firmware/Marlin_main.cpp:3265 ../../Firmware/messages.cpp:218
 msgid "Please open idler and remove filament manually."
 msgstr "Ouvrez l'idler et retirez le filament manuellement."
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2806 ../../Firmware/messages.cpp:80
-#: ../../Firmware/ultralcd.cpp:3860
+#: ../../Firmware/mesh_bed_calibration.cpp:2791 ../../Firmware/messages.cpp:80
 msgid "Please place steel sheet on heatbed."
 msgstr "Placez la plaque en acier sur le lit."
 
 #. MSG_PRESS_TO_UNLOAD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:11215 ../../Firmware/Marlin_main.cpp:11245
+#: ../../Firmware/Marlin_main.cpp:10287 ../../Firmware/Marlin_main.cpp:10317
 #: ../../Firmware/messages.cpp:84
 msgid "Please press the knob to unload filament"
 msgstr "Appuyez sur le bouton pour décharger le filament"
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:4932
+#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:4888
 msgid "Please pull out filament immediately"
 msgstr "Retirez immédiatement le filament"
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/messages.cpp:295 ../../Firmware/ultralcd.cpp:3856
+#: ../../Firmware/messages.cpp:307 ../../Firmware/ultralcd.cpp:3882
 msgid "Please remove shipping helpers first."
 msgstr "Retirez d'abord les protections de transport."
 
 #. MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3240 ../../Firmware/Marlin_main.cpp:4755
-#: ../../Firmware/messages.cpp:89
+#: ../../Firmware/Marlin_main.cpp:4324 ../../Firmware/messages.cpp:89
 msgid "Please remove steel sheet from heatbed."
 msgstr "Retirez la plaque en acier du lit."
 
 #. MSG_RUN_XYZ c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4731 ../../Firmware/messages.cpp:207
+#: ../../Firmware/Marlin_main.cpp:4300 ../../Firmware/messages.cpp:219
 msgid "Please run XYZ calibration first."
 msgstr "Veuillez d'abord lancer la calibration XYZ."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/messages.cpp:336 ../../Firmware/ultralcd.cpp:6020
+#: ../../Firmware/messages.cpp:348 ../../Firmware/ultralcd.cpp:4359
+#: ../../Firmware/ultralcd.cpp:5996
 msgid "Please unload the filament first, then repeat this action."
 msgstr "SVP, déchargez le filament et réessayez."
 
 #. MSG_NEW_FIRMWARE_PLEASE_UPGRADE c=20
-#: ../../Firmware/messages.cpp:366 ../../Firmware/util.cpp:213
+#: ../../Firmware/messages.cpp:378 ../../Firmware/util.cpp:218
 msgid "Please upgrade."
 msgstr "Mettez a jour le FW."
 
 #. MSG_PLEASE_WAIT c=20
-#: ../../Firmware/Marlin_main.cpp:3521 ../../Firmware/Marlin_main.cpp:8090
-#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:2179
-#: ../../Firmware/ultralcd.cpp:2190
+#: ../../Firmware/Marlin_main.cpp:3261 ../../Firmware/Marlin_main.cpp:7262
+#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:2190
+#: ../../Firmware/ultralcd.cpp:2204
 msgid "Please wait"
 msgstr "Merci de patienter"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:1232
-#: ../../Firmware/ultralcd.cpp:1261
+#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:1242
+#: ../../Firmware/ultralcd.cpp:1271
 msgid "Power failures"
 msgstr "Coup.de courant"
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/messages.cpp:323 ../../Firmware/ultralcd.cpp:5260
+#: ../../Firmware/messages.cpp:335 ../../Firmware/ultralcd.cpp:5222
 msgid "Preheat"
 msgstr "Préchauffage"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:2254
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:2268
 msgid "Preheat the nozzle!"
 msgstr "Préchauffez la buse!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:2771
-#: ../../Firmware/ultralcd.cpp:3690 ../../Firmware/ultralcd.cpp:3692
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:2788
+#: ../../Firmware/ultralcd.cpp:3700 ../../Firmware/ultralcd.cpp:3702
 msgid "Preheating nozzle. Please wait."
 msgstr "Préchauffage de la buse. Merci de patienter."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/messages.cpp:237 ../../Firmware/ultralcd.cpp:1999
+#: ../../Firmware/messages.cpp:249 ../../Firmware/ultralcd.cpp:2005
 msgid "Preheating to cut"
 msgstr "Chauffe pour couper"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/messages.cpp:236 ../../Firmware/ultralcd.cpp:1996
+#: ../../Firmware/messages.cpp:248 ../../Firmware/ultralcd.cpp:2002
 msgid "Preheating to eject"
 msgstr "Chauf. pour remonter"
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/messages.cpp:234 ../../Firmware/ultralcd.cpp:1987
+#: ../../Firmware/messages.cpp:246 ../../Firmware/ultralcd.cpp:1995
 msgid "Preheating to load"
 msgstr "Chauffe pour charger"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/messages.cpp:235 ../../Firmware/ultralcd.cpp:1992
+#: ../../Firmware/messages.cpp:247 ../../Firmware/ultralcd.cpp:1999
 msgid "Preheating to unload"
 msgstr "Chauf.pour décharger"
 
@@ -1645,12 +1638,12 @@ msgid "Preparing blade"
 msgstr "Preparation lame"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/messages.cpp:231 ../../Firmware/ultralcd.cpp:1799
+#: ../../Firmware/messages.cpp:243 ../../Firmware/ultralcd.cpp:1809
 msgid "Press the knob"
 msgstr "App. sur sur bouton"
 
 #. MSG_PRESS_TO_PREHEAT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:11227 ../../Firmware/messages.cpp:212
+#: ../../Firmware/Marlin_main.cpp:10299 ../../Firmware/messages.cpp:224
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Appuyez sur le bouton pour préchauffer la buse et continuer."
 
@@ -1660,46 +1653,46 @@ msgid "Print aborted"
 msgstr "Impression annulée"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1106
-#: ../../Firmware/ultralcd.cpp:6994
+#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1116
+#: ../../Firmware/ultralcd.cpp:6971
 msgid "Print fan:"
 msgstr "Vent. impr:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:5313
+#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5279
 msgid "Print from SD"
 msgstr "Impr. depuis la SD"
 
 #. MSG_PRINT_PAUSED c=20
-#: ../../Firmware/Marlin_main.cpp:3582 ../../Firmware/messages.cpp:79
+#: ../../Firmware/Marlin_main.cpp:3323 ../../Firmware/messages.cpp:79
 #: ../../Firmware/ultralcd.cpp:814
 msgid "Print paused"
 msgstr "Impression en pause"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/messages.cpp:247 ../../Firmware/ultralcd.cpp:2348
+#: ../../Firmware/messages.cpp:259 ../../Firmware/ultralcd.cpp:2365
 msgid "Print time"
 msgstr "Temps d'impression"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/messages.cpp:225 ../../Firmware/ultralcd.cpp:1689
+#: ../../Firmware/messages.cpp:237 ../../Firmware/ultralcd.cpp:1699
 msgid "Printer IP Addr:"
 msgstr "Adr.IP imprimante:"
 
 #. MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1602 ../../Firmware/messages.cpp:46
+#: ../../Firmware/Marlin_main.cpp:1529 ../../Firmware/messages.cpp:46
 msgid ""
 "Printer has not been calibrated yet. Please follow the manual, chapter First"
 " steps, section Calibration flow."
 msgstr "L'imprimante n'a pas encore été calibrée. Suivez le manuel."
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:153 ../../Firmware/util.cpp:289
+#: ../../Firmware/messages.cpp:160 ../../Firmware/util.cpp:296
 msgid "Nozzle diameter differs from the G-code. Continue?"
 msgstr "Diamètre de la buse diffère du G-Code. Continuer?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:154 ../../Firmware/util.cpp:290
+#: ../../Firmware/messages.cpp:161 ../../Firmware/util.cpp:297
 msgid ""
 "Nozzle diameter differs from the G-code. Please check the value in settings."
 " Print cancelled."
@@ -1726,22 +1719,22 @@ msgid "QUEUE FULL"
 msgstr "FILE PLEINE"
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:4465
 msgid "RPi port"
 msgstr "Port RPi"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/messages.cpp:261 ../../Firmware/ultralcd.cpp:2712
+#: ../../Firmware/messages.cpp:273 ../../Firmware/ultralcd.cpp:2729
 msgid "Rear side [µm]"
 msgstr "Arrière [µm]"
 
 #. MSG_RECOVERING_PRINT c=20
-#: ../../Firmware/messages.cpp:216 ../../Firmware/power_panic.cpp:316
+#: ../../Firmware/messages.cpp:228 ../../Firmware/power_panic.cpp:328
 msgid "Recovering print"
 msgstr "Récup. impression"
 
 #. MSG_RENAME c=18
-#: ../../Firmware/messages.cpp:322 ../../Firmware/ultralcd.cpp:5143
+#: ../../Firmware/messages.cpp:334 ../../Firmware/ultralcd.cpp:5103
 msgid "Rename"
 msgstr "Renommer"
 
@@ -1755,19 +1748,19 @@ msgstr ""
 " dans le G-Code un index d'outil hors plage (T0-T4)"
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:2713
-#: ../../Firmware/ultralcd.cpp:5144
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:2730
+#: ../../Firmware/ultralcd.cpp:5104
 msgid "Reset"
 msgstr "Réinitialiser"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/messages.cpp:320 ../../Firmware/ultralcd.cpp:4594
+#: ../../Firmware/messages.cpp:332 ../../Firmware/ultralcd.cpp:4550
 msgid "Reset XYZ calibr."
 msgstr "Réinit. calib. XYZ"
 
 #. MSG_RESUME_PRINT c=18
-#: ../../Firmware/Marlin_main.cpp:680 ../../Firmware/messages.cpp:91
-#: ../../Firmware/ultralcd.cpp:5286 ../../Firmware/ultralcd.cpp:5288
+#: ../../Firmware/Marlin_main.cpp:645 ../../Firmware/messages.cpp:91
+#: ../../Firmware/ultralcd.cpp:5252 ../../Firmware/ultralcd.cpp:5254
 msgid "Resume print"
 msgstr "Reprise impression"
 
@@ -1794,17 +1787,17 @@ msgid "Returning selector"
 msgstr "Retournement select."
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/messages.cpp:252 ../../Firmware/ultralcd.cpp:2479
+#: ../../Firmware/messages.cpp:264 ../../Firmware/ultralcd.cpp:2496
 msgid "Right"
 msgstr "Droite"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/messages.cpp:259 ../../Firmware/ultralcd.cpp:2710
+#: ../../Firmware/messages.cpp:271 ../../Firmware/ultralcd.cpp:2727
 msgid "Right side[µm]"
 msgstr "Droite [µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/messages.cpp:286 ../../Firmware/ultralcd.cpp:3656
+#: ../../Firmware/messages.cpp:298 ../../Firmware/ultralcd.cpp:3666
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1813,8 +1806,8 @@ msgstr ""
 "et commencera du début. Continuer?"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4509
-#: ../../Firmware/ultralcd.cpp:4511
+#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4476
+#: ../../Firmware/ultralcd.cpp:4478
 msgid "SD card"
 msgstr "Carte SD"
 
@@ -1829,23 +1822,23 @@ msgid "SELECTOR CANNOT MOVE"
 msgstr "ÉCHEC MOUV.T SELECT."
 
 #. MSG_STOPPED c=20
-#: ../../Firmware/Marlin_main.cpp:9887 ../../Firmware/messages.cpp:125
+#: ../../Firmware/Marlin_main.cpp:9047 ../../Firmware/messages.cpp:130
 msgid "STOPPED."
 msgstr "ARRÊTÉ"
 
 #. MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3223 ../../Firmware/Marlin_main.cpp:3245
-#: ../../Firmware/mesh_bed_calibration.cpp:2246 ../../Firmware/messages.cpp:44
+#: ../../Firmware/Marlin_main.cpp:2967 ../../Firmware/Marlin_main.cpp:2984
+#: ../../Firmware/mesh_bed_calibration.cpp:2231 ../../Firmware/messages.cpp:44
 msgid "Searching bed calibration point"
 msgstr "Recherche point calibration du lit"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/messages.cpp:321 ../../Firmware/ultralcd.cpp:5136
+#: ../../Firmware/messages.cpp:333 ../../Firmware/ultralcd.cpp:5096
 msgid "Select"
 msgstr "Sélectionner"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/messages.cpp:290 ../../Firmware/ultralcd.cpp:3730
+#: ../../Firmware/messages.cpp:302 ../../Firmware/ultralcd.cpp:3740
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
@@ -1854,27 +1847,27 @@ msgstr ""
 "sélectionnez-le dans le menu."
 
 #. MSG_SELECT_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3453 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3612
-#: ../../Firmware/ultralcd.cpp:6822
+#: ../../Firmware/Marlin_main.cpp:3192 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3622
+#: ../../Firmware/ultralcd.cpp:6798
 msgid "Select filament:"
 msgstr "Choix du filament:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:110 ../../Firmware/ultralcd.cpp:3464
-#: ../../Firmware/ultralcd.cpp:4504
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:3474
+#: ../../Firmware/ultralcd.cpp:4471
 msgid "Select language"
 msgstr "Choisir langue"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/messages.cpp:300 ../../Firmware/ultralcd.cpp:3900
+#: ../../Firmware/messages.cpp:312 ../../Firmware/ultralcd.cpp:3924
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr ""
 "Sélectionnez la temperature de préchauffage de la buse qui correspond à "
 "votre matériel."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/messages.cpp:291 ../../Firmware/ultralcd.cpp:3735
+#: ../../Firmware/messages.cpp:303 ../../Firmware/ultralcd.cpp:3745
 msgid "Select temperature which matches your material."
 msgstr "Sélectionnez la température qui correspond à votre matériel."
 
@@ -1885,62 +1878,62 @@ msgid "Selecting fil. slot"
 msgstr "Sélection du fil."
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/messages.cpp:341 ../../Firmware/ultralcd.cpp:6274
+#: ../../Firmware/messages.cpp:353 ../../Firmware/ultralcd.cpp:6250
 msgid "Selftest OK"
 msgstr "Selftest OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/messages.cpp:340 ../../Firmware/ultralcd.cpp:6057
+#: ../../Firmware/messages.cpp:352 ../../Firmware/ultralcd.cpp:6033
 msgid "Selftest start"
 msgstr "Début selftest"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/messages.cpp:315 ../../Firmware/ultralcd.cpp:4581
+#: ../../Firmware/messages.cpp:327 ../../Firmware/ultralcd.cpp:4537
 msgid "Selftest"
 msgstr "Selftest"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/messages.cpp:342 ../../Firmware/ultralcd.cpp:6699
+#: ../../Firmware/messages.cpp:354 ../../Firmware/ultralcd.cpp:6675
 msgid "Selftest error!"
 msgstr "Erreur selftest!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6279
-#: ../../Firmware/ultralcd.cpp:6786 ../../Firmware/ultralcd.cpp:6984
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6255
+#: ../../Firmware/ultralcd.cpp:6762 ../../Firmware/ultralcd.cpp:6961
 msgid "Selftest failed"
 msgstr "Échec du selftest"
 
 #. MSG_FORCE_SELFTEST c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1577 ../../Firmware/messages.cpp:202
+#: ../../Firmware/Marlin_main.cpp:1504 ../../Firmware/messages.cpp:214
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr ""
 "Le Selftest sera lancé pour caliber la remise à zéro précise sans capteur"
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/messages.cpp:228 ../../Firmware/ultralcd.cpp:1701
+#: ../../Firmware/messages.cpp:240 ../../Firmware/ultralcd.cpp:1711
 msgid "Sensor info"
 msgstr "Info capteur"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/messages.cpp:338 ../../Firmware/ultralcd.cpp:6027
+#: ../../Firmware/messages.cpp:350 ../../Firmware/ultralcd.cpp:6003
 msgid "Sensor verified, remove the filament now."
 msgstr "Capteur vérifié, retirez le filament maintenant."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/messages.cpp:262 ../../Firmware/ultralcd.cpp:2730
+#: ../../Firmware/messages.cpp:274 ../../Firmware/ultralcd.cpp:2747
 msgid "Set temperature:"
 msgstr "Régler temp.:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3348
-#: ../../Firmware/ultralcd.cpp:3479 ../../Firmware/ultralcd.cpp:3984
-#: ../../Firmware/ultralcd.cpp:5374 ../../Firmware/ultralcd.cpp:5585
-#: ../../Firmware/ultralcd.cpp:5631
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3358
+#: ../../Firmware/ultralcd.cpp:3489 ../../Firmware/ultralcd.cpp:4008
+#: ../../Firmware/ultralcd.cpp:5341 ../../Firmware/ultralcd.cpp:5558
+#: ../../Firmware/ultralcd.cpp:5604
 msgid "Settings"
 msgstr "Réglages"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/messages.cpp:255 ../../Firmware/ultralcd.cpp:2522
+#: ../../Firmware/messages.cpp:267 ../../Firmware/ultralcd.cpp:2539
 msgid "Severe skew"
 msgstr "Déviat. sévère"
 
@@ -1951,7 +1944,7 @@ msgid "Sheet"
 msgstr "Plaque"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/messages.cpp:284 ../../Firmware/ultralcd.cpp:3604
+#: ../../Firmware/messages.cpp:296 ../../Firmware/ultralcd.cpp:3614
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1964,23 +1957,23 @@ msgstr ""
 "%cRéinitialiser"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/messages.cpp:319 ../../Firmware/ultralcd.cpp:4592
+#: ../../Firmware/messages.cpp:331 ../../Firmware/ultralcd.cpp:4548
 msgid "Show end stops"
 msgstr "Afficher butées"
 
 #. MSG_SILENT c=7
-#: ../../Firmware/Marlin_main.cpp:8497 ../../Firmware/messages.cpp:120
-#: ../../Firmware/ultralcd.cpp:4155 ../../Firmware/ultralcd.cpp:4194
+#: ../../Firmware/Marlin_main.cpp:7668 ../../Firmware/messages.cpp:124
+#: ../../Firmware/ultralcd.cpp:4179 ../../Firmware/ultralcd.cpp:4218
 msgid "Silent"
 msgstr "Furtif"
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/messages.cpp:254 ../../Firmware/ultralcd.cpp:2521
+#: ../../Firmware/messages.cpp:266 ../../Firmware/ultralcd.cpp:2538
 msgid "Slight skew"
 msgstr "Déviat. légère"
 
 #. MSG_FILE_CNT c=20 r=6
-#: ../../Firmware/cardreader.cpp:805 ../../Firmware/messages.cpp:197
+#: ../../Firmware/cardreader.cpp:805 ../../Firmware/messages.cpp:209
 msgid ""
 "Some files will not be sorted. Max. No. of files in 1 folder for sorting is "
 "100."
@@ -1988,59 +1981,59 @@ msgstr ""
 "Certains fichiers ne seront pas tries. Max 100 fichiers tries par dossier."
 
 #. MSG_ZLEVELING_ENFORCED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3043 ../../Firmware/messages.cpp:204
+#: ../../Firmware/Marlin_main.cpp:2783 ../../Firmware/messages.cpp:216
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Problème rencontré, cliquez sur le bouton pour niveler l'axe Z..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:4514
-#: ../../Firmware/ultralcd.cpp:4515 ../../Firmware/ultralcd.cpp:4516
+#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4481
+#: ../../Firmware/ultralcd.cpp:4482 ../../Firmware/ultralcd.cpp:4483
 msgid "Sort"
 msgstr "Tri"
 
 #. MSG_SORTING_FILES c=20
 #: ../../Firmware/cardreader.cpp:849 ../../Firmware/cardreader.cpp:916
-#: ../../Firmware/messages.cpp:111
+#: ../../Firmware/messages.cpp:115
 msgid "Sorting files"
 msgstr "Tri des fichiers"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4188
-#: ../../Firmware/ultralcd.cpp:4191 ../../Firmware/ultralcd.cpp:4194
-#: ../../Firmware/ultralcd.cpp:4197 ../../Firmware/ultralcd.cpp:4200
+#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4215 ../../Firmware/ultralcd.cpp:4218
+#: ../../Firmware/ultralcd.cpp:4221 ../../Firmware/ultralcd.cpp:4224
 msgid "Sound"
 msgstr "Son"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/messages.cpp:333 ../../Firmware/ultralcd.cpp:5516
+#: ../../Firmware/messages.cpp:345 ../../Firmware/ultralcd.cpp:5483
 msgid "Speed"
 msgstr "Vitesse"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6861
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6837
 msgid "Spinning"
 msgstr "Tourne"
 
 #. MSG_TEMP_CAL_WARNING c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4744 ../../Firmware/messages.cpp:208
+#: ../../Firmware/Marlin_main.cpp:4313 ../../Firmware/messages.cpp:220
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr ""
 "Une temperature ambiante stable de 21-26C et un support stable sont requis."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/messages.cpp:329 ../../Firmware/ultralcd.cpp:5379
+#: ../../Firmware/messages.cpp:341 ../../Firmware/ultralcd.cpp:5346
 msgid "Statistics"
 msgstr "Statistiques"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:4096
-#: ../../Firmware/ultralcd.cpp:4144
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4120
+#: ../../Firmware/ultralcd.cpp:4168
 msgid "Stealth"
 msgstr "Furtif"
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4421
-#: ../../Firmware/ultralcd.cpp:5133
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4388
+#: ../../Firmware/ultralcd.cpp:5093
 msgid "Steel sheets"
 msgstr "Plaques en acier"
 
@@ -2050,29 +2043,28 @@ msgid "Stop"
 msgstr "Stop"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:5293
-#: ../../Firmware/ultralcd.cpp:5781
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:5259
+#: ../../Firmware/ultralcd.cpp:5757
 msgid "Stop print"
 msgstr "Arrêter impression"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4236
-#: ../../Firmware/ultralcd.cpp:4316 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4315
 msgid "Strict"
 msgstr "Stricte"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/messages.cpp:332 ../../Firmware/ultralcd.cpp:5394
+#: ../../Firmware/messages.cpp:344 ../../Firmware/ultralcd.cpp:5361
 msgid "Support"
 msgstr "Support"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/messages.cpp:354 ../../Firmware/ultralcd.cpp:6758
+#: ../../Firmware/messages.cpp:366 ../../Firmware/ultralcd.cpp:6734
 msgid "Swapped"
 msgstr "Échangé"
 
 #. MSG_THERMAL_ANOMALY c=20
-#: ../../Firmware/messages.cpp:188 ../../Firmware/temperature.cpp:2223
+#: ../../Firmware/messages.cpp:195 ../../Firmware/temperature.cpp:2197
 msgid "THERMAL ANOMALY"
 msgstr "ANOMALIE THERMIQUE"
 
@@ -2107,7 +2099,7 @@ msgid "TMC UNDERVOLTAGE ERR"
 msgstr "ERR SOUS TENSION TMC"
 
 #. MSG_TM_CAL c=20 r=4
-#: ../../Firmware/messages.cpp:299 ../../Firmware/ultralcd.cpp:3881
+#: ../../Firmware/messages.cpp:311 ../../Firmware/ultralcd.cpp:3905
 msgid ""
 "Thermal model cal. takes approx. 12 mins. See\n"
 "prusa.io/tm-cal"
@@ -2116,22 +2108,22 @@ msgstr ""
 "prusa.io/tm-cal"
 
 #. MSG_TM_NOT_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1613 ../../Firmware/messages.cpp:189
+#: ../../Firmware/Marlin_main.cpp:1540 ../../Firmware/messages.cpp:196
 msgid "Thermal model not calibrated yet."
 msgstr "Modèle thermique non calibré."
 
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/messages.cpp:309 ../../Firmware/ultralcd.cpp:4455
+#: ../../Firmware/messages.cpp:321 ../../Firmware/ultralcd.cpp:4422
 msgid "Temperature"
 msgstr "Temperature"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/messages.cpp:229 ../../Firmware/ultralcd.cpp:1707
+#: ../../Firmware/messages.cpp:241 ../../Firmware/ultralcd.cpp:1717
 msgid "Temperatures"
 msgstr "Temperatures"
 
 #. MSG_TESTING_FILAMENT c=20
-#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:388
+#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:389
 msgid "Testing filament"
 msgstr "Test du filament"
 
@@ -2152,7 +2144,7 @@ msgstr ""
 "que ce que soit qui bloque son mouvement."
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/messages.cpp:292 ../../Firmware/ultralcd.cpp:3738
+#: ../../Firmware/messages.cpp:304 ../../Firmware/ultralcd.cpp:3748
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -2162,7 +2154,7 @@ msgstr ""
 "jusqu'a atteindre la hauteur optimale. Consultez les photos dans le manuel."
 
 #. MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1606 ../../Firmware/messages.cpp:47
+#: ../../Firmware/Marlin_main.cpp:1533 ../../Firmware/messages.cpp:47
 msgid ""
 "There is still a need to make Z calibration. Please follow the manual, "
 "chapter First steps, section Calibration flow."
@@ -2170,40 +2162,40 @@ msgstr ""
 "Il faut toujours effectuer la calibration Z. Veuillez suivre le manuel."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:4514
+#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:4481
 msgid "Time"
 msgstr "Heure"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:176 ../../Firmware/ultralcd.cpp:5622
+#: ../../Firmware/messages.cpp:183 ../../Firmware/ultralcd.cpp:5595
 msgid "Timeout"
 msgstr "Délai écoulé"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:1129
-#: ../../Firmware/ultralcd.cpp:1287
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:1139
+#: ../../Firmware/ultralcd.cpp:1297
 msgid "Total"
 msgstr "Totale"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:1177
-#: ../../Firmware/ultralcd.cpp:1231 ../../Firmware/ultralcd.cpp:1317
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:1187
+#: ../../Firmware/ultralcd.cpp:1241 ../../Firmware/ultralcd.cpp:1327
 msgid "Total failures"
 msgstr "Total des échecs"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/messages.cpp:248 ../../Firmware/ultralcd.cpp:2369
+#: ../../Firmware/messages.cpp:260 ../../Firmware/ultralcd.cpp:2386
 msgid "Total filament"
 msgstr "Filament total"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/messages.cpp:249 ../../Firmware/ultralcd.cpp:2370
+#: ../../Firmware/messages.cpp:261 ../../Firmware/ultralcd.cpp:2387
 msgid "Total print time"
 msgstr "Temps total impr."
 
 #. MSG_TUNE c=8
-#: ../../Firmware/messages.cpp:116 ../../Firmware/mmu2/errors_list.h:372
-#: ../../Firmware/ultralcd.cpp:5258
+#: ../../Firmware/messages.cpp:120 ../../Firmware/mmu2/errors_list.h:372
+#: ../../Firmware/ultralcd.cpp:5220
 msgid "Tune"
 msgstr "Régler"
 
@@ -2218,16 +2210,16 @@ msgid "Unload"
 msgstr "Déch."
 
 #. MSG_UNLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:2206
-#: ../../Firmware/ultralcd.cpp:5347 ../../Firmware/ultralcd.cpp:5364
-#: ../../Firmware/ultralcd.cpp:5369
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:2220
+#: ../../Firmware/ultralcd.cpp:5313 ../../Firmware/ultralcd.cpp:5331
+#: ../../Firmware/ultralcd.cpp:5336
 msgid "Unload filament"
 msgstr "Décharger fil."
 
 #. MSG_UNLOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3436 ../../Firmware/messages.cpp:129
+#: ../../Firmware/Marlin_main.cpp:3175 ../../Firmware/messages.cpp:134
 #: ../../Firmware/mmu2_progress_converter.cpp:50
-#: ../../Firmware/ultralcd.cpp:4911
+#: ../../Firmware/ultralcd.cpp:4867
 msgid "Unloading filament"
 msgstr "Déchargement fil."
 
@@ -2244,12 +2236,12 @@ msgid "Unloading to pulley"
 msgstr "Déchar.t vers poulie"
 
 #. MSG_FIL_FAILED c=20 r=4
-#: ../../Firmware/messages.cpp:339 ../../Firmware/ultralcd.cpp:6030
+#: ../../Firmware/messages.cpp:351 ../../Firmware/ultralcd.cpp:6006
 msgid "Verification failed, remove the filament and try again."
 msgstr "Vérification échouée, retirez le filament, et réessayez."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/messages.cpp:230 ../../Firmware/ultralcd.cpp:1710
+#: ../../Firmware/messages.cpp:242 ../../Firmware/ultralcd.cpp:1720
 msgid "Voltages"
 msgstr "Tensions"
 
@@ -2260,7 +2252,7 @@ msgid "WARNING TMC TOO HOT"
 msgstr "ATT TMC TROP CHAUD"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/messages.cpp:281 ../../Firmware/ultralcd.cpp:3381
+#: ../../Firmware/messages.cpp:293 ../../Firmware/ultralcd.cpp:3391
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -2273,89 +2265,88 @@ msgstr ""
 "mode furtif"
 
 #. MSG_USERWAIT c=20
-#: ../../Firmware/Marlin_main.cpp:5240 ../../Firmware/messages.cpp:209
+#: ../../Firmware/Marlin_main.cpp:4747 ../../Firmware/messages.cpp:221
 msgid "Wait for user..."
 msgstr "Attente utilisateur."
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/messages.cpp:263 ../../Firmware/ultralcd.cpp:2753
+#: ../../Firmware/messages.cpp:275 ../../Firmware/ultralcd.cpp:2770
 msgid "Waiting for PINDA probe cooling"
 msgstr "Attente du refroidissement de la sonde PINDA"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/messages.cpp:264 ../../Firmware/ultralcd.cpp:2782
+#: ../../Firmware/messages.cpp:276 ../../Firmware/ultralcd.cpp:2799
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Attente du refroidissement de la buse et lit"
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:4233
-#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4352
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4312
 msgid "Warn"
 msgstr "Avert"
 
 #. MSG_CHANGED_BOTH c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1554 ../../Firmware/messages.cpp:200
+#: ../../Firmware/Marlin_main.cpp:1481 ../../Firmware/messages.cpp:212
 msgid "Warning: both printer type and motherboard type changed."
 msgstr "Attention: Types d'imprimante et de carte mere modifies"
 
 #. MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1546 ../../Firmware/messages.cpp:198
+#: ../../Firmware/Marlin_main.cpp:1473 ../../Firmware/messages.cpp:210
 msgid "Warning: motherboard type changed."
 msgstr "Attention: Type de carte mere modifie."
 
 #. MSG_CHANGED_PRINTER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1550 ../../Firmware/messages.cpp:199
+#: ../../Firmware/Marlin_main.cpp:1477 ../../Firmware/messages.cpp:211
 msgid "Warning: printer type changed."
 msgstr "Attention: Type d'imprimante modifie"
 
 #. MSG_UNLOAD_SUCCESSFUL c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3517 ../../Firmware/messages.cpp:205
+#: ../../Firmware/Marlin_main.cpp:3257 ../../Firmware/messages.cpp:217
 msgid "Was filament unload successful?"
 msgstr "Déchargement du filament réussi?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:6710
-#: ../../Firmware/ultralcd.cpp:6714 ../../Firmware/ultralcd.cpp:6734
-#: ../../Firmware/ultralcd.cpp:6740 ../../Firmware/ultralcd.cpp:6764
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:6686
+#: ../../Firmware/ultralcd.cpp:6690 ../../Firmware/ultralcd.cpp:6710
+#: ../../Firmware/ultralcd.cpp:6716 ../../Firmware/ultralcd.cpp:6740
 msgid "Wiring error"
 msgstr "Erreur de câblage"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/messages.cpp:313 ../../Firmware/ultralcd.cpp:4572
+#: ../../Firmware/messages.cpp:325 ../../Firmware/ultralcd.cpp:4528
 msgid "Wizard"
 msgstr "Assistant"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/messages.cpp:304 ../../Firmware/ultralcd.cpp:3986
+#: ../../Firmware/messages.cpp:316 ../../Firmware/ultralcd.cpp:4010
 msgid "X-correct"
 msgstr "Correct-X"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/messages.cpp:226 ../../Firmware/ultralcd.cpp:1699
+#: ../../Firmware/messages.cpp:238 ../../Firmware/ultralcd.cpp:1709
 msgid "XYZ cal. details"
 msgstr "Details calib. XYZ"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/messages.cpp:275 ../../Firmware/ultralcd.cpp:3207
+#: ../../Firmware/messages.cpp:287 ../../Firmware/ultralcd.cpp:3217
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr "Calibration XYZ OK. L'écart sera corrigé automatiquement."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/messages.cpp:274 ../../Firmware/ultralcd.cpp:3204
+#: ../../Firmware/messages.cpp:286 ../../Firmware/ultralcd.cpp:3214
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr ""
 "Calibration XYZ OK. Les axes X/Y sont légèrement non perpendiculaires. Bon "
 "boulot!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/messages.cpp:271 ../../Firmware/ultralcd.cpp:3185
+#: ../../Firmware/messages.cpp:283 ../../Firmware/ultralcd.cpp:3195
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr ""
 "Calibration XYZ compromise. Les points de calibration en avant ne sont pas "
 "atteignables."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/messages.cpp:272 ../../Firmware/ultralcd.cpp:3188
+#: ../../Firmware/messages.cpp:284 ../../Firmware/ultralcd.cpp:3198
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr ""
@@ -2363,108 +2354,111 @@ msgstr ""
 "atteignable."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/messages.cpp:268 ../../Firmware/ultralcd.cpp:3167
+#: ../../Firmware/messages.cpp:280 ../../Firmware/ultralcd.cpp:3177
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr ""
 "Échec calibration XYZ. Le point de calibration du lit n'a pas été trouvé."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/messages.cpp:269 ../../Firmware/ultralcd.cpp:3173
+#: ../../Firmware/messages.cpp:281 ../../Firmware/ultralcd.cpp:3183
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr ""
 "Échec calibration XYZ. Les points de calibration en avant ne sont pas "
 "atteignables."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3170
-#: ../../Firmware/ultralcd.cpp:3198
+#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3180
+#: ../../Firmware/ultralcd.cpp:3208
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "Échec calibration XYZ. Consultez le manuel."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/messages.cpp:270 ../../Firmware/ultralcd.cpp:3176
+#: ../../Firmware/messages.cpp:282 ../../Firmware/ultralcd.cpp:3186
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr ""
 "Échec calibration XYZ. Le point de calibration avant droit n'est pas "
 "atteignable."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/messages.cpp:273 ../../Firmware/ultralcd.cpp:3201
+#: ../../Firmware/messages.cpp:285 ../../Firmware/ultralcd.cpp:3211
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr ""
 "Calibration XYZ OK. Les axes X/Y sont perpendiculaires. Felicitations!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/messages.cpp:250 ../../Firmware/ultralcd.cpp:2476
+#: ../../Firmware/messages.cpp:262 ../../Firmware/ultralcd.cpp:2493
 msgid "Y distance from min"
 msgstr "Distance Y du min"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/messages.cpp:305 ../../Firmware/ultralcd.cpp:3987
+#: ../../Firmware/messages.cpp:317 ../../Firmware/ultralcd.cpp:4011
 msgid "Y-correct"
 msgstr "Correct-Y"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:3029
-#: ../../Firmware/ultralcd.cpp:4443 ../../Firmware/ultralcd.cpp:4531
-#: ../../Firmware/ultralcd.cpp:5790
+#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:2275
+#: ../../Firmware/ultralcd.cpp:2279 ../../Firmware/ultralcd.cpp:3046
+#: ../../Firmware/ultralcd.cpp:4410 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/ultralcd.cpp:5766
 msgid "Yes"
 msgstr "Oui"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:3950
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:3974
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr ""
 "Vous pouvez toujours relancer l'Assistant dans Calibration > Assistant."
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/messages.cpp:306 ../../Firmware/ultralcd.cpp:3988
+#: ../../Firmware/messages.cpp:318 ../../Firmware/ultralcd.cpp:4012
 msgid "Z-correct"
 msgstr "Correct-Z"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5593
+#: ../../Firmware/messages.cpp:175 ../../Firmware/ultralcd.cpp:5566
 msgid "Z-probe nr."
 msgstr "Mesurer x-fois"
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/messages.cpp:256 ../../Firmware/ultralcd.cpp:2546
+#: ../../Firmware/messages.cpp:268 ../../Firmware/ultralcd.cpp:2563
 msgid "[0;0] point offset"
 msgstr "Offset point [0;0]"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/messages.cpp:239 ../../Firmware/ultralcd.cpp:2147
+#: ../../Firmware/messages.cpp:251 ../../Firmware/ultralcd.cpp:2158
 msgid "and press the knob"
-msgstr "et appuyez\nsur le bouton"
+msgstr ""
+"et appuyez\n"
+"sur le bouton"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/messages.cpp:232 ../../Firmware/ultralcd.cpp:1807
+#: ../../Firmware/messages.cpp:244 ../../Firmware/ultralcd.cpp:1816
 msgid "to load filament"
 msgstr "pour charger le fil."
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/messages.cpp:233 ../../Firmware/ultralcd.cpp:1811
+#: ../../Firmware/messages.cpp:245 ../../Firmware/ultralcd.cpp:1820
 msgid "to unload filament"
 msgstr "pour décharger fil."
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/messages.cpp:224 ../../Firmware/ultralcd.cpp:1666
+#: ../../Firmware/messages.cpp:236 ../../Firmware/ultralcd.cpp:1676
 msgid "unknown"
 msgstr "inconnu"
 
 #. MSG_IR_UNKNOWN c=18
-#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:184
+#: ../../Firmware/Filament_sensor.cpp:286 ../../Firmware/messages.cpp:191
 msgid "unknown state"
 msgstr "État inconnu"
 
 #. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:5858
-#: ../../Firmware/ultralcd.cpp:5861
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:5834
+#: ../../Firmware/ultralcd.cpp:5837
 msgid "🔃Refresh"
 msgstr "🔃Rafraîchir"
 
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1180
+#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1190
 msgid "MMU power fails"
 msgstr "Def. alim. MMU"
 
@@ -2502,8 +2496,8 @@ msgid "MMU MCU ERROR"
 msgstr "MMU MCU ERREUR"
 
 #. MSG_MATERIAL_CHANGES c=18
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:1130
-#: ../../Firmware/ultralcd.cpp:1204
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:1140
+#: ../../Firmware/ultralcd.cpp:1214
 msgid "Material changes"
 msgstr "Changes matériels"
 
@@ -2535,17 +2529,17 @@ msgstr ""
 "vers la version 3.0.3."
 
 #. MSG_PRELOAD_TO_MMU c=17
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5344
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5310
 msgid "Preload to MMU"
 msgstr "Précharge à MMU"
 
 #. MSG_FW_MK3_DETECTED c=20 r=4
-#: ../../Firmware/messages.cpp:367 ../../Firmware/Marlin_main.cpp:920
+#: ../../Firmware/messages.cpp:379 ../../Firmware/Marlin_main.cpp:854
 msgid "MK3 firmware detected on MK3S printer"
 msgstr "Firmware MK3 détecté sur imprimante MK3S"
 
 #. MSG_FW_MK3S_DETECTED c=20 r=4
-#: ../../Firmware/messages.cpp:367 ../../Firmware/Marlin_main.cpp:920
+#: ../../Firmware/messages.cpp:379 ../../Firmware/Marlin_main.cpp:854
 msgid "MK3S firmware detected on MK3 printer"
 msgstr "Firmware MK3S détecté sur imprimante MK3"
 
@@ -2559,8 +2553,9 @@ msgstr "ERREUR INCONNUE"
 msgid "Unexpected error occurred."
 msgstr "Une erreur inattendue s'est produite."
 
-#. MSG_BTN_EJECT c=8
-#: ../../Firmware/mmu2/errors_list.h:358 ../../Firmware/mmu2/errors_list.h:371
+#. MSG_EJECT c=8
+#: ../../Firmware/messages.cpp:21 ../../Firmware/mmu2/errors_list.h:371
+#: ../../Firmware/ultralcd.cpp:2275 ../../Firmware/ultralcd.cpp:2279
 msgid "Eject"
 msgstr "Éjecter"
 
@@ -2582,58 +2577,58 @@ msgstr ""
 "l'ancien."
 
 #. MSG_MMU_SENSITIVITY c=18
-#: ../../Firmware/messages.cpp:215 ../../Firmware/mmu2_reporting.cpp:458
+#: ../../Firmware/messages.cpp:227 ../../Firmware/mmu2_reporting.cpp:459
 msgid "Sensitivity"
 msgstr "Sensibilité"
 
 #. MSG_MBL_FAILED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3038 ../../Firmware/messages.cpp:203
+#: ../../Firmware/Marlin_main.cpp:2776 ../../Firmware/messages.cpp:215
 msgid "Mesh bed leveling failed. Print canceled."
 msgstr "Mesh bed leveling a échoué. Impression annulée."
 
 #. MSG_SET_READY c=18
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:5265
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:5228
 msgid "Set Ready"
 msgstr "Ensemble prête"
 
 #. MSG_SET_NOT_READY c=18
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:5263
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5226
 msgid "Set not Ready"
 msgstr "Ensemble pas prête"
 
 #. MSG_HOSTPRINT c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5285
+#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:5231
 msgid "Print from host"
 msgstr "Impr depuis l'hôte"
 
 #. MSG_REPRINT c=18
-#: ../../Firmware/messages.cpp:196 ../../Firmware/ultralcd.cpp:5243
-#: ../../Firmware/ultralcd.cpp:5245
+#: ../../Firmware/messages.cpp:208 ../../Firmware/ultralcd.cpp:5205
+#: ../../Firmware/ultralcd.cpp:5207
 msgid "Reprint"
 msgstr "Ré-imprimer"
 
 #. MSG_SHUTDOWN_HOST c=18
-#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:5390
+#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:5357
 msgid "Shutdown host"
 msgstr "Arrêter l'hôte"
 
 #. MSG_NOZZLE_CNG_COOLDOWN c=20 r=3
-#: ../../Firmware/messages.cpp:198 ../../Firmware/ultralcd.cpp:1002
+#: ../../Firmware/messages.cpp:203 ../../Firmware/ultralcd.cpp:999
 msgid "Nozzle is hot! Wait for cooldown."
 msgstr "La buse est chaude! Attendre le refroidissement."
 
 #. MSG_NOZZLE_CNG_CHANGED_QUICK c=20 r=3
-#: ../../Firmware/messages.cpp:199
+#: ../../Firmware/messages.cpp:204
 msgid "Nozzle changed?"
 msgstr "La buse a été changée?"
 
 #. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:388
+#: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:388
 msgid "There is no filament loaded. Continue?"
 msgstr "Il n'y a pas de filament chargé. Continuer?"
 
 #. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:389
+#: ../../Firmware/messages.cpp:159 ../../Firmware/util.cpp:389
 msgid "There is no filament loaded. Print cancelled."
 msgstr "Il n'y a pas de filament chargé. Impression annulée."
 

--- a/lang/po/Firmware_hr.po
+++ b/lang/po/Firmware_hr.po
@@ -16,91 +16,91 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 
 #. MSG_IR_03_OR_OLDER c=18
-#: ../../Firmware/Filament_sensor.cpp:280
-#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:183
+#: ../../Firmware/Filament_sensor.cpp:282
+#: ../../Firmware/Filament_sensor.cpp:344 ../../Firmware/messages.cpp:190
 msgid " 0.3 or older"
 msgstr " 0.3 ili stariji"
 
 #. MSG_IR_04_OR_NEWER c=18
-#: ../../Firmware/Filament_sensor.cpp:282
-#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:182
+#: ../../Firmware/Filament_sensor.cpp:284
+#: ../../Firmware/Filament_sensor.cpp:347 ../../Firmware/messages.cpp:189
 msgid " 0.4 or newer"
 msgstr " 0.4 ili noviji"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/messages.cpp:356 ../../Firmware/ultralcd.cpp:6773
+#: ../../Firmware/messages.cpp:368 ../../Firmware/ultralcd.cpp:6749
 msgid "%s level expected"
 msgstr "%s level ocekivan"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:1978
-#: ../../Firmware/ultralcd.cpp:3613
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:1986
+#: ../../Firmware/ultralcd.cpp:3623
 msgid ">Cancel"
 msgstr ">Otkazati"
 
 #. MSG_BABYSTEPPING_Z c=13
-#: ../../Firmware/messages.cpp:257 ../../Firmware/ultralcd.cpp:2635
+#: ../../Firmware/messages.cpp:269 ../../Firmware/ultralcd.cpp:2652
 msgid "Adjusting Z"
 msgstr "Podesavanje Z"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/messages.cpp:360 ../../Firmware/ultralcd.cpp:6983
+#: ../../Firmware/messages.cpp:372 ../../Firmware/ultralcd.cpp:6960
 msgid "All correct"
 msgstr "Sve je u redu"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:3955
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:3979
 msgid "All is done. Happy printing!"
 msgstr "Sve je gotovo. Sretno printanje!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4482
 msgid "Alphabet"
 msgstr "Abeceda"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4086
+#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4110
 msgid "Always"
 msgstr "Uvijek"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/messages.cpp:221 ../../Firmware/ultralcd.cpp:1393
+#: ../../Firmware/messages.cpp:233 ../../Firmware/ultralcd.cpp:1403
 msgid "Ambient"
 msgstr "Ambijent"
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=3
-#: ../../Firmware/messages.cpp:267 ../../Firmware/ultralcd.cpp:2848
+#: ../../Firmware/messages.cpp:279 ../../Firmware/ultralcd.cpp:2865
 msgid "Are left and right Z-carriages all up?"
 msgstr "Jesu lijevi i desni Z-nosaci podignuti?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4197
+#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:4221
 msgid "Assist"
 msgstr "Pomoc"
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:179 ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/messages.cpp:186 ../../Firmware/ultralcd.cpp:5594
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
-#: ../../Firmware/Marlin_main.cpp:3198 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:4577 ../../Firmware/ultralcd.cpp:5529
+#: ../../Firmware/Marlin_main.cpp:2942 ../../Firmware/messages.cpp:12
+#: ../../Firmware/ultralcd.cpp:4533 ../../Firmware/ultralcd.cpp:5496
 msgid "Auto home"
 msgstr "Pocetna tocka"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4182
 msgid "Auto power"
 msgstr "Auto napaj"
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:328 ../../Firmware/ultralcd.cpp:5359
+#: ../../Firmware/messages.cpp:340 ../../Firmware/ultralcd.cpp:5328
 msgid "AutoLoad filament"
 msgstr "Autopunj filamenta"
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/messages.cpp:245 ../../Firmware/ultralcd.cpp:2272
+#: ../../Firmware/messages.cpp:257 ../../Firmware/ultralcd.cpp:2289
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr "Auto punjenje fil. je aktivno, pritisnite gumb i umetnite fil.."
@@ -112,51 +112,50 @@ msgid "Avoiding grind"
 msgstr "Sprecavanje mljevenj"
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/messages.cpp:352 ../../Firmware/ultralcd.cpp:6752
+#: ../../Firmware/messages.cpp:364 ../../Firmware/ultralcd.cpp:6728
 msgid "Axis"
 msgstr "Os"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/messages.cpp:351 ../../Firmware/ultralcd.cpp:6751
+#: ../../Firmware/messages.cpp:363 ../../Firmware/ultralcd.cpp:6727
 msgid "Axis length"
 msgstr "Duljina osi"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2708
-#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:5618
-#: ../../Firmware/ultralcd.cpp:7484
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2725
+#: ../../Firmware/ultralcd.cpp:4061 ../../Firmware/ultralcd.cpp:5591
+#: ../../Firmware/ultralcd.cpp:7461
 msgid "Back"
 msgstr "Natrag"
 
 #. MSG_BED c=13
-#: ../../Firmware/Marlin_main.cpp:2081 ../../Firmware/Marlin_main.cpp:4627
-#: ../../Firmware/Marlin_main.cpp:4678 ../../Firmware/messages.cpp:15
-#: ../../Firmware/ultralcd.cpp:1391 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/Marlin_main.cpp:4247 ../../Firmware/messages.cpp:15
+#: ../../Firmware/ultralcd.cpp:1401 ../../Firmware/ultralcd.cpp:4197
 msgid "Bed"
 msgstr "Podloga"
 
 #. MSG_BED_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6240 ../../Firmware/messages.cpp:17
+#: ../../Firmware/Marlin_main.cpp:5470 ../../Firmware/messages.cpp:17
 #: ../../Firmware/ultralcd.cpp:534
 msgid "Bed Heating"
 msgstr "Podloga se zagrijava"
 
 #. MSG_BED_DONE c=20
-#: ../../Firmware/Marlin_main.cpp:6277 ../../Firmware/messages.cpp:16
+#: ../../Firmware/Marlin_main.cpp:5507 ../../Firmware/messages.cpp:16
 #: ../../Firmware/ultralcd.cpp:537
 msgid "Bed done"
 msgstr "Podloga zagrijana"
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/messages.cpp:317 ../../Firmware/ultralcd.cpp:4589
+#: ../../Firmware/messages.cpp:329 ../../Firmware/ultralcd.cpp:4545
 msgid "Bed level correct"
 msgstr "Podloga ispravna"
 
 #. MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:2262 ../../Firmware/Marlin_main.cpp:2999
-#: ../../Firmware/Marlin_main.cpp:3008
-#: ../../Firmware/mesh_bed_calibration.cpp:2878
-#: ../../Firmware/mesh_bed_calibration.cpp:2903 ../../Firmware/messages.cpp:18
+#: ../../Firmware/Marlin_main.cpp:2048 ../../Firmware/Marlin_main.cpp:2736
+#: ../../Firmware/Marlin_main.cpp:2745
+#: ../../Firmware/mesh_bed_calibration.cpp:2863
+#: ../../Firmware/mesh_bed_calibration.cpp:2888 ../../Firmware/messages.cpp:18
 msgid ""
 "Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for "
 "reset."
@@ -165,34 +164,34 @@ msgstr ""
 "mlaznici? Ceka se resetiranje."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/messages.cpp:346 ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/messages.cpp:358 ../../Firmware/ultralcd.cpp:6685
 msgid "Bed/Heater"
 msgstr "Grijac/Podloga"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1444
-#: ../../Firmware/ultralcd.cpp:1704
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1454
+#: ../../Firmware/ultralcd.cpp:1714
 msgid "Belt status"
 msgstr "Status remena"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/messages.cpp:314 ../../Firmware/ultralcd.cpp:4579
+#: ../../Firmware/messages.cpp:326 ../../Firmware/ultralcd.cpp:4535
 msgid "Belt test"
 msgstr "Testiranje remena"
 
 #. MSG_RECOVER_PRINT c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:1660 ../../Firmware/messages.cpp:87
+#: ../../Firmware/Marlin_main.cpp:1587 ../../Firmware/messages.cpp:87
 msgid "Blackout occurred. Recover print?"
 msgstr "Doslo je do gasenja. Oporaviti print?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:177 ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:5594
 msgid "Bright"
 msgstr "Svijet"
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:4526
-#: ../../Firmware/ultralcd.cpp:5546
+#: ../../Firmware/messages.cpp:180 ../../Firmware/ultralcd.cpp:4493
+#: ../../Firmware/ultralcd.cpp:5513
 msgid "Brightness"
 msgstr "Svjetlina"
 
@@ -202,17 +201,17 @@ msgid "COMMUNICATION ERROR"
 msgstr "KOM. GRESKA"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/messages.cpp:316 ../../Firmware/ultralcd.cpp:4583
+#: ../../Firmware/messages.cpp:328 ../../Firmware/ultralcd.cpp:4539
 msgid "Calibrate XYZ"
 msgstr "Kalibrirajte XYZ"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4585
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4541
 msgid "Calibrate Z"
 msgstr "Kalibrirajte Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/messages.cpp:266 ../../Firmware/ultralcd.cpp:2813
+#: ../../Firmware/messages.cpp:278 ../../Firmware/ultralcd.cpp:2830
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -221,13 +220,13 @@ msgstr ""
 "Kliknite kada je zavrseno."
 
 #. MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: ../../Firmware/Marlin_main.cpp:2218 ../../Firmware/messages.cpp:22
+#: ../../Firmware/Marlin_main.cpp:2009 ../../Firmware/messages.cpp:23
 #: ../../Firmware/ultralcd.cpp:582
 msgid "Calibrating Z"
 msgstr "Kalibriracija Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/messages.cpp:265 ../../Firmware/ultralcd.cpp:2812
+#: ../../Firmware/messages.cpp:277 ../../Firmware/ultralcd.cpp:2829
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -236,17 +235,17 @@ msgstr ""
 "Kliknite kada je zavrseno."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/messages.cpp:361 ../../Firmware/ultralcd.cpp:6985
+#: ../../Firmware/messages.cpp:373 ../../Firmware/ultralcd.cpp:6962
 msgid "Calibrating home"
 msgstr "Kalibracija nultocke"
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5375
+#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5342
 msgid "Calibration"
 msgstr "Kalibriranje"
 
 #. MSG_HOMEYZ_DONE c=20
-#: ../../Firmware/messages.cpp:217 ../../Firmware/ultralcd.cpp:593
+#: ../../Firmware/messages.cpp:229 ../../Firmware/ultralcd.cpp:593
 msgid "Calibration done"
 msgstr "Kalibracija gotova"
 
@@ -264,128 +263,128 @@ msgstr ""
 "Nije moguce izvrsiti radnju, filament je već napunjen. Prvo ga isprazni."
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/messages.cpp:364 ../../Firmware/ultralcd.cpp:7405
+#: ../../Firmware/messages.cpp:376 ../../Firmware/ultralcd.cpp:7382
 msgid "Card removed"
 msgstr "Kartica je uklonjena"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/messages.cpp:324 ../../Firmware/ultralcd.cpp:5316
+#: ../../Firmware/messages.cpp:336 ../../Firmware/ultralcd.cpp:5282
 msgid "Change SD card"
 msgstr "Promjeni SD karti."
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5254
-#: ../../Firmware/ultralcd.cpp:5526
+#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5216
+#: ../../Firmware/ultralcd.cpp:5493
 msgid "Change filament"
 msgstr "Promijeni filament"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/messages.cpp:240 ../../Firmware/ultralcd.cpp:2156
+#: ../../Firmware/messages.cpp:252 ../../Firmware/ultralcd.cpp:2167
 msgid "Change success!"
 msgstr "Promijena uspjesna!"
 
 #. MSG_CORRECTLY c=19
-#: ../../Firmware/messages.cpp:242 ../../Firmware/ultralcd.cpp:2203
+#: ../../Firmware/messages.cpp:254 ../../Firmware/ultralcd.cpp:2217
 msgid "Changed correctly"
 msgstr "Ispravno izmjenjeno"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5951
-#: ../../Firmware/ultralcd.cpp:6975
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5927
+#: ../../Firmware/ultralcd.cpp:6952
 msgid "Checking X axis"
 msgstr "Provjera X osi"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5961
-#: ../../Firmware/ultralcd.cpp:6976
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:5937
+#: ../../Firmware/ultralcd.cpp:6953
 msgid "Checking Y axis"
 msgstr "Provjera Y osi"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/messages.cpp:358 ../../Firmware/ultralcd.cpp:6977
+#: ../../Firmware/messages.cpp:370 ../../Firmware/ultralcd.cpp:6954
 msgid "Checking Z axis"
 msgstr "Provjera Z osi"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6978
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6955
 msgid "Checking bed"
 msgstr "Provjera podloge"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/messages.cpp:357 ../../Firmware/ultralcd.cpp:6974
+#: ../../Firmware/messages.cpp:369 ../../Firmware/ultralcd.cpp:6951
 msgid "Checking endstops"
 msgstr "Provjera granicnika"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/messages.cpp:362 ../../Firmware/ultralcd.cpp:7070
+#: ../../Firmware/messages.cpp:374 ../../Firmware/ultralcd.cpp:7047
 msgid "Checking file"
 msgstr "Provjera datoteke"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/messages.cpp:359 ../../Firmware/ultralcd.cpp:6980
+#: ../../Firmware/messages.cpp:371 ../../Firmware/ultralcd.cpp:6957
 msgid "Checking hotend"
 msgstr "Provjera hotenda"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6981
-#: ../../Firmware/ultralcd.cpp:6982
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6958
+#: ../../Firmware/ultralcd.cpp:6959
 msgid "Checking sensors"
 msgstr "Provjera senzora"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/messages.cpp:308 ../../Firmware/ultralcd.cpp:4424
+#: ../../Firmware/messages.cpp:320 ../../Firmware/ultralcd.cpp:4391
 msgid "Checks"
 msgstr "Provjere"
 
 #. MSG_TM_ACK_ERROR c=18
-#: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5297
+#: ../../Firmware/messages.cpp:197 ../../Firmware/ultralcd.cpp:5263
 msgid "Clear TM error"
 msgstr "Obriši TM pogrešku"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/messages.cpp:244 ../../Firmware/ultralcd.cpp:2205
+#: ../../Firmware/messages.cpp:256 ../../Firmware/ultralcd.cpp:2219
 msgid "Color not correct"
 msgstr "Boja nije ispravna"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:3508
+#: ../../Firmware/messages.cpp:27 ../../Firmware/ultralcd.cpp:3518
 msgid "Community made"
 msgstr "Napravilo zajedno"
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:4059
+#: ../../Firmware/messages.cpp:178 ../../Firmware/ultralcd.cpp:4083
 msgid "Cont."
 msgstr "Nast."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:2129
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2135
 msgid "Cooldown"
 msgstr "Ohladi"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/messages.cpp:283 ../../Firmware/ultralcd.cpp:3450
+#: ../../Firmware/messages.cpp:295 ../../Firmware/ultralcd.cpp:3460
 msgid "Copy selected language?"
 msgstr "Kopirati odabrani jezik?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:1234
-#: ../../Firmware/ultralcd.cpp:1263
+#: ../../Firmware/messages.cpp:30 ../../Firmware/ultralcd.cpp:1244
+#: ../../Firmware/ultralcd.cpp:1273
 msgid "Crash"
 msgstr "Udar"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4146
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/ultralcd.cpp:4170
 msgid "Crash det."
 msgstr "Udar detekti."
 
 #. MSG_CRASH_DETECTED c=20
-#: ../../Firmware/Marlin_main.cpp:630 ../../Firmware/messages.cpp:30
+#: ../../Firmware/Marlin_main.cpp:595 ../../Firmware/messages.cpp:31
 msgid "Crash detected."
 msgstr "Udar otkriven."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/messages.cpp:280 ../../Firmware/ultralcd.cpp:3374
+#: ../../Firmware/messages.cpp:292 ../../Firmware/ultralcd.cpp:3384
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -393,24 +392,24 @@ msgid ""
 msgstr "Detekcija udarca moze biti ukljuceno samo u Normalnom nacinu rada"
 
 #. MSG_CUT_FILAMENT c=16
-#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:380
-#: ../../Firmware/ultralcd.cpp:4854 ../../Firmware/ultralcd.cpp:5351
+#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:381
+#: ../../Firmware/ultralcd.cpp:4810 ../../Firmware/ultralcd.cpp:5317
 msgid "Cut filament"
 msgstr "Odrezite fil."
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4081
-#: ../../Firmware/ultralcd.cpp:4086 ../../Firmware/ultralcd.cpp:4091
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:4105
+#: ../../Firmware/ultralcd.cpp:4110 ../../Firmware/ultralcd.cpp:4115
 msgid "Cutter"
 msgstr "Rezac"
 
 #. MSG_DATE c=17
-#: ../../Firmware/messages.cpp:222 ../../Firmware/ultralcd.cpp:1645
+#: ../../Firmware/messages.cpp:234 ../../Firmware/ultralcd.cpp:1655
 msgid "Date:"
 msgstr "Datum:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:178 ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/messages.cpp:185 ../../Firmware/ultralcd.cpp:5594
 msgid "Dim"
 msgstr "Tamno"
 
@@ -420,7 +419,7 @@ msgid "Disable"
 msgstr "Onemogu."
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/messages.cpp:311 ../../Firmware/ultralcd.cpp:4460
+#: ../../Firmware/messages.cpp:323 ../../Firmware/ultralcd.cpp:4427
 msgid "Disable steppers"
 msgstr "Onemoguci stepere"
 
@@ -432,7 +431,7 @@ msgid "Disengaging idler"
 msgstr "Iskl. kliznika"
 
 #. MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: ../../Firmware/Marlin_main.cpp:1610 ../../Firmware/Marlin_main.cpp:3334
+#: ../../Firmware/Marlin_main.cpp:1537 ../../Firmware/Marlin_main.cpp:3073
 #: ../../Firmware/messages.cpp:14
 msgid ""
 "Distance between tip of the nozzle and the bed surface has not been set yet."
@@ -444,7 +443,7 @@ msgstr ""
 "prvog sloja."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/messages.cpp:301 ../../Firmware/ultralcd.cpp:3923
+#: ../../Firmware/messages.cpp:313 ../../Firmware/ultralcd.cpp:3947
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -453,13 +452,13 @@ msgstr ""
 "mlaznice i grijace podloge?"
 
 #. MSG_DONE c=8
-#: ../../Firmware/messages.cpp:32 ../../Firmware/mmu2/errors_list.h:367
-#: ../../Firmware/mmu2_reporting.cpp:456
+#: ../../Firmware/messages.cpp:33 ../../Firmware/mmu2/errors_list.h:367
+#: ../../Firmware/mmu2_reporting.cpp:457
 msgid "Done"
 msgstr "Gotov"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/messages.cpp:307 ../../Firmware/ultralcd.cpp:3990
+#: ../../Firmware/messages.cpp:319 ../../Firmware/ultralcd.cpp:4014
 msgid "E-correct"
 msgstr "E-ispravan"
 
@@ -488,13 +487,13 @@ msgid "ERR Wait for User"
 msgstr "ERR Cekam korisnika"
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:2253
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:2267
 msgid "ERROR:"
 msgstr "POGRESKA:"
 
 #. MSG_EJECT_FROM_MMU c=16
-#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:384
-#: ../../Firmware/ultralcd.cpp:4845 ../../Firmware/ultralcd.cpp:5348
+#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:385
+#: ../../Firmware/ultralcd.cpp:4801 ../../Firmware/ultralcd.cpp:5314
 msgid "Eject from MMU"
 msgstr "Izbaci iz MMU"
 
@@ -506,17 +505,17 @@ msgid "Ejecting filament"
 msgstr "Izbacivanje fil."
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/messages.cpp:348 ../../Firmware/ultralcd.cpp:6722
+#: ../../Firmware/messages.cpp:360 ../../Firmware/ultralcd.cpp:6698
 msgid "Endstop"
 msgstr "Granicnik"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/messages.cpp:349 ../../Firmware/ultralcd.cpp:6727
+#: ../../Firmware/messages.cpp:361 ../../Firmware/ultralcd.cpp:6703
 msgid "Endstop not hit"
 msgstr "Granicnik nije aktiv"
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/messages.cpp:347 ../../Firmware/ultralcd.cpp:6713
+#: ../../Firmware/messages.cpp:359 ../../Firmware/ultralcd.cpp:6689
 msgid "Endstops"
 msgstr "Granicnici"
 
@@ -528,30 +527,30 @@ msgid "Engaging idler"
 msgstr "Angaziranje klizaca"
 
 #. MSG_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:3352
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:3362
 msgid "Extruder"
 msgstr "Ekstruder"
 
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/messages.cpp:227 ../../Firmware/ultralcd.cpp:1700
+#: ../../Firmware/messages.cpp:239 ../../Firmware/ultralcd.cpp:1710
 msgid "Extruder info"
 msgstr "Info o ekstruderu"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4044
-#: ../../Firmware/ultralcd.cpp:4051
+#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4068
+#: ../../Firmware/ultralcd.cpp:4075
 msgid "F. autoload"
 msgstr "F. auto.punj"
 
 #. MSG_FSENSOR_JAM_DETECTION c=13
-#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4046
-#: ../../Firmware/ultralcd.cpp:4053
+#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4070
+#: ../../Firmware/ultralcd.cpp:4077
 msgid "F. jam detect"
 msgstr "F. zastopan"
 
 #. MSG_FSENSOR_RUNOUT c=13
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4074
 msgid "F. runout"
 msgstr "F. isteko"
 
@@ -589,8 +588,8 @@ msgid "FINDA FILAM. STUCK"
 msgstr "FINDA FILAM. ZAPEO"
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:4059
-#: ../../Firmware/ultralcd.cpp:4062
+#: ../../Firmware/messages.cpp:177 ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/ultralcd.cpp:4086
 msgid "FS Action"
 msgstr "FS Akcija"
 
@@ -615,34 +614,34 @@ msgid "FW RUNTIME ERROR"
 msgstr "FW GRESKA IZVRSENJA"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/messages.cpp:330 ../../Firmware/ultralcd.cpp:5382
+#: ../../Firmware/messages.cpp:342 ../../Firmware/ultralcd.cpp:5349
 msgid "Fail stats"
 msgstr "Neuspjesna stat"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/messages.cpp:331 ../../Firmware/ultralcd.cpp:5385
+#: ../../Firmware/messages.cpp:343 ../../Firmware/ultralcd.cpp:5352
 msgid "Fail stats MMU"
 msgstr "Neuspjes. MMU stat"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/messages.cpp:355 ../../Firmware/ultralcd.cpp:6768
+#: ../../Firmware/messages.cpp:367 ../../Firmware/ultralcd.cpp:6744
 msgid "False triggering"
 msgstr "Lazno aktiviranje"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4175
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4199
 msgid "Fan speed"
 msgstr "Brzina vent"
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6844
-#: ../../Firmware/ultralcd.cpp:6971 ../../Firmware/ultralcd.cpp:6972
-#: ../../Firmware/ultralcd.cpp:6973
+#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6820
+#: ../../Firmware/ultralcd.cpp:6948 ../../Firmware/ultralcd.cpp:6949
+#: ../../Firmware/ultralcd.cpp:6950
 msgid "Fan test"
 msgstr "Test ventilatora"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:4179
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:4203
 msgid "Fans check"
 msgstr "Provjera vent"
 
@@ -671,34 +670,34 @@ msgid "Feeding to nozzle"
 msgstr "Dovod do mlaznice"
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1233
-#: ../../Firmware/ultralcd.cpp:1262 ../../Firmware/ultralcd.cpp:1316
-#: ../../Firmware/ultralcd.cpp:1318
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:1243
+#: ../../Firmware/ultralcd.cpp:1272 ../../Firmware/ultralcd.cpp:1326
+#: ../../Firmware/ultralcd.cpp:1328
 msgid "Fil. runouts"
 msgstr "Bez filmaneta"
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3313
-#: ../../Firmware/ultralcd.cpp:4039 ../../Firmware/ultralcd.cpp:4464
-#: ../../Firmware/ultralcd.cpp:5532
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3323
+#: ../../Firmware/ultralcd.cpp:4063 ../../Firmware/ultralcd.cpp:4431
+#: ../../Firmware/ultralcd.cpp:5499
 msgid "Fil. sensor"
 msgstr "Fil. senzor"
 
 #. MSG_FILAMENT_CLEAN c=20 r=3
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2261
-#: ../../Firmware/ultralcd.cpp:2265
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2275
+#: ../../Firmware/ultralcd.cpp:2279
 msgid "Filament extruding & with correct color?"
 msgstr "Ekstrudiranje fil.s sa ispravnom bojom?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/messages.cpp:243 ../../Firmware/ultralcd.cpp:2204
+#: ../../Firmware/messages.cpp:255 ../../Firmware/ultralcd.cpp:2218
 msgid "Filament not loaded"
 msgstr "Fil. nije napunjen"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6763
-#: ../../Firmware/ultralcd.cpp:6767 ../../Firmware/ultralcd.cpp:6771
-#: ../../Firmware/ultralcd.cpp:7000
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6739
+#: ../../Firmware/ultralcd.cpp:6743 ../../Firmware/ultralcd.cpp:6747
+#: ../../Firmware/ultralcd.cpp:6977
 msgid "Filament sensor"
 msgstr "Senzor filamenta"
 
@@ -730,42 +729,42 @@ msgstr ""
 " li je nešto zapelo u PTFE cijevi. Ocitava li senzor ispravno."
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/messages.cpp:246 ../../Firmware/ultralcd.cpp:2347
+#: ../../Firmware/messages.cpp:258 ../../Firmware/ultralcd.cpp:2364
 msgid "Filament used"
 msgstr "Iskoristeni fil."
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/messages.cpp:363 ../../Firmware/ultralcd.cpp:7139
+#: ../../Firmware/messages.cpp:375 ../../Firmware/ultralcd.cpp:7116
 msgid "File incomplete. Continue anyway?"
 msgstr "Datoteka je nepotpuna. Svejedno nastaviti?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
 #: ../../Firmware/messages.cpp:45
 #: ../../Firmware/mmu2_progress_converter.cpp:43
-#: ../../Firmware/ultralcd.cpp:5021 ../../Firmware/ultralcd.cpp:5425
+#: ../../Firmware/ultralcd.cpp:4977 ../../Firmware/ultralcd.cpp:5392
 msgid "Finishing movements"
 msgstr "Zavrsni pokreti"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4575
-#: ../../Firmware/ultralcd.cpp:5141
+#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4531
+#: ../../Firmware/ultralcd.cpp:5101
 msgid "First layer cal."
 msgstr "Prvi sloj kalib."
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/messages.cpp:293 ../../Firmware/ultralcd.cpp:3846
+#: ../../Firmware/messages.cpp:305 ../../Firmware/ultralcd.cpp:3872
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Prvo cu pokrenuti samotestiranje kako bih provjerio najcesce probleme sa "
 "montazom."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/messages.cpp:334 ../../Firmware/ultralcd.cpp:5520
+#: ../../Firmware/messages.cpp:346 ../../Firmware/ultralcd.cpp:5487
 msgid "Flow"
 msgstr "Protok"
 
 #. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
-#: ../../Firmware/messages.cpp:194 ../../Firmware/ultralcd.cpp:985
+#: ../../Firmware/messages.cpp:201 ../../Firmware/ultralcd.cpp:987
 msgid ""
 "For a Nozzle change please read\n"
 "prusa.io/nozzle-mk3s"
@@ -774,28 +773,28 @@ msgstr ""
 "prusa.io/nozzle-mk3s"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6733
-#: ../../Firmware/ultralcd.cpp:6850 ../../Firmware/ultralcd.cpp:6855
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/ultralcd.cpp:6826 ../../Firmware/ultralcd.cpp:6831
 msgid "Front print fan?"
 msgstr "Prednji print vent?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/messages.cpp:260 ../../Firmware/ultralcd.cpp:2711
+#: ../../Firmware/messages.cpp:272 ../../Firmware/ultralcd.cpp:2728
 msgid "Front side[µm]"
 msgstr "Prednj str[µm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/messages.cpp:353 ../../Firmware/ultralcd.cpp:6757
+#: ../../Firmware/messages.cpp:365 ../../Firmware/ultralcd.cpp:6733
 msgid "Front/left fans"
 msgstr "Prednji/lijevi vent"
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:151 ../../Firmware/util.cpp:382
+#: ../../Firmware/messages.cpp:156 ../../Firmware/util.cpp:417
 msgid "G-code sliced for a different level. Continue?"
 msgstr "G-kod izrezan za drugu razinu. Nastavite?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:152 ../../Firmware/util.cpp:383
+#: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:418
 msgid ""
 "G-code sliced for a different level. Please re-slice the model again. Print "
 "cancelled."
@@ -804,14 +803,14 @@ msgstr ""
 "otkazan."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:147 ../../Firmware/util.cpp:312
-#: ../../Firmware/util.cpp:401
+#: ../../Firmware/messages.cpp:152 ../../Firmware/util.cpp:319
+#: ../../Firmware/util.cpp:436
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr "G-kod izrezan za drugu vrstu printera. Nastavite?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:148 ../../Firmware/util.cpp:313
-#: ../../Firmware/util.cpp:402
+#: ../../Firmware/messages.cpp:153 ../../Firmware/util.cpp:320
+#: ../../Firmware/util.cpp:437
 msgid ""
 "G-code sliced for a different printer type. Please re-slice the model again."
 " Print cancelled."
@@ -820,12 +819,12 @@ msgstr ""
 "je otkazan."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:149 ../../Firmware/util.cpp:362
+#: ../../Firmware/messages.cpp:154 ../../Firmware/util.cpp:369
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "G-kod izrezan za noviji firmware. Nastavite?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:150 ../../Firmware/util.cpp:363
+#: ../../Firmware/messages.cpp:155 ../../Firmware/util.cpp:370
 msgid ""
 "G-code sliced for a newer firmware. Please update the firmware. Print "
 "cancelled."
@@ -834,35 +833,35 @@ msgstr ""
 "otkazan."
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4366
-#: ../../Firmware/ultralcd.cpp:4383 ../../Firmware/ultralcd.cpp:4485
+#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4325
+#: ../../Firmware/ultralcd.cpp:4343 ../../Firmware/ultralcd.cpp:4452
 msgid "HW Setup"
 msgstr "HW podesavanje"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/messages.cpp:344 ../../Firmware/ultralcd.cpp:6705
+#: ../../Firmware/messages.cpp:356 ../../Firmware/ultralcd.cpp:6681
 msgid "Heater/Thermistor"
 msgstr "Grijac/Termostat"
 
 #. MSG_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6184 ../../Firmware/messages.cpp:52
+#: ../../Firmware/Marlin_main.cpp:5416 ../../Firmware/messages.cpp:52
 #: ../../Firmware/ultralcd.cpp:526
 msgid "Heating"
 msgstr "Grijanje"
 
 #. MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:9647 ../../Firmware/messages.cpp:211
+#: ../../Firmware/Marlin_main.cpp:8807 ../../Firmware/messages.cpp:223
 msgid "Heating disabled by safety timer."
 msgstr "Grijanje je onemoguceno sigurnosnim mjeracem vremena."
 
 #. MSG_HEATING_COMPLETE c=20
-#: ../../Firmware/Marlin_main.cpp:6215 ../../Firmware/messages.cpp:53
+#: ../../Firmware/Marlin_main.cpp:5445 ../../Firmware/messages.cpp:53
 #: ../../Firmware/ultralcd.cpp:529
 msgid "Heating done."
 msgstr "Grijanje obavljeno."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=12
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:3806
+#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:3832
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -873,7 +872,7 @@ msgstr ""
 "printanje."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:3810
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:3836
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -882,8 +881,8 @@ msgstr ""
 "postupak postavljanja?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4152
-#: ../../Firmware/ultralcd.cpp:4161
+#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:4176
+#: ../../Firmware/ultralcd.cpp:4185
 msgid "High power"
 msgstr "Visoka sna"
 
@@ -894,24 +893,24 @@ msgid "Homing"
 msgstr "Navodjenje"
 
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
-#: ../../Firmware/messages.cpp:195 ../../Firmware/ultralcd.cpp:1005
+#: ../../Firmware/messages.cpp:206 ../../Firmware/ultralcd.cpp:1011
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr ""
 "Zagrijati na 280C! Mlaznica promijenjena i stegnuta prema specifikacijama?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1106
-#: ../../Firmware/ultralcd.cpp:6991
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1116
+#: ../../Firmware/ultralcd.cpp:6968
 msgid "Hotend fan:"
 msgstr "Hotend vent:"
 
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/messages.cpp:294 ../../Firmware/ultralcd.cpp:3851
+#: ../../Firmware/messages.cpp:306 ../../Firmware/ultralcd.cpp:3877
 msgid "I will run xyz calibration now. It will take up to 24 mins."
 msgstr "Sada cu pokrenuti xyz kalibraciju. Trebat ce do 24 min."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/messages.cpp:297 ../../Firmware/ultralcd.cpp:3862
+#: ../../Firmware/messages.cpp:309 ../../Firmware/ultralcd.cpp:3884
 msgid "I will run z calibration now."
 msgstr "Sada cu pokrenuti z kalibraciju."
 
@@ -936,7 +935,7 @@ msgid "INVALID TOOL"
 msgstr "NEVALJAN ALAT"
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=8
-#: ../../Firmware/messages.cpp:303 ../../Firmware/ultralcd.cpp:3931
+#: ../../Firmware/messages.cpp:315 ../../Firmware/ultralcd.cpp:3955
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -945,28 +944,28 @@ msgstr ""
 "postavke u Postavke - HW Podesavanje - Celicne ploce."
 
 #. MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2540
-#: ../../Firmware/messages.cpp:213
+#: ../../Firmware/mesh_bed_calibration.cpp:2525
+#: ../../Firmware/messages.cpp:225
 msgid "Improving bed calibration point"
 msgstr "Poboljšanje točke kalibracije podloge"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:5222
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:5184
 msgid "Info screen"
 msgstr "Info zaslon"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/messages.cpp:326 ../../Firmware/ultralcd.cpp:5323
+#: ../../Firmware/messages.cpp:338 ../../Firmware/ultralcd.cpp:5289
 msgid "Init. SD card"
 msgstr "Obrada SD kartice"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/messages.cpp:238 ../../Firmware/ultralcd.cpp:2142
+#: ../../Firmware/messages.cpp:250 ../../Firmware/ultralcd.cpp:2148
 msgid "Insert filament"
 msgstr "Umetnite filament"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/messages.cpp:335 ../../Firmware/ultralcd.cpp:5998
+#: ../../Firmware/messages.cpp:347 ../../Firmware/ultralcd.cpp:5974
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
@@ -982,115 +981,115 @@ msgstr ""
 "firmware."
 
 #. MSG_FILAMENT_LOADED c=20 r=3
-#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3628
-#: ../../Firmware/ultralcd.cpp:3890
+#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3638
+#: ../../Firmware/ultralcd.cpp:3914
 msgid "Is filament loaded?"
 msgstr "Je li filament napunjen?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3238 ../../Firmware/Marlin_main.cpp:4745
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:3858
+#: ../../Firmware/Marlin_main.cpp:4314 ../../Firmware/messages.cpp:127
+#: ../../Firmware/ultralcd.cpp:3760
 msgid "Is steel sheet on heatbed?"
 msgstr "Je li celicna ploca na grijanoj podlozi?"
 
 #. MSG_ITERATION c=12
-#: ../../Firmware/mesh_bed_calibration.cpp:2265 ../../Firmware/messages.cpp:55
+#: ../../Firmware/mesh_bed_calibration.cpp:2250 ../../Firmware/messages.cpp:55
 msgid "Iteration"
 msgstr "Ponavljanje"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1128
-#: ../../Firmware/ultralcd.cpp:1286
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1138
+#: ../../Firmware/ultralcd.cpp:1296
 msgid "Last print"
 msgstr "Zadnji print"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1152
-#: ../../Firmware/ultralcd.cpp:1260 ../../Firmware/ultralcd.cpp:1315
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1162
+#: ../../Firmware/ultralcd.cpp:1270 ../../Firmware/ultralcd.cpp:1325
 msgid "Last print failures"
 msgstr "Zadnji neusp. print"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/messages.cpp:251 ../../Firmware/ultralcd.cpp:2478
+#: ../../Firmware/messages.cpp:263 ../../Firmware/ultralcd.cpp:2495
 msgid "Left"
 msgstr "Lijevo"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6739
-#: ../../Firmware/ultralcd.cpp:6850 ../../Firmware/ultralcd.cpp:6855
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6715
+#: ../../Firmware/ultralcd.cpp:6826 ../../Firmware/ultralcd.cpp:6831
 msgid "Left hotend fan?"
 msgstr "Lijevi hotend vent?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/messages.cpp:258 ../../Firmware/ultralcd.cpp:2709
+#: ../../Firmware/messages.cpp:270 ../../Firmware/ultralcd.cpp:2726
 msgid "Left side [µm]"
 msgstr "Lijeva str[µm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:5619
+#: ../../Firmware/messages.cpp:181 ../../Firmware/ultralcd.cpp:5592
 msgid "Level Bright"
 msgstr "Razina svjet"
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:175 ../../Firmware/ultralcd.cpp:5620
+#: ../../Firmware/messages.cpp:182 ../../Firmware/ultralcd.cpp:5593
 msgid "Level Dimmed"
 msgstr "Razina zatam"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/messages.cpp:312 ../../Firmware/ultralcd.cpp:4491
+#: ../../Firmware/messages.cpp:324 ../../Firmware/ultralcd.cpp:4458
 msgid "Lin. correction"
 msgstr "Lin. ispravak"
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4501
-#: ../../Firmware/ultralcd.cpp:5251
+#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4468
+#: ../../Firmware/ultralcd.cpp:5213
 msgid "Live adjust Z"
 msgstr "Live podesavanje Z"
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/messages.cpp:192 ../../Firmware/ultralcd.cpp:4794
-#: ../../Firmware/ultralcd.cpp:4880
+#: ../../Firmware/messages.cpp:199 ../../Firmware/ultralcd.cpp:4750
+#: ../../Firmware/ultralcd.cpp:4836
 msgid "Load All"
 msgstr "Puni sve"
 
 #. MSG_LOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4796
-#: ../../Firmware/ultralcd.cpp:4833 ../../Firmware/ultralcd.cpp:4882
-#: ../../Firmware/ultralcd.cpp:5361 ../../Firmware/ultralcd.cpp:5368
+#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4752
+#: ../../Firmware/ultralcd.cpp:4789 ../../Firmware/ultralcd.cpp:4838
+#: ../../Firmware/ultralcd.cpp:5324 ../../Firmware/ultralcd.cpp:5335
 msgid "Load filament"
 msgstr "Napunite fil."
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/messages.cpp:327 ../../Firmware/ultralcd.cpp:5346
+#: ../../Firmware/messages.cpp:339 ../../Firmware/ultralcd.cpp:5312
 msgid "Load to nozzle"
 msgstr "Punjenje u mlazn"
 
 #. MSG_LOADING_TEST c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4476
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4443
 msgid "Loading Test"
 msgstr "Punjenje test"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/messages.cpp:241 ../../Firmware/ultralcd.cpp:2178
+#: ../../Firmware/messages.cpp:253 ../../Firmware/ultralcd.cpp:2189
 msgid "Loading color"
 msgstr "Ucitavanje boje"
 
 #. MSG_LOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3598 ../../Firmware/messages.cpp:62
+#: ../../Firmware/Marlin_main.cpp:3343 ../../Firmware/messages.cpp:62
 #: ../../Firmware/mmu2_progress_converter.cpp:51
-#: ../../Firmware/mmu2_reporting.cpp:392 ../../Firmware/ultralcd.cpp:2189
-#: ../../Firmware/ultralcd.cpp:3715
+#: ../../Firmware/mmu2_reporting.cpp:393 ../../Firmware/ultralcd.cpp:2199
+#: ../../Firmware/ultralcd.cpp:3725
 msgid "Loading filament"
 msgstr "Punjenje filamenta"
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/messages.cpp:350 ../../Firmware/ultralcd.cpp:6745
+#: ../../Firmware/messages.cpp:362 ../../Firmware/ultralcd.cpp:6721
 msgid "Loose pulley"
 msgstr "Labava remenica"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4188
-#: ../../Firmware/ultralcd.cpp:4200
+#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4224
 msgid "Loud"
 msgstr "Glasno"
 
@@ -1105,7 +1104,7 @@ msgid "MMU Firmware internal error, please reset the MMU."
 msgstr "Interna pogreska firmware MMU-a, resetirajte MMU."
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:4096
+#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4120
 msgid "MMU Mode"
 msgstr "MMU Mod"
 
@@ -1115,7 +1114,7 @@ msgid "MMU NOT RESPONDING"
 msgstr "MMU NE ODGOVARA"
 
 #. MSG_MMU_RESTORE_TEMP c=20 r=4
-#: ../../Firmware/messages.cpp:214 ../../Firmware/mmu2_reporting.cpp:396
+#: ../../Firmware/messages.cpp:226 ../../Firmware/mmu2_reporting.cpp:397
 msgid "MMU Retry: Restoring temperature..."
 msgstr "MMU Ponovni pokusaj: Vracanje temperature..."
 
@@ -1126,14 +1125,14 @@ msgid "MMU SELFTEST FAILED"
 msgstr "MMU SELFTEST N USPIO"
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1153
-#: ../../Firmware/ultralcd.cpp:1178
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1163
+#: ../../Firmware/ultralcd.cpp:1188
 msgid "MMU fails"
 msgstr "MMU ne uspijeva"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1154
-#: ../../Firmware/ultralcd.cpp:1179
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1164
+#: ../../Firmware/ultralcd.cpp:1189
 msgid "MMU load fails"
 msgstr "Neusp. MMU punj"
 
@@ -1148,66 +1147,64 @@ msgid "MMU not responding. Check the wiring and connectors."
 msgstr "MMU ne reagira. Provjerite ozicenje i konektore."
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/messages.cpp:223 ../../Firmware/ultralcd.cpp:1657
+#: ../../Firmware/messages.cpp:235 ../../Firmware/ultralcd.cpp:1667
 msgid "MMU connected"
 msgstr "MMU spojen"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/messages.cpp:176 ../../Firmware/ultralcd.cpp:5567
 msgid "Magnets comp."
 msgstr "Magnet. komp."
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1127
-#: ../../Firmware/ultralcd.cpp:1285 ../../Firmware/ultralcd.cpp:1327
-#: ../../Firmware/ultralcd.cpp:1631 ../../Firmware/ultralcd.cpp:4453
-#: ../../Firmware/ultralcd.cpp:4571 ../../Firmware/ultralcd.cpp:4793
-#: ../../Firmware/ultralcd.cpp:4826 ../../Firmware/ultralcd.cpp:4879
-#: ../../Firmware/ultralcd.cpp:5515
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1137
+#: ../../Firmware/ultralcd.cpp:1295 ../../Firmware/ultralcd.cpp:1337
+#: ../../Firmware/ultralcd.cpp:1641 ../../Firmware/ultralcd.cpp:4420
+#: ../../Firmware/ultralcd.cpp:4527 ../../Firmware/ultralcd.cpp:4749
+#: ../../Firmware/ultralcd.cpp:4782 ../../Firmware/ultralcd.cpp:4835
+#: ../../Firmware/ultralcd.cpp:5482
 msgid "Main"
 msgstr "Nazad"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/messages.cpp:253 ../../Firmware/ultralcd.cpp:2519
+#: ../../Firmware/messages.cpp:265 ../../Firmware/ultralcd.cpp:2536
 msgid "Measured skew"
 msgstr "Mjereni nagib"
 
 #. MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3219
-#: ../../Firmware/mesh_bed_calibration.cpp:2852 ../../Firmware/messages.cpp:70
+#: ../../Firmware/Marlin_main.cpp:2963
+#: ../../Firmware/mesh_bed_calibration.cpp:2837 ../../Firmware/messages.cpp:70
 msgid "Measuring reference height of calibration point"
 msgstr "Mjerenje referentne visine kalibracijske tocke"
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:5590
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:5563
 msgid "Mesh"
 msgstr "Mreza"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4488
-#: ../../Firmware/ultralcd.cpp:4587
+#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:4455
+#: ../../Firmware/ultralcd.cpp:4543
 msgid "Mesh Bed Leveling"
 msgstr "Izrav. mrez. podl"
 
 #. MSG_MODE c=6
-#: ../../Firmware/Marlin_main.cpp:8495 ../../Firmware/messages.cpp:117
-#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4132
-#: ../../Firmware/ultralcd.cpp:4140 ../../Firmware/ultralcd.cpp:4144
-#: ../../Firmware/ultralcd.cpp:4152 ../../Firmware/ultralcd.cpp:4155
-#: ../../Firmware/ultralcd.cpp:4158 ../../Firmware/ultralcd.cpp:4161
-#: ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/Marlin_main.cpp:7666 ../../Firmware/messages.cpp:121
+#: ../../Firmware/ultralcd.cpp:4152 ../../Firmware/ultralcd.cpp:4156
+#: ../../Firmware/ultralcd.cpp:4164 ../../Firmware/ultralcd.cpp:4168
+#: ../../Firmware/ultralcd.cpp:4176 ../../Firmware/ultralcd.cpp:4179
+#: ../../Firmware/ultralcd.cpp:4182 ../../Firmware/ultralcd.cpp:4185
+#: ../../Firmware/ultralcd.cpp:5594
 msgid "Mode"
 msgstr "Mod"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/messages.cpp:282 ../../Firmware/ultralcd.cpp:3413
+#: ../../Firmware/messages.cpp:294 ../../Firmware/ultralcd.cpp:3423
 msgid "Mode change in progress..."
 msgstr "Promjena moda u tijeku..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:4310
-#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4316
-#: ../../Firmware/ultralcd.cpp:4319
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4327
 msgid "Model"
 msgstr "Model"
 
@@ -1228,28 +1225,28 @@ msgid "More details online."
 msgstr "Vise detalja online."
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6719
-#: ../../Firmware/ultralcd.cpp:6728 ../../Firmware/ultralcd.cpp:6746
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6695
+#: ../../Firmware/ultralcd.cpp:6704 ../../Firmware/ultralcd.cpp:6722
 msgid "Motor"
 msgstr "Motor"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/messages.cpp:277 ../../Firmware/ultralcd.cpp:3349
+#: ../../Firmware/messages.cpp:289 ../../Firmware/ultralcd.cpp:3359
 msgid "Move X"
 msgstr "Pomaknite X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/messages.cpp:278 ../../Firmware/ultralcd.cpp:3350
+#: ../../Firmware/messages.cpp:290 ../../Firmware/ultralcd.cpp:3360
 msgid "Move Y"
 msgstr "Pomaknite Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/messages.cpp:279 ../../Firmware/ultralcd.cpp:3351
+#: ../../Firmware/messages.cpp:291 ../../Firmware/ultralcd.cpp:3361
 msgid "Move Z"
 msgstr "Pomaknite Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/messages.cpp:310 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:322 ../../Firmware/ultralcd.cpp:4426
 msgid "Move axis"
 msgstr "Pomaknite os"
 
@@ -1260,63 +1257,62 @@ msgid "Moving selector"
 msgstr "Pomicanje odabiraca"
 
 #. MSG_NA c=3
-#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:141
-#: ../../Firmware/ultralcd.cpp:2484 ../../Firmware/ultralcd.cpp:2528
-#: ../../Firmware/ultralcd.cpp:3279 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:4044 ../../Firmware/ultralcd.cpp:4046
-#: ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:146
+#: ../../Firmware/ultralcd.cpp:2501 ../../Firmware/ultralcd.cpp:2545
+#: ../../Firmware/ultralcd.cpp:3289 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4068 ../../Firmware/ultralcd.cpp:4070
+#: ../../Firmware/ultralcd.cpp:5567
 msgid "N/A"
 msgstr "N/A"
 
 #. MSG_NEW_FIRMWARE_AVAILABLE c=20 r=2
-#: ../../Firmware/messages.cpp:365 ../../Firmware/util.cpp:209
+#: ../../Firmware/messages.cpp:377 ../../Firmware/util.cpp:214
 msgid "New firmware version available:"
 msgstr "Dostupna nova verzija firmwera:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:3029
-#: ../../Firmware/ultralcd.cpp:4443 ../../Firmware/ultralcd.cpp:4531
-#: ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:2275
+#: ../../Firmware/ultralcd.cpp:2279 ../../Firmware/ultralcd.cpp:3046
+#: ../../Firmware/ultralcd.cpp:4410 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/ultralcd.cpp:5765
 msgid "No"
 msgstr "Ne"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/messages.cpp:325 ../../Firmware/ultralcd.cpp:5321
+#: ../../Firmware/messages.cpp:337 ../../Firmware/ultralcd.cpp:5287
 msgid "No SD card"
 msgstr "Nema SD kartice"
 
 #. MSG_NO_MOVE c=20
-#: ../../Firmware/Marlin_main.cpp:5271 ../../Firmware/messages.cpp:210
+#: ../../Firmware/Marlin_main.cpp:4778 ../../Firmware/messages.cpp:222
 msgid "No move."
 msgstr "Bez pomaka."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4239 ../../Firmware/ultralcd.cpp:4310
-#: ../../Firmware/ultralcd.cpp:4319 ../../Firmware/ultralcd.cpp:4349
-#: ../../Firmware/ultralcd.cpp:4358 ../../Firmware/ultralcd.cpp:4516
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4309
+#: ../../Firmware/ultralcd.cpp:4318 ../../Firmware/ultralcd.cpp:4483
 msgid "None"
 msgstr "Nema"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/Marlin_main.cpp:8497 ../../Firmware/messages.cpp:121
-#: ../../Firmware/ultralcd.cpp:4096 ../../Firmware/ultralcd.cpp:4132
-#: ../../Firmware/ultralcd.cpp:4511
+#: ../../Firmware/Marlin_main.cpp:7668 ../../Firmware/messages.cpp:125
+#: ../../Firmware/ultralcd.cpp:4120 ../../Firmware/ultralcd.cpp:4156
+#: ../../Firmware/ultralcd.cpp:4478
 msgid "Normal"
 msgstr "Normal"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/messages.cpp:345 ../../Firmware/ultralcd.cpp:6706
+#: ../../Firmware/messages.cpp:357 ../../Firmware/ultralcd.cpp:6682
 msgid "Not connected"
 msgstr "Nije povezano"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6863
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6839
 msgid "Not spinning"
 msgstr "Ne okrece se"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/messages.cpp:289 ../../Firmware/ultralcd.cpp:3726
+#: ../../Firmware/messages.cpp:301 ../../Firmware/ultralcd.cpp:3736
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr ""
@@ -1324,33 +1320,31 @@ msgstr ""
 "podloge."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/messages.cpp:298 ../../Firmware/ultralcd.cpp:3871
+#: ../../Firmware/messages.cpp:310 ../../Firmware/ultralcd.cpp:3894
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Sada cu zagrijati mlaznicu za PLA."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/messages.cpp:296 ../../Firmware/ultralcd.cpp:3857
+#: ../../Firmware/messages.cpp:308 ../../Firmware/ultralcd.cpp:3883
 msgid "Now remove the test print from steel sheet."
 msgstr "Sada uklonite probni print sa celicne ploce."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1390
-#: ../../Firmware/ultralcd.cpp:4170 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4233 ../../Firmware/ultralcd.cpp:4236
-#: ../../Firmware/ultralcd.cpp:4239
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1400
+#: ../../Firmware/ultralcd.cpp:4194 ../../Firmware/ultralcd.cpp:4326
 msgid "Nozzle"
 msgstr "Mlaznica"
 
 #. MSG_NOZZLE_CNG_MENU c=18
-#: ../../Firmware/messages.cpp:193 ../../Firmware/ultralcd.cpp:4423
-#: ../../Firmware/ultralcd.cpp:4486
+#: ../../Firmware/messages.cpp:200 ../../Firmware/ultralcd.cpp:4390
+#: ../../Firmware/ultralcd.cpp:4453
 msgid "Nozzle change"
 msgstr "Promjena mlaznice"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4276
-#: ../../Firmware/ultralcd.cpp:4278 ../../Firmware/ultralcd.cpp:4279
-#: ../../Firmware/ultralcd.cpp:4280
+#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4261
+#: ../../Firmware/ultralcd.cpp:4263 ../../Firmware/ultralcd.cpp:4264
+#: ../../Firmware/ultralcd.cpp:4265
 msgid "Nozzle d."
 msgstr "Mlaznica."
 
@@ -1361,81 +1355,81 @@ msgid "OK"
 msgstr "Ok"
 
 #. MSG_OFF c=3
-#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:139
-#: ../../Firmware/mmu2.cpp:65 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4050 ../../Firmware/ultralcd.cpp:4051
-#: ../../Firmware/ultralcd.cpp:4053 ../../Firmware/ultralcd.cpp:4076
-#: ../../Firmware/ultralcd.cpp:4091 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4179 ../../Firmware/ultralcd.cpp:4467
-#: ../../Firmware/ultralcd.cpp:4495 ../../Firmware/ultralcd.cpp:4498
-#: ../../Firmware/ultralcd.cpp:5439 ../../Firmware/ultralcd.cpp:5594
-#: ../../Firmware/ultralcd.cpp:7487 ../../Firmware/ultralcd.cpp:7491
+#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:144
+#: ../../Firmware/mmu2.cpp:65 ../../Firmware/ultralcd.cpp:4063
+#: ../../Firmware/ultralcd.cpp:4074 ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4077 ../../Firmware/ultralcd.cpp:4100
+#: ../../Firmware/ultralcd.cpp:4115 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/ultralcd.cpp:4203 ../../Firmware/ultralcd.cpp:4434
+#: ../../Firmware/ultralcd.cpp:4462 ../../Firmware/ultralcd.cpp:4465
+#: ../../Firmware/ultralcd.cpp:5406 ../../Firmware/ultralcd.cpp:5567
+#: ../../Firmware/ultralcd.cpp:7464 ../../Firmware/ultralcd.cpp:7468
 msgid "Off"
 msgstr "Off"
 
 #. MSG_DEFAULT_SETTINGS_LOADED c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:1562 ../../Firmware/messages.cpp:201
+#: ../../Firmware/Marlin_main.cpp:1489 ../../Firmware/messages.cpp:213
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr "Pronadene stare postavke. Postavit ce se zadani PID, Esteps itd."
 
 #. MSG_ON c=3
-#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:140
-#: ../../Firmware/mmu2.cpp:63 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4050 ../../Firmware/ultralcd.cpp:4051
-#: ../../Firmware/ultralcd.cpp:4053 ../../Firmware/ultralcd.cpp:4076
-#: ../../Firmware/ultralcd.cpp:4081 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4179 ../../Firmware/ultralcd.cpp:4467
-#: ../../Firmware/ultralcd.cpp:4495 ../../Firmware/ultralcd.cpp:4498
-#: ../../Firmware/ultralcd.cpp:5594 ../../Firmware/ultralcd.cpp:7487
-#: ../../Firmware/ultralcd.cpp:7491
+#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:145
+#: ../../Firmware/mmu2.cpp:63 ../../Firmware/ultralcd.cpp:4063
+#: ../../Firmware/ultralcd.cpp:4074 ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4077 ../../Firmware/ultralcd.cpp:4100
+#: ../../Firmware/ultralcd.cpp:4105 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/ultralcd.cpp:4203 ../../Firmware/ultralcd.cpp:4434
+#: ../../Firmware/ultralcd.cpp:4462 ../../Firmware/ultralcd.cpp:4465
+#: ../../Firmware/ultralcd.cpp:5567 ../../Firmware/ultralcd.cpp:7464
+#: ../../Firmware/ultralcd.cpp:7468
 msgid "On"
 msgstr "On"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4191
+#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:4215
 msgid "Once"
 msgstr "Jednom"
 
 #. MSG_PAUSED_THERMAL_ERROR c=20
-#: ../../Firmware/Marlin_main.cpp:9861 ../../Firmware/messages.cpp:186
+#: ../../Firmware/Marlin_main.cpp:9021 ../../Firmware/messages.cpp:193
 msgid "PAUSED THERMAL ERROR"
 msgstr "PAUZIRAN TERMAL EROR"
 
 #. MSG_PID_RUNNING c=20
-#: ../../Firmware/messages.cpp:219 ../../Firmware/ultralcd.cpp:897
+#: ../../Firmware/messages.cpp:231 ../../Firmware/ultralcd.cpp:897
 msgid "PID cal."
 msgstr "PID kal."
 
 #. MSG_PID_FINISHED c=20
-#: ../../Firmware/messages.cpp:220 ../../Firmware/ultralcd.cpp:902
+#: ../../Firmware/messages.cpp:232 ../../Firmware/ultralcd.cpp:902
 msgid "PID cal. finished"
 msgstr "PID kal. zavrsena"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:318 ../../Firmware/ultralcd.cpp:4590
+#: ../../Firmware/messages.cpp:330 ../../Firmware/ultralcd.cpp:4546
 msgid "PID calibration"
 msgstr "PID kalibracija"
 
 #. MSG_PINDA_PREHEAT c=20
-#: ../../Firmware/messages.cpp:218 ../../Firmware/ultralcd.cpp:610
+#: ../../Firmware/messages.cpp:230 ../../Firmware/ultralcd.cpp:610
 msgid "PINDA Heating"
 msgstr "PINDA se Zagrijava"
 
 #. MSG_PINDA_CALIBRATION c=13
-#: ../../Firmware/Marlin_main.cpp:4790 ../../Firmware/Marlin_main.cpp:4892
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:607
-#: ../../Firmware/ultralcd.cpp:4495 ../../Firmware/ultralcd.cpp:4597
+#: ../../Firmware/Marlin_main.cpp:4359 ../../Firmware/Marlin_main.cpp:4461
+#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:607
+#: ../../Firmware/ultralcd.cpp:4462 ../../Firmware/ultralcd.cpp:4553
 msgid "PINDA cal."
 msgstr "PINDA kal."
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/messages.cpp:276 ../../Firmware/ultralcd.cpp:3233
+#: ../../Firmware/messages.cpp:288 ../../Firmware/ultralcd.cpp:3243
 msgid "PINDA calibration failed"
 msgstr "Kalibracija PINDA nije uspjela"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:4967 ../../Firmware/messages.cpp:127
-#: ../../Firmware/ultralcd.cpp:3230
+#: ../../Firmware/Marlin_main.cpp:4536 ../../Firmware/messages.cpp:132
+#: ../../Firmware/ultralcd.cpp:3240
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1455,13 +1449,13 @@ msgid "Parking selector"
 msgstr "Selektor parkiranja"
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:4062
+#: ../../Firmware/messages.cpp:179 ../../Firmware/ultralcd.cpp:4086
 msgid "Pause"
 msgstr "Pauza"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5271
-#: ../../Firmware/ultralcd.cpp:5273
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5237
+#: ../../Firmware/ultralcd.cpp:5239
 msgid "Pause print"
 msgstr "Pauzirajte print"
 
@@ -1472,7 +1466,7 @@ msgid "Performing cut"
 msgstr "Izvodjenje reza"
 
 #. MSG_PAPER c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3243 ../../Firmware/messages.cpp:77
+#: ../../Firmware/Marlin_main.cpp:2982 ../../Firmware/messages.cpp:77
 msgid ""
 "Place a sheet of paper under the nozzle during the calibration of first 4 "
 "points. If the nozzle catches the paper, power off the printer immediately."
@@ -1481,7 +1475,7 @@ msgstr ""
 "mlaznica uhvati papir, odmah iskljucite printer."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:3963
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:3987
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1490,33 +1484,33 @@ msgstr ""
 "ponovnim pokretanjem printera."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/messages.cpp:337 ../../Firmware/ultralcd.cpp:6023
+#: ../../Firmware/messages.cpp:349 ../../Firmware/ultralcd.cpp:5999
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "Provjerite IR prikljucak senzora, izvadite filament ako postoji."
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/messages.cpp:343 ../../Firmware/ultralcd.cpp:6700
+#: ../../Firmware/messages.cpp:355 ../../Firmware/ultralcd.cpp:6676
 msgid "Please check:"
 msgstr "Molimo provjerite:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/messages.cpp:302 ../../Firmware/ultralcd.cpp:3926
+#: ../../Firmware/messages.cpp:314 ../../Firmware/ultralcd.cpp:3950
 msgid "Please clean heatbed and then press the knob."
 msgstr "Ocistite grijacu podlogu, a zatim pritisnite gumb."
 
 #. MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3217 ../../Firmware/messages.cpp:27
+#: ../../Firmware/Marlin_main.cpp:2960 ../../Firmware/messages.cpp:28
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Molimo ocistite mlaznicu radi kalibracije. Kliknite kada ste gotovi."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/messages.cpp:288 ../../Firmware/ultralcd.cpp:3712
+#: ../../Firmware/messages.cpp:300 ../../Firmware/ultralcd.cpp:3722
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr "Umetnite filament u ekstruder, a zatim pritisnite gumb za punjenje."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/messages.cpp:287 ../../Firmware/ultralcd.cpp:3705
+#: ../../Firmware/messages.cpp:299 ../../Firmware/ultralcd.cpp:3715
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1524,104 +1518,103 @@ msgstr ""
 "Umetnite filament u prvu cijev MMU-a, a zatim pritisnite gumb za punjenje."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/messages.cpp:285 ../../Firmware/ultralcd.cpp:3633
+#: ../../Firmware/messages.cpp:297 ../../Firmware/ultralcd.cpp:3643
 msgid "Please load filament first."
 msgstr "Molimo prvo ubacite filament."
 
 #. MSG_CHECK_IDLER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3525 ../../Firmware/messages.cpp:206
+#: ../../Firmware/Marlin_main.cpp:3265 ../../Firmware/messages.cpp:218
 msgid "Please open idler and remove filament manually."
 msgstr "Molimo otvorite klizac i rucno uklonite filament."
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2806 ../../Firmware/messages.cpp:80
-#: ../../Firmware/ultralcd.cpp:3860
+#: ../../Firmware/mesh_bed_calibration.cpp:2791 ../../Firmware/messages.cpp:80
 msgid "Please place steel sheet on heatbed."
 msgstr "Stavite celicnu plocu na grijacu podlogu."
 
 #. MSG_PRESS_TO_UNLOAD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:11215 ../../Firmware/Marlin_main.cpp:11245
+#: ../../Firmware/Marlin_main.cpp:10287 ../../Firmware/Marlin_main.cpp:10317
 #: ../../Firmware/messages.cpp:84
 msgid "Please press the knob to unload filament"
 msgstr "Pritisnite gumb za praznjenje filamenta"
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:4932
+#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:4888
 msgid "Please pull out filament immediately"
 msgstr "Molimo odmah izvucite filament"
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/messages.cpp:295 ../../Firmware/ultralcd.cpp:3856
+#: ../../Firmware/messages.cpp:307 ../../Firmware/ultralcd.cpp:3882
 msgid "Please remove shipping helpers first."
 msgstr "Najprije uklonite prijevozne osloce."
 
 #. MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3240 ../../Firmware/Marlin_main.cpp:4755
-#: ../../Firmware/messages.cpp:89
+#: ../../Firmware/Marlin_main.cpp:4324 ../../Firmware/messages.cpp:89
 msgid "Please remove steel sheet from heatbed."
 msgstr "Molimo uklonite celicnu plocu sa grijace podloge."
 
 #. MSG_RUN_XYZ c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4731 ../../Firmware/messages.cpp:207
+#: ../../Firmware/Marlin_main.cpp:4300 ../../Firmware/messages.cpp:219
 msgid "Please run XYZ calibration first."
 msgstr "Prvo pokrenite XYZ kalibraciju."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/messages.cpp:336 ../../Firmware/ultralcd.cpp:6020
+#: ../../Firmware/messages.cpp:348 ../../Firmware/ultralcd.cpp:4359
+#: ../../Firmware/ultralcd.cpp:5996
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Prvo izvadite filament, a zatim ponovite ovu radnju."
 
 #. MSG_NEW_FIRMWARE_PLEASE_UPGRADE c=20
-#: ../../Firmware/messages.cpp:366 ../../Firmware/util.cpp:213
+#: ../../Firmware/messages.cpp:378 ../../Firmware/util.cpp:218
 msgid "Please upgrade."
 msgstr "Molimo nadogradite."
 
 #. MSG_PLEASE_WAIT c=20
-#: ../../Firmware/Marlin_main.cpp:3521 ../../Firmware/Marlin_main.cpp:8090
-#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:2179
-#: ../../Firmware/ultralcd.cpp:2190
+#: ../../Firmware/Marlin_main.cpp:3261 ../../Firmware/Marlin_main.cpp:7262
+#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:2190
+#: ../../Firmware/ultralcd.cpp:2204
 msgid "Please wait"
 msgstr "Molimo pricekajte"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:1232
-#: ../../Firmware/ultralcd.cpp:1261
+#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:1242
+#: ../../Firmware/ultralcd.cpp:1271
 msgid "Power failures"
 msgstr "Prekidi struje"
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/messages.cpp:323 ../../Firmware/ultralcd.cpp:5260
+#: ../../Firmware/messages.cpp:335 ../../Firmware/ultralcd.cpp:5222
 msgid "Preheat"
 msgstr "Predgrijavanje"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:2254
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:2268
 msgid "Preheat the nozzle!"
 msgstr "Predgr. mlaznicu!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:2771
-#: ../../Firmware/ultralcd.cpp:3690 ../../Firmware/ultralcd.cpp:3692
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:2788
+#: ../../Firmware/ultralcd.cpp:3700 ../../Firmware/ultralcd.cpp:3702
 msgid "Preheating nozzle. Please wait."
 msgstr "Predgrijavanje mlaznice. Molim vas pricekajte."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/messages.cpp:237 ../../Firmware/ultralcd.cpp:1999
+#: ../../Firmware/messages.cpp:249 ../../Firmware/ultralcd.cpp:2005
 msgid "Preheating to cut"
 msgstr "Predgr. za rezanje"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/messages.cpp:236 ../../Firmware/ultralcd.cpp:1996
+#: ../../Firmware/messages.cpp:248 ../../Firmware/ultralcd.cpp:2002
 msgid "Preheating to eject"
 msgstr "Predgr. za izbaci."
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/messages.cpp:234 ../../Firmware/ultralcd.cpp:1987
+#: ../../Firmware/messages.cpp:246 ../../Firmware/ultralcd.cpp:1995
 msgid "Preheating to load"
 msgstr "Predgr. za punjenje"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/messages.cpp:235 ../../Firmware/ultralcd.cpp:1992
+#: ../../Firmware/messages.cpp:247 ../../Firmware/ultralcd.cpp:1999
 msgid "Preheating to unload"
 msgstr "Predgr. za praznj."
 
@@ -1632,12 +1625,12 @@ msgid "Preparing blade"
 msgstr "Priprema ostrice"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/messages.cpp:231 ../../Firmware/ultralcd.cpp:1799
+#: ../../Firmware/messages.cpp:243 ../../Firmware/ultralcd.cpp:1809
 msgid "Press the knob"
 msgstr "Pritisnite gumb"
 
 #. MSG_PRESS_TO_PREHEAT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:11227 ../../Firmware/messages.cpp:212
+#: ../../Firmware/Marlin_main.cpp:10299 ../../Firmware/messages.cpp:224
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Pritisnite gumb za predgrijavanje mlaznice i nastavite."
 
@@ -1647,34 +1640,34 @@ msgid "Print aborted"
 msgstr "Print je prekinut"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1106
-#: ../../Firmware/ultralcd.cpp:6994
+#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1116
+#: ../../Firmware/ultralcd.cpp:6971
 msgid "Print fan:"
 msgstr "Vent printa:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:5313
+#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5279
 msgid "Print from SD"
 msgstr "Printaj sa SD"
 
 #. MSG_PRINT_PAUSED c=20
-#: ../../Firmware/Marlin_main.cpp:3582 ../../Firmware/messages.cpp:79
+#: ../../Firmware/Marlin_main.cpp:3323 ../../Firmware/messages.cpp:79
 #: ../../Firmware/ultralcd.cpp:814
 msgid "Print paused"
 msgstr "Print pauziran"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/messages.cpp:247 ../../Firmware/ultralcd.cpp:2348
+#: ../../Firmware/messages.cpp:259 ../../Firmware/ultralcd.cpp:2365
 msgid "Print time"
 msgstr "Vrijeme printanja"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/messages.cpp:225 ../../Firmware/ultralcd.cpp:1689
+#: ../../Firmware/messages.cpp:237 ../../Firmware/ultralcd.cpp:1699
 msgid "Printer IP Addr:"
 msgstr "Printer IP Adr:"
 
 #. MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1602 ../../Firmware/messages.cpp:46
+#: ../../Firmware/Marlin_main.cpp:1529 ../../Firmware/messages.cpp:46
 msgid ""
 "Printer has not been calibrated yet. Please follow the manual, chapter First"
 " steps, section Calibration flow."
@@ -1683,12 +1676,12 @@ msgstr ""
 "koraci, odjeljak Tijek kalibracije."
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:153 ../../Firmware/util.cpp:289
+#: ../../Firmware/messages.cpp:160 ../../Firmware/util.cpp:296
 msgid "Nozzle diameter differs from the G-code. Continue?"
 msgstr "Promjer mlaznice razlikuje se od G-koda. Nastavite?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:154 ../../Firmware/util.cpp:290
+#: ../../Firmware/messages.cpp:161 ../../Firmware/util.cpp:297
 msgid ""
 "Nozzle diameter differs from the G-code. Please check the value in settings."
 " Print cancelled."
@@ -1715,22 +1708,22 @@ msgid "QUEUE FULL"
 msgstr "RED PUN"
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:4465
 msgid "RPi port"
 msgstr "RPi utor"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/messages.cpp:261 ../../Firmware/ultralcd.cpp:2712
+#: ../../Firmware/messages.cpp:273 ../../Firmware/ultralcd.cpp:2729
 msgid "Rear side [µm]"
 msgstr "Zad. str.[µm]"
 
 #. MSG_RECOVERING_PRINT c=20
-#: ../../Firmware/messages.cpp:216 ../../Firmware/power_panic.cpp:316
+#: ../../Firmware/messages.cpp:228 ../../Firmware/power_panic.cpp:328
 msgid "Recovering print"
 msgstr "Oporavak printa"
 
 #. MSG_RENAME c=18
-#: ../../Firmware/messages.cpp:322 ../../Firmware/ultralcd.cpp:5143
+#: ../../Firmware/messages.cpp:334 ../../Firmware/ultralcd.cpp:5103
 msgid "Rename"
 msgstr "Preimenuj"
 
@@ -1744,19 +1737,19 @@ msgstr ""
 "za indeks alata izvan raspona (T0-T4)."
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:2713
-#: ../../Firmware/ultralcd.cpp:5144
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:2730
+#: ../../Firmware/ultralcd.cpp:5104
 msgid "Reset"
 msgstr "Resetiraj"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/messages.cpp:320 ../../Firmware/ultralcd.cpp:4594
+#: ../../Firmware/messages.cpp:332 ../../Firmware/ultralcd.cpp:4550
 msgid "Reset XYZ calibr."
 msgstr "Reset XYZ kalibr."
 
 #. MSG_RESUME_PRINT c=18
-#: ../../Firmware/Marlin_main.cpp:680 ../../Firmware/messages.cpp:91
-#: ../../Firmware/ultralcd.cpp:5286 ../../Firmware/ultralcd.cpp:5288
+#: ../../Firmware/Marlin_main.cpp:645 ../../Firmware/messages.cpp:91
+#: ../../Firmware/ultralcd.cpp:5252 ../../Firmware/ultralcd.cpp:5254
 msgid "Resume print"
 msgstr "Nastavite print"
 
@@ -1783,17 +1776,17 @@ msgid "Returning selector"
 msgstr "Povratak izbornika"
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/messages.cpp:252 ../../Firmware/ultralcd.cpp:2479
+#: ../../Firmware/messages.cpp:264 ../../Firmware/ultralcd.cpp:2496
 msgid "Right"
 msgstr "Tocno"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/messages.cpp:259 ../../Firmware/ultralcd.cpp:2710
+#: ../../Firmware/messages.cpp:271 ../../Firmware/ultralcd.cpp:2727
 msgid "Right side[µm]"
 msgstr "Desna str.[µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/messages.cpp:286 ../../Firmware/ultralcd.cpp:3656
+#: ../../Firmware/messages.cpp:298 ../../Firmware/ultralcd.cpp:3666
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1802,8 +1795,8 @@ msgstr ""
 "ispocetka. Nastavite?"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4509
-#: ../../Firmware/ultralcd.cpp:4511
+#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4476
+#: ../../Firmware/ultralcd.cpp:4478
 msgid "SD card"
 msgstr "SD karti"
 
@@ -1818,23 +1811,23 @@ msgid "SELECTOR CANNOT MOVE"
 msgstr "IZBORNIK SE NE MICE"
 
 #. MSG_STOPPED c=20
-#: ../../Firmware/Marlin_main.cpp:9887 ../../Firmware/messages.cpp:125
+#: ../../Firmware/Marlin_main.cpp:9047 ../../Firmware/messages.cpp:130
 msgid "STOPPED."
 msgstr "ZAUSTAVLJENO."
 
 #. MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3223 ../../Firmware/Marlin_main.cpp:3245
-#: ../../Firmware/mesh_bed_calibration.cpp:2246 ../../Firmware/messages.cpp:44
+#: ../../Firmware/Marlin_main.cpp:2967 ../../Firmware/Marlin_main.cpp:2984
+#: ../../Firmware/mesh_bed_calibration.cpp:2231 ../../Firmware/messages.cpp:44
 msgid "Searching bed calibration point"
 msgstr "Trazenje tocke kalibracije podloge"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/messages.cpp:321 ../../Firmware/ultralcd.cpp:5136
+#: ../../Firmware/messages.cpp:333 ../../Firmware/ultralcd.cpp:5096
 msgid "Select"
 msgstr "Odaberi"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/messages.cpp:290 ../../Firmware/ultralcd.cpp:3730
+#: ../../Firmware/messages.cpp:302 ../../Firmware/ultralcd.cpp:3740
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
@@ -1843,27 +1836,27 @@ msgstr ""
 "zaslonu."
 
 #. MSG_SELECT_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3453 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3612
-#: ../../Firmware/ultralcd.cpp:6822
+#: ../../Firmware/Marlin_main.cpp:3192 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3622
+#: ../../Firmware/ultralcd.cpp:6798
 msgid "Select filament:"
 msgstr "Odaberi filament:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:110 ../../Firmware/ultralcd.cpp:3464
-#: ../../Firmware/ultralcd.cpp:4504
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:3474
+#: ../../Firmware/ultralcd.cpp:4471
 msgid "Select language"
 msgstr "Izaberi jezik"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/messages.cpp:300 ../../Firmware/ultralcd.cpp:3900
+#: ../../Firmware/messages.cpp:312 ../../Firmware/ultralcd.cpp:3924
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr ""
 "Odaberite temperaturu predgrijavanja mlaznice koja odgovara vasem "
 "materijalu."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/messages.cpp:291 ../../Firmware/ultralcd.cpp:3735
+#: ../../Firmware/messages.cpp:303 ../../Firmware/ultralcd.cpp:3745
 msgid "Select temperature which matches your material."
 msgstr "Odaberite temperaturu koja odgovara vasem materijalu."
 
@@ -1874,63 +1867,63 @@ msgid "Selecting fil. slot"
 msgstr "Odabir fil. utora"
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/messages.cpp:341 ../../Firmware/ultralcd.cpp:6274
+#: ../../Firmware/messages.cpp:353 ../../Firmware/ultralcd.cpp:6250
 msgid "Selftest OK"
 msgstr "Samotestiranje OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/messages.cpp:340 ../../Firmware/ultralcd.cpp:6057
+#: ../../Firmware/messages.cpp:352 ../../Firmware/ultralcd.cpp:6033
 msgid "Selftest start"
 msgstr "Pocetak selftesta"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/messages.cpp:315 ../../Firmware/ultralcd.cpp:4581
+#: ../../Firmware/messages.cpp:327 ../../Firmware/ultralcd.cpp:4537
 msgid "Selftest"
 msgstr "Selftest"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/messages.cpp:342 ../../Firmware/ultralcd.cpp:6699
+#: ../../Firmware/messages.cpp:354 ../../Firmware/ultralcd.cpp:6675
 msgid "Selftest error!"
 msgstr "Selftest error!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6279
-#: ../../Firmware/ultralcd.cpp:6786 ../../Firmware/ultralcd.cpp:6984
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6255
+#: ../../Firmware/ultralcd.cpp:6762 ../../Firmware/ultralcd.cpp:6961
 msgid "Selftest failed"
 msgstr "Selftest nije uspio"
 
 #. MSG_FORCE_SELFTEST c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1577 ../../Firmware/messages.cpp:202
+#: ../../Firmware/Marlin_main.cpp:1504 ../../Firmware/messages.cpp:214
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr ""
 "Provest ce se selftest radi kalibracije preciznog ponovnog postavljanja bez "
 "senzora."
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/messages.cpp:228 ../../Firmware/ultralcd.cpp:1701
+#: ../../Firmware/messages.cpp:240 ../../Firmware/ultralcd.cpp:1711
 msgid "Sensor info"
 msgstr "Info senzora"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/messages.cpp:338 ../../Firmware/ultralcd.cpp:6027
+#: ../../Firmware/messages.cpp:350 ../../Firmware/ultralcd.cpp:6003
 msgid "Sensor verified, remove the filament now."
 msgstr "Senzor je provjeren, odmah uklonite filament."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/messages.cpp:262 ../../Firmware/ultralcd.cpp:2730
+#: ../../Firmware/messages.cpp:274 ../../Firmware/ultralcd.cpp:2747
 msgid "Set temperature:"
 msgstr "Postavi temperaturu:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3348
-#: ../../Firmware/ultralcd.cpp:3479 ../../Firmware/ultralcd.cpp:3984
-#: ../../Firmware/ultralcd.cpp:5374 ../../Firmware/ultralcd.cpp:5585
-#: ../../Firmware/ultralcd.cpp:5631
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3358
+#: ../../Firmware/ultralcd.cpp:3489 ../../Firmware/ultralcd.cpp:4008
+#: ../../Firmware/ultralcd.cpp:5341 ../../Firmware/ultralcd.cpp:5558
+#: ../../Firmware/ultralcd.cpp:5604
 msgid "Settings"
 msgstr "Postavke"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/messages.cpp:255 ../../Firmware/ultralcd.cpp:2522
+#: ../../Firmware/messages.cpp:267 ../../Firmware/ultralcd.cpp:2539
 msgid "Severe skew"
 msgstr "Veliki nagib"
 
@@ -1941,7 +1934,7 @@ msgid "Sheet"
 msgstr "Ploca"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/messages.cpp:284 ../../Firmware/ultralcd.cpp:3604
+#: ../../Firmware/messages.cpp:296 ../../Firmware/ultralcd.cpp:3614
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1954,23 +1947,23 @@ msgstr ""
 "%cResetiraj"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/messages.cpp:319 ../../Firmware/ultralcd.cpp:4592
+#: ../../Firmware/messages.cpp:331 ../../Firmware/ultralcd.cpp:4548
 msgid "Show end stops"
 msgstr "Pokazi granicnike"
 
 #. MSG_SILENT c=7
-#: ../../Firmware/Marlin_main.cpp:8497 ../../Firmware/messages.cpp:120
-#: ../../Firmware/ultralcd.cpp:4155 ../../Firmware/ultralcd.cpp:4194
+#: ../../Firmware/Marlin_main.cpp:7668 ../../Firmware/messages.cpp:124
+#: ../../Firmware/ultralcd.cpp:4179 ../../Firmware/ultralcd.cpp:4218
 msgid "Silent"
 msgstr "Tih"
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/messages.cpp:254 ../../Firmware/ultralcd.cpp:2521
+#: ../../Firmware/messages.cpp:266 ../../Firmware/ultralcd.cpp:2538
 msgid "Slight skew"
 msgstr "Lagani nagib"
 
 #. MSG_FILE_CNT c=20 r=6
-#: ../../Firmware/cardreader.cpp:805 ../../Firmware/messages.cpp:197
+#: ../../Firmware/cardreader.cpp:805 ../../Firmware/messages.cpp:209
 msgid ""
 "Some files will not be sorted. Max. No. of files in 1 folder for sorting is "
 "100."
@@ -1979,60 +1972,60 @@ msgstr ""
 " je 100."
 
 #. MSG_ZLEVELING_ENFORCED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3043 ../../Firmware/messages.cpp:204
+#: ../../Firmware/Marlin_main.cpp:2783 ../../Firmware/messages.cpp:216
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Naisao je neki problem, nametnuto Z-niveliranje..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:4514
-#: ../../Firmware/ultralcd.cpp:4515 ../../Firmware/ultralcd.cpp:4516
+#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4481
+#: ../../Firmware/ultralcd.cpp:4482 ../../Firmware/ultralcd.cpp:4483
 msgid "Sort"
 msgstr "Vrsta"
 
 #. MSG_SORTING_FILES c=20
 #: ../../Firmware/cardreader.cpp:849 ../../Firmware/cardreader.cpp:916
-#: ../../Firmware/messages.cpp:111
+#: ../../Firmware/messages.cpp:115
 msgid "Sorting files"
 msgstr "Sortiranje datoteka"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4188
-#: ../../Firmware/ultralcd.cpp:4191 ../../Firmware/ultralcd.cpp:4194
-#: ../../Firmware/ultralcd.cpp:4197 ../../Firmware/ultralcd.cpp:4200
+#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4215 ../../Firmware/ultralcd.cpp:4218
+#: ../../Firmware/ultralcd.cpp:4221 ../../Firmware/ultralcd.cpp:4224
 msgid "Sound"
 msgstr "Zvuk"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/messages.cpp:333 ../../Firmware/ultralcd.cpp:5516
+#: ../../Firmware/messages.cpp:345 ../../Firmware/ultralcd.cpp:5483
 msgid "Speed"
 msgstr "Brzina"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6861
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6837
 msgid "Spinning"
 msgstr "Okrece se"
 
 #. MSG_TEMP_CAL_WARNING c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4744 ../../Firmware/messages.cpp:208
+#: ../../Firmware/Marlin_main.cpp:4313 ../../Firmware/messages.cpp:220
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr ""
 "Potrebna je stabilna temperatura okoline 21-26C, potrebno je cvrsto "
 "postolje."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/messages.cpp:329 ../../Firmware/ultralcd.cpp:5379
+#: ../../Firmware/messages.cpp:341 ../../Firmware/ultralcd.cpp:5346
 msgid "Statistics"
 msgstr "Statistika"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:4096
-#: ../../Firmware/ultralcd.cpp:4144
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4120
+#: ../../Firmware/ultralcd.cpp:4168
 msgid "Stealth"
 msgstr "Tiho"
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4421
-#: ../../Firmware/ultralcd.cpp:5133
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4388
+#: ../../Firmware/ultralcd.cpp:5093
 msgid "Steel sheets"
 msgstr "Celicna ploca"
 
@@ -2042,29 +2035,28 @@ msgid "Stop"
 msgstr "Stop"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:5293
-#: ../../Firmware/ultralcd.cpp:5781
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:5259
+#: ../../Firmware/ultralcd.cpp:5757
 msgid "Stop print"
 msgstr "Zaustavi print"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4236
-#: ../../Firmware/ultralcd.cpp:4316 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4315
 msgid "Strict"
 msgstr "Strogo"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/messages.cpp:332 ../../Firmware/ultralcd.cpp:5394
+#: ../../Firmware/messages.cpp:344 ../../Firmware/ultralcd.cpp:5361
 msgid "Support"
 msgstr "Podrska"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/messages.cpp:354 ../../Firmware/ultralcd.cpp:6758
+#: ../../Firmware/messages.cpp:366 ../../Firmware/ultralcd.cpp:6734
 msgid "Swapped"
 msgstr "Zamjenjeno"
 
 #. MSG_THERMAL_ANOMALY c=20
-#: ../../Firmware/messages.cpp:188 ../../Firmware/temperature.cpp:2223
+#: ../../Firmware/messages.cpp:195 ../../Firmware/temperature.cpp:2197
 msgid "THERMAL ANOMALY"
 msgstr "TERMALNA ANOMALIJA"
 
@@ -2099,7 +2091,7 @@ msgid "TMC UNDERVOLTAGE ERR"
 msgstr "TMC NISKA VOLTAZA"
 
 #. MSG_TM_CAL c=20 r=4
-#: ../../Firmware/messages.cpp:299 ../../Firmware/ultralcd.cpp:3881
+#: ../../Firmware/messages.cpp:311 ../../Firmware/ultralcd.cpp:3905
 msgid ""
 "Thermal model cal. takes approx. 12 mins. See\n"
 "prusa.io/tm-cal"
@@ -2108,22 +2100,22 @@ msgstr ""
 "prusa.io/tm-cal"
 
 #. MSG_TM_NOT_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1613 ../../Firmware/messages.cpp:189
+#: ../../Firmware/Marlin_main.cpp:1540 ../../Firmware/messages.cpp:196
 msgid "Thermal model not calibrated yet."
 msgstr "Toplinski model još nije kalibriran."
 
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/messages.cpp:309 ../../Firmware/ultralcd.cpp:4455
+#: ../../Firmware/messages.cpp:321 ../../Firmware/ultralcd.cpp:4422
 msgid "Temperature"
 msgstr "Temperatura"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/messages.cpp:229 ../../Firmware/ultralcd.cpp:1707
+#: ../../Firmware/messages.cpp:241 ../../Firmware/ultralcd.cpp:1717
 msgid "Temperatures"
 msgstr "Temperature"
 
 #. MSG_TESTING_FILAMENT c=20
-#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:388
+#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:389
 msgid "Testing filament"
 msgstr "Testiram filament"
 
@@ -2144,7 +2136,7 @@ msgstr ""
 "sprjecava njegovo kretanje."
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/messages.cpp:292 ../../Firmware/ultralcd.cpp:3738
+#: ../../Firmware/messages.cpp:304 ../../Firmware/ultralcd.cpp:3748
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -2154,7 +2146,7 @@ msgstr ""
 "optimalnu visinu. Provjerite slike u prirucniku (poglavlje Kalibracija)."
 
 #. MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1606 ../../Firmware/messages.cpp:47
+#: ../../Firmware/Marlin_main.cpp:1533 ../../Firmware/messages.cpp:47
 msgid ""
 "There is still a need to make Z calibration. Please follow the manual, "
 "chapter First steps, section Calibration flow."
@@ -2163,40 +2155,40 @@ msgstr ""
 "poglavlje Prvi koraci, odjeljak Tijek kalibracije."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:4514
+#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:4481
 msgid "Time"
 msgstr "Vrijeme"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:176 ../../Firmware/ultralcd.cpp:5622
+#: ../../Firmware/messages.cpp:183 ../../Firmware/ultralcd.cpp:5595
 msgid "Timeout"
 msgstr "Pauza"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:1129
-#: ../../Firmware/ultralcd.cpp:1287
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:1139
+#: ../../Firmware/ultralcd.cpp:1297
 msgid "Total"
 msgstr "Ukupno"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:1177
-#: ../../Firmware/ultralcd.cpp:1231 ../../Firmware/ultralcd.cpp:1317
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:1187
+#: ../../Firmware/ultralcd.cpp:1241 ../../Firmware/ultralcd.cpp:1327
 msgid "Total failures"
 msgstr "Totalne pogreske"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/messages.cpp:248 ../../Firmware/ultralcd.cpp:2369
+#: ../../Firmware/messages.cpp:260 ../../Firmware/ultralcd.cpp:2386
 msgid "Total filament"
 msgstr "Totalno filamenta"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/messages.cpp:249 ../../Firmware/ultralcd.cpp:2370
+#: ../../Firmware/messages.cpp:261 ../../Firmware/ultralcd.cpp:2387
 msgid "Total print time"
 msgstr "Vrijeme printanja"
 
 #. MSG_TUNE c=8
-#: ../../Firmware/messages.cpp:116 ../../Firmware/mmu2/errors_list.h:372
-#: ../../Firmware/ultralcd.cpp:5258
+#: ../../Firmware/messages.cpp:120 ../../Firmware/mmu2/errors_list.h:372
+#: ../../Firmware/ultralcd.cpp:5220
 msgid "Tune"
 msgstr "Ugodi"
 
@@ -2211,16 +2203,16 @@ msgid "Unload"
 msgstr "Prazni"
 
 #. MSG_UNLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:2206
-#: ../../Firmware/ultralcd.cpp:5347 ../../Firmware/ultralcd.cpp:5364
-#: ../../Firmware/ultralcd.cpp:5369
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:2220
+#: ../../Firmware/ultralcd.cpp:5313 ../../Firmware/ultralcd.cpp:5331
+#: ../../Firmware/ultralcd.cpp:5336
 msgid "Unload filament"
 msgstr "Ispraznite fil."
 
 #. MSG_UNLOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3436 ../../Firmware/messages.cpp:129
+#: ../../Firmware/Marlin_main.cpp:3175 ../../Firmware/messages.cpp:134
 #: ../../Firmware/mmu2_progress_converter.cpp:50
-#: ../../Firmware/ultralcd.cpp:4911
+#: ../../Firmware/ultralcd.cpp:4867
 msgid "Unloading filament"
 msgstr "Praznjenje filamenta"
 
@@ -2237,12 +2229,12 @@ msgid "Unloading to pulley"
 msgstr "PRAZNJ DO REMENICE"
 
 #. MSG_FIL_FAILED c=20 r=4
-#: ../../Firmware/messages.cpp:339 ../../Firmware/ultralcd.cpp:6030
+#: ../../Firmware/messages.cpp:351 ../../Firmware/ultralcd.cpp:6006
 msgid "Verification failed, remove the filament and try again."
 msgstr "Provjera nije uspjela, uklonite filament i pokusajte ponovno."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/messages.cpp:230 ../../Firmware/ultralcd.cpp:1710
+#: ../../Firmware/messages.cpp:242 ../../Firmware/ultralcd.cpp:1720
 msgid "Voltages"
 msgstr "Voltaza"
 
@@ -2253,7 +2245,7 @@ msgid "WARNING TMC TOO HOT"
 msgstr "UPOZORENJE TMC VRUC"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/messages.cpp:281 ../../Firmware/ultralcd.cpp:3381
+#: ../../Firmware/messages.cpp:293 ../../Firmware/ultralcd.cpp:3391
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -2265,190 +2257,190 @@ msgstr ""
 "u tihom modu"
 
 #. MSG_USERWAIT c=20
-#: ../../Firmware/Marlin_main.cpp:5240 ../../Firmware/messages.cpp:209
+#: ../../Firmware/Marlin_main.cpp:4747 ../../Firmware/messages.cpp:221
 msgid "Wait for user..."
 msgstr "Ceka se korisnik..."
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/messages.cpp:263 ../../Firmware/ultralcd.cpp:2753
+#: ../../Firmware/messages.cpp:275 ../../Firmware/ultralcd.cpp:2770
 msgid "Waiting for PINDA probe cooling"
 msgstr "Ceka se hladenje PINDA sonde"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/messages.cpp:264 ../../Firmware/ultralcd.cpp:2782
+#: ../../Firmware/messages.cpp:276 ../../Firmware/ultralcd.cpp:2799
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Ceka se hladjenje mlaznice i podloge"
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:4233
-#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4352
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4312
 msgid "Warn"
 msgstr "Upozore"
 
 #. MSG_CHANGED_BOTH c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1554 ../../Firmware/messages.cpp:200
+#: ../../Firmware/Marlin_main.cpp:1481 ../../Firmware/messages.cpp:212
 msgid "Warning: both printer type and motherboard type changed."
 msgstr "Upozorenje: promijenjeni su i tip printera i tip maticne ploce."
 
 #. MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1546 ../../Firmware/messages.cpp:198
+#: ../../Firmware/Marlin_main.cpp:1473 ../../Firmware/messages.cpp:210
 msgid "Warning: motherboard type changed."
 msgstr "Upozorenje: tip maticne ploce je promijenjen."
 
 #. MSG_CHANGED_PRINTER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1550 ../../Firmware/messages.cpp:199
+#: ../../Firmware/Marlin_main.cpp:1477 ../../Firmware/messages.cpp:211
 msgid "Warning: printer type changed."
 msgstr "Upozorenje: promijenjena je vrsta printera."
 
 #. MSG_UNLOAD_SUCCESSFUL c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3517 ../../Firmware/messages.cpp:205
+#: ../../Firmware/Marlin_main.cpp:3257 ../../Firmware/messages.cpp:217
 msgid "Was filament unload successful?"
 msgstr "Je li praznjenje fil. bilo uspjesno?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:6710
-#: ../../Firmware/ultralcd.cpp:6714 ../../Firmware/ultralcd.cpp:6734
-#: ../../Firmware/ultralcd.cpp:6740 ../../Firmware/ultralcd.cpp:6764
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:6686
+#: ../../Firmware/ultralcd.cpp:6690 ../../Firmware/ultralcd.cpp:6710
+#: ../../Firmware/ultralcd.cpp:6716 ../../Firmware/ultralcd.cpp:6740
 msgid "Wiring error"
 msgstr "Greska u ozicenju"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/messages.cpp:313 ../../Firmware/ultralcd.cpp:4572
+#: ../../Firmware/messages.cpp:325 ../../Firmware/ultralcd.cpp:4528
 msgid "Wizard"
 msgstr "Carobnjak"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/messages.cpp:304 ../../Firmware/ultralcd.cpp:3986
+#: ../../Firmware/messages.cpp:316 ../../Firmware/ultralcd.cpp:4010
 msgid "X-correct"
 msgstr "X-ispravan"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/messages.cpp:226 ../../Firmware/ultralcd.cpp:1699
+#: ../../Firmware/messages.cpp:238 ../../Firmware/ultralcd.cpp:1709
 msgid "XYZ cal. details"
 msgstr "XYZ detalji kal"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/messages.cpp:275 ../../Firmware/ultralcd.cpp:3207
+#: ../../Firmware/messages.cpp:287 ../../Firmware/ultralcd.cpp:3217
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr "XYZ kalibracija u redu. Iskrivljenost ce se automatski ispraviti."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/messages.cpp:274 ../../Firmware/ultralcd.cpp:3204
+#: ../../Firmware/messages.cpp:286 ../../Firmware/ultralcd.cpp:3214
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr "XYZ kalibracija je u redu. Osi X/Y su malo nagnute. Bravo!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/messages.cpp:271 ../../Firmware/ultralcd.cpp:3185
+#: ../../Firmware/messages.cpp:283 ../../Firmware/ultralcd.cpp:3195
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr ""
 "XYZ kalibracija je ugrozena. Prednje kalibracijske tocke nisu dostupne."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/messages.cpp:272 ../../Firmware/ultralcd.cpp:3188
+#: ../../Firmware/messages.cpp:284 ../../Firmware/ultralcd.cpp:3198
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr ""
 "XYZ kalibracija je ugrozena. Desna prednja tocka kalibracije nije dostupna."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/messages.cpp:268 ../../Firmware/ultralcd.cpp:3167
+#: ../../Firmware/messages.cpp:280 ../../Firmware/ultralcd.cpp:3177
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr ""
 "XYZ kalibracija nije uspjela. Tocka kalibracije podloga nije pronadena."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/messages.cpp:269 ../../Firmware/ultralcd.cpp:3173
+#: ../../Firmware/messages.cpp:281 ../../Firmware/ultralcd.cpp:3183
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr ""
 "XYZ kalibracija nije uspjela. Prednje kalibracijske tocke nisu dostupne."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3170
-#: ../../Firmware/ultralcd.cpp:3198
+#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3180
+#: ../../Firmware/ultralcd.cpp:3208
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "XYZ kalibracija nije uspjela. Molimo pogledajte prirucnik."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/messages.cpp:270 ../../Firmware/ultralcd.cpp:3176
+#: ../../Firmware/messages.cpp:282 ../../Firmware/ultralcd.cpp:3186
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr ""
 "XYZ kalibracija nije uspjela. Desna prednja tocka kalibracije nije dostupna."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/messages.cpp:273 ../../Firmware/ultralcd.cpp:3201
+#: ../../Firmware/messages.cpp:285 ../../Firmware/ultralcd.cpp:3211
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "XYZ kalibracija u redu. Osi X/Y su okomite. Cestitamo!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/messages.cpp:250 ../../Firmware/ultralcd.cpp:2476
+#: ../../Firmware/messages.cpp:262 ../../Firmware/ultralcd.cpp:2493
 msgid "Y distance from min"
 msgstr "Y distanca od min"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/messages.cpp:305 ../../Firmware/ultralcd.cpp:3987
+#: ../../Firmware/messages.cpp:317 ../../Firmware/ultralcd.cpp:4011
 msgid "Y-correct"
 msgstr "Y-ispravan"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:3029
-#: ../../Firmware/ultralcd.cpp:4443 ../../Firmware/ultralcd.cpp:4531
-#: ../../Firmware/ultralcd.cpp:5790
+#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:2275
+#: ../../Firmware/ultralcd.cpp:2279 ../../Firmware/ultralcd.cpp:3046
+#: ../../Firmware/ultralcd.cpp:4410 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/ultralcd.cpp:5766
 msgid "Yes"
 msgstr "Da"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:3950
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:3974
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr "Carobnjak uvijek mozete nastaviti iz Kalibracija -> Carobnjak."
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/messages.cpp:306 ../../Firmware/ultralcd.cpp:3988
+#: ../../Firmware/messages.cpp:318 ../../Firmware/ultralcd.cpp:4012
 msgid "Z-correct"
 msgstr "Z-ispravan"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5593
+#: ../../Firmware/messages.cpp:175 ../../Firmware/ultralcd.cpp:5566
 msgid "Z-probe nr."
 msgstr "Z-sonda br."
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/messages.cpp:256 ../../Firmware/ultralcd.cpp:2546
+#: ../../Firmware/messages.cpp:268 ../../Firmware/ultralcd.cpp:2563
 msgid "[0;0] point offset"
 msgstr "[0;0] razmak tocke"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/messages.cpp:239 ../../Firmware/ultralcd.cpp:2147
+#: ../../Firmware/messages.cpp:251 ../../Firmware/ultralcd.cpp:2158
 msgid "and press the knob"
 msgstr "i pritisnite gumb"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/messages.cpp:232 ../../Firmware/ultralcd.cpp:1807
+#: ../../Firmware/messages.cpp:244 ../../Firmware/ultralcd.cpp:1816
 msgid "to load filament"
 msgstr "da napuni filament"
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/messages.cpp:233 ../../Firmware/ultralcd.cpp:1811
+#: ../../Firmware/messages.cpp:245 ../../Firmware/ultralcd.cpp:1820
 msgid "to unload filament"
 msgstr "da isprazni filament"
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/messages.cpp:224 ../../Firmware/ultralcd.cpp:1666
+#: ../../Firmware/messages.cpp:236 ../../Firmware/ultralcd.cpp:1676
 msgid "unknown"
 msgstr "nepoznato"
 
 #. MSG_IR_UNKNOWN c=18
-#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:184
+#: ../../Firmware/Filament_sensor.cpp:286 ../../Firmware/messages.cpp:191
 msgid "unknown state"
 msgstr "nepoznato stanje"
 
 #. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:5858
-#: ../../Firmware/ultralcd.cpp:5861
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:5834
+#: ../../Firmware/ultralcd.cpp:5837
 msgid "🔃Refresh"
 msgstr "🔃Osvjeziti"
 
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1180
+#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1190
 msgid "MMU power fails"
 msgstr "Neusp. MMU nap"
 
@@ -2486,8 +2478,8 @@ msgid "MMU MCU ERROR"
 msgstr "MMU MCU GRESKA"
 
 #. MSG_MATERIAL_CHANGES c=18
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:1130
-#: ../../Firmware/ultralcd.cpp:1204
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:1140
+#: ../../Firmware/ultralcd.cpp:1214
 msgid "Material changes"
 msgstr "Materijal razmjene"
 
@@ -2519,17 +2511,17 @@ msgstr ""
 "3.0.3."
 
 #. MSG_PRELOAD_TO_MMU c=17
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5344
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5310
 msgid "Preload to MMU"
 msgstr "Predpunjenje MMU"
 
 #. MSG_FW_MK3_DETECTED c=20 r=4
-#: ../../Firmware/messages.cpp:367 ../../Firmware/Marlin_main.cpp:920
+#: ../../Firmware/messages.cpp:379 ../../Firmware/Marlin_main.cpp:854
 msgid "MK3 firmware detected on MK3S printer"
 msgstr "MK3 firmware otkriven na MK3S printeru"
 
 #. MSG_FW_MK3S_DETECTED c=20 r=4
-#: ../../Firmware/messages.cpp:367 ../../Firmware/Marlin_main.cpp:920
+#: ../../Firmware/messages.cpp:379 ../../Firmware/Marlin_main.cpp:854
 msgid "MK3S firmware detected on MK3 printer"
 msgstr "MK3S firmware detektiran na MK3 printeru"
 
@@ -2543,8 +2535,9 @@ msgstr "NEPOZNATA POGREŠKA"
 msgid "Unexpected error occurred."
 msgstr "Došlo je do neočekivane pogreške."
 
-#. MSG_BTN_EJECT c=8
-#: ../../Firmware/mmu2/errors_list.h:358 ../../Firmware/mmu2/errors_list.h:371
+#. MSG_EJECT c=8
+#: ../../Firmware/messages.cpp:21 ../../Firmware/mmu2/errors_list.h:371
+#: ../../Firmware/ultralcd.cpp:2275 ../../Firmware/ultralcd.cpp:2279
 msgid "Eject"
 msgstr "Izbaciti"
 
@@ -2564,58 +2557,58 @@ msgid "M600 Filament Change. Load a new filament or eject the old one."
 msgstr "Promjena filamenta M600. Stavite novu nit ili izbacite staru."
 
 #. MSG_MMU_SENSITIVITY c=18
-#: ../../Firmware/messages.cpp:215 ../../Firmware/mmu2_reporting.cpp:458
+#: ../../Firmware/messages.cpp:227 ../../Firmware/mmu2_reporting.cpp:459
 msgid "Sensitivity"
 msgstr "Osjetljivost"
 
 #. MSG_MBL_FAILED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3038 ../../Firmware/messages.cpp:203
+#: ../../Firmware/Marlin_main.cpp:2776 ../../Firmware/messages.cpp:215
 msgid "Mesh bed leveling failed. Print canceled."
 msgstr "Niveliranje podloge nije uspijelo. Print je otkazan."
 
 #. MSG_SET_READY c=18
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:5265
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:5228
 msgid "Set Ready"
 msgstr "Set spreman"
 
 #. MSG_SET_NOT_READY c=18
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:5263
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5226
 msgid "Set not Ready"
 msgstr "Set nije spreman"
 
 #. MSG_HOSTPRINT c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5285
+#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:5231
 msgid "Print from host"
 msgstr "Printaj sa host"
 
 #. MSG_REPRINT c=18
-#: ../../Firmware/messages.cpp:196 ../../Firmware/ultralcd.cpp:5243
-#: ../../Firmware/ultralcd.cpp:5245
+#: ../../Firmware/messages.cpp:208 ../../Firmware/ultralcd.cpp:5205
+#: ../../Firmware/ultralcd.cpp:5207
 msgid "Reprint"
 msgstr "Ponovno tiskanje"
 
 #. MSG_SHUTDOWN_HOST c=18
-#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:5390
+#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:5357
 msgid "Shutdown host"
 msgstr "Iskljuciti host"
 
 #. MSG_NOZZLE_CNG_COOLDOWN c=20 r=3
-#: ../../Firmware/messages.cpp:198 ../../Firmware/ultralcd.cpp:1002
+#: ../../Firmware/messages.cpp:203 ../../Firmware/ultralcd.cpp:999
 msgid "Nozzle is hot! Wait for cooldown."
 msgstr "Mlaznica je vruća! Pričekajte hlađenje."
 
 #. MSG_NOZZLE_CNG_CHANGED_QUICK c=20 r=3
-#: ../../Firmware/messages.cpp:199
+#: ../../Firmware/messages.cpp:204
 msgid "Nozzle changed?"
 msgstr "Mlaznica se promijenila?"
 
 #. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:388
+#: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:388
 msgid "There is no filament loaded. Continue?"
 msgstr "Nema umetnute niti. Nastavite?"
 
 #. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:389
+#: ../../Firmware/messages.cpp:159 ../../Firmware/util.cpp:389
 msgid "There is no filament loaded. Print cancelled."
 msgstr "Nema umetnute niti. Print je otkazan."
 

--- a/lang/po/Firmware_hu.po
+++ b/lang/po/Firmware_hu.po
@@ -16,91 +16,91 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 
 #. MSG_IR_03_OR_OLDER c=18
-#: ../../Firmware/Filament_sensor.cpp:280
-#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:183
+#: ../../Firmware/Filament_sensor.cpp:282
+#: ../../Firmware/Filament_sensor.cpp:344 ../../Firmware/messages.cpp:190
 msgid " 0.3 or older"
 msgstr " 0.3 vagy regebbi"
 
 #. MSG_IR_04_OR_NEWER c=18
-#: ../../Firmware/Filament_sensor.cpp:282
-#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:182
+#: ../../Firmware/Filament_sensor.cpp:284
+#: ../../Firmware/Filament_sensor.cpp:347 ../../Firmware/messages.cpp:189
 msgid " 0.4 or newer"
 msgstr " 0.4 v. ujabb"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/messages.cpp:356 ../../Firmware/ultralcd.cpp:6773
+#: ../../Firmware/messages.cpp:368 ../../Firmware/ultralcd.cpp:6749
 msgid "%s level expected"
 msgstr "Vart szint: %s"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:1978
-#: ../../Firmware/ultralcd.cpp:3613
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:1986
+#: ../../Firmware/ultralcd.cpp:3623
 msgid ">Cancel"
 msgstr ">Megsem"
 
 #. MSG_BABYSTEPPING_Z c=13
-#: ../../Firmware/messages.cpp:257 ../../Firmware/ultralcd.cpp:2635
+#: ../../Firmware/messages.cpp:269 ../../Firmware/ultralcd.cpp:2652
 msgid "Adjusting Z"
 msgstr "Z allitasa"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/messages.cpp:360 ../../Firmware/ultralcd.cpp:6983
+#: ../../Firmware/messages.cpp:372 ../../Firmware/ultralcd.cpp:6960
 msgid "All correct"
 msgstr "Minden rendben"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:3955
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:3979
 msgid "All is done. Happy printing!"
 msgstr "Keszen vagyunk. Jo nyomtatast!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4482
 msgid "Alphabet"
 msgstr "Abece"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4086
+#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4110
 msgid "Always"
 msgstr "Mindig"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/messages.cpp:221 ../../Firmware/ultralcd.cpp:1393
+#: ../../Firmware/messages.cpp:233 ../../Firmware/ultralcd.cpp:1403
 msgid "Ambient"
 msgstr "Kornyezet"
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=3
-#: ../../Firmware/messages.cpp:267 ../../Firmware/ultralcd.cpp:2848
+#: ../../Firmware/messages.cpp:279 ../../Firmware/ultralcd.cpp:2865
 msgid "Are left and right Z-carriages all up?"
 msgstr "A Z tengely a felso vegponton van?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4197
+#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:4221
 msgid "Assist"
 msgstr "Seged"
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:179 ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/messages.cpp:186 ../../Firmware/ultralcd.cpp:5594
 msgid "Auto"
 msgstr "Autom."
 
 #. MSG_AUTO_HOME c=18
-#: ../../Firmware/Marlin_main.cpp:3198 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:4577 ../../Firmware/ultralcd.cpp:5529
+#: ../../Firmware/Marlin_main.cpp:2942 ../../Firmware/messages.cpp:12
+#: ../../Firmware/ultralcd.cpp:4533 ../../Firmware/ultralcd.cpp:5496
 msgid "Auto home"
 msgstr "Auto homeolas"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4182
 msgid "Auto power"
 msgstr "Auto ero"
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:328 ../../Firmware/ultralcd.cpp:5359
+#: ../../Firmware/messages.cpp:340 ../../Firmware/ultralcd.cpp:5328
 msgid "AutoLoad filament"
 msgstr "Fil. auto.betolt."
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/messages.cpp:245 ../../Firmware/ultralcd.cpp:2272
+#: ../../Firmware/messages.cpp:257 ../../Firmware/ultralcd.cpp:2289
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr "Autom. betoltes be, nyomd meg a gombot es helyzed be a filamentet."
@@ -112,51 +112,50 @@ msgid "Avoiding grind"
 msgstr "Daralas megelozese"
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/messages.cpp:352 ../../Firmware/ultralcd.cpp:6752
+#: ../../Firmware/messages.cpp:364 ../../Firmware/ultralcd.cpp:6728
 msgid "Axis"
 msgstr "Tengely"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/messages.cpp:351 ../../Firmware/ultralcd.cpp:6751
+#: ../../Firmware/messages.cpp:363 ../../Firmware/ultralcd.cpp:6727
 msgid "Axis length"
 msgstr "Tengely hossz"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2708
-#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:5618
-#: ../../Firmware/ultralcd.cpp:7484
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2725
+#: ../../Firmware/ultralcd.cpp:4061 ../../Firmware/ultralcd.cpp:5591
+#: ../../Firmware/ultralcd.cpp:7461
 msgid "Back"
 msgstr "Vissza"
 
 #. MSG_BED c=13
-#: ../../Firmware/Marlin_main.cpp:2081 ../../Firmware/Marlin_main.cpp:4627
-#: ../../Firmware/Marlin_main.cpp:4678 ../../Firmware/messages.cpp:15
-#: ../../Firmware/ultralcd.cpp:1391 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/Marlin_main.cpp:4247 ../../Firmware/messages.cpp:15
+#: ../../Firmware/ultralcd.cpp:1401 ../../Firmware/ultralcd.cpp:4197
 msgid "Bed"
 msgstr "Asztal"
 
 #. MSG_BED_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6240 ../../Firmware/messages.cpp:17
+#: ../../Firmware/Marlin_main.cpp:5470 ../../Firmware/messages.cpp:17
 #: ../../Firmware/ultralcd.cpp:534
 msgid "Bed Heating"
 msgstr "Asztal futes"
 
 #. MSG_BED_DONE c=20
-#: ../../Firmware/Marlin_main.cpp:6277 ../../Firmware/messages.cpp:16
+#: ../../Firmware/Marlin_main.cpp:5507 ../../Firmware/messages.cpp:16
 #: ../../Firmware/ultralcd.cpp:537
 msgid "Bed done"
 msgstr "Asztal kesz"
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/messages.cpp:317 ../../Firmware/ultralcd.cpp:4589
+#: ../../Firmware/messages.cpp:329 ../../Firmware/ultralcd.cpp:4545
 msgid "Bed level correct"
 msgstr "Szint. korrekcio"
 
 #. MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:2262 ../../Firmware/Marlin_main.cpp:2999
-#: ../../Firmware/Marlin_main.cpp:3008
-#: ../../Firmware/mesh_bed_calibration.cpp:2878
-#: ../../Firmware/mesh_bed_calibration.cpp:2903 ../../Firmware/messages.cpp:18
+#: ../../Firmware/Marlin_main.cpp:2048 ../../Firmware/Marlin_main.cpp:2736
+#: ../../Firmware/Marlin_main.cpp:2745
+#: ../../Firmware/mesh_bed_calibration.cpp:2863
+#: ../../Firmware/mesh_bed_calibration.cpp:2888 ../../Firmware/messages.cpp:18
 msgid ""
 "Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for "
 "reset."
@@ -165,34 +164,34 @@ msgstr ""
 " az ujrainditast."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/messages.cpp:346 ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/messages.cpp:358 ../../Firmware/ultralcd.cpp:6685
 msgid "Bed/Heater"
 msgstr "Asztal/Fej futes"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1444
-#: ../../Firmware/ultralcd.cpp:1704
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1454
+#: ../../Firmware/ultralcd.cpp:1714
 msgid "Belt status"
 msgstr "Szij allapot"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/messages.cpp:314 ../../Firmware/ultralcd.cpp:4579
+#: ../../Firmware/messages.cpp:326 ../../Firmware/ultralcd.cpp:4535
 msgid "Belt test"
 msgstr "Szij teszt"
 
 #. MSG_RECOVER_PRINT c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:1660 ../../Firmware/messages.cpp:87
+#: ../../Firmware/Marlin_main.cpp:1587 ../../Firmware/messages.cpp:87
 msgid "Blackout occurred. Recover print?"
 msgstr "Aramkieses volt, nyomt. folytatasa?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:177 ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:5594
 msgid "Bright"
 msgstr "Fenyes"
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:4526
-#: ../../Firmware/ultralcd.cpp:5546
+#: ../../Firmware/messages.cpp:180 ../../Firmware/ultralcd.cpp:4493
+#: ../../Firmware/ultralcd.cpp:5513
 msgid "Brightness"
 msgstr "Fenyero"
 
@@ -202,17 +201,17 @@ msgid "COMMUNICATION ERROR"
 msgstr "KOMUNIKACIOS HIBA"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/messages.cpp:316 ../../Firmware/ultralcd.cpp:4583
+#: ../../Firmware/messages.cpp:328 ../../Firmware/ultralcd.cpp:4539
 msgid "Calibrate XYZ"
 msgstr "XYZ kalibracio"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4585
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4541
 msgid "Calibrate Z"
 msgstr "Z kalibracio"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/messages.cpp:266 ../../Firmware/ultralcd.cpp:2813
+#: ../../Firmware/messages.cpp:278 ../../Firmware/ultralcd.cpp:2830
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -221,13 +220,13 @@ msgstr ""
 "nem er, majd nyomd meg ha keszen vagy."
 
 #. MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: ../../Firmware/Marlin_main.cpp:2218 ../../Firmware/messages.cpp:22
+#: ../../Firmware/Marlin_main.cpp:2009 ../../Firmware/messages.cpp:23
 #: ../../Firmware/ultralcd.cpp:582
 msgid "Calibrating Z"
 msgstr "Z kalibralasa"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/messages.cpp:265 ../../Firmware/ultralcd.cpp:2812
+#: ../../Firmware/messages.cpp:277 ../../Firmware/ultralcd.cpp:2829
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -236,17 +235,17 @@ msgstr ""
 "er, majd nyomd meg ha keszen vagy."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/messages.cpp:361 ../../Firmware/ultralcd.cpp:6985
+#: ../../Firmware/messages.cpp:373 ../../Firmware/ultralcd.cpp:6962
 msgid "Calibrating home"
 msgstr "Home poz. kalibralas"
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5375
+#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5342
 msgid "Calibration"
 msgstr "Kalibracio"
 
 #. MSG_HOMEYZ_DONE c=20
-#: ../../Firmware/messages.cpp:217 ../../Firmware/ultralcd.cpp:593
+#: ../../Firmware/messages.cpp:229 ../../Firmware/ultralcd.cpp:593
 msgid "Calibration done"
 msgstr "Kalibracio kesz"
 
@@ -264,128 +263,128 @@ msgstr ""
 "A muvelet nem hajthato vegre, a filament mar be van toltve. Vedd ki elobb."
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/messages.cpp:364 ../../Firmware/ultralcd.cpp:7405
+#: ../../Firmware/messages.cpp:376 ../../Firmware/ultralcd.cpp:7382
 msgid "Card removed"
 msgstr "Kartya eltavolitva"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/messages.cpp:324 ../../Firmware/ultralcd.cpp:5316
+#: ../../Firmware/messages.cpp:336 ../../Firmware/ultralcd.cpp:5282
 msgid "Change SD card"
 msgstr "Cserelj SD kartyat"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5254
-#: ../../Firmware/ultralcd.cpp:5526
+#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5216
+#: ../../Firmware/ultralcd.cpp:5493
 msgid "Change filament"
 msgstr "Filament csere"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/messages.cpp:240 ../../Firmware/ultralcd.cpp:2156
+#: ../../Firmware/messages.cpp:252 ../../Firmware/ultralcd.cpp:2167
 msgid "Change success!"
 msgstr "Csere sikerult!"
 
 #. MSG_CORRECTLY c=19
-#: ../../Firmware/messages.cpp:242 ../../Firmware/ultralcd.cpp:2203
+#: ../../Firmware/messages.cpp:254 ../../Firmware/ultralcd.cpp:2217
 msgid "Changed correctly"
 msgstr "Sikerult a csere"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5951
-#: ../../Firmware/ultralcd.cpp:6975
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5927
+#: ../../Firmware/ultralcd.cpp:6952
 msgid "Checking X axis"
 msgstr "X tengely ellenorzes"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5961
-#: ../../Firmware/ultralcd.cpp:6976
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:5937
+#: ../../Firmware/ultralcd.cpp:6953
 msgid "Checking Y axis"
 msgstr "Y tengely ellenorzes"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/messages.cpp:358 ../../Firmware/ultralcd.cpp:6977
+#: ../../Firmware/messages.cpp:370 ../../Firmware/ultralcd.cpp:6954
 msgid "Checking Z axis"
 msgstr "Z tengely ellenorzes"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6978
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6955
 msgid "Checking bed"
 msgstr "Asztal ellenorzese"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/messages.cpp:357 ../../Firmware/ultralcd.cpp:6974
+#: ../../Firmware/messages.cpp:369 ../../Firmware/ultralcd.cpp:6951
 msgid "Checking endstops"
 msgstr "Vegallaskapcs. ellen"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/messages.cpp:362 ../../Firmware/ultralcd.cpp:7070
+#: ../../Firmware/messages.cpp:374 ../../Firmware/ultralcd.cpp:7047
 msgid "Checking file"
 msgstr "Fajl ellenorzese"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/messages.cpp:359 ../../Firmware/ultralcd.cpp:6980
+#: ../../Firmware/messages.cpp:371 ../../Firmware/ultralcd.cpp:6957
 msgid "Checking hotend"
 msgstr "Hotend ellenorzese"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6981
-#: ../../Firmware/ultralcd.cpp:6982
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6958
+#: ../../Firmware/ultralcd.cpp:6959
 msgid "Checking sensors"
 msgstr "Szenz. ellenorzese"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/messages.cpp:308 ../../Firmware/ultralcd.cpp:4424
+#: ../../Firmware/messages.cpp:320 ../../Firmware/ultralcd.cpp:4391
 msgid "Checks"
 msgstr "Ellenorzesek"
 
 #. MSG_TM_ACK_ERROR c=18
-#: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5297
+#: ../../Firmware/messages.cpp:197 ../../Firmware/ultralcd.cpp:5263
 msgid "Clear TM error"
 msgstr "TM hiba törlése"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/messages.cpp:244 ../../Firmware/ultralcd.cpp:2205
+#: ../../Firmware/messages.cpp:256 ../../Firmware/ultralcd.cpp:2219
 msgid "Color not correct"
 msgstr "Szin nem jo"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:3508
+#: ../../Firmware/messages.cpp:27 ../../Firmware/ultralcd.cpp:3518
 msgid "Community made"
 msgstr "Kozossegi"
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:4059
+#: ../../Firmware/messages.cpp:178 ../../Firmware/ultralcd.cpp:4083
 msgid "Cont."
 msgstr "Folyt"
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:2129
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2135
 msgid "Cooldown"
 msgstr "Lehutes"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/messages.cpp:283 ../../Firmware/ultralcd.cpp:3450
+#: ../../Firmware/messages.cpp:295 ../../Firmware/ultralcd.cpp:3460
 msgid "Copy selected language?"
 msgstr "Kivalasztott nyelv masolasa?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:1234
-#: ../../Firmware/ultralcd.cpp:1263
+#: ../../Firmware/messages.cpp:30 ../../Firmware/ultralcd.cpp:1244
+#: ../../Firmware/ultralcd.cpp:1273
 msgid "Crash"
 msgstr "Utkozes"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4146
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/ultralcd.cpp:4170
 msgid "Crash det."
 msgstr "Utkozes erz."
 
 #. MSG_CRASH_DETECTED c=20
-#: ../../Firmware/Marlin_main.cpp:630 ../../Firmware/messages.cpp:30
+#: ../../Firmware/Marlin_main.cpp:595 ../../Firmware/messages.cpp:31
 msgid "Crash detected."
 msgstr "Utkozes erzekelve."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/messages.cpp:280 ../../Firmware/ultralcd.cpp:3374
+#: ../../Firmware/messages.cpp:292 ../../Firmware/ultralcd.cpp:3384
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -396,24 +395,24 @@ msgstr ""
 "kapcsolhato be"
 
 #. MSG_CUT_FILAMENT c=16
-#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:380
-#: ../../Firmware/ultralcd.cpp:4854 ../../Firmware/ultralcd.cpp:5351
+#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:381
+#: ../../Firmware/ultralcd.cpp:4810 ../../Firmware/ultralcd.cpp:5317
 msgid "Cut filament"
 msgstr "Filament vagasa"
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4081
-#: ../../Firmware/ultralcd.cpp:4086 ../../Firmware/ultralcd.cpp:4091
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:4105
+#: ../../Firmware/ultralcd.cpp:4110 ../../Firmware/ultralcd.cpp:4115
 msgid "Cutter"
 msgstr "Vago"
 
 #. MSG_DATE c=17
-#: ../../Firmware/messages.cpp:222 ../../Firmware/ultralcd.cpp:1645
+#: ../../Firmware/messages.cpp:234 ../../Firmware/ultralcd.cpp:1655
 msgid "Date:"
 msgstr "Datum:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:178 ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/messages.cpp:185 ../../Firmware/ultralcd.cpp:5594
 msgid "Dim"
 msgstr "Sotet"
 
@@ -423,7 +422,7 @@ msgid "Disable"
 msgstr "Letilt"
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/messages.cpp:311 ../../Firmware/ultralcd.cpp:4460
+#: ../../Firmware/messages.cpp:323 ../../Firmware/ultralcd.cpp:4427
 msgid "Disable steppers"
 msgstr "Motorok kikapcsol."
 
@@ -435,7 +434,7 @@ msgid "Disengaging idler"
 msgstr "Gorgo levalasztasa"
 
 #. MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: ../../Firmware/Marlin_main.cpp:1610 ../../Firmware/Marlin_main.cpp:3334
+#: ../../Firmware/Marlin_main.cpp:1537 ../../Firmware/Marlin_main.cpp:3073
 #: ../../Firmware/messages.cpp:14
 msgid ""
 "Distance between tip of the nozzle and the bed surface has not been set yet."
@@ -447,7 +446,7 @@ msgstr ""
 " bekezdest."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/messages.cpp:301 ../../Firmware/ultralcd.cpp:3923
+#: ../../Firmware/messages.cpp:313 ../../Firmware/ultralcd.cpp:3947
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -456,13 +455,13 @@ msgstr ""
 "asztal kozotti tavolsagot?"
 
 #. MSG_DONE c=8
-#: ../../Firmware/messages.cpp:32 ../../Firmware/mmu2/errors_list.h:367
-#: ../../Firmware/mmu2_reporting.cpp:456
+#: ../../Firmware/messages.cpp:33 ../../Firmware/mmu2/errors_list.h:367
+#: ../../Firmware/mmu2_reporting.cpp:457
 msgid "Done"
 msgstr "Kesz"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/messages.cpp:307 ../../Firmware/ultralcd.cpp:3990
+#: ../../Firmware/messages.cpp:319 ../../Firmware/ultralcd.cpp:4014
 msgid "E-correct"
 msgstr "E-korrekcio"
 
@@ -491,13 +490,13 @@ msgid "ERR Wait for User"
 msgstr "Felh. varakozas HIBA"
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:2253
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:2267
 msgid "ERROR:"
 msgstr "HIBA:"
 
 #. MSG_EJECT_FROM_MMU c=16
-#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:384
-#: ../../Firmware/ultralcd.cpp:4845 ../../Firmware/ultralcd.cpp:5348
+#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:385
+#: ../../Firmware/ultralcd.cpp:4801 ../../Firmware/ultralcd.cpp:5314
 msgid "Eject from MMU"
 msgstr "Kiadás az MMUból"
 
@@ -509,17 +508,17 @@ msgid "Ejecting filament"
 msgstr "Filament kiadasa"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/messages.cpp:348 ../../Firmware/ultralcd.cpp:6722
+#: ../../Firmware/messages.cpp:360 ../../Firmware/ultralcd.cpp:6698
 msgid "Endstop"
 msgstr "Vegallaskapcsolo"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/messages.cpp:349 ../../Firmware/ultralcd.cpp:6727
+#: ../../Firmware/messages.cpp:361 ../../Firmware/ultralcd.cpp:6703
 msgid "Endstop not hit"
 msgstr "Vegallask. nem kapcs"
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/messages.cpp:347 ../../Firmware/ultralcd.cpp:6713
+#: ../../Firmware/messages.cpp:359 ../../Firmware/ultralcd.cpp:6689
 msgid "Endstops"
 msgstr "Vegallaskapcsolok"
 
@@ -531,30 +530,30 @@ msgid "Engaging idler"
 msgstr "Gorgo becsatolasa"
 
 #. MSG_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:3352
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:3362
 msgid "Extruder"
 msgstr "Extruder"
 
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/messages.cpp:227 ../../Firmware/ultralcd.cpp:1700
+#: ../../Firmware/messages.cpp:239 ../../Firmware/ultralcd.cpp:1710
 msgid "Extruder info"
 msgstr "Extruder info"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4044
-#: ../../Firmware/ultralcd.cpp:4051
+#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4068
+#: ../../Firmware/ultralcd.cpp:4075
 msgid "F. autoload"
 msgstr "F. autobetolt"
 
 #. MSG_FSENSOR_JAM_DETECTION c=13
-#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4046
-#: ../../Firmware/ultralcd.cpp:4053
+#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4070
+#: ../../Firmware/ultralcd.cpp:4077
 msgid "F. jam detect"
 msgstr "Dugul. eszlel"
 
 #. MSG_FSENSOR_RUNOUT c=13
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4074
 msgid "F. runout"
 msgstr "F. fogyas"
 
@@ -592,8 +591,8 @@ msgid "FINDA FILAM. STUCK"
 msgstr "FINDA FIL. SZORULT"
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:4059
-#: ../../Firmware/ultralcd.cpp:4062
+#: ../../Firmware/messages.cpp:177 ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/ultralcd.cpp:4086
 msgid "FS Action"
 msgstr "FSz akcio"
 
@@ -618,34 +617,34 @@ msgid "FW RUNTIME ERROR"
 msgstr "FW FUTAS HIBA"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/messages.cpp:330 ../../Firmware/ultralcd.cpp:5382
+#: ../../Firmware/messages.cpp:342 ../../Firmware/ultralcd.cpp:5349
 msgid "Fail stats"
 msgstr "Hiba statisztika"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/messages.cpp:331 ../../Firmware/ultralcd.cpp:5385
+#: ../../Firmware/messages.cpp:343 ../../Firmware/ultralcd.cpp:5352
 msgid "Fail stats MMU"
 msgstr "MMU hiba stat."
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/messages.cpp:355 ../../Firmware/ultralcd.cpp:6768
+#: ../../Firmware/messages.cpp:367 ../../Firmware/ultralcd.cpp:6744
 msgid "False triggering"
 msgstr "Hamis kivalto ok"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4175
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4199
 msgid "Fan speed"
 msgstr "Vent. sebesseg"
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6844
-#: ../../Firmware/ultralcd.cpp:6971 ../../Firmware/ultralcd.cpp:6972
-#: ../../Firmware/ultralcd.cpp:6973
+#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6820
+#: ../../Firmware/ultralcd.cpp:6948 ../../Firmware/ultralcd.cpp:6949
+#: ../../Firmware/ultralcd.cpp:6950
 msgid "Fan test"
 msgstr "Ventillator teszt"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:4179
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:4203
 msgid "Fans check"
 msgstr "Vent.proba"
 
@@ -674,34 +673,34 @@ msgid "Feeding to nozzle"
 msgstr "Fuvokahoz toltes"
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1233
-#: ../../Firmware/ultralcd.cpp:1262 ../../Firmware/ultralcd.cpp:1316
-#: ../../Firmware/ultralcd.cpp:1318
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:1243
+#: ../../Firmware/ultralcd.cpp:1272 ../../Firmware/ultralcd.cpp:1326
+#: ../../Firmware/ultralcd.cpp:1328
 msgid "Fil. runouts"
 msgstr "Fil. kifutasok"
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3313
-#: ../../Firmware/ultralcd.cpp:4039 ../../Firmware/ultralcd.cpp:4464
-#: ../../Firmware/ultralcd.cpp:5532
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3323
+#: ../../Firmware/ultralcd.cpp:4063 ../../Firmware/ultralcd.cpp:4431
+#: ../../Firmware/ultralcd.cpp:5499
 msgid "Fil. sensor"
 msgstr "Fil. szenzor"
 
 #. MSG_FILAMENT_CLEAN c=20 r=3
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2261
-#: ../../Firmware/ultralcd.cpp:2265
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2275
+#: ../../Firmware/ultralcd.cpp:2279
 msgid "Filament extruding & with correct color?"
 msgstr "Filament es a szine rendben?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/messages.cpp:243 ../../Firmware/ultralcd.cpp:2204
+#: ../../Firmware/messages.cpp:255 ../../Firmware/ultralcd.cpp:2218
 msgid "Filament not loaded"
 msgstr "Fil. nincs betoltve"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6763
-#: ../../Firmware/ultralcd.cpp:6767 ../../Firmware/ultralcd.cpp:6771
-#: ../../Firmware/ultralcd.cpp:7000
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6739
+#: ../../Firmware/ultralcd.cpp:6743 ../../Firmware/ultralcd.cpp:6747
+#: ../../Firmware/ultralcd.cpp:6977
 msgid "Filament sensor"
 msgstr "Filament szenzor"
 
@@ -733,42 +732,42 @@ msgstr ""
 "Ellenorizd a PTFE csovet es a szenzort."
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/messages.cpp:246 ../../Firmware/ultralcd.cpp:2347
+#: ../../Firmware/messages.cpp:258 ../../Firmware/ultralcd.cpp:2364
 msgid "Filament used"
 msgstr "Felhasznalt filam."
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/messages.cpp:363 ../../Firmware/ultralcd.cpp:7139
+#: ../../Firmware/messages.cpp:375 ../../Firmware/ultralcd.cpp:7116
 msgid "File incomplete. Continue anyway?"
 msgstr "A fajl vege hianyzik. Folytatod igy is?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
 #: ../../Firmware/messages.cpp:45
 #: ../../Firmware/mmu2_progress_converter.cpp:43
-#: ../../Firmware/ultralcd.cpp:5021 ../../Firmware/ultralcd.cpp:5425
+#: ../../Firmware/ultralcd.cpp:4977 ../../Firmware/ultralcd.cpp:5392
 msgid "Finishing movements"
 msgstr "Mozdulat befejezese"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4575
-#: ../../Firmware/ultralcd.cpp:5141
+#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4531
+#: ../../Firmware/ultralcd.cpp:5101
 msgid "First layer cal."
 msgstr "Elso reteg kal."
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/messages.cpp:293 ../../Firmware/ultralcd.cpp:3846
+#: ../../Firmware/messages.cpp:305 ../../Firmware/ultralcd.cpp:3872
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Elsokent lefuttatom az onellenorzest, hogy megnezzem a leggyakoribb "
 "osszeszerelesi problemakat."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/messages.cpp:334 ../../Firmware/ultralcd.cpp:5520
+#: ../../Firmware/messages.cpp:346 ../../Firmware/ultralcd.cpp:5487
 msgid "Flow"
 msgstr "Flow"
 
 #. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
-#: ../../Firmware/messages.cpp:194 ../../Firmware/ultralcd.cpp:985
+#: ../../Firmware/messages.cpp:201 ../../Firmware/ultralcd.cpp:987
 msgid ""
 "For a Nozzle change please read\n"
 "prusa.io/nozzle-mk3s"
@@ -777,28 +776,28 @@ msgstr ""
 "prusa.io/nozzle-mk3s"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6733
-#: ../../Firmware/ultralcd.cpp:6850 ../../Firmware/ultralcd.cpp:6855
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/ultralcd.cpp:6826 ../../Firmware/ultralcd.cpp:6831
 msgid "Front print fan?"
 msgstr "Elso targyhuto vent?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/messages.cpp:260 ../../Firmware/ultralcd.cpp:2711
+#: ../../Firmware/messages.cpp:272 ../../Firmware/ultralcd.cpp:2728
 msgid "Front side[µm]"
 msgstr "Elulso old[µm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/messages.cpp:353 ../../Firmware/ultralcd.cpp:6757
+#: ../../Firmware/messages.cpp:365 ../../Firmware/ultralcd.cpp:6733
 msgid "Front/left fans"
 msgstr "Elso/bal ventillator"
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:151 ../../Firmware/util.cpp:382
+#: ../../Firmware/messages.cpp:156 ../../Firmware/util.cpp:417
 msgid "G-code sliced for a different level. Continue?"
 msgstr "A G-kod mas szintre lett elokesztve. Folytassam?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:152 ../../Firmware/util.cpp:383
+#: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:418
 msgid ""
 "G-code sliced for a different level. Please re-slice the model again. Print "
 "cancelled."
@@ -807,14 +806,14 @@ msgstr ""
 "megallitva."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:147 ../../Firmware/util.cpp:312
-#: ../../Firmware/util.cpp:401
+#: ../../Firmware/messages.cpp:152 ../../Firmware/util.cpp:319
+#: ../../Firmware/util.cpp:436
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr "A G-kod mas nyomtato tipusra lett elokesztve.Folytassam?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:148 ../../Firmware/util.cpp:313
-#: ../../Firmware/util.cpp:402
+#: ../../Firmware/messages.cpp:153 ../../Firmware/util.cpp:320
+#: ../../Firmware/util.cpp:437
 msgid ""
 "G-code sliced for a different printer type. Please re-slice the model again."
 " Print cancelled."
@@ -823,12 +822,12 @@ msgstr ""
 "Nyomtatas megallitva."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:149 ../../Firmware/util.cpp:362
+#: ../../Firmware/messages.cpp:154 ../../Firmware/util.cpp:369
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "A G-kod ujabb firmverre lett elokesztve.Folytassam?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:150 ../../Firmware/util.cpp:363
+#: ../../Firmware/messages.cpp:155 ../../Firmware/util.cpp:370
 msgid ""
 "G-code sliced for a newer firmware. Please update the firmware. Print "
 "cancelled."
@@ -837,35 +836,35 @@ msgstr ""
 "Nyomtatas megallitva."
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4366
-#: ../../Firmware/ultralcd.cpp:4383 ../../Firmware/ultralcd.cpp:4485
+#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4325
+#: ../../Firmware/ultralcd.cpp:4343 ../../Firmware/ultralcd.cpp:4452
 msgid "HW Setup"
 msgstr "HW beallitas"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/messages.cpp:344 ../../Firmware/ultralcd.cpp:6705
+#: ../../Firmware/messages.cpp:356 ../../Firmware/ultralcd.cpp:6681
 msgid "Heater/Thermistor"
 msgstr "Futotest/Termisztor"
 
 #. MSG_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6184 ../../Firmware/messages.cpp:52
+#: ../../Firmware/Marlin_main.cpp:5416 ../../Firmware/messages.cpp:52
 #: ../../Firmware/ultralcd.cpp:526
 msgid "Heating"
 msgstr "Futes folyamatban"
 
 #. MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:9647 ../../Firmware/messages.cpp:211
+#: ../../Firmware/Marlin_main.cpp:8807 ../../Firmware/messages.cpp:223
 msgid "Heating disabled by safety timer."
 msgstr "A bizonsagi idozito leallitotta a futest"
 
 #. MSG_HEATING_COMPLETE c=20
-#: ../../Firmware/Marlin_main.cpp:6215 ../../Firmware/messages.cpp:53
+#: ../../Firmware/Marlin_main.cpp:5445 ../../Firmware/messages.cpp:53
 #: ../../Firmware/ultralcd.cpp:529
 msgid "Heating done."
 msgstr "Futes kesz."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=12
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:3806
+#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:3832
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -876,7 +875,7 @@ msgstr ""
 "nyomtathatsz is."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:3810
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:3836
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -885,8 +884,8 @@ msgstr ""
 " a beallitasi folyamaton?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4152
-#: ../../Firmware/ultralcd.cpp:4161
+#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:4176
+#: ../../Firmware/ultralcd.cpp:4185
 msgid "High power"
 msgstr "Magas ero"
 
@@ -897,23 +896,23 @@ msgid "Homing"
 msgstr "Homeolas"
 
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
-#: ../../Firmware/messages.cpp:195 ../../Firmware/ultralcd.cpp:1005
+#: ../../Firmware/messages.cpp:206 ../../Firmware/ultralcd.cpp:1011
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr "A hotend 280C-os! Fuvoka kicserleve es kelloen meghuzva?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1106
-#: ../../Firmware/ultralcd.cpp:6991
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1116
+#: ../../Firmware/ultralcd.cpp:6968
 msgid "Hotend fan:"
 msgstr "Hotend vent.:"
 
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/messages.cpp:294 ../../Firmware/ultralcd.cpp:3851
+#: ../../Firmware/messages.cpp:306 ../../Firmware/ultralcd.cpp:3877
 msgid "I will run xyz calibration now. It will take up to 24 mins."
 msgstr "Lefuttatom az XYZ kalibraciot. Ez akár 24 percig is eltarthat."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/messages.cpp:297 ../../Firmware/ultralcd.cpp:3862
+#: ../../Firmware/messages.cpp:309 ../../Firmware/ultralcd.cpp:3884
 msgid "I will run z calibration now."
 msgstr "Lefuttatom a Z kalibraciot."
 
@@ -938,7 +937,7 @@ msgid "INVALID TOOL"
 msgstr "HELYTELEN SZERSZAM"
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=8
-#: ../../Firmware/messages.cpp:303 ../../Firmware/ultralcd.cpp:3931
+#: ../../Firmware/messages.cpp:315 ../../Firmware/ultralcd.cpp:3955
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -947,28 +946,28 @@ msgstr ""
 "Acellapok menupont alatt."
 
 #. MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2540
-#: ../../Firmware/messages.cpp:213
+#: ../../Firmware/mesh_bed_calibration.cpp:2525
+#: ../../Firmware/messages.cpp:225
 msgid "Improving bed calibration point"
 msgstr "Bed kalibracio pontositasa"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:5222
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:5184
 msgid "Info screen"
 msgstr "Info kepernyo"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/messages.cpp:326 ../../Firmware/ultralcd.cpp:5323
+#: ../../Firmware/messages.cpp:338 ../../Firmware/ultralcd.cpp:5289
 msgid "Init. SD card"
 msgstr "SD kartya inic."
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/messages.cpp:238 ../../Firmware/ultralcd.cpp:2142
+#: ../../Firmware/messages.cpp:250 ../../Firmware/ultralcd.cpp:2148
 msgid "Insert filament"
 msgstr "Helyezd be a filam."
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/messages.cpp:335 ../../Firmware/ultralcd.cpp:5998
+#: ../../Firmware/messages.cpp:347 ../../Firmware/ultralcd.cpp:5974
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
@@ -983,115 +982,115 @@ msgid ""
 msgstr "Futas kozbeni hiba. Inditsd ujra az MMU-t vagy frissitsd a firmwaret."
 
 #. MSG_FILAMENT_LOADED c=20 r=3
-#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3628
-#: ../../Firmware/ultralcd.cpp:3890
+#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3638
+#: ../../Firmware/ultralcd.cpp:3914
 msgid "Is filament loaded?"
 msgstr "Filament behelyezve?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3238 ../../Firmware/Marlin_main.cpp:4745
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:3858
+#: ../../Firmware/Marlin_main.cpp:4314 ../../Firmware/messages.cpp:127
+#: ../../Firmware/ultralcd.cpp:3760
 msgid "Is steel sheet on heatbed?"
 msgstr "Rajta van az acellap a targyasztalon?"
 
 #. MSG_ITERATION c=12
-#: ../../Firmware/mesh_bed_calibration.cpp:2265 ../../Firmware/messages.cpp:55
+#: ../../Firmware/mesh_bed_calibration.cpp:2250 ../../Firmware/messages.cpp:55
 msgid "Iteration"
 msgstr "Iteracio"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1128
-#: ../../Firmware/ultralcd.cpp:1286
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1138
+#: ../../Firmware/ultralcd.cpp:1296
 msgid "Last print"
 msgstr "Utolso nyomtatas"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1152
-#: ../../Firmware/ultralcd.cpp:1260 ../../Firmware/ultralcd.cpp:1315
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1162
+#: ../../Firmware/ultralcd.cpp:1270 ../../Firmware/ultralcd.cpp:1325
 msgid "Last print failures"
 msgstr "Utolso nyomt. hibak"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/messages.cpp:251 ../../Firmware/ultralcd.cpp:2478
+#: ../../Firmware/messages.cpp:263 ../../Firmware/ultralcd.cpp:2495
 msgid "Left"
 msgstr "Bal"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6739
-#: ../../Firmware/ultralcd.cpp:6850 ../../Firmware/ultralcd.cpp:6855
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6715
+#: ../../Firmware/ultralcd.cpp:6826 ../../Firmware/ultralcd.cpp:6831
 msgid "Left hotend fan?"
 msgstr "Bal hotend vent.?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/messages.cpp:258 ../../Firmware/ultralcd.cpp:2709
+#: ../../Firmware/messages.cpp:270 ../../Firmware/ultralcd.cpp:2726
 msgid "Left side [µm]"
 msgstr "Bal [µm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:5619
+#: ../../Firmware/messages.cpp:181 ../../Firmware/ultralcd.cpp:5592
 msgid "Level Bright"
 msgstr "Fenyes szint"
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:175 ../../Firmware/ultralcd.cpp:5620
+#: ../../Firmware/messages.cpp:182 ../../Firmware/ultralcd.cpp:5593
 msgid "Level Dimmed"
 msgstr "Sotet szint"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/messages.cpp:312 ../../Firmware/ultralcd.cpp:4491
+#: ../../Firmware/messages.cpp:324 ../../Firmware/ultralcd.cpp:4458
 msgid "Lin. correction"
 msgstr "Lin. korrekcio"
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4501
-#: ../../Firmware/ultralcd.cpp:5251
+#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4468
+#: ../../Firmware/ultralcd.cpp:5213
 msgid "Live adjust Z"
 msgstr "Z magassag beall."
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/messages.cpp:192 ../../Firmware/ultralcd.cpp:4794
-#: ../../Firmware/ultralcd.cpp:4880
+#: ../../Firmware/messages.cpp:199 ../../Firmware/ultralcd.cpp:4750
+#: ../../Firmware/ultralcd.cpp:4836
 msgid "Load All"
 msgstr "Ossz.bet"
 
 #. MSG_LOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4796
-#: ../../Firmware/ultralcd.cpp:4833 ../../Firmware/ultralcd.cpp:4882
-#: ../../Firmware/ultralcd.cpp:5361 ../../Firmware/ultralcd.cpp:5368
+#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4752
+#: ../../Firmware/ultralcd.cpp:4789 ../../Firmware/ultralcd.cpp:4838
+#: ../../Firmware/ultralcd.cpp:5324 ../../Firmware/ultralcd.cpp:5335
 msgid "Load filament"
 msgstr "Filament betolt."
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/messages.cpp:327 ../../Firmware/ultralcd.cpp:5346
+#: ../../Firmware/messages.cpp:339 ../../Firmware/ultralcd.cpp:5312
 msgid "Load to nozzle"
 msgstr "Betolt. fuvokahoz"
 
 #. MSG_LOADING_TEST c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4476
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4443
 msgid "Loading Test"
 msgstr "Betöltési teszt"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/messages.cpp:241 ../../Firmware/ultralcd.cpp:2178
+#: ../../Firmware/messages.cpp:253 ../../Firmware/ultralcd.cpp:2189
 msgid "Loading color"
 msgstr "Szin tisztitasa"
 
 #. MSG_LOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3598 ../../Firmware/messages.cpp:62
+#: ../../Firmware/Marlin_main.cpp:3343 ../../Firmware/messages.cpp:62
 #: ../../Firmware/mmu2_progress_converter.cpp:51
-#: ../../Firmware/mmu2_reporting.cpp:392 ../../Firmware/ultralcd.cpp:2189
-#: ../../Firmware/ultralcd.cpp:3715
+#: ../../Firmware/mmu2_reporting.cpp:393 ../../Firmware/ultralcd.cpp:2199
+#: ../../Firmware/ultralcd.cpp:3725
 msgid "Loading filament"
 msgstr "Filament betoltese"
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/messages.cpp:350 ../../Firmware/ultralcd.cpp:6745
+#: ../../Firmware/messages.cpp:362 ../../Firmware/ultralcd.cpp:6721
 msgid "Loose pulley"
 msgstr "Laza szijtarcsa"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4188
-#: ../../Firmware/ultralcd.cpp:4200
+#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4224
 msgid "Loud"
 msgstr "Hangos"
 
@@ -1106,7 +1105,7 @@ msgid "MMU Firmware internal error, please reset the MMU."
 msgstr "MMU Firmware hiba, kerlek inditsd ujra az MMU-t"
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:4096
+#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4120
 msgid "MMU Mode"
 msgstr "MMU Mod"
 
@@ -1116,7 +1115,7 @@ msgid "MMU NOT RESPONDING"
 msgstr "MMU NEM VALASZOL"
 
 #. MSG_MMU_RESTORE_TEMP c=20 r=4
-#: ../../Firmware/messages.cpp:214 ../../Firmware/mmu2_reporting.cpp:396
+#: ../../Firmware/messages.cpp:226 ../../Firmware/mmu2_reporting.cpp:397
 msgid "MMU Retry: Restoring temperature..."
 msgstr "MMU Ujra: Homerseklet visszaallitasa"
 
@@ -1127,14 +1126,14 @@ msgid "MMU SELFTEST FAILED"
 msgstr "MMU SELFTEST HIBA"
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1153
-#: ../../Firmware/ultralcd.cpp:1178
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1163
+#: ../../Firmware/ultralcd.cpp:1188
 msgid "MMU fails"
 msgstr "MMU hibak"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1154
-#: ../../Firmware/ultralcd.cpp:1179
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1164
+#: ../../Firmware/ultralcd.cpp:1189
 msgid "MMU load fails"
 msgstr "MMU bet. hibak"
 
@@ -1150,66 +1149,64 @@ msgid "MMU not responding. Check the wiring and connectors."
 msgstr "Az MMU nem valaszol. Nezd meg a kabelezest es a konnektorokat."
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/messages.cpp:223 ../../Firmware/ultralcd.cpp:1657
+#: ../../Firmware/messages.cpp:235 ../../Firmware/ultralcd.cpp:1667
 msgid "MMU connected"
 msgstr "MMU csatlakozott"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/messages.cpp:176 ../../Firmware/ultralcd.cpp:5567
 msgid "Magnets comp."
 msgstr "Magnes komp."
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1127
-#: ../../Firmware/ultralcd.cpp:1285 ../../Firmware/ultralcd.cpp:1327
-#: ../../Firmware/ultralcd.cpp:1631 ../../Firmware/ultralcd.cpp:4453
-#: ../../Firmware/ultralcd.cpp:4571 ../../Firmware/ultralcd.cpp:4793
-#: ../../Firmware/ultralcd.cpp:4826 ../../Firmware/ultralcd.cpp:4879
-#: ../../Firmware/ultralcd.cpp:5515
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1137
+#: ../../Firmware/ultralcd.cpp:1295 ../../Firmware/ultralcd.cpp:1337
+#: ../../Firmware/ultralcd.cpp:1641 ../../Firmware/ultralcd.cpp:4420
+#: ../../Firmware/ultralcd.cpp:4527 ../../Firmware/ultralcd.cpp:4749
+#: ../../Firmware/ultralcd.cpp:4782 ../../Firmware/ultralcd.cpp:4835
+#: ../../Firmware/ultralcd.cpp:5482
 msgid "Main"
 msgstr "Fomenu"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/messages.cpp:253 ../../Firmware/ultralcd.cpp:2519
+#: ../../Firmware/messages.cpp:265 ../../Firmware/ultralcd.cpp:2536
 msgid "Measured skew"
 msgstr "Meroleg. hiba"
 
 #. MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3219
-#: ../../Firmware/mesh_bed_calibration.cpp:2852 ../../Firmware/messages.cpp:70
+#: ../../Firmware/Marlin_main.cpp:2963
+#: ../../Firmware/mesh_bed_calibration.cpp:2837 ../../Firmware/messages.cpp:70
 msgid "Measuring reference height of calibration point"
 msgstr "Kalibracios pont magassaganak merese"
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:5590
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:5563
 msgid "Mesh"
 msgstr "Halo"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4488
-#: ../../Firmware/ultralcd.cpp:4587
+#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:4455
+#: ../../Firmware/ultralcd.cpp:4543
 msgid "Mesh Bed Leveling"
 msgstr "Asztal szintezes"
 
 #. MSG_MODE c=6
-#: ../../Firmware/Marlin_main.cpp:8495 ../../Firmware/messages.cpp:117
-#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4132
-#: ../../Firmware/ultralcd.cpp:4140 ../../Firmware/ultralcd.cpp:4144
-#: ../../Firmware/ultralcd.cpp:4152 ../../Firmware/ultralcd.cpp:4155
-#: ../../Firmware/ultralcd.cpp:4158 ../../Firmware/ultralcd.cpp:4161
-#: ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/Marlin_main.cpp:7666 ../../Firmware/messages.cpp:121
+#: ../../Firmware/ultralcd.cpp:4152 ../../Firmware/ultralcd.cpp:4156
+#: ../../Firmware/ultralcd.cpp:4164 ../../Firmware/ultralcd.cpp:4168
+#: ../../Firmware/ultralcd.cpp:4176 ../../Firmware/ultralcd.cpp:4179
+#: ../../Firmware/ultralcd.cpp:4182 ../../Firmware/ultralcd.cpp:4185
+#: ../../Firmware/ultralcd.cpp:5594
 msgid "Mode"
 msgstr "Mod"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/messages.cpp:282 ../../Firmware/ultralcd.cpp:3413
+#: ../../Firmware/messages.cpp:294 ../../Firmware/ultralcd.cpp:3423
 msgid "Mode change in progress..."
 msgstr "Modvaltas folyamatban..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:4310
-#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4316
-#: ../../Firmware/ultralcd.cpp:4319
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4327
 msgid "Model"
 msgstr "Modell"
 
@@ -1230,28 +1227,28 @@ msgid "More details online."
 msgstr "Tovabbi reszletek a neten."
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6719
-#: ../../Firmware/ultralcd.cpp:6728 ../../Firmware/ultralcd.cpp:6746
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6695
+#: ../../Firmware/ultralcd.cpp:6704 ../../Firmware/ultralcd.cpp:6722
 msgid "Motor"
 msgstr "Motor"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/messages.cpp:277 ../../Firmware/ultralcd.cpp:3349
+#: ../../Firmware/messages.cpp:289 ../../Firmware/ultralcd.cpp:3359
 msgid "Move X"
 msgstr "X mozgatasa"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/messages.cpp:278 ../../Firmware/ultralcd.cpp:3350
+#: ../../Firmware/messages.cpp:290 ../../Firmware/ultralcd.cpp:3360
 msgid "Move Y"
 msgstr "Y mozgatasa"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/messages.cpp:279 ../../Firmware/ultralcd.cpp:3351
+#: ../../Firmware/messages.cpp:291 ../../Firmware/ultralcd.cpp:3361
 msgid "Move Z"
 msgstr "Z mozgatasa"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/messages.cpp:310 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:322 ../../Firmware/ultralcd.cpp:4426
 msgid "Move axis"
 msgstr "Tengely mozgatasa"
 
@@ -1262,96 +1259,93 @@ msgid "Moving selector"
 msgstr "Szelektor mozgatasa"
 
 #. MSG_NA c=3
-#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:141
-#: ../../Firmware/ultralcd.cpp:2484 ../../Firmware/ultralcd.cpp:2528
-#: ../../Firmware/ultralcd.cpp:3279 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:4044 ../../Firmware/ultralcd.cpp:4046
-#: ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:146
+#: ../../Firmware/ultralcd.cpp:2501 ../../Firmware/ultralcd.cpp:2545
+#: ../../Firmware/ultralcd.cpp:3289 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4068 ../../Firmware/ultralcd.cpp:4070
+#: ../../Firmware/ultralcd.cpp:5567
 msgid "N/A"
 msgstr "N/A"
 
 #. MSG_NEW_FIRMWARE_AVAILABLE c=20 r=2
-#: ../../Firmware/messages.cpp:365 ../../Firmware/util.cpp:209
+#: ../../Firmware/messages.cpp:377 ../../Firmware/util.cpp:214
 msgid "New firmware version available:"
 msgstr "Uj firmver verzio erheto el:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:3029
-#: ../../Firmware/ultralcd.cpp:4443 ../../Firmware/ultralcd.cpp:4531
-#: ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:2275
+#: ../../Firmware/ultralcd.cpp:2279 ../../Firmware/ultralcd.cpp:3046
+#: ../../Firmware/ultralcd.cpp:4410 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/ultralcd.cpp:5765
 msgid "No"
 msgstr "Nem"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/messages.cpp:325 ../../Firmware/ultralcd.cpp:5321
+#: ../../Firmware/messages.cpp:337 ../../Firmware/ultralcd.cpp:5287
 msgid "No SD card"
 msgstr "Nincs SD kartya"
 
 #. MSG_NO_MOVE c=20
-#: ../../Firmware/Marlin_main.cpp:5271 ../../Firmware/messages.cpp:210
+#: ../../Firmware/Marlin_main.cpp:4778 ../../Firmware/messages.cpp:222
 msgid "No move."
 msgstr "Nincs mozgas."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4239 ../../Firmware/ultralcd.cpp:4310
-#: ../../Firmware/ultralcd.cpp:4319 ../../Firmware/ultralcd.cpp:4349
-#: ../../Firmware/ultralcd.cpp:4358 ../../Firmware/ultralcd.cpp:4516
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4309
+#: ../../Firmware/ultralcd.cpp:4318 ../../Firmware/ultralcd.cpp:4483
 msgid "None"
 msgstr "Nincs"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/Marlin_main.cpp:8497 ../../Firmware/messages.cpp:121
-#: ../../Firmware/ultralcd.cpp:4096 ../../Firmware/ultralcd.cpp:4132
-#: ../../Firmware/ultralcd.cpp:4511
+#: ../../Firmware/Marlin_main.cpp:7668 ../../Firmware/messages.cpp:125
+#: ../../Firmware/ultralcd.cpp:4120 ../../Firmware/ultralcd.cpp:4156
+#: ../../Firmware/ultralcd.cpp:4478
 msgid "Normal"
 msgstr "Normal"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/messages.cpp:345 ../../Firmware/ultralcd.cpp:6706
+#: ../../Firmware/messages.cpp:357 ../../Firmware/ultralcd.cpp:6682
 msgid "Not connected"
 msgstr "Nincs csatlakoztatva"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6863
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6839
 msgid "Not spinning"
 msgstr "Nem forog"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/messages.cpp:289 ../../Firmware/ultralcd.cpp:3726
+#: ../../Firmware/messages.cpp:301 ../../Firmware/ultralcd.cpp:3736
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr ""
 "Most beallitjuk a fuvoka hegye es a targyasztal felulete kozotti tavolsagot."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/messages.cpp:298 ../../Firmware/ultralcd.cpp:3871
+#: ../../Firmware/messages.cpp:310 ../../Firmware/ultralcd.cpp:3894
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Felfutom a fuvokat PLA-hoz."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/messages.cpp:296 ../../Firmware/ultralcd.cpp:3857
+#: ../../Firmware/messages.cpp:308 ../../Firmware/ultralcd.cpp:3883
 msgid "Now remove the test print from steel sheet."
 msgstr "Vedd le a tesztnyomatot az acellaprol."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1390
-#: ../../Firmware/ultralcd.cpp:4170 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4233 ../../Firmware/ultralcd.cpp:4236
-#: ../../Firmware/ultralcd.cpp:4239
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1400
+#: ../../Firmware/ultralcd.cpp:4194 ../../Firmware/ultralcd.cpp:4326
 msgid "Nozzle"
 msgstr "Fuvoka"
 
 #. MSG_NOZZLE_CNG_MENU c=18
-#: ../../Firmware/messages.cpp:193 ../../Firmware/ultralcd.cpp:4423
-#: ../../Firmware/ultralcd.cpp:4486
+#: ../../Firmware/messages.cpp:200 ../../Firmware/ultralcd.cpp:4390
+#: ../../Firmware/ultralcd.cpp:4453
 msgid "Nozzle change"
 msgstr "Fuvoka csereand"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4276
-#: ../../Firmware/ultralcd.cpp:4278 ../../Firmware/ultralcd.cpp:4279
-#: ../../Firmware/ultralcd.cpp:4280
+#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4261
+#: ../../Firmware/ultralcd.cpp:4263 ../../Firmware/ultralcd.cpp:4264
+#: ../../Firmware/ultralcd.cpp:4265
 msgid "Nozzle d."
 msgstr "Fuv. atm."
 
@@ -1362,82 +1356,82 @@ msgid "OK"
 msgstr "OK"
 
 #. MSG_OFF c=3
-#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:139
-#: ../../Firmware/mmu2.cpp:65 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4050 ../../Firmware/ultralcd.cpp:4051
-#: ../../Firmware/ultralcd.cpp:4053 ../../Firmware/ultralcd.cpp:4076
-#: ../../Firmware/ultralcd.cpp:4091 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4179 ../../Firmware/ultralcd.cpp:4467
-#: ../../Firmware/ultralcd.cpp:4495 ../../Firmware/ultralcd.cpp:4498
-#: ../../Firmware/ultralcd.cpp:5439 ../../Firmware/ultralcd.cpp:5594
-#: ../../Firmware/ultralcd.cpp:7487 ../../Firmware/ultralcd.cpp:7491
+#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:144
+#: ../../Firmware/mmu2.cpp:65 ../../Firmware/ultralcd.cpp:4063
+#: ../../Firmware/ultralcd.cpp:4074 ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4077 ../../Firmware/ultralcd.cpp:4100
+#: ../../Firmware/ultralcd.cpp:4115 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/ultralcd.cpp:4203 ../../Firmware/ultralcd.cpp:4434
+#: ../../Firmware/ultralcd.cpp:4462 ../../Firmware/ultralcd.cpp:4465
+#: ../../Firmware/ultralcd.cpp:5406 ../../Firmware/ultralcd.cpp:5567
+#: ../../Firmware/ultralcd.cpp:7464 ../../Firmware/ultralcd.cpp:7468
 msgid "Off"
 msgstr "Ki"
 
 #. MSG_DEFAULT_SETTINGS_LOADED c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:1562 ../../Firmware/messages.cpp:201
+#: ../../Firmware/Marlin_main.cpp:1489 ../../Firmware/messages.cpp:213
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr ""
 "Regi beallitasokat talaltam. Az alap PID, Esteps, stb. lesz beallitva."
 
 #. MSG_ON c=3
-#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:140
-#: ../../Firmware/mmu2.cpp:63 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4050 ../../Firmware/ultralcd.cpp:4051
-#: ../../Firmware/ultralcd.cpp:4053 ../../Firmware/ultralcd.cpp:4076
-#: ../../Firmware/ultralcd.cpp:4081 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4179 ../../Firmware/ultralcd.cpp:4467
-#: ../../Firmware/ultralcd.cpp:4495 ../../Firmware/ultralcd.cpp:4498
-#: ../../Firmware/ultralcd.cpp:5594 ../../Firmware/ultralcd.cpp:7487
-#: ../../Firmware/ultralcd.cpp:7491
+#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:145
+#: ../../Firmware/mmu2.cpp:63 ../../Firmware/ultralcd.cpp:4063
+#: ../../Firmware/ultralcd.cpp:4074 ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4077 ../../Firmware/ultralcd.cpp:4100
+#: ../../Firmware/ultralcd.cpp:4105 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/ultralcd.cpp:4203 ../../Firmware/ultralcd.cpp:4434
+#: ../../Firmware/ultralcd.cpp:4462 ../../Firmware/ultralcd.cpp:4465
+#: ../../Firmware/ultralcd.cpp:5567 ../../Firmware/ultralcd.cpp:7464
+#: ../../Firmware/ultralcd.cpp:7468
 msgid "On"
 msgstr "Be"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4191
+#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:4215
 msgid "Once"
 msgstr "Egyszer"
 
 #. MSG_PAUSED_THERMAL_ERROR c=20
-#: ../../Firmware/Marlin_main.cpp:9861 ../../Firmware/messages.cpp:186
+#: ../../Firmware/Marlin_main.cpp:9021 ../../Firmware/messages.cpp:193
 msgid "PAUSED THERMAL ERROR"
 msgstr "SZUNET HOMERSEK.HIBA"
 
 #. MSG_PID_RUNNING c=20
-#: ../../Firmware/messages.cpp:219 ../../Firmware/ultralcd.cpp:897
+#: ../../Firmware/messages.cpp:231 ../../Firmware/ultralcd.cpp:897
 msgid "PID cal."
 msgstr "PID kalibracio"
 
 #. MSG_PID_FINISHED c=20
-#: ../../Firmware/messages.cpp:220 ../../Firmware/ultralcd.cpp:902
+#: ../../Firmware/messages.cpp:232 ../../Firmware/ultralcd.cpp:902
 msgid "PID cal. finished"
 msgstr "PID kal. kesz"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:318 ../../Firmware/ultralcd.cpp:4590
+#: ../../Firmware/messages.cpp:330 ../../Firmware/ultralcd.cpp:4546
 msgid "PID calibration"
 msgstr "PID kalibracio"
 
 #. MSG_PINDA_PREHEAT c=20
-#: ../../Firmware/messages.cpp:218 ../../Firmware/ultralcd.cpp:610
+#: ../../Firmware/messages.cpp:230 ../../Firmware/ultralcd.cpp:610
 msgid "PINDA Heating"
 msgstr "PINDA Futes"
 
 #. MSG_PINDA_CALIBRATION c=13
-#: ../../Firmware/Marlin_main.cpp:4790 ../../Firmware/Marlin_main.cpp:4892
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:607
-#: ../../Firmware/ultralcd.cpp:4495 ../../Firmware/ultralcd.cpp:4597
+#: ../../Firmware/Marlin_main.cpp:4359 ../../Firmware/Marlin_main.cpp:4461
+#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:607
+#: ../../Firmware/ultralcd.cpp:4462 ../../Firmware/ultralcd.cpp:4553
 msgid "PINDA cal."
 msgstr "PINDA kal."
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/messages.cpp:276 ../../Firmware/ultralcd.cpp:3233
+#: ../../Firmware/messages.cpp:288 ../../Firmware/ultralcd.cpp:3243
 msgid "PINDA calibration failed"
 msgstr "PINDA kalibracio sikertelen."
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:4967 ../../Firmware/messages.cpp:127
-#: ../../Firmware/ultralcd.cpp:3230
+#: ../../Firmware/Marlin_main.cpp:4536 ../../Firmware/messages.cpp:132
+#: ../../Firmware/ultralcd.cpp:3240
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1455,13 +1449,13 @@ msgid "Parking selector"
 msgstr "Szelektor parkolasa"
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:4062
+#: ../../Firmware/messages.cpp:179 ../../Firmware/ultralcd.cpp:4086
 msgid "Pause"
 msgstr "Szun."
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5271
-#: ../../Firmware/ultralcd.cpp:5273
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5237
+#: ../../Firmware/ultralcd.cpp:5239
 msgid "Pause print"
 msgstr "Nyomtatas szunet"
 
@@ -1472,7 +1466,7 @@ msgid "Performing cut"
 msgstr "Filament vagas"
 
 #. MSG_PAPER c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3243 ../../Firmware/messages.cpp:77
+#: ../../Firmware/Marlin_main.cpp:2982 ../../Firmware/messages.cpp:77
 msgid ""
 "Place a sheet of paper under the nozzle during the calibration of first 4 "
 "points. If the nozzle catches the paper, power off the printer immediately."
@@ -1481,7 +1475,7 @@ msgstr ""
 " fuvoka hozzaer a papirlaphoz, azonnal kapcsold ki a nyomtatot."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:3963
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:3987
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1490,29 +1484,29 @@ msgstr ""
 "folytathatod az uzembe helyezest a nyomtato ujrainditasaval."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/messages.cpp:337 ../../Firmware/ultralcd.cpp:6023
+#: ../../Firmware/messages.cpp:349 ../../Firmware/ultralcd.cpp:5999
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "Nezd meg az IR szenzor csatlakoz., vedd ki a filam., ha bent van."
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/messages.cpp:343 ../../Firmware/ultralcd.cpp:6700
+#: ../../Firmware/messages.cpp:355 ../../Firmware/ultralcd.cpp:6676
 msgid "Please check:"
 msgstr "Kerlek ellenorizd:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/messages.cpp:302 ../../Firmware/ultralcd.cpp:3926
+#: ../../Firmware/messages.cpp:314 ../../Firmware/ultralcd.cpp:3950
 msgid "Please clean heatbed and then press the knob."
 msgstr "Kerlek, tisztisd le a targyasztalt, majd nyomd meg a gombot."
 
 #. MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3217 ../../Firmware/messages.cpp:27
+#: ../../Firmware/Marlin_main.cpp:2960 ../../Firmware/messages.cpp:28
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr ""
 "Kerlek, tisztisd meg a fuvokat kalibracio elott. Nyomd meg a gombot, ha "
 "keszen vagy."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/messages.cpp:288 ../../Firmware/ultralcd.cpp:3712
+#: ../../Firmware/messages.cpp:300 ../../Firmware/ultralcd.cpp:3722
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr ""
@@ -1520,7 +1514,7 @@ msgstr ""
 "betolteshez."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/messages.cpp:287 ../../Firmware/ultralcd.cpp:3705
+#: ../../Firmware/messages.cpp:299 ../../Firmware/ultralcd.cpp:3715
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1529,105 +1523,104 @@ msgstr ""
 "a betolteshez."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/messages.cpp:285 ../../Firmware/ultralcd.cpp:3633
+#: ../../Firmware/messages.cpp:297 ../../Firmware/ultralcd.cpp:3643
 msgid "Please load filament first."
 msgstr "Kerlek eloszor toltsd be a filamentet."
 
 #. MSG_CHECK_IDLER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3525 ../../Firmware/messages.cpp:206
+#: ../../Firmware/Marlin_main.cpp:3265 ../../Firmware/messages.cpp:218
 msgid "Please open idler and remove filament manually."
 msgstr ""
 "Kerlek, nyisd ki a nyomogorgo ajtajat, es tavolitsd el a filamentet kezzel."
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2806 ../../Firmware/messages.cpp:80
-#: ../../Firmware/ultralcd.cpp:3860
+#: ../../Firmware/mesh_bed_calibration.cpp:2791 ../../Firmware/messages.cpp:80
 msgid "Please place steel sheet on heatbed."
 msgstr "Kerlek, helyzed az acellapot a targyasztalra."
 
 #. MSG_PRESS_TO_UNLOAD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:11215 ../../Firmware/Marlin_main.cpp:11245
+#: ../../Firmware/Marlin_main.cpp:10287 ../../Firmware/Marlin_main.cpp:10317
 #: ../../Firmware/messages.cpp:84
 msgid "Please press the knob to unload filament"
 msgstr "Kerlek, nyomd meg a gombot a filament kiadasahoz"
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:4932
+#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:4888
 msgid "Please pull out filament immediately"
 msgstr "Kerlek, huzd ki a filamentet most"
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/messages.cpp:295 ../../Firmware/ultralcd.cpp:3856
+#: ../../Firmware/messages.cpp:307 ../../Firmware/ultralcd.cpp:3882
 msgid "Please remove shipping helpers first."
 msgstr "Tavolitsd el a szallitasi segedanyagokat."
 
 #. MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3240 ../../Firmware/Marlin_main.cpp:4755
-#: ../../Firmware/messages.cpp:89
+#: ../../Firmware/Marlin_main.cpp:4324 ../../Firmware/messages.cpp:89
 msgid "Please remove steel sheet from heatbed."
 msgstr "Kerlek, tavolisd el az acellapot az asztalrol."
 
 #. MSG_RUN_XYZ c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4731 ../../Firmware/messages.cpp:207
+#: ../../Firmware/Marlin_main.cpp:4300 ../../Firmware/messages.cpp:219
 msgid "Please run XYZ calibration first."
 msgstr "Kerlek, elobb futtasd le az XYZ kalibraciot."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/messages.cpp:336 ../../Firmware/ultralcd.cpp:6020
+#: ../../Firmware/messages.cpp:348 ../../Firmware/ultralcd.cpp:4359
+#: ../../Firmware/ultralcd.cpp:5996
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Kerlek eloszor vedd ki a filamentet, majd probalkozz ujra."
 
 #. MSG_NEW_FIRMWARE_PLEASE_UPGRADE c=20
-#: ../../Firmware/messages.cpp:366 ../../Firmware/util.cpp:213
+#: ../../Firmware/messages.cpp:378 ../../Firmware/util.cpp:218
 msgid "Please upgrade."
 msgstr "Kerlek frissits."
 
 #. MSG_PLEASE_WAIT c=20
-#: ../../Firmware/Marlin_main.cpp:3521 ../../Firmware/Marlin_main.cpp:8090
-#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:2179
-#: ../../Firmware/ultralcd.cpp:2190
+#: ../../Firmware/Marlin_main.cpp:3261 ../../Firmware/Marlin_main.cpp:7262
+#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:2190
+#: ../../Firmware/ultralcd.cpp:2204
 msgid "Please wait"
 msgstr "Kerlek varj"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:1232
-#: ../../Firmware/ultralcd.cpp:1261
+#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:1242
+#: ../../Firmware/ultralcd.cpp:1271
 msgid "Power failures"
 msgstr "Aramkimaradasok"
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/messages.cpp:323 ../../Firmware/ultralcd.cpp:5260
+#: ../../Firmware/messages.cpp:335 ../../Firmware/ultralcd.cpp:5222
 msgid "Preheat"
 msgstr "Elofutes"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:2254
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:2268
 msgid "Preheat the nozzle!"
 msgstr "Futsd fel a fuvokat!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:2771
-#: ../../Firmware/ultralcd.cpp:3690 ../../Firmware/ultralcd.cpp:3692
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:2788
+#: ../../Firmware/ultralcd.cpp:3700 ../../Firmware/ultralcd.cpp:3702
 msgid "Preheating nozzle. Please wait."
 msgstr "Fuvoka futese folyamatban. Kerlek, varj."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/messages.cpp:237 ../../Firmware/ultralcd.cpp:1999
+#: ../../Firmware/messages.cpp:249 ../../Firmware/ultralcd.cpp:2005
 msgid "Preheating to cut"
 msgstr "Melegites vagashoz"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/messages.cpp:236 ../../Firmware/ultralcd.cpp:1996
+#: ../../Firmware/messages.cpp:248 ../../Firmware/ultralcd.cpp:2002
 msgid "Preheating to eject"
 msgstr "Melegites kiadashoz"
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/messages.cpp:234 ../../Firmware/ultralcd.cpp:1987
+#: ../../Firmware/messages.cpp:246 ../../Firmware/ultralcd.cpp:1995
 msgid "Preheating to load"
 msgstr "Felfutes betolteshez"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/messages.cpp:235 ../../Firmware/ultralcd.cpp:1992
+#: ../../Firmware/messages.cpp:247 ../../Firmware/ultralcd.cpp:1999
 msgid "Preheating to unload"
 msgstr "Felfutes kiadashoz"
 
@@ -1638,12 +1631,12 @@ msgid "Preparing blade"
 msgstr "Penge elokeszites"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/messages.cpp:231 ../../Firmware/ultralcd.cpp:1799
+#: ../../Firmware/messages.cpp:243 ../../Firmware/ultralcd.cpp:1809
 msgid "Press the knob"
 msgstr "Nyomd meg a gombot"
 
 #. MSG_PRESS_TO_PREHEAT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:11227 ../../Firmware/messages.cpp:212
+#: ../../Firmware/Marlin_main.cpp:10299 ../../Firmware/messages.cpp:224
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Nyomd meg a gombot a folytatashoz es a fuvoka felfutesehez."
 
@@ -1653,34 +1646,34 @@ msgid "Print aborted"
 msgstr "Nyomt. megszakitva"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1106
-#: ../../Firmware/ultralcd.cpp:6994
+#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1116
+#: ../../Firmware/ultralcd.cpp:6971
 msgid "Print fan:"
 msgstr "Targyhuto:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:5313
+#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5279
 msgid "Print from SD"
 msgstr "Nyomtatas SD-rol"
 
 #. MSG_PRINT_PAUSED c=20
-#: ../../Firmware/Marlin_main.cpp:3582 ../../Firmware/messages.cpp:79
+#: ../../Firmware/Marlin_main.cpp:3323 ../../Firmware/messages.cpp:79
 #: ../../Firmware/ultralcd.cpp:814
 msgid "Print paused"
 msgstr "Nyomt. szuneteltetve"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/messages.cpp:247 ../../Firmware/ultralcd.cpp:2348
+#: ../../Firmware/messages.cpp:259 ../../Firmware/ultralcd.cpp:2365
 msgid "Print time"
 msgstr "Nyomtatasi ido"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/messages.cpp:225 ../../Firmware/ultralcd.cpp:1689
+#: ../../Firmware/messages.cpp:237 ../../Firmware/ultralcd.cpp:1699
 msgid "Printer IP Addr:"
 msgstr "Nyomtato IP cime:"
 
 #. MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1602 ../../Firmware/messages.cpp:46
+#: ../../Firmware/Marlin_main.cpp:1529 ../../Firmware/messages.cpp:46
 msgid ""
 "Printer has not been calibrated yet. Please follow the manual, chapter First"
 " steps, section Calibration flow."
@@ -1689,12 +1682,12 @@ msgstr ""
 "lepesek fejezetenek Kalibracio menete bekezdeset."
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:153 ../../Firmware/util.cpp:289
+#: ../../Firmware/messages.cpp:160 ../../Firmware/util.cpp:296
 msgid "Nozzle diameter differs from the G-code. Continue?"
 msgstr "A fuvoka atmeroje elter a G-kodtol. Folytasasm?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:154 ../../Firmware/util.cpp:290
+#: ../../Firmware/messages.cpp:161 ../../Firmware/util.cpp:297
 msgid ""
 "Nozzle diameter differs from the G-code. Please check the value in settings."
 " Print cancelled."
@@ -1719,22 +1712,22 @@ msgid "QUEUE FULL"
 msgstr "SOR TELE"
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:4465
 msgid "RPi port"
 msgstr "RPi port"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/messages.cpp:261 ../../Firmware/ultralcd.cpp:2712
+#: ../../Firmware/messages.cpp:273 ../../Firmware/ultralcd.cpp:2729
 msgid "Rear side [µm]"
 msgstr "Hatso old.[µm]"
 
 #. MSG_RECOVERING_PRINT c=20
-#: ../../Firmware/messages.cpp:216 ../../Firmware/power_panic.cpp:316
+#: ../../Firmware/messages.cpp:228 ../../Firmware/power_panic.cpp:328
 msgid "Recovering print"
 msgstr "Nyomt. visszaallit"
 
 #. MSG_RENAME c=18
-#: ../../Firmware/messages.cpp:322 ../../Firmware/ultralcd.cpp:5143
+#: ../../Firmware/messages.cpp:334 ../../Firmware/ultralcd.cpp:5103
 msgid "Rename"
 msgstr "Atnevezes"
 
@@ -1748,19 +1741,19 @@ msgstr ""
 "kivuli ertekeket a G kodban."
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:2713
-#: ../../Firmware/ultralcd.cpp:5144
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:2730
+#: ../../Firmware/ultralcd.cpp:5104
 msgid "Reset"
 msgstr "Ujrainditas"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/messages.cpp:320 ../../Firmware/ultralcd.cpp:4594
+#: ../../Firmware/messages.cpp:332 ../../Firmware/ultralcd.cpp:4550
 msgid "Reset XYZ calibr."
 msgstr "XYZ kal. nullazas"
 
 #. MSG_RESUME_PRINT c=18
-#: ../../Firmware/Marlin_main.cpp:680 ../../Firmware/messages.cpp:91
-#: ../../Firmware/ultralcd.cpp:5286 ../../Firmware/ultralcd.cpp:5288
+#: ../../Firmware/Marlin_main.cpp:645 ../../Firmware/messages.cpp:91
+#: ../../Firmware/ultralcd.cpp:5252 ../../Firmware/ultralcd.cpp:5254
 msgid "Resume print"
 msgstr "Nyomt. folytatasa"
 
@@ -1787,17 +1780,17 @@ msgid "Returning selector"
 msgstr "Szelektor vissza"
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/messages.cpp:252 ../../Firmware/ultralcd.cpp:2479
+#: ../../Firmware/messages.cpp:264 ../../Firmware/ultralcd.cpp:2496
 msgid "Right"
 msgstr "Jobb"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/messages.cpp:259 ../../Firmware/ultralcd.cpp:2710
+#: ../../Firmware/messages.cpp:271 ../../Firmware/ultralcd.cpp:2727
 msgid "Right side[µm]"
 msgstr "Jobb old.[µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/messages.cpp:286 ../../Firmware/ultralcd.cpp:3656
+#: ../../Firmware/messages.cpp:298 ../../Firmware/ultralcd.cpp:3666
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1806,8 +1799,8 @@ msgstr ""
 "fog mindent kezdeni. Folytatod?"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4509
-#: ../../Firmware/ultralcd.cpp:4511
+#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4476
+#: ../../Firmware/ultralcd.cpp:4478
 msgid "SD card"
 msgstr "SDkartya"
 
@@ -1822,50 +1815,50 @@ msgid "SELECTOR CANNOT MOVE"
 msgstr "SZELEKTOR NEM MOZOG"
 
 #. MSG_STOPPED c=20
-#: ../../Firmware/Marlin_main.cpp:9887 ../../Firmware/messages.cpp:125
+#: ../../Firmware/Marlin_main.cpp:9047 ../../Firmware/messages.cpp:130
 msgid "STOPPED."
 msgstr "MEGALLITVA."
 
 #. MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3223 ../../Firmware/Marlin_main.cpp:3245
-#: ../../Firmware/mesh_bed_calibration.cpp:2246 ../../Firmware/messages.cpp:44
+#: ../../Firmware/Marlin_main.cpp:2967 ../../Firmware/Marlin_main.cpp:2984
+#: ../../Firmware/mesh_bed_calibration.cpp:2231 ../../Firmware/messages.cpp:44
 msgid "Searching bed calibration point"
 msgstr "Kalibracios pont keresese az asztalon"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/messages.cpp:321 ../../Firmware/ultralcd.cpp:5136
+#: ../../Firmware/messages.cpp:333 ../../Firmware/ultralcd.cpp:5096
 msgid "Select"
 msgstr "Kivalasztas"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/messages.cpp:290 ../../Firmware/ultralcd.cpp:3730
+#: ../../Firmware/messages.cpp:302 ../../Firmware/ultralcd.cpp:3740
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
 msgstr "Valassz egy filamentet az elso reteg kalibraciojahoz a menubol."
 
 #. MSG_SELECT_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3453 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3612
-#: ../../Firmware/ultralcd.cpp:6822
+#: ../../Firmware/Marlin_main.cpp:3192 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3622
+#: ../../Firmware/ultralcd.cpp:6798
 msgid "Select filament:"
 msgstr "Valassz filamentet:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:110 ../../Firmware/ultralcd.cpp:3464
-#: ../../Firmware/ultralcd.cpp:4504
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:3474
+#: ../../Firmware/ultralcd.cpp:4471
 msgid "Select language"
 msgstr "Valassz nyelvet"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/messages.cpp:300 ../../Firmware/ultralcd.cpp:3900
+#: ../../Firmware/messages.cpp:312 ../../Firmware/ultralcd.cpp:3924
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr ""
 "Valaszd ki a fuvoka homersekletet, amelyik megfelel az altalad hasznalt "
 "anyaghoz ajanlott homersekletnek."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/messages.cpp:291 ../../Firmware/ultralcd.cpp:3735
+#: ../../Firmware/messages.cpp:303 ../../Firmware/ultralcd.cpp:3745
 msgid "Select temperature which matches your material."
 msgstr "Valassz homersekletet, ami megfelel a filamenthez."
 
@@ -1876,62 +1869,62 @@ msgid "Selecting fil. slot"
 msgstr "Fil.poz.kivalasztasa"
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/messages.cpp:341 ../../Firmware/ultralcd.cpp:6274
+#: ../../Firmware/messages.cpp:353 ../../Firmware/ultralcd.cpp:6250
 msgid "Selftest OK"
 msgstr "Ondiagnosztika OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/messages.cpp:340 ../../Firmware/ultralcd.cpp:6057
+#: ../../Firmware/messages.cpp:352 ../../Firmware/ultralcd.cpp:6033
 msgid "Selftest start"
 msgstr "Ondiagnosztika indul"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/messages.cpp:315 ../../Firmware/ultralcd.cpp:4581
+#: ../../Firmware/messages.cpp:327 ../../Firmware/ultralcd.cpp:4537
 msgid "Selftest"
 msgstr "Ondiagnosztika"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/messages.cpp:342 ../../Firmware/ultralcd.cpp:6699
+#: ../../Firmware/messages.cpp:354 ../../Firmware/ultralcd.cpp:6675
 msgid "Selftest error!"
 msgstr "Ondiagnosztika hiba!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6279
-#: ../../Firmware/ultralcd.cpp:6786 ../../Firmware/ultralcd.cpp:6984
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6255
+#: ../../Firmware/ultralcd.cpp:6762 ../../Firmware/ultralcd.cpp:6961
 msgid "Selftest failed"
 msgstr "Ondiag. sikertelen"
 
 #. MSG_FORCE_SELFTEST c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1577 ../../Firmware/messages.cpp:202
+#: ../../Firmware/Marlin_main.cpp:1504 ../../Firmware/messages.cpp:214
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr ""
 "A pontos szenzor nelkuli homing erdekeben lefuttatom az ondiagnosztikat."
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/messages.cpp:228 ../../Firmware/ultralcd.cpp:1701
+#: ../../Firmware/messages.cpp:240 ../../Firmware/ultralcd.cpp:1711
 msgid "Sensor info"
 msgstr "Szenzor info"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/messages.cpp:338 ../../Firmware/ultralcd.cpp:6027
+#: ../../Firmware/messages.cpp:350 ../../Firmware/ultralcd.cpp:6003
 msgid "Sensor verified, remove the filament now."
 msgstr "Szenzor OK, vedd ki a filamentet most."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/messages.cpp:262 ../../Firmware/ultralcd.cpp:2730
+#: ../../Firmware/messages.cpp:274 ../../Firmware/ultralcd.cpp:2747
 msgid "Set temperature:"
 msgstr "Homerseklet beall.:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3348
-#: ../../Firmware/ultralcd.cpp:3479 ../../Firmware/ultralcd.cpp:3984
-#: ../../Firmware/ultralcd.cpp:5374 ../../Firmware/ultralcd.cpp:5585
-#: ../../Firmware/ultralcd.cpp:5631
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3358
+#: ../../Firmware/ultralcd.cpp:3489 ../../Firmware/ultralcd.cpp:4008
+#: ../../Firmware/ultralcd.cpp:5341 ../../Firmware/ultralcd.cpp:5558
+#: ../../Firmware/ultralcd.cpp:5604
 msgid "Settings"
 msgstr "Beallitasok"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/messages.cpp:255 ../../Firmware/ultralcd.cpp:2522
+#: ../../Firmware/messages.cpp:267 ../../Firmware/ultralcd.cpp:2539
 msgid "Severe skew"
 msgstr "NagyMerol.hiba"
 
@@ -1942,7 +1935,7 @@ msgid "Sheet"
 msgstr "Acellap"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/messages.cpp:284 ../../Firmware/ultralcd.cpp:3604
+#: ../../Firmware/messages.cpp:296 ../../Firmware/ultralcd.cpp:3614
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1955,23 +1948,23 @@ msgstr ""
 "%cUjrainditas"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/messages.cpp:319 ../../Firmware/ultralcd.cpp:4592
+#: ../../Firmware/messages.cpp:331 ../../Firmware/ultralcd.cpp:4548
 msgid "Show end stops"
 msgstr "Vegallaskapcsolok"
 
 #. MSG_SILENT c=7
-#: ../../Firmware/Marlin_main.cpp:8497 ../../Firmware/messages.cpp:120
-#: ../../Firmware/ultralcd.cpp:4155 ../../Firmware/ultralcd.cpp:4194
+#: ../../Firmware/Marlin_main.cpp:7668 ../../Firmware/messages.cpp:124
+#: ../../Firmware/ultralcd.cpp:4179 ../../Firmware/ultralcd.cpp:4218
 msgid "Silent"
 msgstr "Halk"
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/messages.cpp:254 ../../Firmware/ultralcd.cpp:2521
+#: ../../Firmware/messages.cpp:266 ../../Firmware/ultralcd.cpp:2538
 msgid "Slight skew"
 msgstr "Kis merol.hiba"
 
 #. MSG_FILE_CNT c=20 r=6
-#: ../../Firmware/cardreader.cpp:805 ../../Firmware/messages.cpp:197
+#: ../../Firmware/cardreader.cpp:805 ../../Firmware/messages.cpp:209
 msgid ""
 "Some files will not be sorted. Max. No. of files in 1 folder for sorting is "
 "100."
@@ -1980,58 +1973,58 @@ msgstr ""
 "konyvtaron belul."
 
 #. MSG_ZLEVELING_ENFORCED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3043 ../../Firmware/messages.cpp:204
+#: ../../Firmware/Marlin_main.cpp:2783 ../../Firmware/messages.cpp:216
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Hiba tortent, Z szintezes indul..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:4514
-#: ../../Firmware/ultralcd.cpp:4515 ../../Firmware/ultralcd.cpp:4516
+#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4481
+#: ../../Firmware/ultralcd.cpp:4482 ../../Firmware/ultralcd.cpp:4483
 msgid "Sort"
 msgstr "Rendez"
 
 #. MSG_SORTING_FILES c=20
 #: ../../Firmware/cardreader.cpp:849 ../../Firmware/cardreader.cpp:916
-#: ../../Firmware/messages.cpp:111
+#: ../../Firmware/messages.cpp:115
 msgid "Sorting files"
 msgstr "Fajlok rendezese"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4188
-#: ../../Firmware/ultralcd.cpp:4191 ../../Firmware/ultralcd.cpp:4194
-#: ../../Firmware/ultralcd.cpp:4197 ../../Firmware/ultralcd.cpp:4200
+#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4215 ../../Firmware/ultralcd.cpp:4218
+#: ../../Firmware/ultralcd.cpp:4221 ../../Firmware/ultralcd.cpp:4224
 msgid "Sound"
 msgstr "Hang"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/messages.cpp:333 ../../Firmware/ultralcd.cpp:5516
+#: ../../Firmware/messages.cpp:345 ../../Firmware/ultralcd.cpp:5483
 msgid "Speed"
 msgstr "Sebesseg"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6861
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6837
 msgid "Spinning"
 msgstr "Forog"
 
 #. MSG_TEMP_CAL_WARNING c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4744 ../../Firmware/messages.cpp:208
+#: ../../Firmware/Marlin_main.cpp:4313 ../../Firmware/messages.cpp:220
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr "Stabil 21-26C homerseklet es egy merev allvany (asztal) szukseges."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/messages.cpp:329 ../../Firmware/ultralcd.cpp:5379
+#: ../../Firmware/messages.cpp:341 ../../Firmware/ultralcd.cpp:5346
 msgid "Statistics"
 msgstr "Statisztika"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:4096
-#: ../../Firmware/ultralcd.cpp:4144
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4120
+#: ../../Firmware/ultralcd.cpp:4168
 msgid "Stealth"
 msgstr "Halk"
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4421
-#: ../../Firmware/ultralcd.cpp:5133
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4388
+#: ../../Firmware/ultralcd.cpp:5093
 msgid "Steel sheets"
 msgstr "Acellapok"
 
@@ -2041,29 +2034,28 @@ msgid "Stop"
 msgstr "Allj"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:5293
-#: ../../Firmware/ultralcd.cpp:5781
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:5259
+#: ../../Firmware/ultralcd.cpp:5757
 msgid "Stop print"
 msgstr "Nyomt. megallitasa"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4236
-#: ../../Firmware/ultralcd.cpp:4316 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4315
 msgid "Strict"
 msgstr "Szigoru"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/messages.cpp:332 ../../Firmware/ultralcd.cpp:5394
+#: ../../Firmware/messages.cpp:344 ../../Firmware/ultralcd.cpp:5361
 msgid "Support"
 msgstr "Tamogatas"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/messages.cpp:354 ../../Firmware/ultralcd.cpp:6758
+#: ../../Firmware/messages.cpp:366 ../../Firmware/ultralcd.cpp:6734
 msgid "Swapped"
 msgstr "Felcserelve"
 
 #. MSG_THERMAL_ANOMALY c=20
-#: ../../Firmware/messages.cpp:188 ../../Firmware/temperature.cpp:2223
+#: ../../Firmware/messages.cpp:195 ../../Firmware/temperature.cpp:2197
 msgid "THERMAL ANOMALY"
 msgstr "Homersekl. anomalia"
 
@@ -2098,7 +2090,7 @@ msgid "TMC UNDERVOLTAGE ERR"
 msgstr "TMC ALACSONY FESZ."
 
 #. MSG_TM_CAL c=20 r=4
-#: ../../Firmware/messages.cpp:299 ../../Firmware/ultralcd.cpp:3881
+#: ../../Firmware/messages.cpp:311 ../../Firmware/ultralcd.cpp:3905
 msgid ""
 "Thermal model cal. takes approx. 12 mins. See\n"
 "prusa.io/tm-cal"
@@ -2107,22 +2099,22 @@ msgstr ""
 "prusa.io/tm-cal"
 
 #. MSG_TM_NOT_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1613 ../../Firmware/messages.cpp:189
+#: ../../Firmware/Marlin_main.cpp:1540 ../../Firmware/messages.cpp:196
 msgid "Thermal model not calibrated yet."
 msgstr "A termikus modell még nincs kalibrálva."
 
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/messages.cpp:309 ../../Firmware/ultralcd.cpp:4455
+#: ../../Firmware/messages.cpp:321 ../../Firmware/ultralcd.cpp:4422
 msgid "Temperature"
 msgstr "Homerseklet"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/messages.cpp:229 ../../Firmware/ultralcd.cpp:1707
+#: ../../Firmware/messages.cpp:241 ../../Firmware/ultralcd.cpp:1717
 msgid "Temperatures"
 msgstr "Homersekletek"
 
 #. MSG_TESTING_FILAMENT c=20
-#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:388
+#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:389
 msgid "Testing filament"
 msgstr "Filament tesztelese"
 
@@ -2143,7 +2135,7 @@ msgstr ""
 "mozgasat."
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/messages.cpp:292 ../../Firmware/ultralcd.cpp:3738
+#: ../../Firmware/messages.cpp:304 ../../Firmware/ultralcd.cpp:3748
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -2154,7 +2146,7 @@ msgstr ""
 "Kalibracio fejezeteben."
 
 #. MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1606 ../../Firmware/messages.cpp:47
+#: ../../Firmware/Marlin_main.cpp:1533 ../../Firmware/messages.cpp:47
 msgid ""
 "There is still a need to make Z calibration. Please follow the manual, "
 "chapter First steps, section Calibration flow."
@@ -2163,40 +2155,40 @@ msgstr ""
 " fejezetenek Kalibracio menete bekezdeset."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:4514
+#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:4481
 msgid "Time"
 msgstr "Ido"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:176 ../../Firmware/ultralcd.cpp:5622
+#: ../../Firmware/messages.cpp:183 ../../Firmware/ultralcd.cpp:5595
 msgid "Timeout"
 msgstr "Idotullepes"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:1129
-#: ../../Firmware/ultralcd.cpp:1287
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:1139
+#: ../../Firmware/ultralcd.cpp:1297
 msgid "Total"
 msgstr "Ossz."
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:1177
-#: ../../Firmware/ultralcd.cpp:1231 ../../Firmware/ultralcd.cpp:1317
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:1187
+#: ../../Firmware/ultralcd.cpp:1241 ../../Firmware/ultralcd.cpp:1327
 msgid "Total failures"
 msgstr "Ossz. hiba"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/messages.cpp:248 ../../Firmware/ultralcd.cpp:2369
+#: ../../Firmware/messages.cpp:260 ../../Firmware/ultralcd.cpp:2386
 msgid "Total filament"
 msgstr "Osszes filament"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/messages.cpp:249 ../../Firmware/ultralcd.cpp:2370
+#: ../../Firmware/messages.cpp:261 ../../Firmware/ultralcd.cpp:2387
 msgid "Total print time"
 msgstr "Ossz. nyomt. ido"
 
 #. MSG_TUNE c=8
-#: ../../Firmware/messages.cpp:116 ../../Firmware/mmu2/errors_list.h:372
-#: ../../Firmware/ultralcd.cpp:5258
+#: ../../Firmware/messages.cpp:120 ../../Firmware/mmu2/errors_list.h:372
+#: ../../Firmware/ultralcd.cpp:5220
 msgid "Tune"
 msgstr "Hangolás"
 
@@ -2211,16 +2203,16 @@ msgid "Unload"
 msgstr "Kiadas"
 
 #. MSG_UNLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:2206
-#: ../../Firmware/ultralcd.cpp:5347 ../../Firmware/ultralcd.cpp:5364
-#: ../../Firmware/ultralcd.cpp:5369
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:2220
+#: ../../Firmware/ultralcd.cpp:5313 ../../Firmware/ultralcd.cpp:5331
+#: ../../Firmware/ultralcd.cpp:5336
 msgid "Unload filament"
 msgstr "Filament kiadasa"
 
 #. MSG_UNLOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3436 ../../Firmware/messages.cpp:129
+#: ../../Firmware/Marlin_main.cpp:3175 ../../Firmware/messages.cpp:134
 #: ../../Firmware/mmu2_progress_converter.cpp:50
-#: ../../Firmware/ultralcd.cpp:4911
+#: ../../Firmware/ultralcd.cpp:4867
 msgid "Unloading filament"
 msgstr "Filament kiadasa"
 
@@ -2237,12 +2229,12 @@ msgid "Unloading to pulley"
 msgstr "Kiadas a gorgohoz"
 
 #. MSG_FIL_FAILED c=20 r=4
-#: ../../Firmware/messages.cpp:339 ../../Firmware/ultralcd.cpp:6030
+#: ../../Firmware/messages.cpp:351 ../../Firmware/ultralcd.cpp:6006
 msgid "Verification failed, remove the filament and try again."
 msgstr "Ellenorzes sikertelen, vedd ki a filamentet es probald ujra."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/messages.cpp:230 ../../Firmware/ultralcd.cpp:1710
+#: ../../Firmware/messages.cpp:242 ../../Firmware/ultralcd.cpp:1720
 msgid "Voltages"
 msgstr "Feszultsegek"
 
@@ -2253,7 +2245,7 @@ msgid "WARNING TMC TOO HOT"
 msgstr "FIGYELEM A TMC FORRO"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/messages.cpp:281 ../../Firmware/ultralcd.cpp:3381
+#: ../../Firmware/messages.cpp:293 ../../Firmware/ultralcd.cpp:3391
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -2266,193 +2258,195 @@ msgstr ""
 "Halk modban"
 
 #. MSG_USERWAIT c=20
-#: ../../Firmware/Marlin_main.cpp:5240 ../../Firmware/messages.cpp:209
+#: ../../Firmware/Marlin_main.cpp:4747 ../../Firmware/messages.cpp:221
 msgid "Wait for user..."
 msgstr "Var. a felhasznalora"
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/messages.cpp:263 ../../Firmware/ultralcd.cpp:2753
+#: ../../Firmware/messages.cpp:275 ../../Firmware/ultralcd.cpp:2770
 msgid "Waiting for PINDA probe cooling"
 msgstr "A PINDA szenzor kihuleset varom."
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/messages.cpp:264 ../../Firmware/ultralcd.cpp:2782
+#: ../../Firmware/messages.cpp:276 ../../Firmware/ultralcd.cpp:2799
 msgid "Waiting for nozzle and bed cooling"
 msgstr "A fuvoka es az asztal kihuleset varom."
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:4233
-#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4352
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4312
 msgid "Warn"
 msgstr "Figylem."
 
 #. MSG_CHANGED_BOTH c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1554 ../../Firmware/messages.cpp:200
+#: ../../Firmware/Marlin_main.cpp:1481 ../../Firmware/messages.cpp:212
 msgid "Warning: both printer type and motherboard type changed."
 msgstr "Figyelem: a nyomtato es az alaplap tipusa is megvaltozott."
 
 #. MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1546 ../../Firmware/messages.cpp:198
+#: ../../Firmware/Marlin_main.cpp:1473 ../../Firmware/messages.cpp:210
 msgid "Warning: motherboard type changed."
 msgstr "Figyelem: az alaplap tipusa megvaltozott."
 
 #. MSG_CHANGED_PRINTER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1550 ../../Firmware/messages.cpp:199
+#: ../../Firmware/Marlin_main.cpp:1477 ../../Firmware/messages.cpp:211
 msgid "Warning: printer type changed."
 msgstr "Figyelem: a nyomtato tipusa megvaltozott."
 
 #. MSG_UNLOAD_SUCCESSFUL c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3517 ../../Firmware/messages.cpp:205
+#: ../../Firmware/Marlin_main.cpp:3257 ../../Firmware/messages.cpp:217
 msgid "Was filament unload successful?"
 msgstr "Sikerult kivenni a filamentet?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:6710
-#: ../../Firmware/ultralcd.cpp:6714 ../../Firmware/ultralcd.cpp:6734
-#: ../../Firmware/ultralcd.cpp:6740 ../../Firmware/ultralcd.cpp:6764
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:6686
+#: ../../Firmware/ultralcd.cpp:6690 ../../Firmware/ultralcd.cpp:6710
+#: ../../Firmware/ultralcd.cpp:6716 ../../Firmware/ultralcd.cpp:6740
 msgid "Wiring error"
 msgstr "Kabelezesi hiba"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/messages.cpp:313 ../../Firmware/ultralcd.cpp:4572
+#: ../../Firmware/messages.cpp:325 ../../Firmware/ultralcd.cpp:4528
 msgid "Wizard"
 msgstr "Varazslo"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/messages.cpp:304 ../../Firmware/ultralcd.cpp:3986
+#: ../../Firmware/messages.cpp:316 ../../Firmware/ultralcd.cpp:4010
 msgid "X-correct"
 msgstr "X-korrekcio"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/messages.cpp:226 ../../Firmware/ultralcd.cpp:1699
+#: ../../Firmware/messages.cpp:238 ../../Firmware/ultralcd.cpp:1709
 msgid "XYZ cal. details"
 msgstr "XYZ kal. reszlet"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/messages.cpp:275 ../../Firmware/ultralcd.cpp:3207
+#: ../../Firmware/messages.cpp:287 ../../Firmware/ultralcd.cpp:3217
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr ""
 "XYZ kalibracio OK. Az esetleges X/Y merolegessegi hiba automatikusan "
 "korrigalva lesz."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/messages.cpp:274 ../../Firmware/ultralcd.cpp:3204
+#: ../../Firmware/messages.cpp:286 ../../Firmware/ultralcd.cpp:3214
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr ""
 "XYZ kalibracio sikerult. Az X/Y tengelyeken enyhe merolegessegi hiba van."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/messages.cpp:271 ../../Firmware/ultralcd.cpp:3185
+#: ../../Firmware/messages.cpp:283 ../../Firmware/ultralcd.cpp:3195
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr ""
 "Az XYZ kalibracio sikertelen. Az elulso kalibracios pontok nem erhetoek el."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/messages.cpp:272 ../../Firmware/ultralcd.cpp:3188
+#: ../../Firmware/messages.cpp:284 ../../Firmware/ultralcd.cpp:3198
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr ""
 "Az XYZ kalibracio sikertelen. A jobb kalibracios pontok nem erhetoek el."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/messages.cpp:268 ../../Firmware/ultralcd.cpp:3167
+#: ../../Firmware/messages.cpp:280 ../../Firmware/ultralcd.cpp:3177
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr ""
 "Az XYZ kalibracio sikertelen. Az asztal kalibracios pontja nem erheto el."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/messages.cpp:269 ../../Firmware/ultralcd.cpp:3173
+#: ../../Firmware/messages.cpp:281 ../../Firmware/ultralcd.cpp:3183
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr ""
 "Az XYZ kalibracio sikertelen. Az elulso kalibracios pontok nem erhetoek el."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3170
-#: ../../Firmware/ultralcd.cpp:3198
+#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3180
+#: ../../Firmware/ultralcd.cpp:3208
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "XYZ kalibracio sikertelen. Kerlek, nezz bele a kezikonyvbe."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/messages.cpp:270 ../../Firmware/ultralcd.cpp:3176
+#: ../../Firmware/messages.cpp:282 ../../Firmware/ultralcd.cpp:3186
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr ""
 "Az XYZ kalibracio sikertelen. A jobb kalibracios pontok nem erhetoek el."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/messages.cpp:273 ../../Firmware/ultralcd.cpp:3201
+#: ../../Firmware/messages.cpp:285 ../../Firmware/ultralcd.cpp:3211
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "XYZ kalibracio OK. Az X/Y tengelyek merolegesek. Gratulalok!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/messages.cpp:250 ../../Firmware/ultralcd.cpp:2476
+#: ../../Firmware/messages.cpp:262 ../../Firmware/ultralcd.cpp:2493
 msgid "Y distance from min"
 msgstr "Y-minimum tavolsag"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/messages.cpp:305 ../../Firmware/ultralcd.cpp:3987
+#: ../../Firmware/messages.cpp:317 ../../Firmware/ultralcd.cpp:4011
 msgid "Y-correct"
 msgstr "Y-korrekcio"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:3029
-#: ../../Firmware/ultralcd.cpp:4443 ../../Firmware/ultralcd.cpp:4531
-#: ../../Firmware/ultralcd.cpp:5790
+#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:2275
+#: ../../Firmware/ultralcd.cpp:2279 ../../Firmware/ultralcd.cpp:3046
+#: ../../Firmware/ultralcd.cpp:4410 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/ultralcd.cpp:5766
 msgid "Yes"
 msgstr "Igen"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:3950
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:3974
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr "A Varazsolt barmikor elered a Kalibracio -> Varazslo menubol."
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/messages.cpp:306 ../../Firmware/ultralcd.cpp:3988
+#: ../../Firmware/messages.cpp:318 ../../Firmware/ultralcd.cpp:4012
 msgid "Z-correct"
 msgstr "Z-korrekcio"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5593
+#: ../../Firmware/messages.cpp:175 ../../Firmware/ultralcd.cpp:5566
 msgid "Z-probe nr."
 msgstr "Z meres szama"
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/messages.cpp:256 ../../Firmware/ultralcd.cpp:2546
+#: ../../Firmware/messages.cpp:268 ../../Firmware/ultralcd.cpp:2563
 msgid "[0;0] point offset"
 msgstr "[0;0] pont offszet"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/messages.cpp:239 ../../Firmware/ultralcd.cpp:2147
+#: ../../Firmware/messages.cpp:251 ../../Firmware/ultralcd.cpp:2158
 msgid "and press the knob"
-msgstr "es nyomd meg\na gombot"
+msgstr ""
+"es nyomd meg\n"
+"a gombot"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/messages.cpp:232 ../../Firmware/ultralcd.cpp:1807
+#: ../../Firmware/messages.cpp:244 ../../Firmware/ultralcd.cpp:1816
 msgid "to load filament"
 msgstr "filam. betoltesehez"
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/messages.cpp:233 ../../Firmware/ultralcd.cpp:1811
+#: ../../Firmware/messages.cpp:245 ../../Firmware/ultralcd.cpp:1820
 msgid "to unload filament"
 msgstr "filament kiadasahoz"
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/messages.cpp:224 ../../Firmware/ultralcd.cpp:1666
+#: ../../Firmware/messages.cpp:236 ../../Firmware/ultralcd.cpp:1676
 msgid "unknown"
 msgstr "ismeretlen"
 
 #. MSG_IR_UNKNOWN c=18
-#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:184
+#: ../../Firmware/Filament_sensor.cpp:286 ../../Firmware/messages.cpp:191
 msgid "unknown state"
 msgstr "ismeretlen allapot"
 
 #. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:5858
-#: ../../Firmware/ultralcd.cpp:5861
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:5834
+#: ../../Firmware/ultralcd.cpp:5837
 msgid "🔃Refresh"
 msgstr "🔃Frissites"
 
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1180
+#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1190
 msgid "MMU power fails"
 msgstr "MMU tap hibak"
 
@@ -2490,8 +2484,8 @@ msgid "MMU MCU ERROR"
 msgstr "MMU MCU HIBA"
 
 #. MSG_MATERIAL_CHANGES c=18
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:1130
-#: ../../Firmware/ultralcd.cpp:1204
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:1140
+#: ../../Firmware/ultralcd.cpp:1214
 msgid "Material changes"
 msgstr "Anyagcserék"
 
@@ -2523,17 +2517,17 @@ msgstr ""
 "3.0.3-es verzióra."
 
 #. MSG_PRELOAD_TO_MMU c=17
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5344
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5310
 msgid "Preload to MMU"
 msgstr "Betöltés az MMUba"
 
 #. MSG_FW_MK3_DETECTED c=20 r=4
-#: ../../Firmware/messages.cpp:367 ../../Firmware/Marlin_main.cpp:920
+#: ../../Firmware/messages.cpp:379 ../../Firmware/Marlin_main.cpp:854
 msgid "MK3 firmware detected on MK3S printer"
 msgstr "MK3 firmver telepitve MK3S nyomtatora"
 
 #. MSG_FW_MK3S_DETECTED c=20 r=4
-#: ../../Firmware/messages.cpp:367 ../../Firmware/Marlin_main.cpp:920
+#: ../../Firmware/messages.cpp:379 ../../Firmware/Marlin_main.cpp:854
 msgid "MK3S firmware detected on MK3 printer"
 msgstr "MK3S firmver eszlelve MK3 nyomtaton"
 
@@ -2547,8 +2541,9 @@ msgstr "ISMERETLEN HIBA"
 msgid "Unexpected error occurred."
 msgstr "Váratlan hiba történt."
 
-#. MSG_BTN_EJECT c=8
-#: ../../Firmware/mmu2/errors_list.h:358 ../../Firmware/mmu2/errors_list.h:371
+#. MSG_EJECT c=8
+#: ../../Firmware/messages.cpp:21 ../../Firmware/mmu2/errors_list.h:371
+#: ../../Firmware/ultralcd.cpp:2275 ../../Firmware/ultralcd.cpp:2279
 msgid "Eject"
 msgstr "Kiadás"
 
@@ -2569,58 +2564,58 @@ msgstr ""
 "M600 Filamentcsere. Helyezz be egy új filamentet, vagy vedd ki a régit."
 
 #. MSG_MMU_SENSITIVITY c=18
-#: ../../Firmware/messages.cpp:215 ../../Firmware/mmu2_reporting.cpp:458
+#: ../../Firmware/messages.cpp:227 ../../Firmware/mmu2_reporting.cpp:459
 msgid "Sensitivity"
 msgstr "Érzékenység"
 
 #. MSG_MBL_FAILED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3038 ../../Firmware/messages.cpp:203
+#: ../../Firmware/Marlin_main.cpp:2776 ../../Firmware/messages.cpp:215
 msgid "Mesh bed leveling failed. Print canceled."
 msgstr "Sikertelen asztal szintezés. Nyomtatas megallitva."
 
 #. MSG_SET_READY c=18
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:5265
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:5228
 msgid "Set Ready"
 msgstr "Készen áll"
 
 #. MSG_SET_NOT_READY c=18
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:5263
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5226
 msgid "Set not Ready"
 msgstr "Nem áll készen"
 
 #. MSG_HOSTPRINT c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5285
+#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:5231
 msgid "Print from host"
 msgstr "Nyomtatás gépről"
 
 #. MSG_REPRINT c=18
-#: ../../Firmware/messages.cpp:196 ../../Firmware/ultralcd.cpp:5243
-#: ../../Firmware/ultralcd.cpp:5245
+#: ../../Firmware/messages.cpp:208 ../../Firmware/ultralcd.cpp:5205
+#: ../../Firmware/ultralcd.cpp:5207
 msgid "Reprint"
 msgstr "Újranyomtatás"
 
 #. MSG_SHUTDOWN_HOST c=18
-#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:5390
+#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:5357
 msgid "Shutdown host"
 msgstr "Gazdagép leállítás"
 
 #. MSG_NOZZLE_CNG_COOLDOWN c=20 r=3
-#: ../../Firmware/messages.cpp:198 ../../Firmware/ultralcd.cpp:1002
+#: ../../Firmware/messages.cpp:203 ../../Firmware/ultralcd.cpp:999
 msgid "Nozzle is hot! Wait for cooldown."
 msgstr "A fúvóka forró! Várja meg a lehűlést."
 
 #. MSG_NOZZLE_CNG_CHANGED_QUICK c=20 r=3
-#: ../../Firmware/messages.cpp:199
+#: ../../Firmware/messages.cpp:204
 msgid "Nozzle changed?"
 msgstr "Fúvóka cserélve?"
 
 #. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:388
+#: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:388
 msgid "There is no filament loaded. Continue?"
 msgstr "Nincs befűzve filament. Folytassam?"
 
 #. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:389
+#: ../../Firmware/messages.cpp:159 ../../Firmware/util.cpp:389
 msgid "There is no filament loaded. Print cancelled."
 msgstr "Nincs befűzve filament. Nyomtatás megállítva."
 

--- a/lang/po/Firmware_it.po
+++ b/lang/po/Firmware_it.po
@@ -16,91 +16,91 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 
 #. MSG_IR_03_OR_OLDER c=18
-#: ../../Firmware/Filament_sensor.cpp:280
-#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:183
+#: ../../Firmware/Filament_sensor.cpp:282
+#: ../../Firmware/Filament_sensor.cpp:344 ../../Firmware/messages.cpp:190
 msgid " 0.3 or older"
 msgstr " 0.3 o inferiore"
 
 #. MSG_IR_04_OR_NEWER c=18
-#: ../../Firmware/Filament_sensor.cpp:282
-#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:182
+#: ../../Firmware/Filament_sensor.cpp:284
+#: ../../Firmware/Filament_sensor.cpp:347 ../../Firmware/messages.cpp:189
 msgid " 0.4 or newer"
 msgstr " 0.4 o superiore"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/messages.cpp:356 ../../Firmware/ultralcd.cpp:6773
+#: ../../Firmware/messages.cpp:368 ../../Firmware/ultralcd.cpp:6749
 msgid "%s level expected"
 msgstr "atteso livello %s"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:1978
-#: ../../Firmware/ultralcd.cpp:3613
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:1986
+#: ../../Firmware/ultralcd.cpp:3623
 msgid ">Cancel"
 msgstr ">Annulla"
 
 #. MSG_BABYSTEPPING_Z c=13
-#: ../../Firmware/messages.cpp:257 ../../Firmware/ultralcd.cpp:2635
+#: ../../Firmware/messages.cpp:269 ../../Firmware/ultralcd.cpp:2652
 msgid "Adjusting Z"
 msgstr "Compensaz. Z"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/messages.cpp:360 ../../Firmware/ultralcd.cpp:6983
+#: ../../Firmware/messages.cpp:372 ../../Firmware/ultralcd.cpp:6960
 msgid "All correct"
 msgstr "Nessun errore"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:3955
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:3979
 msgid "All is done. Happy printing!"
 msgstr "Tutto fatto. Buona stampa!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4482
 msgid "Alphabet"
 msgstr "Alfabeti"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4086
+#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4110
 msgid "Always"
 msgstr "Sempre"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/messages.cpp:221 ../../Firmware/ultralcd.cpp:1393
+#: ../../Firmware/messages.cpp:233 ../../Firmware/ultralcd.cpp:1403
 msgid "Ambient"
 msgstr "Ambiente"
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=3
-#: ../../Firmware/messages.cpp:267 ../../Firmware/ultralcd.cpp:2848
+#: ../../Firmware/messages.cpp:279 ../../Firmware/ultralcd.cpp:2865
 msgid "Are left and right Z-carriages all up?"
 msgstr "I carrelli Z sin/des sono altezza max?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4197
+#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:4221
 msgid "Assist"
 msgstr "Assist."
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:179 ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/messages.cpp:186 ../../Firmware/ultralcd.cpp:5594
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
-#: ../../Firmware/Marlin_main.cpp:3198 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:4577 ../../Firmware/ultralcd.cpp:5529
+#: ../../Firmware/Marlin_main.cpp:2942 ../../Firmware/messages.cpp:12
+#: ../../Firmware/ultralcd.cpp:4533 ../../Firmware/ultralcd.cpp:5496
 msgid "Auto home"
 msgstr "Trova origine"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4182
 msgid "Auto power"
 msgstr "Automatico"
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:328 ../../Firmware/ultralcd.cpp:5359
+#: ../../Firmware/messages.cpp:340 ../../Firmware/ultralcd.cpp:5328
 msgid "AutoLoad filament"
 msgstr "Autocaric. filam."
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/messages.cpp:245 ../../Firmware/ultralcd.cpp:2272
+#: ../../Firmware/messages.cpp:257 ../../Firmware/ultralcd.cpp:2289
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
@@ -113,51 +113,50 @@ msgid "Avoiding grind"
 msgstr "Evito triturazione"
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/messages.cpp:352 ../../Firmware/ultralcd.cpp:6752
+#: ../../Firmware/messages.cpp:364 ../../Firmware/ultralcd.cpp:6728
 msgid "Axis"
 msgstr "Assi"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/messages.cpp:351 ../../Firmware/ultralcd.cpp:6751
+#: ../../Firmware/messages.cpp:363 ../../Firmware/ultralcd.cpp:6727
 msgid "Axis length"
 msgstr "Lunghezza dell'asse"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2708
-#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:5618
-#: ../../Firmware/ultralcd.cpp:7484
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2725
+#: ../../Firmware/ultralcd.cpp:4061 ../../Firmware/ultralcd.cpp:5591
+#: ../../Firmware/ultralcd.cpp:7461
 msgid "Back"
 msgstr "Indietro"
 
 #. MSG_BED c=13
-#: ../../Firmware/Marlin_main.cpp:2081 ../../Firmware/Marlin_main.cpp:4627
-#: ../../Firmware/Marlin_main.cpp:4678 ../../Firmware/messages.cpp:15
-#: ../../Firmware/ultralcd.cpp:1391 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/Marlin_main.cpp:4247 ../../Firmware/messages.cpp:15
+#: ../../Firmware/ultralcd.cpp:1401 ../../Firmware/ultralcd.cpp:4197
 msgid "Bed"
 msgstr "Piano"
 
 #. MSG_BED_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6240 ../../Firmware/messages.cpp:17
+#: ../../Firmware/Marlin_main.cpp:5470 ../../Firmware/messages.cpp:17
 #: ../../Firmware/ultralcd.cpp:534
 msgid "Bed Heating"
 msgstr "Riscald. piano"
 
 #. MSG_BED_DONE c=20
-#: ../../Firmware/Marlin_main.cpp:6277 ../../Firmware/messages.cpp:16
+#: ../../Firmware/Marlin_main.cpp:5507 ../../Firmware/messages.cpp:16
 #: ../../Firmware/ultralcd.cpp:537
 msgid "Bed done"
 msgstr "Piano fatto."
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/messages.cpp:317 ../../Firmware/ultralcd.cpp:4589
+#: ../../Firmware/messages.cpp:329 ../../Firmware/ultralcd.cpp:4545
 msgid "Bed level correct"
 msgstr "Correz. liv.piano"
 
 #. MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:2262 ../../Firmware/Marlin_main.cpp:2999
-#: ../../Firmware/Marlin_main.cpp:3008
-#: ../../Firmware/mesh_bed_calibration.cpp:2878
-#: ../../Firmware/mesh_bed_calibration.cpp:2903 ../../Firmware/messages.cpp:18
+#: ../../Firmware/Marlin_main.cpp:2048 ../../Firmware/Marlin_main.cpp:2736
+#: ../../Firmware/Marlin_main.cpp:2745
+#: ../../Firmware/mesh_bed_calibration.cpp:2863
+#: ../../Firmware/mesh_bed_calibration.cpp:2888 ../../Firmware/messages.cpp:18
 msgid ""
 "Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for "
 "reset."
@@ -166,34 +165,34 @@ msgstr ""
 "reset."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/messages.cpp:346 ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/messages.cpp:358 ../../Firmware/ultralcd.cpp:6685
 msgid "Bed/Heater"
 msgstr "Piano/Riscald."
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1444
-#: ../../Firmware/ultralcd.cpp:1704
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1454
+#: ../../Firmware/ultralcd.cpp:1714
 msgid "Belt status"
 msgstr "Stato cinghie"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/messages.cpp:314 ../../Firmware/ultralcd.cpp:4579
+#: ../../Firmware/messages.cpp:326 ../../Firmware/ultralcd.cpp:4535
 msgid "Belt test"
 msgstr "Test cinghie"
 
 #. MSG_RECOVER_PRINT c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:1660 ../../Firmware/messages.cpp:87
+#: ../../Firmware/Marlin_main.cpp:1587 ../../Firmware/messages.cpp:87
 msgid "Blackout occurred. Recover print?"
 msgstr "Blackout rilevato. Recuperare stampa?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:177 ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:5594
 msgid "Bright"
 msgstr "Chiaro"
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:4526
-#: ../../Firmware/ultralcd.cpp:5546
+#: ../../Firmware/messages.cpp:180 ../../Firmware/ultralcd.cpp:4493
+#: ../../Firmware/ultralcd.cpp:5513
 msgid "Brightness"
 msgstr "Luminosita'"
 
@@ -203,17 +202,17 @@ msgid "COMMUNICATION ERROR"
 msgstr "ERRORE COMUNICAZIONE"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/messages.cpp:316 ../../Firmware/ultralcd.cpp:4583
+#: ../../Firmware/messages.cpp:328 ../../Firmware/ultralcd.cpp:4539
 msgid "Calibrate XYZ"
 msgstr "Calibra XYZ"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4585
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4541
 msgid "Calibrate Z"
 msgstr "Calibra Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/messages.cpp:266 ../../Firmware/ultralcd.cpp:2813
+#: ../../Firmware/messages.cpp:278 ../../Firmware/ultralcd.cpp:2830
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -222,13 +221,13 @@ msgstr ""
 "all'altezza massima. Click per terminare."
 
 #. MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: ../../Firmware/Marlin_main.cpp:2218 ../../Firmware/messages.cpp:22
+#: ../../Firmware/Marlin_main.cpp:2009 ../../Firmware/messages.cpp:23
 #: ../../Firmware/ultralcd.cpp:582
 msgid "Calibrating Z"
 msgstr "Calibrando Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/messages.cpp:265 ../../Firmware/ultralcd.cpp:2812
+#: ../../Firmware/messages.cpp:277 ../../Firmware/ultralcd.cpp:2829
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -237,17 +236,17 @@ msgstr ""
 "all'altezza massima. Click per terminare."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/messages.cpp:361 ../../Firmware/ultralcd.cpp:6985
+#: ../../Firmware/messages.cpp:373 ../../Firmware/ultralcd.cpp:6962
 msgid "Calibrating home"
 msgstr "Calibrazione Home"
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5375
+#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5342
 msgid "Calibration"
 msgstr "Calibrazione"
 
 #. MSG_HOMEYZ_DONE c=20
-#: ../../Firmware/messages.cpp:217 ../../Firmware/ultralcd.cpp:593
+#: ../../Firmware/messages.cpp:229 ../../Firmware/ultralcd.cpp:593
 msgid "Calibration done"
 msgstr "Calibr. completa"
 
@@ -266,128 +265,128 @@ msgstr ""
 "prima."
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/messages.cpp:364 ../../Firmware/ultralcd.cpp:7405
+#: ../../Firmware/messages.cpp:376 ../../Firmware/ultralcd.cpp:7382
 msgid "Card removed"
 msgstr "SD rimossa"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/messages.cpp:324 ../../Firmware/ultralcd.cpp:5316
+#: ../../Firmware/messages.cpp:336 ../../Firmware/ultralcd.cpp:5282
 msgid "Change SD card"
 msgstr "Cambia scheda SD"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5254
-#: ../../Firmware/ultralcd.cpp:5526
+#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5216
+#: ../../Firmware/ultralcd.cpp:5493
 msgid "Change filament"
 msgstr "Cambia filamento"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/messages.cpp:240 ../../Firmware/ultralcd.cpp:2156
+#: ../../Firmware/messages.cpp:252 ../../Firmware/ultralcd.cpp:2167
 msgid "Change success!"
 msgstr "Cambio riuscito!"
 
 #. MSG_CORRECTLY c=19
-#: ../../Firmware/messages.cpp:242 ../../Firmware/ultralcd.cpp:2203
+#: ../../Firmware/messages.cpp:254 ../../Firmware/ultralcd.cpp:2217
 msgid "Changed correctly"
 msgstr "Cambio corretto"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5951
-#: ../../Firmware/ultralcd.cpp:6975
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5927
+#: ../../Firmware/ultralcd.cpp:6952
 msgid "Checking X axis"
 msgstr "Verifica asse X"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5961
-#: ../../Firmware/ultralcd.cpp:6976
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:5937
+#: ../../Firmware/ultralcd.cpp:6953
 msgid "Checking Y axis"
 msgstr "Verifica asse Y"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/messages.cpp:358 ../../Firmware/ultralcd.cpp:6977
+#: ../../Firmware/messages.cpp:370 ../../Firmware/ultralcd.cpp:6954
 msgid "Checking Z axis"
 msgstr "Verifica asse Z"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6978
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6955
 msgid "Checking bed"
 msgstr "Verifica piano"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/messages.cpp:357 ../../Firmware/ultralcd.cpp:6974
+#: ../../Firmware/messages.cpp:369 ../../Firmware/ultralcd.cpp:6951
 msgid "Checking endstops"
 msgstr "Verifica finecorsa"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/messages.cpp:362 ../../Firmware/ultralcd.cpp:7070
+#: ../../Firmware/messages.cpp:374 ../../Firmware/ultralcd.cpp:7047
 msgid "Checking file"
 msgstr "Verifica file"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/messages.cpp:359 ../../Firmware/ultralcd.cpp:6980
+#: ../../Firmware/messages.cpp:371 ../../Firmware/ultralcd.cpp:6957
 msgid "Checking hotend"
 msgstr "Verifica ugello"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6981
-#: ../../Firmware/ultralcd.cpp:6982
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6958
+#: ../../Firmware/ultralcd.cpp:6959
 msgid "Checking sensors"
 msgstr "Controllo sensori"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/messages.cpp:308 ../../Firmware/ultralcd.cpp:4424
+#: ../../Firmware/messages.cpp:320 ../../Firmware/ultralcd.cpp:4391
 msgid "Checks"
 msgstr "Controlli"
 
 #. MSG_TM_ACK_ERROR c=18
-#: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5297
+#: ../../Firmware/messages.cpp:197 ../../Firmware/ultralcd.cpp:5263
 msgid "Clear TM error"
 msgstr "Cancella errore TM"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/messages.cpp:244 ../../Firmware/ultralcd.cpp:2205
+#: ../../Firmware/messages.cpp:256 ../../Firmware/ultralcd.cpp:2219
 msgid "Color not correct"
 msgstr "Colore non puro"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:3508
+#: ../../Firmware/messages.cpp:27 ../../Firmware/ultralcd.cpp:3518
 msgid "Community made"
 msgstr "Contribuiti"
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:4059
+#: ../../Firmware/messages.cpp:178 ../../Firmware/ultralcd.cpp:4083
 msgid "Cont."
 msgstr "Cont."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:2129
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2135
 msgid "Cooldown"
 msgstr "Raffredda"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/messages.cpp:283 ../../Firmware/ultralcd.cpp:3450
+#: ../../Firmware/messages.cpp:295 ../../Firmware/ultralcd.cpp:3460
 msgid "Copy selected language?"
 msgstr "Copiare la lingua selezionata?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:1234
-#: ../../Firmware/ultralcd.cpp:1263
+#: ../../Firmware/messages.cpp:30 ../../Firmware/ultralcd.cpp:1244
+#: ../../Firmware/ultralcd.cpp:1273
 msgid "Crash"
 msgstr "Impatto"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4146
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/ultralcd.cpp:4170
 msgid "Crash det."
 msgstr "Rileva.crash"
 
 #. MSG_CRASH_DETECTED c=20
-#: ../../Firmware/Marlin_main.cpp:630 ../../Firmware/messages.cpp:30
+#: ../../Firmware/Marlin_main.cpp:595 ../../Firmware/messages.cpp:31
 msgid "Crash detected."
 msgstr "Rilevato impatto."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/messages.cpp:280 ../../Firmware/ultralcd.cpp:3374
+#: ../../Firmware/messages.cpp:292 ../../Firmware/ultralcd.cpp:3384
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -398,24 +397,24 @@ msgstr ""
 "in Modalita normale"
 
 #. MSG_CUT_FILAMENT c=16
-#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:380
-#: ../../Firmware/ultralcd.cpp:4854 ../../Firmware/ultralcd.cpp:5351
+#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:381
+#: ../../Firmware/ultralcd.cpp:4810 ../../Firmware/ultralcd.cpp:5317
 msgid "Cut filament"
 msgstr "Taglia filamento"
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4081
-#: ../../Firmware/ultralcd.cpp:4086 ../../Firmware/ultralcd.cpp:4091
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:4105
+#: ../../Firmware/ultralcd.cpp:4110 ../../Firmware/ultralcd.cpp:4115
 msgid "Cutter"
 msgstr "Tagliatr."
 
 #. MSG_DATE c=17
-#: ../../Firmware/messages.cpp:222 ../../Firmware/ultralcd.cpp:1645
+#: ../../Firmware/messages.cpp:234 ../../Firmware/ultralcd.cpp:1655
 msgid "Date:"
 msgstr "Data:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:178 ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/messages.cpp:185 ../../Firmware/ultralcd.cpp:5594
 msgid "Dim"
 msgstr "Scuro"
 
@@ -425,7 +424,7 @@ msgid "Disable"
 msgstr "Disatt."
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/messages.cpp:311 ../../Firmware/ultralcd.cpp:4460
+#: ../../Firmware/messages.cpp:323 ../../Firmware/ultralcd.cpp:4427
 msgid "Disable steppers"
 msgstr "Disattiva motori"
 
@@ -437,7 +436,7 @@ msgid "Disengaging idler"
 msgstr "Distacco idler"
 
 #. MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: ../../Firmware/Marlin_main.cpp:1610 ../../Firmware/Marlin_main.cpp:3334
+#: ../../Firmware/Marlin_main.cpp:1537 ../../Firmware/Marlin_main.cpp:3073
 #: ../../Firmware/messages.cpp:14
 msgid ""
 "Distance between tip of the nozzle and the bed surface has not been set yet."
@@ -448,7 +447,7 @@ msgstr ""
 "impostata. Seguire manuale, Primi Passi, Calibrazione primo strato."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/messages.cpp:301 ../../Firmware/ultralcd.cpp:3923
+#: ../../Firmware/messages.cpp:313 ../../Firmware/ultralcd.cpp:3947
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -457,13 +456,13 @@ msgstr ""
 " piatto?"
 
 #. MSG_DONE c=8
-#: ../../Firmware/messages.cpp:32 ../../Firmware/mmu2/errors_list.h:367
-#: ../../Firmware/mmu2_reporting.cpp:456
+#: ../../Firmware/messages.cpp:33 ../../Firmware/mmu2/errors_list.h:367
+#: ../../Firmware/mmu2_reporting.cpp:457
 msgid "Done"
 msgstr "Fatto"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/messages.cpp:307 ../../Firmware/ultralcd.cpp:3990
+#: ../../Firmware/messages.cpp:319 ../../Firmware/ultralcd.cpp:4014
 msgid "E-correct"
 msgstr "Correzione-E"
 
@@ -492,13 +491,13 @@ msgid "ERR Wait for User"
 msgstr "ERR Attendere utente"
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:2253
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:2267
 msgid "ERROR:"
 msgstr "ERRORE:"
 
 #. MSG_EJECT_FROM_MMU c=16
-#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:384
-#: ../../Firmware/ultralcd.cpp:4845 ../../Firmware/ultralcd.cpp:5348
+#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:385
+#: ../../Firmware/ultralcd.cpp:4801 ../../Firmware/ultralcd.cpp:5314
 msgid "Eject from MMU"
 msgstr "Espelli da MMU"
 
@@ -510,17 +509,17 @@ msgid "Ejecting filament"
 msgstr "Espellendo filamento"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/messages.cpp:348 ../../Firmware/ultralcd.cpp:6722
+#: ../../Firmware/messages.cpp:360 ../../Firmware/ultralcd.cpp:6698
 msgid "Endstop"
 msgstr "Finecorsa"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/messages.cpp:349 ../../Firmware/ultralcd.cpp:6727
+#: ../../Firmware/messages.cpp:361 ../../Firmware/ultralcd.cpp:6703
 msgid "Endstop not hit"
 msgstr "Finec. fuori portata"
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/messages.cpp:347 ../../Firmware/ultralcd.cpp:6713
+#: ../../Firmware/messages.cpp:359 ../../Firmware/ultralcd.cpp:6689
 msgid "Endstops"
 msgstr "Finecorsa"
 
@@ -532,30 +531,30 @@ msgid "Engaging idler"
 msgstr "Ingaggio idler"
 
 #. MSG_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:3352
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:3362
 msgid "Extruder"
 msgstr "Estrusore"
 
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/messages.cpp:227 ../../Firmware/ultralcd.cpp:1700
+#: ../../Firmware/messages.cpp:239 ../../Firmware/ultralcd.cpp:1710
 msgid "Extruder info"
 msgstr "Info estrusore"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4044
-#: ../../Firmware/ultralcd.cpp:4051
+#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4068
+#: ../../Firmware/ultralcd.cpp:4075
 msgid "F. autoload"
 msgstr "Autocar.fil."
 
 #. MSG_FSENSOR_JAM_DETECTION c=13
-#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4046
-#: ../../Firmware/ultralcd.cpp:4053
+#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4070
+#: ../../Firmware/ultralcd.cpp:4077
 msgid "F. jam detect"
 msgstr "Ril. blocco"
 
 #. MSG_FSENSOR_RUNOUT c=13
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4074
 msgid "F. runout"
 msgstr "Ril. fine fil"
 
@@ -593,8 +592,8 @@ msgid "FINDA FILAM. STUCK"
 msgstr "FINDA FILAM. BLOCC"
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:4059
-#: ../../Firmware/ultralcd.cpp:4062
+#: ../../Firmware/messages.cpp:177 ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/ultralcd.cpp:4086
 msgid "FS Action"
 msgstr "Azione FS"
 
@@ -619,34 +618,34 @@ msgid "FW RUNTIME ERROR"
 msgstr "FW RUNTIME ERROR"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/messages.cpp:330 ../../Firmware/ultralcd.cpp:5382
+#: ../../Firmware/messages.cpp:342 ../../Firmware/ultralcd.cpp:5349
 msgid "Fail stats"
 msgstr "Stat. fallimenti"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/messages.cpp:331 ../../Firmware/ultralcd.cpp:5385
+#: ../../Firmware/messages.cpp:343 ../../Firmware/ultralcd.cpp:5352
 msgid "Fail stats MMU"
 msgstr "Stat.fall. MMU"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/messages.cpp:355 ../../Firmware/ultralcd.cpp:6768
+#: ../../Firmware/messages.cpp:367 ../../Firmware/ultralcd.cpp:6744
 msgid "False triggering"
 msgstr "Falso innesco"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4175
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4199
 msgid "Fan speed"
 msgstr "Velocita vent."
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6844
-#: ../../Firmware/ultralcd.cpp:6971 ../../Firmware/ultralcd.cpp:6972
-#: ../../Firmware/ultralcd.cpp:6973
+#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6820
+#: ../../Firmware/ultralcd.cpp:6948 ../../Firmware/ultralcd.cpp:6949
+#: ../../Firmware/ultralcd.cpp:6950
 msgid "Fan test"
 msgstr "Test ventola"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:4179
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:4203
 msgid "Fans check"
 msgstr "Control.vent"
 
@@ -675,34 +674,34 @@ msgid "Feeding to nozzle"
 msgstr "Alim. in ugello"
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1233
-#: ../../Firmware/ultralcd.cpp:1262 ../../Firmware/ultralcd.cpp:1316
-#: ../../Firmware/ultralcd.cpp:1318
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:1243
+#: ../../Firmware/ultralcd.cpp:1272 ../../Firmware/ultralcd.cpp:1326
+#: ../../Firmware/ultralcd.cpp:1328
 msgid "Fil. runouts"
 msgstr "Fil. esauriti"
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3313
-#: ../../Firmware/ultralcd.cpp:4039 ../../Firmware/ultralcd.cpp:4464
-#: ../../Firmware/ultralcd.cpp:5532
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3323
+#: ../../Firmware/ultralcd.cpp:4063 ../../Firmware/ultralcd.cpp:4431
+#: ../../Firmware/ultralcd.cpp:5499
 msgid "Fil. sensor"
 msgstr "Sensore fil."
 
 #. MSG_FILAMENT_CLEAN c=20 r=3
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2261
-#: ../../Firmware/ultralcd.cpp:2265
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2275
+#: ../../Firmware/ultralcd.cpp:2279
 msgid "Filament extruding & with correct color?"
 msgstr "Filamento estruso e con colore corretto?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/messages.cpp:243 ../../Firmware/ultralcd.cpp:2204
+#: ../../Firmware/messages.cpp:255 ../../Firmware/ultralcd.cpp:2218
 msgid "Filament not loaded"
 msgstr "Fil. non caricato"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6763
-#: ../../Firmware/ultralcd.cpp:6767 ../../Firmware/ultralcd.cpp:6771
-#: ../../Firmware/ultralcd.cpp:7000
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6739
+#: ../../Firmware/ultralcd.cpp:6743 ../../Firmware/ultralcd.cpp:6747
+#: ../../Firmware/ultralcd.cpp:6977
 msgid "Filament sensor"
 msgstr "Sensore filam."
 
@@ -735,42 +734,42 @@ msgstr ""
 "correttamente."
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/messages.cpp:246 ../../Firmware/ultralcd.cpp:2347
+#: ../../Firmware/messages.cpp:258 ../../Firmware/ultralcd.cpp:2364
 msgid "Filament used"
 msgstr "Fil. utilizzato"
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/messages.cpp:363 ../../Firmware/ultralcd.cpp:7139
+#: ../../Firmware/messages.cpp:375 ../../Firmware/ultralcd.cpp:7116
 msgid "File incomplete. Continue anyway?"
 msgstr "File incompleto. Continuare comunque?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
 #: ../../Firmware/messages.cpp:45
 #: ../../Firmware/mmu2_progress_converter.cpp:43
-#: ../../Firmware/ultralcd.cpp:5021 ../../Firmware/ultralcd.cpp:5425
+#: ../../Firmware/ultralcd.cpp:4977 ../../Firmware/ultralcd.cpp:5392
 msgid "Finishing movements"
 msgstr "Finaliz. spostamenti"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4575
-#: ../../Firmware/ultralcd.cpp:5141
+#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4531
+#: ../../Firmware/ultralcd.cpp:5101
 msgid "First layer cal."
 msgstr "Cal. primo strato"
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/messages.cpp:293 ../../Firmware/ultralcd.cpp:3846
+#: ../../Firmware/messages.cpp:305 ../../Firmware/ultralcd.cpp:3872
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Per primo avviero l'autotest per controllare gli errori di assemblaggio piu "
 "comuni."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/messages.cpp:334 ../../Firmware/ultralcd.cpp:5520
+#: ../../Firmware/messages.cpp:346 ../../Firmware/ultralcd.cpp:5487
 msgid "Flow"
 msgstr "Flusso"
 
 #. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
-#: ../../Firmware/messages.cpp:194 ../../Firmware/ultralcd.cpp:985
+#: ../../Firmware/messages.cpp:201 ../../Firmware/ultralcd.cpp:987
 msgid ""
 "For a Nozzle change please read\n"
 "prusa.io/nozzle-mk3s"
@@ -779,28 +778,28 @@ msgstr ""
 "prusa.io/nozzle-mk3s"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6733
-#: ../../Firmware/ultralcd.cpp:6850 ../../Firmware/ultralcd.cpp:6855
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/ultralcd.cpp:6826 ../../Firmware/ultralcd.cpp:6831
 msgid "Front print fan?"
 msgstr "Ventola frontale?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/messages.cpp:260 ../../Firmware/ultralcd.cpp:2711
+#: ../../Firmware/messages.cpp:272 ../../Firmware/ultralcd.cpp:2728
 msgid "Front side[µm]"
 msgstr "Fronte [µm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/messages.cpp:353 ../../Firmware/ultralcd.cpp:6757
+#: ../../Firmware/messages.cpp:365 ../../Firmware/ultralcd.cpp:6733
 msgid "Front/left fans"
 msgstr "Ventola frontale/sin"
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:151 ../../Firmware/util.cpp:382
+#: ../../Firmware/messages.cpp:156 ../../Firmware/util.cpp:417
 msgid "G-code sliced for a different level. Continue?"
 msgstr "G-code processato per un livello diverso. Continuare?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:152 ../../Firmware/util.cpp:383
+#: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:418
 msgid ""
 "G-code sliced for a different level. Please re-slice the model again. Print "
 "cancelled."
@@ -809,14 +808,14 @@ msgstr ""
 "slice del modello. Stampa annullata."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:147 ../../Firmware/util.cpp:312
-#: ../../Firmware/util.cpp:401
+#: ../../Firmware/messages.cpp:152 ../../Firmware/util.cpp:319
+#: ../../Firmware/util.cpp:436
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr "G-code processato per una stampante diversa. Continuare?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:148 ../../Firmware/util.cpp:313
-#: ../../Firmware/util.cpp:402
+#: ../../Firmware/messages.cpp:153 ../../Firmware/util.cpp:320
+#: ../../Firmware/util.cpp:437
 msgid ""
 "G-code sliced for a different printer type. Please re-slice the model again."
 " Print cancelled."
@@ -825,12 +824,12 @@ msgstr ""
 "Annullamento stampa."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:149 ../../Firmware/util.cpp:362
+#: ../../Firmware/messages.cpp:154 ../../Firmware/util.cpp:369
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "G-code processato per un FW piu recente. Continuare?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:150 ../../Firmware/util.cpp:363
+#: ../../Firmware/messages.cpp:155 ../../Firmware/util.cpp:370
 msgid ""
 "G-code sliced for a newer firmware. Please update the firmware. Print "
 "cancelled."
@@ -839,35 +838,35 @@ msgstr ""
 "annullata."
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4366
-#: ../../Firmware/ultralcd.cpp:4383 ../../Firmware/ultralcd.cpp:4485
+#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4325
+#: ../../Firmware/ultralcd.cpp:4343 ../../Firmware/ultralcd.cpp:4452
 msgid "HW Setup"
 msgstr "Impostazioni HW"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/messages.cpp:344 ../../Firmware/ultralcd.cpp:6705
+#: ../../Firmware/messages.cpp:356 ../../Firmware/ultralcd.cpp:6681
 msgid "Heater/Thermistor"
 msgstr "Riscald./Termist."
 
 #. MSG_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6184 ../../Firmware/messages.cpp:52
+#: ../../Firmware/Marlin_main.cpp:5416 ../../Firmware/messages.cpp:52
 #: ../../Firmware/ultralcd.cpp:526
 msgid "Heating"
 msgstr "Riscaldamento..."
 
 #. MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:9647 ../../Firmware/messages.cpp:211
+#: ../../Firmware/Marlin_main.cpp:8807 ../../Firmware/messages.cpp:223
 msgid "Heating disabled by safety timer."
 msgstr "Riscaldamento fermato dal timer di sicurezza."
 
 #. MSG_HEATING_COMPLETE c=20
-#: ../../Firmware/Marlin_main.cpp:6215 ../../Firmware/messages.cpp:53
+#: ../../Firmware/Marlin_main.cpp:5445 ../../Firmware/messages.cpp:53
 #: ../../Firmware/ultralcd.cpp:529
 msgid "Heating done."
 msgstr "Riscald. completo"
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=12
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:3806
+#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:3832
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -878,7 +877,7 @@ msgstr ""
 "stampare."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:3810
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:3836
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -887,8 +886,8 @@ msgstr ""
 "processo di configurazione?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4152
-#: ../../Firmware/ultralcd.cpp:4161
+#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:4176
+#: ../../Firmware/ultralcd.cpp:4185
 msgid "High power"
 msgstr "Forte"
 
@@ -899,23 +898,23 @@ msgid "Homing"
 msgstr "Homing"
 
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
-#: ../../Firmware/messages.cpp:195 ../../Firmware/ultralcd.cpp:1005
+#: ../../Firmware/messages.cpp:206 ../../Firmware/ultralcd.cpp:1011
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr "Hotend a 280C! Ugello cambiato e serrato secondo le specifiche?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1106
-#: ../../Firmware/ultralcd.cpp:6991
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1116
+#: ../../Firmware/ultralcd.cpp:6968
 msgid "Hotend fan:"
 msgstr "Ventola hotend:"
 
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/messages.cpp:294 ../../Firmware/ultralcd.cpp:3851
+#: ../../Firmware/messages.cpp:306 ../../Firmware/ultralcd.cpp:3877
 msgid "I will run xyz calibration now. It will take up to 24 mins."
 msgstr "Adesso avviero una Calibrazione XYZ. Puo durare fino a 24 min."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/messages.cpp:297 ../../Firmware/ultralcd.cpp:3862
+#: ../../Firmware/messages.cpp:309 ../../Firmware/ultralcd.cpp:3884
 msgid "I will run z calibration now."
 msgstr "Adesso avviero la Calibrazione Z."
 
@@ -940,7 +939,7 @@ msgid "INVALID TOOL"
 msgstr "STRUM NON VAL"
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=8
-#: ../../Firmware/messages.cpp:303 ../../Firmware/ultralcd.cpp:3931
+#: ../../Firmware/messages.cpp:315 ../../Firmware/ultralcd.cpp:3955
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -949,28 +948,28 @@ msgstr ""
 "Setup HW - Piastre in Acciaio."
 
 #. MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2540
-#: ../../Firmware/messages.cpp:213
+#: ../../Firmware/mesh_bed_calibration.cpp:2525
+#: ../../Firmware/messages.cpp:225
 msgid "Improving bed calibration point"
 msgstr "Miglioramento punto di calibrazione del piatto"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:5222
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:5184
 msgid "Info screen"
 msgstr "Schermata info"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/messages.cpp:326 ../../Firmware/ultralcd.cpp:5323
+#: ../../Firmware/messages.cpp:338 ../../Firmware/ultralcd.cpp:5289
 msgid "Init. SD card"
 msgstr "Inizial. scheda SD"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/messages.cpp:238 ../../Firmware/ultralcd.cpp:2142
+#: ../../Firmware/messages.cpp:250 ../../Firmware/ultralcd.cpp:2148
 msgid "Insert filament"
 msgstr "Inserire filamento"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/messages.cpp:335 ../../Firmware/ultralcd.cpp:5998
+#: ../../Firmware/messages.cpp:347 ../../Firmware/ultralcd.cpp:5974
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
@@ -985,115 +984,115 @@ msgstr ""
 "Errore runtime interno. Provare a resettare la MMU o ad aggiornare il FW."
 
 #. MSG_FILAMENT_LOADED c=20 r=3
-#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3628
-#: ../../Firmware/ultralcd.cpp:3890
+#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3638
+#: ../../Firmware/ultralcd.cpp:3914
 msgid "Is filament loaded?"
 msgstr "Il filamento e' stato caricato?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3238 ../../Firmware/Marlin_main.cpp:4745
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:3858
+#: ../../Firmware/Marlin_main.cpp:4314 ../../Firmware/messages.cpp:127
+#: ../../Firmware/ultralcd.cpp:3760
 msgid "Is steel sheet on heatbed?"
 msgstr "Piastra d'acciaio su piano riscaldato?"
 
 #. MSG_ITERATION c=12
-#: ../../Firmware/mesh_bed_calibration.cpp:2265 ../../Firmware/messages.cpp:55
+#: ../../Firmware/mesh_bed_calibration.cpp:2250 ../../Firmware/messages.cpp:55
 msgid "Iteration"
 msgstr "Iterazione"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1128
-#: ../../Firmware/ultralcd.cpp:1286
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1138
+#: ../../Firmware/ultralcd.cpp:1296
 msgid "Last print"
 msgstr "Ultima stampa"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1152
-#: ../../Firmware/ultralcd.cpp:1260 ../../Firmware/ultralcd.cpp:1315
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1162
+#: ../../Firmware/ultralcd.cpp:1270 ../../Firmware/ultralcd.cpp:1325
 msgid "Last print failures"
 msgstr "Errori ultima stampa"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/messages.cpp:251 ../../Firmware/ultralcd.cpp:2478
+#: ../../Firmware/messages.cpp:263 ../../Firmware/ultralcd.cpp:2495
 msgid "Left"
 msgstr "Sinistra"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6739
-#: ../../Firmware/ultralcd.cpp:6850 ../../Firmware/ultralcd.cpp:6855
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6715
+#: ../../Firmware/ultralcd.cpp:6826 ../../Firmware/ultralcd.cpp:6831
 msgid "Left hotend fan?"
 msgstr "Vent SX hotend?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/messages.cpp:258 ../../Firmware/ultralcd.cpp:2709
+#: ../../Firmware/messages.cpp:270 ../../Firmware/ultralcd.cpp:2726
 msgid "Left side [µm]"
 msgstr "Sinistra [µm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:5619
+#: ../../Firmware/messages.cpp:181 ../../Firmware/ultralcd.cpp:5592
 msgid "Level Bright"
 msgstr "Liv. Chiaro"
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:175 ../../Firmware/ultralcd.cpp:5620
+#: ../../Firmware/messages.cpp:182 ../../Firmware/ultralcd.cpp:5593
 msgid "Level Dimmed"
 msgstr "Liv. Scuro"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/messages.cpp:312 ../../Firmware/ultralcd.cpp:4491
+#: ../../Firmware/messages.cpp:324 ../../Firmware/ultralcd.cpp:4458
 msgid "Lin. correction"
 msgstr "Correzione lineare"
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4501
-#: ../../Firmware/ultralcd.cpp:5251
+#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4468
+#: ../../Firmware/ultralcd.cpp:5213
 msgid "Live adjust Z"
 msgstr "Compensazione Z"
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/messages.cpp:192 ../../Firmware/ultralcd.cpp:4794
-#: ../../Firmware/ultralcd.cpp:4880
+#: ../../Firmware/messages.cpp:199 ../../Firmware/ultralcd.cpp:4750
+#: ../../Firmware/ultralcd.cpp:4836
 msgid "Load All"
 msgstr "Carica tutti"
 
 #. MSG_LOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4796
-#: ../../Firmware/ultralcd.cpp:4833 ../../Firmware/ultralcd.cpp:4882
-#: ../../Firmware/ultralcd.cpp:5361 ../../Firmware/ultralcd.cpp:5368
+#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4752
+#: ../../Firmware/ultralcd.cpp:4789 ../../Firmware/ultralcd.cpp:4838
+#: ../../Firmware/ultralcd.cpp:5324 ../../Firmware/ultralcd.cpp:5335
 msgid "Load filament"
 msgstr "Carica filamento"
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/messages.cpp:327 ../../Firmware/ultralcd.cpp:5346
+#: ../../Firmware/messages.cpp:339 ../../Firmware/ultralcd.cpp:5312
 msgid "Load to nozzle"
 msgstr "Carica ugello"
 
 #. MSG_LOADING_TEST c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4476
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4443
 msgid "Loading Test"
 msgstr "Prova di carica."
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/messages.cpp:241 ../../Firmware/ultralcd.cpp:2178
+#: ../../Firmware/messages.cpp:253 ../../Firmware/ultralcd.cpp:2189
 msgid "Loading color"
 msgstr "Caricando colore"
 
 #. MSG_LOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3598 ../../Firmware/messages.cpp:62
+#: ../../Firmware/Marlin_main.cpp:3343 ../../Firmware/messages.cpp:62
 #: ../../Firmware/mmu2_progress_converter.cpp:51
-#: ../../Firmware/mmu2_reporting.cpp:392 ../../Firmware/ultralcd.cpp:2189
-#: ../../Firmware/ultralcd.cpp:3715
+#: ../../Firmware/mmu2_reporting.cpp:393 ../../Firmware/ultralcd.cpp:2199
+#: ../../Firmware/ultralcd.cpp:3725
 msgid "Loading filament"
 msgstr "Caricando filamento"
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/messages.cpp:350 ../../Firmware/ultralcd.cpp:6745
+#: ../../Firmware/messages.cpp:362 ../../Firmware/ultralcd.cpp:6721
 msgid "Loose pulley"
 msgstr "Puleggia lenta"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4188
-#: ../../Firmware/ultralcd.cpp:4200
+#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4224
 msgid "Loud"
 msgstr "Forte"
 
@@ -1108,7 +1107,7 @@ msgid "MMU Firmware internal error, please reset the MMU."
 msgstr "Errore interno FW MMU, resettare la MMU."
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:4096
+#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4120
 msgid "MMU Mode"
 msgstr "Mod. MMU"
 
@@ -1118,7 +1117,7 @@ msgid "MMU NOT RESPONDING"
 msgstr "MMU NON RISPONDE"
 
 #. MSG_MMU_RESTORE_TEMP c=20 r=4
-#: ../../Firmware/messages.cpp:214 ../../Firmware/mmu2_reporting.cpp:396
+#: ../../Firmware/messages.cpp:226 ../../Firmware/mmu2_reporting.cpp:397
 msgid "MMU Retry: Restoring temperature..."
 msgstr "MMU Riprova. Ripristino temperatura..."
 
@@ -1129,14 +1128,14 @@ msgid "MMU SELFTEST FAILED"
 msgstr "MMU AUTOTEST FALLITO"
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1153
-#: ../../Firmware/ultralcd.cpp:1178
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1163
+#: ../../Firmware/ultralcd.cpp:1188
 msgid "MMU fails"
 msgstr "Fallimenti MMU"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1154
-#: ../../Firmware/ultralcd.cpp:1179
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1164
+#: ../../Firmware/ultralcd.cpp:1189
 msgid "MMU load fails"
 msgstr "Car MMU falliti"
 
@@ -1151,66 +1150,64 @@ msgid "MMU not responding. Check the wiring and connectors."
 msgstr "MMU non risponde. Controlla cavi e connettori."
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/messages.cpp:223 ../../Firmware/ultralcd.cpp:1657
+#: ../../Firmware/messages.cpp:235 ../../Firmware/ultralcd.cpp:1667
 msgid "MMU connected"
 msgstr "MMU connessa"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/messages.cpp:176 ../../Firmware/ultralcd.cpp:5567
 msgid "Magnets comp."
 msgstr "Comp. Magneti"
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1127
-#: ../../Firmware/ultralcd.cpp:1285 ../../Firmware/ultralcd.cpp:1327
-#: ../../Firmware/ultralcd.cpp:1631 ../../Firmware/ultralcd.cpp:4453
-#: ../../Firmware/ultralcd.cpp:4571 ../../Firmware/ultralcd.cpp:4793
-#: ../../Firmware/ultralcd.cpp:4826 ../../Firmware/ultralcd.cpp:4879
-#: ../../Firmware/ultralcd.cpp:5515
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1137
+#: ../../Firmware/ultralcd.cpp:1295 ../../Firmware/ultralcd.cpp:1337
+#: ../../Firmware/ultralcd.cpp:1641 ../../Firmware/ultralcd.cpp:4420
+#: ../../Firmware/ultralcd.cpp:4527 ../../Firmware/ultralcd.cpp:4749
+#: ../../Firmware/ultralcd.cpp:4782 ../../Firmware/ultralcd.cpp:4835
+#: ../../Firmware/ultralcd.cpp:5482
 msgid "Main"
 msgstr "Menu principale"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/messages.cpp:253 ../../Firmware/ultralcd.cpp:2519
+#: ../../Firmware/messages.cpp:265 ../../Firmware/ultralcd.cpp:2536
 msgid "Measured skew"
 msgstr "Dev. misurata"
 
 #. MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3219
-#: ../../Firmware/mesh_bed_calibration.cpp:2852 ../../Firmware/messages.cpp:70
+#: ../../Firmware/Marlin_main.cpp:2963
+#: ../../Firmware/mesh_bed_calibration.cpp:2837 ../../Firmware/messages.cpp:70
 msgid "Measuring reference height of calibration point"
 msgstr "Misura altezza di rif. del punto di calib."
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:5590
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:5563
 msgid "Mesh"
 msgstr "Griglia"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4488
-#: ../../Firmware/ultralcd.cpp:4587
+#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:4455
+#: ../../Firmware/ultralcd.cpp:4543
 msgid "Mesh Bed Leveling"
 msgstr "Liv. griglia piano"
 
 #. MSG_MODE c=6
-#: ../../Firmware/Marlin_main.cpp:8495 ../../Firmware/messages.cpp:117
-#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4132
-#: ../../Firmware/ultralcd.cpp:4140 ../../Firmware/ultralcd.cpp:4144
-#: ../../Firmware/ultralcd.cpp:4152 ../../Firmware/ultralcd.cpp:4155
-#: ../../Firmware/ultralcd.cpp:4158 ../../Firmware/ultralcd.cpp:4161
-#: ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/Marlin_main.cpp:7666 ../../Firmware/messages.cpp:121
+#: ../../Firmware/ultralcd.cpp:4152 ../../Firmware/ultralcd.cpp:4156
+#: ../../Firmware/ultralcd.cpp:4164 ../../Firmware/ultralcd.cpp:4168
+#: ../../Firmware/ultralcd.cpp:4176 ../../Firmware/ultralcd.cpp:4179
+#: ../../Firmware/ultralcd.cpp:4182 ../../Firmware/ultralcd.cpp:4185
+#: ../../Firmware/ultralcd.cpp:5594
 msgid "Mode"
 msgstr "Mod."
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/messages.cpp:282 ../../Firmware/ultralcd.cpp:3413
+#: ../../Firmware/messages.cpp:294 ../../Firmware/ultralcd.cpp:3423
 msgid "Mode change in progress..."
 msgstr "Cambio modalita in corso..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:4310
-#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4316
-#: ../../Firmware/ultralcd.cpp:4319
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4327
 msgid "Model"
 msgstr "Modello"
 
@@ -1231,28 +1228,28 @@ msgid "More details online."
 msgstr "Piu dettagli online."
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6719
-#: ../../Firmware/ultralcd.cpp:6728 ../../Firmware/ultralcd.cpp:6746
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6695
+#: ../../Firmware/ultralcd.cpp:6704 ../../Firmware/ultralcd.cpp:6722
 msgid "Motor"
 msgstr "Motore"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/messages.cpp:277 ../../Firmware/ultralcd.cpp:3349
+#: ../../Firmware/messages.cpp:289 ../../Firmware/ultralcd.cpp:3359
 msgid "Move X"
 msgstr "Sposta X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/messages.cpp:278 ../../Firmware/ultralcd.cpp:3350
+#: ../../Firmware/messages.cpp:290 ../../Firmware/ultralcd.cpp:3360
 msgid "Move Y"
 msgstr "Sposta Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/messages.cpp:279 ../../Firmware/ultralcd.cpp:3351
+#: ../../Firmware/messages.cpp:291 ../../Firmware/ultralcd.cpp:3361
 msgid "Move Z"
 msgstr "Sposta Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/messages.cpp:310 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:322 ../../Firmware/ultralcd.cpp:4426
 msgid "Move axis"
 msgstr "Muovi asse"
 
@@ -1263,95 +1260,92 @@ msgid "Moving selector"
 msgstr "Muovo il selettore"
 
 #. MSG_NA c=3
-#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:141
-#: ../../Firmware/ultralcd.cpp:2484 ../../Firmware/ultralcd.cpp:2528
-#: ../../Firmware/ultralcd.cpp:3279 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:4044 ../../Firmware/ultralcd.cpp:4046
-#: ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:146
+#: ../../Firmware/ultralcd.cpp:2501 ../../Firmware/ultralcd.cpp:2545
+#: ../../Firmware/ultralcd.cpp:3289 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4068 ../../Firmware/ultralcd.cpp:4070
+#: ../../Firmware/ultralcd.cpp:5567
 msgid "N/A"
 msgstr "N/D"
 
 #. MSG_NEW_FIRMWARE_AVAILABLE c=20 r=2
-#: ../../Firmware/messages.cpp:365 ../../Firmware/util.cpp:209
+#: ../../Firmware/messages.cpp:377 ../../Firmware/util.cpp:214
 msgid "New firmware version available:"
 msgstr "Nuova vers. FW disponibile:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:3029
-#: ../../Firmware/ultralcd.cpp:4443 ../../Firmware/ultralcd.cpp:4531
-#: ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:2275
+#: ../../Firmware/ultralcd.cpp:2279 ../../Firmware/ultralcd.cpp:3046
+#: ../../Firmware/ultralcd.cpp:4410 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/ultralcd.cpp:5765
 msgid "No"
 msgstr "No"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/messages.cpp:325 ../../Firmware/ultralcd.cpp:5321
+#: ../../Firmware/messages.cpp:337 ../../Firmware/ultralcd.cpp:5287
 msgid "No SD card"
 msgstr "Nessuna SD"
 
 #. MSG_NO_MOVE c=20
-#: ../../Firmware/Marlin_main.cpp:5271 ../../Firmware/messages.cpp:210
+#: ../../Firmware/Marlin_main.cpp:4778 ../../Firmware/messages.cpp:222
 msgid "No move."
 msgstr "Nessun movimento."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4239 ../../Firmware/ultralcd.cpp:4310
-#: ../../Firmware/ultralcd.cpp:4319 ../../Firmware/ultralcd.cpp:4349
-#: ../../Firmware/ultralcd.cpp:4358 ../../Firmware/ultralcd.cpp:4516
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4309
+#: ../../Firmware/ultralcd.cpp:4318 ../../Firmware/ultralcd.cpp:4483
 msgid "None"
 msgstr "Nessuno"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/Marlin_main.cpp:8497 ../../Firmware/messages.cpp:121
-#: ../../Firmware/ultralcd.cpp:4096 ../../Firmware/ultralcd.cpp:4132
-#: ../../Firmware/ultralcd.cpp:4511
+#: ../../Firmware/Marlin_main.cpp:7668 ../../Firmware/messages.cpp:125
+#: ../../Firmware/ultralcd.cpp:4120 ../../Firmware/ultralcd.cpp:4156
+#: ../../Firmware/ultralcd.cpp:4478
 msgid "Normal"
 msgstr "Normale"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/messages.cpp:345 ../../Firmware/ultralcd.cpp:6706
+#: ../../Firmware/messages.cpp:357 ../../Firmware/ultralcd.cpp:6682
 msgid "Not connected"
 msgstr "Non connesso"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6863
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6839
 msgid "Not spinning"
 msgstr "Non gira"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/messages.cpp:289 ../../Firmware/ultralcd.cpp:3726
+#: ../../Firmware/messages.cpp:301 ../../Firmware/ultralcd.cpp:3736
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr "Adesso calibro la distanza fra ugello e superfice del piatto."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/messages.cpp:298 ../../Firmware/ultralcd.cpp:3871
+#: ../../Firmware/messages.cpp:310 ../../Firmware/ultralcd.cpp:3894
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Adesso preriscaldero l'ugello per PLA."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/messages.cpp:296 ../../Firmware/ultralcd.cpp:3857
+#: ../../Firmware/messages.cpp:308 ../../Firmware/ultralcd.cpp:3883
 msgid "Now remove the test print from steel sheet."
 msgstr "Ora rimuovete la stampa di prova dalla piastra in acciaio."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1390
-#: ../../Firmware/ultralcd.cpp:4170 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4233 ../../Firmware/ultralcd.cpp:4236
-#: ../../Firmware/ultralcd.cpp:4239
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1400
+#: ../../Firmware/ultralcd.cpp:4194 ../../Firmware/ultralcd.cpp:4326
 msgid "Nozzle"
 msgstr "Ugello"
 
 #. MSG_NOZZLE_CNG_MENU c=18
-#: ../../Firmware/messages.cpp:193 ../../Firmware/ultralcd.cpp:4423
-#: ../../Firmware/ultralcd.cpp:4486
+#: ../../Firmware/messages.cpp:200 ../../Firmware/ultralcd.cpp:4390
+#: ../../Firmware/ultralcd.cpp:4453
 msgid "Nozzle change"
 msgstr "Cambio dell'ugello"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4276
-#: ../../Firmware/ultralcd.cpp:4278 ../../Firmware/ultralcd.cpp:4279
-#: ../../Firmware/ultralcd.cpp:4280
+#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4261
+#: ../../Firmware/ultralcd.cpp:4263 ../../Firmware/ultralcd.cpp:4264
+#: ../../Firmware/ultralcd.cpp:4265
 msgid "Nozzle d."
 msgstr "Dia.Ugello"
 
@@ -1362,83 +1356,83 @@ msgid "OK"
 msgstr "OK"
 
 #. MSG_OFF c=3
-#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:139
-#: ../../Firmware/mmu2.cpp:65 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4050 ../../Firmware/ultralcd.cpp:4051
-#: ../../Firmware/ultralcd.cpp:4053 ../../Firmware/ultralcd.cpp:4076
-#: ../../Firmware/ultralcd.cpp:4091 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4179 ../../Firmware/ultralcd.cpp:4467
-#: ../../Firmware/ultralcd.cpp:4495 ../../Firmware/ultralcd.cpp:4498
-#: ../../Firmware/ultralcd.cpp:5439 ../../Firmware/ultralcd.cpp:5594
-#: ../../Firmware/ultralcd.cpp:7487 ../../Firmware/ultralcd.cpp:7491
+#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:144
+#: ../../Firmware/mmu2.cpp:65 ../../Firmware/ultralcd.cpp:4063
+#: ../../Firmware/ultralcd.cpp:4074 ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4077 ../../Firmware/ultralcd.cpp:4100
+#: ../../Firmware/ultralcd.cpp:4115 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/ultralcd.cpp:4203 ../../Firmware/ultralcd.cpp:4434
+#: ../../Firmware/ultralcd.cpp:4462 ../../Firmware/ultralcd.cpp:4465
+#: ../../Firmware/ultralcd.cpp:5406 ../../Firmware/ultralcd.cpp:5567
+#: ../../Firmware/ultralcd.cpp:7464 ../../Firmware/ultralcd.cpp:7468
 msgid "Off"
 msgstr "Off"
 
 #. MSG_DEFAULT_SETTINGS_LOADED c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:1562 ../../Firmware/messages.cpp:201
+#: ../../Firmware/Marlin_main.cpp:1489 ../../Firmware/messages.cpp:213
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr ""
 "Sono state trovate impostazioni vecchie. Verranno impostati i valori "
 "predefiniti di PID, Esteps etc."
 
 #. MSG_ON c=3
-#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:140
-#: ../../Firmware/mmu2.cpp:63 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4050 ../../Firmware/ultralcd.cpp:4051
-#: ../../Firmware/ultralcd.cpp:4053 ../../Firmware/ultralcd.cpp:4076
-#: ../../Firmware/ultralcd.cpp:4081 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4179 ../../Firmware/ultralcd.cpp:4467
-#: ../../Firmware/ultralcd.cpp:4495 ../../Firmware/ultralcd.cpp:4498
-#: ../../Firmware/ultralcd.cpp:5594 ../../Firmware/ultralcd.cpp:7487
-#: ../../Firmware/ultralcd.cpp:7491
+#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:145
+#: ../../Firmware/mmu2.cpp:63 ../../Firmware/ultralcd.cpp:4063
+#: ../../Firmware/ultralcd.cpp:4074 ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4077 ../../Firmware/ultralcd.cpp:4100
+#: ../../Firmware/ultralcd.cpp:4105 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/ultralcd.cpp:4203 ../../Firmware/ultralcd.cpp:4434
+#: ../../Firmware/ultralcd.cpp:4462 ../../Firmware/ultralcd.cpp:4465
+#: ../../Firmware/ultralcd.cpp:5567 ../../Firmware/ultralcd.cpp:7464
+#: ../../Firmware/ultralcd.cpp:7468
 msgid "On"
 msgstr "On"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4191
+#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:4215
 msgid "Once"
 msgstr "Singolo"
 
 #. MSG_PAUSED_THERMAL_ERROR c=20
-#: ../../Firmware/Marlin_main.cpp:9861 ../../Firmware/messages.cpp:186
+#: ../../Firmware/Marlin_main.cpp:9021 ../../Firmware/messages.cpp:193
 msgid "PAUSED THERMAL ERROR"
 msgstr "PAUSA ERRORE TERMICO"
 
 #. MSG_PID_RUNNING c=20
-#: ../../Firmware/messages.cpp:219 ../../Firmware/ultralcd.cpp:897
+#: ../../Firmware/messages.cpp:231 ../../Firmware/ultralcd.cpp:897
 msgid "PID cal."
 msgstr "Calibrazione PID"
 
 #. MSG_PID_FINISHED c=20
-#: ../../Firmware/messages.cpp:220 ../../Firmware/ultralcd.cpp:902
+#: ../../Firmware/messages.cpp:232 ../../Firmware/ultralcd.cpp:902
 msgid "PID cal. finished"
 msgstr "Calib. PID completa"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:318 ../../Firmware/ultralcd.cpp:4590
+#: ../../Firmware/messages.cpp:330 ../../Firmware/ultralcd.cpp:4546
 msgid "PID calibration"
 msgstr "Calibrazione PID"
 
 #. MSG_PINDA_PREHEAT c=20
-#: ../../Firmware/messages.cpp:218 ../../Firmware/ultralcd.cpp:610
+#: ../../Firmware/messages.cpp:230 ../../Firmware/ultralcd.cpp:610
 msgid "PINDA Heating"
 msgstr "Riscaldamento PINDA"
 
 #. MSG_PINDA_CALIBRATION c=13
-#: ../../Firmware/Marlin_main.cpp:4790 ../../Firmware/Marlin_main.cpp:4892
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:607
-#: ../../Firmware/ultralcd.cpp:4495 ../../Firmware/ultralcd.cpp:4597
+#: ../../Firmware/Marlin_main.cpp:4359 ../../Firmware/Marlin_main.cpp:4461
+#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:607
+#: ../../Firmware/ultralcd.cpp:4462 ../../Firmware/ultralcd.cpp:4553
 msgid "PINDA cal."
 msgstr "Calib. PINDA"
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/messages.cpp:276 ../../Firmware/ultralcd.cpp:3233
+#: ../../Firmware/messages.cpp:288 ../../Firmware/ultralcd.cpp:3243
 msgid "PINDA calibration failed"
 msgstr "Calibrazione temperatura fallita"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:4967 ../../Firmware/messages.cpp:127
-#: ../../Firmware/ultralcd.cpp:3230
+#: ../../Firmware/Marlin_main.cpp:4536 ../../Firmware/messages.cpp:132
+#: ../../Firmware/ultralcd.cpp:3240
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1458,13 +1452,13 @@ msgid "Parking selector"
 msgstr "Posteggio selettore"
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:4062
+#: ../../Firmware/messages.cpp:179 ../../Firmware/ultralcd.cpp:4086
 msgid "Pause"
 msgstr "Pausa"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5271
-#: ../../Firmware/ultralcd.cpp:5273
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5237
+#: ../../Firmware/ultralcd.cpp:5239
 msgid "Pause print"
 msgstr "Metti in pausa"
 
@@ -1475,7 +1469,7 @@ msgid "Performing cut"
 msgstr "Eseguo taglio"
 
 #. MSG_PAPER c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3243 ../../Firmware/messages.cpp:77
+#: ../../Firmware/Marlin_main.cpp:2982 ../../Firmware/messages.cpp:77
 msgid ""
 "Place a sheet of paper under the nozzle during the calibration of first 4 "
 "points. If the nozzle catches the paper, power off the printer immediately."
@@ -1484,7 +1478,7 @@ msgstr ""
 "punti. In caso l'ugello muova il foglio spegnere subito la stampante."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:3963
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:3987
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1493,34 +1487,34 @@ msgstr ""
 "riprendi il Wizard."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/messages.cpp:337 ../../Firmware/ultralcd.cpp:6023
+#: ../../Firmware/messages.cpp:349 ../../Firmware/ultralcd.cpp:5999
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "Controllare il collegamento al sensore e rimuovere il filamento."
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/messages.cpp:343 ../../Firmware/ultralcd.cpp:6700
+#: ../../Firmware/messages.cpp:355 ../../Firmware/ultralcd.cpp:6676
 msgid "Please check:"
 msgstr "Verifica:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/messages.cpp:302 ../../Firmware/ultralcd.cpp:3926
+#: ../../Firmware/messages.cpp:314 ../../Firmware/ultralcd.cpp:3950
 msgid "Please clean heatbed and then press the knob."
 msgstr "Pulisci il piatto, poi premi la manopola."
 
 #. MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3217 ../../Firmware/messages.cpp:27
+#: ../../Firmware/Marlin_main.cpp:2960 ../../Firmware/messages.cpp:28
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Pulire l'ugello per la calibrazione, poi fare click."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/messages.cpp:288 ../../Firmware/ultralcd.cpp:3712
+#: ../../Firmware/messages.cpp:300 ../../Firmware/ultralcd.cpp:3722
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr ""
 "Inserisci il filamento nell'estrusore, poi premi la manopola per caricarlo."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/messages.cpp:287 ../../Firmware/ultralcd.cpp:3705
+#: ../../Firmware/messages.cpp:299 ../../Firmware/ultralcd.cpp:3715
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1529,104 +1523,103 @@ msgstr ""
 "caricarlo."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/messages.cpp:285 ../../Firmware/ultralcd.cpp:3633
+#: ../../Firmware/messages.cpp:297 ../../Firmware/ultralcd.cpp:3643
 msgid "Please load filament first."
 msgstr "Carica il filamento, per favore."
 
 #. MSG_CHECK_IDLER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3525 ../../Firmware/messages.cpp:206
+#: ../../Firmware/Marlin_main.cpp:3265 ../../Firmware/messages.cpp:218
 msgid "Please open idler and remove filament manually."
 msgstr "Aprire la guida filam. e rimuovere il filam. a mano"
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2806 ../../Firmware/messages.cpp:80
-#: ../../Firmware/ultralcd.cpp:3860
+#: ../../Firmware/mesh_bed_calibration.cpp:2791 ../../Firmware/messages.cpp:80
 msgid "Please place steel sheet on heatbed."
 msgstr "Posizionate la piastra d'acciaio sul piano riscaldato."
 
 #. MSG_PRESS_TO_UNLOAD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:11215 ../../Firmware/Marlin_main.cpp:11245
+#: ../../Firmware/Marlin_main.cpp:10287 ../../Firmware/Marlin_main.cpp:10317
 #: ../../Firmware/messages.cpp:84
 msgid "Please press the knob to unload filament"
 msgstr "Premete la manopola per scaricare il filamento"
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:4932
+#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:4888
 msgid "Please pull out filament immediately"
 msgstr "Estrarre il filamento immediatamente"
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/messages.cpp:295 ../../Firmware/ultralcd.cpp:3856
+#: ../../Firmware/messages.cpp:307 ../../Firmware/ultralcd.cpp:3882
 msgid "Please remove shipping helpers first."
 msgstr "Rimuovete i materiali da spedizione"
 
 #. MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3240 ../../Firmware/Marlin_main.cpp:4755
-#: ../../Firmware/messages.cpp:89
+#: ../../Firmware/Marlin_main.cpp:4324 ../../Firmware/messages.cpp:89
 msgid "Please remove steel sheet from heatbed."
 msgstr "Rimuovete la piastra di acciaio dal piano riscaldato"
 
 #. MSG_RUN_XYZ c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4731 ../../Firmware/messages.cpp:207
+#: ../../Firmware/Marlin_main.cpp:4300 ../../Firmware/messages.cpp:219
 msgid "Please run XYZ calibration first."
 msgstr "Esegui la calibrazione XYZ prima."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/messages.cpp:336 ../../Firmware/ultralcd.cpp:6020
+#: ../../Firmware/messages.cpp:348 ../../Firmware/ultralcd.cpp:4359
+#: ../../Firmware/ultralcd.cpp:5996
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Scaricare prima il filamento, poi ripetere l'operazione."
 
 #. MSG_NEW_FIRMWARE_PLEASE_UPGRADE c=20
-#: ../../Firmware/messages.cpp:366 ../../Firmware/util.cpp:213
+#: ../../Firmware/messages.cpp:378 ../../Firmware/util.cpp:218
 msgid "Please upgrade."
 msgstr "Prego aggiornare."
 
 #. MSG_PLEASE_WAIT c=20
-#: ../../Firmware/Marlin_main.cpp:3521 ../../Firmware/Marlin_main.cpp:8090
-#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:2179
-#: ../../Firmware/ultralcd.cpp:2190
+#: ../../Firmware/Marlin_main.cpp:3261 ../../Firmware/Marlin_main.cpp:7262
+#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:2190
+#: ../../Firmware/ultralcd.cpp:2204
 msgid "Please wait"
 msgstr "Attendere"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:1232
-#: ../../Firmware/ultralcd.cpp:1261
+#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:1242
+#: ../../Firmware/ultralcd.cpp:1271
 msgid "Power failures"
 msgstr "Interr. corr."
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/messages.cpp:323 ../../Firmware/ultralcd.cpp:5260
+#: ../../Firmware/messages.cpp:335 ../../Firmware/ultralcd.cpp:5222
 msgid "Preheat"
 msgstr "Preriscalda"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:2254
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:2268
 msgid "Preheat the nozzle!"
 msgstr "Prerisc. ugello!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:2771
-#: ../../Firmware/ultralcd.cpp:3690 ../../Firmware/ultralcd.cpp:3692
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:2788
+#: ../../Firmware/ultralcd.cpp:3700 ../../Firmware/ultralcd.cpp:3702
 msgid "Preheating nozzle. Please wait."
 msgstr "Preriscaldando l'ugello. Attendere prego."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/messages.cpp:237 ../../Firmware/ultralcd.cpp:1999
+#: ../../Firmware/messages.cpp:249 ../../Firmware/ultralcd.cpp:2005
 msgid "Preheating to cut"
 msgstr "Preriscalda. taglio"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/messages.cpp:236 ../../Firmware/ultralcd.cpp:1996
+#: ../../Firmware/messages.cpp:248 ../../Firmware/ultralcd.cpp:2002
 msgid "Preheating to eject"
 msgstr "Preriscalda. espuls."
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/messages.cpp:234 ../../Firmware/ultralcd.cpp:1987
+#: ../../Firmware/messages.cpp:246 ../../Firmware/ultralcd.cpp:1995
 msgid "Preheating to load"
 msgstr "Preriscald. carico"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/messages.cpp:235 ../../Firmware/ultralcd.cpp:1992
+#: ../../Firmware/messages.cpp:247 ../../Firmware/ultralcd.cpp:1999
 msgid "Preheating to unload"
 msgstr "Preriscald. scarico"
 
@@ -1637,12 +1630,12 @@ msgid "Preparing blade"
 msgstr "Preparo la lama"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/messages.cpp:231 ../../Firmware/ultralcd.cpp:1799
+#: ../../Firmware/messages.cpp:243 ../../Firmware/ultralcd.cpp:1809
 msgid "Press the knob"
 msgstr "Premere la manopola"
 
 #. MSG_PRESS_TO_PREHEAT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:11227 ../../Firmware/messages.cpp:212
+#: ../../Firmware/Marlin_main.cpp:10299 ../../Firmware/messages.cpp:224
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Premete la manopola per preriscaldare l'ugello e continuare."
 
@@ -1652,34 +1645,34 @@ msgid "Print aborted"
 msgstr "Stampa interrotta"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1106
-#: ../../Firmware/ultralcd.cpp:6994
+#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1116
+#: ../../Firmware/ultralcd.cpp:6971
 msgid "Print fan:"
 msgstr "Vent.stam:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:5313
+#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5279
 msgid "Print from SD"
 msgstr "Stampa da SD"
 
 #. MSG_PRINT_PAUSED c=20
-#: ../../Firmware/Marlin_main.cpp:3582 ../../Firmware/messages.cpp:79
+#: ../../Firmware/Marlin_main.cpp:3323 ../../Firmware/messages.cpp:79
 #: ../../Firmware/ultralcd.cpp:814
 msgid "Print paused"
 msgstr "Stampa in pausa"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/messages.cpp:247 ../../Firmware/ultralcd.cpp:2348
+#: ../../Firmware/messages.cpp:259 ../../Firmware/ultralcd.cpp:2365
 msgid "Print time"
 msgstr "Tempo di stampa"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/messages.cpp:225 ../../Firmware/ultralcd.cpp:1689
+#: ../../Firmware/messages.cpp:237 ../../Firmware/ultralcd.cpp:1699
 msgid "Printer IP Addr:"
 msgstr "Ind. IP stampante:"
 
 #. MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1602 ../../Firmware/messages.cpp:46
+#: ../../Firmware/Marlin_main.cpp:1529 ../../Firmware/messages.cpp:46
 msgid ""
 "Printer has not been calibrated yet. Please follow the manual, chapter First"
 " steps, section Calibration flow."
@@ -1688,12 +1681,12 @@ msgstr ""
 "Primi Passi."
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:153 ../../Firmware/util.cpp:289
+#: ../../Firmware/messages.cpp:160 ../../Firmware/util.cpp:296
 msgid "Nozzle diameter differs from the G-code. Continue?"
 msgstr "Diametro ugello diverso da G-Code. Continuare?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:154 ../../Firmware/util.cpp:290
+#: ../../Firmware/messages.cpp:161 ../../Firmware/util.cpp:297
 msgid ""
 "Nozzle diameter differs from the G-code. Please check the value in settings."
 " Print cancelled."
@@ -1720,22 +1713,22 @@ msgid "QUEUE FULL"
 msgstr "CODA PIENA"
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:4465
 msgid "RPi port"
 msgstr "Porta RPi"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/messages.cpp:261 ../../Firmware/ultralcd.cpp:2712
+#: ../../Firmware/messages.cpp:273 ../../Firmware/ultralcd.cpp:2729
 msgid "Rear side [µm]"
 msgstr "Retro [µm]"
 
 #. MSG_RECOVERING_PRINT c=20
-#: ../../Firmware/messages.cpp:216 ../../Firmware/power_panic.cpp:316
+#: ../../Firmware/messages.cpp:228 ../../Firmware/power_panic.cpp:328
 msgid "Recovering print"
 msgstr "Recupero stampa"
 
 #. MSG_RENAME c=18
-#: ../../Firmware/messages.cpp:322 ../../Firmware/ultralcd.cpp:5143
+#: ../../Firmware/messages.cpp:334 ../../Firmware/ultralcd.cpp:5103
 msgid "Rename"
 msgstr "Rinomina"
 
@@ -1749,19 +1742,19 @@ msgstr ""
 "Controllare l'indice strumento nel G-code (T0-T4)."
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:2713
-#: ../../Firmware/ultralcd.cpp:5144
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:2730
+#: ../../Firmware/ultralcd.cpp:5104
 msgid "Reset"
 msgstr "Reset"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/messages.cpp:320 ../../Firmware/ultralcd.cpp:4594
+#: ../../Firmware/messages.cpp:332 ../../Firmware/ultralcd.cpp:4550
 msgid "Reset XYZ calibr."
 msgstr "Reset calibr. XYZ."
 
 #. MSG_RESUME_PRINT c=18
-#: ../../Firmware/Marlin_main.cpp:680 ../../Firmware/messages.cpp:91
-#: ../../Firmware/ultralcd.cpp:5286 ../../Firmware/ultralcd.cpp:5288
+#: ../../Firmware/Marlin_main.cpp:645 ../../Firmware/messages.cpp:91
+#: ../../Firmware/ultralcd.cpp:5252 ../../Firmware/ultralcd.cpp:5254
 msgid "Resume print"
 msgstr "Riprendi stampa"
 
@@ -1788,17 +1781,17 @@ msgid "Returning selector"
 msgstr "Ritorno selettore"
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/messages.cpp:252 ../../Firmware/ultralcd.cpp:2479
+#: ../../Firmware/messages.cpp:264 ../../Firmware/ultralcd.cpp:2496
 msgid "Right"
 msgstr "Destra"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/messages.cpp:259 ../../Firmware/ultralcd.cpp:2710
+#: ../../Firmware/messages.cpp:271 ../../Firmware/ultralcd.cpp:2727
 msgid "Right side[µm]"
 msgstr "Destra [µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/messages.cpp:286 ../../Firmware/ultralcd.cpp:3656
+#: ../../Firmware/messages.cpp:298 ../../Firmware/ultralcd.cpp:3666
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1807,8 +1800,8 @@ msgstr ""
 "ricominciare dall'inizio. Continuare?"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4509
-#: ../../Firmware/ultralcd.cpp:4511
+#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4476
+#: ../../Firmware/ultralcd.cpp:4478
 msgid "SD card"
 msgstr "Mem. SD"
 
@@ -1823,23 +1816,23 @@ msgid "SELECTOR CANNOT MOVE"
 msgstr "SELETTORE BLOCCATO"
 
 #. MSG_STOPPED c=20
-#: ../../Firmware/Marlin_main.cpp:9887 ../../Firmware/messages.cpp:125
+#: ../../Firmware/Marlin_main.cpp:9047 ../../Firmware/messages.cpp:130
 msgid "STOPPED."
 msgstr "ARRESTATO."
 
 #. MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3223 ../../Firmware/Marlin_main.cpp:3245
-#: ../../Firmware/mesh_bed_calibration.cpp:2246 ../../Firmware/messages.cpp:44
+#: ../../Firmware/Marlin_main.cpp:2967 ../../Firmware/Marlin_main.cpp:2984
+#: ../../Firmware/mesh_bed_calibration.cpp:2231 ../../Firmware/messages.cpp:44
 msgid "Searching bed calibration point"
 msgstr "Ricerca punti calibrazione piano"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/messages.cpp:321 ../../Firmware/ultralcd.cpp:5136
+#: ../../Firmware/messages.cpp:333 ../../Firmware/ultralcd.cpp:5096
 msgid "Select"
 msgstr "Seleziona"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/messages.cpp:290 ../../Firmware/ultralcd.cpp:3730
+#: ../../Firmware/messages.cpp:302 ../../Firmware/ultralcd.cpp:3740
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
@@ -1848,27 +1841,27 @@ msgstr ""
 "menu sullo schermo."
 
 #. MSG_SELECT_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3453 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3612
-#: ../../Firmware/ultralcd.cpp:6822
+#: ../../Firmware/Marlin_main.cpp:3192 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3622
+#: ../../Firmware/ultralcd.cpp:6798
 msgid "Select filament:"
 msgstr "Seleziona il filam.:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:110 ../../Firmware/ultralcd.cpp:3464
-#: ../../Firmware/ultralcd.cpp:4504
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:3474
+#: ../../Firmware/ultralcd.cpp:4471
 msgid "Select language"
 msgstr "Seleziona lingua"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/messages.cpp:300 ../../Firmware/ultralcd.cpp:3900
+#: ../../Firmware/messages.cpp:312 ../../Firmware/ultralcd.cpp:3924
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr ""
 "Selezionate la temperatura per il preriscaldamento dell'ugello adatta al "
 "vostro materiale."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/messages.cpp:291 ../../Firmware/ultralcd.cpp:3735
+#: ../../Firmware/messages.cpp:303 ../../Firmware/ultralcd.cpp:3745
 msgid "Select temperature which matches your material."
 msgstr "Seleziona la temperatura appropriata per il tuo materiale."
 
@@ -1879,61 +1872,61 @@ msgid "Selecting fil. slot"
 msgstr "Seleziono slot fil."
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/messages.cpp:341 ../../Firmware/ultralcd.cpp:6274
+#: ../../Firmware/messages.cpp:353 ../../Firmware/ultralcd.cpp:6250
 msgid "Selftest OK"
 msgstr "Autotest OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/messages.cpp:340 ../../Firmware/ultralcd.cpp:6057
+#: ../../Firmware/messages.cpp:352 ../../Firmware/ultralcd.cpp:6033
 msgid "Selftest start"
 msgstr "Avvia autotest"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/messages.cpp:315 ../../Firmware/ultralcd.cpp:4581
+#: ../../Firmware/messages.cpp:327 ../../Firmware/ultralcd.cpp:4537
 msgid "Selftest"
 msgstr "Autotest"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/messages.cpp:342 ../../Firmware/ultralcd.cpp:6699
+#: ../../Firmware/messages.cpp:354 ../../Firmware/ultralcd.cpp:6675
 msgid "Selftest error!"
 msgstr "Errore Autotest!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6279
-#: ../../Firmware/ultralcd.cpp:6786 ../../Firmware/ultralcd.cpp:6984
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6255
+#: ../../Firmware/ultralcd.cpp:6762 ../../Firmware/ultralcd.cpp:6961
 msgid "Selftest failed"
 msgstr "Autotest fallito"
 
 #. MSG_FORCE_SELFTEST c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1577 ../../Firmware/messages.cpp:202
+#: ../../Firmware/Marlin_main.cpp:1504 ../../Firmware/messages.cpp:214
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr "Verra effettuato un self test per calibrare l'homing senza sensori"
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/messages.cpp:228 ../../Firmware/ultralcd.cpp:1701
+#: ../../Firmware/messages.cpp:240 ../../Firmware/ultralcd.cpp:1711
 msgid "Sensor info"
 msgstr "Info Sensore"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/messages.cpp:338 ../../Firmware/ultralcd.cpp:6027
+#: ../../Firmware/messages.cpp:350 ../../Firmware/ultralcd.cpp:6003
 msgid "Sensor verified, remove the filament now."
 msgstr "Sensore verificato, rimuovere il filamento."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/messages.cpp:262 ../../Firmware/ultralcd.cpp:2730
+#: ../../Firmware/messages.cpp:274 ../../Firmware/ultralcd.cpp:2747
 msgid "Set temperature:"
 msgstr "Imposta temperatura:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3348
-#: ../../Firmware/ultralcd.cpp:3479 ../../Firmware/ultralcd.cpp:3984
-#: ../../Firmware/ultralcd.cpp:5374 ../../Firmware/ultralcd.cpp:5585
-#: ../../Firmware/ultralcd.cpp:5631
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3358
+#: ../../Firmware/ultralcd.cpp:3489 ../../Firmware/ultralcd.cpp:4008
+#: ../../Firmware/ultralcd.cpp:5341 ../../Firmware/ultralcd.cpp:5558
+#: ../../Firmware/ultralcd.cpp:5604
 msgid "Settings"
 msgstr "Impostazioni"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/messages.cpp:255 ../../Firmware/ultralcd.cpp:2522
+#: ../../Firmware/messages.cpp:267 ../../Firmware/ultralcd.cpp:2539
 msgid "Severe skew"
 msgstr "Deviaz. forte"
 
@@ -1944,7 +1937,7 @@ msgid "Sheet"
 msgstr "Piano"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/messages.cpp:284 ../../Firmware/ultralcd.cpp:3604
+#: ../../Firmware/messages.cpp:296 ../../Firmware/ultralcd.cpp:3614
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1957,23 +1950,23 @@ msgstr ""
 "%cReset"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/messages.cpp:319 ../../Firmware/ultralcd.cpp:4592
+#: ../../Firmware/messages.cpp:331 ../../Firmware/ultralcd.cpp:4548
 msgid "Show end stops"
 msgstr "Stato finecorsa"
 
 #. MSG_SILENT c=7
-#: ../../Firmware/Marlin_main.cpp:8497 ../../Firmware/messages.cpp:120
-#: ../../Firmware/ultralcd.cpp:4155 ../../Firmware/ultralcd.cpp:4194
+#: ../../Firmware/Marlin_main.cpp:7668 ../../Firmware/messages.cpp:124
+#: ../../Firmware/ultralcd.cpp:4179 ../../Firmware/ultralcd.cpp:4218
 msgid "Silent"
 msgstr "Silenz."
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/messages.cpp:254 ../../Firmware/ultralcd.cpp:2521
+#: ../../Firmware/messages.cpp:266 ../../Firmware/ultralcd.cpp:2538
 msgid "Slight skew"
 msgstr "Deviaz. lieve"
 
 #. MSG_FILE_CNT c=20 r=6
-#: ../../Firmware/cardreader.cpp:805 ../../Firmware/messages.cpp:197
+#: ../../Firmware/cardreader.cpp:805 ../../Firmware/messages.cpp:209
 msgid ""
 "Some files will not be sorted. Max. No. of files in 1 folder for sorting is "
 "100."
@@ -1982,59 +1975,59 @@ msgstr ""
 "e 100 perche siano ordinati."
 
 #. MSG_ZLEVELING_ENFORCED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3043 ../../Firmware/messages.cpp:204
+#: ../../Firmware/Marlin_main.cpp:2783 ../../Firmware/messages.cpp:216
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Sono stati rilevati problemi, avviato livellamento Z ..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:4514
-#: ../../Firmware/ultralcd.cpp:4515 ../../Firmware/ultralcd.cpp:4516
+#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4481
+#: ../../Firmware/ultralcd.cpp:4482 ../../Firmware/ultralcd.cpp:4483
 msgid "Sort"
 msgstr "Ordina"
 
 #. MSG_SORTING_FILES c=20
 #: ../../Firmware/cardreader.cpp:849 ../../Firmware/cardreader.cpp:916
-#: ../../Firmware/messages.cpp:111
+#: ../../Firmware/messages.cpp:115
 msgid "Sorting files"
 msgstr "Ordinando i file"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4188
-#: ../../Firmware/ultralcd.cpp:4191 ../../Firmware/ultralcd.cpp:4194
-#: ../../Firmware/ultralcd.cpp:4197 ../../Firmware/ultralcd.cpp:4200
+#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4215 ../../Firmware/ultralcd.cpp:4218
+#: ../../Firmware/ultralcd.cpp:4221 ../../Firmware/ultralcd.cpp:4224
 msgid "Sound"
 msgstr "Suono"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/messages.cpp:333 ../../Firmware/ultralcd.cpp:5516
+#: ../../Firmware/messages.cpp:345 ../../Firmware/ultralcd.cpp:5483
 msgid "Speed"
 msgstr "Velocita"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6861
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6837
 msgid "Spinning"
 msgstr "Gira"
 
 #. MSG_TEMP_CAL_WARNING c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4744 ../../Firmware/messages.cpp:208
+#: ../../Firmware/Marlin_main.cpp:4313 ../../Firmware/messages.cpp:220
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr ""
 "Sono necessari una temperatura ambiente di 21-26C e una superficie rigida."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/messages.cpp:329 ../../Firmware/ultralcd.cpp:5379
+#: ../../Firmware/messages.cpp:341 ../../Firmware/ultralcd.cpp:5346
 msgid "Statistics"
 msgstr "Statistiche"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:4096
-#: ../../Firmware/ultralcd.cpp:4144
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4120
+#: ../../Firmware/ultralcd.cpp:4168
 msgid "Stealth"
 msgstr "Silenz."
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4421
-#: ../../Firmware/ultralcd.cpp:5133
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4388
+#: ../../Firmware/ultralcd.cpp:5093
 msgid "Steel sheets"
 msgstr "Piani d'acciaio"
 
@@ -2044,29 +2037,28 @@ msgid "Stop"
 msgstr "Stop"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:5293
-#: ../../Firmware/ultralcd.cpp:5781
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:5259
+#: ../../Firmware/ultralcd.cpp:5757
 msgid "Stop print"
 msgstr "Arresta stampa"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4236
-#: ../../Firmware/ultralcd.cpp:4316 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4315
 msgid "Strict"
 msgstr "Esatto"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/messages.cpp:332 ../../Firmware/ultralcd.cpp:5394
+#: ../../Firmware/messages.cpp:344 ../../Firmware/ultralcd.cpp:5361
 msgid "Support"
 msgstr "Supporto"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/messages.cpp:354 ../../Firmware/ultralcd.cpp:6758
+#: ../../Firmware/messages.cpp:366 ../../Firmware/ultralcd.cpp:6734
 msgid "Swapped"
 msgstr "Scambiato"
 
 #. MSG_THERMAL_ANOMALY c=20
-#: ../../Firmware/messages.cpp:188 ../../Firmware/temperature.cpp:2223
+#: ../../Firmware/messages.cpp:195 ../../Firmware/temperature.cpp:2197
 msgid "THERMAL ANOMALY"
 msgstr "ANOMALIA TERMICA"
 
@@ -2101,7 +2093,7 @@ msgid "TMC UNDERVOLTAGE ERR"
 msgstr "TMC UNDERVOLTAGE ERR"
 
 #. MSG_TM_CAL c=20 r=4
-#: ../../Firmware/messages.cpp:299 ../../Firmware/ultralcd.cpp:3881
+#: ../../Firmware/messages.cpp:311 ../../Firmware/ultralcd.cpp:3905
 msgid ""
 "Thermal model cal. takes approx. 12 mins. See\n"
 "prusa.io/tm-cal"
@@ -2110,22 +2102,22 @@ msgstr ""
 "prusa.io/tm-cal"
 
 #. MSG_TM_NOT_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1613 ../../Firmware/messages.cpp:189
+#: ../../Firmware/Marlin_main.cpp:1540 ../../Firmware/messages.cpp:196
 msgid "Thermal model not calibrated yet."
 msgstr "Modello termico non calibrato."
 
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/messages.cpp:309 ../../Firmware/ultralcd.cpp:4455
+#: ../../Firmware/messages.cpp:321 ../../Firmware/ultralcd.cpp:4422
 msgid "Temperature"
 msgstr "Temperatura"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/messages.cpp:229 ../../Firmware/ultralcd.cpp:1707
+#: ../../Firmware/messages.cpp:241 ../../Firmware/ultralcd.cpp:1717
 msgid "Temperatures"
 msgstr "Temperature"
 
 #. MSG_TESTING_FILAMENT c=20
-#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:388
+#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:389
 msgid "Testing filament"
 msgstr "Provo il filamento"
 
@@ -2146,7 +2138,7 @@ msgstr ""
 " sia nulla che ne blocchi il movimento."
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/messages.cpp:292 ../../Firmware/ultralcd.cpp:3738
+#: ../../Firmware/messages.cpp:304 ../../Firmware/ultralcd.cpp:3748
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -2157,7 +2149,7 @@ msgstr ""
 "manuale (capitolo sulla calibrazione)."
 
 #. MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1606 ../../Firmware/messages.cpp:47
+#: ../../Firmware/Marlin_main.cpp:1533 ../../Firmware/messages.cpp:47
 msgid ""
 "There is still a need to make Z calibration. Please follow the manual, "
 "chapter First steps, section Calibration flow."
@@ -2166,40 +2158,40 @@ msgstr ""
 "Primi Passi - Sequenza di Calibrazione."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:4514
+#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:4481
 msgid "Time"
 msgstr "Cron."
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:176 ../../Firmware/ultralcd.cpp:5622
+#: ../../Firmware/messages.cpp:183 ../../Firmware/ultralcd.cpp:5595
 msgid "Timeout"
 msgstr "Timeout"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:1129
-#: ../../Firmware/ultralcd.cpp:1287
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:1139
+#: ../../Firmware/ultralcd.cpp:1297
 msgid "Total"
 msgstr "Totale"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:1177
-#: ../../Firmware/ultralcd.cpp:1231 ../../Firmware/ultralcd.cpp:1317
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:1187
+#: ../../Firmware/ultralcd.cpp:1241 ../../Firmware/ultralcd.cpp:1327
 msgid "Total failures"
 msgstr "Totale fallimenti"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/messages.cpp:248 ../../Firmware/ultralcd.cpp:2369
+#: ../../Firmware/messages.cpp:260 ../../Firmware/ultralcd.cpp:2386
 msgid "Total filament"
 msgstr "Filamento totale"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/messages.cpp:249 ../../Firmware/ultralcd.cpp:2370
+#: ../../Firmware/messages.cpp:261 ../../Firmware/ultralcd.cpp:2387
 msgid "Total print time"
 msgstr "Tempo stampa totale"
 
 #. MSG_TUNE c=8
-#: ../../Firmware/messages.cpp:116 ../../Firmware/mmu2/errors_list.h:372
-#: ../../Firmware/ultralcd.cpp:5258
+#: ../../Firmware/messages.cpp:120 ../../Firmware/mmu2/errors_list.h:372
+#: ../../Firmware/ultralcd.cpp:5220
 msgid "Tune"
 msgstr "Regola"
 
@@ -2214,16 +2206,16 @@ msgid "Unload"
 msgstr "Scarica"
 
 #. MSG_UNLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:2206
-#: ../../Firmware/ultralcd.cpp:5347 ../../Firmware/ultralcd.cpp:5364
-#: ../../Firmware/ultralcd.cpp:5369
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:2220
+#: ../../Firmware/ultralcd.cpp:5313 ../../Firmware/ultralcd.cpp:5331
+#: ../../Firmware/ultralcd.cpp:5336
 msgid "Unload filament"
 msgstr "Scarica filam."
 
 #. MSG_UNLOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3436 ../../Firmware/messages.cpp:129
+#: ../../Firmware/Marlin_main.cpp:3175 ../../Firmware/messages.cpp:134
 #: ../../Firmware/mmu2_progress_converter.cpp:50
-#: ../../Firmware/ultralcd.cpp:4911
+#: ../../Firmware/ultralcd.cpp:4867
 msgid "Unloading filament"
 msgstr "Scaricando filamento"
 
@@ -2240,12 +2232,12 @@ msgid "Unloading to pulley"
 msgstr "Scarico in puleggia"
 
 #. MSG_FIL_FAILED c=20 r=4
-#: ../../Firmware/messages.cpp:339 ../../Firmware/ultralcd.cpp:6030
+#: ../../Firmware/messages.cpp:351 ../../Firmware/ultralcd.cpp:6006
 msgid "Verification failed, remove the filament and try again."
 msgstr "Verifica fallita, rimuovere il filamento e riprovare."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/messages.cpp:230 ../../Firmware/ultralcd.cpp:1710
+#: ../../Firmware/messages.cpp:242 ../../Firmware/ultralcd.cpp:1720
 msgid "Voltages"
 msgstr "Voltaggi"
 
@@ -2256,7 +2248,7 @@ msgid "WARNING TMC TOO HOT"
 msgstr "ATTENZIONE TMC CALDO"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/messages.cpp:281 ../../Firmware/ultralcd.cpp:3381
+#: ../../Firmware/messages.cpp:293 ../../Firmware/ultralcd.cpp:3391
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -2269,191 +2261,191 @@ msgstr ""
 "Modalita silenziosa"
 
 #. MSG_USERWAIT c=20
-#: ../../Firmware/Marlin_main.cpp:5240 ../../Firmware/messages.cpp:209
+#: ../../Firmware/Marlin_main.cpp:4747 ../../Firmware/messages.cpp:221
 msgid "Wait for user..."
 msgstr "Attendendo utente..."
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/messages.cpp:263 ../../Firmware/ultralcd.cpp:2753
+#: ../../Firmware/messages.cpp:275 ../../Firmware/ultralcd.cpp:2770
 msgid "Waiting for PINDA probe cooling"
 msgstr "In attesa del raffreddamento della sonda PINDA"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/messages.cpp:264 ../../Firmware/ultralcd.cpp:2782
+#: ../../Firmware/messages.cpp:276 ../../Firmware/ultralcd.cpp:2799
 msgid "Waiting for nozzle and bed cooling"
 msgstr "In attesa del raffreddamento dell'ugello e del piano"
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:4233
-#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4352
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4312
 msgid "Warn"
 msgstr "Avviso"
 
 #. MSG_CHANGED_BOTH c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1554 ../../Firmware/messages.cpp:200
+#: ../../Firmware/Marlin_main.cpp:1481 ../../Firmware/messages.cpp:212
 msgid "Warning: both printer type and motherboard type changed."
 msgstr "Attenzione: tipo di stampante e di scheda madre cambiati."
 
 #. MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1546 ../../Firmware/messages.cpp:198
+#: ../../Firmware/Marlin_main.cpp:1473 ../../Firmware/messages.cpp:210
 msgid "Warning: motherboard type changed."
 msgstr "Avviso: tipo di scheda madre cambiato"
 
 #. MSG_CHANGED_PRINTER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1550 ../../Firmware/messages.cpp:199
+#: ../../Firmware/Marlin_main.cpp:1477 ../../Firmware/messages.cpp:211
 msgid "Warning: printer type changed."
 msgstr "Avviso: tipo di stampante cambiato."
 
 #. MSG_UNLOAD_SUCCESSFUL c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3517 ../../Firmware/messages.cpp:205
+#: ../../Firmware/Marlin_main.cpp:3257 ../../Firmware/messages.cpp:217
 msgid "Was filament unload successful?"
 msgstr "Filamento scaricato con successo?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:6710
-#: ../../Firmware/ultralcd.cpp:6714 ../../Firmware/ultralcd.cpp:6734
-#: ../../Firmware/ultralcd.cpp:6740 ../../Firmware/ultralcd.cpp:6764
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:6686
+#: ../../Firmware/ultralcd.cpp:6690 ../../Firmware/ultralcd.cpp:6710
+#: ../../Firmware/ultralcd.cpp:6716 ../../Firmware/ultralcd.cpp:6740
 msgid "Wiring error"
 msgstr "Errore cablaggio"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/messages.cpp:313 ../../Firmware/ultralcd.cpp:4572
+#: ../../Firmware/messages.cpp:325 ../../Firmware/ultralcd.cpp:4528
 msgid "Wizard"
 msgstr "Wizard"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/messages.cpp:304 ../../Firmware/ultralcd.cpp:3986
+#: ../../Firmware/messages.cpp:316 ../../Firmware/ultralcd.cpp:4010
 msgid "X-correct"
 msgstr "Correzione-X"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/messages.cpp:226 ../../Firmware/ultralcd.cpp:1699
+#: ../../Firmware/messages.cpp:238 ../../Firmware/ultralcd.cpp:1709
 msgid "XYZ cal. details"
 msgstr "XYZ Cal. dettagli"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/messages.cpp:275 ../../Firmware/ultralcd.cpp:3207
+#: ../../Firmware/messages.cpp:287 ../../Firmware/ultralcd.cpp:3217
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr ""
 "Calibrazione XYZ corretta. La distorsione verra compensata automaticamente."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/messages.cpp:274 ../../Firmware/ultralcd.cpp:3204
+#: ../../Firmware/messages.cpp:286 ../../Firmware/ultralcd.cpp:3214
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr "Calibrazione XYZ corretta. Assi X/Y leggermente storti. Ben fatto!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/messages.cpp:271 ../../Firmware/ultralcd.cpp:3185
+#: ../../Firmware/messages.cpp:283 ../../Firmware/ultralcd.cpp:3195
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr "Calibrazione XYZ compromessa. Punti anteriori non raggiungibili."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/messages.cpp:272 ../../Firmware/ultralcd.cpp:3188
+#: ../../Firmware/messages.cpp:284 ../../Firmware/ultralcd.cpp:3198
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr ""
 "Calibrazione XYZ compromessa. Punto anteriore destro non raggiungibile."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/messages.cpp:268 ../../Firmware/ultralcd.cpp:3167
+#: ../../Firmware/messages.cpp:280 ../../Firmware/ultralcd.cpp:3177
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr ""
 "Calibrazione XYZ fallita. Il punto di calibrazione sul piano non e' stato "
 "trovato."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/messages.cpp:269 ../../Firmware/ultralcd.cpp:3173
+#: ../../Firmware/messages.cpp:281 ../../Firmware/ultralcd.cpp:3183
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr "Calibrazione XYZ fallita. Punti anteriori non raggiungibili."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3170
-#: ../../Firmware/ultralcd.cpp:3198
+#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3180
+#: ../../Firmware/ultralcd.cpp:3208
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "Calibrazione XYZ fallita. Consultare manuale."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/messages.cpp:270 ../../Firmware/ultralcd.cpp:3176
+#: ../../Firmware/messages.cpp:282 ../../Firmware/ultralcd.cpp:3186
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr "Calibrazione XYZ fallita. Punto anteriore destro non raggiungibile."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/messages.cpp:273 ../../Firmware/ultralcd.cpp:3201
+#: ../../Firmware/messages.cpp:285 ../../Firmware/ultralcd.cpp:3211
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "Calibrazione XYZ OK. Gli assi X/Y sono perpendicolari. Complimenti!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/messages.cpp:250 ../../Firmware/ultralcd.cpp:2476
+#: ../../Firmware/messages.cpp:262 ../../Firmware/ultralcd.cpp:2493
 msgid "Y distance from min"
 msgstr "Distanza Y dal min"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/messages.cpp:305 ../../Firmware/ultralcd.cpp:3987
+#: ../../Firmware/messages.cpp:317 ../../Firmware/ultralcd.cpp:4011
 msgid "Y-correct"
 msgstr "Correzione-Y"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:3029
-#: ../../Firmware/ultralcd.cpp:4443 ../../Firmware/ultralcd.cpp:4531
-#: ../../Firmware/ultralcd.cpp:5790
+#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:2275
+#: ../../Firmware/ultralcd.cpp:2279 ../../Firmware/ultralcd.cpp:3046
+#: ../../Firmware/ultralcd.cpp:4410 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/ultralcd.cpp:5766
 msgid "Yes"
 msgstr "Si"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:3950
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:3974
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr ""
 "E possibile riprendere il Wizard in qualsiasi momento attraverso "
 "Calibrazione -> Wizard."
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/messages.cpp:306 ../../Firmware/ultralcd.cpp:3988
+#: ../../Firmware/messages.cpp:318 ../../Firmware/ultralcd.cpp:4012
 msgid "Z-correct"
 msgstr "Correzione-Z"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5593
+#: ../../Firmware/messages.cpp:175 ../../Firmware/ultralcd.cpp:5566
 msgid "Z-probe nr."
 msgstr "Nr. Z-test"
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/messages.cpp:256 ../../Firmware/ultralcd.cpp:2546
+#: ../../Firmware/messages.cpp:268 ../../Firmware/ultralcd.cpp:2563
 msgid "[0;0] point offset"
 msgstr "[0;0] punto offset"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/messages.cpp:239 ../../Firmware/ultralcd.cpp:2147
+#: ../../Firmware/messages.cpp:251 ../../Firmware/ultralcd.cpp:2158
 msgid "and press the knob"
 msgstr "e cliccare manopola"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/messages.cpp:232 ../../Firmware/ultralcd.cpp:1807
+#: ../../Firmware/messages.cpp:244 ../../Firmware/ultralcd.cpp:1816
 msgid "to load filament"
 msgstr "per caricare il fil."
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/messages.cpp:233 ../../Firmware/ultralcd.cpp:1811
+#: ../../Firmware/messages.cpp:245 ../../Firmware/ultralcd.cpp:1820
 msgid "to unload filament"
 msgstr "per scaricare fil."
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/messages.cpp:224 ../../Firmware/ultralcd.cpp:1666
+#: ../../Firmware/messages.cpp:236 ../../Firmware/ultralcd.cpp:1676
 msgid "unknown"
 msgstr "sconosciuto"
 
 #. MSG_IR_UNKNOWN c=18
-#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:184
+#: ../../Firmware/Filament_sensor.cpp:286 ../../Firmware/messages.cpp:191
 msgid "unknown state"
 msgstr "stato sconosciuto"
 
 #. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:5858
-#: ../../Firmware/ultralcd.cpp:5861
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:5834
+#: ../../Firmware/ultralcd.cpp:5837
 msgid "🔃Refresh"
 msgstr "🔃Ricaricare"
 
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1180
+#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1190
 msgid "MMU power fails"
 msgstr "Manc. corr. MMU"
 
@@ -2491,8 +2483,8 @@ msgid "MMU MCU ERROR"
 msgstr "ERRORE MMU MCU"
 
 #. MSG_MATERIAL_CHANGES c=18
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:1130
-#: ../../Firmware/ultralcd.cpp:1204
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:1140
+#: ../../Firmware/ultralcd.cpp:1214
 msgid "Material changes"
 msgstr "Scambi materiali"
 
@@ -2524,17 +2516,17 @@ msgstr ""
 "stampante. Aggiornamento alla versione 3.0.3."
 
 #. MSG_PRELOAD_TO_MMU c=17
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5344
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5310
 msgid "Preload to MMU"
 msgstr "Precarica MMU"
 
 #. MSG_FW_MK3_DETECTED c=20 r=4
-#: ../../Firmware/messages.cpp:367 ../../Firmware/Marlin_main.cpp:920
+#: ../../Firmware/messages.cpp:379 ../../Firmware/Marlin_main.cpp:854
 msgid "MK3 firmware detected on MK3S printer"
 msgstr "Firmware MK3 rilevato su stampante MK3S"
 
 #. MSG_FW_MK3S_DETECTED c=20 r=4
-#: ../../Firmware/messages.cpp:367 ../../Firmware/Marlin_main.cpp:920
+#: ../../Firmware/messages.cpp:379 ../../Firmware/Marlin_main.cpp:854
 msgid "MK3S firmware detected on MK3 printer"
 msgstr "Firmware MK3S rilevato su stampante MK3"
 
@@ -2548,8 +2540,9 @@ msgstr "ERRORE SCONOSCIUTO"
 msgid "Unexpected error occurred."
 msgstr "Si è verificato un errore imprevisto."
 
-#. MSG_BTN_EJECT c=8
-#: ../../Firmware/mmu2/errors_list.h:358 ../../Firmware/mmu2/errors_list.h:371
+#. MSG_EJECT c=8
+#: ../../Firmware/messages.cpp:21 ../../Firmware/mmu2/errors_list.h:371
+#: ../../Firmware/ultralcd.cpp:2275 ../../Firmware/ultralcd.cpp:2279
 msgid "Eject"
 msgstr "Espelli"
 
@@ -2570,58 +2563,58 @@ msgstr ""
 "Cambio filamento M600. Carica un nuovo filamento o espelli quello vecchio."
 
 #. MSG_MMU_SENSITIVITY c=18
-#: ../../Firmware/messages.cpp:215 ../../Firmware/mmu2_reporting.cpp:458
+#: ../../Firmware/messages.cpp:227 ../../Firmware/mmu2_reporting.cpp:459
 msgid "Sensitivity"
 msgstr "Sensibilità"
 
 #. MSG_MBL_FAILED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3038 ../../Firmware/messages.cpp:203
+#: ../../Firmware/Marlin_main.cpp:2776 ../../Firmware/messages.cpp:215
 msgid "Mesh bed leveling failed. Print canceled."
 msgstr "Livellamento piano fallito. Stampa annullata."
 
 #. MSG_SET_READY c=18
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:5265
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:5228
 msgid "Set Ready"
 msgstr "Imposta pronta"
 
 #. MSG_SET_NOT_READY c=18
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:5263
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5226
 msgid "Set not Ready"
 msgstr "Imposta non pronta"
 
 #. MSG_HOSTPRINT c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5285
+#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:5231
 msgid "Print from host"
 msgstr "Stampa da host"
 
 #. MSG_REPRINT c=18
-#: ../../Firmware/messages.cpp:196 ../../Firmware/ultralcd.cpp:5243
-#: ../../Firmware/ultralcd.cpp:5245
+#: ../../Firmware/messages.cpp:208 ../../Firmware/ultralcd.cpp:5205
+#: ../../Firmware/ultralcd.cpp:5207
 msgid "Reprint"
 msgstr "Ristampa"
 
 #. MSG_SHUTDOWN_HOST c=18
-#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:5390
+#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:5357
 msgid "Shutdown host"
 msgstr "Spegnere l'host"
 
 #. MSG_NOZZLE_CNG_COOLDOWN c=20 r=3
-#: ../../Firmware/messages.cpp:198 ../../Firmware/ultralcd.cpp:1002
+#: ../../Firmware/messages.cpp:203 ../../Firmware/ultralcd.cpp:999
 msgid "Nozzle is hot! Wait for cooldown."
 msgstr "L'ugello è caldo! Attendere il raffreddamento."
 
 #. MSG_NOZZLE_CNG_CHANGED_QUICK c=20 r=3
-#: ../../Firmware/messages.cpp:199
+#: ../../Firmware/messages.cpp:204
 msgid "Nozzle changed?"
 msgstr "L'ugello è cambiato?"
 
 #. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:388
+#: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:388
 msgid "There is no filament loaded. Continue?"
 msgstr "Nessun filamento caricato. Continuare?"
 
 #. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:389
+#: ../../Firmware/messages.cpp:159 ../../Firmware/util.cpp:389
 msgid "There is no filament loaded. Print cancelled."
 msgstr "Nessun filamento caricato. Stampa annullata."
 

--- a/lang/po/Firmware_nl.po
+++ b/lang/po/Firmware_nl.po
@@ -16,91 +16,91 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 
 #. MSG_IR_03_OR_OLDER c=18
-#: ../../Firmware/Filament_sensor.cpp:280
-#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:183
+#: ../../Firmware/Filament_sensor.cpp:282
+#: ../../Firmware/Filament_sensor.cpp:344 ../../Firmware/messages.cpp:190
 msgid " 0.3 or older"
 msgstr " 0.3 of ouder"
 
 #. MSG_IR_04_OR_NEWER c=18
-#: ../../Firmware/Filament_sensor.cpp:282
-#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:182
+#: ../../Firmware/Filament_sensor.cpp:284
+#: ../../Firmware/Filament_sensor.cpp:347 ../../Firmware/messages.cpp:189
 msgid " 0.4 or newer"
 msgstr " 0.4 of nieuwer"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/messages.cpp:356 ../../Firmware/ultralcd.cpp:6773
+#: ../../Firmware/messages.cpp:368 ../../Firmware/ultralcd.cpp:6749
 msgid "%s level expected"
 msgstr "%s niveau verwacht"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:1978
-#: ../../Firmware/ultralcd.cpp:3613
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:1986
+#: ../../Firmware/ultralcd.cpp:3623
 msgid ">Cancel"
 msgstr ">Annuleren"
 
 #. MSG_BABYSTEPPING_Z c=13
-#: ../../Firmware/messages.cpp:257 ../../Firmware/ultralcd.cpp:2635
+#: ../../Firmware/messages.cpp:269 ../../Firmware/ultralcd.cpp:2652
 msgid "Adjusting Z"
 msgstr "Z aanpassen"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/messages.cpp:360 ../../Firmware/ultralcd.cpp:6983
+#: ../../Firmware/messages.cpp:372 ../../Firmware/ultralcd.cpp:6960
 msgid "All correct"
 msgstr "Allemaal goed"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:3955
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:3979
 msgid "All is done. Happy printing!"
 msgstr "Klaar. Happy printing!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4482
 msgid "Alphabet"
 msgstr "Alfabet"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4086
+#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4110
 msgid "Always"
 msgstr "Altijd"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/messages.cpp:221 ../../Firmware/ultralcd.cpp:1393
+#: ../../Firmware/messages.cpp:233 ../../Firmware/ultralcd.cpp:1403
 msgid "Ambient"
 msgstr "Kamertemp."
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=3
-#: ../../Firmware/messages.cpp:267 ../../Firmware/ultralcd.cpp:2848
+#: ../../Firmware/messages.cpp:279 ../../Firmware/ultralcd.cpp:2865
 msgid "Are left and right Z-carriages all up?"
 msgstr "Zijn beide Z wagen heelemaal boven?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4197
+#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:4221
 msgid "Assist"
 msgstr "Assist."
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:179 ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/messages.cpp:186 ../../Firmware/ultralcd.cpp:5594
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
-#: ../../Firmware/Marlin_main.cpp:3198 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:4577 ../../Firmware/ultralcd.cpp:5529
+#: ../../Firmware/Marlin_main.cpp:2942 ../../Firmware/messages.cpp:12
+#: ../../Firmware/ultralcd.cpp:4533 ../../Firmware/ultralcd.cpp:5496
 msgid "Auto home"
 msgstr "Startpositie"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4182
 msgid "Auto power"
 msgstr "Auto power"
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:328 ../../Firmware/ultralcd.cpp:5359
+#: ../../Firmware/messages.cpp:340 ../../Firmware/ultralcd.cpp:5328
 msgid "AutoLoad filament"
 msgstr "Autoladen filament"
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/messages.cpp:245 ../../Firmware/ultralcd.cpp:2272
+#: ../../Firmware/messages.cpp:257 ../../Firmware/ultralcd.cpp:2289
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
@@ -113,51 +113,50 @@ msgid "Avoiding grind"
 msgstr "Slijpen vermijden"
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/messages.cpp:352 ../../Firmware/ultralcd.cpp:6752
+#: ../../Firmware/messages.cpp:364 ../../Firmware/ultralcd.cpp:6728
 msgid "Axis"
 msgstr "As"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/messages.cpp:351 ../../Firmware/ultralcd.cpp:6751
+#: ../../Firmware/messages.cpp:363 ../../Firmware/ultralcd.cpp:6727
 msgid "Axis length"
 msgstr "Aslengte"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2708
-#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:5618
-#: ../../Firmware/ultralcd.cpp:7484
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2725
+#: ../../Firmware/ultralcd.cpp:4061 ../../Firmware/ultralcd.cpp:5591
+#: ../../Firmware/ultralcd.cpp:7461
 msgid "Back"
 msgstr "Terug"
 
 #. MSG_BED c=13
-#: ../../Firmware/Marlin_main.cpp:2081 ../../Firmware/Marlin_main.cpp:4627
-#: ../../Firmware/Marlin_main.cpp:4678 ../../Firmware/messages.cpp:15
-#: ../../Firmware/ultralcd.cpp:1391 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/Marlin_main.cpp:4247 ../../Firmware/messages.cpp:15
+#: ../../Firmware/ultralcd.cpp:1401 ../../Firmware/ultralcd.cpp:4197
 msgid "Bed"
 msgstr "Bed"
 
 #. MSG_BED_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6240 ../../Firmware/messages.cpp:17
+#: ../../Firmware/Marlin_main.cpp:5470 ../../Firmware/messages.cpp:17
 #: ../../Firmware/ultralcd.cpp:534
 msgid "Bed Heating"
 msgstr "Bed opwarmen"
 
 #. MSG_BED_DONE c=20
-#: ../../Firmware/Marlin_main.cpp:6277 ../../Firmware/messages.cpp:16
+#: ../../Firmware/Marlin_main.cpp:5507 ../../Firmware/messages.cpp:16
 #: ../../Firmware/ultralcd.cpp:537
 msgid "Bed done"
 msgstr "Bed klaar"
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/messages.cpp:317 ../../Firmware/ultralcd.cpp:4589
+#: ../../Firmware/messages.cpp:329 ../../Firmware/ultralcd.cpp:4545
 msgid "Bed level correct"
 msgstr "Bed niveau correct"
 
 #. MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:2262 ../../Firmware/Marlin_main.cpp:2999
-#: ../../Firmware/Marlin_main.cpp:3008
-#: ../../Firmware/mesh_bed_calibration.cpp:2878
-#: ../../Firmware/mesh_bed_calibration.cpp:2903 ../../Firmware/messages.cpp:18
+#: ../../Firmware/Marlin_main.cpp:2048 ../../Firmware/Marlin_main.cpp:2736
+#: ../../Firmware/Marlin_main.cpp:2745
+#: ../../Firmware/mesh_bed_calibration.cpp:2863
+#: ../../Firmware/mesh_bed_calibration.cpp:2888 ../../Firmware/messages.cpp:18
 msgid ""
 "Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for "
 "reset."
@@ -166,34 +165,34 @@ msgstr ""
 "reset."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/messages.cpp:346 ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/messages.cpp:358 ../../Firmware/ultralcd.cpp:6685
 msgid "Bed/Heater"
 msgstr "Bed/Verwarming"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1444
-#: ../../Firmware/ultralcd.cpp:1704
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1454
+#: ../../Firmware/ultralcd.cpp:1714
 msgid "Belt status"
 msgstr "Riem status"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/messages.cpp:314 ../../Firmware/ultralcd.cpp:4579
+#: ../../Firmware/messages.cpp:326 ../../Firmware/ultralcd.cpp:4535
 msgid "Belt test"
 msgstr "Riemtest"
 
 #. MSG_RECOVER_PRINT c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:1660 ../../Firmware/messages.cpp:87
+#: ../../Firmware/Marlin_main.cpp:1587 ../../Firmware/messages.cpp:87
 msgid "Blackout occurred. Recover print?"
 msgstr "Stroomstoring. Print herstellen?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:177 ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:5594
 msgid "Bright"
 msgstr "Helder"
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:4526
-#: ../../Firmware/ultralcd.cpp:5546
+#: ../../Firmware/messages.cpp:180 ../../Firmware/ultralcd.cpp:4493
+#: ../../Firmware/ultralcd.cpp:5513
 msgid "Brightness"
 msgstr "Helderheid"
 
@@ -203,17 +202,17 @@ msgid "COMMUNICATION ERROR"
 msgstr "COMMUNICATIEFOUT"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/messages.cpp:316 ../../Firmware/ultralcd.cpp:4583
+#: ../../Firmware/messages.cpp:328 ../../Firmware/ultralcd.cpp:4539
 msgid "Calibrate XYZ"
 msgstr "Kalibratie XYZ"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4585
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4541
 msgid "Calibrate Z"
 msgstr "Kalibratie Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/messages.cpp:266 ../../Firmware/ultralcd.cpp:2813
+#: ../../Firmware/messages.cpp:278 ../../Firmware/ultralcd.cpp:2830
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -222,13 +221,13 @@ msgstr ""
 " stoppers. Druk knop als klaar."
 
 #. MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: ../../Firmware/Marlin_main.cpp:2218 ../../Firmware/messages.cpp:22
+#: ../../Firmware/Marlin_main.cpp:2009 ../../Firmware/messages.cpp:23
 #: ../../Firmware/ultralcd.cpp:582
 msgid "Calibrating Z"
 msgstr "Kalibreren Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/messages.cpp:265 ../../Firmware/ultralcd.cpp:2812
+#: ../../Firmware/messages.cpp:277 ../../Firmware/ultralcd.cpp:2829
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -237,17 +236,17 @@ msgstr ""
 "stoppers. Druk knop als klaar."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/messages.cpp:361 ../../Firmware/ultralcd.cpp:6985
+#: ../../Firmware/messages.cpp:373 ../../Firmware/ultralcd.cpp:6962
 msgid "Calibrating home"
 msgstr "Kalibreren start"
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5375
+#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5342
 msgid "Calibration"
 msgstr "Kalibratie"
 
 #. MSG_HOMEYZ_DONE c=20
-#: ../../Firmware/messages.cpp:217 ../../Firmware/ultralcd.cpp:593
+#: ../../Firmware/messages.cpp:229 ../../Firmware/ultralcd.cpp:593
 msgid "Calibration done"
 msgstr "Kalibratie klaar"
 
@@ -266,128 +265,128 @@ msgstr ""
 "uitladen."
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/messages.cpp:364 ../../Firmware/ultralcd.cpp:7405
+#: ../../Firmware/messages.cpp:376 ../../Firmware/ultralcd.cpp:7382
 msgid "Card removed"
 msgstr "SD verwijderd"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/messages.cpp:324 ../../Firmware/ultralcd.cpp:5316
+#: ../../Firmware/messages.cpp:336 ../../Firmware/ultralcd.cpp:5282
 msgid "Change SD card"
 msgstr "Wissel SD kaart"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5254
-#: ../../Firmware/ultralcd.cpp:5526
+#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5216
+#: ../../Firmware/ultralcd.cpp:5493
 msgid "Change filament"
 msgstr "Wissel filament"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/messages.cpp:240 ../../Firmware/ultralcd.cpp:2156
+#: ../../Firmware/messages.cpp:252 ../../Firmware/ultralcd.cpp:2167
 msgid "Change success!"
 msgstr "Wissel geslaagd!"
 
 #. MSG_CORRECTLY c=19
-#: ../../Firmware/messages.cpp:242 ../../Firmware/ultralcd.cpp:2203
+#: ../../Firmware/messages.cpp:254 ../../Firmware/ultralcd.cpp:2217
 msgid "Changed correctly"
 msgstr "Wissel ok"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5951
-#: ../../Firmware/ultralcd.cpp:6975
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5927
+#: ../../Firmware/ultralcd.cpp:6952
 msgid "Checking X axis"
 msgstr "Controleer X as"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5961
-#: ../../Firmware/ultralcd.cpp:6976
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:5937
+#: ../../Firmware/ultralcd.cpp:6953
 msgid "Checking Y axis"
 msgstr "Controleer Y as"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/messages.cpp:358 ../../Firmware/ultralcd.cpp:6977
+#: ../../Firmware/messages.cpp:370 ../../Firmware/ultralcd.cpp:6954
 msgid "Checking Z axis"
 msgstr "Controleer Z as"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6978
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6955
 msgid "Checking bed"
 msgstr "Controleer bed"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/messages.cpp:357 ../../Firmware/ultralcd.cpp:6974
+#: ../../Firmware/messages.cpp:369 ../../Firmware/ultralcd.cpp:6951
 msgid "Checking endstops"
 msgstr "Controleer endstops"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/messages.cpp:362 ../../Firmware/ultralcd.cpp:7070
+#: ../../Firmware/messages.cpp:374 ../../Firmware/ultralcd.cpp:7047
 msgid "Checking file"
 msgstr "Bestand controle"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/messages.cpp:359 ../../Firmware/ultralcd.cpp:6980
+#: ../../Firmware/messages.cpp:371 ../../Firmware/ultralcd.cpp:6957
 msgid "Checking hotend"
 msgstr "Controleer hotend"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6981
-#: ../../Firmware/ultralcd.cpp:6982
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6958
+#: ../../Firmware/ultralcd.cpp:6959
 msgid "Checking sensors"
 msgstr "Controleer sensors"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/messages.cpp:308 ../../Firmware/ultralcd.cpp:4424
+#: ../../Firmware/messages.cpp:320 ../../Firmware/ultralcd.cpp:4391
 msgid "Checks"
 msgstr "Checks"
 
 #. MSG_TM_ACK_ERROR c=18
-#: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5297
+#: ../../Firmware/messages.cpp:197 ../../Firmware/ultralcd.cpp:5263
 msgid "Clear TM error"
 msgstr "TM-fout wissen"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/messages.cpp:244 ../../Firmware/ultralcd.cpp:2205
+#: ../../Firmware/messages.cpp:256 ../../Firmware/ultralcd.cpp:2219
 msgid "Color not correct"
 msgstr "Kleur niet juist"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:3508
+#: ../../Firmware/messages.cpp:27 ../../Firmware/ultralcd.cpp:3518
 msgid "Community made"
 msgstr "Van de community"
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:4059
+#: ../../Firmware/messages.cpp:178 ../../Firmware/ultralcd.cpp:4083
 msgid "Cont."
 msgstr "Door."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:2129
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2135
 msgid "Cooldown"
 msgstr "Afkoelen"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/messages.cpp:283 ../../Firmware/ultralcd.cpp:3450
+#: ../../Firmware/messages.cpp:295 ../../Firmware/ultralcd.cpp:3460
 msgid "Copy selected language?"
 msgstr "Geselecteerde taal kopiëren?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:1234
-#: ../../Firmware/ultralcd.cpp:1263
+#: ../../Firmware/messages.cpp:30 ../../Firmware/ultralcd.cpp:1244
+#: ../../Firmware/ultralcd.cpp:1273
 msgid "Crash"
 msgstr "Crash"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4146
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/ultralcd.cpp:4170
 msgid "Crash det."
 msgstr "Crashdet."
 
 #. MSG_CRASH_DETECTED c=20
-#: ../../Firmware/Marlin_main.cpp:630 ../../Firmware/messages.cpp:30
+#: ../../Firmware/Marlin_main.cpp:595 ../../Firmware/messages.cpp:31
 msgid "Crash detected."
 msgstr "Crash gedetecteerd."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/messages.cpp:280 ../../Firmware/ultralcd.cpp:3374
+#: ../../Firmware/messages.cpp:292 ../../Firmware/ultralcd.cpp:3384
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -398,24 +397,24 @@ msgstr ""
 "gebruikt worden"
 
 #. MSG_CUT_FILAMENT c=16
-#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:380
-#: ../../Firmware/ultralcd.cpp:4854 ../../Firmware/ultralcd.cpp:5351
+#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:381
+#: ../../Firmware/ultralcd.cpp:4810 ../../Firmware/ultralcd.cpp:5317
 msgid "Cut filament"
 msgstr "Fil. knippen"
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4081
-#: ../../Firmware/ultralcd.cpp:4086 ../../Firmware/ultralcd.cpp:4091
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:4105
+#: ../../Firmware/ultralcd.cpp:4110 ../../Firmware/ultralcd.cpp:4115
 msgid "Cutter"
 msgstr "Mes"
 
 #. MSG_DATE c=17
-#: ../../Firmware/messages.cpp:222 ../../Firmware/ultralcd.cpp:1645
+#: ../../Firmware/messages.cpp:234 ../../Firmware/ultralcd.cpp:1655
 msgid "Date:"
 msgstr "Datum:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:178 ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/messages.cpp:185 ../../Firmware/ultralcd.cpp:5594
 msgid "Dim"
 msgstr "Dim"
 
@@ -425,7 +424,7 @@ msgid "Disable"
 msgstr "Uitschak"
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/messages.cpp:311 ../../Firmware/ultralcd.cpp:4460
+#: ../../Firmware/messages.cpp:323 ../../Firmware/ultralcd.cpp:4427
 msgid "Disable steppers"
 msgstr "Motoren uit"
 
@@ -437,7 +436,7 @@ msgid "Disengaging idler"
 msgstr "Ontkoppel spanrol"
 
 #. MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: ../../Firmware/Marlin_main.cpp:1610 ../../Firmware/Marlin_main.cpp:3334
+#: ../../Firmware/Marlin_main.cpp:1537 ../../Firmware/Marlin_main.cpp:3073
 #: ../../Firmware/messages.cpp:14
 msgid ""
 "Distance between tip of the nozzle and the bed surface has not been set yet."
@@ -449,7 +448,7 @@ msgstr ""
 "calibration."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/messages.cpp:301 ../../Firmware/ultralcd.cpp:3923
+#: ../../Firmware/messages.cpp:313 ../../Firmware/ultralcd.cpp:3947
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -458,13 +457,13 @@ msgstr ""
 "opnieuw in te stellen?"
 
 #. MSG_DONE c=8
-#: ../../Firmware/messages.cpp:32 ../../Firmware/mmu2/errors_list.h:367
-#: ../../Firmware/mmu2_reporting.cpp:456
+#: ../../Firmware/messages.cpp:33 ../../Firmware/mmu2/errors_list.h:367
+#: ../../Firmware/mmu2_reporting.cpp:457
 msgid "Done"
 msgstr "Klaar"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/messages.cpp:307 ../../Firmware/ultralcd.cpp:3990
+#: ../../Firmware/messages.cpp:319 ../../Firmware/ultralcd.cpp:4014
 msgid "E-correct"
 msgstr "E-correctie"
 
@@ -493,13 +492,13 @@ msgid "ERR Wait for User"
 msgstr "FOUT Wacht gebruiker"
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:2253
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:2267
 msgid "ERROR:"
 msgstr "FOUT:"
 
 #. MSG_EJECT_FROM_MMU c=16
-#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:384
-#: ../../Firmware/ultralcd.cpp:4845 ../../Firmware/ultralcd.cpp:5348
+#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:385
+#: ../../Firmware/ultralcd.cpp:4801 ../../Firmware/ultralcd.cpp:5314
 msgid "Eject from MMU"
 msgstr "Uitwerp. van MMU"
 
@@ -511,17 +510,17 @@ msgid "Ejecting filament"
 msgstr "Fil. word ontladen"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/messages.cpp:348 ../../Firmware/ultralcd.cpp:6722
+#: ../../Firmware/messages.cpp:360 ../../Firmware/ultralcd.cpp:6698
 msgid "Endstop"
 msgstr "Eindstop"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/messages.cpp:349 ../../Firmware/ultralcd.cpp:6727
+#: ../../Firmware/messages.cpp:361 ../../Firmware/ultralcd.cpp:6703
 msgid "Endstop not hit"
 msgstr "Endstop niet geraakt"
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/messages.cpp:347 ../../Firmware/ultralcd.cpp:6713
+#: ../../Firmware/messages.cpp:359 ../../Firmware/ultralcd.cpp:6689
 msgid "Endstops"
 msgstr "Eindstops"
 
@@ -533,30 +532,30 @@ msgid "Engaging idler"
 msgstr "Koppel spanrol"
 
 #. MSG_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:3352
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:3362
 msgid "Extruder"
 msgstr "Extruder"
 
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/messages.cpp:227 ../../Firmware/ultralcd.cpp:1700
+#: ../../Firmware/messages.cpp:239 ../../Firmware/ultralcd.cpp:1710
 msgid "Extruder info"
 msgstr "Extruder info"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4044
-#: ../../Firmware/ultralcd.cpp:4051
+#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4068
+#: ../../Firmware/ultralcd.cpp:4075
 msgid "F. autoload"
 msgstr "F. autoladen"
 
 #. MSG_FSENSOR_JAM_DETECTION c=13
-#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4046
-#: ../../Firmware/ultralcd.cpp:4053
+#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4070
+#: ../../Firmware/ultralcd.cpp:4077
 msgid "F. jam detect"
 msgstr "F.Jam ontdek."
 
 #. MSG_FSENSOR_RUNOUT c=13
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4074
 msgid "F. runout"
 msgstr "FS. uitloop"
 
@@ -594,8 +593,8 @@ msgid "FINDA FILAM. STUCK"
 msgstr "FINDA NIET FIL.VRIJ"
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:4059
-#: ../../Firmware/ultralcd.cpp:4062
+#: ../../Firmware/messages.cpp:177 ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/ultralcd.cpp:4086
 msgid "FS Action"
 msgstr "FS actie"
 
@@ -620,34 +619,34 @@ msgid "FW RUNTIME ERROR"
 msgstr "FW RUNTIME FOUT"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/messages.cpp:330 ../../Firmware/ultralcd.cpp:5382
+#: ../../Firmware/messages.cpp:342 ../../Firmware/ultralcd.cpp:5349
 msgid "Fail stats"
 msgstr "Foutstatistieken"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/messages.cpp:331 ../../Firmware/ultralcd.cpp:5385
+#: ../../Firmware/messages.cpp:343 ../../Firmware/ultralcd.cpp:5352
 msgid "Fail stats MMU"
 msgstr "MMU-Fouten"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/messages.cpp:355 ../../Firmware/ultralcd.cpp:6768
+#: ../../Firmware/messages.cpp:367 ../../Firmware/ultralcd.cpp:6744
 msgid "False triggering"
 msgstr "Valse triggering"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4175
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4199
 msgid "Fan speed"
 msgstr "Fan snelh."
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6844
-#: ../../Firmware/ultralcd.cpp:6971 ../../Firmware/ultralcd.cpp:6972
-#: ../../Firmware/ultralcd.cpp:6973
+#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6820
+#: ../../Firmware/ultralcd.cpp:6948 ../../Firmware/ultralcd.cpp:6949
+#: ../../Firmware/ultralcd.cpp:6950
 msgid "Fan test"
 msgstr "Fan test"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:4179
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:4203
 msgid "Fans check"
 msgstr "Fans check"
 
@@ -676,34 +675,34 @@ msgid "Feeding to nozzle"
 msgstr "Voeding tot tuit"
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1233
-#: ../../Firmware/ultralcd.cpp:1262 ../../Firmware/ultralcd.cpp:1316
-#: ../../Firmware/ultralcd.cpp:1318
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:1243
+#: ../../Firmware/ultralcd.cpp:1272 ../../Firmware/ultralcd.cpp:1326
+#: ../../Firmware/ultralcd.cpp:1328
 msgid "Fil. runouts"
 msgstr "Fil. fouten"
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3313
-#: ../../Firmware/ultralcd.cpp:4039 ../../Firmware/ultralcd.cpp:4464
-#: ../../Firmware/ultralcd.cpp:5532
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3323
+#: ../../Firmware/ultralcd.cpp:4063 ../../Firmware/ultralcd.cpp:4431
+#: ../../Firmware/ultralcd.cpp:5499
 msgid "Fil. sensor"
 msgstr "Fil. sensor"
 
 #. MSG_FILAMENT_CLEAN c=20 r=3
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2261
-#: ../../Firmware/ultralcd.cpp:2265
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2275
+#: ../../Firmware/ultralcd.cpp:2279
 msgid "Filament extruding & with correct color?"
 msgstr "Filament extrudeert met de juiste kleur?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/messages.cpp:243 ../../Firmware/ultralcd.cpp:2204
+#: ../../Firmware/messages.cpp:255 ../../Firmware/ultralcd.cpp:2218
 msgid "Filament not loaded"
 msgstr "Fil. niet geladen"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6763
-#: ../../Firmware/ultralcd.cpp:6767 ../../Firmware/ultralcd.cpp:6771
-#: ../../Firmware/ultralcd.cpp:7000
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6739
+#: ../../Firmware/ultralcd.cpp:6743 ../../Firmware/ultralcd.cpp:6747
+#: ../../Firmware/ultralcd.cpp:6977
 msgid "Filament sensor"
 msgstr "Filamentsensor"
 
@@ -735,42 +734,42 @@ msgstr ""
 " of er niets vastzit in de PTFE-buis. Controleer of de sensor goed leest."
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/messages.cpp:246 ../../Firmware/ultralcd.cpp:2347
+#: ../../Firmware/messages.cpp:258 ../../Firmware/ultralcd.cpp:2364
 msgid "Filament used"
 msgstr "Gebruikte filament"
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/messages.cpp:363 ../../Firmware/ultralcd.cpp:7139
+#: ../../Firmware/messages.cpp:375 ../../Firmware/ultralcd.cpp:7116
 msgid "File incomplete. Continue anyway?"
 msgstr "Bestand onvolledig. Toch doorgaan?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
 #: ../../Firmware/messages.cpp:45
 #: ../../Firmware/mmu2_progress_converter.cpp:43
-#: ../../Firmware/ultralcd.cpp:5021 ../../Firmware/ultralcd.cpp:5425
+#: ../../Firmware/ultralcd.cpp:4977 ../../Firmware/ultralcd.cpp:5392
 msgid "Finishing movements"
 msgstr "Voortgang afwerken"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4575
-#: ../../Firmware/ultralcd.cpp:5141
+#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4531
+#: ../../Firmware/ultralcd.cpp:5101
 msgid "First layer cal."
 msgstr "Eerste laag kal."
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/messages.cpp:293 ../../Firmware/ultralcd.cpp:3846
+#: ../../Firmware/messages.cpp:305 ../../Firmware/ultralcd.cpp:3872
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Ten eerste zullen we de zelftest uitvoeren om de meest voorkomende "
 "montageproblemen te controleren."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/messages.cpp:334 ../../Firmware/ultralcd.cpp:5520
+#: ../../Firmware/messages.cpp:346 ../../Firmware/ultralcd.cpp:5487
 msgid "Flow"
 msgstr "Stromen"
 
 #. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
-#: ../../Firmware/messages.cpp:194 ../../Firmware/ultralcd.cpp:985
+#: ../../Firmware/messages.cpp:201 ../../Firmware/ultralcd.cpp:987
 msgid ""
 "For a Nozzle change please read\n"
 "prusa.io/nozzle-mk3s"
@@ -779,28 +778,28 @@ msgstr ""
 "prusa.io/nozzle-mk3s"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6733
-#: ../../Firmware/ultralcd.cpp:6850 ../../Firmware/ultralcd.cpp:6855
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/ultralcd.cpp:6826 ../../Firmware/ultralcd.cpp:6831
 msgid "Front print fan?"
 msgstr "Voorzijde fan?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/messages.cpp:260 ../../Firmware/ultralcd.cpp:2711
+#: ../../Firmware/messages.cpp:272 ../../Firmware/ultralcd.cpp:2728
 msgid "Front side[µm]"
 msgstr "Voorkant [µm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/messages.cpp:353 ../../Firmware/ultralcd.cpp:6757
+#: ../../Firmware/messages.cpp:365 ../../Firmware/ultralcd.cpp:6733
 msgid "Front/left fans"
 msgstr "Fans voor/links"
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:151 ../../Firmware/util.cpp:382
+#: ../../Firmware/messages.cpp:156 ../../Firmware/util.cpp:417
 msgid "G-code sliced for a different level. Continue?"
 msgstr "G-Code is voor een ander niveau geslict. Doorgaan?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:152 ../../Firmware/util.cpp:383
+#: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:418
 msgid ""
 "G-code sliced for a different level. Please re-slice the model again. Print "
 "cancelled."
@@ -809,14 +808,14 @@ msgstr ""
 " Druk geannuleerd."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:147 ../../Firmware/util.cpp:312
-#: ../../Firmware/util.cpp:401
+#: ../../Firmware/messages.cpp:152 ../../Firmware/util.cpp:319
+#: ../../Firmware/util.cpp:436
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr "G-Code is voor een ander printertype geslict. Doorgaan?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:148 ../../Firmware/util.cpp:313
-#: ../../Firmware/util.cpp:402
+#: ../../Firmware/messages.cpp:153 ../../Firmware/util.cpp:320
+#: ../../Firmware/util.cpp:437
 msgid ""
 "G-code sliced for a different printer type. Please re-slice the model again."
 " Print cancelled."
@@ -825,12 +824,12 @@ msgstr ""
 "alsjeblieft. Druk geannuleerd."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:149 ../../Firmware/util.cpp:362
+#: ../../Firmware/messages.cpp:154 ../../Firmware/util.cpp:369
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "G-Code is voor een nieuwere firmware geslict. Doorgaan?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:150 ../../Firmware/util.cpp:363
+#: ../../Firmware/messages.cpp:155 ../../Firmware/util.cpp:370
 msgid ""
 "G-code sliced for a newer firmware. Please update the firmware. Print "
 "cancelled."
@@ -839,35 +838,35 @@ msgstr ""
 "alsjeblieft. Druk geannuleerd."
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4366
-#: ../../Firmware/ultralcd.cpp:4383 ../../Firmware/ultralcd.cpp:4485
+#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4325
+#: ../../Firmware/ultralcd.cpp:4343 ../../Firmware/ultralcd.cpp:4452
 msgid "HW Setup"
 msgstr "HW Configuratie"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/messages.cpp:344 ../../Firmware/ultralcd.cpp:6705
+#: ../../Firmware/messages.cpp:356 ../../Firmware/ultralcd.cpp:6681
 msgid "Heater/Thermistor"
 msgstr "Verwarmer/Therm."
 
 #. MSG_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6184 ../../Firmware/messages.cpp:52
+#: ../../Firmware/Marlin_main.cpp:5416 ../../Firmware/messages.cpp:52
 #: ../../Firmware/ultralcd.cpp:526
 msgid "Heating"
 msgstr "Opwarmen"
 
 #. MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:9647 ../../Firmware/messages.cpp:211
+#: ../../Firmware/Marlin_main.cpp:8807 ../../Firmware/messages.cpp:223
 msgid "Heating disabled by safety timer."
 msgstr "Verwarming uitgeschakeld door veiligheidstimer."
 
 #. MSG_HEATING_COMPLETE c=20
-#: ../../Firmware/Marlin_main.cpp:6215 ../../Firmware/messages.cpp:53
+#: ../../Firmware/Marlin_main.cpp:5445 ../../Firmware/messages.cpp:53
 #: ../../Firmware/ultralcd.cpp:529
 msgid "Heating done."
 msgstr "Opwarmen klaar."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=12
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:3806
+#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:3832
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -878,7 +877,7 @@ msgstr ""
 "printen."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:3810
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:3836
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -887,8 +886,8 @@ msgstr ""
 "installatieproces?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4152
-#: ../../Firmware/ultralcd.cpp:4161
+#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:4176
+#: ../../Firmware/ultralcd.cpp:4185
 msgid "High power"
 msgstr "Hoog verm."
 
@@ -899,23 +898,23 @@ msgid "Homing"
 msgstr "Startpositie"
 
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
-#: ../../Firmware/messages.cpp:195 ../../Firmware/ultralcd.cpp:1005
+#: ../../Firmware/messages.cpp:206 ../../Firmware/ultralcd.cpp:1011
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr "Hotend op 280C! Tuit vervangen en aangedraaid volgens specificaties?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1106
-#: ../../Firmware/ultralcd.cpp:6991
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1116
+#: ../../Firmware/ultralcd.cpp:6968
 msgid "Hotend fan:"
 msgstr "Hotend fan:"
 
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/messages.cpp:294 ../../Firmware/ultralcd.cpp:3851
+#: ../../Firmware/messages.cpp:306 ../../Firmware/ultralcd.cpp:3877
 msgid "I will run xyz calibration now. It will take up to 24 mins."
 msgstr "Begin nu met xyz-kalibratie. Het kan tot 24 min. duren."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/messages.cpp:297 ../../Firmware/ultralcd.cpp:3862
+#: ../../Firmware/messages.cpp:309 ../../Firmware/ultralcd.cpp:3884
 msgid "I will run z calibration now."
 msgstr "Begin nu met z-kalibratie."
 
@@ -940,7 +939,7 @@ msgid "INVALID TOOL"
 msgstr "ONGELDIG TOOL"
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=8
-#: ../../Firmware/messages.cpp:303 ../../Firmware/ultralcd.cpp:3931
+#: ../../Firmware/messages.cpp:315 ../../Firmware/ultralcd.cpp:3955
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -949,28 +948,28 @@ msgstr ""
 "Instellingen - HW Setup - Staalplaten."
 
 #. MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2540
-#: ../../Firmware/messages.cpp:213
+#: ../../Firmware/mesh_bed_calibration.cpp:2525
+#: ../../Firmware/messages.cpp:225
 msgid "Improving bed calibration point"
 msgstr "Verbetering van het bedijkingspunt"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:5222
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:5184
 msgid "Info screen"
 msgstr "Info scherm"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/messages.cpp:326 ../../Firmware/ultralcd.cpp:5323
+#: ../../Firmware/messages.cpp:338 ../../Firmware/ultralcd.cpp:5289
 msgid "Init. SD card"
 msgstr "Init. SD kaart"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/messages.cpp:238 ../../Firmware/ultralcd.cpp:2142
+#: ../../Firmware/messages.cpp:250 ../../Firmware/ultralcd.cpp:2148
 msgid "Insert filament"
 msgstr "Voer filament in"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/messages.cpp:335 ../../Firmware/ultralcd.cpp:5998
+#: ../../Firmware/messages.cpp:347 ../../Firmware/ultralcd.cpp:5974
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
@@ -986,115 +985,115 @@ msgstr ""
 "werken."
 
 #. MSG_FILAMENT_LOADED c=20 r=3
-#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3628
-#: ../../Firmware/ultralcd.cpp:3890
+#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3638
+#: ../../Firmware/ultralcd.cpp:3914
 msgid "Is filament loaded?"
 msgstr "Is filament geladen?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3238 ../../Firmware/Marlin_main.cpp:4745
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:3858
+#: ../../Firmware/Marlin_main.cpp:4314 ../../Firmware/messages.cpp:127
+#: ../../Firmware/ultralcd.cpp:3760
 msgid "Is steel sheet on heatbed?"
 msgstr "Ligt de staalplaat op het bed?"
 
 #. MSG_ITERATION c=12
-#: ../../Firmware/mesh_bed_calibration.cpp:2265 ../../Firmware/messages.cpp:55
+#: ../../Firmware/mesh_bed_calibration.cpp:2250 ../../Firmware/messages.cpp:55
 msgid "Iteration"
 msgstr "Iteratie"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1128
-#: ../../Firmware/ultralcd.cpp:1286
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1138
+#: ../../Firmware/ultralcd.cpp:1296
 msgid "Last print"
 msgstr "Laatste print"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1152
-#: ../../Firmware/ultralcd.cpp:1260 ../../Firmware/ultralcd.cpp:1315
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1162
+#: ../../Firmware/ultralcd.cpp:1270 ../../Firmware/ultralcd.cpp:1325
 msgid "Last print failures"
 msgstr "Laatste printfouten"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/messages.cpp:251 ../../Firmware/ultralcd.cpp:2478
+#: ../../Firmware/messages.cpp:263 ../../Firmware/ultralcd.cpp:2495
 msgid "Left"
 msgstr "Links"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6739
-#: ../../Firmware/ultralcd.cpp:6850 ../../Firmware/ultralcd.cpp:6855
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6715
+#: ../../Firmware/ultralcd.cpp:6826 ../../Firmware/ultralcd.cpp:6831
 msgid "Left hotend fan?"
 msgstr "Linker hotend fan?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/messages.cpp:258 ../../Firmware/ultralcd.cpp:2709
+#: ../../Firmware/messages.cpp:270 ../../Firmware/ultralcd.cpp:2726
 msgid "Left side [µm]"
 msgstr "Linkerkant[µm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:5619
+#: ../../Firmware/messages.cpp:181 ../../Firmware/ultralcd.cpp:5592
 msgid "Level Bright"
 msgstr "Helder waard"
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:175 ../../Firmware/ultralcd.cpp:5620
+#: ../../Firmware/messages.cpp:182 ../../Firmware/ultralcd.cpp:5593
 msgid "Level Dimmed"
 msgstr "Dim waarde"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/messages.cpp:312 ../../Firmware/ultralcd.cpp:4491
+#: ../../Firmware/messages.cpp:324 ../../Firmware/ultralcd.cpp:4458
 msgid "Lin. correction"
 msgstr "Lineaire correctie"
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4501
-#: ../../Firmware/ultralcd.cpp:5251
+#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4468
+#: ../../Firmware/ultralcd.cpp:5213
 msgid "Live adjust Z"
 msgstr "Live Z aanpassen"
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/messages.cpp:192 ../../Firmware/ultralcd.cpp:4794
-#: ../../Firmware/ultralcd.cpp:4880
+#: ../../Firmware/messages.cpp:199 ../../Firmware/ultralcd.cpp:4750
+#: ../../Firmware/ultralcd.cpp:4836
 msgid "Load All"
 msgstr "Laad alle"
 
 #. MSG_LOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4796
-#: ../../Firmware/ultralcd.cpp:4833 ../../Firmware/ultralcd.cpp:4882
-#: ../../Firmware/ultralcd.cpp:5361 ../../Firmware/ultralcd.cpp:5368
+#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4752
+#: ../../Firmware/ultralcd.cpp:4789 ../../Firmware/ultralcd.cpp:4838
+#: ../../Firmware/ultralcd.cpp:5324 ../../Firmware/ultralcd.cpp:5335
 msgid "Load filament"
 msgstr "Filament laden"
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/messages.cpp:327 ../../Firmware/ultralcd.cpp:5346
+#: ../../Firmware/messages.cpp:339 ../../Firmware/ultralcd.cpp:5312
 msgid "Load to nozzle"
 msgstr "Tot tuit laden"
 
 #. MSG_LOADING_TEST c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4476
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4443
 msgid "Loading Test"
 msgstr "Ladingstest"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/messages.cpp:241 ../../Firmware/ultralcd.cpp:2178
+#: ../../Firmware/messages.cpp:253 ../../Firmware/ultralcd.cpp:2189
 msgid "Loading color"
 msgstr "Laden kleur"
 
 #. MSG_LOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3598 ../../Firmware/messages.cpp:62
+#: ../../Firmware/Marlin_main.cpp:3343 ../../Firmware/messages.cpp:62
 #: ../../Firmware/mmu2_progress_converter.cpp:51
-#: ../../Firmware/mmu2_reporting.cpp:392 ../../Firmware/ultralcd.cpp:2189
-#: ../../Firmware/ultralcd.cpp:3715
+#: ../../Firmware/mmu2_reporting.cpp:393 ../../Firmware/ultralcd.cpp:2199
+#: ../../Firmware/ultralcd.cpp:3725
 msgid "Loading filament"
 msgstr "Laden filament"
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/messages.cpp:350 ../../Firmware/ultralcd.cpp:6745
+#: ../../Firmware/messages.cpp:362 ../../Firmware/ultralcd.cpp:6721
 msgid "Loose pulley"
 msgstr "Losse riemschijf"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4188
-#: ../../Firmware/ultralcd.cpp:4200
+#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4224
 msgid "Loud"
 msgstr "Hard"
 
@@ -1109,7 +1108,7 @@ msgid "MMU Firmware internal error, please reset the MMU."
 msgstr "MMU Firmware interne fout, reset de MMU."
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:4096
+#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4120
 msgid "MMU Mode"
 msgstr "MMU Mod"
 
@@ -1119,7 +1118,7 @@ msgid "MMU NOT RESPONDING"
 msgstr "MMU REAGEERT NIET"
 
 #. MSG_MMU_RESTORE_TEMP c=20 r=4
-#: ../../Firmware/messages.cpp:214 ../../Firmware/mmu2_reporting.cpp:396
+#: ../../Firmware/messages.cpp:226 ../../Firmware/mmu2_reporting.cpp:397
 msgid "MMU Retry: Restoring temperature..."
 msgstr "MMU Retry: Temperatuur herstellen..."
 
@@ -1130,14 +1129,14 @@ msgid "MMU SELFTEST FAILED"
 msgstr "MMU ZELFTEST MISLUKT"
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1153
-#: ../../Firmware/ultralcd.cpp:1178
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1163
+#: ../../Firmware/ultralcd.cpp:1188
 msgid "MMU fails"
 msgstr "MMU fout"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1154
-#: ../../Firmware/ultralcd.cpp:1179
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1164
+#: ../../Firmware/ultralcd.cpp:1189
 msgid "MMU load fails"
 msgstr "MMU laadfout"
 
@@ -1152,66 +1151,64 @@ msgid "MMU not responding. Check the wiring and connectors."
 msgstr "MMU reageert niet. Controleer de bedrading en connectoren."
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/messages.cpp:223 ../../Firmware/ultralcd.cpp:1657
+#: ../../Firmware/messages.cpp:235 ../../Firmware/ultralcd.cpp:1667
 msgid "MMU connected"
 msgstr "MMU verbonden"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/messages.cpp:176 ../../Firmware/ultralcd.cpp:5567
 msgid "Magnets comp."
 msgstr "Magnet. comp."
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1127
-#: ../../Firmware/ultralcd.cpp:1285 ../../Firmware/ultralcd.cpp:1327
-#: ../../Firmware/ultralcd.cpp:1631 ../../Firmware/ultralcd.cpp:4453
-#: ../../Firmware/ultralcd.cpp:4571 ../../Firmware/ultralcd.cpp:4793
-#: ../../Firmware/ultralcd.cpp:4826 ../../Firmware/ultralcd.cpp:4879
-#: ../../Firmware/ultralcd.cpp:5515
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1137
+#: ../../Firmware/ultralcd.cpp:1295 ../../Firmware/ultralcd.cpp:1337
+#: ../../Firmware/ultralcd.cpp:1641 ../../Firmware/ultralcd.cpp:4420
+#: ../../Firmware/ultralcd.cpp:4527 ../../Firmware/ultralcd.cpp:4749
+#: ../../Firmware/ultralcd.cpp:4782 ../../Firmware/ultralcd.cpp:4835
+#: ../../Firmware/ultralcd.cpp:5482
 msgid "Main"
 msgstr "Hoofdmenu"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/messages.cpp:253 ../../Firmware/ultralcd.cpp:2519
+#: ../../Firmware/messages.cpp:265 ../../Firmware/ultralcd.cpp:2536
 msgid "Measured skew"
 msgstr "Scheefheid"
 
 #. MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3219
-#: ../../Firmware/mesh_bed_calibration.cpp:2852 ../../Firmware/messages.cpp:70
+#: ../../Firmware/Marlin_main.cpp:2963
+#: ../../Firmware/mesh_bed_calibration.cpp:2837 ../../Firmware/messages.cpp:70
 msgid "Measuring reference height of calibration point"
 msgstr "Referentie hoogte van het kalibratiepunt meten"
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:5590
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:5563
 msgid "Mesh"
 msgstr "Mesh"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4488
-#: ../../Firmware/ultralcd.cpp:4587
+#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:4455
+#: ../../Firmware/ultralcd.cpp:4543
 msgid "Mesh Bed Leveling"
 msgstr "Mesh bed Leveling"
 
 #. MSG_MODE c=6
-#: ../../Firmware/Marlin_main.cpp:8495 ../../Firmware/messages.cpp:117
-#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4132
-#: ../../Firmware/ultralcd.cpp:4140 ../../Firmware/ultralcd.cpp:4144
-#: ../../Firmware/ultralcd.cpp:4152 ../../Firmware/ultralcd.cpp:4155
-#: ../../Firmware/ultralcd.cpp:4158 ../../Firmware/ultralcd.cpp:4161
-#: ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/Marlin_main.cpp:7666 ../../Firmware/messages.cpp:121
+#: ../../Firmware/ultralcd.cpp:4152 ../../Firmware/ultralcd.cpp:4156
+#: ../../Firmware/ultralcd.cpp:4164 ../../Firmware/ultralcd.cpp:4168
+#: ../../Firmware/ultralcd.cpp:4176 ../../Firmware/ultralcd.cpp:4179
+#: ../../Firmware/ultralcd.cpp:4182 ../../Firmware/ultralcd.cpp:4185
+#: ../../Firmware/ultralcd.cpp:5594
 msgid "Mode"
 msgstr "Stand"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/messages.cpp:282 ../../Firmware/ultralcd.cpp:3413
+#: ../../Firmware/messages.cpp:294 ../../Firmware/ultralcd.cpp:3423
 msgid "Mode change in progress..."
 msgstr "Moduswijziging bezig..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:4310
-#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4316
-#: ../../Firmware/ultralcd.cpp:4319
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4327
 msgid "Model"
 msgstr "Model"
 
@@ -1232,28 +1229,28 @@ msgid "More details online."
 msgstr "Meer details online."
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6719
-#: ../../Firmware/ultralcd.cpp:6728 ../../Firmware/ultralcd.cpp:6746
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6695
+#: ../../Firmware/ultralcd.cpp:6704 ../../Firmware/ultralcd.cpp:6722
 msgid "Motor"
 msgstr "Motor"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/messages.cpp:277 ../../Firmware/ultralcd.cpp:3349
+#: ../../Firmware/messages.cpp:289 ../../Firmware/ultralcd.cpp:3359
 msgid "Move X"
 msgstr "Verplaats X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/messages.cpp:278 ../../Firmware/ultralcd.cpp:3350
+#: ../../Firmware/messages.cpp:290 ../../Firmware/ultralcd.cpp:3360
 msgid "Move Y"
 msgstr "Verplaats Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/messages.cpp:279 ../../Firmware/ultralcd.cpp:3351
+#: ../../Firmware/messages.cpp:291 ../../Firmware/ultralcd.cpp:3361
 msgid "Move Z"
 msgstr "Verplaats Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/messages.cpp:310 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:322 ../../Firmware/ultralcd.cpp:4426
 msgid "Move axis"
 msgstr "As verplaatsen"
 
@@ -1264,95 +1261,92 @@ msgid "Moving selector"
 msgstr "Bewege selector"
 
 #. MSG_NA c=3
-#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:141
-#: ../../Firmware/ultralcd.cpp:2484 ../../Firmware/ultralcd.cpp:2528
-#: ../../Firmware/ultralcd.cpp:3279 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:4044 ../../Firmware/ultralcd.cpp:4046
-#: ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:146
+#: ../../Firmware/ultralcd.cpp:2501 ../../Firmware/ultralcd.cpp:2545
+#: ../../Firmware/ultralcd.cpp:3289 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4068 ../../Firmware/ultralcd.cpp:4070
+#: ../../Firmware/ultralcd.cpp:5567
 msgid "N/A"
 msgstr "N/V"
 
 #. MSG_NEW_FIRMWARE_AVAILABLE c=20 r=2
-#: ../../Firmware/messages.cpp:365 ../../Firmware/util.cpp:209
+#: ../../Firmware/messages.cpp:377 ../../Firmware/util.cpp:214
 msgid "New firmware version available:"
 msgstr "Nieuwe firmware versie beschikbaar:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:3029
-#: ../../Firmware/ultralcd.cpp:4443 ../../Firmware/ultralcd.cpp:4531
-#: ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:2275
+#: ../../Firmware/ultralcd.cpp:2279 ../../Firmware/ultralcd.cpp:3046
+#: ../../Firmware/ultralcd.cpp:4410 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/ultralcd.cpp:5765
 msgid "No"
 msgstr "Nee"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/messages.cpp:325 ../../Firmware/ultralcd.cpp:5321
+#: ../../Firmware/messages.cpp:337 ../../Firmware/ultralcd.cpp:5287
 msgid "No SD card"
 msgstr "Geen SD kaart"
 
 #. MSG_NO_MOVE c=20
-#: ../../Firmware/Marlin_main.cpp:5271 ../../Firmware/messages.cpp:210
+#: ../../Firmware/Marlin_main.cpp:4778 ../../Firmware/messages.cpp:222
 msgid "No move."
 msgstr "Geen beweging."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4239 ../../Firmware/ultralcd.cpp:4310
-#: ../../Firmware/ultralcd.cpp:4319 ../../Firmware/ultralcd.cpp:4349
-#: ../../Firmware/ultralcd.cpp:4358 ../../Firmware/ultralcd.cpp:4516
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4309
+#: ../../Firmware/ultralcd.cpp:4318 ../../Firmware/ultralcd.cpp:4483
 msgid "None"
 msgstr "Geen"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/Marlin_main.cpp:8497 ../../Firmware/messages.cpp:121
-#: ../../Firmware/ultralcd.cpp:4096 ../../Firmware/ultralcd.cpp:4132
-#: ../../Firmware/ultralcd.cpp:4511
+#: ../../Firmware/Marlin_main.cpp:7668 ../../Firmware/messages.cpp:125
+#: ../../Firmware/ultralcd.cpp:4120 ../../Firmware/ultralcd.cpp:4156
+#: ../../Firmware/ultralcd.cpp:4478
 msgid "Normal"
 msgstr "Normaal"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/messages.cpp:345 ../../Firmware/ultralcd.cpp:6706
+#: ../../Firmware/messages.cpp:357 ../../Firmware/ultralcd.cpp:6682
 msgid "Not connected"
 msgstr "Niet verbonden"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6863
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6839
 msgid "Not spinning"
 msgstr "Draait niet"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/messages.cpp:289 ../../Firmware/ultralcd.cpp:3726
+#: ../../Firmware/messages.cpp:301 ../../Firmware/ultralcd.cpp:3736
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr "Begin met kalibratie tussen de tuit en het bed."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/messages.cpp:298 ../../Firmware/ultralcd.cpp:3871
+#: ../../Firmware/messages.cpp:310 ../../Firmware/ultralcd.cpp:3894
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Opwarmen van de tuit voor PLA voor."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/messages.cpp:296 ../../Firmware/ultralcd.cpp:3857
+#: ../../Firmware/messages.cpp:308 ../../Firmware/ultralcd.cpp:3883
 msgid "Now remove the test print from steel sheet."
 msgstr "Verwijder nu de testprint van staalplaat."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1390
-#: ../../Firmware/ultralcd.cpp:4170 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4233 ../../Firmware/ultralcd.cpp:4236
-#: ../../Firmware/ultralcd.cpp:4239
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1400
+#: ../../Firmware/ultralcd.cpp:4194 ../../Firmware/ultralcd.cpp:4326
 msgid "Nozzle"
 msgstr "Tuit"
 
 #. MSG_NOZZLE_CNG_MENU c=18
-#: ../../Firmware/messages.cpp:193 ../../Firmware/ultralcd.cpp:4423
-#: ../../Firmware/ultralcd.cpp:4486
+#: ../../Firmware/messages.cpp:200 ../../Firmware/ultralcd.cpp:4390
+#: ../../Firmware/ultralcd.cpp:4453
 msgid "Nozzle change"
 msgstr "Tuit wisselen"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4276
-#: ../../Firmware/ultralcd.cpp:4278 ../../Firmware/ultralcd.cpp:4279
-#: ../../Firmware/ultralcd.cpp:4280
+#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4261
+#: ../../Firmware/ultralcd.cpp:4263 ../../Firmware/ultralcd.cpp:4264
+#: ../../Firmware/ultralcd.cpp:4265
 msgid "Nozzle d."
 msgstr "Tuit d."
 
@@ -1363,83 +1357,83 @@ msgid "OK"
 msgstr "OK"
 
 #. MSG_OFF c=3
-#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:139
-#: ../../Firmware/mmu2.cpp:65 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4050 ../../Firmware/ultralcd.cpp:4051
-#: ../../Firmware/ultralcd.cpp:4053 ../../Firmware/ultralcd.cpp:4076
-#: ../../Firmware/ultralcd.cpp:4091 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4179 ../../Firmware/ultralcd.cpp:4467
-#: ../../Firmware/ultralcd.cpp:4495 ../../Firmware/ultralcd.cpp:4498
-#: ../../Firmware/ultralcd.cpp:5439 ../../Firmware/ultralcd.cpp:5594
-#: ../../Firmware/ultralcd.cpp:7487 ../../Firmware/ultralcd.cpp:7491
+#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:144
+#: ../../Firmware/mmu2.cpp:65 ../../Firmware/ultralcd.cpp:4063
+#: ../../Firmware/ultralcd.cpp:4074 ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4077 ../../Firmware/ultralcd.cpp:4100
+#: ../../Firmware/ultralcd.cpp:4115 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/ultralcd.cpp:4203 ../../Firmware/ultralcd.cpp:4434
+#: ../../Firmware/ultralcd.cpp:4462 ../../Firmware/ultralcd.cpp:4465
+#: ../../Firmware/ultralcd.cpp:5406 ../../Firmware/ultralcd.cpp:5567
+#: ../../Firmware/ultralcd.cpp:7464 ../../Firmware/ultralcd.cpp:7468
 msgid "Off"
 msgstr "Uit"
 
 #. MSG_DEFAULT_SETTINGS_LOADED c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:1562 ../../Firmware/messages.cpp:201
+#: ../../Firmware/Marlin_main.cpp:1489 ../../Firmware/messages.cpp:213
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr ""
 "Oude instellingen gevonden. Standaard PID, E-steps etc. instellingen worden "
 "geladen."
 
 #. MSG_ON c=3
-#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:140
-#: ../../Firmware/mmu2.cpp:63 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4050 ../../Firmware/ultralcd.cpp:4051
-#: ../../Firmware/ultralcd.cpp:4053 ../../Firmware/ultralcd.cpp:4076
-#: ../../Firmware/ultralcd.cpp:4081 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4179 ../../Firmware/ultralcd.cpp:4467
-#: ../../Firmware/ultralcd.cpp:4495 ../../Firmware/ultralcd.cpp:4498
-#: ../../Firmware/ultralcd.cpp:5594 ../../Firmware/ultralcd.cpp:7487
-#: ../../Firmware/ultralcd.cpp:7491
+#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:145
+#: ../../Firmware/mmu2.cpp:63 ../../Firmware/ultralcd.cpp:4063
+#: ../../Firmware/ultralcd.cpp:4074 ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4077 ../../Firmware/ultralcd.cpp:4100
+#: ../../Firmware/ultralcd.cpp:4105 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/ultralcd.cpp:4203 ../../Firmware/ultralcd.cpp:4434
+#: ../../Firmware/ultralcd.cpp:4462 ../../Firmware/ultralcd.cpp:4465
+#: ../../Firmware/ultralcd.cpp:5567 ../../Firmware/ultralcd.cpp:7464
+#: ../../Firmware/ultralcd.cpp:7468
 msgid "On"
 msgstr "Aan"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4191
+#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:4215
 msgid "Once"
 msgstr "Eenmaal"
 
 #. MSG_PAUSED_THERMAL_ERROR c=20
-#: ../../Firmware/Marlin_main.cpp:9861 ../../Firmware/messages.cpp:186
+#: ../../Firmware/Marlin_main.cpp:9021 ../../Firmware/messages.cpp:193
 msgid "PAUSED THERMAL ERROR"
 msgstr "PAUSE TERMISCHE FOUT"
 
 #. MSG_PID_RUNNING c=20
-#: ../../Firmware/messages.cpp:219 ../../Firmware/ultralcd.cpp:897
+#: ../../Firmware/messages.cpp:231 ../../Firmware/ultralcd.cpp:897
 msgid "PID cal."
 msgstr "PID kal."
 
 #. MSG_PID_FINISHED c=20
-#: ../../Firmware/messages.cpp:220 ../../Firmware/ultralcd.cpp:902
+#: ../../Firmware/messages.cpp:232 ../../Firmware/ultralcd.cpp:902
 msgid "PID cal. finished"
 msgstr "PID kalibratie klaar"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:318 ../../Firmware/ultralcd.cpp:4590
+#: ../../Firmware/messages.cpp:330 ../../Firmware/ultralcd.cpp:4546
 msgid "PID calibration"
 msgstr "PID kalibratie"
 
 #. MSG_PINDA_PREHEAT c=20
-#: ../../Firmware/messages.cpp:218 ../../Firmware/ultralcd.cpp:610
+#: ../../Firmware/messages.cpp:230 ../../Firmware/ultralcd.cpp:610
 msgid "PINDA Heating"
 msgstr "PINDA opwarmen"
 
 #. MSG_PINDA_CALIBRATION c=13
-#: ../../Firmware/Marlin_main.cpp:4790 ../../Firmware/Marlin_main.cpp:4892
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:607
-#: ../../Firmware/ultralcd.cpp:4495 ../../Firmware/ultralcd.cpp:4597
+#: ../../Firmware/Marlin_main.cpp:4359 ../../Firmware/Marlin_main.cpp:4461
+#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:607
+#: ../../Firmware/ultralcd.cpp:4462 ../../Firmware/ultralcd.cpp:4553
 msgid "PINDA cal."
 msgstr "PINDA kalib."
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/messages.cpp:276 ../../Firmware/ultralcd.cpp:3233
+#: ../../Firmware/messages.cpp:288 ../../Firmware/ultralcd.cpp:3243
 msgid "PINDA calibration failed"
 msgstr "PINDA-kalibratie mislukt"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:4967 ../../Firmware/messages.cpp:127
-#: ../../Firmware/ultralcd.cpp:3230
+#: ../../Firmware/Marlin_main.cpp:4536 ../../Firmware/messages.cpp:132
+#: ../../Firmware/ultralcd.cpp:3240
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1459,13 +1453,13 @@ msgid "Parking selector"
 msgstr "Parkere selector"
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:4062
+#: ../../Firmware/messages.cpp:179 ../../Firmware/ultralcd.cpp:4086
 msgid "Pause"
 msgstr "Pauze"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5271
-#: ../../Firmware/ultralcd.cpp:5273
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5237
+#: ../../Firmware/ultralcd.cpp:5239
 msgid "Pause print"
 msgstr "Print pauzeren"
 
@@ -1476,7 +1470,7 @@ msgid "Performing cut"
 msgstr "Voer cut uit"
 
 #. MSG_PAPER c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3243 ../../Firmware/messages.cpp:77
+#: ../../Firmware/Marlin_main.cpp:2982 ../../Firmware/messages.cpp:77
 msgid ""
 "Place a sheet of paper under the nozzle during the calibration of first 4 "
 "points. If the nozzle catches the paper, power off the printer immediately."
@@ -1485,7 +1479,7 @@ msgstr ""
 "tuit. Als de tuit het papier beweegt, onmiddellijk uitschakelen."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:3963
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:3987
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1494,36 +1488,36 @@ msgstr ""
 "wizard door de printer opnieuw te starten."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/messages.cpp:337 ../../Firmware/ultralcd.cpp:6023
+#: ../../Firmware/messages.cpp:349 ../../Firmware/ultralcd.cpp:5999
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr ""
 "AUB IR sensor ver- binding kontrolleren , verwijder filament indien "
 "aanwezig."
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/messages.cpp:343 ../../Firmware/ultralcd.cpp:6700
+#: ../../Firmware/messages.cpp:355 ../../Firmware/ultralcd.cpp:6676
 msgid "Please check:"
 msgstr "Controleer aub:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/messages.cpp:302 ../../Firmware/ultralcd.cpp:3926
+#: ../../Firmware/messages.cpp:314 ../../Firmware/ultralcd.cpp:3950
 msgid "Please clean heatbed and then press the knob."
 msgstr "Maak het bed schoon en druk op de knop."
 
 #. MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3217 ../../Firmware/messages.cpp:27
+#: ../../Firmware/Marlin_main.cpp:2960 ../../Firmware/messages.cpp:28
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Reinig de tuit voor de kalibratie. Druk op de knop wanneer gereed."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/messages.cpp:288 ../../Firmware/ultralcd.cpp:3712
+#: ../../Firmware/messages.cpp:300 ../../Firmware/ultralcd.cpp:3722
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr ""
 "Steek a.u.b. filament in de extruder en druk op de knop om het te laden."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/messages.cpp:287 ../../Firmware/ultralcd.cpp:3705
+#: ../../Firmware/messages.cpp:299 ../../Firmware/ultralcd.cpp:3715
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1532,104 +1526,103 @@ msgstr ""
 " te laden."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/messages.cpp:285 ../../Firmware/ultralcd.cpp:3633
+#: ../../Firmware/messages.cpp:297 ../../Firmware/ultralcd.cpp:3643
 msgid "Please load filament first."
 msgstr "Laad a.u.b. eerst filament."
 
 #. MSG_CHECK_IDLER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3525 ../../Firmware/messages.cpp:206
+#: ../../Firmware/Marlin_main.cpp:3265 ../../Firmware/messages.cpp:218
 msgid "Please open idler and remove filament manually."
 msgstr "Open spanrol en verwijder filament handmatig."
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2806 ../../Firmware/messages.cpp:80
-#: ../../Firmware/ultralcd.cpp:3860
+#: ../../Firmware/mesh_bed_calibration.cpp:2791 ../../Firmware/messages.cpp:80
 msgid "Please place steel sheet on heatbed."
 msgstr "Leg staalplaat op bed."
 
 #. MSG_PRESS_TO_UNLOAD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:11215 ../../Firmware/Marlin_main.cpp:11245
+#: ../../Firmware/Marlin_main.cpp:10287 ../../Firmware/Marlin_main.cpp:10317
 #: ../../Firmware/messages.cpp:84
 msgid "Please press the knob to unload filament"
 msgstr "Druk op de knop om filament te verwijderen"
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:4932
+#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:4888
 msgid "Please pull out filament immediately"
 msgstr "Trek onmiddellijk de filament eruit"
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/messages.cpp:295 ../../Firmware/ultralcd.cpp:3856
+#: ../../Firmware/messages.cpp:307 ../../Firmware/ultralcd.cpp:3882
 msgid "Please remove shipping helpers first."
 msgstr "Verwijder eerst de transport beschermers."
 
 #. MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3240 ../../Firmware/Marlin_main.cpp:4755
-#: ../../Firmware/messages.cpp:89
+#: ../../Firmware/Marlin_main.cpp:4324 ../../Firmware/messages.cpp:89
 msgid "Please remove steel sheet from heatbed."
 msgstr "Verwijder staalplaat van het bed."
 
 #. MSG_RUN_XYZ c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4731 ../../Firmware/messages.cpp:207
+#: ../../Firmware/Marlin_main.cpp:4300 ../../Firmware/messages.cpp:219
 msgid "Please run XYZ calibration first."
 msgstr "Voer eerst de XYZ-kalibratie uit."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/messages.cpp:336 ../../Firmware/ultralcd.cpp:6020
+#: ../../Firmware/messages.cpp:348 ../../Firmware/ultralcd.cpp:4359
+#: ../../Firmware/ultralcd.cpp:5996
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Verwijder eerst het filament en probeer het opnieuw."
 
 #. MSG_NEW_FIRMWARE_PLEASE_UPGRADE c=20
-#: ../../Firmware/messages.cpp:366 ../../Firmware/util.cpp:213
+#: ../../Firmware/messages.cpp:378 ../../Firmware/util.cpp:218
 msgid "Please upgrade."
 msgstr "Voer een upgrade uit"
 
 #. MSG_PLEASE_WAIT c=20
-#: ../../Firmware/Marlin_main.cpp:3521 ../../Firmware/Marlin_main.cpp:8090
-#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:2179
-#: ../../Firmware/ultralcd.cpp:2190
+#: ../../Firmware/Marlin_main.cpp:3261 ../../Firmware/Marlin_main.cpp:7262
+#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:2190
+#: ../../Firmware/ultralcd.cpp:2204
 msgid "Please wait"
 msgstr "Even geduld aub"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:1232
-#: ../../Firmware/ultralcd.cpp:1261
+#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:1242
+#: ../../Firmware/ultralcd.cpp:1271
 msgid "Power failures"
 msgstr "Stroomstoringen"
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/messages.cpp:323 ../../Firmware/ultralcd.cpp:5260
+#: ../../Firmware/messages.cpp:335 ../../Firmware/ultralcd.cpp:5222
 msgid "Preheat"
 msgstr "Voorverwarmen"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:2254
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:2268
 msgid "Preheat the nozzle!"
 msgstr "Tuit voorverwarmen!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:2771
-#: ../../Firmware/ultralcd.cpp:3690 ../../Firmware/ultralcd.cpp:3692
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:2788
+#: ../../Firmware/ultralcd.cpp:3700 ../../Firmware/ultralcd.cpp:3702
 msgid "Preheating nozzle. Please wait."
 msgstr "Opwarmen van de tuit. Wacht aub."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/messages.cpp:237 ../../Firmware/ultralcd.cpp:1999
+#: ../../Firmware/messages.cpp:249 ../../Firmware/ultralcd.cpp:2005
 msgid "Preheating to cut"
 msgstr "Opwarm. te snijden"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/messages.cpp:236 ../../Firmware/ultralcd.cpp:1996
+#: ../../Firmware/messages.cpp:248 ../../Firmware/ultralcd.cpp:2002
 msgid "Preheating to eject"
 msgstr "Opwarm.te uitwerpen"
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/messages.cpp:234 ../../Firmware/ultralcd.cpp:1987
+#: ../../Firmware/messages.cpp:246 ../../Firmware/ultralcd.cpp:1995
 msgid "Preheating to load"
 msgstr "Opwarmen invoeren"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/messages.cpp:235 ../../Firmware/ultralcd.cpp:1992
+#: ../../Firmware/messages.cpp:247 ../../Firmware/ultralcd.cpp:1999
 msgid "Preheating to unload"
 msgstr "Opwarmen uitwerpen"
 
@@ -1640,12 +1633,12 @@ msgid "Preparing blade"
 msgstr "Bereid mes voor"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/messages.cpp:231 ../../Firmware/ultralcd.cpp:1799
+#: ../../Firmware/messages.cpp:243 ../../Firmware/ultralcd.cpp:1809
 msgid "Press the knob"
 msgstr "Druk op knop"
 
 #. MSG_PRESS_TO_PREHEAT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:11227 ../../Firmware/messages.cpp:212
+#: ../../Firmware/Marlin_main.cpp:10299 ../../Firmware/messages.cpp:224
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Druk op de knop om de tuit voor te verwarmen en door te gaan."
 
@@ -1655,34 +1648,34 @@ msgid "Print aborted"
 msgstr "Print afgebroken"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1106
-#: ../../Firmware/ultralcd.cpp:6994
+#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1116
+#: ../../Firmware/ultralcd.cpp:6971
 msgid "Print fan:"
 msgstr "Print fan:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:5313
+#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5279
 msgid "Print from SD"
 msgstr "Print van SD"
 
 #. MSG_PRINT_PAUSED c=20
-#: ../../Firmware/Marlin_main.cpp:3582 ../../Firmware/messages.cpp:79
+#: ../../Firmware/Marlin_main.cpp:3323 ../../Firmware/messages.cpp:79
 #: ../../Firmware/ultralcd.cpp:814
 msgid "Print paused"
 msgstr "Print pauzeren"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/messages.cpp:247 ../../Firmware/ultralcd.cpp:2348
+#: ../../Firmware/messages.cpp:259 ../../Firmware/ultralcd.cpp:2365
 msgid "Print time"
 msgstr "Print tijd"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/messages.cpp:225 ../../Firmware/ultralcd.cpp:1689
+#: ../../Firmware/messages.cpp:237 ../../Firmware/ultralcd.cpp:1699
 msgid "Printer IP Addr:"
 msgstr "Printer IP-adres:"
 
 #. MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1602 ../../Firmware/messages.cpp:46
+#: ../../Firmware/Marlin_main.cpp:1529 ../../Firmware/messages.cpp:46
 msgid ""
 "Printer has not been calibrated yet. Please follow the manual, chapter First"
 " steps, section Calibration flow."
@@ -1691,12 +1684,12 @@ msgstr ""
 "steps, sectie Calibration flow."
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:153 ../../Firmware/util.cpp:289
+#: ../../Firmware/messages.cpp:160 ../../Firmware/util.cpp:296
 msgid "Nozzle diameter differs from the G-code. Continue?"
 msgstr "Tuitdiameter wijkt af van de G-code. Doorgaan?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:154 ../../Firmware/util.cpp:290
+#: ../../Firmware/messages.cpp:161 ../../Firmware/util.cpp:297
 msgid ""
 "Nozzle diameter differs from the G-code. Please check the value in settings."
 " Print cancelled."
@@ -1723,22 +1716,22 @@ msgid "QUEUE FULL"
 msgstr "QUEUE VOL"
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:4465
 msgid "RPi port"
 msgstr "RPi port"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/messages.cpp:261 ../../Firmware/ultralcd.cpp:2712
+#: ../../Firmware/messages.cpp:273 ../../Firmware/ultralcd.cpp:2729
 msgid "Rear side [µm]"
 msgstr "Achterkant[µm]"
 
 #. MSG_RECOVERING_PRINT c=20
-#: ../../Firmware/messages.cpp:216 ../../Firmware/power_panic.cpp:316
+#: ../../Firmware/messages.cpp:228 ../../Firmware/power_panic.cpp:328
 msgid "Recovering print"
 msgstr "Print herstellen"
 
 #. MSG_RENAME c=18
-#: ../../Firmware/messages.cpp:322 ../../Firmware/ultralcd.cpp:5143
+#: ../../Firmware/messages.cpp:334 ../../Firmware/ultralcd.cpp:5103
 msgid "Rename"
 msgstr "Hernoem"
 
@@ -1752,19 +1745,19 @@ msgstr ""
 "de G-code voor filament index buiten bereik (T0-T4)."
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:2713
-#: ../../Firmware/ultralcd.cpp:5144
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:2730
+#: ../../Firmware/ultralcd.cpp:5104
 msgid "Reset"
 msgstr "Reset"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/messages.cpp:320 ../../Firmware/ultralcd.cpp:4594
+#: ../../Firmware/messages.cpp:332 ../../Firmware/ultralcd.cpp:4550
 msgid "Reset XYZ calibr."
 msgstr "Reset XYZ kalibr."
 
 #. MSG_RESUME_PRINT c=18
-#: ../../Firmware/Marlin_main.cpp:680 ../../Firmware/messages.cpp:91
-#: ../../Firmware/ultralcd.cpp:5286 ../../Firmware/ultralcd.cpp:5288
+#: ../../Firmware/Marlin_main.cpp:645 ../../Firmware/messages.cpp:91
+#: ../../Firmware/ultralcd.cpp:5252 ../../Firmware/ultralcd.cpp:5254
 msgid "Resume print"
 msgstr "Print hervatten"
 
@@ -1791,17 +1784,17 @@ msgid "Returning selector"
 msgstr "Selctor terugrijden"
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/messages.cpp:252 ../../Firmware/ultralcd.cpp:2479
+#: ../../Firmware/messages.cpp:264 ../../Firmware/ultralcd.cpp:2496
 msgid "Right"
 msgstr "Rechts"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/messages.cpp:259 ../../Firmware/ultralcd.cpp:2710
+#: ../../Firmware/messages.cpp:271 ../../Firmware/ultralcd.cpp:2727
 msgid "Right side[µm]"
 msgstr "Recht.kant[µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/messages.cpp:286 ../../Firmware/ultralcd.cpp:3656
+#: ../../Firmware/messages.cpp:298 ../../Firmware/ultralcd.cpp:3666
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1810,8 +1803,8 @@ msgstr ""
 " vanaf het begin. Doorgaan?"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4509
-#: ../../Firmware/ultralcd.cpp:4511
+#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4476
+#: ../../Firmware/ultralcd.cpp:4478
 msgid "SD card"
 msgstr "SD kaart"
 
@@ -1826,23 +1819,23 @@ msgid "SELECTOR CANNOT MOVE"
 msgstr "SELECTOR BEWEG FOUT"
 
 #. MSG_STOPPED c=20
-#: ../../Firmware/Marlin_main.cpp:9887 ../../Firmware/messages.cpp:125
+#: ../../Firmware/Marlin_main.cpp:9047 ../../Firmware/messages.cpp:130
 msgid "STOPPED."
 msgstr "GESTOPT."
 
 #. MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3223 ../../Firmware/Marlin_main.cpp:3245
-#: ../../Firmware/mesh_bed_calibration.cpp:2246 ../../Firmware/messages.cpp:44
+#: ../../Firmware/Marlin_main.cpp:2967 ../../Firmware/Marlin_main.cpp:2984
+#: ../../Firmware/mesh_bed_calibration.cpp:2231 ../../Firmware/messages.cpp:44
 msgid "Searching bed calibration point"
 msgstr "Zoeken bed kalibratiepunt"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/messages.cpp:321 ../../Firmware/ultralcd.cpp:5136
+#: ../../Firmware/messages.cpp:333 ../../Firmware/ultralcd.cpp:5096
 msgid "Select"
 msgstr "Selecteer"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/messages.cpp:290 ../../Firmware/ultralcd.cpp:3730
+#: ../../Firmware/messages.cpp:302 ../../Firmware/ultralcd.cpp:3740
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
@@ -1851,27 +1844,27 @@ msgstr ""
 " het schermmenu."
 
 #. MSG_SELECT_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3453 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3612
-#: ../../Firmware/ultralcd.cpp:6822
+#: ../../Firmware/Marlin_main.cpp:3192 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3622
+#: ../../Firmware/ultralcd.cpp:6798
 msgid "Select filament:"
 msgstr "Kies filament:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:110 ../../Firmware/ultralcd.cpp:3464
-#: ../../Firmware/ultralcd.cpp:4504
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:3474
+#: ../../Firmware/ultralcd.cpp:4471
 msgid "Select language"
 msgstr "Kies taal"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/messages.cpp:300 ../../Firmware/ultralcd.cpp:3900
+#: ../../Firmware/messages.cpp:312 ../../Firmware/ultralcd.cpp:3924
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr ""
 "Selecteer de voorverwarmingstemperatuur van de tuit die overeenkomt met uw "
 "materiaal."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/messages.cpp:291 ../../Firmware/ultralcd.cpp:3735
+#: ../../Firmware/messages.cpp:303 ../../Firmware/ultralcd.cpp:3745
 msgid "Select temperature which matches your material."
 msgstr "Selecteer de temperatuur die overeenkomt met uw materiaal."
 
@@ -1882,63 +1875,63 @@ msgid "Selecting fil. slot"
 msgstr "Selectere fil. slot"
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/messages.cpp:341 ../../Firmware/ultralcd.cpp:6274
+#: ../../Firmware/messages.cpp:353 ../../Firmware/ultralcd.cpp:6250
 msgid "Selftest OK"
 msgstr "Zelftest OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/messages.cpp:340 ../../Firmware/ultralcd.cpp:6057
+#: ../../Firmware/messages.cpp:352 ../../Firmware/ultralcd.cpp:6033
 msgid "Selftest start"
 msgstr "Zelftest start"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/messages.cpp:315 ../../Firmware/ultralcd.cpp:4581
+#: ../../Firmware/messages.cpp:327 ../../Firmware/ultralcd.cpp:4537
 msgid "Selftest"
 msgstr "Zelftest"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/messages.cpp:342 ../../Firmware/ultralcd.cpp:6699
+#: ../../Firmware/messages.cpp:354 ../../Firmware/ultralcd.cpp:6675
 msgid "Selftest error!"
 msgstr "Zelftest fout!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6279
-#: ../../Firmware/ultralcd.cpp:6786 ../../Firmware/ultralcd.cpp:6984
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6255
+#: ../../Firmware/ultralcd.cpp:6762 ../../Firmware/ultralcd.cpp:6961
 msgid "Selftest failed"
 msgstr "Zelftest mislukt"
 
 #. MSG_FORCE_SELFTEST c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1577 ../../Firmware/messages.cpp:202
+#: ../../Firmware/Marlin_main.cpp:1504 ../../Firmware/messages.cpp:214
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr ""
 "Zelftest zal worden uitgevoerd om nauwkeurige sensorloze auto positie te "
 "kalibreren."
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/messages.cpp:228 ../../Firmware/ultralcd.cpp:1701
+#: ../../Firmware/messages.cpp:240 ../../Firmware/ultralcd.cpp:1711
 msgid "Sensor info"
 msgstr "Sensor info"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/messages.cpp:338 ../../Firmware/ultralcd.cpp:6027
+#: ../../Firmware/messages.cpp:350 ../../Firmware/ultralcd.cpp:6003
 msgid "Sensor verified, remove the filament now."
 msgstr "Sensor geverifieerd, verwijder nu het filament."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/messages.cpp:262 ../../Firmware/ultralcd.cpp:2730
+#: ../../Firmware/messages.cpp:274 ../../Firmware/ultralcd.cpp:2747
 msgid "Set temperature:"
 msgstr "Temp. instellen:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3348
-#: ../../Firmware/ultralcd.cpp:3479 ../../Firmware/ultralcd.cpp:3984
-#: ../../Firmware/ultralcd.cpp:5374 ../../Firmware/ultralcd.cpp:5585
-#: ../../Firmware/ultralcd.cpp:5631
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3358
+#: ../../Firmware/ultralcd.cpp:3489 ../../Firmware/ultralcd.cpp:4008
+#: ../../Firmware/ultralcd.cpp:5341 ../../Firmware/ultralcd.cpp:5558
+#: ../../Firmware/ultralcd.cpp:5604
 msgid "Settings"
 msgstr "Instellingen"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/messages.cpp:255 ../../Firmware/ultralcd.cpp:2522
+#: ../../Firmware/messages.cpp:267 ../../Firmware/ultralcd.cpp:2539
 msgid "Severe skew"
 msgstr "Erg scheef"
 
@@ -1949,7 +1942,7 @@ msgid "Sheet"
 msgstr "Staalplaat"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/messages.cpp:284 ../../Firmware/ultralcd.cpp:3604
+#: ../../Firmware/messages.cpp:296 ../../Firmware/ultralcd.cpp:3614
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1962,23 +1955,23 @@ msgstr ""
 "%cReset"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/messages.cpp:319 ../../Firmware/ultralcd.cpp:4592
+#: ../../Firmware/messages.cpp:331 ../../Firmware/ultralcd.cpp:4548
 msgid "Show end stops"
 msgstr "Toon endstops"
 
 #. MSG_SILENT c=7
-#: ../../Firmware/Marlin_main.cpp:8497 ../../Firmware/messages.cpp:120
-#: ../../Firmware/ultralcd.cpp:4155 ../../Firmware/ultralcd.cpp:4194
+#: ../../Firmware/Marlin_main.cpp:7668 ../../Firmware/messages.cpp:124
+#: ../../Firmware/ultralcd.cpp:4179 ../../Firmware/ultralcd.cpp:4218
 msgid "Silent"
 msgstr "Stil"
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/messages.cpp:254 ../../Firmware/ultralcd.cpp:2521
+#: ../../Firmware/messages.cpp:266 ../../Firmware/ultralcd.cpp:2538
 msgid "Slight skew"
 msgstr "Beetje scheef"
 
 #. MSG_FILE_CNT c=20 r=6
-#: ../../Firmware/cardreader.cpp:805 ../../Firmware/messages.cpp:197
+#: ../../Firmware/cardreader.cpp:805 ../../Firmware/messages.cpp:209
 msgid ""
 "Some files will not be sorted. Max. No. of files in 1 folder for sorting is "
 "100."
@@ -1987,60 +1980,60 @@ msgstr ""
 "per map 100 is."
 
 #. MSG_ZLEVELING_ENFORCED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3043 ../../Firmware/messages.cpp:204
+#: ../../Firmware/Marlin_main.cpp:2783 ../../Firmware/messages.cpp:216
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Er is een probleem opgetreden, Z-kalibratie afgedwongen ..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:4514
-#: ../../Firmware/ultralcd.cpp:4515 ../../Firmware/ultralcd.cpp:4516
+#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4481
+#: ../../Firmware/ultralcd.cpp:4482 ../../Firmware/ultralcd.cpp:4483
 msgid "Sort"
 msgstr "Sort."
 
 #. MSG_SORTING_FILES c=20
 #: ../../Firmware/cardreader.cpp:849 ../../Firmware/cardreader.cpp:916
-#: ../../Firmware/messages.cpp:111
+#: ../../Firmware/messages.cpp:115
 msgid "Sorting files"
 msgstr "Bestanden sorteren"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4188
-#: ../../Firmware/ultralcd.cpp:4191 ../../Firmware/ultralcd.cpp:4194
-#: ../../Firmware/ultralcd.cpp:4197 ../../Firmware/ultralcd.cpp:4200
+#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4215 ../../Firmware/ultralcd.cpp:4218
+#: ../../Firmware/ultralcd.cpp:4221 ../../Firmware/ultralcd.cpp:4224
 msgid "Sound"
 msgstr "Geluid"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/messages.cpp:333 ../../Firmware/ultralcd.cpp:5516
+#: ../../Firmware/messages.cpp:345 ../../Firmware/ultralcd.cpp:5483
 msgid "Speed"
 msgstr "Snelheid"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6861
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6837
 msgid "Spinning"
 msgstr "Draait"
 
 #. MSG_TEMP_CAL_WARNING c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4744 ../../Firmware/messages.cpp:208
+#: ../../Firmware/Marlin_main.cpp:4313 ../../Firmware/messages.cpp:220
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr ""
 "En stabiele 21-26C omgevingstemperatuur is nodig,een stevige stand is "
 "vereist."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/messages.cpp:329 ../../Firmware/ultralcd.cpp:5379
+#: ../../Firmware/messages.cpp:341 ../../Firmware/ultralcd.cpp:5346
 msgid "Statistics"
 msgstr "Statistieken"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:4096
-#: ../../Firmware/ultralcd.cpp:4144
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4120
+#: ../../Firmware/ultralcd.cpp:4168
 msgid "Stealth"
 msgstr "Stil"
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4421
-#: ../../Firmware/ultralcd.cpp:5133
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4388
+#: ../../Firmware/ultralcd.cpp:5093
 msgid "Steel sheets"
 msgstr "Staalplaten"
 
@@ -2050,29 +2043,28 @@ msgid "Stop"
 msgstr "Stop"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:5293
-#: ../../Firmware/ultralcd.cpp:5781
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:5259
+#: ../../Firmware/ultralcd.cpp:5757
 msgid "Stop print"
 msgstr "Print stoppen"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4236
-#: ../../Firmware/ultralcd.cpp:4316 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4315
 msgid "Strict"
 msgstr "Strikt"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/messages.cpp:332 ../../Firmware/ultralcd.cpp:5394
+#: ../../Firmware/messages.cpp:344 ../../Firmware/ultralcd.cpp:5361
 msgid "Support"
 msgstr "Support"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/messages.cpp:354 ../../Firmware/ultralcd.cpp:6758
+#: ../../Firmware/messages.cpp:366 ../../Firmware/ultralcd.cpp:6734
 msgid "Swapped"
 msgstr "Gewisseld"
 
 #. MSG_THERMAL_ANOMALY c=20
-#: ../../Firmware/messages.cpp:188 ../../Firmware/temperature.cpp:2223
+#: ../../Firmware/messages.cpp:195 ../../Firmware/temperature.cpp:2197
 msgid "THERMAL ANOMALY"
 msgstr "THERMISCHE ANOMALIE"
 
@@ -2107,7 +2099,7 @@ msgid "TMC UNDERVOLTAGE ERR"
 msgstr "TMC ONDERVOLT. FOUT"
 
 #. MSG_TM_CAL c=20 r=4
-#: ../../Firmware/messages.cpp:299 ../../Firmware/ultralcd.cpp:3881
+#: ../../Firmware/messages.cpp:311 ../../Firmware/ultralcd.cpp:3905
 msgid ""
 "Thermal model cal. takes approx. 12 mins. See\n"
 "prusa.io/tm-cal"
@@ -2116,22 +2108,22 @@ msgstr ""
 "prusa.io/tm-cal"
 
 #. MSG_TM_NOT_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1613 ../../Firmware/messages.cpp:189
+#: ../../Firmware/Marlin_main.cpp:1540 ../../Firmware/messages.cpp:196
 msgid "Thermal model not calibrated yet."
 msgstr "Thermo model nog ongekalibreerd."
 
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/messages.cpp:309 ../../Firmware/ultralcd.cpp:4455
+#: ../../Firmware/messages.cpp:321 ../../Firmware/ultralcd.cpp:4422
 msgid "Temperature"
 msgstr "Temperatuur"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/messages.cpp:229 ../../Firmware/ultralcd.cpp:1707
+#: ../../Firmware/messages.cpp:241 ../../Firmware/ultralcd.cpp:1717
 msgid "Temperatures"
 msgstr "Temperaturen"
 
 #. MSG_TESTING_FILAMENT c=20
-#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:388
+#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:389
 msgid "Testing filament"
 msgstr "Teste filament"
 
@@ -2152,7 +2144,7 @@ msgstr ""
 "zit."
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/messages.cpp:292 ../../Firmware/ultralcd.cpp:3738
+#: ../../Firmware/messages.cpp:304 ../../Firmware/ultralcd.cpp:3748
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -2163,7 +2155,7 @@ msgstr ""
 "(Calibration chapter)."
 
 #. MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1606 ../../Firmware/messages.cpp:47
+#: ../../Firmware/Marlin_main.cpp:1533 ../../Firmware/messages.cpp:47
 msgid ""
 "There is still a need to make Z calibration. Please follow the manual, "
 "chapter First steps, section Calibration flow."
@@ -2172,40 +2164,40 @@ msgstr ""
 "handleiding, hoofdstuk First steps, section Calibration flow."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:4514
+#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:4481
 msgid "Time"
 msgstr "Tijd"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:176 ../../Firmware/ultralcd.cpp:5622
+#: ../../Firmware/messages.cpp:183 ../../Firmware/ultralcd.cpp:5595
 msgid "Timeout"
 msgstr "Time-out"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:1129
-#: ../../Firmware/ultralcd.cpp:1287
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:1139
+#: ../../Firmware/ultralcd.cpp:1297
 msgid "Total"
 msgstr "Totaal"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:1177
-#: ../../Firmware/ultralcd.cpp:1231 ../../Firmware/ultralcd.cpp:1317
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:1187
+#: ../../Firmware/ultralcd.cpp:1241 ../../Firmware/ultralcd.cpp:1327
 msgid "Total failures"
 msgstr "Totaal fouten"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/messages.cpp:248 ../../Firmware/ultralcd.cpp:2369
+#: ../../Firmware/messages.cpp:260 ../../Firmware/ultralcd.cpp:2386
 msgid "Total filament"
 msgstr "Totaal fil."
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/messages.cpp:249 ../../Firmware/ultralcd.cpp:2370
+#: ../../Firmware/messages.cpp:261 ../../Firmware/ultralcd.cpp:2387
 msgid "Total print time"
 msgstr "Totaal printtijd"
 
 #. MSG_TUNE c=8
-#: ../../Firmware/messages.cpp:116 ../../Firmware/mmu2/errors_list.h:372
-#: ../../Firmware/ultralcd.cpp:5258
+#: ../../Firmware/messages.cpp:120 ../../Firmware/mmu2/errors_list.h:372
+#: ../../Firmware/ultralcd.cpp:5220
 msgid "Tune"
 msgstr "Tune"
 
@@ -2220,16 +2212,16 @@ msgid "Unload"
 msgstr "Ontla."
 
 #. MSG_UNLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:2206
-#: ../../Firmware/ultralcd.cpp:5347 ../../Firmware/ultralcd.cpp:5364
-#: ../../Firmware/ultralcd.cpp:5369
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:2220
+#: ../../Firmware/ultralcd.cpp:5313 ../../Firmware/ultralcd.cpp:5331
+#: ../../Firmware/ultralcd.cpp:5336
 msgid "Unload filament"
 msgstr "Fil. uitwerpen"
 
 #. MSG_UNLOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3436 ../../Firmware/messages.cpp:129
+#: ../../Firmware/Marlin_main.cpp:3175 ../../Firmware/messages.cpp:134
 #: ../../Firmware/mmu2_progress_converter.cpp:50
-#: ../../Firmware/ultralcd.cpp:4911
+#: ../../Firmware/ultralcd.cpp:4867
 msgid "Unloading filament"
 msgstr "Uitwerpen filament"
 
@@ -2246,12 +2238,12 @@ msgid "Unloading to pulley"
 msgstr "Ontlade n. riemschi."
 
 #. MSG_FIL_FAILED c=20 r=4
-#: ../../Firmware/messages.cpp:339 ../../Firmware/ultralcd.cpp:6030
+#: ../../Firmware/messages.cpp:351 ../../Firmware/ultralcd.cpp:6006
 msgid "Verification failed, remove the filament and try again."
 msgstr "Verificatie mislukt, verwijder het filament en probeer het opnieuw."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/messages.cpp:230 ../../Firmware/ultralcd.cpp:1710
+#: ../../Firmware/messages.cpp:242 ../../Firmware/ultralcd.cpp:1720
 msgid "Voltages"
 msgstr "Spanning"
 
@@ -2262,7 +2254,7 @@ msgid "WARNING TMC TOO HOT"
 msgstr "WAARSCH. TMC TE HEET"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/messages.cpp:281 ../../Firmware/ultralcd.cpp:3381
+#: ../../Firmware/messages.cpp:293 ../../Firmware/ultralcd.cpp:3391
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -2275,188 +2267,188 @@ msgstr ""
 "Stealth stand"
 
 #. MSG_USERWAIT c=20
-#: ../../Firmware/Marlin_main.cpp:5240 ../../Firmware/messages.cpp:209
+#: ../../Firmware/Marlin_main.cpp:4747 ../../Firmware/messages.cpp:221
 msgid "Wait for user..."
 msgstr "Wacht op gebruiker.."
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/messages.cpp:263 ../../Firmware/ultralcd.cpp:2753
+#: ../../Firmware/messages.cpp:275 ../../Firmware/ultralcd.cpp:2770
 msgid "Waiting for PINDA probe cooling"
 msgstr "Wachten op afkoelen van PINDA"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/messages.cpp:264 ../../Firmware/ultralcd.cpp:2782
+#: ../../Firmware/messages.cpp:276 ../../Firmware/ultralcd.cpp:2799
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Wachten op afkoelen van tuit en bed"
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:4233
-#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4352
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4312
 msgid "Warn"
 msgstr "Waarsch."
 
 #. MSG_CHANGED_BOTH c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1554 ../../Firmware/messages.cpp:200
+#: ../../Firmware/Marlin_main.cpp:1481 ../../Firmware/messages.cpp:212
 msgid "Warning: both printer type and motherboard type changed."
 msgstr ""
 "Waarschuwing: zowel het printertype als het moederbordtype is gewijzigd."
 
 #. MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1546 ../../Firmware/messages.cpp:198
+#: ../../Firmware/Marlin_main.cpp:1473 ../../Firmware/messages.cpp:210
 msgid "Warning: motherboard type changed."
 msgstr "Waarschuwing: type moederbord gewijzigd."
 
 #. MSG_CHANGED_PRINTER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1550 ../../Firmware/messages.cpp:199
+#: ../../Firmware/Marlin_main.cpp:1477 ../../Firmware/messages.cpp:211
 msgid "Warning: printer type changed."
 msgstr "Waarschuwing: printertype gewijzigd."
 
 #. MSG_UNLOAD_SUCCESSFUL c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3517 ../../Firmware/messages.cpp:205
+#: ../../Firmware/Marlin_main.cpp:3257 ../../Firmware/messages.cpp:217
 msgid "Was filament unload successful?"
 msgstr "Is filament succes- vol verwijderd?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:6710
-#: ../../Firmware/ultralcd.cpp:6714 ../../Firmware/ultralcd.cpp:6734
-#: ../../Firmware/ultralcd.cpp:6740 ../../Firmware/ultralcd.cpp:6764
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:6686
+#: ../../Firmware/ultralcd.cpp:6690 ../../Firmware/ultralcd.cpp:6710
+#: ../../Firmware/ultralcd.cpp:6716 ../../Firmware/ultralcd.cpp:6740
 msgid "Wiring error"
 msgstr "Aansluitingsfout"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/messages.cpp:313 ../../Firmware/ultralcd.cpp:4572
+#: ../../Firmware/messages.cpp:325 ../../Firmware/ultralcd.cpp:4528
 msgid "Wizard"
 msgstr "Wizard"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/messages.cpp:304 ../../Firmware/ultralcd.cpp:3986
+#: ../../Firmware/messages.cpp:316 ../../Firmware/ultralcd.cpp:4010
 msgid "X-correct"
 msgstr "X-correctie"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/messages.cpp:226 ../../Firmware/ultralcd.cpp:1699
+#: ../../Firmware/messages.cpp:238 ../../Firmware/ultralcd.cpp:1709
 msgid "XYZ cal. details"
 msgstr "XYZ kal. details"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/messages.cpp:275 ../../Firmware/ultralcd.cpp:3207
+#: ../../Firmware/messages.cpp:287 ../../Firmware/ultralcd.cpp:3217
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr ""
 "XYZ-kalibratie in orde. Scheefheid zal automatisch worden gecorrigeerd."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/messages.cpp:274 ../../Firmware/ultralcd.cpp:3204
+#: ../../Firmware/messages.cpp:286 ../../Firmware/ultralcd.cpp:3214
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr "XYZ-kalibratie in orde. X / Y-assen zijn licht scheef. Goed gedaan!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/messages.cpp:271 ../../Firmware/ultralcd.cpp:3185
+#: ../../Firmware/messages.cpp:283 ../../Firmware/ultralcd.cpp:3195
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr "XYZ-kalibratie niet gelukt. Voorste kalibratiepunten niet bereikbaar."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/messages.cpp:272 ../../Firmware/ultralcd.cpp:3188
+#: ../../Firmware/messages.cpp:284 ../../Firmware/ultralcd.cpp:3198
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr ""
 "XYZ-kalibratie niet gelukt. Rechter voor kalibratiepunt niet bereikbaar."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/messages.cpp:268 ../../Firmware/ultralcd.cpp:3167
+#: ../../Firmware/messages.cpp:280 ../../Firmware/ultralcd.cpp:3177
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr "XYZ-kalibratie mislukt. Bed ijkpunt niet gevonden."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/messages.cpp:269 ../../Firmware/ultralcd.cpp:3173
+#: ../../Firmware/messages.cpp:281 ../../Firmware/ultralcd.cpp:3183
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr "XYZ-kalibratie mislukt. Voorste kalibratiepunten niet bereikbaar."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3170
-#: ../../Firmware/ultralcd.cpp:3198
+#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3180
+#: ../../Firmware/ultralcd.cpp:3208
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "XYZ-kalibratie mislukt. Raadpleeg de handleiding aub."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/messages.cpp:270 ../../Firmware/ultralcd.cpp:3176
+#: ../../Firmware/messages.cpp:282 ../../Firmware/ultralcd.cpp:3186
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr "XYZ-kalibratie mislukt. Rechter voor kalibratiepunt niet bereikbaar."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/messages.cpp:273 ../../Firmware/ultralcd.cpp:3201
+#: ../../Firmware/messages.cpp:285 ../../Firmware/ultralcd.cpp:3211
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "XYZ-kalibratie ok. X / Y-assen staan loodrecht. Gefeliciteerd!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/messages.cpp:250 ../../Firmware/ultralcd.cpp:2476
+#: ../../Firmware/messages.cpp:262 ../../Firmware/ultralcd.cpp:2493
 msgid "Y distance from min"
 msgstr "Y afstand van min"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/messages.cpp:305 ../../Firmware/ultralcd.cpp:3987
+#: ../../Firmware/messages.cpp:317 ../../Firmware/ultralcd.cpp:4011
 msgid "Y-correct"
 msgstr "Y-correctie"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:3029
-#: ../../Firmware/ultralcd.cpp:4443 ../../Firmware/ultralcd.cpp:4531
-#: ../../Firmware/ultralcd.cpp:5790
+#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:2275
+#: ../../Firmware/ultralcd.cpp:2279 ../../Firmware/ultralcd.cpp:3046
+#: ../../Firmware/ultralcd.cpp:4410 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/ultralcd.cpp:5766
 msgid "Yes"
 msgstr "Ja"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:3950
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:3974
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr "U kunt de wizard altijd hervatten via Kalibratie -> Wizard."
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/messages.cpp:306 ../../Firmware/ultralcd.cpp:3988
+#: ../../Firmware/messages.cpp:318 ../../Firmware/ultralcd.cpp:4012
 msgid "Z-correct"
 msgstr "Z-correctie"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5593
+#: ../../Firmware/messages.cpp:175 ../../Firmware/ultralcd.cpp:5566
 msgid "Z-probe nr."
 msgstr "Z-test nr."
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/messages.cpp:256 ../../Firmware/ultralcd.cpp:2546
+#: ../../Firmware/messages.cpp:268 ../../Firmware/ultralcd.cpp:2563
 msgid "[0;0] point offset"
 msgstr "[0;0] punt offset"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/messages.cpp:239 ../../Firmware/ultralcd.cpp:2147
+#: ../../Firmware/messages.cpp:251 ../../Firmware/ultralcd.cpp:2158
 msgid "and press the knob"
 msgstr "en druk op knop"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/messages.cpp:232 ../../Firmware/ultralcd.cpp:1807
+#: ../../Firmware/messages.cpp:244 ../../Firmware/ultralcd.cpp:1816
 msgid "to load filament"
 msgstr "om filament te laden"
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/messages.cpp:233 ../../Firmware/ultralcd.cpp:1811
+#: ../../Firmware/messages.cpp:245 ../../Firmware/ultralcd.cpp:1820
 msgid "to unload filament"
 msgstr "om fil. uitwerpen"
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/messages.cpp:224 ../../Firmware/ultralcd.cpp:1666
+#: ../../Firmware/messages.cpp:236 ../../Firmware/ultralcd.cpp:1676
 msgid "unknown"
 msgstr "onbekend"
 
 #. MSG_IR_UNKNOWN c=18
-#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:184
+#: ../../Firmware/Filament_sensor.cpp:286 ../../Firmware/messages.cpp:191
 msgid "unknown state"
 msgstr "Status onbekend"
 
 #. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:5858
-#: ../../Firmware/ultralcd.cpp:5861
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:5834
+#: ../../Firmware/ultralcd.cpp:5837
 msgid "🔃Refresh"
 msgstr "🔃Refresh"
 
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1180
+#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1190
 msgid "MMU power fails"
 msgstr "MMU stroomstor."
 
@@ -2494,8 +2486,8 @@ msgid "MMU MCU ERROR"
 msgstr "MMU MCU FOUT"
 
 #. MSG_MATERIAL_CHANGES c=18
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:1130
-#: ../../Firmware/ultralcd.cpp:1204
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:1140
+#: ../../Firmware/ultralcd.cpp:1214
 msgid "Material changes"
 msgstr "Materailwisseling."
 
@@ -2527,17 +2519,17 @@ msgstr ""
 "printer. Update naar versie 3.0.3."
 
 #. MSG_PRELOAD_TO_MMU c=17
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5344
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5310
 msgid "Preload to MMU"
 msgstr "Voorladen in MMU"
 
 #. MSG_FW_MK3_DETECTED c=20 r=4
-#: ../../Firmware/messages.cpp:367 ../../Firmware/Marlin_main.cpp:920
+#: ../../Firmware/messages.cpp:379 ../../Firmware/Marlin_main.cpp:854
 msgid "MK3 firmware detected on MK3S printer"
 msgstr "MK3-firmware bij MK3S-printer gedetecteerd"
 
 #. MSG_FW_MK3S_DETECTED c=20 r=4
-#: ../../Firmware/messages.cpp:367 ../../Firmware/Marlin_main.cpp:920
+#: ../../Firmware/messages.cpp:379 ../../Firmware/Marlin_main.cpp:854
 msgid "MK3S firmware detected on MK3 printer"
 msgstr "MK3S-firmware op MK3-printer ontdekt"
 
@@ -2551,8 +2543,9 @@ msgstr "ONBEKENDE FOUT"
 msgid "Unexpected error occurred."
 msgstr "Er is een onverwachte fout opgetreden."
 
-#. MSG_BTN_EJECT c=8
-#: ../../Firmware/mmu2/errors_list.h:358 ../../Firmware/mmu2/errors_list.h:371
+#. MSG_EJECT c=8
+#: ../../Firmware/messages.cpp:21 ../../Firmware/mmu2/errors_list.h:371
+#: ../../Firmware/ultralcd.cpp:2275 ../../Firmware/ultralcd.cpp:2279
 msgid "Eject"
 msgstr "Uitwerp."
 
@@ -2572,58 +2565,58 @@ msgid "M600 Filament Change. Load a new filament or eject the old one."
 msgstr "M600-filamentwissel. Laad een nieuw filament of werp het oude uit."
 
 #. MSG_MMU_SENSITIVITY c=18
-#: ../../Firmware/messages.cpp:215 ../../Firmware/mmu2_reporting.cpp:458
+#: ../../Firmware/messages.cpp:227 ../../Firmware/mmu2_reporting.cpp:459
 msgid "Sensitivity"
 msgstr "Sensitiviteit"
 
 #. MSG_MBL_FAILED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3038 ../../Firmware/messages.cpp:203
+#: ../../Firmware/Marlin_main.cpp:2776 ../../Firmware/messages.cpp:215
 msgid "Mesh bed leveling failed. Print canceled."
 msgstr "Bed leveling mislukt. Printen geannuleerd."
 
 #. MSG_SET_READY c=18
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:5265
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:5228
 msgid "Set Ready"
 msgstr "Gereed zetten"
 
 #. MSG_SET_NOT_READY c=18
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:5263
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5226
 msgid "Set not Ready"
 msgstr "Niet gereed zetten"
 
 #. MSG_HOSTPRINT c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5285
+#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:5231
 msgid "Print from host"
 msgstr "Print van host"
 
 #. MSG_REPRINT c=18
-#: ../../Firmware/messages.cpp:196 ../../Firmware/ultralcd.cpp:5243
-#: ../../Firmware/ultralcd.cpp:5245
+#: ../../Firmware/messages.cpp:208 ../../Firmware/ultralcd.cpp:5205
+#: ../../Firmware/ultralcd.cpp:5207
 msgid "Reprint"
 msgstr "Herhaal druk"
 
 #. MSG_SHUTDOWN_HOST c=18
-#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:5390
+#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:5357
 msgid "Shutdown host"
 msgstr "Host uitschakelen"
 
 #. MSG_NOZZLE_CNG_COOLDOWN c=20 r=3
-#: ../../Firmware/messages.cpp:198 ../../Firmware/ultralcd.cpp:1002
+#: ../../Firmware/messages.cpp:203 ../../Firmware/ultralcd.cpp:999
 msgid "Nozzle is hot! Wait for cooldown."
 msgstr "Mondstuk is heet! Wacht op afkoeling."
 
 #. MSG_NOZZLE_CNG_CHANGED_QUICK c=20 r=3
-#: ../../Firmware/messages.cpp:199
+#: ../../Firmware/messages.cpp:204
 msgid "Nozzle changed?"
 msgstr "Mondstuk veranderd?"
 
 #. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:388
+#: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:388
 msgid "There is no filament loaded. Continue?"
 msgstr "Geen filament geladen. Doorgaan?"
 
 #. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:389
+#: ../../Firmware/messages.cpp:159 ../../Firmware/util.cpp:389
 msgid "There is no filament loaded. Print cancelled."
 msgstr "Geen filament geladen. Printen geannuleerd."
 

--- a/lang/po/Firmware_no.po
+++ b/lang/po/Firmware_no.po
@@ -16,91 +16,91 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 
 #. MSG_IR_03_OR_OLDER c=18
-#: ../../Firmware/Filament_sensor.cpp:280
-#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:183
+#: ../../Firmware/Filament_sensor.cpp:282
+#: ../../Firmware/Filament_sensor.cpp:344 ../../Firmware/messages.cpp:190
 msgid " 0.3 or older"
 msgstr " 0.3 eller eldre"
 
 #. MSG_IR_04_OR_NEWER c=18
-#: ../../Firmware/Filament_sensor.cpp:282
-#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:182
+#: ../../Firmware/Filament_sensor.cpp:284
+#: ../../Firmware/Filament_sensor.cpp:347 ../../Firmware/messages.cpp:189
 msgid " 0.4 or newer"
 msgstr " 0.4 eller nyere"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/messages.cpp:356 ../../Firmware/ultralcd.cpp:6773
+#: ../../Firmware/messages.cpp:368 ../../Firmware/ultralcd.cpp:6749
 msgid "%s level expected"
 msgstr "%s nivå ventet"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:1978
-#: ../../Firmware/ultralcd.cpp:3613
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:1986
+#: ../../Firmware/ultralcd.cpp:3623
 msgid ">Cancel"
 msgstr ">Avbryt"
 
 #. MSG_BABYSTEPPING_Z c=13
-#: ../../Firmware/messages.cpp:257 ../../Firmware/ultralcd.cpp:2635
+#: ../../Firmware/messages.cpp:269 ../../Firmware/ultralcd.cpp:2652
 msgid "Adjusting Z"
 msgstr "Justerer Z"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/messages.cpp:360 ../../Firmware/ultralcd.cpp:6983
+#: ../../Firmware/messages.cpp:372 ../../Firmware/ultralcd.cpp:6960
 msgid "All correct"
 msgstr "Alt korrekt"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:3955
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:3979
 msgid "All is done. Happy printing!"
 msgstr "Alt klart. God printing!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4482
 msgid "Alphabet"
 msgstr "Alfabet"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4086
+#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4110
 msgid "Always"
 msgstr "Alltid"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/messages.cpp:221 ../../Firmware/ultralcd.cpp:1393
+#: ../../Firmware/messages.cpp:233 ../../Firmware/ultralcd.cpp:1403
 msgid "Ambient"
 msgstr "Omgivelse"
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=3
-#: ../../Firmware/messages.cpp:267 ../../Firmware/ultralcd.cpp:2848
+#: ../../Firmware/messages.cpp:279 ../../Firmware/ultralcd.cpp:2865
 msgid "Are left and right Z-carriages all up?"
 msgstr "Er venstre og høyre Z-vogn helt oppe?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4197
+#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:4221
 msgid "Assist"
 msgstr "Hjelp"
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:179 ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/messages.cpp:186 ../../Firmware/ultralcd.cpp:5594
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
-#: ../../Firmware/Marlin_main.cpp:3198 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:4577 ../../Firmware/ultralcd.cpp:5529
+#: ../../Firmware/Marlin_main.cpp:2942 ../../Firmware/messages.cpp:12
+#: ../../Firmware/ultralcd.cpp:4533 ../../Firmware/ultralcd.cpp:5496
 msgid "Auto home"
 msgstr "Auto hjem"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4182
 msgid "Auto power"
 msgstr "Autostyrke"
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:328 ../../Firmware/ultralcd.cpp:5359
+#: ../../Firmware/messages.cpp:340 ../../Firmware/ultralcd.cpp:5328
 msgid "AutoLoad filament"
 msgstr "AutoLast filament"
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/messages.cpp:245 ../../Firmware/ultralcd.cpp:2272
+#: ../../Firmware/messages.cpp:257 ../../Firmware/ultralcd.cpp:2289
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
@@ -113,51 +113,50 @@ msgid "Avoiding grind"
 msgstr "Unngår sliping"
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/messages.cpp:352 ../../Firmware/ultralcd.cpp:6752
+#: ../../Firmware/messages.cpp:364 ../../Firmware/ultralcd.cpp:6728
 msgid "Axis"
 msgstr "Akse"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/messages.cpp:351 ../../Firmware/ultralcd.cpp:6751
+#: ../../Firmware/messages.cpp:363 ../../Firmware/ultralcd.cpp:6727
 msgid "Axis length"
 msgstr "Akselengde"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2708
-#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:5618
-#: ../../Firmware/ultralcd.cpp:7484
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2725
+#: ../../Firmware/ultralcd.cpp:4061 ../../Firmware/ultralcd.cpp:5591
+#: ../../Firmware/ultralcd.cpp:7461
 msgid "Back"
 msgstr "Tilbake"
 
 #. MSG_BED c=13
-#: ../../Firmware/Marlin_main.cpp:2081 ../../Firmware/Marlin_main.cpp:4627
-#: ../../Firmware/Marlin_main.cpp:4678 ../../Firmware/messages.cpp:15
-#: ../../Firmware/ultralcd.cpp:1391 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/Marlin_main.cpp:4247 ../../Firmware/messages.cpp:15
+#: ../../Firmware/ultralcd.cpp:1401 ../../Firmware/ultralcd.cpp:4197
 msgid "Bed"
 msgstr "Seng"
 
 #. MSG_BED_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6240 ../../Firmware/messages.cpp:17
+#: ../../Firmware/Marlin_main.cpp:5470 ../../Firmware/messages.cpp:17
 #: ../../Firmware/ultralcd.cpp:534
 msgid "Bed Heating"
 msgstr "Sengen varmes"
 
 #. MSG_BED_DONE c=20
-#: ../../Firmware/Marlin_main.cpp:6277 ../../Firmware/messages.cpp:16
+#: ../../Firmware/Marlin_main.cpp:5507 ../../Firmware/messages.cpp:16
 #: ../../Firmware/ultralcd.cpp:537
 msgid "Bed done"
 msgstr "Seng ferdig"
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/messages.cpp:317 ../../Firmware/ultralcd.cpp:4589
+#: ../../Firmware/messages.cpp:329 ../../Firmware/ultralcd.cpp:4545
 msgid "Bed level correct"
 msgstr "Plankorrekt seng"
 
 #. MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:2262 ../../Firmware/Marlin_main.cpp:2999
-#: ../../Firmware/Marlin_main.cpp:3008
-#: ../../Firmware/mesh_bed_calibration.cpp:2878
-#: ../../Firmware/mesh_bed_calibration.cpp:2903 ../../Firmware/messages.cpp:18
+#: ../../Firmware/Marlin_main.cpp:2048 ../../Firmware/Marlin_main.cpp:2736
+#: ../../Firmware/Marlin_main.cpp:2745
+#: ../../Firmware/mesh_bed_calibration.cpp:2863
+#: ../../Firmware/mesh_bed_calibration.cpp:2888 ../../Firmware/messages.cpp:18
 msgid ""
 "Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for "
 "reset."
@@ -166,34 +165,34 @@ msgstr ""
 "omstart."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/messages.cpp:346 ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/messages.cpp:358 ../../Firmware/ultralcd.cpp:6685
 msgid "Bed/Heater"
 msgstr "Seng/Varmer"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1444
-#: ../../Firmware/ultralcd.cpp:1704
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1454
+#: ../../Firmware/ultralcd.cpp:1714
 msgid "Belt status"
 msgstr "Beltestatus"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/messages.cpp:314 ../../Firmware/ultralcd.cpp:4579
+#: ../../Firmware/messages.cpp:326 ../../Firmware/ultralcd.cpp:4535
 msgid "Belt test"
 msgstr "Belte test"
 
 #. MSG_RECOVER_PRINT c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:1660 ../../Firmware/messages.cpp:87
+#: ../../Firmware/Marlin_main.cpp:1587 ../../Firmware/messages.cpp:87
 msgid "Blackout occurred. Recover print?"
 msgstr "Oppdaget Strømbrudd! Gjenoppta print?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:177 ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:5594
 msgid "Bright"
 msgstr "Lys"
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:4526
-#: ../../Firmware/ultralcd.cpp:5546
+#: ../../Firmware/messages.cpp:180 ../../Firmware/ultralcd.cpp:4493
+#: ../../Firmware/ultralcd.cpp:5513
 msgid "Brightness"
 msgstr "Lysstyrke"
 
@@ -203,17 +202,17 @@ msgid "COMMUNICATION ERROR"
 msgstr "KOMMUNIKASJONSFEIL"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/messages.cpp:316 ../../Firmware/ultralcd.cpp:4583
+#: ../../Firmware/messages.cpp:328 ../../Firmware/ultralcd.cpp:4539
 msgid "Calibrate XYZ"
 msgstr "Kalibrer XYZ"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4585
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4541
 msgid "Calibrate Z"
 msgstr "Kalibrer Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/messages.cpp:266 ../../Firmware/ultralcd.cpp:2813
+#: ../../Firmware/messages.cpp:278 ../../Firmware/ultralcd.cpp:2830
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -222,13 +221,13 @@ msgstr ""
 "Deretter trykk."
 
 #. MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: ../../Firmware/Marlin_main.cpp:2218 ../../Firmware/messages.cpp:22
+#: ../../Firmware/Marlin_main.cpp:2009 ../../Firmware/messages.cpp:23
 #: ../../Firmware/ultralcd.cpp:582
 msgid "Calibrating Z"
 msgstr "Kalibrer Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/messages.cpp:265 ../../Firmware/ultralcd.cpp:2812
+#: ../../Firmware/messages.cpp:277 ../../Firmware/ultralcd.cpp:2829
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -237,17 +236,17 @@ msgstr ""
 " trykk."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/messages.cpp:361 ../../Firmware/ultralcd.cpp:6985
+#: ../../Firmware/messages.cpp:373 ../../Firmware/ultralcd.cpp:6962
 msgid "Calibrating home"
 msgstr "Kalibrerer hjem"
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5375
+#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5342
 msgid "Calibration"
 msgstr "Kalibrering"
 
 #. MSG_HOMEYZ_DONE c=20
-#: ../../Firmware/messages.cpp:217 ../../Firmware/ultralcd.cpp:593
+#: ../../Firmware/messages.cpp:229 ../../Firmware/ultralcd.cpp:593
 msgid "Calibration done"
 msgstr "Kalibrering ferdig"
 
@@ -265,128 +264,128 @@ msgstr ""
 "Kan ikke utføre handling, filamentet er allerede lasted. Avless det først."
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/messages.cpp:364 ../../Firmware/ultralcd.cpp:7405
+#: ../../Firmware/messages.cpp:376 ../../Firmware/ultralcd.cpp:7382
 msgid "Card removed"
 msgstr "Kort fjernet"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/messages.cpp:324 ../../Firmware/ultralcd.cpp:5316
+#: ../../Firmware/messages.cpp:336 ../../Firmware/ultralcd.cpp:5282
 msgid "Change SD card"
 msgstr "Bytt SD kort"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5254
-#: ../../Firmware/ultralcd.cpp:5526
+#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5216
+#: ../../Firmware/ultralcd.cpp:5493
 msgid "Change filament"
 msgstr "Bytt filament"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/messages.cpp:240 ../../Firmware/ultralcd.cpp:2156
+#: ../../Firmware/messages.cpp:252 ../../Firmware/ultralcd.cpp:2167
 msgid "Change success!"
 msgstr "Bytte vellykket!"
 
 #. MSG_CORRECTLY c=19
-#: ../../Firmware/messages.cpp:242 ../../Firmware/ultralcd.cpp:2203
+#: ../../Firmware/messages.cpp:254 ../../Firmware/ultralcd.cpp:2217
 msgid "Changed correctly"
 msgstr "Byttet riktig"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5951
-#: ../../Firmware/ultralcd.cpp:6975
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5927
+#: ../../Firmware/ultralcd.cpp:6952
 msgid "Checking X axis"
 msgstr "Sjekker X aksen"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5961
-#: ../../Firmware/ultralcd.cpp:6976
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:5937
+#: ../../Firmware/ultralcd.cpp:6953
 msgid "Checking Y axis"
 msgstr "Sjekker Y aksen"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/messages.cpp:358 ../../Firmware/ultralcd.cpp:6977
+#: ../../Firmware/messages.cpp:370 ../../Firmware/ultralcd.cpp:6954
 msgid "Checking Z axis"
 msgstr "Sjekker Z aksen"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6978
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6955
 msgid "Checking bed"
 msgstr "Sjekker seng"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/messages.cpp:357 ../../Firmware/ultralcd.cpp:6974
+#: ../../Firmware/messages.cpp:369 ../../Firmware/ultralcd.cpp:6951
 msgid "Checking endstops"
 msgstr "Sjekker endesensorer"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/messages.cpp:362 ../../Firmware/ultralcd.cpp:7070
+#: ../../Firmware/messages.cpp:374 ../../Firmware/ultralcd.cpp:7047
 msgid "Checking file"
 msgstr "Sjekker fil"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/messages.cpp:359 ../../Firmware/ultralcd.cpp:6980
+#: ../../Firmware/messages.cpp:371 ../../Firmware/ultralcd.cpp:6957
 msgid "Checking hotend"
 msgstr "Sjekker hotend"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6981
-#: ../../Firmware/ultralcd.cpp:6982
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6958
+#: ../../Firmware/ultralcd.cpp:6959
 msgid "Checking sensors"
 msgstr "Sjekker sensorer"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/messages.cpp:308 ../../Firmware/ultralcd.cpp:4424
+#: ../../Firmware/messages.cpp:320 ../../Firmware/ultralcd.cpp:4391
 msgid "Checks"
 msgstr "G-code sjekk"
 
 #. MSG_TM_ACK_ERROR c=18
-#: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5297
+#: ../../Firmware/messages.cpp:197 ../../Firmware/ultralcd.cpp:5263
 msgid "Clear TM error"
 msgstr "Fjern TM-feil"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/messages.cpp:244 ../../Firmware/ultralcd.cpp:2205
+#: ../../Firmware/messages.cpp:256 ../../Firmware/ultralcd.cpp:2219
 msgid "Color not correct"
 msgstr "Farge ikke riktig"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:3508
+#: ../../Firmware/messages.cpp:27 ../../Firmware/ultralcd.cpp:3518
 msgid "Community made"
 msgstr "Community laget"
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:4059
+#: ../../Firmware/messages.cpp:178 ../../Firmware/ultralcd.cpp:4083
 msgid "Cont."
 msgstr "Fort."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:2129
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2135
 msgid "Cooldown"
 msgstr "Nedkjøling"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/messages.cpp:283 ../../Firmware/ultralcd.cpp:3450
+#: ../../Firmware/messages.cpp:295 ../../Firmware/ultralcd.cpp:3460
 msgid "Copy selected language?"
 msgstr "Kopiere det valgte språket?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:1234
-#: ../../Firmware/ultralcd.cpp:1263
+#: ../../Firmware/messages.cpp:30 ../../Firmware/ultralcd.cpp:1244
+#: ../../Firmware/ultralcd.cpp:1273
 msgid "Crash"
 msgstr "Krasj"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4146
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/ultralcd.cpp:4170
 msgid "Crash det."
 msgstr "Krasjdetek."
 
 #. MSG_CRASH_DETECTED c=20
-#: ../../Firmware/Marlin_main.cpp:630 ../../Firmware/messages.cpp:30
+#: ../../Firmware/Marlin_main.cpp:595 ../../Firmware/messages.cpp:31
 msgid "Crash detected."
 msgstr "Krasj oppdaget."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/messages.cpp:280 ../../Firmware/ultralcd.cpp:3374
+#: ../../Firmware/messages.cpp:292 ../../Firmware/ultralcd.cpp:3384
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -397,24 +396,24 @@ msgstr ""
 "Normal modus"
 
 #. MSG_CUT_FILAMENT c=16
-#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:380
-#: ../../Firmware/ultralcd.cpp:4854 ../../Firmware/ultralcd.cpp:5351
+#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:381
+#: ../../Firmware/ultralcd.cpp:4810 ../../Firmware/ultralcd.cpp:5317
 msgid "Cut filament"
 msgstr "Kutt filament"
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4081
-#: ../../Firmware/ultralcd.cpp:4086 ../../Firmware/ultralcd.cpp:4091
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:4105
+#: ../../Firmware/ultralcd.cpp:4110 ../../Firmware/ultralcd.cpp:4115
 msgid "Cutter"
 msgstr "Kutter"
 
 #. MSG_DATE c=17
-#: ../../Firmware/messages.cpp:222 ../../Firmware/ultralcd.cpp:1645
+#: ../../Firmware/messages.cpp:234 ../../Firmware/ultralcd.cpp:1655
 msgid "Date:"
 msgstr "Dato:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:178 ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/messages.cpp:185 ../../Firmware/ultralcd.cpp:5594
 msgid "Dim"
 msgstr "Svak"
 
@@ -424,7 +423,7 @@ msgid "Disable"
 msgstr "Deaktiv."
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/messages.cpp:311 ../../Firmware/ultralcd.cpp:4460
+#: ../../Firmware/messages.cpp:323 ../../Firmware/ultralcd.cpp:4427
 msgid "Disable steppers"
 msgstr "Frigjør motorer"
 
@@ -436,7 +435,7 @@ msgid "Disengaging idler"
 msgstr "Frigjør tomgangshjul"
 
 #. MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: ../../Firmware/Marlin_main.cpp:1610 ../../Firmware/Marlin_main.cpp:3334
+#: ../../Firmware/Marlin_main.cpp:1537 ../../Firmware/Marlin_main.cpp:3073
 #: ../../Firmware/messages.cpp:14
 msgid ""
 "Distance between tip of the nozzle and the bed surface has not been set yet."
@@ -447,7 +446,7 @@ msgstr ""
 "manualen, under First Steps, for hvordan det første laget skal kalibreres."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/messages.cpp:301 ../../Firmware/ultralcd.cpp:3923
+#: ../../Firmware/messages.cpp:313 ../../Firmware/ultralcd.cpp:3947
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -456,13 +455,13 @@ msgstr ""
 "platen?"
 
 #. MSG_DONE c=8
-#: ../../Firmware/messages.cpp:32 ../../Firmware/mmu2/errors_list.h:367
-#: ../../Firmware/mmu2_reporting.cpp:456
+#: ../../Firmware/messages.cpp:33 ../../Firmware/mmu2/errors_list.h:367
+#: ../../Firmware/mmu2_reporting.cpp:457
 msgid "Done"
 msgstr "Ferdig"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/messages.cpp:307 ../../Firmware/ultralcd.cpp:3990
+#: ../../Firmware/messages.cpp:319 ../../Firmware/ultralcd.cpp:4014
 msgid "E-correct"
 msgstr "E-korreksjon"
 
@@ -491,13 +490,13 @@ msgid "ERR Wait for User"
 msgstr "ERR Vent på Bruker"
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:2253
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:2267
 msgid "ERROR:"
 msgstr "FEIL:"
 
 #. MSG_EJECT_FROM_MMU c=16
-#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:384
-#: ../../Firmware/ultralcd.cpp:4845 ../../Firmware/ultralcd.cpp:5348
+#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:385
+#: ../../Firmware/ultralcd.cpp:4801 ../../Firmware/ultralcd.cpp:5314
 msgid "Eject from MMU"
 msgstr "Løs ut fra MMU"
 
@@ -509,17 +508,17 @@ msgid "Ejecting filament"
 msgstr "Mater ut filament"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/messages.cpp:348 ../../Firmware/ultralcd.cpp:6722
+#: ../../Firmware/messages.cpp:360 ../../Firmware/ultralcd.cpp:6698
 msgid "Endstop"
 msgstr "Endesensor"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/messages.cpp:349 ../../Firmware/ultralcd.cpp:6727
+#: ../../Firmware/messages.cpp:361 ../../Firmware/ultralcd.cpp:6703
 msgid "Endstop not hit"
 msgstr "Traff ikke endesens."
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/messages.cpp:347 ../../Firmware/ultralcd.cpp:6713
+#: ../../Firmware/messages.cpp:359 ../../Firmware/ultralcd.cpp:6689
 msgid "Endstops"
 msgstr "Endesensorer"
 
@@ -531,30 +530,30 @@ msgid "Engaging idler"
 msgstr "Aktiverer tomgangsh."
 
 #. MSG_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:3352
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:3362
 msgid "Extruder"
 msgstr "Ekstruder"
 
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/messages.cpp:227 ../../Firmware/ultralcd.cpp:1700
+#: ../../Firmware/messages.cpp:239 ../../Firmware/ultralcd.cpp:1710
 msgid "Extruder info"
 msgstr "Ekstruderinfo"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4044
-#: ../../Firmware/ultralcd.cpp:4051
+#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4068
+#: ../../Firmware/ultralcd.cpp:4075
 msgid "F. autoload"
 msgstr "F. autolast"
 
 #. MSG_FSENSOR_JAM_DETECTION c=13
-#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4046
-#: ../../Firmware/ultralcd.cpp:4053
+#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4070
+#: ../../Firmware/ultralcd.cpp:4077
 msgid "F. jam detect"
 msgstr "F. kork føle"
 
 #. MSG_FSENSOR_RUNOUT c=13
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4074
 msgid "F. runout"
 msgstr "F. Løput"
 
@@ -592,8 +591,8 @@ msgid "FINDA FILAM. STUCK"
 msgstr "FINDA FILAM. FAST"
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:4059
-#: ../../Firmware/ultralcd.cpp:4062
+#: ../../Firmware/messages.cpp:177 ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/ultralcd.cpp:4086
 msgid "FS Action"
 msgstr "FS aksjon"
 
@@ -618,34 +617,34 @@ msgid "FW RUNTIME ERROR"
 msgstr "FW RUNTIME FEIL"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/messages.cpp:330 ../../Firmware/ultralcd.cpp:5382
+#: ../../Firmware/messages.cpp:342 ../../Firmware/ultralcd.cpp:5349
 msgid "Fail stats"
 msgstr "Feilstatistikk"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/messages.cpp:331 ../../Firmware/ultralcd.cpp:5385
+#: ../../Firmware/messages.cpp:343 ../../Firmware/ultralcd.cpp:5352
 msgid "Fail stats MMU"
 msgstr "Feil stat. MMU"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/messages.cpp:355 ../../Firmware/ultralcd.cpp:6768
+#: ../../Firmware/messages.cpp:367 ../../Firmware/ultralcd.cpp:6744
 msgid "False triggering"
 msgstr "Falskt utløsning"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4175
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4199
 msgid "Fan speed"
 msgstr "Viftehastighet"
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6844
-#: ../../Firmware/ultralcd.cpp:6971 ../../Firmware/ultralcd.cpp:6972
-#: ../../Firmware/ultralcd.cpp:6973
+#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6820
+#: ../../Firmware/ultralcd.cpp:6948 ../../Firmware/ultralcd.cpp:6949
+#: ../../Firmware/ultralcd.cpp:6950
 msgid "Fan test"
 msgstr "Viftetest"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:4179
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:4203
 msgid "Fans check"
 msgstr "Viftesjekk"
 
@@ -674,34 +673,34 @@ msgid "Feeding to nozzle"
 msgstr "Mater til dyse"
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1233
-#: ../../Firmware/ultralcd.cpp:1262 ../../Firmware/ultralcd.cpp:1316
-#: ../../Firmware/ultralcd.cpp:1318
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:1243
+#: ../../Firmware/ultralcd.cpp:1272 ../../Firmware/ultralcd.cpp:1326
+#: ../../Firmware/ultralcd.cpp:1328
 msgid "Fil. runouts"
 msgstr "Tomt filament"
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3313
-#: ../../Firmware/ultralcd.cpp:4039 ../../Firmware/ultralcd.cpp:4464
-#: ../../Firmware/ultralcd.cpp:5532
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3323
+#: ../../Firmware/ultralcd.cpp:4063 ../../Firmware/ultralcd.cpp:4431
+#: ../../Firmware/ultralcd.cpp:5499
 msgid "Fil. sensor"
 msgstr "Fil. Sensor"
 
 #. MSG_FILAMENT_CLEAN c=20 r=3
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2261
-#: ../../Firmware/ultralcd.cpp:2265
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2275
+#: ../../Firmware/ultralcd.cpp:2279
 msgid "Filament extruding & with correct color?"
 msgstr "Kommer Filament ut og har riktig farge?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/messages.cpp:243 ../../Firmware/ultralcd.cpp:2204
+#: ../../Firmware/messages.cpp:255 ../../Firmware/ultralcd.cpp:2218
 msgid "Filament not loaded"
 msgstr "Fil. ikke lastet"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6763
-#: ../../Firmware/ultralcd.cpp:6767 ../../Firmware/ultralcd.cpp:6771
-#: ../../Firmware/ultralcd.cpp:7000
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6739
+#: ../../Firmware/ultralcd.cpp:6743 ../../Firmware/ultralcd.cpp:6747
+#: ../../Firmware/ultralcd.cpp:6977
 msgid "Filament sensor"
 msgstr "Filamentsensor"
 
@@ -733,40 +732,40 @@ msgstr ""
 "ingenting står fast i PTFE røret. Sjekk at sensoren leser riktig."
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/messages.cpp:246 ../../Firmware/ultralcd.cpp:2347
+#: ../../Firmware/messages.cpp:258 ../../Firmware/ultralcd.cpp:2364
 msgid "Filament used"
 msgstr "Brukt filament"
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/messages.cpp:363 ../../Firmware/ultralcd.cpp:7139
+#: ../../Firmware/messages.cpp:375 ../../Firmware/ultralcd.cpp:7116
 msgid "File incomplete. Continue anyway?"
 msgstr "Fil er ukomplett. Fortsette allikevel?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
 #: ../../Firmware/messages.cpp:45
 #: ../../Firmware/mmu2_progress_converter.cpp:43
-#: ../../Firmware/ultralcd.cpp:5021 ../../Firmware/ultralcd.cpp:5425
+#: ../../Firmware/ultralcd.cpp:4977 ../../Firmware/ultralcd.cpp:5392
 msgid "Finishing movements"
 msgstr "Avslutter bevegelser"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4575
-#: ../../Firmware/ultralcd.cpp:5141
+#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4531
+#: ../../Firmware/ultralcd.cpp:5101
 msgid "First layer cal."
 msgstr "Førstelagskal."
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/messages.cpp:293 ../../Firmware/ultralcd.cpp:3846
+#: ../../Firmware/messages.cpp:305 ../../Firmware/ultralcd.cpp:3872
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr "Først skal jeg kjøre en selvtest for å sjekke vanlige byggefeil."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/messages.cpp:334 ../../Firmware/ultralcd.cpp:5520
+#: ../../Firmware/messages.cpp:346 ../../Firmware/ultralcd.cpp:5487
 msgid "Flow"
 msgstr "Flyt"
 
 #. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
-#: ../../Firmware/messages.cpp:194 ../../Firmware/ultralcd.cpp:985
+#: ../../Firmware/messages.cpp:201 ../../Firmware/ultralcd.cpp:987
 msgid ""
 "For a Nozzle change please read\n"
 "prusa.io/nozzle-mk3s"
@@ -775,28 +774,28 @@ msgstr ""
 "prusa.io/nozzle-mk3s"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6733
-#: ../../Firmware/ultralcd.cpp:6850 ../../Firmware/ultralcd.cpp:6855
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/ultralcd.cpp:6826 ../../Firmware/ultralcd.cpp:6831
 msgid "Front print fan?"
 msgstr "Fremre printvifte?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/messages.cpp:260 ../../Firmware/ultralcd.cpp:2711
+#: ../../Firmware/messages.cpp:272 ../../Firmware/ultralcd.cpp:2728
 msgid "Front side[µm]"
 msgstr "Fremsiden [µm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/messages.cpp:353 ../../Firmware/ultralcd.cpp:6757
+#: ../../Firmware/messages.cpp:365 ../../Firmware/ultralcd.cpp:6733
 msgid "Front/left fans"
 msgstr "Fremre/venstre vifte"
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:151 ../../Firmware/util.cpp:382
+#: ../../Firmware/messages.cpp:156 ../../Firmware/util.cpp:417
 msgid "G-code sliced for a different level. Continue?"
 msgstr "G-code sliced for en annen høyde. Fortsette?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:152 ../../Firmware/util.cpp:383
+#: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:418
 msgid ""
 "G-code sliced for a different level. Please re-slice the model again. Print "
 "cancelled."
@@ -804,14 +803,14 @@ msgstr ""
 "G-code sliced for en annen høyde. Vennligst slice igjen. Print avbrutt."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:147 ../../Firmware/util.cpp:312
-#: ../../Firmware/util.cpp:401
+#: ../../Firmware/messages.cpp:152 ../../Firmware/util.cpp:319
+#: ../../Firmware/util.cpp:436
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr "G-code sliced for en annen printer. Fortsette?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:148 ../../Firmware/util.cpp:313
-#: ../../Firmware/util.cpp:402
+#: ../../Firmware/messages.cpp:153 ../../Firmware/util.cpp:320
+#: ../../Firmware/util.cpp:437
 msgid ""
 "G-code sliced for a different printer type. Please re-slice the model again."
 " Print cancelled."
@@ -819,12 +818,12 @@ msgstr ""
 "G-code sliced for en annen printer. Vennligst slice igjen. Print avbrutt."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:149 ../../Firmware/util.cpp:362
+#: ../../Firmware/messages.cpp:154 ../../Firmware/util.cpp:369
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "G-code sliced for nyere fastvare. Fortsette?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:150 ../../Firmware/util.cpp:363
+#: ../../Firmware/messages.cpp:155 ../../Firmware/util.cpp:370
 msgid ""
 "G-code sliced for a newer firmware. Please update the firmware. Print "
 "cancelled."
@@ -833,35 +832,35 @@ msgstr ""
 "avbrutt."
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4366
-#: ../../Firmware/ultralcd.cpp:4383 ../../Firmware/ultralcd.cpp:4485
+#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4325
+#: ../../Firmware/ultralcd.cpp:4343 ../../Firmware/ultralcd.cpp:4452
 msgid "HW Setup"
 msgstr "GW oppsett"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/messages.cpp:344 ../../Firmware/ultralcd.cpp:6705
+#: ../../Firmware/messages.cpp:356 ../../Firmware/ultralcd.cpp:6681
 msgid "Heater/Thermistor"
 msgstr "Varmer/Termistor"
 
 #. MSG_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6184 ../../Firmware/messages.cpp:52
+#: ../../Firmware/Marlin_main.cpp:5416 ../../Firmware/messages.cpp:52
 #: ../../Firmware/ultralcd.cpp:526
 msgid "Heating"
 msgstr "Varmer opp"
 
 #. MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:9647 ../../Firmware/messages.cpp:211
+#: ../../Firmware/Marlin_main.cpp:8807 ../../Firmware/messages.cpp:223
 msgid "Heating disabled by safety timer."
 msgstr "Varme skrudd av pga. sikkerhet."
 
 #. MSG_HEATING_COMPLETE c=20
-#: ../../Firmware/Marlin_main.cpp:6215 ../../Firmware/messages.cpp:53
+#: ../../Firmware/Marlin_main.cpp:5445 ../../Firmware/messages.cpp:53
 #: ../../Firmware/ultralcd.cpp:529
 msgid "Heating done."
 msgstr "Oppvarming ferdig."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=12
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:3806
+#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:3832
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -871,7 +870,7 @@ msgstr ""
 "oppsett, hvor Z aksen blir kalibrert. Du er da klar til å printe."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:3810
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:3836
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -880,8 +879,8 @@ msgstr ""
 "gjennom oppsettprosessen?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4152
-#: ../../Firmware/ultralcd.cpp:4161
+#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:4176
+#: ../../Firmware/ultralcd.cpp:4185
 msgid "High power"
 msgstr "Høy styrke"
 
@@ -892,23 +891,23 @@ msgid "Homing"
 msgstr "Søker"
 
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
-#: ../../Firmware/messages.cpp:195 ../../Firmware/ultralcd.cpp:1005
+#: ../../Firmware/messages.cpp:206 ../../Firmware/ultralcd.cpp:1011
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr "Hotend på 280C! Dyse byttet og strammet til spesifikasjonene?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1106
-#: ../../Firmware/ultralcd.cpp:6991
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1116
+#: ../../Firmware/ultralcd.cpp:6968
 msgid "Hotend fan:"
 msgstr "Hotend-vifte:"
 
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/messages.cpp:294 ../../Firmware/ultralcd.cpp:3851
+#: ../../Firmware/messages.cpp:306 ../../Firmware/ultralcd.cpp:3877
 msgid "I will run xyz calibration now. It will take up to 24 mins."
 msgstr "Nå skal jeg kjøre kalibreringen. Det kan ta opptil 24 min."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/messages.cpp:297 ../../Firmware/ultralcd.cpp:3862
+#: ../../Firmware/messages.cpp:309 ../../Firmware/ultralcd.cpp:3884
 msgid "I will run z calibration now."
 msgstr "Nå kjører jeg Z-kalibreringen."
 
@@ -933,7 +932,7 @@ msgid "INVALID TOOL"
 msgstr "UGYLDIG VERKTØY"
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=8
-#: ../../Firmware/messages.cpp:303 ../../Firmware/ultralcd.cpp:3931
+#: ../../Firmware/messages.cpp:315 ../../Firmware/ultralcd.cpp:3955
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -942,28 +941,28 @@ msgstr ""
 "Stålplater."
 
 #. MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2540
-#: ../../Firmware/messages.cpp:213
+#: ../../Firmware/mesh_bed_calibration.cpp:2525
+#: ../../Firmware/messages.cpp:225
 msgid "Improving bed calibration point"
 msgstr "Forbedrer seng kalibreringspunkt"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:5222
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:5184
 msgid "Info screen"
 msgstr "Infoskjerm"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/messages.cpp:326 ../../Firmware/ultralcd.cpp:5323
+#: ../../Firmware/messages.cpp:338 ../../Firmware/ultralcd.cpp:5289
 msgid "Init. SD card"
 msgstr "Init. SD kort"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/messages.cpp:238 ../../Firmware/ultralcd.cpp:2142
+#: ../../Firmware/messages.cpp:250 ../../Firmware/ultralcd.cpp:2148
 msgid "Insert filament"
 msgstr "Sett inn filament"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/messages.cpp:335 ../../Firmware/ultralcd.cpp:5998
+#: ../../Firmware/messages.cpp:347 ../../Firmware/ultralcd.cpp:5974
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
@@ -976,115 +975,115 @@ msgid ""
 msgstr "Intern runtime feil. Prøv omstart av MMU eller oppdater fastvaren."
 
 #. MSG_FILAMENT_LOADED c=20 r=3
-#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3628
-#: ../../Firmware/ultralcd.cpp:3890
+#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3638
+#: ../../Firmware/ultralcd.cpp:3914
 msgid "Is filament loaded?"
 msgstr "Er filament lastet?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3238 ../../Firmware/Marlin_main.cpp:4745
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:3858
+#: ../../Firmware/Marlin_main.cpp:4314 ../../Firmware/messages.cpp:127
+#: ../../Firmware/ultralcd.cpp:3760
 msgid "Is steel sheet on heatbed?"
 msgstr "Er stålplaten på varmesenga?"
 
 #. MSG_ITERATION c=12
-#: ../../Firmware/mesh_bed_calibration.cpp:2265 ../../Firmware/messages.cpp:55
+#: ../../Firmware/mesh_bed_calibration.cpp:2250 ../../Firmware/messages.cpp:55
 msgid "Iteration"
 msgstr "Iterasjon"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1128
-#: ../../Firmware/ultralcd.cpp:1286
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1138
+#: ../../Firmware/ultralcd.cpp:1296
 msgid "Last print"
 msgstr "Siste print"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1152
-#: ../../Firmware/ultralcd.cpp:1260 ../../Firmware/ultralcd.cpp:1315
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1162
+#: ../../Firmware/ultralcd.cpp:1270 ../../Firmware/ultralcd.cpp:1325
 msgid "Last print failures"
 msgstr "Siste printfeil"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/messages.cpp:251 ../../Firmware/ultralcd.cpp:2478
+#: ../../Firmware/messages.cpp:263 ../../Firmware/ultralcd.cpp:2495
 msgid "Left"
 msgstr "Venstre"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6739
-#: ../../Firmware/ultralcd.cpp:6850 ../../Firmware/ultralcd.cpp:6855
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6715
+#: ../../Firmware/ultralcd.cpp:6826 ../../Firmware/ultralcd.cpp:6831
 msgid "Left hotend fan?"
 msgstr "Venst. hotendvifte?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/messages.cpp:258 ../../Firmware/ultralcd.cpp:2709
+#: ../../Firmware/messages.cpp:270 ../../Firmware/ultralcd.cpp:2726
 msgid "Left side [µm]"
 msgstr "Vens. side[µm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:5619
+#: ../../Firmware/messages.cpp:181 ../../Firmware/ultralcd.cpp:5592
 msgid "Level Bright"
 msgstr "Nivå Lyst"
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:175 ../../Firmware/ultralcd.cpp:5620
+#: ../../Firmware/messages.cpp:182 ../../Firmware/ultralcd.cpp:5593
 msgid "Level Dimmed"
 msgstr "Nivå Dimmet"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/messages.cpp:312 ../../Firmware/ultralcd.cpp:4491
+#: ../../Firmware/messages.cpp:324 ../../Firmware/ultralcd.cpp:4458
 msgid "Lin. correction"
 msgstr "Lin. korreksjon"
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4501
-#: ../../Firmware/ultralcd.cpp:5251
+#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4468
+#: ../../Firmware/ultralcd.cpp:5213
 msgid "Live adjust Z"
 msgstr "Juster Live-Z"
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/messages.cpp:192 ../../Firmware/ultralcd.cpp:4794
-#: ../../Firmware/ultralcd.cpp:4880
+#: ../../Firmware/messages.cpp:199 ../../Firmware/ultralcd.cpp:4750
+#: ../../Firmware/ultralcd.cpp:4836
 msgid "Load All"
 msgstr "Last Alle"
 
 #. MSG_LOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4796
-#: ../../Firmware/ultralcd.cpp:4833 ../../Firmware/ultralcd.cpp:4882
-#: ../../Firmware/ultralcd.cpp:5361 ../../Firmware/ultralcd.cpp:5368
+#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4752
+#: ../../Firmware/ultralcd.cpp:4789 ../../Firmware/ultralcd.cpp:4838
+#: ../../Firmware/ultralcd.cpp:5324 ../../Firmware/ultralcd.cpp:5335
 msgid "Load filament"
 msgstr "Last inn filam."
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/messages.cpp:327 ../../Firmware/ultralcd.cpp:5346
+#: ../../Firmware/messages.cpp:339 ../../Firmware/ultralcd.cpp:5312
 msgid "Load to nozzle"
 msgstr "Last til dysen"
 
 #. MSG_LOADING_TEST c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4476
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4443
 msgid "Loading Test"
 msgstr "Lastetest"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/messages.cpp:241 ../../Firmware/ultralcd.cpp:2178
+#: ../../Firmware/messages.cpp:253 ../../Firmware/ultralcd.cpp:2189
 msgid "Loading color"
 msgstr "Laster farge"
 
 #. MSG_LOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3598 ../../Firmware/messages.cpp:62
+#: ../../Firmware/Marlin_main.cpp:3343 ../../Firmware/messages.cpp:62
 #: ../../Firmware/mmu2_progress_converter.cpp:51
-#: ../../Firmware/mmu2_reporting.cpp:392 ../../Firmware/ultralcd.cpp:2189
-#: ../../Firmware/ultralcd.cpp:3715
+#: ../../Firmware/mmu2_reporting.cpp:393 ../../Firmware/ultralcd.cpp:2199
+#: ../../Firmware/ultralcd.cpp:3725
 msgid "Loading filament"
 msgstr "Laster filament"
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/messages.cpp:350 ../../Firmware/ultralcd.cpp:6745
+#: ../../Firmware/messages.cpp:362 ../../Firmware/ultralcd.cpp:6721
 msgid "Loose pulley"
 msgstr "Løs reim"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4188
-#: ../../Firmware/ultralcd.cpp:4200
+#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4224
 msgid "Loud"
 msgstr "Høyt"
 
@@ -1099,7 +1098,7 @@ msgid "MMU Firmware internal error, please reset the MMU."
 msgstr "MMU fastvare intern feil, vennligst nullstill MMU-en."
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:4096
+#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4120
 msgid "MMU Mode"
 msgstr "MMU Mod."
 
@@ -1109,7 +1108,7 @@ msgid "MMU NOT RESPONDING"
 msgstr "MMU SVARER IKKE"
 
 #. MSG_MMU_RESTORE_TEMP c=20 r=4
-#: ../../Firmware/messages.cpp:214 ../../Firmware/mmu2_reporting.cpp:396
+#: ../../Firmware/messages.cpp:226 ../../Firmware/mmu2_reporting.cpp:397
 msgid "MMU Retry: Restoring temperature..."
 msgstr "MMU Retry: gjenoppretter temperatur..."
 
@@ -1120,14 +1119,14 @@ msgid "MMU SELFTEST FAILED"
 msgstr "MMU SELVTEST FEILET"
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1153
-#: ../../Firmware/ultralcd.cpp:1178
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1163
+#: ../../Firmware/ultralcd.cpp:1188
 msgid "MMU fails"
 msgstr "MMU feil"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1154
-#: ../../Firmware/ultralcd.cpp:1179
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1164
+#: ../../Firmware/ultralcd.cpp:1189
 msgid "MMU load fails"
 msgstr "MMU lastefeil"
 
@@ -1142,66 +1141,64 @@ msgid "MMU not responding. Check the wiring and connectors."
 msgstr "MMU svarer ikke. Sjekk ledninger og koblinger."
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/messages.cpp:223 ../../Firmware/ultralcd.cpp:1657
+#: ../../Firmware/messages.cpp:235 ../../Firmware/ultralcd.cpp:1667
 msgid "MMU connected"
 msgstr "MMU tilkoblet"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/messages.cpp:176 ../../Firmware/ultralcd.cpp:5567
 msgid "Magnets comp."
 msgstr "Magnet komp."
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1127
-#: ../../Firmware/ultralcd.cpp:1285 ../../Firmware/ultralcd.cpp:1327
-#: ../../Firmware/ultralcd.cpp:1631 ../../Firmware/ultralcd.cpp:4453
-#: ../../Firmware/ultralcd.cpp:4571 ../../Firmware/ultralcd.cpp:4793
-#: ../../Firmware/ultralcd.cpp:4826 ../../Firmware/ultralcd.cpp:4879
-#: ../../Firmware/ultralcd.cpp:5515
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1137
+#: ../../Firmware/ultralcd.cpp:1295 ../../Firmware/ultralcd.cpp:1337
+#: ../../Firmware/ultralcd.cpp:1641 ../../Firmware/ultralcd.cpp:4420
+#: ../../Firmware/ultralcd.cpp:4527 ../../Firmware/ultralcd.cpp:4749
+#: ../../Firmware/ultralcd.cpp:4782 ../../Firmware/ultralcd.cpp:4835
+#: ../../Firmware/ultralcd.cpp:5482
 msgid "Main"
 msgstr "Hovedmeny"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/messages.cpp:253 ../../Firmware/ultralcd.cpp:2519
+#: ../../Firmware/messages.cpp:265 ../../Firmware/ultralcd.cpp:2536
 msgid "Measured skew"
 msgstr "Målt skjevhet"
 
 #. MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3219
-#: ../../Firmware/mesh_bed_calibration.cpp:2852 ../../Firmware/messages.cpp:70
+#: ../../Firmware/Marlin_main.cpp:2963
+#: ../../Firmware/mesh_bed_calibration.cpp:2837 ../../Firmware/messages.cpp:70
 msgid "Measuring reference height of calibration point"
 msgstr "Måler referansehøyde for kalibreringspunkt"
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:5590
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:5563
 msgid "Mesh"
 msgstr "Plan-nett"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4488
-#: ../../Firmware/ultralcd.cpp:4587
+#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:4455
+#: ../../Firmware/ultralcd.cpp:4543
 msgid "Mesh Bed Leveling"
 msgstr "Sengeplanering"
 
 #. MSG_MODE c=6
-#: ../../Firmware/Marlin_main.cpp:8495 ../../Firmware/messages.cpp:117
-#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4132
-#: ../../Firmware/ultralcd.cpp:4140 ../../Firmware/ultralcd.cpp:4144
-#: ../../Firmware/ultralcd.cpp:4152 ../../Firmware/ultralcd.cpp:4155
-#: ../../Firmware/ultralcd.cpp:4158 ../../Firmware/ultralcd.cpp:4161
-#: ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/Marlin_main.cpp:7666 ../../Firmware/messages.cpp:121
+#: ../../Firmware/ultralcd.cpp:4152 ../../Firmware/ultralcd.cpp:4156
+#: ../../Firmware/ultralcd.cpp:4164 ../../Firmware/ultralcd.cpp:4168
+#: ../../Firmware/ultralcd.cpp:4176 ../../Firmware/ultralcd.cpp:4179
+#: ../../Firmware/ultralcd.cpp:4182 ../../Firmware/ultralcd.cpp:4185
+#: ../../Firmware/ultralcd.cpp:5594
 msgid "Mode"
 msgstr "Modus"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/messages.cpp:282 ../../Firmware/ultralcd.cpp:3413
+#: ../../Firmware/messages.cpp:294 ../../Firmware/ultralcd.cpp:3423
 msgid "Mode change in progress..."
 msgstr "Modus endres..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:4310
-#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4316
-#: ../../Firmware/ultralcd.cpp:4319
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4327
 msgid "Model"
 msgstr "Modell"
 
@@ -1222,28 +1219,28 @@ msgid "More details online."
 msgstr "Flere detaljer online"
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6719
-#: ../../Firmware/ultralcd.cpp:6728 ../../Firmware/ultralcd.cpp:6746
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6695
+#: ../../Firmware/ultralcd.cpp:6704 ../../Firmware/ultralcd.cpp:6722
 msgid "Motor"
 msgstr "Motor"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/messages.cpp:277 ../../Firmware/ultralcd.cpp:3349
+#: ../../Firmware/messages.cpp:289 ../../Firmware/ultralcd.cpp:3359
 msgid "Move X"
 msgstr "Beveg X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/messages.cpp:278 ../../Firmware/ultralcd.cpp:3350
+#: ../../Firmware/messages.cpp:290 ../../Firmware/ultralcd.cpp:3360
 msgid "Move Y"
 msgstr "Beveg Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/messages.cpp:279 ../../Firmware/ultralcd.cpp:3351
+#: ../../Firmware/messages.cpp:291 ../../Firmware/ultralcd.cpp:3361
 msgid "Move Z"
 msgstr "Beveg Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/messages.cpp:310 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:322 ../../Firmware/ultralcd.cpp:4426
 msgid "Move axis"
 msgstr "Beveg akse"
 
@@ -1254,95 +1251,92 @@ msgid "Moving selector"
 msgstr "Flytter velger"
 
 #. MSG_NA c=3
-#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:141
-#: ../../Firmware/ultralcd.cpp:2484 ../../Firmware/ultralcd.cpp:2528
-#: ../../Firmware/ultralcd.cpp:3279 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:4044 ../../Firmware/ultralcd.cpp:4046
-#: ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:146
+#: ../../Firmware/ultralcd.cpp:2501 ../../Firmware/ultralcd.cpp:2545
+#: ../../Firmware/ultralcd.cpp:3289 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4068 ../../Firmware/ultralcd.cpp:4070
+#: ../../Firmware/ultralcd.cpp:5567
 msgid "N/A"
 msgstr " -"
 
 #. MSG_NEW_FIRMWARE_AVAILABLE c=20 r=2
-#: ../../Firmware/messages.cpp:365 ../../Firmware/util.cpp:209
+#: ../../Firmware/messages.cpp:377 ../../Firmware/util.cpp:214
 msgid "New firmware version available:"
 msgstr "Ny fastvare tilgjengelig:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:3029
-#: ../../Firmware/ultralcd.cpp:4443 ../../Firmware/ultralcd.cpp:4531
-#: ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:2275
+#: ../../Firmware/ultralcd.cpp:2279 ../../Firmware/ultralcd.cpp:3046
+#: ../../Firmware/ultralcd.cpp:4410 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/ultralcd.cpp:5765
 msgid "No"
 msgstr "Nei"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/messages.cpp:325 ../../Firmware/ultralcd.cpp:5321
+#: ../../Firmware/messages.cpp:337 ../../Firmware/ultralcd.cpp:5287
 msgid "No SD card"
 msgstr "SD-kort mangler"
 
 #. MSG_NO_MOVE c=20
-#: ../../Firmware/Marlin_main.cpp:5271 ../../Firmware/messages.cpp:210
+#: ../../Firmware/Marlin_main.cpp:4778 ../../Firmware/messages.cpp:222
 msgid "No move."
 msgstr "Ingen bevegelse."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4239 ../../Firmware/ultralcd.cpp:4310
-#: ../../Firmware/ultralcd.cpp:4319 ../../Firmware/ultralcd.cpp:4349
-#: ../../Firmware/ultralcd.cpp:4358 ../../Firmware/ultralcd.cpp:4516
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4309
+#: ../../Firmware/ultralcd.cpp:4318 ../../Firmware/ultralcd.cpp:4483
 msgid "None"
 msgstr "Ingen"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/Marlin_main.cpp:8497 ../../Firmware/messages.cpp:121
-#: ../../Firmware/ultralcd.cpp:4096 ../../Firmware/ultralcd.cpp:4132
-#: ../../Firmware/ultralcd.cpp:4511
+#: ../../Firmware/Marlin_main.cpp:7668 ../../Firmware/messages.cpp:125
+#: ../../Firmware/ultralcd.cpp:4120 ../../Firmware/ultralcd.cpp:4156
+#: ../../Firmware/ultralcd.cpp:4478
 msgid "Normal"
 msgstr "Normal"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/messages.cpp:345 ../../Firmware/ultralcd.cpp:6706
+#: ../../Firmware/messages.cpp:357 ../../Firmware/ultralcd.cpp:6682
 msgid "Not connected"
 msgstr "Ikke tilkoblet"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6863
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6839
 msgid "Not spinning"
 msgstr "Spinner ikke"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/messages.cpp:289 ../../Firmware/ultralcd.cpp:3726
+#: ../../Firmware/messages.cpp:301 ../../Firmware/ultralcd.cpp:3736
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr "Jeg vil nå kalibrere avstanden mellom tuppen av dysen og varmeplaten."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/messages.cpp:298 ../../Firmware/ultralcd.cpp:3871
+#: ../../Firmware/messages.cpp:310 ../../Firmware/ultralcd.cpp:3894
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Jeg vil nå forvarme dysen for PLA."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/messages.cpp:296 ../../Firmware/ultralcd.cpp:3857
+#: ../../Firmware/messages.cpp:308 ../../Firmware/ultralcd.cpp:3883
 msgid "Now remove the test print from steel sheet."
 msgstr "Fjern nå testprintet fra stålplaten."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1390
-#: ../../Firmware/ultralcd.cpp:4170 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4233 ../../Firmware/ultralcd.cpp:4236
-#: ../../Firmware/ultralcd.cpp:4239
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1400
+#: ../../Firmware/ultralcd.cpp:4194 ../../Firmware/ultralcd.cpp:4326
 msgid "Nozzle"
 msgstr "Dyse"
 
 #. MSG_NOZZLE_CNG_MENU c=18
-#: ../../Firmware/messages.cpp:193 ../../Firmware/ultralcd.cpp:4423
-#: ../../Firmware/ultralcd.cpp:4486
+#: ../../Firmware/messages.cpp:200 ../../Firmware/ultralcd.cpp:4390
+#: ../../Firmware/ultralcd.cpp:4453
 msgid "Nozzle change"
 msgstr "Dysebytte"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4276
-#: ../../Firmware/ultralcd.cpp:4278 ../../Firmware/ultralcd.cpp:4279
-#: ../../Firmware/ultralcd.cpp:4280
+#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4261
+#: ../../Firmware/ultralcd.cpp:4263 ../../Firmware/ultralcd.cpp:4264
+#: ../../Firmware/ultralcd.cpp:4265
 msgid "Nozzle d."
 msgstr "Dyse diam."
 
@@ -1353,82 +1347,82 @@ msgid "OK"
 msgstr "OK"
 
 #. MSG_OFF c=3
-#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:139
-#: ../../Firmware/mmu2.cpp:65 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4050 ../../Firmware/ultralcd.cpp:4051
-#: ../../Firmware/ultralcd.cpp:4053 ../../Firmware/ultralcd.cpp:4076
-#: ../../Firmware/ultralcd.cpp:4091 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4179 ../../Firmware/ultralcd.cpp:4467
-#: ../../Firmware/ultralcd.cpp:4495 ../../Firmware/ultralcd.cpp:4498
-#: ../../Firmware/ultralcd.cpp:5439 ../../Firmware/ultralcd.cpp:5594
-#: ../../Firmware/ultralcd.cpp:7487 ../../Firmware/ultralcd.cpp:7491
+#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:144
+#: ../../Firmware/mmu2.cpp:65 ../../Firmware/ultralcd.cpp:4063
+#: ../../Firmware/ultralcd.cpp:4074 ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4077 ../../Firmware/ultralcd.cpp:4100
+#: ../../Firmware/ultralcd.cpp:4115 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/ultralcd.cpp:4203 ../../Firmware/ultralcd.cpp:4434
+#: ../../Firmware/ultralcd.cpp:4462 ../../Firmware/ultralcd.cpp:4465
+#: ../../Firmware/ultralcd.cpp:5406 ../../Firmware/ultralcd.cpp:5567
+#: ../../Firmware/ultralcd.cpp:7464 ../../Firmware/ultralcd.cpp:7468
 msgid "Off"
 msgstr "Av"
 
 #. MSG_DEFAULT_SETTINGS_LOADED c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:1562 ../../Firmware/messages.cpp:201
+#: ../../Firmware/Marlin_main.cpp:1489 ../../Firmware/messages.cpp:213
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr ""
 "Gamle verdier funnet Standarinnstillinger for PID, Esteg etc. blir satt."
 
 #. MSG_ON c=3
-#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:140
-#: ../../Firmware/mmu2.cpp:63 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4050 ../../Firmware/ultralcd.cpp:4051
-#: ../../Firmware/ultralcd.cpp:4053 ../../Firmware/ultralcd.cpp:4076
-#: ../../Firmware/ultralcd.cpp:4081 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4179 ../../Firmware/ultralcd.cpp:4467
-#: ../../Firmware/ultralcd.cpp:4495 ../../Firmware/ultralcd.cpp:4498
-#: ../../Firmware/ultralcd.cpp:5594 ../../Firmware/ultralcd.cpp:7487
-#: ../../Firmware/ultralcd.cpp:7491
+#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:145
+#: ../../Firmware/mmu2.cpp:63 ../../Firmware/ultralcd.cpp:4063
+#: ../../Firmware/ultralcd.cpp:4074 ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4077 ../../Firmware/ultralcd.cpp:4100
+#: ../../Firmware/ultralcd.cpp:4105 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/ultralcd.cpp:4203 ../../Firmware/ultralcd.cpp:4434
+#: ../../Firmware/ultralcd.cpp:4462 ../../Firmware/ultralcd.cpp:4465
+#: ../../Firmware/ultralcd.cpp:5567 ../../Firmware/ultralcd.cpp:7464
+#: ../../Firmware/ultralcd.cpp:7468
 msgid "On"
 msgstr "På"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4191
+#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:4215
 msgid "Once"
 msgstr "En gang"
 
 #. MSG_PAUSED_THERMAL_ERROR c=20
-#: ../../Firmware/Marlin_main.cpp:9861 ../../Firmware/messages.cpp:186
+#: ../../Firmware/Marlin_main.cpp:9021 ../../Firmware/messages.cpp:193
 msgid "PAUSED THERMAL ERROR"
 msgstr "PAUSET THERMISK FEIL"
 
 #. MSG_PID_RUNNING c=20
-#: ../../Firmware/messages.cpp:219 ../../Firmware/ultralcd.cpp:897
+#: ../../Firmware/messages.cpp:231 ../../Firmware/ultralcd.cpp:897
 msgid "PID cal."
 msgstr "PID kal."
 
 #. MSG_PID_FINISHED c=20
-#: ../../Firmware/messages.cpp:220 ../../Firmware/ultralcd.cpp:902
+#: ../../Firmware/messages.cpp:232 ../../Firmware/ultralcd.cpp:902
 msgid "PID cal. finished"
 msgstr "PID kal. ferdig"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:318 ../../Firmware/ultralcd.cpp:4590
+#: ../../Firmware/messages.cpp:330 ../../Firmware/ultralcd.cpp:4546
 msgid "PID calibration"
 msgstr "PID kalibrering"
 
 #. MSG_PINDA_PREHEAT c=20
-#: ../../Firmware/messages.cpp:218 ../../Firmware/ultralcd.cpp:610
+#: ../../Firmware/messages.cpp:230 ../../Firmware/ultralcd.cpp:610
 msgid "PINDA Heating"
 msgstr "PINDA varmes"
 
 #. MSG_PINDA_CALIBRATION c=13
-#: ../../Firmware/Marlin_main.cpp:4790 ../../Firmware/Marlin_main.cpp:4892
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:607
-#: ../../Firmware/ultralcd.cpp:4495 ../../Firmware/ultralcd.cpp:4597
+#: ../../Firmware/Marlin_main.cpp:4359 ../../Firmware/Marlin_main.cpp:4461
+#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:607
+#: ../../Firmware/ultralcd.cpp:4462 ../../Firmware/ultralcd.cpp:4553
 msgid "PINDA cal."
 msgstr "PINDA kal."
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/messages.cpp:276 ../../Firmware/ultralcd.cpp:3233
+#: ../../Firmware/messages.cpp:288 ../../Firmware/ultralcd.cpp:3243
 msgid "PINDA calibration failed"
 msgstr "PINDA kalibrering mislyktes"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:4967 ../../Firmware/messages.cpp:127
-#: ../../Firmware/ultralcd.cpp:3230
+#: ../../Firmware/Marlin_main.cpp:4536 ../../Firmware/messages.cpp:132
+#: ../../Firmware/ultralcd.cpp:3240
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1448,13 +1442,13 @@ msgid "Parking selector"
 msgstr "Parkerer velger"
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:4062
+#: ../../Firmware/messages.cpp:179 ../../Firmware/ultralcd.cpp:4086
 msgid "Pause"
 msgstr "Pause"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5271
-#: ../../Firmware/ultralcd.cpp:5273
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5237
+#: ../../Firmware/ultralcd.cpp:5239
 msgid "Pause print"
 msgstr "Pause printjobben"
 
@@ -1465,7 +1459,7 @@ msgid "Performing cut"
 msgstr "Utfører kutt"
 
 #. MSG_PAPER c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3243 ../../Firmware/messages.cpp:77
+#: ../../Firmware/Marlin_main.cpp:2982 ../../Firmware/messages.cpp:77
 msgid ""
 "Place a sheet of paper under the nozzle during the calibration of first 4 "
 "points. If the nozzle catches the paper, power off the printer immediately."
@@ -1474,7 +1468,7 @@ msgstr ""
 "dysen tar papiret, skru umiddelbart av printeren."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:3963
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:3987
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1483,34 +1477,34 @@ msgstr ""
 "omstarte printeren."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/messages.cpp:337 ../../Firmware/ultralcd.cpp:6023
+#: ../../Firmware/messages.cpp:349 ../../Firmware/ultralcd.cpp:5999
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr ""
 "Vennligst sjekk koblingen til IR sensorer. Last ut filament om lastet."
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/messages.cpp:343 ../../Firmware/ultralcd.cpp:6700
+#: ../../Firmware/messages.cpp:355 ../../Firmware/ultralcd.cpp:6676
 msgid "Please check:"
 msgstr "Venligst sjekk:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/messages.cpp:302 ../../Firmware/ultralcd.cpp:3926
+#: ../../Firmware/messages.cpp:314 ../../Firmware/ultralcd.cpp:3950
 msgid "Please clean heatbed and then press the knob."
 msgstr "Rengjør stålplaten og trykk valghjulet."
 
 #. MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3217 ../../Firmware/messages.cpp:27
+#: ../../Firmware/Marlin_main.cpp:2960 ../../Firmware/messages.cpp:28
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Rengjør dysen og trykk valghjulet."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/messages.cpp:288 ../../Firmware/ultralcd.cpp:3712
+#: ../../Firmware/messages.cpp:300 ../../Firmware/ultralcd.cpp:3722
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr "Sett inn filament I ekstruderen og trykk valghjulet for å laste."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/messages.cpp:287 ../../Firmware/ultralcd.cpp:3705
+#: ../../Firmware/messages.cpp:299 ../../Firmware/ultralcd.cpp:3715
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1519,105 +1513,104 @@ msgstr ""
 "laste."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/messages.cpp:285 ../../Firmware/ultralcd.cpp:3633
+#: ../../Firmware/messages.cpp:297 ../../Firmware/ultralcd.cpp:3643
 msgid "Please load filament first."
 msgstr "Vennligst sett inn filament først."
 
 #. MSG_CHECK_IDLER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3525 ../../Firmware/messages.cpp:206
+#: ../../Firmware/Marlin_main.cpp:3265 ../../Firmware/messages.cpp:218
 msgid "Please open idler and remove filament manually."
 msgstr "Åpne taljedøren og fjern filamentet for hånd."
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2806 ../../Firmware/messages.cpp:80
-#: ../../Firmware/ultralcd.cpp:3860
+#: ../../Firmware/mesh_bed_calibration.cpp:2791 ../../Firmware/messages.cpp:80
 msgid "Please place steel sheet on heatbed."
 msgstr "Plasser stålplaten på varmesenga."
 
 #. MSG_PRESS_TO_UNLOAD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:11215 ../../Firmware/Marlin_main.cpp:11245
+#: ../../Firmware/Marlin_main.cpp:10287 ../../Firmware/Marlin_main.cpp:10317
 #: ../../Firmware/messages.cpp:84
 msgid "Please press the knob to unload filament"
 msgstr "Trykk valghjulet for å ta ut filamentet"
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:4932
+#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:4888
 msgid "Please pull out filament immediately"
 msgstr "Trekk ut filamented med en gang"
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/messages.cpp:295 ../../Firmware/ultralcd.cpp:3856
+#: ../../Firmware/messages.cpp:307 ../../Firmware/ultralcd.cpp:3882
 msgid "Please remove shipping helpers first."
 msgstr "Vennligst fjern sendingsbeskyttelsen først."
 
 #. MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3240 ../../Firmware/Marlin_main.cpp:4755
-#: ../../Firmware/messages.cpp:89
+#: ../../Firmware/Marlin_main.cpp:4324 ../../Firmware/messages.cpp:89
 msgid "Please remove steel sheet from heatbed."
 msgstr "Vennligst ta stålplaten av varmesenga."
 
 #. MSG_RUN_XYZ c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4731 ../../Firmware/messages.cpp:207
+#: ../../Firmware/Marlin_main.cpp:4300 ../../Firmware/messages.cpp:219
 msgid "Please run XYZ calibration first."
 msgstr "Vennligst fullfør XYZ kalibreringen først."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/messages.cpp:336 ../../Firmware/ultralcd.cpp:6020
+#: ../../Firmware/messages.cpp:348 ../../Firmware/ultralcd.cpp:4359
+#: ../../Firmware/ultralcd.cpp:5996
 msgid "Please unload the filament first, then repeat this action."
 msgstr ""
 "Vennligst last ut filamentet først, deretter repeter denne handlingen."
 
 #. MSG_NEW_FIRMWARE_PLEASE_UPGRADE c=20
-#: ../../Firmware/messages.cpp:366 ../../Firmware/util.cpp:213
+#: ../../Firmware/messages.cpp:378 ../../Firmware/util.cpp:218
 msgid "Please upgrade."
 msgstr "Vennligst oppdater."
 
 #. MSG_PLEASE_WAIT c=20
-#: ../../Firmware/Marlin_main.cpp:3521 ../../Firmware/Marlin_main.cpp:8090
-#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:2179
-#: ../../Firmware/ultralcd.cpp:2190
+#: ../../Firmware/Marlin_main.cpp:3261 ../../Firmware/Marlin_main.cpp:7262
+#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:2190
+#: ../../Firmware/ultralcd.cpp:2204
 msgid "Please wait"
 msgstr "Vennligst vent"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:1232
-#: ../../Firmware/ultralcd.cpp:1261
+#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:1242
+#: ../../Firmware/ultralcd.cpp:1271
 msgid "Power failures"
 msgstr "Strømfeil"
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/messages.cpp:323 ../../Firmware/ultralcd.cpp:5260
+#: ../../Firmware/messages.cpp:335 ../../Firmware/ultralcd.cpp:5222
 msgid "Preheat"
 msgstr "Forvarming"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:2254
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:2268
 msgid "Preheat the nozzle!"
 msgstr "Forvarm dysen!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:2771
-#: ../../Firmware/ultralcd.cpp:3690 ../../Firmware/ultralcd.cpp:3692
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:2788
+#: ../../Firmware/ultralcd.cpp:3700 ../../Firmware/ultralcd.cpp:3702
 msgid "Preheating nozzle. Please wait."
 msgstr "Forvarmer dysen. Vennligst vent..."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/messages.cpp:237 ../../Firmware/ultralcd.cpp:1999
+#: ../../Firmware/messages.cpp:249 ../../Firmware/ultralcd.cpp:2005
 msgid "Preheating to cut"
 msgstr "Forvarmer for kutt"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/messages.cpp:236 ../../Firmware/ultralcd.cpp:1996
+#: ../../Firmware/messages.cpp:248 ../../Firmware/ultralcd.cpp:2002
 msgid "Preheating to eject"
 msgstr "Forvarmer for utmat."
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/messages.cpp:234 ../../Firmware/ultralcd.cpp:1987
+#: ../../Firmware/messages.cpp:246 ../../Firmware/ultralcd.cpp:1995
 msgid "Preheating to load"
 msgstr "Forvarmer for last"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/messages.cpp:235 ../../Firmware/ultralcd.cpp:1992
+#: ../../Firmware/messages.cpp:247 ../../Firmware/ultralcd.cpp:1999
 msgid "Preheating to unload"
 msgstr "Forvarmer for fil."
 
@@ -1628,12 +1621,12 @@ msgid "Preparing blade"
 msgstr "Forbereder blad"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/messages.cpp:231 ../../Firmware/ultralcd.cpp:1799
+#: ../../Firmware/messages.cpp:243 ../../Firmware/ultralcd.cpp:1809
 msgid "Press the knob"
 msgstr "Trykk valghjulet"
 
 #. MSG_PRESS_TO_PREHEAT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:11227 ../../Firmware/messages.cpp:212
+#: ../../Firmware/Marlin_main.cpp:10299 ../../Firmware/messages.cpp:224
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Trykk valghjulet for å forvarme dysen og fortsette."
 
@@ -1643,34 +1636,34 @@ msgid "Print aborted"
 msgstr "Print avbrutt"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1106
-#: ../../Firmware/ultralcd.cpp:6994
+#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1116
+#: ../../Firmware/ultralcd.cpp:6971
 msgid "Print fan:"
 msgstr "Printvifte:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:5313
+#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5279
 msgid "Print from SD"
 msgstr "Print fra SD-kort"
 
 #. MSG_PRINT_PAUSED c=20
-#: ../../Firmware/Marlin_main.cpp:3582 ../../Firmware/messages.cpp:79
+#: ../../Firmware/Marlin_main.cpp:3323 ../../Firmware/messages.cpp:79
 #: ../../Firmware/ultralcd.cpp:814
 msgid "Print paused"
 msgstr "Print satt på pause"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/messages.cpp:247 ../../Firmware/ultralcd.cpp:2348
+#: ../../Firmware/messages.cpp:259 ../../Firmware/ultralcd.cpp:2365
 msgid "Print time"
 msgstr "Printetid"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/messages.cpp:225 ../../Firmware/ultralcd.cpp:1689
+#: ../../Firmware/messages.cpp:237 ../../Firmware/ultralcd.cpp:1699
 msgid "Printer IP Addr:"
 msgstr "Printer IP adr.:"
 
 #. MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1602 ../../Firmware/messages.cpp:46
+#: ../../Firmware/Marlin_main.cpp:1529 ../../Firmware/messages.cpp:46
 msgid ""
 "Printer has not been calibrated yet. Please follow the manual, chapter First"
 " steps, section Calibration flow."
@@ -1678,12 +1671,12 @@ msgstr ""
 "Printeren er ikke kalibrert. Vennligst se manualen, under First Steps."
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:153 ../../Firmware/util.cpp:289
+#: ../../Firmware/messages.cpp:160 ../../Firmware/util.cpp:296
 msgid "Nozzle diameter differs from the G-code. Continue?"
 msgstr "Dysediameteren er forskjellig fra G-Code. Fortsette?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:154 ../../Firmware/util.cpp:290
+#: ../../Firmware/messages.cpp:161 ../../Firmware/util.cpp:297
 msgid ""
 "Nozzle diameter differs from the G-code. Please check the value in settings."
 " Print cancelled."
@@ -1708,22 +1701,22 @@ msgid "QUEUE FULL"
 msgstr "FULL KØ"
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:4465
 msgid "RPi port"
 msgstr "RPi port"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/messages.cpp:261 ../../Firmware/ultralcd.cpp:2712
+#: ../../Firmware/messages.cpp:273 ../../Firmware/ultralcd.cpp:2729
 msgid "Rear side [µm]"
 msgstr "Baksiden [µm]"
 
 #. MSG_RECOVERING_PRINT c=20
-#: ../../Firmware/messages.cpp:216 ../../Firmware/power_panic.cpp:316
+#: ../../Firmware/messages.cpp:228 ../../Firmware/power_panic.cpp:328
 msgid "Recovering print"
 msgstr "Gjenopptar print"
 
 #. MSG_RENAME c=18
-#: ../../Firmware/messages.cpp:322 ../../Firmware/ultralcd.cpp:5143
+#: ../../Firmware/messages.cpp:334 ../../Firmware/ultralcd.cpp:5103
 msgid "Rename"
 msgstr "Gi nytt navn"
 
@@ -1737,19 +1730,19 @@ msgstr ""
 "g-code for verktøys-inteks ut av rekkevidde (T0-T4)"
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:2713
-#: ../../Firmware/ultralcd.cpp:5144
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:2730
+#: ../../Firmware/ultralcd.cpp:5104
 msgid "Reset"
 msgstr "Nullstill"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/messages.cpp:320 ../../Firmware/ultralcd.cpp:4594
+#: ../../Firmware/messages.cpp:332 ../../Firmware/ultralcd.cpp:4550
 msgid "Reset XYZ calibr."
 msgstr "Nullstill XYZ kal."
 
 #. MSG_RESUME_PRINT c=18
-#: ../../Firmware/Marlin_main.cpp:680 ../../Firmware/messages.cpp:91
-#: ../../Firmware/ultralcd.cpp:5286 ../../Firmware/ultralcd.cpp:5288
+#: ../../Firmware/Marlin_main.cpp:645 ../../Firmware/messages.cpp:91
+#: ../../Firmware/ultralcd.cpp:5252 ../../Firmware/ultralcd.cpp:5254
 msgid "Resume print"
 msgstr "Gjenoppta print"
 
@@ -1776,17 +1769,17 @@ msgid "Returning selector"
 msgstr "Returnerer velger"
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/messages.cpp:252 ../../Firmware/ultralcd.cpp:2479
+#: ../../Firmware/messages.cpp:264 ../../Firmware/ultralcd.cpp:2496
 msgid "Right"
 msgstr "Høyre"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/messages.cpp:259 ../../Firmware/ultralcd.cpp:2710
+#: ../../Firmware/messages.cpp:271 ../../Firmware/ultralcd.cpp:2727
 msgid "Right side[µm]"
 msgstr "Høyre side[µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/messages.cpp:286 ../../Firmware/ultralcd.cpp:3656
+#: ../../Firmware/messages.cpp:298 ../../Firmware/ultralcd.cpp:3666
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1795,8 +1788,8 @@ msgstr ""
 "begynne på nytt. Fortsette?"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4509
-#: ../../Firmware/ultralcd.cpp:4511
+#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4476
+#: ../../Firmware/ultralcd.cpp:4478
 msgid "SD card"
 msgstr "SD-kort"
 
@@ -1811,48 +1804,48 @@ msgid "SELECTOR CANNOT MOVE"
 msgstr "SELEKTOR STÅR FAST"
 
 #. MSG_STOPPED c=20
-#: ../../Firmware/Marlin_main.cpp:9887 ../../Firmware/messages.cpp:125
+#: ../../Firmware/Marlin_main.cpp:9047 ../../Firmware/messages.cpp:130
 msgid "STOPPED."
 msgstr "STOPPET."
 
 #. MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3223 ../../Firmware/Marlin_main.cpp:3245
-#: ../../Firmware/mesh_bed_calibration.cpp:2246 ../../Firmware/messages.cpp:44
+#: ../../Firmware/Marlin_main.cpp:2967 ../../Firmware/Marlin_main.cpp:2984
+#: ../../Firmware/mesh_bed_calibration.cpp:2231 ../../Firmware/messages.cpp:44
 msgid "Searching bed calibration point"
 msgstr "Søker etter kalibreringspunkt"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/messages.cpp:321 ../../Firmware/ultralcd.cpp:5136
+#: ../../Firmware/messages.cpp:333 ../../Firmware/ultralcd.cpp:5096
 msgid "Select"
 msgstr "Velg"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/messages.cpp:290 ../../Firmware/ultralcd.cpp:3730
+#: ../../Firmware/messages.cpp:302 ../../Firmware/ultralcd.cpp:3740
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
 msgstr "Velg filamenttype for Førstelags- kalibrering."
 
 #. MSG_SELECT_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3453 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3612
-#: ../../Firmware/ultralcd.cpp:6822
+#: ../../Firmware/Marlin_main.cpp:3192 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3622
+#: ../../Firmware/ultralcd.cpp:6798
 msgid "Select filament:"
 msgstr "Velg filament:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:110 ../../Firmware/ultralcd.cpp:3464
-#: ../../Firmware/ultralcd.cpp:4504
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:3474
+#: ../../Firmware/ultralcd.cpp:4471
 msgid "Select language"
 msgstr "Velg språk"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/messages.cpp:300 ../../Firmware/ultralcd.cpp:3900
+#: ../../Firmware/messages.cpp:312 ../../Firmware/ultralcd.cpp:3924
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr "Velg dysetemperatur som passer ditt materiale."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/messages.cpp:291 ../../Firmware/ultralcd.cpp:3735
+#: ../../Firmware/messages.cpp:303 ../../Firmware/ultralcd.cpp:3745
 msgid "Select temperature which matches your material."
 msgstr "Velg temperaturen som passer ditt materiale."
 
@@ -1863,62 +1856,62 @@ msgid "Selecting fil. slot"
 msgstr "Velger fil. spor"
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/messages.cpp:341 ../../Firmware/ultralcd.cpp:6274
+#: ../../Firmware/messages.cpp:353 ../../Firmware/ultralcd.cpp:6250
 msgid "Selftest OK"
 msgstr "Selvtest OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/messages.cpp:340 ../../Firmware/ultralcd.cpp:6057
+#: ../../Firmware/messages.cpp:352 ../../Firmware/ultralcd.cpp:6033
 msgid "Selftest start"
 msgstr "Selvtest starter"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/messages.cpp:315 ../../Firmware/ultralcd.cpp:4581
+#: ../../Firmware/messages.cpp:327 ../../Firmware/ultralcd.cpp:4537
 msgid "Selftest"
 msgstr "Selvtest"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/messages.cpp:342 ../../Firmware/ultralcd.cpp:6699
+#: ../../Firmware/messages.cpp:354 ../../Firmware/ultralcd.cpp:6675
 msgid "Selftest error!"
 msgstr "Selvtest feil!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6279
-#: ../../Firmware/ultralcd.cpp:6786 ../../Firmware/ultralcd.cpp:6984
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6255
+#: ../../Firmware/ultralcd.cpp:6762 ../../Firmware/ultralcd.cpp:6961
 msgid "Selftest failed"
 msgstr "Selvtest feilet"
 
 #. MSG_FORCE_SELFTEST c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1577 ../../Firmware/messages.cpp:202
+#: ../../Firmware/Marlin_main.cpp:1504 ../../Firmware/messages.cpp:214
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr ""
 "Selvtest vil bli kjørt for å kalibrere nøyaktig sensorløs hjemposisjon."
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/messages.cpp:228 ../../Firmware/ultralcd.cpp:1701
+#: ../../Firmware/messages.cpp:240 ../../Firmware/ultralcd.cpp:1711
 msgid "Sensor info"
 msgstr "Sensorinformasjon"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/messages.cpp:338 ../../Firmware/ultralcd.cpp:6027
+#: ../../Firmware/messages.cpp:350 ../../Firmware/ultralcd.cpp:6003
 msgid "Sensor verified, remove the filament now."
 msgstr "Sensor verifiserte, fjern filamentet nå."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/messages.cpp:262 ../../Firmware/ultralcd.cpp:2730
+#: ../../Firmware/messages.cpp:274 ../../Firmware/ultralcd.cpp:2747
 msgid "Set temperature:"
 msgstr "Satt temperatur:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3348
-#: ../../Firmware/ultralcd.cpp:3479 ../../Firmware/ultralcd.cpp:3984
-#: ../../Firmware/ultralcd.cpp:5374 ../../Firmware/ultralcd.cpp:5585
-#: ../../Firmware/ultralcd.cpp:5631
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3358
+#: ../../Firmware/ultralcd.cpp:3489 ../../Firmware/ultralcd.cpp:4008
+#: ../../Firmware/ultralcd.cpp:5341 ../../Firmware/ultralcd.cpp:5558
+#: ../../Firmware/ultralcd.cpp:5604
 msgid "Settings"
 msgstr "Innstillinger"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/messages.cpp:255 ../../Firmware/ultralcd.cpp:2522
+#: ../../Firmware/messages.cpp:267 ../../Firmware/ultralcd.cpp:2539
 msgid "Severe skew"
 msgstr "Stor skjevhet"
 
@@ -1929,7 +1922,7 @@ msgid "Sheet"
 msgstr "Plate"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/messages.cpp:284 ../../Firmware/ultralcd.cpp:3604
+#: ../../Firmware/messages.cpp:296 ../../Firmware/ultralcd.cpp:3614
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1942,82 +1935,82 @@ msgstr ""
 "%cNullstill"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/messages.cpp:319 ../../Firmware/ultralcd.cpp:4592
+#: ../../Firmware/messages.cpp:331 ../../Firmware/ultralcd.cpp:4548
 msgid "Show end stops"
 msgstr "Vis endesensorer"
 
 #. MSG_SILENT c=7
-#: ../../Firmware/Marlin_main.cpp:8497 ../../Firmware/messages.cpp:120
-#: ../../Firmware/ultralcd.cpp:4155 ../../Firmware/ultralcd.cpp:4194
+#: ../../Firmware/Marlin_main.cpp:7668 ../../Firmware/messages.cpp:124
+#: ../../Firmware/ultralcd.cpp:4179 ../../Firmware/ultralcd.cpp:4218
 msgid "Silent"
 msgstr "Lydløs"
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/messages.cpp:254 ../../Firmware/ultralcd.cpp:2521
+#: ../../Firmware/messages.cpp:266 ../../Firmware/ultralcd.cpp:2538
 msgid "Slight skew"
 msgstr "Lett skjevhet"
 
 #. MSG_FILE_CNT c=20 r=6
-#: ../../Firmware/cardreader.cpp:805 ../../Firmware/messages.cpp:197
+#: ../../Firmware/cardreader.cpp:805 ../../Firmware/messages.cpp:209
 msgid ""
 "Some files will not be sorted. Max. No. of files in 1 folder for sorting is "
 "100."
 msgstr "Noen filer vil ikke bli sortert. Maks antall filer i en mappe er 100."
 
 #. MSG_ZLEVELING_ENFORCED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3043 ../../Firmware/messages.cpp:204
+#: ../../Firmware/Marlin_main.cpp:2783 ../../Firmware/messages.cpp:216
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Problem møtt. Z aksjeplanering tvunget ..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:4514
-#: ../../Firmware/ultralcd.cpp:4515 ../../Firmware/ultralcd.cpp:4516
+#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4481
+#: ../../Firmware/ultralcd.cpp:4482 ../../Firmware/ultralcd.cpp:4483
 msgid "Sort"
 msgstr "Sorter"
 
 #. MSG_SORTING_FILES c=20
 #: ../../Firmware/cardreader.cpp:849 ../../Firmware/cardreader.cpp:916
-#: ../../Firmware/messages.cpp:111
+#: ../../Firmware/messages.cpp:115
 msgid "Sorting files"
 msgstr "Sorter filer"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4188
-#: ../../Firmware/ultralcd.cpp:4191 ../../Firmware/ultralcd.cpp:4194
-#: ../../Firmware/ultralcd.cpp:4197 ../../Firmware/ultralcd.cpp:4200
+#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4215 ../../Firmware/ultralcd.cpp:4218
+#: ../../Firmware/ultralcd.cpp:4221 ../../Firmware/ultralcd.cpp:4224
 msgid "Sound"
 msgstr "Lyd"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/messages.cpp:333 ../../Firmware/ultralcd.cpp:5516
+#: ../../Firmware/messages.cpp:345 ../../Firmware/ultralcd.cpp:5483
 msgid "Speed"
 msgstr "Hastighet"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6861
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6837
 msgid "Spinning"
 msgstr "Spinner"
 
 #. MSG_TEMP_CAL_WARNING c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4744 ../../Firmware/messages.cpp:208
+#: ../../Firmware/Marlin_main.cpp:4313 ../../Firmware/messages.cpp:220
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr ""
 "En stabil rom- temperatur på 21-26C og et solid underlag er nødvendig."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/messages.cpp:329 ../../Firmware/ultralcd.cpp:5379
+#: ../../Firmware/messages.cpp:341 ../../Firmware/ultralcd.cpp:5346
 msgid "Statistics"
 msgstr "Statistikk"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:4096
-#: ../../Firmware/ultralcd.cpp:4144
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4120
+#: ../../Firmware/ultralcd.cpp:4168
 msgid "Stealth"
 msgstr "Stille"
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4421
-#: ../../Firmware/ultralcd.cpp:5133
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4388
+#: ../../Firmware/ultralcd.cpp:5093
 msgid "Steel sheets"
 msgstr "Stål plate"
 
@@ -2027,29 +2020,28 @@ msgid "Stop"
 msgstr "Stop"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:5293
-#: ../../Firmware/ultralcd.cpp:5781
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:5259
+#: ../../Firmware/ultralcd.cpp:5757
 msgid "Stop print"
 msgstr "Stopp printjobb"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4236
-#: ../../Firmware/ultralcd.cpp:4316 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4315
 msgid "Strict"
 msgstr "Streng"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/messages.cpp:332 ../../Firmware/ultralcd.cpp:5394
+#: ../../Firmware/messages.cpp:344 ../../Firmware/ultralcd.cpp:5361
 msgid "Support"
 msgstr "System info"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/messages.cpp:354 ../../Firmware/ultralcd.cpp:6758
+#: ../../Firmware/messages.cpp:366 ../../Firmware/ultralcd.cpp:6734
 msgid "Swapped"
 msgstr "Byttet"
 
 #. MSG_THERMAL_ANOMALY c=20
-#: ../../Firmware/messages.cpp:188 ../../Firmware/temperature.cpp:2223
+#: ../../Firmware/messages.cpp:195 ../../Firmware/temperature.cpp:2197
 msgid "THERMAL ANOMALY"
 msgstr "THERMISK ANOMALI"
 
@@ -2084,7 +2076,7 @@ msgid "TMC UNDERVOLTAGE ERR"
 msgstr "TMC LAVSPENNING FEIL"
 
 #. MSG_TM_CAL c=20 r=4
-#: ../../Firmware/messages.cpp:299 ../../Firmware/ultralcd.cpp:3881
+#: ../../Firmware/messages.cpp:311 ../../Firmware/ultralcd.cpp:3905
 msgid ""
 "Thermal model cal. takes approx. 12 mins. See\n"
 "prusa.io/tm-cal"
@@ -2093,22 +2085,22 @@ msgstr ""
 "prusa.io/tm-cal"
 
 #. MSG_TM_NOT_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1613 ../../Firmware/messages.cpp:189
+#: ../../Firmware/Marlin_main.cpp:1540 ../../Firmware/messages.cpp:196
 msgid "Thermal model not calibrated yet."
 msgstr "Termisk modell ikke kalibrert enda."
 
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/messages.cpp:309 ../../Firmware/ultralcd.cpp:4455
+#: ../../Firmware/messages.cpp:321 ../../Firmware/ultralcd.cpp:4422
 msgid "Temperature"
 msgstr "Temperatur"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/messages.cpp:229 ../../Firmware/ultralcd.cpp:1707
+#: ../../Firmware/messages.cpp:241 ../../Firmware/ultralcd.cpp:1717
 msgid "Temperatures"
 msgstr "Temperaturer"
 
 #. MSG_TESTING_FILAMENT c=20
-#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:388
+#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:389
 msgid "Testing filament"
 msgstr "Tester filament"
 
@@ -2127,7 +2119,7 @@ msgstr ""
 "Velgeren kan ikke gå hjem riktig. sjekk om noe står i veien for bevegelsen."
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/messages.cpp:292 ../../Firmware/ultralcd.cpp:3738
+#: ../../Firmware/messages.cpp:304 ../../Firmware/ultralcd.cpp:3748
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -2138,7 +2130,7 @@ msgstr ""
 "skal se ut."
 
 #. MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1606 ../../Firmware/messages.cpp:47
+#: ../../Firmware/Marlin_main.cpp:1533 ../../Firmware/messages.cpp:47
 msgid ""
 "There is still a need to make Z calibration. Please follow the manual, "
 "chapter First steps, section Calibration flow."
@@ -2147,40 +2139,40 @@ msgstr ""
 "hovedmenyen og følg Veilederen."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:4514
+#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:4481
 msgid "Time"
 msgstr "Dato"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:176 ../../Firmware/ultralcd.cpp:5622
+#: ../../Firmware/messages.cpp:183 ../../Firmware/ultralcd.cpp:5595
 msgid "Timeout"
 msgstr "Tidsavbrudd"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:1129
-#: ../../Firmware/ultralcd.cpp:1287
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:1139
+#: ../../Firmware/ultralcd.cpp:1297
 msgid "Total"
 msgstr "Totalt"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:1177
-#: ../../Firmware/ultralcd.cpp:1231 ../../Firmware/ultralcd.cpp:1317
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:1187
+#: ../../Firmware/ultralcd.cpp:1241 ../../Firmware/ultralcd.cpp:1327
 msgid "Total failures"
 msgstr "Feil totalt"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/messages.cpp:248 ../../Firmware/ultralcd.cpp:2369
+#: ../../Firmware/messages.cpp:260 ../../Firmware/ultralcd.cpp:2386
 msgid "Total filament"
 msgstr "Filament totalt"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/messages.cpp:249 ../../Firmware/ultralcd.cpp:2370
+#: ../../Firmware/messages.cpp:261 ../../Firmware/ultralcd.cpp:2387
 msgid "Total print time"
 msgstr "Printetid totalt"
 
 #. MSG_TUNE c=8
-#: ../../Firmware/messages.cpp:116 ../../Firmware/mmu2/errors_list.h:372
-#: ../../Firmware/ultralcd.cpp:5258
+#: ../../Firmware/messages.cpp:120 ../../Firmware/mmu2/errors_list.h:372
+#: ../../Firmware/ultralcd.cpp:5220
 msgid "Tune"
 msgstr "Juster"
 
@@ -2195,16 +2187,16 @@ msgid "Unload"
 msgstr "Last ut"
 
 #. MSG_UNLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:2206
-#: ../../Firmware/ultralcd.cpp:5347 ../../Firmware/ultralcd.cpp:5364
-#: ../../Firmware/ultralcd.cpp:5369
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:2220
+#: ../../Firmware/ultralcd.cpp:5313 ../../Firmware/ultralcd.cpp:5331
+#: ../../Firmware/ultralcd.cpp:5336
 msgid "Unload filament"
 msgstr "Last ut filament"
 
 #. MSG_UNLOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3436 ../../Firmware/messages.cpp:129
+#: ../../Firmware/Marlin_main.cpp:3175 ../../Firmware/messages.cpp:134
 #: ../../Firmware/mmu2_progress_converter.cpp:50
-#: ../../Firmware/ultralcd.cpp:4911
+#: ../../Firmware/ultralcd.cpp:4867
 msgid "Unloading filament"
 msgstr "Laster ut filament"
 
@@ -2221,12 +2213,12 @@ msgid "Unloading to pulley"
 msgstr "Utlaster til trinse"
 
 #. MSG_FIL_FAILED c=20 r=4
-#: ../../Firmware/messages.cpp:339 ../../Firmware/ultralcd.cpp:6030
+#: ../../Firmware/messages.cpp:351 ../../Firmware/ultralcd.cpp:6006
 msgid "Verification failed, remove the filament and try again."
 msgstr "Verifisering feilet. Fjern filamentet og prøv igjen."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/messages.cpp:230 ../../Firmware/ultralcd.cpp:1710
+#: ../../Firmware/messages.cpp:242 ../../Firmware/ultralcd.cpp:1720
 msgid "Voltages"
 msgstr "Strøm/Volt"
 
@@ -2237,7 +2229,7 @@ msgid "WARNING TMC TOO HOT"
 msgstr "VARSEL TMC FOR VARM"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/messages.cpp:281 ../../Firmware/ultralcd.cpp:3381
+#: ../../Firmware/messages.cpp:293 ../../Firmware/ultralcd.cpp:3391
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -2250,187 +2242,187 @@ msgstr ""
 "Stillemodus"
 
 #. MSG_USERWAIT c=20
-#: ../../Firmware/Marlin_main.cpp:5240 ../../Firmware/messages.cpp:209
+#: ../../Firmware/Marlin_main.cpp:4747 ../../Firmware/messages.cpp:221
 msgid "Wait for user..."
 msgstr "Venter på bruker..."
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/messages.cpp:263 ../../Firmware/ultralcd.cpp:2753
+#: ../../Firmware/messages.cpp:275 ../../Firmware/ultralcd.cpp:2770
 msgid "Waiting for PINDA probe cooling"
 msgstr "Venter på PINDA nedkjøling"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/messages.cpp:264 ../../Firmware/ultralcd.cpp:2782
+#: ../../Firmware/messages.cpp:276 ../../Firmware/ultralcd.cpp:2799
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Venter på dyse- og platenedkjøling"
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:4233
-#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4352
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4312
 msgid "Warn"
 msgstr "Advarsel"
 
 #. MSG_CHANGED_BOTH c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1554 ../../Firmware/messages.cpp:200
+#: ../../Firmware/Marlin_main.cpp:1481 ../../Firmware/messages.cpp:212
 msgid "Warning: both printer type and motherboard type changed."
 msgstr "Advarsel: Både printertype og hovedkortype er forandret."
 
 #. MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1546 ../../Firmware/messages.cpp:198
+#: ../../Firmware/Marlin_main.cpp:1473 ../../Firmware/messages.cpp:210
 msgid "Warning: motherboard type changed."
 msgstr "Advarsel: Hovedkortype forandret."
 
 #. MSG_CHANGED_PRINTER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1550 ../../Firmware/messages.cpp:199
+#: ../../Firmware/Marlin_main.cpp:1477 ../../Firmware/messages.cpp:211
 msgid "Warning: printer type changed."
 msgstr "Advarsel: Printertype forandret."
 
 #. MSG_UNLOAD_SUCCESSFUL c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3517 ../../Firmware/messages.cpp:205
+#: ../../Firmware/Marlin_main.cpp:3257 ../../Firmware/messages.cpp:217
 msgid "Was filament unload successful?"
 msgstr "Ble filamentet lastet helt ut?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:6710
-#: ../../Firmware/ultralcd.cpp:6714 ../../Firmware/ultralcd.cpp:6734
-#: ../../Firmware/ultralcd.cpp:6740 ../../Firmware/ultralcd.cpp:6764
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:6686
+#: ../../Firmware/ultralcd.cpp:6690 ../../Firmware/ultralcd.cpp:6710
+#: ../../Firmware/ultralcd.cpp:6716 ../../Firmware/ultralcd.cpp:6740
 msgid "Wiring error"
 msgstr "Koblingsfeil"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/messages.cpp:313 ../../Firmware/ultralcd.cpp:4572
+#: ../../Firmware/messages.cpp:325 ../../Firmware/ultralcd.cpp:4528
 msgid "Wizard"
 msgstr "Veileder"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/messages.cpp:304 ../../Firmware/ultralcd.cpp:3986
+#: ../../Firmware/messages.cpp:316 ../../Firmware/ultralcd.cpp:4010
 msgid "X-correct"
 msgstr "X-korreksjon"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/messages.cpp:226 ../../Firmware/ultralcd.cpp:1699
+#: ../../Firmware/messages.cpp:238 ../../Firmware/ultralcd.cpp:1709
 msgid "XYZ cal. details"
 msgstr "XYZ cal. detaljer"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/messages.cpp:275 ../../Firmware/ultralcd.cpp:3207
+#: ../../Firmware/messages.cpp:287 ../../Firmware/ultralcd.cpp:3217
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr "XYZ kalibreringen er grei. Skjevhet blir justert automatisk."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/messages.cpp:274 ../../Firmware/ultralcd.cpp:3204
+#: ../../Firmware/messages.cpp:286 ../../Firmware/ultralcd.cpp:3214
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr "XYZ kalibreringen er god. Godt jobba!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/messages.cpp:271 ../../Firmware/ultralcd.cpp:3185
+#: ../../Firmware/messages.cpp:283 ../../Firmware/ultralcd.cpp:3195
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr "XYZ kalibreringen feilet. Front kalibreringspunkt ikke nådd."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/messages.cpp:272 ../../Firmware/ultralcd.cpp:3188
+#: ../../Firmware/messages.cpp:284 ../../Firmware/ultralcd.cpp:3198
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr "XYZ kalibreringen feilet. Høyre front kalibreringspunkt ikke nådd."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/messages.cpp:268 ../../Firmware/ultralcd.cpp:3167
+#: ../../Firmware/messages.cpp:280 ../../Firmware/ultralcd.cpp:3177
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr "XYZ kalibreringen feilet. Kalibreringspunkt ikke funnet."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/messages.cpp:269 ../../Firmware/ultralcd.cpp:3173
+#: ../../Firmware/messages.cpp:281 ../../Firmware/ultralcd.cpp:3183
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr "XYZ kalibreringen feilet. Front kalibreringspunkt ikke nådd."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3170
-#: ../../Firmware/ultralcd.cpp:3198
+#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3180
+#: ../../Firmware/ultralcd.cpp:3208
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "XYZ kal. mislyktes. Vennligst rådfør med håndboken."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/messages.cpp:270 ../../Firmware/ultralcd.cpp:3176
+#: ../../Firmware/messages.cpp:282 ../../Firmware/ultralcd.cpp:3186
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr "XYZ kalibreringen feilet. Høyre front kalibreringspunkt ikke nådd."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/messages.cpp:273 ../../Firmware/ultralcd.cpp:3201
+#: ../../Firmware/messages.cpp:285 ../../Firmware/ultralcd.cpp:3211
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr ""
 "XYZ kalibrering OK.\n"
 "X og Y aksen er perpendikulær. Gratulerer!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/messages.cpp:250 ../../Firmware/ultralcd.cpp:2476
+#: ../../Firmware/messages.cpp:262 ../../Firmware/ultralcd.cpp:2493
 msgid "Y distance from min"
 msgstr "Y distanse fra min."
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/messages.cpp:305 ../../Firmware/ultralcd.cpp:3987
+#: ../../Firmware/messages.cpp:317 ../../Firmware/ultralcd.cpp:4011
 msgid "Y-correct"
 msgstr "Y-korreksjon"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:3029
-#: ../../Firmware/ultralcd.cpp:4443 ../../Firmware/ultralcd.cpp:4531
-#: ../../Firmware/ultralcd.cpp:5790
+#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:2275
+#: ../../Firmware/ultralcd.cpp:2279 ../../Firmware/ultralcd.cpp:3046
+#: ../../Firmware/ultralcd.cpp:4410 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/ultralcd.cpp:5766
 msgid "Yes"
 msgstr "Ja"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:3950
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:3974
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr "Du kan alltid starte Veilederen fra Kalibrering -> Veileder."
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/messages.cpp:306 ../../Firmware/ultralcd.cpp:3988
+#: ../../Firmware/messages.cpp:318 ../../Firmware/ultralcd.cpp:4012
 msgid "Z-correct"
 msgstr "Z-korreksjon"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5593
+#: ../../Firmware/messages.cpp:175 ../../Firmware/ultralcd.cpp:5566
 msgid "Z-probe nr."
 msgstr "Z-sensor nr."
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/messages.cpp:256 ../../Firmware/ultralcd.cpp:2546
+#: ../../Firmware/messages.cpp:268 ../../Firmware/ultralcd.cpp:2563
 msgid "[0;0] point offset"
 msgstr "[0;0] punktforskyv."
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/messages.cpp:239 ../../Firmware/ultralcd.cpp:2147
+#: ../../Firmware/messages.cpp:251 ../../Firmware/ultralcd.cpp:2158
 msgid "and press the knob"
 msgstr "og trykk på knappen"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/messages.cpp:232 ../../Firmware/ultralcd.cpp:1807
+#: ../../Firmware/messages.cpp:244 ../../Firmware/ultralcd.cpp:1816
 msgid "to load filament"
 msgstr "for filamentlast"
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/messages.cpp:233 ../../Firmware/ultralcd.cpp:1811
+#: ../../Firmware/messages.cpp:245 ../../Firmware/ultralcd.cpp:1820
 msgid "to unload filament"
 msgstr "for filament ut"
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/messages.cpp:224 ../../Firmware/ultralcd.cpp:1666
+#: ../../Firmware/messages.cpp:236 ../../Firmware/ultralcd.cpp:1676
 msgid "unknown"
 msgstr "ukjent"
 
 #. MSG_IR_UNKNOWN c=18
-#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:184
+#: ../../Firmware/Filament_sensor.cpp:286 ../../Firmware/messages.cpp:191
 msgid "unknown state"
 msgstr "ukjent tilstand"
 
 #. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:5858
-#: ../../Firmware/ultralcd.cpp:5861
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:5834
+#: ../../Firmware/ultralcd.cpp:5837
 msgid "🔃Refresh"
 msgstr "🔃Forfriske"
 
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1180
+#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1190
 msgid "MMU power fails"
 msgstr "MMU strøm feil"
 
@@ -2468,8 +2460,8 @@ msgid "MMU MCU ERROR"
 msgstr "MMU MCU FEIL"
 
 #. MSG_MATERIAL_CHANGES c=18
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:1130
-#: ../../Firmware/ultralcd.cpp:1204
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:1140
+#: ../../Firmware/ultralcd.cpp:1214
 msgid "Material changes"
 msgstr "Materialutveksling"
 
@@ -2501,17 +2493,17 @@ msgstr ""
 "versjon 3.0.3."
 
 #. MSG_PRELOAD_TO_MMU c=17
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5344
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5310
 msgid "Preload to MMU"
 msgstr "Forlast til MMU"
 
 #. MSG_FW_MK3_DETECTED c=20 r=4
-#: ../../Firmware/messages.cpp:367 ../../Firmware/Marlin_main.cpp:920
+#: ../../Firmware/messages.cpp:379 ../../Firmware/Marlin_main.cpp:854
 msgid "MK3 firmware detected on MK3S printer"
 msgstr "MK3 system funnet på MK3S printer"
 
 #. MSG_FW_MK3S_DETECTED c=20 r=4
-#: ../../Firmware/messages.cpp:367 ../../Firmware/Marlin_main.cpp:920
+#: ../../Firmware/messages.cpp:379 ../../Firmware/Marlin_main.cpp:854
 msgid "MK3S firmware detected on MK3 printer"
 msgstr "MK3S systemvare funnet på MK3 printer"
 
@@ -2525,8 +2517,9 @@ msgstr "UKJENT FEIL"
 msgid "Unexpected error occurred."
 msgstr "Det oppstod en uventet feil."
 
-#. MSG_BTN_EJECT c=8
-#: ../../Firmware/mmu2/errors_list.h:358 ../../Firmware/mmu2/errors_list.h:371
+#. MSG_EJECT c=8
+#: ../../Firmware/messages.cpp:21 ../../Firmware/mmu2/errors_list.h:371
+#: ../../Firmware/ultralcd.cpp:2275 ../../Firmware/ultralcd.cpp:2279
 msgid "Eject"
 msgstr "Løs ut"
 
@@ -2546,58 +2539,58 @@ msgid "M600 Filament Change. Load a new filament or eject the old one."
 msgstr "M600 filamentskifte. Sett inn en ny filament eller løs ut den gamle."
 
 #. MSG_MMU_SENSITIVITY c=18
-#: ../../Firmware/messages.cpp:215 ../../Firmware/mmu2_reporting.cpp:458
+#: ../../Firmware/messages.cpp:227 ../../Firmware/mmu2_reporting.cpp:459
 msgid "Sensitivity"
 msgstr "Sensitivitet"
 
 #. MSG_MBL_FAILED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3038 ../../Firmware/messages.cpp:203
+#: ../../Firmware/Marlin_main.cpp:2776 ../../Firmware/messages.cpp:215
 msgid "Mesh bed leveling failed. Print canceled."
 msgstr "Sengeplanering feilet. Print avbrutt."
 
 #. MSG_SET_READY c=18
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:5265
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:5228
 msgid "Set Ready"
 msgstr "Gjør klar"
 
 #. MSG_SET_NOT_READY c=18
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:5263
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5226
 msgid "Set not Ready"
 msgstr "Sett ikke klar"
 
 #. MSG_HOSTPRINT c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5285
+#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:5231
 msgid "Print from host"
 msgstr "Print fra vert"
 
 #. MSG_REPRINT c=18
-#: ../../Firmware/messages.cpp:196 ../../Firmware/ultralcd.cpp:5243
-#: ../../Firmware/ultralcd.cpp:5245
+#: ../../Firmware/messages.cpp:208 ../../Firmware/ultralcd.cpp:5205
+#: ../../Firmware/ultralcd.cpp:5207
 msgid "Reprint"
 msgstr "Gjenta print"
 
 #. MSG_SHUTDOWN_HOST c=18
-#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:5390
+#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:5357
 msgid "Shutdown host"
 msgstr "Slå av vert"
 
 #. MSG_NOZZLE_CNG_COOLDOWN c=20 r=3
-#: ../../Firmware/messages.cpp:198 ../../Firmware/ultralcd.cpp:1002
+#: ../../Firmware/messages.cpp:203 ../../Firmware/ultralcd.cpp:999
 msgid "Nozzle is hot! Wait for cooldown."
 msgstr "Dysen er varm! Vent på nedkjøling."
 
 #. MSG_NOZZLE_CNG_CHANGED_QUICK c=20 r=3
-#: ../../Firmware/messages.cpp:199
+#: ../../Firmware/messages.cpp:204
 msgid "Nozzle changed?"
 msgstr "Har du byttet dyse?"
 
 #. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:388
+#: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:388
 msgid "There is no filament loaded. Continue?"
 msgstr "Det er ingen filament lastet. Fortsette?"
 
 #. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:389
+#: ../../Firmware/messages.cpp:159 ../../Firmware/util.cpp:389
 msgid "There is no filament loaded. Print cancelled."
 msgstr "Det er ingen filament lastet. Print avbrutt."
 

--- a/lang/po/Firmware_pl.po
+++ b/lang/po/Firmware_pl.po
@@ -16,91 +16,91 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 
 #. MSG_IR_03_OR_OLDER c=18
-#: ../../Firmware/Filament_sensor.cpp:280
-#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:183
+#: ../../Firmware/Filament_sensor.cpp:282
+#: ../../Firmware/Filament_sensor.cpp:344 ../../Firmware/messages.cpp:190
 msgid " 0.3 or older"
 msgstr " 0.3 lub starszy"
 
 #. MSG_IR_04_OR_NEWER c=18
-#: ../../Firmware/Filament_sensor.cpp:282
-#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:182
+#: ../../Firmware/Filament_sensor.cpp:284
+#: ../../Firmware/Filament_sensor.cpp:347 ../../Firmware/messages.cpp:189
 msgid " 0.4 or newer"
 msgstr " 0.4 lub nowszy"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/messages.cpp:356 ../../Firmware/ultralcd.cpp:6773
+#: ../../Firmware/messages.cpp:368 ../../Firmware/ultralcd.cpp:6749
 msgid "%s level expected"
 msgstr "Oczekiwano wersji %s"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:1978
-#: ../../Firmware/ultralcd.cpp:3613
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:1986
+#: ../../Firmware/ultralcd.cpp:3623
 msgid ">Cancel"
 msgstr ">Anuluj"
 
 #. MSG_BABYSTEPPING_Z c=13
-#: ../../Firmware/messages.cpp:257 ../../Firmware/ultralcd.cpp:2635
+#: ../../Firmware/messages.cpp:269 ../../Firmware/ultralcd.cpp:2652
 msgid "Adjusting Z"
 msgstr "Ustawianie Z"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/messages.cpp:360 ../../Firmware/ultralcd.cpp:6983
+#: ../../Firmware/messages.cpp:372 ../../Firmware/ultralcd.cpp:6960
 msgid "All correct"
 msgstr "Wszystko OK"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:3955
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:3979
 msgid "All is done. Happy printing!"
 msgstr "Gotowe. Udanego drukowania!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4482
 msgid "Alphabet"
 msgstr "Alfabet"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4086
+#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4110
 msgid "Always"
 msgstr "Zawsze"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/messages.cpp:221 ../../Firmware/ultralcd.cpp:1393
+#: ../../Firmware/messages.cpp:233 ../../Firmware/ultralcd.cpp:1403
 msgid "Ambient"
 msgstr "Otoczenie"
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=3
-#: ../../Firmware/messages.cpp:267 ../../Firmware/ultralcd.cpp:2848
+#: ../../Firmware/messages.cpp:279 ../../Firmware/ultralcd.cpp:2865
 msgid "Are left and right Z-carriages all up?"
 msgstr "Obydwa końce osi Z są na szczycie?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4197
+#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:4221
 msgid "Assist"
 msgstr "Asyst."
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:179 ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/messages.cpp:186 ../../Firmware/ultralcd.cpp:5594
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
-#: ../../Firmware/Marlin_main.cpp:3198 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:4577 ../../Firmware/ultralcd.cpp:5529
+#: ../../Firmware/Marlin_main.cpp:2942 ../../Firmware/messages.cpp:12
+#: ../../Firmware/ultralcd.cpp:4533 ../../Firmware/ultralcd.cpp:5496
 msgid "Auto home"
 msgstr "Auto bazowanie"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4182
 msgid "Auto power"
 msgstr "Automatycz"
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:328 ../../Firmware/ultralcd.cpp:5359
+#: ../../Firmware/messages.cpp:340 ../../Firmware/ultralcd.cpp:5328
 msgid "AutoLoad filament"
 msgstr "Autoładowanie fil."
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/messages.cpp:245 ../../Firmware/ultralcd.cpp:2272
+#: ../../Firmware/messages.cpp:257 ../../Firmware/ultralcd.cpp:2289
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
@@ -113,51 +113,50 @@ msgid "Avoiding grind"
 msgstr "Unikaj ścierania"
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/messages.cpp:352 ../../Firmware/ultralcd.cpp:6752
+#: ../../Firmware/messages.cpp:364 ../../Firmware/ultralcd.cpp:6728
 msgid "Axis"
 msgstr "Oś"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/messages.cpp:351 ../../Firmware/ultralcd.cpp:6751
+#: ../../Firmware/messages.cpp:363 ../../Firmware/ultralcd.cpp:6727
 msgid "Axis length"
 msgstr "Długość osi"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2708
-#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:5618
-#: ../../Firmware/ultralcd.cpp:7484
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2725
+#: ../../Firmware/ultralcd.cpp:4061 ../../Firmware/ultralcd.cpp:5591
+#: ../../Firmware/ultralcd.cpp:7461
 msgid "Back"
 msgstr "Wstecz"
 
 #. MSG_BED c=13
-#: ../../Firmware/Marlin_main.cpp:2081 ../../Firmware/Marlin_main.cpp:4627
-#: ../../Firmware/Marlin_main.cpp:4678 ../../Firmware/messages.cpp:15
-#: ../../Firmware/ultralcd.cpp:1391 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/Marlin_main.cpp:4247 ../../Firmware/messages.cpp:15
+#: ../../Firmware/ultralcd.cpp:1401 ../../Firmware/ultralcd.cpp:4197
 msgid "Bed"
 msgstr "Stół"
 
 #. MSG_BED_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6240 ../../Firmware/messages.cpp:17
+#: ../../Firmware/Marlin_main.cpp:5470 ../../Firmware/messages.cpp:17
 #: ../../Firmware/ultralcd.cpp:534
 msgid "Bed Heating"
 msgstr "Grzanie stołu"
 
 #. MSG_BED_DONE c=20
-#: ../../Firmware/Marlin_main.cpp:6277 ../../Firmware/messages.cpp:16
+#: ../../Firmware/Marlin_main.cpp:5507 ../../Firmware/messages.cpp:16
 #: ../../Firmware/ultralcd.cpp:537
 msgid "Bed done"
 msgstr "Stół OK"
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/messages.cpp:317 ../../Firmware/ultralcd.cpp:4589
+#: ../../Firmware/messages.cpp:329 ../../Firmware/ultralcd.cpp:4545
 msgid "Bed level correct"
 msgstr "Korekta stołu"
 
 #. MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:2262 ../../Firmware/Marlin_main.cpp:2999
-#: ../../Firmware/Marlin_main.cpp:3008
-#: ../../Firmware/mesh_bed_calibration.cpp:2878
-#: ../../Firmware/mesh_bed_calibration.cpp:2903 ../../Firmware/messages.cpp:18
+#: ../../Firmware/Marlin_main.cpp:2048 ../../Firmware/Marlin_main.cpp:2736
+#: ../../Firmware/Marlin_main.cpp:2745
+#: ../../Firmware/mesh_bed_calibration.cpp:2863
+#: ../../Firmware/mesh_bed_calibration.cpp:2888 ../../Firmware/messages.cpp:18
 msgid ""
 "Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for "
 "reset."
@@ -166,34 +165,34 @@ msgstr ""
 "Czekam na reset."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/messages.cpp:346 ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/messages.cpp:358 ../../Firmware/ultralcd.cpp:6685
 msgid "Bed/Heater"
 msgstr "Stół/Grzanie"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1444
-#: ../../Firmware/ultralcd.cpp:1704
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1454
+#: ../../Firmware/ultralcd.cpp:1714
 msgid "Belt status"
 msgstr "Stan pasków"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/messages.cpp:314 ../../Firmware/ultralcd.cpp:4579
+#: ../../Firmware/messages.cpp:326 ../../Firmware/ultralcd.cpp:4535
 msgid "Belt test"
 msgstr "Test pasków"
 
 #. MSG_RECOVER_PRINT c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:1660 ../../Firmware/messages.cpp:87
+#: ../../Firmware/Marlin_main.cpp:1587 ../../Firmware/messages.cpp:87
 msgid "Blackout occurred. Recover print?"
 msgstr "Wykryto zanik napięcia. Wznowić druk?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:177 ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:5594
 msgid "Bright"
 msgstr "Jasny"
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:4526
-#: ../../Firmware/ultralcd.cpp:5546
+#: ../../Firmware/messages.cpp:180 ../../Firmware/ultralcd.cpp:4493
+#: ../../Firmware/ultralcd.cpp:5513
 msgid "Brightness"
 msgstr "Jasność"
 
@@ -203,17 +202,17 @@ msgid "COMMUNICATION ERROR"
 msgstr "BŁĄD KOMUNIKACJI"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/messages.cpp:316 ../../Firmware/ultralcd.cpp:4583
+#: ../../Firmware/messages.cpp:328 ../../Firmware/ultralcd.cpp:4539
 msgid "Calibrate XYZ"
 msgstr "Kalibracja XYZ"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4585
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4541
 msgid "Calibrate Z"
 msgstr "Kalibruj Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/messages.cpp:266 ../../Firmware/ultralcd.cpp:2813
+#: ../../Firmware/messages.cpp:278 ../../Firmware/ultralcd.cpp:2830
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -222,13 +221,13 @@ msgstr ""
 "Naciśnij pokrętło gdy gotowe."
 
 #. MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: ../../Firmware/Marlin_main.cpp:2218 ../../Firmware/messages.cpp:22
+#: ../../Firmware/Marlin_main.cpp:2009 ../../Firmware/messages.cpp:23
 #: ../../Firmware/ultralcd.cpp:582
 msgid "Calibrating Z"
 msgstr "Kalibruję Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/messages.cpp:265 ../../Firmware/ultralcd.cpp:2812
+#: ../../Firmware/messages.cpp:277 ../../Firmware/ultralcd.cpp:2829
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -237,17 +236,17 @@ msgstr ""
 "Naciśnij gdy gotowe."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/messages.cpp:361 ../../Firmware/ultralcd.cpp:6985
+#: ../../Firmware/messages.cpp:373 ../../Firmware/ultralcd.cpp:6962
 msgid "Calibrating home"
 msgstr "Bazowanie osi"
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5375
+#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5342
 msgid "Calibration"
 msgstr "Kalibracja"
 
 #. MSG_HOMEYZ_DONE c=20
-#: ../../Firmware/messages.cpp:217 ../../Firmware/ultralcd.cpp:593
+#: ../../Firmware/messages.cpp:229 ../../Firmware/ultralcd.cpp:593
 msgid "Calibration done"
 msgstr "Kalibracja OK"
 
@@ -265,128 +264,128 @@ msgstr ""
 "Nie można wykonać akcji, filament jest już załadowany. Wyładuj go najpierw."
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/messages.cpp:364 ../../Firmware/ultralcd.cpp:7405
+#: ../../Firmware/messages.cpp:376 ../../Firmware/ultralcd.cpp:7382
 msgid "Card removed"
 msgstr "Karta wyjęta"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/messages.cpp:324 ../../Firmware/ultralcd.cpp:5316
+#: ../../Firmware/messages.cpp:336 ../../Firmware/ultralcd.cpp:5282
 msgid "Change SD card"
 msgstr "Zmiana karty SD"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5254
-#: ../../Firmware/ultralcd.cpp:5526
+#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5216
+#: ../../Firmware/ultralcd.cpp:5493
 msgid "Change filament"
 msgstr "Wymiana filamentu"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/messages.cpp:240 ../../Firmware/ultralcd.cpp:2156
+#: ../../Firmware/messages.cpp:252 ../../Firmware/ultralcd.cpp:2167
 msgid "Change success!"
 msgstr "Wymiana udana!"
 
 #. MSG_CORRECTLY c=19
-#: ../../Firmware/messages.cpp:242 ../../Firmware/ultralcd.cpp:2203
+#: ../../Firmware/messages.cpp:254 ../../Firmware/ultralcd.cpp:2217
 msgid "Changed correctly"
 msgstr "Wymiana udała się"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5951
-#: ../../Firmware/ultralcd.cpp:6975
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5927
+#: ../../Firmware/ultralcd.cpp:6952
 msgid "Checking X axis"
 msgstr "Kontrola osi X"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5961
-#: ../../Firmware/ultralcd.cpp:6976
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:5937
+#: ../../Firmware/ultralcd.cpp:6953
 msgid "Checking Y axis"
 msgstr "Kontrola osi Y"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/messages.cpp:358 ../../Firmware/ultralcd.cpp:6977
+#: ../../Firmware/messages.cpp:370 ../../Firmware/ultralcd.cpp:6954
 msgid "Checking Z axis"
 msgstr "Kontrola osi Z"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6978
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6955
 msgid "Checking bed"
 msgstr "Kontrola stołu"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/messages.cpp:357 ../../Firmware/ultralcd.cpp:6974
+#: ../../Firmware/messages.cpp:369 ../../Firmware/ultralcd.cpp:6951
 msgid "Checking endstops"
 msgstr "Kontrola krańcówek"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/messages.cpp:362 ../../Firmware/ultralcd.cpp:7070
+#: ../../Firmware/messages.cpp:374 ../../Firmware/ultralcd.cpp:7047
 msgid "Checking file"
 msgstr "Sprawdzanie pliku"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/messages.cpp:359 ../../Firmware/ultralcd.cpp:6980
+#: ../../Firmware/messages.cpp:371 ../../Firmware/ultralcd.cpp:6957
 msgid "Checking hotend"
 msgstr "Kontrola hotendu"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6981
-#: ../../Firmware/ultralcd.cpp:6982
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6958
+#: ../../Firmware/ultralcd.cpp:6959
 msgid "Checking sensors"
 msgstr "Kontrola czujników"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/messages.cpp:308 ../../Firmware/ultralcd.cpp:4424
+#: ../../Firmware/messages.cpp:320 ../../Firmware/ultralcd.cpp:4391
 msgid "Checks"
 msgstr "Testy"
 
 #. MSG_TM_ACK_ERROR c=18
-#: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5297
+#: ../../Firmware/messages.cpp:197 ../../Firmware/ultralcd.cpp:5263
 msgid "Clear TM error"
 msgstr "Wyczyść błąd TM"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/messages.cpp:244 ../../Firmware/ultralcd.cpp:2205
+#: ../../Firmware/messages.cpp:256 ../../Firmware/ultralcd.cpp:2219
 msgid "Color not correct"
 msgstr "Kolor nieprawidłowy"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:3508
+#: ../../Firmware/messages.cpp:27 ../../Firmware/ultralcd.cpp:3518
 msgid "Community made"
 msgstr "Od społeczności"
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:4059
+#: ../../Firmware/messages.cpp:178 ../../Firmware/ultralcd.cpp:4083
 msgid "Cont."
 msgstr "Kont."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:2129
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2135
 msgid "Cooldown"
 msgstr "Wychładzanie"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/messages.cpp:283 ../../Firmware/ultralcd.cpp:3450
+#: ../../Firmware/messages.cpp:295 ../../Firmware/ultralcd.cpp:3460
 msgid "Copy selected language?"
 msgstr "Skopiować wybrany język?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:1234
-#: ../../Firmware/ultralcd.cpp:1263
+#: ../../Firmware/messages.cpp:30 ../../Firmware/ultralcd.cpp:1244
+#: ../../Firmware/ultralcd.cpp:1273
 msgid "Crash"
 msgstr "Zderzeń"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4146
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/ultralcd.cpp:4170
 msgid "Crash det."
 msgstr "Wykr.zderzeń"
 
 #. MSG_CRASH_DETECTED c=20
-#: ../../Firmware/Marlin_main.cpp:630 ../../Firmware/messages.cpp:30
+#: ../../Firmware/Marlin_main.cpp:595 ../../Firmware/messages.cpp:31
 msgid "Crash detected."
 msgstr "Zderzenie wykryte."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/messages.cpp:280 ../../Firmware/ultralcd.cpp:3374
+#: ../../Firmware/messages.cpp:292 ../../Firmware/ultralcd.cpp:3384
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -398,24 +397,24 @@ msgstr ""
 "trybie Normalnym"
 
 #. MSG_CUT_FILAMENT c=16
-#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:380
-#: ../../Firmware/ultralcd.cpp:4854 ../../Firmware/ultralcd.cpp:5351
+#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:381
+#: ../../Firmware/ultralcd.cpp:4810 ../../Firmware/ultralcd.cpp:5317
 msgid "Cut filament"
 msgstr "Cięcie filamentu"
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4081
-#: ../../Firmware/ultralcd.cpp:4086 ../../Firmware/ultralcd.cpp:4091
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:4105
+#: ../../Firmware/ultralcd.cpp:4110 ../../Firmware/ultralcd.cpp:4115
 msgid "Cutter"
 msgstr "Nożyk"
 
 #. MSG_DATE c=17
-#: ../../Firmware/messages.cpp:222 ../../Firmware/ultralcd.cpp:1645
+#: ../../Firmware/messages.cpp:234 ../../Firmware/ultralcd.cpp:1655
 msgid "Date:"
 msgstr "Data:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:178 ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/messages.cpp:185 ../../Firmware/ultralcd.cpp:5594
 msgid "Dim"
 msgstr "Ściemn"
 
@@ -425,7 +424,7 @@ msgid "Disable"
 msgstr "Wyłącz"
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/messages.cpp:311 ../../Firmware/ultralcd.cpp:4460
+#: ../../Firmware/messages.cpp:323 ../../Firmware/ultralcd.cpp:4427
 msgid "Disable steppers"
 msgstr "Wyłącz silniki"
 
@@ -437,7 +436,7 @@ msgid "Disengaging idler"
 msgstr "Zwalnianie docisku"
 
 #. MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: ../../Firmware/Marlin_main.cpp:1610 ../../Firmware/Marlin_main.cpp:3334
+#: ../../Firmware/Marlin_main.cpp:1537 ../../Firmware/Marlin_main.cpp:3073
 #: ../../Firmware/messages.cpp:14
 msgid ""
 "Distance between tip of the nozzle and the bed surface has not been set yet."
@@ -449,7 +448,7 @@ msgstr ""
 "warstwy."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/messages.cpp:301 ../../Firmware/ultralcd.cpp:3923
+#: ../../Firmware/messages.cpp:313 ../../Firmware/ultralcd.cpp:3947
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -458,13 +457,13 @@ msgstr ""
 "stołem?"
 
 #. MSG_DONE c=8
-#: ../../Firmware/messages.cpp:32 ../../Firmware/mmu2/errors_list.h:367
-#: ../../Firmware/mmu2_reporting.cpp:456
+#: ../../Firmware/messages.cpp:33 ../../Firmware/mmu2/errors_list.h:367
+#: ../../Firmware/mmu2_reporting.cpp:457
 msgid "Done"
 msgstr "Gotowe"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/messages.cpp:307 ../../Firmware/ultralcd.cpp:3990
+#: ../../Firmware/messages.cpp:319 ../../Firmware/ultralcd.cpp:4014
 msgid "E-correct"
 msgstr "Korekcja-E"
 
@@ -493,13 +492,13 @@ msgid "ERR Wait for User"
 msgstr "ERR Czekam na Użytk."
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:2253
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:2267
 msgid "ERROR:"
 msgstr "BŁĄD:"
 
 #. MSG_EJECT_FROM_MMU c=16
-#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:384
-#: ../../Firmware/ultralcd.cpp:4845 ../../Firmware/ultralcd.cpp:5348
+#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:385
+#: ../../Firmware/ultralcd.cpp:4801 ../../Firmware/ultralcd.cpp:5314
 msgid "Eject from MMU"
 msgstr "Wysuń z MMU"
 
@@ -511,17 +510,17 @@ msgid "Ejecting filament"
 msgstr "Wysuwanie filamentu"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/messages.cpp:348 ../../Firmware/ultralcd.cpp:6722
+#: ../../Firmware/messages.cpp:360 ../../Firmware/ultralcd.cpp:6698
 msgid "Endstop"
 msgstr "Krańcówka"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/messages.cpp:349 ../../Firmware/ultralcd.cpp:6727
+#: ../../Firmware/messages.cpp:361 ../../Firmware/ultralcd.cpp:6703
 msgid "Endstop not hit"
 msgstr "Krańcówka nie aktyw."
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/messages.cpp:347 ../../Firmware/ultralcd.cpp:6713
+#: ../../Firmware/messages.cpp:359 ../../Firmware/ultralcd.cpp:6689
 msgid "Endstops"
 msgstr "Krańcówki"
 
@@ -533,30 +532,30 @@ msgid "Engaging idler"
 msgstr "Uruchamianie docisku"
 
 #. MSG_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:3352
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:3362
 msgid "Extruder"
 msgstr "Ekstruder"
 
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/messages.cpp:227 ../../Firmware/ultralcd.cpp:1700
+#: ../../Firmware/messages.cpp:239 ../../Firmware/ultralcd.cpp:1710
 msgid "Extruder info"
 msgstr "Ekstruder - info"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4044
-#: ../../Firmware/ultralcd.cpp:4051
+#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4068
+#: ../../Firmware/ultralcd.cpp:4075
 msgid "F. autoload"
 msgstr "Autolad. fil."
 
 #. MSG_FSENSOR_JAM_DETECTION c=13
-#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4046
-#: ../../Firmware/ultralcd.cpp:4053
+#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4070
+#: ../../Firmware/ultralcd.cpp:4077
 msgid "F. jam detect"
 msgstr "Zacięcie fil."
 
 #. MSG_FSENSOR_RUNOUT c=13
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4074
 msgid "F. runout"
 msgstr "Koniec fil."
 
@@ -594,8 +593,8 @@ msgid "FINDA FILAM. STUCK"
 msgstr "FINDA FIL. ZABLOK."
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:4059
-#: ../../Firmware/ultralcd.cpp:4062
+#: ../../Firmware/messages.cpp:177 ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/ultralcd.cpp:4086
 msgid "FS Action"
 msgstr "Akcja FS"
 
@@ -620,34 +619,34 @@ msgid "FW RUNTIME ERROR"
 msgstr "BŁĄD DZIAŁANIA FW"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/messages.cpp:330 ../../Firmware/ultralcd.cpp:5382
+#: ../../Firmware/messages.cpp:342 ../../Firmware/ultralcd.cpp:5349
 msgid "Fail stats"
 msgstr "Statystyki błędów"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/messages.cpp:331 ../../Firmware/ultralcd.cpp:5385
+#: ../../Firmware/messages.cpp:343 ../../Firmware/ultralcd.cpp:5352
 msgid "Fail stats MMU"
 msgstr "Błędy MMU"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/messages.cpp:355 ../../Firmware/ultralcd.cpp:6768
+#: ../../Firmware/messages.cpp:367 ../../Firmware/ultralcd.cpp:6744
 msgid "False triggering"
 msgstr "Fałszywy alarm"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4175
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4199
 msgid "Fan speed"
 msgstr "Prędkość went."
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6844
-#: ../../Firmware/ultralcd.cpp:6971 ../../Firmware/ultralcd.cpp:6972
-#: ../../Firmware/ultralcd.cpp:6973
+#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6820
+#: ../../Firmware/ultralcd.cpp:6948 ../../Firmware/ultralcd.cpp:6949
+#: ../../Firmware/ultralcd.cpp:6950
 msgid "Fan test"
 msgstr "Test wentylatora"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:4179
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:4203
 msgid "Fans check"
 msgstr "Sprawdz.went."
 
@@ -676,34 +675,34 @@ msgid "Feeding to nozzle"
 msgstr "Podaję do dyszy"
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1233
-#: ../../Firmware/ultralcd.cpp:1262 ../../Firmware/ultralcd.cpp:1316
-#: ../../Firmware/ultralcd.cpp:1318
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:1243
+#: ../../Firmware/ultralcd.cpp:1272 ../../Firmware/ultralcd.cpp:1326
+#: ../../Firmware/ultralcd.cpp:1328
 msgid "Fil. runouts"
 msgstr "Końc. filamentu"
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3313
-#: ../../Firmware/ultralcd.cpp:4039 ../../Firmware/ultralcd.cpp:4464
-#: ../../Firmware/ultralcd.cpp:5532
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3323
+#: ../../Firmware/ultralcd.cpp:4063 ../../Firmware/ultralcd.cpp:4431
+#: ../../Firmware/ultralcd.cpp:5499
 msgid "Fil. sensor"
 msgstr "Czuj. filam."
 
 #. MSG_FILAMENT_CLEAN c=20 r=3
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2261
-#: ../../Firmware/ultralcd.cpp:2265
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2275
+#: ../../Firmware/ultralcd.cpp:2279
 msgid "Filament extruding & with correct color?"
 msgstr "Czy filament wychodzi z dyszy, w prawidłowym kolorze?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/messages.cpp:243 ../../Firmware/ultralcd.cpp:2204
+#: ../../Firmware/messages.cpp:255 ../../Firmware/ultralcd.cpp:2218
 msgid "Filament not loaded"
 msgstr "Fil. nie załadowany"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6763
-#: ../../Firmware/ultralcd.cpp:6767 ../../Firmware/ultralcd.cpp:6771
-#: ../../Firmware/ultralcd.cpp:7000
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6739
+#: ../../Firmware/ultralcd.cpp:6743 ../../Firmware/ultralcd.cpp:6747
+#: ../../Firmware/ultralcd.cpp:6977
 msgid "Filament sensor"
 msgstr "Czujnik filamentu"
 
@@ -735,42 +734,42 @@ msgstr ""
 "nic nie utknęło w rurce PTFE. Sprawdź czy czujnik odczytuje prawidłowo."
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/messages.cpp:246 ../../Firmware/ultralcd.cpp:2347
+#: ../../Firmware/messages.cpp:258 ../../Firmware/ultralcd.cpp:2364
 msgid "Filament used"
 msgstr "Użyty filament"
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/messages.cpp:363 ../../Firmware/ultralcd.cpp:7139
+#: ../../Firmware/messages.cpp:375 ../../Firmware/ultralcd.cpp:7116
 msgid "File incomplete. Continue anyway?"
 msgstr "Plik niekompletny. Kontynuowac?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
 #: ../../Firmware/messages.cpp:45
 #: ../../Firmware/mmu2_progress_converter.cpp:43
-#: ../../Firmware/ultralcd.cpp:5021 ../../Firmware/ultralcd.cpp:5425
+#: ../../Firmware/ultralcd.cpp:4977 ../../Firmware/ultralcd.cpp:5392
 msgid "Finishing movements"
 msgstr "Kończenie druku"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4575
-#: ../../Firmware/ultralcd.cpp:5141
+#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4531
+#: ../../Firmware/ultralcd.cpp:5101
 msgid "First layer cal."
 msgstr "Kalibr. 1. warstwy"
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/messages.cpp:293 ../../Firmware/ultralcd.cpp:3846
+#: ../../Firmware/messages.cpp:305 ../../Firmware/ultralcd.cpp:3872
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Najpierw włączę selftest w celu sprawdzenia najczęstszych problemów podczas "
 "montażu."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/messages.cpp:334 ../../Firmware/ultralcd.cpp:5520
+#: ../../Firmware/messages.cpp:346 ../../Firmware/ultralcd.cpp:5487
 msgid "Flow"
 msgstr "Przepływ"
 
 #. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
-#: ../../Firmware/messages.cpp:194 ../../Firmware/ultralcd.cpp:985
+#: ../../Firmware/messages.cpp:201 ../../Firmware/ultralcd.cpp:987
 msgid ""
 "For a Nozzle change please read\n"
 "prusa.io/nozzle-mk3s"
@@ -779,28 +778,28 @@ msgstr ""
 "prusa.io/nozzle-mk3s"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6733
-#: ../../Firmware/ultralcd.cpp:6850 ../../Firmware/ultralcd.cpp:6855
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/ultralcd.cpp:6826 ../../Firmware/ultralcd.cpp:6831
 msgid "Front print fan?"
 msgstr "Przedni went. druku?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/messages.cpp:260 ../../Firmware/ultralcd.cpp:2711
+#: ../../Firmware/messages.cpp:272 ../../Firmware/ultralcd.cpp:2728
 msgid "Front side[µm]"
 msgstr "Przód [µm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/messages.cpp:353 ../../Firmware/ultralcd.cpp:6757
+#: ../../Firmware/messages.cpp:365 ../../Firmware/ultralcd.cpp:6733
 msgid "Front/left fans"
 msgstr "Przedni/lewy wentyl."
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:151 ../../Firmware/util.cpp:382
+#: ../../Firmware/messages.cpp:156 ../../Firmware/util.cpp:417
 msgid "G-code sliced for a different level. Continue?"
 msgstr "G-code pocięty dla innej wersji. Kontynuować?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:152 ../../Firmware/util.cpp:383
+#: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:418
 msgid ""
 "G-code sliced for a different level. Please re-slice the model again. Print "
 "cancelled."
@@ -808,14 +807,14 @@ msgstr ""
 "G-code pocięty na innym poziomie. Potnij model ponownie. Druk anulowany."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:147 ../../Firmware/util.cpp:312
-#: ../../Firmware/util.cpp:401
+#: ../../Firmware/messages.cpp:152 ../../Firmware/util.cpp:319
+#: ../../Firmware/util.cpp:436
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr "G-code pocięty dla innej drukarki. Kontynuować?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:148 ../../Firmware/util.cpp:313
-#: ../../Firmware/util.cpp:402
+#: ../../Firmware/messages.cpp:153 ../../Firmware/util.cpp:320
+#: ../../Firmware/util.cpp:437
 msgid ""
 "G-code sliced for a different printer type. Please re-slice the model again."
 " Print cancelled."
@@ -824,12 +823,12 @@ msgstr ""
 "anulowany."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:149 ../../Firmware/util.cpp:362
+#: ../../Firmware/messages.cpp:154 ../../Firmware/util.cpp:369
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "G-code pocięty dla nowszego firmware. Kontynuować?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:150 ../../Firmware/util.cpp:363
+#: ../../Firmware/messages.cpp:155 ../../Firmware/util.cpp:370
 msgid ""
 "G-code sliced for a newer firmware. Please update the firmware. Print "
 "cancelled."
@@ -837,35 +836,35 @@ msgstr ""
 "G-code pocięty dla nowszego firmware. Zaktualizuj firmware. Druk anulowany."
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4366
-#: ../../Firmware/ultralcd.cpp:4383 ../../Firmware/ultralcd.cpp:4485
+#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4325
+#: ../../Firmware/ultralcd.cpp:4343 ../../Firmware/ultralcd.cpp:4452
 msgid "HW Setup"
 msgstr "Ustawienia HW"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/messages.cpp:344 ../../Firmware/ultralcd.cpp:6705
+#: ../../Firmware/messages.cpp:356 ../../Firmware/ultralcd.cpp:6681
 msgid "Heater/Thermistor"
 msgstr "Grzałka/Termistor"
 
 #. MSG_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6184 ../../Firmware/messages.cpp:52
+#: ../../Firmware/Marlin_main.cpp:5416 ../../Firmware/messages.cpp:52
 #: ../../Firmware/ultralcd.cpp:526
 msgid "Heating"
 msgstr "Grzanie..."
 
 #. MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:9647 ../../Firmware/messages.cpp:211
+#: ../../Firmware/Marlin_main.cpp:8807 ../../Firmware/messages.cpp:223
 msgid "Heating disabled by safety timer."
 msgstr "Grzanie wyłączone przez wył. czasowy."
 
 #. MSG_HEATING_COMPLETE c=20
-#: ../../Firmware/Marlin_main.cpp:6215 ../../Firmware/messages.cpp:53
+#: ../../Firmware/Marlin_main.cpp:5445 ../../Firmware/messages.cpp:53
 #: ../../Firmware/ultralcd.cpp:529
 msgid "Heating done."
 msgstr "Grzanie zakończone."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=12
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:3806
+#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:3832
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -875,7 +874,7 @@ msgstr ""
 "kalibrację osi Z, po której możesz rozpocząć drukowanie."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:3810
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:3836
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -884,8 +883,8 @@ msgstr ""
 "ustawieniami?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4152
-#: ../../Firmware/ultralcd.cpp:4161
+#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:4176
+#: ../../Firmware/ultralcd.cpp:4185
 msgid "High power"
 msgstr "Wysoka wyd"
 
@@ -896,24 +895,24 @@ msgid "Homing"
 msgstr "Bazowanie"
 
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
-#: ../../Firmware/messages.cpp:195 ../../Firmware/ultralcd.cpp:1005
+#: ../../Firmware/messages.cpp:206 ../../Firmware/ultralcd.cpp:1011
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr ""
 "Hotend rozgrzany do 280°C! Dysza wymieniona i dokręcona wg specyfikacji?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1106
-#: ../../Firmware/ultralcd.cpp:6991
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1116
+#: ../../Firmware/ultralcd.cpp:6968
 msgid "Hotend fan:"
 msgstr "Went. hotendu:"
 
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/messages.cpp:294 ../../Firmware/ultralcd.cpp:3851
+#: ../../Firmware/messages.cpp:306 ../../Firmware/ultralcd.cpp:3877
 msgid "I will run xyz calibration now. It will take up to 24 mins."
 msgstr "Przeprowadzę teraz kalibrację XYZ. Zajmie to do 24 min."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/messages.cpp:297 ../../Firmware/ultralcd.cpp:3862
+#: ../../Firmware/messages.cpp:309 ../../Firmware/ultralcd.cpp:3884
 msgid "I will run z calibration now."
 msgstr "Przeprowadzę teraz kalibracje Z."
 
@@ -938,7 +937,7 @@ msgid "INVALID TOOL"
 msgstr "BŁĘDNE NARZĘDZIE"
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=8
-#: ../../Firmware/messages.cpp:303 ../../Firmware/ultralcd.cpp:3931
+#: ../../Firmware/messages.cpp:315 ../../Firmware/ultralcd.cpp:3955
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -947,28 +946,28 @@ msgstr ""
 "Ustawienia - Ustawienia HW - Płyty stalowe."
 
 #. MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2540
-#: ../../Firmware/messages.cpp:213
+#: ../../Firmware/mesh_bed_calibration.cpp:2525
+#: ../../Firmware/messages.cpp:225
 msgid "Improving bed calibration point"
 msgstr "Poprawianie punktu kalibracji stołu"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:5222
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:5184
 msgid "Info screen"
 msgstr "Ekran informacyjny"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/messages.cpp:326 ../../Firmware/ultralcd.cpp:5323
+#: ../../Firmware/messages.cpp:338 ../../Firmware/ultralcd.cpp:5289
 msgid "Init. SD card"
 msgstr "Inic. karty SD"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/messages.cpp:238 ../../Firmware/ultralcd.cpp:2142
+#: ../../Firmware/messages.cpp:250 ../../Firmware/ultralcd.cpp:2148
 msgid "Insert filament"
 msgstr "Wprowadź filament"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/messages.cpp:335 ../../Firmware/ultralcd.cpp:5998
+#: ../../Firmware/messages.cpp:347 ../../Firmware/ultralcd.cpp:5974
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
@@ -983,115 +982,115 @@ msgid ""
 msgstr "Wewnętrzny błąd działania. Zresetuj MMU lub zaktualizuj firmware."
 
 #. MSG_FILAMENT_LOADED c=20 r=3
-#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3628
-#: ../../Firmware/ultralcd.cpp:3890
+#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3638
+#: ../../Firmware/ultralcd.cpp:3914
 msgid "Is filament loaded?"
 msgstr "Filament jest załadowany?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3238 ../../Firmware/Marlin_main.cpp:4745
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:3858
+#: ../../Firmware/Marlin_main.cpp:4314 ../../Firmware/messages.cpp:127
+#: ../../Firmware/ultralcd.cpp:3760
 msgid "Is steel sheet on heatbed?"
 msgstr "Czy płyta stalowa jest na stole?"
 
 #. MSG_ITERATION c=12
-#: ../../Firmware/mesh_bed_calibration.cpp:2265 ../../Firmware/messages.cpp:55
+#: ../../Firmware/mesh_bed_calibration.cpp:2250 ../../Firmware/messages.cpp:55
 msgid "Iteration"
 msgstr "Iteracja"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1128
-#: ../../Firmware/ultralcd.cpp:1286
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1138
+#: ../../Firmware/ultralcd.cpp:1296
 msgid "Last print"
 msgstr "Ostatni wydruk"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1152
-#: ../../Firmware/ultralcd.cpp:1260 ../../Firmware/ultralcd.cpp:1315
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1162
+#: ../../Firmware/ultralcd.cpp:1270 ../../Firmware/ultralcd.cpp:1325
 msgid "Last print failures"
 msgstr "Ostatnie błędy druku"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/messages.cpp:251 ../../Firmware/ultralcd.cpp:2478
+#: ../../Firmware/messages.cpp:263 ../../Firmware/ultralcd.cpp:2495
 msgid "Left"
 msgstr "Lewa"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6739
-#: ../../Firmware/ultralcd.cpp:6850 ../../Firmware/ultralcd.cpp:6855
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6715
+#: ../../Firmware/ultralcd.cpp:6826 ../../Firmware/ultralcd.cpp:6831
 msgid "Left hotend fan?"
 msgstr "Lewy went. hotendu?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/messages.cpp:258 ../../Firmware/ultralcd.cpp:2709
+#: ../../Firmware/messages.cpp:270 ../../Firmware/ultralcd.cpp:2726
 msgid "Left side [µm]"
 msgstr "Lewo [µm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:5619
+#: ../../Firmware/messages.cpp:181 ../../Firmware/ultralcd.cpp:5592
 msgid "Level Bright"
 msgstr "Poziom jasn."
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:175 ../../Firmware/ultralcd.cpp:5620
+#: ../../Firmware/messages.cpp:182 ../../Firmware/ultralcd.cpp:5593
 msgid "Level Dimmed"
 msgstr "Poziom ciem."
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/messages.cpp:312 ../../Firmware/ultralcd.cpp:4491
+#: ../../Firmware/messages.cpp:324 ../../Firmware/ultralcd.cpp:4458
 msgid "Lin. correction"
 msgstr "Korekcja liniowa"
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4501
-#: ../../Firmware/ultralcd.cpp:5251
+#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4468
+#: ../../Firmware/ultralcd.cpp:5213
 msgid "Live adjust Z"
 msgstr "Ustawianie Live Z"
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/messages.cpp:192 ../../Firmware/ultralcd.cpp:4794
-#: ../../Firmware/ultralcd.cpp:4880
+#: ../../Firmware/messages.cpp:199 ../../Firmware/ultralcd.cpp:4750
+#: ../../Firmware/ultralcd.cpp:4836
 msgid "Load All"
 msgstr "Załaduj Wszystkie"
 
 #. MSG_LOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4796
-#: ../../Firmware/ultralcd.cpp:4833 ../../Firmware/ultralcd.cpp:4882
-#: ../../Firmware/ultralcd.cpp:5361 ../../Firmware/ultralcd.cpp:5368
+#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4752
+#: ../../Firmware/ultralcd.cpp:4789 ../../Firmware/ultralcd.cpp:4838
+#: ../../Firmware/ultralcd.cpp:5324 ../../Firmware/ultralcd.cpp:5335
 msgid "Load filament"
 msgstr "Ładowanie fil."
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/messages.cpp:327 ../../Firmware/ultralcd.cpp:5346
+#: ../../Firmware/messages.cpp:339 ../../Firmware/ultralcd.cpp:5312
 msgid "Load to nozzle"
 msgstr "Załaduj do dyszy"
 
 #. MSG_LOADING_TEST c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4476
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4443
 msgid "Loading Test"
 msgstr "Test ładowania"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/messages.cpp:241 ../../Firmware/ultralcd.cpp:2178
+#: ../../Firmware/messages.cpp:253 ../../Firmware/ultralcd.cpp:2189
 msgid "Loading color"
 msgstr "Ładowanie koloru"
 
 #. MSG_LOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3598 ../../Firmware/messages.cpp:62
+#: ../../Firmware/Marlin_main.cpp:3343 ../../Firmware/messages.cpp:62
 #: ../../Firmware/mmu2_progress_converter.cpp:51
-#: ../../Firmware/mmu2_reporting.cpp:392 ../../Firmware/ultralcd.cpp:2189
-#: ../../Firmware/ultralcd.cpp:3715
+#: ../../Firmware/mmu2_reporting.cpp:393 ../../Firmware/ultralcd.cpp:2199
+#: ../../Firmware/ultralcd.cpp:3725
 msgid "Loading filament"
 msgstr "Ładowanie filamentu"
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/messages.cpp:350 ../../Firmware/ultralcd.cpp:6745
+#: ../../Firmware/messages.cpp:362 ../../Firmware/ultralcd.cpp:6721
 msgid "Loose pulley"
 msgstr "Luźne koło pasowe"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4188
-#: ../../Firmware/ultralcd.cpp:4200
+#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4224
 msgid "Loud"
 msgstr "Głośny"
 
@@ -1106,7 +1105,7 @@ msgid "MMU Firmware internal error, please reset the MMU."
 msgstr "Błąd wewnętrzny Firmware MMU. Proszę zresetuj MMU."
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:4096
+#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4120
 msgid "MMU Mode"
 msgstr "Tryb MMU"
 
@@ -1116,7 +1115,7 @@ msgid "MMU NOT RESPONDING"
 msgstr "MMU NIE ODPOWIADA"
 
 #. MSG_MMU_RESTORE_TEMP c=20 r=4
-#: ../../Firmware/messages.cpp:214 ../../Firmware/mmu2_reporting.cpp:396
+#: ../../Firmware/messages.cpp:226 ../../Firmware/mmu2_reporting.cpp:397
 msgid "MMU Retry: Restoring temperature..."
 msgstr "MMU Ponawianie: Nagrzewanie..."
 
@@ -1127,14 +1126,14 @@ msgid "MMU SELFTEST FAILED"
 msgstr "MMU SELFTEST NIEUD."
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1153
-#: ../../Firmware/ultralcd.cpp:1178
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1163
+#: ../../Firmware/ultralcd.cpp:1188
 msgid "MMU fails"
 msgstr "Błędy MMU"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1154
-#: ../../Firmware/ultralcd.cpp:1179
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1164
+#: ../../Firmware/ultralcd.cpp:1189
 msgid "MMU load fails"
 msgstr "Błędy ład. MMU"
 
@@ -1149,66 +1148,64 @@ msgid "MMU not responding. Check the wiring and connectors."
 msgstr "MMU nie reaguje. Sprawdź okablowanie i złącza."
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/messages.cpp:223 ../../Firmware/ultralcd.cpp:1657
+#: ../../Firmware/messages.cpp:235 ../../Firmware/ultralcd.cpp:1667
 msgid "MMU connected"
 msgstr "MMU połączone"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/messages.cpp:176 ../../Firmware/ultralcd.cpp:5567
 msgid "Magnets comp."
 msgstr "Kor. magnesów"
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1127
-#: ../../Firmware/ultralcd.cpp:1285 ../../Firmware/ultralcd.cpp:1327
-#: ../../Firmware/ultralcd.cpp:1631 ../../Firmware/ultralcd.cpp:4453
-#: ../../Firmware/ultralcd.cpp:4571 ../../Firmware/ultralcd.cpp:4793
-#: ../../Firmware/ultralcd.cpp:4826 ../../Firmware/ultralcd.cpp:4879
-#: ../../Firmware/ultralcd.cpp:5515
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1137
+#: ../../Firmware/ultralcd.cpp:1295 ../../Firmware/ultralcd.cpp:1337
+#: ../../Firmware/ultralcd.cpp:1641 ../../Firmware/ultralcd.cpp:4420
+#: ../../Firmware/ultralcd.cpp:4527 ../../Firmware/ultralcd.cpp:4749
+#: ../../Firmware/ultralcd.cpp:4782 ../../Firmware/ultralcd.cpp:4835
+#: ../../Firmware/ultralcd.cpp:5482
 msgid "Main"
 msgstr "Menu główne"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/messages.cpp:253 ../../Firmware/ultralcd.cpp:2519
+#: ../../Firmware/messages.cpp:265 ../../Firmware/ultralcd.cpp:2536
 msgid "Measured skew"
 msgstr "Zmierz. skos"
 
 #. MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3219
-#: ../../Firmware/mesh_bed_calibration.cpp:2852 ../../Firmware/messages.cpp:70
+#: ../../Firmware/Marlin_main.cpp:2963
+#: ../../Firmware/mesh_bed_calibration.cpp:2837 ../../Firmware/messages.cpp:70
 msgid "Measuring reference height of calibration point"
 msgstr "Określanie wysokości odniesienia punktu kalibracyjnego"
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:5590
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:5563
 msgid "Mesh"
 msgstr "Siatka"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4488
-#: ../../Firmware/ultralcd.cpp:4587
+#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:4455
+#: ../../Firmware/ultralcd.cpp:4543
 msgid "Mesh Bed Leveling"
 msgstr "Poziomowanie stołu"
 
 #. MSG_MODE c=6
-#: ../../Firmware/Marlin_main.cpp:8495 ../../Firmware/messages.cpp:117
-#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4132
-#: ../../Firmware/ultralcd.cpp:4140 ../../Firmware/ultralcd.cpp:4144
-#: ../../Firmware/ultralcd.cpp:4152 ../../Firmware/ultralcd.cpp:4155
-#: ../../Firmware/ultralcd.cpp:4158 ../../Firmware/ultralcd.cpp:4161
-#: ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/Marlin_main.cpp:7666 ../../Firmware/messages.cpp:121
+#: ../../Firmware/ultralcd.cpp:4152 ../../Firmware/ultralcd.cpp:4156
+#: ../../Firmware/ultralcd.cpp:4164 ../../Firmware/ultralcd.cpp:4168
+#: ../../Firmware/ultralcd.cpp:4176 ../../Firmware/ultralcd.cpp:4179
+#: ../../Firmware/ultralcd.cpp:4182 ../../Firmware/ultralcd.cpp:4185
+#: ../../Firmware/ultralcd.cpp:5594
 msgid "Mode"
 msgstr "Tryb"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/messages.cpp:282 ../../Firmware/ultralcd.cpp:3413
+#: ../../Firmware/messages.cpp:294 ../../Firmware/ultralcd.cpp:3423
 msgid "Mode change in progress..."
 msgstr "Trwa zmiana trybu..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:4310
-#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4316
-#: ../../Firmware/ultralcd.cpp:4319
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4327
 msgid "Model"
 msgstr "Model"
 
@@ -1229,28 +1226,28 @@ msgid "More details online."
 msgstr "Więcej szczegółów online."
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6719
-#: ../../Firmware/ultralcd.cpp:6728 ../../Firmware/ultralcd.cpp:6746
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6695
+#: ../../Firmware/ultralcd.cpp:6704 ../../Firmware/ultralcd.cpp:6722
 msgid "Motor"
 msgstr "Silnik"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/messages.cpp:277 ../../Firmware/ultralcd.cpp:3349
+#: ../../Firmware/messages.cpp:289 ../../Firmware/ultralcd.cpp:3359
 msgid "Move X"
 msgstr "Ruch osi X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/messages.cpp:278 ../../Firmware/ultralcd.cpp:3350
+#: ../../Firmware/messages.cpp:290 ../../Firmware/ultralcd.cpp:3360
 msgid "Move Y"
 msgstr "Ruch osi Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/messages.cpp:279 ../../Firmware/ultralcd.cpp:3351
+#: ../../Firmware/messages.cpp:291 ../../Firmware/ultralcd.cpp:3361
 msgid "Move Z"
 msgstr "Ruch osi Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/messages.cpp:310 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:322 ../../Firmware/ultralcd.cpp:4426
 msgid "Move axis"
 msgstr "Ruch osi"
 
@@ -1261,95 +1258,92 @@ msgid "Moving selector"
 msgstr "Ruch wybieraka"
 
 #. MSG_NA c=3
-#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:141
-#: ../../Firmware/ultralcd.cpp:2484 ../../Firmware/ultralcd.cpp:2528
-#: ../../Firmware/ultralcd.cpp:3279 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:4044 ../../Firmware/ultralcd.cpp:4046
-#: ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:146
+#: ../../Firmware/ultralcd.cpp:2501 ../../Firmware/ultralcd.cpp:2545
+#: ../../Firmware/ultralcd.cpp:3289 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4068 ../../Firmware/ultralcd.cpp:4070
+#: ../../Firmware/ultralcd.cpp:5567
 msgid "N/A"
 msgstr "N/D"
 
 #. MSG_NEW_FIRMWARE_AVAILABLE c=20 r=2
-#: ../../Firmware/messages.cpp:365 ../../Firmware/util.cpp:209
+#: ../../Firmware/messages.cpp:377 ../../Firmware/util.cpp:214
 msgid "New firmware version available:"
 msgstr "Dostępna jest nowa wersja firmware:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:3029
-#: ../../Firmware/ultralcd.cpp:4443 ../../Firmware/ultralcd.cpp:4531
-#: ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:2275
+#: ../../Firmware/ultralcd.cpp:2279 ../../Firmware/ultralcd.cpp:3046
+#: ../../Firmware/ultralcd.cpp:4410 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/ultralcd.cpp:5765
 msgid "No"
 msgstr "Nie"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/messages.cpp:325 ../../Firmware/ultralcd.cpp:5321
+#: ../../Firmware/messages.cpp:337 ../../Firmware/ultralcd.cpp:5287
 msgid "No SD card"
 msgstr "Brak karty SD"
 
 #. MSG_NO_MOVE c=20
-#: ../../Firmware/Marlin_main.cpp:5271 ../../Firmware/messages.cpp:210
+#: ../../Firmware/Marlin_main.cpp:4778 ../../Firmware/messages.cpp:222
 msgid "No move."
 msgstr "Brak ruchu."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4239 ../../Firmware/ultralcd.cpp:4310
-#: ../../Firmware/ultralcd.cpp:4319 ../../Firmware/ultralcd.cpp:4349
-#: ../../Firmware/ultralcd.cpp:4358 ../../Firmware/ultralcd.cpp:4516
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4309
+#: ../../Firmware/ultralcd.cpp:4318 ../../Firmware/ultralcd.cpp:4483
 msgid "None"
 msgstr "Brak"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/Marlin_main.cpp:8497 ../../Firmware/messages.cpp:121
-#: ../../Firmware/ultralcd.cpp:4096 ../../Firmware/ultralcd.cpp:4132
-#: ../../Firmware/ultralcd.cpp:4511
+#: ../../Firmware/Marlin_main.cpp:7668 ../../Firmware/messages.cpp:125
+#: ../../Firmware/ultralcd.cpp:4120 ../../Firmware/ultralcd.cpp:4156
+#: ../../Firmware/ultralcd.cpp:4478
 msgid "Normal"
 msgstr "Normal"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/messages.cpp:345 ../../Firmware/ultralcd.cpp:6706
+#: ../../Firmware/messages.cpp:357 ../../Firmware/ultralcd.cpp:6682
 msgid "Not connected"
 msgstr "Nie podłączono"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6863
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6839
 msgid "Not spinning"
 msgstr "Nie kręci się"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/messages.cpp:289 ../../Firmware/ultralcd.cpp:3726
+#: ../../Firmware/messages.cpp:301 ../../Firmware/ultralcd.cpp:3736
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr "Kalibruję odległość między końcówką dyszy, a powierzchnią druku."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/messages.cpp:298 ../../Firmware/ultralcd.cpp:3871
+#: ../../Firmware/messages.cpp:310 ../../Firmware/ultralcd.cpp:3894
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Nagrzewam dyszę dla PLA."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/messages.cpp:296 ../../Firmware/ultralcd.cpp:3857
+#: ../../Firmware/messages.cpp:308 ../../Firmware/ultralcd.cpp:3883
 msgid "Now remove the test print from steel sheet."
 msgstr "Teraz zdejmij wydruk testowy ze stołu."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1390
-#: ../../Firmware/ultralcd.cpp:4170 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4233 ../../Firmware/ultralcd.cpp:4236
-#: ../../Firmware/ultralcd.cpp:4239
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1400
+#: ../../Firmware/ultralcd.cpp:4194 ../../Firmware/ultralcd.cpp:4326
 msgid "Nozzle"
 msgstr "Dysza"
 
 #. MSG_NOZZLE_CNG_MENU c=18
-#: ../../Firmware/messages.cpp:193 ../../Firmware/ultralcd.cpp:4423
-#: ../../Firmware/ultralcd.cpp:4486
+#: ../../Firmware/messages.cpp:200 ../../Firmware/ultralcd.cpp:4390
+#: ../../Firmware/ultralcd.cpp:4453
 msgid "Nozzle change"
 msgstr "Wymiana dyszy"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4276
-#: ../../Firmware/ultralcd.cpp:4278 ../../Firmware/ultralcd.cpp:4279
-#: ../../Firmware/ultralcd.cpp:4280
+#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4261
+#: ../../Firmware/ultralcd.cpp:4263 ../../Firmware/ultralcd.cpp:4264
+#: ../../Firmware/ultralcd.cpp:4265
 msgid "Nozzle d."
 msgstr "Śr. dyszy"
 
@@ -1360,83 +1354,83 @@ msgid "OK"
 msgstr "OK"
 
 #. MSG_OFF c=3
-#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:139
-#: ../../Firmware/mmu2.cpp:65 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4050 ../../Firmware/ultralcd.cpp:4051
-#: ../../Firmware/ultralcd.cpp:4053 ../../Firmware/ultralcd.cpp:4076
-#: ../../Firmware/ultralcd.cpp:4091 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4179 ../../Firmware/ultralcd.cpp:4467
-#: ../../Firmware/ultralcd.cpp:4495 ../../Firmware/ultralcd.cpp:4498
-#: ../../Firmware/ultralcd.cpp:5439 ../../Firmware/ultralcd.cpp:5594
-#: ../../Firmware/ultralcd.cpp:7487 ../../Firmware/ultralcd.cpp:7491
+#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:144
+#: ../../Firmware/mmu2.cpp:65 ../../Firmware/ultralcd.cpp:4063
+#: ../../Firmware/ultralcd.cpp:4074 ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4077 ../../Firmware/ultralcd.cpp:4100
+#: ../../Firmware/ultralcd.cpp:4115 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/ultralcd.cpp:4203 ../../Firmware/ultralcd.cpp:4434
+#: ../../Firmware/ultralcd.cpp:4462 ../../Firmware/ultralcd.cpp:4465
+#: ../../Firmware/ultralcd.cpp:5406 ../../Firmware/ultralcd.cpp:5567
+#: ../../Firmware/ultralcd.cpp:7464 ../../Firmware/ultralcd.cpp:7468
 msgid "Off"
 msgstr "Wył"
 
 #. MSG_DEFAULT_SETTINGS_LOADED c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:1562 ../../Firmware/messages.cpp:201
+#: ../../Firmware/Marlin_main.cpp:1489 ../../Firmware/messages.cpp:213
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr ""
 "Znaleziono stare ustawienia. Zostaną przywrócone domyślne ustawienia PID, "
 "Ekroków, itp."
 
 #. MSG_ON c=3
-#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:140
-#: ../../Firmware/mmu2.cpp:63 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4050 ../../Firmware/ultralcd.cpp:4051
-#: ../../Firmware/ultralcd.cpp:4053 ../../Firmware/ultralcd.cpp:4076
-#: ../../Firmware/ultralcd.cpp:4081 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4179 ../../Firmware/ultralcd.cpp:4467
-#: ../../Firmware/ultralcd.cpp:4495 ../../Firmware/ultralcd.cpp:4498
-#: ../../Firmware/ultralcd.cpp:5594 ../../Firmware/ultralcd.cpp:7487
-#: ../../Firmware/ultralcd.cpp:7491
+#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:145
+#: ../../Firmware/mmu2.cpp:63 ../../Firmware/ultralcd.cpp:4063
+#: ../../Firmware/ultralcd.cpp:4074 ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4077 ../../Firmware/ultralcd.cpp:4100
+#: ../../Firmware/ultralcd.cpp:4105 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/ultralcd.cpp:4203 ../../Firmware/ultralcd.cpp:4434
+#: ../../Firmware/ultralcd.cpp:4462 ../../Firmware/ultralcd.cpp:4465
+#: ../../Firmware/ultralcd.cpp:5567 ../../Firmware/ultralcd.cpp:7464
+#: ../../Firmware/ultralcd.cpp:7468
 msgid "On"
 msgstr "Wł"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4191
+#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:4215
 msgid "Once"
 msgstr "1-raz"
 
 #. MSG_PAUSED_THERMAL_ERROR c=20
-#: ../../Firmware/Marlin_main.cpp:9861 ../../Firmware/messages.cpp:186
+#: ../../Firmware/Marlin_main.cpp:9021 ../../Firmware/messages.cpp:193
 msgid "PAUSED THERMAL ERROR"
 msgstr "PAUZA BŁĄD TERMICZNY"
 
 #. MSG_PID_RUNNING c=20
-#: ../../Firmware/messages.cpp:219 ../../Firmware/ultralcd.cpp:897
+#: ../../Firmware/messages.cpp:231 ../../Firmware/ultralcd.cpp:897
 msgid "PID cal."
 msgstr "Kalibracja PID"
 
 #. MSG_PID_FINISHED c=20
-#: ../../Firmware/messages.cpp:220 ../../Firmware/ultralcd.cpp:902
+#: ../../Firmware/messages.cpp:232 ../../Firmware/ultralcd.cpp:902
 msgid "PID cal. finished"
 msgstr "Kal. PID zakończona"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:318 ../../Firmware/ultralcd.cpp:4590
+#: ../../Firmware/messages.cpp:330 ../../Firmware/ultralcd.cpp:4546
 msgid "PID calibration"
 msgstr "Kalibracja PID"
 
 #. MSG_PINDA_PREHEAT c=20
-#: ../../Firmware/messages.cpp:218 ../../Firmware/ultralcd.cpp:610
+#: ../../Firmware/messages.cpp:230 ../../Firmware/ultralcd.cpp:610
 msgid "PINDA Heating"
 msgstr "Grzanie sondy PINDA"
 
 #. MSG_PINDA_CALIBRATION c=13
-#: ../../Firmware/Marlin_main.cpp:4790 ../../Firmware/Marlin_main.cpp:4892
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:607
-#: ../../Firmware/ultralcd.cpp:4495 ../../Firmware/ultralcd.cpp:4597
+#: ../../Firmware/Marlin_main.cpp:4359 ../../Firmware/Marlin_main.cpp:4461
+#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:607
+#: ../../Firmware/ultralcd.cpp:4462 ../../Firmware/ultralcd.cpp:4553
 msgid "PINDA cal."
 msgstr "Kalib. PINDA"
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/messages.cpp:276 ../../Firmware/ultralcd.cpp:3233
+#: ../../Firmware/messages.cpp:288 ../../Firmware/ultralcd.cpp:3243
 msgid "PINDA calibration failed"
 msgstr "Kalibracja PINDA nieudana"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:4967 ../../Firmware/messages.cpp:127
-#: ../../Firmware/ultralcd.cpp:3230
+#: ../../Firmware/Marlin_main.cpp:4536 ../../Firmware/messages.cpp:132
+#: ../../Firmware/ultralcd.cpp:3240
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1456,13 +1450,13 @@ msgid "Parking selector"
 msgstr "Parkowanie wybieraka"
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:4062
+#: ../../Firmware/messages.cpp:179 ../../Firmware/ultralcd.cpp:4086
 msgid "Pause"
 msgstr "Pauza"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5271
-#: ../../Firmware/ultralcd.cpp:5273
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5237
+#: ../../Firmware/ultralcd.cpp:5239
 msgid "Pause print"
 msgstr "Wstrzym. wydruku"
 
@@ -1473,7 +1467,7 @@ msgid "Performing cut"
 msgstr "Odcinanie"
 
 #. MSG_PAPER c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3243 ../../Firmware/messages.cpp:77
+#: ../../Firmware/Marlin_main.cpp:2982 ../../Firmware/messages.cpp:77
 msgid ""
 "Place a sheet of paper under the nozzle during the calibration of first 4 "
 "points. If the nozzle catches the paper, power off the printer immediately."
@@ -1482,7 +1476,7 @@ msgstr ""
 "punktow. Jeśli dysza zahaczy o papier, natychmiast wyłącz drukarkę."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:3963
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:3987
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1491,33 +1485,33 @@ msgstr ""
 "Asystenta przez restart drukarki."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/messages.cpp:337 ../../Firmware/ultralcd.cpp:6023
+#: ../../Firmware/messages.cpp:349 ../../Firmware/ultralcd.cpp:5999
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "Sprawdź połączenie czujnika IR, wyładuj filament, jesli załadowany."
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/messages.cpp:343 ../../Firmware/ultralcd.cpp:6700
+#: ../../Firmware/messages.cpp:355 ../../Firmware/ultralcd.cpp:6676
 msgid "Please check:"
 msgstr "Sprawdź:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/messages.cpp:302 ../../Firmware/ultralcd.cpp:3926
+#: ../../Firmware/messages.cpp:314 ../../Firmware/ultralcd.cpp:3950
 msgid "Please clean heatbed and then press the knob."
 msgstr "Oczyść powierzchnię druku i naciśnij pokrętło."
 
 #. MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3217 ../../Firmware/messages.cpp:27
+#: ../../Firmware/Marlin_main.cpp:2960 ../../Firmware/messages.cpp:28
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Dla prawidłowej kalibracji należy oczyścić dyszę. Potwierdź guzikiem."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/messages.cpp:288 ../../Firmware/ultralcd.cpp:3712
+#: ../../Firmware/messages.cpp:300 ../../Firmware/ultralcd.cpp:3722
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr "Wsuń filament do ekstrudera i naciśnij pokrętło, aby go załadować."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/messages.cpp:287 ../../Firmware/ultralcd.cpp:3705
+#: ../../Firmware/messages.cpp:299 ../../Firmware/ultralcd.cpp:3715
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1526,104 +1520,103 @@ msgstr ""
 "załadować."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/messages.cpp:285 ../../Firmware/ultralcd.cpp:3633
+#: ../../Firmware/messages.cpp:297 ../../Firmware/ultralcd.cpp:3643
 msgid "Please load filament first."
 msgstr "Najpierw załaduj filament."
 
 #. MSG_CHECK_IDLER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3525 ../../Firmware/messages.cpp:206
+#: ../../Firmware/Marlin_main.cpp:3265 ../../Firmware/messages.cpp:218
 msgid "Please open idler and remove filament manually."
 msgstr "Odciągnij dźwignię dociskową ekstrudera i ręcznie usuń filament."
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2806 ../../Firmware/messages.cpp:80
-#: ../../Firmware/ultralcd.cpp:3860
+#: ../../Firmware/mesh_bed_calibration.cpp:2791 ../../Firmware/messages.cpp:80
 msgid "Please place steel sheet on heatbed."
 msgstr "Umieść płytę stalową na podgrzewanym stole."
 
 #. MSG_PRESS_TO_UNLOAD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:11215 ../../Firmware/Marlin_main.cpp:11245
+#: ../../Firmware/Marlin_main.cpp:10287 ../../Firmware/Marlin_main.cpp:10317
 #: ../../Firmware/messages.cpp:84
 msgid "Please press the knob to unload filament"
 msgstr "Naciśnij pokrętło aby rozładować filament"
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:4932
+#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:4888
 msgid "Please pull out filament immediately"
 msgstr "Wyciągnij filament teraz"
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/messages.cpp:295 ../../Firmware/ultralcd.cpp:3856
+#: ../../Firmware/messages.cpp:307 ../../Firmware/ultralcd.cpp:3882
 msgid "Please remove shipping helpers first."
 msgstr "Najpierw usuń zabezpieczenia transportowe."
 
 #. MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3240 ../../Firmware/Marlin_main.cpp:4755
-#: ../../Firmware/messages.cpp:89
+#: ../../Firmware/Marlin_main.cpp:4324 ../../Firmware/messages.cpp:89
 msgid "Please remove steel sheet from heatbed."
 msgstr "Usuń płytę stalową z podgrzewanego stołu."
 
 #. MSG_RUN_XYZ c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4731 ../../Firmware/messages.cpp:207
+#: ../../Firmware/Marlin_main.cpp:4300 ../../Firmware/messages.cpp:219
 msgid "Please run XYZ calibration first."
 msgstr "Najpierw uruchom kalibrację XYZ."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/messages.cpp:336 ../../Firmware/ultralcd.cpp:6020
+#: ../../Firmware/messages.cpp:348 ../../Firmware/ultralcd.cpp:4359
+#: ../../Firmware/ultralcd.cpp:5996
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Najpierw wyładuj filament, następnie powtórz czynność."
 
 #. MSG_NEW_FIRMWARE_PLEASE_UPGRADE c=20
-#: ../../Firmware/messages.cpp:366 ../../Firmware/util.cpp:213
+#: ../../Firmware/messages.cpp:378 ../../Firmware/util.cpp:218
 msgid "Please upgrade."
 msgstr "Proszę zaktualizować"
 
 #. MSG_PLEASE_WAIT c=20
-#: ../../Firmware/Marlin_main.cpp:3521 ../../Firmware/Marlin_main.cpp:8090
-#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:2179
-#: ../../Firmware/ultralcd.cpp:2190
+#: ../../Firmware/Marlin_main.cpp:3261 ../../Firmware/Marlin_main.cpp:7262
+#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:2190
+#: ../../Firmware/ultralcd.cpp:2204
 msgid "Please wait"
 msgstr "Proszę czekać"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:1232
-#: ../../Firmware/ultralcd.cpp:1261
+#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:1242
+#: ../../Firmware/ultralcd.cpp:1271
 msgid "Power failures"
 msgstr "Zaniki zasil."
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/messages.cpp:323 ../../Firmware/ultralcd.cpp:5260
+#: ../../Firmware/messages.cpp:335 ../../Firmware/ultralcd.cpp:5222
 msgid "Preheat"
 msgstr "Grzanie"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:2254
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:2268
 msgid "Preheat the nozzle!"
 msgstr "Nagrzej dyszę!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:2771
-#: ../../Firmware/ultralcd.cpp:3690 ../../Firmware/ultralcd.cpp:3692
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:2788
+#: ../../Firmware/ultralcd.cpp:3700 ../../Firmware/ultralcd.cpp:3702
 msgid "Preheating nozzle. Please wait."
 msgstr "Nagrzewanie dyszy. Proszę czekać."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/messages.cpp:237 ../../Firmware/ultralcd.cpp:1999
+#: ../../Firmware/messages.cpp:249 ../../Firmware/ultralcd.cpp:2005
 msgid "Preheating to cut"
 msgstr "Nagrzew. do cięcia"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/messages.cpp:236 ../../Firmware/ultralcd.cpp:1996
+#: ../../Firmware/messages.cpp:248 ../../Firmware/ultralcd.cpp:2002
 msgid "Preheating to eject"
 msgstr "Nagrzew. do wysun."
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/messages.cpp:234 ../../Firmware/ultralcd.cpp:1987
+#: ../../Firmware/messages.cpp:246 ../../Firmware/ultralcd.cpp:1995
 msgid "Preheating to load"
 msgstr "Grzanie do załad."
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/messages.cpp:235 ../../Firmware/ultralcd.cpp:1992
+#: ../../Firmware/messages.cpp:247 ../../Firmware/ultralcd.cpp:1999
 msgid "Preheating to unload"
 msgstr "Nagrzew. do rozład."
 
@@ -1634,12 +1627,12 @@ msgid "Preparing blade"
 msgstr "Przygot. ostrza"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/messages.cpp:231 ../../Firmware/ultralcd.cpp:1799
+#: ../../Firmware/messages.cpp:243 ../../Firmware/ultralcd.cpp:1809
 msgid "Press the knob"
 msgstr "Wciśnij pokrętło"
 
 #. MSG_PRESS_TO_PREHEAT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:11227 ../../Firmware/messages.cpp:212
+#: ../../Firmware/Marlin_main.cpp:10299 ../../Firmware/messages.cpp:224
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Wciśnij pokrętło aby rozgrzać dyszę i kontynuować."
 
@@ -1649,34 +1642,34 @@ msgid "Print aborted"
 msgstr "Druk przerwany"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1106
-#: ../../Firmware/ultralcd.cpp:6994
+#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1116
+#: ../../Firmware/ultralcd.cpp:6971
 msgid "Print fan:"
 msgstr "Went. druku:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:5313
+#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5279
 msgid "Print from SD"
 msgstr "Druk z karty SD"
 
 #. MSG_PRINT_PAUSED c=20
-#: ../../Firmware/Marlin_main.cpp:3582 ../../Firmware/messages.cpp:79
+#: ../../Firmware/Marlin_main.cpp:3323 ../../Firmware/messages.cpp:79
 #: ../../Firmware/ultralcd.cpp:814
 msgid "Print paused"
 msgstr "Druk wstrzymany"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/messages.cpp:247 ../../Firmware/ultralcd.cpp:2348
+#: ../../Firmware/messages.cpp:259 ../../Firmware/ultralcd.cpp:2365
 msgid "Print time"
 msgstr "Czas druku"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/messages.cpp:225 ../../Firmware/ultralcd.cpp:1689
+#: ../../Firmware/messages.cpp:237 ../../Firmware/ultralcd.cpp:1699
 msgid "Printer IP Addr:"
 msgstr "Adr. IP drukarki:"
 
 #. MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1602 ../../Firmware/messages.cpp:46
+#: ../../Firmware/Marlin_main.cpp:1529 ../../Firmware/messages.cpp:46
 msgid ""
 "Printer has not been calibrated yet. Please follow the manual, chapter First"
 " steps, section Calibration flow."
@@ -1685,12 +1678,12 @@ msgstr ""
 "Pierwsze kroki."
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:153 ../../Firmware/util.cpp:289
+#: ../../Firmware/messages.cpp:160 ../../Firmware/util.cpp:296
 msgid "Nozzle diameter differs from the G-code. Continue?"
 msgstr "Średnica dyszy różni się od tej w G-code. Kontynuować?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:154 ../../Firmware/util.cpp:290
+#: ../../Firmware/messages.cpp:161 ../../Firmware/util.cpp:297
 msgid ""
 "Nozzle diameter differs from the G-code. Please check the value in settings."
 " Print cancelled."
@@ -1717,22 +1710,22 @@ msgid "QUEUE FULL"
 msgstr "KOLEJKA PEŁNA"
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:4465
 msgid "RPi port"
 msgstr "Port RPi"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/messages.cpp:261 ../../Firmware/ultralcd.cpp:2712
+#: ../../Firmware/messages.cpp:273 ../../Firmware/ultralcd.cpp:2729
 msgid "Rear side [µm]"
 msgstr "Tył [µm]"
 
 #. MSG_RECOVERING_PRINT c=20
-#: ../../Firmware/messages.cpp:216 ../../Firmware/power_panic.cpp:316
+#: ../../Firmware/messages.cpp:228 ../../Firmware/power_panic.cpp:328
 msgid "Recovering print"
 msgstr "Wznawianie druku"
 
 #. MSG_RENAME c=18
-#: ../../Firmware/messages.cpp:322 ../../Firmware/ultralcd.cpp:5143
+#: ../../Firmware/messages.cpp:334 ../../Firmware/ultralcd.cpp:5103
 msgid "Rename"
 msgstr "Zmień nazwę"
 
@@ -1746,19 +1739,19 @@ msgstr ""
 " pod względem indeksu narzędzia z poza zakresu (T0-T4)."
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:2713
-#: ../../Firmware/ultralcd.cpp:5144
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:2730
+#: ../../Firmware/ultralcd.cpp:5104
 msgid "Reset"
 msgstr "Reset"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/messages.cpp:320 ../../Firmware/ultralcd.cpp:4594
+#: ../../Firmware/messages.cpp:332 ../../Firmware/ultralcd.cpp:4550
 msgid "Reset XYZ calibr."
 msgstr "Reset kalibr. XYZ"
 
 #. MSG_RESUME_PRINT c=18
-#: ../../Firmware/Marlin_main.cpp:680 ../../Firmware/messages.cpp:91
-#: ../../Firmware/ultralcd.cpp:5286 ../../Firmware/ultralcd.cpp:5288
+#: ../../Firmware/Marlin_main.cpp:645 ../../Firmware/messages.cpp:91
+#: ../../Firmware/ultralcd.cpp:5252 ../../Firmware/ultralcd.cpp:5254
 msgid "Resume print"
 msgstr "Wznowić druk"
 
@@ -1785,17 +1778,17 @@ msgid "Returning selector"
 msgstr "Powrót wybieraka"
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/messages.cpp:252 ../../Firmware/ultralcd.cpp:2479
+#: ../../Firmware/messages.cpp:264 ../../Firmware/ultralcd.cpp:2496
 msgid "Right"
 msgstr "Prawa"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/messages.cpp:259 ../../Firmware/ultralcd.cpp:2710
+#: ../../Firmware/messages.cpp:271 ../../Firmware/ultralcd.cpp:2727
 msgid "Right side[µm]"
 msgstr "Prawo [µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/messages.cpp:286 ../../Firmware/ultralcd.cpp:3656
+#: ../../Firmware/messages.cpp:298 ../../Firmware/ultralcd.cpp:3666
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1804,8 +1797,8 @@ msgstr ""
 "Kontynuować?"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4509
-#: ../../Firmware/ultralcd.cpp:4511
+#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4476
+#: ../../Firmware/ultralcd.cpp:4478
 msgid "SD card"
 msgstr "Karta SD"
 
@@ -1820,23 +1813,23 @@ msgid "SELECTOR CANNOT MOVE"
 msgstr "WYBIERAK NIE RUSZA"
 
 #. MSG_STOPPED c=20
-#: ../../Firmware/Marlin_main.cpp:9887 ../../Firmware/messages.cpp:125
+#: ../../Firmware/Marlin_main.cpp:9047 ../../Firmware/messages.cpp:130
 msgid "STOPPED."
 msgstr "ZATRZYMANO."
 
 #. MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3223 ../../Firmware/Marlin_main.cpp:3245
-#: ../../Firmware/mesh_bed_calibration.cpp:2246 ../../Firmware/messages.cpp:44
+#: ../../Firmware/Marlin_main.cpp:2967 ../../Firmware/Marlin_main.cpp:2984
+#: ../../Firmware/mesh_bed_calibration.cpp:2231 ../../Firmware/messages.cpp:44
 msgid "Searching bed calibration point"
 msgstr "Szukam punktu kalib. na stole"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/messages.cpp:321 ../../Firmware/ultralcd.cpp:5136
+#: ../../Firmware/messages.cpp:333 ../../Firmware/ultralcd.cpp:5096
 msgid "Select"
 msgstr "Wybierz"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/messages.cpp:290 ../../Firmware/ultralcd.cpp:3730
+#: ../../Firmware/messages.cpp:302 ../../Firmware/ultralcd.cpp:3740
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
@@ -1845,25 +1838,25 @@ msgstr ""
 "ekranowym."
 
 #. MSG_SELECT_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3453 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3612
-#: ../../Firmware/ultralcd.cpp:6822
+#: ../../Firmware/Marlin_main.cpp:3192 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3622
+#: ../../Firmware/ultralcd.cpp:6798
 msgid "Select filament:"
 msgstr "Wybierz filament:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:110 ../../Firmware/ultralcd.cpp:3464
-#: ../../Firmware/ultralcd.cpp:4504
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:3474
+#: ../../Firmware/ultralcd.cpp:4471
 msgid "Select language"
 msgstr "Wybór języka"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/messages.cpp:300 ../../Firmware/ultralcd.cpp:3900
+#: ../../Firmware/messages.cpp:312 ../../Firmware/ultralcd.cpp:3924
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr "Wybierz temperaturę grzania dyszy odpowiednią dla materiału."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/messages.cpp:291 ../../Firmware/ultralcd.cpp:3735
+#: ../../Firmware/messages.cpp:303 ../../Firmware/ultralcd.cpp:3745
 msgid "Select temperature which matches your material."
 msgstr "Wybierz temperaturę, która odpowiada Twojemu filamentowi."
 
@@ -1874,63 +1867,63 @@ msgid "Selecting fil. slot"
 msgstr "Wyb. kanału fil."
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/messages.cpp:341 ../../Firmware/ultralcd.cpp:6274
+#: ../../Firmware/messages.cpp:353 ../../Firmware/ultralcd.cpp:6250
 msgid "Selftest OK"
 msgstr "Selftest OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/messages.cpp:340 ../../Firmware/ultralcd.cpp:6057
+#: ../../Firmware/messages.cpp:352 ../../Firmware/ultralcd.cpp:6033
 msgid "Selftest start"
 msgstr "Selftest startuje"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/messages.cpp:315 ../../Firmware/ultralcd.cpp:4581
+#: ../../Firmware/messages.cpp:327 ../../Firmware/ultralcd.cpp:4537
 msgid "Selftest"
 msgstr "Selftest"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/messages.cpp:342 ../../Firmware/ultralcd.cpp:6699
+#: ../../Firmware/messages.cpp:354 ../../Firmware/ultralcd.cpp:6675
 msgid "Selftest error!"
 msgstr "Błąd selftest!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6279
-#: ../../Firmware/ultralcd.cpp:6786 ../../Firmware/ultralcd.cpp:6984
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6255
+#: ../../Firmware/ultralcd.cpp:6762 ../../Firmware/ultralcd.cpp:6961
 msgid "Selftest failed"
 msgstr "Selftest nieudany"
 
 #. MSG_FORCE_SELFTEST c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1577 ../../Firmware/messages.cpp:202
+#: ../../Firmware/Marlin_main.cpp:1504 ../../Firmware/messages.cpp:214
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr ""
 "Zostanie uruchomiony Selftest aby dokładnie skalibrować punkt bazowy bez "
 "krańcówek."
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/messages.cpp:228 ../../Firmware/ultralcd.cpp:1701
+#: ../../Firmware/messages.cpp:240 ../../Firmware/ultralcd.cpp:1711
 msgid "Sensor info"
 msgstr "Info o sensorach"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/messages.cpp:338 ../../Firmware/ultralcd.cpp:6027
+#: ../../Firmware/messages.cpp:350 ../../Firmware/ultralcd.cpp:6003
 msgid "Sensor verified, remove the filament now."
 msgstr "Czujnik sprawdzony, wyciągnij filament."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/messages.cpp:262 ../../Firmware/ultralcd.cpp:2730
+#: ../../Firmware/messages.cpp:274 ../../Firmware/ultralcd.cpp:2747
 msgid "Set temperature:"
 msgstr "Ustaw temperaturę:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3348
-#: ../../Firmware/ultralcd.cpp:3479 ../../Firmware/ultralcd.cpp:3984
-#: ../../Firmware/ultralcd.cpp:5374 ../../Firmware/ultralcd.cpp:5585
-#: ../../Firmware/ultralcd.cpp:5631
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3358
+#: ../../Firmware/ultralcd.cpp:3489 ../../Firmware/ultralcd.cpp:4008
+#: ../../Firmware/ultralcd.cpp:5341 ../../Firmware/ultralcd.cpp:5558
+#: ../../Firmware/ultralcd.cpp:5604
 msgid "Settings"
 msgstr "Ustawienia"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/messages.cpp:255 ../../Firmware/ultralcd.cpp:2522
+#: ../../Firmware/messages.cpp:267 ../../Firmware/ultralcd.cpp:2539
 msgid "Severe skew"
 msgstr "Znaczny skos"
 
@@ -1941,7 +1934,7 @@ msgid "Sheet"
 msgstr "Płyta"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/messages.cpp:284 ../../Firmware/ultralcd.cpp:3604
+#: ../../Firmware/messages.cpp:296 ../../Firmware/ultralcd.cpp:3614
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1954,23 +1947,23 @@ msgstr ""
 "%cReset"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/messages.cpp:319 ../../Firmware/ultralcd.cpp:4592
+#: ../../Firmware/messages.cpp:331 ../../Firmware/ultralcd.cpp:4548
 msgid "Show end stops"
 msgstr "Pokaż krańcówki"
 
 #. MSG_SILENT c=7
-#: ../../Firmware/Marlin_main.cpp:8497 ../../Firmware/messages.cpp:120
-#: ../../Firmware/ultralcd.cpp:4155 ../../Firmware/ultralcd.cpp:4194
+#: ../../Firmware/Marlin_main.cpp:7668 ../../Firmware/messages.cpp:124
+#: ../../Firmware/ultralcd.cpp:4179 ../../Firmware/ultralcd.cpp:4218
 msgid "Silent"
 msgstr "Cichy"
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/messages.cpp:254 ../../Firmware/ultralcd.cpp:2521
+#: ../../Firmware/messages.cpp:266 ../../Firmware/ultralcd.cpp:2538
 msgid "Slight skew"
 msgstr "Lekki skos"
 
 #. MSG_FILE_CNT c=20 r=6
-#: ../../Firmware/cardreader.cpp:805 ../../Firmware/messages.cpp:197
+#: ../../Firmware/cardreader.cpp:805 ../../Firmware/messages.cpp:209
 msgid ""
 "Some files will not be sorted. Max. No. of files in 1 folder for sorting is "
 "100."
@@ -1979,59 +1972,59 @@ msgstr ""
 "100."
 
 #. MSG_ZLEVELING_ENFORCED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3043 ../../Firmware/messages.cpp:204
+#: ../../Firmware/Marlin_main.cpp:2783 ../../Firmware/messages.cpp:216
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Wykryto problem - wymuszono poziomowanie osi Z."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:4514
-#: ../../Firmware/ultralcd.cpp:4515 ../../Firmware/ultralcd.cpp:4516
+#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4481
+#: ../../Firmware/ultralcd.cpp:4482 ../../Firmware/ultralcd.cpp:4483
 msgid "Sort"
 msgstr "Sort."
 
 #. MSG_SORTING_FILES c=20
 #: ../../Firmware/cardreader.cpp:849 ../../Firmware/cardreader.cpp:916
-#: ../../Firmware/messages.cpp:111
+#: ../../Firmware/messages.cpp:115
 msgid "Sorting files"
 msgstr "Sortowanie plików"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4188
-#: ../../Firmware/ultralcd.cpp:4191 ../../Firmware/ultralcd.cpp:4194
-#: ../../Firmware/ultralcd.cpp:4197 ../../Firmware/ultralcd.cpp:4200
+#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4215 ../../Firmware/ultralcd.cpp:4218
+#: ../../Firmware/ultralcd.cpp:4221 ../../Firmware/ultralcd.cpp:4224
 msgid "Sound"
 msgstr "Dźwięk"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/messages.cpp:333 ../../Firmware/ultralcd.cpp:5516
+#: ../../Firmware/messages.cpp:345 ../../Firmware/ultralcd.cpp:5483
 msgid "Speed"
 msgstr "Prędkość"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6861
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6837
 msgid "Spinning"
 msgstr "Kręci się"
 
 #. MSG_TEMP_CAL_WARNING c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4744 ../../Firmware/messages.cpp:208
+#: ../../Firmware/Marlin_main.cpp:4313 ../../Firmware/messages.cpp:220
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr ""
 "Potrzebna jest stabilna temperatura otoczenia 21-26C i stabilne podłoże."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/messages.cpp:329 ../../Firmware/ultralcd.cpp:5379
+#: ../../Firmware/messages.cpp:341 ../../Firmware/ultralcd.cpp:5346
 msgid "Statistics"
 msgstr "Statystyki"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:4096
-#: ../../Firmware/ultralcd.cpp:4144
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4120
+#: ../../Firmware/ultralcd.cpp:4168
 msgid "Stealth"
 msgstr "Cichy"
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4421
-#: ../../Firmware/ultralcd.cpp:5133
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4388
+#: ../../Firmware/ultralcd.cpp:5093
 msgid "Steel sheets"
 msgstr "Płyty stalowe"
 
@@ -2041,29 +2034,28 @@ msgid "Stop"
 msgstr "Stop"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:5293
-#: ../../Firmware/ultralcd.cpp:5781
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:5259
+#: ../../Firmware/ultralcd.cpp:5757
 msgid "Stop print"
 msgstr "Przerwanie druku"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4236
-#: ../../Firmware/ultralcd.cpp:4316 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4315
 msgid "Strict"
 msgstr "Restr."
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/messages.cpp:332 ../../Firmware/ultralcd.cpp:5394
+#: ../../Firmware/messages.cpp:344 ../../Firmware/ultralcd.cpp:5361
 msgid "Support"
 msgstr "Wsparcie"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/messages.cpp:354 ../../Firmware/ultralcd.cpp:6758
+#: ../../Firmware/messages.cpp:366 ../../Firmware/ultralcd.cpp:6734
 msgid "Swapped"
 msgstr "Zamieniono"
 
 #. MSG_THERMAL_ANOMALY c=20
-#: ../../Firmware/messages.cpp:188 ../../Firmware/temperature.cpp:2223
+#: ../../Firmware/messages.cpp:195 ../../Firmware/temperature.cpp:2197
 msgid "THERMAL ANOMALY"
 msgstr "ANOMALIA TERMICZNA"
 
@@ -2098,7 +2090,7 @@ msgid "TMC UNDERVOLTAGE ERR"
 msgstr "ZA NIS. NAPIĘCIE TMC"
 
 #. MSG_TM_CAL c=20 r=4
-#: ../../Firmware/messages.cpp:299 ../../Firmware/ultralcd.cpp:3881
+#: ../../Firmware/messages.cpp:311 ../../Firmware/ultralcd.cpp:3905
 msgid ""
 "Thermal model cal. takes approx. 12 mins. See\n"
 "prusa.io/tm-cal"
@@ -2107,22 +2099,22 @@ msgstr ""
 "prusa.io/tm-cal"
 
 #. MSG_TM_NOT_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1613 ../../Firmware/messages.cpp:189
+#: ../../Firmware/Marlin_main.cpp:1540 ../../Firmware/messages.cpp:196
 msgid "Thermal model not calibrated yet."
 msgstr "Model termiczny nie został jeszcze skalib."
 
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/messages.cpp:309 ../../Firmware/ultralcd.cpp:4455
+#: ../../Firmware/messages.cpp:321 ../../Firmware/ultralcd.cpp:4422
 msgid "Temperature"
 msgstr "Temperatura"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/messages.cpp:229 ../../Firmware/ultralcd.cpp:1707
+#: ../../Firmware/messages.cpp:241 ../../Firmware/ultralcd.cpp:1717
 msgid "Temperatures"
 msgstr "Temperatury"
 
 #. MSG_TESTING_FILAMENT c=20
-#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:388
+#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:389
 msgid "Testing filament"
 msgstr "Testowanie filamentu"
 
@@ -2143,7 +2135,7 @@ msgstr ""
 " ruchu."
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/messages.cpp:292 ../../Firmware/ultralcd.cpp:3738
+#: ../../Firmware/messages.cpp:304 ../../Firmware/ultralcd.cpp:3748
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -2154,7 +2146,7 @@ msgstr ""
 " Kalibracja)."
 
 #. MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1606 ../../Firmware/messages.cpp:47
+#: ../../Firmware/Marlin_main.cpp:1533 ../../Firmware/messages.cpp:47
 msgid ""
 "There is still a need to make Z calibration. Please follow the manual, "
 "chapter First steps, section Calibration flow."
@@ -2163,40 +2155,40 @@ msgstr ""
 "Pierwsze Kroki."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:4514
+#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:4481
 msgid "Time"
 msgstr "Czas"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:176 ../../Firmware/ultralcd.cpp:5622
+#: ../../Firmware/messages.cpp:183 ../../Firmware/ultralcd.cpp:5595
 msgid "Timeout"
 msgstr "Wył. czas."
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:1129
-#: ../../Firmware/ultralcd.cpp:1287
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:1139
+#: ../../Firmware/ultralcd.cpp:1297
 msgid "Total"
 msgstr "Suma"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:1177
-#: ../../Firmware/ultralcd.cpp:1231 ../../Firmware/ultralcd.cpp:1317
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:1187
+#: ../../Firmware/ultralcd.cpp:1241 ../../Firmware/ultralcd.cpp:1327
 msgid "Total failures"
 msgstr "Suma błędów"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/messages.cpp:248 ../../Firmware/ultralcd.cpp:2369
+#: ../../Firmware/messages.cpp:260 ../../Firmware/ultralcd.cpp:2386
 msgid "Total filament"
 msgstr "Zużycie filamentu"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/messages.cpp:249 ../../Firmware/ultralcd.cpp:2370
+#: ../../Firmware/messages.cpp:261 ../../Firmware/ultralcd.cpp:2387
 msgid "Total print time"
 msgstr "Łączny czas druku"
 
 #. MSG_TUNE c=8
-#: ../../Firmware/messages.cpp:116 ../../Firmware/mmu2/errors_list.h:372
-#: ../../Firmware/ultralcd.cpp:5258
+#: ../../Firmware/messages.cpp:120 ../../Firmware/mmu2/errors_list.h:372
+#: ../../Firmware/ultralcd.cpp:5220
 msgid "Tune"
 msgstr "Dostrój"
 
@@ -2211,16 +2203,16 @@ msgid "Unload"
 msgstr "Wyładuj"
 
 #. MSG_UNLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:2206
-#: ../../Firmware/ultralcd.cpp:5347 ../../Firmware/ultralcd.cpp:5364
-#: ../../Firmware/ultralcd.cpp:5369
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:2220
+#: ../../Firmware/ultralcd.cpp:5313 ../../Firmware/ultralcd.cpp:5331
+#: ../../Firmware/ultralcd.cpp:5336
 msgid "Unload filament"
 msgstr "Wyładuj filament"
 
 #. MSG_UNLOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3436 ../../Firmware/messages.cpp:129
+#: ../../Firmware/Marlin_main.cpp:3175 ../../Firmware/messages.cpp:134
 #: ../../Firmware/mmu2_progress_converter.cpp:50
-#: ../../Firmware/ultralcd.cpp:4911
+#: ../../Firmware/ultralcd.cpp:4867
 msgid "Unloading filament"
 msgstr "Wyładowuję filament"
 
@@ -2237,12 +2229,12 @@ msgid "Unloading to pulley"
 msgstr "Wyład. do radełka"
 
 #. MSG_FIL_FAILED c=20 r=4
-#: ../../Firmware/messages.cpp:339 ../../Firmware/ultralcd.cpp:6030
+#: ../../Firmware/messages.cpp:351 ../../Firmware/ultralcd.cpp:6006
 msgid "Verification failed, remove the filament and try again."
 msgstr "Niepowodzenie sprawdzenia, wyciągnij filament i spróbuj ponownie."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/messages.cpp:230 ../../Firmware/ultralcd.cpp:1710
+#: ../../Firmware/messages.cpp:242 ../../Firmware/ultralcd.cpp:1720
 msgid "Voltages"
 msgstr "Napięcia"
 
@@ -2253,7 +2245,7 @@ msgid "WARNING TMC TOO HOT"
 msgstr "UWAGA TMC ZA GORĄCY"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/messages.cpp:281 ../../Firmware/ultralcd.cpp:3381
+#: ../../Firmware/messages.cpp:293 ../../Firmware/ultralcd.cpp:3391
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -2266,187 +2258,187 @@ msgstr ""
 "trybie Stealth"
 
 #. MSG_USERWAIT c=20
-#: ../../Firmware/Marlin_main.cpp:5240 ../../Firmware/messages.cpp:209
+#: ../../Firmware/Marlin_main.cpp:4747 ../../Firmware/messages.cpp:221
 msgid "Wait for user..."
 msgstr "Czekam na użytk. ..."
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/messages.cpp:263 ../../Firmware/ultralcd.cpp:2753
+#: ../../Firmware/messages.cpp:275 ../../Firmware/ultralcd.cpp:2770
 msgid "Waiting for PINDA probe cooling"
 msgstr "Czekam na wychłodzenie sondy PINDA"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/messages.cpp:264 ../../Firmware/ultralcd.cpp:2782
+#: ../../Firmware/messages.cpp:276 ../../Firmware/ultralcd.cpp:2799
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Oczekiwanie na wychłodzenie dyszy i stołu"
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:4233
-#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4352
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4312
 msgid "Warn"
 msgstr "Ostrzeź"
 
 #. MSG_CHANGED_BOTH c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1554 ../../Firmware/messages.cpp:200
+#: ../../Firmware/Marlin_main.cpp:1481 ../../Firmware/messages.cpp:212
 msgid "Warning: both printer type and motherboard type changed."
 msgstr "Ostrzeżenie: typ drukarki i płyta główna uległy zmianie."
 
 #. MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1546 ../../Firmware/messages.cpp:198
+#: ../../Firmware/Marlin_main.cpp:1473 ../../Firmware/messages.cpp:210
 msgid "Warning: motherboard type changed."
 msgstr "Ostrzeżenie: płyta główna uległa zmianie."
 
 #. MSG_CHANGED_PRINTER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1550 ../../Firmware/messages.cpp:199
+#: ../../Firmware/Marlin_main.cpp:1477 ../../Firmware/messages.cpp:211
 msgid "Warning: printer type changed."
 msgstr "Ostrzeżenie: rodzaj drukarki uległ zmianie."
 
 #. MSG_UNLOAD_SUCCESSFUL c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3517 ../../Firmware/messages.cpp:205
+#: ../../Firmware/Marlin_main.cpp:3257 ../../Firmware/messages.cpp:217
 msgid "Was filament unload successful?"
 msgstr "Wyładowanie fil. udane?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:6710
-#: ../../Firmware/ultralcd.cpp:6714 ../../Firmware/ultralcd.cpp:6734
-#: ../../Firmware/ultralcd.cpp:6740 ../../Firmware/ultralcd.cpp:6764
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:6686
+#: ../../Firmware/ultralcd.cpp:6690 ../../Firmware/ultralcd.cpp:6710
+#: ../../Firmware/ultralcd.cpp:6716 ../../Firmware/ultralcd.cpp:6740
 msgid "Wiring error"
 msgstr "Błąd połączenia"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/messages.cpp:313 ../../Firmware/ultralcd.cpp:4572
+#: ../../Firmware/messages.cpp:325 ../../Firmware/ultralcd.cpp:4528
 msgid "Wizard"
 msgstr "Asystent"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/messages.cpp:304 ../../Firmware/ultralcd.cpp:3986
+#: ../../Firmware/messages.cpp:316 ../../Firmware/ultralcd.cpp:4010
 msgid "X-correct"
 msgstr "Korekcja-X"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/messages.cpp:226 ../../Firmware/ultralcd.cpp:1699
+#: ../../Firmware/messages.cpp:238 ../../Firmware/ultralcd.cpp:1709
 msgid "XYZ cal. details"
 msgstr "Szczegóły kal. XYZ"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/messages.cpp:275 ../../Firmware/ultralcd.cpp:3207
+#: ../../Firmware/messages.cpp:287 ../../Firmware/ultralcd.cpp:3217
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr "Kalibracja XYZ pomyślna. Skos będzie automatycznie korygowany."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/messages.cpp:274 ../../Firmware/ultralcd.cpp:3204
+#: ../../Firmware/messages.cpp:286 ../../Firmware/ultralcd.cpp:3214
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr "Kalibracja XYZ prawidłowa. Osie X/Y lekko skośne. Dobra robota!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/messages.cpp:271 ../../Firmware/ultralcd.cpp:3185
+#: ../../Firmware/messages.cpp:283 ../../Firmware/ultralcd.cpp:3195
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr "Kalibr. XYZ niedokładna. Przednie punkty kalibr. nieosiągalne."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/messages.cpp:272 ../../Firmware/ultralcd.cpp:3188
+#: ../../Firmware/messages.cpp:284 ../../Firmware/ultralcd.cpp:3198
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr "Kalibracja XYZ niedokładna. Prawy przedni punkt nieosiągalny."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/messages.cpp:268 ../../Firmware/ultralcd.cpp:3167
+#: ../../Firmware/messages.cpp:280 ../../Firmware/ultralcd.cpp:3177
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr "Kalibracja XYZ nieudana. Nie znaleziono punktów kalibracyjnych."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/messages.cpp:269 ../../Firmware/ultralcd.cpp:3173
+#: ../../Firmware/messages.cpp:281 ../../Firmware/ultralcd.cpp:3183
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr "Kalibracja XYZ nieudana. Przednie punkty kalibracji nieosiągalne."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3170
-#: ../../Firmware/ultralcd.cpp:3198
+#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3180
+#: ../../Firmware/ultralcd.cpp:3208
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr ""
 "Kalibracja XYZ nieudana. Sprawdź przyczyny i rozwiązania w podręczniku."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/messages.cpp:270 ../../Firmware/ultralcd.cpp:3176
+#: ../../Firmware/messages.cpp:282 ../../Firmware/ultralcd.cpp:3186
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr "Kalibracja XYZ nieudana. Prawy przedni punkt nieosiągalny."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/messages.cpp:273 ../../Firmware/ultralcd.cpp:3201
+#: ../../Firmware/messages.cpp:285 ../../Firmware/ultralcd.cpp:3211
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "Kalibracja XYZ ok. Osie X/Y są prostopadłe. Gratulacje!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/messages.cpp:250 ../../Firmware/ultralcd.cpp:2476
+#: ../../Firmware/messages.cpp:262 ../../Firmware/ultralcd.cpp:2493
 msgid "Y distance from min"
 msgstr "Dystans od 0 w osi Y"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/messages.cpp:305 ../../Firmware/ultralcd.cpp:3987
+#: ../../Firmware/messages.cpp:317 ../../Firmware/ultralcd.cpp:4011
 msgid "Y-correct"
 msgstr "Korekcja-Y"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:3029
-#: ../../Firmware/ultralcd.cpp:4443 ../../Firmware/ultralcd.cpp:4531
-#: ../../Firmware/ultralcd.cpp:5790
+#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:2275
+#: ../../Firmware/ultralcd.cpp:2279 ../../Firmware/ultralcd.cpp:3046
+#: ../../Firmware/ultralcd.cpp:4410 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/ultralcd.cpp:5766
 msgid "Yes"
 msgstr "Tak"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:3950
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:3974
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr ""
 "Zawsze możesz uruchomić Asystenta ponownie przez Kalibracja -> Asystent."
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/messages.cpp:306 ../../Firmware/ultralcd.cpp:3988
+#: ../../Firmware/messages.cpp:318 ../../Firmware/ultralcd.cpp:4012
 msgid "Z-correct"
 msgstr "Korekcja-Z"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5593
+#: ../../Firmware/messages.cpp:175 ../../Firmware/ultralcd.cpp:5566
 msgid "Z-probe nr."
 msgstr "Ilość Pomiarów"
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/messages.cpp:256 ../../Firmware/ultralcd.cpp:2546
+#: ../../Firmware/messages.cpp:268 ../../Firmware/ultralcd.cpp:2563
 msgid "[0;0] point offset"
 msgstr "[0;0] przesuń.punktu"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/messages.cpp:239 ../../Firmware/ultralcd.cpp:2147
+#: ../../Firmware/messages.cpp:251 ../../Firmware/ultralcd.cpp:2158
 msgid "and press the knob"
 msgstr "i naciśnij pokrętło"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/messages.cpp:232 ../../Firmware/ultralcd.cpp:1807
+#: ../../Firmware/messages.cpp:244 ../../Firmware/ultralcd.cpp:1816
 msgid "to load filament"
 msgstr "aby załadow. fil."
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/messages.cpp:233 ../../Firmware/ultralcd.cpp:1811
+#: ../../Firmware/messages.cpp:245 ../../Firmware/ultralcd.cpp:1820
 msgid "to unload filament"
 msgstr "aby wyład. filament"
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/messages.cpp:224 ../../Firmware/ultralcd.cpp:1666
+#: ../../Firmware/messages.cpp:236 ../../Firmware/ultralcd.cpp:1676
 msgid "unknown"
 msgstr "nieznane"
 
 #. MSG_IR_UNKNOWN c=18
-#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:184
+#: ../../Firmware/Filament_sensor.cpp:286 ../../Firmware/messages.cpp:191
 msgid "unknown state"
 msgstr "Stan nieznany"
 
 #. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:5858
-#: ../../Firmware/ultralcd.cpp:5861
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:5834
+#: ../../Firmware/ultralcd.cpp:5837
 msgid "🔃Refresh"
 msgstr "🔃Odświeżać"
 
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1180
+#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1190
 msgid "MMU power fails"
 msgstr "Zaniki zas. MMU"
 
@@ -2484,8 +2476,8 @@ msgid "MMU MCU ERROR"
 msgstr "MMU MCU BŁĄD"
 
 #. MSG_MATERIAL_CHANGES c=18
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:1130
-#: ../../Firmware/ultralcd.cpp:1204
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:1140
+#: ../../Firmware/ultralcd.cpp:1214
 msgid "Material changes"
 msgstr "Wymiany materiałów"
 
@@ -2517,17 +2509,17 @@ msgstr ""
 "wersji 3.0.3."
 
 #. MSG_PRELOAD_TO_MMU c=17
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5344
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5310
 msgid "Preload to MMU"
 msgstr "Załaduj do MMU"
 
 #. MSG_FW_MK3_DETECTED c=20 r=4
-#: ../../Firmware/messages.cpp:367 ../../Firmware/Marlin_main.cpp:920
+#: ../../Firmware/messages.cpp:379 ../../Firmware/Marlin_main.cpp:854
 msgid "MK3 firmware detected on MK3S printer"
 msgstr "Wykryto firmware MK3 w drukarce MK3S"
 
 #. MSG_FW_MK3S_DETECTED c=20 r=4
-#: ../../Firmware/messages.cpp:367 ../../Firmware/Marlin_main.cpp:920
+#: ../../Firmware/messages.cpp:379 ../../Firmware/Marlin_main.cpp:854
 msgid "MK3S firmware detected on MK3 printer"
 msgstr "Wykryto firmware MK3S w drukarce MK3"
 
@@ -2541,8 +2533,9 @@ msgstr "NIEZNANY BŁĄD"
 msgid "Unexpected error occurred."
 msgstr "Pojawił się nieoczekiwany błąd."
 
-#. MSG_BTN_EJECT c=8
-#: ../../Firmware/mmu2/errors_list.h:358 ../../Firmware/mmu2/errors_list.h:371
+#. MSG_EJECT c=8
+#: ../../Firmware/messages.cpp:21 ../../Firmware/mmu2/errors_list.h:371
+#: ../../Firmware/ultralcd.cpp:2275 ../../Firmware/ultralcd.cpp:2279
 msgid "Eject"
 msgstr "Wysuń"
 
@@ -2562,58 +2555,58 @@ msgid "M600 Filament Change. Load a new filament or eject the old one."
 msgstr "Załaduj nowy filament lub wyładuj poprzedni."
 
 #. MSG_MMU_SENSITIVITY c=18
-#: ../../Firmware/messages.cpp:215 ../../Firmware/mmu2_reporting.cpp:458
+#: ../../Firmware/messages.cpp:227 ../../Firmware/mmu2_reporting.cpp:459
 msgid "Sensitivity"
 msgstr "Czułość"
 
 #. MSG_MBL_FAILED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3038 ../../Firmware/messages.cpp:203
+#: ../../Firmware/Marlin_main.cpp:2776 ../../Firmware/messages.cpp:215
 msgid "Mesh bed leveling failed. Print canceled."
 msgstr "Poziomowanie stołu nieudane. Druk anulowany."
 
 #. MSG_SET_READY c=18
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:5265
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:5228
 msgid "Set Ready"
 msgstr "Ustaw gotowość"
 
 #. MSG_SET_NOT_READY c=18
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:5263
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5226
 msgid "Set not Ready"
 msgstr "Cofnij gotowość"
 
 #. MSG_HOSTPRINT c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5285
+#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:5231
 msgid "Print from host"
 msgstr "Drukuj z hosta"
 
 #. MSG_REPRINT c=18
-#: ../../Firmware/messages.cpp:196 ../../Firmware/ultralcd.cpp:5243
-#: ../../Firmware/ultralcd.cpp:5245
+#: ../../Firmware/messages.cpp:208 ../../Firmware/ultralcd.cpp:5205
+#: ../../Firmware/ultralcd.cpp:5207
 msgid "Reprint"
 msgstr "Przedruk"
 
 #. MSG_SHUTDOWN_HOST c=18
-#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:5390
+#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:5357
 msgid "Shutdown host"
 msgstr "Zamknięcie hosta"
 
 #. MSG_NOZZLE_CNG_COOLDOWN c=20 r=3
-#: ../../Firmware/messages.cpp:198 ../../Firmware/ultralcd.cpp:1002
+#: ../../Firmware/messages.cpp:203 ../../Firmware/ultralcd.cpp:999
 msgid "Nozzle is hot! Wait for cooldown."
 msgstr "Dysza jest gorąca! Poczekaj na schłodzenie."
 
 #. MSG_NOZZLE_CNG_CHANGED_QUICK c=20 r=3
-#: ../../Firmware/messages.cpp:199
+#: ../../Firmware/messages.cpp:204
 msgid "Nozzle changed?"
 msgstr "Dysza została zmieniona?"
 
 #. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:388
+#: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:388
 msgid "There is no filament loaded. Continue?"
 msgstr "Nie ma załadowanego filamentu. Kontynuować?"
 
 #. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:389
+#: ../../Firmware/messages.cpp:159 ../../Firmware/util.cpp:389
 msgid "There is no filament loaded. Print cancelled."
 msgstr "Nie ma załadowanego filamentu. Druk anulowany."
 

--- a/lang/po/Firmware_ro.po
+++ b/lang/po/Firmware_ro.po
@@ -16,91 +16,91 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 
 #. MSG_IR_03_OR_OLDER c=18
-#: ../../Firmware/Filament_sensor.cpp:280
-#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:183
+#: ../../Firmware/Filament_sensor.cpp:282
+#: ../../Firmware/Filament_sensor.cpp:344 ../../Firmware/messages.cpp:190
 msgid " 0.3 or older"
 msgstr " 0.3 / mai vechi"
 
 #. MSG_IR_04_OR_NEWER c=18
-#: ../../Firmware/Filament_sensor.cpp:282
-#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:182
+#: ../../Firmware/Filament_sensor.cpp:284
+#: ../../Firmware/Filament_sensor.cpp:347 ../../Firmware/messages.cpp:189
 msgid " 0.4 or newer"
 msgstr " 0.4 / mai nou"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/messages.cpp:356 ../../Firmware/ultralcd.cpp:6773
+#: ../../Firmware/messages.cpp:368 ../../Firmware/ultralcd.cpp:6749
 msgid "%s level expected"
 msgstr "nivel %s așteptat"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:1978
-#: ../../Firmware/ultralcd.cpp:3613
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:1986
+#: ../../Firmware/ultralcd.cpp:3623
 msgid ">Cancel"
 msgstr ">Anulează"
 
 #. MSG_BABYSTEPPING_Z c=13
-#: ../../Firmware/messages.cpp:257 ../../Firmware/ultralcd.cpp:2635
+#: ../../Firmware/messages.cpp:269 ../../Firmware/ultralcd.cpp:2652
 msgid "Adjusting Z"
 msgstr "Ajustare Z"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/messages.cpp:360 ../../Firmware/ultralcd.cpp:6983
+#: ../../Firmware/messages.cpp:372 ../../Firmware/ultralcd.cpp:6960
 msgid "All correct"
 msgstr "Totul OK"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:3955
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:3979
 msgid "All is done. Happy printing!"
 msgstr "Totul este OK. Distracție plăcută!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4482
 msgid "Alphabet"
 msgstr "Alfabet"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4086
+#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4110
 msgid "Always"
 msgstr "Mereu"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/messages.cpp:221 ../../Firmware/ultralcd.cpp:1393
+#: ../../Firmware/messages.cpp:233 ../../Firmware/ultralcd.cpp:1403
 msgid "Ambient"
 msgstr "Ambiental"
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=3
-#: ../../Firmware/messages.cpp:267 ../../Firmware/ultralcd.cpp:2848
+#: ../../Firmware/messages.cpp:279 ../../Firmware/ultralcd.cpp:2865
 msgid "Are left and right Z-carriages all up?"
 msgstr "Este axa Z aliniată sus?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4197
+#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:4221
 msgid "Assist"
 msgstr "Asist."
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:179 ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/messages.cpp:186 ../../Firmware/ultralcd.cpp:5594
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
-#: ../../Firmware/Marlin_main.cpp:3198 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:4577 ../../Firmware/ultralcd.cpp:5529
+#: ../../Firmware/Marlin_main.cpp:2942 ../../Firmware/messages.cpp:12
+#: ../../Firmware/ultralcd.cpp:4533 ../../Firmware/ultralcd.cpp:5496
 msgid "Auto home"
 msgstr "Auto home"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4182
 msgid "Auto power"
 msgstr "Put. auto"
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:328 ../../Firmware/ultralcd.cpp:5359
+#: ../../Firmware/messages.cpp:340 ../../Firmware/ultralcd.cpp:5328
 msgid "AutoLoad filament"
 msgstr "Înc.auto filament"
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/messages.cpp:245 ../../Firmware/ultralcd.cpp:2272
+#: ../../Firmware/messages.cpp:257 ../../Firmware/ultralcd.cpp:2289
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
@@ -114,51 +114,50 @@ msgid "Avoiding grind"
 msgstr "Avoiding grind"
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/messages.cpp:352 ../../Firmware/ultralcd.cpp:6752
+#: ../../Firmware/messages.cpp:364 ../../Firmware/ultralcd.cpp:6728
 msgid "Axis"
 msgstr "Axa"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/messages.cpp:351 ../../Firmware/ultralcd.cpp:6751
+#: ../../Firmware/messages.cpp:363 ../../Firmware/ultralcd.cpp:6727
 msgid "Axis length"
 msgstr "Lungime axă"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2708
-#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:5618
-#: ../../Firmware/ultralcd.cpp:7484
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2725
+#: ../../Firmware/ultralcd.cpp:4061 ../../Firmware/ultralcd.cpp:5591
+#: ../../Firmware/ultralcd.cpp:7461
 msgid "Back"
 msgstr "Înapoi"
 
 #. MSG_BED c=13
-#: ../../Firmware/Marlin_main.cpp:2081 ../../Firmware/Marlin_main.cpp:4627
-#: ../../Firmware/Marlin_main.cpp:4678 ../../Firmware/messages.cpp:15
-#: ../../Firmware/ultralcd.cpp:1391 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/Marlin_main.cpp:4247 ../../Firmware/messages.cpp:15
+#: ../../Firmware/ultralcd.cpp:1401 ../../Firmware/ultralcd.cpp:4197
 msgid "Bed"
 msgstr "Pat"
 
 #. MSG_BED_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6240 ../../Firmware/messages.cpp:17
+#: ../../Firmware/Marlin_main.cpp:5470 ../../Firmware/messages.cpp:17
 #: ../../Firmware/ultralcd.cpp:534
 msgid "Bed Heating"
 msgstr "Patul se incălzește"
 
 #. MSG_BED_DONE c=20
-#: ../../Firmware/Marlin_main.cpp:6277 ../../Firmware/messages.cpp:16
+#: ../../Firmware/Marlin_main.cpp:5507 ../../Firmware/messages.cpp:16
 #: ../../Firmware/ultralcd.cpp:537
 msgid "Bed done"
 msgstr "Pat încălzit"
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/messages.cpp:317 ../../Firmware/ultralcd.cpp:4589
+#: ../../Firmware/messages.cpp:329 ../../Firmware/ultralcd.cpp:4545
 msgid "Bed level correct"
 msgstr "Nivelare pat"
 
 #. MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:2262 ../../Firmware/Marlin_main.cpp:2999
-#: ../../Firmware/Marlin_main.cpp:3008
-#: ../../Firmware/mesh_bed_calibration.cpp:2878
-#: ../../Firmware/mesh_bed_calibration.cpp:2903 ../../Firmware/messages.cpp:18
+#: ../../Firmware/Marlin_main.cpp:2048 ../../Firmware/Marlin_main.cpp:2736
+#: ../../Firmware/Marlin_main.cpp:2745
+#: ../../Firmware/mesh_bed_calibration.cpp:2863
+#: ../../Firmware/mesh_bed_calibration.cpp:2888 ../../Firmware/messages.cpp:18
 msgid ""
 "Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for "
 "reset."
@@ -167,34 +166,34 @@ msgstr ""
 "reset."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/messages.cpp:346 ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/messages.cpp:358 ../../Firmware/ultralcd.cpp:6685
 msgid "Bed/Heater"
 msgstr "Încălzitor/Pat"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1444
-#: ../../Firmware/ultralcd.cpp:1704
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1454
+#: ../../Firmware/ultralcd.cpp:1714
 msgid "Belt status"
 msgstr "Status curele"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/messages.cpp:314 ../../Firmware/ultralcd.cpp:4579
+#: ../../Firmware/messages.cpp:326 ../../Firmware/ultralcd.cpp:4535
 msgid "Belt test"
 msgstr "Test curele"
 
 #. MSG_RECOVER_PRINT c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:1660 ../../Firmware/messages.cpp:87
+#: ../../Firmware/Marlin_main.cpp:1587 ../../Firmware/messages.cpp:87
 msgid "Blackout occurred. Recover print?"
 msgstr "Pană de curent. Continuați printul?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:177 ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:5594
 msgid "Bright"
 msgstr "Maxim"
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:4526
-#: ../../Firmware/ultralcd.cpp:5546
+#: ../../Firmware/messages.cpp:180 ../../Firmware/ultralcd.cpp:4493
+#: ../../Firmware/ultralcd.cpp:5513
 msgid "Brightness"
 msgstr "Luminozitate ecran"
 
@@ -204,17 +203,17 @@ msgid "COMMUNICATION ERROR"
 msgstr "EROARE DE COMUNICARE"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/messages.cpp:316 ../../Firmware/ultralcd.cpp:4583
+#: ../../Firmware/messages.cpp:328 ../../Firmware/ultralcd.cpp:4539
 msgid "Calibrate XYZ"
 msgstr "Calibrare XYZ"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4585
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4541
 msgid "Calibrate Z"
 msgstr "Calibrare Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/messages.cpp:266 ../../Firmware/ultralcd.cpp:2813
+#: ../../Firmware/messages.cpp:278 ../../Firmware/ultralcd.cpp:2830
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -223,13 +222,13 @@ msgstr ""
 "butonul când este gata."
 
 #. MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: ../../Firmware/Marlin_main.cpp:2218 ../../Firmware/messages.cpp:22
+#: ../../Firmware/Marlin_main.cpp:2009 ../../Firmware/messages.cpp:23
 #: ../../Firmware/ultralcd.cpp:582
 msgid "Calibrating Z"
 msgstr "Calibrare Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/messages.cpp:265 ../../Firmware/ultralcd.cpp:2812
+#: ../../Firmware/messages.cpp:277 ../../Firmware/ultralcd.cpp:2829
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -238,17 +237,17 @@ msgstr ""
 "butonul când este gata."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/messages.cpp:361 ../../Firmware/ultralcd.cpp:6985
+#: ../../Firmware/messages.cpp:373 ../../Firmware/ultralcd.cpp:6962
 msgid "Calibrating home"
 msgstr "Calibrare home"
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5375
+#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5342
 msgid "Calibration"
 msgstr "Calibrare"
 
 #. MSG_HOMEYZ_DONE c=20
-#: ../../Firmware/messages.cpp:217 ../../Firmware/ultralcd.cpp:593
+#: ../../Firmware/messages.cpp:229 ../../Firmware/ultralcd.cpp:593
 msgid "Calibration done"
 msgstr "Calibrare gata"
 
@@ -267,128 +266,128 @@ msgstr ""
 "întâi."
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/messages.cpp:364 ../../Firmware/ultralcd.cpp:7405
+#: ../../Firmware/messages.cpp:376 ../../Firmware/ultralcd.cpp:7382
 msgid "Card removed"
 msgstr "Card scos"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/messages.cpp:324 ../../Firmware/ultralcd.cpp:5316
+#: ../../Firmware/messages.cpp:336 ../../Firmware/ultralcd.cpp:5282
 msgid "Change SD card"
 msgstr "Schimbă card SD"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5254
-#: ../../Firmware/ultralcd.cpp:5526
+#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5216
+#: ../../Firmware/ultralcd.cpp:5493
 msgid "Change filament"
 msgstr "Schimbă filamentul"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/messages.cpp:240 ../../Firmware/ultralcd.cpp:2156
+#: ../../Firmware/messages.cpp:252 ../../Firmware/ultralcd.cpp:2167
 msgid "Change success!"
 msgstr "Schimbare cu succes!"
 
 #. MSG_CORRECTLY c=19
-#: ../../Firmware/messages.cpp:242 ../../Firmware/ultralcd.cpp:2203
+#: ../../Firmware/messages.cpp:254 ../../Firmware/ultralcd.cpp:2217
 msgid "Changed correctly"
 msgstr "Schimbat corect"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5951
-#: ../../Firmware/ultralcd.cpp:6975
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5927
+#: ../../Firmware/ultralcd.cpp:6952
 msgid "Checking X axis"
 msgstr "Verificare axa X"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5961
-#: ../../Firmware/ultralcd.cpp:6976
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:5937
+#: ../../Firmware/ultralcd.cpp:6953
 msgid "Checking Y axis"
 msgstr "Verificare axa Y"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/messages.cpp:358 ../../Firmware/ultralcd.cpp:6977
+#: ../../Firmware/messages.cpp:370 ../../Firmware/ultralcd.cpp:6954
 msgid "Checking Z axis"
 msgstr "Verificare axa Z"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6978
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6955
 msgid "Checking bed"
 msgstr "Verificare pat"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/messages.cpp:357 ../../Firmware/ultralcd.cpp:6974
+#: ../../Firmware/messages.cpp:369 ../../Firmware/ultralcd.cpp:6951
 msgid "Checking endstops"
 msgstr "Verif. endstop-uri"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/messages.cpp:362 ../../Firmware/ultralcd.cpp:7070
+#: ../../Firmware/messages.cpp:374 ../../Firmware/ultralcd.cpp:7047
 msgid "Checking file"
 msgstr "Verif. fișier"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/messages.cpp:359 ../../Firmware/ultralcd.cpp:6980
+#: ../../Firmware/messages.cpp:371 ../../Firmware/ultralcd.cpp:6957
 msgid "Checking hotend"
 msgstr "Verificare hotend"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6981
-#: ../../Firmware/ultralcd.cpp:6982
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6958
+#: ../../Firmware/ultralcd.cpp:6959
 msgid "Checking sensors"
 msgstr "Verificare senzori"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/messages.cpp:308 ../../Firmware/ultralcd.cpp:4424
+#: ../../Firmware/messages.cpp:320 ../../Firmware/ultralcd.cpp:4391
 msgid "Checks"
 msgstr "Verificări"
 
 #. MSG_TM_ACK_ERROR c=18
-#: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5297
+#: ../../Firmware/messages.cpp:197 ../../Firmware/ultralcd.cpp:5263
 msgid "Clear TM error"
 msgstr "Ștergeți eroare TM"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/messages.cpp:244 ../../Firmware/ultralcd.cpp:2205
+#: ../../Firmware/messages.cpp:256 ../../Firmware/ultralcd.cpp:2219
 msgid "Color not correct"
 msgstr "Culoare greșită"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:3508
+#: ../../Firmware/messages.cpp:27 ../../Firmware/ultralcd.cpp:3518
 msgid "Community made"
 msgstr "De la comunitate"
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:4059
+#: ../../Firmware/messages.cpp:178 ../../Firmware/ultralcd.cpp:4083
 msgid "Cont."
 msgstr "Cont."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:2129
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2135
 msgid "Cooldown"
 msgstr "Răcire"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/messages.cpp:283 ../../Firmware/ultralcd.cpp:3450
+#: ../../Firmware/messages.cpp:295 ../../Firmware/ultralcd.cpp:3460
 msgid "Copy selected language?"
 msgstr "Copiază limba selectată?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:1234
-#: ../../Firmware/ultralcd.cpp:1263
+#: ../../Firmware/messages.cpp:30 ../../Firmware/ultralcd.cpp:1244
+#: ../../Firmware/ultralcd.cpp:1273
 msgid "Crash"
 msgstr "Coliz."
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4146
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/ultralcd.cpp:4170
 msgid "Crash det."
 msgstr "Det.coliziune"
 
 #. MSG_CRASH_DETECTED c=20
-#: ../../Firmware/Marlin_main.cpp:630 ../../Firmware/messages.cpp:30
+#: ../../Firmware/Marlin_main.cpp:595 ../../Firmware/messages.cpp:31
 msgid "Crash detected."
 msgstr "Coliziune detectată."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/messages.cpp:280 ../../Firmware/ultralcd.cpp:3374
+#: ../../Firmware/messages.cpp:292 ../../Firmware/ultralcd.cpp:3384
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -399,24 +398,24 @@ msgstr ""
 "doar in modul normal"
 
 #. MSG_CUT_FILAMENT c=16
-#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:380
-#: ../../Firmware/ultralcd.cpp:4854 ../../Firmware/ultralcd.cpp:5351
+#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:381
+#: ../../Firmware/ultralcd.cpp:4810 ../../Firmware/ultralcd.cpp:5317
 msgid "Cut filament"
 msgstr "Taie filamentul"
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4081
-#: ../../Firmware/ultralcd.cpp:4086 ../../Firmware/ultralcd.cpp:4091
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:4105
+#: ../../Firmware/ultralcd.cpp:4110 ../../Firmware/ultralcd.cpp:4115
 msgid "Cutter"
 msgstr "Cutter"
 
 #. MSG_DATE c=17
-#: ../../Firmware/messages.cpp:222 ../../Firmware/ultralcd.cpp:1645
+#: ../../Firmware/messages.cpp:234 ../../Firmware/ultralcd.cpp:1655
 msgid "Date:"
 msgstr "Data:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:178 ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/messages.cpp:185 ../../Firmware/ultralcd.cpp:5594
 msgid "Dim"
 msgstr "Minim"
 
@@ -426,7 +425,7 @@ msgid "Disable"
 msgstr "Dezactiv"
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/messages.cpp:311 ../../Firmware/ultralcd.cpp:4460
+#: ../../Firmware/messages.cpp:323 ../../Firmware/ultralcd.cpp:4427
 msgid "Disable steppers"
 msgstr "Oprire steppere"
 
@@ -438,7 +437,7 @@ msgid "Disengaging idler"
 msgstr "Decuplare idler"
 
 #. MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: ../../Firmware/Marlin_main.cpp:1610 ../../Firmware/Marlin_main.cpp:3334
+#: ../../Firmware/Marlin_main.cpp:1537 ../../Firmware/Marlin_main.cpp:3073
 #: ../../Firmware/messages.cpp:14
 msgid ""
 "Distance between tip of the nozzle and the bed surface has not been set yet."
@@ -449,7 +448,7 @@ msgstr ""
 "manual, capitolul First steps, secțiunea First layer calibration."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/messages.cpp:301 ../../Firmware/ultralcd.cpp:3923
+#: ../../Firmware/messages.cpp:313 ../../Firmware/ultralcd.cpp:3947
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -458,13 +457,13 @@ msgstr ""
 "suprafața de print?"
 
 #. MSG_DONE c=8
-#: ../../Firmware/messages.cpp:32 ../../Firmware/mmu2/errors_list.h:367
-#: ../../Firmware/mmu2_reporting.cpp:456
+#: ../../Firmware/messages.cpp:33 ../../Firmware/mmu2/errors_list.h:367
+#: ../../Firmware/mmu2_reporting.cpp:457
 msgid "Done"
 msgstr "Gata"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/messages.cpp:307 ../../Firmware/ultralcd.cpp:3990
+#: ../../Firmware/messages.cpp:319 ../../Firmware/ultralcd.cpp:4014
 msgid "E-correct"
 msgstr "E-corecție"
 
@@ -493,13 +492,13 @@ msgid "ERR Wait for User"
 msgstr "ERR Aștept utilizat."
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:2253
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:2267
 msgid "ERROR:"
 msgstr "EROARE:"
 
 #. MSG_EJECT_FROM_MMU c=16
-#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:384
-#: ../../Firmware/ultralcd.cpp:4845 ../../Firmware/ultralcd.cpp:5348
+#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:385
+#: ../../Firmware/ultralcd.cpp:4801 ../../Firmware/ultralcd.cpp:5314
 msgid "Eject from MMU"
 msgstr "Scoateți din MMU"
 
@@ -511,17 +510,17 @@ msgid "Ejecting filament"
 msgstr "Se scoate filamentul"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/messages.cpp:348 ../../Firmware/ultralcd.cpp:6722
+#: ../../Firmware/messages.cpp:360 ../../Firmware/ultralcd.cpp:6698
 msgid "Endstop"
 msgstr "Endstop"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/messages.cpp:349 ../../Firmware/ultralcd.cpp:6727
+#: ../../Firmware/messages.cpp:361 ../../Firmware/ultralcd.cpp:6703
 msgid "Endstop not hit"
 msgstr "Endstop neatins"
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/messages.cpp:347 ../../Firmware/ultralcd.cpp:6713
+#: ../../Firmware/messages.cpp:359 ../../Firmware/ultralcd.cpp:6689
 msgid "Endstops"
 msgstr "Endstop-uri"
 
@@ -533,30 +532,30 @@ msgid "Engaging idler"
 msgstr "Cuplare idler"
 
 #. MSG_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:3352
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:3362
 msgid "Extruder"
 msgstr "Extruder"
 
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/messages.cpp:227 ../../Firmware/ultralcd.cpp:1700
+#: ../../Firmware/messages.cpp:239 ../../Firmware/ultralcd.cpp:1710
 msgid "Extruder info"
 msgstr "Info. extruder"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4044
-#: ../../Firmware/ultralcd.cpp:4051
+#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4068
+#: ../../Firmware/ultralcd.cpp:4075
 msgid "F. autoload"
 msgstr "Autoload fil."
 
 #. MSG_FSENSOR_JAM_DETECTION c=13
-#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4046
-#: ../../Firmware/ultralcd.cpp:4053
+#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4070
+#: ../../Firmware/ultralcd.cpp:4077
 msgid "F. jam detect"
 msgstr "F. blocaj det"
 
 #. MSG_FSENSOR_RUNOUT c=13
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4074
 msgid "F. runout"
 msgstr "Fil. epuizat"
 
@@ -594,8 +593,8 @@ msgid "FINDA FILAM. STUCK"
 msgstr "FINDA FILAM. BLOCAT"
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:4059
-#: ../../Firmware/ultralcd.cpp:4062
+#: ../../Firmware/messages.cpp:177 ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/ultralcd.cpp:4086
 msgid "FS Action"
 msgstr "Acțiune FS"
 
@@ -620,34 +619,34 @@ msgid "FW RUNTIME ERROR"
 msgstr "Eroare FW RUNTIME"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/messages.cpp:330 ../../Firmware/ultralcd.cpp:5382
+#: ../../Firmware/messages.cpp:342 ../../Firmware/ultralcd.cpp:5349
 msgid "Fail stats"
 msgstr "Statistici erori"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/messages.cpp:331 ../../Firmware/ultralcd.cpp:5385
+#: ../../Firmware/messages.cpp:343 ../../Firmware/ultralcd.cpp:5352
 msgid "Fail stats MMU"
 msgstr "Stat. erori MMU"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/messages.cpp:355 ../../Firmware/ultralcd.cpp:6768
+#: ../../Firmware/messages.cpp:367 ../../Firmware/ultralcd.cpp:6744
 msgid "False triggering"
 msgstr "Detecție eronată"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4175
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4199
 msgid "Fan speed"
 msgstr "Viteză vent."
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6844
-#: ../../Firmware/ultralcd.cpp:6971 ../../Firmware/ultralcd.cpp:6972
-#: ../../Firmware/ultralcd.cpp:6973
+#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6820
+#: ../../Firmware/ultralcd.cpp:6948 ../../Firmware/ultralcd.cpp:6949
+#: ../../Firmware/ultralcd.cpp:6950
 msgid "Fan test"
 msgstr "Test ventilator"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:4179
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:4203
 msgid "Fans check"
 msgstr "Verif. vent."
 
@@ -676,34 +675,34 @@ msgid "Feeding to nozzle"
 msgstr "Încărcare la vârf"
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1233
-#: ../../Firmware/ultralcd.cpp:1262 ../../Firmware/ultralcd.cpp:1316
-#: ../../Firmware/ultralcd.cpp:1318
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:1243
+#: ../../Firmware/ultralcd.cpp:1272 ../../Firmware/ultralcd.cpp:1326
+#: ../../Firmware/ultralcd.cpp:1328
 msgid "Fil. runouts"
 msgstr "Epuizări Fil."
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3313
-#: ../../Firmware/ultralcd.cpp:4039 ../../Firmware/ultralcd.cpp:4464
-#: ../../Firmware/ultralcd.cpp:5532
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3323
+#: ../../Firmware/ultralcd.cpp:4063 ../../Firmware/ultralcd.cpp:4431
+#: ../../Firmware/ultralcd.cpp:5499
 msgid "Fil. sensor"
 msgstr "Senzor Fil."
 
 #. MSG_FILAMENT_CLEAN c=20 r=3
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2261
-#: ../../Firmware/ultralcd.cpp:2265
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2275
+#: ../../Firmware/ultralcd.cpp:2279
 msgid "Filament extruding & with correct color?"
 msgstr "Fil. curge și are culoarea corectă?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/messages.cpp:243 ../../Firmware/ultralcd.cpp:2204
+#: ../../Firmware/messages.cpp:255 ../../Firmware/ultralcd.cpp:2218
 msgid "Filament not loaded"
 msgstr "Fil. nu e încărcat"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6763
-#: ../../Firmware/ultralcd.cpp:6767 ../../Firmware/ultralcd.cpp:6771
-#: ../../Firmware/ultralcd.cpp:7000
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6739
+#: ../../Firmware/ultralcd.cpp:6743 ../../Firmware/ultralcd.cpp:6747
+#: ../../Firmware/ultralcd.cpp:6977
 msgid "Filament sensor"
 msgstr "Senz. de filament"
 
@@ -735,42 +734,42 @@ msgstr ""
 " nu este nimic blocat in tubul PTFE. Verifică dacă senz. funcț. corect."
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/messages.cpp:246 ../../Firmware/ultralcd.cpp:2347
+#: ../../Firmware/messages.cpp:258 ../../Firmware/ultralcd.cpp:2364
 msgid "Filament used"
 msgstr "Filament folosit"
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/messages.cpp:363 ../../Firmware/ultralcd.cpp:7139
+#: ../../Firmware/messages.cpp:375 ../../Firmware/ultralcd.cpp:7116
 msgid "File incomplete. Continue anyway?"
 msgstr "Fișier incomplet. Continuă oricum?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
 #: ../../Firmware/messages.cpp:45
 #: ../../Firmware/mmu2_progress_converter.cpp:43
-#: ../../Firmware/ultralcd.cpp:5021 ../../Firmware/ultralcd.cpp:5425
+#: ../../Firmware/ultralcd.cpp:4977 ../../Firmware/ultralcd.cpp:5392
 msgid "Finishing movements"
 msgstr "Finalizare mișcări"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4575
-#: ../../Firmware/ultralcd.cpp:5141
+#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4531
+#: ../../Firmware/ultralcd.cpp:5101
 msgid "First layer cal."
 msgstr "Cal. first layer"
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/messages.cpp:293 ../../Firmware/ultralcd.cpp:3846
+#: ../../Firmware/messages.cpp:305 ../../Firmware/ultralcd.cpp:3872
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Mai întâi voi rula testele automate pentru a verifica cele mai întâlnite "
 "probleme de asamblare."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/messages.cpp:334 ../../Firmware/ultralcd.cpp:5520
+#: ../../Firmware/messages.cpp:346 ../../Firmware/ultralcd.cpp:5487
 msgid "Flow"
 msgstr "Flow"
 
 #. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
-#: ../../Firmware/messages.cpp:194 ../../Firmware/ultralcd.cpp:985
+#: ../../Firmware/messages.cpp:201 ../../Firmware/ultralcd.cpp:987
 msgid ""
 "For a Nozzle change please read\n"
 "prusa.io/nozzle-mk3s"
@@ -779,28 +778,28 @@ msgstr ""
 "prusa.io/nozzle-mk3s"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6733
-#: ../../Firmware/ultralcd.cpp:6850 ../../Firmware/ultralcd.cpp:6855
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/ultralcd.cpp:6826 ../../Firmware/ultralcd.cpp:6831
 msgid "Front print fan?"
 msgstr "Vent. print?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/messages.cpp:260 ../../Firmware/ultralcd.cpp:2711
+#: ../../Firmware/messages.cpp:272 ../../Firmware/ultralcd.cpp:2728
 msgid "Front side[µm]"
 msgstr "Față [µm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/messages.cpp:353 ../../Firmware/ultralcd.cpp:6757
+#: ../../Firmware/messages.cpp:365 ../../Firmware/ultralcd.cpp:6733
 msgid "Front/left fans"
 msgstr "Ventilatoarele sunt"
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:151 ../../Firmware/util.cpp:382
+#: ../../Firmware/messages.cpp:156 ../../Firmware/util.cpp:417
 msgid "G-code sliced for a different level. Continue?"
 msgstr "Versiune de G-code e incorectă. Continuați?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:152 ../../Firmware/util.cpp:383
+#: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:418
 msgid ""
 "G-code sliced for a different level. Please re-slice the model again. Print "
 "cancelled."
@@ -809,14 +808,14 @@ msgstr ""
 "anulat."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:147 ../../Firmware/util.cpp:312
-#: ../../Firmware/util.cpp:401
+#: ../../Firmware/messages.cpp:152 ../../Firmware/util.cpp:319
+#: ../../Firmware/util.cpp:436
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr "G-code pregătit pentru un alt tip de printer. Continuați?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:148 ../../Firmware/util.cpp:313
-#: ../../Firmware/util.cpp:402
+#: ../../Firmware/messages.cpp:153 ../../Firmware/util.cpp:320
+#: ../../Firmware/util.cpp:437
 msgid ""
 "G-code sliced for a different printer type. Please re-slice the model again."
 " Print cancelled."
@@ -825,12 +824,12 @@ msgstr ""
 "din nou. Print anulat."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:149 ../../Firmware/util.cpp:362
+#: ../../Firmware/messages.cpp:154 ../../Firmware/util.cpp:369
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "G-code pregătit pentru firmware mai nou. Continuați?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:150 ../../Firmware/util.cpp:363
+#: ../../Firmware/messages.cpp:155 ../../Firmware/util.cpp:370
 msgid ""
 "G-code sliced for a newer firmware. Please update the firmware. Print "
 "cancelled."
@@ -839,35 +838,35 @@ msgstr ""
 "Print anulat."
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4366
-#: ../../Firmware/ultralcd.cpp:4383 ../../Firmware/ultralcd.cpp:4485
+#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4325
+#: ../../Firmware/ultralcd.cpp:4343 ../../Firmware/ultralcd.cpp:4452
 msgid "HW Setup"
 msgstr "Setup HW"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/messages.cpp:344 ../../Firmware/ultralcd.cpp:6705
+#: ../../Firmware/messages.cpp:356 ../../Firmware/ultralcd.cpp:6681
 msgid "Heater/Thermistor"
 msgstr "Încălzitor/Termistor"
 
 #. MSG_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6184 ../../Firmware/messages.cpp:52
+#: ../../Firmware/Marlin_main.cpp:5416 ../../Firmware/messages.cpp:52
 #: ../../Firmware/ultralcd.cpp:526
 msgid "Heating"
 msgstr "Încălzire"
 
 #. MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:9647 ../../Firmware/messages.cpp:211
+#: ../../Firmware/Marlin_main.cpp:8807 ../../Firmware/messages.cpp:223
 msgid "Heating disabled by safety timer."
 msgstr "Încălzirea dezactivată de timer-ul de siguranță"
 
 #. MSG_HEATING_COMPLETE c=20
-#: ../../Firmware/Marlin_main.cpp:6215 ../../Firmware/messages.cpp:53
+#: ../../Firmware/Marlin_main.cpp:5445 ../../Firmware/messages.cpp:53
 #: ../../Firmware/ultralcd.cpp:529
 msgid "Heating done."
 msgstr "Încălzirea gata."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=12
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:3806
+#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:3832
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -878,7 +877,7 @@ msgstr ""
 "printezi."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:3810
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:3836
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -887,8 +886,8 @@ msgstr ""
 "automate și calibrările?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4152
-#: ../../Firmware/ultralcd.cpp:4161
+#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:4176
+#: ../../Firmware/ultralcd.cpp:4185
 msgid "High power"
 msgstr "Put. max"
 
@@ -899,23 +898,23 @@ msgid "Homing"
 msgstr "Homing"
 
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
-#: ../../Firmware/messages.cpp:195 ../../Firmware/ultralcd.cpp:1005
+#: ../../Firmware/messages.cpp:206 ../../Firmware/ultralcd.cpp:1011
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr "Hotend la 280C! Vârf schimbat și strâns conf. specificației?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1106
-#: ../../Firmware/ultralcd.cpp:6991
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1116
+#: ../../Firmware/ultralcd.cpp:6968
 msgid "Hotend fan:"
 msgstr "Vent. hotend:"
 
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/messages.cpp:294 ../../Firmware/ultralcd.cpp:3851
+#: ../../Firmware/messages.cpp:306 ../../Firmware/ultralcd.cpp:3877
 msgid "I will run xyz calibration now. It will take up to 24 mins."
 msgstr "Voi rula calibrarea XYZ acum. Va dura până la 24 de min."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/messages.cpp:297 ../../Firmware/ultralcd.cpp:3862
+#: ../../Firmware/messages.cpp:309 ../../Firmware/ultralcd.cpp:3884
 msgid "I will run z calibration now."
 msgstr "Voi rula calibrarea Z acum."
 
@@ -940,7 +939,7 @@ msgid "INVALID TOOL"
 msgstr "FILAMENT INVALID"
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=8
-#: ../../Firmware/messages.cpp:303 ../../Firmware/ultralcd.cpp:3931
+#: ../../Firmware/messages.cpp:315 ../../Firmware/ultralcd.cpp:3955
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -949,28 +948,28 @@ msgstr ""
 "- Suprafețe print."
 
 #. MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2540
-#: ../../Firmware/messages.cpp:213
+#: ../../Firmware/mesh_bed_calibration.cpp:2525
+#: ../../Firmware/messages.cpp:225
 msgid "Improving bed calibration point"
 msgstr "Îmbunătățirea punctului de calibrare al patului"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:5222
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:5184
 msgid "Info screen"
 msgstr "Ecran informații"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/messages.cpp:326 ../../Firmware/ultralcd.cpp:5323
+#: ../../Firmware/messages.cpp:338 ../../Firmware/ultralcd.cpp:5289
 msgid "Init. SD card"
 msgstr "Init. card SD"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/messages.cpp:238 ../../Firmware/ultralcd.cpp:2142
+#: ../../Firmware/messages.cpp:250 ../../Firmware/ultralcd.cpp:2148
 msgid "Insert filament"
 msgstr "Încarcă filament"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/messages.cpp:335 ../../Firmware/ultralcd.cpp:5998
+#: ../../Firmware/messages.cpp:347 ../../Firmware/ultralcd.cpp:5974
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
@@ -985,115 +984,115 @@ msgstr ""
 "firmwarul."
 
 #. MSG_FILAMENT_LOADED c=20 r=3
-#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3628
-#: ../../Firmware/ultralcd.cpp:3890
+#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3638
+#: ../../Firmware/ultralcd.cpp:3914
 msgid "Is filament loaded?"
 msgstr "Este filamentul încărcat?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3238 ../../Firmware/Marlin_main.cpp:4745
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:3858
+#: ../../Firmware/Marlin_main.cpp:4314 ../../Firmware/messages.cpp:127
+#: ../../Firmware/ultralcd.cpp:3760
 msgid "Is steel sheet on heatbed?"
 msgstr "Este suprafața de print pe pat?"
 
 #. MSG_ITERATION c=12
-#: ../../Firmware/mesh_bed_calibration.cpp:2265 ../../Firmware/messages.cpp:55
+#: ../../Firmware/mesh_bed_calibration.cpp:2250 ../../Firmware/messages.cpp:55
 msgid "Iteration"
 msgstr "Iterația"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1128
-#: ../../Firmware/ultralcd.cpp:1286
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1138
+#: ../../Firmware/ultralcd.cpp:1296
 msgid "Last print"
 msgstr "Ultimul print"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1152
-#: ../../Firmware/ultralcd.cpp:1260 ../../Firmware/ultralcd.cpp:1315
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1162
+#: ../../Firmware/ultralcd.cpp:1270 ../../Firmware/ultralcd.cpp:1325
 msgid "Last print failures"
 msgstr "Erorile ultim. print"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/messages.cpp:251 ../../Firmware/ultralcd.cpp:2478
+#: ../../Firmware/messages.cpp:263 ../../Firmware/ultralcd.cpp:2495
 msgid "Left"
 msgstr "Stânga"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6739
-#: ../../Firmware/ultralcd.cpp:6850 ../../Firmware/ultralcd.cpp:6855
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6715
+#: ../../Firmware/ultralcd.cpp:6826 ../../Firmware/ultralcd.cpp:6831
 msgid "Left hotend fan?"
 msgstr "Vent. hotend?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/messages.cpp:258 ../../Firmware/ultralcd.cpp:2709
+#: ../../Firmware/messages.cpp:270 ../../Firmware/ultralcd.cpp:2726
 msgid "Left side [µm]"
 msgstr "Stânga [µm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:5619
+#: ../../Firmware/messages.cpp:181 ../../Firmware/ultralcd.cpp:5592
 msgid "Level Bright"
 msgstr "Lum. maxim"
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:175 ../../Firmware/ultralcd.cpp:5620
+#: ../../Firmware/messages.cpp:182 ../../Firmware/ultralcd.cpp:5593
 msgid "Level Dimmed"
 msgstr "Lum. minim"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/messages.cpp:312 ../../Firmware/ultralcd.cpp:4491
+#: ../../Firmware/messages.cpp:324 ../../Firmware/ultralcd.cpp:4458
 msgid "Lin. correction"
 msgstr "Corecție lin."
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4501
-#: ../../Firmware/ultralcd.cpp:5251
+#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4468
+#: ../../Firmware/ultralcd.cpp:5213
 msgid "Live adjust Z"
 msgstr "Reglare Z live"
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/messages.cpp:192 ../../Firmware/ultralcd.cpp:4794
-#: ../../Firmware/ultralcd.cpp:4880
+#: ../../Firmware/messages.cpp:199 ../../Firmware/ultralcd.cpp:4750
+#: ../../Firmware/ultralcd.cpp:4836
 msgid "Load All"
 msgstr "Încarcă toate"
 
 #. MSG_LOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4796
-#: ../../Firmware/ultralcd.cpp:4833 ../../Firmware/ultralcd.cpp:4882
-#: ../../Firmware/ultralcd.cpp:5361 ../../Firmware/ultralcd.cpp:5368
+#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4752
+#: ../../Firmware/ultralcd.cpp:4789 ../../Firmware/ultralcd.cpp:4838
+#: ../../Firmware/ultralcd.cpp:5324 ../../Firmware/ultralcd.cpp:5335
 msgid "Load filament"
 msgstr "Încarcă filament"
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/messages.cpp:327 ../../Firmware/ultralcd.cpp:5346
+#: ../../Firmware/messages.cpp:339 ../../Firmware/ultralcd.cpp:5312
 msgid "Load to nozzle"
 msgstr "Încarcă la vârf"
 
 #. MSG_LOADING_TEST c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4476
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4443
 msgid "Loading Test"
 msgstr "Test încărcare"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/messages.cpp:241 ../../Firmware/ultralcd.cpp:2178
+#: ../../Firmware/messages.cpp:253 ../../Firmware/ultralcd.cpp:2189
 msgid "Loading color"
 msgstr "Încărcare culoare"
 
 #. MSG_LOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3598 ../../Firmware/messages.cpp:62
+#: ../../Firmware/Marlin_main.cpp:3343 ../../Firmware/messages.cpp:62
 #: ../../Firmware/mmu2_progress_converter.cpp:51
-#: ../../Firmware/mmu2_reporting.cpp:392 ../../Firmware/ultralcd.cpp:2189
-#: ../../Firmware/ultralcd.cpp:3715
+#: ../../Firmware/mmu2_reporting.cpp:393 ../../Firmware/ultralcd.cpp:2199
+#: ../../Firmware/ultralcd.cpp:3725
 msgid "Loading filament"
 msgstr "Încărcare filament"
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/messages.cpp:350 ../../Firmware/ultralcd.cpp:6745
+#: ../../Firmware/messages.cpp:362 ../../Firmware/ultralcd.cpp:6721
 msgid "Loose pulley"
 msgstr "Fulie slăbită"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4188
-#: ../../Firmware/ultralcd.cpp:4200
+#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4224
 msgid "Loud"
 msgstr "Tare"
 
@@ -1108,7 +1107,7 @@ msgid "MMU Firmware internal error, please reset the MMU."
 msgstr "Eroare internă MMU, vă rog resetați MMU."
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:4096
+#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4120
 msgid "MMU Mode"
 msgstr "Mod MMU"
 
@@ -1118,7 +1117,7 @@ msgid "MMU NOT RESPONDING"
 msgstr "MMU NU RĂSPUNDE"
 
 #. MSG_MMU_RESTORE_TEMP c=20 r=4
-#: ../../Firmware/messages.cpp:214 ../../Firmware/mmu2_reporting.cpp:396
+#: ../../Firmware/messages.cpp:226 ../../Firmware/mmu2_reporting.cpp:397
 msgid "MMU Retry: Restoring temperature..."
 msgstr "MMU: Restabilirea temperaturii..."
 
@@ -1129,14 +1128,14 @@ msgid "MMU SELFTEST FAILED"
 msgstr "MMU AUTOTEST. EȘUATĂ"
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1153
-#: ../../Firmware/ultralcd.cpp:1178
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1163
+#: ../../Firmware/ultralcd.cpp:1188
 msgid "MMU fails"
 msgstr "Erori MMU"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1154
-#: ../../Firmware/ultralcd.cpp:1179
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1164
+#: ../../Firmware/ultralcd.cpp:1189
 msgid "MMU load fails"
 msgstr "Err. încărc MMU"
 
@@ -1151,66 +1150,64 @@ msgid "MMU not responding. Check the wiring and connectors."
 msgstr "MMU nu răspunde. Verificați cablajul si conectorii."
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/messages.cpp:223 ../../Firmware/ultralcd.cpp:1657
+#: ../../Firmware/messages.cpp:235 ../../Firmware/ultralcd.cpp:1667
 msgid "MMU connected"
 msgstr "MMU conectat"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/messages.cpp:176 ../../Firmware/ultralcd.cpp:5567
 msgid "Magnets comp."
 msgstr "Comp. magneți"
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1127
-#: ../../Firmware/ultralcd.cpp:1285 ../../Firmware/ultralcd.cpp:1327
-#: ../../Firmware/ultralcd.cpp:1631 ../../Firmware/ultralcd.cpp:4453
-#: ../../Firmware/ultralcd.cpp:4571 ../../Firmware/ultralcd.cpp:4793
-#: ../../Firmware/ultralcd.cpp:4826 ../../Firmware/ultralcd.cpp:4879
-#: ../../Firmware/ultralcd.cpp:5515
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1137
+#: ../../Firmware/ultralcd.cpp:1295 ../../Firmware/ultralcd.cpp:1337
+#: ../../Firmware/ultralcd.cpp:1641 ../../Firmware/ultralcd.cpp:4420
+#: ../../Firmware/ultralcd.cpp:4527 ../../Firmware/ultralcd.cpp:4749
+#: ../../Firmware/ultralcd.cpp:4782 ../../Firmware/ultralcd.cpp:4835
+#: ../../Firmware/ultralcd.cpp:5482
 msgid "Main"
 msgstr "Meniu principal"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/messages.cpp:253 ../../Firmware/ultralcd.cpp:2519
+#: ../../Firmware/messages.cpp:265 ../../Firmware/ultralcd.cpp:2536
 msgid "Measured skew"
 msgstr "Distorsiune"
 
 #. MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3219
-#: ../../Firmware/mesh_bed_calibration.cpp:2852 ../../Firmware/messages.cpp:70
+#: ../../Firmware/Marlin_main.cpp:2963
+#: ../../Firmware/mesh_bed_calibration.cpp:2837 ../../Firmware/messages.cpp:70
 msgid "Measuring reference height of calibration point"
 msgstr "Măsurare distanță de referință pentru punctul de calib."
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:5590
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:5563
 msgid "Mesh"
 msgstr "Mesh"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4488
-#: ../../Firmware/ultralcd.cpp:4587
+#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:4455
+#: ../../Firmware/ultralcd.cpp:4543
 msgid "Mesh Bed Leveling"
 msgstr "Calibrare mesh"
 
 #. MSG_MODE c=6
-#: ../../Firmware/Marlin_main.cpp:8495 ../../Firmware/messages.cpp:117
-#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4132
-#: ../../Firmware/ultralcd.cpp:4140 ../../Firmware/ultralcd.cpp:4144
-#: ../../Firmware/ultralcd.cpp:4152 ../../Firmware/ultralcd.cpp:4155
-#: ../../Firmware/ultralcd.cpp:4158 ../../Firmware/ultralcd.cpp:4161
-#: ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/Marlin_main.cpp:7666 ../../Firmware/messages.cpp:121
+#: ../../Firmware/ultralcd.cpp:4152 ../../Firmware/ultralcd.cpp:4156
+#: ../../Firmware/ultralcd.cpp:4164 ../../Firmware/ultralcd.cpp:4168
+#: ../../Firmware/ultralcd.cpp:4176 ../../Firmware/ultralcd.cpp:4179
+#: ../../Firmware/ultralcd.cpp:4182 ../../Firmware/ultralcd.cpp:4185
+#: ../../Firmware/ultralcd.cpp:5594
 msgid "Mode"
 msgstr "Mod"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/messages.cpp:282 ../../Firmware/ultralcd.cpp:3413
+#: ../../Firmware/messages.cpp:294 ../../Firmware/ultralcd.cpp:3423
 msgid "Mode change in progress..."
 msgstr "Schimbare mod în progres..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:4310
-#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4316
-#: ../../Firmware/ultralcd.cpp:4319
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4327
 msgid "Model"
 msgstr "Model"
 
@@ -1231,28 +1228,28 @@ msgid "More details online."
 msgstr "Mai multe detalii online"
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6719
-#: ../../Firmware/ultralcd.cpp:6728 ../../Firmware/ultralcd.cpp:6746
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6695
+#: ../../Firmware/ultralcd.cpp:6704 ../../Firmware/ultralcd.cpp:6722
 msgid "Motor"
 msgstr "Motor"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/messages.cpp:277 ../../Firmware/ultralcd.cpp:3349
+#: ../../Firmware/messages.cpp:289 ../../Firmware/ultralcd.cpp:3359
 msgid "Move X"
 msgstr "Mișcare X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/messages.cpp:278 ../../Firmware/ultralcd.cpp:3350
+#: ../../Firmware/messages.cpp:290 ../../Firmware/ultralcd.cpp:3360
 msgid "Move Y"
 msgstr "Mișcare Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/messages.cpp:279 ../../Firmware/ultralcd.cpp:3351
+#: ../../Firmware/messages.cpp:291 ../../Firmware/ultralcd.cpp:3361
 msgid "Move Z"
 msgstr "Mișcare Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/messages.cpp:310 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:322 ../../Firmware/ultralcd.cpp:4426
 msgid "Move axis"
 msgstr "Mișcare axe"
 
@@ -1263,95 +1260,92 @@ msgid "Moving selector"
 msgstr "Mișcare selector"
 
 #. MSG_NA c=3
-#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:141
-#: ../../Firmware/ultralcd.cpp:2484 ../../Firmware/ultralcd.cpp:2528
-#: ../../Firmware/ultralcd.cpp:3279 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:4044 ../../Firmware/ultralcd.cpp:4046
-#: ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:146
+#: ../../Firmware/ultralcd.cpp:2501 ../../Firmware/ultralcd.cpp:2545
+#: ../../Firmware/ultralcd.cpp:3289 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4068 ../../Firmware/ultralcd.cpp:4070
+#: ../../Firmware/ultralcd.cpp:5567
 msgid "N/A"
 msgstr "N/A"
 
 #. MSG_NEW_FIRMWARE_AVAILABLE c=20 r=2
-#: ../../Firmware/messages.cpp:365 ../../Firmware/util.cpp:209
+#: ../../Firmware/messages.cpp:377 ../../Firmware/util.cpp:214
 msgid "New firmware version available:"
 msgstr "Vers. de firmware nouă disponibilă:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:3029
-#: ../../Firmware/ultralcd.cpp:4443 ../../Firmware/ultralcd.cpp:4531
-#: ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:2275
+#: ../../Firmware/ultralcd.cpp:2279 ../../Firmware/ultralcd.cpp:3046
+#: ../../Firmware/ultralcd.cpp:4410 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/ultralcd.cpp:5765
 msgid "No"
 msgstr "Nu"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/messages.cpp:325 ../../Firmware/ultralcd.cpp:5321
+#: ../../Firmware/messages.cpp:337 ../../Firmware/ultralcd.cpp:5287
 msgid "No SD card"
 msgstr "Card SD lipsă"
 
 #. MSG_NO_MOVE c=20
-#: ../../Firmware/Marlin_main.cpp:5271 ../../Firmware/messages.cpp:210
+#: ../../Firmware/Marlin_main.cpp:4778 ../../Firmware/messages.cpp:222
 msgid "No move."
 msgstr "Fară mișcare."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4239 ../../Firmware/ultralcd.cpp:4310
-#: ../../Firmware/ultralcd.cpp:4319 ../../Firmware/ultralcd.cpp:4349
-#: ../../Firmware/ultralcd.cpp:4358 ../../Firmware/ultralcd.cpp:4516
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4309
+#: ../../Firmware/ultralcd.cpp:4318 ../../Firmware/ultralcd.cpp:4483
 msgid "None"
 msgstr "N/A"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/Marlin_main.cpp:8497 ../../Firmware/messages.cpp:121
-#: ../../Firmware/ultralcd.cpp:4096 ../../Firmware/ultralcd.cpp:4132
-#: ../../Firmware/ultralcd.cpp:4511
+#: ../../Firmware/Marlin_main.cpp:7668 ../../Firmware/messages.cpp:125
+#: ../../Firmware/ultralcd.cpp:4120 ../../Firmware/ultralcd.cpp:4156
+#: ../../Firmware/ultralcd.cpp:4478
 msgid "Normal"
 msgstr "Normal"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/messages.cpp:345 ../../Firmware/ultralcd.cpp:6706
+#: ../../Firmware/messages.cpp:357 ../../Firmware/ultralcd.cpp:6682
 msgid "Not connected"
 msgstr "Nu este conectat"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6863
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6839
 msgid "Not spinning"
 msgstr "Nu se rotește"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/messages.cpp:289 ../../Firmware/ultralcd.cpp:3726
+#: ../../Firmware/messages.cpp:301 ../../Firmware/ultralcd.cpp:3736
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr "Acum voi calibra distanța dintre vârf și suprafața patului."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/messages.cpp:298 ../../Firmware/ultralcd.cpp:3871
+#: ../../Firmware/messages.cpp:310 ../../Firmware/ultralcd.cpp:3894
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Acum voi preîncălzi extruderul pentru PLA."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/messages.cpp:296 ../../Firmware/ultralcd.cpp:3857
+#: ../../Firmware/messages.cpp:308 ../../Firmware/ultralcd.cpp:3883
 msgid "Now remove the test print from steel sheet."
 msgstr "Acum înlăturați printul de test de pe suprafața de print."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1390
-#: ../../Firmware/ultralcd.cpp:4170 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4233 ../../Firmware/ultralcd.cpp:4236
-#: ../../Firmware/ultralcd.cpp:4239
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1400
+#: ../../Firmware/ultralcd.cpp:4194 ../../Firmware/ultralcd.cpp:4326
 msgid "Nozzle"
 msgstr "Vârf"
 
 #. MSG_NOZZLE_CNG_MENU c=18
-#: ../../Firmware/messages.cpp:193 ../../Firmware/ultralcd.cpp:4423
-#: ../../Firmware/ultralcd.cpp:4486
+#: ../../Firmware/messages.cpp:200 ../../Firmware/ultralcd.cpp:4390
+#: ../../Firmware/ultralcd.cpp:4453
 msgid "Nozzle change"
 msgstr "Schimbare vârf"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4276
-#: ../../Firmware/ultralcd.cpp:4278 ../../Firmware/ultralcd.cpp:4279
-#: ../../Firmware/ultralcd.cpp:4280
+#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4261
+#: ../../Firmware/ultralcd.cpp:4263 ../../Firmware/ultralcd.cpp:4264
+#: ../../Firmware/ultralcd.cpp:4265
 msgid "Nozzle d."
 msgstr "Diam. vârf"
 
@@ -1362,81 +1356,81 @@ msgid "OK"
 msgstr "OK"
 
 #. MSG_OFF c=3
-#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:139
-#: ../../Firmware/mmu2.cpp:65 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4050 ../../Firmware/ultralcd.cpp:4051
-#: ../../Firmware/ultralcd.cpp:4053 ../../Firmware/ultralcd.cpp:4076
-#: ../../Firmware/ultralcd.cpp:4091 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4179 ../../Firmware/ultralcd.cpp:4467
-#: ../../Firmware/ultralcd.cpp:4495 ../../Firmware/ultralcd.cpp:4498
-#: ../../Firmware/ultralcd.cpp:5439 ../../Firmware/ultralcd.cpp:5594
-#: ../../Firmware/ultralcd.cpp:7487 ../../Firmware/ultralcd.cpp:7491
+#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:144
+#: ../../Firmware/mmu2.cpp:65 ../../Firmware/ultralcd.cpp:4063
+#: ../../Firmware/ultralcd.cpp:4074 ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4077 ../../Firmware/ultralcd.cpp:4100
+#: ../../Firmware/ultralcd.cpp:4115 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/ultralcd.cpp:4203 ../../Firmware/ultralcd.cpp:4434
+#: ../../Firmware/ultralcd.cpp:4462 ../../Firmware/ultralcd.cpp:4465
+#: ../../Firmware/ultralcd.cpp:5406 ../../Firmware/ultralcd.cpp:5567
+#: ../../Firmware/ultralcd.cpp:7464 ../../Firmware/ultralcd.cpp:7468
 msgid "Off"
 msgstr "Off"
 
 #. MSG_DEFAULT_SETTINGS_LOADED c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:1562 ../../Firmware/messages.cpp:201
+#: ../../Firmware/Marlin_main.cpp:1489 ../../Firmware/messages.cpp:213
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr "Setări vechi detectate. PID, Esteps etc. implicite vor fi setate."
 
 #. MSG_ON c=3
-#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:140
-#: ../../Firmware/mmu2.cpp:63 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4050 ../../Firmware/ultralcd.cpp:4051
-#: ../../Firmware/ultralcd.cpp:4053 ../../Firmware/ultralcd.cpp:4076
-#: ../../Firmware/ultralcd.cpp:4081 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4179 ../../Firmware/ultralcd.cpp:4467
-#: ../../Firmware/ultralcd.cpp:4495 ../../Firmware/ultralcd.cpp:4498
-#: ../../Firmware/ultralcd.cpp:5594 ../../Firmware/ultralcd.cpp:7487
-#: ../../Firmware/ultralcd.cpp:7491
+#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:145
+#: ../../Firmware/mmu2.cpp:63 ../../Firmware/ultralcd.cpp:4063
+#: ../../Firmware/ultralcd.cpp:4074 ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4077 ../../Firmware/ultralcd.cpp:4100
+#: ../../Firmware/ultralcd.cpp:4105 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/ultralcd.cpp:4203 ../../Firmware/ultralcd.cpp:4434
+#: ../../Firmware/ultralcd.cpp:4462 ../../Firmware/ultralcd.cpp:4465
+#: ../../Firmware/ultralcd.cpp:5567 ../../Firmware/ultralcd.cpp:7464
+#: ../../Firmware/ultralcd.cpp:7468
 msgid "On"
 msgstr "On"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4191
+#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:4215
 msgid "Once"
 msgstr "O dată"
 
 #. MSG_PAUSED_THERMAL_ERROR c=20
-#: ../../Firmware/Marlin_main.cpp:9861 ../../Firmware/messages.cpp:186
+#: ../../Firmware/Marlin_main.cpp:9021 ../../Firmware/messages.cpp:193
 msgid "PAUSED THERMAL ERROR"
 msgstr "OPRIT THERMAL ERROR"
 
 #. MSG_PID_RUNNING c=20
-#: ../../Firmware/messages.cpp:219 ../../Firmware/ultralcd.cpp:897
+#: ../../Firmware/messages.cpp:231 ../../Firmware/ultralcd.cpp:897
 msgid "PID cal."
 msgstr "Calibrare PID"
 
 #. MSG_PID_FINISHED c=20
-#: ../../Firmware/messages.cpp:220 ../../Firmware/ultralcd.cpp:902
+#: ../../Firmware/messages.cpp:232 ../../Firmware/ultralcd.cpp:902
 msgid "PID cal. finished"
 msgstr "Calibrare PID gata"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:318 ../../Firmware/ultralcd.cpp:4590
+#: ../../Firmware/messages.cpp:330 ../../Firmware/ultralcd.cpp:4546
 msgid "PID calibration"
 msgstr "Calibrare PID"
 
 #. MSG_PINDA_PREHEAT c=20
-#: ../../Firmware/messages.cpp:218 ../../Firmware/ultralcd.cpp:610
+#: ../../Firmware/messages.cpp:230 ../../Firmware/ultralcd.cpp:610
 msgid "PINDA Heating"
 msgstr "Încălzire PINDA"
 
 #. MSG_PINDA_CALIBRATION c=13
-#: ../../Firmware/Marlin_main.cpp:4790 ../../Firmware/Marlin_main.cpp:4892
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:607
-#: ../../Firmware/ultralcd.cpp:4495 ../../Firmware/ultralcd.cpp:4597
+#: ../../Firmware/Marlin_main.cpp:4359 ../../Firmware/Marlin_main.cpp:4461
+#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:607
+#: ../../Firmware/ultralcd.cpp:4462 ../../Firmware/ultralcd.cpp:4553
 msgid "PINDA cal."
 msgstr "Cal. PINDA"
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/messages.cpp:276 ../../Firmware/ultralcd.cpp:3233
+#: ../../Firmware/messages.cpp:288 ../../Firmware/ultralcd.cpp:3243
 msgid "PINDA calibration failed"
 msgstr "Calibrarea PINDA a eșuat"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:4967 ../../Firmware/messages.cpp:127
-#: ../../Firmware/ultralcd.cpp:3230
+#: ../../Firmware/Marlin_main.cpp:4536 ../../Firmware/messages.cpp:132
+#: ../../Firmware/ultralcd.cpp:3240
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1456,13 +1450,13 @@ msgid "Parking selector"
 msgstr "Parcare selector"
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:4062
+#: ../../Firmware/messages.cpp:179 ../../Firmware/ultralcd.cpp:4086
 msgid "Pause"
 msgstr "Pauză"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5271
-#: ../../Firmware/ultralcd.cpp:5273
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5237
+#: ../../Firmware/ultralcd.cpp:5239
 msgid "Pause print"
 msgstr "Pauză print"
 
@@ -1473,7 +1467,7 @@ msgid "Performing cut"
 msgstr "Efect. tăiere"
 
 #. MSG_PAPER c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3243 ../../Firmware/messages.cpp:77
+#: ../../Firmware/Marlin_main.cpp:2982 ../../Firmware/messages.cpp:77
 msgid ""
 "Place a sheet of paper under the nozzle during the calibration of first 4 "
 "points. If the nozzle catches the paper, power off the printer immediately."
@@ -1482,7 +1476,7 @@ msgstr ""
 "Dacă vârful prinde hârtia, opriți imediat imprimanta."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:3963
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:3987
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1491,27 +1485,27 @@ msgstr ""
 "ul repornind imprimanta."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/messages.cpp:337 ../../Firmware/ultralcd.cpp:6023
+#: ../../Firmware/messages.cpp:349 ../../Firmware/ultralcd.cpp:5999
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "Verificați senzorul IR, scoateți filamentul dacă există."
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/messages.cpp:343 ../../Firmware/ultralcd.cpp:6700
+#: ../../Firmware/messages.cpp:355 ../../Firmware/ultralcd.cpp:6676
 msgid "Please check:"
 msgstr "Verificați:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/messages.cpp:302 ../../Firmware/ultralcd.cpp:3926
+#: ../../Firmware/messages.cpp:314 ../../Firmware/ultralcd.cpp:3950
 msgid "Please clean heatbed and then press the knob."
 msgstr "Curățați patul și apoi apăsați butonul pentru a continua."
 
 #. MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3217 ../../Firmware/messages.cpp:27
+#: ../../Firmware/Marlin_main.cpp:2960 ../../Firmware/messages.cpp:28
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Curățați vârful pentru calibrare. Apăsați butonul când terminați."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/messages.cpp:288 ../../Firmware/ultralcd.cpp:3712
+#: ../../Firmware/messages.cpp:300 ../../Firmware/ultralcd.cpp:3722
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr ""
@@ -1519,7 +1513,7 @@ msgstr ""
 "a-l încărca."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/messages.cpp:287 ../../Firmware/ultralcd.cpp:3705
+#: ../../Firmware/messages.cpp:299 ../../Firmware/ultralcd.cpp:3715
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1528,104 +1522,103 @@ msgstr ""
 "pentru a-l încărca."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/messages.cpp:285 ../../Firmware/ultralcd.cpp:3633
+#: ../../Firmware/messages.cpp:297 ../../Firmware/ultralcd.cpp:3643
 msgid "Please load filament first."
 msgstr "Vă rugăm încărcați filamentul mai întâi."
 
 #. MSG_CHECK_IDLER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3525 ../../Firmware/messages.cpp:206
+#: ../../Firmware/Marlin_main.cpp:3265 ../../Firmware/messages.cpp:218
 msgid "Please open idler and remove filament manually."
 msgstr "Deschideți idler-ul și scoateți filamentul manual."
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2806 ../../Firmware/messages.cpp:80
-#: ../../Firmware/ultralcd.cpp:3860
+#: ../../Firmware/mesh_bed_calibration.cpp:2791 ../../Firmware/messages.cpp:80
 msgid "Please place steel sheet on heatbed."
 msgstr "Așezați suprafața de print pe pat."
 
 #. MSG_PRESS_TO_UNLOAD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:11215 ../../Firmware/Marlin_main.cpp:11245
+#: ../../Firmware/Marlin_main.cpp:10287 ../../Firmware/Marlin_main.cpp:10317
 #: ../../Firmware/messages.cpp:84
 msgid "Please press the knob to unload filament"
 msgstr "Apăsați butonul pentru a scoate filamentul."
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:4932
+#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:4888
 msgid "Please pull out filament immediately"
 msgstr "Vă rugăm scoateți filamentul imediat"
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/messages.cpp:295 ../../Firmware/ultralcd.cpp:3856
+#: ../../Firmware/messages.cpp:307 ../../Firmware/ultralcd.cpp:3882
 msgid "Please remove shipping helpers first."
 msgstr "Vă rugăm scoateți protecțiile de transport mai întâi."
 
 #. MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3240 ../../Firmware/Marlin_main.cpp:4755
-#: ../../Firmware/messages.cpp:89
+#: ../../Firmware/Marlin_main.cpp:4324 ../../Firmware/messages.cpp:89
 msgid "Please remove steel sheet from heatbed."
 msgstr "Vă rugăm îndepărtați suprafața de print de pe pat."
 
 #. MSG_RUN_XYZ c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4731 ../../Firmware/messages.cpp:207
+#: ../../Firmware/Marlin_main.cpp:4300 ../../Firmware/messages.cpp:219
 msgid "Please run XYZ calibration first."
 msgstr "Vă rugăm rulați calibrarea XYZ mai întâi."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/messages.cpp:336 ../../Firmware/ultralcd.cpp:6020
+#: ../../Firmware/messages.cpp:348 ../../Firmware/ultralcd.cpp:4359
+#: ../../Firmware/ultralcd.cpp:5996
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Vă rugăm mai întâi să scoateți filamentul, apoi încercați din nou."
 
 #. MSG_NEW_FIRMWARE_PLEASE_UPGRADE c=20
-#: ../../Firmware/messages.cpp:366 ../../Firmware/util.cpp:213
+#: ../../Firmware/messages.cpp:378 ../../Firmware/util.cpp:218
 msgid "Please upgrade."
 msgstr "Vă rugăm actualizați"
 
 #. MSG_PLEASE_WAIT c=20
-#: ../../Firmware/Marlin_main.cpp:3521 ../../Firmware/Marlin_main.cpp:8090
-#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:2179
-#: ../../Firmware/ultralcd.cpp:2190
+#: ../../Firmware/Marlin_main.cpp:3261 ../../Firmware/Marlin_main.cpp:7262
+#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:2190
+#: ../../Firmware/ultralcd.cpp:2204
 msgid "Please wait"
 msgstr "Vă rog așteptați"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:1232
-#: ../../Firmware/ultralcd.cpp:1261
+#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:1242
+#: ../../Firmware/ultralcd.cpp:1271
 msgid "Power failures"
 msgstr "Err. alimentare"
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/messages.cpp:323 ../../Firmware/ultralcd.cpp:5260
+#: ../../Firmware/messages.cpp:335 ../../Firmware/ultralcd.cpp:5222
 msgid "Preheat"
 msgstr "Preîncălzire"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:2254
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:2268
 msgid "Preheat the nozzle!"
 msgstr "Preîncălziți vârful!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:2771
-#: ../../Firmware/ultralcd.cpp:3690 ../../Firmware/ultralcd.cpp:3692
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:2788
+#: ../../Firmware/ultralcd.cpp:3700 ../../Firmware/ultralcd.cpp:3702
 msgid "Preheating nozzle. Please wait."
 msgstr "Preîncălzire extruder. Vă rugăm așteptați."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/messages.cpp:237 ../../Firmware/ultralcd.cpp:1999
+#: ../../Firmware/messages.cpp:249 ../../Firmware/ultralcd.cpp:2005
 msgid "Preheating to cut"
 msgstr "Preîncălzire..."
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/messages.cpp:236 ../../Firmware/ultralcd.cpp:1996
+#: ../../Firmware/messages.cpp:248 ../../Firmware/ultralcd.cpp:2002
 msgid "Preheating to eject"
 msgstr "Preîncălzire..."
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/messages.cpp:234 ../../Firmware/ultralcd.cpp:1987
+#: ../../Firmware/messages.cpp:246 ../../Firmware/ultralcd.cpp:1995
 msgid "Preheating to load"
 msgstr "Preîncălz. încărcare"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/messages.cpp:235 ../../Firmware/ultralcd.cpp:1992
+#: ../../Firmware/messages.cpp:247 ../../Firmware/ultralcd.cpp:1999
 msgid "Preheating to unload"
 msgstr "Preîncălz. scoatere"
 
@@ -1636,12 +1629,12 @@ msgid "Preparing blade"
 msgstr "Pregătire lamă"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/messages.cpp:231 ../../Firmware/ultralcd.cpp:1799
+#: ../../Firmware/messages.cpp:243 ../../Firmware/ultralcd.cpp:1809
 msgid "Press the knob"
 msgstr "Apăsați butonul"
 
 #. MSG_PRESS_TO_PREHEAT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:11227 ../../Firmware/messages.cpp:212
+#: ../../Firmware/Marlin_main.cpp:10299 ../../Firmware/messages.cpp:224
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Apăsați butonul pentru a preîncălzi extruder-ul și continuați."
 
@@ -1651,34 +1644,34 @@ msgid "Print aborted"
 msgstr "Print anulat"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1106
-#: ../../Firmware/ultralcd.cpp:6994
+#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1116
+#: ../../Firmware/ultralcd.cpp:6971
 msgid "Print fan:"
 msgstr "Vent. print:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:5313
+#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5279
 msgid "Print from SD"
 msgstr "Printare de pe SD"
 
 #. MSG_PRINT_PAUSED c=20
-#: ../../Firmware/Marlin_main.cpp:3582 ../../Firmware/messages.cpp:79
+#: ../../Firmware/Marlin_main.cpp:3323 ../../Firmware/messages.cpp:79
 #: ../../Firmware/ultralcd.cpp:814
 msgid "Print paused"
 msgstr "Print oprit"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/messages.cpp:247 ../../Firmware/ultralcd.cpp:2348
+#: ../../Firmware/messages.cpp:259 ../../Firmware/ultralcd.cpp:2365
 msgid "Print time"
 msgstr "Durată print"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/messages.cpp:225 ../../Firmware/ultralcd.cpp:1689
+#: ../../Firmware/messages.cpp:237 ../../Firmware/ultralcd.cpp:1699
 msgid "Printer IP Addr:"
 msgstr "Adresă IP:"
 
 #. MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1602 ../../Firmware/messages.cpp:46
+#: ../../Firmware/Marlin_main.cpp:1529 ../../Firmware/messages.cpp:46
 msgid ""
 "Printer has not been calibrated yet. Please follow the manual, chapter First"
 " steps, section Calibration flow."
@@ -1687,12 +1680,12 @@ msgstr ""
 " steps, secțiunea Calibration flow."
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:153 ../../Firmware/util.cpp:289
+#: ../../Firmware/messages.cpp:160 ../../Firmware/util.cpp:296
 msgid "Nozzle diameter differs from the G-code. Continue?"
 msgstr "Diametrul vârfului diferă de cel din G-code. Continuați?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:154 ../../Firmware/util.cpp:290
+#: ../../Firmware/messages.cpp:161 ../../Firmware/util.cpp:297
 msgid ""
 "Nozzle diameter differs from the G-code. Please check the value in settings."
 " Print cancelled."
@@ -1719,22 +1712,22 @@ msgid "QUEUE FULL"
 msgstr "QUEUE PLIN"
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:4465
 msgid "RPi port"
 msgstr "Port RPi"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/messages.cpp:261 ../../Firmware/ultralcd.cpp:2712
+#: ../../Firmware/messages.cpp:273 ../../Firmware/ultralcd.cpp:2729
 msgid "Rear side [µm]"
 msgstr "Spate [µm]"
 
 #. MSG_RECOVERING_PRINT c=20
-#: ../../Firmware/messages.cpp:216 ../../Firmware/power_panic.cpp:316
+#: ../../Firmware/messages.cpp:228 ../../Firmware/power_panic.cpp:328
 msgid "Recovering print"
 msgstr "Recuperare print"
 
 #. MSG_RENAME c=18
-#: ../../Firmware/messages.cpp:322 ../../Firmware/ultralcd.cpp:5143
+#: ../../Firmware/messages.cpp:334 ../../Firmware/ultralcd.cpp:5103
 msgid "Rename"
 msgstr "Redenumește"
 
@@ -1748,19 +1741,19 @@ msgstr ""
 "folosește filam. în afara intervalului (T0-T4)."
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:2713
-#: ../../Firmware/ultralcd.cpp:5144
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:2730
+#: ../../Firmware/ultralcd.cpp:5104
 msgid "Reset"
 msgstr "Reset."
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/messages.cpp:320 ../../Firmware/ultralcd.cpp:4594
+#: ../../Firmware/messages.cpp:332 ../../Firmware/ultralcd.cpp:4550
 msgid "Reset XYZ calibr."
 msgstr "Reset. calibr. XYZ"
 
 #. MSG_RESUME_PRINT c=18
-#: ../../Firmware/Marlin_main.cpp:680 ../../Firmware/messages.cpp:91
-#: ../../Firmware/ultralcd.cpp:5286 ../../Firmware/ultralcd.cpp:5288
+#: ../../Firmware/Marlin_main.cpp:645 ../../Firmware/messages.cpp:91
+#: ../../Firmware/ultralcd.cpp:5252 ../../Firmware/ultralcd.cpp:5254
 msgid "Resume print"
 msgstr "Continuă print"
 
@@ -1787,17 +1780,17 @@ msgid "Returning selector"
 msgstr "Revenire selector"
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/messages.cpp:252 ../../Firmware/ultralcd.cpp:2479
+#: ../../Firmware/messages.cpp:264 ../../Firmware/ultralcd.cpp:2496
 msgid "Right"
 msgstr "Dreapta"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/messages.cpp:259 ../../Firmware/ultralcd.cpp:2710
+#: ../../Firmware/messages.cpp:271 ../../Firmware/ultralcd.cpp:2727
 msgid "Right side[µm]"
 msgstr "Dreapta [µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/messages.cpp:286 ../../Firmware/ultralcd.cpp:3656
+#: ../../Firmware/messages.cpp:298 ../../Firmware/ultralcd.cpp:3666
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1806,8 +1799,8 @@ msgstr ""
 " de la început. Continuați?"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4509
-#: ../../Firmware/ultralcd.cpp:4511
+#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4476
+#: ../../Firmware/ultralcd.cpp:4478
 msgid "SD card"
 msgstr "Card SD"
 
@@ -1822,23 +1815,23 @@ msgid "SELECTOR CANNOT MOVE"
 msgstr "SELECTOR NU SE MIȘCĂ"
 
 #. MSG_STOPPED c=20
-#: ../../Firmware/Marlin_main.cpp:9887 ../../Firmware/messages.cpp:125
+#: ../../Firmware/Marlin_main.cpp:9047 ../../Firmware/messages.cpp:130
 msgid "STOPPED."
 msgstr "OPRIT."
 
 #. MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3223 ../../Firmware/Marlin_main.cpp:3245
-#: ../../Firmware/mesh_bed_calibration.cpp:2246 ../../Firmware/messages.cpp:44
+#: ../../Firmware/Marlin_main.cpp:2967 ../../Firmware/Marlin_main.cpp:2984
+#: ../../Firmware/mesh_bed_calibration.cpp:2231 ../../Firmware/messages.cpp:44
 msgid "Searching bed calibration point"
 msgstr "Se caută punctele de calibrare"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/messages.cpp:321 ../../Firmware/ultralcd.cpp:5136
+#: ../../Firmware/messages.cpp:333 ../../Firmware/ultralcd.cpp:5096
 msgid "Select"
 msgstr "Selectează"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/messages.cpp:290 ../../Firmware/ultralcd.cpp:3730
+#: ../../Firmware/messages.cpp:302 ../../Firmware/ultralcd.cpp:3740
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
@@ -1847,26 +1840,26 @@ msgstr ""
 "ecran."
 
 #. MSG_SELECT_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3453 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3612
-#: ../../Firmware/ultralcd.cpp:6822
+#: ../../Firmware/Marlin_main.cpp:3192 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3622
+#: ../../Firmware/ultralcd.cpp:6798
 msgid "Select filament:"
 msgstr "Select. filamentul:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:110 ../../Firmware/ultralcd.cpp:3464
-#: ../../Firmware/ultralcd.cpp:4504
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:3474
+#: ../../Firmware/ultralcd.cpp:4471
 msgid "Select language"
 msgstr "Selectați limba"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/messages.cpp:300 ../../Firmware/ultralcd.cpp:3900
+#: ../../Firmware/messages.cpp:312 ../../Firmware/ultralcd.cpp:3924
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr ""
 "Selectați temperatura de încălzire a extruder-ului pentru materialul ales."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/messages.cpp:291 ../../Firmware/ultralcd.cpp:3735
+#: ../../Firmware/messages.cpp:303 ../../Firmware/ultralcd.cpp:3745
 msgid "Select temperature which matches your material."
 msgstr "Selectați temp. potrivită pentru materialul curent."
 
@@ -1877,62 +1870,62 @@ msgid "Selecting fil. slot"
 msgstr "Selectare slot fil."
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/messages.cpp:341 ../../Firmware/ultralcd.cpp:6274
+#: ../../Firmware/messages.cpp:353 ../../Firmware/ultralcd.cpp:6250
 msgid "Selftest OK"
 msgstr "Testare automată OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/messages.cpp:340 ../../Firmware/ultralcd.cpp:6057
+#: ../../Firmware/messages.cpp:352 ../../Firmware/ultralcd.cpp:6033
 msgid "Selftest start"
 msgstr "Start Autotestare"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/messages.cpp:315 ../../Firmware/ultralcd.cpp:4581
+#: ../../Firmware/messages.cpp:327 ../../Firmware/ultralcd.cpp:4537
 msgid "Selftest"
 msgstr "Testare automată"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/messages.cpp:342 ../../Firmware/ultralcd.cpp:6699
+#: ../../Firmware/messages.cpp:354 ../../Firmware/ultralcd.cpp:6675
 msgid "Selftest error!"
 msgstr "Err. test. automată!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6279
-#: ../../Firmware/ultralcd.cpp:6786 ../../Firmware/ultralcd.cpp:6984
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6255
+#: ../../Firmware/ultralcd.cpp:6762 ../../Firmware/ultralcd.cpp:6961
 msgid "Selftest failed"
 msgstr "Autotestare eșuată"
 
 #. MSG_FORCE_SELFTEST c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1577 ../../Firmware/messages.cpp:202
+#: ../../Firmware/Marlin_main.cpp:1504 ../../Firmware/messages.cpp:214
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr ""
 "Testarea automată va fi rulată pentru a calibra sensorless rehoming-ul."
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/messages.cpp:228 ../../Firmware/ultralcd.cpp:1701
+#: ../../Firmware/messages.cpp:240 ../../Firmware/ultralcd.cpp:1711
 msgid "Sensor info"
 msgstr "Info. senzori"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/messages.cpp:338 ../../Firmware/ultralcd.cpp:6027
+#: ../../Firmware/messages.cpp:350 ../../Firmware/ultralcd.cpp:6003
 msgid "Sensor verified, remove the filament now."
 msgstr "Senzorul a fost verificat, scoate filamentul."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/messages.cpp:262 ../../Firmware/ultralcd.cpp:2730
+#: ../../Firmware/messages.cpp:274 ../../Firmware/ultralcd.cpp:2747
 msgid "Set temperature:"
 msgstr "Setați temperatura:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3348
-#: ../../Firmware/ultralcd.cpp:3479 ../../Firmware/ultralcd.cpp:3984
-#: ../../Firmware/ultralcd.cpp:5374 ../../Firmware/ultralcd.cpp:5585
-#: ../../Firmware/ultralcd.cpp:5631
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3358
+#: ../../Firmware/ultralcd.cpp:3489 ../../Firmware/ultralcd.cpp:4008
+#: ../../Firmware/ultralcd.cpp:5341 ../../Firmware/ultralcd.cpp:5558
+#: ../../Firmware/ultralcd.cpp:5604
 msgid "Settings"
 msgstr "Setări"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/messages.cpp:255 ../../Firmware/ultralcd.cpp:2522
+#: ../../Firmware/messages.cpp:267 ../../Firmware/ultralcd.cpp:2539
 msgid "Severe skew"
 msgstr "Deform. severă"
 
@@ -1943,7 +1936,7 @@ msgid "Sheet"
 msgstr "Suprafață"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/messages.cpp:284 ../../Firmware/ultralcd.cpp:3604
+#: ../../Firmware/messages.cpp:296 ../../Firmware/ultralcd.cpp:3614
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1956,23 +1949,23 @@ msgstr ""
 "%cReset."
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/messages.cpp:319 ../../Firmware/ultralcd.cpp:4592
+#: ../../Firmware/messages.cpp:331 ../../Firmware/ultralcd.cpp:4548
 msgid "Show end stops"
 msgstr "Stare endstop-uri"
 
 #. MSG_SILENT c=7
-#: ../../Firmware/Marlin_main.cpp:8497 ../../Firmware/messages.cpp:120
-#: ../../Firmware/ultralcd.cpp:4155 ../../Firmware/ultralcd.cpp:4194
+#: ../../Firmware/Marlin_main.cpp:7668 ../../Firmware/messages.cpp:124
+#: ../../Firmware/ultralcd.cpp:4179 ../../Firmware/ultralcd.cpp:4218
 msgid "Silent"
 msgstr "Silenț."
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/messages.cpp:254 ../../Firmware/ultralcd.cpp:2521
+#: ../../Firmware/messages.cpp:266 ../../Firmware/ultralcd.cpp:2538
 msgid "Slight skew"
 msgstr "Dist. ușoară"
 
 #. MSG_FILE_CNT c=20 r=6
-#: ../../Firmware/cardreader.cpp:805 ../../Firmware/messages.cpp:197
+#: ../../Firmware/cardreader.cpp:805 ../../Firmware/messages.cpp:209
 msgid ""
 "Some files will not be sorted. Max. No. of files in 1 folder for sorting is "
 "100."
@@ -1981,59 +1974,59 @@ msgstr ""
 "care pot fi sortate este 100."
 
 #. MSG_ZLEVELING_ENFORCED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3043 ../../Firmware/messages.cpp:204
+#: ../../Firmware/Marlin_main.cpp:2783 ../../Firmware/messages.cpp:216
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "A fost întâmpinată o problemă, calibrarea Z a fost inițiată..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:4514
-#: ../../Firmware/ultralcd.cpp:4515 ../../Firmware/ultralcd.cpp:4516
+#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4481
+#: ../../Firmware/ultralcd.cpp:4482 ../../Firmware/ultralcd.cpp:4483
 msgid "Sort"
 msgstr "Sortare"
 
 #. MSG_SORTING_FILES c=20
 #: ../../Firmware/cardreader.cpp:849 ../../Firmware/cardreader.cpp:916
-#: ../../Firmware/messages.cpp:111
+#: ../../Firmware/messages.cpp:115
 msgid "Sorting files"
 msgstr "Sortare fișiere..."
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4188
-#: ../../Firmware/ultralcd.cpp:4191 ../../Firmware/ultralcd.cpp:4194
-#: ../../Firmware/ultralcd.cpp:4197 ../../Firmware/ultralcd.cpp:4200
+#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4215 ../../Firmware/ultralcd.cpp:4218
+#: ../../Firmware/ultralcd.cpp:4221 ../../Firmware/ultralcd.cpp:4224
 msgid "Sound"
 msgstr "Sunet"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/messages.cpp:333 ../../Firmware/ultralcd.cpp:5516
+#: ../../Firmware/messages.cpp:345 ../../Firmware/ultralcd.cpp:5483
 msgid "Speed"
 msgstr "Viteză"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6861
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6837
 msgid "Spinning"
 msgstr "Se rotește"
 
 #. MSG_TEMP_CAL_WARNING c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4744 ../../Firmware/messages.cpp:208
+#: ../../Firmware/Marlin_main.cpp:4313 ../../Firmware/messages.cpp:220
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr ""
 "Temp. ambient. stabilă (21-26C) și o suprafață de lucru rigidă necesare."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/messages.cpp:329 ../../Firmware/ultralcd.cpp:5379
+#: ../../Firmware/messages.cpp:341 ../../Firmware/ultralcd.cpp:5346
 msgid "Statistics"
 msgstr "Statistici"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:4096
-#: ../../Firmware/ultralcd.cpp:4144
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4120
+#: ../../Firmware/ultralcd.cpp:4168
 msgid "Stealth"
 msgstr "Silenț."
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4421
-#: ../../Firmware/ultralcd.cpp:5133
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4388
+#: ../../Firmware/ultralcd.cpp:5093
 msgid "Steel sheets"
 msgstr "Suprafețe print"
 
@@ -2043,29 +2036,28 @@ msgid "Stop"
 msgstr "Stop"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:5293
-#: ../../Firmware/ultralcd.cpp:5781
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:5259
+#: ../../Firmware/ultralcd.cpp:5757
 msgid "Stop print"
 msgstr "Oprire print"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4236
-#: ../../Firmware/ultralcd.cpp:4316 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4315
 msgid "Strict"
 msgstr "Strict"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/messages.cpp:332 ../../Firmware/ultralcd.cpp:5394
+#: ../../Firmware/messages.cpp:344 ../../Firmware/ultralcd.cpp:5361
 msgid "Support"
 msgstr "Informații"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/messages.cpp:354 ../../Firmware/ultralcd.cpp:6758
+#: ../../Firmware/messages.cpp:366 ../../Firmware/ultralcd.cpp:6734
 msgid "Swapped"
 msgstr "inversate"
 
 #. MSG_THERMAL_ANOMALY c=20
-#: ../../Firmware/messages.cpp:188 ../../Firmware/temperature.cpp:2223
+#: ../../Firmware/messages.cpp:195 ../../Firmware/temperature.cpp:2197
 msgid "THERMAL ANOMALY"
 msgstr "ANOMALIE TERMICĂ"
 
@@ -2100,7 +2092,7 @@ msgid "TMC UNDERVOLTAGE ERR"
 msgstr "ERR SUBTENSIUNE TMC"
 
 #. MSG_TM_CAL c=20 r=4
-#: ../../Firmware/messages.cpp:299 ../../Firmware/ultralcd.cpp:3881
+#: ../../Firmware/messages.cpp:311 ../../Firmware/ultralcd.cpp:3905
 msgid ""
 "Thermal model cal. takes approx. 12 mins. See\n"
 "prusa.io/tm-cal"
@@ -2109,22 +2101,22 @@ msgstr ""
 "prusa.io/tm-cal"
 
 #. MSG_TM_NOT_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1613 ../../Firmware/messages.cpp:189
+#: ../../Firmware/Marlin_main.cpp:1540 ../../Firmware/messages.cpp:196
 msgid "Thermal model not calibrated yet."
 msgstr "Modelul termic nu este înca calibrat."
 
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/messages.cpp:309 ../../Firmware/ultralcd.cpp:4455
+#: ../../Firmware/messages.cpp:321 ../../Firmware/ultralcd.cpp:4422
 msgid "Temperature"
 msgstr "Temperatura"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/messages.cpp:229 ../../Firmware/ultralcd.cpp:1707
+#: ../../Firmware/messages.cpp:241 ../../Firmware/ultralcd.cpp:1717
 msgid "Temperatures"
 msgstr "Temperaturi"
 
 #. MSG_TESTING_FILAMENT c=20
-#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:388
+#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:389
 msgid "Testing filament"
 msgstr "Testare filament"
 
@@ -2145,7 +2137,7 @@ msgstr ""
 "blocheză mișcarea."
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/messages.cpp:292 ../../Firmware/ultralcd.cpp:3738
+#: ../../Firmware/messages.cpp:304 ../../Firmware/ultralcd.cpp:3748
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -2155,7 +2147,7 @@ msgstr ""
 "înălțimea optimă. Folosiți pozele din handbook (capitolul Calibration)."
 
 #. MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1606 ../../Firmware/messages.cpp:47
+#: ../../Firmware/Marlin_main.cpp:1533 ../../Firmware/messages.cpp:47
 msgid ""
 "There is still a need to make Z calibration. Please follow the manual, "
 "chapter First steps, section Calibration flow."
@@ -2164,40 +2156,40 @@ msgstr ""
 "First steps, secțiunea Calibration flow."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:4514
+#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:4481
 msgid "Time"
 msgstr "Dată"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:176 ../../Firmware/ultralcd.cpp:5622
+#: ../../Firmware/messages.cpp:183 ../../Firmware/ultralcd.cpp:5595
 msgid "Timeout"
 msgstr "Timeout"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:1129
-#: ../../Firmware/ultralcd.cpp:1287
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:1139
+#: ../../Firmware/ultralcd.cpp:1297
 msgid "Total"
 msgstr "Total"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:1177
-#: ../../Firmware/ultralcd.cpp:1231 ../../Firmware/ultralcd.cpp:1317
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:1187
+#: ../../Firmware/ultralcd.cpp:1241 ../../Firmware/ultralcd.cpp:1327
 msgid "Total failures"
 msgstr "Total erori"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/messages.cpp:248 ../../Firmware/ultralcd.cpp:2369
+#: ../../Firmware/messages.cpp:260 ../../Firmware/ultralcd.cpp:2386
 msgid "Total filament"
 msgstr "Filament total"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/messages.cpp:249 ../../Firmware/ultralcd.cpp:2370
+#: ../../Firmware/messages.cpp:261 ../../Firmware/ultralcd.cpp:2387
 msgid "Total print time"
 msgstr "Durata totală print"
 
 #. MSG_TUNE c=8
-#: ../../Firmware/messages.cpp:116 ../../Firmware/mmu2/errors_list.h:372
-#: ../../Firmware/ultralcd.cpp:5258
+#: ../../Firmware/messages.cpp:120 ../../Firmware/mmu2/errors_list.h:372
+#: ../../Firmware/ultralcd.cpp:5220
 msgid "Tune"
 msgstr "Opțiuni"
 
@@ -2212,16 +2204,16 @@ msgid "Unload"
 msgstr "Descărc."
 
 #. MSG_UNLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:2206
-#: ../../Firmware/ultralcd.cpp:5347 ../../Firmware/ultralcd.cpp:5364
-#: ../../Firmware/ultralcd.cpp:5369
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:2220
+#: ../../Firmware/ultralcd.cpp:5313 ../../Firmware/ultralcd.cpp:5331
+#: ../../Firmware/ultralcd.cpp:5336
 msgid "Unload filament"
 msgstr "Descarcă filam."
 
 #. MSG_UNLOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3436 ../../Firmware/messages.cpp:129
+#: ../../Firmware/Marlin_main.cpp:3175 ../../Firmware/messages.cpp:134
 #: ../../Firmware/mmu2_progress_converter.cpp:50
-#: ../../Firmware/ultralcd.cpp:4911
+#: ../../Firmware/ultralcd.cpp:4867
 msgid "Unloading filament"
 msgstr "Descărcare filament"
 
@@ -2238,12 +2230,12 @@ msgid "Unloading to pulley"
 msgstr "Descărcare la pulley"
 
 #. MSG_FIL_FAILED c=20 r=4
-#: ../../Firmware/messages.cpp:339 ../../Firmware/ultralcd.cpp:6030
+#: ../../Firmware/messages.cpp:351 ../../Firmware/ultralcd.cpp:6006
 msgid "Verification failed, remove the filament and try again."
 msgstr "Verificarea a eșuat, scoateți filamentul și încercați din nou."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/messages.cpp:230 ../../Firmware/ultralcd.cpp:1710
+#: ../../Firmware/messages.cpp:242 ../../Firmware/ultralcd.cpp:1720
 msgid "Voltages"
 msgstr "Voltaje"
 
@@ -2254,7 +2246,7 @@ msgid "WARNING TMC TOO HOT"
 msgstr "TMC SUPRAÎNCĂLZIT"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/messages.cpp:281 ../../Firmware/ultralcd.cpp:3381
+#: ../../Firmware/messages.cpp:293 ../../Firmware/ultralcd.cpp:3391
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -2267,87 +2259,86 @@ msgstr ""
 "modul silențios"
 
 #. MSG_USERWAIT c=20
-#: ../../Firmware/Marlin_main.cpp:5240 ../../Firmware/messages.cpp:209
+#: ../../Firmware/Marlin_main.cpp:4747 ../../Firmware/messages.cpp:221
 msgid "Wait for user..."
 msgstr "Se așteaptă..."
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/messages.cpp:263 ../../Firmware/ultralcd.cpp:2753
+#: ../../Firmware/messages.cpp:275 ../../Firmware/ultralcd.cpp:2770
 msgid "Waiting for PINDA probe cooling"
 msgstr "Se așteaptă răcirea probei PINDA"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/messages.cpp:264 ../../Firmware/ultralcd.cpp:2782
+#: ../../Firmware/messages.cpp:276 ../../Firmware/ultralcd.cpp:2799
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Se așteaptă răcirea extruderului și a patului"
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:4233
-#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4352
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4312
 msgid "Warn"
 msgstr "Avert."
 
 #. MSG_CHANGED_BOTH c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1554 ../../Firmware/messages.cpp:200
+#: ../../Firmware/Marlin_main.cpp:1481 ../../Firmware/messages.cpp:212
 msgid "Warning: both printer type and motherboard type changed."
 msgstr "Atenție: tipul imprimantei și al plăcii de bază s-au schimbat."
 
 #. MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1546 ../../Firmware/messages.cpp:198
+#: ../../Firmware/Marlin_main.cpp:1473 ../../Firmware/messages.cpp:210
 msgid "Warning: motherboard type changed."
 msgstr "Atenție: tipul plăcii de bază s-a schimbat."
 
 #. MSG_CHANGED_PRINTER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1550 ../../Firmware/messages.cpp:199
+#: ../../Firmware/Marlin_main.cpp:1477 ../../Firmware/messages.cpp:211
 msgid "Warning: printer type changed."
 msgstr "Atenție: tipul imprimantei s-a schimbat."
 
 #. MSG_UNLOAD_SUCCESSFUL c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3517 ../../Firmware/messages.cpp:205
+#: ../../Firmware/Marlin_main.cpp:3257 ../../Firmware/messages.cpp:217
 msgid "Was filament unload successful?"
 msgstr "Filamentul a fost scos cu succes?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:6710
-#: ../../Firmware/ultralcd.cpp:6714 ../../Firmware/ultralcd.cpp:6734
-#: ../../Firmware/ultralcd.cpp:6740 ../../Firmware/ultralcd.cpp:6764
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:6686
+#: ../../Firmware/ultralcd.cpp:6690 ../../Firmware/ultralcd.cpp:6710
+#: ../../Firmware/ultralcd.cpp:6716 ../../Firmware/ultralcd.cpp:6740
 msgid "Wiring error"
 msgstr "Eroare cablaj"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/messages.cpp:313 ../../Firmware/ultralcd.cpp:4572
+#: ../../Firmware/messages.cpp:325 ../../Firmware/ultralcd.cpp:4528
 msgid "Wizard"
 msgstr "Wizard"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/messages.cpp:304 ../../Firmware/ultralcd.cpp:3986
+#: ../../Firmware/messages.cpp:316 ../../Firmware/ultralcd.cpp:4010
 msgid "X-correct"
 msgstr "Corecț. X"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/messages.cpp:226 ../../Firmware/ultralcd.cpp:1699
+#: ../../Firmware/messages.cpp:238 ../../Firmware/ultralcd.cpp:1709
 msgid "XYZ cal. details"
 msgstr "Detalii cal. XYZ"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/messages.cpp:275 ../../Firmware/ultralcd.cpp:3207
+#: ../../Firmware/messages.cpp:287 ../../Firmware/ultralcd.cpp:3217
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr "Calibrarea XYZ în regulă. Distorsiunea va fi corectată automat."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/messages.cpp:274 ../../Firmware/ultralcd.cpp:3204
+#: ../../Firmware/messages.cpp:286 ../../Firmware/ultralcd.cpp:3214
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr ""
 "Calibrarea XYZ în regulă. Axele X/Y sunt distorsionate puțin. Felicitări!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/messages.cpp:271 ../../Firmware/ultralcd.cpp:3185
+#: ../../Firmware/messages.cpp:283 ../../Firmware/ultralcd.cpp:3195
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr ""
 "Calibrarea XYZ compromisă. Punctele de calibrare din față nu pot fi atinse."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/messages.cpp:272 ../../Firmware/ultralcd.cpp:3188
+#: ../../Firmware/messages.cpp:284 ../../Firmware/ultralcd.cpp:3198
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr ""
@@ -2355,105 +2346,106 @@ msgstr ""
 "atinse."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/messages.cpp:268 ../../Firmware/ultralcd.cpp:3167
+#: ../../Firmware/messages.cpp:280 ../../Firmware/ultralcd.cpp:3177
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr ""
 "Calibrarea XYZ a esuat. Un punct de calibrare a patului nu a fost găsit."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/messages.cpp:269 ../../Firmware/ultralcd.cpp:3173
+#: ../../Firmware/messages.cpp:281 ../../Firmware/ultralcd.cpp:3183
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr ""
 "Calibrarea XYZ a eșuat. Punctele de calibrare din față nu pot fi atinse."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3170
-#: ../../Firmware/ultralcd.cpp:3198
+#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3180
+#: ../../Firmware/ultralcd.cpp:3208
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "Calibrarea XYZ a eșuat. Vă rugăm consultați manualul."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/messages.cpp:270 ../../Firmware/ultralcd.cpp:3176
+#: ../../Firmware/messages.cpp:282 ../../Firmware/ultralcd.cpp:3186
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr ""
 "Calibrarea XYZ a eșuat. Punctele de calibrare din față dreapta nu pot fi "
 "atinse."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/messages.cpp:273 ../../Firmware/ultralcd.cpp:3201
+#: ../../Firmware/messages.cpp:285 ../../Firmware/ultralcd.cpp:3211
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "Calibrarea XYZ ok. Axele X/Y sunt perpendiculare. Felicitări!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/messages.cpp:250 ../../Firmware/ultralcd.cpp:2476
+#: ../../Firmware/messages.cpp:262 ../../Firmware/ultralcd.cpp:2493
 msgid "Y distance from min"
 msgstr "Distanța Y de la min"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/messages.cpp:305 ../../Firmware/ultralcd.cpp:3987
+#: ../../Firmware/messages.cpp:317 ../../Firmware/ultralcd.cpp:4011
 msgid "Y-correct"
 msgstr "Corecț. Y"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:3029
-#: ../../Firmware/ultralcd.cpp:4443 ../../Firmware/ultralcd.cpp:4531
-#: ../../Firmware/ultralcd.cpp:5790
+#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:2275
+#: ../../Firmware/ultralcd.cpp:2279 ../../Firmware/ultralcd.cpp:3046
+#: ../../Firmware/ultralcd.cpp:4410 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/ultralcd.cpp:5766
 msgid "Yes"
 msgstr "Da"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:3950
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:3974
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr "Puteți oricând să reluați Wizard-ul din Calibrare -> Wizard."
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/messages.cpp:306 ../../Firmware/ultralcd.cpp:3988
+#: ../../Firmware/messages.cpp:318 ../../Firmware/ultralcd.cpp:4012
 msgid "Z-correct"
 msgstr "Corecț. Z"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5593
+#: ../../Firmware/messages.cpp:175 ../../Firmware/ultralcd.cpp:5566
 msgid "Z-probe nr."
 msgstr "Nr. Z-probe"
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/messages.cpp:256 ../../Firmware/ultralcd.cpp:2546
+#: ../../Firmware/messages.cpp:268 ../../Firmware/ultralcd.cpp:2563
 msgid "[0;0] point offset"
 msgstr "[0;0] offset origine"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/messages.cpp:239 ../../Firmware/ultralcd.cpp:2147
+#: ../../Firmware/messages.cpp:251 ../../Firmware/ultralcd.cpp:2158
 msgid "and press the knob"
 msgstr "și apasă butonul"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/messages.cpp:232 ../../Firmware/ultralcd.cpp:1807
+#: ../../Firmware/messages.cpp:244 ../../Firmware/ultralcd.cpp:1816
 msgid "to load filament"
 msgstr "a încărca filament"
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/messages.cpp:233 ../../Firmware/ultralcd.cpp:1811
+#: ../../Firmware/messages.cpp:245 ../../Firmware/ultralcd.cpp:1820
 msgid "to unload filament"
 msgstr "a scoate filament"
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/messages.cpp:224 ../../Firmware/ultralcd.cpp:1666
+#: ../../Firmware/messages.cpp:236 ../../Firmware/ultralcd.cpp:1676
 msgid "unknown"
 msgstr "necunoscut"
 
 #. MSG_IR_UNKNOWN c=18
-#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:184
+#: ../../Firmware/Filament_sensor.cpp:286 ../../Firmware/messages.cpp:191
 msgid "unknown state"
 msgstr "vers. necunoscută"
 
 #. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:5858
-#: ../../Firmware/ultralcd.cpp:5861
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:5834
+#: ../../Firmware/ultralcd.cpp:5837
 msgid "🔃Refresh"
 msgstr "🔃Reîmprospătează"
 
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1180
+#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1190
 msgid "MMU power fails"
 msgstr "Err. MMU curent"
 
@@ -2491,8 +2483,8 @@ msgid "MMU MCU ERROR"
 msgstr "MMU: EROARE MCU"
 
 #. MSG_MATERIAL_CHANGES c=18
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:1130
-#: ../../Firmware/ultralcd.cpp:1204
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:1140
+#: ../../Firmware/ultralcd.cpp:1214
 msgid "Material changes"
 msgstr "Schimburi material"
 
@@ -2525,17 +2517,17 @@ msgstr ""
 "Actualizați la versiunea 3.0.3."
 
 #. MSG_PRELOAD_TO_MMU c=17
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5344
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5310
 msgid "Preload to MMU"
 msgstr "Preîncărcare MMU"
 
 #. MSG_FW_MK3_DETECTED c=20 r=4
-#: ../../Firmware/messages.cpp:367 ../../Firmware/Marlin_main.cpp:920
+#: ../../Firmware/messages.cpp:379 ../../Firmware/Marlin_main.cpp:854
 msgid "MK3 firmware detected on MK3S printer"
 msgstr "Firmware MK3 detectat pe imprimanta MK3S"
 
 #. MSG_FW_MK3S_DETECTED c=20 r=4
-#: ../../Firmware/messages.cpp:367 ../../Firmware/Marlin_main.cpp:920
+#: ../../Firmware/messages.cpp:379 ../../Firmware/Marlin_main.cpp:854
 msgid "MK3S firmware detected on MK3 printer"
 msgstr "Firmware MK3S detectat pe imprimanta MK3"
 
@@ -2549,8 +2541,9 @@ msgstr "EROARE NECUNOSCUTĂ"
 msgid "Unexpected error occurred."
 msgstr "A apărut o eroare neașteptată."
 
-#. MSG_BTN_EJECT c=8
-#: ../../Firmware/mmu2/errors_list.h:358 ../../Firmware/mmu2/errors_list.h:371
+#. MSG_EJECT c=8
+#: ../../Firmware/messages.cpp:21 ../../Firmware/mmu2/errors_list.h:371
+#: ../../Firmware/ultralcd.cpp:2275 ../../Firmware/ultralcd.cpp:2279
 msgid "Eject"
 msgstr "Scoateți"
 
@@ -2571,58 +2564,58 @@ msgstr ""
 "M600: Schimbare filament. Încarcă un filament nou sau scoate-l pe cel vechi."
 
 #. MSG_MMU_SENSITIVITY c=18
-#: ../../Firmware/messages.cpp:215 ../../Firmware/mmu2_reporting.cpp:458
+#: ../../Firmware/messages.cpp:227 ../../Firmware/mmu2_reporting.cpp:459
 msgid "Sensitivity"
 msgstr "Sensibilitate"
 
 #. MSG_MBL_FAILED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3038 ../../Firmware/messages.cpp:203
+#: ../../Firmware/Marlin_main.cpp:2776 ../../Firmware/messages.cpp:215
 msgid "Mesh bed leveling failed. Print canceled."
 msgstr "Nivelarea patului a eșuat. Print anulat."
 
 #. MSG_SET_READY c=18
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:5265
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:5228
 msgid "Set Ready"
 msgstr "Printer pregătit"
 
 #. MSG_SET_NOT_READY c=18
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:5263
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5226
 msgid "Set not Ready"
 msgstr "Print. nu pregătit"
 
 #. MSG_HOSTPRINT c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5285
+#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:5231
 msgid "Print from host"
 msgstr "Print. de pe gazdă"
 
 #. MSG_REPRINT c=18
-#: ../../Firmware/messages.cpp:196 ../../Firmware/ultralcd.cpp:5243
-#: ../../Firmware/ultralcd.cpp:5245
+#: ../../Firmware/messages.cpp:208 ../../Firmware/ultralcd.cpp:5205
+#: ../../Firmware/ultralcd.cpp:5207
 msgid "Reprint"
 msgstr "Repetă print"
 
 #. MSG_SHUTDOWN_HOST c=18
-#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:5390
+#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:5357
 msgid "Shutdown host"
 msgstr "Oprește gazda"
 
 #. MSG_NOZZLE_CNG_COOLDOWN c=20 r=3
-#: ../../Firmware/messages.cpp:198 ../../Firmware/ultralcd.cpp:1002
+#: ../../Firmware/messages.cpp:203 ../../Firmware/ultralcd.cpp:999
 msgid "Nozzle is hot! Wait for cooldown."
 msgstr "Duza este fierbinte! Așteptați să se răcească."
 
 #. MSG_NOZZLE_CNG_CHANGED_QUICK c=20 r=3
-#: ../../Firmware/messages.cpp:199
+#: ../../Firmware/messages.cpp:204
 msgid "Nozzle changed?"
 msgstr "S-a schimbat duza?"
 
 #. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:388
+#: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:388
 msgid "There is no filament loaded. Continue?"
 msgstr "Filamentul nu este detectat. Continuați?"
 
 #. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:389
+#: ../../Firmware/messages.cpp:159 ../../Firmware/util.cpp:389
 msgid "There is no filament loaded. Print cancelled."
 msgstr "Filamentul nu este detectat. Print anulat."
 

--- a/lang/po/Firmware_sk.po
+++ b/lang/po/Firmware_sk.po
@@ -16,91 +16,91 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 
 #. MSG_IR_03_OR_OLDER c=18
-#: ../../Firmware/Filament_sensor.cpp:280
-#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:183
+#: ../../Firmware/Filament_sensor.cpp:282
+#: ../../Firmware/Filament_sensor.cpp:344 ../../Firmware/messages.cpp:190
 msgid " 0.3 or older"
 msgstr " 0.3 a staršie"
 
 #. MSG_IR_04_OR_NEWER c=18
-#: ../../Firmware/Filament_sensor.cpp:282
-#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:182
+#: ../../Firmware/Filament_sensor.cpp:284
+#: ../../Firmware/Filament_sensor.cpp:347 ../../Firmware/messages.cpp:189
 msgid " 0.4 or newer"
 msgstr " 0.4 a novšie"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/messages.cpp:356 ../../Firmware/ultralcd.cpp:6773
+#: ../../Firmware/messages.cpp:368 ../../Firmware/ultralcd.cpp:6749
 msgid "%s level expected"
 msgstr "Očakávaná verzia %s"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:1978
-#: ../../Firmware/ultralcd.cpp:3613
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:1986
+#: ../../Firmware/ultralcd.cpp:3623
 msgid ">Cancel"
 msgstr ">Zrušiť"
 
 #. MSG_BABYSTEPPING_Z c=13
-#: ../../Firmware/messages.cpp:257 ../../Firmware/ultralcd.cpp:2635
+#: ../../Firmware/messages.cpp:269 ../../Firmware/ultralcd.cpp:2652
 msgid "Adjusting Z"
 msgstr "Doladenie Z"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/messages.cpp:360 ../../Firmware/ultralcd.cpp:6983
+#: ../../Firmware/messages.cpp:372 ../../Firmware/ultralcd.cpp:6960
 msgid "All correct"
 msgstr "Všetko OK"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:3955
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:3979
 msgid "All is done. Happy printing!"
 msgstr "Všetko je hotové!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4482
 msgid "Alphabet"
 msgstr "Abeceda"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4086
+#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4110
 msgid "Always"
 msgstr "Vždy"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/messages.cpp:221 ../../Firmware/ultralcd.cpp:1393
+#: ../../Firmware/messages.cpp:233 ../../Firmware/ultralcd.cpp:1403
 msgid "Ambient"
 msgstr "Okolie"
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=3
-#: ../../Firmware/messages.cpp:267 ../../Firmware/ultralcd.cpp:2848
+#: ../../Firmware/messages.cpp:279 ../../Firmware/ultralcd.cpp:2865
 msgid "Are left and right Z-carriages all up?"
 msgstr "Došli oba Z vozíky k hornému dorazu?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4197
+#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:4221
 msgid "Assist"
 msgstr "Asist."
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:179 ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/messages.cpp:186 ../../Firmware/ultralcd.cpp:5594
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
-#: ../../Firmware/Marlin_main.cpp:3198 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:4577 ../../Firmware/ultralcd.cpp:5529
+#: ../../Firmware/Marlin_main.cpp:2942 ../../Firmware/messages.cpp:12
+#: ../../Firmware/ultralcd.cpp:4533 ../../Firmware/ultralcd.cpp:5496
 msgid "Auto home"
 msgstr "Auto home"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4182
 msgid "Auto power"
 msgstr "Automat."
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:328 ../../Firmware/ultralcd.cpp:5359
+#: ../../Firmware/messages.cpp:340 ../../Firmware/ultralcd.cpp:5328
 msgid "AutoLoad filament"
 msgstr "Autozav. filamentu"
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/messages.cpp:245 ../../Firmware/ultralcd.cpp:2272
+#: ../../Firmware/messages.cpp:257 ../../Firmware/ultralcd.cpp:2289
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
@@ -113,51 +113,50 @@ msgid "Avoiding grind"
 msgstr "Avoiding grind"
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/messages.cpp:352 ../../Firmware/ultralcd.cpp:6752
+#: ../../Firmware/messages.cpp:364 ../../Firmware/ultralcd.cpp:6728
 msgid "Axis"
 msgstr "Os"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/messages.cpp:351 ../../Firmware/ultralcd.cpp:6751
+#: ../../Firmware/messages.cpp:363 ../../Firmware/ultralcd.cpp:6727
 msgid "Axis length"
 msgstr "Dĺžka osi"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2708
-#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:5618
-#: ../../Firmware/ultralcd.cpp:7484
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2725
+#: ../../Firmware/ultralcd.cpp:4061 ../../Firmware/ultralcd.cpp:5591
+#: ../../Firmware/ultralcd.cpp:7461
 msgid "Back"
 msgstr "Späť"
 
 #. MSG_BED c=13
-#: ../../Firmware/Marlin_main.cpp:2081 ../../Firmware/Marlin_main.cpp:4627
-#: ../../Firmware/Marlin_main.cpp:4678 ../../Firmware/messages.cpp:15
-#: ../../Firmware/ultralcd.cpp:1391 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/Marlin_main.cpp:4247 ../../Firmware/messages.cpp:15
+#: ../../Firmware/ultralcd.cpp:1401 ../../Firmware/ultralcd.cpp:4197
 msgid "Bed"
 msgstr "Podložka"
 
 #. MSG_BED_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6240 ../../Firmware/messages.cpp:17
+#: ../../Firmware/Marlin_main.cpp:5470 ../../Firmware/messages.cpp:17
 #: ../../Firmware/ultralcd.cpp:534
 msgid "Bed Heating"
 msgstr "Zahrievanie podložky"
 
 #. MSG_BED_DONE c=20
-#: ../../Firmware/Marlin_main.cpp:6277 ../../Firmware/messages.cpp:16
+#: ../../Firmware/Marlin_main.cpp:5507 ../../Firmware/messages.cpp:16
 #: ../../Firmware/ultralcd.cpp:537
 msgid "Bed done"
 msgstr "Podložka OK."
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/messages.cpp:317 ../../Firmware/ultralcd.cpp:4589
+#: ../../Firmware/messages.cpp:329 ../../Firmware/ultralcd.cpp:4545
 msgid "Bed level correct"
 msgstr "Korekcia podložky"
 
 #. MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:2262 ../../Firmware/Marlin_main.cpp:2999
-#: ../../Firmware/Marlin_main.cpp:3008
-#: ../../Firmware/mesh_bed_calibration.cpp:2878
-#: ../../Firmware/mesh_bed_calibration.cpp:2903 ../../Firmware/messages.cpp:18
+#: ../../Firmware/Marlin_main.cpp:2048 ../../Firmware/Marlin_main.cpp:2736
+#: ../../Firmware/Marlin_main.cpp:2745
+#: ../../Firmware/mesh_bed_calibration.cpp:2863
+#: ../../Firmware/mesh_bed_calibration.cpp:2888 ../../Firmware/messages.cpp:18
 msgid ""
 "Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for "
 "reset."
@@ -165,34 +164,34 @@ msgstr ""
 "Kalibrácia Z zlyhala. Senzor nezopol. Znečistená tryska? Čakám na reset."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/messages.cpp:346 ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/messages.cpp:358 ../../Firmware/ultralcd.cpp:6685
 msgid "Bed/Heater"
 msgstr "Podložka/Zohrievanie"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1444
-#: ../../Firmware/ultralcd.cpp:1704
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1454
+#: ../../Firmware/ultralcd.cpp:1714
 msgid "Belt status"
 msgstr "Stav remeňa"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/messages.cpp:314 ../../Firmware/ultralcd.cpp:4579
+#: ../../Firmware/messages.cpp:326 ../../Firmware/ultralcd.cpp:4535
 msgid "Belt test"
 msgstr "Test remeňa"
 
 #. MSG_RECOVER_PRINT c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:1660 ../../Firmware/messages.cpp:87
+#: ../../Firmware/Marlin_main.cpp:1587 ../../Firmware/messages.cpp:87
 msgid "Blackout occurred. Recover print?"
 msgstr "Nastal výpadok prúdu. Obnoviť tlač?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:177 ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:5594
 msgid "Bright"
 msgstr "Jasné"
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:4526
-#: ../../Firmware/ultralcd.cpp:5546
+#: ../../Firmware/messages.cpp:180 ../../Firmware/ultralcd.cpp:4493
+#: ../../Firmware/ultralcd.cpp:5513
 msgid "Brightness"
 msgstr "Podsvietenie"
 
@@ -202,17 +201,17 @@ msgid "COMMUNICATION ERROR"
 msgstr "COMMUNICATION ERROR"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/messages.cpp:316 ../../Firmware/ultralcd.cpp:4583
+#: ../../Firmware/messages.cpp:328 ../../Firmware/ultralcd.cpp:4539
 msgid "Calibrate XYZ"
 msgstr "Kalibrácia XYZ"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4585
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4541
 msgid "Calibrate Z"
 msgstr "Kalibrovať Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/messages.cpp:266 ../../Firmware/ultralcd.cpp:2813
+#: ../../Firmware/messages.cpp:278 ../../Firmware/ultralcd.cpp:2830
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -221,13 +220,13 @@ msgstr ""
 " tlačidlom."
 
 #. MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: ../../Firmware/Marlin_main.cpp:2218 ../../Firmware/messages.cpp:22
+#: ../../Firmware/Marlin_main.cpp:2009 ../../Firmware/messages.cpp:23
 #: ../../Firmware/ultralcd.cpp:582
 msgid "Calibrating Z"
 msgstr "Kalibrujem Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/messages.cpp:265 ../../Firmware/ultralcd.cpp:2812
+#: ../../Firmware/messages.cpp:277 ../../Firmware/ultralcd.cpp:2829
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -236,17 +235,17 @@ msgstr ""
 "tlačidlom."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/messages.cpp:361 ../../Firmware/ultralcd.cpp:6985
+#: ../../Firmware/messages.cpp:373 ../../Firmware/ultralcd.cpp:6962
 msgid "Calibrating home"
 msgstr "Kalibr. východziu p."
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5375
+#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5342
 msgid "Calibration"
 msgstr "Kalibrácia"
 
 #. MSG_HOMEYZ_DONE c=20
-#: ../../Firmware/messages.cpp:217 ../../Firmware/ultralcd.cpp:593
+#: ../../Firmware/messages.cpp:229 ../../Firmware/ultralcd.cpp:593
 msgid "Calibration done"
 msgstr "Kalibrácia OK"
 
@@ -264,128 +263,128 @@ msgstr ""
 "Nie je možné vykonať akciu, filament je už zavedený. Najskôr ho vytiahnite."
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/messages.cpp:364 ../../Firmware/ultralcd.cpp:7405
+#: ../../Firmware/messages.cpp:376 ../../Firmware/ultralcd.cpp:7382
 msgid "Card removed"
 msgstr "Karta vysunutá"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/messages.cpp:324 ../../Firmware/ultralcd.cpp:5316
+#: ../../Firmware/messages.cpp:336 ../../Firmware/ultralcd.cpp:5282
 msgid "Change SD card"
 msgstr "Zmeniť SD kartu"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5254
-#: ../../Firmware/ultralcd.cpp:5526
+#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5216
+#: ../../Firmware/ultralcd.cpp:5493
 msgid "Change filament"
 msgstr "Vymeniť filament"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/messages.cpp:240 ../../Firmware/ultralcd.cpp:2156
+#: ../../Firmware/messages.cpp:252 ../../Firmware/ultralcd.cpp:2167
 msgid "Change success!"
 msgstr "Výmena úspešná!"
 
 #. MSG_CORRECTLY c=19
-#: ../../Firmware/messages.cpp:242 ../../Firmware/ultralcd.cpp:2203
+#: ../../Firmware/messages.cpp:254 ../../Firmware/ultralcd.cpp:2217
 msgid "Changed correctly"
 msgstr "Výmena ok"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5951
-#: ../../Firmware/ultralcd.cpp:6975
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5927
+#: ../../Firmware/ultralcd.cpp:6952
 msgid "Checking X axis"
 msgstr "Kontrola osi X"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5961
-#: ../../Firmware/ultralcd.cpp:6976
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:5937
+#: ../../Firmware/ultralcd.cpp:6953
 msgid "Checking Y axis"
 msgstr "Kontrola osi Y"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/messages.cpp:358 ../../Firmware/ultralcd.cpp:6977
+#: ../../Firmware/messages.cpp:370 ../../Firmware/ultralcd.cpp:6954
 msgid "Checking Z axis"
 msgstr "Kontrola osi Z"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6978
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6955
 msgid "Checking bed"
 msgstr "Kontrola podložky"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/messages.cpp:357 ../../Firmware/ultralcd.cpp:6974
+#: ../../Firmware/messages.cpp:369 ../../Firmware/ultralcd.cpp:6951
 msgid "Checking endstops"
 msgstr "Kontrola endstopu"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/messages.cpp:362 ../../Firmware/ultralcd.cpp:7070
+#: ../../Firmware/messages.cpp:374 ../../Firmware/ultralcd.cpp:7047
 msgid "Checking file"
 msgstr "Kontrolujem súbor"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/messages.cpp:359 ../../Firmware/ultralcd.cpp:6980
+#: ../../Firmware/messages.cpp:371 ../../Firmware/ultralcd.cpp:6957
 msgid "Checking hotend"
 msgstr "Kontrola hotend"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6981
-#: ../../Firmware/ultralcd.cpp:6982
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6958
+#: ../../Firmware/ultralcd.cpp:6959
 msgid "Checking sensors"
 msgstr "Kontrola senzorov"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/messages.cpp:308 ../../Firmware/ultralcd.cpp:4424
+#: ../../Firmware/messages.cpp:320 ../../Firmware/ultralcd.cpp:4391
 msgid "Checks"
 msgstr "Kontroly"
 
 #. MSG_TM_ACK_ERROR c=18
-#: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5297
+#: ../../Firmware/messages.cpp:197 ../../Firmware/ultralcd.cpp:5263
 msgid "Clear TM error"
 msgstr "Vymazanie chyby TM"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/messages.cpp:244 ../../Firmware/ultralcd.cpp:2205
+#: ../../Firmware/messages.cpp:256 ../../Firmware/ultralcd.cpp:2219
 msgid "Color not correct"
 msgstr "Nesprávna farba"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:3508
+#: ../../Firmware/messages.cpp:27 ../../Firmware/ultralcd.cpp:3518
 msgid "Community made"
 msgstr "Komunitný prekl."
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:4059
+#: ../../Firmware/messages.cpp:178 ../../Firmware/ultralcd.cpp:4083
 msgid "Cont."
 msgstr "Pokr."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:2129
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2135
 msgid "Cooldown"
 msgstr "Schladiť"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/messages.cpp:283 ../../Firmware/ultralcd.cpp:3450
+#: ../../Firmware/messages.cpp:295 ../../Firmware/ultralcd.cpp:3460
 msgid "Copy selected language?"
 msgstr "Kopírovať vybraný jazyk?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:1234
-#: ../../Firmware/ultralcd.cpp:1263
+#: ../../Firmware/messages.cpp:30 ../../Firmware/ultralcd.cpp:1244
+#: ../../Firmware/ultralcd.cpp:1273
 msgid "Crash"
 msgstr "Náraz"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4146
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/ultralcd.cpp:4170
 msgid "Crash det."
 msgstr "Det. nárazu"
 
 #. MSG_CRASH_DETECTED c=20
-#: ../../Firmware/Marlin_main.cpp:630 ../../Firmware/messages.cpp:30
+#: ../../Firmware/Marlin_main.cpp:595 ../../Firmware/messages.cpp:31
 msgid "Crash detected."
 msgstr "Zistený náraz."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/messages.cpp:280 ../../Firmware/ultralcd.cpp:3374
+#: ../../Firmware/messages.cpp:292 ../../Firmware/ultralcd.cpp:3384
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -396,24 +395,24 @@ msgstr ""
 "Normálnom režime"
 
 #. MSG_CUT_FILAMENT c=16
-#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:380
-#: ../../Firmware/ultralcd.cpp:4854 ../../Firmware/ultralcd.cpp:5351
+#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:381
+#: ../../Firmware/ultralcd.cpp:4810 ../../Firmware/ultralcd.cpp:5317
 msgid "Cut filament"
 msgstr "Odstrihnúť fil."
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4081
-#: ../../Firmware/ultralcd.cpp:4086 ../../Firmware/ultralcd.cpp:4091
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:4105
+#: ../../Firmware/ultralcd.cpp:4110 ../../Firmware/ultralcd.cpp:4115
 msgid "Cutter"
 msgstr "Strihanie"
 
 #. MSG_DATE c=17
-#: ../../Firmware/messages.cpp:222 ../../Firmware/ultralcd.cpp:1645
+#: ../../Firmware/messages.cpp:234 ../../Firmware/ultralcd.cpp:1655
 msgid "Date:"
 msgstr "Dátum:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:178 ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/messages.cpp:185 ../../Firmware/ultralcd.cpp:5594
 msgid "Dim"
 msgstr "Tmavý"
 
@@ -423,7 +422,7 @@ msgid "Disable"
 msgstr "Vypnúť"
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/messages.cpp:311 ../../Firmware/ultralcd.cpp:4460
+#: ../../Firmware/messages.cpp:323 ../../Firmware/ultralcd.cpp:4427
 msgid "Disable steppers"
 msgstr "Vypnúť motory"
 
@@ -435,7 +434,7 @@ msgid "Disengaging idler"
 msgstr "Uvoľnenie idlera"
 
 #. MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: ../../Firmware/Marlin_main.cpp:1610 ../../Firmware/Marlin_main.cpp:3334
+#: ../../Firmware/Marlin_main.cpp:1537 ../../Firmware/Marlin_main.cpp:3073
 #: ../../Firmware/messages.cpp:14
 msgid ""
 "Distance between tip of the nozzle and the bed surface has not been set yet."
@@ -446,7 +445,7 @@ msgstr ""
 "manuálu, kapitola Začíname, odstavec Nastavenie prvej vrstvy."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/messages.cpp:301 ../../Firmware/ultralcd.cpp:3923
+#: ../../Firmware/messages.cpp:313 ../../Firmware/ultralcd.cpp:3947
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -455,13 +454,13 @@ msgstr ""
 "podložkou?"
 
 #. MSG_DONE c=8
-#: ../../Firmware/messages.cpp:32 ../../Firmware/mmu2/errors_list.h:367
-#: ../../Firmware/mmu2_reporting.cpp:456
+#: ../../Firmware/messages.cpp:33 ../../Firmware/mmu2/errors_list.h:367
+#: ../../Firmware/mmu2_reporting.cpp:457
 msgid "Done"
 msgstr "Hotov"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/messages.cpp:307 ../../Firmware/ultralcd.cpp:3990
+#: ../../Firmware/messages.cpp:319 ../../Firmware/ultralcd.cpp:4014
 msgid "E-correct"
 msgstr "Korekcia E"
 
@@ -490,13 +489,13 @@ msgid "ERR Wait for User"
 msgstr "ERR Wait for User"
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:2253
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:2267
 msgid "ERROR:"
 msgstr "ERROR:"
 
 #. MSG_EJECT_FROM_MMU c=16
-#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:384
-#: ../../Firmware/ultralcd.cpp:4845 ../../Firmware/ultralcd.cpp:5348
+#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:385
+#: ../../Firmware/ultralcd.cpp:4801 ../../Firmware/ultralcd.cpp:5314
 msgid "Eject from MMU"
 msgstr "Vysunúť z MMU"
 
@@ -508,17 +507,17 @@ msgid "Ejecting filament"
 msgstr "Vysunutie filamentu"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/messages.cpp:348 ../../Firmware/ultralcd.cpp:6722
+#: ../../Firmware/messages.cpp:360 ../../Firmware/ultralcd.cpp:6698
 msgid "Endstop"
 msgstr "Koncový spínač"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/messages.cpp:349 ../../Firmware/ultralcd.cpp:6727
+#: ../../Firmware/messages.cpp:361 ../../Firmware/ultralcd.cpp:6703
 msgid "Endstop not hit"
 msgstr "Kon. spínač nezopol"
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/messages.cpp:347 ../../Firmware/ultralcd.cpp:6713
+#: ../../Firmware/messages.cpp:359 ../../Firmware/ultralcd.cpp:6689
 msgid "Endstops"
 msgstr "Konc. spínače"
 
@@ -530,30 +529,30 @@ msgid "Engaging idler"
 msgstr "Zapojenie idlera"
 
 #. MSG_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:3352
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:3362
 msgid "Extruder"
 msgstr "Extrúder"
 
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/messages.cpp:227 ../../Firmware/ultralcd.cpp:1700
+#: ../../Firmware/messages.cpp:239 ../../Firmware/ultralcd.cpp:1710
 msgid "Extruder info"
 msgstr "Extrúder info"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4044
-#: ../../Firmware/ultralcd.cpp:4051
+#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4068
+#: ../../Firmware/ultralcd.cpp:4075
 msgid "F. autoload"
 msgstr "F. autozav."
 
 #. MSG_FSENSOR_JAM_DETECTION c=13
-#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4046
-#: ../../Firmware/ultralcd.cpp:4053
+#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4070
+#: ../../Firmware/ultralcd.cpp:4077
 msgid "F. jam detect"
 msgstr "F. zasek"
 
 #. MSG_FSENSOR_RUNOUT c=13
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4074
 msgid "F. runout"
 msgstr "F. výpadok"
 
@@ -591,8 +590,8 @@ msgid "FINDA FILAM. STUCK"
 msgstr "FINDA FILAM. STUCK"
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:4059
-#: ../../Firmware/ultralcd.cpp:4062
+#: ../../Firmware/messages.cpp:177 ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/ultralcd.cpp:4086
 msgid "FS Action"
 msgstr "FS Akcia"
 
@@ -617,34 +616,34 @@ msgid "FW RUNTIME ERROR"
 msgstr "FW RUNTIME ERROR"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/messages.cpp:330 ../../Firmware/ultralcd.cpp:5382
+#: ../../Firmware/messages.cpp:342 ../../Firmware/ultralcd.cpp:5349
 msgid "Fail stats"
 msgstr "Štatistiky zlyhaní"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/messages.cpp:331 ../../Firmware/ultralcd.cpp:5385
+#: ../../Firmware/messages.cpp:343 ../../Firmware/ultralcd.cpp:5352
 msgid "Fail stats MMU"
 msgstr "Zlyhania MMU"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/messages.cpp:355 ../../Firmware/ultralcd.cpp:6768
+#: ../../Firmware/messages.cpp:367 ../../Firmware/ultralcd.cpp:6744
 msgid "False triggering"
 msgstr "Falošné spustenie"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4175
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4199
 msgid "Fan speed"
 msgstr "Rýchlosť vent."
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6844
-#: ../../Firmware/ultralcd.cpp:6971 ../../Firmware/ultralcd.cpp:6972
-#: ../../Firmware/ultralcd.cpp:6973
+#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6820
+#: ../../Firmware/ultralcd.cpp:6948 ../../Firmware/ultralcd.cpp:6949
+#: ../../Firmware/ultralcd.cpp:6950
 msgid "Fan test"
 msgstr "Test ventilátora"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:4179
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:4203
 msgid "Fans check"
 msgstr "Kontr. vent."
 
@@ -673,34 +672,34 @@ msgid "Feeding to nozzle"
 msgstr "Zavedenie do trysky"
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1233
-#: ../../Firmware/ultralcd.cpp:1262 ../../Firmware/ultralcd.cpp:1316
-#: ../../Firmware/ultralcd.cpp:1318
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:1243
+#: ../../Firmware/ultralcd.cpp:1272 ../../Firmware/ultralcd.cpp:1326
+#: ../../Firmware/ultralcd.cpp:1328
 msgid "Fil. runouts"
 msgstr "Výpadky filam."
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3313
-#: ../../Firmware/ultralcd.cpp:4039 ../../Firmware/ultralcd.cpp:4464
-#: ../../Firmware/ultralcd.cpp:5532
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3323
+#: ../../Firmware/ultralcd.cpp:4063 ../../Firmware/ultralcd.cpp:4431
+#: ../../Firmware/ultralcd.cpp:5499
 msgid "Fil. sensor"
 msgstr "Fil. senzor"
 
 #. MSG_FILAMENT_CLEAN c=20 r=3
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2261
-#: ../../Firmware/ultralcd.cpp:2265
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2275
+#: ../../Firmware/ultralcd.cpp:2279
 msgid "Filament extruding & with correct color?"
 msgstr "Filament vytlačený a správnej farby?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/messages.cpp:243 ../../Firmware/ultralcd.cpp:2204
+#: ../../Firmware/messages.cpp:255 ../../Firmware/ultralcd.cpp:2218
 msgid "Filament not loaded"
 msgstr "Filament nezavedený"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6763
-#: ../../Firmware/ultralcd.cpp:6767 ../../Firmware/ultralcd.cpp:6771
-#: ../../Firmware/ultralcd.cpp:7000
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6739
+#: ../../Firmware/ultralcd.cpp:6743 ../../Firmware/ultralcd.cpp:6747
+#: ../../Firmware/ultralcd.cpp:6977
 msgid "Filament sensor"
 msgstr "Senzor filamentu"
 
@@ -732,42 +731,42 @@ msgstr ""
 " či je PTFE trubička priechodzia a senzor funguje správne."
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/messages.cpp:246 ../../Firmware/ultralcd.cpp:2347
+#: ../../Firmware/messages.cpp:258 ../../Firmware/ultralcd.cpp:2364
 msgid "Filament used"
 msgstr "Spotrebovaný filam."
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/messages.cpp:363 ../../Firmware/ultralcd.cpp:7139
+#: ../../Firmware/messages.cpp:375 ../../Firmware/ultralcd.cpp:7116
 msgid "File incomplete. Continue anyway?"
 msgstr "Súbor nekompletný. Pokračovať?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
 #: ../../Firmware/messages.cpp:45
 #: ../../Firmware/mmu2_progress_converter.cpp:43
-#: ../../Firmware/ultralcd.cpp:5021 ../../Firmware/ultralcd.cpp:5425
+#: ../../Firmware/ultralcd.cpp:4977 ../../Firmware/ultralcd.cpp:5392
 msgid "Finishing movements"
 msgstr "Dokončovanie pohybu"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4575
-#: ../../Firmware/ultralcd.cpp:5141
+#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4531
+#: ../../Firmware/ultralcd.cpp:5101
 msgid "First layer cal."
 msgstr "Kal. prvej vrstvy"
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/messages.cpp:293 ../../Firmware/ultralcd.cpp:3846
+#: ../../Firmware/messages.cpp:305 ../../Firmware/ultralcd.cpp:3872
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Najskôr pomocou selftestu skontrolujem najčastejšie chyby vznikajúce pri "
 "zostavení tlačiarne."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/messages.cpp:334 ../../Firmware/ultralcd.cpp:5520
+#: ../../Firmware/messages.cpp:346 ../../Firmware/ultralcd.cpp:5487
 msgid "Flow"
 msgstr "Prietok"
 
 #. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
-#: ../../Firmware/messages.cpp:194 ../../Firmware/ultralcd.cpp:985
+#: ../../Firmware/messages.cpp:201 ../../Firmware/ultralcd.cpp:987
 msgid ""
 "For a Nozzle change please read\n"
 "prusa.io/nozzle-mk3s"
@@ -776,28 +775,28 @@ msgstr ""
 "prusa.io/nozzle-mk3s"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6733
-#: ../../Firmware/ultralcd.cpp:6850 ../../Firmware/ultralcd.cpp:6855
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/ultralcd.cpp:6826 ../../Firmware/ultralcd.cpp:6831
 msgid "Front print fan?"
 msgstr "Predný tlačový vent?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/messages.cpp:260 ../../Firmware/ultralcd.cpp:2711
+#: ../../Firmware/messages.cpp:272 ../../Firmware/ultralcd.cpp:2728
 msgid "Front side[µm]"
 msgstr "Predná st.[µm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/messages.cpp:353 ../../Firmware/ultralcd.cpp:6757
+#: ../../Firmware/messages.cpp:365 ../../Firmware/ultralcd.cpp:6733
 msgid "Front/left fans"
 msgstr "Predný/ľavý vent."
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:151 ../../Firmware/util.cpp:382
+#: ../../Firmware/messages.cpp:156 ../../Firmware/util.cpp:417
 msgid "G-code sliced for a different level. Continue?"
 msgstr "G-code pripravený pre inú úroveň. Pokračovať?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:152 ../../Firmware/util.cpp:383
+#: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:418
 msgid ""
 "G-code sliced for a different level. Please re-slice the model again. Print "
 "cancelled."
@@ -805,14 +804,14 @@ msgstr ""
 "G-code pripravený pre inú verziu. Vygenerujte G-code znova. Tlač zrušená."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:147 ../../Firmware/util.cpp:312
-#: ../../Firmware/util.cpp:401
+#: ../../Firmware/messages.cpp:152 ../../Firmware/util.cpp:319
+#: ../../Firmware/util.cpp:436
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr "G-code je pripravený pre iný typ tlačiarne.Pokračovať?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:148 ../../Firmware/util.cpp:313
-#: ../../Firmware/util.cpp:402
+#: ../../Firmware/messages.cpp:153 ../../Firmware/util.cpp:320
+#: ../../Firmware/util.cpp:437
 msgid ""
 "G-code sliced for a different printer type. Please re-slice the model again."
 " Print cancelled."
@@ -821,12 +820,12 @@ msgstr ""
 "zrušená."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:149 ../../Firmware/util.cpp:362
+#: ../../Firmware/messages.cpp:154 ../../Firmware/util.cpp:369
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "G-code je pripravený pre novší firmware. Pokračovať?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:150 ../../Firmware/util.cpp:363
+#: ../../Firmware/messages.cpp:155 ../../Firmware/util.cpp:370
 msgid ""
 "G-code sliced for a newer firmware. Please update the firmware. Print "
 "cancelled."
@@ -835,35 +834,35 @@ msgstr ""
 "zrušená."
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4366
-#: ../../Firmware/ultralcd.cpp:4383 ../../Firmware/ultralcd.cpp:4485
+#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4325
+#: ../../Firmware/ultralcd.cpp:4343 ../../Firmware/ultralcd.cpp:4452
 msgid "HW Setup"
 msgstr "HW nastavenie"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/messages.cpp:344 ../../Firmware/ultralcd.cpp:6705
+#: ../../Firmware/messages.cpp:356 ../../Firmware/ultralcd.cpp:6681
 msgid "Heater/Thermistor"
 msgstr "Zohr./Termistor"
 
 #. MSG_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6184 ../../Firmware/messages.cpp:52
+#: ../../Firmware/Marlin_main.cpp:5416 ../../Firmware/messages.cpp:52
 #: ../../Firmware/ultralcd.cpp:526
 msgid "Heating"
 msgstr "Zahrievanie"
 
 #. MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:9647 ../../Firmware/messages.cpp:211
+#: ../../Firmware/Marlin_main.cpp:8807 ../../Firmware/messages.cpp:223
 msgid "Heating disabled by safety timer."
 msgstr "Zohrievanie prerušené bezpečnostným časovačom."
 
 #. MSG_HEATING_COMPLETE c=20
-#: ../../Firmware/Marlin_main.cpp:6215 ../../Firmware/messages.cpp:53
+#: ../../Firmware/Marlin_main.cpp:5445 ../../Firmware/messages.cpp:53
 #: ../../Firmware/ultralcd.cpp:529
 msgid "Heating done."
 msgstr "Zahrievanie OK."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=12
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:3806
+#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:3832
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -873,7 +872,7 @@ msgstr ""
 "nastavenia, v ktorom skalibrujem os Z. Potom budete môcť začať tlačiť."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:3810
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:3836
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -882,8 +881,8 @@ msgstr ""
 "previedla kalibračným procesom?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4152
-#: ../../Firmware/ultralcd.cpp:4161
+#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:4176
+#: ../../Firmware/ultralcd.cpp:4185
 msgid "High power"
 msgstr "Vys. výkon"
 
@@ -894,23 +893,23 @@ msgid "Homing"
 msgstr "Návrat"
 
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
-#: ../../Firmware/messages.cpp:195 ../../Firmware/ultralcd.cpp:1005
+#: ../../Firmware/messages.cpp:206 ../../Firmware/ultralcd.cpp:1011
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr "Hotend má 280C! Tryska je vymenená a utiahnutá podľa špecifikácie?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1106
-#: ../../Firmware/ultralcd.cpp:6991
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1116
+#: ../../Firmware/ultralcd.cpp:6968
 msgid "Hotend fan:"
 msgstr "Hotend vent.:"
 
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/messages.cpp:294 ../../Firmware/ultralcd.cpp:3851
+#: ../../Firmware/messages.cpp:306 ../../Firmware/ultralcd.cpp:3877
 msgid "I will run xyz calibration now. It will take up to 24 mins."
 msgstr "Teraz urobím XYZ kalibráciu. Zaberie to až 24 min."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/messages.cpp:297 ../../Firmware/ultralcd.cpp:3862
+#: ../../Firmware/messages.cpp:309 ../../Firmware/ultralcd.cpp:3884
 msgid "I will run z calibration now."
 msgstr "Teraz urobím kalibráciu Z."
 
@@ -935,7 +934,7 @@ msgid "INVALID TOOL"
 msgstr "INVALID TOOL"
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=8
-#: ../../Firmware/messages.cpp:303 ../../Firmware/ultralcd.cpp:3931
+#: ../../Firmware/messages.cpp:315 ../../Firmware/ultralcd.cpp:3955
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -944,28 +943,28 @@ msgstr ""
 "Platne"
 
 #. MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2540
-#: ../../Firmware/messages.cpp:213
+#: ../../Firmware/mesh_bed_calibration.cpp:2525
+#: ../../Firmware/messages.cpp:225
 msgid "Improving bed calibration point"
 msgstr "Zlepšenie bodu kalibrácie podložky"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:5222
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:5184
 msgid "Info screen"
 msgstr "Informácie"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/messages.cpp:326 ../../Firmware/ultralcd.cpp:5323
+#: ../../Firmware/messages.cpp:338 ../../Firmware/ultralcd.cpp:5289
 msgid "Init. SD card"
 msgstr "Načítanie SD karty"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/messages.cpp:238 ../../Firmware/ultralcd.cpp:2142
+#: ../../Firmware/messages.cpp:250 ../../Firmware/ultralcd.cpp:2148
 msgid "Insert filament"
 msgstr "Vložte filament"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/messages.cpp:335 ../../Firmware/ultralcd.cpp:5998
+#: ../../Firmware/messages.cpp:347 ../../Firmware/ultralcd.cpp:5974
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
@@ -978,115 +977,115 @@ msgid ""
 msgstr "Interná chyba. Skúste resetovať MMU alebo aktualizovať firmware."
 
 #. MSG_FILAMENT_LOADED c=20 r=3
-#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3628
-#: ../../Firmware/ultralcd.cpp:3890
+#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3638
+#: ../../Firmware/ultralcd.cpp:3914
 msgid "Is filament loaded?"
 msgstr "Je filament zavedený?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3238 ../../Firmware/Marlin_main.cpp:4745
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:3858
+#: ../../Firmware/Marlin_main.cpp:4314 ../../Firmware/messages.cpp:127
+#: ../../Firmware/ultralcd.cpp:3760
 msgid "Is steel sheet on heatbed?"
 msgstr "Je platňa na podložke?"
 
 #. MSG_ITERATION c=12
-#: ../../Firmware/mesh_bed_calibration.cpp:2265 ../../Firmware/messages.cpp:55
+#: ../../Firmware/mesh_bed_calibration.cpp:2250 ../../Firmware/messages.cpp:55
 msgid "Iteration"
 msgstr "Opakovanie"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1128
-#: ../../Firmware/ultralcd.cpp:1286
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1138
+#: ../../Firmware/ultralcd.cpp:1296
 msgid "Last print"
 msgstr "Posledná tlač"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1152
-#: ../../Firmware/ultralcd.cpp:1260 ../../Firmware/ultralcd.cpp:1315
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1162
+#: ../../Firmware/ultralcd.cpp:1270 ../../Firmware/ultralcd.cpp:1325
 msgid "Last print failures"
 msgstr "Zlyhanie posl. tlače"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/messages.cpp:251 ../../Firmware/ultralcd.cpp:2478
+#: ../../Firmware/messages.cpp:263 ../../Firmware/ultralcd.cpp:2495
 msgid "Left"
 msgstr "Vľavo"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6739
-#: ../../Firmware/ultralcd.cpp:6850 ../../Firmware/ultralcd.cpp:6855
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6715
+#: ../../Firmware/ultralcd.cpp:6826 ../../Firmware/ultralcd.cpp:6831
 msgid "Left hotend fan?"
 msgstr "Ľavý vent na tryske?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/messages.cpp:258 ../../Firmware/ultralcd.cpp:2709
+#: ../../Firmware/messages.cpp:270 ../../Firmware/ultralcd.cpp:2726
 msgid "Left side [µm]"
 msgstr "Lava str.[µm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:5619
+#: ../../Firmware/messages.cpp:181 ../../Firmware/ultralcd.cpp:5592
 msgid "Level Bright"
 msgstr "Normálne"
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:175 ../../Firmware/ultralcd.cpp:5620
+#: ../../Firmware/messages.cpp:182 ../../Firmware/ultralcd.cpp:5593
 msgid "Level Dimmed"
 msgstr "Stlmené"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/messages.cpp:312 ../../Firmware/ultralcd.cpp:4491
+#: ../../Firmware/messages.cpp:324 ../../Firmware/ultralcd.cpp:4458
 msgid "Lin. correction"
 msgstr "Korekcia lin."
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4501
-#: ../../Firmware/ultralcd.cpp:5251
+#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4468
+#: ../../Firmware/ultralcd.cpp:5213
 msgid "Live adjust Z"
 msgstr "Doladenie osi Z"
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/messages.cpp:192 ../../Firmware/ultralcd.cpp:4794
-#: ../../Firmware/ultralcd.cpp:4880
+#: ../../Firmware/messages.cpp:199 ../../Firmware/ultralcd.cpp:4750
+#: ../../Firmware/ultralcd.cpp:4836
 msgid "Load All"
 msgstr "Zaviesť všetko"
 
 #. MSG_LOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4796
-#: ../../Firmware/ultralcd.cpp:4833 ../../Firmware/ultralcd.cpp:4882
-#: ../../Firmware/ultralcd.cpp:5361 ../../Firmware/ultralcd.cpp:5368
+#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4752
+#: ../../Firmware/ultralcd.cpp:4789 ../../Firmware/ultralcd.cpp:4838
+#: ../../Firmware/ultralcd.cpp:5324 ../../Firmware/ultralcd.cpp:5335
 msgid "Load filament"
 msgstr "Zaviesť filament"
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/messages.cpp:327 ../../Firmware/ultralcd.cpp:5346
+#: ../../Firmware/messages.cpp:339 ../../Firmware/ultralcd.cpp:5312
 msgid "Load to nozzle"
 msgstr "Zaved. do trysky"
 
 #. MSG_LOADING_TEST c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4476
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4443
 msgid "Loading Test"
 msgstr "Záťažový test"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/messages.cpp:241 ../../Firmware/ultralcd.cpp:2178
+#: ../../Firmware/messages.cpp:253 ../../Firmware/ultralcd.cpp:2189
 msgid "Loading color"
 msgstr "Čistenie farby"
 
 #. MSG_LOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3598 ../../Firmware/messages.cpp:62
+#: ../../Firmware/Marlin_main.cpp:3343 ../../Firmware/messages.cpp:62
 #: ../../Firmware/mmu2_progress_converter.cpp:51
-#: ../../Firmware/mmu2_reporting.cpp:392 ../../Firmware/ultralcd.cpp:2189
-#: ../../Firmware/ultralcd.cpp:3715
+#: ../../Firmware/mmu2_reporting.cpp:393 ../../Firmware/ultralcd.cpp:2199
+#: ../../Firmware/ultralcd.cpp:3725
 msgid "Loading filament"
 msgstr "Zavedenie filamentu"
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/messages.cpp:350 ../../Firmware/ultralcd.cpp:6745
+#: ../../Firmware/messages.cpp:362 ../../Firmware/ultralcd.cpp:6721
 msgid "Loose pulley"
 msgstr "Uvoľnená remenica"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4188
-#: ../../Firmware/ultralcd.cpp:4200
+#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4224
 msgid "Loud"
 msgstr "Hlasný"
 
@@ -1101,7 +1100,7 @@ msgid "MMU Firmware internal error, please reset the MMU."
 msgstr "Chyba MMU Firmwaru, resetujte MMU."
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:4096
+#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4120
 msgid "MMU Mode"
 msgstr "MMU mod"
 
@@ -1111,7 +1110,7 @@ msgid "MMU NOT RESPONDING"
 msgstr "MMU NOT RESPONDING"
 
 #. MSG_MMU_RESTORE_TEMP c=20 r=4
-#: ../../Firmware/messages.cpp:214 ../../Firmware/mmu2_reporting.cpp:396
+#: ../../Firmware/messages.cpp:226 ../../Firmware/mmu2_reporting.cpp:397
 msgid "MMU Retry: Restoring temperature..."
 msgstr "MMU: Obnovenie teploty..."
 
@@ -1122,14 +1121,14 @@ msgid "MMU SELFTEST FAILED"
 msgstr "MMU SAMOTEST ZLYHAL"
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1153
-#: ../../Firmware/ultralcd.cpp:1178
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1163
+#: ../../Firmware/ultralcd.cpp:1188
 msgid "MMU fails"
 msgstr "Zlyhanie MMU"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1154
-#: ../../Firmware/ultralcd.cpp:1179
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1164
+#: ../../Firmware/ultralcd.cpp:1189
 msgid "MMU load fails"
 msgstr "MMU zlyhalo"
 
@@ -1144,66 +1143,64 @@ msgid "MMU not responding. Check the wiring and connectors."
 msgstr "MMU neodpovedá. Skontrolujte zapojenie a konektory."
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/messages.cpp:223 ../../Firmware/ultralcd.cpp:1657
+#: ../../Firmware/messages.cpp:235 ../../Firmware/ultralcd.cpp:1667
 msgid "MMU connected"
 msgstr "MMU pripojene"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/messages.cpp:176 ../../Firmware/ultralcd.cpp:5567
 msgid "Magnets comp."
 msgstr "Komp. magnetu"
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1127
-#: ../../Firmware/ultralcd.cpp:1285 ../../Firmware/ultralcd.cpp:1327
-#: ../../Firmware/ultralcd.cpp:1631 ../../Firmware/ultralcd.cpp:4453
-#: ../../Firmware/ultralcd.cpp:4571 ../../Firmware/ultralcd.cpp:4793
-#: ../../Firmware/ultralcd.cpp:4826 ../../Firmware/ultralcd.cpp:4879
-#: ../../Firmware/ultralcd.cpp:5515
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1137
+#: ../../Firmware/ultralcd.cpp:1295 ../../Firmware/ultralcd.cpp:1337
+#: ../../Firmware/ultralcd.cpp:1641 ../../Firmware/ultralcd.cpp:4420
+#: ../../Firmware/ultralcd.cpp:4527 ../../Firmware/ultralcd.cpp:4749
+#: ../../Firmware/ultralcd.cpp:4782 ../../Firmware/ultralcd.cpp:4835
+#: ../../Firmware/ultralcd.cpp:5482
 msgid "Main"
 msgstr "Hlavná ponuka"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/messages.cpp:253 ../../Firmware/ultralcd.cpp:2519
+#: ../../Firmware/messages.cpp:265 ../../Firmware/ultralcd.cpp:2536
 msgid "Measured skew"
 msgstr "Merané skos."
 
 #. MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3219
-#: ../../Firmware/mesh_bed_calibration.cpp:2852 ../../Firmware/messages.cpp:70
+#: ../../Firmware/Marlin_main.cpp:2963
+#: ../../Firmware/mesh_bed_calibration.cpp:2837 ../../Firmware/messages.cpp:70
 msgid "Measuring reference height of calibration point"
 msgstr "Meriam referenčnú výšku kalibračného bodu"
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:5590
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:5563
 msgid "Mesh"
 msgstr "Mriežka"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4488
-#: ../../Firmware/ultralcd.cpp:4587
+#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:4455
+#: ../../Firmware/ultralcd.cpp:4543
 msgid "Mesh Bed Leveling"
 msgstr "Vyrovnanie podl."
 
 #. MSG_MODE c=6
-#: ../../Firmware/Marlin_main.cpp:8495 ../../Firmware/messages.cpp:117
-#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4132
-#: ../../Firmware/ultralcd.cpp:4140 ../../Firmware/ultralcd.cpp:4144
-#: ../../Firmware/ultralcd.cpp:4152 ../../Firmware/ultralcd.cpp:4155
-#: ../../Firmware/ultralcd.cpp:4158 ../../Firmware/ultralcd.cpp:4161
-#: ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/Marlin_main.cpp:7666 ../../Firmware/messages.cpp:121
+#: ../../Firmware/ultralcd.cpp:4152 ../../Firmware/ultralcd.cpp:4156
+#: ../../Firmware/ultralcd.cpp:4164 ../../Firmware/ultralcd.cpp:4168
+#: ../../Firmware/ultralcd.cpp:4176 ../../Firmware/ultralcd.cpp:4179
+#: ../../Firmware/ultralcd.cpp:4182 ../../Firmware/ultralcd.cpp:4185
+#: ../../Firmware/ultralcd.cpp:5594
 msgid "Mode"
 msgstr "Režim"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/messages.cpp:282 ../../Firmware/ultralcd.cpp:3413
+#: ../../Firmware/messages.cpp:294 ../../Firmware/ultralcd.cpp:3423
 msgid "Mode change in progress..."
 msgstr "Prebieha zmena modu..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:4310
-#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4316
-#: ../../Firmware/ultralcd.cpp:4319
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4327
 msgid "Model"
 msgstr "Model"
 
@@ -1224,28 +1221,28 @@ msgid "More details online."
 msgstr "Viac podrobností online."
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6719
-#: ../../Firmware/ultralcd.cpp:6728 ../../Firmware/ultralcd.cpp:6746
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6695
+#: ../../Firmware/ultralcd.cpp:6704 ../../Firmware/ultralcd.cpp:6722
 msgid "Motor"
 msgstr "Motor"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/messages.cpp:277 ../../Firmware/ultralcd.cpp:3349
+#: ../../Firmware/messages.cpp:289 ../../Firmware/ultralcd.cpp:3359
 msgid "Move X"
 msgstr "Posunúť X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/messages.cpp:278 ../../Firmware/ultralcd.cpp:3350
+#: ../../Firmware/messages.cpp:290 ../../Firmware/ultralcd.cpp:3360
 msgid "Move Y"
 msgstr "Posunúť Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/messages.cpp:279 ../../Firmware/ultralcd.cpp:3351
+#: ../../Firmware/messages.cpp:291 ../../Firmware/ultralcd.cpp:3361
 msgid "Move Z"
 msgstr "Posunúť Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/messages.cpp:310 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:322 ../../Firmware/ultralcd.cpp:4426
 msgid "Move axis"
 msgstr "Posunúť os"
 
@@ -1256,96 +1253,93 @@ msgid "Moving selector"
 msgstr "Presun selektora"
 
 #. MSG_NA c=3
-#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:141
-#: ../../Firmware/ultralcd.cpp:2484 ../../Firmware/ultralcd.cpp:2528
-#: ../../Firmware/ultralcd.cpp:3279 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:4044 ../../Firmware/ultralcd.cpp:4046
-#: ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:146
+#: ../../Firmware/ultralcd.cpp:2501 ../../Firmware/ultralcd.cpp:2545
+#: ../../Firmware/ultralcd.cpp:3289 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4068 ../../Firmware/ultralcd.cpp:4070
+#: ../../Firmware/ultralcd.cpp:5567
 msgid "N/A"
 msgstr "N/A"
 
 #. MSG_NEW_FIRMWARE_AVAILABLE c=20 r=2
-#: ../../Firmware/messages.cpp:365 ../../Firmware/util.cpp:209
+#: ../../Firmware/messages.cpp:377 ../../Firmware/util.cpp:214
 msgid "New firmware version available:"
 msgstr "Vyšla nová verzia firmware:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:3029
-#: ../../Firmware/ultralcd.cpp:4443 ../../Firmware/ultralcd.cpp:4531
-#: ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:2275
+#: ../../Firmware/ultralcd.cpp:2279 ../../Firmware/ultralcd.cpp:3046
+#: ../../Firmware/ultralcd.cpp:4410 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/ultralcd.cpp:5765
 msgid "No"
 msgstr "Nie"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/messages.cpp:325 ../../Firmware/ultralcd.cpp:5321
+#: ../../Firmware/messages.cpp:337 ../../Firmware/ultralcd.cpp:5287
 msgid "No SD card"
 msgstr "Žiadna SD karta"
 
 #. MSG_NO_MOVE c=20
-#: ../../Firmware/Marlin_main.cpp:5271 ../../Firmware/messages.cpp:210
+#: ../../Firmware/Marlin_main.cpp:4778 ../../Firmware/messages.cpp:222
 msgid "No move."
 msgstr "Bez pohybu."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4239 ../../Firmware/ultralcd.cpp:4310
-#: ../../Firmware/ultralcd.cpp:4319 ../../Firmware/ultralcd.cpp:4349
-#: ../../Firmware/ultralcd.cpp:4358 ../../Firmware/ultralcd.cpp:4516
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4309
+#: ../../Firmware/ultralcd.cpp:4318 ../../Firmware/ultralcd.cpp:4483
 msgid "None"
 msgstr "Žiadne"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/Marlin_main.cpp:8497 ../../Firmware/messages.cpp:121
-#: ../../Firmware/ultralcd.cpp:4096 ../../Firmware/ultralcd.cpp:4132
-#: ../../Firmware/ultralcd.cpp:4511
+#: ../../Firmware/Marlin_main.cpp:7668 ../../Firmware/messages.cpp:125
+#: ../../Firmware/ultralcd.cpp:4120 ../../Firmware/ultralcd.cpp:4156
+#: ../../Firmware/ultralcd.cpp:4478
 msgid "Normal"
 msgstr "Normál"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/messages.cpp:345 ../../Firmware/ultralcd.cpp:6706
+#: ../../Firmware/messages.cpp:357 ../../Firmware/ultralcd.cpp:6682
 msgid "Not connected"
 msgstr "Nezapojené"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6863
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6839
 msgid "Not spinning"
 msgstr "Netočí sa"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/messages.cpp:289 ../../Firmware/ultralcd.cpp:3726
+#: ../../Firmware/messages.cpp:301 ../../Firmware/ultralcd.cpp:3736
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr ""
 "Teraz skalibrujem vzdialenosť medzi koncom trysky a povrchom podložky."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/messages.cpp:298 ../../Firmware/ultralcd.cpp:3871
+#: ../../Firmware/messages.cpp:310 ../../Firmware/ultralcd.cpp:3894
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Teraz predhrejem trysku pre PLA."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/messages.cpp:296 ../../Firmware/ultralcd.cpp:3857
+#: ../../Firmware/messages.cpp:308 ../../Firmware/ultralcd.cpp:3883
 msgid "Now remove the test print from steel sheet."
 msgstr "Teraz odstráňte testovací výtlačok z platne."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1390
-#: ../../Firmware/ultralcd.cpp:4170 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4233 ../../Firmware/ultralcd.cpp:4236
-#: ../../Firmware/ultralcd.cpp:4239
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1400
+#: ../../Firmware/ultralcd.cpp:4194 ../../Firmware/ultralcd.cpp:4326
 msgid "Nozzle"
 msgstr "Tryska"
 
 #. MSG_NOZZLE_CNG_MENU c=18
-#: ../../Firmware/messages.cpp:193 ../../Firmware/ultralcd.cpp:4423
-#: ../../Firmware/ultralcd.cpp:4486
+#: ../../Firmware/messages.cpp:200 ../../Firmware/ultralcd.cpp:4390
+#: ../../Firmware/ultralcd.cpp:4453
 msgid "Nozzle change"
 msgstr "Výmena trysky"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4276
-#: ../../Firmware/ultralcd.cpp:4278 ../../Firmware/ultralcd.cpp:4279
-#: ../../Firmware/ultralcd.cpp:4280
+#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4261
+#: ../../Firmware/ultralcd.cpp:4263 ../../Firmware/ultralcd.cpp:4264
+#: ../../Firmware/ultralcd.cpp:4265
 msgid "Nozzle d."
 msgstr "Tryska"
 
@@ -1356,81 +1350,81 @@ msgid "OK"
 msgstr "OK"
 
 #. MSG_OFF c=3
-#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:139
-#: ../../Firmware/mmu2.cpp:65 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4050 ../../Firmware/ultralcd.cpp:4051
-#: ../../Firmware/ultralcd.cpp:4053 ../../Firmware/ultralcd.cpp:4076
-#: ../../Firmware/ultralcd.cpp:4091 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4179 ../../Firmware/ultralcd.cpp:4467
-#: ../../Firmware/ultralcd.cpp:4495 ../../Firmware/ultralcd.cpp:4498
-#: ../../Firmware/ultralcd.cpp:5439 ../../Firmware/ultralcd.cpp:5594
-#: ../../Firmware/ultralcd.cpp:7487 ../../Firmware/ultralcd.cpp:7491
+#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:144
+#: ../../Firmware/mmu2.cpp:65 ../../Firmware/ultralcd.cpp:4063
+#: ../../Firmware/ultralcd.cpp:4074 ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4077 ../../Firmware/ultralcd.cpp:4100
+#: ../../Firmware/ultralcd.cpp:4115 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/ultralcd.cpp:4203 ../../Firmware/ultralcd.cpp:4434
+#: ../../Firmware/ultralcd.cpp:4462 ../../Firmware/ultralcd.cpp:4465
+#: ../../Firmware/ultralcd.cpp:5406 ../../Firmware/ultralcd.cpp:5567
+#: ../../Firmware/ultralcd.cpp:7464 ../../Firmware/ultralcd.cpp:7468
 msgid "Off"
 msgstr "Vyp"
 
 #. MSG_DEFAULT_SETTINGS_LOADED c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:1562 ../../Firmware/messages.cpp:201
+#: ../../Firmware/Marlin_main.cpp:1489 ../../Firmware/messages.cpp:213
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr "Neplatné hodnoty nastavenia. Bude použité predvolené PID, Esteps atď."
 
 #. MSG_ON c=3
-#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:140
-#: ../../Firmware/mmu2.cpp:63 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4050 ../../Firmware/ultralcd.cpp:4051
-#: ../../Firmware/ultralcd.cpp:4053 ../../Firmware/ultralcd.cpp:4076
-#: ../../Firmware/ultralcd.cpp:4081 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4179 ../../Firmware/ultralcd.cpp:4467
-#: ../../Firmware/ultralcd.cpp:4495 ../../Firmware/ultralcd.cpp:4498
-#: ../../Firmware/ultralcd.cpp:5594 ../../Firmware/ultralcd.cpp:7487
-#: ../../Firmware/ultralcd.cpp:7491
+#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:145
+#: ../../Firmware/mmu2.cpp:63 ../../Firmware/ultralcd.cpp:4063
+#: ../../Firmware/ultralcd.cpp:4074 ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4077 ../../Firmware/ultralcd.cpp:4100
+#: ../../Firmware/ultralcd.cpp:4105 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/ultralcd.cpp:4203 ../../Firmware/ultralcd.cpp:4434
+#: ../../Firmware/ultralcd.cpp:4462 ../../Firmware/ultralcd.cpp:4465
+#: ../../Firmware/ultralcd.cpp:5567 ../../Firmware/ultralcd.cpp:7464
+#: ../../Firmware/ultralcd.cpp:7468
 msgid "On"
 msgstr "Zap"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4191
+#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:4215
 msgid "Once"
 msgstr "Raz"
 
 #. MSG_PAUSED_THERMAL_ERROR c=20
-#: ../../Firmware/Marlin_main.cpp:9861 ../../Firmware/messages.cpp:186
+#: ../../Firmware/Marlin_main.cpp:9021 ../../Firmware/messages.cpp:193
 msgid "PAUSED THERMAL ERROR"
 msgstr "PAUSED THERMAL ERROR"
 
 #. MSG_PID_RUNNING c=20
-#: ../../Firmware/messages.cpp:219 ../../Firmware/ultralcd.cpp:897
+#: ../../Firmware/messages.cpp:231 ../../Firmware/ultralcd.cpp:897
 msgid "PID cal."
 msgstr "PID kal."
 
 #. MSG_PID_FINISHED c=20
-#: ../../Firmware/messages.cpp:220 ../../Firmware/ultralcd.cpp:902
+#: ../../Firmware/messages.cpp:232 ../../Firmware/ultralcd.cpp:902
 msgid "PID cal. finished"
 msgstr "PID kal. ukončená"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:318 ../../Firmware/ultralcd.cpp:4590
+#: ../../Firmware/messages.cpp:330 ../../Firmware/ultralcd.cpp:4546
 msgid "PID calibration"
 msgstr "PID kalibrácia"
 
 #. MSG_PINDA_PREHEAT c=20
-#: ../../Firmware/messages.cpp:218 ../../Firmware/ultralcd.cpp:610
+#: ../../Firmware/messages.cpp:230 ../../Firmware/ultralcd.cpp:610
 msgid "PINDA Heating"
 msgstr "Nahrievanie PINDA"
 
 #. MSG_PINDA_CALIBRATION c=13
-#: ../../Firmware/Marlin_main.cpp:4790 ../../Firmware/Marlin_main.cpp:4892
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:607
-#: ../../Firmware/ultralcd.cpp:4495 ../../Firmware/ultralcd.cpp:4597
+#: ../../Firmware/Marlin_main.cpp:4359 ../../Firmware/Marlin_main.cpp:4461
+#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:607
+#: ../../Firmware/ultralcd.cpp:4462 ../../Firmware/ultralcd.cpp:4553
 msgid "PINDA cal."
 msgstr "PINDA kal."
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/messages.cpp:276 ../../Firmware/ultralcd.cpp:3233
+#: ../../Firmware/messages.cpp:288 ../../Firmware/ultralcd.cpp:3243
 msgid "PINDA calibration failed"
 msgstr "Kalibrácia PINDA zlyhala"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:4967 ../../Firmware/messages.cpp:127
-#: ../../Firmware/ultralcd.cpp:3230
+#: ../../Firmware/Marlin_main.cpp:4536 ../../Firmware/messages.cpp:132
+#: ../../Firmware/ultralcd.cpp:3240
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1450,13 +1444,13 @@ msgid "Parking selector"
 msgstr "Parkovanie selektora"
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:4062
+#: ../../Firmware/messages.cpp:179 ../../Firmware/ultralcd.cpp:4086
 msgid "Pause"
 msgstr "Pauza"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5271
-#: ../../Firmware/ultralcd.cpp:5273
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5237
+#: ../../Firmware/ultralcd.cpp:5239
 msgid "Pause print"
 msgstr "Pozastaviť tlač"
 
@@ -1467,7 +1461,7 @@ msgid "Performing cut"
 msgstr "Strihanie"
 
 #. MSG_PAPER c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3243 ../../Firmware/messages.cpp:77
+#: ../../Firmware/Marlin_main.cpp:2982 ../../Firmware/messages.cpp:77
 msgid ""
 "Place a sheet of paper under the nozzle during the calibration of first 4 "
 "points. If the nozzle catches the paper, power off the printer immediately."
@@ -1476,7 +1470,7 @@ msgstr ""
 "tryska zachytí papier, ihneď vypnite tlačiareň."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:3963
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:3987
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1485,35 +1479,35 @@ msgstr ""
 "reštartovaním tlačiarne."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/messages.cpp:337 ../../Firmware/ultralcd.cpp:6023
+#: ../../Firmware/messages.cpp:349 ../../Firmware/ultralcd.cpp:5999
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "Prosím skontrolujte zapojenie IR senzoru a vyberte filament"
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/messages.cpp:343 ../../Firmware/ultralcd.cpp:6700
+#: ../../Firmware/messages.cpp:355 ../../Firmware/ultralcd.cpp:6676
 msgid "Please check:"
 msgstr "Skontrolujte:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/messages.cpp:302 ../../Firmware/ultralcd.cpp:3926
+#: ../../Firmware/messages.cpp:314 ../../Firmware/ultralcd.cpp:3950
 msgid "Please clean heatbed and then press the knob."
 msgstr "Prosím očistite podložku a stlačte tlačidlo."
 
 #. MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3217 ../../Firmware/messages.cpp:27
+#: ../../Firmware/Marlin_main.cpp:2960 ../../Firmware/messages.cpp:28
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr ""
 "Pre úspešnú kalibráciu očistite prosím tlačovú trysku. Potvrďte tlačidlom."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/messages.cpp:288 ../../Firmware/ultralcd.cpp:3712
+#: ../../Firmware/messages.cpp:300 ../../Firmware/ultralcd.cpp:3722
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr ""
 "Prosím vložte filament do extrúderu a stlačte tlačidlo k jeho zavedeniu"
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/messages.cpp:287 ../../Firmware/ultralcd.cpp:3705
+#: ../../Firmware/messages.cpp:299 ../../Firmware/ultralcd.cpp:3715
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1522,104 +1516,103 @@ msgstr ""
 "zavedeniu"
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/messages.cpp:285 ../../Firmware/ultralcd.cpp:3633
+#: ../../Firmware/messages.cpp:297 ../../Firmware/ultralcd.cpp:3643
 msgid "Please load filament first."
 msgstr "Prosím najskôr zaveďte filament"
 
 #. MSG_CHECK_IDLER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3525 ../../Firmware/messages.cpp:206
+#: ../../Firmware/Marlin_main.cpp:3265 ../../Firmware/messages.cpp:218
 msgid "Please open idler and remove filament manually."
 msgstr "Prosím otvorte idler a manuálne odstráňte filament."
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2806 ../../Firmware/messages.cpp:80
-#: ../../Firmware/ultralcd.cpp:3860
+#: ../../Firmware/mesh_bed_calibration.cpp:2791 ../../Firmware/messages.cpp:80
 msgid "Please place steel sheet on heatbed."
 msgstr "Umiestnite prosím platňu na podložku"
 
 #. MSG_PRESS_TO_UNLOAD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:11215 ../../Firmware/Marlin_main.cpp:11245
+#: ../../Firmware/Marlin_main.cpp:10287 ../../Firmware/Marlin_main.cpp:10317
 #: ../../Firmware/messages.cpp:84
 msgid "Please press the knob to unload filament"
 msgstr "Pre vysunutie filamentu stlačte tlačidlo"
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:4932
+#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:4888
 msgid "Please pull out filament immediately"
 msgstr "Prosím vyberte urýchlene filament"
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/messages.cpp:295 ../../Firmware/ultralcd.cpp:3856
+#: ../../Firmware/messages.cpp:307 ../../Firmware/ultralcd.cpp:3882
 msgid "Please remove shipping helpers first."
 msgstr "Najskôr prosím odstráňte prevozné pomôcky."
 
 #. MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3240 ../../Firmware/Marlin_main.cpp:4755
-#: ../../Firmware/messages.cpp:89
+#: ../../Firmware/Marlin_main.cpp:4324 ../../Firmware/messages.cpp:89
 msgid "Please remove steel sheet from heatbed."
 msgstr "Odstráňte prosím platňu z podložky."
 
 #. MSG_RUN_XYZ c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4731 ../../Firmware/messages.cpp:207
+#: ../../Firmware/Marlin_main.cpp:4300 ../../Firmware/messages.cpp:219
 msgid "Please run XYZ calibration first."
 msgstr "Najskôr spustite kalibráciu XYZ."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/messages.cpp:336 ../../Firmware/ultralcd.cpp:6020
+#: ../../Firmware/messages.cpp:348 ../../Firmware/ultralcd.cpp:4359
+#: ../../Firmware/ultralcd.cpp:5996
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Prosím vyberte filament a zopakujte túto akciu"
 
 #. MSG_NEW_FIRMWARE_PLEASE_UPGRADE c=20
-#: ../../Firmware/messages.cpp:366 ../../Firmware/util.cpp:213
+#: ../../Firmware/messages.cpp:378 ../../Firmware/util.cpp:218
 msgid "Please upgrade."
 msgstr "Aktualizujte prosím."
 
 #. MSG_PLEASE_WAIT c=20
-#: ../../Firmware/Marlin_main.cpp:3521 ../../Firmware/Marlin_main.cpp:8090
-#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:2179
-#: ../../Firmware/ultralcd.cpp:2190
+#: ../../Firmware/Marlin_main.cpp:3261 ../../Firmware/Marlin_main.cpp:7262
+#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:2190
+#: ../../Firmware/ultralcd.cpp:2204
 msgid "Please wait"
 msgstr "Čakajte prosím"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:1232
-#: ../../Firmware/ultralcd.cpp:1261
+#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:1242
+#: ../../Firmware/ultralcd.cpp:1271
 msgid "Power failures"
 msgstr "Výpadky prúdu"
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/messages.cpp:323 ../../Firmware/ultralcd.cpp:5260
+#: ../../Firmware/messages.cpp:335 ../../Firmware/ultralcd.cpp:5222
 msgid "Preheat"
 msgstr "Predohrev"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:2254
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:2268
 msgid "Preheat the nozzle!"
 msgstr "Predhrejte trysku!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:2771
-#: ../../Firmware/ultralcd.cpp:3690 ../../Firmware/ultralcd.cpp:3692
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:2788
+#: ../../Firmware/ultralcd.cpp:3700 ../../Firmware/ultralcd.cpp:3702
 msgid "Preheating nozzle. Please wait."
 msgstr "Predohrev trysky. Prosím čakajte."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/messages.cpp:237 ../../Firmware/ultralcd.cpp:1999
+#: ../../Firmware/messages.cpp:249 ../../Firmware/ultralcd.cpp:2005
 msgid "Preheating to cut"
 msgstr "Predohrev k strihu"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/messages.cpp:236 ../../Firmware/ultralcd.cpp:1996
+#: ../../Firmware/messages.cpp:248 ../../Firmware/ultralcd.cpp:2002
 msgid "Preheating to eject"
 msgstr "Predhrev k vysunutiu"
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/messages.cpp:234 ../../Firmware/ultralcd.cpp:1987
+#: ../../Firmware/messages.cpp:246 ../../Firmware/ultralcd.cpp:1995
 msgid "Preheating to load"
 msgstr "Predhrev k zavedeniu"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/messages.cpp:235 ../../Firmware/ultralcd.cpp:1992
+#: ../../Firmware/messages.cpp:247 ../../Firmware/ultralcd.cpp:1999
 msgid "Preheating to unload"
 msgstr "Predohrev k vybratiu"
 
@@ -1630,12 +1623,12 @@ msgid "Preparing blade"
 msgstr "Príprava čepele"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/messages.cpp:231 ../../Firmware/ultralcd.cpp:1799
+#: ../../Firmware/messages.cpp:243 ../../Firmware/ultralcd.cpp:1809
 msgid "Press the knob"
 msgstr "Stlačte tlačidlo"
 
 #. MSG_PRESS_TO_PREHEAT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:11227 ../../Firmware/messages.cpp:212
+#: ../../Firmware/Marlin_main.cpp:10299 ../../Firmware/messages.cpp:224
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Pre zahriatie trysky a pokračovanie stlačte tlačidlo."
 
@@ -1645,34 +1638,34 @@ msgid "Print aborted"
 msgstr "Tlač prerušená"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1106
-#: ../../Firmware/ultralcd.cpp:6994
+#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1116
+#: ../../Firmware/ultralcd.cpp:6971
 msgid "Print fan:"
 msgstr "Tlačový vent.:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:5313
+#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5279
 msgid "Print from SD"
 msgstr "Tlač z SD"
 
 #. MSG_PRINT_PAUSED c=20
-#: ../../Firmware/Marlin_main.cpp:3582 ../../Firmware/messages.cpp:79
+#: ../../Firmware/Marlin_main.cpp:3323 ../../Firmware/messages.cpp:79
 #: ../../Firmware/ultralcd.cpp:814
 msgid "Print paused"
 msgstr "Tlač pozastavená"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/messages.cpp:247 ../../Firmware/ultralcd.cpp:2348
+#: ../../Firmware/messages.cpp:259 ../../Firmware/ultralcd.cpp:2365
 msgid "Print time"
 msgstr "Čas tlače"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/messages.cpp:225 ../../Firmware/ultralcd.cpp:1689
+#: ../../Firmware/messages.cpp:237 ../../Firmware/ultralcd.cpp:1699
 msgid "Printer IP Addr:"
 msgstr "IP adr. tlačiarne:"
 
 #. MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1602 ../../Firmware/messages.cpp:46
+#: ../../Firmware/Marlin_main.cpp:1529 ../../Firmware/messages.cpp:46
 msgid ""
 "Printer has not been calibrated yet. Please follow the manual, chapter First"
 " steps, section Calibration flow."
@@ -1681,12 +1674,12 @@ msgstr ""
 "kapitola Začíname, odstavec Postup kalibrácie."
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:153 ../../Firmware/util.cpp:289
+#: ../../Firmware/messages.cpp:160 ../../Firmware/util.cpp:296
 msgid "Nozzle diameter differs from the G-code. Continue?"
 msgstr "Priemer trysky tlačiarne sa líši od G-code. Pokračovať?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:154 ../../Firmware/util.cpp:290
+#: ../../Firmware/messages.cpp:161 ../../Firmware/util.cpp:297
 msgid ""
 "Nozzle diameter differs from the G-code. Please check the value in settings."
 " Print cancelled."
@@ -1713,22 +1706,22 @@ msgid "QUEUE FULL"
 msgstr "QUEUE FULL"
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:4465
 msgid "RPi port"
 msgstr "RPi port"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/messages.cpp:261 ../../Firmware/ultralcd.cpp:2712
+#: ../../Firmware/messages.cpp:273 ../../Firmware/ultralcd.cpp:2729
 msgid "Rear side [µm]"
 msgstr "Zadná str.[µm]"
 
 #. MSG_RECOVERING_PRINT c=20
-#: ../../Firmware/messages.cpp:216 ../../Firmware/power_panic.cpp:316
+#: ../../Firmware/messages.cpp:228 ../../Firmware/power_panic.cpp:328
 msgid "Recovering print"
 msgstr "Obnovovanie tlače"
 
 #. MSG_RENAME c=18
-#: ../../Firmware/messages.cpp:322 ../../Firmware/ultralcd.cpp:5143
+#: ../../Firmware/messages.cpp:334 ../../Firmware/ultralcd.cpp:5103
 msgid "Rename"
 msgstr "Premenovať"
 
@@ -1742,19 +1735,19 @@ msgstr ""
 "nástroj mimo rozsah (T0-T4)."
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:2713
-#: ../../Firmware/ultralcd.cpp:5144
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:2730
+#: ../../Firmware/ultralcd.cpp:5104
 msgid "Reset"
 msgstr "Reset"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/messages.cpp:320 ../../Firmware/ultralcd.cpp:4594
+#: ../../Firmware/messages.cpp:332 ../../Firmware/ultralcd.cpp:4550
 msgid "Reset XYZ calibr."
 msgstr "Reset XYZ kalibr."
 
 #. MSG_RESUME_PRINT c=18
-#: ../../Firmware/Marlin_main.cpp:680 ../../Firmware/messages.cpp:91
-#: ../../Firmware/ultralcd.cpp:5286 ../../Firmware/ultralcd.cpp:5288
+#: ../../Firmware/Marlin_main.cpp:645 ../../Firmware/messages.cpp:91
+#: ../../Firmware/ultralcd.cpp:5252 ../../Firmware/ultralcd.cpp:5254
 msgid "Resume print"
 msgstr "Pokračovať"
 
@@ -1781,17 +1774,17 @@ msgid "Returning selector"
 msgstr "Návrat selektora"
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/messages.cpp:252 ../../Firmware/ultralcd.cpp:2479
+#: ../../Firmware/messages.cpp:264 ../../Firmware/ultralcd.cpp:2496
 msgid "Right"
 msgstr "Vpravo"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/messages.cpp:259 ../../Firmware/ultralcd.cpp:2710
+#: ../../Firmware/messages.cpp:271 ../../Firmware/ultralcd.cpp:2727
 msgid "Right side[µm]"
 msgstr "Pravá str.[µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/messages.cpp:286 ../../Firmware/ultralcd.cpp:3656
+#: ../../Firmware/messages.cpp:298 ../../Firmware/ultralcd.cpp:3666
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1800,8 +1793,8 @@ msgstr ""
 "kalibračný proces od začiatku. Pokračovať?"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4509
-#: ../../Firmware/ultralcd.cpp:4511
+#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4476
+#: ../../Firmware/ultralcd.cpp:4478
 msgid "SD card"
 msgstr "SD karta"
 
@@ -1816,48 +1809,48 @@ msgid "SELECTOR CANNOT MOVE"
 msgstr "SELECTOR CANNOT MOVE"
 
 #. MSG_STOPPED c=20
-#: ../../Firmware/Marlin_main.cpp:9887 ../../Firmware/messages.cpp:125
+#: ../../Firmware/Marlin_main.cpp:9047 ../../Firmware/messages.cpp:130
 msgid "STOPPED."
 msgstr "ZASTAVENE."
 
 #. MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3223 ../../Firmware/Marlin_main.cpp:3245
-#: ../../Firmware/mesh_bed_calibration.cpp:2246 ../../Firmware/messages.cpp:44
+#: ../../Firmware/Marlin_main.cpp:2967 ../../Firmware/Marlin_main.cpp:2984
+#: ../../Firmware/mesh_bed_calibration.cpp:2231 ../../Firmware/messages.cpp:44
 msgid "Searching bed calibration point"
 msgstr "Hľadám kalibračný bod podložky"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/messages.cpp:321 ../../Firmware/ultralcd.cpp:5136
+#: ../../Firmware/messages.cpp:333 ../../Firmware/ultralcd.cpp:5096
 msgid "Select"
 msgstr "Vybrať"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/messages.cpp:290 ../../Firmware/ultralcd.cpp:3730
+#: ../../Firmware/messages.cpp:302 ../../Firmware/ultralcd.cpp:3740
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
 msgstr "Zvoľte filament pre kalibráciu prvej vrstvy z nasledujúceho menu"
 
 #. MSG_SELECT_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3453 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3612
-#: ../../Firmware/ultralcd.cpp:6822
+#: ../../Firmware/Marlin_main.cpp:3192 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3622
+#: ../../Firmware/ultralcd.cpp:6798
 msgid "Select filament:"
 msgstr "Zvoľte filament:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:110 ../../Firmware/ultralcd.cpp:3464
-#: ../../Firmware/ultralcd.cpp:4504
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:3474
+#: ../../Firmware/ultralcd.cpp:4471
 msgid "Select language"
 msgstr "Výber jazyka"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/messages.cpp:300 ../../Firmware/ultralcd.cpp:3900
+#: ../../Firmware/messages.cpp:312 ../../Firmware/ultralcd.cpp:3924
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr "Vyberte teplotu predohrevu trysky ktorá zodpovedá vášmu materiálu."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/messages.cpp:291 ../../Firmware/ultralcd.cpp:3735
+#: ../../Firmware/messages.cpp:303 ../../Firmware/ultralcd.cpp:3745
 msgid "Select temperature which matches your material."
 msgstr "Zvoľte teplotu, ktorá zodpovedá vášmu materiálu."
 
@@ -1868,61 +1861,61 @@ msgid "Selecting fil. slot"
 msgstr "Vyber slotu fil."
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/messages.cpp:341 ../../Firmware/ultralcd.cpp:6274
+#: ../../Firmware/messages.cpp:353 ../../Firmware/ultralcd.cpp:6250
 msgid "Selftest OK"
 msgstr "Samotest OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/messages.cpp:340 ../../Firmware/ultralcd.cpp:6057
+#: ../../Firmware/messages.cpp:352 ../../Firmware/ultralcd.cpp:6033
 msgid "Selftest start"
 msgstr "Začiatok testu"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/messages.cpp:315 ../../Firmware/ultralcd.cpp:4581
+#: ../../Firmware/messages.cpp:327 ../../Firmware/ultralcd.cpp:4537
 msgid "Selftest"
 msgstr "Samotest"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/messages.cpp:342 ../../Firmware/ultralcd.cpp:6699
+#: ../../Firmware/messages.cpp:354 ../../Firmware/ultralcd.cpp:6675
 msgid "Selftest error!"
 msgstr "Chyba samotestu!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6279
-#: ../../Firmware/ultralcd.cpp:6786 ../../Firmware/ultralcd.cpp:6984
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6255
+#: ../../Firmware/ultralcd.cpp:6762 ../../Firmware/ultralcd.cpp:6961
 msgid "Selftest failed"
 msgstr "Samotest zlyhal"
 
 #. MSG_FORCE_SELFTEST c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1577 ../../Firmware/messages.cpp:202
+#: ../../Firmware/Marlin_main.cpp:1504 ../../Firmware/messages.cpp:214
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr "Bude spustený test pre kalibráciu presného návratu."
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/messages.cpp:228 ../../Firmware/ultralcd.cpp:1701
+#: ../../Firmware/messages.cpp:240 ../../Firmware/ultralcd.cpp:1711
 msgid "Sensor info"
 msgstr "Senzor info"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/messages.cpp:338 ../../Firmware/ultralcd.cpp:6027
+#: ../../Firmware/messages.cpp:350 ../../Firmware/ultralcd.cpp:6003
 msgid "Sensor verified, remove the filament now."
 msgstr "Senzor overený, vyberte filament."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/messages.cpp:262 ../../Firmware/ultralcd.cpp:2730
+#: ../../Firmware/messages.cpp:274 ../../Firmware/ultralcd.cpp:2747
 msgid "Set temperature:"
 msgstr "Nastavte teplotu:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3348
-#: ../../Firmware/ultralcd.cpp:3479 ../../Firmware/ultralcd.cpp:3984
-#: ../../Firmware/ultralcd.cpp:5374 ../../Firmware/ultralcd.cpp:5585
-#: ../../Firmware/ultralcd.cpp:5631
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3358
+#: ../../Firmware/ultralcd.cpp:3489 ../../Firmware/ultralcd.cpp:4008
+#: ../../Firmware/ultralcd.cpp:5341 ../../Firmware/ultralcd.cpp:5558
+#: ../../Firmware/ultralcd.cpp:5604
 msgid "Settings"
 msgstr "Nastavenia"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/messages.cpp:255 ../../Firmware/ultralcd.cpp:2522
+#: ../../Firmware/messages.cpp:267 ../../Firmware/ultralcd.cpp:2539
 msgid "Severe skew"
 msgstr "Ťažké skos."
 
@@ -1933,7 +1926,7 @@ msgid "Sheet"
 msgstr "Platňa"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/messages.cpp:284 ../../Firmware/ultralcd.cpp:3604
+#: ../../Firmware/messages.cpp:296 ../../Firmware/ultralcd.cpp:3614
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1946,23 +1939,23 @@ msgstr ""
 "%cReset"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/messages.cpp:319 ../../Firmware/ultralcd.cpp:4592
+#: ../../Firmware/messages.cpp:331 ../../Firmware/ultralcd.cpp:4548
 msgid "Show end stops"
 msgstr "Stav konc. spin."
 
 #. MSG_SILENT c=7
-#: ../../Firmware/Marlin_main.cpp:8497 ../../Firmware/messages.cpp:120
-#: ../../Firmware/ultralcd.cpp:4155 ../../Firmware/ultralcd.cpp:4194
+#: ../../Firmware/Marlin_main.cpp:7668 ../../Firmware/messages.cpp:124
+#: ../../Firmware/ultralcd.cpp:4179 ../../Firmware/ultralcd.cpp:4218
 msgid "Silent"
 msgstr "Tichý"
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/messages.cpp:254 ../../Firmware/ultralcd.cpp:2521
+#: ../../Firmware/messages.cpp:266 ../../Firmware/ultralcd.cpp:2538
 msgid "Slight skew"
 msgstr "Ľahké skos."
 
 #. MSG_FILE_CNT c=20 r=6
-#: ../../Firmware/cardreader.cpp:805 ../../Firmware/messages.cpp:197
+#: ../../Firmware/cardreader.cpp:805 ../../Firmware/messages.cpp:209
 msgid ""
 "Some files will not be sorted. Max. No. of files in 1 folder for sorting is "
 "100."
@@ -1971,58 +1964,58 @@ msgstr ""
 "zoradenie je 100."
 
 #. MSG_ZLEVELING_ENFORCED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3043 ../../Firmware/messages.cpp:204
+#: ../../Firmware/Marlin_main.cpp:2783 ../../Firmware/messages.cpp:216
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Vyskytol sa problém, zarovnám os Z ..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:4514
-#: ../../Firmware/ultralcd.cpp:4515 ../../Firmware/ultralcd.cpp:4516
+#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4481
+#: ../../Firmware/ultralcd.cpp:4482 ../../Firmware/ultralcd.cpp:4483
 msgid "Sort"
 msgstr "Triediť"
 
 #. MSG_SORTING_FILES c=20
 #: ../../Firmware/cardreader.cpp:849 ../../Firmware/cardreader.cpp:916
-#: ../../Firmware/messages.cpp:111
+#: ../../Firmware/messages.cpp:115
 msgid "Sorting files"
 msgstr "Triedenie súborov"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4188
-#: ../../Firmware/ultralcd.cpp:4191 ../../Firmware/ultralcd.cpp:4194
-#: ../../Firmware/ultralcd.cpp:4197 ../../Firmware/ultralcd.cpp:4200
+#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4215 ../../Firmware/ultralcd.cpp:4218
+#: ../../Firmware/ultralcd.cpp:4221 ../../Firmware/ultralcd.cpp:4224
 msgid "Sound"
 msgstr "Zvuk"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/messages.cpp:333 ../../Firmware/ultralcd.cpp:5516
+#: ../../Firmware/messages.cpp:345 ../../Firmware/ultralcd.cpp:5483
 msgid "Speed"
 msgstr "Rýchlosť"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6861
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6837
 msgid "Spinning"
 msgstr "Točí sa"
 
 #. MSG_TEMP_CAL_WARNING c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4744 ../../Firmware/messages.cpp:208
+#: ../../Firmware/Marlin_main.cpp:4313 ../../Firmware/messages.cpp:220
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr "Je vyžadovaná stabilná izbová teplota 21-26C a pevná podložka."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/messages.cpp:329 ../../Firmware/ultralcd.cpp:5379
+#: ../../Firmware/messages.cpp:341 ../../Firmware/ultralcd.cpp:5346
 msgid "Statistics"
 msgstr "Štatistika"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:4096
-#: ../../Firmware/ultralcd.cpp:4144
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4120
+#: ../../Firmware/ultralcd.cpp:4168
 msgid "Stealth"
 msgstr "Tichý"
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4421
-#: ../../Firmware/ultralcd.cpp:5133
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4388
+#: ../../Firmware/ultralcd.cpp:5093
 msgid "Steel sheets"
 msgstr "Platne"
 
@@ -2032,29 +2025,28 @@ msgid "Stop"
 msgstr "Zast."
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:5293
-#: ../../Firmware/ultralcd.cpp:5781
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:5259
+#: ../../Firmware/ultralcd.cpp:5757
 msgid "Stop print"
 msgstr "Zastaviť tlač"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4236
-#: ../../Firmware/ultralcd.cpp:4316 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4315
 msgid "Strict"
 msgstr "Prísne"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/messages.cpp:332 ../../Firmware/ultralcd.cpp:5394
+#: ../../Firmware/messages.cpp:344 ../../Firmware/ultralcd.cpp:5361
 msgid "Support"
 msgstr "Podpora"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/messages.cpp:354 ../../Firmware/ultralcd.cpp:6758
+#: ../../Firmware/messages.cpp:366 ../../Firmware/ultralcd.cpp:6734
 msgid "Swapped"
 msgstr "Prehodené"
 
 #. MSG_THERMAL_ANOMALY c=20
-#: ../../Firmware/messages.cpp:188 ../../Firmware/temperature.cpp:2223
+#: ../../Firmware/messages.cpp:195 ../../Firmware/temperature.cpp:2197
 msgid "THERMAL ANOMALY"
 msgstr "THERMAL ANOMALY"
 
@@ -2089,7 +2081,7 @@ msgid "TMC UNDERVOLTAGE ERR"
 msgstr "TMC UNDERVOLTAGE ERR"
 
 #. MSG_TM_CAL c=20 r=4
-#: ../../Firmware/messages.cpp:299 ../../Firmware/ultralcd.cpp:3881
+#: ../../Firmware/messages.cpp:311 ../../Firmware/ultralcd.cpp:3905
 msgid ""
 "Thermal model cal. takes approx. 12 mins. See\n"
 "prusa.io/tm-cal"
@@ -2098,22 +2090,22 @@ msgstr ""
 "prusa.io/tm-cal"
 
 #. MSG_TM_NOT_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1613 ../../Firmware/messages.cpp:189
+#: ../../Firmware/Marlin_main.cpp:1540 ../../Firmware/messages.cpp:196
 msgid "Thermal model not calibrated yet."
 msgstr "Termálny model zatiaľ nebol kalibrovaný"
 
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/messages.cpp:309 ../../Firmware/ultralcd.cpp:4455
+#: ../../Firmware/messages.cpp:321 ../../Firmware/ultralcd.cpp:4422
 msgid "Temperature"
 msgstr "Teplota"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/messages.cpp:229 ../../Firmware/ultralcd.cpp:1707
+#: ../../Firmware/messages.cpp:241 ../../Firmware/ultralcd.cpp:1717
 msgid "Temperatures"
 msgstr "Teploty"
 
 #. MSG_TESTING_FILAMENT c=20
-#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:388
+#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:389
 msgid "Testing filament"
 msgstr "Kontrola filamentu"
 
@@ -2134,7 +2126,7 @@ msgstr ""
 "pohyb."
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/messages.cpp:292 ../../Firmware/ultralcd.cpp:3738
+#: ../../Firmware/messages.cpp:304 ../../Firmware/ultralcd.cpp:3748
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -2144,7 +2136,7 @@ msgstr ""
 "výšku. Postupujte podľa obrázku v handbooku (kapitola Kalibrácia)."
 
 #. MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1606 ../../Firmware/messages.cpp:47
+#: ../../Firmware/Marlin_main.cpp:1533 ../../Firmware/messages.cpp:47
 msgid ""
 "There is still a need to make Z calibration. Please follow the manual, "
 "chapter First steps, section Calibration flow."
@@ -2153,40 +2145,40 @@ msgstr ""
 "Začíname, sekcia Postup kalibrácie."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:4514
+#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:4481
 msgid "Time"
 msgstr "Čas"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:176 ../../Firmware/ultralcd.cpp:5622
+#: ../../Firmware/messages.cpp:183 ../../Firmware/ultralcd.cpp:5595
 msgid "Timeout"
 msgstr "Časovač"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:1129
-#: ../../Firmware/ultralcd.cpp:1287
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:1139
+#: ../../Firmware/ultralcd.cpp:1297
 msgid "Total"
 msgstr "Celkom"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:1177
-#: ../../Firmware/ultralcd.cpp:1231 ../../Firmware/ultralcd.cpp:1317
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:1187
+#: ../../Firmware/ultralcd.cpp:1241 ../../Firmware/ultralcd.cpp:1327
 msgid "Total failures"
 msgstr "Celkom zlyhaní"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/messages.cpp:248 ../../Firmware/ultralcd.cpp:2369
+#: ../../Firmware/messages.cpp:260 ../../Firmware/ultralcd.cpp:2386
 msgid "Total filament"
 msgstr "Filament celkom"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/messages.cpp:249 ../../Firmware/ultralcd.cpp:2370
+#: ../../Firmware/messages.cpp:261 ../../Firmware/ultralcd.cpp:2387
 msgid "Total print time"
 msgstr "Celkový čas tlače"
 
 #. MSG_TUNE c=8
-#: ../../Firmware/messages.cpp:116 ../../Firmware/mmu2/errors_list.h:372
-#: ../../Firmware/ultralcd.cpp:5258
+#: ../../Firmware/messages.cpp:120 ../../Firmware/mmu2/errors_list.h:372
+#: ../../Firmware/ultralcd.cpp:5220
 msgid "Tune"
 msgstr "Ladiť"
 
@@ -2201,16 +2193,16 @@ msgid "Unload"
 msgstr "Výsuv"
 
 #. MSG_UNLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:2206
-#: ../../Firmware/ultralcd.cpp:5347 ../../Firmware/ultralcd.cpp:5364
-#: ../../Firmware/ultralcd.cpp:5369
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:2220
+#: ../../Firmware/ultralcd.cpp:5313 ../../Firmware/ultralcd.cpp:5331
+#: ../../Firmware/ultralcd.cpp:5336
 msgid "Unload filament"
 msgstr "Vybrať filament"
 
 #. MSG_UNLOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3436 ../../Firmware/messages.cpp:129
+#: ../../Firmware/Marlin_main.cpp:3175 ../../Firmware/messages.cpp:134
 #: ../../Firmware/mmu2_progress_converter.cpp:50
-#: ../../Firmware/ultralcd.cpp:4911
+#: ../../Firmware/ultralcd.cpp:4867
 msgid "Unloading filament"
 msgstr "Vysúvanie filamentu"
 
@@ -2227,12 +2219,12 @@ msgid "Unloading to pulley"
 msgstr "Vysúv. do remenice"
 
 #. MSG_FIL_FAILED c=20 r=4
-#: ../../Firmware/messages.cpp:339 ../../Firmware/ultralcd.cpp:6030
+#: ../../Firmware/messages.cpp:351 ../../Firmware/ultralcd.cpp:6006
 msgid "Verification failed, remove the filament and try again."
 msgstr "Overenie zlyhalo, vyberte filament a skúste znova."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/messages.cpp:230 ../../Firmware/ultralcd.cpp:1710
+#: ../../Firmware/messages.cpp:242 ../../Firmware/ultralcd.cpp:1720
 msgid "Voltages"
 msgstr "Napätie"
 
@@ -2243,7 +2235,7 @@ msgid "WARNING TMC TOO HOT"
 msgstr "WARNING TMC TOO HOT"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/messages.cpp:281 ../../Firmware/ultralcd.cpp:3381
+#: ../../Firmware/messages.cpp:293 ../../Firmware/ultralcd.cpp:3391
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -2256,187 +2248,187 @@ msgstr ""
 "Tichom režime"
 
 #. MSG_USERWAIT c=20
-#: ../../Firmware/Marlin_main.cpp:5240 ../../Firmware/messages.cpp:209
+#: ../../Firmware/Marlin_main.cpp:4747 ../../Firmware/messages.cpp:221
 msgid "Wait for user..."
 msgstr "Čaká sa na užívateľa"
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/messages.cpp:263 ../../Firmware/ultralcd.cpp:2753
+#: ../../Firmware/messages.cpp:275 ../../Firmware/ultralcd.cpp:2770
 msgid "Waiting for PINDA probe cooling"
 msgstr "Čaká sa na ochladenie PINDA"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/messages.cpp:264 ../../Firmware/ultralcd.cpp:2782
+#: ../../Firmware/messages.cpp:276 ../../Firmware/ultralcd.cpp:2799
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Čakanie na schladenie trysky a podložky."
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:4233
-#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4352
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4312
 msgid "Warn"
 msgstr "Varovať"
 
 #. MSG_CHANGED_BOTH c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1554 ../../Firmware/messages.cpp:200
+#: ../../Firmware/Marlin_main.cpp:1481 ../../Firmware/messages.cpp:212
 msgid "Warning: both printer type and motherboard type changed."
 msgstr "Varovanie: Došlo k zmene typu tlačiarne a matičnej dosky."
 
 #. MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1546 ../../Firmware/messages.cpp:198
+#: ../../Firmware/Marlin_main.cpp:1473 ../../Firmware/messages.cpp:210
 msgid "Warning: motherboard type changed."
 msgstr "Varovanie: Došlo k zmene typu matičnej dosky."
 
 #. MSG_CHANGED_PRINTER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1550 ../../Firmware/messages.cpp:199
+#: ../../Firmware/Marlin_main.cpp:1477 ../../Firmware/messages.cpp:211
 msgid "Warning: printer type changed."
 msgstr "Varovanie: Došlo k zmene typu tlačiarne."
 
 #. MSG_UNLOAD_SUCCESSFUL c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3517 ../../Firmware/messages.cpp:205
+#: ../../Firmware/Marlin_main.cpp:3257 ../../Firmware/messages.cpp:217
 msgid "Was filament unload successful?"
 msgstr "Bolo vysunutie filamentu úspešné?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:6710
-#: ../../Firmware/ultralcd.cpp:6714 ../../Firmware/ultralcd.cpp:6734
-#: ../../Firmware/ultralcd.cpp:6740 ../../Firmware/ultralcd.cpp:6764
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:6686
+#: ../../Firmware/ultralcd.cpp:6690 ../../Firmware/ultralcd.cpp:6710
+#: ../../Firmware/ultralcd.cpp:6716 ../../Firmware/ultralcd.cpp:6740
 msgid "Wiring error"
 msgstr "Chyba zapojenia"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/messages.cpp:313 ../../Firmware/ultralcd.cpp:4572
+#: ../../Firmware/messages.cpp:325 ../../Firmware/ultralcd.cpp:4528
 msgid "Wizard"
 msgstr "Sprievodca"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/messages.cpp:304 ../../Firmware/ultralcd.cpp:3986
+#: ../../Firmware/messages.cpp:316 ../../Firmware/ultralcd.cpp:4010
 msgid "X-correct"
 msgstr "Korekcia X"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/messages.cpp:226 ../../Firmware/ultralcd.cpp:1699
+#: ../../Firmware/messages.cpp:238 ../../Firmware/ultralcd.cpp:1709
 msgid "XYZ cal. details"
 msgstr "Detaily XYZ kal."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/messages.cpp:275 ../../Firmware/ultralcd.cpp:3207
+#: ../../Firmware/messages.cpp:287 ../../Firmware/ultralcd.cpp:3217
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr ""
 "Kalibrácia XYZ v poriadku. Skosenie bude automaticky vyrovnané pri tlači."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/messages.cpp:274 ../../Firmware/ultralcd.cpp:3204
+#: ../../Firmware/messages.cpp:286 ../../Firmware/ultralcd.cpp:3214
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr "Kalibrácia XYZ v poriadku. X/Y osi mierne skosené. Dobrá práca!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/messages.cpp:271 ../../Firmware/ultralcd.cpp:3185
+#: ../../Firmware/messages.cpp:283 ../../Firmware/ultralcd.cpp:3195
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr "Kalibrácia XYZ je nepresná. Predné kalibračné body sú nedostupné."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/messages.cpp:272 ../../Firmware/ultralcd.cpp:3188
+#: ../../Firmware/messages.cpp:284 ../../Firmware/ultralcd.cpp:3198
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr "Kalibrácia XYZ je nepresná. Pravý predný bod je nedostupný."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/messages.cpp:268 ../../Firmware/ultralcd.cpp:3167
+#: ../../Firmware/messages.cpp:280 ../../Firmware/ultralcd.cpp:3177
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr "Kalibrácia XYZ zlyhala. Kalibračný bod podložky nenájdený."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/messages.cpp:269 ../../Firmware/ultralcd.cpp:3173
+#: ../../Firmware/messages.cpp:281 ../../Firmware/ultralcd.cpp:3183
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr "Kalibrácia XYZ zlyhala. Predné kalibračné body sú nedostupné."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3170
-#: ../../Firmware/ultralcd.cpp:3198
+#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3180
+#: ../../Firmware/ultralcd.cpp:3208
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "Kalibrácia XYZ zlyhala. Nahliadnite do manuálu."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/messages.cpp:270 ../../Firmware/ultralcd.cpp:3176
+#: ../../Firmware/messages.cpp:282 ../../Firmware/ultralcd.cpp:3186
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr "Kalibrácia XYZ zlyhala. Pravý predný bod je nedostupný."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/messages.cpp:273 ../../Firmware/ultralcd.cpp:3201
+#: ../../Firmware/messages.cpp:285 ../../Firmware/ultralcd.cpp:3211
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "Kalibrácia XYZ v poriadku. X/Y osi sú kolmé. Gratulujeme!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/messages.cpp:250 ../../Firmware/ultralcd.cpp:2476
+#: ../../Firmware/messages.cpp:262 ../../Firmware/ultralcd.cpp:2493
 msgid "Y distance from min"
 msgstr "Y vzdialenosť od min"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/messages.cpp:305 ../../Firmware/ultralcd.cpp:3987
+#: ../../Firmware/messages.cpp:317 ../../Firmware/ultralcd.cpp:4011
 msgid "Y-correct"
 msgstr "Korekcia Y"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:3029
-#: ../../Firmware/ultralcd.cpp:4443 ../../Firmware/ultralcd.cpp:4531
-#: ../../Firmware/ultralcd.cpp:5790
+#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:2275
+#: ../../Firmware/ultralcd.cpp:2279 ../../Firmware/ultralcd.cpp:3046
+#: ../../Firmware/ultralcd.cpp:4410 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/ultralcd.cpp:5766
 msgid "Yes"
 msgstr "Áno"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:3950
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:3974
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr ""
 "Sprievodcu môžete kedykoľvek znovu spustiť z menu Kalibrácia -> Sprievodca"
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/messages.cpp:306 ../../Firmware/ultralcd.cpp:3988
+#: ../../Firmware/messages.cpp:318 ../../Firmware/ultralcd.cpp:4012
 msgid "Z-correct"
 msgstr "Korekcia Z"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5593
+#: ../../Firmware/messages.cpp:175 ../../Firmware/ultralcd.cpp:5566
 msgid "Z-probe nr."
 msgstr "Počet meraní Z"
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/messages.cpp:256 ../../Firmware/ultralcd.cpp:2546
+#: ../../Firmware/messages.cpp:268 ../../Firmware/ultralcd.cpp:2563
 msgid "[0;0] point offset"
 msgstr "[0;0] odsadenie bodu"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/messages.cpp:239 ../../Firmware/ultralcd.cpp:2147
+#: ../../Firmware/messages.cpp:251 ../../Firmware/ultralcd.cpp:2158
 msgid "and press the knob"
 msgstr "a stlačte tlačidlo"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/messages.cpp:232 ../../Firmware/ultralcd.cpp:1807
+#: ../../Firmware/messages.cpp:244 ../../Firmware/ultralcd.cpp:1816
 msgid "to load filament"
 msgstr "k zavedeniu filam."
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/messages.cpp:233 ../../Firmware/ultralcd.cpp:1811
+#: ../../Firmware/messages.cpp:245 ../../Firmware/ultralcd.cpp:1820
 msgid "to unload filament"
 msgstr "k vybraniu filamentu"
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/messages.cpp:224 ../../Firmware/ultralcd.cpp:1666
+#: ../../Firmware/messages.cpp:236 ../../Firmware/ultralcd.cpp:1676
 msgid "unknown"
 msgstr "neznámy"
 
 #. MSG_IR_UNKNOWN c=18
-#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:184
+#: ../../Firmware/Filament_sensor.cpp:286 ../../Firmware/messages.cpp:191
 msgid "unknown state"
 msgstr "neznámy stav"
 
 #. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:5858
-#: ../../Firmware/ultralcd.cpp:5861
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:5834
+#: ../../Firmware/ultralcd.cpp:5837
 msgid "🔃Refresh"
 msgstr "🔃Obnoviť"
 
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1180
+#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1190
 msgid "MMU power fails"
 msgstr "MMU vyp. prúdu"
 
@@ -2474,8 +2466,8 @@ msgid "MMU MCU ERROR"
 msgstr "MMU MCU CHYBA"
 
 #. MSG_MATERIAL_CHANGES c=18
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:1130
-#: ../../Firmware/ultralcd.cpp:1204
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:1140
+#: ../../Firmware/ultralcd.cpp:1214
 msgid "Material changes"
 msgstr "Výmena materiálu"
 
@@ -2507,17 +2499,17 @@ msgstr ""
 "verziu 3.0.3."
 
 #. MSG_PRELOAD_TO_MMU c=17
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5344
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5310
 msgid "Preload to MMU"
 msgstr "Predzásobenie MMU"
 
 #. MSG_FW_MK3_DETECTED c=20 r=4
-#: ../../Firmware/messages.cpp:367 ../../Firmware/Marlin_main.cpp:920
+#: ../../Firmware/messages.cpp:379 ../../Firmware/Marlin_main.cpp:854
 msgid "MK3 firmware detected on MK3S printer"
 msgstr "MK3 firmware na MK3S tlačiarni"
 
 #. MSG_FW_MK3S_DETECTED c=20 r=4
-#: ../../Firmware/messages.cpp:367 ../../Firmware/Marlin_main.cpp:920
+#: ../../Firmware/messages.cpp:379 ../../Firmware/Marlin_main.cpp:854
 msgid "MK3S firmware detected on MK3 printer"
 msgstr "MK3S firmware na MK3 tlačiarni"
 
@@ -2531,8 +2523,9 @@ msgstr "NEZNÁMA CHYBA"
 msgid "Unexpected error occurred."
 msgstr "Vyskytla sa neočakávaná chyba."
 
-#. MSG_BTN_EJECT c=8
-#: ../../Firmware/mmu2/errors_list.h:358 ../../Firmware/mmu2/errors_list.h:371
+#. MSG_EJECT c=8
+#: ../../Firmware/messages.cpp:21 ../../Firmware/mmu2/errors_list.h:371
+#: ../../Firmware/ultralcd.cpp:2275 ../../Firmware/ultralcd.cpp:2279
 msgid "Eject"
 msgstr "Vysunúť"
 
@@ -2552,58 +2545,58 @@ msgid "M600 Filament Change. Load a new filament or eject the old one."
 msgstr "Výmena filamentu M600. Vložte nový filament alebo vysuňte starý."
 
 #. MSG_MMU_SENSITIVITY c=18
-#: ../../Firmware/messages.cpp:215 ../../Firmware/mmu2_reporting.cpp:458
+#: ../../Firmware/messages.cpp:227 ../../Firmware/mmu2_reporting.cpp:459
 msgid "Sensitivity"
 msgstr "Citlivosť"
 
 #. MSG_MBL_FAILED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3038 ../../Firmware/messages.cpp:203
+#: ../../Firmware/Marlin_main.cpp:2776 ../../Firmware/messages.cpp:215
 msgid "Mesh bed leveling failed. Print canceled."
 msgstr "Vyrovnanie platne zlyhalo. Tlač zrušená."
 
 #. MSG_SET_READY c=18
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:5265
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:5228
 msgid "Set Ready"
 msgstr "Pripravené"
 
 #. MSG_SET_NOT_READY c=18
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:5263
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5226
 msgid "Set not Ready"
 msgstr "Nie je pripravené"
 
 #. MSG_HOSTPRINT c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5285
+#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:5231
 msgid "Print from host"
 msgstr "Tlač z hostiteľa"
 
 #. MSG_REPRINT c=18
-#: ../../Firmware/messages.cpp:196 ../../Firmware/ultralcd.cpp:5243
-#: ../../Firmware/ultralcd.cpp:5245
+#: ../../Firmware/messages.cpp:208 ../../Firmware/ultralcd.cpp:5205
+#: ../../Firmware/ultralcd.cpp:5207
 msgid "Reprint"
 msgstr "Vytlačiť znova"
 
 #. MSG_SHUTDOWN_HOST c=18
-#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:5390
+#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:5357
 msgid "Shutdown host"
 msgstr "Vypnutie hostiteľa"
 
 #. MSG_NOZZLE_CNG_COOLDOWN c=20 r=3
-#: ../../Firmware/messages.cpp:198 ../../Firmware/ultralcd.cpp:1002
+#: ../../Firmware/messages.cpp:203 ../../Firmware/ultralcd.cpp:999
 msgid "Nozzle is hot! Wait for cooldown."
 msgstr "Tryska je horúca! Počkajte na vychladnutie."
 
 #. MSG_NOZZLE_CNG_CHANGED_QUICK c=20 r=3
-#: ../../Firmware/messages.cpp:199
+#: ../../Firmware/messages.cpp:204
 msgid "Nozzle changed?"
 msgstr "Vymenili ste trysku?"
 
 #. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:388
+#: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:388
 msgid "There is no filament loaded. Continue?"
 msgstr "Nie je zavedený žiaden filament. Pokračovať?"
 
 #. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:389
+#: ../../Firmware/messages.cpp:159 ../../Firmware/util.cpp:389
 msgid "There is no filament loaded. Print cancelled."
 msgstr "Nie je zavedený žiaden filament. Tlač zrušená."
 

--- a/lang/po/Firmware_sv.po
+++ b/lang/po/Firmware_sv.po
@@ -16,91 +16,91 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 
 #. MSG_IR_03_OR_OLDER c=18
-#: ../../Firmware/Filament_sensor.cpp:280
-#: ../../Firmware/Filament_sensor.cpp:357 ../../Firmware/messages.cpp:183
+#: ../../Firmware/Filament_sensor.cpp:282
+#: ../../Firmware/Filament_sensor.cpp:344 ../../Firmware/messages.cpp:190
 msgid " 0.3 or older"
 msgstr " 0.3 el äldre"
 
 #. MSG_IR_04_OR_NEWER c=18
-#: ../../Firmware/Filament_sensor.cpp:282
-#: ../../Firmware/Filament_sensor.cpp:360 ../../Firmware/messages.cpp:182
+#: ../../Firmware/Filament_sensor.cpp:284
+#: ../../Firmware/Filament_sensor.cpp:347 ../../Firmware/messages.cpp:189
 msgid " 0.4 or newer"
 msgstr " 0.4 el nyare"
 
 #. MSG_SELFTEST_FS_LEVEL c=20
-#: ../../Firmware/messages.cpp:356 ../../Firmware/ultralcd.cpp:6773
+#: ../../Firmware/messages.cpp:368 ../../Firmware/ultralcd.cpp:6749
 msgid "%s level expected"
 msgstr "%s nivå förväntad"
 
 #. MSG_CANCEL c=10
-#: ../../Firmware/messages.cpp:21 ../../Firmware/ultralcd.cpp:1978
-#: ../../Firmware/ultralcd.cpp:3613
+#: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:1986
+#: ../../Firmware/ultralcd.cpp:3623
 msgid ">Cancel"
 msgstr ">Avbryt"
 
 #. MSG_BABYSTEPPING_Z c=13
-#: ../../Firmware/messages.cpp:257 ../../Firmware/ultralcd.cpp:2635
+#: ../../Firmware/messages.cpp:269 ../../Firmware/ultralcd.cpp:2652
 msgid "Adjusting Z"
 msgstr "Justerar Z"
 
 #. MSG_SELFTEST_CHECK_ALLCORRECT c=20
-#: ../../Firmware/messages.cpp:360 ../../Firmware/ultralcd.cpp:6983
+#: ../../Firmware/messages.cpp:372 ../../Firmware/ultralcd.cpp:6960
 msgid "All correct"
 msgstr "Allt korrekt"
 
 #. MSG_WIZARD_DONE c=20 r=3
-#: ../../Firmware/messages.cpp:132 ../../Firmware/ultralcd.cpp:3955
+#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:3979
 msgid "All is done. Happy printing!"
 msgstr "Allt är klart. God utskrift!"
 
 #. MSG_SORT_ALPHA c=8
-#: ../../Firmware/messages.cpp:160 ../../Firmware/ultralcd.cpp:4515
+#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4482
 msgid "Alphabet"
 msgstr "Alfabet"
 
 #. MSG_ALWAYS c=6
-#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4086
+#: ../../Firmware/messages.cpp:11 ../../Firmware/ultralcd.cpp:4110
 msgid "Always"
 msgstr "Alltid"
 
 #. MSG_AMBIENT c=14
-#: ../../Firmware/messages.cpp:221 ../../Firmware/ultralcd.cpp:1393
+#: ../../Firmware/messages.cpp:233 ../../Firmware/ultralcd.cpp:1403
 msgid "Ambient"
 msgstr "Omgivande"
 
 #. MSG_CONFIRM_CARRIAGE_AT_THE_TOP c=20 r=3
-#: ../../Firmware/messages.cpp:267 ../../Firmware/ultralcd.cpp:2848
+#: ../../Firmware/messages.cpp:279 ../../Firmware/ultralcd.cpp:2865
 msgid "Are left and right Z-carriages all up?"
 msgstr "Är båda Z-vagnarna helt uppe?"
 
 #. MSG_SOUND_BLIND c=7
-#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4197
+#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:4221
 msgid "Assist"
 msgstr "Assist"
 
 #. MSG_AUTO c=6
-#: ../../Firmware/messages.cpp:179 ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/messages.cpp:186 ../../Firmware/ultralcd.cpp:5594
 msgid "Auto"
 msgstr "Auto"
 
 #. MSG_AUTO_HOME c=18
-#: ../../Firmware/Marlin_main.cpp:3198 ../../Firmware/messages.cpp:12
-#: ../../Firmware/ultralcd.cpp:4577 ../../Firmware/ultralcd.cpp:5529
+#: ../../Firmware/Marlin_main.cpp:2942 ../../Firmware/messages.cpp:12
+#: ../../Firmware/ultralcd.cpp:4533 ../../Firmware/ultralcd.cpp:5496
 msgid "Auto home"
 msgstr "Auto hem"
 
 #. MSG_AUTO_POWER c=10
-#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:4182
 msgid "Auto power"
 msgstr "Auto kraft"
 
 #. MSG_AUTOLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:328 ../../Firmware/ultralcd.cpp:5359
+#: ../../Firmware/messages.cpp:340 ../../Firmware/ultralcd.cpp:5328
 msgid "AutoLoad filament"
 msgstr "Autoladda filament"
 
 #. MSG_AUTOLOADING_ENABLED c=20 r=4
-#: ../../Firmware/messages.cpp:245 ../../Firmware/ultralcd.cpp:2272
+#: ../../Firmware/messages.cpp:257 ../../Firmware/ultralcd.cpp:2289
 msgid ""
 "Autoloading filament is active, just press the knob and insert filament..."
 msgstr ""
@@ -113,51 +113,50 @@ msgid "Avoiding grind"
 msgstr "Undviker slipning"
 
 #. MSG_SELFTEST_AXIS c=16
-#: ../../Firmware/messages.cpp:352 ../../Firmware/ultralcd.cpp:6752
+#: ../../Firmware/messages.cpp:364 ../../Firmware/ultralcd.cpp:6728
 msgid "Axis"
 msgstr "Axel"
 
 #. MSG_SELFTEST_AXIS_LENGTH c=20
-#: ../../Firmware/messages.cpp:351 ../../Firmware/ultralcd.cpp:6751
+#: ../../Firmware/messages.cpp:363 ../../Firmware/ultralcd.cpp:6727
 msgid "Axis length"
 msgstr "Axellängd"
 
 #. MSG_BACK c=18
-#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2708
-#: ../../Firmware/ultralcd.cpp:4037 ../../Firmware/ultralcd.cpp:5618
-#: ../../Firmware/ultralcd.cpp:7484
+#: ../../Firmware/messages.cpp:67 ../../Firmware/ultralcd.cpp:2725
+#: ../../Firmware/ultralcd.cpp:4061 ../../Firmware/ultralcd.cpp:5591
+#: ../../Firmware/ultralcd.cpp:7461
 msgid "Back"
 msgstr "Tillbaka"
 
 #. MSG_BED c=13
-#: ../../Firmware/Marlin_main.cpp:2081 ../../Firmware/Marlin_main.cpp:4627
-#: ../../Firmware/Marlin_main.cpp:4678 ../../Firmware/messages.cpp:15
-#: ../../Firmware/ultralcd.cpp:1391 ../../Firmware/ultralcd.cpp:4173
+#: ../../Firmware/Marlin_main.cpp:4247 ../../Firmware/messages.cpp:15
+#: ../../Firmware/ultralcd.cpp:1401 ../../Firmware/ultralcd.cpp:4197
 msgid "Bed"
 msgstr "Bädd"
 
 #. MSG_BED_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6240 ../../Firmware/messages.cpp:17
+#: ../../Firmware/Marlin_main.cpp:5470 ../../Firmware/messages.cpp:17
 #: ../../Firmware/ultralcd.cpp:534
 msgid "Bed Heating"
 msgstr "Bädden värms upp"
 
 #. MSG_BED_DONE c=20
-#: ../../Firmware/Marlin_main.cpp:6277 ../../Firmware/messages.cpp:16
+#: ../../Firmware/Marlin_main.cpp:5507 ../../Firmware/messages.cpp:16
 #: ../../Firmware/ultralcd.cpp:537
 msgid "Bed done"
 msgstr "Bädd klar"
 
 #. MSG_BED_CORRECTION_MENU c=18
-#: ../../Firmware/messages.cpp:317 ../../Firmware/ultralcd.cpp:4589
+#: ../../Firmware/messages.cpp:329 ../../Firmware/ultralcd.cpp:4545
 msgid "Bed level correct"
 msgstr "Bäddnivå korrekt"
 
 #. MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:2262 ../../Firmware/Marlin_main.cpp:2999
-#: ../../Firmware/Marlin_main.cpp:3008
-#: ../../Firmware/mesh_bed_calibration.cpp:2878
-#: ../../Firmware/mesh_bed_calibration.cpp:2903 ../../Firmware/messages.cpp:18
+#: ../../Firmware/Marlin_main.cpp:2048 ../../Firmware/Marlin_main.cpp:2736
+#: ../../Firmware/Marlin_main.cpp:2745
+#: ../../Firmware/mesh_bed_calibration.cpp:2863
+#: ../../Firmware/mesh_bed_calibration.cpp:2888 ../../Firmware/messages.cpp:18
 msgid ""
 "Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for "
 "reset."
@@ -166,34 +165,34 @@ msgstr ""
 " på återställning."
 
 #. MSG_SELFTEST_BEDHEATER c=20
-#: ../../Firmware/messages.cpp:346 ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/messages.cpp:358 ../../Firmware/ultralcd.cpp:6685
 msgid "Bed/Heater"
 msgstr "Bädd/Värmare"
 
 #. MSG_BELT_STATUS c=18
-#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1444
-#: ../../Firmware/ultralcd.cpp:1704
+#: ../../Firmware/messages.cpp:20 ../../Firmware/ultralcd.cpp:1454
+#: ../../Firmware/ultralcd.cpp:1714
 msgid "Belt status"
 msgstr "Bält status"
 
 #. MSG_BELTTEST c=18
-#: ../../Firmware/messages.cpp:314 ../../Firmware/ultralcd.cpp:4579
+#: ../../Firmware/messages.cpp:326 ../../Firmware/ultralcd.cpp:4535
 msgid "Belt test"
 msgstr "Bält test"
 
 #. MSG_RECOVER_PRINT c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:1660 ../../Firmware/messages.cpp:87
+#: ../../Firmware/Marlin_main.cpp:1587 ../../Firmware/messages.cpp:87
 msgid "Blackout occurred. Recover print?"
 msgstr "Blackout inträffat. Återställa utskr?"
 
 #. MSG_BRIGHT c=6
-#: ../../Firmware/messages.cpp:177 ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/messages.cpp:184 ../../Firmware/ultralcd.cpp:5594
 msgid "Bright"
 msgstr "Ljus"
 
 #. MSG_BRIGHTNESS c=18
-#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:4526
-#: ../../Firmware/ultralcd.cpp:5546
+#: ../../Firmware/messages.cpp:180 ../../Firmware/ultralcd.cpp:4493
+#: ../../Firmware/ultralcd.cpp:5513
 msgid "Brightness"
 msgstr "Ljusstyrka"
 
@@ -203,17 +202,17 @@ msgid "COMMUNICATION ERROR"
 msgstr "KOMMUNIKATIONSFEL"
 
 #. MSG_CALIBRATE_BED c=18
-#: ../../Firmware/messages.cpp:316 ../../Firmware/ultralcd.cpp:4583
+#: ../../Firmware/messages.cpp:328 ../../Firmware/ultralcd.cpp:4539
 msgid "Calibrate XYZ"
 msgstr "Kalibrera XYZ"
 
 #. MSG_HOMEYZ c=18
-#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4585
+#: ../../Firmware/messages.cpp:54 ../../Firmware/ultralcd.cpp:4541
 msgid "Calibrate Z"
 msgstr "Kalibrera Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP c=20 r=8
-#: ../../Firmware/messages.cpp:266 ../../Firmware/ultralcd.cpp:2813
+#: ../../Firmware/messages.cpp:278 ../../Firmware/ultralcd.cpp:2830
 msgid ""
 "Calibrating XYZ. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -222,13 +221,13 @@ msgstr ""
 "Klicka när du är klar."
 
 #. MSG_CALIBRATE_Z_AUTO c=20 r=2
-#: ../../Firmware/Marlin_main.cpp:2218 ../../Firmware/messages.cpp:22
+#: ../../Firmware/Marlin_main.cpp:2009 ../../Firmware/messages.cpp:23
 #: ../../Firmware/ultralcd.cpp:582
 msgid "Calibrating Z"
 msgstr "Kalibrerar Z"
 
 #. MSG_MOVE_CARRIAGE_TO_THE_TOP_Z c=20 r=8
-#: ../../Firmware/messages.cpp:265 ../../Firmware/ultralcd.cpp:2812
+#: ../../Firmware/messages.cpp:277 ../../Firmware/ultralcd.cpp:2829
 msgid ""
 "Calibrating Z. Rotate the knob to move the Z carriage up to the end "
 "stoppers. Click when done."
@@ -237,17 +236,17 @@ msgstr ""
 "Klicka när du är klar."
 
 #. MSG_CALIBRATING_HOME c=20
-#: ../../Firmware/messages.cpp:361 ../../Firmware/ultralcd.cpp:6985
+#: ../../Firmware/messages.cpp:373 ../../Firmware/ultralcd.cpp:6962
 msgid "Calibrating home"
 msgstr "Kalibrerar hem"
 
 #. MSG_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5375
+#: ../../Firmware/messages.cpp:71 ../../Firmware/ultralcd.cpp:5342
 msgid "Calibration"
 msgstr "Kalibrering"
 
 #. MSG_HOMEYZ_DONE c=20
-#: ../../Firmware/messages.cpp:217 ../../Firmware/ultralcd.cpp:593
+#: ../../Firmware/messages.cpp:229 ../../Firmware/ultralcd.cpp:593
 msgid "Calibration done"
 msgstr "Kalibraring utförd"
 
@@ -265,128 +264,128 @@ msgstr ""
 "Kan inte utföra åtgärden, filament är redan laddat. Ta bort det först."
 
 #. MSG_SD_REMOVED c=20
-#: ../../Firmware/messages.cpp:364 ../../Firmware/ultralcd.cpp:7405
+#: ../../Firmware/messages.cpp:376 ../../Firmware/ultralcd.cpp:7382
 msgid "Card removed"
 msgstr "Kort borttaget"
 
 #. MSG_CNG_SDCARD c=18
-#: ../../Firmware/messages.cpp:324 ../../Firmware/ultralcd.cpp:5316
+#: ../../Firmware/messages.cpp:336 ../../Firmware/ultralcd.cpp:5282
 msgid "Change SD card"
 msgstr "Byt ut SD-kort"
 
 #. MSG_FILAMENTCHANGE c=18
-#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5254
-#: ../../Firmware/ultralcd.cpp:5526
+#: ../../Firmware/messages.cpp:43 ../../Firmware/ultralcd.cpp:5216
+#: ../../Firmware/ultralcd.cpp:5493
 msgid "Change filament"
 msgstr "Ändra filament"
 
 #. MSG_CHANGE_SUCCESS c=20
-#: ../../Firmware/messages.cpp:240 ../../Firmware/ultralcd.cpp:2156
+#: ../../Firmware/messages.cpp:252 ../../Firmware/ultralcd.cpp:2167
 msgid "Change success!"
 msgstr "Ändring utförd!"
 
 #. MSG_CORRECTLY c=19
-#: ../../Firmware/messages.cpp:242 ../../Firmware/ultralcd.cpp:2203
+#: ../../Firmware/messages.cpp:254 ../../Firmware/ultralcd.cpp:2217
 msgid "Changed correctly"
 msgstr "Ändring korrekt"
 
 #. MSG_CHECKING_X c=20
-#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5951
-#: ../../Firmware/ultralcd.cpp:6975
+#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5927
+#: ../../Firmware/ultralcd.cpp:6952
 msgid "Checking X axis"
 msgstr "Kontroll X-axel"
 
 #. MSG_CHECKING_Y c=20
-#: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5961
-#: ../../Firmware/ultralcd.cpp:6976
+#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:5937
+#: ../../Firmware/ultralcd.cpp:6953
 msgid "Checking Y axis"
 msgstr "Kontroll Y-axel"
 
 #. MSG_SELFTEST_CHECK_Z c=20
-#: ../../Firmware/messages.cpp:358 ../../Firmware/ultralcd.cpp:6977
+#: ../../Firmware/messages.cpp:370 ../../Firmware/ultralcd.cpp:6954
 msgid "Checking Z axis"
 msgstr "Kontroll Z-axel"
 
 #. MSG_SELFTEST_CHECK_BED c=20
-#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6978
+#: ../../Firmware/messages.cpp:99 ../../Firmware/ultralcd.cpp:6955
 msgid "Checking bed"
 msgstr "Kontroll bädd"
 
 #. MSG_SELFTEST_CHECK_ENDSTOPS c=20
-#: ../../Firmware/messages.cpp:357 ../../Firmware/ultralcd.cpp:6974
+#: ../../Firmware/messages.cpp:369 ../../Firmware/ultralcd.cpp:6951
 msgid "Checking endstops"
 msgstr "Kontroll ändlägen"
 
 #. MSG_CHECKING_FILE c=17
-#: ../../Firmware/messages.cpp:362 ../../Firmware/ultralcd.cpp:7070
+#: ../../Firmware/messages.cpp:374 ../../Firmware/ultralcd.cpp:7047
 msgid "Checking file"
 msgstr "Kontrollerar fil"
 
 #. MSG_SELFTEST_CHECK_HOTEND c=20
-#: ../../Firmware/messages.cpp:359 ../../Firmware/ultralcd.cpp:6980
+#: ../../Firmware/messages.cpp:371 ../../Firmware/ultralcd.cpp:6957
 msgid "Checking hotend"
 msgstr "Kontroll hotend"
 
 #. MSG_SELFTEST_CHECK_FSENSOR c=20
-#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6981
-#: ../../Firmware/ultralcd.cpp:6982
+#: ../../Firmware/messages.cpp:100 ../../Firmware/ultralcd.cpp:6958
+#: ../../Firmware/ultralcd.cpp:6959
 msgid "Checking sensors"
 msgstr "Kontroll sensorer"
 
 #. MSG_CHECKS c=18
-#: ../../Firmware/messages.cpp:308 ../../Firmware/ultralcd.cpp:4424
+#: ../../Firmware/messages.cpp:320 ../../Firmware/ultralcd.cpp:4391
 msgid "Checks"
 msgstr "Kontroller"
 
 #. MSG_TM_ACK_ERROR c=18
-#: ../../Firmware/messages.cpp:190 ../../Firmware/ultralcd.cpp:5297
+#: ../../Firmware/messages.cpp:197 ../../Firmware/ultralcd.cpp:5263
 msgid "Clear TM error"
 msgstr "Rensa TM-fel"
 
 #. MSG_NOT_COLOR c=19
-#: ../../Firmware/messages.cpp:244 ../../Firmware/ultralcd.cpp:2205
+#: ../../Firmware/messages.cpp:256 ../../Firmware/ultralcd.cpp:2219
 msgid "Color not correct"
 msgstr "Färg ej korrekt"
 
 #. MSG_COMMUNITY_MADE c=18
-#: ../../Firmware/messages.cpp:26 ../../Firmware/ultralcd.cpp:3508
+#: ../../Firmware/messages.cpp:27 ../../Firmware/ultralcd.cpp:3518
 msgid "Community made"
 msgstr "Allmänhetsgjord"
 
 #. MSG_CONTINUE_SHORT c=5
-#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:4059
+#: ../../Firmware/messages.cpp:178 ../../Firmware/ultralcd.cpp:4083
 msgid "Cont."
 msgstr "Frts."
 
 #. MSG_COOLDOWN c=18
-#: ../../Firmware/messages.cpp:28 ../../Firmware/ultralcd.cpp:2129
+#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:2135
 msgid "Cooldown"
 msgstr "Kyla ner"
 
 #. MSG_COPY_SEL_LANG c=20 r=3
-#: ../../Firmware/messages.cpp:283 ../../Firmware/ultralcd.cpp:3450
+#: ../../Firmware/messages.cpp:295 ../../Firmware/ultralcd.cpp:3460
 msgid "Copy selected language?"
 msgstr "Kopiera det valda språket?"
 
 #. MSG_CRASH c=7
-#: ../../Firmware/messages.cpp:29 ../../Firmware/ultralcd.cpp:1234
-#: ../../Firmware/ultralcd.cpp:1263
+#: ../../Firmware/messages.cpp:30 ../../Firmware/ultralcd.cpp:1244
+#: ../../Firmware/ultralcd.cpp:1273
 msgid "Crash"
 msgstr "Krock"
 
 #. MSG_CRASHDETECT c=13
-#: ../../Firmware/messages.cpp:31 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4146
+#: ../../Firmware/messages.cpp:32 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/ultralcd.cpp:4170
 msgid "Crash det."
 msgstr "Krockdetekt."
 
 #. MSG_CRASH_DETECTED c=20
-#: ../../Firmware/Marlin_main.cpp:630 ../../Firmware/messages.cpp:30
+#: ../../Firmware/Marlin_main.cpp:595 ../../Firmware/messages.cpp:31
 msgid "Crash detected."
 msgstr "Krock upptäckt."
 
 #. MSG_CRASH_DET_ONLY_IN_NORMAL c=20 r=4
-#: ../../Firmware/messages.cpp:280 ../../Firmware/ultralcd.cpp:3374
+#: ../../Firmware/messages.cpp:292 ../../Firmware/ultralcd.cpp:3384
 msgid ""
 "Crash detection can\n"
 "be turned on only in\n"
@@ -397,24 +396,24 @@ msgstr ""
 "normalt läge"
 
 #. MSG_CUT_FILAMENT c=16
-#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:380
-#: ../../Firmware/ultralcd.cpp:4854 ../../Firmware/ultralcd.cpp:5351
+#: ../../Firmware/messages.cpp:65 ../../Firmware/mmu2_reporting.cpp:381
+#: ../../Firmware/ultralcd.cpp:4810 ../../Firmware/ultralcd.cpp:5317
 msgid "Cut filament"
 msgstr "Skär filament"
 
 #. MSG_CUTTER c=9
-#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:4081
-#: ../../Firmware/ultralcd.cpp:4086 ../../Firmware/ultralcd.cpp:4091
+#: ../../Firmware/messages.cpp:147 ../../Firmware/ultralcd.cpp:4105
+#: ../../Firmware/ultralcd.cpp:4110 ../../Firmware/ultralcd.cpp:4115
 msgid "Cutter"
 msgstr "Skärare"
 
 #. MSG_DATE c=17
-#: ../../Firmware/messages.cpp:222 ../../Firmware/ultralcd.cpp:1645
+#: ../../Firmware/messages.cpp:234 ../../Firmware/ultralcd.cpp:1655
 msgid "Date:"
 msgstr "Datum:"
 
 #. MSG_DIM c=6
-#: ../../Firmware/messages.cpp:178 ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/messages.cpp:185 ../../Firmware/ultralcd.cpp:5594
 msgid "Dim"
 msgstr "Dim"
 
@@ -424,7 +423,7 @@ msgid "Disable"
 msgstr "Inaktiv."
 
 #. MSG_DISABLE_STEPPERS c=18
-#: ../../Firmware/messages.cpp:311 ../../Firmware/ultralcd.cpp:4460
+#: ../../Firmware/messages.cpp:323 ../../Firmware/ultralcd.cpp:4427
 msgid "Disable steppers"
 msgstr "Inaktivera stepper"
 
@@ -436,7 +435,7 @@ msgid "Disengaging idler"
 msgstr "Kopplar ur Idler"
 
 #. MSG_BABYSTEP_Z_NOT_SET c=20 r=12
-#: ../../Firmware/Marlin_main.cpp:1610 ../../Firmware/Marlin_main.cpp:3334
+#: ../../Firmware/Marlin_main.cpp:1537 ../../Firmware/Marlin_main.cpp:3073
 #: ../../Firmware/messages.cpp:14
 msgid ""
 "Distance between tip of the nozzle and the bed surface has not been set yet."
@@ -447,7 +446,7 @@ msgstr ""
 "Vänligen följ manualen Första lagrets kalibrering."
 
 #. MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-#: ../../Firmware/messages.cpp:301 ../../Firmware/ultralcd.cpp:3923
+#: ../../Firmware/messages.cpp:313 ../../Firmware/ultralcd.cpp:3947
 msgid ""
 "Do you want to repeat last step to readjust distance between nozzle and "
 "heatbed?"
@@ -456,13 +455,13 @@ msgstr ""
 "bädden?"
 
 #. MSG_DONE c=8
-#: ../../Firmware/messages.cpp:32 ../../Firmware/mmu2/errors_list.h:367
-#: ../../Firmware/mmu2_reporting.cpp:456
+#: ../../Firmware/messages.cpp:33 ../../Firmware/mmu2/errors_list.h:367
+#: ../../Firmware/mmu2_reporting.cpp:457
 msgid "Done"
 msgstr "Klar"
 
 #. MSG_EXTRUDER_CORRECTION c=13
-#: ../../Firmware/messages.cpp:307 ../../Firmware/ultralcd.cpp:3990
+#: ../../Firmware/messages.cpp:319 ../../Firmware/ultralcd.cpp:4014
 msgid "E-correct"
 msgstr "E-korrektion"
 
@@ -491,13 +490,13 @@ msgid "ERR Wait for User"
 msgstr "FEL Inväntar anv"
 
 #. MSG_ERROR c=10
-#: ../../Firmware/messages.cpp:33 ../../Firmware/ultralcd.cpp:2253
+#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:2267
 msgid "ERROR:"
 msgstr "FEL:"
 
 #. MSG_EJECT_FROM_MMU c=16
-#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:384
-#: ../../Firmware/ultralcd.cpp:4845 ../../Firmware/ultralcd.cpp:5348
+#: ../../Firmware/messages.cpp:64 ../../Firmware/mmu2_reporting.cpp:385
+#: ../../Firmware/ultralcd.cpp:4801 ../../Firmware/ultralcd.cpp:5314
 msgid "Eject from MMU"
 msgstr "Utmat från MMU"
 
@@ -509,17 +508,17 @@ msgid "Ejecting filament"
 msgstr "Matar ut filament"
 
 #. MSG_SELFTEST_ENDSTOP c=16
-#: ../../Firmware/messages.cpp:348 ../../Firmware/ultralcd.cpp:6722
+#: ../../Firmware/messages.cpp:360 ../../Firmware/ultralcd.cpp:6698
 msgid "Endstop"
 msgstr "Ändläge"
 
 #. MSG_SELFTEST_ENDSTOP_NOTHIT c=20
-#: ../../Firmware/messages.cpp:349 ../../Firmware/ultralcd.cpp:6727
+#: ../../Firmware/messages.cpp:361 ../../Firmware/ultralcd.cpp:6703
 msgid "Endstop not hit"
 msgstr "Ändlage inte nått"
 
 #. MSG_SELFTEST_ENDSTOPS c=20
-#: ../../Firmware/messages.cpp:347 ../../Firmware/ultralcd.cpp:6713
+#: ../../Firmware/messages.cpp:359 ../../Firmware/ultralcd.cpp:6689
 msgid "Endstops"
 msgstr "Ändlägen"
 
@@ -531,30 +530,30 @@ msgid "Engaging idler"
 msgstr "Koppla in Idler"
 
 #. MSG_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:34 ../../Firmware/ultralcd.cpp:3352
+#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:3362
 msgid "Extruder"
 msgstr "Extruder"
 
 #. MSG_INFO_EXTRUDER c=18
-#: ../../Firmware/messages.cpp:227 ../../Firmware/ultralcd.cpp:1700
+#: ../../Firmware/messages.cpp:239 ../../Firmware/ultralcd.cpp:1710
 msgid "Extruder info"
 msgstr "Extruder info"
 
 #. MSG_FSENSOR_AUTOLOAD c=13
-#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4044
-#: ../../Firmware/ultralcd.cpp:4051
+#: ../../Firmware/messages.cpp:49 ../../Firmware/ultralcd.cpp:4068
+#: ../../Firmware/ultralcd.cpp:4075
 msgid "F. autoload"
 msgstr "F. autoladdn"
 
 #. MSG_FSENSOR_JAM_DETECTION c=13
-#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4046
-#: ../../Firmware/ultralcd.cpp:4053
+#: ../../Firmware/messages.cpp:50 ../../Firmware/ultralcd.cpp:4070
+#: ../../Firmware/ultralcd.cpp:4077
 msgid "F. jam detect"
 msgstr "F.stopp skett"
 
 #. MSG_FSENSOR_RUNOUT c=13
-#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:4050
+#: ../../Firmware/messages.cpp:48 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4074
 msgid "F. runout"
 msgstr "F. slut"
 
@@ -592,8 +591,8 @@ msgid "FINDA FILAM. STUCK"
 msgstr "FINDA FILAM. STOPP"
 
 #. MSG_FS_ACTION c=10
-#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:4059
-#: ../../Firmware/ultralcd.cpp:4062
+#: ../../Firmware/messages.cpp:177 ../../Firmware/ultralcd.cpp:4083
+#: ../../Firmware/ultralcd.cpp:4086
 msgid "FS Action"
 msgstr "FS aktion"
 
@@ -618,34 +617,34 @@ msgid "FW RUNTIME ERROR"
 msgstr "FW RUNTIME FEL"
 
 #. MSG_FAIL_STATS c=18
-#: ../../Firmware/messages.cpp:330 ../../Firmware/ultralcd.cpp:5382
+#: ../../Firmware/messages.cpp:342 ../../Firmware/ultralcd.cpp:5349
 msgid "Fail stats"
 msgstr "Felstatistik"
 
 #. MSG_MMU_FAIL_STATS c=18
-#: ../../Firmware/messages.cpp:331 ../../Firmware/ultralcd.cpp:5385
+#: ../../Firmware/messages.cpp:343 ../../Firmware/ultralcd.cpp:5352
 msgid "Fail stats MMU"
 msgstr "Felstatistik MMU"
 
 #. MSG_FALSE_TRIGGERING c=20
-#: ../../Firmware/messages.cpp:355 ../../Firmware/ultralcd.cpp:6768
+#: ../../Firmware/messages.cpp:367 ../../Firmware/ultralcd.cpp:6744
 msgid "False triggering"
 msgstr "Felaktig triggning"
 
 #. MSG_FAN_SPEED c=14
-#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4175
+#: ../../Firmware/messages.cpp:38 ../../Firmware/ultralcd.cpp:4199
 msgid "Fan speed"
 msgstr "Fläktfart"
 
 #. MSG_SELFTEST_FAN c=20
-#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6844
-#: ../../Firmware/ultralcd.cpp:6971 ../../Firmware/ultralcd.cpp:6972
-#: ../../Firmware/ultralcd.cpp:6973
+#: ../../Firmware/messages.cpp:96 ../../Firmware/ultralcd.cpp:6820
+#: ../../Firmware/ultralcd.cpp:6948 ../../Firmware/ultralcd.cpp:6949
+#: ../../Firmware/ultralcd.cpp:6950
 msgid "Fan test"
 msgstr "Fläkttest"
 
 #. MSG_FANS_CHECK c=13
-#: ../../Firmware/messages.cpp:35 ../../Firmware/ultralcd.cpp:4179
+#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:4203
 msgid "Fans check"
 msgstr "Fläktcheck"
 
@@ -674,34 +673,34 @@ msgid "Feeding to nozzle"
 msgstr "Matar till munstycke"
 
 #. MSG_FIL_RUNOUTS c=15
-#: ../../Firmware/messages.cpp:36 ../../Firmware/ultralcd.cpp:1233
-#: ../../Firmware/ultralcd.cpp:1262 ../../Firmware/ultralcd.cpp:1316
-#: ../../Firmware/ultralcd.cpp:1318
+#: ../../Firmware/messages.cpp:37 ../../Firmware/ultralcd.cpp:1243
+#: ../../Firmware/ultralcd.cpp:1272 ../../Firmware/ultralcd.cpp:1326
+#: ../../Firmware/ultralcd.cpp:1328
 msgid "Fil. runouts"
 msgstr "Fil. avbrott"
 
 #. MSG_FSENSOR c=12
-#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3313
-#: ../../Firmware/ultralcd.cpp:4039 ../../Firmware/ultralcd.cpp:4464
-#: ../../Firmware/ultralcd.cpp:5532
+#: ../../Firmware/messages.cpp:51 ../../Firmware/ultralcd.cpp:3323
+#: ../../Firmware/ultralcd.cpp:4063 ../../Firmware/ultralcd.cpp:4431
+#: ../../Firmware/ultralcd.cpp:5499
 msgid "Fil. sensor"
 msgstr "Fil. sensor"
 
 #. MSG_FILAMENT_CLEAN c=20 r=3
-#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2261
-#: ../../Firmware/ultralcd.cpp:2265
+#: ../../Firmware/messages.cpp:41 ../../Firmware/ultralcd.cpp:2275
+#: ../../Firmware/ultralcd.cpp:2279
 msgid "Filament extruding & with correct color?"
 msgstr "Extruderas filament med rätt färg?"
 
 #. MSG_NOT_LOADED c=19
-#: ../../Firmware/messages.cpp:243 ../../Firmware/ultralcd.cpp:2204
+#: ../../Firmware/messages.cpp:255 ../../Firmware/ultralcd.cpp:2218
 msgid "Filament not loaded"
 msgstr "Filament ej laddat"
 
 #. MSG_SELFTEST_FILAMENT_SENSOR c=17
-#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6763
-#: ../../Firmware/ultralcd.cpp:6767 ../../Firmware/ultralcd.cpp:6771
-#: ../../Firmware/ultralcd.cpp:7000
+#: ../../Firmware/messages.cpp:102 ../../Firmware/ultralcd.cpp:6739
+#: ../../Firmware/ultralcd.cpp:6743 ../../Firmware/ultralcd.cpp:6747
+#: ../../Firmware/ultralcd.cpp:6977
 msgid "Filament sensor"
 msgstr "Filament sensor"
 
@@ -733,42 +732,42 @@ msgstr ""
 "extruder.Kontrollera PFFE-slang och att sensorn läser korrekt."
 
 #. MSG_FILAMENT_USED c=19
-#: ../../Firmware/messages.cpp:246 ../../Firmware/ultralcd.cpp:2347
+#: ../../Firmware/messages.cpp:258 ../../Firmware/ultralcd.cpp:2364
 msgid "Filament used"
 msgstr "Använt filament"
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
-#: ../../Firmware/messages.cpp:363 ../../Firmware/ultralcd.cpp:7139
+#: ../../Firmware/messages.cpp:375 ../../Firmware/ultralcd.cpp:7116
 msgid "File incomplete. Continue anyway?"
 msgstr "Filen är ofullständig. Fortsätta ändå?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
 #: ../../Firmware/messages.cpp:45
 #: ../../Firmware/mmu2_progress_converter.cpp:43
-#: ../../Firmware/ultralcd.cpp:5021 ../../Firmware/ultralcd.cpp:5425
+#: ../../Firmware/ultralcd.cpp:4977 ../../Firmware/ultralcd.cpp:5392
 msgid "Finishing movements"
 msgstr "Avslutar flyttning"
 
 #. MSG_V2_CALIBRATION c=18
-#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:4575
-#: ../../Firmware/ultralcd.cpp:5141
+#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4531
+#: ../../Firmware/ultralcd.cpp:5101
 msgid "First layer cal."
 msgstr "Förstalager kalib."
 
 #. MSG_WIZARD_SELFTEST c=20 r=8
-#: ../../Firmware/messages.cpp:293 ../../Firmware/ultralcd.cpp:3846
+#: ../../Firmware/messages.cpp:305 ../../Firmware/ultralcd.cpp:3872
 msgid "First, I will run the selftest to check most common assembly problems."
 msgstr ""
 "Först kommer jag att utföra självtestet för att kontrollera de vanligaste "
 "monteringsproblemen."
 
 #. MSG_FLOW c=15
-#: ../../Firmware/messages.cpp:334 ../../Firmware/ultralcd.cpp:5520
+#: ../../Firmware/messages.cpp:346 ../../Firmware/ultralcd.cpp:5487
 msgid "Flow"
 msgstr "Flöde"
 
 #. MSG_NOZZLE_CNG_READ_HELP c=20 r=4
-#: ../../Firmware/messages.cpp:194 ../../Firmware/ultralcd.cpp:985
+#: ../../Firmware/messages.cpp:201 ../../Firmware/ultralcd.cpp:987
 msgid ""
 "For a Nozzle change please read\n"
 "prusa.io/nozzle-mk3s"
@@ -777,28 +776,28 @@ msgstr ""
 " prusa.io/nozzle-mk3s"
 
 #. MSG_SELFTEST_PART_FAN c=20
-#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6733
-#: ../../Firmware/ultralcd.cpp:6850 ../../Firmware/ultralcd.cpp:6855
+#: ../../Firmware/messages.cpp:93 ../../Firmware/ultralcd.cpp:6709
+#: ../../Firmware/ultralcd.cpp:6826 ../../Firmware/ultralcd.cpp:6831
 msgid "Front print fan?"
 msgstr "Frontfläkt?"
 
 #. MSG_BED_CORRECTION_FRONT c=14
-#: ../../Firmware/messages.cpp:260 ../../Firmware/ultralcd.cpp:2711
+#: ../../Firmware/messages.cpp:272 ../../Firmware/ultralcd.cpp:2728
 msgid "Front side[µm]"
 msgstr "Frontsida[µm]"
 
 #. MSG_SELFTEST_FANS c=20
-#: ../../Firmware/messages.cpp:353 ../../Firmware/ultralcd.cpp:6757
+#: ../../Firmware/messages.cpp:365 ../../Firmware/ultralcd.cpp:6733
 msgid "Front/left fans"
 msgstr "Front/vänster fläkt"
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:151 ../../Firmware/util.cpp:382
+#: ../../Firmware/messages.cpp:156 ../../Firmware/util.cpp:417
 msgid "G-code sliced for a different level. Continue?"
 msgstr "G-code genererad för en annan nivå. Fortsätta?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:152 ../../Firmware/util.cpp:383
+#: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:418
 msgid ""
 "G-code sliced for a different level. Please re-slice the model again. Print "
 "cancelled."
@@ -807,14 +806,14 @@ msgstr ""
 "Utskriften avbröts."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:147 ../../Firmware/util.cpp:312
-#: ../../Firmware/util.cpp:401
+#: ../../Firmware/messages.cpp:152 ../../Firmware/util.cpp:319
+#: ../../Firmware/util.cpp:436
 msgid "G-code sliced for a different printer type. Continue?"
 msgstr "G-code genererad för en annan skrivartyp. Fortsätta?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:148 ../../Firmware/util.cpp:313
-#: ../../Firmware/util.cpp:402
+#: ../../Firmware/messages.cpp:153 ../../Firmware/util.cpp:320
+#: ../../Firmware/util.cpp:437
 msgid ""
 "G-code sliced for a different printer type. Please re-slice the model again."
 " Print cancelled."
@@ -823,12 +822,12 @@ msgstr ""
 "igen. Utskriften avbröts."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:149 ../../Firmware/util.cpp:362
+#: ../../Firmware/messages.cpp:154 ../../Firmware/util.cpp:369
 msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "G-code genererad för en nyare firmware. Fortsätta?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:150 ../../Firmware/util.cpp:363
+#: ../../Firmware/messages.cpp:155 ../../Firmware/util.cpp:370
 msgid ""
 "G-code sliced for a newer firmware. Please update the firmware. Print "
 "cancelled."
@@ -837,35 +836,35 @@ msgstr ""
 "Utskriften avbröts."
 
 #. MSG_HW_SETUP c=18
-#: ../../Firmware/messages.cpp:115 ../../Firmware/ultralcd.cpp:4366
-#: ../../Firmware/ultralcd.cpp:4383 ../../Firmware/ultralcd.cpp:4485
+#: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4325
+#: ../../Firmware/ultralcd.cpp:4343 ../../Firmware/ultralcd.cpp:4452
 msgid "HW Setup"
 msgstr "HW inställning"
 
 #. MSG_SELFTEST_HEATERTHERMISTOR c=20
-#: ../../Firmware/messages.cpp:344 ../../Firmware/ultralcd.cpp:6705
+#: ../../Firmware/messages.cpp:356 ../../Firmware/ultralcd.cpp:6681
 msgid "Heater/Thermistor"
 msgstr "Värmare/Termistor"
 
 #. MSG_HEATING c=20
-#: ../../Firmware/Marlin_main.cpp:6184 ../../Firmware/messages.cpp:52
+#: ../../Firmware/Marlin_main.cpp:5416 ../../Firmware/messages.cpp:52
 #: ../../Firmware/ultralcd.cpp:526
 msgid "Heating"
 msgstr "Uppvärmning"
 
 #. MSG_BED_HEATING_SAFETY_DISABLED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:9647 ../../Firmware/messages.cpp:211
+#: ../../Firmware/Marlin_main.cpp:8807 ../../Firmware/messages.cpp:223
 msgid "Heating disabled by safety timer."
 msgstr "Uppvärmning avaktiverad av säkerhetstimer."
 
 #. MSG_HEATING_COMPLETE c=20
-#: ../../Firmware/Marlin_main.cpp:6215 ../../Firmware/messages.cpp:53
+#: ../../Firmware/Marlin_main.cpp:5445 ../../Firmware/messages.cpp:53
 #: ../../Firmware/ultralcd.cpp:529
 msgid "Heating done."
 msgstr "Uppvärmning klar."
 
 #. MSG_WIZARD_WELCOME_SHIPPING c=20 r=12
-#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:3806
+#: ../../Firmware/messages.cpp:141 ../../Firmware/ultralcd.cpp:3832
 msgid ""
 "Hi, I am your Original Prusa i3 printer. I will guide you through a short "
 "setup process, in which the Z-axis will be calibrated. Then, you will be "
@@ -876,7 +875,7 @@ msgstr ""
 "att skriva ut."
 
 #. MSG_WIZARD_WELCOME c=20 r=7
-#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:3810
+#: ../../Firmware/messages.cpp:140 ../../Firmware/ultralcd.cpp:3836
 msgid ""
 "Hi, I am your Original Prusa i3 printer. Would you like me to guide you "
 "through the setup process?"
@@ -885,8 +884,8 @@ msgstr ""
 "installationsprocessen?"
 
 #. MSG_HIGH_POWER c=10
-#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:4152
-#: ../../Firmware/ultralcd.cpp:4161
+#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:4176
+#: ../../Firmware/ultralcd.cpp:4185
 msgid "High power"
 msgstr "Hög kraft"
 
@@ -897,23 +896,23 @@ msgid "Homing"
 msgstr "Flyttar till hempos"
 
 #. MSG_NOZZLE_CNG_CHANGED c=20 r=6
-#: ../../Firmware/messages.cpp:195 ../../Firmware/ultralcd.cpp:1005
+#: ../../Firmware/messages.cpp:206 ../../Firmware/ultralcd.cpp:1011
 msgid "Hotend at 280C! Nozzle changed and tightened to specs?"
 msgstr "Hotend temperatur är 280C! Är munstycket bytt och spänt enligt specs?"
 
 #. MSG_HOTEND_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1106
-#: ../../Firmware/ultralcd.cpp:6991
+#: ../../Firmware/messages.cpp:39 ../../Firmware/ultralcd.cpp:1116
+#: ../../Firmware/ultralcd.cpp:6968
 msgid "Hotend fan:"
 msgstr "Hotend-fläkt:"
 
 #. MSG_WIZARD_XYZ_CAL c=20 r=8
-#: ../../Firmware/messages.cpp:294 ../../Firmware/ultralcd.cpp:3851
+#: ../../Firmware/messages.cpp:306 ../../Firmware/ultralcd.cpp:3877
 msgid "I will run xyz calibration now. It will take up to 24 mins."
 msgstr "Jag kommer att utföra en xyz-kalibrering nu. Det tar upp till 24 min."
 
 #. MSG_WIZARD_Z_CAL c=20 r=8
-#: ../../Firmware/messages.cpp:297 ../../Firmware/ultralcd.cpp:3862
+#: ../../Firmware/messages.cpp:309 ../../Firmware/ultralcd.cpp:3884
 msgid "I will run z calibration now."
 msgstr "Jag kommer att utföra z-kalibrering nu."
 
@@ -938,7 +937,7 @@ msgid "INVALID TOOL"
 msgstr "OGILTIGT VERKTYG"
 
 #. MSG_ADDITIONAL_SHEETS c=20 r=8
-#: ../../Firmware/messages.cpp:303 ../../Firmware/ultralcd.cpp:3931
+#: ../../Firmware/messages.cpp:315 ../../Firmware/ultralcd.cpp:3955
 msgid ""
 "If you have additional steel sheets, calibrate their presets in Settings - "
 "HW Setup - Steel sheets."
@@ -947,28 +946,28 @@ msgstr ""
 "Inställningar - HW inställning - Metallskiva."
 
 #. MSG_IMPROVE_BED_OFFSET_AND_SKEW_LINE1 c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2540
-#: ../../Firmware/messages.cpp:213
+#: ../../Firmware/mesh_bed_calibration.cpp:2525
+#: ../../Firmware/messages.cpp:225
 msgid "Improving bed calibration point"
 msgstr "Förbättrar bäddens kalibreringspunkt"
 
 #. MSG_INFO_SCREEN c=18
-#: ../../Firmware/messages.cpp:130 ../../Firmware/ultralcd.cpp:5222
+#: ../../Firmware/messages.cpp:135 ../../Firmware/ultralcd.cpp:5184
 msgid "Info screen"
 msgstr "Infoskärm"
 
 #. MSG_INIT_SDCARD c=18
-#: ../../Firmware/messages.cpp:326 ../../Firmware/ultralcd.cpp:5323
+#: ../../Firmware/messages.cpp:338 ../../Firmware/ultralcd.cpp:5289
 msgid "Init. SD card"
 msgstr "Init. SD-kort"
 
 #. MSG_INSERT_FILAMENT c=20
-#: ../../Firmware/messages.cpp:238 ../../Firmware/ultralcd.cpp:2142
+#: ../../Firmware/messages.cpp:250 ../../Firmware/ultralcd.cpp:2148
 msgid "Insert filament"
 msgstr "Sätt i filament"
 
 #. MSG_INSERT_FIL c=20 r=6
-#: ../../Firmware/messages.cpp:335 ../../Firmware/ultralcd.cpp:5998
+#: ../../Firmware/messages.cpp:347 ../../Firmware/ultralcd.cpp:5974
 msgid ""
 "Insert the filament (do not load it) into the extruder and then press the "
 "knob."
@@ -983,115 +982,115 @@ msgid ""
 msgstr "Internt körtidsfel. Prova återställa MMU eller uppdatera firmware."
 
 #. MSG_FILAMENT_LOADED c=20 r=3
-#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3628
-#: ../../Firmware/ultralcd.cpp:3890
+#: ../../Firmware/messages.cpp:42 ../../Firmware/ultralcd.cpp:3638
+#: ../../Firmware/ultralcd.cpp:3914
 msgid "Is filament loaded?"
 msgstr "Är filament laddat?"
 
 #. MSG_STEEL_SHEET_CHECK c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3238 ../../Firmware/Marlin_main.cpp:4745
-#: ../../Firmware/messages.cpp:123 ../../Firmware/ultralcd.cpp:3858
+#: ../../Firmware/Marlin_main.cpp:4314 ../../Firmware/messages.cpp:127
+#: ../../Firmware/ultralcd.cpp:3760
 msgid "Is steel sheet on heatbed?"
 msgstr "Ligger metallskiva på värmebädden?"
 
 #. MSG_ITERATION c=12
-#: ../../Firmware/mesh_bed_calibration.cpp:2265 ../../Firmware/messages.cpp:55
+#: ../../Firmware/mesh_bed_calibration.cpp:2250 ../../Firmware/messages.cpp:55
 msgid "Iteration"
 msgstr "Iteration"
 
 #. MSG_LAST_PRINT c=18
-#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1128
-#: ../../Firmware/ultralcd.cpp:1286
+#: ../../Firmware/messages.cpp:57 ../../Firmware/ultralcd.cpp:1138
+#: ../../Firmware/ultralcd.cpp:1296
 msgid "Last print"
 msgstr "Senaste utskrift"
 
 #. MSG_LAST_PRINT_FAILURES c=20
-#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1152
-#: ../../Firmware/ultralcd.cpp:1260 ../../Firmware/ultralcd.cpp:1315
+#: ../../Firmware/messages.cpp:58 ../../Firmware/ultralcd.cpp:1162
+#: ../../Firmware/ultralcd.cpp:1270 ../../Firmware/ultralcd.cpp:1325
 msgid "Last print failures"
 msgstr "Senaste utskriftsfel"
 
 #. MSG_LEFT c=10
-#: ../../Firmware/messages.cpp:251 ../../Firmware/ultralcd.cpp:2478
+#: ../../Firmware/messages.cpp:263 ../../Firmware/ultralcd.cpp:2495
 msgid "Left"
 msgstr "Vänster"
 
 #. MSG_SELFTEST_HOTEND_FAN c=20
-#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6739
-#: ../../Firmware/ultralcd.cpp:6850 ../../Firmware/ultralcd.cpp:6855
+#: ../../Firmware/messages.cpp:94 ../../Firmware/ultralcd.cpp:6715
+#: ../../Firmware/ultralcd.cpp:6826 ../../Firmware/ultralcd.cpp:6831
 msgid "Left hotend fan?"
 msgstr "Vänst hotend fläkt?"
 
 #. MSG_BED_CORRECTION_LEFT c=14
-#: ../../Firmware/messages.cpp:258 ../../Firmware/ultralcd.cpp:2709
+#: ../../Firmware/messages.cpp:270 ../../Firmware/ultralcd.cpp:2726
 msgid "Left side [µm]"
 msgstr "Vänstsida [µm]"
 
 #. MSG_BL_HIGH c=12
-#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:5619
+#: ../../Firmware/messages.cpp:181 ../../Firmware/ultralcd.cpp:5592
 msgid "Level Bright"
 msgstr "Ljusnivå"
 
 #. MSG_BL_LOW c=12
-#: ../../Firmware/messages.cpp:175 ../../Firmware/ultralcd.cpp:5620
+#: ../../Firmware/messages.cpp:182 ../../Firmware/ultralcd.cpp:5593
 msgid "Level Dimmed"
 msgstr "Nivå dämpad"
 
 #. MSG_LIN_CORRECTION c=18
-#: ../../Firmware/messages.cpp:312 ../../Firmware/ultralcd.cpp:4491
+#: ../../Firmware/messages.cpp:324 ../../Firmware/ultralcd.cpp:4458
 msgid "Lin. correction"
 msgstr "Linjär korrektion"
 
 #. MSG_BABYSTEP_Z c=18
-#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4501
-#: ../../Firmware/ultralcd.cpp:5251
+#: ../../Firmware/messages.cpp:13 ../../Firmware/ultralcd.cpp:4468
+#: ../../Firmware/ultralcd.cpp:5213
 msgid "Live adjust Z"
 msgstr "Live justera Z"
 
 #. MSG_LOAD_ALL c=18
-#: ../../Firmware/messages.cpp:192 ../../Firmware/ultralcd.cpp:4794
-#: ../../Firmware/ultralcd.cpp:4880
+#: ../../Firmware/messages.cpp:199 ../../Firmware/ultralcd.cpp:4750
+#: ../../Firmware/ultralcd.cpp:4836
 msgid "Load All"
 msgstr "Ladda alla"
 
 #. MSG_LOAD_FILAMENT c=16
-#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4796
-#: ../../Firmware/ultralcd.cpp:4833 ../../Firmware/ultralcd.cpp:4882
-#: ../../Firmware/ultralcd.cpp:5361 ../../Firmware/ultralcd.cpp:5368
+#: ../../Firmware/messages.cpp:60 ../../Firmware/ultralcd.cpp:4752
+#: ../../Firmware/ultralcd.cpp:4789 ../../Firmware/ultralcd.cpp:4838
+#: ../../Firmware/ultralcd.cpp:5324 ../../Firmware/ultralcd.cpp:5335
 msgid "Load filament"
 msgstr "Ladda filament"
 
 #. MSG_LOAD_TO_NOZZLE c=18
-#: ../../Firmware/messages.cpp:327 ../../Firmware/ultralcd.cpp:5346
+#: ../../Firmware/messages.cpp:339 ../../Firmware/ultralcd.cpp:5312
 msgid "Load to nozzle"
 msgstr "Ladd till munstyck"
 
 #. MSG_LOADING_TEST c=18
-#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4476
+#: ../../Firmware/messages.cpp:61 ../../Firmware/ultralcd.cpp:4443
 msgid "Loading Test"
 msgstr "Laddningstest"
 
 #. MSG_LOADING_COLOR c=20
-#: ../../Firmware/messages.cpp:241 ../../Firmware/ultralcd.cpp:2178
+#: ../../Firmware/messages.cpp:253 ../../Firmware/ultralcd.cpp:2189
 msgid "Loading color"
 msgstr "Laddar färg"
 
 #. MSG_LOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3598 ../../Firmware/messages.cpp:62
+#: ../../Firmware/Marlin_main.cpp:3343 ../../Firmware/messages.cpp:62
 #: ../../Firmware/mmu2_progress_converter.cpp:51
-#: ../../Firmware/mmu2_reporting.cpp:392 ../../Firmware/ultralcd.cpp:2189
-#: ../../Firmware/ultralcd.cpp:3715
+#: ../../Firmware/mmu2_reporting.cpp:393 ../../Firmware/ultralcd.cpp:2199
+#: ../../Firmware/ultralcd.cpp:3725
 msgid "Loading filament"
 msgstr "Laddar filament"
 
 #. MSG_LOOSE_PULLEY c=20
-#: ../../Firmware/messages.cpp:350 ../../Firmware/ultralcd.cpp:6745
+#: ../../Firmware/messages.cpp:362 ../../Firmware/ultralcd.cpp:6721
 msgid "Loose pulley"
 msgstr "Lös pulley"
 
 #. MSG_SOUND_LOUD c=7
-#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4188
-#: ../../Firmware/ultralcd.cpp:4200
+#: ../../Firmware/messages.cpp:170 ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4224
 msgid "Loud"
 msgstr "Högt"
 
@@ -1106,7 +1105,7 @@ msgid "MMU Firmware internal error, please reset the MMU."
 msgstr "MMU Firmware internt fel, vänligen återställ MMU."
 
 #. MSG_MMU_MODE c=8
-#: ../../Firmware/messages.cpp:156 ../../Firmware/ultralcd.cpp:4096
+#: ../../Firmware/messages.cpp:163 ../../Firmware/ultralcd.cpp:4120
 msgid "MMU Mode"
 msgstr "MMU-läge"
 
@@ -1116,7 +1115,7 @@ msgid "MMU NOT RESPONDING"
 msgstr "MMU SVARAR INTE"
 
 #. MSG_MMU_RESTORE_TEMP c=20 r=4
-#: ../../Firmware/messages.cpp:214 ../../Firmware/mmu2_reporting.cpp:396
+#: ../../Firmware/messages.cpp:226 ../../Firmware/mmu2_reporting.cpp:397
 msgid "MMU Retry: Restoring temperature..."
 msgstr "MMU försök igen: Återställer temperatur..."
 
@@ -1127,14 +1126,14 @@ msgid "MMU SELFTEST FAILED"
 msgstr "MMU SJÄLVTEST FELADE"
 
 #. MSG_MMU_FAILS c=15
-#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1153
-#: ../../Firmware/ultralcd.cpp:1178
+#: ../../Firmware/messages.cpp:72 ../../Firmware/ultralcd.cpp:1163
+#: ../../Firmware/ultralcd.cpp:1188
 msgid "MMU fails"
 msgstr "MMU felar"
 
 #. MSG_MMU_LOAD_FAILS c=15
-#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1154
-#: ../../Firmware/ultralcd.cpp:1179
+#: ../../Firmware/messages.cpp:73 ../../Firmware/ultralcd.cpp:1164
+#: ../../Firmware/ultralcd.cpp:1189
 msgid "MMU load fails"
 msgstr "MMU-laddn felar"
 
@@ -1149,66 +1148,64 @@ msgid "MMU not responding. Check the wiring and connectors."
 msgstr "MMU svarar inte. Kontrollera kablarna och kontakterna."
 
 #. MSG_MMU_CONNECTED c=18
-#: ../../Firmware/messages.cpp:223 ../../Firmware/ultralcd.cpp:1657
+#: ../../Firmware/messages.cpp:235 ../../Firmware/ultralcd.cpp:1667
 msgid "MMU connected"
 msgstr "MMU ansluten"
 
 #. MSG_MAGNETS_COMP c=13
-#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/messages.cpp:176 ../../Firmware/ultralcd.cpp:5567
 msgid "Magnets comp."
 msgstr "Magnets komp."
 
 #. MSG_MAIN c=18
-#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1127
-#: ../../Firmware/ultralcd.cpp:1285 ../../Firmware/ultralcd.cpp:1327
-#: ../../Firmware/ultralcd.cpp:1631 ../../Firmware/ultralcd.cpp:4453
-#: ../../Firmware/ultralcd.cpp:4571 ../../Firmware/ultralcd.cpp:4793
-#: ../../Firmware/ultralcd.cpp:4826 ../../Firmware/ultralcd.cpp:4879
-#: ../../Firmware/ultralcd.cpp:5515
+#: ../../Firmware/messages.cpp:66 ../../Firmware/ultralcd.cpp:1137
+#: ../../Firmware/ultralcd.cpp:1295 ../../Firmware/ultralcd.cpp:1337
+#: ../../Firmware/ultralcd.cpp:1641 ../../Firmware/ultralcd.cpp:4420
+#: ../../Firmware/ultralcd.cpp:4527 ../../Firmware/ultralcd.cpp:4749
+#: ../../Firmware/ultralcd.cpp:4782 ../../Firmware/ultralcd.cpp:4835
+#: ../../Firmware/ultralcd.cpp:5482
 msgid "Main"
 msgstr "Huvudmeny"
 
 #. MSG_MEASURED_SKEW c=14
-#: ../../Firmware/messages.cpp:253 ../../Firmware/ultralcd.cpp:2519
+#: ../../Firmware/messages.cpp:265 ../../Firmware/ultralcd.cpp:2536
 msgid "Measured skew"
 msgstr "Mätt skevhet"
 
 #. MSG_MEASURE_BED_REFERENCE_HEIGHT_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3219
-#: ../../Firmware/mesh_bed_calibration.cpp:2852 ../../Firmware/messages.cpp:70
+#: ../../Firmware/Marlin_main.cpp:2963
+#: ../../Firmware/mesh_bed_calibration.cpp:2837 ../../Firmware/messages.cpp:70
 msgid "Measuring reference height of calibration point"
 msgstr "Mätning av referenshöjd för kalibreringspunkt"
 
 #. MSG_MESH c=12
-#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:5590
+#: ../../Firmware/messages.cpp:173 ../../Firmware/ultralcd.cpp:5563
 msgid "Mesh"
 msgstr "Nätverk"
 
 #. MSG_MESH_BED_LEVELING c=18
-#: ../../Firmware/messages.cpp:167 ../../Firmware/ultralcd.cpp:4488
-#: ../../Firmware/ultralcd.cpp:4587
+#: ../../Firmware/messages.cpp:174 ../../Firmware/ultralcd.cpp:4455
+#: ../../Firmware/ultralcd.cpp:4543
 msgid "Mesh Bed Leveling"
 msgstr "Bäddytsjustering"
 
 #. MSG_MODE c=6
-#: ../../Firmware/Marlin_main.cpp:8495 ../../Firmware/messages.cpp:117
-#: ../../Firmware/ultralcd.cpp:4128 ../../Firmware/ultralcd.cpp:4132
-#: ../../Firmware/ultralcd.cpp:4140 ../../Firmware/ultralcd.cpp:4144
-#: ../../Firmware/ultralcd.cpp:4152 ../../Firmware/ultralcd.cpp:4155
-#: ../../Firmware/ultralcd.cpp:4158 ../../Firmware/ultralcd.cpp:4161
-#: ../../Firmware/ultralcd.cpp:5621
+#: ../../Firmware/Marlin_main.cpp:7666 ../../Firmware/messages.cpp:121
+#: ../../Firmware/ultralcd.cpp:4152 ../../Firmware/ultralcd.cpp:4156
+#: ../../Firmware/ultralcd.cpp:4164 ../../Firmware/ultralcd.cpp:4168
+#: ../../Firmware/ultralcd.cpp:4176 ../../Firmware/ultralcd.cpp:4179
+#: ../../Firmware/ultralcd.cpp:4182 ../../Firmware/ultralcd.cpp:4185
+#: ../../Firmware/ultralcd.cpp:5594
 msgid "Mode"
 msgstr "Mode"
 
 #. MSG_MODE_CHANGE_IN_PROGRESS c=20 r=3
-#: ../../Firmware/messages.cpp:282 ../../Firmware/ultralcd.cpp:3413
+#: ../../Firmware/messages.cpp:294 ../../Firmware/ultralcd.cpp:3423
 msgid "Mode change in progress..."
 msgstr "Lägesändring pågår..."
 
 #. MSG_MODEL c=8
-#: ../../Firmware/messages.cpp:146 ../../Firmware/ultralcd.cpp:4310
-#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4316
-#: ../../Firmware/ultralcd.cpp:4319
+#: ../../Firmware/messages.cpp:151 ../../Firmware/ultralcd.cpp:4327
 msgid "Model"
 msgstr "Modell"
 
@@ -1229,28 +1226,28 @@ msgid "More details online."
 msgstr "Mera detaljer online."
 
 #. MSG_SELFTEST_MOTOR c=18
-#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6719
-#: ../../Firmware/ultralcd.cpp:6728 ../../Firmware/ultralcd.cpp:6746
+#: ../../Firmware/messages.cpp:101 ../../Firmware/ultralcd.cpp:6695
+#: ../../Firmware/ultralcd.cpp:6704 ../../Firmware/ultralcd.cpp:6722
 msgid "Motor"
 msgstr "Motor"
 
 #. MSG_MOVE_X c=18
-#: ../../Firmware/messages.cpp:277 ../../Firmware/ultralcd.cpp:3349
+#: ../../Firmware/messages.cpp:289 ../../Firmware/ultralcd.cpp:3359
 msgid "Move X"
 msgstr "Flytta X"
 
 #. MSG_MOVE_Y c=18
-#: ../../Firmware/messages.cpp:278 ../../Firmware/ultralcd.cpp:3350
+#: ../../Firmware/messages.cpp:290 ../../Firmware/ultralcd.cpp:3360
 msgid "Move Y"
 msgstr "Flytta Y"
 
 #. MSG_MOVE_Z c=18
-#: ../../Firmware/messages.cpp:279 ../../Firmware/ultralcd.cpp:3351
+#: ../../Firmware/messages.cpp:291 ../../Firmware/ultralcd.cpp:3361
 msgid "Move Z"
 msgstr "Flytta Z"
 
 #. MSG_MOVE_AXIS c=18
-#: ../../Firmware/messages.cpp:310 ../../Firmware/ultralcd.cpp:4459
+#: ../../Firmware/messages.cpp:322 ../../Firmware/ultralcd.cpp:4426
 msgid "Move axis"
 msgstr "Flytta axlar"
 
@@ -1261,96 +1258,93 @@ msgid "Moving selector"
 msgstr "Flyttar väljare"
 
 #. MSG_NA c=3
-#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:141
-#: ../../Firmware/ultralcd.cpp:2484 ../../Firmware/ultralcd.cpp:2528
-#: ../../Firmware/ultralcd.cpp:3279 ../../Firmware/ultralcd.cpp:4043
-#: ../../Firmware/ultralcd.cpp:4044 ../../Firmware/ultralcd.cpp:4046
-#: ../../Firmware/ultralcd.cpp:5594
+#: ../../Firmware/menu.cpp:174 ../../Firmware/messages.cpp:146
+#: ../../Firmware/ultralcd.cpp:2501 ../../Firmware/ultralcd.cpp:2545
+#: ../../Firmware/ultralcd.cpp:3289 ../../Firmware/ultralcd.cpp:4067
+#: ../../Firmware/ultralcd.cpp:4068 ../../Firmware/ultralcd.cpp:4070
+#: ../../Firmware/ultralcd.cpp:5567
 msgid "N/A"
 msgstr "N/A"
 
 #. MSG_NEW_FIRMWARE_AVAILABLE c=20 r=2
-#: ../../Firmware/messages.cpp:365 ../../Firmware/util.cpp:209
+#: ../../Firmware/messages.cpp:377 ../../Firmware/util.cpp:214
 msgid "New firmware version available:"
 msgstr "Ny firmware vers tillgänglig:"
 
 #. MSG_NO c=4
-#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:3029
-#: ../../Firmware/ultralcd.cpp:4443 ../../Firmware/ultralcd.cpp:4531
-#: ../../Firmware/ultralcd.cpp:5789
+#: ../../Firmware/messages.cpp:75 ../../Firmware/ultralcd.cpp:2275
+#: ../../Firmware/ultralcd.cpp:2279 ../../Firmware/ultralcd.cpp:3046
+#: ../../Firmware/ultralcd.cpp:4410 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/ultralcd.cpp:5765
 msgid "No"
 msgstr "Nej"
 
 #. MSG_NO_CARD c=18
-#: ../../Firmware/messages.cpp:325 ../../Firmware/ultralcd.cpp:5321
+#: ../../Firmware/messages.cpp:337 ../../Firmware/ultralcd.cpp:5287
 msgid "No SD card"
 msgstr "Inget SD-kort"
 
 #. MSG_NO_MOVE c=20
-#: ../../Firmware/Marlin_main.cpp:5271 ../../Firmware/messages.cpp:210
+#: ../../Firmware/Marlin_main.cpp:4778 ../../Firmware/messages.cpp:222
 msgid "No move."
 msgstr "Ingen rörelse."
 
 #. MSG_NONE c=8
-#: ../../Firmware/messages.cpp:143 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4239 ../../Firmware/ultralcd.cpp:4310
-#: ../../Firmware/ultralcd.cpp:4319 ../../Firmware/ultralcd.cpp:4349
-#: ../../Firmware/ultralcd.cpp:4358 ../../Firmware/ultralcd.cpp:4516
+#: ../../Firmware/messages.cpp:148 ../../Firmware/ultralcd.cpp:4309
+#: ../../Firmware/ultralcd.cpp:4318 ../../Firmware/ultralcd.cpp:4483
 msgid "None"
 msgstr "Ingen"
 
 #. MSG_NORMAL c=7
-#: ../../Firmware/Marlin_main.cpp:8497 ../../Firmware/messages.cpp:121
-#: ../../Firmware/ultralcd.cpp:4096 ../../Firmware/ultralcd.cpp:4132
-#: ../../Firmware/ultralcd.cpp:4511
+#: ../../Firmware/Marlin_main.cpp:7668 ../../Firmware/messages.cpp:125
+#: ../../Firmware/ultralcd.cpp:4120 ../../Firmware/ultralcd.cpp:4156
+#: ../../Firmware/ultralcd.cpp:4478
 msgid "Normal"
 msgstr "Normal"
 
 #. MSG_SELFTEST_NOTCONNECTED c=20
-#: ../../Firmware/messages.cpp:345 ../../Firmware/ultralcd.cpp:6706
+#: ../../Firmware/messages.cpp:357 ../../Firmware/ultralcd.cpp:6682
 msgid "Not connected"
 msgstr "Inte ansluten"
 
 #. MSG_SELFTEST_FAN_NO c=19
-#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6863
+#: ../../Firmware/messages.cpp:97 ../../Firmware/ultralcd.cpp:6839
 msgid "Not spinning"
 msgstr "Roterar inte"
 
 #. MSG_WIZARD_V2_CAL c=20 r=8
-#: ../../Firmware/messages.cpp:289 ../../Firmware/ultralcd.cpp:3726
+#: ../../Firmware/messages.cpp:301 ../../Firmware/ultralcd.cpp:3736
 msgid ""
 "Now I will calibrate distance between tip of the nozzle and heatbed surface."
 msgstr ""
 "Nu ska jag kalibrera avståndet mellan munstyckets spets och värmebäddsytan."
 
 #. MSG_WIZARD_WILL_PREHEAT c=20 r=4
-#: ../../Firmware/messages.cpp:298 ../../Firmware/ultralcd.cpp:3871
+#: ../../Firmware/messages.cpp:310 ../../Firmware/ultralcd.cpp:3894
 msgid "Now I will preheat nozzle for PLA."
 msgstr "Nu ska jag förvärma munstycket för PLA."
 
 #. MSG_REMOVE_TEST_PRINT c=20 r=4
-#: ../../Firmware/messages.cpp:296 ../../Firmware/ultralcd.cpp:3857
+#: ../../Firmware/messages.cpp:308 ../../Firmware/ultralcd.cpp:3883
 msgid "Now remove the test print from steel sheet."
 msgstr "Ta nu bort testutskriften från metallskivan."
 
 #. MSG_NOZZLE c=10
-#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1390
-#: ../../Firmware/ultralcd.cpp:4170 ../../Firmware/ultralcd.cpp:4230
-#: ../../Firmware/ultralcd.cpp:4233 ../../Firmware/ultralcd.cpp:4236
-#: ../../Firmware/ultralcd.cpp:4239
+#: ../../Firmware/messages.cpp:76 ../../Firmware/ultralcd.cpp:1400
+#: ../../Firmware/ultralcd.cpp:4194 ../../Firmware/ultralcd.cpp:4326
 msgid "Nozzle"
 msgstr "Munstycke"
 
 #. MSG_NOZZLE_CNG_MENU c=18
-#: ../../Firmware/messages.cpp:193 ../../Firmware/ultralcd.cpp:4423
-#: ../../Firmware/ultralcd.cpp:4486
+#: ../../Firmware/messages.cpp:200 ../../Firmware/ultralcd.cpp:4390
+#: ../../Firmware/ultralcd.cpp:4453
 msgid "Nozzle change"
 msgstr "Munstycksbyte"
 
 #. MSG_NOZZLE_DIAMETER c=10
-#: ../../Firmware/messages.cpp:155 ../../Firmware/ultralcd.cpp:4276
-#: ../../Firmware/ultralcd.cpp:4278 ../../Firmware/ultralcd.cpp:4279
-#: ../../Firmware/ultralcd.cpp:4280
+#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4261
+#: ../../Firmware/ultralcd.cpp:4263 ../../Firmware/ultralcd.cpp:4264
+#: ../../Firmware/ultralcd.cpp:4265
 msgid "Nozzle d."
 msgstr "Munst dia."
 
@@ -1361,82 +1355,82 @@ msgid "OK"
 msgstr "OK"
 
 #. MSG_OFF c=3
-#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:139
-#: ../../Firmware/mmu2.cpp:65 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4050 ../../Firmware/ultralcd.cpp:4051
-#: ../../Firmware/ultralcd.cpp:4053 ../../Firmware/ultralcd.cpp:4076
-#: ../../Firmware/ultralcd.cpp:4091 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4179 ../../Firmware/ultralcd.cpp:4467
-#: ../../Firmware/ultralcd.cpp:4495 ../../Firmware/ultralcd.cpp:4498
-#: ../../Firmware/ultralcd.cpp:5439 ../../Firmware/ultralcd.cpp:5594
-#: ../../Firmware/ultralcd.cpp:7487 ../../Firmware/ultralcd.cpp:7491
+#: ../../Firmware/SpoolJoin.cpp:25 ../../Firmware/messages.cpp:144
+#: ../../Firmware/mmu2.cpp:65 ../../Firmware/ultralcd.cpp:4063
+#: ../../Firmware/ultralcd.cpp:4074 ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4077 ../../Firmware/ultralcd.cpp:4100
+#: ../../Firmware/ultralcd.cpp:4115 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/ultralcd.cpp:4203 ../../Firmware/ultralcd.cpp:4434
+#: ../../Firmware/ultralcd.cpp:4462 ../../Firmware/ultralcd.cpp:4465
+#: ../../Firmware/ultralcd.cpp:5406 ../../Firmware/ultralcd.cpp:5567
+#: ../../Firmware/ultralcd.cpp:7464 ../../Firmware/ultralcd.cpp:7468
 msgid "Off"
 msgstr "Av"
 
 #. MSG_DEFAULT_SETTINGS_LOADED c=20 r=6
-#: ../../Firmware/Marlin_main.cpp:1562 ../../Firmware/messages.cpp:201
+#: ../../Firmware/Marlin_main.cpp:1489 ../../Firmware/messages.cpp:213
 msgid "Old settings found. Default PID, Esteps etc. will be set."
 msgstr ""
 "Gamla inställningar funna. Standard PID, Esteps etc. kommer att ställas in."
 
 #. MSG_ON c=3
-#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:140
-#: ../../Firmware/mmu2.cpp:63 ../../Firmware/ultralcd.cpp:4039
-#: ../../Firmware/ultralcd.cpp:4050 ../../Firmware/ultralcd.cpp:4051
-#: ../../Firmware/ultralcd.cpp:4053 ../../Firmware/ultralcd.cpp:4076
-#: ../../Firmware/ultralcd.cpp:4081 ../../Firmware/ultralcd.cpp:4134
-#: ../../Firmware/ultralcd.cpp:4179 ../../Firmware/ultralcd.cpp:4467
-#: ../../Firmware/ultralcd.cpp:4495 ../../Firmware/ultralcd.cpp:4498
-#: ../../Firmware/ultralcd.cpp:5594 ../../Firmware/ultralcd.cpp:7487
-#: ../../Firmware/ultralcd.cpp:7491
+#: ../../Firmware/SpoolJoin.cpp:23 ../../Firmware/messages.cpp:145
+#: ../../Firmware/mmu2.cpp:63 ../../Firmware/ultralcd.cpp:4063
+#: ../../Firmware/ultralcd.cpp:4074 ../../Firmware/ultralcd.cpp:4075
+#: ../../Firmware/ultralcd.cpp:4077 ../../Firmware/ultralcd.cpp:4100
+#: ../../Firmware/ultralcd.cpp:4105 ../../Firmware/ultralcd.cpp:4158
+#: ../../Firmware/ultralcd.cpp:4203 ../../Firmware/ultralcd.cpp:4434
+#: ../../Firmware/ultralcd.cpp:4462 ../../Firmware/ultralcd.cpp:4465
+#: ../../Firmware/ultralcd.cpp:5567 ../../Firmware/ultralcd.cpp:7464
+#: ../../Firmware/ultralcd.cpp:7468
 msgid "On"
 msgstr "På"
 
 #. MSG_SOUND_ONCE c=7
-#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4191
+#: ../../Firmware/messages.cpp:171 ../../Firmware/ultralcd.cpp:4215
 msgid "Once"
 msgstr "En gång"
 
 #. MSG_PAUSED_THERMAL_ERROR c=20
-#: ../../Firmware/Marlin_main.cpp:9861 ../../Firmware/messages.cpp:186
+#: ../../Firmware/Marlin_main.cpp:9021 ../../Firmware/messages.cpp:193
 msgid "PAUSED THERMAL ERROR"
 msgstr "PAUSAT TERMISKT FEL"
 
 #. MSG_PID_RUNNING c=20
-#: ../../Firmware/messages.cpp:219 ../../Firmware/ultralcd.cpp:897
+#: ../../Firmware/messages.cpp:231 ../../Firmware/ultralcd.cpp:897
 msgid "PID cal."
 msgstr "PID kalibrering."
 
 #. MSG_PID_FINISHED c=20
-#: ../../Firmware/messages.cpp:220 ../../Firmware/ultralcd.cpp:902
+#: ../../Firmware/messages.cpp:232 ../../Firmware/ultralcd.cpp:902
 msgid "PID cal. finished"
 msgstr "PID kalibrering klar"
 
 #. MSG_PID_EXTRUDER c=17
-#: ../../Firmware/messages.cpp:318 ../../Firmware/ultralcd.cpp:4590
+#: ../../Firmware/messages.cpp:330 ../../Firmware/ultralcd.cpp:4546
 msgid "PID calibration"
 msgstr "PID kalibrering"
 
 #. MSG_PINDA_PREHEAT c=20
-#: ../../Firmware/messages.cpp:218 ../../Firmware/ultralcd.cpp:610
+#: ../../Firmware/messages.cpp:230 ../../Firmware/ultralcd.cpp:610
 msgid "PINDA Heating"
 msgstr "PINDA uppvärmning"
 
 #. MSG_PINDA_CALIBRATION c=13
-#: ../../Firmware/Marlin_main.cpp:4790 ../../Firmware/Marlin_main.cpp:4892
-#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:607
-#: ../../Firmware/ultralcd.cpp:4495 ../../Firmware/ultralcd.cpp:4597
+#: ../../Firmware/Marlin_main.cpp:4359 ../../Firmware/Marlin_main.cpp:4461
+#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:607
+#: ../../Firmware/ultralcd.cpp:4462 ../../Firmware/ultralcd.cpp:4553
 msgid "PINDA cal."
 msgstr "PINDA kal."
 
 #. MSG_PINDA_CAL_FAILED c=20 r=4
-#: ../../Firmware/messages.cpp:276 ../../Firmware/ultralcd.cpp:3233
+#: ../../Firmware/messages.cpp:288 ../../Firmware/ultralcd.cpp:3243
 msgid "PINDA calibration failed"
 msgstr "PINDA-kalibrering misslyckades"
 
 #. MSG_PINDA_CALIBRATION_DONE c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:4967 ../../Firmware/messages.cpp:127
-#: ../../Firmware/ultralcd.cpp:3230
+#: ../../Firmware/Marlin_main.cpp:4536 ../../Firmware/messages.cpp:132
+#: ../../Firmware/ultralcd.cpp:3240
 msgid ""
 "PINDA calibration is finished and active. It can be disabled in menu "
 "Settings->PINDA cal."
@@ -1456,13 +1450,13 @@ msgid "Parking selector"
 msgstr "Parkerar väljare"
 
 #. MSG_PAUSE c=5
-#: ../../Firmware/messages.cpp:172 ../../Firmware/ultralcd.cpp:4062
+#: ../../Firmware/messages.cpp:179 ../../Firmware/ultralcd.cpp:4086
 msgid "Pause"
 msgstr "Paus"
 
 #. MSG_PAUSE_PRINT c=18
-#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5271
-#: ../../Firmware/ultralcd.cpp:5273
+#: ../../Firmware/messages.cpp:78 ../../Firmware/ultralcd.cpp:5237
+#: ../../Firmware/ultralcd.cpp:5239
 msgid "Pause print"
 msgstr "Pausa utskrift"
 
@@ -1473,7 +1467,7 @@ msgid "Performing cut"
 msgstr "Utför skärning"
 
 #. MSG_PAPER c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3243 ../../Firmware/messages.cpp:77
+#: ../../Firmware/Marlin_main.cpp:2982 ../../Firmware/messages.cpp:77
 msgid ""
 "Place a sheet of paper under the nozzle during the calibration of first 4 "
 "points. If the nozzle catches the paper, power off the printer immediately."
@@ -1482,7 +1476,7 @@ msgstr ""
 "punkterna. Om munstycket fångar papperet, stäng av omedelbart."
 
 #. MSG_WIZARD_CALIBRATION_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:131 ../../Firmware/ultralcd.cpp:3963
+#: ../../Firmware/messages.cpp:136 ../../Firmware/ultralcd.cpp:3987
 msgid ""
 "Please check our handbook and fix the problem. Then resume the Wizard by "
 "rebooting the printer."
@@ -1491,27 +1485,27 @@ msgstr ""
 "starta om skrivaren."
 
 #. MSG_CHECK_IR_CONNECTION c=20 r=4
-#: ../../Firmware/messages.cpp:337 ../../Firmware/ultralcd.cpp:6023
+#: ../../Firmware/messages.cpp:349 ../../Firmware/ultralcd.cpp:5999
 msgid "Please check the IR sensor connection, unload filament if present."
 msgstr "Kontrollera IR-sensorns anslutning, mata ut eventuellt filament."
 
 #. MSG_SELFTEST_PLEASECHECK c=20
-#: ../../Firmware/messages.cpp:343 ../../Firmware/ultralcd.cpp:6700
+#: ../../Firmware/messages.cpp:355 ../../Firmware/ultralcd.cpp:6676
 msgid "Please check:"
 msgstr "Kontrollera:"
 
 #. MSG_WIZARD_CLEAN_HEATBED c=20 r=8
-#: ../../Firmware/messages.cpp:302 ../../Firmware/ultralcd.cpp:3926
+#: ../../Firmware/messages.cpp:314 ../../Firmware/ultralcd.cpp:3950
 msgid "Please clean heatbed and then press the knob."
 msgstr "Rengör bädden och tryck sedan på knappen."
 
 #. MSG_CONFIRM_NOZZLE_CLEAN c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:3217 ../../Firmware/messages.cpp:27
+#: ../../Firmware/Marlin_main.cpp:2960 ../../Firmware/messages.cpp:28
 msgid "Please clean the nozzle for calibration. Click when done."
 msgstr "Rengör munstycket för kalibrering. Klicka när du är klar."
 
 #. MSG_WIZARD_LOAD_FILAMENT c=20 r=6
-#: ../../Firmware/messages.cpp:288 ../../Firmware/ultralcd.cpp:3712
+#: ../../Firmware/messages.cpp:300 ../../Firmware/ultralcd.cpp:3722
 msgid ""
 "Please insert filament into the extruder, then press the knob to load it."
 msgstr ""
@@ -1519,7 +1513,7 @@ msgstr ""
 "inladdning.."
 
 #. MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
-#: ../../Firmware/messages.cpp:287 ../../Firmware/ultralcd.cpp:3705
+#: ../../Firmware/messages.cpp:299 ../../Firmware/ultralcd.cpp:3715
 msgid ""
 "Please insert filament into the first tube of the MMU, then press the knob "
 "to load it."
@@ -1528,104 +1522,103 @@ msgstr ""
 "knappen för inladdning."
 
 #. MSG_PLEASE_LOAD_PLA c=20 r=4
-#: ../../Firmware/messages.cpp:285 ../../Firmware/ultralcd.cpp:3633
+#: ../../Firmware/messages.cpp:297 ../../Firmware/ultralcd.cpp:3643
 msgid "Please load filament first."
 msgstr "Vänligen ladda filament först."
 
 #. MSG_CHECK_IDLER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3525 ../../Firmware/messages.cpp:206
+#: ../../Firmware/Marlin_main.cpp:3265 ../../Firmware/messages.cpp:218
 msgid "Please open idler and remove filament manually."
 msgstr "Öppna idler och ta bort filamentet manuellt."
 
 #. MSG_PLACE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/mesh_bed_calibration.cpp:2806 ../../Firmware/messages.cpp:80
-#: ../../Firmware/ultralcd.cpp:3860
+#: ../../Firmware/mesh_bed_calibration.cpp:2791 ../../Firmware/messages.cpp:80
 msgid "Please place steel sheet on heatbed."
 msgstr "Placera metallskiva på värmebädden."
 
 #. MSG_PRESS_TO_UNLOAD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:11215 ../../Firmware/Marlin_main.cpp:11245
+#: ../../Firmware/Marlin_main.cpp:10287 ../../Firmware/Marlin_main.cpp:10317
 #: ../../Firmware/messages.cpp:84
 msgid "Please press the knob to unload filament"
 msgstr "Vänligen tryck på knappen för att mata ut filament"
 
 #. MSG_PULL_OUT_FILAMENT c=20 r=4
-#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:4932
+#: ../../Firmware/messages.cpp:86 ../../Firmware/ultralcd.cpp:4888
 msgid "Please pull out filament immediately"
 msgstr "Vänligen ta ut filamentet omedelbart"
 
 #. MSG_REMOVE_SHIPPING_HELPERS c=20 r=3
-#: ../../Firmware/messages.cpp:295 ../../Firmware/ultralcd.cpp:3856
+#: ../../Firmware/messages.cpp:307 ../../Firmware/ultralcd.cpp:3882
 msgid "Please remove shipping helpers first."
 msgstr "Vänligen ta bort fraktinsatserna först."
 
 #. MSG_REMOVE_STEEL_SHEET c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3240 ../../Firmware/Marlin_main.cpp:4755
-#: ../../Firmware/messages.cpp:89
+#: ../../Firmware/Marlin_main.cpp:4324 ../../Firmware/messages.cpp:89
 msgid "Please remove steel sheet from heatbed."
 msgstr "Ta bort metallskivan från värmebädden."
 
 #. MSG_RUN_XYZ c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4731 ../../Firmware/messages.cpp:207
+#: ../../Firmware/Marlin_main.cpp:4300 ../../Firmware/messages.cpp:219
 msgid "Please run XYZ calibration first."
 msgstr "Utför XYZ-kalibrering först."
 
 #. MSG_UNLOAD_FILAMENT_REPEAT c=20 r=4
-#: ../../Firmware/messages.cpp:336 ../../Firmware/ultralcd.cpp:6020
+#: ../../Firmware/messages.cpp:348 ../../Firmware/ultralcd.cpp:4359
+#: ../../Firmware/ultralcd.cpp:5996
 msgid "Please unload the filament first, then repeat this action."
 msgstr "Vänligen mata ut filamentet först och upprepa sedan denna åtgärd."
 
 #. MSG_NEW_FIRMWARE_PLEASE_UPGRADE c=20
-#: ../../Firmware/messages.cpp:366 ../../Firmware/util.cpp:213
+#: ../../Firmware/messages.cpp:378 ../../Firmware/util.cpp:218
 msgid "Please upgrade."
 msgstr "Vänligen uppgradera."
 
 #. MSG_PLEASE_WAIT c=20
-#: ../../Firmware/Marlin_main.cpp:3521 ../../Firmware/Marlin_main.cpp:8090
-#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:2179
-#: ../../Firmware/ultralcd.cpp:2190
+#: ../../Firmware/Marlin_main.cpp:3261 ../../Firmware/Marlin_main.cpp:7262
+#: ../../Firmware/messages.cpp:81 ../../Firmware/ultralcd.cpp:2190
+#: ../../Firmware/ultralcd.cpp:2204
 msgid "Please wait"
 msgstr "Vänligen vänta"
 
 #. MSG_POWER_FAILURES c=15
-#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:1232
-#: ../../Firmware/ultralcd.cpp:1261
+#: ../../Firmware/messages.cpp:82 ../../Firmware/ultralcd.cpp:1242
+#: ../../Firmware/ultralcd.cpp:1271
 msgid "Power failures"
 msgstr "Strömavbrott"
 
 #. MSG_PREHEAT c=18
-#: ../../Firmware/messages.cpp:323 ../../Firmware/ultralcd.cpp:5260
+#: ../../Firmware/messages.cpp:335 ../../Firmware/ultralcd.cpp:5222
 msgid "Preheat"
 msgstr "Förvärm"
 
 #. MSG_PREHEAT_NOZZLE c=20
-#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:2254
+#: ../../Firmware/messages.cpp:83 ../../Firmware/ultralcd.cpp:2268
 msgid "Preheat the nozzle!"
 msgstr "Förvärm munstycket!"
 
 #. MSG_WIZARD_HEATING c=20 r=3
-#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:2771
-#: ../../Firmware/ultralcd.cpp:3690 ../../Firmware/ultralcd.cpp:3692
+#: ../../Firmware/messages.cpp:138 ../../Firmware/ultralcd.cpp:2788
+#: ../../Firmware/ultralcd.cpp:3700 ../../Firmware/ultralcd.cpp:3702
 msgid "Preheating nozzle. Please wait."
 msgstr "Förvärmer munstycke. Vänta."
 
 #. MSG_PREHEATING_TO_CUT c=20
-#: ../../Firmware/messages.cpp:237 ../../Firmware/ultralcd.cpp:1999
+#: ../../Firmware/messages.cpp:249 ../../Firmware/ultralcd.cpp:2005
 msgid "Preheating to cut"
 msgstr "Förvärmer för skära"
 
 #. MSG_PREHEATING_TO_EJECT c=20
-#: ../../Firmware/messages.cpp:236 ../../Firmware/ultralcd.cpp:1996
+#: ../../Firmware/messages.cpp:248 ../../Firmware/ultralcd.cpp:2002
 msgid "Preheating to eject"
 msgstr "Förvämer för utmatn"
 
 #. MSG_PREHEATING_TO_LOAD c=20
-#: ../../Firmware/messages.cpp:234 ../../Firmware/ultralcd.cpp:1987
+#: ../../Firmware/messages.cpp:246 ../../Firmware/ultralcd.cpp:1995
 msgid "Preheating to load"
 msgstr "Förvärmer för laddn"
 
 #. MSG_PREHEATING_TO_UNLOAD c=20
-#: ../../Firmware/messages.cpp:235 ../../Firmware/ultralcd.cpp:1992
+#: ../../Firmware/messages.cpp:247 ../../Firmware/ultralcd.cpp:1999
 msgid "Preheating to unload"
 msgstr "Förvärmer for utmatn"
 
@@ -1636,12 +1629,12 @@ msgid "Preparing blade"
 msgstr "Förbereder blad"
 
 #. MSG_PRESS_KNOB c=20
-#: ../../Firmware/messages.cpp:231 ../../Firmware/ultralcd.cpp:1799
+#: ../../Firmware/messages.cpp:243 ../../Firmware/ultralcd.cpp:1809
 msgid "Press the knob"
 msgstr "Tryck på knappen"
 
 #. MSG_PRESS_TO_PREHEAT c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:11227 ../../Firmware/messages.cpp:212
+#: ../../Firmware/Marlin_main.cpp:10299 ../../Firmware/messages.cpp:224
 msgid "Press the knob to preheat nozzle and continue."
 msgstr "Tryck på knappen för att förvärma munstycket och fortsätta."
 
@@ -1651,34 +1644,34 @@ msgid "Print aborted"
 msgstr "Utskriften avbröts"
 
 #. MSG_PRINT_FAN_SPEED c=15
-#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1106
-#: ../../Firmware/ultralcd.cpp:6994
+#: ../../Firmware/messages.cpp:40 ../../Firmware/ultralcd.cpp:1116
+#: ../../Firmware/ultralcd.cpp:6971
 msgid "Print fan:"
 msgstr "Utskriftsfläkt:"
 
 #. MSG_CARD_MENU c=18
-#: ../../Firmware/messages.cpp:23 ../../Firmware/ultralcd.cpp:5313
+#: ../../Firmware/messages.cpp:24 ../../Firmware/ultralcd.cpp:5279
 msgid "Print from SD"
 msgstr "Skriv ut från SD"
 
 #. MSG_PRINT_PAUSED c=20
-#: ../../Firmware/Marlin_main.cpp:3582 ../../Firmware/messages.cpp:79
+#: ../../Firmware/Marlin_main.cpp:3323 ../../Firmware/messages.cpp:79
 #: ../../Firmware/ultralcd.cpp:814
 msgid "Print paused"
 msgstr "Utskriften pausad"
 
 #. MSG_PRINT_TIME c=19
-#: ../../Firmware/messages.cpp:247 ../../Firmware/ultralcd.cpp:2348
+#: ../../Firmware/messages.cpp:259 ../../Firmware/ultralcd.cpp:2365
 msgid "Print time"
 msgstr "Utskriftstid"
 
 #. MSG_PRINTER_IP c=18
-#: ../../Firmware/messages.cpp:225 ../../Firmware/ultralcd.cpp:1689
+#: ../../Firmware/messages.cpp:237 ../../Firmware/ultralcd.cpp:1699
 msgid "Printer IP Addr:"
 msgstr "Skrivarens IP adr:"
 
 #. MSG_FOLLOW_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1602 ../../Firmware/messages.cpp:46
+#: ../../Firmware/Marlin_main.cpp:1529 ../../Firmware/messages.cpp:46
 msgid ""
 "Printer has not been calibrated yet. Please follow the manual, chapter First"
 " steps, section Calibration flow."
@@ -1687,12 +1680,12 @@ msgstr ""
 "stegen, avsnitt Kalibreringsflöde."
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:153 ../../Firmware/util.cpp:289
+#: ../../Firmware/messages.cpp:160 ../../Firmware/util.cpp:296
 msgid "Nozzle diameter differs from the G-code. Continue?"
 msgstr "Munstycksdiametern skiljer sig från G-codeen. Fortsätta?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:154 ../../Firmware/util.cpp:290
+#: ../../Firmware/messages.cpp:161 ../../Firmware/util.cpp:297
 msgid ""
 "Nozzle diameter differs from the G-code. Please check the value in settings."
 " Print cancelled."
@@ -1719,22 +1712,22 @@ msgid "QUEUE FULL"
 msgstr "KÖ FULL"
 
 #. MSG_RPI_PORT c=13
-#: ../../Firmware/messages.cpp:161 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:4465
 msgid "RPi port"
 msgstr "RPi port"
 
 #. MSG_BED_CORRECTION_REAR c=14
-#: ../../Firmware/messages.cpp:261 ../../Firmware/ultralcd.cpp:2712
+#: ../../Firmware/messages.cpp:273 ../../Firmware/ultralcd.cpp:2729
 msgid "Rear side [µm]"
 msgstr "Baksida [µm]"
 
 #. MSG_RECOVERING_PRINT c=20
-#: ../../Firmware/messages.cpp:216 ../../Firmware/power_panic.cpp:316
+#: ../../Firmware/messages.cpp:228 ../../Firmware/power_panic.cpp:328
 msgid "Recovering print"
 msgstr "Återställer utskrift"
 
 #. MSG_RENAME c=18
-#: ../../Firmware/messages.cpp:322 ../../Firmware/ultralcd.cpp:5143
+#: ../../Firmware/messages.cpp:334 ../../Firmware/ultralcd.cpp:5103
 msgid "Rename"
 msgstr "Döp om"
 
@@ -1748,19 +1741,19 @@ msgstr ""
 "G-codeen för verktygsindex utanför intervallet (T0-T4)."
 
 #. MSG_RESET c=14
-#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:2713
-#: ../../Firmware/ultralcd.cpp:5144
+#: ../../Firmware/messages.cpp:90 ../../Firmware/ultralcd.cpp:2730
+#: ../../Firmware/ultralcd.cpp:5104
 msgid "Reset"
 msgstr "Återställ"
 
 #. MSG_CALIBRATE_BED_RESET c=18
-#: ../../Firmware/messages.cpp:320 ../../Firmware/ultralcd.cpp:4594
+#: ../../Firmware/messages.cpp:332 ../../Firmware/ultralcd.cpp:4550
 msgid "Reset XYZ calibr."
 msgstr "Återställ XYZ-kal."
 
 #. MSG_RESUME_PRINT c=18
-#: ../../Firmware/Marlin_main.cpp:680 ../../Firmware/messages.cpp:91
-#: ../../Firmware/ultralcd.cpp:5286 ../../Firmware/ultralcd.cpp:5288
+#: ../../Firmware/Marlin_main.cpp:645 ../../Firmware/messages.cpp:91
+#: ../../Firmware/ultralcd.cpp:5252 ../../Firmware/ultralcd.cpp:5254
 msgid "Resume print"
 msgstr "Återuppta utskrift"
 
@@ -1787,17 +1780,17 @@ msgid "Returning selector"
 msgstr "Återvändande väljare"
 
 #. MSG_RIGHT c=10
-#: ../../Firmware/messages.cpp:252 ../../Firmware/ultralcd.cpp:2479
+#: ../../Firmware/messages.cpp:264 ../../Firmware/ultralcd.cpp:2496
 msgid "Right"
 msgstr "Höger"
 
 #. MSG_BED_CORRECTION_RIGHT c=14
-#: ../../Firmware/messages.cpp:259 ../../Firmware/ultralcd.cpp:2710
+#: ../../Firmware/messages.cpp:271 ../../Firmware/ultralcd.cpp:2727
 msgid "Right side[µm]"
 msgstr "Höger sida[µm]"
 
 #. MSG_WIZARD_RERUN c=20 r=7
-#: ../../Firmware/messages.cpp:286 ../../Firmware/ultralcd.cpp:3656
+#: ../../Firmware/messages.cpp:298 ../../Firmware/ultralcd.cpp:3666
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
 "beginning. Continue?"
@@ -1806,8 +1799,8 @@ msgstr ""
 "börja om från början. Fortsätta?"
 
 #. MSG_SD_CARD c=8
-#: ../../Firmware/messages.cpp:157 ../../Firmware/ultralcd.cpp:4509
-#: ../../Firmware/ultralcd.cpp:4511
+#: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4476
+#: ../../Firmware/ultralcd.cpp:4478
 msgid "SD card"
 msgstr "SD-kort"
 
@@ -1822,23 +1815,23 @@ msgid "SELECTOR CANNOT MOVE"
 msgstr "VÄLJARE FASTNAT"
 
 #. MSG_STOPPED c=20
-#: ../../Firmware/Marlin_main.cpp:9887 ../../Firmware/messages.cpp:125
+#: ../../Firmware/Marlin_main.cpp:9047 ../../Firmware/messages.cpp:130
 msgid "STOPPED."
 msgstr "STOPPAD."
 
 #. MSG_FIND_BED_OFFSET_AND_SKEW_LINE1 c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3223 ../../Firmware/Marlin_main.cpp:3245
-#: ../../Firmware/mesh_bed_calibration.cpp:2246 ../../Firmware/messages.cpp:44
+#: ../../Firmware/Marlin_main.cpp:2967 ../../Firmware/Marlin_main.cpp:2984
+#: ../../Firmware/mesh_bed_calibration.cpp:2231 ../../Firmware/messages.cpp:44
 msgid "Searching bed calibration point"
 msgstr "Söker efter kalibreringspunkt för bädden"
 
 #. MSG_SELECT c=18
-#: ../../Firmware/messages.cpp:321 ../../Firmware/ultralcd.cpp:5136
+#: ../../Firmware/messages.cpp:333 ../../Firmware/ultralcd.cpp:5096
 msgid "Select"
 msgstr "Välj"
 
 #. MSG_SELECT_FIL_1ST_LAYERCAL c=20 r=7
-#: ../../Firmware/messages.cpp:290 ../../Firmware/ultralcd.cpp:3730
+#: ../../Firmware/messages.cpp:302 ../../Firmware/ultralcd.cpp:3740
 msgid ""
 "Select a filament for the First Layer Calibration and select it in the on-"
 "screen menu."
@@ -1846,25 +1839,25 @@ msgstr ""
 "Välj ett filament för första lagrets kalibrering och välj det i skärmmenyn."
 
 #. MSG_SELECT_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3453 ../../Firmware/Tcodes.cpp:34
-#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3612
-#: ../../Firmware/ultralcd.cpp:6822
+#: ../../Firmware/Marlin_main.cpp:3192 ../../Firmware/Tcodes.cpp:34
+#: ../../Firmware/messages.cpp:56 ../../Firmware/ultralcd.cpp:3622
+#: ../../Firmware/ultralcd.cpp:6798
 msgid "Select filament:"
 msgstr "Välj filament:"
 
 #. MSG_SELECT_LANGUAGE c=18
-#: ../../Firmware/messages.cpp:110 ../../Firmware/ultralcd.cpp:3464
-#: ../../Firmware/ultralcd.cpp:4504
+#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:3474
+#: ../../Firmware/ultralcd.cpp:4471
 msgid "Select language"
 msgstr "Välj språk"
 
 #. MSG_SEL_PREHEAT_TEMP c=20 r=6
-#: ../../Firmware/messages.cpp:300 ../../Firmware/ultralcd.cpp:3900
+#: ../../Firmware/messages.cpp:312 ../../Firmware/ultralcd.cpp:3924
 msgid "Select nozzle preheat temperature which matches your material."
 msgstr "Välj munstycksförvärmningstemperatur som passar ditt material."
 
 #. MSG_SELECT_TEMP_MATCHES_MATERIAL c=20 r=4
-#: ../../Firmware/messages.cpp:291 ../../Firmware/ultralcd.cpp:3735
+#: ../../Firmware/messages.cpp:303 ../../Firmware/ultralcd.cpp:3745
 msgid "Select temperature which matches your material."
 msgstr "Välj temperatur som passar ditt material."
 
@@ -1875,62 +1868,62 @@ msgid "Selecting fil. slot"
 msgstr "Välj fil. spår"
 
 #. MSG_SELFTEST_OK c=20
-#: ../../Firmware/messages.cpp:341 ../../Firmware/ultralcd.cpp:6274
+#: ../../Firmware/messages.cpp:353 ../../Firmware/ultralcd.cpp:6250
 msgid "Selftest OK"
 msgstr "Självtest OK"
 
 #. MSG_SELFTEST_START c=20
-#: ../../Firmware/messages.cpp:340 ../../Firmware/ultralcd.cpp:6057
+#: ../../Firmware/messages.cpp:352 ../../Firmware/ultralcd.cpp:6033
 msgid "Selftest start"
 msgstr "Självteststart"
 
 #. MSG_SELFTEST c=18
-#: ../../Firmware/messages.cpp:315 ../../Firmware/ultralcd.cpp:4581
+#: ../../Firmware/messages.cpp:327 ../../Firmware/ultralcd.cpp:4537
 msgid "Selftest"
 msgstr "Självtest"
 
 #. MSG_SELFTEST_ERROR c=20
-#: ../../Firmware/messages.cpp:342 ../../Firmware/ultralcd.cpp:6699
+#: ../../Firmware/messages.cpp:354 ../../Firmware/ultralcd.cpp:6675
 msgid "Selftest error!"
 msgstr "Självtestfel!"
 
 #. MSG_SELFTEST_FAILED c=20
-#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6279
-#: ../../Firmware/ultralcd.cpp:6786 ../../Firmware/ultralcd.cpp:6984
+#: ../../Firmware/messages.cpp:95 ../../Firmware/ultralcd.cpp:6255
+#: ../../Firmware/ultralcd.cpp:6762 ../../Firmware/ultralcd.cpp:6961
 msgid "Selftest failed"
 msgstr "Självtestet felade"
 
 #. MSG_FORCE_SELFTEST c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1577 ../../Firmware/messages.cpp:202
+#: ../../Firmware/Marlin_main.cpp:1504 ../../Firmware/messages.cpp:214
 msgid "Selftest will be run to calibrate accurate sensorless rehoming."
 msgstr ""
 "Självtest kommer att utföras för att kalibrera exakt sensorlös hemposition."
 
 #. MSG_INFO_SENSORS c=18
-#: ../../Firmware/messages.cpp:228 ../../Firmware/ultralcd.cpp:1701
+#: ../../Firmware/messages.cpp:240 ../../Firmware/ultralcd.cpp:1711
 msgid "Sensor info"
 msgstr "Sensorinfo"
 
 #. MSG_FS_VERIFIED c=20 r=3
-#: ../../Firmware/messages.cpp:338 ../../Firmware/ultralcd.cpp:6027
+#: ../../Firmware/messages.cpp:350 ../../Firmware/ultralcd.cpp:6003
 msgid "Sensor verified, remove the filament now."
 msgstr "Sensor verifierad, ta bort filamentet nu."
 
 #. MSG_SET_TEMPERATURE c=20
-#: ../../Firmware/messages.cpp:262 ../../Firmware/ultralcd.cpp:2730
+#: ../../Firmware/messages.cpp:274 ../../Firmware/ultralcd.cpp:2747
 msgid "Set temperature:"
 msgstr "Sätt temperatur:"
 
 #. MSG_SETTINGS c=18
-#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3348
-#: ../../Firmware/ultralcd.cpp:3479 ../../Firmware/ultralcd.cpp:3984
-#: ../../Firmware/ultralcd.cpp:5374 ../../Firmware/ultralcd.cpp:5585
-#: ../../Firmware/ultralcd.cpp:5631
+#: ../../Firmware/messages.cpp:104 ../../Firmware/ultralcd.cpp:3358
+#: ../../Firmware/ultralcd.cpp:3489 ../../Firmware/ultralcd.cpp:4008
+#: ../../Firmware/ultralcd.cpp:5341 ../../Firmware/ultralcd.cpp:5558
+#: ../../Firmware/ultralcd.cpp:5604
 msgid "Settings"
 msgstr "Inställningar"
 
 #. MSG_SEVERE_SKEW c=14
-#: ../../Firmware/messages.cpp:255 ../../Firmware/ultralcd.cpp:2522
+#: ../../Firmware/messages.cpp:267 ../../Firmware/ultralcd.cpp:2539
 msgid "Severe skew"
 msgstr "Hög skevhet"
 
@@ -1941,7 +1934,7 @@ msgid "Sheet"
 msgstr "Skiva"
 
 #. MSG_SHEET_OFFSET c=20 r=4
-#: ../../Firmware/messages.cpp:284 ../../Firmware/ultralcd.cpp:3604
+#: ../../Firmware/messages.cpp:296 ../../Firmware/ultralcd.cpp:3614
 msgid ""
 "Sheet %.7s\n"
 "Z offset: %+1.3fmm\n"
@@ -1954,23 +1947,23 @@ msgstr ""
 "%cÅterställ"
 
 #. MSG_SHOW_END_STOPS c=18
-#: ../../Firmware/messages.cpp:319 ../../Firmware/ultralcd.cpp:4592
+#: ../../Firmware/messages.cpp:331 ../../Firmware/ultralcd.cpp:4548
 msgid "Show end stops"
 msgstr "Visa ändlägen"
 
 #. MSG_SILENT c=7
-#: ../../Firmware/Marlin_main.cpp:8497 ../../Firmware/messages.cpp:120
-#: ../../Firmware/ultralcd.cpp:4155 ../../Firmware/ultralcd.cpp:4194
+#: ../../Firmware/Marlin_main.cpp:7668 ../../Firmware/messages.cpp:124
+#: ../../Firmware/ultralcd.cpp:4179 ../../Firmware/ultralcd.cpp:4218
 msgid "Silent"
 msgstr "Tyst"
 
 #. MSG_SLIGHT_SKEW c=14
-#: ../../Firmware/messages.cpp:254 ../../Firmware/ultralcd.cpp:2521
+#: ../../Firmware/messages.cpp:266 ../../Firmware/ultralcd.cpp:2538
 msgid "Slight skew"
 msgstr "Låg skevhet"
 
 #. MSG_FILE_CNT c=20 r=6
-#: ../../Firmware/cardreader.cpp:805 ../../Firmware/messages.cpp:197
+#: ../../Firmware/cardreader.cpp:805 ../../Firmware/messages.cpp:209
 msgid ""
 "Some files will not be sorted. Max. No. of files in 1 folder for sorting is "
 "100."
@@ -1979,58 +1972,58 @@ msgstr ""
 "sortering är 100."
 
 #. MSG_ZLEVELING_ENFORCED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3043 ../../Firmware/messages.cpp:204
+#: ../../Firmware/Marlin_main.cpp:2783 ../../Firmware/messages.cpp:216
 msgid "Some problem encountered, Z-leveling enforced ..."
 msgstr "Ett problem har uppstått, Z-nivellering utförs..."
 
 #. MSG_SORT c=7
-#: ../../Firmware/messages.cpp:158 ../../Firmware/ultralcd.cpp:4514
-#: ../../Firmware/ultralcd.cpp:4515 ../../Firmware/ultralcd.cpp:4516
+#: ../../Firmware/messages.cpp:165 ../../Firmware/ultralcd.cpp:4481
+#: ../../Firmware/ultralcd.cpp:4482 ../../Firmware/ultralcd.cpp:4483
 msgid "Sort"
 msgstr "Sortera"
 
 #. MSG_SORTING_FILES c=20
 #: ../../Firmware/cardreader.cpp:849 ../../Firmware/cardreader.cpp:916
-#: ../../Firmware/messages.cpp:111
+#: ../../Firmware/messages.cpp:115
 msgid "Sorting files"
 msgstr "Sorterar filer"
 
 #. MSG_SOUND c=9
-#: ../../Firmware/messages.cpp:162 ../../Firmware/ultralcd.cpp:4188
-#: ../../Firmware/ultralcd.cpp:4191 ../../Firmware/ultralcd.cpp:4194
-#: ../../Firmware/ultralcd.cpp:4197 ../../Firmware/ultralcd.cpp:4200
+#: ../../Firmware/messages.cpp:169 ../../Firmware/ultralcd.cpp:4212
+#: ../../Firmware/ultralcd.cpp:4215 ../../Firmware/ultralcd.cpp:4218
+#: ../../Firmware/ultralcd.cpp:4221 ../../Firmware/ultralcd.cpp:4224
 msgid "Sound"
 msgstr "Ljud"
 
 #. MSG_SPEED c=15
-#: ../../Firmware/messages.cpp:333 ../../Firmware/ultralcd.cpp:5516
+#: ../../Firmware/messages.cpp:345 ../../Firmware/ultralcd.cpp:5483
 msgid "Speed"
 msgstr "Fart"
 
 #. MSG_SELFTEST_FAN_YES c=19
-#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6861
+#: ../../Firmware/messages.cpp:98 ../../Firmware/ultralcd.cpp:6837
 msgid "Spinning"
 msgstr "Rotation"
 
 #. MSG_TEMP_CAL_WARNING c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:4744 ../../Firmware/messages.cpp:208
+#: ../../Firmware/Marlin_main.cpp:4313 ../../Firmware/messages.cpp:220
 msgid "Stable ambient temperature 21-26C is needed a rigid stand is required."
 msgstr "Stabil omgivningstemperatur 21-26C krävs samt ett styvt stativ."
 
 #. MSG_STATISTICS c=18
-#: ../../Firmware/messages.cpp:329 ../../Firmware/ultralcd.cpp:5379
+#: ../../Firmware/messages.cpp:341 ../../Firmware/ultralcd.cpp:5346
 msgid "Statistics"
 msgstr "Statistik"
 
 #. MSG_STEALTH c=7
-#: ../../Firmware/messages.cpp:122 ../../Firmware/ultralcd.cpp:4096
-#: ../../Firmware/ultralcd.cpp:4144
+#: ../../Firmware/messages.cpp:126 ../../Firmware/ultralcd.cpp:4120
+#: ../../Firmware/ultralcd.cpp:4168
 msgid "Stealth"
 msgstr "Tyst"
 
 #. MSG_STEEL_SHEETS c=18
-#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4421
-#: ../../Firmware/ultralcd.cpp:5133
+#: ../../Firmware/messages.cpp:69 ../../Firmware/ultralcd.cpp:4388
+#: ../../Firmware/ultralcd.cpp:5093
 msgid "Steel sheets"
 msgstr "Metallskivor"
 
@@ -2040,29 +2033,28 @@ msgid "Stop"
 msgstr "Stopp"
 
 #. MSG_STOP_PRINT c=18
-#: ../../Firmware/messages.cpp:124 ../../Firmware/ultralcd.cpp:5293
-#: ../../Firmware/ultralcd.cpp:5781
+#: ../../Firmware/messages.cpp:129 ../../Firmware/ultralcd.cpp:5259
+#: ../../Firmware/ultralcd.cpp:5757
 msgid "Stop print"
 msgstr "Stoppa utskriften"
 
 #. MSG_STRICT c=8
-#: ../../Firmware/messages.cpp:145 ../../Firmware/ultralcd.cpp:4236
-#: ../../Firmware/ultralcd.cpp:4316 ../../Firmware/ultralcd.cpp:4355
+#: ../../Firmware/messages.cpp:150 ../../Firmware/ultralcd.cpp:4315
 msgid "Strict"
 msgstr "Strikt"
 
 #. MSG_SUPPORT c=18
-#: ../../Firmware/messages.cpp:332 ../../Firmware/ultralcd.cpp:5394
+#: ../../Firmware/messages.cpp:344 ../../Firmware/ultralcd.cpp:5361
 msgid "Support"
 msgstr "Support"
 
 #. MSG_SELFTEST_SWAPPED c=16
-#: ../../Firmware/messages.cpp:354 ../../Firmware/ultralcd.cpp:6758
+#: ../../Firmware/messages.cpp:366 ../../Firmware/ultralcd.cpp:6734
 msgid "Swapped"
 msgstr "Utbytt"
 
 #. MSG_THERMAL_ANOMALY c=20
-#: ../../Firmware/messages.cpp:188 ../../Firmware/temperature.cpp:2223
+#: ../../Firmware/messages.cpp:195 ../../Firmware/temperature.cpp:2197
 msgid "THERMAL ANOMALY"
 msgstr "TERMISK ANOMALI"
 
@@ -2097,7 +2089,7 @@ msgid "TMC UNDERVOLTAGE ERR"
 msgstr "TMC UNDERSPÄNNINGFEL"
 
 #. MSG_TM_CAL c=20 r=4
-#: ../../Firmware/messages.cpp:299 ../../Firmware/ultralcd.cpp:3881
+#: ../../Firmware/messages.cpp:311 ../../Firmware/ultralcd.cpp:3905
 msgid ""
 "Thermal model cal. takes approx. 12 mins. See\n"
 "prusa.io/tm-cal"
@@ -2106,22 +2098,22 @@ msgstr ""
 "prusa.io/tm-cal"
 
 #. MSG_TM_NOT_CAL c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1613 ../../Firmware/messages.cpp:189
+#: ../../Firmware/Marlin_main.cpp:1540 ../../Firmware/messages.cpp:196
 msgid "Thermal model not calibrated yet."
 msgstr "Termisk-modellen är inte kalibrerad ännu."
 
 #. MSG_TEMPERATURE c=18
-#: ../../Firmware/messages.cpp:309 ../../Firmware/ultralcd.cpp:4455
+#: ../../Firmware/messages.cpp:321 ../../Firmware/ultralcd.cpp:4422
 msgid "Temperature"
 msgstr "Temperatur"
 
 #. MSG_MENU_TEMPERATURES c=18
-#: ../../Firmware/messages.cpp:229 ../../Firmware/ultralcd.cpp:1707
+#: ../../Firmware/messages.cpp:241 ../../Firmware/ultralcd.cpp:1717
 msgid "Temperatures"
 msgstr "Temperaturer"
 
 #. MSG_TESTING_FILAMENT c=20
-#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:388
+#: ../../Firmware/messages.cpp:63 ../../Firmware/mmu2_reporting.cpp:389
 msgid "Testing filament"
 msgstr "Testar filament"
 
@@ -2142,7 +2134,7 @@ msgstr ""
 "blockerar dess rörelse."
 
 #. MSG_WIZARD_V2_CAL_2 c=20 r=12
-#: ../../Firmware/messages.cpp:292 ../../Firmware/ultralcd.cpp:3738
+#: ../../Firmware/messages.cpp:304 ../../Firmware/ultralcd.cpp:3748
 msgid ""
 "The printer will start printing a zig-zag line. Rotate the knob until you "
 "reach the optimal height. Check the pictures in the handbook (Calibration "
@@ -2152,7 +2144,7 @@ msgstr ""
 "optimal höjd. Kontrollera med bilderna i handboken (Kalibreringskapitlet)."
 
 #. MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=8
-#: ../../Firmware/Marlin_main.cpp:1606 ../../Firmware/messages.cpp:47
+#: ../../Firmware/Marlin_main.cpp:1533 ../../Firmware/messages.cpp:47
 msgid ""
 "There is still a need to make Z calibration. Please follow the manual, "
 "chapter First steps, section Calibration flow."
@@ -2161,40 +2153,40 @@ msgstr ""
 "kap Första stegen, avs Kalibreringsflöde."
 
 #. MSG_SORT_TIME c=8
-#: ../../Firmware/messages.cpp:159 ../../Firmware/ultralcd.cpp:4514
+#: ../../Firmware/messages.cpp:166 ../../Firmware/ultralcd.cpp:4481
 msgid "Time"
 msgstr "Tid"
 
 #. MSG_TIMEOUT c=12
-#: ../../Firmware/messages.cpp:176 ../../Firmware/ultralcd.cpp:5622
+#: ../../Firmware/messages.cpp:183 ../../Firmware/ultralcd.cpp:5595
 msgid "Timeout"
 msgstr "Timeout"
 
 #. MSG_TOTAL c=6
-#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:1129
-#: ../../Firmware/ultralcd.cpp:1287
+#: ../../Firmware/messages.cpp:116 ../../Firmware/ultralcd.cpp:1139
+#: ../../Firmware/ultralcd.cpp:1297
 msgid "Total"
 msgstr "Total"
 
 #. MSG_TOTAL_FAILURES c=20
-#: ../../Firmware/messages.cpp:114 ../../Firmware/ultralcd.cpp:1177
-#: ../../Firmware/ultralcd.cpp:1231 ../../Firmware/ultralcd.cpp:1317
+#: ../../Firmware/messages.cpp:118 ../../Firmware/ultralcd.cpp:1187
+#: ../../Firmware/ultralcd.cpp:1241 ../../Firmware/ultralcd.cpp:1327
 msgid "Total failures"
 msgstr "Totala fel"
 
 #. MSG_TOTAL_FILAMENT c=19
-#: ../../Firmware/messages.cpp:248 ../../Firmware/ultralcd.cpp:2369
+#: ../../Firmware/messages.cpp:260 ../../Firmware/ultralcd.cpp:2386
 msgid "Total filament"
 msgstr "Total filament"
 
 #. MSG_TOTAL_PRINT_TIME c=19
-#: ../../Firmware/messages.cpp:249 ../../Firmware/ultralcd.cpp:2370
+#: ../../Firmware/messages.cpp:261 ../../Firmware/ultralcd.cpp:2387
 msgid "Total print time"
 msgstr "Tot utskriftstid"
 
 #. MSG_TUNE c=8
-#: ../../Firmware/messages.cpp:116 ../../Firmware/mmu2/errors_list.h:372
-#: ../../Firmware/ultralcd.cpp:5258
+#: ../../Firmware/messages.cpp:120 ../../Firmware/mmu2/errors_list.h:372
+#: ../../Firmware/ultralcd.cpp:5220
 msgid "Tune"
 msgstr "Ställ in"
 
@@ -2209,16 +2201,16 @@ msgid "Unload"
 msgstr "Ladda ur"
 
 #. MSG_UNLOAD_FILAMENT c=18
-#: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:2206
-#: ../../Firmware/ultralcd.cpp:5347 ../../Firmware/ultralcd.cpp:5364
-#: ../../Firmware/ultralcd.cpp:5369
+#: ../../Firmware/messages.cpp:133 ../../Firmware/ultralcd.cpp:2220
+#: ../../Firmware/ultralcd.cpp:5313 ../../Firmware/ultralcd.cpp:5331
+#: ../../Firmware/ultralcd.cpp:5336
 msgid "Unload filament"
 msgstr "Ta bort filament"
 
 #. MSG_UNLOADING_FILAMENT c=20
-#: ../../Firmware/Marlin_main.cpp:3436 ../../Firmware/messages.cpp:129
+#: ../../Firmware/Marlin_main.cpp:3175 ../../Firmware/messages.cpp:134
 #: ../../Firmware/mmu2_progress_converter.cpp:50
-#: ../../Firmware/ultralcd.cpp:4911
+#: ../../Firmware/ultralcd.cpp:4867
 msgid "Unloading filament"
 msgstr "Tar bort filament"
 
@@ -2235,12 +2227,12 @@ msgid "Unloading to pulley"
 msgstr "Ladd ur t. remskiva"
 
 #. MSG_FIL_FAILED c=20 r=4
-#: ../../Firmware/messages.cpp:339 ../../Firmware/ultralcd.cpp:6030
+#: ../../Firmware/messages.cpp:351 ../../Firmware/ultralcd.cpp:6006
 msgid "Verification failed, remove the filament and try again."
 msgstr "Verifieringen felade, ta bort filamentet, försök igen."
 
 #. MSG_MENU_VOLTAGES c=18
-#: ../../Firmware/messages.cpp:230 ../../Firmware/ultralcd.cpp:1710
+#: ../../Firmware/messages.cpp:242 ../../Firmware/ultralcd.cpp:1720
 msgid "Voltages"
 msgstr "Spänning"
 
@@ -2251,7 +2243,7 @@ msgid "WARNING TMC TOO HOT"
 msgstr "VARNING TMC FÖR VARM"
 
 #. MSG_CRASH_DET_STEALTH_FORCE_OFF c=20 r=4
-#: ../../Firmware/messages.cpp:281 ../../Firmware/ultralcd.cpp:3381
+#: ../../Firmware/messages.cpp:293 ../../Firmware/ultralcd.cpp:3391
 msgid ""
 "WARNING:\n"
 "Crash detection\n"
@@ -2264,186 +2256,186 @@ msgstr ""
 "tyst-läge"
 
 #. MSG_USERWAIT c=20
-#: ../../Firmware/Marlin_main.cpp:5240 ../../Firmware/messages.cpp:209
+#: ../../Firmware/Marlin_main.cpp:4747 ../../Firmware/messages.cpp:221
 msgid "Wait for user..."
 msgstr "Väntar på användare."
 
 #. MSG_WAITING_TEMP_PINDA c=20 r=3
-#: ../../Firmware/messages.cpp:263 ../../Firmware/ultralcd.cpp:2753
+#: ../../Firmware/messages.cpp:275 ../../Firmware/ultralcd.cpp:2770
 msgid "Waiting for PINDA probe cooling"
 msgstr "Väntar på PINDA-sondens kylning"
 
 #. MSG_WAITING_TEMP c=20 r=4
-#: ../../Firmware/messages.cpp:264 ../../Firmware/ultralcd.cpp:2782
+#: ../../Firmware/messages.cpp:276 ../../Firmware/ultralcd.cpp:2799
 msgid "Waiting for nozzle and bed cooling"
 msgstr "Väntar på munstycks- och bäddkylning"
 
 #. MSG_WARN c=8
-#: ../../Firmware/messages.cpp:144 ../../Firmware/ultralcd.cpp:4233
-#: ../../Firmware/ultralcd.cpp:4313 ../../Firmware/ultralcd.cpp:4352
+#: ../../Firmware/messages.cpp:149 ../../Firmware/ultralcd.cpp:4312
 msgid "Warn"
 msgstr "Varna"
 
 #. MSG_CHANGED_BOTH c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1554 ../../Firmware/messages.cpp:200
+#: ../../Firmware/Marlin_main.cpp:1481 ../../Firmware/messages.cpp:212
 msgid "Warning: both printer type and motherboard type changed."
 msgstr "Varning: både skrivartyp och moderkortstyp har ändrats."
 
 #. MSG_CHANGED_MOTHERBOARD c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1546 ../../Firmware/messages.cpp:198
+#: ../../Firmware/Marlin_main.cpp:1473 ../../Firmware/messages.cpp:210
 msgid "Warning: motherboard type changed."
 msgstr "Varning: moderkortstyp ändrad."
 
 #. MSG_CHANGED_PRINTER c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:1550 ../../Firmware/messages.cpp:199
+#: ../../Firmware/Marlin_main.cpp:1477 ../../Firmware/messages.cpp:211
 msgid "Warning: printer type changed."
 msgstr "Varning: skrivartyp ändrats."
 
 #. MSG_UNLOAD_SUCCESSFUL c=20 r=3
-#: ../../Firmware/Marlin_main.cpp:3517 ../../Firmware/messages.cpp:205
+#: ../../Firmware/Marlin_main.cpp:3257 ../../Firmware/messages.cpp:217
 msgid "Was filament unload successful?"
 msgstr "Lyckades filamentutmatningen?"
 
 #. MSG_SELFTEST_WIRINGERROR c=18
-#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:6710
-#: ../../Firmware/ultralcd.cpp:6714 ../../Firmware/ultralcd.cpp:6734
-#: ../../Firmware/ultralcd.cpp:6740 ../../Firmware/ultralcd.cpp:6764
+#: ../../Firmware/messages.cpp:103 ../../Firmware/ultralcd.cpp:6686
+#: ../../Firmware/ultralcd.cpp:6690 ../../Firmware/ultralcd.cpp:6710
+#: ../../Firmware/ultralcd.cpp:6716 ../../Firmware/ultralcd.cpp:6740
 msgid "Wiring error"
 msgstr "Kabelfel"
 
 #. MSG_WIZARD c=17
-#: ../../Firmware/messages.cpp:313 ../../Firmware/ultralcd.cpp:4572
+#: ../../Firmware/messages.cpp:325 ../../Firmware/ultralcd.cpp:4528
 msgid "Wizard"
 msgstr "Guide"
 
 #. MSG_X_CORRECTION c=13
-#: ../../Firmware/messages.cpp:304 ../../Firmware/ultralcd.cpp:3986
+#: ../../Firmware/messages.cpp:316 ../../Firmware/ultralcd.cpp:4010
 msgid "X-correct"
 msgstr "X-korrektion"
 
 #. MSG_XYZ_DETAILS c=18
-#: ../../Firmware/messages.cpp:226 ../../Firmware/ultralcd.cpp:1699
+#: ../../Firmware/messages.cpp:238 ../../Firmware/ultralcd.cpp:1709
 msgid "XYZ cal. details"
 msgstr "XYZ kal. detaljer"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_EXTREME c=20 r=8
-#: ../../Firmware/messages.cpp:275 ../../Firmware/ultralcd.cpp:3207
+#: ../../Firmware/messages.cpp:287 ../../Firmware/ultralcd.cpp:3217
 msgid "XYZ calibration all right. Skew will be corrected automatically."
 msgstr "XYZ-kalibrering ok. Skevhet kommer att korrigeras automatiskt."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_SKEW_MILD c=20 r=8
-#: ../../Firmware/messages.cpp:274 ../../Firmware/ultralcd.cpp:3204
+#: ../../Firmware/messages.cpp:286 ../../Firmware/ultralcd.cpp:3214
 msgid "XYZ calibration all right. X/Y axes are slightly skewed. Good job!"
 msgstr "XYZ-kalibrering ok. X/Y-axlarna är mycket lite skeva. Bra jobbat!"
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_BOTH_FAR c=20 r=8
-#: ../../Firmware/messages.cpp:271 ../../Firmware/ultralcd.cpp:3185
+#: ../../Firmware/messages.cpp:283 ../../Firmware/ultralcd.cpp:3195
 msgid "XYZ calibration compromised. Front calibration points not reachable."
 msgstr "XYZ-kalibrering komprometterad. Främre kalibreringspunkt kan ej nås."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_WARNING_FRONT_RIGHT_FAR c=20 r=8
-#: ../../Firmware/messages.cpp:272 ../../Firmware/ultralcd.cpp:3188
+#: ../../Firmware/messages.cpp:284 ../../Firmware/ultralcd.cpp:3198
 msgid ""
 "XYZ calibration compromised. Right front calibration point not reachable."
 msgstr ""
 "XYZ-kalibrering komprometterad. Främre hö kalibreringspunkter kan ej nås."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_POINT_NOT_FOUND c=20 r=6
-#: ../../Firmware/messages.cpp:268 ../../Firmware/ultralcd.cpp:3167
+#: ../../Firmware/messages.cpp:280 ../../Firmware/ultralcd.cpp:3177
 msgid "XYZ calibration failed. Bed calibration point was not found."
 msgstr "XYZ-kalibrering felade. Kalibreringspunkter ej funna."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_BOTH_FAR c=20 r=6
-#: ../../Firmware/messages.cpp:269 ../../Firmware/ultralcd.cpp:3173
+#: ../../Firmware/messages.cpp:281 ../../Firmware/ultralcd.cpp:3183
 msgid "XYZ calibration failed. Front calibration points not reachable."
 msgstr "XYZ-kalibrering felade. Främre kalibreringspunkt kan ej nås."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
-#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3170
-#: ../../Firmware/ultralcd.cpp:3198
+#: ../../Firmware/messages.cpp:19 ../../Firmware/ultralcd.cpp:3180
+#: ../../Firmware/ultralcd.cpp:3208
 msgid "XYZ calibration failed. Please consult the manual."
 msgstr "XYZ-kalibrering felade. Se bruksanvisningen."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_FAILED_FRONT_RIGHT_FAR c=20 r=6
-#: ../../Firmware/messages.cpp:270 ../../Firmware/ultralcd.cpp:3176
+#: ../../Firmware/messages.cpp:282 ../../Firmware/ultralcd.cpp:3186
 msgid "XYZ calibration failed. Right front calibration point not reachable."
 msgstr "XYZ-kalibrering felade. Höger främre kalibreringspunkt kan ej nås."
 
 #. MSG_BED_SKEW_OFFSET_DETECTION_PERFECT c=20 r=8
-#: ../../Firmware/messages.cpp:273 ../../Firmware/ultralcd.cpp:3201
+#: ../../Firmware/messages.cpp:285 ../../Firmware/ultralcd.cpp:3211
 msgid "XYZ calibration ok. X/Y axes are perpendicular. Congratulations!"
 msgstr "XYZ-kalibrering ok. X/Y-axlarna ar vinkelräta. Grattis!"
 
 #. MSG_Y_DIST_FROM_MIN c=20
-#: ../../Firmware/messages.cpp:250 ../../Firmware/ultralcd.cpp:2476
+#: ../../Firmware/messages.cpp:262 ../../Firmware/ultralcd.cpp:2493
 msgid "Y distance from min"
 msgstr "Y avstånd från min"
 
 #. MSG_Y_CORRECTION c=13
-#: ../../Firmware/messages.cpp:305 ../../Firmware/ultralcd.cpp:3987
+#: ../../Firmware/messages.cpp:317 ../../Firmware/ultralcd.cpp:4011
 msgid "Y-correct"
 msgstr "Y-korrekt"
 
 #. MSG_YES c=4
-#: ../../Firmware/messages.cpp:137 ../../Firmware/ultralcd.cpp:3029
-#: ../../Firmware/ultralcd.cpp:4443 ../../Firmware/ultralcd.cpp:4531
-#: ../../Firmware/ultralcd.cpp:5790
+#: ../../Firmware/messages.cpp:142 ../../Firmware/ultralcd.cpp:2275
+#: ../../Firmware/ultralcd.cpp:2279 ../../Firmware/ultralcd.cpp:3046
+#: ../../Firmware/ultralcd.cpp:4410 ../../Firmware/ultralcd.cpp:4498
+#: ../../Firmware/ultralcd.cpp:5766
 msgid "Yes"
 msgstr "Ja"
 
 #. MSG_WIZARD_QUIT c=20 r=8
-#: ../../Firmware/messages.cpp:134 ../../Firmware/ultralcd.cpp:3950
+#: ../../Firmware/messages.cpp:139 ../../Firmware/ultralcd.cpp:3974
 msgid "You can always resume the Wizard from Calibration -> Wizard."
 msgstr "Du kan alltid återuppta guiden från Kalibrering -> Guide."
 
 #. MSG_Z_CORRECTION c=13
-#: ../../Firmware/messages.cpp:306 ../../Firmware/ultralcd.cpp:3988
+#: ../../Firmware/messages.cpp:318 ../../Firmware/ultralcd.cpp:4012
 msgid "Z-correct"
 msgstr "Z-korrekt"
 
 #. MSG_Z_PROBE_NR c=14
-#: ../../Firmware/messages.cpp:168 ../../Firmware/ultralcd.cpp:5593
+#: ../../Firmware/messages.cpp:175 ../../Firmware/ultralcd.cpp:5566
 msgid "Z-probe nr."
 msgstr "Z-sond nr."
 
 #. MSG_MEASURED_OFFSET c=20
-#: ../../Firmware/messages.cpp:256 ../../Firmware/ultralcd.cpp:2546
+#: ../../Firmware/messages.cpp:268 ../../Firmware/ultralcd.cpp:2563
 msgid "[0;0] point offset"
 msgstr "[0;0] punktförskjutn"
 
 #. MSG_PRESS c=20 r=2
-#: ../../Firmware/messages.cpp:239 ../../Firmware/ultralcd.cpp:2147
+#: ../../Firmware/messages.cpp:251 ../../Firmware/ultralcd.cpp:2158
 msgid "and press the knob"
 msgstr "och tryck på knapp"
 
 #. MSG_TO_LOAD_FIL c=20
-#: ../../Firmware/messages.cpp:232 ../../Firmware/ultralcd.cpp:1807
+#: ../../Firmware/messages.cpp:244 ../../Firmware/ultralcd.cpp:1816
 msgid "to load filament"
 msgstr "att ladda filament"
 
 #. MSG_TO_UNLOAD_FIL c=20
-#: ../../Firmware/messages.cpp:233 ../../Firmware/ultralcd.cpp:1811
+#: ../../Firmware/messages.cpp:245 ../../Firmware/ultralcd.cpp:1820
 msgid "to unload filament"
 msgstr "att ta bort filament"
 
 #. MSG_UNKNOWN c=13
-#: ../../Firmware/messages.cpp:224 ../../Firmware/ultralcd.cpp:1666
+#: ../../Firmware/messages.cpp:236 ../../Firmware/ultralcd.cpp:1676
 msgid "unknown"
 msgstr "okänd"
 
 #. MSG_IR_UNKNOWN c=18
-#: ../../Firmware/Filament_sensor.cpp:284 ../../Firmware/messages.cpp:184
+#: ../../Firmware/Filament_sensor.cpp:286 ../../Firmware/messages.cpp:191
 msgid "unknown state"
 msgstr "okänt stat"
 
 #. MSG_REFRESH c=18
-#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:5858
-#: ../../Firmware/ultralcd.cpp:5861
+#: ../../Firmware/messages.cpp:88 ../../Firmware/ultralcd.cpp:5834
+#: ../../Firmware/ultralcd.cpp:5837
 msgid "🔃Refresh"
 msgstr "🔃Uppdatera"
 
 #. MSG_MMU_POWER_FAILS c=15
-#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1180
+#: ../../Firmware/messages.cpp:74 ../../Firmware/ultralcd.cpp:1190
 msgid "MMU power fails"
 msgstr "MMU strömavbr."
 
@@ -2481,8 +2473,8 @@ msgid "MMU MCU ERROR"
 msgstr "MMU MCU FEL"
 
 #. MSG_MATERIAL_CHANGES c=18
-#: ../../Firmware/messages.cpp:113 ../../Firmware/ultralcd.cpp:1130
-#: ../../Firmware/ultralcd.cpp:1204
+#: ../../Firmware/messages.cpp:117 ../../Firmware/ultralcd.cpp:1140
+#: ../../Firmware/ultralcd.cpp:1214
 msgid "Material changes"
 msgstr "Materialutbyten"
 
@@ -2514,17 +2506,17 @@ msgstr ""
 "version 3.0.3."
 
 #. MSG_PRELOAD_TO_MMU c=17
-#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5344
+#: ../../Firmware/messages.cpp:59 ../../Firmware/ultralcd.cpp:5310
 msgid "Preload to MMU"
 msgstr "Förladdning MMU"
 
 #. MSG_FW_MK3_DETECTED c=20 r=4
-#: ../../Firmware/messages.cpp:367 ../../Firmware/Marlin_main.cpp:920
+#: ../../Firmware/messages.cpp:379 ../../Firmware/Marlin_main.cpp:854
 msgid "MK3 firmware detected on MK3S printer"
 msgstr "MK3-firmware upptäckt på MK3S-skrivare"
 
 #. MSG_FW_MK3S_DETECTED c=20 r=4
-#: ../../Firmware/messages.cpp:367 ../../Firmware/Marlin_main.cpp:920
+#: ../../Firmware/messages.cpp:379 ../../Firmware/Marlin_main.cpp:854
 msgid "MK3S firmware detected on MK3 printer"
 msgstr "MK3S-firmware upptäckt på MK3-skrivare"
 
@@ -2538,8 +2530,9 @@ msgstr "OKÄNT FEL"
 msgid "Unexpected error occurred."
 msgstr "Ett oväntat fel inträffade."
 
-#. MSG_BTN_EJECT c=8
-#: ../../Firmware/mmu2/errors_list.h:358 ../../Firmware/mmu2/errors_list.h:371
+#. MSG_EJECT c=8
+#: ../../Firmware/messages.cpp:21 ../../Firmware/mmu2/errors_list.h:371
+#: ../../Firmware/ultralcd.cpp:2275 ../../Firmware/ultralcd.cpp:2279
 msgid "Eject"
 msgstr "Mata ut"
 
@@ -2559,58 +2552,58 @@ msgid "M600 Filament Change. Load a new filament or eject the old one."
 msgstr "M600 filamentbyte. Ladda en ny filament eller mata ut den gamla."
 
 #. MSG_MMU_SENSITIVITY c=18
-#: ../../Firmware/messages.cpp:215 ../../Firmware/mmu2_reporting.cpp:458
+#: ../../Firmware/messages.cpp:227 ../../Firmware/mmu2_reporting.cpp:459
 msgid "Sensitivity"
 msgstr "Känslighet"
 
 #. MSG_MBL_FAILED c=20 r=4
-#: ../../Firmware/Marlin_main.cpp:3038 ../../Firmware/messages.cpp:203
+#: ../../Firmware/Marlin_main.cpp:2776 ../../Firmware/messages.cpp:215
 msgid "Mesh bed leveling failed. Print canceled."
 msgstr "Bäddnivelleringen felade. Utskriften avbröts."
 
 #. MSG_SET_READY c=18
-#: ../../Firmware/messages.cpp:105 ../../Firmware/ultralcd.cpp:5265
+#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:5228
 msgid "Set Ready"
 msgstr "Gör klar"
 
 #. MSG_SET_NOT_READY c=18
-#: ../../Firmware/messages.cpp:106 ../../Firmware/ultralcd.cpp:5263
+#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5226
 msgid "Set not Ready"
 msgstr "Set inte klart"
 
 #. MSG_HOSTPRINT c=18
-#: ../../Firmware/messages.cpp:107 ../../Firmware/ultralcd.cpp:5285
+#: ../../Firmware/messages.cpp:109 ../../Firmware/ultralcd.cpp:5231
 msgid "Print from host"
 msgstr "Skriv ut från värd"
 
 #. MSG_REPRINT c=18
-#: ../../Firmware/messages.cpp:196 ../../Firmware/ultralcd.cpp:5243
-#: ../../Firmware/ultralcd.cpp:5245
+#: ../../Firmware/messages.cpp:208 ../../Firmware/ultralcd.cpp:5205
+#: ../../Firmware/ultralcd.cpp:5207
 msgid "Reprint"
 msgstr "Upprepa trycket"
 
 #. MSG_SHUTDOWN_HOST c=18
-#: ../../Firmware/messages.cpp:108 ../../Firmware/ultralcd.cpp:5390
+#: ../../Firmware/messages.cpp:112 ../../Firmware/ultralcd.cpp:5357
 msgid "Shutdown host"
 msgstr "Stänga av värd"
 
 #. MSG_NOZZLE_CNG_COOLDOWN c=20 r=3
-#: ../../Firmware/messages.cpp:198 ../../Firmware/ultralcd.cpp:1002
+#: ../../Firmware/messages.cpp:203 ../../Firmware/ultralcd.cpp:999
 msgid "Nozzle is hot! Wait for cooldown."
 msgstr "Munstycket är varmt! Vänta på nedkylning."
 
 #. MSG_NOZZLE_CNG_CHANGED_QUICK c=20 r=3
-#: ../../Firmware/messages.cpp:199
+#: ../../Firmware/messages.cpp:204
 msgid "Nozzle changed?"
 msgstr "Har munstycket ändrats?"
 
 #. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
-#: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:388
+#: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:388
 msgid "There is no filament loaded. Continue?"
 msgstr "Det finns ingen filament laddad. Fortsätta?"
 
 #. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
-#: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:389
+#: ../../Firmware/messages.cpp:159 ../../Firmware/util.cpp:389
 msgid "There is no filament loaded. Print cancelled."
 msgstr "Det finns ingen filament laddad. Utskriften avbröts."
 


### PR DESCRIPTION
Tested the firmware and changes
- [X] Factory reset and Wizard
  - [X] Without and with MMU3
- [X] SD card print
  - [X] Power panic
- [X] PrusaLink / PrusaConnect  print
  - [X] Power panic
- [X] Tested [3.14.1 Milestone changes](https://github.com/prusa3d/Prusa-Firmware/pulls?q=is%3Apr+milestone%3A%22FW+3.14.1%22+is%3Aclosed)

Changes of this PR 
- [X] Updated `pot` and `po` translation files
- [X] Bumped up version to 3.14.1-RC1

ToDo:
- [X] Create `MK3_3.14.1` branch
- [X] Create `t3.14.1` tag
