### PR TITLE
Add Set parameter in M78 Statistics gcode

### DIFF
--- a/Firmware/ConfigurationStore.cpp
+++ b/Firmware/ConfigurationStore.cpp
@@ -106,6 +106,9 @@ void Config_PrintSettings(uint8_t level)
 #ifdef THERMAL_MODEL
     thermal_model_report_settings();
 #endif
+		printf_P(PSTR(
+        "%SStatistics:\n%S  M78 S%lu T%lu\n"),
+        echomagic, echomagic, eeprom_read_dword((uint32_t *)EEPROM_FILAMENTUSED), eeprom_read_dword((uint32_t *)EEPROM_TOTALTIME));
 }
 #endif
 

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -5253,7 +5253,6 @@ void process_commands()
     */
     case 78:
     {
-        // @todo useful for maintenance notifications
         const char *_m_fil;
         const char *_m_time;
         uint32_t _cm = 0;
@@ -5262,8 +5261,8 @@ void process_commands()
         if (printJobOngoing()) {
           _m_fil = _O(MSG_FILAMENT_USED);
           _m_time = _O(MSG_PRINT_TIME);
-          _cm = ((uint32_t)total_filament_used) / (1000);
-          _min = (print_job_timer.duration() / 60);
+          _cm = (uint32_t)total_filament_used / 1000;
+          _min = print_job_timer.duration() / 60;
         } else {
           if (code_seen('S')) {
           eeprom_update_dword_notify((uint32_t *)EEPROM_FILAMENTUSED, code_value());
@@ -9179,7 +9178,7 @@ void setPwmFrequency(uint8_t pin, int val)
 #endif //FAST_PWM_FAN
 
 void save_statistics() {
-    uint32_t _previous_filament = eeprom_init_default_dword((uint32_t *)EEPROM_FILAMENTUSED, 0); //_previous_filament unit: meter
+    uint32_t _previous_filament = eeprom_init_default_dword((uint32_t *)EEPROM_FILAMENTUSED, 0); //_previous_filament unit: centimeter
     uint32_t _previous_time = eeprom_init_default_dword((uint32_t *)EEPROM_TOTALTIME, 0);        //_previous_time unit: min
 
     uint32_t time_minutes = print_job_timer.duration() / 60;

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -5241,16 +5241,42 @@ void process_commands()
     }
 
     /*!
-    ### M78 - Show statistical information about the print jobs <a href="https://reprap.org/wiki/G-code#M78:_Show_statistical_information_about_the_print_jobs">M78: Show statistical information about the print jobs</a>
+    ### M78 - Get/set statistics <a href="https://reprap.org/wiki/G-code#M78:_Show_statistical_information_about_the_print_jobs">M78: Show statistical information about the print jobs</a>
+
+    #### Usage
+
+        M78 [ S | T ]
+
+    #### Parameters
+    - `S` - Set used filament length in cm
+    - `T` - Set total print time in minutes
     */
     case 78:
     {
         // @todo useful for maintenance notifications
-        SERIAL_ECHOPGM("STATS ");
-        SERIAL_ECHO(eeprom_read_dword((uint32_t *)EEPROM_TOTALTIME));
-        SERIAL_ECHOPGM(" min ");
-        SERIAL_ECHO(eeprom_read_dword((uint32_t *)EEPROM_FILAMENTUSED));
-        SERIAL_ECHOLNPGM(" cm.");
+        const char *_m_fil;
+        const char *_m_time;
+        uint32_t _cm = 0;
+        uint32_t _min = 0;
+
+        if (printJobOngoing()) {
+          _m_fil = _O(MSG_FILAMENT_USED);
+          _m_time = _O(MSG_PRINT_TIME);
+          _cm = ((uint32_t)total_filament_used) / (1000);
+          _min = (print_job_timer.duration() / 60);
+        } else {
+          if (code_seen('S')) {
+          eeprom_update_dword_notify((uint32_t *)EEPROM_FILAMENTUSED, code_value());
+          }
+          if (code_seen('T')) {
+          eeprom_update_dword_notify((uint32_t *)EEPROM_TOTALTIME, code_value());
+          }
+          _m_fil = _O(MSG_TOTAL_FILAMENT);
+          _m_time = _O(MSG_TOTAL_PRINT_TIME);
+          _cm = eeprom_read_dword((uint32_t *)EEPROM_FILAMENTUSED);
+          _min = eeprom_read_dword((uint32_t *)EEPROM_TOTALTIME);
+        }
+        printf_P(_N("%S:%lu cm\n%S:%lu min\n"),_m_fil,_cm,_m_time,_min);
         break;
     }
 

--- a/Firmware/eeprom.h
+++ b/Firmware/eeprom.h
@@ -108,7 +108,7 @@ static_assert(sizeof(Sheets) == EEPROM_SHEETS_SIZEOF, "Sizeof(Sheets) is not EEP
 | ^           | ^       | ^                                     | fah 250      | ^                     | needs XYZ calibration                             | ^            | ^
 | ^           | ^       | ^                                     | 00h 0        | ^                     | Unknown (legacy)                                  | ^            | ^
 | 0x0FF5 4085 | uint16  | _EEPROM_FREE_NR12_                    | ???          | ff ffh 65535          | _Free EEPROM space_                               | _free space_ | D3 Ax0ff5 C2
-| 0x0FF1 4081 | uint32  | EEPROM_FILAMENTUSED                   | ???          | 00 00 00 00h 0 __S/P__| Filament used in meters                           | ???          | D3 Ax0ff1 C4
+| 0x0FF1 4081 | uint32  | EEPROM_FILAMENTUSED                   | ???          | 00 00 00 00h 0 __S/P__| Filament used in cenitmeters                      | ???          | D3 Ax0ff1 C4
 | 0x0FED 4077 | uint32  | EEPROM_TOTALTIME                      | ???          | 00 00 00 00h 0 __S/P__| Total print time in minutes                       | ???          | D3 Ax0fed C4
 | 0x0FE5 4069 | float   | EEPROM_BED_CALIBRATION_CENTER         | ???          | ff ff ff ffh          | ???                                               | ???          | D3 Ax0fe5 C8
 | 0x0FDD 4061 | float   | EEPROM_BED_CALIBRATION_VEC_X          | ???          | ff ff ff ffh          | ???                                               | ???          | D3 Ax0fdd C8

--- a/Firmware/eeprom.h
+++ b/Firmware/eeprom.h
@@ -108,7 +108,7 @@ static_assert(sizeof(Sheets) == EEPROM_SHEETS_SIZEOF, "Sizeof(Sheets) is not EEP
 | ^           | ^       | ^                                     | fah 250      | ^                     | needs XYZ calibration                             | ^            | ^
 | ^           | ^       | ^                                     | 00h 0        | ^                     | Unknown (legacy)                                  | ^            | ^
 | 0x0FF5 4085 | uint16  | _EEPROM_FREE_NR12_                    | ???          | ff ffh 65535          | _Free EEPROM space_                               | _free space_ | D3 Ax0ff5 C2
-| 0x0FF1 4081 | uint32  | EEPROM_FILAMENTUSED                   | ???          | 00 00 00 00h 0 __S/P__| Filament used in cenitmeters                      | ???          | D3 Ax0ff1 C4
+| 0x0FF1 4081 | uint32  | EEPROM_FILAMENTUSED                   | ???          | 00 00 00 00h 0 __S/P__| Filament used in centimeters                      | ???          | D3 Ax0ff1 C4
 | 0x0FED 4077 | uint32  | EEPROM_TOTALTIME                      | ???          | 00 00 00 00h 0 __S/P__| Total print time in minutes                       | ???          | D3 Ax0fed C4
 | 0x0FE5 4069 | float   | EEPROM_BED_CALIBRATION_CENTER         | ???          | ff ff ff ffh          | ???                                               | ???          | D3 Ax0fe5 C8
 | 0x0FDD 4061 | float   | EEPROM_BED_CALIBRATION_VEC_X          | ???          | ff ff ff ffh          | ???                                               | ???          | D3 Ax0fdd C8

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2367,7 +2367,7 @@ void lcd_menu_statistics()
 	}
 	else
 	{
-		uint32_t _filament = eeprom_read_dword((uint32_t *)EEPROM_FILAMENTUSED); // in meters
+		uint32_t _filament = eeprom_read_dword((uint32_t *)EEPROM_FILAMENTUSED); // in centimeters
 		uint32_t _time = eeprom_read_dword((uint32_t *)EEPROM_TOTALTIME); // in minutes
 		uint8_t _hours, _minutes;
 		uint32_t _days;


### PR DESCRIPTION
Often a full factory reset is the best way to solve some issues. But that also means that the statistics are lost and often user complain why we can't keep them.

This is an attempt to give the user the option to get the statistics AND restore them if needed.

Added new parameters to `M78` to be able to restore statistics after a factory reset.
Also added the output to `M503`

Tested on MK404:
1. Connect via serial terminal
2. Open LCD Statistic menu
3. While printer is Idle send `M78`
  a. Example response when LCD Statistics menu shows `4.75m` and `0d 2h 6m`
```
Total filament:475 cm
Total print time:126 min
```
4. Simulate a print by sending `M75` to start the print timer
6. On LCD it switches from `Total filament` and `Total print time` to `Filament used` and `Print time`
7. Send `M78` after waiting at least 1 minute 
  a. Example response when LCD Statistics menu show `0.00m` and `0h 02m 05s`
```
Filament used:0 cm
Print time:2 min
```
8. Send `M77` to stop the print timer
9. The Statistics menu switches back to `Total` and you see the additional print time being added.
10. Send `M503`
  a. Example response in serial with total values being `4.75m` and `0d 02h 08m
```
echo:Statistics:
echo:  M78 S475 T128
``` 
11. Perform Factory reset -> Statistics
12. Open again LCD -> Statistics menu
13. Send again `M78` and you see
```
Total filament:0 cm
Total print time:0 min
```
14. Restore statistics using the output from `M503`
15. Example values: Send `M78 S475 T128`
16. On LCD you see the values being restored
17. Send `M78` and also in serial output you see the restored values.

Thanks to @crabbedh for the request https://github.com/prusa3d/Prusa-Firmware/issues/3448 sorry it took so long to be implemented.