### PR TITLE
Remove hardcoded MMU tool count

### DIFF
--- a/Firmware/SpoolJoin.cpp
+++ b/Firmware/SpoolJoin.cpp
@@ -55,7 +55,7 @@ uint8_t SpoolJoin::nextSlot()
     SERIAL_ECHOPGM("SpoolJoin: ");
     SERIAL_ECHO((int)currentMMUSlot);
 
-    if (currentMMUSlot >= 4) currentMMUSlot = 0;
+    if (currentMMUSlot >= MMU_FILAMENT_COUNT-1) currentMMUSlot = 0;
     else currentMMUSlot++;
 
     SERIAL_ECHOPGM(" -> ");

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -4735,7 +4735,7 @@ static void lcd_disable_farm_mode()
 }
 
 static inline void load_all_wrapper(){
-    for(uint8_t i = 0; i < 5; ++i){
+    for(uint8_t i = 0; i < MMU_FILAMENT_COUNT; ++i){
         MMU2::mmu2.load_filament(i);
     }
 }
@@ -4812,7 +4812,7 @@ static void mmu_cut_filament_menu() {
 #endif //MMU_HAS_CUTTER
 
 static inline void loading_test_all_wrapper(){
-    for(uint8_t i = 0; i < 5; ++i){
+    for(uint8_t i = 0; i < MMU_FILAMENT_COUNT; ++i){
         MMU2::mmu2.loading_test(i);
     }
 


### PR DESCRIPTION
1. Remove hard coded tool values https://github.com/prusa3d/Prusa-Firmware/pull/4805/commits/cdb6635eac3b061276e2c722a7c9a3dd5d62a1fd
  1.1. Preload to MMU -> All
  1.2. Loading Test -> All
  1.3.  SpoolJoin

