### PR TITLE
Fix multiple choice

### DIFF
--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -18,7 +18,7 @@ const char MSG_BED_HEATING[] PROGMEM_I1 = ISTR("Bed Heating"); ////MSG_BED_HEATI
 const char MSG_BED_LEVELING_FAILED_POINT_LOW[] PROGMEM_I1 = ISTR("Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for reset."); ////MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
 const char MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED[] PROGMEM_I1 = ISTR("XYZ calibration failed. Please consult the manual."); ////MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
 const char MSG_BELT_STATUS[] PROGMEM_I1 = ISTR("Belt status");////MSG_BELT_STATUS c=18
-const char MSG_EJECT[] PROGMEM_I1 = ISTR("Eject"); ////MSG_EJECT c=8
+const char MSG_EJECT[] PROGMEM_I1 = ISTR("Eject"); ////MSG_EJECT c=9
 const char MSG_CANCEL[] PROGMEM_I1 = ISTR(">Cancel");////MSG_CANCEL c=10
 const char MSG_CALIBRATE_Z_AUTO[] PROGMEM_I1 = ISTR("Calibrating Z"); ////MSG_CALIBRATE_Z_AUTO c=20 r=2
 const char MSG_CARD_MENU[] PROGMEM_I1 = ISTR("Print from SD"); ////MSG_CARD_MENU c=18

--- a/Firmware/mmu2/errors_list.h
+++ b/Firmware/mmu2/errors_list.h
@@ -355,7 +355,7 @@ static const char MSG_BTN_RETRY[] PROGMEM_I1 = ISTR("Retry"); ////MSG_BTN_RETRY 
 static const char MSG_BTN_RESET_MMU[] PROGMEM_I1 = ISTR("ResetMMU"); ////MSG_BTN_RESET_MMU c=8
 static const char MSG_BTN_UNLOAD[] PROGMEM_I1 = ISTR("Unload"); ////MSG_BTN_UNLOAD c=8
 static const char MSG_BTN_LOAD[] PROGMEM_I1 = ISTR("Load"); ////MSG_BTN_LOAD c=8
-//static const char MSG_BTN_EJECT[] PROGMEM_I1 = ISTR("Eject"); //Reuse MSG_EJECT c=8
+//static const char MSG_BTN_EJECT[] PROGMEM_I1 = ISTR("Eject"); //Reuse MSG_EJECT c=9
 //static const char MSG_BTN_TUNE_MMU[] PROGMEM_I1 = ISTR("Tune"); //Reuse MSG_TUNE c=8
 static const char MSG_BTN_STOP[] PROGMEM_I1 = ISTR("Stop"); ////MSG_BTN_STOP c=8
 static const char MSG_BTN_DISABLE_MMU[] PROGMEM_I1 = ISTR("Disable"); ////MSG_BTN_DISABLE_MMU c=8

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2266,11 +2266,25 @@ void show_preheat_nozzle_warning()
 
 void lcd_load_filament_color_check()
 {
-    uint8_t clean = lcd_show_multiscreen_message_with_choices_and_wait_P(_T(MSG_FILAMENT_CLEAN), false, LCD_LEFT_BUTTON_CHOICE, _T(MSG_YES), _T(MSG_NO), _T(MSG_EJECT), 8);
+    // The total length of the individual messages MSG_YES c=4, MSG_NO c=4 and MSG_EJECT c=8 with the selectors and spaces between
+    // exceeds the LCD width.
+    // 01234567890123456789
+    // >yyyy >nnnn >eeeeeeee
+    // As long the translations of MSG_YES, MSG_NO and MSG_EJECT combined length do not exceed 15 chars, we don't have to shorten
+    // the MSG_EJECT message/translation. We can set the second_col value to the length of the first choice + the selector and space.
+    // Examples:
+    // German
+    // 01234567890123456789
+    // >Ja >Nein  >Auswerf.
+    // Hungarian
+    // 01234567890123456789
+    // >Igen >Nem   >Kiadás
+
+    uint8_t clean = lcd_show_multiscreen_message_with_choices_and_wait_P(_T(MSG_FILAMENT_CLEAN), false, LCD_LEFT_BUTTON_CHOICE, _T(MSG_YES), _T(MSG_NO), _T(MSG_EJECT), strlen_P(_T(MSG_YES))+2);
     while (clean == LCD_MIDDLE_BUTTON_CHOICE) {
         load_filament_final_feed();
         st_synchronize();
-        clean = lcd_show_multiscreen_message_with_choices_and_wait_P(_T(MSG_FILAMENT_CLEAN), false, LCD_LEFT_BUTTON_CHOICE, _T(MSG_YES), _T(MSG_NO), _T(MSG_EJECT), 8);
+        clean = lcd_show_multiscreen_message_with_choices_and_wait_P(_T(MSG_FILAMENT_CLEAN), false, LCD_LEFT_BUTTON_CHOICE, _T(MSG_YES), _T(MSG_NO), _T(MSG_EJECT), strlen_P(_T(MSG_YES))+2);
     }
     if (clean == LCD_RIGHT_BUTTON_CHOICE) {
         unload_filament(FILAMENTCHANGE_FINALRETRACT);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2266,7 +2266,7 @@ void show_preheat_nozzle_warning()
 
 void lcd_load_filament_color_check()
 {
-    // The total length of the individual messages MSG_YES c=4, MSG_NO c=4 and MSG_EJECT c=8 with the selectors and spaces between
+    // The total length of the individual messages MSG_YES c=4, MSG_NO c=4 and MSG_EJECT c=9 with the selectors and spaces between
     // exceeds the LCD width.
     // 01234567890123456789
     // >yyyy >nnnn >eeeeeeee
@@ -2275,7 +2275,7 @@ void lcd_load_filament_color_check()
     // Examples:
     // German
     // 01234567890123456789
-    // >Ja >Nein  >Auswerf.
+    // >Ja >Nein >Auswerfen
     // Hungarian
     // 01234567890123456789
     // >Igen >Nem   >Kiadás

--- a/lang/po/Firmware.pot
+++ b/lang/po/Firmware.pot
@@ -470,7 +470,7 @@ msgstr ""
 msgid "ERROR:"
 msgstr ""
 
-#. MSG_EJECT c=8
+#. MSG_EJECT c=9
 #: ../../Firmware/messages.cpp:21 ../../Firmware/mmu2/errors_list.h:371
 #: ../../Firmware/ultralcd.cpp:2275 ../../Firmware/ultralcd.cpp:2279
 msgid "Eject"

--- a/lang/po/Firmware_cs.po
+++ b/lang/po/Firmware_cs.po
@@ -2518,7 +2518,7 @@ msgstr "NEZNÁMÁ CHYBA"
 msgid "Unexpected error occurred."
 msgstr "Došlo k neočekávané chybě."
 
-#. MSG_EJECT c=8
+#. MSG_EJECT c=9
 #: ../../Firmware/messages.cpp:21 ../../Firmware/mmu2/errors_list.h:371
 #: ../../Firmware/ultralcd.cpp:2275 ../../Firmware/ultralcd.cpp:2279
 msgid "Eject"

--- a/lang/po/Firmware_de.po
+++ b/lang/po/Firmware_de.po
@@ -2544,11 +2544,11 @@ msgstr "UNBEKANNTER FEHLER"
 msgid "Unexpected error occurred."
 msgstr "Ein unerwarteter Fehler ist aufgetreten."
 
-#. MSG_EJECT c=8
+#. MSG_EJECT c=9
 #: ../../Firmware/messages.cpp:21 ../../Firmware/mmu2/errors_list.h:371
 #: ../../Firmware/ultralcd.cpp:2275 ../../Firmware/ultralcd.cpp:2279
 msgid "Eject"
-msgstr "Auswerf."
+msgstr "Auswerfen"
 
 #. MSG_TITLE_FILAMENT_CHANGE c=20
 #: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236

--- a/lang/po/Firmware_es.po
+++ b/lang/po/Firmware_es.po
@@ -2540,7 +2540,7 @@ msgstr "ERROR DESCONOCIDO"
 msgid "Unexpected error occurred."
 msgstr "Ocurrió un error inesperado."
 
-#. MSG_EJECT c=8
+#. MSG_EJECT c=9
 #: ../../Firmware/messages.cpp:21 ../../Firmware/mmu2/errors_list.h:371
 #: ../../Firmware/ultralcd.cpp:2275 ../../Firmware/ultralcd.cpp:2279
 msgid "Eject"

--- a/lang/po/Firmware_fr.po
+++ b/lang/po/Firmware_fr.po
@@ -2553,7 +2553,7 @@ msgstr "ERREUR INCONNUE"
 msgid "Unexpected error occurred."
 msgstr "Une erreur inattendue s'est produite."
 
-#. MSG_EJECT c=8
+#. MSG_EJECT c=9
 #: ../../Firmware/messages.cpp:21 ../../Firmware/mmu2/errors_list.h:371
 #: ../../Firmware/ultralcd.cpp:2275 ../../Firmware/ultralcd.cpp:2279
 msgid "Eject"

--- a/lang/po/Firmware_hr.po
+++ b/lang/po/Firmware_hr.po
@@ -2535,7 +2535,7 @@ msgstr "NEPOZNATA POGREŠKA"
 msgid "Unexpected error occurred."
 msgstr "Došlo je do neočekivane pogreške."
 
-#. MSG_EJECT c=8
+#. MSG_EJECT c=9
 #: ../../Firmware/messages.cpp:21 ../../Firmware/mmu2/errors_list.h:371
 #: ../../Firmware/ultralcd.cpp:2275 ../../Firmware/ultralcd.cpp:2279
 msgid "Eject"

--- a/lang/po/Firmware_hu.po
+++ b/lang/po/Firmware_hu.po
@@ -2541,7 +2541,7 @@ msgstr "ISMERETLEN HIBA"
 msgid "Unexpected error occurred."
 msgstr "Váratlan hiba történt."
 
-#. MSG_EJECT c=8
+#. MSG_EJECT c=9
 #: ../../Firmware/messages.cpp:21 ../../Firmware/mmu2/errors_list.h:371
 #: ../../Firmware/ultralcd.cpp:2275 ../../Firmware/ultralcd.cpp:2279
 msgid "Eject"

--- a/lang/po/Firmware_it.po
+++ b/lang/po/Firmware_it.po
@@ -2540,7 +2540,7 @@ msgstr "ERRORE SCONOSCIUTO"
 msgid "Unexpected error occurred."
 msgstr "Si è verificato un errore imprevisto."
 
-#. MSG_EJECT c=8
+#. MSG_EJECT c=9
 #: ../../Firmware/messages.cpp:21 ../../Firmware/mmu2/errors_list.h:371
 #: ../../Firmware/ultralcd.cpp:2275 ../../Firmware/ultralcd.cpp:2279
 msgid "Eject"

--- a/lang/po/Firmware_nl.po
+++ b/lang/po/Firmware_nl.po
@@ -2543,11 +2543,11 @@ msgstr "ONBEKENDE FOUT"
 msgid "Unexpected error occurred."
 msgstr "Er is een onverwachte fout opgetreden."
 
-#. MSG_EJECT c=8
+#. MSG_EJECT c=9
 #: ../../Firmware/messages.cpp:21 ../../Firmware/mmu2/errors_list.h:371
 #: ../../Firmware/ultralcd.cpp:2275 ../../Firmware/ultralcd.cpp:2279
 msgid "Eject"
-msgstr "Uitwerp."
+msgstr "Uitwerpen"
 
 #. MSG_TITLE_FILAMENT_CHANGE c=20
 #: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236

--- a/lang/po/Firmware_no.po
+++ b/lang/po/Firmware_no.po
@@ -2517,7 +2517,7 @@ msgstr "UKJENT FEIL"
 msgid "Unexpected error occurred."
 msgstr "Det oppstod en uventet feil."
 
-#. MSG_EJECT c=8
+#. MSG_EJECT c=9
 #: ../../Firmware/messages.cpp:21 ../../Firmware/mmu2/errors_list.h:371
 #: ../../Firmware/ultralcd.cpp:2275 ../../Firmware/ultralcd.cpp:2279
 msgid "Eject"

--- a/lang/po/Firmware_pl.po
+++ b/lang/po/Firmware_pl.po
@@ -2533,7 +2533,7 @@ msgstr "NIEZNANY BŁĄD"
 msgid "Unexpected error occurred."
 msgstr "Pojawił się nieoczekiwany błąd."
 
-#. MSG_EJECT c=8
+#. MSG_EJECT c=9
 #: ../../Firmware/messages.cpp:21 ../../Firmware/mmu2/errors_list.h:371
 #: ../../Firmware/ultralcd.cpp:2275 ../../Firmware/ultralcd.cpp:2279
 msgid "Eject"

--- a/lang/po/Firmware_ro.po
+++ b/lang/po/Firmware_ro.po
@@ -2541,7 +2541,7 @@ msgstr "EROARE NECUNOSCUTĂ"
 msgid "Unexpected error occurred."
 msgstr "A apărut o eroare neașteptată."
 
-#. MSG_EJECT c=8
+#. MSG_EJECT c=9
 #: ../../Firmware/messages.cpp:21 ../../Firmware/mmu2/errors_list.h:371
 #: ../../Firmware/ultralcd.cpp:2275 ../../Firmware/ultralcd.cpp:2279
 msgid "Eject"

--- a/lang/po/Firmware_sk.po
+++ b/lang/po/Firmware_sk.po
@@ -2523,7 +2523,7 @@ msgstr "NEZNÁMA CHYBA"
 msgid "Unexpected error occurred."
 msgstr "Vyskytla sa neočakávaná chyba."
 
-#. MSG_EJECT c=8
+#. MSG_EJECT c=9
 #: ../../Firmware/messages.cpp:21 ../../Firmware/mmu2/errors_list.h:371
 #: ../../Firmware/ultralcd.cpp:2275 ../../Firmware/ultralcd.cpp:2279
 msgid "Eject"

--- a/lang/po/Firmware_sv.po
+++ b/lang/po/Firmware_sv.po
@@ -2530,7 +2530,7 @@ msgstr "OKÄNT FEL"
 msgid "Unexpected error occurred."
 msgstr "Ett oväntat fel inträffade."
 
-#. MSG_EJECT c=8
+#. MSG_EJECT c=9
 #: ../../Firmware/messages.cpp:21 ../../Firmware/mmu2/errors_list.h:371
 #: ../../Firmware/ultralcd.cpp:2275 ../../Firmware/ultralcd.cpp:2279
 msgid "Eject"


### PR DESCRIPTION
Fixes #4819

Issue was that the second column was set to fixed position 8 which causes issues in most languages. 
This cause the reported LCD overwriting by @Smooph86.

```
01234567890123456789
>Yes    >No   >Eject
>Ano    >Ne >Vysunout
>Ja     >Nein >Auswerf.
>Si     >No >Expulsar
>Oui    >Non >Éjecter
>Da     >Ne >Izbaciti
>Igen   >Nem >Kiadás
>Si     >No >Espelli
>Ja     >Nee >Uitwerp.
>Ja     >Nei >Løs ut
>Tak    >Nie  >Wysuń
>Da     >Nu >Scoateți
>Áno    >Nie >Vysunúť
>Ja     >Nej >Mata ut
```


![Multi_choice_de](https://github.com/user-attachments/assets/76487929-4805-409a-a1ba-223198f75f30)
![Multi_choice_cs](https://github.com/user-attachments/assets/4a3f3ab8-7620-4f8a-9768-c31eb7f818e1)
![Multi_choice_nl](https://github.com/user-attachments/assets/a714954b-919e-4a65-8895-120210b3f27b)


All translations of MSG_YES, MSG_NO and MSG_EJECT combined including the selector and spaces do not exceed the LCD width 

```
01234567890123456789
>Yes >No      >Eject
>Ano >Ne   >Vysunout
>Ja >Nein  >Auswerf.
>Si >No    >Expulsar
>Oui >Non   >Éjecter
>Da >Ne    >Izbaciti
>Igen >Nem   >Kiadás
>Si >No     >Espelli
>Ja >Nee   >Uitwerp.
>Ja >Nei     >Løs ut
>Tak >Nie     >Wysuń
>Da >Nu    >Scoateți
>Áno >Nie   >Vysunúť
>Ja >Nej    >Mata ut
```

![Fixed_Multi_choice_de](https://github.com/user-attachments/assets/68e42ecb-3421-448c-9e50-e2692fe43bc9)

Second commit un-shortens German and Dutch translation and makes it more readable.
 
![Long_fixed_multi_choice_de](https://github.com/user-attachments/assets/4c8d75b6-8d32-47d8-a4c9-56b97e52803f)
