### PR TITLE
Show filename after SD print finished

### DIFF
--- a/Firmware/cmdqueue.cpp
+++ b/Firmware/cmdqueue.cpp
@@ -670,7 +670,9 @@ void get_command()
           sprintf_P(time, PSTR("%i hours %i minutes"),hours, minutes);
           SERIAL_ECHO_START;
           SERIAL_ECHOLN(time);
+#ifndef SHOW_FILENAME_AFTER_FINISH
           lcd_setstatus(time);
+#endif //SHOW_FILENAME_AFTER_FINISH
           card.printingHasFinished();
           card.checkautostart(true);
 

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -542,14 +542,14 @@ void lcdui_print_status_line(void) {
             break;
         }
     }
-    else if (((IS_SD_PRINTING) &&
-        (custom_message_type == CustomMsg::Status) &&
-        (lcd_status_message_level <= LCD_STATUS_INFO) &&
-        lcd_status_message_timeout.expired_cont(LCD_STATUS_INFO_TIMEOUT))
+    else if (((IS_SD_PRINTING)
 #ifdef SHOW_FILENAME_AFTER_FINISH
         || (GetPrinterState() == PrinterState::SDPrintingFinished)
 #endif //SHOW_FILENAME_AFTER_FINISH
-        )
+        ) &&
+        (custom_message_type == CustomMsg::Status) &&
+        (lcd_status_message_level <= LCD_STATUS_INFO) &&
+        lcd_status_message_timeout.expired_cont(LCD_STATUS_INFO_TIMEOUT))
     {
         // If printing from SD, show what we are printing
         const char* longFilenameOLD = (card.longFilename[0] ? card.longFilename : card.filename);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -542,10 +542,14 @@ void lcdui_print_status_line(void) {
             break;
         }
     }
-    else if ((IS_SD_PRINTING) &&
+    else if (((IS_SD_PRINTING) &&
         (custom_message_type == CustomMsg::Status) &&
         (lcd_status_message_level <= LCD_STATUS_INFO) &&
         lcd_status_message_timeout.expired_cont(LCD_STATUS_INFO_TIMEOUT))
+#ifdef SHOW_FILENAME_AFTER_FINISH
+        || (GetPrinterState() == PrinterState::SDPrintingFinished)
+#endif //SHOW_FILENAME_AFTER_FINISH
+        )
     {
         // If printing from SD, show what we are printing
         const char* longFilenameOLD = (card.longFilename[0] ? card.longFilename : card.filename);

--- a/Firmware/variants/MK25-RAMBo10a.h
+++ b/Firmware/variants/MK25-RAMBo10a.h
@@ -520,4 +520,11 @@
 #define DEFAULT_MIN_ARC_SEGMENTS 20 // The enforced minimum segments in a full circle of the same radius.  Set to 0 to disable
 #define DEFAULT_ARC_SEGMENTS_PER_SEC 0 // Use feedrate to choose segment length. Set to 0 to disable
 
+/*------------------------------------
+ COMMUNITY FEATURES
+ *------------------------------------*/
+
+//Show filename instead of print time after SD card print finished
+//#define SHOW_FILENAME_AFTER_FINISH
+
 #endif //__CONFIGURATION_PRUSA_H

--- a/Firmware/variants/MK25-RAMBo13a.h
+++ b/Firmware/variants/MK25-RAMBo13a.h
@@ -524,4 +524,11 @@
 #define DEFAULT_MIN_ARC_SEGMENTS 20 // The enforced minimum segments in a full circle of the same radius.  Set to 0 to disable
 #define DEFAULT_ARC_SEGMENTS_PER_SEC 0 // Use feedrate to choose segment length. Set to 0 to disable
 
+/*------------------------------------
+ COMMUNITY FEATURES
+ *------------------------------------*/
+
+//Show filename instead of print time after SD card print finished
+//#define SHOW_FILENAME_AFTER_FINISH
+
 #endif //__CONFIGURATION_PRUSA_H

--- a/Firmware/variants/MK25S-RAMBo10a.h
+++ b/Firmware/variants/MK25S-RAMBo10a.h
@@ -528,4 +528,11 @@
 #define DEFAULT_MIN_ARC_SEGMENTS 20 // The enforced minimum segments in a full circle of the same radius.  Set to 0 to disable
 #define DEFAULT_ARC_SEGMENTS_PER_SEC 0 // Use feedrate to choose segment length. Set to 0 to disable
 
+/*------------------------------------
+ COMMUNITY FEATURES
+ *------------------------------------*/
+
+//Show filename instead of print time after SD card print finished
+//#define SHOW_FILENAME_AFTER_FINISH
+
 #endif //__CONFIGURATION_PRUSA_H

--- a/Firmware/variants/MK25S-RAMBo13a.h
+++ b/Firmware/variants/MK25S-RAMBo13a.h
@@ -529,4 +529,11 @@
 #define DEFAULT_MIN_ARC_SEGMENTS 20 // The enforced minimum segments in a full circle of the same radius.  Set to 0 to disable
 #define DEFAULT_ARC_SEGMENTS_PER_SEC 0 // Use feedrate to choose segment length. Set to 0 to disable
 
+/*------------------------------------
+ COMMUNITY FEATURES
+ *------------------------------------*/
+
+//Show filename instead of print time after SD card print finished
+//#define SHOW_FILENAME_AFTER_FINISH
+
 #endif //__CONFIGURATION_PRUSA_H

--- a/Firmware/variants/MK3-E3DREVO.h
+++ b/Firmware/variants/MK3-E3DREVO.h
@@ -687,4 +687,11 @@
 #define DEFAULT_MIN_ARC_SEGMENTS 20 // The enforced minimum segments in a full circle of the same radius.  Set to 0 to disable
 #define DEFAULT_ARC_SEGMENTS_PER_SEC 0 // Use feedrate to choose segment length. Set to 0 to disable
 
+/*------------------------------------
+ COMMUNITY FEATURES
+ *------------------------------------*/
+
+//Show filename instead of print time after SD card print finished
+//#define SHOW_FILENAME_AFTER_FINISH
+
 #endif //__CONFIGURATION_PRUSA_H

--- a/Firmware/variants/MK3-E3DREVO_HF_60W.h
+++ b/Firmware/variants/MK3-E3DREVO_HF_60W.h
@@ -688,4 +688,11 @@
 #define DEFAULT_MIN_ARC_SEGMENTS 20 // The enforced minimum segments in a full circle of the same radius.  Set to 0 to disable
 #define DEFAULT_ARC_SEGMENTS_PER_SEC 0 // Use feedrate to choose segment length. Set to 0 to disable
 
+/*------------------------------------
+ COMMUNITY FEATURES
+ *------------------------------------*/
+
+//Show filename instead of print time after SD card print finished
+//#define SHOW_FILENAME_AFTER_FINISH
+
 #endif //__CONFIGURATION_PRUSA_H

--- a/Firmware/variants/MK3.h
+++ b/Firmware/variants/MK3.h
@@ -690,4 +690,11 @@
 #define DEFAULT_MIN_ARC_SEGMENTS 20 // The enforced minimum segments in a full circle of the same radius.  Set to 0 to disable
 #define DEFAULT_ARC_SEGMENTS_PER_SEC 0 // Use feedrate to choose segment length. Set to 0 to disable
 
+/*------------------------------------
+ COMMUNITY FEATURES
+ *------------------------------------*/
+
+//Show filename instead of print time after SD card print finished
+//#define SHOW_FILENAME_AFTER_FINISH
+
 #endif //__CONFIGURATION_PRUSA_H

--- a/Firmware/variants/MK3S-E3DREVO.h
+++ b/Firmware/variants/MK3S-E3DREVO.h
@@ -699,4 +699,11 @@
 #define DEFAULT_MIN_ARC_SEGMENTS 20 // The enforced minimum segments in a full circle of the same radius.  Set to 0 to disable
 #define DEFAULT_ARC_SEGMENTS_PER_SEC 0 // Use feedrate to choose segment length. Set to 0 to disable
 
+/*------------------------------------
+ COMMUNITY FEATURES
+ *------------------------------------*/
+
+//Show filename instead of print time after SD card print finished
+//#define SHOW_FILENAME_AFTER_FINISH
+
 #endif //__CONFIGURATION_PRUSA_H

--- a/Firmware/variants/MK3S-E3DREVO_HF_60W.h
+++ b/Firmware/variants/MK3S-E3DREVO_HF_60W.h
@@ -700,4 +700,11 @@
 #define DEFAULT_MIN_ARC_SEGMENTS 20 // The enforced minimum segments in a full circle of the same radius.  Set to 0 to disable
 #define DEFAULT_ARC_SEGMENTS_PER_SEC 0 // Use feedrate to choose segment length. Set to 0 to disable
 
+/*------------------------------------
+ COMMUNITY FEATURES
+ *------------------------------------*/
+
+//Show filename instead of print time after SD card print finished
+//#define SHOW_FILENAME_AFTER_FINISH
+
 #endif //__CONFIGURATION_PRUSA_H

--- a/Firmware/variants/MK3S.h
+++ b/Firmware/variants/MK3S.h
@@ -702,4 +702,11 @@
 #define DEFAULT_MIN_ARC_SEGMENTS 20 // The enforced minimum segments in a full circle of the same radius.  Set to 0 to disable
 #define DEFAULT_ARC_SEGMENTS_PER_SEC 0 // Use feedrate to choose segment length. Set to 0 to disable
 
+/*------------------------------------
+ COMMUNITY FEATURES
+ *------------------------------------*/
+
+//Show filename instead of print time after SD card print finished
+//#define SHOW_FILENAME_AFTER_FINISH
+
 #endif //__CONFIGURATION_PRUSA_H

--- a/Firmware/variants/obsolete/1_75mm_MK2-RAMBo10a-E3Dv6full.h
+++ b/Firmware/variants/obsolete/1_75mm_MK2-RAMBo10a-E3Dv6full.h
@@ -430,4 +430,11 @@ THERMISTORS SETTINGS
 #define DEFAULT_MIN_ARC_SEGMENTS 20 // The enforced minimum segments in a full circle of the same radius.  Set to 0 to disable
 #define DEFAULT_ARC_SEGMENTS_PER_SEC 0 // Use feedrate to choose segment length. Set to 0 to disable
 
+/*------------------------------------
+ COMMUNITY FEATURES
+ *------------------------------------*/
+
+//Show filename instead of print time after SD card print finished
+//#define SHOW_FILENAME_AFTER_FINISH
+
 #endif //__CONFIGURATION_PRUSA_H

--- a/Firmware/variants/obsolete/1_75mm_MK2-RAMBo13a-E3Dv6full.h
+++ b/Firmware/variants/obsolete/1_75mm_MK2-RAMBo13a-E3Dv6full.h
@@ -429,4 +429,11 @@ THERMISTORS SETTINGS
 #define DEFAULT_MIN_ARC_SEGMENTS 20 // The enforced minimum segments in a full circle of the same radius.  Set to 0 to disable
 #define DEFAULT_ARC_SEGMENTS_PER_SEC 0 // Use feedrate to choose segment length. Set to 0 to disable
 
+/*------------------------------------
+ COMMUNITY FEATURES
+ *------------------------------------*/
+
+//Show filename instead of print time after SD card print finished
+//#define SHOW_FILENAME_AFTER_FINISH
+
 #endif //__CONFIGURATION_PRUSA_H


### PR DESCRIPTION
Adds the community option to show the printed filename instead of the printed time. Thanks for the suggestion https://github.com/prusa3d/Prusa-Firmware/issues/4107

To enable this community feature you need to un-comment `#define SHOW_FILENAME_AFTER_FINISH` in the variant file.