### PR TITLE
PFW-1561 Fix MMU unload issue

### DIFF
--- a/Firmware/fancheck.cpp
+++ b/Firmware/fancheck.cpp
@@ -149,7 +149,7 @@ void checkFanSpeed()
         lcd_reset_alert_level(); //for another fan speed error
         lcd_setstatuspgm(MSG_WELCOME); // Reset the status line message to visually show the error is gone
     }
-    if (fans_check_enabled && (fan_check_error == EFCE_OK))
+    if (fans_check_enabled && (fan_check_error != EFCE_REPORTED))
     {
         for (uint8_t fan = 0; fan < 2; fan++)
         {

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5216,7 +5216,7 @@ static void lcd_main_menu()
         MENU_ITEM_FUNCTION_P(_T(MSG_FILAMENTCHANGE), lcd_colorprint_change);//8
 
     if (!printer_recovering()) {
-        if ( moves_planned() || printer_active()) {
+        if ( moves_planned() || printer_active() || fan_check_error == EFCE_REPORTED) {
             MENU_ITEM_SUBMENU_P(_T(MSG_TUNE), lcd_tune_menu);
         } else if (!Stopped) {
             MENU_ITEM_SUBMENU_P(_T(MSG_PREHEAT), lcd_preheat_menu);
@@ -5719,9 +5719,8 @@ void print_stop(bool interactive, bool unconditional_stop)
         // Reset the sd status
         card.sdprinting = false;
         card.closefile();
-    } else {
-        SERIAL_ECHOLNRPGM(MSG_HOST_ACTION_CANCEL);
     }
+    SERIAL_ECHOLNRPGM(MSG_HOST_ACTION_CANCEL);
 
 #ifdef MESH_BED_LEVELING
     mbl.active = false;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5216,7 +5216,11 @@ static void lcd_main_menu()
         MENU_ITEM_FUNCTION_P(_T(MSG_FILAMENTCHANGE), lcd_colorprint_change);//8
 
     if (!printer_recovering()) {
-        if ( moves_planned() || printer_active() || fan_check_error == EFCE_REPORTED) {
+        if ( moves_planned() || printer_active()
+#ifdef FANCHECK
+         || fan_check_error == EFCE_REPORTED
+#endif //End FANCHECK
+        ) {
             MENU_ITEM_SUBMENU_P(_T(MSG_TUNE), lcd_tune_menu);
         } else if (!Stopped) {
             MENU_ITEM_SUBMENU_P(_T(MSG_PREHEAT), lcd_preheat_menu);


### PR DESCRIPTION
The Tune menu is now also available during a fan error, so the user can decide to en/disable the fan check.
Send `//action:cancel` to host when Stop print is executed.

Steps to reproduce:

-  Check Settings -> Fan check [On]
-  Start MMU print
-  While printing stall the hotend fan until the printer has finished pausing the print job.
- You can stop halting the fan now.
- Now, sit back and wait until the extruder temperature is below EXTRUDER_AUTO_FAN_TEMPERATURE (50°C). This can take ~10 minutes.
- Stop the print job via LCD menu

Results:
1. If fan is spinning the printer will heat up to target temperature and unload the filament from the MMU
2. If fan is still blocked ther printer will try to heat up but again fail with a fan error. A second Stop print is needed.

The preferred state of printer + MMU is to have no filament loaded after a print finished or has been stopped.
Advantages: 
- Printer and MMU can reset and home after a startup.
- Next MMU print doesn't need an extra unload or purge sequence
- Switching MMU filament doesn't need an extra unload or purge sequence

Replaces https://github.com/prusa3d/Prusa-Firmware/pull/4771

ToDo

- [ ] Create cherry-pick PR to MK3_3.14.1 branch