### PR TITLE
Fix bug where Load and Unload filament menus may be missing & other related situations

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -4380,7 +4380,7 @@ static void sheets_menu()
 static void nozzle_change()
 {
 #ifdef FILAMENT_SENSOR
-    if (fsensor.isEnabled() && fsensor.getFilamentPresent()) {
+    if (fsensor.isReady() && fsensor.getFilamentPresent()) {
         lcd_show_fullscreen_message_and_wait_P(_T(MSG_UNLOAD_FILAMENT_REPEAT));
         lcd_return_to_status();
         return;
@@ -5348,7 +5348,7 @@ static void lcd_main_menu()
 #endif //MMU_HAS_CUTTER
             } else {
 #ifdef FILAMENT_SENSOR
-                if (fsensor.isEnabled()) {
+                if (fsensor.isReady()) {
                     if (!fsensor.getAutoLoadEnabled()) {
                         MENU_ITEM_SUBMENU_P(_T(MSG_LOAD_FILAMENT), lcd_LoadFilament);
                     }

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -4047,7 +4047,8 @@ static void fsensor_reinit() {
 }
 
 static void lcd_fsensor_enabled_set(void) {
-    fsensor.setEnabled(!fsensor.isEnabled());
+    bool current_setting = eeprom_read_byte((uint8_t *)EEPROM_FSENSOR);
+    fsensor.setEnabled(!current_setting);
 }
 
 static void lcd_fsensor_runout_set() {
@@ -4084,7 +4085,7 @@ static void lcd_fsensor_settings_menu() {
     MENU_BEGIN();
     MENU_ITEM_BACK_P(_T(MSG_BACK));
 
-    MENU_ITEM_TOGGLE_P(_T(MSG_FSENSOR), fsensor.isEnabled() ? _T(MSG_ON) : _T(MSG_OFF), lcd_fsensor_enabled_set);
+    MENU_ITEM_TOGGLE_P(_T(MSG_FSENSOR), eeprom_read_byte((uint8_t *)EEPROM_FSENSOR) ? _T(MSG_ON) : _T(MSG_OFF), lcd_fsensor_enabled_set);
 
     if (fsensor.isEnabled()) {
         if (fsensor.isError()) {

--- a/Firmware/util.cpp
+++ b/Firmware/util.cpp
@@ -379,7 +379,7 @@ bool filament_presence_check() {
         goto done;
     }
 
-    if (fsensor.isEnabled() && !fsensor.getFilamentPresent()) {
+    if (fsensor.isReady() && !fsensor.getFilamentPresent()) {
         if (oCheckFilament == ClCheckMode::_None) {
             goto done;
         }


### PR DESCRIPTION
* Fix an issue introduced in 3.14.0 where if the filament sensor state machine is in error state, then the Load filament and Unload filament menus wouldn't be shown.
    * This same fix applies in two situations:
    * Nozzle change: detecting if there is filament loaded requires that filament sensor not to be in error state. Previously the firmware would try to use the sensor regardless even though the sensor was toggled OFF in menus.
    * M862: The filament presence check is not executed if the filament sensor is in error condition. Previously if the sensor was in error state, the firmware would try run M862 even though the filament sensor was toggled OFF in menus.
* The On / Off text in the Filament sensor menu is now using the EEPROM value to check if the sensor is enabled or not.

Fixes #4808 

Steps to reproduce:
It is easiest to use PAT9125 sensor.

1. Disconnect the PAT9125 sensor, such that the firmware will failing reading/writings its registers.
2. Expected result 1: Both Load and Unload filament menus should be present
3. Expected result 2: If the filament sensor is toggled OFF in the menus, it will remain OFF through reboots.