### PR TITLE
Add M256 [ B | D | S | T ]

### DIFF
--- a/Firmware/Configuration.h
+++ b/Firmware/Configuration.h
@@ -324,6 +324,10 @@ your extruder heater takes 2 minutes to hit the target on heating.
 #define SDSUPPORT
 #define LCD_WIDTH 20
 #define LCD_HEIGHT 4
+#define LCD_BACKLIGHT_LEVEL_HIGH 130
+#define LCD_BACKLIGHT_LEVEL_LOW 50
+#define LCD_BACKLIGHT_FORCE_ON 30
+#define LCD_BACKLIGHT_TIMEOUT 15
 
 
 // Increase the FAN pwm frequency. Removes the PWM noise but increases heating in the FET/Arduino

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -6661,17 +6661,10 @@ void process_commands()
      case 256:
     {
       if (backlightSupport) {
-        if (code_seen('B') ) backlightLevel_HIGH=code_value_uint8();
-        if (code_seen('D')) backlightLevel_LOW=code_value_uint8();
-        if (code_seen('S')) {
-          backlightMode=code_value_uint8();
-          if (backlightMode >2 ) backlightMode = 2;
-        }
-        if (code_seen('T')) {
-          backlightTimer_period=code_value_short();
-          if (backlightTimer_period < LCD_BACKLIGHT_TIMEOUT) backlightTimer_period = LCD_BACKLIGHT_TIMEOUT;
-          if (backlightTimer_period > LCD_BACKLIGHT_TIMEOUT*60) backlightTimer_period = LCD_BACKLIGHT_TIMEOUT*60;
-        }
+        if (code_seen('B') ) backlightLevel_HIGH = code_value_uint8();
+        if (code_seen('D')) backlightLevel_LOW = code_value_uint8();
+        if (code_seen('S')) backlightMode = max(static_cast<Backlight_Mode>(code_value_uint8()), BACKLIGHT_MODE_AUTO);
+        if (code_seen('T')) backlightTimer_period = constrain(code_value_short(), LCD_BACKLIGHT_TIMEOUT, LCD_BACKLIGHT_TIMEOUT*60);
         printf_P(PSTR("M256 B%d D%d S%d T%u\n"), backlightLevel_HIGH, backlightLevel_LOW, backlightMode, backlightTimer_period);
         backlight_save();
       }

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3710,7 +3710,7 @@ extern uint8_t st_backlash_y;
 //!@n M221 - Set extrude factor override percentage
 //!@n M226 - Wait for Pin state
 //!@n M240 - Trigger camera
-//!@n M250 - Set LCD contrast C<contrast value> (value 0..63)
+//!@n M256 - Set LCD brightness
 //!@n M300 - Play tone
 //!@n M301 - Set hotend PID
 //!@n M302 - Allow cold extrude, or set minimum extrude temperature
@@ -6640,6 +6640,44 @@ void process_commands()
      }
     break;
     #ifdef PREVENT_DANGEROUS_EXTRUDE
+
+    /*!
+    ### M256 - Set LCD brightness <a href="https://reprap.org/wiki/G-code#M256:_Set_LCD_brightness">M256: Set LCD brightness</a>
+    Set and/or get the LCD brightness. The value is constrained based on the LCD, but typically a value of 0 is the dimmest and 255 is the brightest.
+    #### Usage
+
+        M256 [ B | D | S | T ]
+
+    #### Parameters
+    - `B` - Normal Brightness value (0 - 255), default 130
+    - `D` - Dimmed Brightness value (0 - 255), default 50
+    - `S` - Brightness mode, default Auto
+      - `0` - Dim
+      - `1` - Bright
+      - `2` - Auto
+    - `T` - Brightness timeout  (15 - 900), default 15 seconds
+    */
+    #ifdef LCD_BL_PIN
+     case 256:
+    {
+      if (backlightSupport) {
+        if (code_seen('B') ) backlightLevel_HIGH=code_value_uint8();
+        if (code_seen('D')) backlightLevel_LOW=code_value_uint8();
+        if (code_seen('S')) {
+          backlightMode=code_value_uint8();
+          if (backlightMode >2 ) backlightMode = 2;
+        }
+        if (code_seen('T')) {
+          backlightTimer_period=code_value_short();
+          if (backlightTimer_period < LCD_BACKLIGHT_TIMEOUT) backlightTimer_period = LCD_BACKLIGHT_TIMEOUT;
+          if (backlightTimer_period > LCD_BACKLIGHT_TIMEOUT*60) backlightTimer_period = LCD_BACKLIGHT_TIMEOUT*60;
+        }
+        printf_P(PSTR("M256 B%d D%d S%d T%u\n"), backlightLevel_HIGH, backlightLevel_LOW, backlightMode, backlightTimer_period);
+        backlight_save();
+      }
+    }
+    break;
+    #endif //LCD_BL_PIN
 
     /*!
     ### M302 - Allow cold extrude, or set minimum extrude temperature <a href="https://reprap.org/wiki/G-code#M302:_Allow_cold_extrudes">M302: Allow cold extrudes</a>

--- a/Firmware/backlight.cpp
+++ b/Firmware/backlight.cpp
@@ -17,7 +17,7 @@ bool backlightSupport = 0; //only if it's true will any of the settings be visib
 uint8_t backlightLevel_HIGH = 0;
 uint8_t backlightLevel_LOW = 0;
 uint8_t backlightMode = BACKLIGHT_MODE_BRIGHT;
-int16_t backlightTimer_period = 10;
+int16_t backlightTimer_period = LCD_BACKLIGHT_TIMEOUT;
 LongTimer backlightTimer;
 
 static void backlightTimer_reset() //used for resetting the timer and waking the display. Triggered on user interactions.
@@ -32,7 +32,7 @@ void force_bl_on(bool section_start)
     if (section_start)
     {
         backlightMode = BACKLIGHT_MODE_BRIGHT;
-        if (backlightLevel_HIGH < 30) backlightLevel_HIGH = 30;
+        if (backlightLevel_HIGH < LCD_BACKLIGHT_FORCE_ON) backlightLevel_HIGH = LCD_BACKLIGHT_FORCE_ON;
     }
     else
     {
@@ -93,9 +93,9 @@ void backlight_init()
 
     //initialize backlight
     backlightMode = eeprom_init_default_byte((uint8_t *)EEPROM_BACKLIGHT_MODE, BACKLIGHT_MODE_AUTO);
-    backlightLevel_HIGH = eeprom_init_default_byte((uint8_t *)EEPROM_BACKLIGHT_LEVEL_HIGH, 130);
-    backlightLevel_LOW = eeprom_init_default_byte((uint8_t *)EEPROM_BACKLIGHT_LEVEL_LOW, 50);
-    backlightTimer_period = eeprom_init_default_word((uint16_t *)EEPROM_BACKLIGHT_TIMEOUT, 10); // in seconds
+    backlightLevel_HIGH = eeprom_init_default_byte((uint8_t *)EEPROM_BACKLIGHT_LEVEL_HIGH, LCD_BACKLIGHT_LEVEL_HIGH);
+    backlightLevel_LOW = eeprom_init_default_byte((uint8_t *)EEPROM_BACKLIGHT_LEVEL_LOW, LCD_BACKLIGHT_LEVEL_LOW);
+    backlightTimer_period = eeprom_init_default_word((uint16_t *)EEPROM_BACKLIGHT_TIMEOUT, LCD_BACKLIGHT_TIMEOUT); // in seconds
 
     SET_OUTPUT(LCD_BL_PIN);
     backlightTimer_reset();

--- a/Firmware/menu.cpp
+++ b/Firmware/menu.cpp
@@ -475,10 +475,8 @@ static void _menu_edit_P()
             // disable after first use and/or if the initial value is not minEditValue
             _md->minJumpValue = 0;
         }
-
 		_md->currentValue += lcd_encoder;
 		lcd_encoder = 0; // Consume knob rotation event
-
 		// Constrain the value in case it's outside the allowed limits
 		_md->currentValue = constrain(_md->currentValue, _md->minEditValue, _md->maxEditValue);
 		lcd_set_cursor(0, 1);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -5620,7 +5620,7 @@ static void lcd_backlight_menu()
     MENU_ITEM_EDIT_int3_P(_T(MSG_BL_HIGH), &backlightLevel_HIGH, backlightLevel_LOW, 255);
     MENU_ITEM_EDIT_int3_P(_T(MSG_BL_LOW), &backlightLevel_LOW, 0, backlightLevel_HIGH);
 	MENU_ITEM_TOGGLE_P(_T(MSG_MODE), ((backlightMode==BACKLIGHT_MODE_BRIGHT) ? _T(MSG_BRIGHT) : ((backlightMode==BACKLIGHT_MODE_DIM) ? _T(MSG_DIM) : _T(MSG_AUTO))), backlight_mode_toggle);
-    MENU_ITEM_EDIT_int3_P(_T(MSG_TIMEOUT), &backlightTimer_period, 1, 999);
+    MENU_ITEM_EDIT_int3_P(_T(MSG_TIMEOUT), &backlightTimer_period, LCD_BACKLIGHT_TIMEOUT, LCD_BACKLIGHT_TIMEOUT*60);
 
     MENU_END();
 }


### PR DESCRIPTION
Solves feature request https://github.com/prusa3d/Prusa-Firmware/issues/3470

- Removed hard coded values and added
  - LCD_BACKLIGHT_LEVEL_HIGH 130
  - LCD_BACKLIGHT_LEVEL_LOW 50
  - LCD_BACKLIGHT_FORCE_ON 30
  - LCD_BACKLIGHT_TIMEOUT 15


M256 [ B | D | S | T ]

    Parameters
    - `B` - Normal Brightness value (0 - 255), default 130
    - `D` - Dimmed Brightness value (0 - 255), default 50
    - `S` - Brightness mode, default Auto
      - `0` - Dim
      - `1` - Bright
      - `2` - Auto
    - `T` - Brightness timeout  (15 - 900), default 15 seconds
    
    
Post release tasks
- [ ] Update Gcode doxygen
- [ ] Update RepRap Gcode Wiki