### PR TITLE
Remove incomplete dual stepper configuration

### DIFF
--- a/Firmware/Configuration_adv.h
+++ b/Firmware/Configuration_adv.h
@@ -125,34 +125,6 @@
 #endif //End auto min/max positions
 //END AUTOSET LOCATIONS OF LIMIT SWITCHES -ZP
 
-
-// A single Z stepper driver is usually used to drive 2 stepper motors.
-// Uncomment this define to utilize a separate stepper driver for each Z axis motor.
-// Only a few motherboards support this, like RAMPS, which have dual extruder support (the 2nd, often unused, extruder driver is used
-// to control the 2nd Z axis stepper motor). The pins are currently only defined for a RAMPS motherboards.
-// On a RAMPS (or other 5 driver) motherboard, using this feature will limit you to using 1 extruder.
-//#define Z_DUAL_STEPPER_DRIVERS
-
-#ifdef Z_DUAL_STEPPER_DRIVERS
-  #undef EXTRUDERS
-  #define EXTRUDERS 1
-#endif
-
-// Same again but for Y Axis.
-//#define Y_DUAL_STEPPER_DRIVERS
-
-// Define if the two Y drives need to rotate in opposite directions
-#define INVERT_Y2_VS_Y_DIR 1
-
-#ifdef Y_DUAL_STEPPER_DRIVERS
-  #undef EXTRUDERS
-  #define EXTRUDERS 1
-#endif
-
-#if defined (Z_DUAL_STEPPER_DRIVERS) && defined (Y_DUAL_STEPPER_DRIVERS)
-  #error "You cannot have dual drivers for both Y and Z"
-#endif
-
 //homing hits the endstop, then retracts by this distance, before it tries to slowly bump again:
 #define X_HOME_RETRACT_MM 5
 #define Y_HOME_RETRACT_MM 5

--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -121,13 +121,8 @@ void manage_inactivity(bool ignore_stepper_queue=false);
 #endif
 
 #if defined(Y_ENABLE_PIN) && Y_ENABLE_PIN > -1
-  #ifdef Y_DUAL_STEPPER_DRIVERS
-    #define  enable_y() { WRITE(Y_ENABLE_PIN, Y_ENABLE_ON); WRITE(Y2_ENABLE_PIN,  Y_ENABLE_ON); }
-    #define disable_y() { WRITE(Y_ENABLE_PIN,!Y_ENABLE_ON); WRITE(Y2_ENABLE_PIN, !Y_ENABLE_ON); axis_known_position[Y_AXIS] = false; }
-  #else
-    #define  enable_y() WRITE(Y_ENABLE_PIN, Y_ENABLE_ON)
-    #define disable_y() { WRITE(Y_ENABLE_PIN,!Y_ENABLE_ON); axis_known_position[Y_AXIS] = false; }
-  #endif
+  #define  enable_y() WRITE(Y_ENABLE_PIN, Y_ENABLE_ON)
+  #define disable_y() { WRITE(Y_ENABLE_PIN,!Y_ENABLE_ON); axis_known_position[Y_AXIS] = false; }
 #else
   #define enable_y() ;
   #define disable_y() ;
@@ -135,21 +130,11 @@ void manage_inactivity(bool ignore_stepper_queue=false);
 
 #if defined(Z_ENABLE_PIN) && Z_ENABLE_PIN > -1
 	#if defined(Z_AXIS_ALWAYS_ON)
-		  #ifdef Z_DUAL_STEPPER_DRIVERS
-			#define  poweron_z() { WRITE(Z_ENABLE_PIN, Z_ENABLE_ON); WRITE(Z2_ENABLE_PIN, Z_ENABLE_ON); }
-			#define poweroff_z() { WRITE(Z_ENABLE_PIN,!Z_ENABLE_ON); WRITE(Z2_ENABLE_PIN,!Z_ENABLE_ON); axis_known_position[Z_AXIS] = false; }
-		  #else
 			#define  poweron_z() WRITE(Z_ENABLE_PIN, Z_ENABLE_ON)
 			#define poweroff_z() {}
-		  #endif
 	#else
-		#ifdef Z_DUAL_STEPPER_DRIVERS
-			#define  poweron_z() { WRITE(Z_ENABLE_PIN, Z_ENABLE_ON); WRITE(Z2_ENABLE_PIN, Z_ENABLE_ON); }
-			#define poweroff_z() { WRITE(Z_ENABLE_PIN,!Z_ENABLE_ON); WRITE(Z2_ENABLE_PIN,!Z_ENABLE_ON); axis_known_position[Z_AXIS] = false; }
-		#else
 			#define  poweron_z() WRITE(Z_ENABLE_PIN, Z_ENABLE_ON)
 			#define poweroff_z() { WRITE(Z_ENABLE_PIN,!Z_ENABLE_ON); axis_known_position[Z_AXIS] = false; }
-		#endif
 	#endif
 #else
     #define  poweron_z() {}

--- a/Firmware/stepper.cpp
+++ b/Firmware/stepper.cpp
@@ -59,14 +59,6 @@ uint16_t SP_min = 0x21FF;
 #ifdef DEBUG_YSTEP_DUP_PIN
 #define _STEP_PIN_Y_DUP_AXIS DEBUG_YSTEP_DUP_PIN
 #endif
-#ifdef Y_DUAL_STEPPER_DRIVERS
-#error Y_DUAL_STEPPER_DRIVERS not fully implemented
-#define _STEP_PIN_Y2_AXIS Y2_STEP_PIN
-#endif
-#ifdef Z_DUAL_STEPPER_DRIVERS
-#error Z_DUAL_STEPPER_DRIVERS not fully implemented
-#define _STEP_PIN_Z2_AXIS Z2_STEP_PIN
-#endif
 
 #ifdef TMC2130
 #define STEPPER_MINIMUM_PULSE TMC2130_MINIMUM_PULSE
@@ -1079,17 +1071,9 @@ void st_init()
   #endif
   #if defined(Y_DIR_PIN) && Y_DIR_PIN > -1
     SET_OUTPUT(Y_DIR_PIN);
-
-	#if defined(Y_DUAL_STEPPER_DRIVERS) && defined(Y2_DIR_PIN) && (Y2_DIR_PIN > -1)
-	  SET_OUTPUT(Y2_DIR_PIN);
-	#endif
   #endif
   #if defined(Z_DIR_PIN) && Z_DIR_PIN > -1
     SET_OUTPUT(Z_DIR_PIN);
-
-    #if defined(Z_DUAL_STEPPER_DRIVERS) && defined(Z2_DIR_PIN) && (Z2_DIR_PIN > -1)
-      SET_OUTPUT(Z2_DIR_PIN);
-    #endif
   #endif
   #if defined(E0_DIR_PIN) && E0_DIR_PIN > -1
     SET_OUTPUT(E0_DIR_PIN);
@@ -1108,20 +1092,10 @@ void st_init()
   #if defined(Y_ENABLE_PIN) && Y_ENABLE_PIN > -1
     SET_OUTPUT(Y_ENABLE_PIN);
     if(!Y_ENABLE_ON) WRITE(Y_ENABLE_PIN,HIGH);
-
-	#if defined(Y_DUAL_STEPPER_DRIVERS) && defined(Y2_ENABLE_PIN) && (Y2_ENABLE_PIN > -1)
-	  SET_OUTPUT(Y2_ENABLE_PIN);
-	  if(!Y_ENABLE_ON) WRITE(Y2_ENABLE_PIN,HIGH);
-	#endif
   #endif
   #if defined(Z_ENABLE_PIN) && Z_ENABLE_PIN > -1
     SET_OUTPUT(Z_ENABLE_PIN);
     if(!Z_ENABLE_ON) WRITE(Z_ENABLE_PIN,HIGH);
-
-    #if defined(Z_DUAL_STEPPER_DRIVERS) && defined(Z2_ENABLE_PIN) && (Z2_ENABLE_PIN > -1)
-      SET_OUTPUT(Z2_ENABLE_PIN);
-      if(!Z_ENABLE_ON) WRITE(Z2_ENABLE_PIN,HIGH);
-    #endif
   #endif
   #if defined(E0_ENABLE_PIN) && (E0_ENABLE_PIN > -1)
     SET_OUTPUT(E0_ENABLE_PIN);
@@ -1201,19 +1175,11 @@ void st_init()
     SET_OUTPUT(DEBUG_YSTEP_DUP_PIN);
     WRITE(DEBUG_YSTEP_DUP_PIN,INVERT_Y_STEP_PIN);
 #endif //DEBUG_YSTEP_DUP_PIN
-    #if defined(Y_DUAL_STEPPER_DRIVERS) && defined(Y2_STEP_PIN) && (Y2_STEP_PIN > -1)
-      SET_OUTPUT(Y2_STEP_PIN);
-      WRITE(Y2_STEP_PIN,INVERT_Y_STEP_PIN);
-    #endif
     disable_y();
   #endif
   #if defined(Z_STEP_PIN) && (Z_STEP_PIN > -1)
     SET_OUTPUT(Z_STEP_PIN);
     WRITE(Z_STEP_PIN,INVERT_Z_STEP_PIN);
-    #if defined(Z_DUAL_STEPPER_DRIVERS) && defined(Z2_STEP_PIN) && (Z2_STEP_PIN > -1)
-      SET_OUTPUT(Z2_STEP_PIN);
-      WRITE(Z2_STEP_PIN,INVERT_Z_STEP_PIN);
-    #endif
     #ifdef PSU_Delta
       init_force_z();
     #endif // PSU_Delta
@@ -1373,7 +1339,7 @@ void babystep(const uint8_t axis,const bool direction)
     case X_AXIS:
     {
         enable_x();
-        uint8_t old_x_dir_pin = READ(X_DIR_PIN);  //if dualzstepper, both point to same direction.
+        uint8_t old_x_dir_pin = READ(X_DIR_PIN);
         uint8_t new_x_dir_pin = (INVERT_X_DIR)^direction;
 
         //setup new step
@@ -1401,7 +1367,7 @@ void babystep(const uint8_t axis,const bool direction)
     case Y_AXIS:
     {
         enable_y();
-        uint8_t old_y_dir_pin = READ(Y_DIR_PIN);  //if dualzstepper, both point to same direction.
+        uint8_t old_y_dir_pin = READ(Y_DIR_PIN);
         uint8_t new_y_dir_pin = (INVERT_Y_DIR)^direction;
 
         //setup new step
@@ -1429,35 +1395,23 @@ void babystep(const uint8_t axis,const bool direction)
     case Z_AXIS:
     {
         enable_z();
-        uint8_t old_z_dir_pin = READ(Z_DIR_PIN);  //if dualzstepper, both point to same direction.
+        uint8_t old_z_dir_pin = READ(Z_DIR_PIN);
         uint8_t new_z_dir_pin = (INVERT_Z_DIR)^direction^BABYSTEP_INVERT_Z;
 
         //setup new step
         if (new_z_dir_pin != old_z_dir_pin) {
             WRITE_NC(Z_DIR_PIN, new_z_dir_pin);
-#ifdef Z_DUAL_STEPPER_DRIVERS
-            WRITE_NC(Z2_DIR_PIN, new_z_dir_pin);
-#endif
             delayMicroseconds(STEPPER_SET_DIR_DELAY);
         }
 
         //perform step
         STEP_NC_HI(Z_AXIS);
-#ifdef Z_DUAL_STEPPER_DRIVERS
-        STEP_NC_HI(Z2_AXIS);
-#endif
         STEPPER_MINIMUM_DELAY;
         STEP_NC_LO(Z_AXIS);
-#ifdef Z_DUAL_STEPPER_DRIVERS
-        STEP_NC_LO(Z2_AXIS);
-#endif
 
         //get old pin state back.
         if (new_z_dir_pin != old_z_dir_pin) {
             WRITE_NC(Z_DIR_PIN, old_z_dir_pin);
-#ifdef Z_DUAL_STEPPER_DRIVERS
-            WRITE_NC(Z2_DIR_PIN, old_z_dir_pin);
-#endif
         }
     }
     break;


### PR DESCRIPTION
If either `Y_DUAL_STEPPER_DRIVERS` or `Z_DUAL_STEPPER_DRIVERS` is defined the compilation will fail with an error message. This configuration will likely never be fully implemented unless someone from the community steps up.

I was looking into cleaning up the configuration headers in general, and thought it would be best to do this removal separately since its a lot more code.