### PR TITLE
Align MIN_Z raise for unload & load

### DIFF
--- a/Firmware/Configuration.h
+++ b/Firmware/Configuration.h
@@ -358,8 +358,8 @@ your extruder heater takes 2 minutes to hit the target on heating.
 
 // Try to maintain a minimum distance from the bed even when Z is
 // unknown when doing the following operations
-#define MIN_Z_FOR_LOAD    50 // lcd filament loading or autoload
-#define MIN_Z_FOR_UNLOAD  20 // lcd filament unloading
+#define MIN_Z_FOR_LOAD    35 // lcd filament loading or autoload (values for load and unload have been unified to prevent movement between unload & load operations!)
+#define MIN_Z_FOR_UNLOAD  35 // lcd filament unloading
 #define MIN_Z_FOR_SWAP    27 // filament change (including M600)
 #define MIN_Z_FOR_PREHEAT 10 // lcd preheat
 


### PR DESCRIPTION
Align values for MIN_Z raise, to prevent movement between unload & load operations.

Fixes #4838