### PR TITLE
Add M88 G-code to align Z-axis to full-step position

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,6 @@ on:
     branches: [ MK3, MK3_* ]
     tags:
     - 'v*'
-    - 't*'
-    - 'c*'
 
 env:
   GH_ANNOTATIONS: 1
@@ -43,7 +41,7 @@ jobs:
         fetch-depth: 0
 
     - name: Cache Dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v4.0.0
       id: cache-pkgs
       with:
           path: ".dependencies"
@@ -65,17 +63,16 @@ jobs:
 
     - name: Upload artifacts
       if: ${{ !github.event.pull_request }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3.1.1
       with:
         name: Firmware
         path: build/*.hex
 
     - name: RELEASE THE KRAKEN
-      if: startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/t') || startsWith(github.ref, 'refs/tags/c')
+      if: startsWith(github.ref, 'refs/tags/v')
       uses: "marvinpinto/action-automatic-releases@latest"
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
-        automatic_release_tag: ${{ github.ref_name }}
         draft: true
         files: |
           ${{ github.workspace }}/build/release/*.hex
@@ -109,7 +106,7 @@ jobs:
         fetch-depth: 0
 
     - name: Cache Dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v4.0.0
       id: cache-pkgs
       with:
           path: ".dependencies"
@@ -157,7 +154,7 @@ jobs:
         fetch-depth: 0
 
     - name: Cache Dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v4.0.0
       id: cache-pkgs
       with:
           path: ".dependencies"

--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -26,7 +26,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Cache Dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v4.0.0
       id: cache-pkgs
       with:
           path: ".dependencies"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ message(STATUS "Filename debug suffix ...........: ${FN_VERSION_DEBUG_SUFFIX}")
 # SET(FW_COMMIT_DSC "v3.13.0-1234")
 
 if(NOT "${PROJECT_VERSION_HASH}" STREQUAL "UNKNOWN" AND NOT "${FW_COMMIT_DSC}" MATCHES ".+NOTFOUND.+") # else -> no commit hash is known... likely no git.
-string(REGEX MATCH "[v|t|c]([0-9]+)\.([0-9]+)\.([0-9]+)-?(${DEV_TAG_REGEX})?([0-9]+)?-([0-9]+)" TAG_VERSION "${FW_COMMIT_DSC}")
+string(REGEX MATCH "[v|t]([0-9]+)\.([0-9]+)\.([0-9]+)-?(${DEV_TAG_REGEX})?([0-9]+)?-([0-9]+)" TAG_VERSION "${FW_COMMIT_DSC}")
 
 if (CMAKE_MATCH_4) # Do we have a build type?
     decode_flavor_code(PROJECT_VER_TAG_FLV "${CMAKE_MATCH_4}" "${CMAKE_MATCH_5}")

--- a/Firmware/Configuration.h
+++ b/Firmware/Configuration.h
@@ -324,10 +324,6 @@ your extruder heater takes 2 minutes to hit the target on heating.
 #define SDSUPPORT
 #define LCD_WIDTH 20
 #define LCD_HEIGHT 4
-#define LCD_BACKLIGHT_LEVEL_HIGH 130
-#define LCD_BACKLIGHT_LEVEL_LOW 50
-#define LCD_BACKLIGHT_FORCE_ON 30
-#define LCD_BACKLIGHT_TIMEOUT 15
 
 
 // Increase the FAN pwm frequency. Removes the PWM noise but increases heating in the FET/Arduino
@@ -362,8 +358,8 @@ your extruder heater takes 2 minutes to hit the target on heating.
 
 // Try to maintain a minimum distance from the bed even when Z is
 // unknown when doing the following operations
-#define MIN_Z_FOR_LOAD    35 // lcd filament loading or autoload (values for load and unload have been unified to prevent movement between unload & load operations!)
-#define MIN_Z_FOR_UNLOAD  35 // lcd filament unloading
+#define MIN_Z_FOR_LOAD    50 // lcd filament loading or autoload
+#define MIN_Z_FOR_UNLOAD  20 // lcd filament unloading
 #define MIN_Z_FOR_SWAP    27 // filament change (including M600)
 #define MIN_Z_FOR_PREHEAT 10 // lcd preheat
 

--- a/Firmware/Configuration_adv.h
+++ b/Firmware/Configuration_adv.h
@@ -125,6 +125,34 @@
 #endif //End auto min/max positions
 //END AUTOSET LOCATIONS OF LIMIT SWITCHES -ZP
 
+
+// A single Z stepper driver is usually used to drive 2 stepper motors.
+// Uncomment this define to utilize a separate stepper driver for each Z axis motor.
+// Only a few motherboards support this, like RAMPS, which have dual extruder support (the 2nd, often unused, extruder driver is used
+// to control the 2nd Z axis stepper motor). The pins are currently only defined for a RAMPS motherboards.
+// On a RAMPS (or other 5 driver) motherboard, using this feature will limit you to using 1 extruder.
+//#define Z_DUAL_STEPPER_DRIVERS
+
+#ifdef Z_DUAL_STEPPER_DRIVERS
+  #undef EXTRUDERS
+  #define EXTRUDERS 1
+#endif
+
+// Same again but for Y Axis.
+//#define Y_DUAL_STEPPER_DRIVERS
+
+// Define if the two Y drives need to rotate in opposite directions
+#define INVERT_Y2_VS_Y_DIR 1
+
+#ifdef Y_DUAL_STEPPER_DRIVERS
+  #undef EXTRUDERS
+  #define EXTRUDERS 1
+#endif
+
+#if defined (Z_DUAL_STEPPER_DRIVERS) && defined (Y_DUAL_STEPPER_DRIVERS)
+  #error "You cannot have dual drivers for both Y and Z"
+#endif
+
 //homing hits the endstop, then retracts by this distance, before it tries to slowly bump again:
 #define X_HOME_RETRACT_MM 5
 #define Y_HOME_RETRACT_MM 5

--- a/Firmware/Marlin.h
+++ b/Firmware/Marlin.h
@@ -121,8 +121,13 @@ void manage_inactivity(bool ignore_stepper_queue=false);
 #endif
 
 #if defined(Y_ENABLE_PIN) && Y_ENABLE_PIN > -1
-  #define  enable_y() WRITE(Y_ENABLE_PIN, Y_ENABLE_ON)
-  #define disable_y() { WRITE(Y_ENABLE_PIN,!Y_ENABLE_ON); axis_known_position[Y_AXIS] = false; }
+  #ifdef Y_DUAL_STEPPER_DRIVERS
+    #define  enable_y() { WRITE(Y_ENABLE_PIN, Y_ENABLE_ON); WRITE(Y2_ENABLE_PIN,  Y_ENABLE_ON); }
+    #define disable_y() { WRITE(Y_ENABLE_PIN,!Y_ENABLE_ON); WRITE(Y2_ENABLE_PIN, !Y_ENABLE_ON); axis_known_position[Y_AXIS] = false; }
+  #else
+    #define  enable_y() WRITE(Y_ENABLE_PIN, Y_ENABLE_ON)
+    #define disable_y() { WRITE(Y_ENABLE_PIN,!Y_ENABLE_ON); axis_known_position[Y_AXIS] = false; }
+  #endif
 #else
   #define enable_y() ;
   #define disable_y() ;
@@ -130,11 +135,21 @@ void manage_inactivity(bool ignore_stepper_queue=false);
 
 #if defined(Z_ENABLE_PIN) && Z_ENABLE_PIN > -1
 	#if defined(Z_AXIS_ALWAYS_ON)
+		  #ifdef Z_DUAL_STEPPER_DRIVERS
+			#define  poweron_z() { WRITE(Z_ENABLE_PIN, Z_ENABLE_ON); WRITE(Z2_ENABLE_PIN, Z_ENABLE_ON); }
+			#define poweroff_z() { WRITE(Z_ENABLE_PIN,!Z_ENABLE_ON); WRITE(Z2_ENABLE_PIN,!Z_ENABLE_ON); axis_known_position[Z_AXIS] = false; }
+		  #else
 			#define  poweron_z() WRITE(Z_ENABLE_PIN, Z_ENABLE_ON)
 			#define poweroff_z() {}
+		  #endif
 	#else
+		#ifdef Z_DUAL_STEPPER_DRIVERS
+			#define  poweron_z() { WRITE(Z_ENABLE_PIN, Z_ENABLE_ON); WRITE(Z2_ENABLE_PIN, Z_ENABLE_ON); }
+			#define poweroff_z() { WRITE(Z_ENABLE_PIN,!Z_ENABLE_ON); WRITE(Z2_ENABLE_PIN,!Z_ENABLE_ON); axis_known_position[Z_AXIS] = false; }
+		#else
 			#define  poweron_z() WRITE(Z_ENABLE_PIN, Z_ENABLE_ON)
 			#define poweroff_z() { WRITE(Z_ENABLE_PIN,!Z_ENABLE_ON); axis_known_position[Z_AXIS] = false; }
+		#endif
 	#endif
 #else
     #define  poweron_z() {}

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -5707,6 +5707,22 @@ void process_commands()
 	  break;
 #endif
 
+/*!
+    ### M88 - Move Z axis to a full-step position
+    */
+#ifdef TMC2130
+    case 88:
+      if (axis_known_position[Z_AXIS]) {
+        float target_z = current_position[Z_AXIS] + float(1024 - tmc2130_rd_MSCNT(Z_AXIS)) / (tmc2130_get_res(Z_AXIS) * cs.axis_steps_per_mm[Z_AXIS]) + 0.16f;
+        if (target_z <= max_pos[Z_AXIS]) {
+          current_position[Z_AXIS] = target_z;
+          plan_buffer_line_curposXYZE(homing_feedrate[Z_AXIS]/60);
+          st_synchronize();
+        }
+      }
+    break;
+#endif
+
     /*!
     ### M92 - Set Axis steps-per-unit <a href="https://reprap.org/wiki/G-code#M92:_Set_axis_steps_per_unit">M92: Set axis_steps_per_unit</a>
     Allows programming of steps per unit (usually mm) for motor drives. These values are reset to firmware defaults on power on, unless saved to EEPROM if available (M500 in Marlin)

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -4606,15 +4606,15 @@ void process_commands()
             calibration_status_set(CALIBRATION_STATUS_LIVE_ADJUST);
             break;
 
-        /*!
-        ### G88 - Reserved <a href="https://reprap.org/wiki/G-code#G88:_Reserved">G88: Reserved</a>
 
-        Currently has no effect.
+        /*!
+        ### G88 - Move Z axis to next full-step position
         */
 
-        // Prusa3D specific: Don't know what it is for, it is in V2Calibration.gcode
-
 		    case 88:
+            if (axis_known_position[Z_AXIS]) {
+                move_z_to_next_fullstep();
+            }
 			      break;
 
 
@@ -5705,22 +5705,6 @@ void process_commands()
 		safetyTimer.start();
 	  }
 	  break;
-#endif
-
-/*!
-    ### M88 - Move Z axis to a full-step position
-    */
-#ifdef TMC2130
-    case 88:
-      if (axis_known_position[Z_AXIS]) {
-        float target_z = current_position[Z_AXIS] + float(1024 - tmc2130_rd_MSCNT(Z_AXIS)) / (tmc2130_get_res(Z_AXIS) * cs.axis_steps_per_mm[Z_AXIS]) + 0.16f;
-        if (target_z <= max_pos[Z_AXIS]) {
-          current_position[Z_AXIS] = target_z;
-          plan_buffer_line_curposXYZE(homing_feedrate[Z_AXIS]/60);
-          st_synchronize();
-        }
-      }
-    break;
 #endif
 
     /*!

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3630,7 +3630,7 @@ extern uint8_t st_backlash_y;
 //!@n G81 - Mesh bed leveling status
 //!@n G86 - Disable babystep correction after home
 //!@n G87 - Enable babystep correction after home
-//!@n G88 - Reserved
+//!@n G88 - Move Z axis to next full-step position
 //!@n G90 - Use Absolute Coordinates
 //!@n G91 - Use Relative Coordinates
 //!@n G92 - Set current position to coordinates given

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3710,7 +3710,7 @@ extern uint8_t st_backlash_y;
 //!@n M221 - Set extrude factor override percentage
 //!@n M226 - Wait for Pin state
 //!@n M240 - Trigger camera
-//!@n M256 - Set LCD brightness
+//!@n M250 - Set LCD contrast C<contrast value> (value 0..63)
 //!@n M300 - Play tone
 //!@n M301 - Set hotend PID
 //!@n M302 - Allow cold extrude, or set minimum extrude temperature
@@ -6531,11 +6531,11 @@ void process_commands()
 
     #### Parameters
     - `S` - frequency in Hz. Not all firmware versions support this parameter
-    - `P` - duration in milliseconds max 3500ms
+    - `P` - duration in milliseconds
     */
     case 300: // M300
     {
-      uint16_t beepP = code_seen('P') ? min(code_value(), 3500) : 1000;
+      uint16_t beepP = code_seen('P') ? code_value() : 1000;
       uint16_t beepS;
       if (!code_seen('S'))
           beepS = 0;
@@ -6656,42 +6656,6 @@ void process_commands()
      }
     break;
     #ifdef PREVENT_DANGEROUS_EXTRUDE
-
-    /*!
-    ### M256 - Set LCD brightness <a href="https://reprap.org/wiki/G-code#M256:_Set_LCD_brightness">M256: Set LCD brightness</a>
-    Set and/or get the LCD brightness. The value is constrained based on the LCD, but typically a value of 0 is the dimmest and 255 is the brightest.
-    #### Usage
-
-        M256 [ B | D | S | T ]
-
-    #### Parameters
-    - `B` - Normal Brightness value (0 - 255), default 130
-    - `D` - Dimmed Brightness value (0 - 255), default 50
-    - `S` - Brightness mode, default Auto
-      - `0` - Dim
-      - `1` - Bright
-      - `2` - Auto
-    - `T` - Brightness timeout  (15 - 900), default 15 seconds
-    */
-    #ifdef LCD_BL_PIN
-     case 256:
-    {
-      if (backlightSupport) {
-        if (code_seen('B') ) backlightLevel_HIGH = code_value_uint8();
-        if (code_seen('D')) backlightLevel_LOW = code_value_uint8();
-        if (code_seen('S')) {
-          uint8_t mode = code_value_uint8();
-          if (mode <= BACKLIGHT_MODE_AUTO) {
-            backlightMode = static_cast<Backlight_Mode>(mode);
-         }
-        }
-        if (code_seen('T')) backlightTimer_period = constrain(code_value_short(), LCD_BACKLIGHT_TIMEOUT, LCD_BACKLIGHT_TIMEOUT*60);
-        printf_P(PSTR("M256 B%d D%d S%d T%u\n"), backlightLevel_HIGH, backlightLevel_LOW, backlightMode, backlightTimer_period);
-        backlight_save();
-      }
-    }
-    break;
-    #endif //LCD_BL_PIN
 
     /*!
     ### M302 - Allow cold extrude, or set minimum extrude temperature <a href="https://reprap.org/wiki/G-code#M302:_Allow_cold_extrudes">M302: Allow cold extrudes</a>

--- a/Firmware/backlight.cpp
+++ b/Firmware/backlight.cpp
@@ -17,7 +17,7 @@ bool backlightSupport = 0; //only if it's true will any of the settings be visib
 uint8_t backlightLevel_HIGH = 0;
 uint8_t backlightLevel_LOW = 0;
 uint8_t backlightMode = BACKLIGHT_MODE_BRIGHT;
-int16_t backlightTimer_period = LCD_BACKLIGHT_TIMEOUT;
+int16_t backlightTimer_period = 10;
 LongTimer backlightTimer;
 
 static void backlightTimer_reset() //used for resetting the timer and waking the display. Triggered on user interactions.
@@ -32,7 +32,7 @@ void force_bl_on(bool section_start)
     if (section_start)
     {
         backlightMode = BACKLIGHT_MODE_BRIGHT;
-        if (backlightLevel_HIGH < LCD_BACKLIGHT_FORCE_ON) backlightLevel_HIGH = LCD_BACKLIGHT_FORCE_ON;
+        if (backlightLevel_HIGH < 30) backlightLevel_HIGH = 30;
     }
     else
     {
@@ -93,9 +93,9 @@ void backlight_init()
 
     //initialize backlight
     backlightMode = eeprom_init_default_byte((uint8_t *)EEPROM_BACKLIGHT_MODE, BACKLIGHT_MODE_AUTO);
-    backlightLevel_HIGH = eeprom_init_default_byte((uint8_t *)EEPROM_BACKLIGHT_LEVEL_HIGH, LCD_BACKLIGHT_LEVEL_HIGH);
-    backlightLevel_LOW = eeprom_init_default_byte((uint8_t *)EEPROM_BACKLIGHT_LEVEL_LOW, LCD_BACKLIGHT_LEVEL_LOW);
-    backlightTimer_period = eeprom_init_default_word((uint16_t *)EEPROM_BACKLIGHT_TIMEOUT, LCD_BACKLIGHT_TIMEOUT); // in seconds
+    backlightLevel_HIGH = eeprom_init_default_byte((uint8_t *)EEPROM_BACKLIGHT_LEVEL_HIGH, 130);
+    backlightLevel_LOW = eeprom_init_default_byte((uint8_t *)EEPROM_BACKLIGHT_LEVEL_LOW, 50);
+    backlightTimer_period = eeprom_init_default_word((uint16_t *)EEPROM_BACKLIGHT_TIMEOUT, 10); // in seconds
 
     SET_OUTPUT(LCD_BL_PIN);
     backlightTimer_reset();

--- a/Firmware/cmdqueue.cpp
+++ b/Firmware/cmdqueue.cpp
@@ -670,9 +670,7 @@ void get_command()
           sprintf_P(time, PSTR("%i hours %i minutes"),hours, minutes);
           SERIAL_ECHO_START;
           SERIAL_ECHOLN(time);
-#ifndef SHOW_FILENAME_AFTER_FINISH
           lcd_setstatus(time);
-#endif //SHOW_FILENAME_AFTER_FINISH
           card.printingHasFinished();
           card.checkautostart(true);
 

--- a/Firmware/menu.cpp
+++ b/Firmware/menu.cpp
@@ -475,8 +475,10 @@ static void _menu_edit_P()
             // disable after first use and/or if the initial value is not minEditValue
             _md->minJumpValue = 0;
         }
+
 		_md->currentValue += lcd_encoder;
 		lcd_encoder = 0; // Consume knob rotation event
+
 		// Constrain the value in case it's outside the allowed limits
 		_md->currentValue = constrain(_md->currentValue, _md->minEditValue, _md->maxEditValue);
 		lcd_set_cursor(0, 1);

--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -377,6 +377,7 @@ extern const char MSG_SD_REMOVED [] PROGMEM_I1 = ISTR("Card removed"); ////MSG_S
 extern const char MSG_NEW_FIRMWARE_AVAILABLE [] PROGMEM_I1 = ISTR("New firmware version available:"); ////MSG_NEW_FIRMWARE_AVAILABLE c=20 r=2
 extern const char MSG_NEW_FIRMWARE_PLEASE_UPGRADE [] PROGMEM_I1 = ISTR("Please upgrade."); ////MSG_NEW_FIRMWARE_PLEASE_UPGRADE c=20
 extern const char MSG_FW_MK3_DETECTED [] PROGMEM_I1 = ISTR(PRINTER_NAME " firmware detected on " PRINTER_NAME_ALTERNATE " printer"); ////MSG_FW_MK3_DETECTED c=20 r=4
+extern const char MSG_FULLSTEP_Z[] PROGMEM_I1 = ISTR("Fullstep Z axis"); ////MSG_FULLSTEP_Z c=18
 //not internationalized messages
 const char MSG_SPOOL_JOIN[] PROGMEM_N1 = "SpoolJoin"; ////MSG_SPOOL_JOIN c=13
 const char MSG_FIRMWARE[] PROGMEM_N1 = "Firmware"; ////MSG_FIRMWARE c=8
@@ -413,7 +414,6 @@ const char MSG_HOST_ACTION_START[] PROGMEM_N1 = "//action:start"; ////
 const char MSG_HOST_ACTION_UVLO_RECOVERY_READY[] PROGMEM_N1 = "//action:uvlo_recovery_ready"; ////
 const char MSG_HOST_ACTION_UVLO_AUTO_RECOVERY_READY[] PROGMEM_N1 = "//action:uvlo_auto_recovery_ready"; ////
 const char MSG_HOST_ACTION_NOTIFICATION[] PROGMEM_N1 = "//action:notification %S\n"; ////
-const char MSG_FULLSTEP_Z[] PROGMEM_N1 = "Fullstep Z axis"; ////
 #ifdef HOST_SHUTDOWN
 const char MSG_HOST_ACTION_SHUTDOWN[] PROGMEM_N1 = "//action:shutdown"; ////
 #endif //HOST_SHUTOWN

--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -413,6 +413,7 @@ const char MSG_HOST_ACTION_START[] PROGMEM_N1 = "//action:start"; ////
 const char MSG_HOST_ACTION_UVLO_RECOVERY_READY[] PROGMEM_N1 = "//action:uvlo_recovery_ready"; ////
 const char MSG_HOST_ACTION_UVLO_AUTO_RECOVERY_READY[] PROGMEM_N1 = "//action:uvlo_auto_recovery_ready"; ////
 const char MSG_HOST_ACTION_NOTIFICATION[] PROGMEM_N1 = "//action:notification %S\n"; ////
+const char MSG_FULLSTEP_Z[] PROGMEM_N1 = "Fullstep Z axis"; ////
 #ifdef HOST_SHUTDOWN
 const char MSG_HOST_ACTION_SHUTDOWN[] PROGMEM_N1 = "//action:shutdown"; ////
 #endif //HOST_SHUTOWN

--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -414,6 +414,7 @@ const char MSG_HOST_ACTION_START[] PROGMEM_N1 = "//action:start"; ////
 const char MSG_HOST_ACTION_UVLO_RECOVERY_READY[] PROGMEM_N1 = "//action:uvlo_recovery_ready"; ////
 const char MSG_HOST_ACTION_UVLO_AUTO_RECOVERY_READY[] PROGMEM_N1 = "//action:uvlo_auto_recovery_ready"; ////
 const char MSG_HOST_ACTION_NOTIFICATION[] PROGMEM_N1 = "//action:notification %S\n"; ////
+const char MSG_FULLSTEP_Z[] PROGMEM_N1 = "Fullstep Z axis"; ////
 #ifdef HOST_SHUTDOWN
 const char MSG_HOST_ACTION_SHUTDOWN[] PROGMEM_N1 = "//action:shutdown"; ////
 #endif //HOST_SHUTOWN

--- a/Firmware/messages.cpp
+++ b/Firmware/messages.cpp
@@ -18,8 +18,8 @@ const char MSG_BED_HEATING[] PROGMEM_I1 = ISTR("Bed Heating"); ////MSG_BED_HEATI
 const char MSG_BED_LEVELING_FAILED_POINT_LOW[] PROGMEM_I1 = ISTR("Bed leveling failed. Sensor didn't trigger. Debris on nozzle? Waiting for reset."); ////MSG_BED_LEVELING_FAILED_POINT_LOW c=20 r=6
 const char MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED[] PROGMEM_I1 = ISTR("XYZ calibration failed. Please consult the manual."); ////MSG_BED_SKEW_OFFSET_DETECTION_FITTING_FAILED c=20 r=8
 const char MSG_BELT_STATUS[] PROGMEM_I1 = ISTR("Belt status");////MSG_BELT_STATUS c=18
-const char MSG_EJECT[] PROGMEM_I1 = ISTR("Eject"); ////MSG_EJECT c=9
-const char MSG_CANCEL[] PROGMEM_I1 = ISTR("Cancel");////MSG_CANCEL c=9
+const char MSG_EJECT[] PROGMEM_I1 = ISTR("Eject"); ////MSG_EJECT c=8
+const char MSG_CANCEL[] PROGMEM_I1 = ISTR(">Cancel");////MSG_CANCEL c=10
 const char MSG_CALIBRATE_Z_AUTO[] PROGMEM_I1 = ISTR("Calibrating Z"); ////MSG_CALIBRATE_Z_AUTO c=20 r=2
 const char MSG_CARD_MENU[] PROGMEM_I1 = ISTR("Print from SD"); ////MSG_CARD_MENU c=18
 const char MSG_CHECKING_X[] PROGMEM_I1 = ISTR("Checking X axis"); ////MSG_CHECKING_X c=20
@@ -149,15 +149,16 @@ const char MSG_NONE[] PROGMEM_I1 = ISTR("None"); ////MSG_NONE c=8
 const char MSG_WARN[] PROGMEM_I1 = ISTR("Warn"); ////MSG_WARN c=8
 const char MSG_STRICT[] PROGMEM_I1 = ISTR("Strict"); ////MSG_STRICT c=8
 const char MSG_MODEL[] PROGMEM_I1 = ISTR("Model"); ////MSG_MODEL c=8
-const char MSG_GCODE_DIFF_PRINTER_CONTINUE[] PROGMEM_I1 = ISTR("G-code sliced for a different printer type."); ////MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
-const char MSG_GCODE_DIFF_PRINTER_CANCELLED[] PROGMEM_I1 =ISTR("G-code sliced for a different printer type. Please re-slice the model again."); ////MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
-const char MSG_GCODE_NEWER_FIRMWARE_CONTINUE[] PROGMEM_I1 = ISTR("G-code sliced for a newer firmware."); ////MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
-const char MSG_GCODE_NEWER_FIRMWARE_CANCELLED[] PROGMEM_I1 = ISTR("G-code sliced for a newer firmware. Please update the firmware."); ////MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
-const char MSG_GCODE_DIFF_CONTINUE[] PROGMEM_I1 = ISTR("G-code sliced for a different level."); ////MSG_GCODE_DIFF_CONTINUE c=20 r=3
-const char MSG_GCODE_DIFF_CANCELLED[] PROGMEM_I1 = ISTR("G-code sliced for a different level. Please re-slice the model again."); ////MSG_GCODE_DIFF_CANCELLED c=20 r=8
-const char MSG_MISSING_FILAMENT[] PROGMEM_I1 = ISTR("There is no filament loaded."); ////MSG_MISSING_FILAMENT c=20 r=3
-const char MSG_NOZZLE_DIFFERS_CONTINUE[] PROGMEM_I1 = ISTR("Nozzle diameter differs from the G-code."); ////MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
-const char MSG_NOZZLE_DIFFERS_CANCELLED[] PROGMEM_I1 = ISTR("Nozzle diameter differs from the G-code. Please check the value in settings."); ////MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
+const char MSG_GCODE_DIFF_PRINTER_CONTINUE[] PROGMEM_I1 = ISTR("G-code sliced for a different printer type. Continue?"); ////MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
+const char MSG_GCODE_DIFF_PRINTER_CANCELLED[] PROGMEM_I1 =ISTR("G-code sliced for a different printer type. Please re-slice the model again. Print cancelled."); ////MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
+const char MSG_GCODE_NEWER_FIRMWARE_CONTINUE[] PROGMEM_I1 = ISTR("G-code sliced for a newer firmware. Continue?"); ////MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
+const char MSG_GCODE_NEWER_FIRMWARE_CANCELLED[] PROGMEM_I1 = ISTR("G-code sliced for a newer firmware. Please update the firmware. Print cancelled."); ////MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
+const char MSG_GCODE_DIFF_CONTINUE[] PROGMEM_I1 = ISTR("G-code sliced for a different level. Continue?"); ////MSG_GCODE_DIFF_CONTINUE c=20 r=3
+const char MSG_GCODE_DIFF_CANCELLED[] PROGMEM_I1 = ISTR("G-code sliced for a different level. Please re-slice the model again. Print cancelled."); ////MSG_GCODE_DIFF_CANCELLED c=20 r=8
+const char MSG_MISSING_FILAMENT_CONTINUE[] PROGMEM_I1 = ISTR("There is no filament loaded. Continue?"); ////MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
+const char MSG_MISSING_FILAMENT_CANCELLED[] PROGMEM_I1 = ISTR("There is no filament loaded. Print cancelled."); ////MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
+const char MSG_NOZZLE_DIFFERS_CONTINUE[] PROGMEM_I1 = ISTR("Nozzle diameter differs from the G-code. Continue?"); ////MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
+const char MSG_NOZZLE_DIFFERS_CANCELLED[] PROGMEM_I1 = ISTR("Nozzle diameter differs from the G-code. Please check the value in settings. Print cancelled."); ////MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
 const char MSG_NOZZLE_DIAMETER[] PROGMEM_I1 = ISTR("Nozzle d."); ////MSG_NOZZLE_DIAMETER c=10
 const char MSG_MMU_MODE[] PROGMEM_I1 = ISTR("MMU Mode"); ////MSG_MMU_MODE c=8
 const char MSG_SD_CARD[] PROGMEM_I1 = ISTR("SD card"); ////MSG_SD_CARD c=8
@@ -253,9 +254,7 @@ extern const char MSG_LOADING_COLOR [] PROGMEM_I1 = ISTR("Loading color"); ////M
 extern const char MSG_CORRECTLY [] PROGMEM_I1 = ISTR("Changed correctly"); ////MSG_CORRECTLY c=19
 extern const char MSG_NOT_LOADED [] PROGMEM_I1 = ISTR("Filament not loaded"); ////MSG_NOT_LOADED c=19
 extern const char MSG_NOT_COLOR [] PROGMEM_I1 = ISTR("Color not correct"); ////MSG_NOT_COLOR c=19
-#ifndef REMOVE_AUTOLOAD_FILAMENT_MENU_ENTRY
 extern const char MSG_AUTOLOADING_ENABLED [] PROGMEM_I1 = ISTR("Autoloading filament is active, just press the knob and insert filament..."); ////MSG_AUTOLOADING_ENABLED c=20 r=4
-#endif //REMOVE_AUTOLOAD_FILAMENT_MENU_ENTRY
 extern const char MSG_FILAMENT_USED [] PROGMEM_I1 = ISTR("Filament used"); ////MSG_FILAMENT_USED c=19
 extern const char MSG_PRINT_TIME [] PROGMEM_I1 = ISTR("Print time"); ////MSG_PRINT_TIME c=19
 extern const char MSG_TOTAL_FILAMENT [] PROGMEM_I1 = ISTR("Total filament"); ////MSG_TOTAL_FILAMENT c=19
@@ -296,7 +295,7 @@ extern const char MSG_MODE_CHANGE_IN_PROGRESS [] PROGMEM_I1 = ISTR("Mode change 
 extern const char MSG_COPY_SEL_LANG [] PROGMEM_I1 = ISTR("Copy selected language?"); ////MSG_COPY_SEL_LANG c=20 r=3
 extern const char MSG_SHEET_OFFSET [] PROGMEM_I1 = ISTR("Sheet %.7s\nZ offset: %+1.3fmm\n%cContinue\n%cReset"); ////MSG_SHEET_OFFSET c=20 r=4
 extern const char MSG_PLEASE_LOAD_PLA [] PROGMEM_I1 = ISTR("Please load filament first."); ////MSG_PLEASE_LOAD_PLA c=20 r=4
-extern const char MSG_WIZARD_RERUN [] PROGMEM_I1 = ISTR("Running Wizard will delete current calibration results and start from the beginning."); ////MSG_WIZARD_RERUN c=20 r=7
+extern const char MSG_WIZARD_RERUN [] PROGMEM_I1 = ISTR("Running Wizard will delete current calibration results and start from the beginning. Continue?"); ////MSG_WIZARD_RERUN c=20 r=7
 extern const char MSG_MMU_INSERT_FILAMENT_FIRST_TUBE [] PROGMEM_I1 = ISTR("Please insert filament into the first tube of the MMU, then press the knob to load it."); ////MSG_MMU_INSERT_FILAMENT_FIRST_TUBE c=20 r=6
 extern const char MSG_WIZARD_LOAD_FILAMENT [] PROGMEM_I1 = ISTR("Please insert filament into the extruder, then press the knob to load it."); ////MSG_WIZARD_LOAD_FILAMENT c=20 r=6
 extern const char MSG_WIZARD_V2_CAL [] PROGMEM_I1 = ISTR("Now I will calibrate distance between tip of the nozzle and heatbed surface."); ////MSG_WIZARD_V2_CAL c=20 r=8
@@ -373,7 +372,7 @@ extern const char MSG_SELFTEST_CHECK_HOTEND [] PROGMEM_I1 = ISTR("Checking hoten
 extern const char MSG_SELFTEST_CHECK_ALLCORRECT [] PROGMEM_I1 = ISTR("All correct"); ////MSG_SELFTEST_CHECK_ALLCORRECT c=20
 extern const char MSG_CALIBRATING_HOME [] PROGMEM_I1 = ISTR("Calibrating home"); ////MSG_CALIBRATING_HOME c=20
 extern const char MSG_CHECKING_FILE [] PROGMEM_I1 = ISTR("Checking file"); ////MSG_CHECKING_FILE c=17
-extern const char MSG_FILE_INCOMPLETE [] PROGMEM_I1 = ISTR("File incomplete."); ////MSG_FILE_INCOMPLETE c=20 r=3
+extern const char MSG_FILE_INCOMPLETE [] PROGMEM_I1 = ISTR("File incomplete. Continue anyway?"); ////MSG_FILE_INCOMPLETE c=20 r=3
 extern const char MSG_SD_REMOVED [] PROGMEM_I1 = ISTR("Card removed"); ////MSG_SD_REMOVED c=20
 extern const char MSG_NEW_FIRMWARE_AVAILABLE [] PROGMEM_I1 = ISTR("New firmware version available:"); ////MSG_NEW_FIRMWARE_AVAILABLE c=20 r=2
 extern const char MSG_NEW_FIRMWARE_PLEASE_UPGRADE [] PROGMEM_I1 = ISTR("Please upgrade."); ////MSG_NEW_FIRMWARE_PLEASE_UPGRADE c=20

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -415,6 +415,7 @@ extern const char MSG_HOST_ACTION_START[];
 extern const char MSG_HOST_ACTION_UVLO_RECOVERY_READY[];
 extern const char MSG_HOST_ACTION_UVLO_AUTO_RECOVERY_READY[];
 extern const char MSG_HOST_ACTION_NOTIFICATION[];
+extern const char MSG_FULLSTEP_Z[];
 #ifdef HOST_SHUTDOWN
 extern const char MSG_HOST_ACTION_SHUTDOWN[];
 #endif //HOST_SHUTOWN

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -416,6 +416,7 @@ extern const char MSG_HOST_ACTION_START[];
 extern const char MSG_HOST_ACTION_UVLO_RECOVERY_READY[];
 extern const char MSG_HOST_ACTION_UVLO_AUTO_RECOVERY_READY[];
 extern const char MSG_HOST_ACTION_NOTIFICATION[];
+extern const char MSG_FULLSTEP_Z[];
 #ifdef HOST_SHUTDOWN
 extern const char MSG_HOST_ACTION_SHUTDOWN[];
 #endif //HOST_SHUTOWN

--- a/Firmware/messages.h
+++ b/Firmware/messages.h
@@ -157,7 +157,8 @@ extern const char MSG_GCODE_NEWER_FIRMWARE_CONTINUE[];
 extern const char MSG_GCODE_NEWER_FIRMWARE_CANCELLED[];
 extern const char MSG_GCODE_DIFF_CONTINUE[];
 extern const char MSG_GCODE_DIFF_CANCELLED[];
-extern const char MSG_MISSING_FILAMENT[];
+extern const char MSG_MISSING_FILAMENT_CONTINUE[];
+extern const char MSG_MISSING_FILAMENT_CANCELLED[];
 extern const char MSG_NOZZLE_DIFFERS_CONTINUE[];
 extern const char MSG_NOZZLE_DIFFERS_CANCELLED[];
 extern const char MSG_NOZZLE_DIAMETER[];
@@ -252,9 +253,7 @@ extern const char MSG_LOADING_COLOR [];
 extern const char MSG_CORRECTLY [];
 extern const char MSG_NOT_LOADED [];
 extern const char MSG_NOT_COLOR [];
-#ifndef REMOVE_AUTOLOAD_FILAMENT_MENU_ENTRY
 extern const char MSG_AUTOLOADING_ENABLED [];
-#endif //REMOVE_AUTOLOAD_FILAMENT_MENU_ENTRY
 extern const char MSG_FILAMENT_USED [];
 extern const char MSG_PRINT_TIME [];
 extern const char MSG_TOTAL_FILAMENT [];

--- a/Firmware/mmu2/errors_list.h
+++ b/Firmware/mmu2/errors_list.h
@@ -355,7 +355,7 @@ static const char MSG_BTN_RETRY[] PROGMEM_I1 = ISTR("Retry"); ////MSG_BTN_RETRY 
 static const char MSG_BTN_RESET_MMU[] PROGMEM_I1 = ISTR("ResetMMU"); ////MSG_BTN_RESET_MMU c=8
 static const char MSG_BTN_UNLOAD[] PROGMEM_I1 = ISTR("Unload"); ////MSG_BTN_UNLOAD c=8
 static const char MSG_BTN_LOAD[] PROGMEM_I1 = ISTR("Load"); ////MSG_BTN_LOAD c=8
-//static const char MSG_BTN_EJECT[] PROGMEM_I1 = ISTR("Eject"); //Reuse MSG_EJECT c=9
+//static const char MSG_BTN_EJECT[] PROGMEM_I1 = ISTR("Eject"); //Reuse MSG_EJECT c=8
 //static const char MSG_BTN_TUNE_MMU[] PROGMEM_I1 = ISTR("Tune"); //Reuse MSG_TUNE c=8
 static const char MSG_BTN_STOP[] PROGMEM_I1 = ISTR("Stop"); ////MSG_BTN_STOP c=8
 static const char MSG_BTN_DISABLE_MMU[] PROGMEM_I1 = ISTR("Disable"); ////MSG_BTN_DISABLE_MMU c=8

--- a/Firmware/power_panic.cpp
+++ b/Firmware/power_panic.cpp
@@ -135,17 +135,7 @@ void uvlo_() {
     st_synchronize();
     disable_e0();
 
-    // Read out the current Z motor microstep counter to move the axis up towards
-    // a full step before powering off. NOTE: we need to ensure to schedule more
-    // than "dropsegments" steps in order to move (this is always the case here
-    // due to UVLO_Z_AXIS_SHIFT being used)
-    uint16_t z_res = tmc2130_get_res(Z_AXIS);
-    uint16_t z_microsteps = tmc2130_rd_MSCNT(Z_AXIS);
-    current_position[Z_AXIS] += float(1024 - z_microsteps)
-                                / (z_res * cs.axis_steps_per_mm[Z_AXIS])
-                                + UVLO_Z_AXIS_SHIFT;
-    plan_buffer_line_curposXYZE(homing_feedrate[Z_AXIS]/60);
-    st_synchronize();
+    move_z_to_next_fullstep();
     poweroff_z();
 
     // Write the file position.

--- a/Firmware/stepper.cpp
+++ b/Firmware/stepper.cpp
@@ -59,6 +59,14 @@ uint16_t SP_min = 0x21FF;
 #ifdef DEBUG_YSTEP_DUP_PIN
 #define _STEP_PIN_Y_DUP_AXIS DEBUG_YSTEP_DUP_PIN
 #endif
+#ifdef Y_DUAL_STEPPER_DRIVERS
+#error Y_DUAL_STEPPER_DRIVERS not fully implemented
+#define _STEP_PIN_Y2_AXIS Y2_STEP_PIN
+#endif
+#ifdef Z_DUAL_STEPPER_DRIVERS
+#error Z_DUAL_STEPPER_DRIVERS not fully implemented
+#define _STEP_PIN_Z2_AXIS Z2_STEP_PIN
+#endif
 
 #ifdef TMC2130
 #define STEPPER_MINIMUM_PULSE TMC2130_MINIMUM_PULSE
@@ -1071,9 +1079,17 @@ void st_init()
   #endif
   #if defined(Y_DIR_PIN) && Y_DIR_PIN > -1
     SET_OUTPUT(Y_DIR_PIN);
+
+	#if defined(Y_DUAL_STEPPER_DRIVERS) && defined(Y2_DIR_PIN) && (Y2_DIR_PIN > -1)
+	  SET_OUTPUT(Y2_DIR_PIN);
+	#endif
   #endif
   #if defined(Z_DIR_PIN) && Z_DIR_PIN > -1
     SET_OUTPUT(Z_DIR_PIN);
+
+    #if defined(Z_DUAL_STEPPER_DRIVERS) && defined(Z2_DIR_PIN) && (Z2_DIR_PIN > -1)
+      SET_OUTPUT(Z2_DIR_PIN);
+    #endif
   #endif
   #if defined(E0_DIR_PIN) && E0_DIR_PIN > -1
     SET_OUTPUT(E0_DIR_PIN);
@@ -1092,10 +1108,20 @@ void st_init()
   #if defined(Y_ENABLE_PIN) && Y_ENABLE_PIN > -1
     SET_OUTPUT(Y_ENABLE_PIN);
     if(!Y_ENABLE_ON) WRITE(Y_ENABLE_PIN,HIGH);
+
+	#if defined(Y_DUAL_STEPPER_DRIVERS) && defined(Y2_ENABLE_PIN) && (Y2_ENABLE_PIN > -1)
+	  SET_OUTPUT(Y2_ENABLE_PIN);
+	  if(!Y_ENABLE_ON) WRITE(Y2_ENABLE_PIN,HIGH);
+	#endif
   #endif
   #if defined(Z_ENABLE_PIN) && Z_ENABLE_PIN > -1
     SET_OUTPUT(Z_ENABLE_PIN);
     if(!Z_ENABLE_ON) WRITE(Z_ENABLE_PIN,HIGH);
+
+    #if defined(Z_DUAL_STEPPER_DRIVERS) && defined(Z2_ENABLE_PIN) && (Z2_ENABLE_PIN > -1)
+      SET_OUTPUT(Z2_ENABLE_PIN);
+      if(!Z_ENABLE_ON) WRITE(Z2_ENABLE_PIN,HIGH);
+    #endif
   #endif
   #if defined(E0_ENABLE_PIN) && (E0_ENABLE_PIN > -1)
     SET_OUTPUT(E0_ENABLE_PIN);
@@ -1175,11 +1201,19 @@ void st_init()
     SET_OUTPUT(DEBUG_YSTEP_DUP_PIN);
     WRITE(DEBUG_YSTEP_DUP_PIN,INVERT_Y_STEP_PIN);
 #endif //DEBUG_YSTEP_DUP_PIN
+    #if defined(Y_DUAL_STEPPER_DRIVERS) && defined(Y2_STEP_PIN) && (Y2_STEP_PIN > -1)
+      SET_OUTPUT(Y2_STEP_PIN);
+      WRITE(Y2_STEP_PIN,INVERT_Y_STEP_PIN);
+    #endif
     disable_y();
   #endif
   #if defined(Z_STEP_PIN) && (Z_STEP_PIN > -1)
     SET_OUTPUT(Z_STEP_PIN);
     WRITE(Z_STEP_PIN,INVERT_Z_STEP_PIN);
+    #if defined(Z_DUAL_STEPPER_DRIVERS) && defined(Z2_STEP_PIN) && (Z2_STEP_PIN > -1)
+      SET_OUTPUT(Z2_STEP_PIN);
+      WRITE(Z2_STEP_PIN,INVERT_Z_STEP_PIN);
+    #endif
     #ifdef PSU_Delta
       init_force_z();
     #endif // PSU_Delta
@@ -1339,7 +1373,7 @@ void babystep(const uint8_t axis,const bool direction)
     case X_AXIS:
     {
         enable_x();
-        uint8_t old_x_dir_pin = READ(X_DIR_PIN);
+        uint8_t old_x_dir_pin = READ(X_DIR_PIN);  //if dualzstepper, both point to same direction.
         uint8_t new_x_dir_pin = (INVERT_X_DIR)^direction;
 
         //setup new step
@@ -1367,7 +1401,7 @@ void babystep(const uint8_t axis,const bool direction)
     case Y_AXIS:
     {
         enable_y();
-        uint8_t old_y_dir_pin = READ(Y_DIR_PIN);
+        uint8_t old_y_dir_pin = READ(Y_DIR_PIN);  //if dualzstepper, both point to same direction.
         uint8_t new_y_dir_pin = (INVERT_Y_DIR)^direction;
 
         //setup new step
@@ -1395,23 +1429,35 @@ void babystep(const uint8_t axis,const bool direction)
     case Z_AXIS:
     {
         enable_z();
-        uint8_t old_z_dir_pin = READ(Z_DIR_PIN);
+        uint8_t old_z_dir_pin = READ(Z_DIR_PIN);  //if dualzstepper, both point to same direction.
         uint8_t new_z_dir_pin = (INVERT_Z_DIR)^direction^BABYSTEP_INVERT_Z;
 
         //setup new step
         if (new_z_dir_pin != old_z_dir_pin) {
             WRITE_NC(Z_DIR_PIN, new_z_dir_pin);
+#ifdef Z_DUAL_STEPPER_DRIVERS
+            WRITE_NC(Z2_DIR_PIN, new_z_dir_pin);
+#endif
             delayMicroseconds(STEPPER_SET_DIR_DELAY);
         }
 
         //perform step
         STEP_NC_HI(Z_AXIS);
+#ifdef Z_DUAL_STEPPER_DRIVERS
+        STEP_NC_HI(Z2_AXIS);
+#endif
         STEPPER_MINIMUM_DELAY;
         STEP_NC_LO(Z_AXIS);
+#ifdef Z_DUAL_STEPPER_DRIVERS
+        STEP_NC_LO(Z2_AXIS);
+#endif
 
         //get old pin state back.
         if (new_z_dir_pin != old_z_dir_pin) {
             WRITE_NC(Z_DIR_PIN, old_z_dir_pin);
+#ifdef Z_DUAL_STEPPER_DRIVERS
+            WRITE_NC(Z2_DIR_PIN, old_z_dir_pin);
+#endif
         }
     }
     break;

--- a/Firmware/stepper.cpp
+++ b/Firmware/stepper.cpp
@@ -250,6 +250,22 @@ void invert_z_endstop(bool endstop_invert)
   z_endstop_invert = endstop_invert;
 }
 
+void move_z_to_next_fullstep() {
+  #ifdef TMC2130
+	  // Read out the current Z motor microstep counter to move the axis up towards
+    // a full step before powering off. NOTE: we need to ensure to schedule more
+    // than "dropsegments" steps in order to move (this is always the case here
+    // due to UVLO_Z_AXIS_SHIFT being used)
+    uint16_t z_res = tmc2130_get_res(Z_AXIS);
+    uint16_t z_microsteps = tmc2130_rd_MSCNT(Z_AXIS);
+    current_position[Z_AXIS] += float(1024 - z_microsteps)
+                                / (z_res * cs.axis_steps_per_mm[Z_AXIS])
+                                + UVLO_Z_AXIS_SHIFT;
+    plan_buffer_line_curposXYZE(homing_feedrate[Z_AXIS]/60);
+    st_synchronize();
+  #endif
+}
+
 //         __________________________
 //        /|                        |\     _________________         ^
 //       / |                        | \   /|               |\        |

--- a/Firmware/stepper.h
+++ b/Firmware/stepper.h
@@ -67,6 +67,8 @@ bool enable_endstops(bool check); // Enable/disable endstop checking. Return the
 bool enable_z_endstop(bool check);
 void invert_z_endstop(bool endstop_invert);
 
+void move_z_to_next_fullstep(); //Move Z axis up to the next fullstep
+
 void checkStepperErrors(); //Print errors detected by the stepper
 
 extern block_t *current_block;  // A pointer to the block currently being traced

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -4555,6 +4555,9 @@ static void lcd_calibration_menu()
         MENU_ITEM_SUBMENU_P(_T(MSG_V2_CALIBRATION), lcd_first_layer_calibration_reset);
     }
     MENU_ITEM_GCODE_P(_T(MSG_AUTO_HOME), G28W);
+    if (axis_known_position[Z_AXIS]) {
+        MENU_ITEM_GCODE_P(_T(MSG_FULLSTEP_Z), PSTR("M88"));
+    }
 #ifdef TMC2130
     MENU_ITEM_FUNCTION_P(_T(MSG_BELTTEST), lcd_belttest_v);
 #endif //TMC2130

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -4525,6 +4525,9 @@ static void lcd_calibration_menu()
         MENU_ITEM_SUBMENU_P(_T(MSG_V2_CALIBRATION), lcd_first_layer_calibration_reset);
     }
     MENU_ITEM_GCODE_P(_T(MSG_AUTO_HOME), G28W);
+    if (axis_known_position[Z_AXIS]) {
+        MENU_ITEM_GCODE_P(_T(MSG_FULLSTEP_Z), PSTR("M88"));
+    }
 #ifdef TMC2130
     MENU_ITEM_FUNCTION_P(_T(MSG_BELTTEST), lcd_belttest_v);
 #endif //TMC2130

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -542,11 +542,7 @@ void lcdui_print_status_line(void) {
             break;
         }
     }
-    else if (((IS_SD_PRINTING)
-#ifdef SHOW_FILENAME_AFTER_FINISH
-        || (GetPrinterState() == PrinterState::SDPrintingFinished)
-#endif //SHOW_FILENAME_AFTER_FINISH
-        ) &&
+    else if ((IS_SD_PRINTING) &&
         (custom_message_type == CustomMsg::Status) &&
         (lcd_status_message_level <= LCD_STATUS_INFO) &&
         lcd_status_message_timeout.expired_cont(LCD_STATUS_INFO_TIMEOUT))
@@ -1981,8 +1977,7 @@ void mFilamentItem(uint16_t nTemp, uint16_t nTempBed)
             lcd_draw_update = 1;
 
             lcd_clear();
-            lcd_puts_at_P(0,3, PSTR(">"));
-            lcd_puts_at_P(1, 3, _T(MSG_CANCEL));
+            lcd_puts_at_P(0, 3, _T(MSG_CANCEL));
 
             lcd_set_cursor(0, 1);
             switch (eFilamentAction)
@@ -2271,38 +2266,24 @@ void show_preheat_nozzle_warning()
 
 void lcd_load_filament_color_check()
 {
-    // The total length of the individual messages MSG_YES c=4, MSG_NO c=4 and MSG_EJECT c=9 with the selectors and spaces between
-    // exceeds the LCD width.
-    // 01234567890123456789
-    // >yyyy >nnnn >eeeeeeee
-    // As long the translations of MSG_YES, MSG_NO and MSG_EJECT combined length do not exceed 15 chars, we don't have to shorten
-    // the MSG_EJECT message/translation. We can set the second_col value to the length of the first choice + the selector and space.
-    // Examples:
-    // German
-    // 01234567890123456789
-    // >Ja >Nein >Auswerfen
-    // Hungarian
-    // 01234567890123456789
-    // >Igen >Nem   >Kiadás
-
-    uint8_t clean = lcd_show_multiscreen_message_with_choices_and_wait_P(_T(MSG_FILAMENT_CLEAN), false, LCD_LEFT_BUTTON_CHOICE, _T(MSG_YES), _T(MSG_NO), _T(MSG_EJECT), strlen_P(_T(MSG_YES))+2);
+    uint8_t clean = lcd_show_multiscreen_message_with_choices_and_wait_P(_T(MSG_FILAMENT_CLEAN), false, LCD_LEFT_BUTTON_CHOICE, _T(MSG_YES), _T(MSG_NO), _T(MSG_EJECT), 8);
     while (clean == LCD_MIDDLE_BUTTON_CHOICE) {
         load_filament_final_feed();
         st_synchronize();
-        clean = lcd_show_multiscreen_message_with_choices_and_wait_P(_T(MSG_FILAMENT_CLEAN), false, LCD_LEFT_BUTTON_CHOICE, _T(MSG_YES), _T(MSG_NO), _T(MSG_EJECT), strlen_P(_T(MSG_YES))+2);
+        clean = lcd_show_multiscreen_message_with_choices_and_wait_P(_T(MSG_FILAMENT_CLEAN), false, LCD_LEFT_BUTTON_CHOICE, _T(MSG_YES), _T(MSG_NO), _T(MSG_EJECT), 8);
     }
     if (clean == LCD_RIGHT_BUTTON_CHOICE) {
         unload_filament(FILAMENTCHANGE_FINALRETRACT);
     }
 }
 
-#if defined(FILAMENT_SENSOR) && !defined(REMOVE_AUTOLOAD_FILAMENT_MENU_ENTRY)
+#ifdef FILAMENT_SENSOR
 static void lcd_menu_AutoLoadFilament()
 {
     lcd_display_message_fullscreen_nonBlocking_P(_T(MSG_AUTOLOADING_ENABLED));
     menu_back_if_clicked();
 }
-#endif //FILAMENT_SENSOR && REMOVE_AUTOLOAD_FILAMENT_MENU_ENTRY
+#endif //FILAMENT_SENSOR
 
 static void preheat_or_continue(FilamentAction action) {
 
@@ -3058,17 +3039,6 @@ uint8_t lcd_show_multiscreen_message_yes_no_and_wait_P(const char *msg, bool all
 {
     return lcd_show_multiscreen_message_with_choices_and_wait_P(msg, allow_timeouting, default_selection, _T(MSG_YES), _T(MSG_NO), nullptr, 10);
 }
-//! @brief Show multiple screen message with yes and no possible choices and wait with possible timeout
-//! @param msg Message to show. If NULL, do not clear the screen and handle choice selection only.
-//! @param allow_timeouting if true, allows time outing of the screen
-//! @param default_selection if 0, 'Yes' choice is selected by default, otherwise 'No' choice is preselected
-//! @retval 0 cont choice selected by user
-//! @retval 1 cancel choice selected by user
-//! @retval 0xFF button timeout (only possible if allow_timeouting is true)
-uint8_t lcd_show_multiscreen_message_cont_cancel_and_wait_P(const char *msg, bool allow_timeouting, uint8_t default_selection) //currently just max. n*4 + 3 lines supported (set in language header files)
-{
-    return lcd_show_multiscreen_message_with_choices_and_wait_P(msg, allow_timeouting, default_selection, _T(MSG_CONTINUE_SHORT), _T(MSG_CANCEL), nullptr, 10);
-}
 //! @brief Show a two-choice prompt on the last line of the LCD
 //! @param selected Show first choice as selected if true, the second otherwise
 //! @param first_choice text caption of first possible choice
@@ -3644,7 +3614,7 @@ void lcd_v2_calibration() {
 	if (MMU2::mmu2.Enabled()) {
 		const uint8_t filament = choose_menu_P(
 			_T(MSG_SELECT_FILAMENT),
-			MSG_FILAMENT,_T(MSG_CANCEL));
+			MSG_FILAMENT,(_T(MSG_CANCEL)+1)); //Hack to reuse MSG but strip 1st char off
 		if (filament < MMU_FILAMENT_COUNT) {
 			lay1cal_filament = filament;
 		} else {
@@ -3687,7 +3657,7 @@ void lcd_wizard() {
 	bool result = true;
 	if (calibration_status_get(CALIBRATION_WIZARD_STEPS)) {
 		// calibration already performed: ask before clearing the previous status
-		result = !lcd_show_multiscreen_message_cont_cancel_and_wait_P(_T(MSG_WIZARD_RERUN), false);
+		result = !lcd_show_multiscreen_message_yes_no_and_wait_P(_T(MSG_WIZARD_RERUN), false);
 	}
 	if (result) {
 		calibration_status_clear(CALIBRATION_WIZARD_STEPS);
@@ -5354,16 +5324,13 @@ static void lcd_main_menu()
                     if (!fsensor.getAutoLoadEnabled()) {
                         MENU_ITEM_SUBMENU_P(_T(MSG_LOAD_FILAMENT), lcd_LoadFilament);
                     }
-                    if (fsensor.getFilamentPresent()) {
-                        MENU_ITEM_SUBMENU_P(_T(MSG_UNLOAD_FILAMENT), lcd_unLoadFilament);
-                    }
-#ifndef REMOVE_AUTOLOAD_FILAMENT_MENU_ENTRY
-                    else {
+                    if (!fsensor.getFilamentPresent()) {
                         if (fsensor.getAutoLoadEnabled()) {
                             MENU_ITEM_SUBMENU_P(_T(MSG_AUTOLOAD_FILAMENT), lcd_menu_AutoLoadFilament);
-                        }                        
+                        }
+                    } else {
+                        MENU_ITEM_SUBMENU_P(_T(MSG_UNLOAD_FILAMENT), lcd_unLoadFilament);
                     }
-#endif //REMOVE_AUTOLOAD_FILAMENT_MENU_ENTRY 
                 } else {
 #endif //FILAMENT_SENSOR
                     MENU_ITEM_SUBMENU_P(_T(MSG_LOAD_FILAMENT), lcd_LoadFilament);
@@ -5626,7 +5593,7 @@ static void lcd_backlight_menu()
     MENU_ITEM_EDIT_int3_P(_T(MSG_BL_HIGH), &backlightLevel_HIGH, backlightLevel_LOW, 255);
     MENU_ITEM_EDIT_int3_P(_T(MSG_BL_LOW), &backlightLevel_LOW, 0, backlightLevel_HIGH);
 	MENU_ITEM_TOGGLE_P(_T(MSG_MODE), ((backlightMode==BACKLIGHT_MODE_BRIGHT) ? _T(MSG_BRIGHT) : ((backlightMode==BACKLIGHT_MODE_DIM) ? _T(MSG_DIM) : _T(MSG_AUTO))), backlight_mode_toggle);
-    MENU_ITEM_EDIT_int3_P(_T(MSG_TIMEOUT), &backlightTimer_period, LCD_BACKLIGHT_TIMEOUT, LCD_BACKLIGHT_TIMEOUT*60);
+    MENU_ITEM_EDIT_int3_P(_T(MSG_TIMEOUT), &backlightTimer_period, 1, 999);
 
     MENU_END();
 }
@@ -7146,7 +7113,7 @@ static void menu_action_sdfile(const char* filename)
     }
 
   if (!check_file(selected_filename)) {
-      result = !lcd_show_multiscreen_message_cont_cancel_and_wait_P(_T(MSG_FILE_INCOMPLETE), false);
+      result = !lcd_show_multiscreen_message_yes_no_and_wait_P(_T(MSG_FILE_INCOMPLETE), false);
       lcd_update_enable(true);
   }
   if (result) {

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -4526,7 +4526,7 @@ static void lcd_calibration_menu()
     }
     MENU_ITEM_GCODE_P(_T(MSG_AUTO_HOME), G28W);
     if (axis_known_position[Z_AXIS]) {
-        MENU_ITEM_GCODE_P(_T(MSG_FULLSTEP_Z), PSTR("M88"));
+        MENU_ITEM_GCODE_P(_T(MSG_FULLSTEP_Z), PSTR("G88"));
     }
 #ifdef TMC2130
     MENU_ITEM_FUNCTION_P(_T(MSG_BELTTEST), lcd_belttest_v);

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -98,7 +98,6 @@ extern uint8_t lcd_show_multiscreen_message_with_choices_and_wait_P(
     const char * const first_choice, const char * const second_choice, const char * const third_choice = nullptr,
     uint8_t second_col = 7);
 extern uint8_t lcd_show_multiscreen_message_yes_no_and_wait_P(const char *msg, bool allow_timeouting = true, uint8_t default_selection = LCD_MIDDLE_BUTTON_CHOICE);
-extern uint8_t lcd_show_multiscreen_message_cont_cancel_and_wait_P(const char *msg, bool allow_timeouting = true, uint8_t default_selection = LCD_MIDDLE_BUTTON_CHOICE);
 // Ask the user to move the Z axis up to the end stoppers and let
 // the user confirm that it has been done.
 

--- a/Firmware/util.cpp
+++ b/Firmware/util.cpp
@@ -268,7 +268,7 @@ void fCheckModeInit() {
 static void render_M862_warnings(const char* warning, const char* strict, uint8_t check)
 {
     if (check == 1) { // Warning, stop print if user selects 'No'
-        if (lcd_show_multiscreen_message_cont_cancel_and_wait_P(warning, true, LCD_LEFT_BUTTON_CHOICE) == LCD_MIDDLE_BUTTON_CHOICE) {
+        if (lcd_show_multiscreen_message_yes_no_and_wait_P(warning, true, LCD_LEFT_BUTTON_CHOICE) == LCD_MIDDLE_BUTTON_CHOICE) {
             lcd_print_stop();
         }
     } else if (check == 2) { // Strict, always stop print
@@ -385,8 +385,8 @@ bool filament_presence_check() {
         }
 
         render_M862_warnings(
-            _T(MSG_MISSING_FILAMENT)
-            ,_T(MSG_MISSING_FILAMENT) //Identical messages
+            _T(MSG_MISSING_FILAMENT_CONTINUE)
+            ,_T(MSG_MISSING_FILAMENT_CANCELLED)
             ,(uint8_t)oCheckFilament
         );
 

--- a/Firmware/variants/MK25-RAMBo10a.h
+++ b/Firmware/variants/MK25-RAMBo10a.h
@@ -520,14 +520,4 @@
 #define DEFAULT_MIN_ARC_SEGMENTS 20 // The enforced minimum segments in a full circle of the same radius.  Set to 0 to disable
 #define DEFAULT_ARC_SEGMENTS_PER_SEC 0 // Use feedrate to choose segment length. Set to 0 to disable
 
-/*------------------------------------
- COMMUNITY FEATURES
- *------------------------------------*/
-
-//Show filename instead of print time after SD card print finished
-//#define SHOW_FILENAME_AFTER_FINISH
-
-//Remove the "AutoLoad filament" LCD menu entry if autoload is enabled.
-//#define REMOVE_AUTOLOAD_FILAMENT_MENU_ENTRY
-
 #endif //__CONFIGURATION_PRUSA_H

--- a/Firmware/variants/MK25-RAMBo13a.h
+++ b/Firmware/variants/MK25-RAMBo13a.h
@@ -524,14 +524,4 @@
 #define DEFAULT_MIN_ARC_SEGMENTS 20 // The enforced minimum segments in a full circle of the same radius.  Set to 0 to disable
 #define DEFAULT_ARC_SEGMENTS_PER_SEC 0 // Use feedrate to choose segment length. Set to 0 to disable
 
-/*------------------------------------
- COMMUNITY FEATURES
- *------------------------------------*/
-
-//Show filename instead of print time after SD card print finished
-//#define SHOW_FILENAME_AFTER_FINISH
-
-//Remove the "AutoLoad filament" LCD menu entry if autoload is enabled.
-//#define REMOVE_AUTOLOAD_FILAMENT_MENU_ENTRY
-
 #endif //__CONFIGURATION_PRUSA_H

--- a/Firmware/variants/MK25S-RAMBo10a.h
+++ b/Firmware/variants/MK25S-RAMBo10a.h
@@ -528,14 +528,4 @@
 #define DEFAULT_MIN_ARC_SEGMENTS 20 // The enforced minimum segments in a full circle of the same radius.  Set to 0 to disable
 #define DEFAULT_ARC_SEGMENTS_PER_SEC 0 // Use feedrate to choose segment length. Set to 0 to disable
 
-/*------------------------------------
- COMMUNITY FEATURES
- *------------------------------------*/
-
-//Show filename instead of print time after SD card print finished
-//#define SHOW_FILENAME_AFTER_FINISH
-
-//Remove the "AutoLoad filament" LCD menu entry if autoload is enabled.
-//#define REMOVE_AUTOLOAD_FILAMENT_MENU_ENTRY
-
 #endif //__CONFIGURATION_PRUSA_H

--- a/Firmware/variants/MK25S-RAMBo13a.h
+++ b/Firmware/variants/MK25S-RAMBo13a.h
@@ -529,14 +529,4 @@
 #define DEFAULT_MIN_ARC_SEGMENTS 20 // The enforced minimum segments in a full circle of the same radius.  Set to 0 to disable
 #define DEFAULT_ARC_SEGMENTS_PER_SEC 0 // Use feedrate to choose segment length. Set to 0 to disable
 
-/*------------------------------------
- COMMUNITY FEATURES
- *------------------------------------*/
-
-//Show filename instead of print time after SD card print finished
-//#define SHOW_FILENAME_AFTER_FINISH
-
-//Remove the "AutoLoad filament" LCD menu entry if autoload is enabled.
-//#define REMOVE_AUTOLOAD_FILAMENT_MENU_ENTRY
-
 #endif //__CONFIGURATION_PRUSA_H

--- a/Firmware/variants/MK3-E3DREVO.h
+++ b/Firmware/variants/MK3-E3DREVO.h
@@ -687,14 +687,4 @@
 #define DEFAULT_MIN_ARC_SEGMENTS 20 // The enforced minimum segments in a full circle of the same radius.  Set to 0 to disable
 #define DEFAULT_ARC_SEGMENTS_PER_SEC 0 // Use feedrate to choose segment length. Set to 0 to disable
 
-/*------------------------------------
- COMMUNITY FEATURES
- *------------------------------------*/
-
-//Show filename instead of print time after SD card print finished
-//#define SHOW_FILENAME_AFTER_FINISH
-
-//Remove the "AutoLoad filament" LCD menu entry if autoload is enabled.
-//#define REMOVE_AUTOLOAD_FILAMENT_MENU_ENTRY
-
 #endif //__CONFIGURATION_PRUSA_H

--- a/Firmware/variants/MK3-E3DREVO_HF_60W.h
+++ b/Firmware/variants/MK3-E3DREVO_HF_60W.h
@@ -688,14 +688,4 @@
 #define DEFAULT_MIN_ARC_SEGMENTS 20 // The enforced minimum segments in a full circle of the same radius.  Set to 0 to disable
 #define DEFAULT_ARC_SEGMENTS_PER_SEC 0 // Use feedrate to choose segment length. Set to 0 to disable
 
-/*------------------------------------
- COMMUNITY FEATURES
- *------------------------------------*/
-
-//Show filename instead of print time after SD card print finished
-//#define SHOW_FILENAME_AFTER_FINISH
-
-//Remove the "AutoLoad filament" LCD menu entry if autoload is enabled.
-//#define REMOVE_AUTOLOAD_FILAMENT_MENU_ENTRY
-
 #endif //__CONFIGURATION_PRUSA_H

--- a/Firmware/variants/MK3.h
+++ b/Firmware/variants/MK3.h
@@ -690,14 +690,4 @@
 #define DEFAULT_MIN_ARC_SEGMENTS 20 // The enforced minimum segments in a full circle of the same radius.  Set to 0 to disable
 #define DEFAULT_ARC_SEGMENTS_PER_SEC 0 // Use feedrate to choose segment length. Set to 0 to disable
 
-/*------------------------------------
- COMMUNITY FEATURES
- *------------------------------------*/
-
-//Show filename instead of print time after SD card print finished
-//#define SHOW_FILENAME_AFTER_FINISH
-
-//Remove the "AutoLoad filament" LCD menu entry if autoload is enabled.
-//#define REMOVE_AUTOLOAD_FILAMENT_MENU_ENTRY
-
 #endif //__CONFIGURATION_PRUSA_H

--- a/Firmware/variants/MK3S-E3DREVO.h
+++ b/Firmware/variants/MK3S-E3DREVO.h
@@ -699,14 +699,4 @@
 #define DEFAULT_MIN_ARC_SEGMENTS 20 // The enforced minimum segments in a full circle of the same radius.  Set to 0 to disable
 #define DEFAULT_ARC_SEGMENTS_PER_SEC 0 // Use feedrate to choose segment length. Set to 0 to disable
 
-/*------------------------------------
- COMMUNITY FEATURES
- *------------------------------------*/
-
-//Show filename instead of print time after SD card print finished
-//#define SHOW_FILENAME_AFTER_FINISH
-
-//Remove the "AutoLoad filament" LCD menu entry if autoload is enabled.
-//#define REMOVE_AUTOLOAD_FILAMENT_MENU_ENTRY
-
 #endif //__CONFIGURATION_PRUSA_H

--- a/Firmware/variants/MK3S-E3DREVO_HF_60W.h
+++ b/Firmware/variants/MK3S-E3DREVO_HF_60W.h
@@ -700,14 +700,4 @@
 #define DEFAULT_MIN_ARC_SEGMENTS 20 // The enforced minimum segments in a full circle of the same radius.  Set to 0 to disable
 #define DEFAULT_ARC_SEGMENTS_PER_SEC 0 // Use feedrate to choose segment length. Set to 0 to disable
 
-/*------------------------------------
- COMMUNITY FEATURES
- *------------------------------------*/
-
-//Show filename instead of print time after SD card print finished
-//#define SHOW_FILENAME_AFTER_FINISH
-
-//Remove the "AutoLoad filament" LCD menu entry if autoload is enabled.
-//#define REMOVE_AUTOLOAD_FILAMENT_MENU_ENTRY
-
 #endif //__CONFIGURATION_PRUSA_H

--- a/Firmware/variants/MK3S.h
+++ b/Firmware/variants/MK3S.h
@@ -702,14 +702,4 @@
 #define DEFAULT_MIN_ARC_SEGMENTS 20 // The enforced minimum segments in a full circle of the same radius.  Set to 0 to disable
 #define DEFAULT_ARC_SEGMENTS_PER_SEC 0 // Use feedrate to choose segment length. Set to 0 to disable
 
-/*------------------------------------
- COMMUNITY FEATURES
- *------------------------------------*/
-
-//Show filename instead of print time after SD card print finished
-//#define SHOW_FILENAME_AFTER_FINISH
-
-//Remove the "AutoLoad filament" LCD menu entry if autoload is enabled.
-//#define REMOVE_AUTOLOAD_FILAMENT_MENU_ENTRY
-
 #endif //__CONFIGURATION_PRUSA_H

--- a/Firmware/variants/obsolete/1_75mm_MK2-RAMBo10a-E3Dv6full.h
+++ b/Firmware/variants/obsolete/1_75mm_MK2-RAMBo10a-E3Dv6full.h
@@ -430,14 +430,4 @@ THERMISTORS SETTINGS
 #define DEFAULT_MIN_ARC_SEGMENTS 20 // The enforced minimum segments in a full circle of the same radius.  Set to 0 to disable
 #define DEFAULT_ARC_SEGMENTS_PER_SEC 0 // Use feedrate to choose segment length. Set to 0 to disable
 
-/*------------------------------------
- COMMUNITY FEATURES
- *------------------------------------*/
-
-//Show filename instead of print time after SD card print finished
-//#define SHOW_FILENAME_AFTER_FINISH
-
-//Remove the "AutoLoad filament" LCD menu entry if autoload is enabled.
-//#define REMOVE_AUTOLOAD_FILAMENT_MENU_ENTRY
-
 #endif //__CONFIGURATION_PRUSA_H

--- a/Firmware/variants/obsolete/1_75mm_MK2-RAMBo13a-E3Dv6full.h
+++ b/Firmware/variants/obsolete/1_75mm_MK2-RAMBo13a-E3Dv6full.h
@@ -429,14 +429,4 @@ THERMISTORS SETTINGS
 #define DEFAULT_MIN_ARC_SEGMENTS 20 // The enforced minimum segments in a full circle of the same radius.  Set to 0 to disable
 #define DEFAULT_ARC_SEGMENTS_PER_SEC 0 // Use feedrate to choose segment length. Set to 0 to disable
 
-/*------------------------------------
- COMMUNITY FEATURES
- *------------------------------------*/
-
-//Show filename instead of print time after SD card print finished
-//#define SHOW_FILENAME_AFTER_FINISH
-
-//Remove the "AutoLoad filament" LCD menu entry if autoload is enabled.
-//#define REMOVE_AUTOLOAD_FILAMENT_MENU_ENTRY
-
 #endif //__CONFIGURATION_PRUSA_H

--- a/README.md
+++ b/README.md
@@ -49,12 +49,6 @@ Assuming a recent Debian/Ubuntu distribution, install the dependencies globally 
 
     sudo apt-get install cmake ninja python3-pyelftools python3-polib python3-regex gettext
 
-When using a recent Fedora(non-atomic)/RHEL distribution, install the dependencies globally with:
-
-    sudo dnf install cmake ninja-build python3-pyelftools python3-polib python3-regex gettext
-
-When using a Fedora Atomic/UBlue distribution use `rpm-ostree install --allow-inactive` instead of `sudo dnf install`
-
 Prusa-Firmware depends on a pinned version of `avr-gcc` and the external `prusa3dboards` package. These can be setup using `./utils/bootstrap.py`:
 
     # automatically setup dependencies

--- a/lang/po/Firmware.pot
+++ b/lang/po/Firmware.pot
@@ -23,10 +23,10 @@ msgstr ""
 msgid "%s level expected"
 msgstr ""
 
-#. MSG_CANCEL c=9
+#. MSG_CANCEL c=10
 #: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:1986
 #: ../../Firmware/ultralcd.cpp:3623
-msgid "Cancel"
+msgid ">Cancel"
 msgstr ""
 
 #. MSG_BABYSTEPPING_Z c=13
@@ -470,7 +470,7 @@ msgstr ""
 msgid "ERROR:"
 msgstr ""
 
-#. MSG_EJECT c=9
+#. MSG_EJECT c=8
 #: ../../Firmware/messages.cpp:21 ../../Firmware/mmu2/errors_list.h:371
 #: ../../Firmware/ultralcd.cpp:2275 ../../Firmware/ultralcd.cpp:2279
 msgid "Eject"
@@ -727,7 +727,7 @@ msgstr ""
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
 #: ../../Firmware/messages.cpp:375 ../../Firmware/ultralcd.cpp:7119
-msgid "File incomplete."
+msgid "File incomplete. Continue anyway?"
 msgstr ""
 
 #. MSG_FINISHING_MOVEMENTS c=20
@@ -778,34 +778,40 @@ msgstr ""
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:156 ../../Firmware/util.cpp:417
-msgid "G-code sliced for a different level."
+msgid "G-code sliced for a different level. Continue?"
 msgstr ""
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:418
-msgid "G-code sliced for a different level. Please re-slice the model again."
+msgid ""
+"G-code sliced for a different level. Please re-slice the model again. Print "
+"cancelled."
 msgstr ""
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:152 ../../Firmware/util.cpp:319
 #: ../../Firmware/util.cpp:436
-msgid "G-code sliced for a different printer type."
+msgid "G-code sliced for a different printer type. Continue?"
 msgstr ""
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:153 ../../Firmware/util.cpp:320
 #: ../../Firmware/util.cpp:437
-msgid "G-code sliced for a different printer type. Please re-slice the model again."
+msgid ""
+"G-code sliced for a different printer type. Please re-slice the model again."
+" Print cancelled."
 msgstr ""
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:154 ../../Firmware/util.cpp:369
-msgid "G-code sliced for a newer firmware."
+msgid "G-code sliced for a newer firmware. Continue?"
 msgstr ""
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:155 ../../Firmware/util.cpp:370
-msgid "G-code sliced for a newer firmware. Please update the firmware."
+msgid ""
+"G-code sliced for a newer firmware. Please update the firmware. Print "
+"cancelled."
 msgstr ""
 
 #. MSG_HW_SETUP c=18
@@ -1367,12 +1373,14 @@ msgstr ""
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:160 ../../Firmware/util.cpp:296
-msgid "Nozzle diameter differs from the G-code."
+msgid "Nozzle diameter differs from the G-code. Continue?"
 msgstr ""
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:161 ../../Firmware/util.cpp:297
-msgid "Nozzle diameter differs from the G-code. Please check the value in settings."
+msgid ""
+"Nozzle diameter differs from the G-code. Please check the value in settings."
+" Print cancelled."
 msgstr ""
 
 #. MSG_NOZZLE_CNG_COOLDOWN c=20 r=3
@@ -1820,7 +1828,7 @@ msgstr ""
 #: ../../Firmware/messages.cpp:298 ../../Firmware/ultralcd.cpp:3666
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
-"beginning."
+"beginning. Continue?"
 msgstr ""
 
 #. MSG_SD_CARD c=8
@@ -2167,9 +2175,14 @@ msgid ""
 "chapter)."
 msgstr ""
 
-#. MSG_MISSING_FILAMENT c=20 r=3
+#. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:388
-msgid "There is no filament loaded."
+msgid "There is no filament loaded. Continue?"
+msgstr ""
+
+#. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
+#: ../../Firmware/messages.cpp:159 ../../Firmware/util.cpp:389
+msgid "There is no filament loaded. Print cancelled."
 msgstr ""
 
 #. MSG_FOLLOW_Z_CALIBRATION_FLOW c=20 r=8

--- a/lang/po/Firmware.pot
+++ b/lang/po/Firmware.pot
@@ -776,6 +776,11 @@ msgstr ""
 msgid "Front/left fans"
 msgstr ""
 
+#. MSG_FULLSTEP_Z c=18
+#: ../../Firmware/messages.cpp:380 ../../Firmware/ultralcd.cpp:4529
+msgid "Fullstep Z axis"
+msgstr ""
+
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:156 ../../Firmware/util.cpp:417
 msgid "G-code sliced for a different level. Continue?"

--- a/lang/po/Firmware_cs.po
+++ b/lang/po/Firmware_cs.po
@@ -2600,6 +2600,11 @@ msgstr "Není vložen filament. Tisk zrušen."
 msgid "Z calibration recommended. Run it now?"
 msgstr "Doporučujeme kalibraci osy Z. Spustit nyní?"
 
+#. MSG_FULLSTEP_Z c=18
+#: ../../Firmware/messages.cpp:380 ../../Firmware/ultralcd.cpp:4529
+msgid "Fullstep Z axis"
+msgstr "Plný krok osy Z"
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Vyjmete stary filament a stisknete tlacitko pro zavedeni noveho."
 

--- a/lang/po/Firmware_cs.po
+++ b/lang/po/Firmware_cs.po
@@ -32,11 +32,11 @@ msgstr " 0.4 nebo novější"
 msgid "%s level expected"
 msgstr "%s očekávaná verze"
 
-#. MSG_CANCEL c=9
+#. MSG_CANCEL c=10
 #: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:1986
 #: ../../Firmware/ultralcd.cpp:3623
-msgid "Cancel"
-msgstr "Zrušit"
+msgid ">Cancel"
+msgstr ">Zrušit"
 
 #. MSG_BABYSTEPPING_Z c=13
 #: ../../Firmware/messages.cpp:269 ../../Firmware/ultralcd.cpp:2652
@@ -731,8 +731,8 @@ msgstr "Spotřebováno filam."
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
 #: ../../Firmware/messages.cpp:375 ../../Firmware/ultralcd.cpp:7119
-msgid "File incomplete."
-msgstr "Soubor nekompletní."
+msgid "File incomplete. Continue anyway?"
+msgstr "Soubor nekompletní. Pokračovat?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
 #: ../../Firmware/messages.cpp:45
@@ -786,35 +786,44 @@ msgstr "Přední/levý vent."
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:156 ../../Firmware/util.cpp:417
-msgid "G-code sliced for a different level."
-msgstr "G-code je připraven pro jinou verzi."
+msgid "G-code sliced for a different level. Continue?"
+msgstr "G-code je připraven pro jinou verzi. Pokračovat?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:418
-msgid "G-code sliced for a different level. Please re-slice the model again."
-msgstr "G-code je připraven pro jinou verzi. Vyslicujte model znovu."
+msgid ""
+"G-code sliced for a different level. Please re-slice the model again. Print "
+"cancelled."
+msgstr ""
+"G-code je připraven pro jinou verzi. Vyslicujte model znovu. Tisk zrušen."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:152 ../../Firmware/util.cpp:319
 #: ../../Firmware/util.cpp:436
-msgid "G-code sliced for a different printer type."
+msgid "G-code sliced for a different printer type. Continue?"
 msgstr "G-code je připraven pro jiný typ tiskárny.Pokračovat?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:153 ../../Firmware/util.cpp:320
 #: ../../Firmware/util.cpp:437
-msgid "G-code sliced for a different printer type. Please re-slice the model again."
-msgstr "G-code je připraven pro jiný typ tiskarny. Vyslicujte model znovu."
+msgid ""
+"G-code sliced for a different printer type. Please re-slice the model again."
+" Print cancelled."
+msgstr ""
+"G-code je připraven pro jiný typ tiskarny. Vyslicujte model znovu. Tisk "
+"zrušen."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:154 ../../Firmware/util.cpp:369
-msgid "G-code sliced for a newer firmware."
-msgstr "G-code je pripraven pro novější FW."
+msgid "G-code sliced for a newer firmware. Continue?"
+msgstr "G-code je pripraven pro novější FW. Pokračovat?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:155 ../../Firmware/util.cpp:370
-msgid "G-code sliced for a newer firmware. Please update the firmware."
-msgstr "G-code je připraven pro novější FW. Aktualizujte FW."
+msgid ""
+"G-code sliced for a newer firmware. Please update the firmware. Print "
+"cancelled."
+msgstr "G-code je připraven pro novější FW. Aktualizujte FW. Tisk zrušen."
 
 #. MSG_HW_SETUP c=18
 #: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4325
@@ -1654,13 +1663,17 @@ msgstr ""
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:160 ../../Firmware/util.cpp:296
-msgid "Nozzle diameter differs from the G-code."
-msgstr "Průměr trysky tiskárny se liší od G-code."
+msgid "Nozzle diameter differs from the G-code. Continue?"
+msgstr "Průměr trysky tiskárny se liší od G-code. Pokračovat?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:161 ../../Firmware/util.cpp:297
-msgid "Nozzle diameter differs from the G-code. Please check the value in settings."
-msgstr "Průměr trysky tiskárny se liší od G-code. Zkontrolujte nastavení."
+msgid ""
+"Nozzle diameter differs from the G-code. Please check the value in settings."
+" Print cancelled."
+msgstr ""
+"Průměr trysky tiskárny se liší od G-code. Zkontrolujte nastavení. Tisk "
+"zrušen."
 
 #. MSG_DESC_PULLEY_CANNOT_MOVE c=20 r=8
 #: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
@@ -1762,10 +1775,10 @@ msgstr "Vpravo [µm]"
 #: ../../Firmware/messages.cpp:298 ../../Firmware/ultralcd.cpp:3666
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
-"beginning."
+"beginning. Continue?"
 msgstr ""
 "Spuštění Průvodce vymaže uložene výsledky všech kalibrací a spustí "
-"kalibrační proces od začátku."
+"kalibrační proces od začátku. Pokračovat?"
 
 #. MSG_SD_CARD c=8
 #: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4476
@@ -2505,7 +2518,7 @@ msgstr "NEZNÁMÁ CHYBA"
 msgid "Unexpected error occurred."
 msgstr "Došlo k neočekávané chybě."
 
-#. MSG_EJECT c=9
+#. MSG_EJECT c=8
 #: ../../Firmware/messages.cpp:21 ../../Firmware/mmu2/errors_list.h:371
 #: ../../Firmware/ultralcd.cpp:2275 ../../Firmware/ultralcd.cpp:2279
 msgid "Eject"
@@ -2572,10 +2585,15 @@ msgstr "Tryska je horká! Počkejte na vychladnutí."
 msgid "Nozzle changed?"
 msgstr "Vyměnili jste trysku?"
 
-#. MSG_MISSING_FILAMENT c=20 r=3
+#. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:388
-msgid "There is no filament loaded."
-msgstr "Není vložen filament."
+msgid "There is no filament loaded. Continue?"
+msgstr "Není vložen filament. Pokračovat?"
+
+#. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
+#: ../../Firmware/messages.cpp:159 ../../Firmware/util.cpp:389
+msgid "There is no filament loaded. Print cancelled."
+msgstr "Není vložen filament. Tisk zrušen."
 
 #. MSG_Z_CALIBRATION_PROMPT c=20 r=3
 #: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:3752

--- a/lang/po/Firmware_de.po
+++ b/lang/po/Firmware_de.po
@@ -2628,6 +2628,11 @@ msgstr "Kein Filament geladen. Druck abgebrochen."
 msgid "Z calibration recommended. Run it now?"
 msgstr "Z-Kalibrierung empfohlen. Jetzt ausführen?"
 
+#. MSG_FULLSTEP_Z c=18
+#: ../../Firmware/messages.cpp:380 ../../Firmware/ultralcd.cpp:4529
+msgid "Fullstep Z axis"
+msgstr "Vollschritt Z-Achse"
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Entferne das alte Fil. und drücke den Knopf, um das neue zu laden."
 

--- a/lang/po/Firmware_de.po
+++ b/lang/po/Firmware_de.po
@@ -32,11 +32,11 @@ msgstr " 0.4 oder neuer"
 msgid "%s level expected"
 msgstr "%s Level erwartet"
 
-#. MSG_CANCEL c=9
+#. MSG_CANCEL c=10
 #: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:1986
 #: ../../Firmware/ultralcd.cpp:3623
-msgid "Cancel"
-msgstr "Abbruch"
+msgid ">Cancel"
+msgstr ">Abbruch"
 
 #. MSG_BABYSTEPPING_Z c=13
 #: ../../Firmware/messages.cpp:269 ../../Firmware/ultralcd.cpp:2652
@@ -734,7 +734,7 @@ msgstr "Filament benutzt"
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
 #: ../../Firmware/messages.cpp:375 ../../Firmware/ultralcd.cpp:7119
-msgid "File incomplete."
+msgid "File incomplete. Continue anyway?"
 msgstr "Datei unvollständig. Trotzdem fortfahren?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
@@ -789,35 +789,47 @@ msgstr "Druck/Hotend Lüfter"
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:156 ../../Firmware/util.cpp:417
-msgid "G-code sliced for a different level."
-msgstr "G-Code ist für einen anderen Level geslict."
+msgid "G-code sliced for a different level. Continue?"
+msgstr "G-Code ist für einen anderen Level geslict. Fortfahren?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:418
-msgid "G-code sliced for a different level. Please re-slice the model again."
-msgstr "G-Code ist für einen anderen Level geslict. Slicen Sie das Modell erneut."
+msgid ""
+"G-code sliced for a different level. Please re-slice the model again. Print "
+"cancelled."
+msgstr ""
+"G-Code ist für einen anderen Level geslict. Slicen Sie das Modell erneut. "
+"Druck abgebrochen."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:152 ../../Firmware/util.cpp:319
 #: ../../Firmware/util.cpp:436
-msgid "G-code sliced for a different printer type."
-msgstr "G-Code ist für einen anderen Drucker geslict."
+msgid "G-code sliced for a different printer type. Continue?"
+msgstr "G-Code ist für einen anderen Drucker geslict. Fortfahren?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:153 ../../Firmware/util.cpp:320
 #: ../../Firmware/util.cpp:437
-msgid "G-code sliced for a different printer type. Please re-slice the model again."
-msgstr "G-Code ist für einen anderen Drucker geslict. Slicen Sie das Modell erneut."
+msgid ""
+"G-code sliced for a different printer type. Please re-slice the model again."
+" Print cancelled."
+msgstr ""
+"G-Code ist für einen anderen Drucker geslict. Slicen Sie das Modell erneut. "
+"Druck abgebrochen."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:154 ../../Firmware/util.cpp:369
-msgid "G-code sliced for a newer firmware."
-msgstr "G-Code ist für eine neuere Firmware geslict."
+msgid "G-code sliced for a newer firmware. Continue?"
+msgstr "G-Code ist für eine neuere Firmware geslict. Fortfahren?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:155 ../../Firmware/util.cpp:370
-msgid "G-code sliced for a newer firmware. Please update the firmware."
-msgstr "G-Code ist für eine neuere Firmware geslict. Aktualisieren die Firmware."
+msgid ""
+"G-code sliced for a newer firmware. Please update the firmware. Print "
+"cancelled."
+msgstr ""
+"G-Code ist für eine neuere Firmware geslict. Aktualisieren die Firmware. "
+"Druck abgebrochen."
 
 #. MSG_HW_SETUP c=18
 #: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4325
@@ -1671,15 +1683,17 @@ msgstr ""
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:160 ../../Firmware/util.cpp:296
-msgid "Nozzle diameter differs from the G-code."
-msgstr "Düsendurchmesser weicht vom G-Code ab."
+msgid "Nozzle diameter differs from the G-code. Continue?"
+msgstr "Düsendurchmesser weicht vom G-Code ab. Fortfahren?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:161 ../../Firmware/util.cpp:297
-msgid "Nozzle diameter differs from the G-code. Please check the value in settings."
+msgid ""
+"Nozzle diameter differs from the G-code. Please check the value in settings."
+" Print cancelled."
 msgstr ""
 "Der Durchmesser der Druckerdüse weicht vom G-Code ab. Bitte überprüfen Sie "
-"den Wert in den Einstellungen."
+"den Wert in den Einstellungen. Druck abgebrochen."
 
 #. MSG_DESC_PULLEY_CANNOT_MOVE c=20 r=8
 #: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
@@ -1781,10 +1795,10 @@ msgstr "Rechts [µm]"
 #: ../../Firmware/messages.cpp:298 ../../Firmware/ultralcd.cpp:3666
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
-"beginning."
+"beginning. Continue?"
 msgstr ""
 "Der Assistent wird die aktuellen Kalibrierungsdaten löschen und von vorne "
-"beginnen."
+"beginnen. Fortfahren?"
 
 #. MSG_SD_CARD c=8
 #: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4476
@@ -2530,11 +2544,11 @@ msgstr "UNBEKANNTER FEHLER"
 msgid "Unexpected error occurred."
 msgstr "Ein unerwarteter Fehler ist aufgetreten."
 
-#. MSG_EJECT c=9
+#. MSG_EJECT c=8
 #: ../../Firmware/messages.cpp:21 ../../Firmware/mmu2/errors_list.h:371
 #: ../../Firmware/ultralcd.cpp:2275 ../../Firmware/ultralcd.cpp:2279
 msgid "Eject"
-msgstr "Auswerfen"
+msgstr "Auswerf."
 
 #. MSG_TITLE_FILAMENT_CHANGE c=20
 #: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
@@ -2599,10 +2613,15 @@ msgstr "Die Düse ist heiß! Auf Abkühlung warten."
 msgid "Nozzle changed?"
 msgstr "Düse gewechselt?"
 
-#. MSG_MISSING_FILAMENT c=20 r=3
+#. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:388
-msgid "There is no filament loaded."
-msgstr "Kein Filament geladen."
+msgid "There is no filament loaded. Continue?"
+msgstr "Kein Filament geladen. Fortfahren?"
+
+#. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
+#: ../../Firmware/messages.cpp:159 ../../Firmware/util.cpp:389
+msgid "There is no filament loaded. Print cancelled."
+msgstr "Kein Filament geladen. Druck abgebrochen."
 
 #. MSG_Z_CALIBRATION_PROMPT c=20 r=3
 #: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:3752

--- a/lang/po/Firmware_de.po
+++ b/lang/po/Firmware_de.po
@@ -2631,7 +2631,7 @@ msgstr "Z-Kalibrierung empfohlen. Jetzt ausführen?"
 #. MSG_FULLSTEP_Z c=18
 #: ../../Firmware/messages.cpp:380 ../../Firmware/ultralcd.cpp:4529
 msgid "Fullstep Z axis"
-msgstr "Vollschritt Z-Achse"
+msgstr "Vollschritt Z"
 
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Entferne das alte Fil. und drücke den Knopf, um das neue zu laden."

--- a/lang/po/Firmware_es.po
+++ b/lang/po/Firmware_es.po
@@ -2626,7 +2626,7 @@ msgstr "Se recomienda calibrar Z. ¿Ejecutarlo ahora?"
 #. MSG_FULLSTEP_Z c=18
 #: ../../Firmware/messages.cpp:380 ../../Firmware/ultralcd.cpp:4529
 msgid "Fullstep Z axis"
-msgstr "Eje Z a paso completo"
+msgstr "Eje Z paso total"
 
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr ""

--- a/lang/po/Firmware_es.po
+++ b/lang/po/Firmware_es.po
@@ -32,11 +32,11 @@ msgstr " 0.4 o más nueva"
 msgid "%s level expected"
 msgstr "%s nivel esperado"
 
-#. MSG_CANCEL c=9
+#. MSG_CANCEL c=10
 #: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:1986
 #: ../../Firmware/ultralcd.cpp:3623
-msgid "Cancel"
-msgstr "Cancelar"
+msgid ">Cancel"
+msgstr ">Cancelar"
 
 #. MSG_BABYSTEPPING_Z c=13
 #: ../../Firmware/messages.cpp:269 ../../Firmware/ultralcd.cpp:2652
@@ -738,7 +738,7 @@ msgstr "Filamento usado"
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
 #: ../../Firmware/messages.cpp:375 ../../Firmware/ultralcd.cpp:7119
-msgid "File incomplete."
+msgid "File incomplete. Continue anyway?"
 msgstr "¿Archivo incompleto. Continuar de todos modos?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
@@ -793,39 +793,47 @@ msgstr "Vents. front/izqui."
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:156 ../../Firmware/util.cpp:417
-msgid "G-code sliced for a different level."
-msgstr "Código G laminado para un nivel dif."
+msgid "G-code sliced for a different level. Continue?"
+msgstr "Código G laminado para un nivel dif. ¿Continuar?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:418
-msgid "G-code sliced for a different level. Please re-slice the model again."
+msgid ""
+"G-code sliced for a different level. Please re-slice the model again. Print "
+"cancelled."
 msgstr ""
 "Código G laminado para un nivel diferente. Vuelve a laminar el modelo de "
-"nuevo."
+"nuevo. Impresión cancelada."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:152 ../../Firmware/util.cpp:319
 #: ../../Firmware/util.cpp:436
-msgid "G-code sliced for a different printer type."
+msgid "G-code sliced for a different printer type. Continue?"
 msgstr "Código G laminado para un tipo de impresora dif.Cont.?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:153 ../../Firmware/util.cpp:320
 #: ../../Firmware/util.cpp:437
-msgid "G-code sliced for a different printer type. Please re-slice the model again."
+msgid ""
+"G-code sliced for a different printer type. Please re-slice the model again."
+" Print cancelled."
 msgstr ""
 "Código G laminado para una impresora diferente. Vuelve a laminar el modelo "
-"de nuevo."
+"de nuevo. Impresión cancelada."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:154 ../../Firmware/util.cpp:369
-msgid "G-code sliced for a newer firmware."
-msgstr "Código G laminado para nuevo firmware."
+msgid "G-code sliced for a newer firmware. Continue?"
+msgstr "Código G laminado para nuevo firmware. ¿Continuar?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:155 ../../Firmware/util.cpp:370
-msgid "G-code sliced for a newer firmware. Please update the firmware."
-msgstr "Código G laminado para nuevo firmware. Actualiza el firmware."
+msgid ""
+"G-code sliced for a newer firmware. Please update the firmware. Print "
+"cancelled."
+msgstr ""
+"Código G laminado para nuevo firmware. Actualiza el firmware. Impresión "
+"cancelada."
 
 #. MSG_HW_SETUP c=18
 #: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4325
@@ -1673,15 +1681,17 @@ msgstr ""
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:160 ../../Firmware/util.cpp:296
-msgid "Nozzle diameter differs from the G-code."
-msgstr "Diámetro boquilla impresora difiere de cod.G."
+msgid "Nozzle diameter differs from the G-code. Continue?"
+msgstr "Diámetro boquilla impresora difiere de cod.G. ¿Continuar?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:161 ../../Firmware/util.cpp:297
-msgid "Nozzle diameter differs from the G-code. Please check the value in settings."
+msgid ""
+"Nozzle diameter differs from the G-code. Please check the value in settings."
+" Print cancelled."
 msgstr ""
 "Diámetro boquilla Impresora difiere de cod.G. Comprueba los valores en "
-"ajustes."
+"ajustes. Impresión cancelada."
 
 #. MSG_DESC_PULLEY_CANNOT_MOVE c=20 r=8
 #: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
@@ -1783,10 +1793,10 @@ msgstr "Derecha [µm]"
 #: ../../Firmware/messages.cpp:298 ../../Firmware/ultralcd.cpp:3666
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
-"beginning."
+"beginning. Continue?"
 msgstr ""
 "Ejecutar el Asistente borrara los valores de calibración actuales y "
-"comenzará de nuevo."
+"comenzará de nuevo. ¿Continuar?"
 
 #. MSG_SD_CARD c=8
 #: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4476
@@ -2530,7 +2540,7 @@ msgstr "ERROR DESCONOCIDO"
 msgid "Unexpected error occurred."
 msgstr "Ocurrió un error inesperado."
 
-#. MSG_EJECT c=9
+#. MSG_EJECT c=8
 #: ../../Firmware/messages.cpp:21 ../../Firmware/mmu2/errors_list.h:371
 #: ../../Firmware/ultralcd.cpp:2275 ../../Firmware/ultralcd.cpp:2279
 msgid "Eject"
@@ -2598,10 +2608,15 @@ msgstr "La boquilla está caliente! Espere a que se enfríe."
 msgid "Nozzle changed?"
 msgstr "Cambió la boquilla?"
 
-#. MSG_MISSING_FILAMENT c=20 r=3
+#. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:388
-msgid "There is no filament loaded."
-msgstr "No hay ningún filamento cargado."
+msgid "There is no filament loaded. Continue?"
+msgstr "No hay ningún filamento cargado. ¿Continuar?"
+
+#. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
+#: ../../Firmware/messages.cpp:159 ../../Firmware/util.cpp:389
+msgid "There is no filament loaded. Print cancelled."
+msgstr "No hay ningún filamento cargado. Impresión cancelada."
 
 #. MSG_Z_CALIBRATION_PROMPT c=20 r=3
 #: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:3752

--- a/lang/po/Firmware_es.po
+++ b/lang/po/Firmware_es.po
@@ -2623,6 +2623,11 @@ msgstr "No hay ningún filamento cargado. Impresión cancelada."
 msgid "Z calibration recommended. Run it now?"
 msgstr "Se recomienda calibrar Z. ¿Ejecutarlo ahora?"
 
+#. MSG_FULLSTEP_Z c=18
+#: ../../Firmware/messages.cpp:380 ../../Firmware/ultralcd.cpp:4529
+msgid "Fullstep Z axis"
+msgstr "Eje Z a paso completo"
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr ""
 #~ "Retira el fil. viejo y presiona el dial para comenzar a cargar el nuevo."

--- a/lang/po/Firmware_fr.po
+++ b/lang/po/Firmware_fr.po
@@ -2640,7 +2640,7 @@ msgstr "Calibrage Z recommandé. Exécuter maintenant?"
 #. MSG_FULLSTEP_Z c=18
 #: ../../Firmware/messages.cpp:380 ../../Firmware/ultralcd.cpp:4529
 msgid "Fullstep Z axis"
-msgstr "Axe Z en pas complet"
+msgstr "Axe Z pas entier"
 
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr ""

--- a/lang/po/Firmware_fr.po
+++ b/lang/po/Firmware_fr.po
@@ -2637,6 +2637,11 @@ msgstr "Il n'y a pas de filament chargé. Impression annulée."
 msgid "Z calibration recommended. Run it now?"
 msgstr "Calibrage Z recommandé. Exécuter maintenant?"
 
+#. MSG_FULLSTEP_Z c=18
+#: ../../Firmware/messages.cpp:380 ../../Firmware/ultralcd.cpp:4529
+msgid "Fullstep Z axis"
+msgstr "Axe Z en pas complet"
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr ""
 #~ "Retirez l'ancien fil. puis appuyez sur le bouton pour charger le nouveau."

--- a/lang/po/Firmware_fr.po
+++ b/lang/po/Firmware_fr.po
@@ -32,11 +32,11 @@ msgstr " 0.4 ou +recent"
 msgid "%s level expected"
 msgstr "niveau %s attendu"
 
-#. MSG_CANCEL c=9
+#. MSG_CANCEL c=10
 #: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:1986
 #: ../../Firmware/ultralcd.cpp:3623
-msgid "Cancel"
-msgstr "Annuler"
+msgid ">Cancel"
+msgstr ">Annuler"
 
 #. MSG_BABYSTEPPING_Z c=13
 #: ../../Firmware/messages.cpp:269 ../../Firmware/ultralcd.cpp:2652
@@ -741,7 +741,7 @@ msgstr "Filament utilise"
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
 #: ../../Firmware/messages.cpp:375 ../../Firmware/ultralcd.cpp:7119
-msgid "File incomplete."
+msgid "File incomplete. Continue anyway?"
 msgstr "Fichier incomplet. Continuer qd meme?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
@@ -796,35 +796,47 @@ msgstr "Ventilos avt/gauche"
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:156 ../../Firmware/util.cpp:417
-msgid "G-code sliced for a different level."
-msgstr "G-code a été préparé pour un niveau diff."
+msgid "G-code sliced for a different level. Continue?"
+msgstr "G-code a été préparé pour un niveau diff. Continuer?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:418
-msgid "G-code sliced for a different level. Please re-slice the model again."
-msgstr "G-code a été préparé pour un niveau différent. Découpez le modèle à nouveau."
+msgid ""
+"G-code sliced for a different level. Please re-slice the model again. Print "
+"cancelled."
+msgstr ""
+"G-code a été préparé pour un niveau différent. Découpez le modèle à nouveau."
+" Impression annulée."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:152 ../../Firmware/util.cpp:319
 #: ../../Firmware/util.cpp:436
-msgid "G-code sliced for a different printer type."
-msgstr "G-code pour un type d'imprimante différent"
+msgid "G-code sliced for a different printer type. Continue?"
+msgstr "G-code pour un type d'imprimante différent. Continue?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:153 ../../Firmware/util.cpp:320
 #: ../../Firmware/util.cpp:437
-msgid "G-code sliced for a different printer type. Please re-slice the model again."
-msgstr "G-code pour un type d'imprimante différent. Découpez le modèle à nouveau."
+msgid ""
+"G-code sliced for a different printer type. Please re-slice the model again."
+" Print cancelled."
+msgstr ""
+"G-code pour un type d'imprimante différent. Découpez le modèle à nouveau. "
+"Impression annulée."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:154 ../../Firmware/util.cpp:369
-msgid "G-code sliced for a newer firmware."
+msgid "G-code sliced for a newer firmware. Continue?"
 msgstr "G-code a été préparé pour un FW plus récent. Cont.?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:155 ../../Firmware/util.cpp:370
-msgid "G-code sliced for a newer firmware. Please update the firmware."
-msgstr "G-code a été préparé pour un nouveau FW. Mettre à jour le FW."
+msgid ""
+"G-code sliced for a newer firmware. Please update the firmware. Print "
+"cancelled."
+msgstr ""
+"G-code a été préparé pour un nouveau FW. Mettre à jour le FW. Impression "
+"annulée."
 
 #. MSG_HW_SETUP c=18
 #: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4325
@@ -1676,13 +1688,17 @@ msgstr "L'imprimante n'a pas encore été calibrée. Suivez le manuel."
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:160 ../../Firmware/util.cpp:296
-msgid "Nozzle diameter differs from the G-code."
-msgstr "Diamètre de la buse diffère du G-Code."
+msgid "Nozzle diameter differs from the G-code. Continue?"
+msgstr "Diamètre de la buse diffère du G-Code. Continuer?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:161 ../../Firmware/util.cpp:297
-msgid "Nozzle diameter differs from the G-code. Please check the value in settings."
-msgstr "Diamètre de la buse diffère du G-Code. Vérifiez la valeur."
+msgid ""
+"Nozzle diameter differs from the G-code. Please check the value in settings."
+" Print cancelled."
+msgstr ""
+"Diamètre de la buse diffère du G-Code. Vérifiez la valeur. Impression "
+"annulée."
 
 #. MSG_DESC_PULLEY_CANNOT_MOVE c=20 r=8
 #: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
@@ -1784,10 +1800,10 @@ msgstr "Droite [µm]"
 #: ../../Firmware/messages.cpp:298 ../../Firmware/ultralcd.cpp:3666
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
-"beginning."
+"beginning. Continue?"
 msgstr ""
 "Le lancement de l'Assistant supprimera les résultats actuels de calibration "
-"et commencera du début."
+"et commencera du début. Continuer?"
 
 #. MSG_SD_CARD c=8
 #: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4476
@@ -2537,7 +2553,7 @@ msgstr "ERREUR INCONNUE"
 msgid "Unexpected error occurred."
 msgstr "Une erreur inattendue s'est produite."
 
-#. MSG_EJECT c=9
+#. MSG_EJECT c=8
 #: ../../Firmware/messages.cpp:21 ../../Firmware/mmu2/errors_list.h:371
 #: ../../Firmware/ultralcd.cpp:2275 ../../Firmware/ultralcd.cpp:2279
 msgid "Eject"
@@ -2606,10 +2622,15 @@ msgstr "La buse est chaude! Attendre le refroidissement."
 msgid "Nozzle changed?"
 msgstr "La buse a été changée?"
 
-#. MSG_MISSING_FILAMENT c=20 r=3
+#. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:388
-msgid "There is no filament loaded."
-msgstr "Il n'y a pas de filament chargé."
+msgid "There is no filament loaded. Continue?"
+msgstr "Il n'y a pas de filament chargé. Continuer?"
+
+#. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
+#: ../../Firmware/messages.cpp:159 ../../Firmware/util.cpp:389
+msgid "There is no filament loaded. Print cancelled."
+msgstr "Il n'y a pas de filament chargé. Impression annulée."
 
 #. MSG_Z_CALIBRATION_PROMPT c=20 r=3
 #: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:3752

--- a/lang/po/Firmware_hr.po
+++ b/lang/po/Firmware_hr.po
@@ -32,11 +32,11 @@ msgstr " 0.4 ili noviji"
 msgid "%s level expected"
 msgstr "%s level ocekivan"
 
-#. MSG_CANCEL c=9
+#. MSG_CANCEL c=10
 #: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:1986
 #: ../../Firmware/ultralcd.cpp:3623
-msgid "Cancel"
-msgstr "Otkazati"
+msgid ">Cancel"
+msgstr ">Otkazati"
 
 #. MSG_BABYSTEPPING_Z c=13
 #: ../../Firmware/messages.cpp:269 ../../Firmware/ultralcd.cpp:2652
@@ -735,7 +735,7 @@ msgstr "Iskoristeni fil."
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
 #: ../../Firmware/messages.cpp:375 ../../Firmware/ultralcd.cpp:7119
-msgid "File incomplete."
+msgid "File incomplete. Continue anyway?"
 msgstr "Datoteka je nepotpuna. Svejedno nastaviti?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
@@ -790,35 +790,47 @@ msgstr "Prednji/lijevi vent"
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:156 ../../Firmware/util.cpp:417
-msgid "G-code sliced for a different level."
-msgstr "G-kod izrezan za drugu razinu."
+msgid "G-code sliced for a different level. Continue?"
+msgstr "G-kod izrezan za drugu razinu. Nastavite?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:418
-msgid "G-code sliced for a different level. Please re-slice the model again."
-msgstr "G-kod izrezan za drugu razinu. Molimo ponovo izrezite model."
+msgid ""
+"G-code sliced for a different level. Please re-slice the model again. Print "
+"cancelled."
+msgstr ""
+"G-kod izrezan za drugu razinu. Molimo ponovo izrezite model. Print je "
+"otkazan."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:152 ../../Firmware/util.cpp:319
 #: ../../Firmware/util.cpp:436
-msgid "G-code sliced for a different printer type."
-msgstr "G-kod izrezan za drugu vrstu printera."
+msgid "G-code sliced for a different printer type. Continue?"
+msgstr "G-kod izrezan za drugu vrstu printera. Nastavite?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:153 ../../Firmware/util.cpp:320
 #: ../../Firmware/util.cpp:437
-msgid "G-code sliced for a different printer type. Please re-slice the model again."
-msgstr "G-kod izrezan za drugu vrstu printera. Molimo ponovo izrezite model."
+msgid ""
+"G-code sliced for a different printer type. Please re-slice the model again."
+" Print cancelled."
+msgstr ""
+"G-kod izrezan za drugu vrstu printera. Molimo ponovo izrezite model. Print "
+"je otkazan."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:154 ../../Firmware/util.cpp:369
-msgid "G-code sliced for a newer firmware."
-msgstr "G-kod izrezan za noviji firmware."
+msgid "G-code sliced for a newer firmware. Continue?"
+msgstr "G-kod izrezan za noviji firmware. Nastavite?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:155 ../../Firmware/util.cpp:370
-msgid "G-code sliced for a newer firmware. Please update the firmware."
-msgstr "G-kod izrezan za noviji firmware. Molimo azurirajte firmware."
+msgid ""
+"G-code sliced for a newer firmware. Please update the firmware. Print "
+"cancelled."
+msgstr ""
+"G-kod izrezan za noviji firmware. Molimo azurirajte firmware. Prime je "
+"otkazan."
 
 #. MSG_HW_SETUP c=18
 #: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4325
@@ -1665,15 +1677,17 @@ msgstr ""
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:160 ../../Firmware/util.cpp:296
-msgid "Nozzle diameter differs from the G-code."
-msgstr "Promjer mlaznice razlikuje se od G-koda."
+msgid "Nozzle diameter differs from the G-code. Continue?"
+msgstr "Promjer mlaznice razlikuje se od G-koda. Nastavite?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:161 ../../Firmware/util.cpp:297
-msgid "Nozzle diameter differs from the G-code. Please check the value in settings."
+msgid ""
+"Nozzle diameter differs from the G-code. Please check the value in settings."
+" Print cancelled."
 msgstr ""
 "Promjer mlaznice printera razlikuje se od G-koda. Molimo provjerite "
-"vrijednost u postavkama."
+"vrijednost u postavkama. Print je otkazan."
 
 #. MSG_DESC_PULLEY_CANNOT_MOVE c=20 r=8
 #: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
@@ -1775,10 +1789,10 @@ msgstr "Desna str.[µm]"
 #: ../../Firmware/messages.cpp:298 ../../Firmware/ultralcd.cpp:3666
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
-"beginning."
+"beginning. Continue?"
 msgstr ""
 "Pokrenuti carobnjak ce izbrisati trenutne rezultate kalibracije i poceti "
-"ispocetka."
+"ispocetka. Nastavite?"
 
 #. MSG_SD_CARD c=8
 #: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4476
@@ -2521,7 +2535,7 @@ msgstr "NEPOZNATA POGREŠKA"
 msgid "Unexpected error occurred."
 msgstr "Došlo je do neočekivane pogreške."
 
-#. MSG_EJECT c=9
+#. MSG_EJECT c=8
 #: ../../Firmware/messages.cpp:21 ../../Firmware/mmu2/errors_list.h:371
 #: ../../Firmware/ultralcd.cpp:2275 ../../Firmware/ultralcd.cpp:2279
 msgid "Eject"
@@ -2588,10 +2602,15 @@ msgstr "Mlaznica je vruća! Pričekajte hlađenje."
 msgid "Nozzle changed?"
 msgstr "Mlaznica se promijenila?"
 
-#. MSG_MISSING_FILAMENT c=20 r=3
+#. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:388
-msgid "There is no filament loaded."
-msgstr "Nema umetnute niti."
+msgid "There is no filament loaded. Continue?"
+msgstr "Nema umetnute niti. Nastavite?"
+
+#. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
+#: ../../Firmware/messages.cpp:159 ../../Firmware/util.cpp:389
+msgid "There is no filament loaded. Print cancelled."
+msgstr "Nema umetnute niti. Print je otkazan."
 
 #. MSG_Z_CALIBRATION_PROMPT c=20 r=3
 #: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:3752

--- a/lang/po/Firmware_hr.po
+++ b/lang/po/Firmware_hr.po
@@ -2617,6 +2617,11 @@ msgstr "Nema umetnute niti. Print je otkazan."
 msgid "Z calibration recommended. Run it now?"
 msgstr "Preporuča se Z kalibracija. Pokrenuti ga sada?"
 
+#. MSG_FULLSTEP_Z c=18
+#: ../../Firmware/messages.cpp:380 ../../Firmware/ultralcd.cpp:4529
+msgid "Fullstep Z axis"
+msgstr "Puni korak osi Z"
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Uklonite stari fil. i pritisnite gumb za pocetak stavljanja novog."
 

--- a/lang/po/Firmware_hu.po
+++ b/lang/po/Firmware_hu.po
@@ -2627,7 +2627,7 @@ msgstr "Z kalibráció javasolt. Futtassam most?"
 #. MSG_FULLSTEP_Z c=18
 #: ../../Firmware/messages.cpp:380 ../../Firmware/ultralcd.cpp:4529
 msgid "Fullstep Z axis"
-msgstr "Teljes lépés Z tengely""
+msgstr "Teljes lépés Z"
 
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Vedd ki a regi fil., majd nyomd meg a gombot az uj fil. betoltesehez."

--- a/lang/po/Firmware_hu.po
+++ b/lang/po/Firmware_hu.po
@@ -32,11 +32,11 @@ msgstr " 0.4 v. ujabb"
 msgid "%s level expected"
 msgstr "Vart szint: %s"
 
-#. MSG_CANCEL c=9
+#. MSG_CANCEL c=10
 #: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:1986
 #: ../../Firmware/ultralcd.cpp:3623
-msgid "Cancel"
-msgstr "Megsem"
+msgid ">Cancel"
+msgstr ">Megsem"
 
 #. MSG_BABYSTEPPING_Z c=13
 #: ../../Firmware/messages.cpp:269 ../../Firmware/ultralcd.cpp:2652
@@ -738,7 +738,7 @@ msgstr "Felhasznalt filam."
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
 #: ../../Firmware/messages.cpp:375 ../../Firmware/ultralcd.cpp:7119
-msgid "File incomplete."
+msgid "File incomplete. Continue anyway?"
 msgstr "A fajl vege hianyzik. Folytatod igy is?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
@@ -793,35 +793,47 @@ msgstr "Elso/bal ventillator"
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:156 ../../Firmware/util.cpp:417
-msgid "G-code sliced for a different level."
-msgstr "A G-kod mas szintre lett elokesztve."
+msgid "G-code sliced for a different level. Continue?"
+msgstr "A G-kod mas szintre lett elokesztve. Folytassam?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:418
-msgid "G-code sliced for a different level. Please re-slice the model again."
-msgstr "A G-kod mas szintre lett elokesztve. Szeleteld ujra a modellt."
+msgid ""
+"G-code sliced for a different level. Please re-slice the model again. Print "
+"cancelled."
+msgstr ""
+"A G-kod mas szintre lett elokesztve. Szeleteld ujra a modellt. Nyomtatas "
+"megallitva."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:152 ../../Firmware/util.cpp:319
 #: ../../Firmware/util.cpp:436
-msgid "G-code sliced for a different printer type."
-msgstr "A G-kod mas nyomtato tipusra lett elokesztve."
+msgid "G-code sliced for a different printer type. Continue?"
+msgstr "A G-kod mas nyomtato tipusra lett elokesztve.Folytassam?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:153 ../../Firmware/util.cpp:320
 #: ../../Firmware/util.cpp:437
-msgid "G-code sliced for a different printer type. Please re-slice the model again."
-msgstr "A G-kod mas nyomtato tipusra lett elokesztve. Szeleteld ujra a modellt."
+msgid ""
+"G-code sliced for a different printer type. Please re-slice the model again."
+" Print cancelled."
+msgstr ""
+"A G-kod mas nyomtato tipusra lett elokesztve. Szeleteld ujra a modellt. "
+"Nyomtatas megallitva."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:154 ../../Firmware/util.cpp:369
-msgid "G-code sliced for a newer firmware."
-msgstr "A G-kod ujabb firmverre lett elokesztve."
+msgid "G-code sliced for a newer firmware. Continue?"
+msgstr "A G-kod ujabb firmverre lett elokesztve.Folytassam?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:155 ../../Firmware/util.cpp:370
-msgid "G-code sliced for a newer firmware. Please update the firmware."
-msgstr "A G-kod ujabb firmverre lett elokesztve. Frissitsd a nyomtato firmveret."
+msgid ""
+"G-code sliced for a newer firmware. Please update the firmware. Print "
+"cancelled."
+msgstr ""
+"A G-kod ujabb firmverre lett elokesztve. Frissitsd a nyomtato firmveret. "
+"Nyomtatas megallitva."
 
 #. MSG_HW_SETUP c=18
 #: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4325
@@ -1671,16 +1683,17 @@ msgstr ""
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:160 ../../Firmware/util.cpp:296
-msgid "Nozzle diameter differs from the G-code."
-msgstr "A fuvoka atmeroje elter a G-kodtol."
+msgid "Nozzle diameter differs from the G-code. Continue?"
+msgstr "A fuvoka atmeroje elter a G-kodtol. Folytasasm?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:161 ../../Firmware/util.cpp:297
 msgid ""
 "Nozzle diameter differs from the G-code. Please check the value in settings."
+" Print cancelled."
 msgstr ""
 "A nyomtato fuvoka atmeroje elter a G-kodtol. Ellenorizd az erteket a "
-"beallitasokban."
+"beallitasokban. Nyomtatas megallitva."
 
 #. MSG_DESC_PULLEY_CANNOT_MOVE c=20 r=8
 #: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
@@ -1780,10 +1793,10 @@ msgstr "Jobb old.[µm]"
 #: ../../Firmware/messages.cpp:298 ../../Firmware/ultralcd.cpp:3666
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
-"beginning."
+"beginning. Continue?"
 msgstr ""
 "A Varazslo futtatasa nullazza a jelenlegi kalibracios ertekeket es elolrol "
-"fog mindent kezdeni."
+"fog mindent kezdeni. Folytatod?"
 
 #. MSG_SD_CARD c=8
 #: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4476
@@ -2528,7 +2541,7 @@ msgstr "ISMERETLEN HIBA"
 msgid "Unexpected error occurred."
 msgstr "Váratlan hiba történt."
 
-#. MSG_EJECT c=9
+#. MSG_EJECT c=8
 #: ../../Firmware/messages.cpp:21 ../../Firmware/mmu2/errors_list.h:371
 #: ../../Firmware/ultralcd.cpp:2275 ../../Firmware/ultralcd.cpp:2279
 msgid "Eject"
@@ -2596,10 +2609,15 @@ msgstr "A fúvóka forró! Várja meg a lehűlést."
 msgid "Nozzle changed?"
 msgstr "Fúvóka cserélve?"
 
-#. MSG_MISSING_FILAMENT c=20 r=3
+#. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:388
-msgid "There is no filament loaded."
-msgstr "Nincs befűzve filament."
+msgid "There is no filament loaded. Continue?"
+msgstr "Nincs befűzve filament. Folytassam?"
+
+#. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
+#: ../../Firmware/messages.cpp:159 ../../Firmware/util.cpp:389
+msgid "There is no filament loaded. Print cancelled."
+msgstr "Nincs befűzve filament. Nyomtatás megállítva."
 
 #. MSG_Z_CALIBRATION_PROMPT c=20 r=3
 #: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:3752

--- a/lang/po/Firmware_hu.po
+++ b/lang/po/Firmware_hu.po
@@ -2624,6 +2624,11 @@ msgstr "Nincs befűzve filament. Nyomtatás megállítva."
 msgid "Z calibration recommended. Run it now?"
 msgstr "Z kalibráció javasolt. Futtassam most?"
 
+#. MSG_FULLSTEP_Z c=18
+#: ../../Firmware/messages.cpp:380 ../../Firmware/ultralcd.cpp:4529
+msgid "Fullstep Z axis"
+msgstr "Teljes lépés Z tengely""
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Vedd ki a regi fil., majd nyomd meg a gombot az uj fil. betoltesehez."
 

--- a/lang/po/Firmware_it.po
+++ b/lang/po/Firmware_it.po
@@ -32,11 +32,11 @@ msgstr " 0.4 o superiore"
 msgid "%s level expected"
 msgstr "atteso livello %s"
 
-#. MSG_CANCEL c=9
+#. MSG_CANCEL c=10
 #: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:1986
 #: ../../Firmware/ultralcd.cpp:3623
-msgid "Cancel"
-msgstr "Annulla"
+msgid ">Cancel"
+msgstr ">Annulla"
 
 #. MSG_BABYSTEPPING_Z c=13
 #: ../../Firmware/messages.cpp:269 ../../Firmware/ultralcd.cpp:2652
@@ -740,7 +740,7 @@ msgstr "Fil. utilizzato"
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
 #: ../../Firmware/messages.cpp:375 ../../Firmware/ultralcd.cpp:7119
-msgid "File incomplete."
+msgid "File incomplete. Continue anyway?"
 msgstr "File incompleto. Continuare comunque?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
@@ -795,37 +795,47 @@ msgstr "Ventola frontale/sin"
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:156 ../../Firmware/util.cpp:417
-msgid "G-code sliced for a different level."
-msgstr "G-code processato per un livello diverso."
+msgid "G-code sliced for a different level. Continue?"
+msgstr "G-code processato per un livello diverso. Continuare?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:418
-msgid "G-code sliced for a different level. Please re-slice the model again."
+msgid ""
+"G-code sliced for a different level. Please re-slice the model again. Print "
+"cancelled."
 msgstr ""
 "G-code processato per un livello diverso. Per favore esegui nuovamente lo "
-"slice del modello."
+"slice del modello. Stampa annullata."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:152 ../../Firmware/util.cpp:319
 #: ../../Firmware/util.cpp:436
-msgid "G-code sliced for a different printer type."
-msgstr "G-code processato per una stampante diversa."
+msgid "G-code sliced for a different printer type. Continue?"
+msgstr "G-code processato per una stampante diversa. Continuare?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:153 ../../Firmware/util.cpp:320
 #: ../../Firmware/util.cpp:437
-msgid "G-code sliced for a different printer type. Please re-slice the model again."
-msgstr "G-code processato per un'altra stampante. Per favore rislice il modello."
+msgid ""
+"G-code sliced for a different printer type. Please re-slice the model again."
+" Print cancelled."
+msgstr ""
+"G-code processato per un'altra stampante. Per favore rislice il modello. "
+"Annullamento stampa."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:154 ../../Firmware/util.cpp:369
-msgid "G-code sliced for a newer firmware."
-msgstr "G-code processato per un FW piu recente."
+msgid "G-code sliced for a newer firmware. Continue?"
+msgstr "G-code processato per un FW piu recente. Continuare?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:155 ../../Firmware/util.cpp:370
-msgid "G-code sliced for a newer firmware. Please update the firmware."
-msgstr "G-code processato per un FW piu recente. Per favore aggiorna il FW."
+msgid ""
+"G-code sliced for a newer firmware. Please update the firmware. Print "
+"cancelled."
+msgstr ""
+"G-code processato per un FW piu recente. Per favore aggiorna il FW. Stampa "
+"annullata."
 
 #. MSG_HW_SETUP c=18
 #: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4325
@@ -1672,13 +1682,17 @@ msgstr ""
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:160 ../../Firmware/util.cpp:296
-msgid "Nozzle diameter differs from the G-code."
-msgstr "Diametro ugello diverso da G-Code."
+msgid "Nozzle diameter differs from the G-code. Continue?"
+msgstr "Diametro ugello diverso da G-Code. Continuare?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:161 ../../Firmware/util.cpp:297
-msgid "Nozzle diameter differs from the G-code. Please check the value in settings."
-msgstr "Diametro ugello diverso dal G-Code. Controlla il valore nelle impostazioni."
+msgid ""
+"Nozzle diameter differs from the G-code. Please check the value in settings."
+" Print cancelled."
+msgstr ""
+"Diametro ugello diverso dal G-Code. Controlla il valore nelle impostazioni. "
+"Stampa annullata."
 
 #. MSG_DESC_PULLEY_CANNOT_MOVE c=20 r=8
 #: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
@@ -1780,10 +1794,10 @@ msgstr "Destra [µm]"
 #: ../../Firmware/messages.cpp:298 ../../Firmware/ultralcd.cpp:3666
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
-"beginning."
+"beginning. Continue?"
 msgstr ""
 "Se avvi il Wizard perderai la calibrazione preesistente e dovrai "
-"ricominciare dall'inizio."
+"ricominciare dall'inizio. Continuare?"
 
 #. MSG_SD_CARD c=8
 #: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4476
@@ -2526,7 +2540,7 @@ msgstr "ERRORE SCONOSCIUTO"
 msgid "Unexpected error occurred."
 msgstr "Si è verificato un errore imprevisto."
 
-#. MSG_EJECT c=9
+#. MSG_EJECT c=8
 #: ../../Firmware/messages.cpp:21 ../../Firmware/mmu2/errors_list.h:371
 #: ../../Firmware/ultralcd.cpp:2275 ../../Firmware/ultralcd.cpp:2279
 msgid "Eject"
@@ -2594,10 +2608,15 @@ msgstr "L'ugello è caldo! Attendere il raffreddamento."
 msgid "Nozzle changed?"
 msgstr "L'ugello è cambiato?"
 
-#. MSG_MISSING_FILAMENT c=20 r=3
+#. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:388
-msgid "There is no filament loaded."
-msgstr "Nessun filamento caricato."
+msgid "There is no filament loaded. Continue?"
+msgstr "Nessun filamento caricato. Continuare?"
+
+#. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
+#: ../../Firmware/messages.cpp:159 ../../Firmware/util.cpp:389
+msgid "There is no filament loaded. Print cancelled."
+msgstr "Nessun filamento caricato. Stampa annullata."
 
 #. MSG_Z_CALIBRATION_PROMPT c=20 r=3
 #: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:3752

--- a/lang/po/Firmware_it.po
+++ b/lang/po/Firmware_it.po
@@ -2623,6 +2623,11 @@ msgstr "Nessun filamento caricato. Stampa annullata."
 msgid "Z calibration recommended. Run it now?"
 msgstr "Si consiglia la calibrazione Z. Eseguirla ora?"
 
+#. MSG_FULLSTEP_Z c=18
+#: ../../Firmware/messages.cpp:380 ../../Firmware/ultralcd.cpp:4529
+msgid "Fullstep Z axis"
+msgstr "Asse Z a passo intero"
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Rimuovi il fil. precedente e premi la manopola per caricare il nuovo."
 

--- a/lang/po/Firmware_it.po
+++ b/lang/po/Firmware_it.po
@@ -2626,7 +2626,7 @@ msgstr "Si consiglia la calibrazione Z. Eseguirla ora?"
 #. MSG_FULLSTEP_Z c=18
 #: ../../Firmware/messages.cpp:380 ../../Firmware/ultralcd.cpp:4529
 msgid "Fullstep Z axis"
-msgstr "Asse Z a passo intero"
+msgstr "Z passo pieno"
 
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Rimuovi il fil. precedente e premi la manopola per caricare il nuovo."

--- a/lang/po/Firmware_nl.po
+++ b/lang/po/Firmware_nl.po
@@ -2628,7 +2628,7 @@ msgstr "Z-kalibratie aanbevolen. Nu uitvoeren?"
 #. MSG_FULLSTEP_Z c=18
 #: ../../Firmware/messages.cpp:380 ../../Firmware/ultralcd.cpp:4529
 msgid "Fullstep Z axis"
-msgstr "Volledige stap Z-as"
+msgstr "Volledige stap Z"
 
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr ""

--- a/lang/po/Firmware_nl.po
+++ b/lang/po/Firmware_nl.po
@@ -32,11 +32,11 @@ msgstr " 0.4 of nieuwer"
 msgid "%s level expected"
 msgstr "%s niveau verwacht"
 
-#. MSG_CANCEL c=9
+#. MSG_CANCEL c=10
 #: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:1986
 #: ../../Firmware/ultralcd.cpp:3623
-msgid "Cancel"
-msgstr "Annuleren"
+msgid ">Cancel"
+msgstr ">Annuleren"
 
 #. MSG_BABYSTEPPING_Z c=13
 #: ../../Firmware/messages.cpp:269 ../../Firmware/ultralcd.cpp:2652
@@ -740,7 +740,7 @@ msgstr "Gebruikte filament"
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
 #: ../../Firmware/messages.cpp:375 ../../Firmware/ultralcd.cpp:7119
-msgid "File incomplete."
+msgid "File incomplete. Continue anyway?"
 msgstr "Bestand onvolledig. Toch doorgaan?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
@@ -795,37 +795,47 @@ msgstr "Fans voor/links"
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:156 ../../Firmware/util.cpp:417
-msgid "G-code sliced for a different level."
-msgstr "G-Code is voor een ander niveau geslict."
+msgid "G-code sliced for a different level. Continue?"
+msgstr "G-Code is voor een ander niveau geslict. Doorgaan?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:418
-msgid "G-code sliced for a different level. Please re-slice the model again."
-msgstr "G-Code is voor een ander niveau geslict. Slice het model opniew alsjeblieft."
+msgid ""
+"G-code sliced for a different level. Please re-slice the model again. Print "
+"cancelled."
+msgstr ""
+"G-Code is voor een ander niveau geslict. Slice het model opniew alsjeblieft."
+" Druk geannuleerd."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:152 ../../Firmware/util.cpp:319
 #: ../../Firmware/util.cpp:436
-msgid "G-code sliced for a different printer type."
-msgstr "G-Code is voor een ander printertype geslict."
+msgid "G-code sliced for a different printer type. Continue?"
+msgstr "G-Code is voor een ander printertype geslict. Doorgaan?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:153 ../../Firmware/util.cpp:320
 #: ../../Firmware/util.cpp:437
-msgid "G-code sliced for a different printer type. Please re-slice the model again."
-msgstr "G-Code is voor een ander printertype geslict. Slice het model opniew "
-"alsjeblieft."
+msgid ""
+"G-code sliced for a different printer type. Please re-slice the model again."
+" Print cancelled."
+msgstr ""
+"G-Code is voor een ander printertype geslict. Slice het model opniew "
+"alsjeblieft. Druk geannuleerd."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:154 ../../Firmware/util.cpp:369
-msgid "G-code sliced for a newer firmware."
-msgstr "G-Code is voor een nieuwere firmware geslict."
+msgid "G-code sliced for a newer firmware. Continue?"
+msgstr "G-Code is voor een nieuwere firmware geslict. Doorgaan?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:155 ../../Firmware/util.cpp:370
-msgid "G-code sliced for a newer firmware. Please update the firmware."
-msgstr "G-Code is voor een nieuwere firmware geslict. Update de firmware "
-"alsjeblieft."
+msgid ""
+"G-code sliced for a newer firmware. Please update the firmware. Print "
+"cancelled."
+msgstr ""
+"G-Code is voor een nieuwere firmware geslict. Update de firmware "
+"alsjeblieft. Druk geannuleerd."
 
 #. MSG_HW_SETUP c=18
 #: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4325
@@ -1675,14 +1685,17 @@ msgstr ""
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:160 ../../Firmware/util.cpp:296
-msgid "Nozzle diameter differs from the G-code."
-msgstr "Tuitdiameter wijkt af van de G-code."
+msgid "Nozzle diameter differs from the G-code. Continue?"
+msgstr "Tuitdiameter wijkt af van de G-code. Doorgaan?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:161 ../../Firmware/util.cpp:297
-msgid "Nozzle diameter differs from the G-code. Please check the value in settings."
-msgstr "De diameter van de tuit van de printer verschilt van de G-code. Controleer "
-"de waarde in de instellingen."
+msgid ""
+"Nozzle diameter differs from the G-code. Please check the value in settings."
+" Print cancelled."
+msgstr ""
+"De diameter van de tuit van de printer verschilt van de G-code. Controleer "
+"de waarde in de instellingen. Printen geannuleerd."
 
 #. MSG_DESC_PULLEY_CANNOT_MOVE c=20 r=8
 #: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
@@ -1784,10 +1797,10 @@ msgstr "Recht.kant[µm]"
 #: ../../Firmware/messages.cpp:298 ../../Firmware/ultralcd.cpp:3666
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
-"beginning."
+"beginning. Continue?"
 msgstr ""
 "Starten van de Wizard verwijdert de huidige kalibreringsresultaten en begint"
-" vanaf het begin."
+" vanaf het begin. Doorgaan?"
 
 #. MSG_SD_CARD c=8
 #: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4476
@@ -2530,11 +2543,11 @@ msgstr "ONBEKENDE FOUT"
 msgid "Unexpected error occurred."
 msgstr "Er is een onverwachte fout opgetreden."
 
-#. MSG_EJECT c=9
+#. MSG_EJECT c=8
 #: ../../Firmware/messages.cpp:21 ../../Firmware/mmu2/errors_list.h:371
 #: ../../Firmware/ultralcd.cpp:2275 ../../Firmware/ultralcd.cpp:2279
 msgid "Eject"
-msgstr "Uitwerpen"
+msgstr "Uitwerp."
 
 #. MSG_TITLE_FILAMENT_CHANGE c=20
 #: ../../Firmware/mmu2/errors_list.h:189 ../../Firmware/mmu2/errors_list.h:236
@@ -2597,10 +2610,15 @@ msgstr "Mondstuk is heet! Wacht op afkoeling."
 msgid "Nozzle changed?"
 msgstr "Mondstuk veranderd?"
 
-#. MSG_MISSING_FILAMENT c=20 r=3
+#. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:388
-msgid "There is no filament loaded."
-msgstr "Geen filament geladen."
+msgid "There is no filament loaded. Continue?"
+msgstr "Geen filament geladen. Doorgaan?"
+
+#. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
+#: ../../Firmware/messages.cpp:159 ../../Firmware/util.cpp:389
+msgid "There is no filament loaded. Print cancelled."
+msgstr "Geen filament geladen. Printen geannuleerd."
 
 #. MSG_Z_CALIBRATION_PROMPT c=20 r=3
 #: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:3752

--- a/lang/po/Firmware_nl.po
+++ b/lang/po/Firmware_nl.po
@@ -2625,6 +2625,11 @@ msgstr "Geen filament geladen. Printen geannuleerd."
 msgid "Z calibration recommended. Run it now?"
 msgstr "Z-kalibratie aanbevolen. Nu uitvoeren?"
 
+#. MSG_FULLSTEP_Z c=18
+#: ../../Firmware/messages.cpp:380 ../../Firmware/ultralcd.cpp:4529
+msgid "Fullstep Z axis"
+msgstr "Volledige stap Z-as"
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr ""
 #~ "Verwijder de oude filament en druk op de knop om nieuwe filament te laden."

--- a/lang/po/Firmware_no.po
+++ b/lang/po/Firmware_no.po
@@ -2599,6 +2599,11 @@ msgstr "Det er ingen filament lastet. Print avbrutt."
 msgid "Z calibration recommended. Run it now?"
 msgstr "Z-kalibrering anbefales. Kjøre det nå?"
 
+#. MSG_FULLSTEP_Z c=18
+#: ../../Firmware/messages.cpp:380 ../../Firmware/ultralcd.cpp:4529
+msgid "Fullstep Z axis"
+msgstr "Fullsteg Z-akse"
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Ta bort det gamle filamentet og trykk valghjulet for å laste et nytt."
 

--- a/lang/po/Firmware_no.po
+++ b/lang/po/Firmware_no.po
@@ -32,11 +32,11 @@ msgstr " 0.4 eller nyere"
 msgid "%s level expected"
 msgstr "%s nivå ventet"
 
-#. MSG_CANCEL c=9
+#. MSG_CANCEL c=10
 #: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:1986
 #: ../../Firmware/ultralcd.cpp:3623
-msgid "Cancel"
-msgstr "Avbryt"
+msgid ">Cancel"
+msgstr ">Avbryt"
 
 #. MSG_BABYSTEPPING_Z c=13
 #: ../../Firmware/messages.cpp:269 ../../Firmware/ultralcd.cpp:2652
@@ -738,7 +738,7 @@ msgstr "Brukt filament"
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
 #: ../../Firmware/messages.cpp:375 ../../Firmware/ultralcd.cpp:7119
-msgid "File incomplete."
+msgid "File incomplete. Continue anyway?"
 msgstr "Fil er ukomplett. Fortsette allikevel?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
@@ -791,35 +791,45 @@ msgstr "Fremre/venstre vifte"
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:156 ../../Firmware/util.cpp:417
-msgid "G-code sliced for a different level."
-msgstr "G-code sliced for en annen høyde."
+msgid "G-code sliced for a different level. Continue?"
+msgstr "G-code sliced for en annen høyde. Fortsette?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:418
-msgid "G-code sliced for a different level. Please re-slice the model again."
-msgstr "G-code sliced for en annen høyde. Vennligst slice igjen."
+msgid ""
+"G-code sliced for a different level. Please re-slice the model again. Print "
+"cancelled."
+msgstr ""
+"G-code sliced for en annen høyde. Vennligst slice igjen. Print avbrutt."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:152 ../../Firmware/util.cpp:319
 #: ../../Firmware/util.cpp:436
-msgid "G-code sliced for a different printer type."
-msgstr "G-code sliced for en annen printer."
+msgid "G-code sliced for a different printer type. Continue?"
+msgstr "G-code sliced for en annen printer. Fortsette?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:153 ../../Firmware/util.cpp:320
 #: ../../Firmware/util.cpp:437
-msgid "G-code sliced for a different printer type. Please re-slice the model again."
-msgstr "G-code sliced for en annen printer. Vennligst slice igjen."
+msgid ""
+"G-code sliced for a different printer type. Please re-slice the model again."
+" Print cancelled."
+msgstr ""
+"G-code sliced for en annen printer. Vennligst slice igjen. Print avbrutt."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:154 ../../Firmware/util.cpp:369
-msgid "G-code sliced for a newer firmware."
-msgstr "G-code sliced for nyere fastvare."
+msgid "G-code sliced for a newer firmware. Continue?"
+msgstr "G-code sliced for nyere fastvare. Fortsette?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:155 ../../Firmware/util.cpp:370
-msgid "G-code sliced for a newer firmware. Please update the firmware."
-msgstr "G-code sliced for nyere fastvare. Vennligst oppdater systemet."
+msgid ""
+"G-code sliced for a newer firmware. Please update the firmware. Print "
+"cancelled."
+msgstr ""
+"G-code sliced for nyere fastvare. Vennligst oppdater systemet. Print "
+"avbrutt."
 
 #. MSG_HW_SETUP c=18
 #: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4325
@@ -1662,14 +1672,17 @@ msgstr ""
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:160 ../../Firmware/util.cpp:296
-msgid "Nozzle diameter differs from the G-code."
-msgstr "Dysediameteren er forskjellig fra G-Code."
+msgid "Nozzle diameter differs from the G-code. Continue?"
+msgstr "Dysediameteren er forskjellig fra G-Code. Fortsette?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:161 ../../Firmware/util.cpp:297
-msgid "Nozzle diameter differs from the G-code. Please check the value in settings."
-msgstr "Printerens dysediameter er forskjellig fra G-Code. Sjekk Innstillinger for "
-"hva som er satt."
+msgid ""
+"Nozzle diameter differs from the G-code. Please check the value in settings."
+" Print cancelled."
+msgstr ""
+"Printerens dysediameter er forskjellig fra G-Code. Sjekk Innstillinger for "
+"hva som er satt. Print avbrutt."
 
 #. MSG_DESC_PULLEY_CANNOT_MOVE c=20 r=8
 #: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
@@ -1769,10 +1782,10 @@ msgstr "Høyre side[µm]"
 #: ../../Firmware/messages.cpp:298 ../../Firmware/ultralcd.cpp:3666
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
-"beginning."
+"beginning. Continue?"
 msgstr ""
 "Ved å kjøre Veilederen slettes all nåværende kalibreringsdata og du må "
-"begynne på nytt."
+"begynne på nytt. Fortsette?"
 
 #. MSG_SD_CARD c=8
 #: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4476
@@ -2504,7 +2517,7 @@ msgstr "UKJENT FEIL"
 msgid "Unexpected error occurred."
 msgstr "Det oppstod en uventet feil."
 
-#. MSG_EJECT c=9
+#. MSG_EJECT c=8
 #: ../../Firmware/messages.cpp:21 ../../Firmware/mmu2/errors_list.h:371
 #: ../../Firmware/ultralcd.cpp:2275 ../../Firmware/ultralcd.cpp:2279
 msgid "Eject"
@@ -2571,10 +2584,15 @@ msgstr "Dysen er varm! Vent på nedkjøling."
 msgid "Nozzle changed?"
 msgstr "Har du byttet dyse?"
 
-#. MSG_MISSING_FILAMENT c=20 r=3
+#. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:388
-msgid "There is no filament loaded."
-msgstr "Det er ingen filament lastet."
+msgid "There is no filament loaded. Continue?"
+msgstr "Det er ingen filament lastet. Fortsette?"
+
+#. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
+#: ../../Firmware/messages.cpp:159 ../../Firmware/util.cpp:389
+msgid "There is no filament loaded. Print cancelled."
+msgstr "Det er ingen filament lastet. Print avbrutt."
 
 #. MSG_Z_CALIBRATION_PROMPT c=20 r=3
 #: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:3752

--- a/lang/po/Firmware_pl.po
+++ b/lang/po/Firmware_pl.po
@@ -32,11 +32,11 @@ msgstr " 0.4 lub nowszy"
 msgid "%s level expected"
 msgstr "Oczekiwano wersji %s"
 
-#. MSG_CANCEL c=9
+#. MSG_CANCEL c=10
 #: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:1986
 #: ../../Firmware/ultralcd.cpp:3623
-msgid "Cancel"
-msgstr "Anuluj"
+msgid ">Cancel"
+msgstr ">Anuluj"
 
 #. MSG_BABYSTEPPING_Z c=13
 #: ../../Firmware/messages.cpp:269 ../../Firmware/ultralcd.cpp:2652
@@ -740,7 +740,7 @@ msgstr "Użyty filament"
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
 #: ../../Firmware/messages.cpp:375 ../../Firmware/ultralcd.cpp:7119
-msgid "File incomplete."
+msgid "File incomplete. Continue anyway?"
 msgstr "Plik niekompletny. Kontynuowac?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
@@ -795,35 +795,45 @@ msgstr "Przedni/lewy wentyl."
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:156 ../../Firmware/util.cpp:417
-msgid "G-code sliced for a different level."
-msgstr "G-code pocięty dla innej wersji."
+msgid "G-code sliced for a different level. Continue?"
+msgstr "G-code pocięty dla innej wersji. Kontynuować?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:418
-msgid "G-code sliced for a different level. Please re-slice the model again."
-msgstr "G-code pocięty na innym poziomie. Potnij model ponownie."
+msgid ""
+"G-code sliced for a different level. Please re-slice the model again. Print "
+"cancelled."
+msgstr ""
+"G-code pocięty na innym poziomie. Potnij model ponownie. Druk anulowany."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:152 ../../Firmware/util.cpp:319
 #: ../../Firmware/util.cpp:436
-msgid "G-code sliced for a different printer type."
-msgstr "G-code pocięty dla innej drukarki."
+msgid "G-code sliced for a different printer type. Continue?"
+msgstr "G-code pocięty dla innej drukarki. Kontynuować?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:153 ../../Firmware/util.cpp:320
 #: ../../Firmware/util.cpp:437
-msgid "G-code sliced for a different printer type. Please re-slice the model again."
-msgstr "G-code pocięty dla drukarki innego typu. Potnij model ponownie."
+msgid ""
+"G-code sliced for a different printer type. Please re-slice the model again."
+" Print cancelled."
+msgstr ""
+"G-code pocięty dla drukarki innego typu. Potnij model ponownie. Druk "
+"anulowany."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:154 ../../Firmware/util.cpp:369
-msgid "G-code sliced for a newer firmware."
-msgstr "G-code pocięty dla nowszego firmware."
+msgid "G-code sliced for a newer firmware. Continue?"
+msgstr "G-code pocięty dla nowszego firmware. Kontynuować?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:155 ../../Firmware/util.cpp:370
-msgid "G-code sliced for a newer firmware. Please update the firmware."
-msgstr "G-code pocięty dla nowszego firmware. Zaktualizuj firmware."
+msgid ""
+"G-code sliced for a newer firmware. Please update the firmware. Print "
+"cancelled."
+msgstr ""
+"G-code pocięty dla nowszego firmware. Zaktualizuj firmware. Druk anulowany."
 
 #. MSG_HW_SETUP c=18
 #: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4325
@@ -1669,13 +1679,17 @@ msgstr ""
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:160 ../../Firmware/util.cpp:296
-msgid "Nozzle diameter differs from the G-code."
-msgstr "Średnica dyszy różni się od tej w G-code."
+msgid "Nozzle diameter differs from the G-code. Continue?"
+msgstr "Średnica dyszy różni się od tej w G-code. Kontynuować?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:161 ../../Firmware/util.cpp:297
-msgid "Nozzle diameter differs from the G-code. Please check the value in settings."
-msgstr "Średnica dyszy różni się od tej w G-code. Sprawdź ustawienia."
+msgid ""
+"Nozzle diameter differs from the G-code. Please check the value in settings."
+" Print cancelled."
+msgstr ""
+"Średnica dyszy różni się od tej w G-code. Sprawdź ustawienia. Druk "
+"anulowany."
 
 #. MSG_DESC_PULLEY_CANNOT_MOVE c=20 r=8
 #: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
@@ -1777,9 +1791,10 @@ msgstr "Prawo [µm]"
 #: ../../Firmware/messages.cpp:298 ../../Firmware/ultralcd.cpp:3666
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
-"beginning."
+"beginning. Continue?"
 msgstr ""
-"Włączenie Asystenta usunie obecne dane kalibracyjne i zacznie od początku."
+"Włączenie Asystenta usunie obecne dane kalibracyjne i zacznie od początku. "
+"Kontynuować?"
 
 #. MSG_SD_CARD c=8
 #: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4476
@@ -2518,7 +2533,7 @@ msgstr "NIEZNANY BŁĄD"
 msgid "Unexpected error occurred."
 msgstr "Pojawił się nieoczekiwany błąd."
 
-#. MSG_EJECT c=9
+#. MSG_EJECT c=8
 #: ../../Firmware/messages.cpp:21 ../../Firmware/mmu2/errors_list.h:371
 #: ../../Firmware/ultralcd.cpp:2275 ../../Firmware/ultralcd.cpp:2279
 msgid "Eject"
@@ -2585,10 +2600,15 @@ msgstr "Dysza jest gorąca! Poczekaj na schłodzenie."
 msgid "Nozzle changed?"
 msgstr "Dysza została zmieniona?"
 
-#. MSG_MISSING_FILAMENT c=20 r=3
+#. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:388
-msgid "There is no filament loaded."
-msgstr "Nie ma załadowanego filamentu."
+msgid "There is no filament loaded. Continue?"
+msgstr "Nie ma załadowanego filamentu. Kontynuować?"
+
+#. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
+#: ../../Firmware/messages.cpp:159 ../../Firmware/util.cpp:389
+msgid "There is no filament loaded. Print cancelled."
+msgstr "Nie ma załadowanego filamentu. Druk anulowany."
 
 #. MSG_Z_CALIBRATION_PROMPT c=20 r=3
 #: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:3752

--- a/lang/po/Firmware_pl.po
+++ b/lang/po/Firmware_pl.po
@@ -2615,6 +2615,11 @@ msgstr "Nie ma załadowanego filamentu. Druk anulowany."
 msgid "Z calibration recommended. Run it now?"
 msgstr "Zalecana kalibracja Z. Uruchomić teraz?"
 
+#. MSG_FULLSTEP_Z c=18
+#: ../../Firmware/messages.cpp:380 ../../Firmware/ultralcd.cpp:4529
+msgid "Fullstep Z axis"
+msgstr "Pełny krok osi Z"
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Wyciągnij poprzedni filament i naciśnij pokrętło aby załadować nowy."
 

--- a/lang/po/Firmware_ro.po
+++ b/lang/po/Firmware_ro.po
@@ -2627,7 +2627,7 @@ msgstr "Calibrarea Z este recomandată. Calibrează acum?"
 #. MSG_FULLSTEP_Z c=18
 #: ../../Firmware/messages.cpp:380 ../../Firmware/ultralcd.cpp:4529
 msgid "Fullstep Z axis"
-msgstr "Axul Z pas complet"
+msgstr "Z pas complet"
 
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Scoateți fil. vechi și apăsați butonul pentru a încărca unul nou."

--- a/lang/po/Firmware_ro.po
+++ b/lang/po/Firmware_ro.po
@@ -32,11 +32,11 @@ msgstr " 0.4 / mai nou"
 msgid "%s level expected"
 msgstr "nivel %s așteptat"
 
-#. MSG_CANCEL c=9
+#. MSG_CANCEL c=10
 #: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:1986
 #: ../../Firmware/ultralcd.cpp:3623
-msgid "Cancel"
-msgstr "Anulează"
+msgid ">Cancel"
+msgstr ">Anulează"
 
 #. MSG_BABYSTEPPING_Z c=13
 #: ../../Firmware/messages.cpp:269 ../../Firmware/ultralcd.cpp:2652
@@ -740,7 +740,7 @@ msgstr "Filament folosit"
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
 #: ../../Firmware/messages.cpp:375 ../../Firmware/ultralcd.cpp:7119
-msgid "File incomplete."
+msgid "File incomplete. Continue anyway?"
 msgstr "Fișier incomplet. Continuă oricum?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
@@ -795,36 +795,47 @@ msgstr "Ventilatoarele sunt"
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:156 ../../Firmware/util.cpp:417
-msgid "G-code sliced for a different level."
-msgstr "Versiune de G-code e incorectă."
+msgid "G-code sliced for a different level. Continue?"
+msgstr "Versiune de G-code e incorectă. Continuați?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:418
-msgid "G-code sliced for a different level. Please re-slice the model again."
-msgstr "Versiune de G-code e incorectă. Vă rugăm pregătiți modelul din nou."
+msgid ""
+"G-code sliced for a different level. Please re-slice the model again. Print "
+"cancelled."
+msgstr ""
+"Versiune de G-code e incorectă. Vă rugăm pregătiți modelul din nou. Print "
+"anulat."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:152 ../../Firmware/util.cpp:319
 #: ../../Firmware/util.cpp:436
-msgid "G-code sliced for a different printer type."
-msgstr "G-code pregătit pentru un alt tip de printer."
+msgid "G-code sliced for a different printer type. Continue?"
+msgstr "G-code pregătit pentru un alt tip de printer. Continuați?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:153 ../../Firmware/util.cpp:320
 #: ../../Firmware/util.cpp:437
-msgid "G-code sliced for a different printer type. Please re-slice the model again."
-msgstr "G-code pregătit pentru un alt tip de printer. Vă rugăm să pregătiți modelul "
-"din nou."
+msgid ""
+"G-code sliced for a different printer type. Please re-slice the model again."
+" Print cancelled."
+msgstr ""
+"G-code pregătit pentru un alt tip de printer. Vă rugăm să pregătiți modelul "
+"din nou. Print anulat."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:154 ../../Firmware/util.cpp:369
-msgid "G-code sliced for a newer firmware."
-msgstr "G-code pregătit pentru firmware mai nou."
+msgid "G-code sliced for a newer firmware. Continue?"
+msgstr "G-code pregătit pentru firmware mai nou. Continuați?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:155 ../../Firmware/util.cpp:370
-msgid "G-code sliced for a newer firmware. Please update the firmware."
-msgstr "G-code pregătit pentru firmware mai nou. Vă rugăm actualizați firmware-ul."
+msgid ""
+"G-code sliced for a newer firmware. Please update the firmware. Print "
+"cancelled."
+msgstr ""
+"G-code pregătit pentru firmware mai nou. Vă rugăm actualizați firmware-ul. "
+"Print anulat."
 
 #. MSG_HW_SETUP c=18
 #: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4325
@@ -1670,14 +1681,17 @@ msgstr ""
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:160 ../../Firmware/util.cpp:296
-msgid "Nozzle diameter differs from the G-code."
-msgstr "Diametrul vârfului diferă de cel din G-code."
+msgid "Nozzle diameter differs from the G-code. Continue?"
+msgstr "Diametrul vârfului diferă de cel din G-code. Continuați?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:161 ../../Firmware/util.cpp:297
-msgid "Nozzle diameter differs from the G-code. Please check the value in settings."
-msgstr "Diametrul vârfului diferă de cel din G-code. Vă rugăm verificați valoarea în"
-" setări."
+msgid ""
+"Nozzle diameter differs from the G-code. Please check the value in settings."
+" Print cancelled."
+msgstr ""
+"Diametrul vârfului diferă de cel din G-code. Vă rugăm verificați valoarea în"
+" setări. Print anulat."
 
 #. MSG_DESC_PULLEY_CANNOT_MOVE c=20 r=8
 #: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
@@ -1779,10 +1793,10 @@ msgstr "Dreapta [µm]"
 #: ../../Firmware/messages.cpp:298 ../../Firmware/ultralcd.cpp:3666
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
-"beginning."
+"beginning. Continue?"
 msgstr ""
 "Rularea Wizard-ului va șterge rezultatele curente ale calibrării și va porni"
-" de la început."
+" de la început. Continuați?"
 
 #. MSG_SD_CARD c=8
 #: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4476
@@ -2527,7 +2541,7 @@ msgstr "EROARE NECUNOSCUTĂ"
 msgid "Unexpected error occurred."
 msgstr "A apărut o eroare neașteptată."
 
-#. MSG_EJECT c=9
+#. MSG_EJECT c=8
 #: ../../Firmware/messages.cpp:21 ../../Firmware/mmu2/errors_list.h:371
 #: ../../Firmware/ultralcd.cpp:2275 ../../Firmware/ultralcd.cpp:2279
 msgid "Eject"
@@ -2595,10 +2609,15 @@ msgstr "Duza este fierbinte! Așteptați să se răcească."
 msgid "Nozzle changed?"
 msgstr "S-a schimbat duza?"
 
-#. MSG_MISSING_FILAMENT c=20 r=3
+#. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:388
-msgid "There is no filament loaded."
-msgstr "Filamentul nu este detectat."
+msgid "There is no filament loaded. Continue?"
+msgstr "Filamentul nu este detectat. Continuați?"
+
+#. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
+#: ../../Firmware/messages.cpp:159 ../../Firmware/util.cpp:389
+msgid "There is no filament loaded. Print cancelled."
+msgstr "Filamentul nu este detectat. Print anulat."
 
 #. MSG_Z_CALIBRATION_PROMPT c=20 r=3
 #: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:3752

--- a/lang/po/Firmware_ro.po
+++ b/lang/po/Firmware_ro.po
@@ -2624,6 +2624,11 @@ msgstr "Filamentul nu este detectat. Print anulat."
 msgid "Z calibration recommended. Run it now?"
 msgstr "Calibrarea Z este recomandată. Calibrează acum?"
 
+#. MSG_FULLSTEP_Z c=18
+#: ../../Firmware/messages.cpp:380 ../../Firmware/ultralcd.cpp:4529
+msgid "Fullstep Z axis"
+msgstr "Axul Z pas complet"
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Scoateți fil. vechi și apăsați butonul pentru a încărca unul nou."
 

--- a/lang/po/Firmware_sk.po
+++ b/lang/po/Firmware_sk.po
@@ -32,11 +32,11 @@ msgstr " 0.4 a novšie"
 msgid "%s level expected"
 msgstr "Očakávaná verzia %s"
 
-#. MSG_CANCEL c=9
+#. MSG_CANCEL c=10
 #: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:1986
 #: ../../Firmware/ultralcd.cpp:3623
-msgid "Cancel"
-msgstr "Zrušiť"
+msgid ">Cancel"
+msgstr ">Zrušiť"
 
 #. MSG_BABYSTEPPING_Z c=13
 #: ../../Firmware/messages.cpp:269 ../../Firmware/ultralcd.cpp:2652
@@ -737,8 +737,8 @@ msgstr "Spotrebovaný filam."
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
 #: ../../Firmware/messages.cpp:375 ../../Firmware/ultralcd.cpp:7119
-msgid "File incomplete."
-msgstr "Súbor nekompletný."
+msgid "File incomplete. Continue anyway?"
+msgstr "Súbor nekompletný. Pokračovať?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
 #: ../../Firmware/messages.cpp:45
@@ -792,35 +792,46 @@ msgstr "Predný/ľavý vent."
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:156 ../../Firmware/util.cpp:417
-msgid "G-code sliced for a different level."
-msgstr "G-code pripravený pre inú úroveň."
+msgid "G-code sliced for a different level. Continue?"
+msgstr "G-code pripravený pre inú úroveň. Pokračovať?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:418
-msgid "G-code sliced for a different level. Please re-slice the model again."
-msgstr "G-code pripravený pre inú verziu. Vygenerujte G-code znova."
+msgid ""
+"G-code sliced for a different level. Please re-slice the model again. Print "
+"cancelled."
+msgstr ""
+"G-code pripravený pre inú verziu. Vygenerujte G-code znova. Tlač zrušená."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:152 ../../Firmware/util.cpp:319
 #: ../../Firmware/util.cpp:436
-msgid "G-code sliced for a different printer type."
+msgid "G-code sliced for a different printer type. Continue?"
 msgstr "G-code je pripravený pre iný typ tlačiarne.Pokračovať?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:153 ../../Firmware/util.cpp:320
 #: ../../Firmware/util.cpp:437
-msgid "G-code sliced for a different printer type. Please re-slice the model again."
-msgstr "G-code je pripravený pre iný typ tlačiarne. Vygenerujte G-code znova."
+msgid ""
+"G-code sliced for a different printer type. Please re-slice the model again."
+" Print cancelled."
+msgstr ""
+"G-code je pripravený pre iný typ tlačiarne. Vygenerujte G-code znova. Tlač "
+"zrušená."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:154 ../../Firmware/util.cpp:369
-msgid "G-code sliced for a newer firmware."
-msgstr "G-code je pripravený pre novší firmware."
+msgid "G-code sliced for a newer firmware. Continue?"
+msgstr "G-code je pripravený pre novší firmware. Pokračovať?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:155 ../../Firmware/util.cpp:370
-msgid "G-code sliced for a newer firmware. Please update the firmware."
-msgstr "G-code je pripravený pre novší firmware. Prosím aktualizujte firmware."
+msgid ""
+"G-code sliced for a newer firmware. Please update the firmware. Print "
+"cancelled."
+msgstr ""
+"G-code je pripravený pre novší firmware. Prosím aktualizujte firmware. Tlač "
+"zrušená."
 
 #. MSG_HW_SETUP c=18
 #: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4325
@@ -1664,13 +1675,17 @@ msgstr ""
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:160 ../../Firmware/util.cpp:296
-msgid "Nozzle diameter differs from the G-code."
-msgstr "Priemer trysky tlačiarne sa líši od G-code."
+msgid "Nozzle diameter differs from the G-code. Continue?"
+msgstr "Priemer trysky tlačiarne sa líši od G-code. Pokračovať?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:161 ../../Firmware/util.cpp:297
-msgid "Nozzle diameter differs from the G-code. Please check the value in settings."
-msgstr "Priemer trysky tlačiarne sa líši od G-code. Prosím skontrolujte nastavenie."
+msgid ""
+"Nozzle diameter differs from the G-code. Please check the value in settings."
+" Print cancelled."
+msgstr ""
+"Priemer trysky tlačiarne sa líši od G-code. Prosím skontrolujte nastavenie. "
+"Tlač zrušená."
 
 #. MSG_DESC_PULLEY_CANNOT_MOVE c=20 r=8
 #: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
@@ -1772,10 +1787,10 @@ msgstr "Pravá str.[µm]"
 #: ../../Firmware/messages.cpp:298 ../../Firmware/ultralcd.cpp:3666
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
-"beginning."
+"beginning. Continue?"
 msgstr ""
 "Spustenie Sprievodcu vymaže uložené výsledky všetkých kalibrácií a spustí "
-"kalibračný proces od začiatku."
+"kalibračný proces od začiatku. Pokračovať?"
 
 #. MSG_SD_CARD c=8
 #: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4476
@@ -2508,7 +2523,7 @@ msgstr "NEZNÁMA CHYBA"
 msgid "Unexpected error occurred."
 msgstr "Vyskytla sa neočakávaná chyba."
 
-#. MSG_EJECT c=9
+#. MSG_EJECT c=8
 #: ../../Firmware/messages.cpp:21 ../../Firmware/mmu2/errors_list.h:371
 #: ../../Firmware/ultralcd.cpp:2275 ../../Firmware/ultralcd.cpp:2279
 msgid "Eject"
@@ -2575,10 +2590,15 @@ msgstr "Tryska je horúca! Počkajte na vychladnutie."
 msgid "Nozzle changed?"
 msgstr "Vymenili ste trysku?"
 
-#. MSG_MISSING_FILAMENT c=20 r=3
+#. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:388
-msgid "There is no filament loaded."
-msgstr "Nie je zavedený žiaden filament."
+msgid "There is no filament loaded. Continue?"
+msgstr "Nie je zavedený žiaden filament. Pokračovať?"
+
+#. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
+#: ../../Firmware/messages.cpp:159 ../../Firmware/util.cpp:389
+msgid "There is no filament loaded. Print cancelled."
+msgstr "Nie je zavedený žiaden filament. Tlač zrušená."
 
 #. MSG_Z_CALIBRATION_PROMPT c=20 r=3
 #: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:3752

--- a/lang/po/Firmware_sk.po
+++ b/lang/po/Firmware_sk.po
@@ -2605,6 +2605,11 @@ msgstr "Nie je zavedený žiaden filament. Tlač zrušená."
 msgid "Z calibration recommended. Run it now?"
 msgstr "Odporúča sa kalibrácia Z. Spustiť ju teraz?"
 
+#. MSG_FULLSTEP_Z c=18
+#: ../../Firmware/messages.cpp:380 ../../Firmware/ultralcd.cpp:4529
+msgid "Fullstep Z axis"
+msgstr "Plný krok osi Z"
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Vyberte starý filament a stlačte tlačidlo pre zavedenie nového."
 

--- a/lang/po/Firmware_sv.po
+++ b/lang/po/Firmware_sv.po
@@ -32,11 +32,11 @@ msgstr " 0.4 el nyare"
 msgid "%s level expected"
 msgstr "%s nivå förväntad"
 
-#. MSG_CANCEL c=9
+#. MSG_CANCEL c=10
 #: ../../Firmware/messages.cpp:22 ../../Firmware/ultralcd.cpp:1986
 #: ../../Firmware/ultralcd.cpp:3623
-msgid "Cancel"
-msgstr "Avbryt"
+msgid ">Cancel"
+msgstr ">Avbryt"
 
 #. MSG_BABYSTEPPING_Z c=13
 #: ../../Firmware/messages.cpp:269 ../../Firmware/ultralcd.cpp:2652
@@ -738,7 +738,7 @@ msgstr "Använt filament"
 
 #. MSG_FILE_INCOMPLETE c=20 r=3
 #: ../../Firmware/messages.cpp:375 ../../Firmware/ultralcd.cpp:7119
-msgid "File incomplete."
+msgid "File incomplete. Continue anyway?"
 msgstr "Filen är ofullständig. Fortsätta ändå?"
 
 #. MSG_FINISHING_MOVEMENTS c=20
@@ -793,36 +793,47 @@ msgstr "Front/vänster fläkt"
 
 #. MSG_GCODE_DIFF_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:156 ../../Firmware/util.cpp:417
-msgid "G-code sliced for a different level."
-msgstr "G-code genererad för en annan nivå."
+msgid "G-code sliced for a different level. Continue?"
+msgstr "G-code genererad för en annan nivå. Fortsätta?"
 
 #. MSG_GCODE_DIFF_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:157 ../../Firmware/util.cpp:418
-msgid "G-code sliced for a different level. Please re-slice the model again."
-msgstr "G-code genererad för en annan nivå. Vänligen re-generera modellen igen."
+msgid ""
+"G-code sliced for a different level. Please re-slice the model again. Print "
+"cancelled."
+msgstr ""
+"G-code genererad för en annan nivå. Vänligen re-generera modellen igen. "
+"Utskriften avbröts."
 
 #. MSG_GCODE_DIFF_PRINTER_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:152 ../../Firmware/util.cpp:319
 #: ../../Firmware/util.cpp:436
-msgid "G-code sliced for a different printer type."
-msgstr "G-code genererad för en annan skrivartyp."
+msgid "G-code sliced for a different printer type. Continue?"
+msgstr "G-code genererad för en annan skrivartyp. Fortsätta?"
 
 #. MSG_GCODE_DIFF_PRINTER_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:153 ../../Firmware/util.cpp:320
 #: ../../Firmware/util.cpp:437
-msgid "G-code sliced for a different printer type. Please re-slice the model again."
-msgstr "G-code genererad för en annan skrivartyp. Vänligen re-generera modellen "
-"igen."
+msgid ""
+"G-code sliced for a different printer type. Please re-slice the model again."
+" Print cancelled."
+msgstr ""
+"G-code genererad för en annan skrivartyp. Vänligen re-generera modellen "
+"igen. Utskriften avbröts."
 
 #. MSG_GCODE_NEWER_FIRMWARE_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:154 ../../Firmware/util.cpp:369
-msgid "G-code sliced for a newer firmware."
-msgstr "G-code genererad för en nyare firmware."
+msgid "G-code sliced for a newer firmware. Continue?"
+msgstr "G-code genererad för en nyare firmware. Fortsätta?"
 
 #. MSG_GCODE_NEWER_FIRMWARE_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:155 ../../Firmware/util.cpp:370
-msgid "G-code sliced for a newer firmware. Please update the firmware."
-msgstr "G-code genererad för en nyare firmware. Vänligen uppdatera firmware."
+msgid ""
+"G-code sliced for a newer firmware. Please update the firmware. Print "
+"cancelled."
+msgstr ""
+"G-code genererad för en nyare firmware. Vänligen uppdatera firmware. "
+"Utskriften avbröts."
 
 #. MSG_HW_SETUP c=18
 #: ../../Firmware/messages.cpp:119 ../../Firmware/ultralcd.cpp:4325
@@ -1670,14 +1681,17 @@ msgstr ""
 
 #. MSG_NOZZLE_DIFFERS_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:160 ../../Firmware/util.cpp:296
-msgid "Nozzle diameter differs from the G-code."
-msgstr "Munstycksdiametern skiljer sig från G-codeen."
+msgid "Nozzle diameter differs from the G-code. Continue?"
+msgstr "Munstycksdiametern skiljer sig från G-codeen. Fortsätta?"
 
 #. MSG_NOZZLE_DIFFERS_CANCELLED c=20 r=8
 #: ../../Firmware/messages.cpp:161 ../../Firmware/util.cpp:297
-msgid "Nozzle diameter differs from the G-code. Please check the value in settings."
-msgstr "Skrivarmunstyckets diameter skiljer sig från G-codeen. Kontrollera värdet i "
-"inställningarna."
+msgid ""
+"Nozzle diameter differs from the G-code. Please check the value in settings."
+" Print cancelled."
+msgstr ""
+"Skrivarmunstyckets diameter skiljer sig från G-codeen. Kontrollera värdet i "
+"inställningarna. Utskriften avbröts."
 
 #. MSG_DESC_PULLEY_CANNOT_MOVE c=20 r=8
 #: ../../Firmware/mmu2/errors_list.h:246 ../../Firmware/mmu2/errors_list.h:302
@@ -1779,10 +1793,10 @@ msgstr "Höger sida[µm]"
 #: ../../Firmware/messages.cpp:298 ../../Firmware/ultralcd.cpp:3666
 msgid ""
 "Running Wizard will delete current calibration results and start from the "
-"beginning."
+"beginning. Continue?"
 msgstr ""
 "Att utföra guiden kommer att radera aktuella kalibreringsinställningar och "
-"börja om från början."
+"börja om från början. Fortsätta?"
 
 #. MSG_SD_CARD c=8
 #: ../../Firmware/messages.cpp:164 ../../Firmware/ultralcd.cpp:4476
@@ -2516,7 +2530,7 @@ msgstr "OKÄNT FEL"
 msgid "Unexpected error occurred."
 msgstr "Ett oväntat fel inträffade."
 
-#. MSG_EJECT c=9
+#. MSG_EJECT c=8
 #: ../../Firmware/messages.cpp:21 ../../Firmware/mmu2/errors_list.h:371
 #: ../../Firmware/ultralcd.cpp:2275 ../../Firmware/ultralcd.cpp:2279
 msgid "Eject"
@@ -2583,10 +2597,15 @@ msgstr "Munstycket är varmt! Vänta på nedkylning."
 msgid "Nozzle changed?"
 msgstr "Har munstycket ändrats?"
 
-#. MSG_MISSING_FILAMENT c=20 r=3
+#. MSG_MISSING_FILAMENT_CONTINUE c=20 r=3
 #: ../../Firmware/messages.cpp:158 ../../Firmware/util.cpp:388
-msgid "There is no filament loaded."
-msgstr "Det finns ingen filament laddad."
+msgid "There is no filament loaded. Continue?"
+msgstr "Det finns ingen filament laddad. Fortsätta?"
+
+#. MSG_MISSING_FILAMENT_CANCELLED c=20 r=8
+#: ../../Firmware/messages.cpp:159 ../../Firmware/util.cpp:389
+msgid "There is no filament loaded. Print cancelled."
+msgstr "Det finns ingen filament laddad. Utskriften avbröts."
 
 #. MSG_Z_CALIBRATION_PROMPT c=20 r=3
 #: ../../Firmware/messages.cpp:128 ../../Firmware/ultralcd.cpp:3752

--- a/lang/po/Firmware_sv.po
+++ b/lang/po/Firmware_sv.po
@@ -2612,6 +2612,11 @@ msgstr "Det finns ingen filament laddad. Utskriften avbröts."
 msgid "Z calibration recommended. Run it now?"
 msgstr "Z-kalibrering rekommenderas. Kör den nu?"
 
+#. MSG_FULLSTEP_Z c=18
+#: ../../Firmware/messages.cpp:380 ../../Firmware/ultralcd.cpp:4529
+msgid "Fullstep Z axis"
+msgstr "Fullsteg Z-axel"
+
 #~ msgid "Remove old filament and press the knob to start loading new filament."
 #~ msgstr "Ta bort det gamla fil. och tryck på knappen för att börja ladda nytt."
 


### PR DESCRIPTION
This pull request introduces a new G-code command `M88` that moves the Z-axis to the nearest full-step position. This enhancement addresses [Issue #2876](https://github.com/prusa3d/Prusa-Firmware/issues/2876), which proposes a method to reduce backlash and improve Z-axis reliability when steppers are disabled.

### Details

- New and unused G-code M88.
- Logic copied from power panic feature.
- Ensures the target position is within Z bounds before executing the move.
- Adds a new LCD menu item labeled `"Fullstep Z axis"` to trigger `M88` manually.
- Message string defined in `messages.cpp` and declared in `messages.h`.

### Benefits

- Reduces Z-axis skew and backlash by aligning Z motors to nearest full-step.
- Provides users with manual control via LCD menu as well as g-code command.

### Notes

- Tested on MK3S+ in both menu and end G-code.

---

### Related Issue

Fixes [#2876](https://github.com/prusa3d/Prusa-Firmware/issues/2876)