### PR TITLE
Steel sheet check

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -5841,7 +5841,7 @@ void process_commands()
       }
 #ifdef STEEL_SHEET_TYPES
       if (eeprom_read_byte((uint8_t*)EEPROM_CHECK_SHEET_TYPE) == (uint8_t)ClCheckMode::_Always) {
-        uint8_t result = lcd_show_multiscreen_message_yes_no_and_wait_P(_T(MSG_SHEET_TYPE_CONTINUE), false, LCD_MIDDLE_BUTTON_CHOICE);
+        uint8_t result = lcd_show_multiscreen_message_cont_cancel_and_wait_P(_T(MSG_CHECK_SHEET_TYPE), false, LCD_MIDDLE_BUTTON_CHOICE);
         if (result == LCD_MIDDLE_BUTTON_CHOICE) {
           print_stop(false, true);
         }

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -5839,6 +5839,14 @@ void process_commands()
           extended_capabilities_report();
 #endif //EXTENDED_CAPABILITIES_REPORT
       }
+#ifdef STEEL_SHEET_TYPES
+      if (eeprom_read_byte((uint8_t*)EEPROM_CHECK_SHEET_TYPE) == (uint8_t)ClCheckMode::_Always) {
+        uint8_t result = lcd_show_multiscreen_message_yes_no_and_wait_P(_T(MSG_SHEET_TYPE_CONTINUE), false, LCD_MIDDLE_BUTTON_CHOICE);
+        if (result == LCD_MIDDLE_BUTTON_CHOICE) {
+          print_stop(false, true);
+        }
+      }
+#endif //STEEL_SHEET_TYPES
       break;
 
     /*!
@@ -7174,22 +7182,27 @@ void process_commands()
     Get and Set Sheet parameters
     #### Usage
 
-         M850 [ S | Z | L | B | P | A ]
+         M850 [ S | Z | L | T | A ]
 
     #### Parameters
      - `S` - Sheet id [0-7]
      - `Z` - Z offset
      - `L` - Label [aA-zZ, 0-9 max 7 chars]
-     - `B` - Bed temp
-     - `P` - PINDA temp
+     - `T` - Type
+      - `0` - Smooth
+      - `1` - Textured
+      - `2` - Satin
+      - `3` - PA Nylon
+      - `4` - PP
      - `A` - Active [0|1]
     */
-    uint8_t iSel = 0;
+  uint8_t iSel = 0;
 	int16_t zraw = 0;
 	float z_val = 0;
 	char strLabel[8];
-	uint8_t iBedC = 0;
-	uint8_t iPindaC = 0;
+#ifdef STEEL_SHEET_TYPES
+	uint8_t iType = 0;
+#endif //STEEL_SHEET_TYPES
 	bool bIsActive=false;
 	strLabel[7] = '\0'; // null terminate.
 	size_t max_sheets = sizeof(EEPROM_Sheets_base->s)/sizeof(EEPROM_Sheets_base->s[0]);
@@ -7238,25 +7251,19 @@ void process_commands()
 		eeprom_read_block(strLabel, EEPROM_Sheets_base->s[iSel].name, sizeof(Sheet::name));
 	}
 
-	if (code_seen('B'))
+#ifdef STEEL_SHEET_TYPES
+	if (code_seen('T'))
 	{
-		iBedC = code_value_uint8();
-		eeprom_update_byte_notify(&EEPROM_Sheets_base->s[iSel].bed_temp, iBedC);
+		iType = code_value_uint8();
+		eeprom_update_byte_notify(&EEPROM_Sheets_base->s[iSel].type, iType);
 	}
 	else
 	{
-		iBedC = eeprom_read_byte(&EEPROM_Sheets_base->s[iSel].bed_temp);
+		iType = eeprom_read_byte(&EEPROM_Sheets_base->s[iSel].type);
 	}
-
-	if (code_seen('P'))
-	{
-		iPindaC = code_value_uint8();
-		eeprom_update_byte_notify(&EEPROM_Sheets_base->s[iSel].pinda_temp, iPindaC);
-	}
-	else
-	{
-		iPindaC = eeprom_read_byte(&EEPROM_Sheets_base->s[iSel].pinda_temp);
-	}
+  // Reset Sheet type if out of range
+  if (iType > STEEL_SHEET_TYPES -1) eeprom_update_byte_notify(&EEPROM_Sheets_base->s[iSel].type, 0);
+#endif //STEEL_SHEET_TYPES
 
 	if (code_seen('A'))
 	{
@@ -7284,10 +7291,10 @@ void process_commands()
 	SERIAL_PROTOCOL((int)zraw);
 	SERIAL_PROTOCOLPGM(" L");
 	SERIAL_PROTOCOL(strLabel);
-	SERIAL_PROTOCOLPGM(" B");
-	SERIAL_PROTOCOL((int)iBedC);
-	SERIAL_PROTOCOLPGM(" P");
-	SERIAL_PROTOCOL((int)iPindaC);
+#ifdef STEEL_SHEET_TYPES
+	SERIAL_PROTOCOLPGM(" T");
+	SERIAL_PROTOCOL((int)iType);
+#endif //STEEL_SHEET_TYPES
 	SERIAL_PROTOCOLPGM(" A");
 	SERIAL_PROTOCOLLN((int)bIsActive);
 	break;
@@ -7417,6 +7424,7 @@ void process_commands()
       - M862.4 { P<fw_version> | Q }
       - M862.5 { P<gcode_level> | Q }
       - M862.6 Not used but reserved by 32-bit
+      - M862.7 { P<sheet type> | Q }
 
     When run with P<> argument, the check is performed against the input value.
     When run with Q argument, the current value is shown.
@@ -7501,6 +7509,18 @@ void process_commands()
                     break;
                case ClPrintChecking::_Features:  // ~ .6 used by 32-bit
                     break;
+#ifdef STEEL_SHEET_TYPES
+               case ClPrintChecking::_SheetType:      // ~ .7
+                    if(code_seen('P'))
+                         {
+                         uint16_t nSheetType;
+                         nSheetType=(uint16_t)code_value_long();
+                         sheet_type_check(nSheetType);
+                         }
+                    else if(code_seen('Q'))
+                         SERIAL_PROTOCOLLN((int)eeprom_read_byte(&EEPROM_Sheets_base->s[eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet))].type));
+                    break;
+#endif //STEEL_SHEET_TYPES
                default:
                     break;
                }

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -5840,8 +5840,8 @@ void process_commands()
 #endif //EXTENDED_CAPABILITIES_REPORT
       }
 #ifdef STEEL_SHEET_TYPES
-      if (eeprom_read_byte((uint8_t*)EEPROM_CHECK_SHEET_TYPE) == (uint8_t)ClCheckMode::_Always) {
-        uint8_t result = lcd_show_multiscreen_message_cont_cancel_and_wait_P(_T(MSG_CHECK_SHEET_TYPE), false, LCD_MIDDLE_BUTTON_CHOICE);
+      if ((eeprom_read_byte((uint8_t*)EEPROM_CHECK_SHEET_TYPE) == (uint8_t)ClCheckMode::_Always) && printer_active()) {
+        uint8_t result = lcd_show_multiscreen_message_cont_cancel_and_wait_P(_T(MSG_CHECK_SHEET_TYPE), true, LCD_MIDDLE_BUTTON_CHOICE);
         if (result == LCD_MIDDLE_BUTTON_CHOICE) {
           print_stop(false, true);
         }
@@ -7424,7 +7424,7 @@ void process_commands()
       - M862.4 { P<fw_version> | Q }
       - M862.5 { P<gcode_level> | Q }
       - M862.6 Not used but reserved by 32-bit
-      - M862.7 { P<sheet type> | Q }
+      - M862.7 { P<sheet type> | W<warn sheet type>| Q }
 
     When run with P<> argument, the check is performed against the input value.
     When run with Q argument, the current value is shown.
@@ -7500,8 +7500,8 @@ void process_commands()
                case ClPrintChecking::_Gcode:      // ~ .5
                     if(code_seen('P'))
                          {
-                         uint16_t nGcodeLevel;
-                         nGcodeLevel=(uint16_t)code_value_long();
+                         uint8_t nGcodeLevel;
+                         nGcodeLevel=(uint8_t)code_value_uint8();
                          gcode_level_check(nGcodeLevel);
                          }
                     else if(code_seen('Q'))
@@ -7513,9 +7513,14 @@ void process_commands()
                case ClPrintChecking::_SheetType:      // ~ .7
                     if(code_seen('P'))
                          {
-                         uint16_t nSheetType;
-                         nSheetType=(uint16_t)code_value_long();
-                         sheet_type_check(nSheetType);
+                         uint8_t nSheetType;
+                         uint8_t wSheetType;
+                         nSheetType=(uint8_t)code_value_uint8();
+                         if(code_seen('W'))
+                            {
+                            wSheetType=(uint8_t)code_value_uint8();
+                            }
+                         sheet_type_check(nSheetType, wSheetType);
                          }
                     else if(code_seen('Q'))
                          SERIAL_PROTOCOLLN((int)eeprom_read_byte(&EEPROM_Sheets_base->s[eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet))].type));

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -7262,7 +7262,7 @@ void process_commands()
 		iType = eeprom_read_byte(&EEPROM_Sheets_base->s[iSel].type);
 	}
   // Reset Sheet type if out of range
-  if (iType > STEEL_SHEET_TYPES -1) eeprom_update_byte_notify(&EEPROM_Sheets_base->s[iSel].type, 0);
+  if (iType > 32) eeprom_update_byte_notify(&EEPROM_Sheets_base->s[iSel].type, 0);
 #endif //STEEL_SHEET_TYPES
 
 	if (code_seen('A'))

--- a/Firmware/eeprom.cpp
+++ b/Firmware/eeprom.cpp
@@ -4,6 +4,9 @@
 
 #include "eeprom.h"
 #include "Marlin.h"
+#ifdef STEEL_SHEET_TYPES
+#include "messages.h"
+#endif //STEEL_SHEET_TYPES
 
 #include <avr/eeprom.h>
 #include <stdint.h>
@@ -46,6 +49,10 @@ void eeprom_init()
     }
     check_babystep();
 
+#ifdef STEEL_SHEET_TYPES
+    eeprom_default_sheet_type();
+#endif //STEEL_SHEET_TPYES
+
     // initialize custom mendel name in eeprom
     if (eeprom_read_byte((uint8_t*)EEPROM_CUSTOM_MENDEL_NAME) == EEPROM_EMPTY_VALUE) {
         //SERIAL_ECHOLN("Init Custom Mendel Name");
@@ -83,8 +90,8 @@ void eeprom_adjust_bed_reset() {
 //! | 3     | Textur2   |
 //! | 4     | Satin     |
 //! | 5     | NylonPA   |
-//! | 6     | Custom1   |
-//! | 7     | Custom2   |
+//! | 6     | PolyPro   |
+//! | 7     | Custom    |
 //!
 //! @param[in] index
 //! @param[out] sheetName
@@ -94,25 +101,53 @@ void eeprom_default_sheet_name(uint8_t index, SheetName &sheetName)
 
     if (index < 2)
     {
+#ifdef STEEL_SHEET_TYPES
+        strcpy_P(sheetName.c, MSG_SHEET_TYPE_SMOOTH);
+#else
         strcpy_P(sheetName.c, PSTR("Smooth"));
+#endif //STEEL_SHEET_TYPES
     }
     else if (index < 4)
     {
+#ifdef STEEL_SHEET_TYPES
+        strcpy_P(sheetName.c, MSG_SHEET_TYPE_TEXTURED);
+#else
         strcpy_P(sheetName.c, PSTR("Textur"));
+#endif //STEEL_SHEET_TYPES
     }
     else if (index < 5)
     {
+#ifdef STEEL_SHEET_TYPES
+        strcpy_P(sheetName.c, MSG_SHEET_TYPE_SATIN);
+#else
         strcpy_P(sheetName.c, PSTR("Satin  "));
+#endif //STEEL_SHEET_TYPES
     }
     else if (index < 6)
     {
+#ifdef STEEL_SHEET_TYPES
+        strcpy_P(sheetName.c, MSG_SHEET_TYPE_NYLON_PA);
+#else
         strcpy_P(sheetName.c, PSTR("NylonPA"));
+#endif //STEEL_SHEET_TYPES
     }
+#ifdef STEEL_SHEET_TYPES
+    else if (index < 7)
+    {
+        strcpy_P(sheetName.c, MSG_SHEET_TYPE_PP);
+    }
+    else
+    {
+        strcpy_P(sheetName.c, MSG_SHEET_TYPE_CUSTOM);
+    }
+    if (index <4)
+#else
     else
     {
         strcpy_P(sheetName.c, PSTR("Custom"));
     }
     if (index <4 || index >5)
+#endif //STEEL_SHEET_TYPES
     {
         sheetName.c[6] = '0' + ((index % 2)+1);
         sheetName.c[7] = '\0';
@@ -136,6 +171,20 @@ int8_t eeprom_next_initialized_sheet(int8_t sheet)
     }
     return -1;
 }
+
+#ifdef STEEL_SHEET_TYPES
+void eeprom_default_sheet_type()
+{
+    eeprom_update_byte_notify(&EEPROM_Sheets_base->s[0].type, 1); //Smooth
+    eeprom_update_byte_notify(&EEPROM_Sheets_base->s[1].type, 1); //Smooth
+    eeprom_update_byte_notify(&EEPROM_Sheets_base->s[2].type, 2); //Textur
+    eeprom_update_byte_notify(&EEPROM_Sheets_base->s[3].type, 2); //Textur
+    eeprom_update_byte_notify(&EEPROM_Sheets_base->s[4].type, 4); //Satin
+    eeprom_update_byte_notify(&EEPROM_Sheets_base->s[5].type, 8); //NylonPA
+    eeprom_update_byte_notify(&EEPROM_Sheets_base->s[6].type, 16); //PolyPro
+    eeprom_update_byte_notify((uint8_t*)EEPROM_CHECK_SHEET_TYPE,1);
+}
+#endif //STEEL_SHEET_TYPES
 
 #ifdef DEBUG_EEPROM_CHANGES
 static void eeprom_byte_notify(uint8_t *dst, uint8_t previous_value, uint8_t value, bool write) {

--- a/Firmware/eeprom.cpp
+++ b/Firmware/eeprom.cpp
@@ -50,7 +50,9 @@ void eeprom_init()
     check_babystep();
 
 #ifdef STEEL_SHEET_TYPES
-    eeprom_default_sheet_type();
+    if (eeprom_read_byte((uint8_t*)EEPROM_CHECK_SHEET_TYPE) == EEPROM_EMPTY_VALUE) {
+        eeprom_default_sheet_type();
+    }
 #endif //STEEL_SHEET_TPYES
 
     // initialize custom mendel name in eeprom

--- a/Firmware/eeprom.h
+++ b/Firmware/eeprom.h
@@ -31,8 +31,8 @@ typedef struct
 {
     unsigned char name[MAX_SHEET_NAME_LENGTH]; //!< Can be null terminated, doesn't need to be null terminated
     int16_t z_offset; //!< Z_BABYSTEP_MIN .. Z_BABYSTEP_MAX = Z_BABYSTEP_MIN*2/1000 [mm] .. Z_BABYSTEP_MAX*2/1000 [mm]
-    uint8_t bed_temp; //!< 0 .. 254 [°C] NOTE: currently only written-to and never used
-    uint8_t pinda_temp; //!< 0 .. 254 [°C] NOTE: currently only written-to and never used
+    uint8_t type; //!< 0 .. 7
+    uint8_t reserved; //! currently only reserved
 } Sheet;
 
 typedef struct
@@ -279,36 +279,36 @@ static_assert(sizeof(Sheets) == EEPROM_SHEETS_SIZEOF, "Sizeof(Sheets) is not EEP
 | 0x0D49 3401 | uint16  | EEPROM_SHEETS_BASE                    | ???          | ffh 255               | ???                                               | LCD menu     | D3 Ax0d49 C89
 | 0x0D49 3401 | char    | _1st Sheet block_                     |536d6f6f746831| ffffffffffffff        | 1st sheet - Name: _Smooth1_                       | ^            | D3 Ax0d49 C7
 | 0x0D50 3408 | uint16  | ^                                     | 00 00h 0     | ff ffh 65535          | 1st sheet - Z offset                              | ^            | D3 Ax0d50 C2
-| 0x0D52 3410 | uint8   | ^                                     | 00h 0        | ffh 255               | 1st sheet - bed temp                              | ^            | D3 Ax0d52 C1
-| 0x0D53 3411 | uint8   | ^                                     | 00h 0        | ffh 255               | 1st sheet - PINDA temp                            | ^            | D3 Ax0d53 C1
+| 0x0D52 3410 | uint8   | ^                                     | 00h 0        | ffh 255               | 1st sheet - Type                                  | ^            | D3 Ax0d52 C1
+| 0x0D53 3411 | uint8   | ^                                     | 00h 0        | ffh 255               | 1st sheet - Reserved                              | ^            | D3 Ax0d53 C1
 | 0x0D54 3412 | char    | _2nd Sheet block_                     |536d6f6f746832| ffffffffffffff        | 2nd sheet - Name: _Smooth2_                       | ^            | D3 Ax0d54 C7
 | 0x0D5B 3419 | uint16  | ^                                     | 00 00h 0     | ff ffh 65535          | 2nd sheet - Z offset                              | ^            | D3 Ax0d5b C2
-| 0x0D5D 3421 | uint8   | ^                                     | 00h 0        | ffh 255               | 2nd sheet - bed temp                              | ^            | D3 Ax0d5d C1
-| 0x0D5E 3422 | uint8   | ^                                     | 00h 0        | ffh 255               | 2nd sheet - PINDA temp                            | ^            | D3 Ax0d5e C1
+| 0x0D5D 3421 | uint8   | ^                                     | 00h 0        | ffh 255               | 2nd sheet - Type                                  | ^            | D3 Ax0d5d C1
+| 0x0D5E 3422 | uint8   | ^                                     | 00h 0        | ffh 255               | 2nd sheet - Reserved                              | ^            | D3 Ax0d5e C1
 | 0x0D5F 3423 | char    | _3rd Sheet block_                     |54657874757231| ffffffffffffff        | 3rd sheet - Name: _Textur1_                       | ^            | D3 Ax0d5f C7
 | 0x0D66 3430 | uint16  | ^                                     | 00 00h 0     | ff ffh 65535          | 3rd sheet - Z offset                              | ^            | D3 Ax0d66 C2
-| 0x0D68 3432 | uint8   | ^                                     | 00h 0        | ffh 255               | 3rd sheet - bed temp                              | ^            | D3 Ax0d68 C1
-| 0x0D69 3433 | uint8   | ^                                     | 00h 0        | ffh 255               | 3rd sheet - PINDA temp                            | ^            | D3 Ax0d69 C1
+| 0x0D68 3432 | uint8   | ^                                     | 00h 0        | ffh 255               | 3rd sheet - Type                                  | ^            | D3 Ax0d68 C1
+| 0x0D69 3433 | uint8   | ^                                     | 00h 0        | ffh 255               | 3rd sheet - Reserved                              | ^            | D3 Ax0d69 C1
 | 0x0D6A 3434 | char    | _4th Sheet block_                     |54657874757232| ffffffffffffff        | 4th sheet - Name: _Textur2_                       | ^            | D3 Ax0d6a C7
 | 0x0D71 3441 | uint16  | ^                                     | 00 00h 0     | ff ffh 65535          | 4th sheet - Z offset                              | ^            | D3 Ax0d71 C2
-| 0x0D73 3443 | uint8   | ^                                     | 00h 0        | ffh 255               | 4th sheet - bed temp                              | ^            | D3 Ax0d73 C1
-| 0x0D74 3444 | uint8   | ^                                     | 00h 0        | ffh 255               | 4th sheet - PINDA temp                            | ^            | D3 Ax0d74 C1
-| 0x0D75 3445 | char    | _5th Sheet block_                     |536174696e2020| ffffffffffffff        | 5th sheet - Name: _Satin  _                       | ^            | D3 Ax0d75 C7
+| 0x0D73 3443 | uint8   | ^                                     | 00h 0        | ffh 255               | 4th sheet - Type                                  | ^            | D3 Ax0d73 C1
+| 0x0D74 3444 | uint8   | ^                                     | 00h 0        | ffh 255               | 4th sheet - Reserved                              | ^            | D3 Ax0d74 C1
+| 0x0D75 3445 | char    | _5th Sheet block_                     |536174696e2020| ffffffffffffff        | 5th sheet - Name: _Satin_                         | ^            | D3 Ax0d75 C7
 | 0x0D7C 3452 | uint16  | ^                                     | 00 00h 0     | ff ffh 65535          | 5th sheet - Z offset                              | ^            | D3 Ax0d7c C2
-| 0x0D7E 3454 | uint8   | ^                                     | 00h 0        | ffh 255               | 5th sheet - bed temp                              | ^            | D3 Ax0d7e C1
-| 0x0D7F 3455 | uint8   | ^                                     | 00h 0        | ffh 255               | 5th sheet - PINDA temp                            | ^            | D3 Ax0d7f C1
+| 0x0D7E 3454 | uint8   | ^                                     | 00h 0        | ffh 255               | 5th sheet - Type                                  | ^            | D3 Ax0d7e C1
+| 0x0D7F 3455 | uint8   | ^                                     | 00h 0        | ffh 255               | 5th sheet - Reserved                              | ^            | D3 Ax0d7f C1
 | 0x0D80 3456 | char    | _6th Sheet block_                     |4e796c6f6e5041| ffffffffffffff        | 6th sheet - Name: _NylonPA_                       | ^            | D3 Ax0d80 C7
 | 0x0D87 3463 | uint16  | ^                                     | 00 00h 0     | ff ffh 65535          | 6th sheet - Z offset                              | ^            | D3 Ax0d87 C2
-| 0x0D89 3465 | uint8   | ^                                     | 00h 0        | ffh 255               | 6th sheet - bed temp                              | ^            | D3 Ax0d89 C1
-| 0x0D8A 3466 | uint8   | ^                                     | 00h 0        | ffh 255               | 6th sheet - PINDA temp                            | ^            | D3 Ax0d8a C1
-| 0x0D8B 3467 | char    | _7th Sheet block_                     |437573746f6d31| ffffffffffffff        | 7th sheet - Name: _Custom1_                       | ^            | D3 Ax0d8b C7
+| 0x0D89 3465 | uint8   | ^                                     | 00h 0        | ffh 255               | 6th sheet - Type                                  | ^            | D3 Ax0d89 C1
+| 0x0D8A 3466 | uint8   | ^                                     | 00h 0        | ffh 255               | 6th sheet - Reserved                              | ^            | D3 Ax0d8a C1
+| 0x0D8B 3467 | char    | _7th Sheet block_                     |437573746f6d31| ffffffffffffff        | 7th sheet - Name: _PP_                       | ^            | D3 Ax0d8b C7
 | 0x0D92 3474 | uint16  | ^                                     | 00 00h 0     | ff ffh 65535          | 7th sheet - Z offset                              | ^            | D3 Ax0d92 C2
-| 0x0D94 3476 | uint8   | ^                                     | 00h 0        | ffh 255               | 7th sheet - bed temp                              | ^            | D3 Ax0d94 C1
-| 0x0D95 3477 | uint8   | ^                                     | 00h 0        | ffh 255               | 7th sheet - PINDA temp                            | ^            | D3 Ax0d95 C1
-| 0x0D96 3478 | char    | _8th Sheet block_                     |437573746f6d32| ffffffffffffff        | 8th sheet - Name: _Custom2_                       | ^            | D3 Ax0d96 C7
+| 0x0D94 3476 | uint8   | ^                                     | 00h 0        | ffh 255               | 7th sheet - Type                                  | ^            | D3 Ax0d94 C1
+| 0x0D95 3477 | uint8   | ^                                     | 00h 0        | ffh 255               | 7th sheet - Reserved                              | ^            | D3 Ax0d95 C1
+| 0x0D96 3478 | char    | _8th Sheet block_                     |437573746f6d32| ffffffffffffff        | 8th sheet - Name: _Custom_                        | ^            | D3 Ax0d96 C7
 | 0x0D9D 3485 | uint16  | ^                                     | 00 00h 0     | ff ffh 65535          | 8th sheet - Z offset                              | ^            | D3 Ax0d9d C2
-| 0x0D9F 3487 | uint8   | ^                                     | 00h 0        | ffh 255               | 8th sheet - bed temp                              | ^            | D3 Ax0d9f C1
-| 0x0DA0 3488 | uint8   | ^                                     | 00h 0        | ffh 255               | 8th sheet - PINDA temp                            | ^            | D3 Ax0da0 C1
+| 0x0D9F 3487 | uint8   | ^                                     | 00h 0        | ffh 255               | 8th sheet - Type                                  | ^            | D3 Ax0d9f C1
+| 0x0DA0 3488 | uint8   | ^                                     | 00h 0        | ffh 255               | 8th sheet - Reserved                              | ^            | D3 Ax0da0 C1
 | 0x0DA1 3489 | uint8   | active_sheet                          | 00h 0        | ffh 255               | Active sheet index                                | ^            | D3 Ax0da1 C1
 | 0x0D48 3400 | uint8   | EEPROM_FSENSOR_PCB                    | ffh 255      | ffh 255               | Filament Sensor type IR unknown                   | LCD Support  | D3 Ax0d48 C1
 | ^           | ^       | ^                                     | 00h 0        | ^                     | Filament Sensor type IR 0.3 or older              | ^            | ^
@@ -414,9 +414,13 @@ static_assert(sizeof(Sheets) == EEPROM_SHEETS_SIZEOF, "Sizeof(Sheets) is not EEP
 | ^           | ^       | ^                                     | ???          | ^                     | Z-axis                                            | ^            | D3 Ax0d29 C4
 | ^           | ^       | ^                                     | ???          | ^                     | Y-axis                                            | ^            | D3 Ax0d25 C4
 | ^           | ^       | ^                                     | ???          | ^                     | X-axis                                            | ^            | D3 Ax0c21 C4
-| 0x0C11 3089 | uint8   | EEPROM_CHECK_FILAMENT                 | 01h 1        | ffh 255               | Check mode for filament is: __warn__              | LCD menu     | D3 Ax0c11 C1
+| 0x0C20 3104 | uint8   | EEPROM_CHECK_FILAMENT                 | 01h 1        | ffh 255               | Check mode for filament is: __warn__              | LCD menu     | D3 Ax0c20 C1
 | ^           | ^       | ^                                     | 02h 2        | ^                     | Check mode for filament is: __strict__            | ^            | ^
 | ^           | ^       | ^                                     | 00h 0        | ^                     | Check mode for filament is: __none__              | ^            | ^
+| 0x0C1f 3103 | uint8   | EEPROM_CHECK_SHEET_TYPE               | 01h 1        | ffh 255               | Check mode for sheet type is: __warn__            | LCD menu     | D3 Ax0c1f C1
+| ^           | ^       | ^                                     | 00h 0        | ^                     | Check mode for sheet type is: __none__            | ^            | ^
+| ^           | ^       | ^                                     | 02h 2        | ^                     | Check mode for sheet type is: __strict__          | ^            | ^
+| ^           | ^       | ^                                     | 03h 3        | ^                     | Check mode for sheet type is: __always__          | ^            | ^
 
 
 |Address begin|Bit/Type | Name                                  | Valid values | Default/FactoryReset  | Description                                       |Gcode/Function| Debug code
@@ -668,8 +672,9 @@ static Sheets * const EEPROM_Sheets_base = (Sheets*)(EEPROM_SHEETS_BASE);
 #define EEPROM_UVLO_MIN_SEGMENT_TIME_US (EEPROM_UVLO_MIN_TRAVEL_FEEDRATE-4) //uint32_t
 #define EEPROM_UVLO_MAX_JERK (EEPROM_UVLO_MIN_SEGMENT_TIME_US-4*4) // 4 x float
 #define EEPROM_CHECK_FILAMENT (EEPROM_UVLO_MAX_JERK-1) // uint8_t
+#define EEPROM_CHECK_SHEET_TYPE (EEPROM_CHECK_FILAMENT-1) // uint8_t
 //This is supposed to point to last item to allow EEPROM overrun check. Please update when adding new items.
-#define EEPROM_LAST_ITEM EEPROM_CHECK_FILAMENT
+#define EEPROM_LAST_ITEM EEPROM_CHECK_SHEET_TYPE
 // !!!!!
 // !!!!! this is end of EEPROM section ... all updates MUST BE inserted before this mark !!!!!
 // !!!!!
@@ -708,6 +713,9 @@ struct SheetName
     char c[sizeof(Sheet::name) + 1];
 };
 void eeprom_default_sheet_name(uint8_t index, SheetName &sheetName);
+#ifdef STEEL_SHEET_TYPES
+void eeprom_default_sheet_type();
+#endif //STEEL_SHEET_TYPES
 int8_t eeprom_next_initialized_sheet(int8_t sheet);
 void eeprom_switch_to_next_sheet();
 bool eeprom_is_sheet_initialized(uint8_t sheet_num);

--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -159,6 +159,10 @@ const char MSG_MISSING_FILAMENT[] PROGMEM_I1 = ISTR("There is no filament loaded
 const char MSG_NOZZLE_DIFFERS_CONTINUE[] PROGMEM_I1 = ISTR("Nozzle diameter differs from the G-code."); ////MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
 const char MSG_NOZZLE_DIFFERS_CANCELLED[] PROGMEM_I1 = ISTR("Nozzle diameter differs from the G-code. Please check the value in settings."); ////MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
 const char MSG_NOZZLE_DIAMETER[] PROGMEM_I1 = ISTR("Nozzle d."); ////MSG_NOZZLE_DIAMETER c=10
+#ifdef STEEL_SHEET_TYPES
+const char MSG_SHEET_TYPE_CONTINUE[] PROGMEM_I1 = ISTR("Check selected sheet. Continue?"); ////MSG_SHEET_TYPE_CONTINUE c=20 r=3
+const char MSG_SHEET_TYPE_CANCELLED[] PROGMEM_I1 = ISTR("Check selected sheet. Print cancelled."); ////MSG_SHEET_TYPE_CANCELLED c=20 r=4
+#endif //STEEL_SHEET_TYPES
 const char MSG_MMU_MODE[] PROGMEM_I1 = ISTR("MMU Mode"); ////MSG_MMU_MODE c=8
 const char MSG_SD_CARD[] PROGMEM_I1 = ISTR("SD card"); ////MSG_SD_CARD c=8
 const char MSG_SORT[] PROGMEM_I1 = ISTR("Sort"); ////MSG_SORT c=7
@@ -425,6 +429,15 @@ const char MSG_POWERPANIC_DETECTED[] PROGMEM_N1 = "POWER PANIC DETECTED"; ////c=
 const char MSG_LCD_STATUS_CHANGED[] PROGMEM_N1 = "LCD status changed";
 const char MSG_UNKNOWN_CODE[] PROGMEM_N1 = "Unknown %c code: %s\n";
 const char MSG_FILAMENT_RUNOUT_DETECTED[] PROGMEM_N1 = "Filament runout detected!"; ////c=20 r=2
+#ifdef STEEL_SHEET_TYPES
+const char MSG_SHEET_TYPE[] PROGMEM_N1 = "Type"; ////c=8
+const char MSG_SHEET_TYPE_SMOOTH[] PROGMEM_N1 = "Smooth"; ////c=6
+const char MSG_SHEET_TYPE_TEXTURED[] PROGMEM_N1 = "Textur"; ////c=6
+const char MSG_SHEET_TYPE_SATIN[] PROGMEM_N1 = "Satin  "; ////c=7
+const char MSG_SHEET_TYPE_NYLON_PA[] PROGMEM_N1 = "NylonPA"; ////c=7
+const char MSG_SHEET_TYPE_PP[] PROGMEM_N1 = "PolyPro"; ////c=7
+const char MSG_SHEET_TYPE_CUSTOM[] PROGMEM_N1 = "Custom "; ////c=7
+#endif //STEEL_SHEET_TYPES
 
 // Common G-gcodes
 const char G1_E_F2700[] PROGMEM_N1 = "G1 E%-.3f F2700";

--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -160,8 +160,7 @@ const char MSG_NOZZLE_DIFFERS_CONTINUE[] PROGMEM_I1 = ISTR("Nozzle diameter diff
 const char MSG_NOZZLE_DIFFERS_CANCELLED[] PROGMEM_I1 = ISTR("Nozzle diameter differs from the G-code. Please check the value in settings."); ////MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
 const char MSG_NOZZLE_DIAMETER[] PROGMEM_I1 = ISTR("Nozzle d."); ////MSG_NOZZLE_DIAMETER c=10
 #ifdef STEEL_SHEET_TYPES
-const char MSG_SHEET_TYPE_CONTINUE[] PROGMEM_I1 = ISTR("Check selected sheet. Continue?"); ////MSG_SHEET_TYPE_CONTINUE c=20 r=3
-const char MSG_SHEET_TYPE_CANCELLED[] PROGMEM_I1 = ISTR("Check selected sheet. Print cancelled."); ////MSG_SHEET_TYPE_CANCELLED c=20 r=4
+const char MSG_CHECK_SHEET_TYPE[] PROGMEM_I1 = ISTR("Check selected steel sheet."); ////MSG_CHECK_SHEET_TYPE c=20 r=3
 #endif //STEEL_SHEET_TYPES
 const char MSG_MMU_MODE[] PROGMEM_I1 = ISTR("MMU Mode"); ////MSG_MMU_MODE c=8
 const char MSG_SD_CARD[] PROGMEM_I1 = ISTR("SD card"); ////MSG_SD_CARD c=8

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -162,8 +162,7 @@ extern const char MSG_NOZZLE_DIFFERS_CONTINUE[];
 extern const char MSG_NOZZLE_DIFFERS_CANCELLED[];
 extern const char MSG_NOZZLE_DIAMETER[];
 #ifdef STEEL_SHEET_TYPES
-extern const char MSG_SHEET_TYPE_CONTINUE[];
-extern const char MSG_SHEET_TYPE_CANCELLED[];
+extern const char MSG_CHECK_SHEET_TYPE[];
 #endif //STEEL_SHEET_TYPES
 extern const char MSG_MMU_MODE[];
 extern const char MSG_SD_CARD[];

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -161,6 +161,10 @@ extern const char MSG_MISSING_FILAMENT[];
 extern const char MSG_NOZZLE_DIFFERS_CONTINUE[];
 extern const char MSG_NOZZLE_DIFFERS_CANCELLED[];
 extern const char MSG_NOZZLE_DIAMETER[];
+#ifdef STEEL_SHEET_TYPES
+extern const char MSG_SHEET_TYPE_CONTINUE[];
+extern const char MSG_SHEET_TYPE_CANCELLED[];
+#endif //STEEL_SHEET_TYPES
 extern const char MSG_MMU_MODE[];
 extern const char MSG_SD_CARD[];
 extern const char MSG_SORT[];
@@ -427,6 +431,15 @@ extern const char MSG_POWERPANIC_DETECTED[];
 extern const char MSG_LCD_STATUS_CHANGED[];
 extern const char MSG_UNKNOWN_CODE[];
 extern const char MSG_FILAMENT_RUNOUT_DETECTED[];
+#ifdef STEEL_SHEET_TYPES
+extern const char MSG_SHEET_TYPE[];
+extern const char MSG_SHEET_TYPE_SMOOTH[];
+extern const char MSG_SHEET_TYPE_TEXTURED[];
+extern const char MSG_SHEET_TYPE_SATIN[];
+extern const char MSG_SHEET_TYPE_NYLON_PA[];
+extern const char MSG_SHEET_TYPE_PP[];
+extern const char MSG_SHEET_TYPE_CUSTOM[];
+#endif //STEEL_SHEET_TYPES
 
 // Common G-gcodes
 extern const char G1_E_F2700[];

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -365,7 +365,7 @@ void lcdui_print_percent_done(void)
 		const int8_t nextSheet = eeprom_next_initialized_sheet(sheetNR);
 		if ((nextSheet >= 0) && (sheetNR != nextSheet))
 		{
-			char sheet[sizeof(Sheet::name)];
+			char sheet[sizeof(Sheet::name)+1UL];
 			eeprom_read_block(sheet, EEPROM_Sheets_base->s[sheetNR].name, sizeof(Sheet::name));
 			sheet[sizeof(Sheet::name)] = '\0';
 			lcd_printf_P(PSTR("%-7s"),sheet);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2669,12 +2669,6 @@ static void lcd_babystep_z()
 		// Only update the EEPROM when leaving the menu.
           uint8_t active_sheet=eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet));
 		eeprom_update_word_notify(reinterpret_cast<uint16_t *>(&(EEPROM_Sheets_base->s[active_sheet].z_offset)),_md->babystepMemZ);
-
-        // NOTE: bed_temp and pinda_temp are not currently read/used anywhere.
-		eeprom_update_byte_notify(&(EEPROM_Sheets_base->s[active_sheet].bed_temp),target_temperature_bed);
-#ifdef PINDA_THERMISTOR
-		eeprom_update_byte_notify(&(EEPROM_Sheets_base->s[active_sheet].pinda_temp),current_temperature_pinda);
-#endif //PINDA_THERMISTOR
 		calibration_status_set(CALIBRATION_STATUS_LIVE_ADJUST);
 	}
 	menu_back_if_clicked();
@@ -4291,6 +4285,63 @@ do\
 }\
 while (0)
 
+#ifdef STEEL_SHEET_TYPES
+static void lcd_sheet_type_cycle(void) {
+    uint8_t nSheetType;
+    switch(oCheckSheetType){
+    case ClCheckSheetType::_Smooth:
+        oCheckSheetType=ClCheckSheetType::_Textured;
+        nSheetType=2;
+        break;
+    case ClCheckSheetType::_Textured:
+        oCheckSheetType=ClCheckSheetType::_Satin;
+        nSheetType=4;
+        break;
+    case ClCheckSheetType::_Satin:
+        oCheckSheetType=ClCheckSheetType::_NylonPA;
+        nSheetType=8;
+        break;
+    case ClCheckSheetType::_NylonPA:
+        oCheckSheetType=ClCheckSheetType::_PP;
+        nSheetType=16;
+        break;
+    case ClCheckSheetType::_PP:
+        oCheckSheetType=ClCheckSheetType::_Custom;
+        nSheetType=32;
+        break;
+    case ClCheckSheetType::_Custom:
+        oCheckSheetType=ClCheckSheetType::_Smooth;
+        nSheetType=1;
+        break;
+    case ClCheckSheetType::_Undef:
+        oCheckSheetType=ClCheckSheetType::_Smooth;
+        nSheetType=1;
+        break;
+    default:
+        oCheckSheetType=ClCheckSheetType::_Smooth;
+        nSheetType=1;
+    }
+    eeprom_update_byte_notify(&EEPROM_Sheets_base->s[selected_sheet].type, nSheetType);
+}
+
+
+#define SETTINGS_SHEET_TYPE \
+do\
+{\
+    switch (oCheckSheetType)\
+    {\
+    case ClCheckSheetType::_Smooth: MENU_ITEM_TOGGLE_P(MSG_SHEET_TYPE, MSG_SHEET_TYPE_SMOOTH, lcd_sheet_type_cycle); break;\
+    case ClCheckSheetType::_Textured: MENU_ITEM_TOGGLE_P(MSG_SHEET_TYPE, MSG_SHEET_TYPE_TEXTURED, lcd_sheet_type_cycle); break;\
+    case ClCheckSheetType::_Satin: MENU_ITEM_TOGGLE_P(MSG_SHEET_TYPE, MSG_SHEET_TYPE_SATIN, lcd_sheet_type_cycle); break;\
+    case ClCheckSheetType::_NylonPA: MENU_ITEM_TOGGLE_P(MSG_SHEET_TYPE, MSG_SHEET_TYPE_NYLON_PA, lcd_sheet_type_cycle); break;\
+    case ClCheckSheetType::_PP: MENU_ITEM_TOGGLE_P(MSG_SHEET_TYPE, MSG_SHEET_TYPE_PP, lcd_sheet_type_cycle); break;\
+    case ClCheckSheetType::_Custom: MENU_ITEM_TOGGLE_P(MSG_SHEET_TYPE, MSG_SHEET_TYPE_CUSTOM, lcd_sheet_type_cycle); break;\
+    case ClCheckSheetType::_Undef: MENU_ITEM_TOGGLE_P(MSG_SHEET_TYPE, _O(MSG_UNKNOWN), lcd_sheet_type_cycle); break;\
+    }\
+}\
+while (0)
+#endif//STEEL_SHEET_TYPES
+
 static void lcd_check_update_RAM(ClCheckMode * oCheckSetting) {
     switch(*oCheckSetting) {
         case ClCheckMode::_None:
@@ -4300,6 +4351,11 @@ static void lcd_check_update_RAM(ClCheckMode * oCheckSetting) {
             *oCheckSetting = ClCheckMode::_Strict;
             break;
         case ClCheckMode::_Strict:
+#ifdef STEEL_SHEET_TYPES
+            *oCheckSetting = ClCheckMode::_Always;
+            break;
+        case ClCheckMode::_Always:
+#endif //STEEL_SHEET_TYPES
             *oCheckSetting = ClCheckMode::_None;
             break;
         default:
@@ -4327,6 +4383,13 @@ static void lcd_check_filament_set() {
     eeprom_update_byte_notify((uint8_t*)EEPROM_CHECK_FILAMENT,(uint8_t)oCheckFilament);
 }
 
+#ifdef STEEL_SHEET_TYPES
+static void lcd_check_sheet_type_set() {
+    lcd_check_update_RAM(&oCheckSheets);
+    eeprom_update_byte_notify((uint8_t*)EEPROM_CHECK_SHEET_TYPE,(uint8_t)oCheckSheets);
+}
+#endif //STEEL_SHEET_TYPES
+
 static void settings_check_toggle(ClCheckMode * oCheckSetting, const char* msg, void (*func)(void)) {
     switch(*oCheckSetting) {
         case ClCheckMode::_None:
@@ -4338,6 +4401,11 @@ static void settings_check_toggle(ClCheckMode * oCheckSetting, const char* msg, 
         case ClCheckMode::_Strict:
             MENU_ITEM_TOGGLE_P(msg, _T(MSG_STRICT), func);
             break;
+#ifdef STEEL_SHEET_TYPES
+        case ClCheckMode::_Always:
+            MENU_ITEM_TOGGLE_P(msg, _T(MSG_ALWAYS), func);
+            break;
+#endif //STEEL_SHEET_TYPES
         default:
             MENU_ITEM_TOGGLE_P(msg, _T(MSG_NONE), func);
     }
@@ -4351,6 +4419,9 @@ static void lcd_checking_menu(void)
     settings_check_toggle(&oCheckModel, _T(MSG_MODEL), lcd_check_model_set);
     settings_check_toggle(&oCheckVersion, MSG_FIRMWARE, lcd_check_version_set);
     settings_check_toggle(&oCheckFilament, MSG_FILAMENT, lcd_check_filament_set);
+#ifdef STEEL_SHEET_TYPES
+    settings_check_toggle(&oCheckSheets, _T(MSG_SHEET), lcd_check_sheet_type_set);
+#endif //STEEL_SHEET_TYPES
     MENU_END();
 }
 
@@ -4358,6 +4429,9 @@ template <uint8_t number>
 static void select_sheet_menu()
 {
     selected_sheet = number;
+#ifdef STEEL_SHEET_TYPES
+    oCheckSheetType = (ClCheckSheetType)eeprom_read_byte((uint8_t *)&EEPROM_Sheets_base->s[selected_sheet].type);
+#endif //STEEL_SHEET_TYPES
     lcd_sheet_menu();
 }
 
@@ -5092,6 +5166,9 @@ static void lcd_reset_sheet()
 {
     SheetName sheetName;
     eeprom_default_sheet_name(selected_sheet, sheetName);
+#ifdef STEEL_SHEET_TYPES
+    eeprom_default_sheet_type();
+#endif // STEEL_SHEET_TYPES
 	eeprom_update_word_notify(reinterpret_cast<uint16_t *>(&(EEPROM_Sheets_base->s[selected_sheet].z_offset)),EEPROM_EMPTY_VALUE16);
 	eeprom_update_block_notify(sheetName.c,EEPROM_Sheets_base->s[selected_sheet].name,sizeof(Sheet::name));
 	if (selected_sheet == eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet)))
@@ -5125,6 +5202,9 @@ static void lcd_sheet_menu()
         MENU_ITEM_SUBMENU_P(_T(MSG_V2_CALIBRATION), activate_calibrate_sheet);
     }
     MENU_ITEM_SUBMENU_P(_T(MSG_RENAME), lcd_rename_sheet_menu);
+#ifdef STEEL_SHEET_TYPES
+    SETTINGS_SHEET_TYPE;
+#endif //STEEL_SHEET_TYPES
 	MENU_ITEM_FUNCTION_P(_T(MSG_RESET), lcd_reset_sheet);
 
     MENU_END();

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -365,9 +365,9 @@ void lcdui_print_percent_done(void)
 		const int8_t nextSheet = eeprom_next_initialized_sheet(sheetNR);
 		if ((nextSheet >= 0) && (sheetNR != nextSheet))
 		{
-			char sheet[8];
-			eeprom_read_block(sheet, EEPROM_Sheets_base->s[sheetNR].name, 7);
-			sheet[7] = '\0';
+			char sheet[sizeof(Sheet::name)];
+			eeprom_read_block(sheet, EEPROM_Sheets_base->s[sheetNR].name, sizeof(Sheet::name));
+			sheet[sizeof(Sheet::name)] = '\0';
 			lcd_printf_P(PSTR("%-7s"),sheet);
 			return; //do not also print the percentage
 		}
@@ -5112,7 +5112,9 @@ static void change_sheet()
 //! @brief Send a notification to the host. Param 'message' must reside in program memory!
 void sendHostNotification_P(const char* message)
 {
-    printf_P(MSG_HOST_ACTION_NOTIFICATION, message);
+    if (M79_timer_get_status()) {
+        printf_P(MSG_HOST_ACTION_NOTIFICATION, message);
+    }
 }
 
 static void lcd_rename_sheet_menu()

--- a/Firmware/util.cpp
+++ b/Firmware/util.cpp
@@ -247,6 +247,10 @@ ClCheckMode oCheckModel;
 ClCheckMode oCheckVersion;
 ClCheckMode oCheckGcode;
 ClCheckMode oCheckFilament;
+#ifdef STEEL_SHEET_TYPES
+ClCheckSheetType oCheckSheetType;
+ClCheckMode oCheckSheets;
+#endif //STEEL_SHEET_TYPES
 
 void fCheckModeInit() {
     oCheckMode = (ClCheckMode)eeprom_init_default_byte((uint8_t *)EEPROM_CHECK_MODE, (uint8_t)ClCheckMode::_Warn);
@@ -263,6 +267,10 @@ void fCheckModeInit() {
     oCheckVersion = (ClCheckMode)eeprom_init_default_byte((uint8_t *)EEPROM_CHECK_VERSION, (uint8_t)ClCheckMode::_Warn);
     oCheckGcode = (ClCheckMode)eeprom_init_default_byte((uint8_t *)EEPROM_CHECK_GCODE, (uint8_t)ClCheckMode::_Warn);
     oCheckFilament = (ClCheckMode)eeprom_init_default_byte((uint8_t *)EEPROM_CHECK_FILAMENT, (uint8_t)ClCheckMode::_Warn);
+#ifdef STEEL_SHEET_TYPES
+    oCheckSheets = (ClCheckMode)eeprom_init_default_byte((uint8_t *)EEPROM_CHECK_SHEET_TYPE, (uint8_t)ClCheckMode::_Warn);
+    oCheckSheetType = (ClCheckSheetType)eeprom_init_default_byte((uint8_t *)&EEPROM_Sheets_base->s[eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet))].type, (uint8_t)ClCheckSheetType::_Smooth);
+#endif //STEEL_SHEET_TYPES
 }
 
 static void render_M862_warnings(const char* warning, const char* strict, uint8_t check)
@@ -274,6 +282,12 @@ static void render_M862_warnings(const char* warning, const char* strict, uint8_
     } else if (check == 2) { // Strict, always stop print
         lcd_show_fullscreen_message_and_wait_P(strict);
         lcd_print_stop();
+#ifdef STEEL_SHEET_TYPES
+    } else if (check == 3 ) { // Always warn, stop print if user selects 'No' This doesn't time out
+        if (lcd_show_multiscreen_message_yes_no_and_wait_P(warning, false, LCD_LEFT_BUTTON_CHOICE) == LCD_MIDDLE_BUTTON_CHOICE) {
+            lcd_print_stop();
+        }
+#endif //STEEL_SHEET_TYPES
     }
 }
 
@@ -420,6 +434,31 @@ void gcode_level_check(uint16_t nGcodeLevel) {
     );
 }
 
+#ifdef STEEL_SHEET_TYPES
+void sheet_type_check(uint16_t nSheetType) {
+    uint16_t actualSheetType;
+    if (oCheckSheets == ClCheckMode::_None)
+        return;
+    actualSheetType = eeprom_read_byte(&EEPROM_Sheets_base->s[eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet))].type);
+    if (nSheetType == actualSheetType)
+        return;
+/*
+    SERIAL_PROTOCOLPGM("Active sheet number: ");
+    SERIAL_PROTOCOL((int)eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet)));
+    SERIAL_PROTOCOLPGM(" Sheet type differs from actual : ");
+    SERIAL_PROTOCOL((int)eeprom_read_byte(&EEPROM_Sheets_base->s[eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet))].type));
+    SERIAL_PROTOCOLPGM(" expected: ");
+    SERIAL_PROTOCOL((int)nSheetType);
+    SERIAL_PROTOCOLPGM(" oCheckSheets: ");
+    SERIAL_PROTOCOLLN((int)oCheckSheets);
+*/
+    render_M862_warnings(
+        _T(MSG_SHEET_TYPE_CONTINUE)
+        ,_T(MSG_SHEET_TYPE_CANCELLED)
+        ,(uint8_t)oCheckSheets
+    );
+}
+#endif //STEEL_SHEET_TYPES
 
 void printer_smodel_check(const char *pStrPos, const char *actualPrinterSModel) {
     unquoted_string smodel = unquoted_string(pStrPos);

--- a/Firmware/util.cpp
+++ b/Firmware/util.cpp
@@ -412,10 +412,10 @@ done:
     return true;
 }
 
-void gcode_level_check(uint16_t nGcodeLevel) {
+void gcode_level_check(uint8_t nGcodeLevel) {
     if (oCheckGcode == ClCheckMode::_None)
         return;
-    if (nGcodeLevel <= (uint16_t)GCODE_LEVEL)
+    if (nGcodeLevel <= (uint8_t)GCODE_LEVEL)
         return;
 
     // SERIAL_ECHO_START;
@@ -433,23 +433,32 @@ void gcode_level_check(uint16_t nGcodeLevel) {
 }
 
 #ifdef STEEL_SHEET_TYPES
-void sheet_type_check(uint16_t nSheetType) {
-    uint16_t actualSheetType;
+void sheet_type_check(uint8_t nSheetType, uint8_t wSheetType) {
+    uint8_t actualSheetType;
     if (oCheckSheets == ClCheckMode::_None)
         return;
     actualSheetType = eeprom_read_byte(&EEPROM_Sheets_base->s[eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet))].type);
-    if (nSheetType == actualSheetType)
-        return;
+    bool n_SheetType = (nSheetType & actualSheetType) ? 1 : 0; //Expected sheet found
+    bool w_SheetType = (wSheetType & actualSheetType) ? 1 : 0; //Warn sheet found
 /*
     SERIAL_PROTOCOLPGM("Active sheet number: ");
     SERIAL_PROTOCOL((int)eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet)));
-    SERIAL_PROTOCOLPGM(" Sheet type differs from actual : ");
+    SERIAL_PROTOCOLPGM(" actual sheet type: ");
     SERIAL_PROTOCOL((int)eeprom_read_byte(&EEPROM_Sheets_base->s[eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet))].type));
-    SERIAL_PROTOCOLPGM(" expected: ");
+    SERIAL_PROTOCOLPGM(" expected sheet type: ");
     SERIAL_PROTOCOL((int)nSheetType);
+    SERIAL_PROTOCOLPGM(" warn sheet type: ");
+    SERIAL_PROTOCOL((int)wSheetType);
+    SERIAL_PROTOCOLPGM(" n_sheet found: ");
+    SERIAL_PROTOCOL((int)n_SheetType);
+    SERIAL_PROTOCOLPGM(" w_sheet not found: ");
+    SERIAL_PROTOCOL((int)w_SheetType);
     SERIAL_PROTOCOLPGM(" oCheckSheets: ");
     SERIAL_PROTOCOLLN((int)oCheckSheets);
 */
+    if (n_SheetType && !w_SheetType && oCheckSheets != ClCheckMode::_Always)
+        return;
+
     render_M862_warnings(
         _T(MSG_CHECK_SHEET_TYPE)
         ,_T(MSG_CHECK_SHEET_TYPE) //Identical messages

--- a/Firmware/util.cpp
+++ b/Firmware/util.cpp
@@ -275,19 +275,17 @@ void fCheckModeInit() {
 
 static void render_M862_warnings(const char* warning, const char* strict, uint8_t check)
 {
+#ifdef STEEL_SHEET_TYPES
+    if (check == 1 || check == 3) { // Warning, stop print if user selects 'No'
+#else
     if (check == 1) { // Warning, stop print if user selects 'No'
+#endif //STEEL_SHEET_TYPES
         if (lcd_show_multiscreen_message_cont_cancel_and_wait_P(warning, true, LCD_LEFT_BUTTON_CHOICE) == LCD_MIDDLE_BUTTON_CHOICE) {
             lcd_print_stop();
         }
     } else if (check == 2) { // Strict, always stop print
         lcd_show_fullscreen_message_and_wait_P(strict);
         lcd_print_stop();
-#ifdef STEEL_SHEET_TYPES
-    } else if (check == 3 ) { // Always warn, stop print if user selects 'No' This doesn't time out
-        if (lcd_show_multiscreen_message_yes_no_and_wait_P(warning, false, LCD_LEFT_BUTTON_CHOICE) == LCD_MIDDLE_BUTTON_CHOICE) {
-            lcd_print_stop();
-        }
-#endif //STEEL_SHEET_TYPES
     }
 }
 
@@ -453,8 +451,8 @@ void sheet_type_check(uint16_t nSheetType) {
     SERIAL_PROTOCOLLN((int)oCheckSheets);
 */
     render_M862_warnings(
-        _T(MSG_SHEET_TYPE_CONTINUE)
-        ,_T(MSG_SHEET_TYPE_CANCELLED)
+        _T(MSG_CHECK_SHEET_TYPE)
+        ,_T(MSG_CHECK_SHEET_TYPE) //Identical messages
         ,(uint8_t)oCheckSheets
     );
 }

--- a/Firmware/util.cpp
+++ b/Firmware/util.cpp
@@ -280,10 +280,12 @@ static void render_M862_warnings(const char* warning, const char* strict, uint8_
 #else
     if (check == 1) { // Warning, stop print if user selects 'No'
 #endif //STEEL_SHEET_TYPES
+        sendHostNotification_P(warning);
         if (lcd_show_multiscreen_message_cont_cancel_and_wait_P(warning, true, LCD_LEFT_BUTTON_CHOICE) == LCD_MIDDLE_BUTTON_CHOICE) {
             lcd_print_stop();
         }
     } else if (check == 2) { // Strict, always stop print
+        sendHostNotification_P(strict);
         lcd_show_fullscreen_message_and_wait_P(strict);
         lcd_print_stop();
     }

--- a/Firmware/util.cpp
+++ b/Firmware/util.cpp
@@ -211,6 +211,7 @@ bool show_upgrade_dialog_if_version_newer(const char *version_string)
         return false;
 
     if (upgrade) {
+        sendHostNotification_P(_O(MSG_NEW_FIRMWARE_AVAILABLE));
         lcd_display_message_fullscreen_P(_T(MSG_NEW_FIRMWARE_AVAILABLE));
         lcd_puts_at_P(0, 2, PSTR(""));
         for (const char *c = version_string; ! is_whitespace_or_nl_or_eol(*c); ++ c)
@@ -280,13 +281,13 @@ static void render_M862_warnings(const char* warning, const char* strict, uint8_
 #else
     if (check == 1) { // Warning, stop print if user selects 'No'
 #endif //STEEL_SHEET_TYPES
-        sendHostNotification_P(warning);
-        if (lcd_show_multiscreen_message_cont_cancel_and_wait_P(warning, true, LCD_LEFT_BUTTON_CHOICE) == LCD_MIDDLE_BUTTON_CHOICE) {
+        sendHostNotification_P(_O(warning));
+        if (lcd_show_multiscreen_message_cont_cancel_and_wait_P(_T(warning), true, LCD_LEFT_BUTTON_CHOICE) == LCD_MIDDLE_BUTTON_CHOICE) {
             lcd_print_stop();
         }
     } else if (check == 2) { // Strict, always stop print
-        sendHostNotification_P(strict);
-        lcd_show_fullscreen_message_and_wait_P(strict);
+        sendHostNotification_P(_O(strict));
+        lcd_show_fullscreen_message_and_wait_P(_T(strict));
         lcd_print_stop();
     }
 }
@@ -307,8 +308,8 @@ void nozzle_diameter_check(uint16_t nDiameter) {
     // SERIAL_ECHOLN((float)(nDiameter/1000.0));
 
     render_M862_warnings(
-        _T(MSG_NOZZLE_DIFFERS_CONTINUE)
-        ,_T(MSG_NOZZLE_DIFFERS_CANCELLED)
+        MSG_NOZZLE_DIFFERS_CONTINUE
+        ,MSG_NOZZLE_DIFFERS_CANCELLED
         ,(uint8_t)oCheckMode
     );
 
@@ -330,8 +331,8 @@ void printer_model_check(uint16_t nPrinterModel, uint16_t actualPrinterModel) {
     // SERIAL_ECHOPGM("expected: ");
     // SERIAL_ECHOLN(nPrinterModel);
     render_M862_warnings(
-        _T(MSG_GCODE_DIFF_PRINTER_CONTINUE)
-        ,_T(MSG_GCODE_DIFF_PRINTER_CANCELLED)
+        MSG_GCODE_DIFF_PRINTER_CONTINUE
+        ,MSG_GCODE_DIFF_PRINTER_CANCELLED
         ,(uint8_t)oCheckModel
     );
 }
@@ -380,8 +381,8 @@ void fw_version_check(const char *pVersion) {
 */
 
     render_M862_warnings(
-        _T(MSG_GCODE_NEWER_FIRMWARE_CONTINUE)
-        ,_T(MSG_GCODE_NEWER_FIRMWARE_CANCELLED)
+        MSG_GCODE_NEWER_FIRMWARE_CONTINUE
+        ,MSG_GCODE_NEWER_FIRMWARE_CANCELLED
         ,(uint8_t)oCheckVersion
     );
 }
@@ -399,8 +400,8 @@ bool filament_presence_check() {
         }
 
         render_M862_warnings(
-            _T(MSG_MISSING_FILAMENT)
-            ,_T(MSG_MISSING_FILAMENT) //Identical messages
+            MSG_MISSING_FILAMENT
+            ,MSG_MISSING_FILAMENT //Identical messages
             ,(uint8_t)oCheckFilament
         );
 
@@ -428,8 +429,8 @@ void gcode_level_check(uint8_t nGcodeLevel) {
     // SERIAL_ECHOLN(nGcodeLevel);
 
     render_M862_warnings(
-        _T(MSG_GCODE_DIFF_CONTINUE)
-        ,_T(MSG_GCODE_DIFF_CANCELLED)
+        MSG_GCODE_DIFF_CONTINUE
+        ,MSG_GCODE_DIFF_CANCELLED
         ,(uint8_t)oCheckGcode
     );
 }
@@ -462,8 +463,8 @@ void sheet_type_check(uint8_t nSheetType, uint8_t wSheetType) {
         return;
 
     render_M862_warnings(
-        _T(MSG_CHECK_SHEET_TYPE)
-        ,_T(MSG_CHECK_SHEET_TYPE) //Identical messages
+        MSG_CHECK_SHEET_TYPE
+        ,MSG_CHECK_SHEET_TYPE //Identical messages
         ,(uint8_t)oCheckSheets
     );
 }
@@ -481,8 +482,8 @@ void printer_smodel_check(const char *pStrPos, const char *actualPrinterSModel) 
     }
 
     render_M862_warnings(
-        _T(MSG_GCODE_DIFF_PRINTER_CONTINUE)
-        ,_T(MSG_GCODE_DIFF_PRINTER_CANCELLED)
+        MSG_GCODE_DIFF_PRINTER_CONTINUE
+        ,MSG_GCODE_DIFF_PRINTER_CANCELLED
         ,(uint8_t)oCheckModel
     );
 }

--- a/Firmware/util.h
+++ b/Firmware/util.h
@@ -35,7 +35,7 @@ enum class ClPrintChecking:uint_least8_t
     _Version=4,
     _Gcode=5,
     _Features=6,
-    _PrinterState=7
+    _SheetType=7
 };
 
 enum class ClNozzleDiameter:uint_least8_t
@@ -47,11 +47,27 @@ enum class ClNozzleDiameter:uint_least8_t
     _Diameter_Undef=EEPROM_EMPTY_VALUE
 };
 
+#ifdef STEEL_SHEET_TYPES
+enum class ClCheckSheetType:uint_least8_t
+{
+    _Smooth     =0b00000001,
+    _Textured   =0b00000010,
+    _Satin      =0b00000100,
+    _NylonPA    =0b00001000,
+    _PP         =0b00010000,
+    _Custom     =0b00100000,
+    _Undef      =0b00000000,
+};
+#endif //STEEL_SHEET_TYPES
+
 enum class ClCheckMode:uint_least8_t
 {
     _None,
     _Warn,
     _Strict,
+#ifdef STEEL_SHEET_TYPES
+    _Always,
+#endif //STEEL_SHEET_TYPES
     _Undef=EEPROM_EMPTY_VALUE
 };
 
@@ -109,6 +125,10 @@ extern ClCheckMode oCheckModel;
 extern ClCheckMode oCheckVersion;
 extern ClCheckMode oCheckGcode;
 extern ClCheckMode oCheckFilament;
+#ifdef STEEL_SHEET_TYPES
+extern ClCheckMode oCheckSheets;
+extern ClCheckSheetType oCheckSheetType;
+#endif //STEEL_SHEET_TYPES
 
 void fCheckModeInit();
 void nozzle_diameter_check(uint16_t nDiameter);
@@ -116,6 +136,9 @@ void printer_model_check(uint16_t nPrinterModel, uint16_t actualPrinterModel);
 void printer_smodel_check(const char *pStrPos, const char *actualPrinterSModel);
 void fw_version_check(const char *pVersion);
 void gcode_level_check(uint16_t nGcodeLevel);
+#ifdef STEEL_SHEET_TYPES
+void sheet_type_check(uint16_t nSheetType);
+#endif //STEEL_SHEET_TYPES
 
 /// Check if the filament is present before starting a print job.
 /// Depending on the check level set in the menus the printer will:

--- a/Firmware/util.h
+++ b/Firmware/util.h
@@ -135,9 +135,9 @@ void nozzle_diameter_check(uint16_t nDiameter);
 void printer_model_check(uint16_t nPrinterModel, uint16_t actualPrinterModel);
 void printer_smodel_check(const char *pStrPos, const char *actualPrinterSModel);
 void fw_version_check(const char *pVersion);
-void gcode_level_check(uint16_t nGcodeLevel);
+void gcode_level_check(uint8_t nGcodeLevel);
 #ifdef STEEL_SHEET_TYPES
-void sheet_type_check(uint16_t nSheetType);
+void sheet_type_check(uint8_t nSheetType, uint8_t wSheetType);
 #endif //STEEL_SHEET_TYPES
 
 /// Check if the filament is present before starting a print job.

--- a/Firmware/variants/MK25-RAMBo10a.h
+++ b/Firmware/variants/MK25-RAMBo10a.h
@@ -25,6 +25,20 @@
 #define HEATBED_V2
 #define STEEL_SHEET
 //#define NEW_FIRST_LAYER_CAL //from front to back
+/* Sheet types
+ bit based
+ - 0 = Smooth
+ - 1 = Textured
+ - 2 = Satin
+ - 3 = NylonPA
+ - 4 = PolyPro
+ - 5 = Custom
+ - 6 = free
+ - 7 = free
+*/
+
+#define STEEL_SHEET_TYPES 6
+
 #define TACH0PULLUP
 
 // Uncomment the below for the E3D PT100 temperature sensor (with or without PT100 Amplifier)

--- a/Firmware/variants/MK25-RAMBo13a.h
+++ b/Firmware/variants/MK25-RAMBo13a.h
@@ -25,6 +25,20 @@
 #define HEATBED_V2
 #define STEEL_SHEET
 //#define NEW_FIRST_LAYER_CAL //from front to back
+/* Sheet types
+ bit based
+ - 0 = Smooth
+ - 1 = Textured
+ - 2 = Satin
+ - 3 = NylonPA
+ - 4 = PolyPro
+ - 5 = Custom
+ - 6 = free
+ - 7 = free
+*/
+
+#define STEEL_SHEET_TYPES 6
+
 #define TACH0PULLUP
 
 // Uncomment the below for the E3D PT100 temperature sensor (with or without PT100 Amplifier)

--- a/Firmware/variants/MK25S-RAMBo10a.h
+++ b/Firmware/variants/MK25S-RAMBo10a.h
@@ -25,6 +25,20 @@
 #define HEATBED_V2
 #define STEEL_SHEET
 //#define NEW_FIRST_LAYER_CAL //from front to back
+/* Sheet types
+ bit based
+ - 0 = Smooth
+ - 1 = Textured
+ - 2 = Satin
+ - 3 = NylonPA
+ - 4 = PolyPro
+ - 5 = Custom
+ - 6 = free
+ - 7 = free
+*/
+
+#define STEEL_SHEET_TYPES 6
+
 #define TACH0PULLUP
 
 // Uncomment the below for the E3D PT100 temperature sensor (with or without PT100 Amplifier)

--- a/Firmware/variants/MK25S-RAMBo13a.h
+++ b/Firmware/variants/MK25S-RAMBo13a.h
@@ -25,6 +25,20 @@
 #define HEATBED_V2
 #define STEEL_SHEET
 //#define NEW_FIRST_LAYER_CAL //from front to back
+/* Sheet types
+ bit based
+ - 0 = Smooth
+ - 1 = Textured
+ - 2 = Satin
+ - 3 = NylonPA
+ - 4 = PolyPro
+ - 5 = Custom
+ - 6 = free
+ - 7 = free
+*/
+
+#define STEEL_SHEET_TYPES 6
+
 #define TACH0PULLUP
 
 // Uncomment the below for the E3D PT100 temperature sensor (with or without PT100 Amplifier)

--- a/Firmware/variants/MK3-E3DREVO.h
+++ b/Firmware/variants/MK3-E3DREVO.h
@@ -24,6 +24,20 @@
 #define MOTHERBOARD BOARD_EINSY_1_0a
 #define STEEL_SHEET
 //#define NEW_FIRST_LAYER_CAL //from front to back
+/* Sheet types
+ bit based
+ - 0 = Smooth
+ - 1 = Textured
+ - 2 = Satin
+ - 3 = NylonPA
+ - 4 = PolyPro
+ - 5 = Custom
+ - 6 = free
+ - 7 = free
+*/
+
+#define STEEL_SHEET_TYPES 6
+
 #define HAS_SECOND_SERIAL_PORT
 
 

--- a/Firmware/variants/MK3-E3DREVO_HF_60W.h
+++ b/Firmware/variants/MK3-E3DREVO_HF_60W.h
@@ -24,6 +24,20 @@
 #define MOTHERBOARD BOARD_EINSY_1_0a
 #define STEEL_SHEET
 //#define NEW_FIRST_LAYER_CAL //from front to back
+/* Sheet types
+ bit based
+ - 0 = Smooth
+ - 1 = Textured
+ - 2 = Satin
+ - 3 = NylonPA
+ - 4 = PolyPro
+ - 5 = Custom
+ - 6 = free
+ - 7 = free
+*/
+
+#define STEEL_SHEET_TYPES 6
+
 #define HAS_SECOND_SERIAL_PORT
 
 

--- a/Firmware/variants/MK3.h
+++ b/Firmware/variants/MK3.h
@@ -24,6 +24,20 @@
 #define MOTHERBOARD BOARD_EINSY_1_0a
 #define STEEL_SHEET
 //#define NEW_FIRST_LAYER_CAL //from front to back
+/* Sheet types
+ bit based
+ - 0 = Smooth
+ - 1 = Textured
+ - 2 = Satin
+ - 3 = NylonPA
+ - 4 = PolyPro
+ - 5 = Custom
+ - 6 = free
+ - 7 = free
+*/
+
+#define STEEL_SHEET_TYPES 6
+
 #define HAS_SECOND_SERIAL_PORT
 
 

--- a/Firmware/variants/MK3S-E3DREVO.h
+++ b/Firmware/variants/MK3S-E3DREVO.h
@@ -23,6 +23,20 @@
 #define MOTHERBOARD BOARD_EINSY_1_0a
 #define STEEL_SHEET
 //#define NEW_FIRST_LAYER_CAL //from front to back
+/* Sheet types
+ bit based
+ - 0 = Smooth
+ - 1 = Textured
+ - 2 = Satin
+ - 3 = NylonPA
+ - 4 = PolyPro
+ - 5 = Custom
+ - 6 = free
+ - 7 = free
+*/
+
+#define STEEL_SHEET_TYPES 6
+
 #define HAS_SECOND_SERIAL_PORT
 
 // PSU

--- a/Firmware/variants/MK3S-E3DREVO_HF_60W.h
+++ b/Firmware/variants/MK3S-E3DREVO_HF_60W.h
@@ -23,6 +23,20 @@
 #define MOTHERBOARD BOARD_EINSY_1_0a
 #define STEEL_SHEET
 //#define NEW_FIRST_LAYER_CAL //from front to back
+/* Sheet types
+ bit based
+ - 0 = Smooth
+ - 1 = Textured
+ - 2 = Satin
+ - 3 = NylonPA
+ - 4 = PolyPro
+ - 5 = Custom
+ - 6 = free
+ - 7 = free
+*/
+
+#define STEEL_SHEET_TYPES 6
+
 #define HAS_SECOND_SERIAL_PORT
 
 // PSU

--- a/Firmware/variants/MK3S.h
+++ b/Firmware/variants/MK3S.h
@@ -186,7 +186,7 @@
 //#define DEBUG_PULLUP_CRASH //Test Pullup crash
 //#define DEBUG_PRINTER_STATES
 
-#define DEBUG_EEPROM_CHANGES //Uses +1188 bytes Flash +6 bytes SRAM
+//#define DEBUG_EEPROM_CHANGES //Uses +1188 bytes Flash +6 bytes SRAM
 //#define DEBUG_BUILD
 //#define DEBUG_SEC_LANG   //secondary language debug output at startup
 //#define DEBUG_XFLASH   //debug external spi flash

--- a/Firmware/variants/MK3S.h
+++ b/Firmware/variants/MK3S.h
@@ -23,6 +23,20 @@
 #define MOTHERBOARD BOARD_EINSY_1_0a
 #define STEEL_SHEET
 //#define NEW_FIRST_LAYER_CAL //from front to back
+/* Sheet types
+ bit based
+ - 0 = Smooth
+ - 1 = Textured
+ - 2 = Satin
+ - 3 = NylonPA
+ - 4 = PolyPro
+ - 5 = Custom
+ - 6 = free
+ - 7 = free
+*/
+
+#define STEEL_SHEET_TYPES 6
+
 #define HAS_SECOND_SERIAL_PORT
 
 // PSU
@@ -172,7 +186,7 @@
 //#define DEBUG_PULLUP_CRASH //Test Pullup crash
 //#define DEBUG_PRINTER_STATES
 
-//#define DEBUG_EEPROM_CHANGES //Uses +1188 bytes Flash +6 bytes SRAM
+#define DEBUG_EEPROM_CHANGES //Uses +1188 bytes Flash +6 bytes SRAM
 //#define DEBUG_BUILD
 //#define DEBUG_SEC_LANG   //secondary language debug output at startup
 //#define DEBUG_XFLASH   //debug external spi flash

--- a/lang/po/Firmware.pot
+++ b/lang/po/Firmware.pot
@@ -272,6 +272,12 @@ msgstr ""
 msgid "Changed correctly"
 msgstr ""
 
+#. MSG_CHECK_SHEET_TYPE c=20 r=3
+#: ../../Firmware/Marlin_main.cpp:5844 ../../Firmware/messages.cpp:163
+#: ../../Firmware/util.cpp:454 ../../Firmware/util.cpp:455
+msgid "Check selected steel sheet."
+msgstr ""
+
 #. MSG_CHECKING_X c=20
 #: ../../Firmware/messages.cpp:25 ../../Firmware/ultralcd.cpp:5930
 #: ../../Firmware/ultralcd.cpp:6955

--- a/lang/po/Firmware_cs.po
+++ b/lang/po/Firmware_cs.po
@@ -2582,6 +2582,12 @@ msgstr "Není vložen filament."
 msgid "Z calibration recommended. Run it now?"
 msgstr "Doporučujeme kalibraci osy Z. Spustit nyní?"
 
+#. MSG_CHECK_SHEET_TYPE c=20 r=3
+#: ../../Firmware/Marlin_main.cpp:5844 ../../Firmware/messages.cpp:163
+#: ../../Firmware/util.cpp:454 ../../Firmware/util.cpp:455
+msgid "Check selected steel sheet."
+msgstr "Zkontrolujte tiskový plát."
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Vyjmete stary filament a stisknete tlacitko pro zavedeni noveho."
 

--- a/lang/po/Firmware_de.po
+++ b/lang/po/Firmware_de.po
@@ -2609,6 +2609,12 @@ msgstr "Kein Filament geladen."
 msgid "Z calibration recommended. Run it now?"
 msgstr "Z-Kalibrierung empfohlen. Jetzt ausführen?"
 
+#. MSG_CHECK_SHEET_TYPE c=20 r=3
+#: ../../Firmware/Marlin_main.cpp:5844 ../../Firmware/messages.cpp:163
+#: ../../Firmware/util.cpp:454 ../../Firmware/util.cpp:455
+msgid "Check selected steel sheet."
+msgstr "Überprüfe ausgewähltes Stahlblech."
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Entferne das alte Fil. und drücke den Knopf, um das neue zu laden."
 

--- a/lang/po/Firmware_es.po
+++ b/lang/po/Firmware_es.po
@@ -2608,6 +2608,12 @@ msgstr "No hay ningún filamento cargado."
 msgid "Z calibration recommended. Run it now?"
 msgstr "Se recomienda calibrar Z. ¿Ejecutarlo ahora?"
 
+#. MSG_CHECK_SHEET_TYPE c=20 r=3
+#: ../../Firmware/Marlin_main.cpp:5844 ../../Firmware/messages.cpp:163
+#: ../../Firmware/util.cpp:454 ../../Firmware/util.cpp:455
+msgid "Check selected steel sheet."
+msgstr "Verifique la lámina de acero seleccionada."
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr ""
 #~ "Retira el fil. viejo y presiona el dial para comenzar a cargar el nuevo."

--- a/lang/po/Firmware_fr.po
+++ b/lang/po/Firmware_fr.po
@@ -2616,6 +2616,12 @@ msgstr "Il n'y a pas de filament chargé."
 msgid "Z calibration recommended. Run it now?"
 msgstr "Calibrage Z recommandé. Exécuter maintenant?"
 
+#. MSG_CHECK_SHEET_TYPE c=20 r=3
+#: ../../Firmware/Marlin_main.cpp:5844 ../../Firmware/messages.cpp:163
+#: ../../Firmware/util.cpp:454 ../../Firmware/util.cpp:455
+msgid "Check selected steel sheet."
+msgstr "Vérifiez la plaque en acier sélectionnée."
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr ""
 #~ "Retirez l'ancien fil. puis appuyez sur le bouton pour charger le nouveau."

--- a/lang/po/Firmware_hr.po
+++ b/lang/po/Firmware_hr.po
@@ -2598,6 +2598,12 @@ msgstr "Nema umetnute niti."
 msgid "Z calibration recommended. Run it now?"
 msgstr "Preporuča se Z kalibracija. Pokrenuti ga sada?"
 
+#. MSG_CHECK_SHEET_TYPE c=20 r=3
+#: ../../Firmware/Marlin_main.cpp:5844 ../../Firmware/messages.cpp:163
+#: ../../Firmware/util.cpp:454 ../../Firmware/util.cpp:455
+msgid "Check selected steel sheet."
+msgstr "Provjerite odabrani čelični ploca."
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Uklonite stari fil. i pritisnite gumb za pocetak stavljanja novog."
 

--- a/lang/po/Firmware_hu.po
+++ b/lang/po/Firmware_hu.po
@@ -2606,6 +2606,12 @@ msgstr "Nincs befűzve filament."
 msgid "Z calibration recommended. Run it now?"
 msgstr "Z kalibráció javasolt. Futtassam most?"
 
+#. MSG_CHECK_SHEET_TYPE c=20 r=3
+#: ../../Firmware/Marlin_main.cpp:5844 ../../Firmware/messages.cpp:163
+#: ../../Firmware/util.cpp:454 ../../Firmware/util.cpp:455
+msgid "Check selected steel sheet."
+msgstr "Nezd meg a kiválasztott az acellapot."
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Vedd ki a regi fil., majd nyomd meg a gombot az uj fil. betoltesehez."
 

--- a/lang/po/Firmware_it.po
+++ b/lang/po/Firmware_it.po
@@ -2604,6 +2604,12 @@ msgstr "Nessun filamento caricato."
 msgid "Z calibration recommended. Run it now?"
 msgstr "Si consiglia la calibrazione Z. Eseguirla ora?"
 
+#. MSG_CHECK_SHEET_TYPE c=20 r=3
+#: ../../Firmware/Marlin_main.cpp:5844 ../../Firmware/messages.cpp:163
+#: ../../Firmware/util.cpp:454 ../../Firmware/util.cpp:455
+msgid "Check selected steel sheet."
+msgstr "Controllare la piastra d'acciaio selezionata."
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Rimuovi il fil. precedente e premi la manopola per caricare il nuovo."
 

--- a/lang/po/Firmware_nl.po
+++ b/lang/po/Firmware_nl.po
@@ -2607,6 +2607,12 @@ msgstr "Geen filament geladen."
 msgid "Z calibration recommended. Run it now?"
 msgstr "Z-kalibratie aanbevolen. Nu uitvoeren?"
 
+#. MSG_CHECK_SHEET_TYPE c=20 r=3
+#: ../../Firmware/Marlin_main.cpp:5844 ../../Firmware/messages.cpp:163
+#: ../../Firmware/util.cpp:454 ../../Firmware/util.cpp:455
+msgid "Check selected steel sheet."
+msgstr "Controleer de geselecteerde staalplaat."
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr ""
 #~ "Verwijder de oude filament en druk op de knop om nieuwe filament te laden."

--- a/lang/po/Firmware_no.po
+++ b/lang/po/Firmware_no.po
@@ -2581,6 +2581,12 @@ msgstr "Det er ingen filament lastet."
 msgid "Z calibration recommended. Run it now?"
 msgstr "Z-kalibrering anbefales. Kjøre det nå?"
 
+#. MSG_CHECK_SHEET_TYPE c=20 r=3
+#: ../../Firmware/Marlin_main.cpp:5844 ../../Firmware/messages.cpp:163
+#: ../../Firmware/util.cpp:454 ../../Firmware/util.cpp:455
+msgid "Check selected steel sheet."
+msgstr "Sjekk valgt stålplaten."
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Ta bort det gamle filamentet og trykk valghjulet for å laste et nytt."
 

--- a/lang/po/Firmware_pl.po
+++ b/lang/po/Firmware_pl.po
@@ -2595,6 +2595,12 @@ msgstr "Nie ma załadowanego filamentu."
 msgid "Z calibration recommended. Run it now?"
 msgstr "Zalecana kalibracja Z. Uruchomić teraz?"
 
+#. MSG_CHECK_SHEET_TYPE c=20 r=3
+#: ../../Firmware/Marlin_main.cpp:5844 ../../Firmware/messages.cpp:163
+#: ../../Firmware/util.cpp:454 ../../Firmware/util.cpp:455
+msgid "Check selected steel sheet."
+msgstr "Sprawdź wybraną płyta stalowa."
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Wyciągnij poprzedni filament i naciśnij pokrętło aby załadować nowy."
 

--- a/lang/po/Firmware_ro.po
+++ b/lang/po/Firmware_ro.po
@@ -2605,6 +2605,12 @@ msgstr "Filamentul nu este detectat."
 msgid "Z calibration recommended. Run it now?"
 msgstr "Calibrarea Z este recomandată. Calibrează acum?"
 
+#. MSG_CHECK_SHEET_TYPE c=20 r=3
+#: ../../Firmware/Marlin_main.cpp:5844 ../../Firmware/messages.cpp:163
+#: ../../Firmware/util.cpp:454 ../../Firmware/util.cpp:455
+msgid "Check selected steel sheet."
+msgstr "Verificați suprafața selectată."
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Scoateți fil. vechi și apăsați butonul pentru a încărca unul nou."
 

--- a/lang/po/Firmware_ro.po
+++ b/lang/po/Firmware_ro.po
@@ -2609,7 +2609,7 @@ msgstr "Calibrarea Z este recomandată. Calibrează acum?"
 #: ../../Firmware/Marlin_main.cpp:5844 ../../Firmware/messages.cpp:163
 #: ../../Firmware/util.cpp:454 ../../Firmware/util.cpp:455
 msgid "Check selected steel sheet."
-msgstr "Verificați suprafața selectată."
+msgstr "Verificați suprafața de print selectată"
 
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Scoateți fil. vechi și apăsați butonul pentru a încărca unul nou."

--- a/lang/po/Firmware_sk.po
+++ b/lang/po/Firmware_sk.po
@@ -2589,7 +2589,7 @@ msgstr "Odporúča sa kalibrácia Z. Spustiť ju teraz?"
 #: ../../Firmware/Marlin_main.cpp:5844 ../../Firmware/messages.cpp:163
 #: ../../Firmware/util.cpp:454 ../../Firmware/util.cpp:455
 msgid "Check selected steel sheet."
-msgstr "Skontrolujte vybraný platňa."
+msgstr "Skontrolujte vybranú platňu."
 
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Vyberte starý filament a stlačte tlačidlo pre zavedenie nového."

--- a/lang/po/Firmware_sk.po
+++ b/lang/po/Firmware_sk.po
@@ -2585,6 +2585,12 @@ msgstr "Nie je zavedený žiaden filament."
 msgid "Z calibration recommended. Run it now?"
 msgstr "Odporúča sa kalibrácia Z. Spustiť ju teraz?"
 
+#. MSG_CHECK_SHEET_TYPE c=20 r=3
+#: ../../Firmware/Marlin_main.cpp:5844 ../../Firmware/messages.cpp:163
+#: ../../Firmware/util.cpp:454 ../../Firmware/util.cpp:455
+msgid "Check selected steel sheet."
+msgstr "Skontrolujte vybraný platňa."
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Vyberte starý filament a stlačte tlačidlo pre zavedenie nového."
 

--- a/lang/po/Firmware_sv.po
+++ b/lang/po/Firmware_sv.po
@@ -2593,6 +2593,12 @@ msgstr "Det finns ingen filament laddad."
 msgid "Z calibration recommended. Run it now?"
 msgstr "Z-kalibrering rekommenderas. Kör den nu?"
 
+#. MSG_CHECK_SHEET_TYPE c=20 r=3
+#: ../../Firmware/Marlin_main.cpp:5844 ../../Firmware/messages.cpp:163
+#: ../../Firmware/util.cpp:454 ../../Firmware/util.cpp:455
+msgid "Check selected steel sheet."
+msgstr "Kontrollera vald metallskivan."
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Ta bort det gamla fil. och tryck på knappen för att börja ladda nytt."
 


### PR DESCRIPTION
Thanks @jfestrada for the idea in #4569. 

This is a different approach for this request.

We have the https://help.prusa3d.com/materials (which is missing the PP powder coated steel sheet) and we could use it to warn users when they start to print:

- [X] Add new parameter Type to the `M850`  gcode and `HW Setup -> Sheets` to set the type of sheet
  - [X] Smooth
  - [X] Textured
  - [X] Satin
  - [X] NylonPA
  - [X] PP
  - [X] Custom

  - [X] Reuse and add eeprom values needed
    - The Bed and PINDA temp values within the sheets eeprom aren't / have never been used. Replace these Sheet type
previous values are `>10` as the MINtemp for Bed would not allow any lower values so resetting these with `255` or default values `0-6` is not an issue

  - [X] Also add `M862.7` to check the compatible sheets with parameter `P`. In the PrusaSlicer Filament profiles we could add it to the custom G-code
As the materials help article shows compatibility :heavy_check_mark:  and warnings :grey_exclamation:and not to use :x: I would suggest a bit based value
bit 0 = Smooth compatible
bit 1 = Textured compatible
bit 2 = Satin compatible
bit 3 = NylonPA compatible
bit 4 = PP compatible
bit 5 = Custom sheet compatible (like G10 sheets see https://www.youtube.com/watch?v=g0PK4oXbJT8)

- [X] Add an additional Check state `Always` or `Wait` which is the same as `Warn` but doesn't timeout and HAS to be confirmed on LCD
  - [X] With `Always` any `M115` Gcode will trigger the LCD message to be confirmed.

- [X] Of course the default setting for the Sheet type check would be warn (with timeout)

**ToDos:**
  - [x] Bit check `M862.7 P` 
  - [x] And an additional `M862.7` parameter `Warn` with same bit based value
       - Example:
       - PLA : M862.7 P7 W0 PLA is compatible on Smooth, Textured and Satin,  no additional warnings BUT NOT compatible on NylonPA and PP
       - ASA: M862.7 P4 W3 ASA is compatible on Satin, warning to use glue stick on Smooth and Textured and BUT NOT compatible on NylonPA

- [x] In case there is a warning or stop print send also an `//action:notification` to inform host users.

In PrusaConnect we already have some sheet information

- [ ] Another check we could add is in the Preheat menu, so users which use that will be warned before the starting a print or 1st layer calibration.

- [ ] Update Materials help page as PP sheet is missing
- [ ] Optional Add [prusa.io/materials](http://prusa.io/materials) link we could use in the warnings
  - This will need new translations as we are then limited to 2 rows for the message and the 3rd would be used for the link.  
- [ ] Update PrusaSlicer filament profiles for MK2.5/S and MK3/S/+ printers.

- [ ] Review translations for `Check selected steel sheet.`
   - [x] :czech_republic: `Zkontrolujte tiskový plát.` @DRracer 
   - [X] :de: `Überprüfe ausgewähltes Stahlblech.` @3d-gussner
   - [ ] :es: `Verifique la lámina de acero seleccionada.`
   - [x] :fr: `Vérifiez la plaque en acier sélectionnée.` @ErwanAliasr1 @Ilovemyhous
   - [ ] :croatia: `Provjerite odabrani čelični ploca.`
   - [ ] :hungary: `Nezd meg a kiválasztott az acellapot.` @AttilaSVK @Hauzman
   - [x] :it: `Controllare la piastra d'acciaio selezionata.` @wavexx 
   - [x] :netherlands: `Controleer de geselecteerde staalplaat.` @vintagepc @3d-gussner @stelgenhof
   - [ ] :norway: `Sjekk valgt stålplaten.`
   - [ ] :poland: `Sprawdź wybraną płyta stalowa.` @arekm
   - [x] :romania: `Verificați suprafața de print selectată` @leptun @Hauzman
   - [x] :slovakia: `Skontrolujte vybranú platňu.` @ingbrzy @shatter136
   - [ ] :sweden: `Kontrollera vald metallskivan.`


**Post release tasks:**

- [ ] Update doxygen documentation
- [ ] Update RepRap Gcode wiki
- [ ] PrusaSlicer profiles PR for MK2.5/S and MK3/S/+

**Test PR:**
- In PrusaSlicer 2.9.0 -> Printer Tab -> Custom G-code -> Start G-code add below
```
M862.3 P "[printer_model]" ; printer model check
M862.1 P[nozzle_diameter] ; nozzle diameter check
```
following lines
```
;Sheet compatibility see https://help.prusa3d.com/materials

;Smooth   SMO  1
;Textured TXT  2
;Satin    SAT  4
;Nylon    NYL  8
;PP       PP  16
;Custom   CUS 32

; P<value> compatible                 W<value> warning, like "with glue stick"
;      SMO TXT SAT NYL PP  CUS         SMO TXT SAT NYL PP  CUS
;PLA :P 1 + 2 + 4              = 7  | W                        = 0
;PET :P     2 + 4 + 8          = 14 | W 1                      = 1
;ASA :P         4              = 4  | W 1 + 2                  = 3
;ABS :P         4              = 4  | W 1 + 2                  = 3
;PC  :P         4              = 4  | W 1 + 2                  = 3
;CPE :P     2 + 4              = 6  | W 1                      = 1
;PVA :P 1 + 2 + 4              = 7  | W                        = 0
;BVOH:P 1 + 2 + 4              = 7  | W                        = 0
;HIPS:P 1 + 2 + 4              = 7  | W                        = 0
;PP  :P                16      = 16 | W 1                      = 1
;FLEX:P     2                  = 2  | W 1     + 4              = 5
;NGEN:P     2 + 4              = 6  | W 1                      = 1
;PA  :P             8          = 8  | W     2 + 4              = 6
;Wood:P         4              = 4  | W                        = 0
;PVB :P 1     + 4              = 5  | W                        = 0
;PEI :P             8          = 8  | W     2                  = 2

M862.7 P{if filament_type[initial_tool] == "FLEX"}2{elsif filament_type[initial_tool] == "ASA" or filament_type[initial_tool] == "ABS" or filament_type[initial_tool] == "PC" or filament_type[initial_tool] == "WOOD"}4{elsif filament_type[initial_tool] == "PVB"}5{elsif filament_type[initial_tool] == "CPE" or filament_type[initial_tool] == "NGEN"}6{elsif filament_type[initial_tool] == "PLA" or filament_type[initial_tool] == "PVA" or filament_type[initial_tool] == "BVOH" or filament_type[initial_tool] == "HIPS" }7{elsif filament_type[initial_tool] == "PA" or filament_type[initial_tool] == "PEI"}8{elsif filament_type[initial_tool] == "PET" or filament_type[initial_tool] == "PETG"}14{elsif filament_type[initial_tool] == "PP"}16{else}0{endif} W{if filament_type[initial_tool] == "PET" or filament_type[initial_tool] == "PETG" or filament_type[initial_tool] == "CPE" or filament_type[initial_tool] == "PP" or filament_type[initial_tool] == "NGEN"}1{elsif filament_type[initial_tool] == "PEI"}2{elsif filament_type[initial_tool] == "ASA" or filament_type[initial_tool] == "ABS" or filament_type[initial_tool] == "PC"}3{elsif filament_type[initial_tool] == "FLEX"}5{elsif filament_type[initial_tool] == "PA"}6{else}0{endif}; steel sheet check
```
and before
```
M115 U3.14.1 ; tell printer latest fw version
```
  - This will add automatically during slicing the needed `M862.7 P<value> W<value>` to the start gcode.
  - I tried to add the `M862.7` to the PrusaSlicer Filament section, but frankly `Custom G-Code`s are added after the Printer tab Start G-Code. These kind of checks need to be at the beginning, like the Printer Type Nozzle size checks already are!

- In LCD Settings -> HW Setup -> Checks -> Sheet default is
  - [Warn] which will warn the user on LCD screen with a timeout message when
    - the expected/supported sheet isn't selected / placed on the printer
    - the selected sheet has some warnings, like `use glue stick`
- In LCD Settings -> HW Setup -> Steel Sheets -> <Sheet name> you find a new menu `Type`
   - [Smooth | Texture | Satin | NylonPA | PolyPro | Custom]
- Ideally you have at lest two Steel sheets calibrated.

**Test 1**

1. Connect with a serial terminal
  a. ideally enable some logging
2. Select LCD Settings -> HW Setup -> Checks -> Sheet [Warn]
3. Select `Smooth` sheet
4. Send `M862.7 P7 W0` to simulate a PLA print, which can be printed on Smooth, Textured and Satin sheets BUT NOT on NylonPA or PP sheets.
   a. Nothing shown on LCD screen
5. Send `M862.7 P14 W1` to simulate a PET/G print, which can be printed on Textured, Satin and NylonPA sheets BUT NOT on PP sheets. With a glue stick applied the usage of the Smooth sheet is possible and will warn the user.
  a. LCD should show for ~30 seconds
```
Check selected steel
sheet.

>Cont.        Cancel
``` 
6. Select LCD Settings -> HW Setup -> Checks -> Sheet [Strict]
7. Repeat Steps 3 to 5
   a. The LCD screen of step 5 shows and NEEDS to be confirmed on LCD
```
Check selected steel
sheet.

                   v
``` 
8. Select LCD Settings -> HW Setup -> Checks -> Sheet [Always]
9. Repeat Steps 3 to 5
 a. The LCD message is always shown, but it times out and will continue

**Test 2**
1. Connect with a serial terminal
  a. ideally enable some logging
2. Select LCD Settings -> HW Setup -> Checks -> Sheet [Warn]
3. Select `Smooth` sheet
4. Slice a simple short PLA print with the new/modified PrusaSlicer profile
5. Start this PLA print
6. As the Smooth sheet is compatible with PLA no warnings are shown.
7. Slice a simple short PETG print with the new/modified PrusaSlicer profile
8. As the Smooth sheet should be used with glue stick while printing PET/G
  a. LCD should show for ~30 seconds
```
Check selected steel
sheet.

>Cont.        Cancel
``` 
9. Select LCD Settings -> HW Setup -> Checks -> Sheet [Strict]
10. Repeat step 3 to 8 and you should get same results as in Test 1
11.  Select LCD Settings -> HW Setup -> Checks -> Sheet [Always]
12. Repeat step 3 to 8 and you should get same results as in Test 1 with one addition
  b. To also check "old" gcode without `M862.7`, the check is also executed when `M115` is send during a print and shows following screen which DOESN'T timeout and NEEDS user interaction!
```
Check selected steel
sheet.

 Cont.       >Cancel
```
   i. To not delay host connections the `M115` doesn't execute the check when the printer is inactive.
   ii. Frankly at this moment new gcode will show the LCD message twice when `Always` is selected.