### PR TITLE
PFW-1561 Fix MMU unload issue

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5676,7 +5676,7 @@ void lcd_print_stop_finish()
 
         if (MMU2::mmu2.Enabled() && MMU2::mmu2.FindaDetectsFilament()
 #ifdef FANCHECK
-            && fan_check_error != EFCE_REPORTED
+            && fan_check_error == EFCE_OK
 #endif //FANCHECK
         ) {
             // The print was aborted while when the nozzle was cold:

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5682,9 +5682,7 @@ void lcd_print_stop_finish()
             // The print was aborted while when the nozzle was cold:
             //     1. in a paused state                      => a partial backup in RAM is always available
             //     2. after a recoverable thermal/fan error had paused the print => only extruder temperature is saved to RAM
-            if (printingIsPaused())
-            {
-                // Restore temperature saved in ram after pausing print
+            if (did_pause_print) {
                 restore_extruder_temperature_from_ram();
             }
 


### PR DESCRIPTION
Steps to reproduce:

1. Check Settings -> Fan check [On]
2. Start MMU print
3. While printing stall the hotend fan until the printer has finished pausing the print job.
4. You can stop halting the fan now.
5. Now, sit back and wait until the extruder temperature is below `EXTRUDER_AUTO_FAN_TEMPERATURE` (50°C). This can take ~10 minutes.
6. Stop the print job via LCD menu

**Expected result:** MMU should **NOT** re-heat the nozzle and unload the filament