### PR TITLE
Update upload-atrifacts to version 4 as 3 is deprecated

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
 
     - name: Upload artifacts
       if: ${{ !github.event.pull_request }}
-      uses: actions/upload-artifact@v3.1.1
+      uses: actions/upload-artifact@v4
       with:
         name: Firmware
         path: build/*.hex


### PR DESCRIPTION
Fixes https://github.com/prusa3d/Prusa-Firmware/actions/runs/13188912408/job/36818019967?pr=4843#step:1:36

See also https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/