### PR TITLE
Fix MMU tool change

### DIFF
--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -386,7 +386,7 @@ bool MMU2::tool_change(uint8_t slot) {
             !marlin_printingIsActive()) {
             // If Tcodes are used manually through the serial
             // we need to unload manually as well -- but only if FINDA detects filament
-            unload();
+            UnloadInner();
         }
 
         ReportingRAII rep(CommandInProgress::ToolChange);
@@ -482,10 +482,6 @@ void MMU2::UnloadInner() {
         IncrementMMUFails();
     }
     MakeSound(Confirm);
-
-    // no active tool
-    SetCurrentTool(MMU2_NO_TOOL);
-    tool_change_extruder = MMU2_NO_TOOL;
 }
 
 bool MMU2::unload() {
@@ -499,6 +495,10 @@ bool MMU2::unload() {
         ReportingRAII rep(CommandInProgress::UnloadFilament);
         UnloadInner();
     }
+
+    // no active tool
+    SetCurrentTool(MMU2_NO_TOOL);
+    tool_change_extruder = MMU2_NO_TOOL;
 
     ScreenUpdateEnable();
     return true;


### PR DESCRIPTION
Fix Tool change https://github.com/prusa3d/Prusa-Firmware/pull/4805/commits/be4104a47c75377c17ea98d39067508dc1dd782d

At some point we broke the tool change. It shows always `?><new tool number>` even when the tool is known.
The tool has been reset all the time even during a tool change while unloading and not ONLY when a final UNLOAD has been requested.

Starting with `F1` loaded:
![MMU_F1_loaded](https://github.com/user-attachments/assets/065d4512-720b-4cec-8587-ca59470fa42f)

Then change from `T0` to `T1`

Before:
![MMU_Change_from_1_to_2_before](https://github.com/user-attachments/assets/ba1e866d-dfb0-469b-9215-080191096c0c)

After:
![MMU_Change_from_1_to_2_after](https://github.com/user-attachments/assets/67223488-5f77-45a8-be02-70c6c5bcee3a)


Tested on MK404

Test steps to the second commit:
1. Flash FW.3.14.0
2. Connect with serial terminal
5. Enable MMU
6. After power up the printer doesn't know which filament is loaded and shows `F?`
7. Preheat the nozzle only Settings -> Temperature -> Nozzle
8. Send `T0` to load the filament from slot 1 on the MMU
9. Now you can see on LCD `F1`
10. Send `T1` to load the 2nd filament
11. This will unload the first filament and then load the second
12. During this operation watch the LCD screen
12.1. It witches from `F1` to `?>2` and finally shows `F2` when the `T1` command has finished
13. The `?` indicates that the filament slot is UNKNOWN
13.1. This is correctly shown when the printer starts up
13.2. BUT it should show during the filament change `{current known filament}>{new selected filament}`.
This has been working with FW 3.12.2 and MMU 1.0.6 and got broken with FW3.13.x and MMU 3.x.x

14. Flash firmware with this PR
15. repeat steps 2 to 12
16. Now you see it switching from `F1` to `1>2` and finally shows `F2` when the `T1` command has finished
16.1 This is the desired output.

Reasons why that happens is that the current firmware "always" reset the filament to UNKNOWN when unload is executed.
The UNKNOWN state should ONLY be set when the filament actually is unknown, which means unloaded for real and not only if the unload of the filament is temporary to be able to load next filament.