### PR TITLE
Add `t` and `c` build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,8 @@ on:
     branches: [ MK3, MK3_* ]
     tags:
     - 'v*'
+    - 't*'
+    - 'c*'
 
 env:
   GH_ANNOTATIONS: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,6 +75,7 @@ jobs:
       uses: "marvinpinto/action-automatic-releases@latest"
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
+        automatic_release_tag: ${{ github.ref_name }}
         draft: true
         files: |
           ${{ github.workspace }}/build/release/*.hex

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
         path: build/*.hex
 
     - name: RELEASE THE KRAKEN
-      if: startsWith(github.ref, 'refs/tags/v')
+      if: startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/t') || startsWith(github.ref, 'refs/tags/c')
       uses: "marvinpinto/action-automatic-releases@latest"
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ message(STATUS "Filename debug suffix ...........: ${FN_VERSION_DEBUG_SUFFIX}")
 # SET(FW_COMMIT_DSC "v3.13.0-1234")
 
 if(NOT "${PROJECT_VERSION_HASH}" STREQUAL "UNKNOWN" AND NOT "${FW_COMMIT_DSC}" MATCHES ".+NOTFOUND.+") # else -> no commit hash is known... likely no git.
-string(REGEX MATCH "[v|t]([0-9]+)\.([0-9]+)\.([0-9]+)-?(${DEV_TAG_REGEX})?([0-9]+)?-([0-9]+)" TAG_VERSION "${FW_COMMIT_DSC}")
+string(REGEX MATCH "[v|t|c]([0-9]+)\.([0-9]+)\.([0-9]+)-?(${DEV_TAG_REGEX})?([0-9]+)?-([0-9]+)" TAG_VERSION "${FW_COMMIT_DSC}")
 
 if (CMAKE_MATCH_4) # Do we have a build type?
     decode_flavor_code(PROJECT_VER_TAG_FLV "${CMAKE_MATCH_4}" "${CMAKE_MATCH_5}")


### PR DESCRIPTION
Add cmake and github action to build a firmware with tags
- `t` test like ALPHA, BETA, RC versions
- `c` community


Tested on my fork see https://github.com/3d-gussner/Prusa-Firmware/actions/runs/14485084102

![c3141-beta1](https://github.com/user-attachments/assets/de0cea96-988b-4e5a-8296-ac218529d99f)
