### PR TITLE
Fix an issue in first layer calibration where MMU unloads with disabled hotend heater

### DIFF
--- a/Firmware/first_lay_cal.cpp
+++ b/Firmware/first_lay_cal.cpp
@@ -37,7 +37,14 @@ static constexpr float spacing(float layer_height, float extrusion_width, float 
 static void lay1cal_common_enqueue_loop(const char * const * cmd_sequence, const uint8_t steps) {
     for (uint8_t i = 0; i < steps; ++i)
     {
-        enquecommand_P(static_cast<char*>(pgm_read_ptr(cmd_sequence + i)));
+        void * pgm_ptr = pgm_read_ptr(cmd_sequence + i);
+
+        // M702 is currently only used with MMU enabled
+        if (pgm_ptr == MSG_M702 && !MMU2::mmu2.Enabled()) {
+            continue;
+        }
+
+        enquecommand_P(static_cast<char*>(pgm_ptr));
     }
 }
 
@@ -225,26 +232,25 @@ void lay1cal_square(uint8_t step, float layer_height, float extrusion_width)
     }
 }
 
-void lay1cal_finish(bool mmu_enabled)
+void lay1cal_finish()
 {
-    static const char cmd_cal_finish_1[] PROGMEM = "G1 E-0.075 F2100"; //retract
-    static const char cmd_cal_finish_2[] PROGMEM = "M104 S0"; // turn off temperature
-    static const char cmd_cal_finish_3[] PROGMEM = "M140 S0"; // turn off heatbed
-    static const char cmd_cal_finish_4[] PROGMEM = "G1 Z10 F1300"; //lift Z
-    static const char cmd_cal_finish_5[] PROGMEM = "G1 X10 Y180 F4000"; //Go to parking position
+    static const char cmd_cal_finish_1[] PROGMEM = "G1 E-0.075 F2100";  // Retract
+    static const char cmd_cal_finish_2[] PROGMEM = "M140 S0";           // Turn off heatbed
+    static const char cmd_cal_finish_3[] PROGMEM = "M104 S0";           // Turn off temperature
+    static const char cmd_cal_finish_4[] PROGMEM = "G1 Z10 F1300";      // Lift Z
+    static const char cmd_cal_finish_5[] PROGMEM = "G1 X10 Y180 F4000"; // Go to parking position
 
     static const char * const cmd_cal_finish[] PROGMEM =
     {
-            MSG_M107, // turn off printer fan
-            cmd_cal_finish_1,
-            cmd_cal_finish_2,
-            cmd_cal_finish_3,
-            cmd_cal_finish_4,
-            cmd_cal_finish_5
+            MSG_M107,         // Turn off printer fan
+            cmd_cal_finish_1, // Retract
+            cmd_cal_finish_2, // Turn off bed heater
+            MSG_M702,         // Unload filament (MMU only)
+            cmd_cal_finish_3, // Turn off hotend heater
+            cmd_cal_finish_4, // Lift Z
+            cmd_cal_finish_5, // Go to parking position
+            MSG_M84           // Disable stepper motors
     };
 
     lay1cal_common_enqueue_loop(cmd_cal_finish, (sizeof(cmd_cal_finish)/sizeof(cmd_cal_finish[0])));
-
-    if (mmu_enabled) enquecommand_P(MSG_M702); //unload from nozzle
-    enquecommand_P(MSG_M84);// disable motors
 }

--- a/Firmware/first_lay_cal.h
+++ b/Firmware/first_lay_cal.h
@@ -13,6 +13,6 @@ void lay1cal_before_meander();
 void lay1cal_meander_start(float layer_height, float extrusion_width);
 void lay1cal_meander(float layer_height, float extrusion_width);
 void lay1cal_square(uint8_t step, float layer_height, float extrusion_width);
-void lay1cal_finish(bool mmu_enabled);
+void lay1cal_finish();
 
 #endif /* FIRMWARE_FIRST_LAY_CAL_H_ */

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -869,7 +869,7 @@ void lcd_commands()
                 lay1cal_square(12, layer_height, extrusion_width);
                 break;
             case 2:
-                lay1cal_finish(MMU2::mmu2.Enabled());
+                lay1cal_finish();
                 break;
             case 1:
                 lcd_setstatuspgm(MSG_WELCOME);


### PR DESCRIPTION
Minor issue I found while reviewing https://github.com/prusa3d/Prusa-Firmware/pull/4811

Change in memory:
Flash: -16 bytes
SRAM: 0 bytes