### PR TITLE
Optimze and new first layer calibration

### DIFF
--- a/Firmware/first_lay_cal.cpp
+++ b/Firmware/first_lay_cal.cpp
@@ -184,19 +184,16 @@ void lay1cal_meander_start(float layer_height, float extrusion_width)
     static const char fmt1[] PROGMEM = "G1Z%g";
     enquecommandf_P(fmt1, layer_height);
     enquecommand_P(feedrate_F1080);
+    enquecommand_P(MSG_G91); //enable relative XYZ
 #ifdef NEW_FIRST_LAYER_CAL
     enquecommandf_P(extrude_fmt_Y, short_length, count_e(layer_height, extrusion_width, short_length));
-#endif //_NEW_FIRST_LAYER_CAL
-
-    enquecommand_P(MSG_G91); //enable relative XYZ
-#ifndef NEW_FIRST_LAYER_CAL
+    enquecommandf_P(extrude_fmt_X, long_length*invert, count_e(layer_height, extrusion_width, long_length));
+    enquecommandf_P(extrude_fmt_Y, -short_length*invert, count_e(layer_height, extrusion_width, short_length));
+#else
     enquecommandf_P(extrude_fmt_X, 25.f*invert, count_e(layer_height, extrusion_width * 4.f, 25));
     enquecommandf_P(extrude_fmt_X, 25.f*invert, count_e(layer_height, extrusion_width * 2.f, 25));
     enquecommandf_P(extrude_fmt_X, 100.f*invert, count_e(layer_height, extrusion_width, 100));
     enquecommandf_P(extrude_fmt_Y, -20.f*invert, count_e(layer_height, extrusion_width, 20));
-#else
-    enquecommandf_P(extrude_fmt_X, long_length*invert, count_e(layer_height, extrusion_width, long_length));
-    enquecommandf_P(extrude_fmt_Y, -short_length*invert, count_e(layer_height, extrusion_width, short_length));
 #endif //_NEW_FIRST_LAYER_CAL
 }
 

--- a/Firmware/first_lay_cal.cpp
+++ b/Firmware/first_lay_cal.cpp
@@ -224,17 +224,16 @@ void lay1cal_meander(float layer_height, float extrusion_width)
 
 //! @brief Print square
 //!
-//! This function needs to be called 4 times with step of 0,4,8,12
+//! This function enqueues 4 lines of the square, so it needs to be called multiple times
 //!
 //! @param cmd_buffer character buffer needed to format gcodes
-//! @param i iteration
-void lay1cal_square(uint8_t step, float layer_height, float extrusion_width)
+void lay1cal_square(float layer_height, float extrusion_width)
 {
     const float Y_spacing = spacing(layer_height, extrusion_width);
     const float long_extrusion = count_e(layer_height, extrusion_width, square_width);
     const float short_extrusion = count_e(layer_height, extrusion_width, Y_spacing);
 
-    for (uint8_t i = step; i < step+4; ++i)
+    for (uint8_t i = 0; i < 4; i++)
     {
         enquecommandf_P(extrude_fmt_X, square_width*invert, long_extrusion);
         enquecommandf_P(extrude_fmt_Y, -Y_spacing*invert, short_extrusion);

--- a/Firmware/first_lay_cal.cpp
+++ b/Firmware/first_lay_cal.cpp
@@ -188,7 +188,7 @@ void lay1cal_meander_start(float layer_height, float extrusion_width)
     enquecommandf_P(extrude_fmt_Y, short_length, count_e(layer_height, extrusion_width, short_length));
 #endif //_NEW_FIRST_LAYER_CAL
 
-    enquecommand_P(PSTR("G91"));
+    enquecommand_P(MSG_G91); //enable relative XYZ
 #ifndef NEW_FIRST_LAYER_CAL
     enquecommandf_P(extrude_fmt_X, (float)25*invert, count_e(layer_height, extrusion_width * 4.f, 25));
     enquecommandf_P(extrude_fmt_X, (float)25*invert, count_e(layer_height, extrusion_width * 2.f, 25));

--- a/Firmware/first_lay_cal.cpp
+++ b/Firmware/first_lay_cal.cpp
@@ -51,6 +51,7 @@ static void lay1cal_common_enqueue_loop(const char * const * cmd_sequence, const
 static const char extrude_fmt_X[] PROGMEM = "G1X%gE%g";
 static const char extrude_fmt_Y[] PROGMEM = "G1Y%gE%g";
 static const char zero_extrusion[] PROGMEM = "G92E0";
+static const char feedrate_F1080[] PROGMEM = "G1F1080";
 #ifndef NEW_FIRST_LAYER_CAL
 int8_t invert = 1;
 const float short_length = 20;
@@ -120,7 +121,7 @@ void lay1cal_intro_line(bool extraPurgeNeeded, float layer_height, float extrusi
     static const char cmd_intro_mmu_8[] PROGMEM = "G1X240E25F2200";
     static const char cmd_intro_mmu_9[] PROGMEM = "G1Y-2F1000";
     static const char cmd_intro_mmu_10[] PROGMEM = "G1X200E8F1400";
-    static const char cmd_intro_mmu_11[] PROGMEM = "G1Z0.2F1000";
+    static const char cmd_intro_mmu_11[] PROGMEM = "G1Z0.2";
     static const char * const cmd_intro_mmu[] PROGMEM =
     {
         // first 2 items are only relevant if filament was not loaded - i.e. extraPurgeNeeded == true
@@ -144,6 +145,7 @@ void lay1cal_intro_line(bool extraPurgeNeeded, float layer_height, float extrusi
     }
     else
     {
+        enquecommand_P(feedrate_F1080); //fixed velocity for the intro line
         enquecommandf_P(extrude_fmt_X, (float)60, count_e(layer_height, extrusion_width * 4.f, 60));
         enquecommandf_P(extrude_fmt_X, (float)202.5, count_e(layer_height, extrusion_width * 8.f, 142.5));
     }
@@ -179,9 +181,9 @@ void lay1cal_meander_start(float layer_height, float extrusion_width)
 #ifndef NEW_FIRST_LAYER_CAL
     enquecommand_P(PSTR("G1X50Y155"));
 #endif //_NEW_FIRST_LAYER_CAL
-    static const char fmt1[] PROGMEM = "G1Z%gF7200";
+    static const char fmt1[] PROGMEM = "G1Z%g";
     enquecommandf_P(fmt1, layer_height);
-    enquecommand_P(PSTR("G1F1080"));
+    enquecommand_P(feedrate_F1080);
 #ifdef NEW_FIRST_LAYER_CAL
     enquecommandf_P(extrude_fmt_Y, short_length, count_e(layer_height, extrusion_width, short_length));
 #endif //_NEW_FIRST_LAYER_CAL

--- a/Firmware/first_lay_cal.cpp
+++ b/Firmware/first_lay_cal.cpp
@@ -146,8 +146,8 @@ void lay1cal_intro_line(bool extraPurgeNeeded, float layer_height, float extrusi
     else
     {
         enquecommand_P(feedrate_F1080); //fixed velocity for the intro line
-        enquecommandf_P(extrude_fmt_X, (float)60, count_e(layer_height, extrusion_width * 4.f, 60));
-        enquecommandf_P(extrude_fmt_X, (float)202.5, count_e(layer_height, extrusion_width * 8.f, 142.5));
+        enquecommandf_P(extrude_fmt_X, 60.f, count_e(layer_height, extrusion_width * 4.f, 60));
+        enquecommandf_P(extrude_fmt_X, 202.5f, count_e(layer_height, extrusion_width * 8.f, 142.5));
     }
 }
 
@@ -190,10 +190,10 @@ void lay1cal_meander_start(float layer_height, float extrusion_width)
 
     enquecommand_P(MSG_G91); //enable relative XYZ
 #ifndef NEW_FIRST_LAYER_CAL
-    enquecommandf_P(extrude_fmt_X, (float)25*invert, count_e(layer_height, extrusion_width * 4.f, 25));
-    enquecommandf_P(extrude_fmt_X, (float)25*invert, count_e(layer_height, extrusion_width * 2.f, 25));
-    enquecommandf_P(extrude_fmt_X, (float)100*invert, count_e(layer_height, extrusion_width, 100));
-    enquecommandf_P(extrude_fmt_Y, (float)-20*invert, count_e(layer_height, extrusion_width, 20));
+    enquecommandf_P(extrude_fmt_X, 25.f*invert, count_e(layer_height, extrusion_width * 4.f, 25));
+    enquecommandf_P(extrude_fmt_X, 25.f*invert, count_e(layer_height, extrusion_width * 2.f, 25));
+    enquecommandf_P(extrude_fmt_X, 100.f*invert, count_e(layer_height, extrusion_width, 100));
+    enquecommandf_P(extrude_fmt_Y, -20.f*invert, count_e(layer_height, extrusion_width, 20));
 #else
     enquecommandf_P(extrude_fmt_X, long_length*invert, count_e(layer_height, extrusion_width, long_length));
     enquecommandf_P(extrude_fmt_Y, -short_length*invert, count_e(layer_height, extrusion_width, short_length));

--- a/Firmware/first_lay_cal.cpp
+++ b/Firmware/first_lay_cal.cpp
@@ -210,7 +210,9 @@ void lay1cal_meander(float layer_height, float extrusion_width)
         enquecommandf_P(extrude_fmt_Y, invert * -short_length, short_extrusion);
     }
 #ifdef NEW_FIRST_LAYER_CAL
-    enquecommandf_P(extrude_fmt_X, -(long_length/2-square_width/2), long_extrusion); //~Middle of bed X125
+    constexpr float mid_length = 0.5f * long_length - 0.5f * square_width;
+    const float mid_extrusion = count_e(layer_height, extrusion_width, mid_length);
+    enquecommandf_P(extrude_fmt_X, -mid_length, mid_extrusion); //~Middle of bed X125
     enquecommandf_P(extrude_fmt_Y, short_length, short_extrusion); //~Middle of bed Y105
 #endif //NEW_FIRST_LAYER_CAL
 

--- a/Firmware/first_lay_cal.cpp
+++ b/Firmware/first_lay_cal.cpp
@@ -37,7 +37,7 @@ static constexpr float spacing(float layer_height, float extrusion_width, float 
 static void lay1cal_common_enqueue_loop(const char * const * cmd_sequence, const uint8_t steps) {
     for (uint8_t i = 0; i < steps; ++i)
     {
-        void * pgm_ptr = pgm_read_ptr(cmd_sequence + i);
+        void * const pgm_ptr = pgm_read_ptr(cmd_sequence + i);
 
         // M702 is currently only used with MMU enabled
         if (pgm_ptr == MSG_M702 && !MMU2::mmu2.Enabled()) {
@@ -53,14 +53,14 @@ static const char extrude_fmt_Y[] PROGMEM = "G1Y%gE%g";
 static const char zero_extrusion[] PROGMEM = "G92E0";
 static const char feedrate_F1080[] PROGMEM = "G1F1080";
 #ifndef NEW_FIRST_LAYER_CAL
-int8_t invert = 1;
-const float short_length = 20;
+static constexpr int8_t invert = 1;
+static constexpr float short_length = 20;
 #else
-int8_t invert = -1;
-const float short_length = 13;
+static constexpr int8_t invert = -1;
+static constexpr float short_length = 13;
 #endif //NEW_FIRST_LAYER_CAL
-const float square_width = 20;
-const float long_length = 150;
+static constexpr float square_width = 20;
+static constexpr float long_length = 150;
 
 //! @brief Wait for preheat
 void lay1cal_wait_preheat()

--- a/Firmware/first_lay_cal.cpp
+++ b/Firmware/first_lay_cal.cpp
@@ -204,15 +204,10 @@ void lay1cal_meander(float layer_height, float extrusion_width)
     const float long_extrusion = count_e(layer_height, extrusion_width, long_length);
     const float short_extrusion = count_e(layer_height, extrusion_width, short_length);
 
-    float x_pos = long_length;
-
-    for(uint8_t i = 0; i <= 4; ++i)
+    for(int8_t i = 0, xdir = -invert; i <= 4; i++, xdir = -xdir)
     {
-        enquecommandf_P(extrude_fmt_X, -x_pos*invert, long_extrusion);
-
-        x_pos = -x_pos;
-
-        enquecommandf_P(extrude_fmt_Y, -short_length*invert, short_extrusion);
+        enquecommandf_P(extrude_fmt_X, xdir * long_length, long_extrusion);
+        enquecommandf_P(extrude_fmt_Y, invert * -short_length, short_extrusion);
     }
 #ifdef NEW_FIRST_LAYER_CAL
     enquecommandf_P(extrude_fmt_X, -(long_length/2-square_width/2), long_extrusion); //~Middle of bed X125

--- a/Firmware/first_lay_cal.cpp
+++ b/Firmware/first_lay_cal.cpp
@@ -48,18 +48,19 @@ static void lay1cal_common_enqueue_loop(const char * const * cmd_sequence, const
     }
 }
 
-static const char extrude_fmt_X[] PROGMEM = "G1X%gE%g";
-static const char extrude_fmt_Y[] PROGMEM = "G1Y%gE%g";
+static const char extrude_fmt_X[] PROGMEM = "G1X%.4fE%.4f";
+static const char extrude_fmt_Y[] PROGMEM = "G1Y%.4fE%.4f";
 static const char zero_extrusion[] PROGMEM = "G92E0";
 static const char feedrate_F1080[] PROGMEM = "G1F1080";
 #ifndef NEW_FIRST_LAYER_CAL
 static constexpr int8_t invert = 1;
 static constexpr float short_length = 20;
+static constexpr float square_width = short_length;
 #else
 static constexpr int8_t invert = -1;
-static constexpr float short_length = 13;
+static constexpr float short_length = 13.2812; //max_pos[1]/2 / meander * 2
+static constexpr float square_width = short_length*2;
 #endif //NEW_FIRST_LAYER_CAL
-static constexpr float square_width = 20;
 static constexpr float long_length = 150;
 
 //! @brief Wait for preheat
@@ -120,7 +121,7 @@ void lay1cal_intro_line(bool extraPurgeNeeded, float layer_height, float extrusi
     static const char cmd_intro_mmu_6[] PROGMEM = "G1Z0.3F1000";
     static const char cmd_intro_mmu_8[] PROGMEM = "G1X240E25F2200";
     static const char cmd_intro_mmu_9[] PROGMEM = "G1Y-2F1000";
-    static const char cmd_intro_mmu_10[] PROGMEM = "G1X200E8F1400";
+    static const char cmd_intro_mmu_10[] PROGMEM = "G1X202.5E8F1400";
     static const char cmd_intro_mmu_11[] PROGMEM = "G1Z0.2";
     static const char * const cmd_intro_mmu[] PROGMEM =
     {
@@ -181,7 +182,7 @@ void lay1cal_meander_start(float layer_height, float extrusion_width)
 #ifndef NEW_FIRST_LAYER_CAL
     enquecommand_P(PSTR("G1X50Y155"));
 #endif //_NEW_FIRST_LAYER_CAL
-    static const char fmt1[] PROGMEM = "G1Z%g";
+    static const char fmt1[] PROGMEM = "G1Z%.2f";
     enquecommandf_P(fmt1, layer_height);
     enquecommand_P(feedrate_F1080);
     enquecommand_P(MSG_G91); //enable relative XYZ
@@ -240,24 +241,23 @@ void lay1cal_square(float layer_height, float extrusion_width)
 
 void lay1cal_finish()
 {
-    static const char cmd_cal_finish_1[] PROGMEM = "G1E-0.075F2100"; // Retract
-    static const char cmd_cal_finish_2[] PROGMEM = "M140S0";         // Turn off bed heater
-    static const char cmd_cal_finish_3[] PROGMEM = "M104S0";         // Turn off hotend heater
-    static const char cmd_cal_finish_4[] PROGMEM = "G1Z10F1300";     // Lift Z
-    static const char cmd_cal_finish_5[] PROGMEM = "G1X10Y180F4000"; // Go to parking position
+    static const char cmd_cal_finish_3[] PROGMEM = "G1E-0.075F2100"; // Retract
+    static const char cmd_cal_finish_4[] PROGMEM = "M140S0";         // Turn off bed heater
+    static const char cmd_cal_finish_5[] PROGMEM = "G1Z10F1300";     // Lift Z
+    static const char cmd_cal_finish_6[] PROGMEM = "G1X10Y180F4000"; // Go to parking position
+    static const char cmd_cal_finish_8[] PROGMEM = "M104S0";         // Turn off hotend heater
 
     static const char * const cmd_cal_finish[] PROGMEM =
     {
         MSG_G90,          // Set to Absolute Positioning
         MSG_M107,         // Turn off printer fan
-        cmd_cal_finish_1, // Retract
-        cmd_cal_finish_2, // Turn off bed heater
-        cmd_cal_finish_4, // Lift Z
-        cmd_cal_finish_5, // Go to parking position
+        cmd_cal_finish_3, // Retract
+        cmd_cal_finish_4, // Turn off bed heater
+        cmd_cal_finish_5, // Lift Z
+        cmd_cal_finish_6, // Go to parking position
         MSG_M702,         // Unload filament (MMU only)
-        cmd_cal_finish_3, // Turn off hotend heater
+        cmd_cal_finish_8, // Turn off hotend heater
         MSG_M84           // Disable stepper motors
-        
     };
 
     lay1cal_common_enqueue_loop(cmd_cal_finish, (sizeof(cmd_cal_finish)/sizeof(cmd_cal_finish[0])));

--- a/Firmware/first_lay_cal.cpp
+++ b/Firmware/first_lay_cal.cpp
@@ -257,10 +257,10 @@ void lay1cal_finish()
         MSG_M107,         // Turn off printer fan
         cmd_cal_finish_1, // Retract
         cmd_cal_finish_2, // Turn off bed heater
-        MSG_M702,         // Unload filament (MMU only)
-        cmd_cal_finish_3, // Turn off hotend heater
         cmd_cal_finish_4, // Lift Z
         cmd_cal_finish_5, // Go to parking position
+        MSG_M702,         // Unload filament (MMU only)
+        cmd_cal_finish_3, // Turn off hotend heater
         MSG_M84           // Disable stepper motors
         
     };

--- a/Firmware/first_lay_cal.h
+++ b/Firmware/first_lay_cal.h
@@ -13,6 +13,6 @@ void lay1cal_before_meander();
 void lay1cal_meander_start(float layer_height, float extrusion_width);
 void lay1cal_meander(float layer_height, float extrusion_width);
 void lay1cal_square(uint8_t step, float layer_height, float extrusion_width);
-void lay1cal_finish(bool mmu_enabled);
+void lay1cal_finish();
 
 #endif /* FIRMWARE_FIRST_LAY_CAL_H_ */

--- a/Firmware/first_lay_cal.h
+++ b/Firmware/first_lay_cal.h
@@ -12,7 +12,7 @@ void lay1cal_intro_line(bool skipExtraPurge, float layer_height, float extrusion
 void lay1cal_before_meander();
 void lay1cal_meander_start(float layer_height, float extrusion_width);
 void lay1cal_meander(float layer_height, float extrusion_width);
-void lay1cal_square(uint8_t step, float layer_height, float extrusion_width);
+void lay1cal_square(float layer_height, float extrusion_width);
 void lay1cal_finish();
 
 #endif /* FIRMWARE_FIRST_LAY_CAL_H_ */

--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -429,6 +429,7 @@ const char MSG_FILAMENT_RUNOUT_DETECTED[] PROGMEM_N1 = "Filament runout detected
 const char G1_E_F2700[] PROGMEM_N1 = "G1 E%-.3f F2700";
 const char G28W[] PROGMEM_N1 = "G28 W";
 const char MSG_G90[] PROGMEM_N1 = "G90";
+const char MSG_G91[] PROGMEM_N1 = "G91";
 const char MSG_M23[] PROGMEM_N1 = "M23 %s";
 const char MSG_M24[] PROGMEM_N1 = "M24";
 const char MSG_M83[] PROGMEM_N1 = "M83";

--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -428,6 +428,7 @@ const char MSG_FILAMENT_RUNOUT_DETECTED[] PROGMEM_N1 = "Filament runout detected
 // Common G-gcodes
 const char G1_E_F2700[] PROGMEM_N1 = "G1 E%-.3f F2700";
 const char G28W[] PROGMEM_N1 = "G28 W";
+const char MSG_G90[] PROGMEM_N1 = "G90";
 const char MSG_M23[] PROGMEM_N1 = "M23 %s";
 const char MSG_M24[] PROGMEM_N1 = "M24";
 const char MSG_M83[] PROGMEM_N1 = "M83";

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -431,6 +431,7 @@ extern const char MSG_FILAMENT_RUNOUT_DETECTED[];
 extern const char G1_E_F2700[];
 extern const char G28W[];
 extern const char MSG_G90[];
+extern const char MSG_G91[];
 extern const char MSG_M23[];
 extern const char MSG_M24[];
 extern const char MSG_M83[];

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -430,6 +430,7 @@ extern const char MSG_FILAMENT_RUNOUT_DETECTED[];
 // Common G-gcodes
 extern const char G1_E_F2700[];
 extern const char G28W[];
+extern const char MSG_G90[];
 extern const char MSG_M23[];
 extern const char MSG_M24[];
 extern const char MSG_M83[];

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -869,7 +869,7 @@ void lcd_commands()
                 lay1cal_square(3, layer_height, extrusion_width);
                 break;
             case 2:
-                lay1cal_finish(MMU2::mmu2.Enabled());
+                lay1cal_finish();
                 break;
             case 1:
                 lcd_setstatuspgm(MSG_WELCOME);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -860,13 +860,13 @@ void lcd_commands()
                 lay1cal_square(0, layer_height, extrusion_width);
                 break;
             case 5:
-                lay1cal_square(4, layer_height, extrusion_width);
+                lay1cal_square(1, layer_height, extrusion_width);
                 break;
             case 4:
-                lay1cal_square(8, layer_height, extrusion_width);
+                lay1cal_square(2, layer_height, extrusion_width);
                 break;
             case 3:
-                lay1cal_square(12, layer_height, extrusion_width);
+                lay1cal_square(3, layer_height, extrusion_width);
                 break;
             case 2:
                 lay1cal_finish(MMU2::mmu2.Enabled());

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -857,14 +857,8 @@ void lcd_commands()
                 lay1cal_meander(layer_height, extrusion_width);
                 break;
             case 6:
-                lay1cal_square(layer_height, extrusion_width);
-                break;
             case 5:
-                lay1cal_square(layer_height, extrusion_width);
-                break;
             case 4:
-                lay1cal_square(layer_height, extrusion_width);
-                break;
             case 3:
                 lay1cal_square(layer_height, extrusion_width);
                 break;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -857,16 +857,16 @@ void lcd_commands()
                 lay1cal_meander(layer_height, extrusion_width);
                 break;
             case 6:
-                lay1cal_square(0, layer_height, extrusion_width);
+                lay1cal_square(layer_height, extrusion_width);
                 break;
             case 5:
-                lay1cal_square(1, layer_height, extrusion_width);
+                lay1cal_square(layer_height, extrusion_width);
                 break;
             case 4:
-                lay1cal_square(2, layer_height, extrusion_width);
+                lay1cal_square(layer_height, extrusion_width);
                 break;
             case 3:
-                lay1cal_square(3, layer_height, extrusion_width);
+                lay1cal_square(layer_height, extrusion_width);
                 break;
             case 2:
                 lay1cal_finish();

--- a/Firmware/variants/MK25-RAMBo10a.h
+++ b/Firmware/variants/MK25-RAMBo10a.h
@@ -24,6 +24,7 @@
 
 #define HEATBED_V2
 #define STEEL_SHEET
+//#define NEW_FIRST_LAYER_CAL //from front to back
 #define TACH0PULLUP
 
 // Uncomment the below for the E3D PT100 temperature sensor (with or without PT100 Amplifier)

--- a/Firmware/variants/MK25-RAMBo13a.h
+++ b/Firmware/variants/MK25-RAMBo13a.h
@@ -24,6 +24,7 @@
 
 #define HEATBED_V2
 #define STEEL_SHEET
+//#define NEW_FIRST_LAYER_CAL //from front to back
 #define TACH0PULLUP
 
 // Uncomment the below for the E3D PT100 temperature sensor (with or without PT100 Amplifier)

--- a/Firmware/variants/MK25S-RAMBo10a.h
+++ b/Firmware/variants/MK25S-RAMBo10a.h
@@ -24,6 +24,7 @@
 
 #define HEATBED_V2
 #define STEEL_SHEET
+//#define NEW_FIRST_LAYER_CAL //from front to back
 #define TACH0PULLUP
 
 // Uncomment the below for the E3D PT100 temperature sensor (with or without PT100 Amplifier)

--- a/Firmware/variants/MK25S-RAMBo13a.h
+++ b/Firmware/variants/MK25S-RAMBo13a.h
@@ -24,6 +24,7 @@
 
 #define HEATBED_V2
 #define STEEL_SHEET
+//#define NEW_FIRST_LAYER_CAL //from front to back
 #define TACH0PULLUP
 
 // Uncomment the below for the E3D PT100 temperature sensor (with or without PT100 Amplifier)

--- a/Firmware/variants/MK3-E3DREVO.h
+++ b/Firmware/variants/MK3-E3DREVO.h
@@ -23,6 +23,7 @@
 // Electronics
 #define MOTHERBOARD BOARD_EINSY_1_0a
 #define STEEL_SHEET
+//#define NEW_FIRST_LAYER_CAL //from front to back
 #define HAS_SECOND_SERIAL_PORT
 
 

--- a/Firmware/variants/MK3-E3DREVO_HF_60W.h
+++ b/Firmware/variants/MK3-E3DREVO_HF_60W.h
@@ -23,6 +23,7 @@
 // Electronics
 #define MOTHERBOARD BOARD_EINSY_1_0a
 #define STEEL_SHEET
+//#define NEW_FIRST_LAYER_CAL //from front to back
 #define HAS_SECOND_SERIAL_PORT
 
 

--- a/Firmware/variants/MK3.h
+++ b/Firmware/variants/MK3.h
@@ -23,6 +23,7 @@
 // Electronics
 #define MOTHERBOARD BOARD_EINSY_1_0a
 #define STEEL_SHEET
+//#define NEW_FIRST_LAYER_CAL //from front to back
 #define HAS_SECOND_SERIAL_PORT
 
 

--- a/Firmware/variants/MK3S-E3DREVO.h
+++ b/Firmware/variants/MK3S-E3DREVO.h
@@ -22,6 +22,7 @@
 // Electronics
 #define MOTHERBOARD BOARD_EINSY_1_0a
 #define STEEL_SHEET
+//#define NEW_FIRST_LAYER_CAL //from front to back
 #define HAS_SECOND_SERIAL_PORT
 
 // PSU

--- a/Firmware/variants/MK3S-E3DREVO_HF_60W.h
+++ b/Firmware/variants/MK3S-E3DREVO_HF_60W.h
@@ -22,6 +22,7 @@
 // Electronics
 #define MOTHERBOARD BOARD_EINSY_1_0a
 #define STEEL_SHEET
+//#define NEW_FIRST_LAYER_CAL //from front to back
 #define HAS_SECOND_SERIAL_PORT
 
 // PSU

--- a/Firmware/variants/MK3S.h
+++ b/Firmware/variants/MK3S.h
@@ -22,6 +22,7 @@
 // Electronics
 #define MOTHERBOARD BOARD_EINSY_1_0a
 #define STEEL_SHEET
+//#define NEW_FIRST_LAYER_CAL //from front to back
 #define HAS_SECOND_SERIAL_PORT
 
 // PSU


### PR DESCRIPTION
- Reduced buffer and flash size by
  - changing to relative mode during the first layer calibration pattern
  - "compressing" the Gcode line by removing spaces 
- added NEW_FIRST_LAYER_CAL to perform 1st layer cal from front to rear as requested in https://github.com/prusa3d/Prusa-Firmware/issues/4572

By default the previous known first layer calibration pattern is used. You need to un-comment `//#define NEW_FIRST_LAYER_CAL` in the variant file to use the new pattern from front to rear.

The new first layer calibration pattern from front to rear with square ends in the middle of the bed.
- The calibration of the first layer at the center is most important
- The left, right, front rear sides can manually corrected via LCD -> Calibration -> Bed level correct menu
- The first layer calibration pattern continues directly after the purge to keep the pressure stable in the nozzle

![New_first_layer_cal](https://github.com/user-attachments/assets/3beb9b61-6aa4-49c8-9c7e-3236044eb8d1)