### PR TITLE
PFW-1562 Fix an issue where safety timer is not handled correctly in `mFilamentPrompt` menu

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -8805,6 +8805,7 @@ static void handleSafetyTimer()
     {
         disable_heater();
         lcd_show_fullscreen_message_and_wait_P(_T(MSG_BED_HEATING_SAFETY_DISABLED));
+        lcd_return_to_status();
     }
 }
 #endif //SAFETYTIMER


### PR DESCRIPTION
Steps to reproduce:
1. Power on MK3S printer
2. Perform Auto home
3. Load and Unload filament
4. Wait for safety timer to expire.

- [X] Cherry-pick Pr to MK3_3.14.1 https://github.com/prusa3d/Prusa-Firmware/pull/4774